### PR TITLE
docs: split PRD user stories into agent-sized tasks

### DIFF
--- a/docs/specs/prd-007-media-data-model-api.md
+++ b/docs/specs/prd-007-media-data-model-api.md
@@ -608,97 +608,89 @@ A: Drizzle doesn't support cross-column CHECK constraints declaratively (e.g., `
 
 > **Standard verification — applies to every US below:**
 > Each story is only done when `pnpm typecheck`, `pnpm lint`, `pnpm test`, and `pnpm build` all pass. No story is merged with broken checks.
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes. Stories within the same batch are parallelisable. Dependencies are between batches only.
 
-### US-1: Create Drizzle schema files and generate migrations
-**As a** developer, **I want** all media tables defined as Drizzle schema files **so that** types and DDL come from a single source of truth and migrations are auto-generated.
+### Batch A — Drizzle Schema Files (parallelisable)
 
-**Acceptance criteria:**
-- Five schema files exist in `src/db/schema/` (movies, tv-shows, watchlist, watch-history, comparisons)
-- `drizzle-kit generate` produces migration SQL for all media tables
-- Generated migrations run successfully on fresh and existing databases
-- Comparison dimensions seeded (via seed script, not migration — Drizzle migrations are structural only)
-- All schema files re-exported from `schema/index.ts`
+#### US-1a: Movies schema file
+**Scope:** Create `src/db/schema/movies.ts` with the `movies` table definition per R2. Include indexes.
+**Acceptance criteria:** Schema file exists, exports `movies` table, `pnpm typecheck` passes.
 
-### US-2: Export media types from @pops/db-types
-**As a** developer, **I want** Drizzle-inferred types re-exported from `@pops/db-types` **so that** the frontend and other packages have type-safe access to media data.
+#### US-1b: TV shows, seasons, episodes schema file
+**Scope:** Create `src/db/schema/tv-shows.ts` with `tvShows`, `seasons`, `episodes` tables per R3. Include FK cascades, unique constraints, indexes.
+**Acceptance criteria:** Schema file exists, exports all three tables, FK references resolve, `pnpm typecheck` passes.
 
-**Acceptance criteria:**
-- `InferSelectModel` and `InferInsertModel` types exported for all 9 media tables
-- Exported from `@pops/db-types` barrel
-- `pnpm typecheck` passes across all packages
+#### US-1c: Watchlist schema file
+**Scope:** Create `src/db/schema/watchlist.ts` with the `watchlist` table per R4. Include unique constraint and indexes.
+**Acceptance criteria:** Schema file exists, exports `watchlist` table, `pnpm typecheck` passes.
 
-### US-3: Create movies sub-module
-**As a** developer, **I want** CRUD tRPC procedures for movies **so that** the metadata integration and UI can read/write movie records.
+#### US-1d: Watch history schema file
+**Scope:** Create `src/db/schema/watch-history.ts` with the `watchHistory` table per R5. Include indexes.
+**Acceptance criteria:** Schema file exists, exports `watchHistory` table, `pnpm typecheck` passes.
 
-**Acceptance criteria:**
-- `media/movies/` module exists with router, service, types
-- All 6 procedures from R9 implemented with zod validation
-- Service uses Drizzle query builder (no raw SQL strings)
-- Unit tests for: create, read by id, read by tmdb_id, list with filters, update, delete
-- Delete cleans up associated watch_history and media_scores rows
+#### US-1e: Comparison tables schema file
+**Scope:** Create `src/db/schema/comparisons.ts` with `comparisonDimensions`, `comparisons`, `mediaScores` tables per R6. Include FK references to movies, indexes, unique constraints.
+**Acceptance criteria:** Schema file exists, exports all three tables, FK references resolve, `pnpm typecheck` passes.
 
-### US-4: Create TV shows sub-module
-**As a** developer, **I want** CRUD tRPC procedures for TV shows, seasons, and episodes **so that** the metadata integration can populate the TV hierarchy.
+### Batch B — Schema Integration (depends on Batch A)
 
-**Acceptance criteria:**
-- `media/tv-shows/` module exists with router, service, types
-- All 8 procedures from R9 implemented
-- `createWithSeasons` inserts show + seasons + episodes in a single transaction
-- `getSeason` returns season with embedded episode list
-- `delete` cascades to seasons and episodes (verified by test)
-- Unit tests for all procedures
+#### US-1f: Schema barrel export and migration generation
+**Scope:** Re-export all media schemas from `src/db/schema/index.ts`. Run `drizzle-kit generate` to produce migration SQL. Verify migrations run on fresh and existing databases.
+**Acceptance criteria:** `schema/index.ts` exports all media tables. Migration SQL generated. Migrations succeed on fresh DB and existing DB with finance data. No conflicts.
 
-### US-5: Create watchlist sub-module
-**As a** developer, **I want** CRUD tRPC procedures for the watchlist **so that** users can queue media to watch later.
+#### US-2: Export media types from @pops/db-types
+**Scope:** Create `packages/db-types/src/media.ts` with `InferSelectModel` and `InferInsertModel` types for all 9 media tables. Re-export from barrel.
+**Acceptance criteria:** Types exported for all tables. `pnpm typecheck` passes across all packages.
 
-**Acceptance criteria:**
-- `media/watchlist/` module exists with router, service, types
-- All 5 procedures from R9 implemented
-- Adding a non-existent media item returns a validation error
-- Adding a duplicate returns a meaningful error (not a raw UNIQUE constraint violation)
-- Unit tests for all procedures including duplicate and invalid media_id cases
+### Batch C — tRPC Routers (parallelisable, depends on Batch B)
 
-### US-6: Create watch history sub-module
-**As a** developer, **I want** tRPC procedures for recording and querying watch events **so that** the tracking and comparison systems have data to work with.
+#### US-3: Movies router
+**Scope:** Create `modules/media/movies/` with router, service, types. Implement all 6 procedures from R9 (getById, getByTmdbId, list, create, update, delete). Drizzle queries, zod validation, unit tests.
+**Acceptance criteria:** All 6 procedures work. Delete cleans up watch_history and media_scores. Unit tests for each procedure.
 
-**Acceptance criteria:**
-- `media/watch-history/` module exists with router, service, types
-- All 6 procedures from R9 implemented
-- `batchLog` inserts all entries in a single transaction
-- `getProgress` correctly counts watched episodes vs total for a TV show
-- `getProgress` identifies the next unwatched episode in sequence
-- Unit tests for all procedures including batch operations and progress calculation
+#### US-4a: TV shows router — basic CRUD
+**Scope:** Create `modules/media/tv-shows/` with router, service, types. Implement: getById, getByTvdbId, list, create, update, delete. Unit tests.
+**Acceptance criteria:** All 6 basic procedures work. Delete cascades verified by test.
 
-### US-7: Create comparisons sub-module with ELO
-**As a** developer, **I want** tRPC procedures for the comparison system and ELO scoring **so that** the ratings and recommendations engines have a foundation.
+#### US-4b: TV shows — createWithSeasons and getSeason
+**Scope:** Add `createWithSeasons` (transactional insert of show + seasons + episodes) and `getSeason` (season with embedded episode list) to the TV shows module. Unit tests.
+**Acceptance criteria:** `createWithSeasons` inserts all rows in one transaction. `getSeason` returns season with episodes. Tests verify transaction rollback on failure.
 
-**Acceptance criteria:**
-- `media/comparisons/` module exists with router, service, types, elo.ts
-- ELO calculation is a pure function with unit tests covering: equal ratings, unequal ratings, K-factor application, symmetric score changes
-- `getRandomPair` only returns watched movies (verified by test)
-- `getRandomPair` doesn't return the same pair consecutively (best-effort)
-- `submit` validates both movies are watched, dimension is active, winner is one of the pair
-- `submit` updates ELO scores atomically in a transaction
-- Dimension CRUD works (create, update, deactivate)
-- Rankings query returns movies sorted by score for a dimension
-- Unit tests for all procedures
+#### US-5: Watchlist router
+**Scope:** Create `modules/media/watchlist/` with router, service, types. Implement all 5 procedures (list, add, remove, updatePriority, updateNotes). Unit tests.
+**Acceptance criteria:** All procedures work. Duplicate add returns meaningful error. Non-existent media returns validation error.
 
-### US-8: Seed media test data
-**As a** developer, **I want** `mise db:seed` to include media test data **so that** E2E tests have a realistic dataset.
+#### US-6a: Watch history router — basic CRUD
+**Scope:** Create `modules/media/watch-history/` with router, service, types. Implement: log, remove, listByMedia, listRecent. Unit tests.
+**Acceptance criteria:** All 4 procedures work. Multiple watch events per item allowed.
 
-**Acceptance criteria:**
-- 10 movies seeded with realistic metadata (titles, genres, years, vote averages)
-- 3 TV shows seeded with full season/episode hierarchy
-- 5 comparison dimensions seeded
-- Seed data uses recognisable TMDB/TheTVDB IDs
-- Existing finance seed data is not affected
-- `mise db:seed` followed by `mise db:seed` is idempotent (no duplicate errors)
+#### US-6b: Watch history — batch log and progress
+**Scope:** Add `batchLog` (batch insert in transaction) and `getProgress` (watched/total count + next episode) to watch history module. Unit tests.
+**Acceptance criteria:** `batchLog` is atomic. `getProgress` counts correctly. Next episode identified in sequence. Tests cover edge cases (no episodes watched, all watched, mid-season).
 
-### US-9: Register media router
-**As a** developer, **I want** the media tRPC router composed into the top-level app router **so that** the frontend can call media procedures.
+#### US-7a: ELO calculation function
+**Scope:** Create `modules/media/comparisons/elo.ts` — pure function `calculateElo(scoreA, scoreB, winner, kFactor)`. Unit tests.
+**Acceptance criteria:** Standard ELO formula. Tests cover: equal ratings, unequal ratings, K-factor application, symmetric score changes, edge cases.
 
