### PR TITLE
feat: add Plus Jakarta Sans font and typography foundation

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,33 @@
+# POPS Design Context
+
+## Target Audience
+Single user (owner) — but displayed on a wall-mounted iPad where others may see it. Must look impressive at a glance while being efficient for daily use.
+
+## Use Cases
+- Financial tracking: transactions, budgets, entity management
+- Media library: movies, TV shows, inventory
+- Dashboard: at-a-glance financial health, recent activity
+- Data import and management workflows
+
+## Brand Personality & Tone
+- **Clean**: uncluttered, well-structured layouts
+- **Warm**: approachable, not cold/corporate
+- **Exciting**: distinctive enough to look impressive on a wall display
+- **Efficient**: data-dense where needed, quick to scan
+
+## Typography
+- **Primary font**: Plus Jakarta Sans Variable (warm geometric sans-serif)
+- **Fallback**: system-ui stack
+- **Scale**: Major third (1.25 ratio), fixed rem-based (app UI, not marketing)
+- **Financial data**: tabular-nums, monospace for amounts
+
+## Color System
+- OKLCH color space for dark mode (perceptually uniform)
+- HSL for light mode
+- Semantic tokens: foreground, muted-foreground, primary, destructive, success, warning, info
+
+## Technical Constraints
+- React + Tailwind CSS v4 (CSS-based @theme, no config file)
+- shadcn/ui component primitives
+- PWA on iPad (wall-mounted) + desktop browser
+- Self-hosted, performance matters (no CDN dependencies)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,6 +18,7 @@
     "format:fix": "prettier --write \"src/**/*.{ts,tsx,css}\""
   },
   "dependencies": {
+    "@fontsource-variable/plus-jakarta-sans": "^5.2.8",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/packages/ui/src/theme/globals.css
+++ b/packages/ui/src/theme/globals.css
@@ -2,6 +2,7 @@
  * Tailwind CSS v4 configuration using CSS-based @theme
  * No tailwind.config.ts file needed
  */
+@import "@fontsource-variable/plus-jakarta-sans";
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
@@ -105,12 +106,14 @@ body {
   background-color: var(--color-background);
   color: var(--color-foreground);
   font-family:
+    "Plus Jakarta Sans Variable",
     system-ui,
     -apple-system,
     BlinkMacSystemFont,
     "Segoe UI",
-    Roboto,
     sans-serif;
+  font-kerning: normal;
+  font-variant-ligatures: common-ligatures;
 }
 
 /*---break---
@@ -205,4 +208,54 @@ body {
   body {
     @apply bg-background text-foreground;
   }
+
+  /**
+   * Typography hierarchy defaults.
+   * Tailwind utility classes (text-2xl, font-bold, etc.) override these
+   * via layer specificity, so components with explicit classes are unaffected.
+   *
+   * Type scale (major third, 1.25 ratio):
+   *   xs:   0.75rem  (12px) — captions, timestamps
+   *   sm:   0.875rem (14px) — secondary UI, metadata
+   *   base: 1rem     (16px) — body text
+   *   lg:   1.25rem  (20px) — subheadings
+   *   xl:   1.5rem   (24px) — section headings
+   *   2xl:  1.875rem (30px) — page titles
+   *   3xl:  2.25rem  (36px) — display / hero
+   */
+  h1 {
+    font-size: 1.875rem;
+    line-height: 1.2;
+    font-weight: 700;
+    letter-spacing: -0.025em;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+    line-height: 1.25;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+
+  h3 {
+    font-size: 1.25rem;
+    line-height: 1.3;
+    font-weight: 600;
+  }
+
+  h4 {
+    font-size: 1rem;
+    line-height: 1.4;
+    font-weight: 600;
+  }
+
+  /* Tabular figures for data-heavy contexts */
+  table {
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+/* Utility: force tabular figures (financial data, counters, dashboards) */
+@utility tabular-nums {
+  font-variant-numeric: tabular-nums;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@fontsource-variable/plus-jakarta-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1078,6 +1081,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/plus-jakarta-sans@5.2.8':
+    resolution: {integrity: sha512-iQecBizIdZxezODNHzOn4SvvRMrZL/S8k4MEXGDynCmUrImVW0VmX+tIAMqnADwH4haXlHSXqMgU6+kcfBQJdw==}
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -5809,6 +5815,8 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/plus-jakarta-sans@5.2.8': {}
 
   '@hono/node-server@1.19.11(hono@4.12.8)':
     dependencies:


### PR DESCRIPTION
## Summary
- Replace system font stack with **Plus Jakarta Sans Variable** (~45KB, bundled via @fontsource — no CDN dependency)
- Add base heading hierarchy (h1–h4) with proper sizes, line-heights, weights, and letter-spacing in `@layer base` — existing Tailwind classes override these, so current components are unaffected
- Enable `tabular-nums` globally on `<table>` elements for aligned financial data
- Add `font-kerning: normal` and `common-ligatures` for typographic polish
- Document the major-third (1.25 ratio) type scale in CSS comments for incremental component migration
- Create `.impeccable.md` design context for future design skill invocations

## Test plan
- [ ] Visual check: verify Plus Jakarta Sans renders in both light and dark mode
- [ ] Verify existing component layouts are unchanged (base heading styles are overridden by Tailwind utilities)
- [ ] Check table number alignment with tabular-nums
- [ ] Confirm font loads without layout shift (bundled, not CDN)
- [ ] Build passes (`pnpm build` verified locally)
- [ ] Typecheck passes (`pnpm typecheck` verified locally)