### PR TITLE
feat: responsive shared UI components [E05-US2]

### DIFF
--- a/packages/ui/src/components/Autocomplete.tsx
+++ b/packages/ui/src/components/Autocomplete.tsx
@@ -12,11 +12,7 @@ import {
   CommandItem,
   CommandList,
 } from "../primitives/command";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "../primitives/popover";
+import { Popover, PopoverContent, PopoverTrigger } from "../primitives/popover";
 
 export interface AutocompleteSuggestion {
   label: string;

--- a/packages/ui/src/components/Chip.tsx
+++ b/packages/ui/src/components/Chip.tsx
@@ -102,7 +102,7 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(
               e.stopPropagation();
               onRemove?.();
             }}
-            className="inline-flex shrink-0 rounded-sm opacity-70 hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring transition-opacity"
+            className="inline-flex shrink-0 items-center justify-center rounded-sm opacity-70 hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring transition-opacity p-1"
             aria-label={removeLabel}
           >
             <XIcon />

--- a/packages/ui/src/components/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect.tsx
@@ -15,11 +15,7 @@ import {
   CommandItem,
   CommandList,
 } from "../primitives/command";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "../primitives/popover";
+import { Popover, PopoverContent, PopoverTrigger } from "../primitives/popover";
 
 export interface ComboboxOption {
   label: string;

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -210,7 +210,7 @@ export function DataTable<TData, TValue>({
 
       {/* Toolbar */}
       {(searchable || columnVisibility) && (
-        <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           {searchable && searchColumn && (
             <TextInput
               placeholder={searchPlaceholder}
@@ -222,7 +222,7 @@ export function DataTable<TData, TValue>({
               onChange={(e) =>
                 table.getColumn(searchColumn)?.setFilterValue(e.target.value)
               }
-              className="max-w-sm"
+              className="w-full sm:max-w-sm"
               clearable
               onClear={() => table.getColumn(searchColumn)?.setFilterValue("")}
             />
@@ -322,8 +322,8 @@ export function DataTable<TData, TValue>({
 
       {/* Pagination */}
       {paginated && (
-        <div className="flex items-center justify-between">
-          <div className="flex-1 text-sm text-muted-foreground">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-sm text-muted-foreground">
             {enableRowSelection && (
               <>
                 {table.getFilteredSelectedRowModel().rows.length} of{" "}
@@ -331,9 +331,11 @@ export function DataTable<TData, TValue>({
               </>
             )}
           </div>
-          <div className="flex items-center gap-6">
+          <div className="flex flex-wrap items-center gap-4 sm:gap-6">
             <div className="flex items-center gap-2">
-              <p className="text-sm font-medium">Rows per page</p>
+              <p className="hidden text-sm font-medium sm:block">
+                Rows per page
+              </p>
               <select
                 value={table.getState().pagination.pageSize}
                 onChange={(e) => {

--- a/packages/ui/src/components/DataTableFilters.tsx
+++ b/packages/ui/src/components/DataTableFilters.tsx
@@ -31,7 +31,7 @@ export function TextFilter({ column, placeholder }: TextFilterProps) {
       onChange={(e) => column.setFilterValue(e.target.value)}
       clearable
       onClear={() => column.setFilterValue("")}
-      className="max-w-sm"
+      className="w-full sm:max-w-sm"
     />
   );
 }
@@ -95,7 +95,7 @@ export function DateRangeFilter({ column }: DateRangeFilterProps) {
   const filterValue = (column.getFilterValue() as [string, string]) ?? ["", ""];
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
       <TextInput
         type="date"
         value={filterValue[0]}
@@ -103,9 +103,9 @@ export function DateRangeFilter({ column }: DateRangeFilterProps) {
           column.setFilterValue([e.target.value, filterValue[1]])
         }
         placeholder="From"
-        className="w-38"
+        className="w-full sm:w-38"
       />
-      <span className="text-muted-foreground">to</span>
+      <span className="hidden text-muted-foreground sm:block">to</span>
       <TextInput
         type="date"
         value={filterValue[1]}
@@ -113,7 +113,7 @@ export function DateRangeFilter({ column }: DateRangeFilterProps) {
           column.setFilterValue([filterValue[0], e.target.value])
         }
         placeholder="To"
-        className="w-38"
+        className="w-full sm:w-38"
       />
     </div>
   );
@@ -136,19 +136,19 @@ export function NumberRangeFilter({
   ];
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
       <NumberInput
         value={filterValue[0]}
         onChange={(value) => column.setFilterValue([value, filterValue[1]])}
         placeholder={minPlaceholder}
-        className="w-25"
+        className="w-full sm:w-25"
       />
-      <span className="text-muted-foreground">to</span>
+      <span className="hidden text-muted-foreground sm:block">to</span>
       <NumberInput
         value={filterValue[1]}
         onChange={(value) => column.setFilterValue([filterValue[0], value])}
         placeholder={maxPlaceholder}
-        className="w-25"
+        className="w-full sm:w-25"
       />
     </div>
   );

--- a/packages/ui/src/components/RadioInput.tsx
+++ b/packages/ui/src/components/RadioInput.tsx
@@ -128,7 +128,9 @@ export const RadioInput = forwardRef<HTMLDivElement, RadioInputProps>(
           required={required}
           aria-invalid={error}
           className={cn(
-            orientation === "horizontal" ? "flex flex-row gap-4" : "grid gap-3"
+            orientation === "horizontal"
+              ? "grid gap-3 sm:flex sm:flex-row sm:gap-4"
+              : "grid gap-3"
           )}
           {...props}
         >

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -32,10 +32,7 @@ export * from "./primitives/tooltip";
 
 // Primitives with naming conflicts — aliased to avoid collision with composites
 // Import directly from "@pops/ui/primitives/button" etc. if primitive versions are needed
-export {
-  Button as ButtonPrimitive,
-  buttonVariants,
-} from "./primitives/button";
+export { Button as ButtonPrimitive, buttonVariants } from "./primitives/button";
 export {
   Select as SelectPrimitive,
   SelectContent,

--- a/packages/ui/src/primitives/Accordion.stories.tsx
+++ b/packages/ui/src/primitives/Accordion.stories.tsx
@@ -164,8 +164,8 @@ export const FAQ: Story = {
         <AccordionItem value="q4">
           <AccordionTrigger>Can I export my data?</AccordionTrigger>
           <AccordionContent>
-            Yes, SQLite is the source of truth, so you can export your data
-            at any time in CSV or other formats via the API.
+            Yes, SQLite is the source of truth, so you can export your data at
+            any time in CSV or other formats via the API.
           </AccordionContent>
         </AccordionItem>
 

--- a/packages/ui/src/primitives/command.tsx
+++ b/packages/ui/src/primitives/command.tsx
@@ -147,7 +147,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-2.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 min-h-11",
         className
       )}
       {...props}

--- a/packages/ui/src/primitives/dialog.tsx
+++ b/packages/ui/src/primitives/dialog.tsx
@@ -59,7 +59,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed z-50 grid w-full gap-4 border p-6 shadow-lg duration-200 outline-none inset-0 rounded-none md:inset-auto md:top-1/2 md:left-1/2 md:max-w-lg md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-lg md:data-[state=closed]:zoom-out-95 md:data-[state=open]:zoom-in-95",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
- **DataTable**: toolbar stacks vertically on mobile, pagination hides "Rows per page" label, search input goes full-width
- **Dialog**: full-screen below 768px (md breakpoint), centered modal on desktop with zoom animation
- **RadioInput**: horizontal orientation falls back to vertical grid on mobile
- **Chip**: touch-friendly remove button with added padding
- **CommandItem**: min-height 44px for touch-friendly dropdown options (affects Autocomplete, ComboboxSelect)
- **DataTableFilters**: range filters (date/number) stack vertically on mobile with full-width inputs, "to" label hidden on mobile
- All changes use Tailwind responsive classes (sm:/md:) — no JS media queries

## Test plan
- [ ] Verify DataTable toolbar stacks at <640px, search input stretches full width
- [ ] Verify DataTable pagination hides "Rows per page" text on mobile, buttons remain usable
- [ ] Verify Dialog renders full-screen below 768px, centered modal above
- [ ] Verify RadioInput with `orientation="horizontal"` stacks vertically on mobile
- [ ] Verify Chip remove button has adequate touch target padding
- [ ] Verify Autocomplete/ComboboxSelect dropdown items have 44px min height
- [ ] Verify DataTableFilters range inputs stack vertically below 640px
- [ ] Verify no horizontal overflow at 375px viewport
- [ ] `pnpm typecheck` passes (UI, shell, PWA all verified)
- [ ] `pnpm lint` passes
- [ ] `pnpm format:check` passes
- [ ] `pnpm build` passes (shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)