### PR TITLE
docs: Foundation theme planning — vision, roadmap, ADRs, PRDs

### DIFF
--- a/docs/architecture/adr-001-sqlite-source.md
+++ b/docs/architecture/adr-001-sqlite-source.md
@@ -1,0 +1,21 @@
+# ADR-001: SQLite as Source of Truth
+
+## Status
+
+Accepted (2026-03-18)
+
+## Context
+
+POPS originally used Notion as the primary data store with SQLite as a sync cache. This created latency, API rate limit issues, and coupling to a third-party service.
+
+## Decision
+
+SQLite is the sole source of truth. Notion dependency has been fully removed.
+
+## Consequences
+
+- All CRUD operations are synchronous and fast
+- No external API dependency for core data operations
+- Single-file database simplifies backups (rclone to Backblaze B2)
+- Cross-domain queries are trivial (joins within one DB)
+- No horizontal scaling — acceptable for single-user system

--- a/docs/architecture/adr-002-shell-architecture.md
+++ b/docs/architecture/adr-002-shell-architecture.md
@@ -1,0 +1,113 @@
+# ADR-002: Shell Architecture
+
+## Status
+
+Accepted (2026-03-18)
+
+## Context
+
+POPS is expanding from a single finance app to a multi-app platform (media, inventory, fitness, etc.). We need a frontend architecture that supports:
+
+- Multiple "apps" with independent pages and domain components
+- Shared shell (layout, navigation, app switcher, theming)
+- Shared UI component library
+- Good dev experience (not 20 Vite servers on different ports)
+- Fast load times (not bundling everything into one 10MB chunk)
+- Single Storybook instance covering the shared library and all apps
+
+### Options Considered
+
+**A. Single SPA with lazy-loaded route modules**
+One Vite dev server, one build. Each app is a set of route modules loaded on demand via `React.lazy()` / dynamic `import()`. Vite code-splits automatically per route.
+
+- Pros: One dev server, shared runtime, trivial cross-app navigation, simple deployment (one Docker image)
+- Cons: All apps in one build graph — slow builds as app count grows, all code in one package.json
+
+**B. Separate Vite builds composed at runtime (Module Federation)**
+Each app is its own Vite project with its own build. A shell app loads them at runtime via Webpack Module Federation or Vite's federation plugin.
+
+- Pros: Independent builds, independent deploys, true isolation
+- Cons: Runtime overhead, complex dev setup (multiple Vite servers), version skew risk for shared deps, significantly more infrastructure
+
+**C. Single SPA with workspace packages per app**
+One Vite dev server and one build, but each app lives in its own workspace package (e.g., `packages/app-media/`). The shell imports them as dependencies. Vite resolves workspace packages natively.
+
+- Pros: One dev server, logical separation per app, independent testing, shared build. Each app has its own package.json, tsconfig, and test config. Storybook can import from all packages.
+- Cons: Slightly more workspace config than option A. Still one build graph.
+
+**D. Next.js migration**
+Replace Vite + React Router with Next.js. App Router provides file-based routing with automatic code splitting.
+
+- Pros: Built-in code splitting, file-based routing, SSR if ever needed
+- Cons: SSR is pointless (self-hosted, single user, no SEO). Adds server complexity. Migration effort is high for no clear benefit over Vite + React Router.
+
+## Decision
+
+**Option C: Single SPA with workspace packages per app.**
+
+Rationale:
+
+- **One dev server** — `yarn dev` starts one Vite instance. No port juggling.
+- **Fast loads** — Vite code-splits per route automatically. Only the active app's code is loaded. Subsequent apps load on navigation.
+- **Logical separation** — Each app is its own package with clear boundaries, its own tests, and its own dependencies. Prevents the monolith-creep that would happen with option A as we add 10+ apps.
+- **One Storybook** — A single Storybook config in `apps/pops-storybook/` discovers stories from `@pops/ui` and all app packages via globs. Stories co-locate with their components, not in the Storybook app.
+- **Simple deployment** — One `vite build` produces one output. One Docker image. One nginx config.
+- **No Module Federation complexity** — We don't need independent deploys. We're one developer with AI agents, not five teams.
+- **No Next.js overhead** — No SSR benefit for a self-hosted single-user PWA behind Cloudflare Tunnel.
+
+## Structure
+
+```
+packages/
+  ui/                  → @pops/ui (shared component library, extracted from current pops-pwa)
+  app-finance/         → @pops/app-finance (finance pages + domain components)
+  app-media/           → @pops/app-media (media pages + domain components)
+  app-inventory/       → @pops/app-inventory (inventory pages + domain components)
+  app-fitness/         → @pops/app-fitness (fitness pages + domain components)
+  ...etc
+
+apps/
+  pops-shell/          → The shell: layout, app switcher, routing, theming, tRPC provider
+                         Imports all @pops/app-* packages as dependencies
+                         Single Vite build, single entry point
+  pops-storybook/      → Storybook config only. No stories live here — discovers *.stories.tsx from all packages via globs
+  pops-api/            → Backend API (renamed from finance-api)
+```
+
+### Routing
+
+Flat, namespaced routes. The shell owns the router and registers each app's routes:
+
+```
+/finance/transactions
+/finance/budgets
+/media/movies
+/media/tv
+/inventory/items
+/fitness/workouts
+```
+
+Each app package exports its routes. The shell lazily imports them:
+
+```typescript
+// pops-shell/src/app/router.tsx
+const financeRoutes = lazy(() => import('@pops/app-finance/routes'))
+const mediaRoutes = lazy(() => import('@pops/app-media/routes'))
+```
+
+### App Switcher
+
+The shell sidebar becomes an app switcher. Each app registers its navigation items. Within an app, secondary navigation shows that app's pages.
+
+## Consequences
+
+- Finance continues to work throughout migration — we extract it into `@pops/app-finance` and the shell imports it. Same code, different packaging.
+- New apps are scaffolded as workspace packages with a known structure.
+- Build time scales with total code, not number of apps — but Vite is fast and code-splitting means dev mode only processes the active route.
+- All apps share one version of React, tRPC client, Zustand, Tailwind. No version skew.
+- Cross-app navigation is instant (SPA, no full page reload).
+
+## Risks
+
+- Workspace package count will grow (11 apps + ui + db-types + shell + storybook). Yarn/Turbo should handle this fine but worth monitoring.
+- Circular dependency risk if app packages import from each other. Rule: apps import from `@pops/ui` and `@pops/db-types`, never from other apps. Cross-app communication goes through the API or shared stores in the shell.

--- a/docs/architecture/adr-003-component-library-and-api.md
+++ b/docs/architecture/adr-003-component-library-and-api.md
@@ -1,0 +1,124 @@
+# ADR-003: Component Library, API Structure & Shared Entities
+
+## Status
+
+Accepted (2026-03-18)
+
+## Context
+
+Three related decisions that follow from ADR-002 (shell architecture):
+
+1. How to package and develop the shared UI component library
+2. How to structure the backend API for multiple domains
+3. Where shared entities live
+
+---
+
+## Decision 1: Component Library as Workspace Package
+
+`@pops/ui` is a workspace package containing all shared components.
+
+### What goes in `@pops/ui`
+
+- shadcn/ui base components (Button, Card, Dialog, etc.)
+- Composite components (DataTable, forms, inputs, Autocomplete, etc.)
+- Layout primitives used across apps
+- Tailwind config and CSS variables (theming)
+- Utility functions (cn(), formatters)
+
+### What stays in app packages
+
+- Domain-specific components (e.g., TransactionCard stays in `@pops/app-finance`)
+- Page components
+- Domain-specific stores
+
+### Build & Development
+
+- No separate build step — Vite resolves workspace packages via TypeScript path resolution. Components are consumed as source, not compiled artifacts.
+- Storybook lives in `apps/pops-storybook/` but is config only — no stories live there. Stories co-locate with their components (e.g., `packages/ui/src/Button.stories.tsx`, `packages/app-finance/src/TransactionCard.stories.tsx`). Storybook discovers them via glob patterns across all workspace packages.
+
+### Tailwind
+
+- Shared Tailwind config and CSS variables live in `@pops/ui`
+- The shell and all app packages reference the shared config
+- Tailwind v4 — CSS-first configuration, no `tailwind.config.js`
+
+---
+
+## Decision 2: API Domain Modules
+
+Rename `finance-api` → `pops-api`. Keep it as one Express/tRPC server. Each domain is a tRPC router module.
+
+### Current structure (finance-only)
+
+```
+apps/finance-api/src/modules/
+  transactions/
+  entities/
+  budgets/
+  ...
+```
+
+### Target structure (multi-domain)
+
+```
+apps/pops-api/src/modules/
+  core/              → entities, auth, health (shared across domains)
+  finance/           → transactions, budgets, subscriptions, imports
+  media/             → movies, tv-shows, watchlist
+  inventory/         → items, warranties
+  fitness/           → exercises, workouts, progress
+  documents/         → paperless integration
+  ...
+```
+
+### Module rules
+
+- Domain modules can import from `core/` (entities, shared utilities)
+- Domain modules CANNOT import from each other directly
+- Cross-domain queries use the `core/` module or a dedicated cross-domain query layer
+- Each module registers its own tRPC router, composed at the top level
+
+### Why not separate services?
+
+One SQLite database. One user. Cross-domain joins are trivial. Separate services would mean inter-service communication, distributed transactions, and multiple processes — complexity with zero benefit for this use case.
+
+---
+
+## Decision 3: Entities as a Core/Global Concept
+
+Entities are promoted from a finance concept to a platform-level concept.
+
+### Current state
+
+Entities are merchants/payees in the finance module. ~940 records. Used for transaction matching.
+
+### Target state
+
+An entity is any named thing that appears across multiple domains:
+
+- A **company**: Woolworths (finance: grocery transactions, inventory: where you bought it)
+- A **person**: A friend (social: contact, finance: gift spend)
+- A **service**: Netflix (finance: subscription, media: streaming platform)
+- A **place**: A hotel (travel: accommodation, finance: booking cost)
+- A **brand**: Sony (inventory: manufacturer, media: studio)
+
+### Schema evolution
+
+The entity table gains a `type` column (or tags) to distinguish categories. Relations from other domains reference the shared entity table. The existing finance entity data migrates as-is — current entities are all type `company` or `person`.
+
+### Where it lives
+
+- Database: `entities` table stays where it is (shared, top-level)
+- API: `core/entities/` module in pops-api
+- Frontend: Entity components (selector, create dialog) live in `@pops/ui` since they're used everywhere
+
+---
+
+## Consequences
+
+- Component library is lightweight to set up — just a workspace package, no build pipeline
+- API stays simple — one server, one database, modular routers
+- Entities become the connective tissue between domains — consistent naming, linking, and search across all apps
+- Storybook is centralised — one place to browse all components from all apps
+- Clear import rules prevent coupling: apps → ui, apps → db-types, apps ✗→ other apps

--- a/docs/architecture/adr-004-tailwind-only-styling.md
+++ b/docs/architecture/adr-004-tailwind-only-styling.md
@@ -1,0 +1,39 @@
+# ADR-004: Tailwind-Only Styling with Design Tokens
+
+## Status
+
+Accepted (2026-03-18)
+
+## Context
+
+POPS will have 10+ app packages sharing a UI library. Styling consistency across apps requires a single source of truth for design tokens (colours, spacing, typography, etc.).
+
+## Decision
+
+All styling MUST use Tailwind utility classes with values defined in the design token system. No exceptions.
+
+### Rules
+
+1. **No arbitrary values** — `w-[960px]`, `text-[#ff0000]`, `p-[13px]` are forbidden. Use only Tailwind's built-in scale or custom tokens defined in `@pops/ui`.
+2. **No inline styles** — No `style={{ width: 960 }}`. Everything goes through Tailwind classes.
+3. **No CSS modules or separate CSS files** — Except for the global Tailwind entry point and design token definitions in `@pops/ui`.
+4. **All colours from the theme** — No hardcoded hex/rgb values in classes. Colours reference the theme's CSS variables via Tailwind (e.g., `bg-primary`, `text-muted-foreground`).
+5. **Design tokens live in `@pops/ui`** — The single source of truth for the Tailwind theme: colours, spacing overrides, typography, breakpoints, shadows, etc.
+6. **Apps consume, not define** — App packages use the tokens from `@pops/ui`. They do not extend or override the Tailwind config.
+
+### What this means for `@pops/ui`
+
+The design token system must be comprehensive enough that apps never need arbitrary values. This includes:
+
+- Full colour palette (light + dark mode)
+- Spacing scale covering all common sizes
+- Typography scale (font sizes, weights, line heights)
+- Container/layout widths as named tokens if the default scale isn't sufficient
+- Breakpoints for responsive design
+
+## Consequences
+
+- Consistent visual language across all apps without manual enforcement
+- Refactoring the design system (e.g., changing the primary colour) is a single-file change
+- Slightly more upfront work defining tokens, but eliminates ad-hoc styling debt
+- If a value isn't in the scale, you extend the design tokens in `@pops/ui` — not hack around it with arbitrary values

