### PR TITLE
fix: address database script review comments

### DIFF
--- a/apps/finance-api/scripts/db-clear.ts
+++ b/apps/finance-api/scripts/db-clear.ts
@@ -5,7 +5,7 @@
 import BetterSqlite3 from "better-sqlite3";
 import { existsSync } from "node:fs";
 
-const DB_PATH = "./data/pops.db";
+const DB_PATH = process.env.SQLITE_PATH ?? "./data/pops.db";
 
 if (!existsSync(DB_PATH)) {
   console.error(`❌ Database not found at ${DB_PATH}`);
@@ -26,7 +26,7 @@ const clearTransaction = db.transaction(() => {
   db.exec(`DELETE FROM transactions`);
   db.exec(`DELETE FROM entities`);
   db.exec(`DELETE FROM budgets`);
-  db.exec(`DELETE FROM inventory`);
+  db.exec(`DELETE FROM home_inventory`);
   db.exec(`DELETE FROM wish_list`);
   db.exec(`DELETE FROM sync_cursors`);
 });
@@ -38,7 +38,7 @@ const counts = {
   transactions: db.prepare("SELECT COUNT(*) as count FROM transactions").get() as { count: number },
   entities: db.prepare("SELECT COUNT(*) as count FROM entities").get() as { count: number },
   budgets: db.prepare("SELECT COUNT(*) as count FROM budgets").get() as { count: number },
-  inventory: db.prepare("SELECT COUNT(*) as count FROM inventory").get() as { count: number },
+  home_inventory: db.prepare("SELECT COUNT(*) as count FROM home_inventory").get() as { count: number },
   wish_list: db.prepare("SELECT COUNT(*) as count FROM wish_list").get() as { count: number },
   sync_cursors: db.prepare("SELECT COUNT(*) as count FROM sync_cursors").get() as { count: number },
 };
@@ -48,7 +48,7 @@ console.log("📊 Table counts:");
 console.log(`  transactions:  ${counts.transactions.count}`);
 console.log(`  entities:      ${counts.entities.count}`);
 console.log(`  budgets:       ${counts.budgets.count}`);
-console.log(`  inventory:     ${counts.inventory.count}`);
+console.log(`  home_inventory:     ${counts.home_inventory.count}`);
 console.log(`  wish_list:     ${counts.wish_list.count}`);
 console.log(`  sync_cursors:  ${counts.sync_cursors.count}`);
 

--- a/apps/finance-api/scripts/init-db.ts
+++ b/apps/finance-api/scripts/init-db.ts
@@ -6,7 +6,7 @@ import BetterSqlite3 from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 
-const DB_PATH = "./data/pops.db";
+const DB_PATH = process.env.SQLITE_PATH ?? "./data/pops.db";
 
 // Create data directory if it doesn't exist
 mkdirSync(dirname(DB_PATH), { recursive: true });
@@ -62,7 +62,7 @@ db.exec(`
     last_edited_time TEXT NOT NULL
   );
 
-  CREATE TABLE IF NOT EXISTS inventory (
+  CREATE TABLE IF NOT EXISTS home_inventory (
     notion_id TEXT PRIMARY KEY,
     item_name TEXT NOT NULL,
     brand TEXT,


### PR DESCRIPTION
## Summary

Addresses all 8 issues identified in PR #30 Copilot review. Ensures database scripts work correctly with notion-sync schema and respect environment configuration.

## Issues Fixed

### 1-2. SQLITE_PATH Environment Variable
**Problem:** Scripts hardcoded `./data/pops.db` instead of respecting `SQLITE_PATH` env var  
**Fixed:** All three scripts now use `process.env.SQLITE_PATH ?? "./data/pops.db"`

### 3-7. Table Name Mismatch
**Problem:** Scripts used `inventory` but notion-sync creates `home_inventory`  
**Fixed:** All references updated to `home_inventory` to match notion-sync schema

### 8. Non-Atomic Seeding
**Problem:** Clear and insert operations in separate transactions → partial state on failure  
**Fixed:** Wrapped entire operation (clear + all inserts) in single atomic transaction

## Files Changed

- `apps/finance-api/scripts/db-clear.ts`
  - Use SQLITE_PATH env var
  - Fix table name: `inventory` → `home_inventory`
  
- `apps/finance-api/scripts/db-seed.ts`
  - Use SQLITE_PATH env var
  - Fix table name: `inventory` → `home_inventory`
  - Single atomic transaction for all operations
  
- `apps/finance-api/scripts/init-db.ts`
  - Use SQLITE_PATH env var
  - Create `home_inventory` table (not `inventory`)

## Test Results

All scripts tested and working:
```bash
✅ mise db:init  # Creates home_inventory table
✅ mise db:seed  # Seeds 44 records atomically
✅ mise db:clear # Clears home_inventory table
```

## Schema Alignment

Now matches notion-sync exactly:
- ✅ `transactions`
- ✅ `entities`
- ✅ `budgets`
- ✅ `home_inventory` (was `inventory`)
- ✅ `wish_list`
- ✅ `sync_cursors`