### PR TITLE
feat: TMDB token bucket rate limiter [PRD-008/US-2]

### DIFF
--- a/apps/pops-api/src/modules/media/tmdb/client.test.ts
+++ b/apps/pops-api/src/modules/media/tmdb/client.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { TmdbClient } from "./client.js";
 import { TmdbApiError } from "./types.js";
+import { TokenBucketRateLimiter } from "./rate-limiter.js";
 import type { RawTmdbSearchResponse, RawTmdbMovieDetail, RawTmdbImageResponse } from "./types.js";
 
 /** Helper to create a mocked Response. */
@@ -432,5 +433,35 @@ describe("error handling", () => {
       expect((err as TmdbApiError).status).toBe(500);
       expect((err as TmdbApiError).message).toContain("500");
     }
+  });
+});
+
+describe("rate limiter integration", () => {
+  it("calls acquire() before each request when rate limiter is provided", async () => {
+    const limiter = new TokenBucketRateLimiter(40, 4);
+    const acquireSpy = vi.spyOn(limiter, "acquire");
+    const rateLimitedClient = new TmdbClient(FAKE_KEY, limiter);
+
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ page: 1, results: [], total_results: 0, total_pages: 0 }),
+    );
+
+    await rateLimitedClient.searchMovies("test");
+
+    expect(acquireSpy).toHaveBeenCalledOnce();
+
+    limiter.destroy();
+  });
+
+  it("does not call acquire() when no rate limiter is provided", async () => {
+    // Default client has no rate limiter
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ page: 1, results: [], total_results: 0, total_pages: 0 }),
+    );
+
+    await client.searchMovies("test");
+
+    // Just verify the request succeeded without rate limiting
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });

--- a/apps/pops-api/src/modules/media/tmdb/client.ts
+++ b/apps/pops-api/src/modules/media/tmdb/client.ts
@@ -15,17 +15,20 @@ import {
   type RawTmdbMovieDetail,
   type RawTmdbImageResponse,
 } from "./types.js";
+import type { TokenBucketRateLimiter } from "./rate-limiter.js";
 
 const BASE_URL = "https://api.themoviedb.org";
 
 export class TmdbClient {
   private readonly apiKey: string;
+  private readonly rateLimiter: TokenBucketRateLimiter | null;
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, rateLimiter?: TokenBucketRateLimiter) {
     if (!apiKey) {
       throw new Error("TMDB API key is required");
     }
     this.apiKey = apiKey;
+    this.rateLimiter = rateLimiter ?? null;
   }
 
   /** Search movies by query string. */
@@ -121,8 +124,12 @@ export class TmdbClient {
     );
   }
 
-  /** Generic GET with Bearer auth and error handling. */
+  /** Generic GET with Bearer auth, rate limiting, and error handling. */
   private async get<T>(path: string): Promise<T> {
+    if (this.rateLimiter) {
+      await this.rateLimiter.acquire();
+    }
+
     let response: Response;
 
     try {

--- a/apps/pops-api/src/modules/media/tmdb/rate-limiter.test.ts
+++ b/apps/pops-api/src/modules/media/tmdb/rate-limiter.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Token bucket rate limiter tests.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { TokenBucketRateLimiter } from "./rate-limiter.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("TokenBucketRateLimiter", () => {
+  it("allows immediate acquisition when tokens are available", async () => {
+    const limiter = new TokenBucketRateLimiter(5, 1);
+
+    // Should resolve immediately for first 5 calls
+    for (let i = 0; i < 5; i++) {
+      await limiter.acquire();
+    }
+
+    limiter.destroy();
+  });
+
+  it("exhausts bucket after capacity is reached", async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(3, 1);
+
+    // Drain all 3 tokens
+    await limiter.acquire();
+    await limiter.acquire();
+    await limiter.acquire();
+
+    // The 4th call should not resolve immediately
+    let resolved = false;
+    const promise = limiter.acquire().then(() => {
+      resolved = true;
+    });
+
+    // Give microtasks a chance to run
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(false);
+
+    // After enough time for 1 token to refill (1 token / 1 per sec = 1000ms)
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+    expect(resolved).toBe(true);
+
+    limiter.destroy();
+  });
+
+  it("refills tokens over time", async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(2, 2); // 2 tokens/sec
+
+    // Drain bucket
+    await limiter.acquire();
+    await limiter.acquire();
+
+    // Wait 1 second — should refill 2 tokens
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // Should be able to acquire 2 more immediately
+    await limiter.acquire();
+    await limiter.acquire();
+
+    limiter.destroy();
+  });
+
+  it("does not exceed capacity on refill", async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(3, 10); // Fast refill
+
+    // Only drain 1 token
+    await limiter.acquire();
+
+    // Wait a long time
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // Should still only have 3 tokens (capacity), not more
+    // Drain all 3
+    await limiter.acquire();
+    await limiter.acquire();
+    await limiter.acquire();
+
+    // 4th should wait
+    let resolved = false;
+    limiter.acquire().then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(false);
+
+    limiter.destroy();
+  });
+
+  it("processes queued waiters in FIFO order", async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(1, 1);
+    const order: number[] = [];
+
+    // Drain the single token
+    await limiter.acquire();
+
+    // Queue 3 waiters
+    limiter.acquire().then(() => order.push(1));
+    limiter.acquire().then(() => order.push(2));
+    limiter.acquire().then(() => order.push(3));
+
+    // Advance enough for 3 tokens
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(order).toEqual([1, 2, 3]);
+
+    limiter.destroy();
+  });
+
+  it("works with TMDB-like settings (40 capacity, 4/sec refill)", async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(40, 4);
+
+    // Should drain all 40 immediately
+    for (let i = 0; i < 40; i++) {
+      await limiter.acquire();
+    }
+
+    // 41st should wait
+    let resolved = false;
+    limiter.acquire().then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(false);
+
+    // At 4 tokens/sec, one token takes 250ms
+    await vi.advanceTimersByTimeAsync(250);
+    expect(resolved).toBe(true);
+
+    limiter.destroy();
+  });
+
+  it("destroy resolves pending waiters and clears timers", async () => {
+    vi.useFakeTimers();
+    const limiter = new TokenBucketRateLimiter(1, 1);
+
+    await limiter.acquire();
+
+    let resolved = false;
+    limiter.acquire().then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(false);
+
+    limiter.destroy();
+
+    // Give microtasks a chance
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(true);
+  });
+});

