### PR TITLE
feat: add item_connections + item_photos Drizzle schemas [Inventory-E00]

### DIFF
--- a/packages/db-types/src/index.ts
+++ b/packages/db-types/src/index.ts
@@ -14,6 +14,8 @@ import type { wishList } from "./schema/wishlist.js";
 import type { transactionCorrections } from "./schema/corrections.js";
 import type { aiUsage } from "./schema/ai-usage.js";
 import type { environments } from "./schema/environments.js";
+import type { itemConnections } from "./schema/item-connections.js";
+import type { itemPhotos } from "./schema/item-photos.js";
 
 // Re-export Drizzle table objects for use in queries
 export {
@@ -25,6 +27,8 @@ export {
   transactionCorrections,
   aiUsage,
   environments,
+  itemConnections,
+  itemPhotos,
 } from "./schema/index.js";
 
 // Select types (what you get back from a SELECT query)
@@ -36,6 +40,8 @@ export type WishListRow = InferSelectModel<typeof wishList>;
 export type TransactionCorrectionRow = InferSelectModel<typeof transactionCorrections>;
 export type AiUsageRow = InferSelectModel<typeof aiUsage>;
 export type EnvironmentRow = InferSelectModel<typeof environments>;
+export type ItemConnectionRow = InferSelectModel<typeof itemConnections>;
+export type ItemPhotoRow = InferSelectModel<typeof itemPhotos>;
 
 // Insert types (what you pass to an INSERT statement)
 export type TransactionInsert = InferInsertModel<typeof transactions>;
@@ -46,6 +52,8 @@ export type WishListInsert = InferInsertModel<typeof wishList>;
 export type TransactionCorrectionInsert = InferInsertModel<typeof transactionCorrections>;
 export type AiUsageInsert = InferInsertModel<typeof aiUsage>;
 export type EnvironmentInsert = InferInsertModel<typeof environments>;
+export type ItemConnectionInsert = InferInsertModel<typeof itemConnections>;
+export type ItemPhotoInsert = InferInsertModel<typeof itemPhotos>;
 
 // Constants
 export const ENTITY_TYPES = [

--- a/packages/db-types/src/schema/index.ts
+++ b/packages/db-types/src/schema/index.ts
@@ -6,3 +6,5 @@ export { wishList } from "./wishlist.js";
 export { transactionCorrections } from "./corrections.js";
 export { aiUsage } from "./ai-usage.js";
 export { environments } from "./environments.js";
+export { itemConnections } from "./item-connections.js";
+export { itemPhotos } from "./item-photos.js";

--- a/packages/db-types/src/schema/item-connections.ts
+++ b/packages/db-types/src/schema/item-connections.ts
@@ -1,0 +1,32 @@
+import { sqliteTable, text, integer, index, unique } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { homeInventory } from "./inventory.js";
+
+/**
+ * Bidirectional item connections — junction table for physical links between
+ * inventory items (e.g. HDMI cable → TV, power board → router).
+ *
+ * Application layer enforces itemAId < itemBId ordering to prevent duplicate
+ * rows for the same connection. The unique constraint is the safety net.
+ * When querying connections for an item, check both columns.
+ */
+export const itemConnections = sqliteTable(
+  "item_connections",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    itemAId: text("item_a_id")
+      .notNull()
+      .references(() => homeInventory.id, { onDelete: "cascade" }),
+    itemBId: text("item_b_id")
+      .notNull()
+      .references(() => homeInventory.id, { onDelete: "cascade" }),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    unique("uq_item_connections_pair").on(table.itemAId, table.itemBId),
+    index("idx_item_connections_a").on(table.itemAId),
+    index("idx_item_connections_b").on(table.itemBId),
+  ]
+);

--- a/packages/db-types/src/schema/item-photos.ts
+++ b/packages/db-types/src/schema/item-photos.ts
@@ -1,0 +1,27 @@
+import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { homeInventory } from "./inventory.js";
+
+/**
+ * Photo references for inventory items.
+ *
+ * filePath is relative to the inventory images directory
+ * (e.g. items/{item_id}/photo_001.jpg). sortOrder controls display
+ * ordering — the first photo (sortOrder=0) is the primary/thumbnail.
+ */
+export const itemPhotos = sqliteTable(
+  "item_photos",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    itemId: text("item_id")
+      .notNull()
+      .references(() => homeInventory.id, { onDelete: "cascade" }),
+    filePath: text("file_path").notNull(),
+    caption: text("caption"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [index("idx_item_photos_item").on(table.itemId)]
+);


### PR DESCRIPTION
## Summary
- Create `item_connections` Drizzle schema — bidirectional junction table for physical links between inventory items (A<B dedup constraint, cascade delete, indexed)
- Create `item_photos` Drizzle schema — photo references per item with file path, caption, sort order (cascade delete, indexed)
- Export both table objects and Row/Insert types from `@pops/db-types`

## Changes
- **packages/db-types/src/schema/item-connections.ts**: New schema with integer PK, TEXT FKs to `home_inventory`, unique pair constraint, indexes
- **packages/db-types/src/schema/item-photos.ts**: New schema with integer PK, TEXT FK to `home_inventory`, file path, caption, sort order
- **packages/db-types/src/schema/index.ts**: Added barrel exports
- **packages/db-types/src/index.ts**: Added `ItemConnectionRow`, `ItemPhotoRow`, `ItemConnectionInsert`, `ItemPhotoInsert` types

## Notes
- FKs reference existing `home_inventory` table (TEXT UUID PKs) — tb-049 will handle the table rename/upgrade to integer PKs
- Schema files only — no migration generated yet (will be done when all inventory schema tasks land)

## Test plan
- [x] `pnpm --filter @pops/db-types typecheck` — clean
- [x] `pnpm --filter @pops/db-types build` — clean
- [x] `pnpm --filter @pops/api typecheck` — clean
- [x] `pnpm --filter @pops/api test` — 498 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)