### PR TITLE
feat: add locations tree CRUD router [Inventory-E00]

### DIFF
--- a/apps/pops-api/src/modules/inventory/index.ts
+++ b/apps/pops-api/src/modules/inventory/index.ts
@@ -1,9 +1,11 @@
 /**
- * Inventory domain — home inventory items.
+ * Inventory domain — home inventory items and location tree.
  */
 import { router } from "../../trpc.js";
 import { inventoryRouter as itemsRouter } from "./items/router.js";
+import { locationsRouter } from "./locations/router.js";
 
 export const inventoryRouter = router({
   items: itemsRouter,
+  locations: locationsRouter,
 });

--- a/apps/pops-api/src/modules/inventory/locations/locations.test.ts
+++ b/apps/pops-api/src/modules/inventory/locations/locations.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import type { Database } from "better-sqlite3";
+import { setupTestContext, seedLocation, createCaller } from "../../../shared/test-utils.js";
+
+const ctx = setupTestContext();
+let caller: ReturnType<typeof createCaller>;
+let db: Database;
+
+beforeEach(() => {
+  ({ caller, db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+describe("inventory.locations.list", () => {
+  it("returns empty list when no locations exist", async () => {
+    const result = await caller.inventory.locations.list();
+    expect(result.data).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("returns all locations sorted by sortOrder then name", async () => {
+    seedLocation(db, { name: "Bedroom", sort_order: 1 });
+    seedLocation(db, { name: "Kitchen", sort_order: 0 });
+    seedLocation(db, { name: "Living Room", sort_order: 0 });
+
+    const result = await caller.inventory.locations.list();
+    expect(result.data).toHaveLength(3);
+    expect(result.data[0].name).toBe("Kitchen");
+    expect(result.data[1].name).toBe("Living Room");
+    expect(result.data[2].name).toBe("Bedroom");
+  });
+});
+
+describe("inventory.locations.get", () => {
+  it("returns a location by ID", async () => {
+    const id = seedLocation(db, { name: "Home" });
+    const result = await caller.inventory.locations.get({ id });
+    expect(result.data.name).toBe("Home");
+    expect(result.data.parentId).toBeNull();
+  });
+
+  it("throws NOT_FOUND for missing ID", async () => {
+    await expect(
+      caller.inventory.locations.get({ id: "nonexistent" })
+    ).rejects.toThrow(TRPCError);
+  });
+});
+
+describe("inventory.locations.tree", () => {
+  it("returns empty tree when no locations exist", async () => {
+    const result = await caller.inventory.locations.tree();
+    expect(result.data).toEqual([]);
+  });
+
+  it("returns flat list as root nodes when no parents", async () => {
+    seedLocation(db, { name: "Home" });
+    seedLocation(db, { name: "Car" });
+
+    const result = await caller.inventory.locations.tree();
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0].children).toEqual([]);
+    expect(result.data[1].children).toEqual([]);
+  });
+
+  it("builds nested tree from parent-child relationships", async () => {
+    const homeId = seedLocation(db, { name: "Home" });
+    const kitchenId = seedLocation(db, { name: "Kitchen", parent_id: homeId });
+    seedLocation(db, { name: "Pantry", parent_id: kitchenId });
+    seedLocation(db, { name: "Bedroom", parent_id: homeId });
+
+    const result = await caller.inventory.locations.tree();
+    expect(result.data).toHaveLength(1); // Only Home is root
+
+    const home = result.data[0];
+    expect(home.name).toBe("Home");
+    expect(home.children).toHaveLength(2); // Kitchen, Bedroom
+
+    const kitchen = home.children.find((c) => c.name === "Kitchen");
+    expect(kitchen).toBeDefined();
+    expect(kitchen!.children).toHaveLength(1); // Pantry
+    expect(kitchen!.children[0].name).toBe("Pantry");
+  });
+});
+
+describe("inventory.locations.children", () => {
+  it("returns direct children of a location", async () => {
+    const homeId = seedLocation(db, { name: "Home" });
+    seedLocation(db, { name: "Kitchen", parent_id: homeId });
+    seedLocation(db, { name: "Bedroom", parent_id: homeId });
+    seedLocation(db, { name: "Car" }); // Not a child
+
+    const result = await caller.inventory.locations.children({ parentId: homeId });
+    expect(result.data).toHaveLength(2);
+  });
+});
+
+describe("inventory.locations.create", () => {
+  it("creates a root location", async () => {
+    const result = await caller.inventory.locations.create({ name: "Home" });
+    expect(result.data.name).toBe("Home");
+    expect(result.data.parentId).toBeNull();
+    expect(result.data.sortOrder).toBe(0);
+  });
+
+  it("creates a child location", async () => {
+    const parent = await caller.inventory.locations.create({ name: "Home" });
+    const child = await caller.inventory.locations.create({
+      name: "Kitchen",
+      parentId: parent.data.id,
+    });
+    expect(child.data.parentId).toBe(parent.data.id);
+  });
+
+  it("creates with custom sort order", async () => {
+    const result = await caller.inventory.locations.create({
+      name: "Garage",
+      sortOrder: 5,
+    });
+    expect(result.data.sortOrder).toBe(5);
+  });
+
+  it("throws NOT_FOUND when parentId does not exist", async () => {
+    await expect(
+      caller.inventory.locations.create({ name: "Child", parentId: "nonexistent" })
+    ).rejects.toThrow(TRPCError);
+  });
+
+  it("rejects empty name", async () => {
+    await expect(
+      caller.inventory.locations.create({ name: "" })
+    ).rejects.toThrow();
+  });
+});
+
+describe("inventory.locations.update", () => {
+  it("renames a location", async () => {
+    const id = seedLocation(db, { name: "Bedoom" });
+    const result = await caller.inventory.locations.update({
+      id,
+      data: { name: "Bedroom" },
+    });
+    expect(result.data.name).toBe("Bedroom");
+  });
+
+  it("moves a location to a new parent", async () => {
+    const homeId = seedLocation(db, { name: "Home" });
+    const garageId = seedLocation(db, { name: "Garage" });
+    const shelfId = seedLocation(db, { name: "Shelf", parent_id: homeId });
+
+    const result = await caller.inventory.locations.update({
+      id: shelfId,
+      data: { parentId: garageId },
+    });
+    expect(result.data.parentId).toBe(garageId);
+  });
+
+  it("moves a location to root", async () => {
+    const homeId = seedLocation(db, { name: "Home" });
+    const roomId = seedLocation(db, { name: "Room", parent_id: homeId });
+
+    const result = await caller.inventory.locations.update({
+      id: roomId,
+      data: { parentId: null },
+    });
+    expect(result.data.parentId).toBeNull();
+  });
+
+  it("rejects setting parentId to self", async () => {
+    const id = seedLocation(db, { name: "Home" });
+    await expect(
+      caller.inventory.locations.update({ id, data: { parentId: id } })
+    ).rejects.toThrow();
+  });
+
+  it("rejects circular reference", async () => {
+    const parentId = seedLocation(db, { name: "Parent" });
+    const childId = seedLocation(db, { name: "Child", parent_id: parentId });
+
+    // Try to make parent a child of its own child
+    await expect(
+      caller.inventory.locations.update({ id: parentId, data: { parentId: childId } })
+    ).rejects.toThrow();
+  });
+
+  it("throws NOT_FOUND for missing location", async () => {
+    await expect(
+      caller.inventory.locations.update({ id: "nonexistent", data: { name: "New" } })
+    ).rejects.toThrow(TRPCError);
+  });
+});
+
+describe("inventory.locations.delete", () => {
+  it("deletes a location", async () => {
+    const id = seedLocation(db, { name: "Temp" });
+    const result = await caller.inventory.locations.delete({ id });
+    expect(result.message).toBe("Location deleted");
+
+    // Verify it's gone
+    await expect(
+      caller.inventory.locations.get({ id })
+    ).rejects.toThrow(TRPCError);
+  });
+
+  it("cascade deletes children", async () => {
+    const parentId = seedLocation(db, { name: "Home" });
+    const childId = seedLocation(db, { name: "Kitchen", parent_id: parentId });
+    seedLocation(db, { name: "Pantry", parent_id: childId });
+
+    await caller.inventory.locations.delete({ id: parentId });
+
+    // All should be gone
+    const list = await caller.inventory.locations.list();
+    expect(list.data).toHaveLength(0);
+  });
+
+  it("throws NOT_FOUND for missing ID", async () => {
+    await expect(
+      caller.inventory.locations.delete({ id: "nonexistent" })
+    ).rejects.toThrow(TRPCError);
+  });
+});

--- a/apps/pops-api/src/modules/inventory/locations/router.ts
+++ b/apps/pops-api/src/modules/inventory/locations/router.ts
@@ -1,0 +1,99 @@
+/**
+ * Locations tRPC router — CRUD procedures for the location tree.
+ */
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { router, protectedProcedure } from "../../../trpc.js";
+import { CreateLocationSchema, UpdateLocationSchema, toLocation } from "./types.js";
+import * as service from "./service.js";
+import { NotFoundError, ConflictError } from "../../../shared/errors.js";
+
+export const locationsRouter = router({
+  /** Get the full location tree as nested nodes. */
+  tree: protectedProcedure.query(() => {
+    return { data: service.getLocationTree() };
+  }),
+
+  /** List all locations (flat). */
+  list: protectedProcedure.query(() => {
+    const { rows, total } = service.listLocations();
+    return {
+      data: rows.map(toLocation),
+      total,
+    };
+  }),
+
+  /** Get a single location by ID. */
+  get: protectedProcedure.input(z.object({ id: z.string() })).query(({ input }) => {
+    try {
+      const row = service.getLocation(input.id);
+      return { data: toLocation(row) };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
+  }),
+
+  /** Get children of a location (one level deep). */
+  children: protectedProcedure.input(z.object({ parentId: z.string() })).query(({ input }) => {
+    const rows = service.getChildren(input.parentId);
+    return { data: rows.map(toLocation) };
+  }),
+
+  /** Create a new location. */
+  create: protectedProcedure.input(CreateLocationSchema).mutation(({ input }) => {
+    try {
+      const row = service.createLocation(input);
+      return {
+        data: toLocation(row),
+        message: "Location created",
+      };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
+  }),
+
+  /** Update an existing location (rename, move, reorder). */
+  update: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        data: UpdateLocationSchema,
+      })
+    )
+    .mutation(({ input }) => {
+      try {
+        const row = service.updateLocation(input.id, input.data);
+        return {
+          data: toLocation(row),
+          message: "Location updated",
+        };
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+        }
+        if (err instanceof ConflictError) {
+          throw new TRPCError({ code: "CONFLICT", message: err.message });
+        }
+        throw err;
+      }
+    }),
+
+  /** Delete a location (cascade deletes children). */
+  delete: protectedProcedure.input(z.object({ id: z.string() })).mutation(({ input }) => {
+    try {
+      service.deleteLocation(input.id);
+      return { message: "Location deleted" };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
+  }),
+});

--- a/apps/pops-api/src/modules/inventory/locations/service.ts
+++ b/apps/pops-api/src/modules/inventory/locations/service.ts
@@ -1,0 +1,198 @@
+/**
+ * Location service — CRUD operations for the location tree.
+ * SQLite is the source of truth. All operations are local.
+ */
+import { eq, asc, count, isNull, sql } from "drizzle-orm";
+import { locations } from "@pops/db-types";
+import { getDrizzle } from "../../../db.js";
+import { NotFoundError, ConflictError } from "../../../shared/errors.js";
+import type { LocationRow, CreateLocationInput, UpdateLocationInput, LocationTreeNode } from "./types.js";
+import { toLocation } from "./types.js";
+
+/** Count + rows for a paginated list. */
+export interface LocationListResult {
+  rows: LocationRow[];
+  total: number;
+}
+
+/** List all locations (flat, ordered by name). */
+export function listLocations(): LocationListResult {
+  const db = getDrizzle();
+
+  const rows = db
+    .select()
+    .from(locations)
+    .orderBy(asc(locations.sortOrder), asc(locations.name))
+    .all();
+
+  return { rows, total: rows.length };
+}
+
+/** Get a single location by ID. Throws NotFoundError if missing. */
+export function getLocation(id: string): LocationRow {
+  const db = getDrizzle();
+  const row = db
+    .select()
+    .from(locations)
+    .where(eq(locations.id, id))
+    .get();
+
+  if (!row) throw new NotFoundError("Location", id);
+  return row;
+}
+
+/**
+ * Get the full location tree as nested nodes.
+ * Uses a single query + in-memory tree assembly.
+ */
+export function getLocationTree(): LocationTreeNode[] {
+  const db = getDrizzle();
+
+  const allRows = db
+    .select()
+    .from(locations)
+    .orderBy(asc(locations.sortOrder), asc(locations.name))
+    .all();
+
+  // Build tree from flat list
+  const nodeMap = new Map<string, LocationTreeNode>();
+  const roots: LocationTreeNode[] = [];
+
+  // First pass: create all nodes
+  for (const row of allRows) {
+    nodeMap.set(row.id, { ...toLocation(row), children: [] });
+  }
+
+  // Second pass: link children to parents
+  for (const row of allRows) {
+    const node = nodeMap.get(row.id)!;
+    if (row.parentId && nodeMap.has(row.parentId)) {
+      nodeMap.get(row.parentId)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  return roots;
+}
+
+/** Get children of a location (one level). */
+export function getChildren(parentId: string): LocationRow[] {
+  const db = getDrizzle();
+  return db
+    .select()
+    .from(locations)
+    .where(eq(locations.parentId, parentId))
+    .orderBy(asc(locations.sortOrder), asc(locations.name))
+    .all();
+}
+
+/**
+ * Create a new location. Returns the created row.
+ * Validates that parentId exists if provided.
+ */
+export function createLocation(input: CreateLocationInput): LocationRow {
+  const db = getDrizzle();
+
+  // Validate parent exists if provided
+  if (input.parentId) {
+    const parent = db
+      .select({ id: locations.id })
+      .from(locations)
+      .where(eq(locations.id, input.parentId))
+      .get();
+    if (!parent) throw new NotFoundError("Parent location", input.parentId);
+  }
+
+  const id = crypto.randomUUID();
+
+  const now = new Date().toISOString();
+
+  db.insert(locations)
+    .values({
+      id,
+      name: input.name,
+      parentId: input.parentId ?? null,
+      sortOrder: input.sortOrder ?? 0,
+      lastEditedTime: now,
+    })
+    .run();
+
+  return getLocation(id);
+}
+
+/**
+ * Update an existing location. Returns the updated row.
+ * Validates parentId if changing it, prevents circular references.
+ */
+export function updateLocation(id: string, input: UpdateLocationInput): LocationRow {
+  const db = getDrizzle();
+
+  // Verify it exists
+  getLocation(id);
+
+  // If changing parent, validate it exists and prevent cycles
+  if (input.parentId !== undefined && input.parentId !== null) {
+    if (input.parentId === id) {
+      throw new ConflictError("A location cannot be its own parent");
+    }
+
+    const parent = db
+      .select({ id: locations.id })
+      .from(locations)
+      .where(eq(locations.id, input.parentId))
+      .get();
+    if (!parent) throw new NotFoundError("Parent location", input.parentId);
+
+    // Check for circular reference: walk up from proposed parent
+    let current: string | null = input.parentId;
+    while (current) {
+      const ancestor = db
+        .select({ parentId: locations.parentId })
+        .from(locations)
+        .where(eq(locations.id, current))
+        .get();
+      if (!ancestor) break;
+      if (ancestor.parentId === id) {
+        throw new ConflictError("Moving this location would create a circular reference");
+      }
+      current = ancestor.parentId;
+    }
+  }
+
+  const updates: Partial<LocationRow> = {};
+  let hasUpdates = false;
+
+  if (input.name !== undefined) {
+    updates.name = input.name;
+    hasUpdates = true;
+  }
+  if (input.parentId !== undefined) {
+    updates.parentId = input.parentId;
+    hasUpdates = true;
+  }
+  if (input.sortOrder !== undefined) {
+    updates.sortOrder = input.sortOrder;
+    hasUpdates = true;
+  }
+
+  if (hasUpdates) {
+    updates.lastEditedTime = new Date().toISOString();
+    db.update(locations).set(updates).where(eq(locations.id, id)).run();
+  }
+
+  return getLocation(id);
+}
+
+/**
+ * Delete a location by ID. Throws NotFoundError if missing.
+ * Children are cascade-deleted by the FK constraint.
+ */
+export function deleteLocation(id: string): void {
+  // Verify it exists
+  getLocation(id);
+
+  const db = getDrizzle();
+  const result = db.delete(locations).where(eq(locations.id, id)).run();
+  if (result.changes === 0) throw new NotFoundError("Location", id);
+}

--- a/apps/pops-api/src/modules/inventory/locations/types.ts
+++ b/apps/pops-api/src/modules/inventory/locations/types.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import type { LocationRow } from "@pops/db-types";
+
+export type { LocationRow };
+
+/** API response shape for a location. */
+export interface Location {
+  id: string;
+  name: string;
+  parentId: string | null;
+  sortOrder: number;
+}
+
+/** Map a database row to the API response shape. */
+export function toLocation(row: LocationRow): Location {
+  return {
+    id: row.id,
+    name: row.name,
+    parentId: row.parentId,
+    sortOrder: row.sortOrder,
+  };
+}
+
+/** A location with its children for tree responses. */
+export interface LocationTreeNode extends Location {
+  children: LocationTreeNode[];
+}
+
+/** Zod schema for creating a location. */
+export const CreateLocationSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  parentId: z.string().nullable().optional(),
+  sortOrder: z.number().int().nonnegative().optional().default(0),
+});
+export type CreateLocationInput = z.infer<typeof CreateLocationSchema>;
+
+/** Zod schema for updating a location. */
+export const UpdateLocationSchema = z.object({
+  name: z.string().min(1, "Name cannot be empty").optional(),
+  parentId: z.string().nullable().optional(),
+  sortOrder: z.number().int().nonnegative().optional(),
+});
+export type UpdateLocationInput = z.infer<typeof UpdateLocationSchema>;

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -68,6 +68,16 @@ export function createTestDb(): Database {
     CREATE INDEX IF NOT EXISTS idx_transactions_entity ON transactions(entity_id);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_checksum ON transactions(checksum);
 
+    CREATE TABLE IF NOT EXISTS locations (
+      id               TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+      name             TEXT NOT NULL,
+      parent_id        TEXT REFERENCES locations(id) ON DELETE CASCADE,
+      sort_order       INTEGER NOT NULL DEFAULT 0,
+      last_edited_time TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_locations_parent ON locations(parent_id);
+    CREATE INDEX IF NOT EXISTS idx_locations_name ON locations(name);
+
     CREATE TABLE IF NOT EXISTS home_inventory (
       id                     TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
       notion_id              TEXT UNIQUE,
@@ -88,10 +98,18 @@ export function createTestDb(): Database {
       purchase_transaction_id TEXT,
       purchased_from_id      TEXT,
       purchased_from_name    TEXT,
+      asset_id               TEXT UNIQUE,
+      notes                  TEXT,
+      location_id            TEXT,
       last_edited_time       TEXT NOT NULL,
       FOREIGN KEY (purchase_transaction_id) REFERENCES transactions(id) ON DELETE SET NULL,
-      FOREIGN KEY (purchased_from_id) REFERENCES entities(id) ON DELETE SET NULL
+      FOREIGN KEY (purchased_from_id) REFERENCES entities(id) ON DELETE SET NULL,
+      FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE SET NULL
     );
+    CREATE INDEX IF NOT EXISTS idx_inventory_asset_id ON home_inventory(asset_id);
+    CREATE INDEX IF NOT EXISTS idx_inventory_name ON home_inventory(item_name);
+    CREATE INDEX IF NOT EXISTS idx_inventory_location ON home_inventory(location_id);
+    CREATE INDEX IF NOT EXISTS idx_inventory_type ON home_inventory(type);
 
     CREATE TABLE IF NOT EXISTS budgets (
       id               TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
@@ -135,6 +153,30 @@ export function createTestDb(): Database {
     CREATE INDEX IF NOT EXISTS idx_corrections_pattern ON transaction_corrections(description_pattern);
     CREATE INDEX IF NOT EXISTS idx_corrections_confidence ON transaction_corrections(confidence DESC);
     CREATE INDEX IF NOT EXISTS idx_corrections_times_applied ON transaction_corrections(times_applied DESC);
+
+    CREATE TABLE IF NOT EXISTS item_connections (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      item_a_id  TEXT NOT NULL,
+      item_b_id  TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (item_a_id) REFERENCES home_inventory(id) ON DELETE CASCADE,
+      FOREIGN KEY (item_b_id) REFERENCES home_inventory(id) ON DELETE CASCADE,
+      CHECK (item_a_id < item_b_id)
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_item_connections_pair ON item_connections(item_a_id, item_b_id);
+    CREATE INDEX IF NOT EXISTS idx_item_connections_a ON item_connections(item_a_id);
+    CREATE INDEX IF NOT EXISTS idx_item_connections_b ON item_connections(item_b_id);
+
+    CREATE TABLE IF NOT EXISTS item_photos (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      item_id    TEXT NOT NULL,
+      file_path  TEXT NOT NULL,
+      caption    TEXT,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (item_id) REFERENCES home_inventory(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_item_photos_item ON item_photos(item_id);
   `);
 
   return db;
@@ -267,6 +309,9 @@ export function seedInventoryItem(
     purchase_transaction_id: string | null;
     purchased_from_id: string | null;
     purchased_from_name: string | null;
+    asset_id: string | null;
+    notes: string | null;
+    location_id: string | null;
     last_edited_time: string;
   }> = {}
 ): string {
@@ -277,12 +322,14 @@ export function seedInventoryItem(
     INSERT INTO home_inventory (
       id, item_name, brand, model, item_id, room, location, type, condition,
       in_use, deductible, purchase_date, warranty_expires, replacement_value, resale_value,
-      purchase_transaction_id, purchased_from_id, purchased_from_name, last_edited_time
+      purchase_transaction_id, purchased_from_id, purchased_from_name,
+      asset_id, notes, location_id, last_edited_time
     )
     VALUES (
       @id, @item_name, @brand, @model, @item_id, @room, @location, @type, @condition,
       @in_use, @deductible, @purchase_date, @warranty_expires, @replacement_value, @resale_value,
-      @purchase_transaction_id, @purchased_from_id, @purchased_from_name, @last_edited_time
+      @purchase_transaction_id, @purchased_from_id, @purchased_from_name,
+      @asset_id, @notes, @location_id, @last_edited_time
     )
   `
   ).run({
@@ -304,10 +351,92 @@ export function seedInventoryItem(
     purchase_transaction_id: overrides.purchase_transaction_id ?? null,
     purchased_from_id: overrides.purchased_from_id ?? null,
     purchased_from_name: overrides.purchased_from_name ?? null,
+    asset_id: overrides.asset_id ?? null,
+    notes: overrides.notes ?? null,
+    location_id: overrides.location_id ?? null,
     last_edited_time: overrides.last_edited_time ?? "2025-01-01T00:00:00.000Z",
   });
 
   return id;
+}
+
+/**
+ * Seed a single location row into the test DB.
+ * Returns the id.
+ */
+export function seedLocation(
+  db: Database,
+  overrides: Partial<{
+    id: string;
+    name: string;
+    parent_id: string | null;
+    sort_order: number;
+    last_edited_time: string;
+  }> = {}
+): string {
+  const id = overrides.id ?? crypto.randomUUID();
+
+  db.prepare(
+    `
+    INSERT INTO locations (id, name, parent_id, sort_order, last_edited_time)
+    VALUES (@id, @name, @parent_id, @sort_order, @last_edited_time)
+  `
+  ).run({
+    id,
+    name: overrides.name ?? "Test Location",
+    parent_id: overrides.parent_id ?? null,
+    sort_order: overrides.sort_order ?? 0,
+    last_edited_time: overrides.last_edited_time ?? "2025-01-01T00:00:00.000Z",
+  });
+
+  return id;
+}
+
+/**
+ * Seed an item connection row into the test DB.
+ * Returns the auto-incremented id.
+ */
+export function seedItemConnection(
+  db: Database,
+  itemAId: string,
+  itemBId: string
+): number {
+  // Enforce A < B ordering
+  const [a, b] = itemAId < itemBId ? [itemAId, itemBId] : [itemBId, itemAId];
+
+  const result = db.prepare(
+    `INSERT INTO item_connections (item_a_id, item_b_id) VALUES (@a, @b)`
+  ).run({ a, b });
+
+  return Number(result.lastInsertRowid);
+}
+
+/**
+ * Seed an item photo row into the test DB.
+ * Returns the auto-incremented id.
+ */
+export function seedItemPhoto(
+  db: Database,
+  overrides: {
+    item_id: string;
+    file_path?: string;
+    caption?: string | null;
+    sort_order?: number;
+  }
+): number {
+  const result = db.prepare(
+    `
+    INSERT INTO item_photos (item_id, file_path, caption, sort_order)
+    VALUES (@item_id, @file_path, @caption, @sort_order)
+  `
+  ).run({
+    item_id: overrides.item_id,
+    file_path: overrides.file_path ?? "items/test/photo_001.jpg",
+    caption: overrides.caption ?? null,
+    sort_order: overrides.sort_order ?? 0,
+  });
+
+  return Number(result.lastInsertRowid);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Create `modules/inventory/locations/` with full CRUD for hierarchical location tree
- Tree operations: create root/child, rename, move (re-parent with cycle detection), delete (cascade)
- Query operations: list flat, get tree (nested nodes), get children
- Circular reference prevention when moving locations
- 22 unit tests covering all operations

## Dependencies
- Based on `feature/inventory-locations-schema` (PR #89) — will rebase to main after merge

## Test plan
- [x] All 520 tests pass (17 test files, +22 new)
- [x] Typecheck clean
- [x] Tests cover: CRUD, tree assembly, circular reference detection, cascade delete, validation

Closes tb-050

🤖 Generated with [Claude Code](https://claude.com/claude-code)