--- a/apps/pops-api/src/modules/media/tmdb/rate-limiter.ts
+++ b/apps/pops-api/src/modules/media/tmdb/rate-limiter.ts
@@ -1,0 +1,87 @@
+/**
+ * Token bucket rate limiter for TMDB API requests.
+ *
+ * TMDB allows 40 requests per 10 seconds per API key.
+ * Bucket starts full and refills at a steady rate.
+ * acquire() waits when exhausted — callers never see 429 errors.
+ */
+
+export class TokenBucketRateLimiter {
+  private tokens: number;
+  private lastRefill: number;
+  private readonly waitQueue: Array<() => void> = [];
+  private drainTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly capacity: number,
+    private readonly refillRate: number,
+  ) {
+    this.tokens = capacity;
+    this.lastRefill = Date.now();
+  }
+
+  /** Consume one token. Resolves immediately if available, waits otherwise. */
+  async acquire(): Promise<void> {
+    this.refill();
+
+    if (this.tokens >= 1) {
+      this.tokens -= 1;
+      return;
+    }
+
+    // No tokens available — queue the caller
+    return new Promise<void>((resolve) => {
+      this.waitQueue.push(resolve);
+      this.scheduleDrain();
+    });
+  }
+
+  /** Refill tokens based on elapsed time since last refill. */
+  private refill(): void {
+    const now = Date.now();
+    const elapsed = (now - this.lastRefill) / 1000;
+    const newTokens = elapsed * this.refillRate;
+
+    if (newTokens >= 1) {
+      this.tokens = Math.min(this.capacity, this.tokens + newTokens);
+      this.lastRefill = now;
+    }
+  }
+
+  /** Schedule a timer to drain the wait queue when tokens become available. */
+  private scheduleDrain(): void {
+    if (this.drainTimer !== null) return;
+
+    // Time until next token is available
+    const msPerToken = 1000 / this.refillRate;
+
+    this.drainTimer = setTimeout(() => {
+      this.drainTimer = null;
+      this.refill();
+
+      while (this.waitQueue.length > 0 && this.tokens >= 1) {
+        this.tokens -= 1;
+        const resolve = this.waitQueue.shift()!;
+        resolve();
+      }
+
+      // If still waiters left, schedule again
+      if (this.waitQueue.length > 0) {
+        this.scheduleDrain();
+      }
+    }, msPerToken);
+  }
+
+  /** Clean up any pending timers. */
+  destroy(): void {
+    if (this.drainTimer !== null) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
+    // Resolve any remaining waiters to prevent hanging promises
+    while (this.waitQueue.length > 0) {
+      const resolve = this.waitQueue.shift()!;
+      resolve();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `TokenBucketRateLimiter` class (capacity=40, refill=4/sec) matching TMDB's 40 req/10s limit
- Wire into `TmdbClient.get()` — optional constructor parameter, calls `acquire()` before each fetch
- Callers never see 429 errors; requests wait when tokens exhausted

## Test plan
- [x] 7 unit tests for rate limiter (immediate acquisition, exhaustion/wait, refill, FIFO ordering, capacity cap, TMDB-like settings, destroy cleanup)
- [x] 2 integration tests for client wiring (acquire called with limiter, no-op without limiter)
- [x] All 526 existing tests still pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)