### PR TITLE
feat: season detail page with episode list [PRD-010/US-7] (tb-074)

### DIFF
--- a/packages/app-media/src/components/EpisodeList.tsx
+++ b/packages/app-media/src/components/EpisodeList.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
+import { formatRuntime } from "../lib/utils";
 
 interface Episode {
   id: number;
@@ -14,10 +15,60 @@ interface EpisodeListProps {
   episodes: Episode[];
 }
 
-function formatRuntime(minutes: number): string {
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+function EpisodeRow({
+  ep,
+  isExpanded,
+  onToggle,
+}: {
+  ep: Episode;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const hasOverview = ep.overview && ep.overview.length > 0;
+
+  return (
+    <div className="px-4 py-3">
+      <div className="flex items-start gap-3">
+        {hasOverview ? (
+          <button
+            type="button"
+            onClick={onToggle}
+            aria-expanded={isExpanded}
+            className="mt-0.5 text-muted-foreground shrink-0 hover:text-foreground"
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+          </button>
+        ) : null}
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2">
+            <span className="text-sm font-medium text-muted-foreground shrink-0">
+              {ep.episodeNumber}
+            </span>
+            <span className="text-sm font-medium truncate">
+              {ep.name ?? `Episode ${ep.episodeNumber}`}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2 mt-0.5 text-xs text-muted-foreground">
+            {ep.airDate && <span>{ep.airDate}</span>}
+            {ep.airDate && ep.runtime && <span>·</span>}
+            {ep.runtime && <span>{formatRuntime(ep.runtime)}</span>}
+          </div>
+        </div>
+      </div>
+
+      {isExpanded && hasOverview && (
+        <p className="mt-2 ml-7 text-sm text-muted-foreground leading-relaxed">
+          {ep.overview}
+        </p>
+      )}
+    </div>
+  );
 }
 
 export function EpisodeList({ episodes }: EpisodeListProps) {
@@ -43,52 +94,14 @@ export function EpisodeList({ episodes }: EpisodeListProps) {
 
   return (
     <div className="divide-y divide-border rounded-lg border">
-      {episodes.map((ep) => {
-        const isExpanded = expandedIds.has(ep.id);
-        const hasOverview = ep.overview && ep.overview.length > 0;
-
-        return (
-          <div key={ep.id} className="px-4 py-3">
-            <div
-              className={`flex items-start gap-3 ${hasOverview ? "cursor-pointer" : ""}`}
-              onClick={hasOverview ? () => toggleExpanded(ep.id) : undefined}
-            >
-              {hasOverview && (
-                <span className="mt-0.5 text-muted-foreground shrink-0">
-                  {isExpanded ? (
-                    <ChevronDown className="h-4 w-4" />
-                  ) : (
-                    <ChevronRight className="h-4 w-4" />
-                  )}
-                </span>
-              )}
-
-              <div className="flex-1 min-w-0">
-                <div className="flex items-baseline gap-2">
-                  <span className="text-sm font-medium text-muted-foreground shrink-0">
-                    {ep.episodeNumber}
-                  </span>
-                  <span className="text-sm font-medium truncate">
-                    {ep.name ?? `Episode ${ep.episodeNumber}`}
-                  </span>
-                </div>
-
-                <div className="flex items-center gap-2 mt-0.5 text-xs text-muted-foreground">
-                  {ep.airDate && <span>{ep.airDate}</span>}
-                  {ep.airDate && ep.runtime && <span>·</span>}
-                  {ep.runtime && <span>{formatRuntime(ep.runtime)}</span>}
-                </div>
-              </div>
-            </div>
-
-            {isExpanded && hasOverview && (
-              <p className="mt-2 ml-7 text-sm text-muted-foreground leading-relaxed">
-                {ep.overview}
-              </p>
-            )}
-          </div>
-        );
-      })}
+      {episodes.map((ep) => (
+        <EpisodeRow
+          key={ep.id}
+          ep={ep}
+          isExpanded={expandedIds.has(ep.id)}
+          onToggle={() => toggleExpanded(ep.id)}
+        />
+      ))}
     </div>
   );
 }

--- a/packages/app-media/src/pages/SeasonDetailPage.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.tsx
@@ -1,7 +1,18 @@
 import { useParams, Link } from "react-router";
-import { Alert, AlertTitle, AlertDescription, Skeleton } from "@pops/ui";
-import { trpc } from "@/lib/trpc";
-import { EpisodeList } from "@/components/EpisodeList";
+import {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  Skeleton,
+} from "@pops/ui";
+import { trpc } from "../lib/trpc";
+import { EpisodeList } from "../components/EpisodeList";
 
 function SeasonDetailSkeleton() {
   return (
@@ -120,17 +131,25 @@ export function SeasonDetailPage() {
   return (
     <div className="p-6 space-y-6 max-w-4xl">
       {/* Breadcrumb */}
-      <nav className="flex items-center gap-1.5 text-sm text-muted-foreground">
-        <Link to="/media" className="hover:text-foreground">
-          Media
-        </Link>
-        <span>›</span>
-        <Link to={`/media/tv/${show.id}`} className="hover:text-foreground">
-          {show.name}
-        </Link>
-        <span>›</span>
-        <span className="text-foreground font-medium">{seasonLabel}</span>
-      </nav>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/media">Media</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to={`/media/tv/${show.id}`}>{show.name}</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>{seasonLabel}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
 
       {/* Season header */}
       <div className="flex flex-col sm:flex-row gap-4">


### PR DESCRIPTION
## Summary
- Implement `SeasonDetailPage` with breadcrumb navigation (Media > Show Name > Season N)
- Season header with poster, name, overview, and episode count
- Create reusable `EpisodeList` component with expandable/collapsible episode overviews
- Handles specials (S0 displayed as "Specials"), 404 for invalid show/season
- Loading skeletons for all sections

**Depends on:** PR #121 (tb-068 scaffold), PR #122 (tb-072 movie detail — includes lib/trpc.ts)

## Test plan
- [x] `pnpm --filter @pops/app-media typecheck` — no app-media errors
- [x] All 23 shell tests pass
- [x] No runtime regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)