### PR TITLE
fix: extract matchesAtBoundary to shared nav utility

### DIFF
--- a/apps/pops-shell/src/app/layout/AppRail.tsx
+++ b/apps/pops-shell/src/app/layout/AppRail.tsx
@@ -8,6 +8,7 @@
 import { useNavigate, useLocation } from "react-router";
 import { registeredApps } from "@/app/nav/registry";
 import { iconMap } from "@/app/nav/icon-map";
+import { matchesAtBoundary } from "@/app/nav/path-utils";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useUIStore } from "@/store/uiStore";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@pops/ui";
@@ -55,7 +56,7 @@ export function AppRail({ className }: AppRailProps) {
         .join(" ")}
     >
       {registeredApps.map((app) => {
-        const isActive = location.pathname.startsWith(app.basePath);
+        const isActive = matchesAtBoundary(location.pathname, app.basePath);
         const Icon = iconMap[app.icon];
 
         return (

--- a/apps/pops-shell/src/app/layout/PageNav.test.ts
+++ b/apps/pops-shell/src/app/layout/PageNav.test.ts
@@ -2,7 +2,7 @@
  * Tests for PageNav helper functions
  */
 import { describe, it, expect } from "vitest";
-import { findActiveApp, isPageActive } from "./PageNav";
+import { findActiveApp, isPageActive } from "@/app/nav/path-utils";
 import type { AppNavConfig } from "@/app/nav/types";
 
 const mockApps: AppNavConfig[] = [

--- a/apps/pops-shell/src/app/layout/PageNav.tsx
+++ b/apps/pops-shell/src/app/layout/PageNav.tsx
@@ -8,35 +8,7 @@
 import { Link, useLocation } from "react-router";
 import { registeredApps } from "@/app/nav/registry";
 import { iconMap } from "@/app/nav/icon-map";
-import type { AppNavConfig } from "@/app/nav/types";
-
-/** Check if pathname matches a prefix at a path-segment boundary. */
-function matchesAtBoundary(pathname: string, prefix: string): boolean {
-  if (!pathname.startsWith(prefix)) return false;
-  // Must match exactly or be followed by / (segment boundary)
-  return pathname.length === prefix.length || pathname[prefix.length] === "/";
-}
-
-/** Find the active app by matching the current pathname against registered base paths. */
-export function findActiveApp(
-  pathname: string,
-  apps: AppNavConfig[],
-): AppNavConfig | undefined {
-  return apps.find((app) => matchesAtBoundary(pathname, app.basePath));
-}
-
-/** Check if a page item is active given the current pathname and its app's basePath. */
-export function isPageActive(
-  pathname: string,
-  basePath: string,
-  itemPath: string,
-): boolean {
-  if (itemPath === "") {
-    return pathname === basePath || pathname === `${basePath}/`;
-  }
-  const fullPath = `${basePath}${itemPath}`;
-  return matchesAtBoundary(pathname, fullPath);
-}
+import { findActiveApp, isPageActive } from "@/app/nav/path-utils";
 
 export function PageNav() {
   const location = useLocation();

--- a/apps/pops-shell/src/app/layout/Sidebar.tsx
+++ b/apps/pops-shell/src/app/layout/Sidebar.tsx
@@ -7,6 +7,7 @@
 import { Link, useLocation } from "react-router";
 import { registeredApps } from "@/app/nav/registry";
 import { iconMap } from "@/app/nav/icon-map";
+import { isPageActive } from "@/app/nav/path-utils";
 import { useUIStore } from "@/store/uiStore";
 import { X } from "lucide-react";
 
@@ -51,11 +52,11 @@ export function Sidebar({ open }: SidebarProps) {
           {registeredApps.map((app) =>
             app.items.map((item) => {
               const fullPath = `${app.basePath}${item.path}`;
-              const isActive =
-                item.path === ""
-                  ? location.pathname === app.basePath ||
-                    location.pathname === `${app.basePath}/`
-                  : location.pathname.startsWith(fullPath);
+              const isActive = isPageActive(
+                location.pathname,
+                app.basePath,
+                item.path,
+              );
               const Icon = iconMap[item.icon];
 
               return (

--- a/apps/pops-shell/src/app/nav/path-utils.ts
+++ b/apps/pops-shell/src/app/nav/path-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared path-matching utilities for navigation components.
+ *
+ * All nav components (AppRail, PageNav, Sidebar) must use these helpers
+ * to avoid prefix-collision bugs (e.g. /fin matching /finance).
+ */
+import type { AppNavConfig } from "./types.js";
+
+/** Check if pathname matches a prefix at a path-segment boundary. */
+export function matchesAtBoundary(
+  pathname: string,
+  prefix: string,
+): boolean {
+  if (!pathname.startsWith(prefix)) return false;
+  return pathname.length === prefix.length || pathname[prefix.length] === "/";
+}
+
+/** Find the active app by matching the current pathname against registered base paths. */
+export function findActiveApp(
+  pathname: string,
+  apps: AppNavConfig[],
+): AppNavConfig | undefined {
+  return apps.find((app) => matchesAtBoundary(pathname, app.basePath));
+}
+
+/** Check if a page item is active given the current pathname and its app's basePath. */
+export function isPageActive(
+  pathname: string,
+  basePath: string,
+  itemPath: string,
+): boolean {
+  if (itemPath === "") {
+    return pathname === basePath || pathname === `${basePath}/`;
+  }
+  const fullPath = `${basePath}${itemPath}`;
+  return matchesAtBoundary(pathname, fullPath);
+}


### PR DESCRIPTION
## Summary
- Extract `matchesAtBoundary()`, `findActiveApp()`, `isPageActive()` to shared `app/nav/path-utils.ts`
- Fix prefix-collision bugs in AppRail and Sidebar (e.g. `/fin` matching `/finance`)
- PageNav, AppRail, and Sidebar all now use the same boundary-safe path matching
- Follow-up fix for QA review on PR #93

## Test plan
- [x] All 23 pops-shell tests pass
- [x] TypeScript compiles cleanly
- [x] Existing PageNav boundary tests now exercise the shared utility
- [ ] QA: verify no prefix collisions in any nav component

🤖 Generated with [Claude Code](https://claude.com/claude-code)