### PR TITLE
feat: integrate AppRail + PageNav into RootLayout [PRD-003/US-4]

### DIFF
--- a/apps/pops-shell/src/app/layout/PageNav.tsx
+++ b/apps/pops-shell/src/app/layout/PageNav.tsx
@@ -7,30 +7,8 @@
  */
 import { Link, useLocation } from "react-router";
 import { registeredApps } from "@/app/nav/registry";
+import { iconMap } from "@/app/nav/icon-map";
 import type { AppNavConfig } from "@/app/nav/types";
-import {
-  LayoutDashboard,
-  CreditCard,
-  Building2,
-  PiggyBank,
-  Package,
-  Star,
-  Download,
-  Bot,
-  type LucideIcon,
-} from "lucide-react";
-
-/** Map icon name strings from navConfig to Lucide components. */
-const iconMap: Record<string, LucideIcon> = {
-  LayoutDashboard,
-  CreditCard,
-  Building2,
-  PiggyBank,
-  Package,
-  Star,
-  Download,
-  Bot,
-};
 
 /** Check if pathname matches a prefix at a path-segment boundary. */
 function matchesAtBoundary(pathname: string, prefix: string): boolean {

--- a/apps/pops-shell/src/app/layout/RootLayout.tsx
+++ b/apps/pops-shell/src/app/layout/RootLayout.tsx
@@ -1,12 +1,13 @@
 /**
- * Root layout - top bar + sidebar + content area
+ * Root layout — top bar + two-level navigation + content area
  *
- * Responsive behaviour:
- * - Desktop (≥768px): Sidebar pushes content with left margin
- * - Mobile (<768px): Content is always full-width; sidebar overlays
+ * Desktop (≥768px): AppRail (icons) + PageNav (page links) push content
+ * Mobile (<768px): Hamburger opens Sidebar overlay with all pages
  */
 import { Outlet } from "react-router";
 import { TopBar } from "./TopBar";
+import { AppRail } from "./AppRail";
+import { PageNav } from "./PageNav";
 import { Sidebar } from "./Sidebar";
 import { ErrorBoundary } from "@pops/ui";
 import { useUIStore } from "@/store/uiStore";
@@ -17,13 +18,17 @@ export function RootLayout() {
   return (
     <div className="min-h-screen bg-background">
       <TopBar />
-      <div className="flex">
+      <div className="flex pt-16">
+        {/* Desktop: two-level nav (app rail + page nav) */}
+        <div className="hidden md:flex h-[calc(100vh-4rem)] sticky top-16">
+          <AppRail />
+          <PageNav />
+        </div>
+
+        {/* Mobile: overlay sidebar */}
         <Sidebar open={sidebarOpen} />
-        <main
-          className={`flex-1 transition-all duration-300 min-w-0 ${
-            sidebarOpen ? "md:ml-64" : "ml-0"
-          }`}
-        >
+
+        <main className="flex-1 min-w-0">
           <ErrorBoundary>
             <div className="p-4 md:p-6">
               <Outlet />

--- a/apps/pops-shell/src/app/layout/Sidebar.tsx
+++ b/apps/pops-shell/src/app/layout/Sidebar.tsx
@@ -1,11 +1,8 @@
 /**
- * Sidebar navigation
+ * Mobile sidebar navigation
  *
- * Renders navigation items driven by registered app navConfigs.
- *
- * Responsive behaviour:
- * - Desktop (≥768px): Fixed sidebar that pushes content
- * - Mobile (<768px): Overlay sidebar with backdrop, closes on link click
+ * Overlay sidebar for mobile (<768px) with backdrop.
+ * Desktop navigation is handled by AppRail + PageNav.
  */
 import { Link, useLocation } from "react-router";
 import { registeredApps } from "@/app/nav/registry";
@@ -24,67 +21,22 @@ export function Sidebar({ open }: SidebarProps) {
   if (!open) return null;
 
   const handleNavClick = () => {
-    // Close sidebar on mobile after navigating
-    if (window.innerWidth < 768) {
-      setSidebarOpen(false);
-    }
+    setSidebarOpen(false);
   };
-
-  const navContent = (
-    <nav className="p-4 space-y-1">
-      {registeredApps.map((app) =>
-        app.items.map((item) => {
-          const fullPath = `${app.basePath}${item.path}`;
-          const isActive =
-            item.path === ""
-              ? location.pathname === app.basePath ||
-                location.pathname === `${app.basePath}/`
-              : location.pathname.startsWith(fullPath);
-          const Icon = iconMap[item.icon];
-
-          return (
-            <Link
-              key={fullPath}
-              to={fullPath}
-              onClick={handleNavClick}
-              className={`flex items-center gap-3 px-4 py-3 md:py-2 rounded-lg transition-colors font-medium min-h-[44px] ${
-                isActive
-                  ? "bg-primary text-primary-foreground"
-                  : "text-foreground hover:bg-muted hover:text-foreground"
-              }`}
-            >
-              {Icon && <Icon className="h-5 w-5 shrink-0" />}
-              <span>{item.label}</span>
-            </Link>
-          );
-        })
-      )}
-    </nav>
-  );
 
   return (
     <>
-      {/* Mobile: overlay backdrop */}
+      {/* Backdrop */}
       <div
         className="fixed inset-0 bg-black/50 z-40 md:hidden"
         onClick={() => setSidebarOpen(false)}
         aria-hidden="true"
       />
 
-      {/* Sidebar panel */}
-      <aside
-        className={[
-          "w-64 bg-card border-r border-border fixed z-50",
-          // Mobile: full height overlay from top
-          "top-0 left-0 h-full",
-          // Desktop: below top bar (md:h-16 = 4rem)
-          "md:top-16 md:h-[calc(100vh-4rem)]",
-          // Desktop: z-index below overlay
-          "md:z-30",
-        ].join(" ")}
-      >
-        {/* Mobile close button */}
-        <div className="flex items-center justify-between p-4 border-b border-border md:hidden">
+      {/* Panel */}
+      <aside className="w-64 bg-card border-r border-border fixed z-50 top-0 left-0 h-full md:hidden">
+        {/* Header with close button */}
+        <div className="flex items-center justify-between p-4 border-b border-border">
           <span className="text-lg font-bold">POPS</span>
           <button
             onClick={() => setSidebarOpen(false)}
@@ -95,7 +47,35 @@ export function Sidebar({ open }: SidebarProps) {
           </button>
         </div>
 
-        {navContent}
+        <nav className="p-4 space-y-1">
+          {registeredApps.map((app) =>
+            app.items.map((item) => {
+              const fullPath = `${app.basePath}${item.path}`;
+              const isActive =
+                item.path === ""
+                  ? location.pathname === app.basePath ||
+                    location.pathname === `${app.basePath}/`
+                  : location.pathname.startsWith(fullPath);
+              const Icon = iconMap[item.icon];
+
+              return (
+                <Link
+                  key={fullPath}
+                  to={fullPath}
+                  onClick={handleNavClick}
+                  className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-colors font-medium min-h-[44px] ${
+                    isActive
+                      ? "bg-primary text-primary-foreground"
+                      : "text-foreground hover:bg-muted hover:text-foreground"
+                  }`}
+                >
+                  {Icon && <Icon className="h-5 w-5 shrink-0" />}
+                  <span>{item.label}</span>
+                </Link>
+              );
+            }),
+          )}
+        </nav>
       </aside>
     </>
   );

--- a/apps/pops-shell/src/app/layout/TopBar.tsx
+++ b/apps/pops-shell/src/app/layout/TopBar.tsx
@@ -17,7 +17,7 @@ export function TopBar() {
     <header className="bg-card border-b border-border h-14 md:h-16 flex items-center px-3 md:px-4 sticky top-0 z-40">
       <button
         onClick={toggleSidebar}
-        className="min-w-[44px] min-h-[44px] flex items-center justify-center hover:bg-muted rounded-lg mr-2 md:mr-4"
+        className="min-w-[44px] min-h-[44px] flex items-center justify-center hover:bg-muted rounded-lg mr-2 md:hidden"
         aria-label="Toggle sidebar"
       >
         <Menu className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- Replaced single Sidebar with two-level navigation in RootLayout: AppRail (icon strip) + PageNav (page links) on desktop
- Sidebar preserved as mobile-only overlay navigation (hidden on desktop via `md:hidden`)
- Hamburger menu hidden on desktop — AppRail has its own collapse toggle
- PageNav updated to use shared `icon-map.ts` instead of local duplicate map
- Root `/` redirect to `/finance` was already in place

This completes PRD-003 App Switcher: all 4 user stories (US-1 through US-4) are now implemented.

## Test plan
- [x] 23 shell tests pass (theme store, UI store, PageNav)
- [x] Typecheck clean (only pre-existing pops-api entity errors)
- [x] Desktop: AppRail + PageNav render side-by-side, sticky below top bar
- [x] Mobile: Sidebar overlay works with hamburger toggle
- [x] All existing finance navigation routes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>