### PR TITLE
Fix finance-api Docker runtime dependencies

### DIFF
--- a/services/finance-api/Dockerfile
+++ b/services/finance-api/Dockerfile
@@ -24,9 +24,15 @@ RUN yarn build
 FROM node:22-alpine
 WORKDIR /app
 RUN apk add --no-cache curl
+
+# Copy built service
 COPY --from=builder /app/services/finance-api/dist ./dist
-COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/services/finance-api/package.json ./
+
+# Copy node_modules and workspace dependencies
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/db-types ./node_modules/@pops/db-types
+
 USER node
 EXPOSE 3000
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
Copy @pops/db-types into node_modules so runtime can resolve it