### PR TITLE
feat: inline notes editing on watchlist items [PRD-011/US-4] (tb-088)

### DIFF
--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { Link } from "react-router";
 import { Alert, AlertTitle, AlertDescription, Badge, Skeleton, Textarea } from "@pops/ui";
 import { trpc } from "../lib/trpc";
@@ -97,7 +97,7 @@ function WatchlistItem({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
       handleSave();
-    } else if (e.key === "Escape") {
+    } else if (e.key === "Escape" && !isUpdating) {
       handleCancel();
     }
   };
@@ -260,26 +260,34 @@ export function WatchlistPage() {
     year: number | null;
   }
 
-  const movieMap = new Map<number, MediaMeta>(
-    (moviesData?.data ?? []).map((m: { id: number; title: string; releaseDate: string | null }) => [
-      m.id,
-      {
-        title: m.title,
-        year: m.releaseDate ? new Date(m.releaseDate).getFullYear() : null,
-      },
-    ])
+  const movieMap = useMemo(
+    () =>
+      new Map<number, MediaMeta>(
+        (moviesData?.data ?? []).map((m: { id: number; title: string; releaseDate: string | null }) => [
+          m.id,
+          {
+            title: m.title,
+            year: m.releaseDate ? new Date(m.releaseDate).getFullYear() : null,
+          },
+        ])
+      ),
+    [moviesData?.data]
   );
 
-  const tvMap = new Map<number, MediaMeta>(
-    (tvShowsData?.data ?? []).map((s: { id: number; name: string; firstAirDate: string | null }) => [
-      s.id,
-      {
-        title: s.name,
-        year: s.firstAirDate
-          ? new Date(s.firstAirDate).getFullYear()
-          : null,
-      },
-    ])
+  const tvMap = useMemo(
+    () =>
+      new Map<number, MediaMeta>(
+        (tvShowsData?.data ?? []).map((s: { id: number; name: string; firstAirDate: string | null }) => [
+          s.id,
+          {
+            title: s.name,
+            year: s.firstAirDate
+              ? new Date(s.firstAirDate).getFullYear()
+              : null,
+          },
+        ])
+      ),
+    [tvShowsData?.data]
   );
 
   // Sort by priority (higher first), then by addedAt (newest first)


### PR DESCRIPTION
## Summary

- Add inline notes editing to watchlist items (click to edit, Ctrl+Enter to save, Escape to cancel)
- All 8 QA issues addressed (7 code fixes + test coverage deferred)

## QA Fixes

1. **@pops/ui Textarea** — replaced raw `<textarea>` with `<Textarea>` from `@pops/ui`
2. **aria-labels** — added to all interactive notes elements (textarea, edit button, add button)
3. **Per-item isUpdating** — tracked via `updateMutation.variables?.id`, not a shared flag
4. **Error handling** — editor stays open on failure, inline error message shown
5. **maxLength** — 500 character limit with live character count
6. **Draft sync** — draft resets to server data when not editing
7. **No optimistic close** — editor closes only after mutation resolves successfully
8. **Test coverage** — deferred, app-media has no test infrastructure (no vitest/testing-library)

## Test plan
- [x] `pnpm typecheck` passes
- [x] No merge conflicts (rebased onto `feature/watchlist-page`)
- [ ] Manual: click "Add note..." → textarea appears, type, Ctrl+Enter saves
- [ ] Manual: click existing note → edit mode, Escape cancels
- [ ] Manual: save failure → editor stays open with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)