### PR TITLE
feat: PageNav component + navConfig type safety [PRD-003/US-3]

### DIFF
--- a/apps/pops-shell/src/app/layout/PageNav.test.ts
+++ b/apps/pops-shell/src/app/layout/PageNav.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for PageNav helper functions
+ */
+import { describe, it, expect } from "vitest";
+import { findActiveApp, isPageActive } from "./PageNav";
+import type { AppNavConfig } from "@/app/nav/types";
+
+const mockApps: AppNavConfig[] = [
+  {
+    id: "finance",
+    label: "Finance",
+    icon: "DollarSign",
+    basePath: "/finance",
+    items: [
+      { path: "", label: "Dashboard", icon: "LayoutDashboard" },
+      { path: "/transactions", label: "Transactions", icon: "CreditCard" },
+    ],
+  },
+  {
+    id: "media",
+    label: "Media",
+    icon: "Film",
+    basePath: "/media",
+    items: [
+      { path: "", label: "Library", icon: "Film" },
+      { path: "/watchlist", label: "Watchlist", icon: "Star" },
+    ],
+  },
+];
+
+describe("findActiveApp", () => {
+  it("returns the app matching the pathname", () => {
+    expect(findActiveApp("/finance/transactions", mockApps)?.id).toBe(
+      "finance",
+    );
+    expect(findActiveApp("/media/watchlist", mockApps)?.id).toBe("media");
+  });
+
+  it("matches app root path", () => {
+    expect(findActiveApp("/finance", mockApps)?.id).toBe("finance");
+    expect(findActiveApp("/finance/", mockApps)?.id).toBe("finance");
+  });
+
+  it("returns undefined for unknown paths", () => {
+    expect(findActiveApp("/settings", mockApps)).toBeUndefined();
+    expect(findActiveApp("/", mockApps)).toBeUndefined();
+  });
+});
+
+describe("isPageActive", () => {
+  it("matches index page on exact basePath", () => {
+    expect(isPageActive("/finance", "/finance", "")).toBe(true);
+    expect(isPageActive("/finance/", "/finance", "")).toBe(true);
+  });
+
+  it("does not match index page on sub-path", () => {
+    expect(isPageActive("/finance/transactions", "/finance", "")).toBe(false);
+  });
+
+  it("matches sub-page by prefix", () => {
+    expect(
+      isPageActive("/finance/transactions", "/finance", "/transactions"),
+    ).toBe(true);
+  });
+
+  it("matches sub-page with deeper path", () => {
+    expect(
+      isPageActive("/finance/transactions/123", "/finance", "/transactions"),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated page", () => {
+    expect(isPageActive("/finance/budgets", "/finance", "/transactions")).toBe(
+      false,
+    );
+  });
+});

--- a/apps/pops-shell/src/app/layout/PageNav.tsx
+++ b/apps/pops-shell/src/app/layout/PageNav.tsx
@@ -1,0 +1,100 @@
+/**
+ * Page navigation panel
+ *
+ * Renders page links for the currently active app, determined by URL.
+ * Designed to sit alongside the AppRail (tb-030) in the two-level
+ * navigation layout defined by PRD-003.
+ */
+import { Link, useLocation } from "react-router";
+import { registeredApps } from "@/app/nav/registry";
+import type { AppNavConfig } from "@/app/nav/types";
+import {
+  LayoutDashboard,
+  CreditCard,
+  Building2,
+  PiggyBank,
+  Package,
+  Star,
+  Download,
+  Bot,
+  type LucideIcon,
+} from "lucide-react";
+
+/** Map icon name strings from navConfig to Lucide components. */
+const iconMap: Record<string, LucideIcon> = {
+  LayoutDashboard,
+  CreditCard,
+  Building2,
+  PiggyBank,
+  Package,
+  Star,
+  Download,
+  Bot,
+};
+
+/** Find the active app by matching the current pathname against registered base paths. */
+export function findActiveApp(
+  pathname: string,
+  apps: AppNavConfig[],
+): AppNavConfig | undefined {
+  return apps.find((app) => pathname.startsWith(app.basePath));
+}
+
+/** Check if a page item is active given the current pathname and its app's basePath. */
+export function isPageActive(
+  pathname: string,
+  basePath: string,
+  itemPath: string,
+): boolean {
+  if (itemPath === "") {
+    return pathname === basePath || pathname === `${basePath}/`;
+  }
+  return pathname.startsWith(`${basePath}${itemPath}`);
+}
+
+export function PageNav() {
+  const location = useLocation();
+  const activeApp = findActiveApp(location.pathname, registeredApps);
+
+  if (!activeApp) return null;
+
+  return (
+    <nav
+      className="w-[200px] bg-card border-r border-border h-full overflow-y-auto transition-all duration-200"
+      aria-label={`${activeApp.label} pages`}
+    >
+      <div className="px-4 py-3 border-b border-border">
+        <span className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          {activeApp.label}
+        </span>
+      </div>
+
+      <div className="p-2 space-y-0.5">
+        {activeApp.items.map((item) => {
+          const fullPath = `${activeApp.basePath}${item.path}`;
+          const active = isPageActive(
+            location.pathname,
+            activeApp.basePath,
+            item.path,
+          );
+          const Icon = iconMap[item.icon];
+
+          return (
+            <Link
+              key={fullPath}
+              to={fullPath}
+              className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors ${
+                active
+                  ? "bg-primary text-primary-foreground"
+                  : "text-foreground hover:bg-muted"
+              }`}
+            >
+              {Icon && <Icon className="h-4 w-4 shrink-0" />}
+              <span>{item.label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/packages/app-finance/src/routes.tsx
+++ b/packages/app-finance/src/routes.tsx
@@ -34,6 +34,15 @@ const AiUsagePage = lazy(() =>
   import("./pages/AiUsagePage").then((m) => ({ default: m.AiUsagePage }))
 );
 
+/** Local type mirror for compile-time safety (shell owns the canonical types). */
+interface AppNavConfigShape {
+  id: string;
+  label: string;
+  icon: string;
+  basePath: string;
+  items: { path: string; label: string; icon: string }[];
+}
+
 export const navConfig = {
   id: "finance",
   label: "Finance",
@@ -49,7 +58,7 @@ export const navConfig = {
     { path: "/import", label: "Import", icon: "Download" },
     { path: "/ai-usage", label: "AI Usage", icon: "Bot" },
   ],
-};
+} satisfies AppNavConfigShape;
 
 export const routes: RouteObject[] = [
   { index: true, element: <DashboardPage /> },


### PR DESCRIPTION
## Summary
- Created `PageNav` component (`apps/pops-shell/src/app/layout/PageNav.tsx`) that renders page links for the active app based on URL matching
- Active page highlighting, Lucide icons, smooth CSS transitions
- Exported pure helper functions (`findActiveApp`, `isPageActive`) for testability
- Added `satisfies AppNavConfigShape` to app-finance `navConfig` (addresses QA feedback from PR #81 — compile-time type safety without circular deps)
- 8 unit tests covering active app detection and page active state logic

## Test plan
- [x] 14 shell tests pass (6 existing + 8 new)
- [x] Typecheck clean (only pre-existing errors in pops-api entities)
- [x] app-finance typecheck clean with `satisfies`
- [x] Component designed to sit alongside AppRail (tb-030) for integration in tb-032

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>