### PR TITLE
Fix db-types build ordering across deploy pipelines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Build shared packages
+        run: cd packages/db-types && yarn build
+
       - name: Type check all services
         run: |
           cd services/finance-api && yarn typecheck

--- a/.github/workflows/finance-api-ci.yml
+++ b/.github/workflows/finance-api-ci.yml
@@ -4,21 +4,20 @@ on:
   pull_request:
     paths:
       - "services/finance-api/**"
+      - "packages/db-types/**"
       - ".github/workflows/finance-api-ci.yml"
   push:
     branches:
       - main
     paths:
       - "services/finance-api/**"
+      - "packages/db-types/**"
       - ".github/workflows/finance-api-ci.yml"
 
 jobs:
   quality-checks:
     name: Quality Checks
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: services/finance-api
 
     steps:
       - name: Checkout repository
@@ -27,27 +26,29 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "yarn"
-          cache-dependency-path: services/finance-api/yarn.lock
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Build shared packages
+        run: cd packages/db-types && yarn build
+
       - name: Type check
-        run: yarn typecheck
+        run: cd services/finance-api && yarn typecheck
 
       - name: Lint
-        run: yarn lint
+        run: cd services/finance-api && yarn lint
 
       - name: Format check
-        run: yarn format
+        run: cd services/finance-api && yarn format
 
       - name: Run tests
-        run: yarn test
+        run: cd services/finance-api && yarn test
 
       - name: Build
-        run: yarn build
+        run: cd services/finance-api && yarn build
 
       - name: Upload build artifacts
         if: success()

--- a/.github/workflows/notion-sync-ci.yml
+++ b/.github/workflows/notion-sync-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
           cache-dependency-path: services/notion-sync/yarn.lock
 

--- a/.github/workflows/pwa-ci.yml
+++ b/.github/workflows/pwa-ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - "services/pops-pwa/**"
+      - "packages/db-types/**"
       - ".github/workflows/pwa-ci.yml"
   pull_request:
     paths:
       - "services/pops-pwa/**"
+      - "packages/db-types/**"
       - ".github/workflows/pwa-ci.yml"
 
 jobs:
@@ -24,6 +26,9 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Build shared packages
+        run: cd packages/db-types && yarn build
 
       - name: Type check
         run: cd services/pops-pwa && yarn typecheck

--- a/.github/workflows/tools-ci.yml
+++ b/.github/workflows/tools-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
           cache-dependency-path: tools/yarn.lock
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -110,6 +110,18 @@ echo ""
 if [ "$SKIP_CHECKS" = false ]; then
     echo -e "${YELLOW}Running quality checks...${NC}"
 
+    # Build shared packages first
+    echo -e "${BLUE}Shared packages:${NC}"
+    cd packages/db-types
+
+    if ! yarn build; then
+        echo -e "${RED}✗ Failed to build db-types${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ db-types built${NC}"
+
+    cd ../..
+
     # Check finance-api
     echo -e "${BLUE}Finance API:${NC}"
     cd services/finance-api

--- a/packages/db-types/package.json
+++ b/packages/db-types/package.json
@@ -19,7 +19,6 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/minimatch": "^6.0.0",
     "typescript": "^5.7.0"
   }
 }

--- a/packages/db-types/tsconfig.json
+++ b/packages/db-types/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": [],
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,

--- a/services/pops-pwa/Dockerfile
+++ b/services/pops-pwa/Dockerfile
@@ -23,7 +23,11 @@ COPY services/pops-pwa/vite.config.ts ./services/pops-pwa/
 COPY services/pops-pwa/index.html ./services/pops-pwa/
 COPY services/pops-pwa/nginx.conf ./services/pops-pwa/
 
-# Build
+# Build db-types first (required by finance-api types, which pops-pwa references)
+WORKDIR /app/packages/db-types
+RUN yarn build
+
+# Build pops-pwa
 WORKDIR /app/services/pops-pwa
 RUN yarn build
 


### PR DESCRIPTION
## Summary
- **Root cause**: `@pops/db-types` shared package was never built before dependent services (`finance-api`, `pops-pwa`) during Docker builds, CI checks, and deploy script — causing TypeScript compilation failures on every deployment
- Added db-types build step to pops-pwa Dockerfile, all CI workflows (deploy, finance-api, pwa), and deploy.sh
- Fixed finance-api CI to install from monorepo root (workspace deps weren't resolving), updated Node 20→22 across all CI workflows
- Removed phantom `@types/minimatch` dependency and added `types: []` to db-types tsconfig to prevent hoisted type auto-discovery errors

## Changes
| File | Change |
|------|--------|
| `services/pops-pwa/Dockerfile` | Add `yarn build` for db-types before PWA build |
| `.github/workflows/deploy.yml` | Add "Build shared packages" step |
| `.github/workflows/finance-api-ci.yml` | Install from root, add db-types build, Node 20→22, add db-types path trigger |
| `.github/workflows/pwa-ci.yml` | Add db-types build step + path trigger |
| `.github/workflows/notion-sync-ci.yml` | Node 20→22 |
| `.github/workflows/tools-ci.yml` | Node 20→22 |
| `deploy.sh` | Add db-types build before quality checks |
| `packages/db-types/package.json` | Remove unused `@types/minimatch` |
| `packages/db-types/tsconfig.json` | Add `types: []` to prevent auto-discovery |

## Test plan
- [x] `yarn build` in `packages/db-types` — passes
- [x] `yarn typecheck` in `services/finance-api` — passes
- [x] `yarn typecheck` in `services/pops-pwa` — passes
- [x] `yarn test --run` in `services/finance-api` — 169 tests pass
- [x] `yarn build` in `services/finance-api` — passes
- [x] `yarn build` in `services/pops-pwa` — passes
- [x] `docker build` finance-api — passes
- [x] `docker build` notion-sync — passes
- [x] `docker build` pops-pwa — passes (was failing before)
- [x] `docker compose config` on production compose — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)