### PR TITLE
feat: scaffold pops-shell app package (E02-US1)

### DIFF
--- a/apps/pops-shell/index.html
+++ b/apps/pops-shell/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#1a1a2e" />
+    <link rel="icon" type="image/png" href="/icons/icon-192.png" />
+    <title>POPS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@pops/shell",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts,.tsx",
+    "lint:fix": "eslint src --ext .ts,.tsx --fix",
+    "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
+    "format:fix": "prettier --write \"src/**/*.{ts,tsx,css}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/finance-api": "workspace:*",
+    "@pops/ui": "workspace:*",
+    "@tanstack/react-query": "5.90.20",
+    "@tailwindcss/vite": "4.0.14",
+    "@trpc/client": "11.13.4",
+    "@trpc/react-query": "11.13.4",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router": "^7.13.1",
+    "react-router-dom": "^7.1.0",
+    "sonner": "^2.0.7",
+    "tailwindcss": "4.0.14",
+    "zustand": "5.0.2"
+  },
+  "devDependencies": {
+    "@tanstack/react-query-devtools": "^5.91.3",
+    "@types/node": "^25.2.2",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.7.0",
+    "vite": "^6.1.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/apps/pops-shell/src/app/App.tsx
+++ b/apps/pops-shell/src/app/App.tsx
@@ -1,0 +1,38 @@
+/**
+ * Root App component with all providers
+ */
+import { useEffect } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { trpc, trpcClient } from "@/lib/trpc";
+import { router } from "./router";
+import { RouterProvider } from "react-router";
+import { useThemeStore } from "@/store/themeStore";
+import { Toaster } from "@pops/ui";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // 5 minutes
+    },
+  },
+});
+
+export function App() {
+  const theme = useThemeStore((state) => state.theme);
+
+  // Apply theme class to root element
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+  }, [theme]);
+
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+        {!import.meta.env.VITE_E2E && <ReactQueryDevtools initialIsOpen={false} />}
+        <Toaster />
+      </QueryClientProvider>
+    </trpc.Provider>
+  );
+}

--- a/apps/pops-shell/src/app/router.tsx
+++ b/apps/pops-shell/src/app/router.tsx
@@ -1,0 +1,25 @@
+/**
+ * Shell router configuration
+ *
+ * Currently renders a placeholder. US-2 and US-3 will wire in
+ * lazy-loaded app routes from @pops/app-finance.
+ */
+import { createBrowserRouter, Navigate } from "react-router";
+
+export const router = createBrowserRouter([
+  {
+    path: "/",
+    children: [
+      { index: true, element: <Navigate to="/finance" replace /> },
+      {
+        path: "finance",
+        children: [
+          {
+            index: true,
+            element: <div>Shell scaffold — finance routes will be wired in US-3</div>,
+          },
+        ],
+      },
+    ],
+  },
+]);

--- a/apps/pops-shell/src/lib/trpc.ts
+++ b/apps/pops-shell/src/lib/trpc.ts
@@ -1,0 +1,26 @@
+/**
+ * tRPC client configuration for the shell
+ * Provides type-safe API access to the finance-api backend
+ */
+import { httpBatchLink } from "@trpc/client";
+import { createTRPCReact } from "@trpc/react-query";
+import type { AppRouter } from "@pops/finance-api";
+
+/**
+ * React Query hooks for tRPC
+ * Use these hooks in components to call backend procedures
+ */
+export const trpc = createTRPCReact<AppRouter>();
+
+/**
+ * Create the tRPC client
+ * Batches multiple requests into a single HTTP call for better performance
+ */
+export const trpcClient = trpc.createClient({
+  links: [
+    httpBatchLink({
+      url: "/trpc", // Proxied by Vite to localhost:3000 in dev
+      maxURLLength: 2083, // Don't batch if URL gets too long
+    }),
+  ],
+});

--- a/apps/pops-shell/src/main.tsx
+++ b/apps/pops-shell/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./app/App";
+import "@pops/ui/theme";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/apps/pops-shell/src/store/themeStore.test.ts
+++ b/apps/pops-shell/src/store/themeStore.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for theme store
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { useThemeStore } from "./themeStore";
+
+describe("themeStore", () => {
+  beforeEach(() => {
+    // Reset store state before each test
+    useThemeStore.setState({ theme: "dark" });
+  });
+
+  it("should have dark as default theme", () => {
+    const { theme } = useThemeStore.getState();
+    expect(theme).toBe("dark");
+  });
+
+  it("should toggle theme from dark to light", () => {
+    const { toggleTheme } = useThemeStore.getState();
+    toggleTheme();
+
+    const { theme } = useThemeStore.getState();
+    expect(theme).toBe("light");
+  });
+
+  it("should toggle theme from light to dark", () => {
+    useThemeStore.setState({ theme: "light" });
+    const { toggleTheme } = useThemeStore.getState();
+    toggleTheme();
+
+    const { theme } = useThemeStore.getState();
+    expect(theme).toBe("dark");
+  });
+
+  it("should set theme directly to light", () => {
+    const { setTheme } = useThemeStore.getState();
+    setTheme("light");
+
+    const { theme } = useThemeStore.getState();
+    expect(theme).toBe("light");
+  });
+
+  it("should set theme directly to dark", () => {
+    useThemeStore.setState({ theme: "light" });
+    const { setTheme } = useThemeStore.getState();
+    setTheme("dark");
+
+    const { theme } = useThemeStore.getState();
+    expect(theme).toBe("dark");
+  });
+
+  it("should maintain state across multiple operations", () => {
+    const { toggleTheme } = useThemeStore.getState();
+    toggleTheme(); // dark -> light
+    toggleTheme(); // light -> dark
+    toggleTheme(); // dark -> light
+
+    const { theme } = useThemeStore.getState();
+    expect(theme).toBe("light");
+  });
+});

