### PR TITLE
Add initial notion-sync on first deploy

### DIFF
--- a/ansible/roles/pops-deploy/tasks/main.yml
+++ b/ansible/roles/pops-deploy/tasks/main.yml
@@ -47,6 +47,23 @@
     chdir: "{{ docker_compose_dir }}"
   changed_when: true
 
+- name: Check if SQLite database exists in volume
+  ansible.builtin.command:
+    cmd: docker run --rm -v pops-sqlite-data:/data/sqlite alpine test -f /data/sqlite/pops.db
+  register: sqlite_db_check
+  failed_when: false
+  changed_when: false
+
+- name: Run initial Notion sync (first deploy only)
+  ansible.builtin.command:
+    cmd: docker compose run --rm notion-sync
+    chdir: "{{ docker_compose_dir }}"
+  become: true
+  become_user: "{{ pops_user }}"
+  when: sqlite_db_check.rc != 0
+  async: 600
+  poll: 30
+
 - name: Create notion-sync systemd service
   ansible.builtin.copy:
     content: |


### PR DESCRIPTION
## Summary
- Adds two Ansible tasks to `pops-deploy` role after `docker compose up -d`
- Checks if SQLite DB exists inside the `pops-sqlite-data` Docker volume
- If DB is missing (fresh deploy), runs `docker compose run --rm notion-sync` with 10-min async timeout
- Ensures fresh deploys have data immediately instead of waiting for the 15-minute systemd timer

## Test plan
- [ ] Run `ansible-playbook playbooks/deploy.yml --diff` against the N95
- [ ] Verify existing DB is detected and sync is skipped
- [ ] Test fresh deploy: remove volume, re-deploy, verify sync runs