--- a/docs/architecture/adr-005-package-manager-and-task-runner.md
+++ b/docs/architecture/adr-005-package-manager-and-task-runner.md
@@ -1,0 +1,56 @@
+# ADR-005: Package Manager & Task Runner
+
+## Status
+
+Accepted (2026-03-18)
+
+## Context
+
+POPS currently uses:
+- **Yarn v1** (Classic) as package manager
+- **Turborepo** for workspace build orchestration
+- **mise** for task running (42+ tasks) and Node version pinning (24.5.0)
+
+As the project expands to 10+ workspace packages, the tooling should be evaluated.
+
+### Package Manager: Yarn v1 → pnpm
+
+Yarn v1 is in maintenance mode. pnpm is the modern standard for monorepos:
+- Strict dependency resolution (no phantom deps)
+- Faster installs via content-addressable store
+- Native workspace support (`pnpm-workspace.yaml`)
+- Better disk usage
+- Active development
+
+### Task Runner: mise → just (or keep mise)
+
+mise currently serves two roles:
+1. **Tool version management** — Pins Node 24.5.0
+2. **Task runner** — 42+ tasks for dev, db, imports, docker, ansible
+
+Options:
+- **Keep mise** — Does both jobs. More complex config but fewer tools.
+- **just + mise for versions only** — `just` handles task running (simpler, more transparent justfile). mise (or fnm/nvm) handles Node version only.
+- **just + no version manager** — Pin Node version via Docker/CI only. Developers manage their own Node version.
+- **just + Turbo** — `just` for orchestration and non-build tasks (db, docker, ansible). Turbo for build/test/lint caching across workspace packages.
+
+## Decision
+
+**pnpm + Turbo + mise.** Drop Yarn v1, keep everything else.
+
+- **pnpm** replaces Yarn v1 as package manager. Strict dependency resolution prevents phantom deps across 10+ workspace packages. Native workspace support via `pnpm-workspace.yaml`.
+- **Turbo** stays for build orchestration. Caching across workspace packages is its core value — matters more as package count grows.
+- **mise** stays for both version management and task running. Auto Node pinning is valuable when AI agents are doing the development. No reason to introduce `just` as a third tool when mise already handles tasks.
+
+## Migration Scope
+
+1. Remove `yarn.lock`, generate `pnpm-lock.yaml`
+2. Create `pnpm-workspace.yaml` (replaces `package.json` workspaces field)
+3. Update root `package.json`: remove `packageManager: yarn`, add `packageManager: pnpm`
+4. Update all scripts and docs referencing `yarn` → `pnpm`
+5. Update CI pipelines
+6. Update CLAUDE.md, mise.toml, and docs
+7. Verify all workspace resolution works
+8. Verify Turbo still caches correctly with pnpm
+
+This should be done **before** Epic 1 (UI Library Extraction) so all new packages start on pnpm.

--- a/docs/ideas/app-ideas.md
+++ b/docs/ideas/app-ideas.md
@@ -1,0 +1,43 @@
+# App Ideas
+
+Brainstorm dump from 2026-03-18. Nothing here is committed to — items get promoted to themes when deliberately prioritised.
+
+## Confirmed (will build)
+
+- **Finance** — Budgeting, transaction tracking, wishlist, bank imports. Heavily automated. *Already exists.*
+- **Home Inventory** — Item tracking, warranties, maintenance schedules, receipts (Paperless-ngx). Most frequently used app. *Partially exists.*
+- **Recipe Book** — Ingredient tracking, recipe management, meal planning. Links to finance (grocery spend) and inventory (kitchen gear).
+- **Media Tracker** — Movies and TV shows. Categorisation, recommendations, monitoring. Plex/Radarr/Sonarr sync, TMDB integration. Could be one app or split movies/TV.
+- **Travel Planner** — Trip planning, organising, tracking. Links to finance (trip budgets), recipes (local cuisine).
+- **AI Hub** — Integrated AI agents that can query and act across all apps. Cross-domain intelligence layer.
+
+## Strong candidates
+
+- **Subscriptions Tracker** — Lives in finance but surfaces recurring costs across media (streaming), recipes (meal kits), home auto (cloud services). Aggregated view of all recurring spend.
+- **Maintenance & Chores** — Extends inventory with service schedules, filter replacements, seasonal tasks. Reminder-driven.
+- **Documents Vault** — Surfaces Paperless-ngx content within POPS. Links receipts/warranties/manuals to inventory items and transactions.
+
+## Worth exploring
+
+- **Books / Reading** — Same pattern as media tracker. Goodreads replacement. Track reading list, reviews, recommendations.
+- **Health & Fitness** — Weight, exercise, meal logging (ties into recipes). Apple Health integration.
+- **Contacts / CRM-lite** — Gift tracking, event planning. "What did I get Sarah for her birthday last year?"
+- **Home Automation** — Dashboard for smart home devices. HomeAssistant integration. Links to inventory (devices).
+- **Mobile App** — Native iOS app wrapping the PWA or React Native. Target: iPhone daily driver + iPad/HomePad wall mount.
+
+## Cross-communication patterns
+
+These are the links that make POPS more than separate apps:
+
+| From | To | Example |
+|------|----|---------|
+| Inventory | Finance | Link item to purchase transaction |
+| Recipes | Finance | "How much did I spend on groceries this month?" |
+| Media | Finance | Track streaming subscription costs |
+| Travel | Finance | Trip budget vs actual spend |
+| Travel | Recipes | Local cuisine research for destinations |
+| Maintenance | Inventory | "When did I last service the vacuum?" |
+| Documents | Inventory | Warranty PDF linked to the item |
+| Documents | Finance | Receipt linked to the transaction |
+| AI Hub | Everything | Natural language queries across all domains |
+| Dashboard | Everything | iPad wall mount pulling widgets from each app |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,113 @@
+# POPS Roadmap
+
+Sequenced by dependency, not by date. Target: feature-complete by end of 2026.
+
+## How to read this
+
+Each phase unlocks the next. Within a phase, items can be parallelised. The roadmap is a living document — reorder as priorities shift, but respect the dependency chains.
+
+## App Priority Order
+
+Agreed sequencing based on daily value, effort, and dependencies:
+
+| # | App | Rationale |
+|---|-----|-----------|
+| 1 | Media Tracker | Quick win, self-contained, validates multi-app architecture |
+| 2 | Inventory Upgrade | High daily use, partially exists, grows into a core app |
+| 3 | Finance Polish + Subscriptions | Already works — reduce friction, add subscriptions as a feature (not separate app) |
+| 4 | Fitness Tracker | Gym and training log. Health integrations (Apple Health, meal logging) layer on later |
+| 5 | Documents Vault | Low effort, high connectivity — unlocks receipt/warranty linking for inventory, finance, travel |
+| 6 | Travel Planner | Benefits from finance (budgets), documents (bookings), and AI (planning) already being in place |
+| 7 | Books / Reading | Same pattern as media tracker, low effort once that template exists |
+| 8 | Recipe Book | Long-term feature, lower daily urgency |
+| 9 | Maintenance & Chores | Natural extension of inventory, reminder-driven |
+| 10 | Contacts / CRM-lite | Lowest urgency — gift tracking, events |
+| 11 | Home Automation | Biggest unknown, explore only if HomeAssistant leaves a clear gap |
+
+## Phase 1 — Foundation
+
+> Extract the shared platform that everything else builds on.
+
+- **Shell & App Switcher** — Extract shell from pops-pwa. Shared layout, routing, navigation, theming, auth.
+- **UI Component Library** — Extract shared components into a package. DataTable, forms, inputs, cards.
+- **API Rename & Modularisation** — finance-api → pops-api. Domain routers as modules, not a monolith name.
+- **DB Schema Patterns** — Establish conventions for new domains: migrations, shared entities, cross-domain foreign keys.
+- **Responsive Foundation** — Ensure the shell and shared components work well on mobile viewports from day one.
+
+**Depends on:** Nothing (current state is the starting point).
+**Unlocks:** Every app below.
+
+## Phase 2 — Core Apps
+
+> Ship the highest-value apps on the new foundation.
+
+- **Media Tracker** — Movies and TV shows. Categorisation, recommendations, watchlist. Plex/Radarr/Sonarr/TMDB integration.
+- **Inventory Upgrade** — Grow from stub to full app. Warranties, purchase linking, Paperless-ngx receipt linking. Most frequently used app.
+- **Finance Polish + Subscriptions** — Reduce friction, automate more, add subscriptions tracking as a built-in feature. Bank apps cover the gap in the meantime.
+- **Fitness Tracker** — Training log: exercises, sets, reps, progress tracking, workout history. Keep it simple — no Apple Health integration yet.
+- **Documents Vault** — Surfaces Paperless-ngx within POPS. Links receipts/warranties to inventory and transactions. Low effort, high connectivity.
+
+**Depends on:** Phase 1 (shell, shared UI, modular API).
+**Unlocks:** Cross-domain linking, AI layer, remaining apps.
+
+## Phase 3 — AI Layer
+
+> The three layers of intelligence that make POPS proactive.
+
+- **AI Overlay** — Contextual assistant integrated into the shell. Knows which app you're in, can query across domains, suggests actions. Think Notion AI but for the whole platform.
+- **AI Categorisation & Input** — Automated data entry, entity matching, transaction categorisation. Extends existing import pipeline patterns to new domains.
+- **AI Inference & Monitoring** — Proactive insights, anomaly detection, smart automations. The Moltbot side — alerts via Telegram, scheduled analysis, "your electricity bill jumped 40% this month."
+
+**Depends on:** Phase 2 (needs multiple domains with real data to be useful).
+**Unlocks:** The "system does more for me" promise.
+
+Note: AI categorisation already exists in the import pipeline and continues to grow in parallel. Phase 3 is about the overlay and inference layers.
+
+## Phase 4 — Expansion Apps
+
+> Fill out the platform with additional domains. Each benefits from the AI layer being in place.
+
+- **Travel Planner** — Trip planning, organising, tracking. Links to finance (budgets), documents (bookings), recipes (local cuisine).
+- **Books / Reading** — Same architecture as media tracker. Reading list, reviews, recommendations.
+- **Recipe Book** — Ingredients, recipes, meal planning. Links to finance (grocery spend), inventory (kitchen gear).
+
+**Depends on:** Phase 2 (architecture proven), Phase 3 (AI reduces input friction).
+
+## Phase 5 — Mobile & Hardware
+
+> Dedicated mobile experience and wall-mounted dashboard.
+
+- **Native Mobile App** — iOS app. Daily driver on iPhone.
+- **HomePad / Wall Mount** — Dashboard mode optimised for always-on tablet. Widgets from every domain.
+
+**Depends on:** Multiple apps live with stable APIs.
+
+## Phase 6 — Long Tail
+
+> Build when the core is solid and there's bandwidth.
+
+- **Maintenance & Chores** — Extends inventory with service schedules and reminders.
+- **Contacts / CRM-lite** — Gift tracking, event planning.
+- **Home Automation** — HomeAssistant integration if there's a clear gap.
+
+**Depends on:** Core platform mature.
+
+---
+
+## Dependency Chain
+
+```
+Foundation → Core Apps ──→ AI Layer → Expansion Apps → Mobile → Long Tail
+                │                         ↑
+                └── AI Categorisation ─────┘
+                    (continues in parallel,
+                     already partially exists)
+```
+
+## Cross-cutting (not phased)
+
+These grow incrementally rather than shipping as a single phase:
+
+- **AI Categorisation** — Extends as new domains are added
+- **Responsive Design** — Every app must work on mobile from day one (PWA)
+- **Cross-domain Linking** — Shared entities, foreign keys between domains, unified search

