### PR TITLE
feat: app switcher registry and nav config types [PRD-003/US-1]

### DIFF
--- a/apps/pops-shell/src/app/layout/Sidebar.tsx
+++ b/apps/pops-shell/src/app/layout/Sidebar.tsx
@@ -8,8 +8,7 @@
  * - Mobile (<768px): Overlay sidebar with backdrop, closes on link click
  */
 import { Link, useLocation } from "react-router";
-import { navConfig } from "@pops/app-finance";
-import type { NavConfig } from "@pops/app-finance";
+import { registeredApps } from "@/app/nav/registry";
 import { useUIStore } from "@/store/uiStore";
 import {
   LayoutDashboard,
@@ -39,9 +38,6 @@ const iconMap: Record<string, LucideIcon> = {
   Download,
   Bot,
 };
-
-/** All registered app nav configs — add new apps here. */
-const registeredApps: NavConfig[] = [navConfig];
 
 export function Sidebar({ open }: SidebarProps) {
   const location = useLocation();

--- a/apps/pops-shell/src/app/nav/registry.ts
+++ b/apps/pops-shell/src/app/nav/registry.ts
@@ -1,0 +1,16 @@
+/**
+ * App registry — single source of truth for navigation.
+ *
+ * To add a new app:
+ * 1. Create a package in packages/app-<name>/
+ * 2. Export a navConfig: AppNavConfig from its index.ts
+ * 3. Import it here and add to the registeredApps array
+ * 4. Add its routes to the shell router (app/router.tsx)
+ */
+import { navConfig as financeNavConfig } from "@pops/app-finance";
+import type { AppNavConfig } from "./types";
+
+/** All registered app nav configs. Order determines display order in the app rail. */
+export const registeredApps: AppNavConfig[] = [financeNavConfig];
+
+export type { AppNavConfig, AppNavItem } from "./types";

--- a/apps/pops-shell/src/app/nav/types.ts
+++ b/apps/pops-shell/src/app/nav/types.ts
@@ -1,0 +1,28 @@
+/**
+ * App navigation types for the POPS shell.
+ *
+ * Each app package exports a navConfig conforming to AppNavConfig.
+ * The shell maintains a registry of all configs — single source of truth
+ * for navigation rendering.
+ */
+
+export interface AppNavItem {
+  /** Relative to basePath. Empty string '' for the index/default page. */
+  path: string;
+  label: string;
+  /** Lucide icon component name (e.g. 'LayoutDashboard', 'CreditCard'). */
+  icon: string;
+}
+
+export interface AppNavConfig {
+  /** Unique app identifier (e.g. 'finance', 'media', 'inventory'). */
+  id: string;
+  /** Display name shown in the app rail tooltip and page nav header. */
+  label: string;
+  /** Lucide icon component name for the app rail (e.g. 'DollarSign'). */
+  icon: string;
+  /** Root path for this app (e.g. '/finance'). */
+  basePath: string;
+  /** Pages within this app. */
+  items: AppNavItem[];
+}

--- a/packages/app-finance/src/index.ts
+++ b/packages/app-finance/src/index.ts
@@ -5,4 +5,3 @@
  * to lazily load finance pages under /finance/*.
  */
 export { routes, navConfig } from "./routes";
-export type { NavConfig, NavItem } from "./routes";

--- a/packages/app-finance/src/routes.tsx
+++ b/packages/app-finance/src/routes.tsx
@@ -34,21 +34,7 @@ const AiUsagePage = lazy(() =>
   import("./pages/AiUsagePage").then((m) => ({ default: m.AiUsagePage }))
 );
 
-export interface NavItem {
-  path: string;
-  label: string;
-  icon: string;
-}
-
-export interface NavConfig {
-  id: string;
-  label: string;
-  icon: string;
-  basePath: string;
-  items: NavItem[];
-}
-
-export const navConfig: NavConfig = {
+export const navConfig = {
   id: "finance",
   label: "Finance",
   icon: "DollarSign",


### PR DESCRIPTION
## Summary
- Created `AppNavConfig` and `AppNavItem` type interfaces in `apps/pops-shell/src/app/nav/types.ts`
- Created app registry (`apps/pops-shell/src/app/nav/registry.ts`) as single source of truth for navigation
- Updated `Sidebar.tsx` to consume navigation from the registry instead of direct app-finance imports
- Removed old `NavConfig`/`NavItem` types from `@pops/app-finance` — uses structural typing to avoid circular deps

## Test plan
- [x] Shell typecheck passes (only pre-existing errors)
- [x] All 6 shell tests pass
- [x] Sidebar renders nav items from registry
- [x] No circular dependency between shell and app-finance

Closes tb-029

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>