### PR TITLE
Fix PWA nginx proxy for /trpc API requests

### DIFF
--- a/apps/pops-pwa/nginx.conf
+++ b/apps/pops-pwa/nginx.conf
@@ -4,6 +4,16 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Proxy API requests to finance-api
+    location /trpc {
+        proxy_pass http://pops-finance-api:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Problem
PWA was loading HTML and JavaScript but React wasn't mounting. The tRPC client couldn't reach the finance-api because there was no proxy configuration in nginx.

## Root Cause
- tRPC client configured to use `/trpc` endpoint (same-origin)
- Dev: Vite proxies `/trpc` → `http://localhost:3000` ✅
- Prod: nginx only served static files, no proxy ❌

## Solution
Add nginx `location /trpc` block to proxy API requests to `pops-finance-api:3000`.

## Testing
After deployment, the PWA should:
1. Load the HTML ✅
2. Load JavaScript ✅  
3. Mount React app ✅ (new)
4. Display Dashboard page with sidebar