--- a/docs/specs/prd-000-pnpm-migration.md
+++ b/docs/specs/prd-000-pnpm-migration.md
@@ -1,0 +1,100 @@
+# PRD-000: pnpm Migration
+
+**Epic:** [00 — pnpm Migration](../themes/foundation/epics/00-pnpm-migration.md)
+**Theme:** Foundation
+**Status:** Approved
+**ADR:** [005 — Package Manager & Task Runner](../architecture/adr-005-package-manager-and-task-runner.md)
+
+## Problem Statement
+
+POPS uses Yarn v1 (maintenance mode) as its package manager. As the project expands to 10+ workspace packages, pnpm's strict dependency resolution and native workspace support are needed. All subsequent Foundation work should start on pnpm.
+
+## Goal
+
+Replace Yarn v1 with pnpm. Zero code changes — only tooling, config, and docs.
+
+## Requirements
+
+### R1: Package Manager Swap
+
+- Remove `yarn.lock`
+- Generate `pnpm-lock.yaml` (via `pnpm import` to migrate existing lockfile, or fresh `pnpm install`)
+- Create `pnpm-workspace.yaml` listing workspace packages:
+  ```yaml
+  packages:
+    - 'apps/*'
+    - 'packages/db-types'
+  ```
+- Update root `package.json`: replace `"packageManager": "yarn@1.22.22"` with pnpm equivalent
+- Note: `packages/import-tools` is standalone (not in workspace) — verify it still works independently
+
+### R2: Update All References
+
+Every reference to `yarn` in the repo must be updated:
+- `mise.toml` — all tasks that invoke `yarn`
+- `CLAUDE.md` — all command examples
+- `turbo.json` — verify pnpm compatibility (Turbo supports pnpm natively)
+- `package.json` scripts across all workspaces (if any reference `yarn` directly)
+- `infra/docker-compose.yml` — if any build steps use yarn
+- Dockerfiles — if any exist with yarn commands
+- CI pipelines — if any exist
+- `docs/` — any references
+
+### R3: Verify Everything Works
+
+All of the following must pass after migration:
+- `pnpm install` resolves all workspace packages
+- `pnpm dev` / `mise dev` starts dev servers
+- `pnpm build` / `mise build` builds all packages
+- `pnpm test` / `mise test` runs all tests
+- `pnpm typecheck` / `mise typecheck` passes
+- `pnpm lint` / `mise lint` passes
+- `pnpm format:check` passes
+- Turbo caching works (`turbo build` caches correctly)
+- Storybook starts
+- E2E tests pass
+
+## Out of Scope
+
+- Code changes of any kind
+- Changing Turbo configuration (beyond pnpm compatibility)
+- Changing mise beyond `yarn` → `pnpm` references
+- Adding new packages or workspace members
+
+## Acceptance Criteria
+
+1. `yarn.lock` deleted, `pnpm-lock.yaml` exists
+2. `pnpm-workspace.yaml` exists and lists all workspace packages
+3. Zero references to `yarn` remain in the repo (except historical git commits)
+4. All verification checks in R3 pass
+5. `packages/import-tools` works independently outside the workspace
+
+## User Stories
+
+> **Standard verification — applies to every US below:**
+> Each story is only done when `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, and `pnpm build` all pass.
+
+### US-1: Migrate lockfile and workspace config
+**As a** developer, **I want** pnpm installed and configured as the package manager **so that** all workspace packages resolve correctly.
+
+**Acceptance criteria:**
+- `yarn.lock` removed
+- `pnpm-lock.yaml` generated
+- `pnpm-workspace.yaml` created with correct package list
+- Root `package.json` updated with pnpm as `packageManager`
+- `pnpm install` succeeds with no errors
+- All workspace packages resolvable (`pnpm ls` shows correct tree)
+- `packages/import-tools` works independently
+
+### US-2: Update tooling and documentation
+**As a** developer (or agent), **I want** all references to `yarn` replaced with `pnpm` **so that** I can follow any doc or task without confusion.
+
+**Acceptance criteria:**
+- `mise.toml` updated — all tasks use `pnpm`
+- `CLAUDE.md` updated — all examples use `pnpm`
+- Dockerfiles / docker-compose updated if applicable
+- `docs/` updated
+- Grep for `yarn` returns zero hits (excluding `pnpm-lock.yaml` internals and git history)
+- Turbo runs correctly with pnpm
+- Storybook starts
+- E2E tests pass

--- a/docs/specs/prd-001-ui-library-extraction.md
+++ b/docs/specs/prd-001-ui-library-extraction.md
@@ -1,0 +1,343 @@
+# PRD-001: UI Library Extraction
+
+**Epic:** [01 — UI Library Extraction](../themes/foundation/epics/01-ui-library-extraction.md)
+**Theme:** Foundation
+**Status:** Approved
+**ADRs:** [002 — Shell Architecture](../architecture/adr-002-shell-architecture.md), [003 — Component Library & API](../architecture/adr-003-component-library-and-api.md), [004 — Tailwind-Only Styling](../architecture/adr-004-tailwind-only-styling.md)
+
+## Problem Statement
+
+All shared UI components currently live in `apps/pops-pwa/src/components/`. As POPS expands to multiple app packages (media, inventory, fitness, etc.), each app needs to import shared components from a common package. Without extraction, we'd either duplicate components across apps or keep everything in a monolithic frontend.
+
+## Goal
+
+Create `packages/ui/` (`@pops/ui`) containing all shared components, the design token system, and utilities. After extraction, `pops-pwa` imports from `@pops/ui` and contains only finance-specific components. The foundation is set for the shell extraction (Epic 2) and all future app packages.
+
+## Requirements
+
+### R1: Package Structure
+
+Create `packages/ui/` as a Yarn workspace package.
+
+```
+packages/ui/
+  package.json              (@pops/ui)
+  tsconfig.json
+  src/
+    index.ts                (public API barrel export)
+    primitives/             (shadcn/ui base components, stories co-located)
+      accordion.tsx
+      accordion.stories.tsx
+      alert-dialog.tsx
+      alert.tsx
+      alert.stories.tsx
+      avatar.tsx
+      avatar.stories.tsx
+      badge.tsx
+      badge.stories.tsx
+      breadcrumb.tsx
+      breadcrumb.stories.tsx
+      button.tsx
+      card.tsx
+      card.stories.tsx
+      checkbox.tsx
+      collapsible.tsx
+      command.tsx
+      dialog.tsx
+      dialog.stories.tsx
+      dropdown-menu.tsx
+      input.tsx
+      label.tsx
+      popover.tsx
+      progress.tsx
+      progress.stories.tsx
+      radio-group.tsx
+      select.tsx
+      separator.tsx
+      separator.stories.tsx
+      skeleton.tsx
+      skeleton.stories.tsx
+      slider.tsx
+      slider.stories.tsx
+      sonner.tsx
+      switch.tsx
+      switch.stories.tsx
+      table.tsx
+      tabs.tsx
+      tabs.stories.tsx
+      textarea.tsx
+      textarea.stories.tsx
+      tooltip.tsx
+      tooltip.stories.tsx
+    components/             (composite components)
+      Autocomplete.tsx
+      Autocomplete.stories.tsx
+      Button.tsx
+      Button.stories.tsx
+      CheckboxInput.tsx
+      CheckboxInput.stories.tsx
+      Chip.tsx
+      Chip.stories.tsx
+      ChipInput.tsx
+      ChipInput.stories.tsx
+      ComboboxSelect.tsx
+      ComboboxSelect.stories.tsx
+      DataTable.tsx
+      DataTable.stories.tsx
+      DataTable.filtering.stories.tsx
+      DataTableFilters.tsx
+      DateTimeInput.tsx
+      DateTimeInput.stories.tsx
+      DropdownMenu.tsx
+      DropdownMenu.stories.tsx
+      EditableCell.tsx
+      ErrorBoundary.tsx
+      InfiniteScrollTable.tsx
+      InfiniteScrollTable.stories.tsx
+      NumberInput.tsx
+      NumberInput.stories.tsx
+      RadioInput.tsx
+      RadioInput.stories.tsx
+      Select.tsx
+      TextInput.tsx
+      TextInput.stories.tsx
+    theme/
+      globals.css           (Tailwind imports, @theme block, CSS variables, light/dark tokens)
+      tokens.ts             (TypeScript constants for any tokens needed in JS — optional)
+    lib/
+      utils.ts              (cn() utility)
+```
+
+### R2: Component Classification
+
+Components are classified as **shared** (→ `@pops/ui`) or **domain-specific** (→ stays in finance).
+
+**Shared (move to @pops/ui):**
+
+| Category | Components | Count |
+|----------|-----------|-------|
+| Primitives | All 28 shadcn/ui components in `ui/` | 28 |
+| Composite | Autocomplete, Button, CheckboxInput, Chip, ChipInput, ComboboxSelect, DataTable, DataTableFilters, DateTimeInput, DropdownMenu, EditableCell, ErrorBoundary, InfiniteScrollTable, NumberInput, RadioInput, Select, TextInput | 17 |
+| Utilities | `cn()` from lib/utils.ts | 1 |
+| Theme | globals.css (CSS variables, @theme block, Tailwind config) | 1 |
+| Stories | All story files for the above components | 28 |
+| **Total** | | **75 files** |
+
+**Domain-specific (stays in finance app):**
+
+| Category | Components | Count |
+|----------|-----------|-------|
+| Import Wizard | ImportWizard, UploadStep, ColumnMapStep, ProcessingStep, ReviewStep, TagReviewStep, SummaryStep, FileUpload, EntityCreateDialog, TransactionCard, EditableTransactionCard, TransactionGroup, LocationField | 13 |
+| Finance-specific | TagEditor (uses tRPC finance procedures) | 1 |
+| Stores | importStore (import wizard state) | 1 |
+| Utilities | transaction-utils.ts | 1 |
+| Stories | TagEditor.stories.tsx, TagReviewStep.stories.tsx | 2 |
+| **Total** | | **18 files** |
+
+### R3: Design Token System
+
+Per ADR-004, all styling must use Tailwind classes with values from the design token system. No arbitrary values.
+
+**Current state:** 19 files use arbitrary Tailwind values. These fall into three categories:
+
+1. **Layout dimensions** (`w-[180px]`, `min-w-[120px]`, `w-[70px]`, etc.) — Replace with Tailwind scale values or named tokens in the `@theme` block.
+2. **Radix UI CSS variable references** (`w-[var(--radix-popover-trigger-width)]`) — These are acceptable. They bind to runtime values from Radix and cannot be replaced with static tokens. Document as the one permitted exception.
+3. **Centering/transform hacks** (`top-[50%]`, `translate-x-[-50%]`, etc.) — Replace with Tailwind's built-in centering utilities (`inset-0 flex items-center justify-center`, or `place-items-center`).
+
+**Action per file:**
+
+| File | Arbitrary Values | Action |
+|------|-----------------|--------|
+| ChipInput.tsx | `min-w-[120px]` | Replace with `min-w-30` |
+| Autocomplete.tsx | `w-[var(--radix-...)]` | Keep (Radix runtime binding) |
+| ComboboxSelect.tsx | `w-[var(--radix-...)]` | Keep (Radix runtime binding) |
+| DataTableFilters.tsx | `w-[180px]`, `min-w-[200px]`, `w-[150px]`, `w-[100px]` | Replace with `w-45`, `min-w-50`, `w-38`, `w-25` |
+| DataTable.tsx | `w-[70px]` | Replace with `w-18` |
+| EditableCell.tsx | `min-h-[2rem]` | Replace with `min-h-8` |
+| dialog.tsx | `max-w-[calc(...)]`, centering | Refactor centering approach |
+| alert-dialog.tsx | Same as dialog | Refactor centering approach |
+| command.tsx | `max-h-[300px]` | Replace with `max-h-75` |
+| switch.tsx | `h-[1.15rem]` | Replace with closest token or add custom token |
+| tabs.tsx | `p-[3px]`, `bottom-[-5px]` | Replace with tokens or add custom tokens |
+| tooltip.tsx | `translate-y-[calc(...)]` | Evaluate if avoidable |
+| dropdown-menu.tsx | `p-[3px]` | Same as tabs |
+| select.tsx | Radix CSS var refs | Keep (Radix runtime binding) |
+| Story files | Various `w-[...]` | Replace with Tailwind scale values |
+
+**Exception rule:** `w-[var(--radix-*)]` and similar Radix UI CSS variable bindings are permitted since they reference runtime-computed values, not design tokens.
+
+### R4: Package Configuration
+
+**package.json:**
+```json
+{
+  "name": "@pops/ui",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./theme": "./src/theme/globals.css",
+    "./primitives/*": "./src/primitives/*"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}
+```
+
+- No build step — consumed as source via Vite workspace resolution
+- Peer dependencies on React (not bundled)
+- Named exports for theme CSS and individual primitives if needed
+- The barrel `index.ts` exports all composite components and primitives
+
+**tsconfig.json:** Extends a shared base or mirrors the current PWA config. Strict mode, path alias `@ui/*` → `src/*`.
+
+### R5: Import API
+
+After extraction, consumer code imports like:
+
+```typescript
+// Composite components
+import { DataTable, TextInput, Button } from '@pops/ui'
+
+// Primitives (if needed directly)
+import { Card, CardHeader, CardContent } from '@pops/ui'
+
+// Utility
+import { cn } from '@pops/ui'
+```
+
+Theme CSS is imported once in the shell's entry point:
+```typescript
+import '@pops/ui/theme'
+```
+
+### R6: Storybook Integration
+
+- Stories co-locate with their component files in `@pops/ui`
+- The Storybook config (currently in `apps/pops-pwa/.storybook/`) discovers stories from `packages/ui/src/**/*.stories.tsx`
+- All existing stories must continue to work after migration
+- No stories live in the Storybook app — it's config only
+
+### R7: Tailwind Integration
+
+- `globals.css` moves to `packages/ui/src/theme/globals.css`
+- Contains: `@import "tailwindcss"`, `@theme` block, CSS variables, light/dark mode tokens
+- The shell (and later each app) imports this CSS file
+- Tailwind v4 content detection automatically finds classes in workspace packages — no manual `content` config needed
+- Apps do NOT define their own theme tokens — they consume from `@pops/ui`
+
+## Out of Scope
+
+- Creating the shell (Epic 2)
+- Moving layout components (RootLayout, TopBar, Sidebar) — these go to the shell, not the UI library
+- Moving page components
+- Moving Zustand stores
+- Moving tRPC client config
+- Building new components
+- Responsive design audit (Epic 5)
+
+## Acceptance Criteria
+
+1. `packages/ui/` exists as a workspace package and is resolvable by other packages
+2. All 28 primitives and 17 composite components are in `@pops/ui`
+3. All associated stories are co-located with their components in `@pops/ui`
+4. `apps/pops-pwa/` imports shared components from `@pops/ui` — no shared components remain in `pops-pwa/src/components/`
+5. `pops-pwa/src/components/` contains only finance-specific components (imports/ directory + TagEditor)
+6. Design token system is in `@pops/ui/theme` — CSS variables, @theme block, light/dark tokens
+7. All arbitrary Tailwind values replaced with token-based classes (except Radix CSS variable bindings)
+8. `yarn typecheck` passes across all packages
+9. `yarn lint` passes across all packages
+10. `yarn format:check` passes across all packages
+11. `yarn build` succeeds
+10. `yarn dev` serves the app with no regressions
+11. Storybook discovers and renders all stories from `@pops/ui`
+12. All existing tests pass (unit + E2E)
+
+## Edge Cases & Decisions
+
+**Q: What about the custom Button.tsx that wraps ui/button.tsx?**
+A: Both move to `@pops/ui`. The primitive goes to `primitives/button.tsx`, the wrapper goes to `components/Button.tsx`. The barrel export exposes the wrapper as `Button` and the primitive as `ButtonPrimitive` if direct access is needed.
+
+**Q: What about components with no stories (DataTableFilters, EditableCell, ErrorBoundary, Select)?**
+A: They move to `@pops/ui` without stories. Adding stories is not in scope for this PRD — it's tech debt to address later.
+
+**Q: TagEditor — shared or domain-specific?**
+A: Domain-specific for now. It imports from `trpc` to fetch tag suggestions, which ties it to finance. If other apps need tagging, we'll extract a generic version later.
+
+**Q: What about the `@` path alias?**
+A: `@pops/ui` components use `@ui/` as their internal path alias. Consumer packages continue using their own aliases. Cross-package imports always use the package name (`@pops/ui`), never path aliases.
+
+## User Stories
+
+> **Standard verification — applies to every US below:**
+> Each story is only done when `yarn typecheck`, `yarn lint`, `yarn format:check`, `yarn test`, and `yarn build` all pass. No story is merged with broken checks or failing tests.
+
+### US-1: Create @pops/ui package scaffold
+**As a** developer, **I want** the `@pops/ui` workspace package to exist with correct configuration **so that** other packages can depend on it.
+
+**Acceptance criteria:**
+- `packages/ui/package.json` exists with correct name, exports, peer deps
+- `packages/ui/tsconfig.json` exists with strict mode
+- `packages/ui/src/index.ts` exists (empty barrel initially)
+- `yarn install` resolves the workspace package
+
+### US-2: Extract design token system
+**As a** developer, **I want** the Tailwind theme (CSS variables, @theme block, light/dark tokens) in `@pops/ui/theme` **so that** all packages share one source of truth for design tokens.
+
+**Acceptance criteria:**
+- `packages/ui/src/theme/globals.css` contains the full theme from current `pops-pwa/src/styles/globals.css`
+- `pops-pwa` imports the theme from `@pops/ui/theme`
+- Light and dark mode work exactly as before
+- No theme-related CSS remains in `pops-pwa`
+
+### US-3: Extract primitive components
+**As a** developer, **I want** all 28 shadcn/ui primitives in `@pops/ui/primitives/` **so that** any app can use base UI elements.
+
+**Acceptance criteria:**
+- All 28 primitives moved to `packages/ui/src/primitives/`
+- All re-exported from `packages/ui/src/index.ts`
+- All imports in `pops-pwa` updated to `@pops/ui`
+- Storybook renders primitive stories correctly
+- No primitive components remain in `pops-pwa/src/components/ui/`
+
+### US-4: Extract composite components
+**As a** developer, **I want** all 17 shared composite components in `@pops/ui/components/` **so that** any app can use DataTable, form inputs, etc.
+
+**Acceptance criteria:**
+- All 17 composites moved to `packages/ui/src/components/`
+- Stories co-located with each component
+- All re-exported from barrel
+- All imports in `pops-pwa` updated
+- `cn()` utility moved to `packages/ui/src/lib/utils.ts`
+- No shared composites remain in `pops-pwa/src/components/`
+
+### US-5: Eliminate arbitrary Tailwind values
+**As a** developer, **I want** all arbitrary Tailwind values replaced with token-based classes **so that** the design system is consistent and enforced.
+
+**Acceptance criteria:**
+- All `w-[Npx]`, `h-[Npx]`, `p-[Npx]`, etc. replaced with Tailwind scale values
+- Centering hacks in dialog/alert-dialog replaced with built-in utilities
+- Radix CSS variable bindings (`w-[var(--radix-*)]`) documented as permitted exception
+- No new arbitrary values introduced
+- Add ESLint rule or Storybook check to prevent future arbitrary values (stretch goal)
+
+### US-6: Update Storybook configuration
+**As a** developer, **I want** Storybook to discover stories from `@pops/ui` **so that** all component stories are browsable in one place.
+
+**Acceptance criteria:**
+- Storybook config updated to glob `packages/ui/src/**/*.stories.tsx`
+- All existing stories render correctly
+- No stories moved to or created in the Storybook app itself
+
+### US-7: Final verification
+**As a** developer, **I want** confirmation that the full extraction is complete with no regressions **so that** we can move to Epic 2.
+
+**Acceptance criteria:**
+- `yarn dev` serves the app with no visual regressions
+- All E2E tests pass (Playwright)
+- `pops-pwa/src/components/` contains only: `imports/` directory, `TagEditor.tsx`, `TagEditor.stories.tsx`

--- a/docs/specs/prd-002-shell-extraction.md
+++ b/docs/specs/prd-002-shell-extraction.md
@@ -1,0 +1,344 @@
+# PRD-002: Shell & App-Finance Extraction
+
+**Epic:** [02 — Shell Extraction](../themes/foundation/epics/02-shell-extraction.md)
+**Theme:** Foundation
+**Status:** Approved
+**ADRs:** [002 — Shell Architecture](../architecture/adr-002-shell-architecture.md)
+
+## Problem Statement
+
+All frontend code lives in `apps/pops-pwa/` — layout, providers, routing, pages, and domain components are interleaved in one package. To support multiple apps (media, inventory, fitness, etc.) on a shared shell, we need to split the platform infrastructure from the finance domain code.
+
+## Goal
+
+Create `apps/pops-shell/` as the single frontend entry point (layout, providers, routing, theming) and `packages/app-finance/` as the first app package (finance pages + domain components). After extraction, adding a new app means creating a new `packages/app-*` package and registering its routes in the shell.
+
+## Requirements
+
+### R1: Shell Package (`apps/pops-shell/`)
+
+The shell owns everything that's shared across apps:
+
+```
+apps/pops-shell/
+  package.json            (@pops/shell)
+  tsconfig.json
+  vite.config.ts          (migrated from pops-pwa, updated aliases)
+  index.html              (migrated from pops-pwa)
+  src/
+    main.tsx              (entry point, mounts App)
+    app/
+      App.tsx             (providers: tRPC, React Query, theme, toaster, router)
+      router.tsx          (lazy-loads app routes, wraps in RootLayout)
+      layout/
+        RootLayout.tsx    (top bar + sidebar + outlet + error boundary)
+        TopBar.tsx        (POPS branding, theme toggle, user info)
+        Sidebar.tsx       (app-level navigation — just Finance for now)
+    lib/
+      trpc.ts             (tRPC client config — unchanged)
+    store/
+      uiStore.ts          (sidebar state)
+      themeStore.ts       (theme state)
+      themeStore.test.ts
+```
+
+**Key changes from current pops-pwa:**
+- `router.tsx` lazily imports route definitions from `@pops/app-finance` instead of statically importing page components
+- Sidebar renders navigation items from the active app's route config (not a hardcoded list)
+- Theme CSS imported from `@pops/ui/theme`
+- All shared component imports come from `@pops/ui`
+
+### R2: App-Finance Package (`packages/app-finance/`)
+
+Finance becomes a workspace package that exports its route definitions:
+
+```
+packages/app-finance/
+  package.json            (@pops/app-finance)
+  tsconfig.json
+  src/
+    index.ts              (exports routes and nav config)
+    routes.tsx            (route definitions with lazy-loaded pages)
+    pages/
+      DashboardPage.tsx
+      TransactionsPage.tsx
+      EntitiesPage.tsx
+      BudgetsPage.tsx
+      InventoryPage.tsx   (stays here for now — moves to app-inventory in Phase 2)
+      WishlistPage.tsx
+      ImportPage.tsx
+      AiUsagePage.tsx
+    components/
+      imports/            (entire ImportWizard and sub-components)
+      TagEditor.tsx
+      TagEditor.stories.tsx
+    store/
+      importStore.ts
+    lib/
+      transaction-utils.ts
+```
+
+**Public API:**
+
+```typescript
+// packages/app-finance/src/index.ts
+export { routes } from './routes'
+export { navConfig } from './routes'
+```
+
+**Route definitions:**
+
+```typescript
+// packages/app-finance/src/routes.tsx
+import { lazy } from 'react'
+
+const DashboardPage = lazy(() => import('./pages/DashboardPage'))
+const TransactionsPage = lazy(() => import('./pages/TransactionsPage'))
+// ... etc
+
+export const navConfig = {
+  id: 'finance',
+  label: 'Finance',
+  icon: '💰',  // placeholder — proper icons in PRD-003
+  basePath: '/finance',
+  items: [
+    { path: '', label: 'Dashboard', icon: '📊' },
+    { path: '/transactions', label: 'Transactions', icon: '💳' },
+    { path: '/entities', label: 'Entities', icon: '🏢' },
+    { path: '/budgets', label: 'Budgets', icon: '💰' },
+    { path: '/inventory', label: 'Inventory', icon: '📦' },
+    { path: '/wishlist', label: 'Wish List', icon: '⭐' },
+    { path: '/import', label: 'Import', icon: '📥' },
+    { path: '/ai-usage', label: 'AI Usage', icon: '🤖' },
+  ],
+}
+
+export const routes = [
+  { index: true, element: <DashboardPage /> },
+  { path: 'transactions', element: <TransactionsPage /> },
+  { path: 'entities', element: <EntitiesPage /> },
+  { path: 'budgets', element: <BudgetsPage /> },
+  { path: 'inventory', element: <InventoryPage /> },
+  { path: 'wishlist', element: <WishlistPage /> },
+  { path: 'import', element: <ImportPage /> },
+  { path: 'ai-usage', element: <AiUsagePage /> },
+]
+```
+
+### R3: Routing Changes
+
+**Current routes:**
+```
+/                → DashboardPage
+/transactions    → TransactionsPage
+/budgets         → BudgetsPage
+...
+```
+
+**New routes:**
+```
+/                → Redirect to /finance
+/finance         → DashboardPage (index)
+/finance/transactions → TransactionsPage
+/finance/budgets      → BudgetsPage
+...
+```
+
+**Shell router structure:**
+
+```typescript
+// apps/pops-shell/src/app/router.tsx
+import { createBrowserRouter, Navigate } from 'react-router'
+import { RootLayout } from './layout/RootLayout'
+import { routes as financeRoutes } from '@pops/app-finance'
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <RootLayout />,
+    children: [
+      { index: true, element: <Navigate to="/finance" replace /> },
+      {
+        path: 'finance',
+        children: financeRoutes,
+      },
+      // Future: { path: 'media', children: mediaRoutes }
+    ],
+  },
+])
+```
+
+### R4: Sidebar Navigation
+
+The Sidebar reads navigation config from registered apps instead of a hardcoded list. For now it only shows Finance, but the data structure supports multiple apps.
+
+```typescript
+// Shell knows about registered apps
+const registeredApps = [
+  { ...financeNavConfig },
+  // Future: { ...mediaNavConfig }
+]
+```
+
+The Sidebar renders:
+- App name/icon for each registered app (clickable, navigates to app's basePath)
+- Page links for the currently active app
+
+This is a minimal version — the full app switcher UX is PRD-003.
+
+### R5: Provider Stack
+
+The provider stack moves from `pops-pwa/App.tsx` to `pops-shell/App.tsx`. No changes to the providers themselves:
+
+```typescript
+<trpc.Provider client={trpcClient} queryClient={queryClient}>
+  <QueryClientProvider client={queryClient}>
+    <RouterProvider router={router} />
+    <ReactQueryDevtools />
+    <Toaster />
+  </QueryClientProvider>
+</trpc.Provider>
+```
+
+The tRPC client config (`lib/trpc.ts`) moves to the shell unchanged. The `AppRouter` type import stays as `@pops/finance-api` until Epic 3 (API modularisation) renames it.
+
+### R6: Vite Config
+
+The shell's Vite config is based on the current `pops-pwa/vite.config.ts`:
+
+- Same plugins: `react()`, `tailwindcss()`
+- Proxy `/trpc` → `localhost:3000` (unchanged)
+- Dev server port: 5566 (unchanged)
+- Resolve alias: `@` → `apps/pops-shell/src`
+- Workspace packages resolved natively by Vite (no special config needed for `@pops/ui`, `@pops/app-finance`)
+- Storybook Vitest plugin config needs updating — story discovery from `packages/` directories
+
+### R7: E2E Test Migration
+
+4 Playwright spec files need route updates:
+
+| File | Change |
+|------|--------|
+| `transactions.spec.ts` | `/transactions` → `/finance/transactions` |
+| `transactions-integration.spec.ts` | `/transactions` → `/finance/transactions` |
+| `import-wizard.spec.ts` | `/import` → `/finance/import` |
+| `import-wizard-integration.spec.ts` | `/import` → `/finance/import` |
+
+E2E tests move to `apps/pops-shell/e2e/` since they test the integrated app, not individual packages. Fixtures and helpers move with them.
+
+### R8: Cleanup
+
+- Delete `apps/pops-pwa/` entirely after all code is extracted
+- Update `pnpm-workspace.yaml` to include `packages/app-finance`
+- Update Turbo config if needed
+- Update mise tasks referencing `pops-pwa`
+- Update Docker/nginx configs to build from `apps/pops-shell/`
+- Update CLAUDE.md
+
+## Out of Scope
+
+- Full app switcher redesign (PRD-003)
+- API rename (Epic 3)
+- New apps (Phase 2)
+- New components
+- Responsive design (Epic 5)
+
+## Acceptance Criteria
+
+1. `apps/pops-shell/` is the single frontend entry point
+2. `packages/app-finance/` contains all finance pages and domain components
+3. `apps/pops-pwa/` is deleted
+4. Routes are namespaced under `/finance/*`
+5. `/` redirects to `/finance`
+6. Sidebar shows Finance nav items driven by the app's exported navConfig
+7. Lazy loading works — finance routes are code-split (verify in network tab)
+8. `pnpm dev` starts one Vite server
+9. `pnpm build` produces one output with code splitting
+10. `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` all pass
+11. All E2E tests pass with updated routes
+12. Storybook discovers stories from both `@pops/ui` and `@pops/app-finance`
+13. Docker/nginx/deployment configs updated and working
+
+## Edge Cases & Decisions
+
+**Q: Where does InventoryPage live?**
+A: In `@pops/app-finance` for now. It moves to `@pops/app-inventory` when that app is built in Phase 2. Don't prematurely extract it.
+
+**Q: Where do E2E tests live?**
+A: In `apps/pops-shell/e2e/`. E2E tests exercise the integrated system, not individual packages. Unit tests for finance components stay in `packages/app-finance/`.
+
+**Q: What about the tRPC AppRouter type import?**
+A: Stays as `import type { AppRouter } from '@pops/finance-api'` until Epic 3 renames the API. The shell owns the tRPC client; app packages use tRPC hooks via the shell's provider.
+
+**Q: How do app packages access tRPC?**
+A: The shell provides the tRPC context via React providers. App packages import the `trpc` object from the shell (or from a shared package). The simplest approach: the shell re-exports `trpc` from a known import path, and app packages list `@pops/shell` as a peer dependency. Alternative: extract `trpc` into a tiny shared package. Decide during implementation based on what's cleaner.
+
+**Q: Do app packages depend on the shell?**
+A: No circular deps. App packages depend on `@pops/ui` and `@pops/db-types`. The shell depends on app packages. For tRPC access, either: (a) the shell passes `trpc` down via context/props, (b) a separate `@pops/trpc` package holds the client config, or (c) app packages list `@pops/shell` as a peer dep. Option (b) is cleanest if it becomes an issue.
+
+## User Stories
+
+> **Standard verification — applies to every US below:**
+> Each story is only done when `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, and `pnpm build` all pass.
+
+### US-1: Create shell package scaffold
+**As a** developer, **I want** `apps/pops-shell/` to exist with entry point, Vite config, and basic providers **so that** I have a running shell to wire apps into.
+
+**Acceptance criteria:**
+- `apps/pops-shell/package.json` exists
+- `apps/pops-shell/vite.config.ts` configured (proxy, aliases, plugins)
+- `apps/pops-shell/index.html` exists
+- `apps/pops-shell/src/main.tsx` mounts the App
+- `apps/pops-shell/src/app/App.tsx` has provider stack (tRPC, React Query, theme, toaster)
+- `pnpm dev` starts the shell on port 5566
+
+### US-2: Create app-finance package
+**As a** developer, **I want** `packages/app-finance/` to exist with all finance pages, domain components, and route exports **so that** the shell can lazily load finance.
+
+**Acceptance criteria:**
+- `packages/app-finance/package.json` exists
+- All 8 finance pages moved to `packages/app-finance/src/pages/`
+- All finance-specific components moved (imports/, TagEditor)
+- `importStore` and `transaction-utils` moved
+- Route definitions and navConfig exported from `packages/app-finance/src/index.ts`
+- All finance page internal imports resolve correctly
+
+### US-3: Wire shell routing with lazy-loaded finance
+**As a** developer, **I want** the shell to lazily load finance routes under `/finance/*` **so that** the app works with the new structure.
+
+**Acceptance criteria:**
+- Shell router imports routes from `@pops/app-finance`
+- `/` redirects to `/finance`
+- All finance pages accessible at `/finance/*` routes
+- Finance routes are code-split (visible in browser network tab as separate chunks)
+- Sidebar renders nav items from finance's exported navConfig
+
+### US-4: Migrate shell layout and stores
+**As a** developer, **I want** RootLayout, TopBar, Sidebar, and shared stores in the shell **so that** the platform chrome is owned by the shell, not any app.
+
+**Acceptance criteria:**
+- `RootLayout.tsx`, `TopBar.tsx`, `Sidebar.tsx` in `apps/pops-shell/src/app/layout/`
+- `uiStore.ts`, `themeStore.ts` in `apps/pops-shell/src/store/`
+- `trpc.ts` in `apps/pops-shell/src/lib/`
+- Sidebar reads navigation from registered app configs, not a hardcoded list
+
+### US-5: Migrate E2E tests
+**As a** developer, **I want** all E2E tests passing in the new structure **so that** we don't lose test coverage.
+
+**Acceptance criteria:**
+- E2E tests in `apps/pops-shell/e2e/`
+- All routes updated (`/transactions` → `/finance/transactions`, etc.)
+- All 4 spec files pass
+- Fixtures and helpers migrated
+
+### US-6: Update config and clean up
+**As a** developer, **I want** all tooling, docs, and deployment config updated **so that** the migration is complete.
+
+**Acceptance criteria:**
+- `apps/pops-pwa/` deleted
+- `pnpm-workspace.yaml` updated
+- Storybook discovers stories from `@pops/ui` and `@pops/app-finance`
+- mise tasks updated (references to pops-pwa → pops-shell)
+- Docker/nginx configs updated
+- CLAUDE.md updated
+- Turbo config updated if needed

--- a/docs/specs/prd-003-app-switcher.md
+++ b/docs/specs/prd-003-app-switcher.md
@@ -1,0 +1,155 @@
+# PRD-003: App Switcher
+
+**Epic:** [02 — Shell Extraction](../themes/foundation/epics/02-shell-extraction.md)
+**Theme:** Foundation
+**Status:** Approved
+**Depends on:** PRD-002 (shell must exist with basic sidebar)
+
+## Problem Statement
+
+PRD-002 delivers a minimal sidebar that shows nav items for the active app. As POPS grows to 5+ apps, users need a way to switch between apps and navigate within them. The current flat nav list doesn't scale.
+
+## Goal
+
+Design and implement a two-level navigation system: app selection (top-level) and page navigation (within the active app). Should feel natural with one app and scale gracefully to ten.
+
+## Requirements
+
+### R1: Navigation Structure
+
+Two distinct levels:
+
+1. **App rail** — Always visible. Shows icons for all registered apps. Highlights the active app. Clicking switches to that app's routes.
+2. **Page nav** — Shows the pages within the active app. Expands from the app rail or displays alongside it.
+
+### R2: App Registration
+
+Each app package exports a `navConfig`:
+
+```typescript
+interface AppNavConfig {
+  id: string           // 'finance', 'media', 'inventory'
+  label: string        // 'Finance'
+  icon: string         // Lucide icon name or component
+  basePath: string     // '/finance'
+  items: AppNavItem[]
+}
+
+interface AppNavItem {
+  path: string         // Relative to basePath. '' for index.
+  label: string
+  icon: string
+}
+```
+
+The shell maintains a registry of all app configs. Adding a new app to the switcher = importing its navConfig and adding it to the registry array.
+
+### R3: Interaction Patterns
+
+**Design reference:** Discord's server selection rail. Vertical strip of icons, single tap to switch context, active indicator, page list expands alongside. Scales from 1 to 50 without redesign.
+
+**Desktop (≥1024px):**
+- App rail is a narrow vertical strip on the left (icon-only, ~64px wide)
+- Active app has a visual pill/indicator (similar to Discord's left-edge indicator)
+- Single click switches context — page nav panel (~200px) immediately shows that app's pages
+- Hover on inactive app shows tooltip with app name
+- Rail can be collapsed entirely via toggle (persisted in uiStore)
+
+**Tablet (768–1023px):**
+- Same as desktop but page nav collapses by default, opens as overlay on app icon click
+
+**Mobile (<768px):**
+- Bottom tab bar with app icons (max 5 visible, overflow into "more" menu)
+- Page nav as a horizontal scroll or dropdown from the top bar
+- Or: hamburger menu that shows both levels
+
+**Note:** Final mobile pattern to be decided during responsive foundation (Epic 5). This PRD establishes the desktop pattern and data model. Mobile can adapt the same data structures.
+
+### R4: Visual Design
+
+- App icons use Lucide icons (already available via shadcn/ui) — not emoji
+- Active app has a visual indicator (background highlight, left border accent, or similar)
+- Active page has standard highlight (existing pattern from Sidebar)
+- Smooth transitions between app switches
+- Dark/light mode support via existing theme tokens
+- All colours and spacing from `@pops/ui` design tokens — no arbitrary values
+
+### R5: Single App Behaviour
+
+With only Finance registered, the app switcher should not feel empty or pointless:
+- App rail still shows the Finance icon (establishes the pattern)
+- Page nav is immediately visible (no need to click to expand when there's only one app)
+- As apps are added, the rail naturally populates
+
+## Out of Scope
+
+- Registering any new apps (Media, Inventory, etc.)
+- Search / command palette (future feature)
+- Favourites or pinning
+- Notifications per app
+- Mobile-optimised layout (Epic 5)
+
+## Acceptance Criteria
+
+1. App rail displays registered apps with Lucide icons
+2. Clicking an app navigates to its basePath and shows its page nav
+3. Active app and active page are visually highlighted
+4. Navigation state persisted (collapsed/expanded) via uiStore
+5. Works correctly with one registered app (Finance)
+6. Adding a second app requires only: importing its navConfig and adding to the registry array
+7. No emoji icons — all Lucide
+8. All colours and spacing use design tokens
+9. `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, `pnpm build` all pass
+
+## Edge Cases & Decisions
+
+**Q: What happens when navigating to `/` ?**
+A: Redirects to the first registered app's basePath (currently `/finance`).
+
+**Q: What if a user navigates to an unknown app path like `/foo`?**
+A: 404 page or redirect to `/`. Decide during implementation.
+
+**Q: Should the page nav remember which page you were on per app?**
+A: Yes. Navigating away from Finance and back should return to the last visited finance page, not the dashboard. React Router handles this naturally if the routes stay mounted.
+
+## User Stories
+
+> **Standard verification — applies to every US below:**
+> Each story is only done when `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, and `pnpm build` all pass.
+
+### US-1: Implement app registry and nav config types
+**As a** developer, **I want** a typed app registry in the shell **so that** apps can register their navigation.
+
+**Acceptance criteria:**
+- `AppNavConfig` and `AppNavItem` types defined
+- Shell has a registry array of app configs
+- Finance's navConfig uses Lucide icon references instead of emoji
+- Registry is the single source of truth for navigation
+
+### US-2: Build app rail component
+**As a** developer, **I want** a vertical app rail showing registered app icons **so that** users can switch between apps.
+
+**Acceptance criteria:**
+- Narrow vertical strip with app icons
+- Active app visually highlighted
+- Clicking an app navigates to its basePath
+- Collapsible via toggle (state persisted in uiStore)
+- Uses design tokens only
+
+### US-3: Build page nav component
+**As a** developer, **I want** a page nav panel showing the active app's pages **so that** users can navigate within an app.
+
+**Acceptance criteria:**
+- Shows page links for the active app
+- Active page highlighted
+- Expands alongside the app rail
+- Smooth transition on app switch
+
+### US-4: Integrate into RootLayout
+**As a** developer, **I want** the app rail + page nav replacing the current Sidebar **so that** the shell uses the new navigation.
+
+**Acceptance criteria:**
+- Old Sidebar component replaced
+- RootLayout uses new app rail + page nav
+- All existing navigation still works
+- E2E tests pass with new navigation structure

--- a/docs/specs/prd-004-api-modularisation.md
+++ b/docs/specs/prd-004-api-modularisation.md
@@ -1,0 +1,194 @@
+# PRD-004: API Modularisation
+
+**Epic:** [03 — API Modularisation](../themes/foundation/epics/03-api-modularisation.md)
+**Theme:** Foundation
+**Status:** Approved
+**ADRs:** [003 — Component Library & API](../architecture/adr-003-component-library-and-api.md)
+**Depends on:** PRD-002 (shell extraction — frontend already on `@pops/app-finance` so import changes are isolated)
+
+## Problem Statement
+
+The backend is named `finance-api` and has a flat module structure — entities, transactions, budgets, inventory, ai-usage, and corrections all sit as siblings. As POPS expands to media, fitness, travel, etc., this structure won't convey which modules belong to which domain. Entities are currently finance-scoped but need to be platform-level.
+
+## Goal
+
+Rename to `pops-api`, restructure modules into domain groups, promote shared modules to `core/`, and establish the pattern for adding new domain modules.
+
+## Requirements
+
+### R1: Rename Package
+
+- `apps/finance-api/` → `apps/pops-api/`
+- `@pops/finance-api` → `@pops/api`
+- Update all references: shell's tRPC AppRouter import, pnpm workspace, Turbo, mise, Docker, nginx, Ansible, CLAUDE.md
+
+### R2: Module Restructure
+
+**Current:**
+```
+src/modules/
+  ai-usage/
+  budgets/
+  corrections/
+  entities/
+  envs/
+  imports/
+  inventory/
+  transactions/
+  wishlist/
+```
+
+**Target:**
+```
+src/modules/
+  core/
+    entities/          (promoted — shared across all domains)
+    health/            (existing health endpoint, formalised)
+    ai-usage/          (platform-level concern)
+    corrections/       (used by import pipeline, will be cross-domain)
+    envs/              (test environment management)
+    index.ts           (barrel export for core router)
+  finance/
+    transactions/
+    budgets/
+    imports/
+    wishlist/
+    index.ts           (barrel export for finance router)
+  inventory/
+    items/             (existing inventory module)
+    index.ts
+```
+
+### R3: Router Composition
+
+**Current** (`src/router.ts`):
+```typescript
+export const appRouter = router({
+  aiUsage: aiUsageRouter,
+  budgets: budgetsRouter,
+  corrections: correctionsRouter,
+  entities: entitiesRouter,
+  imports: importsRouter,
+  inventory: inventoryRouter,
+  transactions: transactionsRouter,
+  wishlist: wishlistRouter,
+})
+```
+
+**Target:**
+```typescript
+export const appRouter = router({
+  core: coreRouter,           // core.entities.list, core.aiUsage.list, etc.
+  finance: financeRouter,     // finance.transactions.list, finance.budgets.list, etc.
+  inventory: inventoryRouter, // inventory.items.list, etc.
+})
+```
+
+Each domain group exports a composed sub-router from its `index.ts`.
+
+### R4: tRPC Procedure Path Changes
+
+This changes every tRPC procedure path. Frontend calls must be updated:
+
+| Current | New |
+|---------|-----|
+| `trpc.transactions.list` | `trpc.finance.transactions.list` |
+| `trpc.budgets.list` | `trpc.finance.budgets.list` |
+| `trpc.wishlist.list` | `trpc.finance.wishlist.list` |
+| `trpc.imports.upload` | `trpc.finance.imports.upload` |
+| `trpc.entities.list` | `trpc.core.entities.list` |
+| `trpc.aiUsage.list` | `trpc.core.aiUsage.list` |
+| `trpc.corrections.list` | `trpc.core.corrections.list` |
+| `trpc.inventory.list` | `trpc.inventory.items.list` |
+
+All references in `@pops/app-finance` pages need updating. tRPC provides type safety — if a path changes, TypeScript will flag every broken call.
+
+### R5: Module Import Rules
+
+Enforced by convention (and PR review):
+
+- Any module can import from `core/`
+- Domain modules (finance, inventory, etc.) CANNOT import from each other
+- Cross-domain queries go through `core/` or a dedicated query layer
+- Each module exports a tRPC router, composed at the domain level, then at the app level
+
+### R6: Infrastructure Updates
+
+- Docker image name: `finance-api` → `pops-api`
+- `docker-compose.yml`: service name, build context, image name
+- Ansible templates: any references to `finance-api`
+- nginx proxy config: likely unchanged (proxies `/trpc` regardless of backend name)
+- mise tasks: `dev:api`, `test:api`, etc.
+- CLAUDE.md: all references
+
+## Out of Scope
+
+- New API endpoints or procedures
+- Database schema changes (that's PRD-005)
+- New domain modules (media, fitness, etc.)
+- Auth middleware implementation (placeholder only)
+- Changing the database layer or connection management
+
+## Acceptance Criteria
+
+1. `apps/pops-api/` exists, `apps/finance-api/` deleted
+2. Modules structured into `core/`, `finance/`, `inventory/` groups
+3. Entities, ai-usage, corrections, envs in `core/`
+4. tRPC router composed as nested domain routers
+5. All frontend tRPC calls updated to new paths
+6. Module import rules followed — no cross-domain imports
+7. All API unit tests pass
+8. All E2E tests pass
+9. `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, `pnpm build` all pass
+10. Docker, mise, Ansible, CLAUDE.md updated
+11. Zero references to `finance-api` remain (except git history)
+
+## Edge Cases & Decisions
+
+**Q: Does the health endpoint need its own module?**
+A: Yes — it's a standard pattern. `core/health/` exports a simple router with a health check procedure. Keep it minimal.
+
+**Q: Auth module — what goes in it?**
+A: Placeholder only. An `index.ts` with a comment describing where CF Access JWT validation middleware will live. The actual middleware already exists in `src/middleware/` — it doesn't need to move yet, just needs a future home documented.
+
+**Q: What about the `imports/lib/` and `imports/transformers/` subdirectories?**
+A: They move with imports into `finance/imports/`. The entity-matcher in `imports/lib/` imports from `core/entities/` service — that's a valid cross-domain reference (domain → core).
+
+**Q: Will the Moltbot finance skill break?**
+A: Check if Moltbot references the API by package name or by HTTP endpoint. If by HTTP endpoint (`/trpc`), no change needed. If by package name, update it.
+
+## User Stories
+
+> **Standard verification — applies to every US below:**
+> Each story is only done when `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, and `pnpm build` all pass.
+
+### US-1: Rename package and restructure modules
+**As a** developer, **I want** the API renamed to `pops-api` with modules grouped by domain **so that** the codebase reflects the multi-domain architecture.
+
+**Acceptance criteria:**
+- `apps/pops-api/` exists with all source code
+- `apps/finance-api/` deleted
+- Modules in `core/`, `finance/`, `inventory/` groups
+- Package name is `@pops/api`
+- All internal imports resolve correctly
+
+### US-2: Update tRPC router composition and frontend calls
+**As a** developer, **I want** the tRPC router nested by domain **so that** procedure paths reflect their domain ownership.
+
+**Acceptance criteria:**
+- `appRouter` composed as `{ core, finance, inventory }`
+- All frontend tRPC calls in `@pops/app-finance` updated to new paths
+- Shell's `AppRouter` type import updated to `@pops/api`
+- TypeScript catches any missed path changes
+
+### US-3: Update infrastructure and documentation
+**As a** developer, **I want** all tooling and deployment references updated **so that** the rename is complete end-to-end.
+
+**Acceptance criteria:**
+- Docker image/service name updated
+- docker-compose.yml updated
+- mise tasks updated
+- Ansible templates updated
+- CLAUDE.md updated
+- All E2E tests pass
+- Zero references to `finance-api` remain in repo

--- a/docs/specs/prd-005-db-schema-patterns.md
+++ b/docs/specs/prd-005-db-schema-patterns.md
@@ -1,0 +1,181 @@
+# PRD-005: DB Schema Patterns
+
+**Epic:** [04 — DB Schema Patterns](../themes/foundation/epics/04-db-schema-patterns.md)
+**Theme:** Foundation
+**Status:** Approved
+**ADRs:** [003 — Component Library & API](../architecture/adr-003-component-library-and-api.md)
+**Can run in parallel with:** PRD-004 (API Modularisation)
+
+## Problem Statement
+
+POPS has one database with tables created by a single `initializeSchema()` function and incremental SQL migrations. As new domains (media, fitness, travel) add their own tables, we need conventions to prevent migration conflicts, establish cross-domain linking patterns, and evolve the entity model from finance-only to platform-level.
+
+## Goal
+
+Establish database conventions that scale to 10+ domains. Upgrade the entity table to support types/tags. Document patterns so that any new app PRD can follow them without re-inventing the approach.
+
+## Requirements
+
+### R1: Migration Conventions
+
+**Naming:** Timestamp-based prefixes to avoid conflicts when multiple agents work in parallel.
+
+```
+YYYYMMDDHHMMSS_domain_description.sql
+
+Examples:
+20260318120000_core_entity_types.sql
+20260320093000_finance_subscription_tracking.sql
+20260321140000_media_movies_table.sql
+```
+
+**Rules:**
+- Each migration file is a single SQL transaction
+- Migrations are idempotent where possible (`IF NOT EXISTS`, `IF NOT NULL`)
+- Each migration has a comment header: domain, description, what it changes
+- Rollback: not automated. Document manual rollback steps in a comment block at the bottom of each migration file
+- Migrations only go forward — no editing applied migrations
+
+**Directory:** Migrations stay in `apps/pops-api/src/db/migrations/`. One flat directory, domain identified by filename prefix.
+
+### R2: Entity Type System
+
+Entities currently have: `id`, `name`, `notion_id` (legacy nullable), `aliases`, `default_category`, `default_location`, `default_country`, `default_online`, `abn`.
+
+**Add a `type` column:**
+
+```sql
+ALTER TABLE entities ADD COLUMN type TEXT NOT NULL DEFAULT 'company';
+```
+
+Supported types (extensible via new values, not schema changes):
+- `company` — Business, retailer, service provider (Woolworths, Netflix, Shell)
+- `person` — Individual (friend, family, employer)
+- `place` — Location (hotel, restaurant, airport)
+- `brand` — Manufacturer/studio (Sony, Apple, Warner Bros)
+- `organisation` — Non-profit, government, institution
+
+**Why a single column, not a tags table?** An entity is primarily one thing — Woolworths is a company, not a company AND a place. If an entity needs multiple classifications, that's better handled by the domains that reference it (e.g., media tags "Warner Bros" as "studio", inventory tags it as "brand"). Keep the core model simple.
+
+**Migration for existing data:** All existing entities default to `company`. The ~940 entities are overwhelmingly merchants. Manual reclassification of employers as `person` and similar corrections can be done via a data migration script or left as a future task.
+
+### R3: Cross-Domain Foreign Key Patterns
+
+**Pattern:** Nullable foreign keys with no CASCADE. Domains link to each other optionally — deleting a transaction doesn't delete an inventory item.
+
+```sql
+-- Example: inventory item links to purchase transaction
+ALTER TABLE home_inventory ADD COLUMN purchase_transaction_id TEXT
+  REFERENCES transactions(id) ON DELETE SET NULL;
+
+-- Example: future media subscription links to finance recurring transaction
+-- media_subscriptions.transaction_id REFERENCES transactions(id) ON DELETE SET NULL
+```
+
+**Rules:**
+- Cross-domain FKs are always NULLABLE — the link is optional
+- ON DELETE SET NULL — breaking a link doesn't cascade destruction
+- ON UPDATE CASCADE — if an ID changes (unlikely with UUIDs), propagate
+- All cross-domain FKs reference `id` (UUID), never other columns
+- Document which domain "owns" each table — the owning domain manages the table's lifecycle
+
+**Existing cross-domain link:** `home_inventory.purchase_transaction` already exists but is stored as a text field, not a proper FK. This should be formalised in a migration.
+
+### R4: Schema Registry
+
+A markdown document listing all tables, their owning domain, and cross-domain relationships. Lives at `docs/architecture/schema-registry.md`. Updated whenever a migration adds or removes tables.
+
+```markdown
+| Table | Domain | Description | Cross-domain FKs |
+|-------|--------|-------------|------------------|
+| entities | core | Merchants, people, places | — |
+| transactions | finance | Ledger entries | entities.id |
+| budgets | finance | Budget targets | — |
+| wish_list | finance | Purchase goals | entities.id |
+| home_inventory | inventory | Owned items | entities.id, transactions.id |
+| ai_usage | core | AI API call tracking | — |
+| transaction_corrections | core | ML correction learning | entities.id |
+| schema_migrations | core | Migration tracking | — |
+| environments | core | Test DB registry | — |
+```
+
+### R5: Table Naming Conventions
+
+- Snake_case, plural for collections (`transactions`, `entities`, `budgets`)
+- Domain prefix for new tables to avoid collisions: `media_movies`, `media_tv_shows`, `fitness_workouts`, `travel_trips`
+- Core tables (entities, ai_usage, etc.) have no prefix — they're shared
+- Existing finance tables (`transactions`, `budgets`, `wish_list`) keep their names — no prefix. They're already established and well-understood.
+
+### R6: Existing Migration Cleanup
+
+The current migration system uses sequential numbers (`007_`, `008_`, etc.) and `initializeSchema()` pre-marks them as applied for fresh databases. This pattern should be preserved:
+
+- Existing migrations (007–011) keep their numbered names
+- New migrations use timestamp-based names
+- `initializeSchema()` updated to include the INCLUDED_MIGRATIONS array for any new migrations
+- Document this dual approach so it's not confusing
+
+## Out of Scope
+
+- Creating schemas for new domains (media, fitness, etc.)
+- Changing the database engine
+- Multi-database setup
+- Automated rollback tooling
+- Data migration scripts for reclassifying entity types
+
+## Acceptance Criteria
+
+1. Migration naming convention documented and a template migration file exists
+2. Entity table has a `type` column with supported values
+3. Existing entities default to `company`
+4. Cross-domain FK pattern documented with `home_inventory.purchase_transaction_id` formalised as a proper FK
+5. Schema registry document created at `docs/architecture/schema-registry.md`
+6. Table naming conventions documented
+7. `initializeSchema()` updated to include new migrations
+8. All existing data preserved — no destructive changes
+9. `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, `pnpm build` all pass
+10. All API and E2E tests pass
+
+## Edge Cases & Decisions
+
+**Q: What if two agents create migrations at the same second?**
+A: Extremely unlikely with timestamp precision to the second. If it happens, one agent renames theirs with a +1 second offset before merging. The migration runner applies them in filename sort order.
+
+**Q: Should we enforce FK constraints at the SQLite level?**
+A: Yes, but with `PRAGMA foreign_keys = ON` (SQLite has this off by default). Verify this is set in `db.ts`. Nullable FKs + SET NULL on delete gives us referential integrity without cascade risk.
+
+**Q: What about the `notion_id` column on entities?**
+A: It's nullable and legacy. Leave it for now. It can be dropped in a future cleanup migration when we're confident no import tooling references it.
+
+## User Stories
+
+> **Standard verification — applies to every US below:**
+> Each story is only done when `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, and `pnpm build` all pass.
+
+### US-1: Establish migration conventions and template
+**As a** developer, **I want** documented migration conventions and a template file **so that** new domains can add tables consistently.
+
+**Acceptance criteria:**
+- Migration naming convention documented (timestamp-based)
+- Template migration file created with header comment format and rollback section
+- Dual approach (legacy numbered + new timestamped) documented
+- `initializeSchema()` pattern documented for fresh databases
+
+### US-2: Add entity type system
+**As a** developer, **I want** entities to have a `type` column **so that** they can be distinguished across domains (company vs person vs place).
+
+**Acceptance criteria:**
+- Migration adds `type TEXT NOT NULL DEFAULT 'company'` to entities
+- Entity service/router updated to accept and return `type`
+- Zod schemas updated
+- Entity API tests updated
+- Existing entities default to `company`
+
+### US-3: Formalise cross-domain FK patterns
+**As a** developer, **I want** cross-domain foreign keys documented and the existing inventory→transaction link formalised **so that** new domains follow a consistent pattern.
+
+**Acceptance criteria:**
+- Cross-domain FK rules documented (nullable, SET NULL, UUID references)
+- `home_inventory.purchase_transaction` converted to proper FK in a migration
+- Schema registry created at `docs/architecture/schema-registry.md`
+- Table naming conventions documented

--- a/docs/specs/prd-006-responsive-foundation.md
+++ b/docs/specs/prd-006-responsive-foundation.md
@@ -1,0 +1,163 @@
+# PRD-006: Responsive Foundation
+
+**Epic:** [05 — Responsive Foundation](../themes/foundation/epics/05-responsive-foundation.md)
+**Theme:** Foundation
+**Status:** Approved
+**Depends on:** PRD-001 (UI library), PRD-002 (shell), PRD-003 (app switcher)
+
+## Problem Statement
+
+The current PWA is built for desktop viewports. As POPS targets iPhone as a daily driver (and eventually iPad/HomePad), the shell and shared components need to work on mobile. This isn't a mobile-first redesign — it's a pass to ensure nothing is broken or unusable on small screens.
+
+## Goal
+
+Every screen in the shell and `@pops/ui` components should be functional on a 375px viewport. Not pixel-perfect mobile design — usable and not broken. Establish responsive patterns that new apps inherit automatically.
+
+## Requirements
+
+### R1: Breakpoint System
+
+Define standard breakpoints in the `@pops/ui` design tokens:
+
+| Name | Width | Use case |
+|------|-------|----------|
+| `sm` | 640px | Large phones landscape |
+| `md` | 768px | Tablets portrait |
+| `lg` | 1024px | Tablets landscape, small laptops |
+| `xl` | 1280px | Desktops |
+
+These are Tailwind v4 defaults. No need to customise unless a specific breakpoint is missing. Document them as the standard set.
+
+### R2: Shell Layout — Mobile
+
+**App Switcher (from PRD-003):**
+- Desktop: side rail + page nav panel (already specified)
+- Mobile (<768px): collapse to bottom tab bar or hamburger menu
+- Decision to be made during implementation — whichever is simpler and more native-feeling on iOS
+
+**TopBar:**
+- Compact on mobile: hide user email, keep theme toggle and hamburger/menu trigger
+- POPS title can shrink or become an icon
+
+**Content area:**
+- Full width on mobile (no side margins wasted)
+- Appropriate padding for touch (min 16px)
+
+### R3: Shared Component Audit
+
+Each `@pops/ui` component checked at 375px:
+
+**DataTable:**
+- Horizontal scroll for tables wider than viewport
+- Or: card/list view for mobile (show key fields, expandable)
+- Column hiding at breakpoints (hide less important columns on mobile)
+- Decision: start with horizontal scroll (simpler), add card view later if needed
+
+**Forms (TextInput, NumberInput, DateTimeInput, CheckboxInput, RadioInput):**
+- Stack labels above inputs on mobile (not side-by-side)
+- Inputs stretch to full width
+- Touch-friendly input sizes (min height 44px)
+
+**Dialogs/Modals:**
+- Full-screen on mobile (<768px)
+- Slide up from bottom (sheet pattern) if feasible, otherwise full-screen overlay
+
+**Autocomplete/ComboboxSelect:**
+- Dropdown positioned correctly on mobile (not clipped by viewport)
+- Touch-friendly option sizes
+
+**ChipInput:**
+- Chips wrap to multiple lines
+- Remove button touch target ≥44px
+
+**DataTableFilters:**
+- Collapse into a "Filters" button that opens a sheet/drawer on mobile
+- Not a row of inline filter dropdowns (doesn't fit)
+
+### R4: Touch Target Standards
+
+Per Apple HIG and WCAG:
+- Minimum touch target: 44x44px
+- Minimum spacing between targets: 8px
+- Apply to all interactive elements: buttons, links, checkboxes, chips, table rows
+
+### R5: Testing
+
+- Visual verification at 375px, 390px, 428px (common iPhone sizes) in Chrome DevTools
+- Verify on actual iPhone if possible (Safari rendering differences)
+- No automated responsive tests required (visual verification is sufficient for this pass)
+- Document any known issues that require deeper redesign (out of scope for this PRD, tracked for future work)
+
+## Out of Scope
+
+- Native mobile app
+- PWA service worker improvements
+- Offline support
+- App-specific page redesigns (finance pages layout is finance's problem)
+- Mobile-specific features (swipe gestures, pull-to-refresh)
+- Performance optimisation for mobile networks
+
+## Acceptance Criteria
+
+1. Shell layout works on 375px+ viewports without horizontal scroll
+2. App switcher has a mobile interaction pattern (bottom bar or hamburger)
+3. All `@pops/ui` components render without overflow/clipping at 375px
+4. Touch targets meet 44x44px minimum on all interactive elements
+5. Forms stack vertically on mobile
+6. DataTable scrolls horizontally or adapts on mobile
+7. Dialogs are full-screen on mobile
+8. DataTableFilters collapse on mobile
+9. Dark and light mode both work on mobile
+10. `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, `pnpm build` all pass
+
+## Edge Cases & Decisions
+
+**Q: Should we add a mobile detection hook?**
+A: No. Use Tailwind responsive classes (`md:`, `lg:`) for layout. Use `useMediaQuery` only if JavaScript behaviour needs to differ (e.g., swapping DataTable for a card list). Prefer CSS-driven responsiveness.
+
+**Q: What about the ImportWizard on mobile?**
+A: The ImportWizard is finance-specific (lives in `@pops/app-finance`). Making it mobile-friendly is out of scope for this PRD. It's a power-user flow unlikely to be used on a phone.
+
+**Q: iPad / HomePad layout?**
+A: iPad (768–1024px) should work naturally with the `md` breakpoint. HomePad is a future concern — likely a dedicated dashboard mode, not the standard app layout.
+
+## User Stories
+
+> **Standard verification — applies to every US below:**
+> Each story is only done when `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, and `pnpm build` all pass.
+
+### US-1: Mobile shell layout
+**As a** user on iPhone, **I want** the shell layout to be usable on my screen **so that** I can navigate POPS without pinching/scrolling horizontally.
+
+**Acceptance criteria:**
+- TopBar compact on mobile
+- App switcher works on mobile (bottom bar or hamburger)
+- Content area full-width with appropriate padding
+- No horizontal overflow at 375px
+
+### US-2: Responsive shared components
+**As a** user on iPhone, **I want** tables, forms, and dialogs to be usable **so that** I can interact with data on a small screen.
+
+**Acceptance criteria:**
+- DataTable horizontal scroll on mobile
+- Forms stack vertically, full-width inputs
+- Dialogs full-screen on mobile
+- Autocomplete/Combobox positioned correctly
+- ChipInput wraps, touch-friendly remove buttons
+
+### US-3: Touch target audit
+**As a** user on a touch device, **I want** all interactive elements to be easy to tap **so that** I don't accidentally hit the wrong thing.
+
+**Acceptance criteria:**
+- All buttons, links, checkboxes, chips meet 44x44px minimum
+- Minimum 8px spacing between adjacent targets
+- DataTableFilters collapsed behind a button on mobile
+
+### US-4: Responsive documentation
+**As a** developer building a new app, **I want** responsive patterns documented **so that** my app is mobile-friendly from day one.
+
+**Acceptance criteria:**
+- Breakpoint system documented
+- Component responsive behaviour documented (how DataTable, forms, dialogs adapt)
+- Touch target standards documented
+- Any known issues or future work noted

--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -1,0 +1,31 @@
+# Themes
+
+Each theme is a strategic initiative grouping related epics. Themes persist across quarters. Detailed theme READMEs are written when work on that theme is about to begin.
+
+See [roadmap.md](../roadmap.md) for sequencing and dependencies.
+
+## Platform Themes
+
+| Theme | One-liner | Phase |
+|-------|-----------|-------|
+| **Foundation** | Extract the shared shell, UI library, and modular API that all apps build on | 1 |
+| **AI — Categorisation** | Automated data entry, entity matching, tagging across all domains. Infrastructure-level — gets applied to each app to reduce input friction | 2+ |
+| **AI — Overlay** | Contextual assistant in the shell. Interactive — "help me do it." Query across domains, suggest actions, answer questions | 3 |
+| **AI — Inference** | Proactive monitoring, anomaly detection, smart automations. Autonomous — "do it for me." Moltbot alerts, scheduled analysis | 3 |
+| **Mobile** | Native iOS app and wall-mounted dashboard/HomePad mode | 5 |
+
+## App Themes
+
+| Theme | One-liner | Phase |
+|-------|-----------|-------|
+| **Media** | Movies and TV show tracking, categorisation, recommendations. Plex/Radarr/Sonarr/TMDB integration | 2 |
+| **Inventory** | Home inventory — items, warranties, purchase linking, Paperless-ngx receipts. Highest daily-use app | 2 |
+| **Finance** | Polish existing finance app, reduce friction, add subscriptions tracking as a built-in feature | 2 |
+| **Fitness** | Gym and training log — exercises, sets, reps, progress. Health integrations (Apple Health, meals) come later | 2 |
+| **Documents** | Surfaces Paperless-ngx within POPS. Links receipts, warranties, manuals to items and transactions | 2 |
+| **Travel** | Trip planning, organising, tracking. Links to finance (budgets), documents (bookings) | 4 |
+| **Books** | Reading tracker — reading list, reviews, recommendations. Same pattern as media | 4 |
+| **Recipes** | Ingredients, recipes, meal planning. Links to finance (grocery spend), inventory (kitchen gear) | 4 |
+| **Maintenance** | Tasks, chores, scheduled reminders. Service schedules, renewals, recurring to-dos. Closer to Todoist than inventory | 6 |
+| **Social** | Contacts, gift tracking, event planning. CRM-lite for personal relationships | 6 |
+| **Home Automation** | HomeAssistant integration. Explore only if there's a clear gap | 6 |

--- a/docs/themes/foundation/README.md
+++ b/docs/themes/foundation/README.md
@@ -1,0 +1,52 @@
+# Theme: Foundation
+
+> Extract the shared platform that all POPS apps build on.
+
+## Strategic Objective
+
+Transform the current single-app codebase (finance-focused PWA + API) into a multi-app platform with a shared shell, component library, and modular API. Every app in the roadmap depends on this work.
+
+## Success Criteria
+
+- A new app can be scaffolded and integrated into the shell with minimal boilerplate
+- Shared components are consumed from a package, not copy-pasted
+- The API supports multiple domain modules without coupling between them
+- The shell handles app switching, navigation, theming, and auth — apps only provide their pages and domain components
+- Everything works on mobile viewports (responsive PWA)
+
+## Epics (ordered by dependency)
+
+| # | Epic | Summary | Status |
+|---|------|---------|--------|
+| 0 | [pnpm Migration](epics/00-pnpm-migration.md) | Replace Yarn v1 with pnpm | Not started |
+| 1 | [UI Library Extraction](epics/01-ui-library-extraction.md) | Extract shared components into `@pops/ui` package | Not started |
+| 2 | [Shell Extraction](epics/02-shell-extraction.md) | Extract shell from pops-pwa, convert finance to app package | Not started |
+| 3 | [API Modularisation](epics/03-api-modularisation.md) | Rename to pops-api, domain module structure, promote entities to core | Not started |
+| 4 | [DB Schema Patterns](epics/04-db-schema-patterns.md) | Migration conventions, entity types, cross-domain FK patterns | Not started |
+| 5 | [Responsive Foundation](epics/05-responsive-foundation.md) | Audit and fix shell + shared components for mobile viewports | Not started |
+
+Epic 0 is a prerequisite to everything. Epics 3 and 4 can run in parallel. Epic 5 depends on 1 and 2.
+
+## Key Decisions to Make
+
+These need to be resolved in PRDs or ADRs before implementation:
+
+1. **Shell architecture** — Single SPA with lazy-loaded route modules? Or separate Vite builds composed at runtime? (Recommendation: single SPA, code-split by route.)
+2. **Component library packaging** — Internal workspace package with Vite library mode? Or just path aliases? How does Storybook fit?
+3. **Routing strategy** — Flat routes (`/media/movies`, `/finance/transactions`) or nested app routers? How does the app switcher interact with the router?
+4. **API module boundaries** — How isolated are domain routers? Can they import each other's services for cross-domain queries? Or do cross-domain queries go through a separate layer?
+5. **Shared entities** — Entities currently belong to finance. When media and inventory also reference entities, where does the entity module live?
+6. **Migration strategy** — How do we get from the current pops-pwa to the new structure without a big-bang rewrite? Can finance continue working throughout?
+
+## Risks
+
+- **Big-bang refactor trap** — Extracting the shell and component library touches every file in pops-pwa. Need a migration strategy that keeps finance working at every step.
+- **Premature abstraction** — We're designing a multi-app platform with only one app. The patterns we establish may not fit apps we haven't built yet. Keep it minimal.
+- **Storybook migration** — 40+ existing stories need to move with the components. Breaking the Storybook setup blocks UI development.
+
+## Out of Scope
+
+- Building any new app (that's Phase 2)
+- AI features
+- Mobile-native anything (responsive PWA is in scope, native app is not)
+- Changing the database engine or API framework

--- a/docs/themes/foundation/epics/00-pnpm-migration.md
+++ b/docs/themes/foundation/epics/00-pnpm-migration.md
@@ -1,0 +1,49 @@
+# Epic: pnpm Migration
+
+**Theme:** Foundation
+**Priority:** 0 (prerequisite to everything else)
+**Status:** Not started
+
+## Goal
+
+Replace Yarn v1 with pnpm as the package manager. All subsequent work (UI library extraction, shell, new app packages) starts on pnpm.
+
+## Scope
+
+### In scope
+
+- Remove `yarn.lock`
+- Generate `pnpm-lock.yaml` via `pnpm import` (migrates from yarn.lock) or fresh `pnpm install`
+- Create `pnpm-workspace.yaml`
+- Update root `package.json`: replace `packageManager: yarn@1.22.22` with pnpm
+- Update all scripts and documentation referencing `yarn` → `pnpm`
+- Update mise.toml tasks that reference yarn
+- Update CI pipelines
+- Update CLAUDE.md
+- Verify Turbo works with pnpm
+- Verify all workspace packages resolve correctly
+- Verify dev, build, test, lint, format, typecheck all pass
+
+### Out of scope
+
+- Changing Turbo config
+- Changing mise config beyond yarn → pnpm references
+- Any code changes
+
+## Deliverables
+
+1. `pnpm-lock.yaml` exists, `yarn.lock` is deleted
+2. `pnpm-workspace.yaml` defines workspace packages
+3. All commands work: `pnpm dev`, `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
+4. Turbo caching works with pnpm
+5. All docs updated
+6. CI passes
+
+## Dependencies
+
+- None (this is the first thing to do)
+
+## Risks
+
+- **Dependency resolution differences** — pnpm's strict mode may surface phantom dependencies that Yarn v1 silently hoisted. These show up as missing imports at build time. Fix by adding explicit dependencies where needed.
+- **mise task breakage** — Any mise task using `yarn` needs updating. Grep for `yarn` in `mise.toml`.

--- a/docs/themes/foundation/epics/01-ui-library-extraction.md
+++ b/docs/themes/foundation/epics/01-ui-library-extraction.md
@@ -1,0 +1,56 @@
+# Epic: UI Library Extraction
+
+**Theme:** Foundation
+**Priority:** 1 (do first — shell and apps both depend on this)
+**Status:** Not started
+
+## Goal
+
+Extract shared UI components from `apps/pops-pwa/` into `packages/ui/` (`@pops/ui`) so that the shell and all app packages can consume them.
+
+## Why first?
+
+Both the shell extraction and every app package need to import from `@pops/ui`. If we extract the shell first, we'd have to move components twice — once into the shell, then again into a shared package. Extracting the library first means the shell and app-finance can both import from it immediately.
+
+## Scope
+
+### In scope
+
+- Create `packages/ui/` workspace package with package.json, tsconfig
+- Move all 28 shadcn/ui base components from `pops-pwa/src/components/ui/`
+- Move shared composite components: DataTable, DataTableFilters, InfiniteScrollTable, Autocomplete, ComboboxSelect, Select, DropdownMenu, EditableCell, ChipInput, ErrorBoundary
+- Move form inputs: TextInput, NumberInput, DateTimeInput, CheckboxInput, RadioInput, Chip
+- Move shared utilities: `cn()`, formatters
+- Move Tailwind CSS variables and shared theme config
+- Establish design token system: colours, spacing, typography, breakpoints, shadows. All apps consume tokens from `@pops/ui` — no arbitrary Tailwind values allowed (see [ADR-004](../../architecture/adr-004-tailwind-only-styling.md))
+- Audit existing components for arbitrary values (`w-[...]`, `text-[#...]`, etc.) and replace with tokens
+- Move associated stories with each component
+- Update all imports in pops-pwa to use `@pops/ui`
+- Ensure Storybook continues to work (stories stay with components, Storybook config updated to discover from packages/)
+
+### Out of scope
+
+- Import wizard components (domain-specific, stays in finance)
+- TagEditor (finance-specific for now)
+- Page components
+- Zustand stores
+- Any new components
+
+## Deliverables
+
+1. `packages/ui/` package exists with all shared components
+2. `apps/pops-pwa/` imports from `@pops/ui` — no shared components remain in pops-pwa
+3. All existing stories pass in Storybook
+4. `yarn typecheck` passes across all packages
+5. `yarn build` produces working output
+6. Zero runtime regressions — finance app works exactly as before
+
+## Dependencies
+
+- None (this is the first epic)
+
+## Risks
+
+- **Import path churn** — Every file that imports a shared component needs updating. Automated with find-and-replace, but easy to miss one.
+- **Tailwind config** — Tailwind v4 uses CSS-first config. Need to ensure the shared CSS variables are properly consumed by downstream packages.
+- **Storybook discovery** — Storybook config needs to glob across workspace packages. May need `.storybook/main.ts` updates.

--- a/docs/themes/foundation/epics/02-shell-extraction.md
+++ b/docs/themes/foundation/epics/02-shell-extraction.md
@@ -1,0 +1,78 @@
+# Epic: Shell Extraction
+
+**Theme:** Foundation
+**Priority:** 2
+**Status:** Not started
+
+## Goal
+
+Extract the shared shell (layout, routing, app switcher, theming, tRPC provider) from `apps/pops-pwa/` into `apps/pops-shell/`. Convert `pops-pwa` into `packages/app-finance/` as the first app package. The shell becomes the single entry point that lazily loads app packages.
+
+## Scope
+
+### In scope
+
+- Create `apps/pops-shell/` with:
+  - `main.tsx` entry point
+  - Root layout (TopBar, Sidebar → App Switcher)
+  - React Router config with lazy-loaded app routes
+  - tRPC client provider
+  - React Query provider
+  - Theme provider (Zustand store)
+  - Vite config (replaces pops-pwa's)
+  - Tailwind entry point (imports from `@pops/ui`)
+- Create `packages/app-finance/` with:
+  - All finance pages (Dashboard, Transactions, Budgets, Entities, Wishlist, AiUsage, Import)
+  - Finance-specific components (ImportWizard, TagEditor, TransactionCard, etc.)
+  - Finance-specific stores (importStore)
+  - Exported route definitions
+  - Finance-specific stories
+- Transform Sidebar into App Switcher:
+  - Top-level: app icons/names (Finance, and later Media, Inventory, etc.)
+  - Second-level: pages within the active app
+- Remove `apps/pops-pwa/` once extraction is complete
+- Update Docker, nginx, and deployment configs to point to pops-shell
+
+### Out of scope
+
+- Building any new app
+- Changing the API (that's epic 3)
+- New UI components
+- Responsive design audit (that's epic 5)
+
+## Deliverables
+
+1. `apps/pops-shell/` is the single frontend entry point
+2. `packages/app-finance/` contains all finance pages and domain components
+3. App switcher shows Finance as the sole app (more added later)
+4. Navigation within Finance works exactly as before
+5. Lazy loading works — finance routes are code-split
+6. `yarn dev` starts one Vite server serving the shell
+7. `yarn build` produces one output bundle with code splitting
+8. All E2E tests pass
+9. `apps/pops-pwa/` is deleted
+
+## Migration Strategy
+
+This is a rename-and-reorganise, not a rewrite:
+
+1. Create `apps/pops-shell/` with minimal config
+2. Create `packages/app-finance/` and move finance pages + domain components
+3. Wire up shell → app-finance route imports
+4. Move providers (tRPC, React Query, theme) into shell
+5. Transform Sidebar → App Switcher
+6. Update Vite config, Storybook globs, Docker/nginx
+7. Verify everything works
+8. Delete `apps/pops-pwa/`
+
+At every step, the app should be runnable. No big-bang switchover.
+
+## Dependencies
+
+- Epic 1 (UI Library Extraction) — shared components must be in `@pops/ui` before we can split the shell from finance
+
+## Risks
+
+- **E2E test breakage** — Playwright tests target current routes. Routes will change from `/transactions` to `/finance/transactions`. Tests need updating.
+- **Vite config complexity** — Resolving workspace packages in dev mode may require alias configuration.
+- **Storybook** — Discovery globs need updating again to include the new app-finance package location.

--- a/docs/themes/foundation/epics/03-api-modularisation.md
+++ b/docs/themes/foundation/epics/03-api-modularisation.md
@@ -1,0 +1,80 @@
+# Epic: API Modularisation
+
+**Theme:** Foundation
+**Priority:** 3
+**Status:** Not started
+
+## Goal
+
+Rename `apps/finance-api/` to `apps/pops-api/`. Restructure modules into domain groupings. Promote entities to `core/`. Establish the pattern for adding new domain modules.
+
+## Scope
+
+### In scope
+
+- Rename `apps/finance-api/` → `apps/pops-api/`, `@pops/finance-api` → `@pops/api`
+- Create `core/` module group:
+  - `core/entities/` — promoted from finance (shared across all future domains)
+  - `core/health/` — health check endpoint (already exists)
+  - `core/auth/` — placeholder for shared auth middleware
+- Create `finance/` module group:
+  - `finance/transactions/`
+  - `finance/budgets/`
+  - `finance/imports/`
+  - `finance/wishlist/`
+- Move `inventory/` to its own domain group (already partially exists)
+- Move `ai-usage/` to `core/` (platform-level concern)
+- Move `corrections/` to `core/` (used by import pipeline, will be cross-domain)
+- Update tRPC router composition
+- Update all tRPC client references in `@pops/app-finance`
+- Update Docker, deployment, mise tasks, CI
+
+### Out of scope
+
+- New API endpoints
+- Database schema changes
+- New domain modules (media, fitness, etc.)
+
+## Deliverables
+
+1. `apps/pops-api/` exists, `apps/finance-api/` is deleted
+2. Module structure follows the domain grouping pattern from ADR-003
+3. Entities are in `core/` and accessible to all future domain modules
+4. All existing API tests pass
+5. All E2E tests pass
+6. Docker, mise tasks, and CI updated
+
+## Target Structure
+
+```
+apps/pops-api/src/modules/
+  core/
+    entities/        (service, router, types)
+    health/
+    auth/
+    ai-usage/
+    corrections/
+  finance/
+    transactions/
+    budgets/
+    imports/
+    wishlist/
+  inventory/
+    items/
+```
+
+## Module Import Rules
+
+- Any module can import from `core/`
+- Domain modules (finance, inventory, etc.) CANNOT import from each other
+- Cross-domain queries go through `core/` or a dedicated query layer
+- Each module exports a tRPC router, composed at the app level
+
+## Dependencies
+
+- Epic 2 (Shell Extraction) — should be done first so frontend references are already on `@pops/app-finance` and the import path changes are isolated
+
+## Risks
+
+- **tRPC router path changes** — Renaming modules changes the tRPC procedure paths (e.g., `transactions.list` → `finance.transactions.list`). Frontend calls need updating.
+- **Docker image name changes** — `finance-api` image name used in docker-compose and Ansible. All references need updating.

--- a/docs/themes/foundation/epics/04-db-schema-patterns.md
+++ b/docs/themes/foundation/epics/04-db-schema-patterns.md
@@ -1,0 +1,44 @@
+# Epic: DB Schema Patterns
+
+**Theme:** Foundation
+**Priority:** 4 (can run in parallel with epic 3)
+**Status:** Not started
+
+## Goal
+
+Establish conventions for database schema management that scale across multiple domains. Ensure new apps can add tables and migrations without conflicting with existing ones.
+
+## Scope
+
+### In scope
+
+- Document migration conventions: naming, ordering, rollback strategy
+- Establish entity type system (entities gain a `type` or `tags` column)
+- Define cross-domain foreign key patterns (e.g., inventory item → finance transaction)
+- Create a schema registry or manifest listing all tables and their owning domain
+- Review and document existing schema for consistency
+- Add migration tooling if current approach doesn't scale (evaluate current `schema_migrations` table)
+
+### Out of scope
+
+- Creating schemas for new domains (media, fitness, etc.) — that happens in their PRDs
+- Changing the database engine
+- Multi-database setup
+
+## Deliverables
+
+1. Migration conventions documented
+2. Entity table updated with type/tag system
+3. Cross-domain FK pattern documented with at least one example (inventory → finance already exists)
+4. Schema registry document listing all tables and owners
+5. Existing migrations cleaned up if needed
+
+## Key Decisions
+
+- **Entity types**: enum column vs tags table vs both? Needs to support: company, person, service, place, brand, and future types.
+- **Migration numbering**: timestamp-based vs sequential? Timestamp avoids conflicts when multiple people/agents work in parallel.
+- **FK constraints**: strict (CASCADE/RESTRICT) vs soft (nullable, app-level validation)? Soft FKs are simpler for optional cross-domain links.
+
+## Dependencies
+
+- Epic 3 (API Modularisation) — entity promotion to `core/` should happen first so the schema changes align with the API structure

--- a/docs/themes/foundation/epics/05-responsive-foundation.md
+++ b/docs/themes/foundation/epics/05-responsive-foundation.md
@@ -1,0 +1,40 @@
+# Epic: Responsive Foundation
+
+**Theme:** Foundation
+**Priority:** 5 (do last — needs the shell and UI library in place)
+**Status:** Not started
+
+## Goal
+
+Audit and fix the shell and shared UI components for mobile viewports. Every screen should be usable on a phone. Not pixel-perfect mobile design — functional and not broken.
+
+## Scope
+
+### In scope
+
+- Audit all `@pops/ui` components on mobile viewports (375px, 390px, 428px)
+- Fix layout issues: overflow, truncation, touch targets, spacing
+- App Switcher: mobile-friendly (bottom nav? hamburger? swipe?)
+- DataTable: horizontal scroll or card view on narrow screens
+- Forms: stack inputs vertically, appropriate input sizes
+- Dialogs/modals: full-screen on mobile
+- Test on actual iPhone (not just DevTools responsive mode)
+
+### Out of scope
+
+- Native mobile app
+- Offline/PWA service worker improvements
+- App-specific page redesigns (just ensure shared components work)
+
+## Deliverables
+
+1. Shell layout works on 375px+ viewports
+2. App Switcher has a mobile-appropriate interaction pattern
+3. All shared components in `@pops/ui` render correctly on mobile
+4. No horizontal scroll on any page at 375px width
+5. Touch targets meet minimum 44x44px
+
+## Dependencies
+
+- Epic 1 (UI Library) — components must be in `@pops/ui`
+- Epic 2 (Shell) — app switcher must exist

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,28 @@
+# POPS — Vision, Mission & Strategy
+
+## Vision
+
+A single self-hosted platform that manages every operational aspect of my life — finances, home, food, entertainment, travel — making daily life easier, better integrated, and less manual.
+
+## Mission
+
+Own my data. Keep it safe. Automate the tedious. Surface insights I'd never find manually. No subscriptions, no vendor lock-in, minimal cloud dependency (backups excepted).
+
+## Strategy
+
+Build modular apps on a shared foundation: one database, one API, one shell. Ship the most-used apps first. Connect domains through shared entities and an AI layer.
+
+The system should do more for me than I do for it. Every app must return more value than the effort it takes to feed it. Automate aggressively — proactive suggestions, automatic categorisation, cross-domain insights — so the platform improves my life before I even open it.
+
+Optimise for one user operating from a phone or a wall-mounted tablet.
+
+## Design Principles
+
+These follow from the strategy and should guide every PRD and technical decision:
+
+1. **Output > Input** — If an app requires more data entry than value it returns, it has failed. Prefer automation, imports, and inference over manual input.
+2. **Connected by default** — Apps share entities, link records across domains, and surface cross-domain insights. Isolated apps are just worse versions of existing products.
+3. **Self-hosted, self-owned** — Data lives on hardware I control. Cloud services are tools (backups, AI APIs), not dependencies.
+4. **Proactive, not reactive** — The system should surface what matters before I ask. Budget alerts, expiring warranties, meal suggestions from what's in stock, upcoming trip prep.
+5. **One interface** — Phone, tablet, wall mount — same app, responsive, fast. No context switching between separate tools.
+6. **Simple until proven otherwise** — One SQLite database, one API, one shell. Split only when there's a concrete reason, not in anticipation of scale that may never come.


### PR DESCRIPTION
## Summary
- Adds project vision, roadmap, and app ideas documentation
- 7 PRDs covering pnpm migration, UI library extraction, shell extraction, app switcher, API modularisation, DB schema patterns, and responsive foundation
- 5 ADRs documenting key architectural decisions (SQLite source of truth, shell architecture, component library, Tailwind-only styling, package manager)
- Foundation theme epic breakdown with acceptance criteria

## Test plan
- [ ] Verify all markdown files render correctly on GitHub
- [ ] Cross-reference PRD numbering with roadmap