### PR TITLE
feat: watchlist toggle on detail pages [PRD-011/US-2] (tb-086)

### DIFF
--- a/packages/app-media/package.json
+++ b/packages/app-media/package.json
@@ -18,7 +18,8 @@
     "lucide-react": "^0.563.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router": "^7.13.1"
+    "react-router": "^7.13.1",
+    "sonner": "^2.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/packages/app-media/src/components/WatchlistToggle.tsx
+++ b/packages/app-media/src/components/WatchlistToggle.tsx
@@ -1,0 +1,103 @@
+import { Button } from "@pops/ui";
+import { Bookmark, BookmarkCheck } from "lucide-react";
+import { toast } from "sonner";
+import { trpc } from "../lib/trpc";
+
+type DisplayMediaType = "movie" | "tv";
+type ApiMediaType = "movie" | "tv_show";
+
+const toApiMediaType = (type: DisplayMediaType): ApiMediaType =>
+  type === "tv" ? "tv_show" : type;
+
+export interface WatchlistToggleProps {
+  mediaType: DisplayMediaType;
+  mediaId: number;
+  className?: string;
+}
+
+export function WatchlistToggle({
+  mediaType,
+  mediaId,
+  className,
+}: WatchlistToggleProps) {
+  const utils = trpc.useUtils();
+  const apiMediaType = toApiMediaType(mediaType);
+
+  const { data: watchlistData, isLoading: isChecking } =
+    trpc.media.watchlist.list.useQuery(
+      { mediaType: apiMediaType },
+      { staleTime: 30_000 },
+    );
+
+  const watchlistEntry = watchlistData?.data?.find(
+    (entry) => entry.mediaId === mediaId,
+  );
+  const isOnWatchlist = !!watchlistEntry;
+
+  const addMutation = trpc.media.watchlist.add.useMutation({
+    onSuccess: () => {
+      toast.success("Added to watchlist");
+      void utils.media.watchlist.list.invalidate();
+    },
+    onError: (err) => {
+      if (err.data?.code === "CONFLICT") {
+        toast.info("Already on watchlist");
+        void utils.media.watchlist.list.invalidate();
+      } else {
+        toast.error(`Failed to add: ${err.message}`);
+      }
+    },
+  });
+
+  const removeMutation = trpc.media.watchlist.remove.useMutation({
+    onSuccess: () => {
+      toast.success("Removed from watchlist");
+      void utils.media.watchlist.list.invalidate();
+    },
+    onError: (err) => {
+      toast.error(`Failed to remove: ${err.message}`);
+    },
+  });
+
+  const isMutating = addMutation.isPending || removeMutation.isPending;
+
+  const handleToggle = () => {
+    if (isMutating) return;
+
+    if (isOnWatchlist && watchlistEntry) {
+      removeMutation.mutate({ id: watchlistEntry.id });
+    } else {
+      addMutation.mutate({ mediaType: apiMediaType, mediaId });
+    }
+  };
+
+  if (isChecking) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        loading
+        loadingText="Checking watchlist"
+        aria-label="Checking watchlist status"
+        className={className}
+      >
+        Loading
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant={isOnWatchlist ? "default" : "outline"}
+      size="sm"
+      onClick={handleToggle}
+      loading={isMutating}
+      loadingText={isOnWatchlist ? "Removing" : "Adding"}
+      prefix={isOnWatchlist ? <BookmarkCheck className="h-4 w-4" /> : <Bookmark className="h-4 w-4" />}
+      aria-label={isOnWatchlist ? "Remove from watchlist" : "Add to watchlist"}
+      className={className}
+    >
+      {isOnWatchlist ? "On Watchlist" : "Add to Watchlist"}
+    </Button>
+  );
+}

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -2,6 +2,7 @@ import { useParams, Link } from "react-router";
 import { Alert, AlertTitle, AlertDescription, Badge, Skeleton } from "@pops/ui";
 import { trpc } from "../lib/trpc";
 import { formatCurrency, formatRuntime } from "../lib/format";
+import { WatchlistToggle } from "../components/WatchlistToggle";
 
 function MovieDetailSkeleton() {
   return (
@@ -160,6 +161,12 @@ export function MovieDetailPage() {
               {year && movie.runtime && <span>·</span>}
               {movie.runtime && <span>{formatRuntime(movie.runtime)}</span>}
             </div>
+
+            <WatchlistToggle
+              mediaType="movie"
+              mediaId={movie.id}
+              className="mt-3"
+            />
           </div>
         </div>
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       react-router:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      sonner:
+        specifier: ^2.0.0
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@types/react':
         specifier: ^19.0.0


### PR DESCRIPTION
## Summary
- New `WatchlistToggle` component: reusable add/remove toggle for movie and TV show detail pages
- Queries `media.watchlist.list` to detect current watchlist status, maps display type ("tv") to API type ("tv_show")
- Bookmark/BookmarkCheck icons, outline→filled transition, toast notifications via sonner
- Added to MovieDetailPage hero section (TvShowDetailPage toggle added when PR #135 merges)
- Extracts `formatRuntime`/`formatCurrency` to shared `lib/format.ts` (also fixes broken EpisodeList import from PR #124)

## Test plan
- [ ] Typecheck passes
- [ ] "Add to Watchlist" button visible on movie detail page
- [ ] Clicking adds item to watchlist, button changes to "On Watchlist" (filled)
- [ ] Clicking again removes from watchlist, reverts to outline
- [ ] Toast notifications on add/remove/error
- [ ] Loading state shows spinner while checking watchlist status

🤖 Generated with [Claude Code](https://claude.com/claude-code)