--- a/apps/pops-shell/src/store/themeStore.ts
+++ b/apps/pops-shell/src/store/themeStore.ts
@@ -1,0 +1,30 @@
+/**
+ * Theme store - manages dark/light mode
+ * Persisted to localStorage
+ */
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type Theme = "light" | "dark";
+
+interface ThemeState {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      theme: "dark", // Default to dark mode
+      toggleTheme: () =>
+        set((state) => ({
+          theme: state.theme === "dark" ? "light" : "dark",
+        })),
+      setTheme: (theme) => set({ theme }),
+    }),
+    {
+      name: "pops-theme-storage",
+    }
+  )
+);

--- a/apps/pops-shell/src/store/uiStore.ts
+++ b/apps/pops-shell/src/store/uiStore.ts
@@ -1,0 +1,26 @@
+/**
+ * UI store - manages UI state like sidebar open/close
+ * Persisted to localStorage
+ */
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface UIState {
+  sidebarOpen: boolean;
+  toggleSidebar: () => void;
+  setSidebarOpen: (open: boolean) => void;
+}
+
+export const useUIStore = create<UIState>()(
+  persist(
+    (set) => ({
+      sidebarOpen: true,
+      toggleSidebar: () =>
+        set((state) => ({ sidebarOpen: !state.sidebarOpen })),
+      setSidebarOpen: (open) => set({ sidebarOpen: open }),
+    }),
+    {
+      name: "pops-ui-storage",
+    }
+  )
+);

--- a/apps/pops-shell/tsconfig.json
+++ b/apps/pops-shell/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/pops-shell/vite.config.ts
+++ b/apps/pops-shell/vite.config.ts
@@ -1,0 +1,30 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import path from "node:path";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  server: {
+    port: 5568,
+    strictPort: true,
+    host: true,
+    clearScreen: false,
+    hmr: {
+      host: "localhost",
+    },
+    proxy: {
+      "/trpc": {
+        target: "http://localhost:3000",
+        changeOrigin: true,
+        // Don't rewrite — tRPC expects /trpc prefix
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,73 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(lightningcss@1.29.2)(msw@2.12.13(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
 
+  apps/pops-shell:
+    dependencies:
+      '@pops/finance-api':
+        specifier: workspace:*
+        version: link:../finance-api
+      '@pops/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@tailwindcss/vite':
+        specifier: 4.0.14
+        version: 4.0.14(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.46.1)(tsx@4.21.0))
+      '@tanstack/react-query':
+        specifier: 5.90.20
+        version: 5.90.20(react@19.2.4)
+      '@trpc/client':
+        specifier: 11.13.4
+        version: 11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3)
+      '@trpc/react-query':
+        specifier: 11.13.4
+        version: 11.13.4(@tanstack/react-query@5.90.20(react@19.2.4))(@trpc/client@11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.13.4(typescript@5.9.3))(react@19.2.4)(typescript@5.9.3)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.13.1
+        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router-dom:
+        specifier: ^7.1.0
+        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwindcss:
+        specifier: 4.0.14
+        version: 4.0.14
+      zustand:
+        specifier: 5.0.2
+        version: 5.0.2(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+    devDependencies:
+      '@tanstack/react-query-devtools':
+        specifier: ^5.91.3
+        version: 5.91.3(@tanstack/react-query@5.90.20(react@19.2.4))(react@19.2.4)
+      '@types/node':
+        specifier: ^25.2.2
+        version: 25.5.0
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.46.1)(tsx@4.21.0))
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.1.0
+        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.46.1)(tsx@4.21.0)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(lightningcss@1.29.2)(msw@2.12.13(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
+
   packages/db-types:
     dependencies:
       zod:
@@ -8813,7 +8880,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -8822,7 +8889,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
   '@types/cookiejar@2.1.5': {}
 
@@ -8864,7 +8931,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -8924,12 +8991,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
   '@types/statuses@2.0.6': {}
 
@@ -8937,7 +9004,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       form-data: 4.0.5
 
   '@types/supertest@6.0.3':


### PR DESCRIPTION
## Summary
- Scaffolds the `@pops/shell` workspace package as the new application shell (Epic 02, US-1)
- Includes provider stack (tRPC, React Query, React Router), Zustand stores (theme + UI), tRPC client with batch link proxy, and placeholder router
- All typechecks pass, 6 theme store unit tests pass

## What's included
- `apps/pops-shell/` — new workspace package with Vite + React + Tailwind
- **App.tsx** — provider composition (tRPC → QueryClient → Router → DevTools → Toaster) with theme binding
- **router.tsx** — placeholder routes redirecting `/` → `/finance` (US-3 will wire lazy-loaded finance routes)
- **trpc.ts** — tRPC React client configured with httpBatchLink proxied to `/trpc`
- **themeStore.ts** — Zustand store persisted to localStorage (light/dark toggle)
- **uiStore.ts** — Zustand store for sidebar state
- **themeStore.test.ts** — 6 unit tests covering toggle, set, and state operations

## Test plan
- [x] `tsc --noEmit` passes for pops-shell, finance-api, and pops-pwa
- [x] `vitest run` passes (6/6 tests)
- [ ] Verify `pnpm dev` starts the shell dev server on port 5568

🤖 Generated with [Claude Code](https://claude.com/claude-code)