-**Acceptance criteria:**
-- Media router registered as `media` namespace in the app router
-- Frontend can call `trpc.media.movies.list.useQuery()` etc.
-- Existing finance procedures are unaffected
-- `pnpm typecheck` passes (AppRouter type includes media namespace)
+#### US-7b: Comparison dimensions CRUD
+**Scope:** Create `modules/media/comparisons/` router with dimension procedures: listDimensions, createDimension, updateDimension. Unit tests.
+**Acceptance criteria:** CRUD works. Deactivated dimensions excluded from list by default. Reorder via sortOrder.
+
+#### US-7c: Comparison submit with ELO scoring
+**Scope:** Add `submit` procedure — validates inputs, calculates ELO (using elo.ts), updates media_scores, inserts comparison row. All in one transaction. Unit tests.
+**Acceptance criteria:** Validates: both movies exist, both watched, dimension active, winner is one of the pair. Scores update atomically. Tests verify validation errors.
+
+#### US-7d: Random pair selection and rankings
+**Scope:** Add `getRandomPair` (random pair from watched movies for a dimension) and `getRankings` (leaderboard sorted by score) procedures. Unit tests.
+**Acceptance criteria:** Pair only from watched movies. No self-pairing. Avoids consecutive duplicate pairs (best-effort). Rankings sorted by score descending with pagination.
+
+### Batch D — Integration (depends on Batch C)
+
+#### US-9: Register media router
+**Scope:** Create `modules/media/index.ts` composing all sub-routers. Register as `media` namespace in top-level app router.
+**Acceptance criteria:** `trpc.media.movies.list` etc. callable. Finance procedures unaffected. `pnpm typecheck` passes.
+
+#### US-8: Seed media test data
+**Scope:** Update `mise db:seed` — insert 10 movies, 3 TV shows (with seasons/episodes), 5 comparison dimensions. Use realistic TMDB/TheTVDB IDs.
+**Acceptance criteria:** Seed data inserted. Finance seed unaffected. Idempotent (re-run doesn't duplicate).

--- a/docs/specs/prd-008-tmdb-client.md
+++ b/docs/specs/prd-008-tmdb-client.md
@@ -308,75 +308,39 @@ A: Default to `language=en-US` for all requests. The user can't change this in v
 
 > **Standard verification — applies to every US below:**
 > Each story is only done when `pnpm typecheck`, `pnpm lint`, `pnpm test`, and `pnpm build` all pass.
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes.
 
-### US-1: TMDB API client
-**As a** developer, **I want** a typed HTTP client for the TMDB v3 API **so that** other services can search and fetch movie data.
+### Batch A — Infrastructure (parallelisable)
 
-**Acceptance criteria:**
-- Client authenticates with Bearer token from `TMDB_API_KEY`
-- Client exposes: `searchMovies(query, page)`, `getMovie(tmdbId)`, `getMovieImages(tmdbId)`, `getGenreList()`
-- All responses are typed (not `any`)
-- HTTP errors throw typed errors with status code and message
-- Unit tests with mocked HTTP responses cover: success, 404, 401, 429, network error
+#### US-1: TMDB HTTP client
+**Scope:** Create `modules/media/tmdb/client.ts` and `types.ts`. Implement: `searchMovies(query, page)`, `getMovie(tmdbId)`, `getMovieImages(tmdbId)`, `getGenreList()`. Bearer token auth from `TMDB_API_KEY`. Typed responses, typed errors. Unit tests with mocked HTTP (success, 404, 401, 429, network error).
+**Files:** `client.ts`, `types.ts`, `client.test.ts`
 
-### US-2: Rate limiter
-**As a** developer, **I want** a token bucket rate limiter **so that** TMDB requests never exceed 40 per 10 seconds.
+#### US-2: Token bucket rate limiter
+**Scope:** Create `modules/media/tmdb/rate-limiter.ts`. Configurable capacity and refill rate. `acquire()` resolves immediately or waits. Unit test verifies throttling. This is a shared class — TheTVDB will reuse it with a separate instance.
+**Files:** `rate-limiter.ts`, `rate-limiter.test.ts`
 
-**Acceptance criteria:**
-- `TokenBucketRateLimiter` with configurable capacity and refill rate
-- `acquire()` resolves immediately when tokens are available
-- `acquire()` waits when tokens are exhausted
-- All TMDB client requests go through the limiter
-- Unit test verifies requests are throttled correctly
+#### US-7: Genre ID-to-name mapping cache
+**Scope:** Add genre cache logic to the TMDB client. Fetch genre list on first use, cache in memory, refresh if >24h old. Search results include genre names not just IDs.
+**Files:** `client.ts` (extend with genre cache)
 
-### US-3: Image cache service
-**As a** developer, **I want** movie images downloaded and cached locally **so that** the UI serves images without external API calls.
+### Batch B — Image system (parallelisable, depends on Batch A)
 
-**Acceptance criteria:**
-- Images download to `{MEDIA_IMAGES_DIR}/movies/{tmdb_id}/poster.jpg` etc.
-- Poster, backdrop, and logo download concurrently
-- Existing files are not re-downloaded (unless forced)
-- Missing images (null path from TMDB) are skipped without error
-- Download failures are logged but don't throw
-- `deleteMovieImages` removes the movie's image directory
-- Unit tests with mocked downloads
+#### US-3: Image cache service
+**Scope:** Create `modules/media/tmdb/image-cache.ts`. Download poster/backdrop/logo concurrently. Store in `{MEDIA_IMAGES_DIR}/movies/{tmdb_id}/`. Skip nulls, log failures without throwing. `deleteMovieImages` removes directory. Unit tests with mocked downloads.
+**Files:** `image-cache.ts`, test
 
-### US-4: Image serving endpoint
-**As a** developer, **I want** an Express route that serves cached images **so that** the frontend loads images from the local API.
+#### US-4: Image serving Express endpoint
+**Scope:** Create Express route `GET /media/images/:mediaType/:id/:filename`. Resolution chain: override → cached file → on-demand download → generated placeholder. Placeholder: genre-coloured background + title text, correct aspect ratio, cached to disk. Headers: `Content-Type`, `Cache-Control: immutable`, `ETag`.
+**Files:** `src/routes/media-images.ts` or `app.ts`
 
-**Acceptance criteria:**
-- `GET /media/images/movie/{tmdb_id}/poster.jpg` serves the cached poster
-- Override resolution: serves `override.jpg` when `poster_override_path` is set
-- Cache miss triggers on-demand download attempt
-- Generated placeholder served when no image exists (correct aspect ratio, genre-coloured, title text)
-- Response headers: correct `Content-Type`, `Cache-Control: immutable`, `ETag`
-- Placeholder is cached to disk after first generation
+### Batch C — Orchestration (depends on A + B)
 
-### US-5: Add movie to library
-**As a** developer, **I want** a single procedure that fetches TMDB metadata and creates the local record **so that** adding a movie is one action.
+#### US-5: Add movie to library flow
+**Scope:** Create `modules/media/tmdb/service.ts`. `addMovie({ tmdbId })`: check exists → fetch detail → fetch images metadata → map to MovieCreateInput (genre IDs → names) → insert via movies router → download images in background. Returns existing record if duplicate. Integration test with mocked TMDB responses.
+**Files:** `service.ts`, `service.test.ts`
 
-**Acceptance criteria:**
-- `media.library.addMovie({ tmdbId })` fetches detail, maps fields, inserts record, downloads images
-- Genres mapped from TMDB IDs to name strings
-- Returns existing record if movie already exists (idempotent)
-- Images download in background (doesn't block response)
-- Integration test: mock TMDB responses → verify DB record + image files created
-
-### US-6: Metadata refresh
-**As a** developer, **I want** to re-fetch TMDB metadata for an existing movie **so that** the local record stays up-to-date.
-
-**Acceptance criteria:**
-- `media.library.refreshMovie({ id, redownloadImages })` fetches fresh TMDB data
-- Updates all metadata columns
-- Preserves `poster_override_path` (does not overwrite user override)
-- `redownloadImages: true` deletes and re-downloads cached images
-- `updated_at` is set to current time
-
-### US-7: Genre mapping cache
-**As a** developer, **I want** TMDB genre IDs mapped to human-readable names **so that** search results display genre labels without extra API calls.
-
-**Acceptance criteria:**
-- Genre list fetched from TMDB and cached in memory
-- Search results include genre names (not just IDs)
-- Cache is populated on first search request (lazy) or on startup
-- Cache is refreshed if older than 24 hours
+#### US-6: Metadata refresh flow
+**Scope:** Add `refreshMovie({ id, redownloadImages })` to service. Fetch fresh TMDB data → update record (preserve `poster_override_path`) → optionally re-download images. Set `updated_at`.
+**Files:** `service.ts`

--- a/docs/specs/prd-009-thetvdb-client.md
+++ b/docs/specs/prd-009-thetvdb-client.md
@@ -339,69 +339,39 @@ A: The free tier API key is sufficient for personal use. TheTVDB's paid tiers ar
 
 > **Standard verification — applies to every US below:**
 > Each story is only done when `pnpm typecheck`, `pnpm lint`, `pnpm test`, and `pnpm build` all pass.
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes.
 
-### US-1: TheTVDB API client with auth
-**As a** developer, **I want** a typed HTTP client for the TheTVDB v4 API with token-based authentication **so that** other services can search and fetch TV show data.
+### Batch A — Infrastructure (parallelisable)
 
-**Acceptance criteria:**
-- Client authenticates via `POST /login` with API key from `THETVDB_API_KEY`
-- Token cached in memory with expiry tracking
-- Token auto-refreshes on expiry or 401 response
-- Client exposes: `searchSeries(query)`, `getSeriesExtended(tvdbId)`, `getSeriesEpisodes(tvdbId, seasonNumber)`
-- All responses are typed (not `any`)
-- HTTP errors throw typed errors with status code and message
-- Unit tests with mocked HTTP cover: success, 401 (triggers re-auth), 404, network error
+#### US-1a: TheTVDB auth module
+**Scope:** Create `modules/media/thetvdb/auth.ts`. Login via `POST /login` with API key from `THETVDB_API_KEY`. Cache JWT token with expiry tracking. Auto-refresh on expiry or 401. Unit tests (success, expired token, re-auth on 401).
+**Files:** `auth.ts`, `auth.test.ts`
 
-### US-2: Rate limiter
-**As a** developer, **I want** a rate limiter for TheTVDB requests **so that** we don't get throttled.
+#### US-1b: TheTVDB HTTP client
+**Scope:** Create `modules/media/thetvdb/client.ts`. Uses auth module for tokens. Implement: `searchSeries(query)`, `getSeriesExtended(tvdbId)`, `getSeriesEpisodes(tvdbId, seasonNumber)`. Typed responses, typed errors. Unit tests with mocked HTTP.
+**Files:** `client.ts`, `client.test.ts`
 
-**Acceptance criteria:**
-- Separate `TokenBucketRateLimiter` instance (20 tokens, 2 tokens/sec refill)
-- All TheTVDB client requests go through the limiter
-- 429 responses trigger exponential backoff (up to 3 retries)
-- Unit test verifies throttling behaviour
+#### US-6: Response mapping functions
+**Scope:** Create mapping functions in `modules/media/thetvdb/types.ts`: `mapSearchResult`, `mapShowDetail`, `mapEpisode`, `mapArtworks`. Drizzle insert builders: `toTvShowInsert`, `toSeasonInsert`, `toEpisodeInsert`. Genre/network name extraction. Unit tests with realistic TheTVDB fixtures.
+**Files:** `types.ts`, test
 
-### US-3: TV image cache
-**As a** developer, **I want** TV show images downloaded and cached locally **so that** the UI serves images without external API calls.
+#### US-2: TheTVDB rate limiter instance
+**Scope:** Instantiate a `TokenBucketRateLimiter` (from PRD-008) with TheTVDB config (20 tokens, 2/sec refill). Wire into TheTVDB client. Add 429 exponential backoff (up to 3 retries).
+**Files:** `client.ts` (instantiation + backoff logic)
 
-**Acceptance criteria:**
-- Images download to `{MEDIA_IMAGES_DIR}/tv/{tvdb_id}/poster.jpg` etc.
-- Best artwork selected from show's artwork array (highest score, English preferred)
-- Existing files not re-downloaded unless forced
-- Missing artwork gracefully skipped
-- Image serving endpoint handles `/media/images/tv/{tvdb_id}/poster.jpg`
-- Generated placeholder for shows with no artwork
+### Batch B — Image system (depends on Batch A)
 
-### US-4: Add TV show to library
-**As a** developer, **I want** a single procedure that fetches TheTVDB metadata and creates the local show with all seasons and episodes **so that** adding a show is one action.
+#### US-3: TV image cache
+**Scope:** Extend the image cache service (from PRD-008) with TV methods: `downloadTvShowImages(tvdbId, posterUrl, backdropUrl)`, `deleteTvShowImages(tvdbId)`. Best artwork selection from artworks array (highest score, English preferred). Store in `{MEDIA_IMAGES_DIR}/tv/{tvdb_id}/`. Image serving endpoint already handles `/media/images/tv/` via PRD-008 US-4.
+**Files:** `image-cache.ts` (extend)
 
-**Acceptance criteria:**
-- `media.library.addTvShow({ tvdbId })` fetches detail + episodes, inserts show + seasons + episodes
-- All inserts happen in a single Drizzle transaction
-- Genres and networks mapped to string arrays
-- Returns existing record if show already exists (idempotent)
-- Images download in background
-- Shows with no seasons/episodes are handled gracefully
-- Specials (season 0) are included
-- Integration test: mock TheTVDB responses → verify DB records created
+### Batch C — Orchestration (depends on A + B)
 
-### US-5: Metadata refresh
-**As a** developer, **I want** to re-fetch TheTVDB metadata for an existing show **so that** new episodes and updated info are captured.
+#### US-4: Add TV show to library flow
+**Scope:** Create `modules/media/thetvdb/service.ts`. `addTvShow({ tvdbId })`: check exists → fetch extended detail → for each season fetch episodes → map all to Drizzle inserts → insert show + seasons + episodes in single transaction → download images in background. Returns existing if duplicate. Handles zero seasons/episodes. Includes specials (season 0). Integration test.
+**Files:** `service.ts`, `service.test.ts`
 
-**Acceptance criteria:**
-- `media.library.refreshTvShow({ id, redownloadImages, refreshEpisodes })` fetches fresh data
-- Show metadata updated, `poster_override_path` preserved
-- New episodes inserted, existing episodes updated (air dates, names)
-- No episodes deleted (data integrity)
-- New seasons inserted if a new season has aired
-- `redownloadImages: true` re-downloads cached images
-- `updated_at` set to current time
-
-### US-6: Response mapping and type conversion
-**As a** developer, **I want** typed mapping functions between TheTVDB API responses and local schema types **so that** the service layer doesn't deal with raw API shapes.
-
-**Acceptance criteria:**
-- Mapping functions for: search results, show detail, episodes, artworks
-- Drizzle insert value builders for show, season, episode
-- Genre and network name extraction from TheTVDB objects to string arrays
-- Unit tests for each mapping function with realistic TheTVDB response fixtures
+#### US-5: TV metadata refresh flow
+**Scope:** Add `refreshTvShow({ id, redownloadImages, refreshEpisodes })` to service. Fetch fresh data → update show metadata (preserve `poster_override_path`) → insert new episodes/seasons, update existing (no deletes) → optionally re-download images.
+**Files:** `service.ts`

--- a/docs/specs/prd-010-app-package-ui.md
+++ b/docs/specs/prd-010-app-package-ui.md
@@ -312,91 +312,63 @@ A: Fire `media.search.movies` and `media.search.tvShows` in parallel via `Promis
 
 > **Standard verification — applies to every US below:**
 > Each story is only done when `pnpm typecheck`, `pnpm lint`, `pnpm test`, and `pnpm build` all pass.
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes.
 
-### US-1: Create @pops/app-media package scaffold
-**As a** developer, **I want** the `@pops/app-media` workspace package to exist with correct configuration **so that** the shell can import media routes.
+### Batch A — Scaffold (sequential, small)
 
-**Acceptance criteria:**
-- `packages/app-media/package.json` exists with correct name, exports, peer deps
-- `packages/app-media/tsconfig.json` extends workspace base
-- `packages/app-media/src/routes.tsx` exports route definitions
-- `pnpm install` resolves the workspace package
-- Shell can `lazy(() => import('@pops/app-media/routes'))` without error
+#### US-1: Package scaffold
+**Scope:** Create `packages/app-media/` with `package.json` (@pops/app-media, exports, peer deps), `tsconfig.json` (extends workspace base), `src/index.ts`, `src/routes.tsx` (empty route array export). Verify `pnpm install` resolves and shell can `lazy(() => import('@pops/app-media/routes'))`.
+**Files:** `packages/app-media/package.json`, `tsconfig.json`, `src/index.ts`, `src/routes.tsx`
 
-### US-2: Register media in app switcher
-**As a** user, **I want** to see "Media" in the app switcher **so that** I can navigate to the media app.
+#### US-2: Shell integration
+**Scope:** Register media in the shell's app switcher. Film/clapperboard icon, "Media" label, `/media` route prefix. Lazy-loaded. Active state on `/media/*` routes.
+**Files:** `apps/pops-shell/` (app switcher config, router)
 
-**Acceptance criteria:**
-- Media appears in the shell app switcher with a film/clapperboard icon
-- Clicking "Media" navigates to `/media`
-- Media routes are lazily loaded (not in the initial bundle)
-- Active state is shown when on a `/media/*` route
+### Batch B — Components (parallelisable, depends on Batch A)
 
-### US-3: Library page
-**As a** user, **I want** to browse all movies and TV shows in my library **so that** I can see what I have.
+#### US-4a: MediaCard component
+**Scope:** Create `MediaCard.tsx` + `MediaCard.stories.tsx`. Poster from local cache, title (2-line truncate), year, type badge ("Movie"/"TV") in top corner. Click navigates to detail page. Story variants: movie, TV show, long title, no poster (placeholder).
+**Files:** `packages/app-media/src/components/MediaCard.tsx`, `.stories.tsx`
 
-**Acceptance criteria:**
-- Grid of `MediaCard` components displays all library items
-- Filter by type (All / Movies / TV Shows)
-- Filter by genre (dropdown of all genres in the library)
-- Sort by title, date added, release date, rating
-- Empty state with CTA shown when library is empty
-- Responsive: 2 columns on mobile, 3-4 on tablet, 4-6 on desktop
-- Loading skeleton shown while data fetches
+#### US-4b: MediaGrid component
+**Scope:** Create `MediaGrid.tsx` + story. Responsive grid of MediaCards. Columns: 2 mobile, 3-4 tablet, 4-6 desktop. Handles empty array.
+**Files:** `packages/app-media/src/components/MediaGrid.tsx`, `.stories.tsx`
 
-### US-4: MediaCard component
-**As a** user, **I want** each item in the grid to show a poster, title, year, and type **so that** I can identify items at a glance.
+#### US-4c: MediaDetail component
+**Scope:** Create `MediaDetail.tsx` + story. Hero section layout: backdrop background with gradient, poster left, title/tagline/year/runtime right. Logo over backdrop when available. Responsive: stacked mobile, side-by-side tablet+.
+**Files:** `packages/app-media/src/components/MediaDetail.tsx`, `.stories.tsx`
 
-**Acceptance criteria:**
-- Poster image loads from local cache endpoint
-- Title truncated to 2 lines
-- Year displayed below title
-- Type badge ("Movie" / "TV") in top corner
-- Click navigates to detail page
-- Storybook story with variants: movie, TV show, long title, no poster (placeholder)
+#### US-4d: EpisodeList component
+**Scope:** Create `EpisodeList.tsx` + story. Vertical list of episode rows: number, name, air date, runtime. Expandable/collapsible overview per episode.
+**Files:** `packages/app-media/src/components/EpisodeList.tsx`, `.stories.tsx`
 
-### US-5: Movie detail page
-**As a** user, **I want** to see full details for a movie **so that** I can learn about it.
+#### US-4e: SearchResults component
+**Scope:** Create `SearchResults.tsx` + story. Result cards: poster thumbnail, title, year, overview (truncated), genre tags, rating. "Add to Library" button per result, "In Library" badge for existing items. Loading state on add.
+**Files:** `packages/app-media/src/components/SearchResults.tsx`, `.stories.tsx`
 
-**Acceptance criteria:**
-- Hero section with backdrop, poster, title, tagline, year, runtime
-- Logo rendered over backdrop when available
-- Overview, genre tags, metadata grid
-- Genre tags clickable → navigate to library with genre filter
-- Responsive: stacked on mobile, side-by-side on tablet+
-- 404 page if movie ID doesn't exist
-- Storybook story for `MediaDetail` component
+#### US-4f: GenreTags and MediaTypeBadge components
+**Scope:** Create `GenreTags.tsx` (clickable genre tag chips) and `MediaTypeBadge.tsx` ("Movie"/"TV" badge) + stories for both.
+**Files:** `packages/app-media/src/components/GenreTags.tsx`, `MediaTypeBadge.tsx`, stories
 
-### US-6: TV show detail page
-**As a** user, **I want** to see show details and a list of seasons **so that** I can navigate to specific seasons.
+### Batch C — Pages (parallelisable, depends on Batch B)
 
-**Acceptance criteria:**
-- Hero section with show metadata
-- Season list with poster thumbnails, episode counts, air dates
-- Click season → navigate to `/media/tv/{id}/season/{num}`
-- 404 if show ID doesn't exist
+#### US-3: Library page
+**Scope:** Create `LibraryPage.tsx`. Grid of MediaCards via MediaGrid. Filter bar: type toggle (All/Movies/TV), genre dropdown, sort options (title, date added, release date, rating). Empty state with CTA linking to `/media/search`. Loading skeleton. Data from `media.movies.list` + `media.tvShows.list`.
+**Files:** `packages/app-media/src/pages/LibraryPage.tsx`, `hooks/useMediaLibrary.ts`
 
-### US-7: Season detail page
-**As a** user, **I want** to see all episodes in a season **so that** I can view episode details.
+#### US-5: Movie detail page
+**Scope:** Create `MovieDetailPage.tsx`. Uses MediaDetail component. Adds: overview text, genre tags (clickable → filter library), metadata grid (status, language, budget, revenue, TMDB rating). 404 if ID not found. Data from `media.movies.getById`.
+**Files:** `packages/app-media/src/pages/MovieDetailPage.tsx`
 
-**Acceptance criteria:**
-- Breadcrumb navigation: Media → Show Name → Season N
-- Episode list with number, name, air date, runtime
-- Expandable overview per episode
-- 404 if season doesn't exist
-- Storybook story for `EpisodeList` component
+#### US-6: TV show detail page
+**Scope:** Create `TvShowDetailPage.tsx`. Uses MediaDetail component. Adds: overview, genre/network tags, metadata (seasons, episodes, runtime), season list (poster thumbnails, episode counts, air dates). Click season → `/media/tv/{id}/season/{num}`. 404 if not found.
+**Files:** `packages/app-media/src/pages/TvShowDetailPage.tsx`
 
-### US-8: Search page
-**As a** user, **I want** to search for movies and TV shows and add them to my library **so that** I can build my collection.
+#### US-7: Season detail page
+**Scope:** Create `SeasonDetailPage.tsx`. Breadcrumb: Media → Show Name → Season N. Season header (poster, name, overview). Uses EpisodeList component. 404 if not found. Data from `media.tvShows.getSeason`.
+**Files:** `packages/app-media/src/pages/SeasonDetailPage.tsx`
 
-**Acceptance criteria:**
-- Search input with 300ms debounce
-- Type toggle: Movies / TV Shows / Both
-- Results show poster, title, year, overview, genres, rating
-- "Add to Library" button per result
-- Button shows loading state during add, changes to "In Library" on success
-- Items already in library show "In Library" badge immediately
-- Error toast on add failure
-- "No results" message for empty search
-- Loading skeletons while searching
-- Storybook story for `SearchResults` component
+#### US-8: Search page
+**Scope:** Create `SearchPage.tsx`. Search input (300ms debounce). Type toggle: Movies/TV/Both. Both mode fires parallel queries. Uses SearchResults component. "Add to Library" calls `media.library.addMovie` or `addTvShow`. Error toast on failure. "No results" message. Loading skeletons.
+**Files:** `packages/app-media/src/pages/SearchPage.tsx`, `hooks/useSearch.ts`

--- a/docs/specs/prd-011-watchlist.md
+++ b/docs/specs/prd-011-watchlist.md
@@ -115,45 +115,25 @@ Display the watchlist count in the media app's navigation:
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes. All stories in this PRD are parallelisable.
 
-### US-1: Watchlist page
-**As a** user, **I want** a dedicated page showing everything I plan to watch **so that** I can decide what to watch next.
+#### US-1: Watchlist page
+**Scope:** Create `WatchlistPage.tsx`. Ordered list by priority. Each item: poster, title, year, type badge, notes. Click navigates to detail page. Empty state with CTA. Add route to `routes.tsx`. Add "Watchlist" to secondary nav with count badge.
+**Files:** `packages/app-media/src/pages/WatchlistPage.tsx`
 
-**Acceptance criteria:**
-- All watchlist items displayed in priority order
-- Each item shows poster, title, year, type, notes
-- Click navigates to detail page
-- Empty state with CTA when empty
+#### US-2: Add/remove watchlist toggle
+**Scope:** Add "Add to Watchlist" / "On Watchlist" toggle button to `MovieDetailPage`, `TvShowDetailPage`, and `MediaCard` (hover/context). Calls `media.watchlist.add` / `media.watchlist.remove`. Toast notifications on success.
+**Files:** `MovieDetailPage.tsx`, `TvShowDetailPage.tsx`, `MediaCard.tsx`
 
-### US-2: Add/remove from watchlist
-**As a** user, **I want** to add and remove items from my watchlist from anywhere in the app **so that** managing my queue is frictionless.
+#### US-3: Watchlist reorder
+**Scope:** Add drag-to-reorder (desktop) or up/down buttons (mobile) to the watchlist page. On reorder, re-index all affected items' priority values via `media.watchlist.updatePriority`. Persist after reload.
+**Files:** `WatchlistPage.tsx`
 
-**Acceptance criteria:**
-- Add button on movie/TV detail pages
-- Add button on library cards (hover/context)
-- Toggle state reflects current watchlist status
-- Toast notifications on add/remove
+#### US-4: Watchlist notes
+**Scope:** Add inline notes editing to watchlist items. Click to add/edit, muted text display below title, empty notes hidden. Calls `media.watchlist.updateNotes`.
+**Files:** `WatchlistPage.tsx`
 
-### US-3: Reorder watchlist
-**As a** user, **I want** to reorder my watchlist **so that** the most urgent items are at the top.
-
-**Acceptance criteria:**
-- Drag-to-reorder or up/down controls
-- Priority persists after page reload
-- Reorder updates priority values for all affected items
-
-### US-4: Watchlist notes
-**As a** user, **I want** to attach notes to watchlist items **so that** I remember why I added something.
-
-**Acceptance criteria:**
-- Inline add/edit for notes
-- Notes displayed below title
-- Empty notes hidden
-
-### US-5: Auto-remove on watch
-**As a** developer, **I want** watched items automatically removed from the watchlist **so that** the list stays current.
-
-**Acceptance criteria:**
-- Movie removed from watchlist when marked as watched
-- TV show removed when all episodes are watched
-- Individual episode watches do not trigger removal
+#### US-5: Auto-remove on watch
+**Scope:** In the watch history service (`modules/media/watch-history/service.ts`), add logic: when logging a movie watch event, check if the movie is on the watchlist and remove it. For TV shows, remove from watchlist only when all episodes are marked watched. Individual episode watches do not trigger removal. Unit tests.
+**Files:** `modules/media/watch-history/service.ts`, test

--- a/docs/specs/prd-012-watch-history.md
+++ b/docs/specs/prd-012-watch-history.md
@@ -132,56 +132,29 @@ Add "History" to the media app's secondary navigation, after "Watchlist."
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes. All stories are parallelisable.
 
-### US-1: Movie watch toggle
-**As a** user, **I want** to mark a movie as watched or unwatched **so that** my library reflects what I've seen.
+#### US-1: Movie watch toggle
+**Scope:** Add "Mark as Watched" / "Watched ✓" / "Watch Again" button to `MovieDetailPage`. Calls `media.watchHistory.log` / `media.watchHistory.remove`. Show watch date on detail page. Multiple watches displayed: "Watched 3 times — last on Mar 15, 2026". Add checkmark overlay to `MediaCard` for watched movies.
+**Files:** `MovieDetailPage.tsx`, `MediaCard.tsx`
 
-**Acceptance criteria:**
-- "Mark as Watched" button on movie detail page
-- Toggles to "Watched ✓" after marking
-- "Watch Again" option for re-watches
-- Checkmark overlay on MediaCard in library grid
-- Watch date shown on detail page
+#### US-2: Episode watch toggles
+**Scope:** Add checkbox/toggle per episode on `SeasonDetailPage` via `EpisodeList` component. Checked = watched, unchecked = unwatched. Each toggle calls `media.watchHistory.log` / `remove` for that episode ID.
+**Files:** `SeasonDetailPage.tsx`, `EpisodeList.tsx`
 
-### US-2: Episode watch toggles
-**As a** user, **I want** to mark individual episodes as watched **so that** I can track my progress through a show.
+#### US-3: Batch watch operations
+**Scope:** Add "Mark Season as Watched" / "Mark Season as Unwatched" buttons to `SeasonDetailPage`. Add "Mark All as Watched" to `TvShowDetailPage`. Calls `media.watchHistory.batchLog`. All operations atomic (single transaction in service layer).
+**Files:** `SeasonDetailPage.tsx`, `TvShowDetailPage.tsx`
 
-**Acceptance criteria:**
-- Toggle per episode on the season detail page
-- Checked/unchecked state persists
-- Toggle triggers individual watch event log/remove
+#### US-4: TV show progress indicators
+**Scope:** Add progress bar to `TvShowDetailPage` ("12 / 24 episodes"). Add per-season progress in season list ("6 / 10"). Add mini progress indicator to `MediaCard` for TV shows. Add "Next episode" indicator with link ("Continue watching: S02E05 — [name]"). Data from `media.watchHistory.getProgress`.
+**Files:** `TvShowDetailPage.tsx`, `MediaCard.tsx`
 
-### US-3: Batch watch operations
-**As a** user, **I want** to mark an entire season or show as watched in one action **so that** I don't toggle 60 episodes individually.
+#### US-5: Watch history page
+**Scope:** Create `HistoryPage.tsx`. Reverse-chronological list of all watch events. Movies show poster + title + date. Episodes show show name + S01E05 + episode name + date. Filter by type (All/Movies/Episodes) and date range. Paginated or infinite scroll. Add route + "History" to secondary nav.
+**Files:** `packages/app-media/src/pages/HistoryPage.tsx`
 
-**Acceptance criteria:**
-- "Mark Season as Watched" button
-- "Mark All as Watched" on show detail page
-- Batch inserts all in one transaction
-- Reverse operations: "Mark Season as Unwatched"
-
-### US-4: TV show progress
-**As a** user, **I want** to see how far through a TV show I am **so that** I know where to pick up.
-
-**Acceptance criteria:**
-- Progress bar on show detail page ("12 / 24 episodes")
-- Per-season progress in season list
-- Mini progress indicator on MediaCard
-- "Next episode" indicator with link
-
-### US-5: Watch history page
-**As a** user, **I want** a chronological log of everything I've watched **so that** I can review my viewing history.
-
-**Acceptance criteria:**
-- Reverse-chronological list of all watches
-- Episodes show show name + S01E05 format
-- Filter by type and date range
-- Paginated or infinite scroll
-
-### US-6: Custom watch date
-**As a** user, **I want** to set a past date when marking something as watched **so that** I can log things I watched before using POPS.
-
-**Acceptance criteria:**
-- Date picker on "Mark as Watched" (defaults to today)
-- Custom dates accepted for individual movie/episode watches
-- History page displays the overridden date
+#### US-6: Custom watch date
+**Scope:** Add optional date picker to the "Mark as Watched" action on `MovieDetailPage` (defaults to today). Passes `watchedAt` to `media.watchHistory.log`. History page displays the custom date.
+**Files:** `MovieDetailPage.tsx`

--- a/docs/specs/prd-013-ratings-comparisons.md
+++ b/docs/specs/prd-013-ratings-comparisons.md
@@ -175,42 +175,27 @@ A: Evaluate recharts (most popular, largest bundle), visx (lower-level, smaller 
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes.
 
-### US-1: Comparison arena
-**As a** user, **I want** to compare two movies side by side and pick a winner **so that** the system learns my taste.
+### Batch A — Core (parallelisable)
 
-**Acceptance criteria:**
-- Two movie cards with poster, title, year
-- Dimension prompt shown
-- Tap card to select winner
-- Animation on selection
-- Next pair auto-loads
-- Skip button works
-- Session counter shown
+#### US-1a: Comparison arena — card layout and selection
+**Scope:** Create `CompareArenaPage.tsx`. Two movie cards side-by-side (poster, title, year). Dimension prompt above cards. Tap/click card to select winner → calls `media.comparisons.submit`. Brief animation on selection (winner pulses). Skip button below cards. Responsive: stacked vertical on mobile, side-by-side on tablet+. Add route + "Compare" to secondary nav.
+**Files:** `packages/app-media/src/pages/CompareArenaPage.tsx`
 
-### US-2: Dimension management
-**As a** user, **I want** to add, edit, and reorder comparison dimensions **so that** I rate movies on the qualities I care about.
+#### US-1b: Comparison arena — flow logic
+**Scope:** Add auto-load-next-pair after selection. Dimension auto-rotation (cycle through active dimensions). Session counter ("5 comparisons this session"). "Done" button exits arena. Dimension selector to switch/lock dimension. Score delta shown briefly in animation ("+12", "-12"). Data from `media.comparisons.getRandomPair`. Error state when <2 watched movies.
+**Files:** `CompareArenaPage.tsx` (enhance)
 
-**Acceptance criteria:**
-- Add new dimension with name + description
-- Edit existing dimensions
-- Deactivate without deleting
-- Reorder dimensions
+#### US-2: Dimension management UI
+**Scope:** Create a settings section or modal accessible from the arena page. Add new dimension (name + description). Edit existing (rename, update description). Deactivate (hides from comparisons, preserves data). Reorder (drag or up/down). Calls dimension CRUD procedures from PRD-007.
+**Files:** New component (DimensionManager or settings section)
 
-### US-3: Rankings page
-**As a** user, **I want** to see my movies ranked by dimension **so that** I can see what my top-rated movies are.
+#### US-3: Rankings page
+**Scope:** Create `RankingsPage.tsx`. Dimension selector (tabs or dropdown) at top. "Overall" tab shows composite score (average across dimensions). Ranked list: position number, poster thumbnail, title, year, score indicator bar. Click movie → detail page. Paginated. Add route + "Rankings" to secondary nav.
+**Files:** `packages/app-media/src/pages/RankingsPage.tsx`
 
-**Acceptance criteria:**
-- Dimension selector (tabs/dropdown)
-- Overall composite ranking
-- Ranked list with position, poster, title, score indicator
-- Click movie → detail page
-
-### US-4: Score visualisation on detail page
-**As a** user, **I want** to see a radar chart of a movie's comparison scores **so that** I understand its strengths at a glance.
-
-**Acceptance criteria:**
-- Radar chart with one axis per dimension
-- Score and comparison count per dimension
-- "Not enough data" for movies with <3 comparisons
-- Storybook story with various data states
+#### US-4: Radar chart on movie detail page
+**Scope:** Add "Your Ratings" section to `MovieDetailPage`. Radar chart (use recharts `RadarChart`) with one axis per dimension. Score and comparison count per dimension displayed as tooltip or legend. "Not enough data" message when <3 total comparisons. Storybook story with variants: no data, partial data, full data.
+**Files:** `MovieDetailPage.tsx`, new chart component, story

--- a/docs/specs/prd-014-discovery-recommendations.md
+++ b/docs/specs/prd-014-discovery-recommendations.md
@@ -180,49 +180,37 @@ Add "Discover" to the media app's secondary navigation — this is a high-visibi
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes.
 
-### US-1: Preference profile
-**As a** developer, **I want** a preference profile derived from comparisons **so that** recommendations are personalised.
+### Batch A — Backend (parallelisable)
 
-**Acceptance criteria:**
-- Genre affinity scores computed from ELO data
-- Dimension weights computed from comparison frequency
-- Profile updates when new comparisons are recorded
-- Unit tests for profile computation
+#### US-1: Preference profile computation
+**Scope:** Create `modules/media/recommendations/profile.ts`. Compute genre affinity scores (average ELO of watched movies per genre). Compute dimension weights (comparison frequency per dimension). Pure functions, unit tests.
+**Files:** `modules/media/recommendations/profile.ts`, test
 
-### US-2: Candidate sourcing and scoring
-**As a** developer, **I want** TMDB candidates scored against the user's profile **so that** recommendations are ranked by relevance.
+#### US-2a: Candidate sourcing from TMDB
+**Scope:** Create `modules/media/recommendations/candidates.ts`. Fetch TMDB "similar" for top 10 library movies, "popular", "top rated", "trending". Deduplicate. Filter out library items and dismissed. Cache locally (in-memory with 24h TTL or DB table).
+**Files:** `modules/media/recommendations/candidates.ts`
 
-**Acceptance criteria:**
-- Candidates fetched from TMDB (similar, popular, trending, top-rated)
-- Filtered to exclude library items and dismissed suggestions
-- Scored using weighted algorithm
-- Cached for 24 hours
-- Unit tests for scoring algorithm
+#### US-2b: Scoring algorithm
+**Scope:** Create `modules/media/recommendations/scoring.ts`. Score = `genre_affinity_match × 0.5 + tmdb_vote_average × 0.3 + source_boost × 0.2`. Source boosts per R3. Pure function, unit tests.
+**Files:** `modules/media/recommendations/scoring.ts`, test
 
-### US-3: Discovery page
-**As a** user, **I want** a page showing movies I might enjoy **so that** I discover new things to watch.
+#### US-5: Dismissed suggestions
+**Scope:** Create `src/db/schema/dismissed.ts` Drizzle schema (`dismissed_suggestions` table). Add tRPC procedures: `media.recommendations.dismiss({ tmdbId })`, `media.recommendations.listDismissed`. Filter dismissed from candidate sourcing. Unit tests.
+**Files:** `src/db/schema/dismissed.ts`, `modules/media/recommendations/router.ts`, test
 
-**Acceptance criteria:**
-- "Recommended for You" with match indicators and explanations
-- "Trending This Week" section
-- "Because You Liked [X]" sections
-- Cold start state with comparison CTA
-- Horizontal scroll rows
+### Batch B — Frontend (parallelisable, depends on Batch A)
 
-### US-4: "What should I watch tonight?"
-**As a** user, **I want** a quick recommendation **so that** I don't spend 30 minutes deciding.
+#### US-3a: Discovery page — Recommended for You
+**Scope:** Create `DiscoverPage.tsx`. "Recommended for You" section: horizontal scroll row of top 10-20 scored candidates. Each card: poster, title, year, genres, match indicator (percentage or "Strong match"), brief explanation ("Because you rated [X] highly"). "Add to Library" / "Add to Watchlist" / "Not Interested" actions. Cold start state (<5 comparisons): hide section, show arena CTA. Add route + "Discover" to secondary nav.
+**Files:** `packages/app-media/src/pages/DiscoverPage.tsx`
 
-**Acceptance criteria:**
-- Single recommendation card with full details
-- "Show Another" for next pick
-- "Not Tonight" to dismiss and close
-- Draws from candidates + watchlist
+#### US-3b: Discovery page — Trending and Similar sections
+**Scope:** Add "Trending This Week" horizontal scroll row (TMDB trending, exclude library items). Add 2-3 "Because You Liked [Movie]" rows (similar movies for top-rated library items, each with row header showing the source movie). Same card format as Recommended section.
+**Files:** `DiscoverPage.tsx` (extend)
 
-### US-5: Dismiss suggestions
-**As a** user, **I want** to dismiss suggestions I'm not interested in **so that** they don't keep appearing.
-
-**Acceptance criteria:**
-- "Not Interested" button on recommendation cards
-- Dismissed movies don't reappear in future recommendations
-- Persisted in `dismissed_suggestions` table
+#### US-4: "What should I watch tonight?" flow
+**Scope:** Create quick-pick component/modal. Prominent button on media home or discover page. Shows single recommendation card (large poster, title, year, overview, genres, match, TMDB rating). Actions: "Watch This" (add to library if needed), "Show Another" (next pick from candidates + watchlist), "Not Tonight" (dismiss and close).
+**Files:** New component

--- a/docs/specs/prd-015-plex-sync.md
+++ b/docs/specs/prd-015-plex-sync.md
@@ -221,54 +221,39 @@ This table enables efficient sync: query Plex for changes, look up the local ID 
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes.
 
-### US-1: Plex client and connection
-**As a** developer, **I want** an HTTP client for the Plex API **so that** the sync service can fetch library and watch data.
+### Batch A — Infrastructure (parallelisable)
 
-**Acceptance criteria:**
-- Client authenticates with `X-Plex-Token`
-- Exposes: library list, library items, item detail, episode list
-- Connection test verifies server reachability
-- Unit tests with mocked Plex responses
+#### US-1: Plex HTTP client
+**Scope:** Create `modules/media/plex/client.ts`. Auth via `X-Plex-Token` header. Implement: `getLibraries()`, `getLibraryItems(sectionId)`, `getItemDetail(metadataId)`, `getEpisodes(showId)`. Connection test (call `GET /` → return server name/version). Typed responses, typed errors. Unit tests with mocked Plex responses.
+**Files:** `modules/media/plex/client.ts`, `types.ts`, `client.test.ts`
 
-### US-2: Metadata matching
-**As a** developer, **I want** Plex items matched to TMDB/TheTVDB IDs **so that** they can be added to the POPS library.
+#### US-2: Metadata matching logic
+**Scope:** Create `modules/media/plex/matcher.ts`. Three strategies in order: (1) extract TMDB/TheTVDB ID from Plex GUID format, (2) extract from Plex external IDs array, (3) title+year search fallback via TMDB/TheTVDB clients. Returns `MatchResult` with `externalId`, `matchMethod`, `confidence`. Logs unmatched items. Unit tests for each strategy.
+**Files:** `modules/media/plex/matcher.ts`, `matcher.test.ts`
 
-**Acceptance criteria:**
-- Agent ID extraction from Plex GUIDs
-- External ID extraction from Plex metadata
-- Title+year search fallback
-- Match confidence reported per item
-- Unmatched items logged
-- Unit tests for each matching strategy
+#### US-schema: Plex link and sync log schemas
+**Scope:** Create `src/db/schema/plex.ts` with `plexLinks` and `plexSyncLog` Drizzle schemas per R7 and R5. Run `drizzle-kit generate`. Add tRPC query for sync log retrieval and connection config.
+**Files:** `src/db/schema/plex.ts`, `modules/media/plex/router.ts`
 
-### US-3: Initial library import
-**As a** user, **I want** to import my entire Plex library into POPS **so that** I don't add 500 movies manually.
+### Batch B — Sync logic (depends on Batch A)
 
-**Acceptance criteria:**
-- All matched movies added via `addMovie` flow
-- All matched shows added via `addTvShow` flow
-- Watch history imported with Plex timestamps
-- Progress queryable during import
-- Duplicate items skipped
-- Unmatched items reported
+#### US-3a: Initial movie import
+**Scope:** In `modules/media/plex/sync-service.ts`, implement movie library import: fetch all items from Plex movie library → match to TMDB → for matched items not in POPS, call `addMovie` → if `importWatchHistory`, check Plex watch status and create `watch_history` entries with Plex timestamps → create `plexLinks` rows. Skip duplicates (match on TMDB ID). Track progress. Integration test with mocked Plex + TMDB responses.
+**Files:** `modules/media/plex/sync-service.ts`, test
 
-### US-4: Periodic sync
-**As a** user, **I want** POPS to automatically sync with Plex **so that** new watches are tracked without manual input.
+#### US-3b: Initial TV import
+**Scope:** Same flow for TV: fetch Plex TV library → match to TheTVDB → call `addTvShow` → sync episode-level watch status → create `plexLinks`. Integration test.
+**Files:** `modules/media/plex/sync-service.ts` (extend)
 
-**Acceptance criteria:**
-- Sync runs every N hours (configurable, default 6)
-- New Plex items added to POPS
-- New watch events created from Plex
-- Sync log records results
-- "Sync Now" button triggers immediate sync
+#### US-4: Periodic sync scheduler
+**Scope:** Add polling scheduler: `setInterval` at configurable interval (`PLEX_SYNC_INTERVAL_HOURS`, default 6). Manual trigger via `media.plex.syncNow` tRPC mutation. On each sync: check for new Plex items, check for new watch events, write sync log entry. `.env.example` updated.
+**Files:** `modules/media/plex/sync-service.ts` (scheduler), `router.ts` (syncNow procedure)
 
-### US-5: Sync status UI
-**As a** user, **I want** to see the status of my Plex connection and sync history **so that** I know the integration is working.
+### Batch C — UI (depends on Batch B)
 
-**Acceptance criteria:**
-- Connection status displayed
-- Last sync time and summary
-- "Sync Now" button with progress
-- Sync history (last 5 runs)
-- Unmatched items list
+#### US-5: Plex sync status UI
+**Scope:** Create Plex settings section (in media settings page or standalone). Connection status ("Connected to [Server Name]" or "Not connected"). Connection test button. Library selection (checkboxes). Last sync time + summary. "Sync Now" button with progress indicator. Sync history (last 5 runs). Unmatched items list.
+**Files:** Media settings page/section

--- a/docs/specs/prd-016-radarr-sonarr.md
+++ b/docs/specs/prd-016-radarr-sonarr.md
@@ -169,47 +169,37 @@ The media app must work fully without Radarr/Sonarr:
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes.
 
-### US-1: Shared *arr base client
-**As a** developer, **I want** a shared HTTP client for the *arr API pattern **so that** Radarr and Sonarr clients share common logic.
+### Batch A — Clients (parallelisable)
 
-**Acceptance criteria:**
-- Base client handles authentication (`X-Api-Key`), request construction, error handling
-- Radarr and Sonarr clients extend the base with service-specific endpoints
-- Connection test works for both services
-- Unit tests with mocked HTTP
+#### US-1a: Shared *arr base client
+**Scope:** Create `modules/media/arr/base-client.ts`. Auth via `X-Api-Key` header. Request construction (base URL + path + params). Error handling (typed errors). Connection test method (`GET /api/v3/system/status`). Unit tests with mocked HTTP.
+**Files:** `modules/media/arr/base-client.ts`, test
 
-### US-2: Radarr status on movie detail
-**As a** user, **I want** to see the Radarr status of a movie on its detail page **so that** I know if it's downloaded or being monitored.
+#### US-1b: Radarr client
+**Scope:** Create `modules/media/arr/radarr-client.ts` extending base client. Endpoints: `getMovies()`, `getMovie(id)`, `getQueue()`. Status mapping: monitored + hasFile → "Available", monitored + !hasFile → "Monitored", in queue → "Downloading X%". Match to local library by TMDB ID. Unit tests.
+**Files:** `modules/media/arr/radarr-client.ts`, test
 
-**Acceptance criteria:**
-- Status badge: Available / Monitored / Downloading / Not in Radarr
-- Colour-coded badge
-- Hidden when Radarr not configured
-- Status cached (not fetched on every page load)
+#### US-1c: Sonarr client
+**Scope:** Create `modules/media/arr/sonarr-client.ts` extending base client. Endpoints: `getSeries()`, `getSeriesById(id)`, `getQueue()`. Status mapping: all episodes filed → "Complete", partial → "Partial (X/Y)", none → "Monitored". Match by TheTVDB ID. Unit tests.
+**Files:** `modules/media/arr/sonarr-client.ts`, test
 
-### US-3: Sonarr status on TV show detail
-**As a** user, **I want** to see the Sonarr status of a TV show on its detail page **so that** I know which episodes are available.
+### Batch B — UI (parallelisable, depends on Batch A)
 
-**Acceptance criteria:**
-- Status badge: Complete / Partial (X/Y) / Monitored / Not in Sonarr
-- Colour-coded badge
-- Hidden when Sonarr not configured
+#### US-2: Radarr status badge on movie detail
+**Scope:** Add Radarr status badge to `MovieDetailPage` metadata section. Badge: "Available" (green) / "Monitored" (yellow) / "Downloading 45%" (yellow) / "Not in Radarr" (grey). Hidden when `RADARR_URL` not configured. Status cached in memory (5 min TTL). Data from Radarr client via a service/tRPC procedure.
+**Files:** `MovieDetailPage.tsx`, service layer
 
-### US-4: Download queue
-**As a** user, **I want** to see what's currently downloading **so that** I know what will be available soon.
+#### US-3: Sonarr status badge on TV show detail
+**Scope:** Add Sonarr status badge to `TvShowDetailPage`. Badge: "Complete" (green) / "Partial (45/62)" (yellow) / "Monitored" (yellow) / "Not in Sonarr" (grey). Hidden when `SONARR_URL` not configured. Cached.
+**Files:** `TvShowDetailPage.tsx`, service layer
 
-**Acceptance criteria:**
-- Combined queue from Radarr + Sonarr
-- Title, progress percentage, ETA per item
-- Auto-refreshes when visible
-- Empty state when nothing downloading
+#### US-4: Download queue widget
+**Scope:** Create download queue component. Combined active downloads from Radarr + Sonarr. Each entry: title, type badge (movie/episode), progress %, ETA. Auto-refreshes every 30 seconds when visible. Empty state: hidden or "Nothing downloading". Can be placed on media home or as a sidebar widget.
+**Files:** New component
 
-### US-5: Graceful degradation
-**As a** developer, **I want** the media app to work fully without Radarr/Sonarr **so that** these integrations are optional.
-
-**Acceptance criteria:**
-- No errors when services aren't configured
-- No badge sections when not configured
-- Stale cache shown when service becomes unreachable
-- Connection failures logged, not thrown
+#### US-5: Graceful degradation
+**Scope:** Ensure the media app works fully when Radarr/Sonarr are not configured or unreachable. No errors when `RADARR_URL` / `SONARR_URL` not set — badge sections hidden. When configured but unreachable: show muted "unavailable" badge, serve stale cache if available, log connection failures without throwing. `.env.example` updated with all 4 variables.
+**Files:** Service layer guards, UI conditional rendering

--- a/docs/specs/prd-017-inventory-schema-upgrade.md
+++ b/docs/specs/prd-017-inventory-schema-upgrade.md
@@ -338,68 +338,61 @@ A: Rename to `inventory_items` during migration. The table name should reflect t
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes.
 
-### US-1: Create Drizzle schema files
-**As a** developer, **I want** all inventory tables defined as Drizzle schemas **so that** types and DDL are a single source of truth.
+### Batch A — Schema files (parallelisable)
 
-**Acceptance criteria:**
-- Schema files for: inventory_items, locations, item_connections, item_photos
-- `drizzle-kit generate` produces migration SQL
-- Migrations run on fresh and existing databases
+#### US-1a: Locations schema
+**Scope:** Create `src/db/schema/locations.ts`. Self-referential tree: `parent_id` FK to self, `ON DELETE CASCADE`. Fields: name, parent_id, sort_order, created_at. Index on parent_id.
+**Files:** `src/db/schema/locations.ts`
 
-### US-2: Migrate existing data
-**As a** developer, **I want** existing inventory data preserved during the schema upgrade **so that** no data is lost.
+#### US-1b: Inventory items schema
+**Scope:** Create `src/db/schema/inventory-items.ts`. Upgraded from `home_inventory`. All fields per R2: asset_id (unique), location_id FK to locations (ON DELETE SET NULL), notes, type/condition enums. Indexes on asset_id, name, location_id, type.
+**Files:** `src/db/schema/inventory-items.ts`
 
-**Acceptance criteria:**
-- Location tree created from existing room/location values
-- Existing items mapped to new schema with correct location_id
-- Old table removed or renamed after verification
+#### US-1c: Item connections schema
+**Scope:** Create `src/db/schema/item-connections.ts`. Junction table: item_a_id, item_b_id (both FK to inventory_items, ON DELETE CASCADE). Unique on (item_a_id, item_b_id). Indexes on both columns.
+**Files:** `src/db/schema/item-connections.ts`
 
-### US-3: Locations tRPC router
-**As a** developer, **I want** CRUD procedures for the location tree **so that** the UI can manage locations.
+#### US-1d: Item photos schema
+**Scope:** Create `src/db/schema/item-photos.ts`. Fields: item_id FK (ON DELETE CASCADE), file_path, caption, sort_order. Index on item_id.
+**Files:** `src/db/schema/item-photos.ts`
 
-**Acceptance criteria:**
-- Full tree retrieval with item counts
-- Create/update/delete with cascade behaviour
-- Breadcrumb path query
-- Items-at-location query with optional children inclusion
-- Unit tests for tree operations
+### Batch B — Migration + types (depends on Batch A)
 
-### US-4: Connections tRPC router
-**As a** developer, **I want** procedures for managing item connections **so that** the UI can connect and disconnect items.
+#### US-1e: Schema integration and migration generation
+**Scope:** Re-export all inventory schemas from `src/db/schema/index.ts`. Run `drizzle-kit generate`. Verify migrations run on fresh and existing databases. Export Drizzle-inferred types from `@pops/db-types`.
+**Files:** `src/db/schema/index.ts`, migrations/, `packages/db-types/`
 
-**Acceptance criteria:**
-- Connect/disconnect with dedup normalisation
-- List connections for an item
-- Recursive chain traversal with depth limit
-- Unit tests including circular connection handling
+#### US-2: Data migration from home_inventory
+**Scope:** Create a migration script that: (1) creates location tree from unique room + location values in old table, (2) maps existing items to new schema with correct location_id, (3) copies asset IDs from old `item_id`/`ID` fields. Verify all 5 existing seed items migrate correctly. Rename old table to `home_inventory_legacy`.
+**Files:** Custom migration script
 
-### US-5: Photos tRPC router
-**As a** developer, **I want** procedures for managing item photos **so that** the UI can upload and display photos.
+### Batch C — Routers (parallelisable, depends on Batch B)
 
-**Acceptance criteria:**
-- Upload with compression (resize, HEIC→JPEG, EXIF strip)
-- Delete removes file and record
-- Reorder updates sort_order
-- Image serving endpoint with cache headers
-- Unit tests for upload validation
+#### US-3a: Locations router — tree CRUD
+**Scope:** Create `modules/inventory/locations/` with router, service, types. Implement: `getTree` (recursive, with item counts), `create` (root or child), `update` (rename, move, reorder), `delete` (with confirmation for non-empty). Unit tests for tree operations.
+**Files:** `modules/inventory/locations/*`
 
-### US-6: Updated items router
-**As a** developer, **I want** the items router extended with new fields **so that** asset IDs, locations, notes, and search work.
+#### US-3b: Locations router — queries
+**Scope:** Add `getItems({ id, includeChildren? })` (items at a location, optionally including subtree) and `getPath({ id })` (breadcrumb array from root to location). Unit tests.
+**Files:** `modules/inventory/locations/service.ts`, test
 
-**Acceptance criteria:**
-- Create/update accept asset_id, location_id, notes
-- List filterable by location (with children option)
-- Search by asset ID (exact match)
-- Get includes location breadcrumb, connection count, photo count
-- Delete cleans up connections and photo files
+#### US-4: Connections router
+**Scope:** Create `modules/inventory/connections/` with router, service, types. Implement: `connect` (normalise A < B, dedup), `disconnect`, `listForItem` (check both columns), `traceChain` (recursive CTE with depth limit, handles cycles via visited set). Unit tests including circular connection handling.
+**Files:** `modules/inventory/connections/*`
 
-### US-7: Seed data
-**As a** developer, **I want** realistic seed data **so that** E2E tests have a meaningful dataset.
+#### US-5: Photos router
+**Scope:** Create `modules/inventory/photos/` with router, service. Upload: multipart form, validate type (JPEG/PNG/HEIC) + size (10MB max), compress (resize to 1920px, HEIC→JPEG, strip EXIF), store in `{INVENTORY_IMAGES_DIR}/items/{item_id}/photo_{NNN}.jpg`. Delete: remove file + record. Reorder: update sort_order. Add Express endpoint `GET /inventory/images/:itemId/:filename` with cache headers. Unit tests.
+**Files:** `modules/inventory/photos/*`, `src/routes/inventory-images.ts`
 
-**Acceptance criteria:**
-- Location tree with 4+ rooms and sub-locations
-- 15+ items with asset IDs across locations
-- 10+ connections forming at least one chain (wall → power board → devices)
-- 2-3 photos on select items
-- Idempotent seeding
+#### US-6: Updated items router
+**Scope:** Extend existing `modules/inventory/items/` router. Add: `assetId`, `locationId`, `notes` to create/update inputs. Add `searchByAssetId` procedure (exact, case-insensitive). Update `list` with `locationId` filter (with `includeChildren` option). Update `get` response to include: location breadcrumb, connection count, photo count. Update `delete` to clean up connections (cascaded) and photo files (application-level). Unit tests.
+**Files:** `modules/inventory/items/*`
+
+### Batch D — Seed (depends on Batch C)
+
+#### US-7: Seed data
+**Scope:** Update `mise db:seed`. Location tree: Home with 4+ rooms (Living Room, Bedroom, Kitchen, Office) and sub-locations (TV Unit, Wardrobe Right Door, etc.). Plus Car, Storage Cage roots. 15+ items with asset IDs across locations. 10+ connections forming a chain (wall plug → PB01 → PS001/PS002 → router/switch). 2-3 placeholder photos. Idempotent.
+**Files:** `src/db/seeder.ts`

--- a/docs/specs/prd-018-notion-import.md
+++ b/docs/specs/prd-018-notion-import.md
@@ -187,57 +187,37 @@ The import should be safe to run multiple times:
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes.
 
-### US-1: Notion data fetch
-**As a** developer, **I want** to fetch all items from the Notion inventory database **so that** I can map them to the POPS schema.
+### Batch A — Core import logic (parallelisable)
 
-**Acceptance criteria:**
-- All items fetched with all properties
-- Page content fetched for photos and notes
-- Handles pagination (Notion API returns max 100 items per request)
+#### US-1: Notion data fetch
+**Scope:** Create the Notion API fetch module for the import script. Paginated fetch of all items from the Home Inventory database (`collection://7784d712-0114-4371-90c1-cb15ea003fe2`). Fetch properties + page content for each item. Handle pagination (max 100 per request). Use Notion MCP integration or build a lightweight REST client.
+**Files:** Import script (notion fetch module)
 
-### US-2: Property mapping and item creation
-**As a** developer, **I want** Notion properties mapped to POPS fields **so that** items are created with correct data.
+#### US-2: Property mapping
+**Scope:** Create mapping functions: Notion properties → POPS inventory_items fields. Map per R2 table: Item Name → name, Brand → brand, ID → asset_id, Room/Location → location_id (via lookup), Type/Condition → enums, In-use/Deductible → booleans (from `__YES__`/`__NO__`), dates → ISO strings, values → numbers. Cross-domain FK matching for Purchase Transaction and Purchased From.
+**Files:** Import script (mapping module)
 
-**Acceptance criteria:**
-- All fields mapped per R2 table
-- Enum values (Type, Condition) mapped correctly
-- Boolean fields (In-use, Deductible) converted from Notion format
-- Dates converted to ISO strings
+#### US-3: Location tree auto-creation
+**Scope:** Create location tree builder for the import. Create "Home" root. For each unique `Room` value, create as child of Home. For each unique `Location` value within a room, create as child of that room. Set `location_id` on items (most specific available). Idempotent — don't duplicate on re-run.
+**Files:** Import script (location builder module)
 
-### US-3: Location tree auto-creation
-**As a** developer, **I want** the location tree built from Notion Room + Location values **so that** items have correct hierarchical locations.
+#### US-4: "Used By" notes preservation
+**Scope:** For each item with "Used By" multi-select values, append to the `notes` field as markdown: `## Connected to (from Notion)\n- Value1\n- Value2`. Preserve existing page content (specs, notes) above the connection list. Items with no "Used By" get no extra content.
+**Files:** Import script (notes builder)
 
-**Acceptance criteria:**
-- "Home" root created
-- Unique rooms created as children of Home
-- Unique locations created as children of their rooms
-- Items linked to most specific location
-- Duplicate locations not created on re-run
+#### US-5: Photo download
+**Scope:** Parse page content for image URLs (Notion's S3 signed URLs). Download each image immediately (URLs expire in ~1 hour). Compress: resize to max 1920px, convert HEIC→JPEG, strip EXIF. Store in `{INVENTORY_IMAGES_DIR}/items/{item_id}/photo_{NNN}.jpg`. Create `item_photos` rows with correct ordering. Handle items with zero photos gracefully.
+**Files:** Import script (photo download module)
 
-### US-4: "Used By" preservation
-**As a** developer, **I want** "Used By" values preserved in item notes **so that** connections can be created manually later.
+### Batch B — Integration (depends on Batch A)
 
-**Acceptance criteria:**
-- "Used By" values appended to notes as a markdown list
-- Formatted under a "Connected to (from Notion)" heading
-- Items with no "Used By" values have no extra notes content
-- Existing notes content (specs, etc.) is preserved above the connection list
+#### US-6: Dry-run mode and reporting
+**Scope:** Add `--execute` flag. Without it, run in dry-run mode: fetch all data, compute everything, generate report (item count, location tree preview, photo count + estimated size, match stats, unmatched references) — but write nothing to the database. With `--execute`, write everything. Add `mise import:notion-inventory` task to `mise.toml`.
+**Files:** Import script (main entry + mise.toml)
 
-### US-5: Photo download
-**As a** developer, **I want** photos downloaded from Notion pages **so that** item images are preserved in POPS.
-
-**Acceptance criteria:**
-- Images downloaded immediately (before URL expiry)
-- Compressed and stored locally
-- HEIC converted to JPEG
-- item_photos rows created with correct ordering
-- Items with no photos handled gracefully
-
-### US-6: Dry-run mode
-**As a** user, **I want** to preview the import without writing **so that** I can verify before committing.
-
-**Acceptance criteria:**
-- Full report: item count, location tree, photo count, match stats
-- No database writes in dry-run mode
-- Estimated photo download size shown
+#### US-7: Idempotency and error handling
+**Scope:** Check `notion_id` before inserting — skip items that already exist. Optional `--update` flag to update existing items on re-run. Import log: total/imported/skipped/error counts. Don't duplicate locations or photos on re-run.
+**Files:** Import script (dedup logic)

--- a/docs/specs/prd-019-inventory-item-ui.md
+++ b/docs/specs/prd-019-inventory-item-ui.md
@@ -218,66 +218,52 @@ All pages and components at three breakpoints:
 
 > **Standard verification — applies to every US below.**
 
-### US-1: Package scaffold and shell integration
-**As a** developer, **I want** `@pops/app-inventory` plugged into the shell **so that** users can navigate to the inventory app.
+### Batch A — Scaffold
 
-**Acceptance criteria:**
-- Package exists, builds, appears in app switcher
-- Lazy-loaded routes
+#### US-1: Package scaffold and shell integration
+**Scope:** Create `packages/app-inventory/` with `package.json` (@pops/app-inventory), `tsconfig.json`, `src/index.ts`, `src/routes.tsx`. Register in shell app switcher (package/box icon, "Inventory", `/inventory`). Lazy-loaded routes. Verify `pnpm install` resolves.
+**Files:** `packages/app-inventory/*`, `apps/pops-shell/` (app switcher config)
 
-### US-2: Item list page
-**As a** user, **I want** to browse all my items with search and filters **so that** I can find what I'm looking for.
+### Batch B — Components (parallelisable, depends on Batch A)
 
-**Acceptance criteria:**
-- Table and grid views with toggle
-- Search by name or asset ID
-- Filter by type, condition, room, in-use
-- Sort by name, date, value, location
-- Total count and value summary
+#### US-c1: InventoryCard component
+**Scope:** Create `InventoryCard.tsx` + story. Photo thumbnail (or placeholder), name, asset ID badge, type badge, location breadcrumb. Click navigates to detail page.
+**Files:** `packages/app-inventory/src/components/InventoryCard.tsx`, story
 
-### US-3: Item detail page
-**As a** user, **I want** to see full details for an item **so that** I know everything about it.
+#### US-c2: InventoryTable component
+**Scope:** Create `InventoryTable.tsx` + story. Enhanced data table with columns: Asset ID, Name, Brand, Type, Condition, Location (breadcrumb), Value, In Use. Sortable columns. Click row → detail page.
+**Files:** `packages/app-inventory/src/components/InventoryTable.tsx`, story
 
-**Acceptance criteria:**
-- All metadata, photos, connections, notes displayed
-- Location as clickable breadcrumb
-- Warranty status with days remaining
-- Edit and delete actions
+#### US-c3: PhotoGallery and PhotoUpload components
+**Scope:** Create `PhotoGallery.tsx` (grid of photos, click → lightbox/fullscreen, first photo = thumbnail) + `PhotoUpload.tsx` (drag-and-drop or file picker, camera capture via `<input capture="environment">`, progress indicator, delete per photo, drag-to-reorder) + stories for both.
+**Files:** `packages/app-inventory/src/components/PhotoGallery.tsx`, `PhotoUpload.tsx`, stories
 
-### US-4: Item create/edit form
-**As a** user, **I want** to add and edit items from the UI **so that** I don't need to use the API directly.
+#### US-c4: LocationPicker component
+**Scope:** Create `LocationPicker.tsx` + story. Button shows current selection as breadcrumb ("Home > Bedroom > Wardrobe"). Click opens tree overlay/modal. Expandable/collapsible nodes. Type to search/filter. Click leaf to select. "Clear" button for no location. "Add location" inline quick-add.
+**Files:** `packages/app-inventory/src/components/LocationPicker.tsx`, story
 
-**Acceptance criteria:**
-- All fields including location picker
-- Asset ID uniqueness validation
-- Create navigates to new item's detail page
-- Edit pre-fills form with current values
-- Unsaved changes warning
+#### US-c5: Badge components
+**Scope:** Create `AssetIdBadge.tsx` (prominent display of asset tag), `ConditionBadge.tsx` (colour-coded: green=New, blue=Excellent, yellow=Good, orange=Fair, red=Poor), `TypeBadge.tsx`, `LocationBreadcrumb.tsx` (clickable path). Stories for all.
+**Files:** `packages/app-inventory/src/components/AssetIdBadge.tsx`, `ConditionBadge.tsx`, `TypeBadge.tsx`, `LocationBreadcrumb.tsx`, stories
 
-### US-5: Photo gallery and upload
-**As a** user, **I want** to view and manage photos for an item **so that** I have a visual record.
+#### US-c6: ConnectionsList component
+**Scope:** Create `ConnectionsList.tsx` + story. List of connected items: asset ID badge, name, type badge. Click → navigate to that item's detail page. Connection count in section header. "Connect to..." button placeholder.
+**Files:** `packages/app-inventory/src/components/ConnectionsList.tsx`, story
 
-**Acceptance criteria:**
-- Grid gallery with lightbox on detail page
-- Upload with compression on edit page
-- Drag-to-reorder photos
-- Camera capture on mobile
-- Delete individual photos
+### Batch C — Pages (parallelisable, depends on Batch B)
 
-### US-6: Location picker
-**As a** user, **I want** to pick a location from a tree **so that** items are placed in the correct spot.
+#### US-2: Item list page
+**Scope:** Create `ItemListPage.tsx`. Table/grid toggle (InventoryTable vs InventoryCard grid). Search bar (by name or asset ID). Filter bar: type, condition, room (from location tree), in-use toggle, deductible toggle. Sort: name, date added, value, location. Total item count + total replacement value summary line. Empty state. Data from `inventory.items.list`.
+**Files:** `packages/app-inventory/src/pages/ItemListPage.tsx`, hooks
 
-**Acceptance criteria:**
-- Tree overlay with expand/collapse
-- Search to filter by name
-- Breadcrumb display of selection
-- Quick-add new location inline
-- Clear to set no location
+#### US-3: Item detail page
+**Scope:** Create `ItemDetailPage.tsx`. Header: name, asset ID badge, type badge, condition badge. PhotoGallery. Metadata: brand, model, location breadcrumb (clickable), in-use/deductible flags, purchase date, warranty status (with days remaining or "Expired"), values, purchased from, purchase transaction. Notes (rendered markdown). ConnectionsList. Documents section (placeholder for PRD-022). Edit + Delete actions (delete with confirmation). 404 if not found.
+**Files:** `packages/app-inventory/src/pages/ItemDetailPage.tsx`
 
-### US-7: Asset ID search
-**As a** user, **I want** to search by asset tag **so that** I can find items by their physical label.
+#### US-4: Item create/edit form
+**Scope:** Create `ItemFormPage.tsx` (shared for create + edit). All fields: name (required), asset ID (validated unique on blur), brand, model, type (select), condition (select), location (LocationPicker), in-use, deductible, purchase date, warranty expires, replacement value, resale value, notes (textarea with markdown preview). PhotoUpload section. Create: `inventory.items.create`, navigate to detail. Edit: pre-fill, `inventory.items.update`. Unsaved changes warning. Toast on success/error.
+**Files:** `packages/app-inventory/src/pages/ItemFormPage.tsx`
 
-**Acceptance criteria:**
-- Exact asset ID match returns result immediately
-- Case-insensitive
-- Works from the list page search bar
+#### US-7: Asset ID search
+**Scope:** In the list page search bar, when the search term exactly matches an asset ID (case-insensitive), navigate directly to that item's detail page or highlight it in the list. Uses `inventory.items.searchByAssetId`.
+**Files:** `ItemListPage.tsx` (search logic)

--- a/docs/specs/prd-020-location-tree-management.md
+++ b/docs/specs/prd-020-location-tree-management.md
@@ -148,54 +148,29 @@ Add "Locations" to the inventory app's secondary navigation.
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes. All stories are parallelisable (all modify the same page but different sections).
 
-### US-1: View location tree
-**As a** user, **I want** to see all my locations in a tree **so that** I understand how my space is organised.
+#### US-1: Location tree display
+**Scope:** Create `LocationTreePage.tsx`. Hierarchical tree of all locations from `inventory.locations.getTree`. Each node: name, item count badge, expand/collapse toggle. Click to select (highlights node). Responsive: full-width tree on mobile, side-by-side tree + contents panel on tablet+. Add route + "Locations" to inventory secondary nav. Storybook stories for `LocationTree` and `LocationNode` components.
+**Files:** `packages/app-inventory/src/pages/LocationTreePage.tsx`, tree components
 
-**Acceptance criteria:**
-- All locations displayed hierarchically
-- Item counts shown per location
-- Expandable/collapsible nodes
+#### US-2: Add locations
+**Scope:** Add "Add root location" button at top of tree. "Add child" icon/action on each node. New node appears with editable text field. Enter saves via `inventory.locations.create`. Escape cancels. New location appears immediately in tree.
+**Files:** `LocationTreePage.tsx`
 
-### US-2: Add locations
-**As a** user, **I want** to add new locations to the tree **so that** I can organise new areas.
+#### US-3: Rename and reorder
+**Scope:** Double-click location name → inline edit mode. Enter saves, Escape cancels. Drag within same parent level → reorder (updates `sort_order`). Mobile fallback: up/down buttons. Calls `inventory.locations.update`.
+**Files:** `LocationTreePage.tsx`
 
-**Acceptance criteria:**
-- Add root location
-- Add child location to any existing location
-- Inline text input for naming
-- Location appears immediately in the tree
+#### US-4: Move locations (reparent)
+**Scope:** Drag a location node onto another → reparent as child of drop target. Visual indicator showing drop target. Validation: can't move a location into its own subtree (circular reference check). Mobile fallback: right-click or menu → "Move to..." → LocationPicker modal. Calls `inventory.locations.update({ id, parentId })`.
+**Files:** `LocationTreePage.tsx`
 
-### US-3: Rename and reorder
-**As a** user, **I want** to rename and reorder locations **so that** the tree stays accurate.
+#### US-5: Delete locations
+**Scope:** Delete icon/action per location. If has items: confirmation "This location has X items. They will become unlocated." If has children: "This location has Y sub-locations with Z items total. All sub-locations will be deleted." Empty locations: delete immediately with toast. Calls `inventory.locations.delete({ id, force: true })`.
+**Files:** `LocationTreePage.tsx`
 
-**Acceptance criteria:**
-- Double-click to rename inline
-- Drag to reorder within a level
-- Changes persist after reload
-
-### US-4: Move locations
-**As a** user, **I want** to move a location (and its children) to a different parent **so that** I can reorganise.
-
-**Acceptance criteria:**
-- Drag-and-drop to reparent
-- "Move to..." dialog as fallback
-- Circular reference prevented
-- Children and items move with the location
-
-### US-5: Delete locations
-**As a** user, **I want** to delete unused locations **so that** the tree stays clean.
-
-**Acceptance criteria:**
-- Confirmation when location has items or children
-- Items become unlocated (not deleted)
-- Empty locations delete immediately
-
-### US-6: Browse location contents
-**As a** user, **I want** to see what's at a location **so that** I can answer "what's in this drawer?"
-
-**Acceptance criteria:**
-- Select location → see items in side panel
-- Toggle to include sub-location items
-- Item count and total value shown
-- Click item to navigate to detail page
+#### US-6: Location contents panel
+**Scope:** When a location is selected in the tree, show its contents in a side panel (desktop) or below (mobile). Location name + breadcrumb. List of items: name, asset ID, type badge. "Include items in sub-locations" toggle. Item count + total replacement value. Click item → navigate to detail page. "Add item here" button → navigate to create form with location pre-selected. Storybook story.
+**Files:** `LocationTreePage.tsx`, `LocationContentsPanel` component

--- a/docs/specs/prd-021-connections-graph.md
+++ b/docs/specs/prd-021-connections-graph.md
@@ -147,45 +147,29 @@ A visual node-and-edge graph of connected items.
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes. All stories are parallelisable.
 
-### US-1: Connect and disconnect items
-**As a** user, **I want** to connect two items and disconnect them **so that** the system tracks physical connections.
+#### US-1a: ConnectDialog component
+**Scope:** Create `ConnectDialog.tsx` + story. Modal/overlay with search input for finding items by name or asset ID. Autocomplete results with asset ID badge, name, type. Select an item to return it to the caller. Prevents selecting the current item (self-connection).
+**Files:** `packages/app-inventory/src/components/ConnectDialog.tsx`, story
 
-**Acceptance criteria:**
-- "Connect to..." with search/autocomplete
-- Disconnect action per connection
-- Bidirectional: both items show the connection
+#### US-1b: Connect/disconnect on detail page
+**Scope:** Add "Connect to..." button to `ItemDetailPage` connections section. Opens `ConnectDialog`. On select, calls `inventory.connections.connect`. "Disconnect" icon button per connection, calls `inventory.connections.disconnect`. Toast on success. Bidirectional: navigating to the connected item shows the reverse connection.
+**Files:** `ItemDetailPage.tsx`
 
-### US-2: View connections list
-**As a** user, **I want** to see what's connected to an item **so that** I know what cables and accessories it uses.
+#### US-2: Enhanced ConnectionsList
+**Scope:** Enhance `ConnectionsList.tsx` (from PRD-019 US-c6). Each connected item shows: asset ID badge, name, type badge, location breadcrumb. Click → navigate to that item's detail page. Connection count in section header ("Connected to (4)"). Order by type then name.
+**Files:** `ConnectionsList.tsx`
 
-**Acceptance criteria:**
-- All direct connections listed with asset ID, name, type
-- Click to navigate to connected item
-- Connection count in header
+#### US-3: Connection chain tracing
+**Scope:** Create `ConnectionChain.tsx` component + story. "Trace connections" button/section on detail page. Uses `inventory.connections.traceChain` data. Renders as expandable tree: each node shows asset ID, name, type badge. Click any node → navigate. Circular connections: visited nodes shown with "↻ already shown" label, not expanded. Depth limit indicator.
+**Files:** `packages/app-inventory/src/components/ConnectionChain.tsx`, story, `ItemDetailPage.tsx`
 
-### US-3: Trace connection chain
-**As a** user, **I want** to trace connections from a wall outlet through power boards to devices **so that** I can see the full chain.
+#### US-4: Connect during item creation
+**Scope:** Add "Connected to" section to `ItemFormPage` (create mode). Uses `ConnectDialog` to search and add connections. Selected connections shown as a removable list. Connections created after item save (in the same operation or immediately after).
+**Files:** `ItemFormPage.tsx`
 
-**Acceptance criteria:**
-- Expandable tree showing recursive connections
-- Each node shows asset ID, name, type
-- Circular connections marked, not infinitely expanded
-- Depth limit of 10
-
-### US-4: Connect during creation
-**As a** user, **I want** to connect a new item to existing items when I create it **so that** I don't have to go back and add connections later.
-
-**Acceptance criteria:**
-- "Connected to" section on create form
-- Search and add connections before saving
-- Connections created with the item
-
-### US-5: Graph visualisation (stretch)
-**As a** user, **I want** a visual graph of item connections **so that** I can see the big picture.
-
-**Acceptance criteria:**
-- Node-and-edge graph with type-based icons
-- Click node to navigate
-- Zoom and pan
-- Filter by room or connected-to
+#### US-5: Graph visualisation (stretch)
+**Scope:** Create visual node-and-edge graph of connected items. Nodes = items (icon by type), edges = connections. Force-directed layout. Click node → navigate to detail. Zoom/pan. Optional filter by room or starting item. Library: react-force-graph or d3-force. Accessible via "View graph" button in connections section. **Stretch goal — implement only if time permits.**
+**Files:** New graph component

--- a/docs/specs/prd-022-paperless-integration.md
+++ b/docs/specs/prd-022-paperless-integration.md
@@ -142,39 +142,33 @@ export const itemDocuments = sqliteTable('item_documents', {
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes.
 
-### US-1: Paperless-ngx API client
-**As a** developer, **I want** a client for the Paperless-ngx REST API **so that** the linking feature can search and fetch documents.
+### Batch A — Backend (parallelisable)
 
-**Acceptance criteria:**
-- Client authenticates with API token
-- Search, metadata fetch, thumbnail proxy work
-- Connection test endpoint
-- Unit tests with mocked responses
+#### US-1a: Paperless-ngx HTTP client
+**Scope:** Create `modules/inventory/paperless/client.ts`. Auth via `Authorization: Token {PAPERLESS_API_TOKEN}`. Implement: `searchDocuments(query)`, `getDocument(id)`, `getDocumentThumbnail(id)`. Connection test: `GET /api/` with token validation. Typed responses. Unit tests with mocked HTTP (success, 401, 404). `.env.example` updated.
+**Files:** `modules/inventory/paperless/client.ts`, `types.ts`, `client.test.ts`
 
-### US-2: Link documents to items
-**As a** user, **I want** to link a Paperless-ngx receipt to an inventory item **so that** I can find proof of purchase from the item page.
+#### US-1b: Item documents schema and router
+**Scope:** Create `src/db/schema/item-documents.ts` Drizzle schema per R2. Create tRPC router with: `link({ itemId, paperlessDocumentId, documentType, title })`, `unlink({ id })`, `listForItem({ itemId })`. Unique constraint prevents duplicate links. Generate migration. Unit tests.
+**Files:** `src/db/schema/item-documents.ts`, `modules/inventory/documents/router.ts`, service, test
 
-**Acceptance criteria:**
-- "Link Document" opens search modal
-- Search returns Paperless-ngx results with thumbnails
-- Select document type and link
-- Linked document appears on detail page
+#### US-1c: Thumbnail proxy
+**Scope:** Add `getThumbnail` tRPC procedure (or Express route) that proxies the thumbnail from Paperless-ngx. Returns base64 or proxied URL. Caches in memory briefly (5 min) to avoid repeated calls.
+**Files:** `modules/inventory/paperless/client.ts` or `modules/inventory/documents/router.ts`
 
-### US-3: View and manage linked documents
-**As a** user, **I want** to see linked documents on the item detail page **so that** I have everything in one place.
+### Batch B — Frontend (parallelisable, depends on Batch A)
 
-**Acceptance criteria:**
-- Documents grouped by type (receipt, warranty, manual)
-- Thumbnail preview per document
-- Click to open in Paperless-ngx
-- Download button
-- Unlink action
+#### US-2: Link Document modal
+**Scope:** Create `LinkDocumentDialog.tsx`. Search input → queries Paperless-ngx via `inventory.documents.search`. Results show: title, date, correspondent, tags, thumbnail preview. Document type selector (receipt/warranty/manual/other). "Link" button per result. Calls `inventory.documents.link`. Linked document appears immediately. Storybook story.
+**Files:** `packages/app-inventory/src/components/LinkDocumentDialog.tsx`, story
 
-### US-4: Graceful degradation
-**As a** developer, **I want** the inventory app to work without Paperless-ngx **so that** the integration is optional.
+#### US-3: Linked documents display on detail page
+**Scope:** Add Documents section to `ItemDetailPage`. Shows linked documents grouped by type: 📄 Receipts, 📋 Warranties, 📖 Manuals, 📎 Other. Each: title, linked date, thumbnail. Click → open in Paperless-ngx (new tab). Download button → proxy file download. "Unlink" action. "Link Document" button opens LinkDocumentDialog.
+**Files:** `ItemDetailPage.tsx`
 
-**Acceptance criteria:**
-- No errors when not configured
-- Documents section hidden when not configured
-- "Unavailable" message when configured but unreachable
+#### US-4: Graceful degradation
+**Scope:** When `PAPERLESS_URL` not set: Documents section hidden on detail page, no errors. When configured but unreachable: show muted "Paperless-ngx unavailable" message in Documents section. Item detail page works fully without documents. Connection test procedure for settings display.
+**Files:** Service layer guards, `ItemDetailPage.tsx` conditional rendering

--- a/docs/specs/prd-023-warranty-value-reporting.md
+++ b/docs/specs/prd-023-warranty-value-reporting.md
@@ -202,45 +202,41 @@ Add "Warranties" to the inventory secondary navigation.
 ## User Stories
 
 > **Standard verification — applies to every US below.**
+>
+> **Sizing:** Each story is scoped for one agent, ~15-20 minutes.
 
-### US-1: Inventory dashboard
-**As a** user, **I want** to see total asset value and key stats at a glance **so that** I know the big picture.
+### Batch A — Backend (parallelisable)
 
-**Acceptance criteria:**
-- Total replacement value prominently displayed
-- Item count, resale value, warranties expiring shown
-- Recently added items
-- Single API call for dashboard data
+#### US-api-1: Dashboard stats endpoint
+**Scope:** Create `modules/inventory/reports/router.ts` with `getDashboard` procedure. Returns: total replacement value (sum), total resale value, total item count, warranties expiring in 30/60/90 days (counts + item list), recently added items (last 5). Single query/aggregate — no N+1. Unit tests.
+**Files:** `modules/inventory/reports/router.ts`, `service.ts`, test
 
-### US-2: Value breakdowns
-**As a** user, **I want** to see asset value broken down by room and type **so that** I know where the value is concentrated.
+#### US-api-2: Value breakdown endpoints
+**Scope:** Add `getValueByLocation({ depth? })` and `getValueByType` procedures. Value by location: aggregate replacement_value grouped by location at specified depth (default: room level). Value by type: aggregate by item type. Both return `{ name, totalValue, itemCount }[]`. Unit tests.
+**Files:** `modules/inventory/reports/service.ts`, test
 
-**Acceptance criteria:**
-- Value by room (chart or table)
-- Value by type (chart or table)
-- Click room → filtered item list
+#### US-api-3: Insurance report endpoint
+**Scope:** Add `generateReport({ locationId?, includeChildren?, sortBy? })` procedure. Returns all items under a location subtree (or all items if no locationId). Each item includes: all metadata, primary photo path, linked document IDs. Total replacement + resale values. Unit tests.
+**Files:** `modules/inventory/reports/service.ts`, test
 
-### US-3: Warranty tracking
-**As a** user, **I want** to see which warranties are expiring soon **so that** I can plan extended warranty purchases or replacements.
+### Batch B — Frontend (parallelisable, depends on Batch A)
 
-**Acceptance criteria:**
-- Items grouped by warranty status (expiring soon, expired, active)
-- Colour-coded urgency
-- Warranty status on item detail page
+#### US-1: Dashboard widgets
+**Scope:** Add dashboard section above the item list on `ItemListPage` (or create a separate dashboard view). Widgets: total replacement value (large number), total resale value (secondary), item count, warranties expiring soon (count, clickable → filtered list), recently added (last 5 items). Data from `inventory.reports.getDashboard`.
+**Files:** `ItemListPage.tsx` (dashboard section)
 
-### US-4: Insurance report
-**As a** user, **I want** to generate a report of everything in a room with values and photos **so that** I can give it to my insurer.
+#### US-2: Value breakdown charts
+**Scope:** Create value breakdown visualisation. Bar chart or table showing replacement value per room and per type. Click room → navigate to item list filtered by that room. Use recharts BarChart or a simple styled table. Data from `inventory.reports.getValueByLocation` and `getValueByType`.
+**Files:** New chart component(s), `ItemListPage.tsx` or dedicated tab
 
-**Acceptance criteria:**
-- Report for any location (room, sub-location, or full inventory)
-- Each item shows: name, brand, model, values, purchase date, warranty, photo
-- Receipt references included when available
-- Printable with clean layout
-- Include sub-locations toggle
+#### US-3: Warranty tracking page
+**Scope:** Create `WarrantiesPage.tsx`. Three groups: "Expiring Soon" (<90 days, colour-coded: red <30d, yellow 30-60d, orange 60-90d), "Expired" (muted styling, "expired X days ago"), "Active" (>90 days, collapsible). Each item: name, asset ID, warranty expiry, days remaining, replacement value. Sorted by expiry date. Add route + "Warranties" to secondary nav. Also add warranty status indicator to `ItemDetailPage` ("Under warranty — 45 days remaining" or "Expired 120 days ago").
+**Files:** `packages/app-inventory/src/pages/WarrantiesPage.tsx`, `ItemDetailPage.tsx`
 
-### US-5: Filtered value queries
-**As a** user, **I want** to see the total value of a filtered set of items **so that** I can answer "how much electronics do I have in the living room?"
+#### US-4: Insurance report page
+**Scope:** Create `ReportPage.tsx`. Location selector (or "Full Inventory"). "Include sub-locations" toggle. Generates a formatted report: header (location, date, summary totals), item list (name, brand, model, asset ID, condition, purchase date, warranty, replacement value, resale value, primary photo thumbnail, linked receipt IDs). Sort by value, name, or type. Printable: `@media print` CSS for clean output. "Print / Save as PDF" button (browser native). Accessible via "Generate Report" button on location tree page and inventory home.
+**Files:** `packages/app-inventory/src/pages/ReportPage.tsx`
 
-**Acceptance criteria:**
-- Total replacement and resale values shown for any filtered list
-- Works with all existing filters (type, room, condition, in-use, deductible)
+#### US-5: Filtered value aggregation
+**Scope:** Add total replacement value and total resale value display to the item list page, shown for the current filtered result set. Updates when filters change. Shows alongside the item count summary line (e.g., "23 items — $12,400 replacement — $5,200 resale"). Add `totalReplacementValue` and `totalResaleValue` to the list endpoint response.
+**Files:** `ItemListPage.tsx`, `modules/inventory/items/service.ts`


### PR DESCRIPTION
## Summary

Rewrites the User Stories section in all 17 PRDs (007-023) to split monolithic stories into agent-sized tasks. Each task is scoped for one agent, 15-20 minutes, one concern.

### What changed
- All 17 PRD files updated (User Stories section only — Requirements, Acceptance Criteria, Edge Cases unchanged)
- Stories organised into **dependency batches** (A → B → C → D)
- Tasks within the same batch are **parallelisable**
- Each task specifies: scope, files touched, acceptance criteria

### Why
The team was hitting scope problems where user stories took 60+ minutes and weren't parallelisable. For example, PRD-007 US-7 "Create comparisons sub-module with ELO" was one story bundling: ELO calculation, dimension CRUD, comparison submit, pair selection, and rankings — five independent concerns.

### Key splits

| PRD | Before | After | Biggest split |
|-----|--------|-------|---------------|
| 007 (Media data model) | 9 | 20 | US-7 → 4 tasks (elo, dimensions, submit, rankings) |
| 008 (TMDB) | 7 | 7 | Already right-sized, restructured into batches |
| 009 (TheTVDB) | 6 | 7 | Auth split from client |
| 010 (Media UI) | 8 | 13 | Components batch (6 parallel) then pages batch (5 parallel) |
| 017 (Inventory schema) | 7 | 13 | 4 schema files parallel, then 5 routers parallel |
| 019 (Inventory UI) | 7 | 13 | 6 components parallel then 4 pages parallel |

### Supersedes
PR #83 (work-breakdown-phase2.md) can be closed — the canonical task splits now live in the PRDs themselves, not a separate reference doc.

## Test plan
- [ ] Review task granularity — are tasks small enough for 15-20 min agent runs?
- [ ] Review batch dependencies — are parallelisation claims correct?
- [ ] Verify no Requirements or Acceptance Criteria sections were accidentally changed