### PR TITLE
fix: resolve layout/CSS regressions — double padding, TopBar height mismatch [tb-083]

### DIFF
--- a/apps/pops-shell/src/app/layout/RootLayout.tsx
+++ b/apps/pops-shell/src/app/layout/RootLayout.tsx
@@ -18,9 +18,9 @@ export function RootLayout() {
   return (
     <div className="min-h-screen bg-background">
       <TopBar />
-      <div className="flex pt-16">
+      <div className="flex pt-14 md:pt-16">
         {/* Desktop: two-level nav (app rail + page nav) */}
-        <div className="hidden md:flex h-[calc(100vh-4rem)] sticky top-16">
+        <div className="hidden md:flex h-[calc(100vh-4rem)] sticky top-16 shrink-0">
           <AppRail />
           <PageNav />
         </div>
@@ -28,11 +28,9 @@ export function RootLayout() {
         {/* Mobile: overlay sidebar */}
         <Sidebar open={sidebarOpen} />
 
-        <main className="flex-1 min-w-0">
+        <main className="flex-1 min-w-0 overflow-x-hidden">
           <ErrorBoundary>
-            <div className="p-4 md:p-6">
-              <Outlet />
-            </div>
+            <Outlet />
           </ErrorBoundary>
         </main>
       </div>


### PR DESCRIPTION
## Summary
- Remove wrapper `p-4 md:p-6` padding from RootLayout (pages already have their own `p-6`)
- Fix mobile TopBar gap: change `pt-16` to `pt-14 md:pt-16` to match TopBar's responsive `h-14 md:h-16`
- Add `shrink-0` to nav container to prevent flex shrinking on content overflow
- Add `overflow-x-hidden` to main content area

## Test plan
- [ ] Verify no double padding on all pages (dashboard, transactions, budgets, etc.)
- [ ] Verify no 8px gap below TopBar on mobile viewport
- [ ] Verify sidebar scroll works without gap on desktop
- [ ] All 23 shell tests pass, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)