### PR TITLE
fix: remove double padding, improve mobile layout

### DIFF
--- a/apps/pops-shell/index.html
+++ b/apps/pops-shell/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#1a1a2e" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="icon" type="image/png" href="/icons/icon-192.png" />
+    <link rel="apple-touch-icon" href="/icons/icon-192.png" />
+    <link rel="manifest" href="/manifest.json" />
     <title>POPS</title>
   </head>
   <body>

--- a/apps/pops-shell/public/manifest.json
+++ b/apps/pops-shell/public/manifest.json
@@ -1,0 +1,22 @@
+{
+  "name": "POPS",
+  "short_name": "POPS",
+  "description": "Personal Operations System",
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#1a1a2e",
+  "theme_color": "#1a1a2e",
+  "icons": [
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/packages/app-finance/src/pages/AiUsagePage.tsx
+++ b/packages/app-finance/src/pages/AiUsagePage.tsx
@@ -36,9 +36,9 @@ export function AiUsagePage() {
   // Loading state
   if (statsLoading || historyLoading) {
     return (
-      <div className="p-6 space-y-6">
+      <div className="space-y-6">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">AI Usage</h1>
+          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">AI Usage</h1>
           <p className="text-muted-foreground">
             Track AI categorization costs and usage
           </p>
@@ -58,8 +58,8 @@ export function AiUsagePage() {
   // Error state
   if (statsError || historyError) {
     return (
-      <div className="p-6">
-        <h1 className="text-3xl font-bold tracking-tight mb-6">AI Usage</h1>
+      <div className="space-y-6">
+        <h1 className="text-2xl md:text-3xl font-bold tracking-tight">AI Usage</h1>
         <Alert variant="destructive">
           <h3 className="font-semibold">Failed to load AI usage data</h3>
           <p className="text-sm mt-1">
@@ -178,10 +178,10 @@ export function AiUsagePage() {
   const cacheHitRate = totalRequests > 0 ? (stats?.cacheHitRate ?? 0) * 100 : 0;
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-bold tracking-tight">AI Usage</h1>
+        <h1 className="text-2xl md:text-3xl font-bold tracking-tight">AI Usage</h1>
         <p className="text-muted-foreground">
           Track AI categorization costs and usage across all imports
         </p>

--- a/packages/app-finance/src/pages/BudgetsPage.tsx
+++ b/packages/app-finance/src/pages/BudgetsPage.tsx
@@ -130,8 +130,8 @@ export function BudgetsPage() {
 
   if (error) {
     return (
-      <div className="p-6 space-y-6">
-        <h1 className="text-3xl font-bold">Budgets</h1>
+      <div className="space-y-6">
+        <h1 className="text-2xl md:text-3xl font-bold">Budgets</h1>
         <Alert variant="destructive">
           <p className="font-semibold">Failed to load budgets</p>
           <p className="text-sm">{error.message}</p>
@@ -144,10 +144,10 @@ export function BudgetsPage() {
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">Budgets</h1>
+          <h1 className="text-2xl md:text-3xl font-bold">Budgets</h1>
           <p className="text-muted-foreground">
             {data && `${data.pagination.total} total budgets`}
           </p>

--- a/packages/app-finance/src/pages/DashboardPage.tsx
+++ b/packages/app-finance/src/pages/DashboardPage.tsx
@@ -74,8 +74,8 @@ export function DashboardPage() {
 
   if (transactionsError) {
     return (
-      <div className="p-6 space-y-6">
-        <h1 className="text-3xl font-bold">Dashboard</h1>
+      <div className="space-y-6">
+        <h1 className="text-2xl md:text-3xl font-bold">Dashboard</h1>
         <Alert variant="destructive">
           <AlertTitle>Unable to load dashboard</AlertTitle>
           <AlertDescription>
@@ -98,9 +98,9 @@ export function DashboardPage() {
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="space-y-6">
       <div>
-        <h1 className="text-3xl font-bold">Dashboard</h1>
+        <h1 className="text-2xl md:text-3xl font-bold">Dashboard</h1>
         <p className="text-muted-foreground">
           Welcome back! Here's your financial overview.
         </p>
@@ -163,7 +163,7 @@ export function DashboardPage() {
               {transactions.data.map((transaction) => (
                 <div
                   key={transaction.id}
-                  className="p-4 flex items-center justify-between hover:bg-muted/50 transition-colors"
+                  className="p-3 sm:p-4 flex items-center justify-between gap-3 hover:bg-muted/50 transition-colors"
                 >
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
@@ -171,7 +171,7 @@ export function DashboardPage() {
                         {transaction.description}
                       </p>
                       {transaction.tags.includes("Online") && (
-                        <Badge variant="secondary" className="text-xs">
+                        <Badge variant="secondary" className="hidden sm:inline-flex text-xs">
                           Online
                         </Badge>
                       )}
@@ -190,12 +190,12 @@ export function DashboardPage() {
                       )}
                     </div>
                   </div>
-                  <div className="flex items-center gap-4">
-                    <Badge variant="outline" className="text-xs">
+                  <div className="flex items-center gap-2 sm:gap-4 shrink-0">
+                    <Badge variant="outline" className="hidden sm:inline-flex text-xs">
                       {transaction.account}
                     </Badge>
                     <p
-                      className={`font-mono font-semibold ${
+                      className={`font-mono font-semibold tabular-nums ${
                         transaction.amount < 0
                           ? "text-red-600 dark:text-red-400"
                           : "text-green-600 dark:text-green-400"

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -151,8 +151,8 @@ export function EntitiesPage() {
 
   if (error) {
     return (
-      <div className="p-6 space-y-6">
-        <h1 className="text-3xl font-bold">Entities</h1>
+      <div className="space-y-6">
+        <h1 className="text-2xl md:text-3xl font-bold">Entities</h1>
         <Alert variant="destructive">
           <p className="font-semibold">Failed to load entities</p>
           <p className="text-sm">{error.message}</p>
@@ -165,10 +165,10 @@ export function EntitiesPage() {
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">Entities</h1>
+          <h1 className="text-2xl md:text-3xl font-bold">Entities</h1>
           <p className="text-muted-foreground">
             {data && `${data.pagination.total} total entities`}
           </p>

--- a/packages/app-finance/src/pages/ImportPage.tsx
+++ b/packages/app-finance/src/pages/ImportPage.tsx
@@ -14,10 +14,10 @@ export function ImportPage() {
   }, [reset]);
 
   return (
-    <div className="container mx-auto py-8 px-4">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Import Transactions</h1>
-        <p className="text-gray-600 dark:text-gray-400">
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl md:text-3xl font-bold">Import Transactions</h1>
+        <p className="text-muted-foreground">
           Import transactions from your bank CSV files into POPS
         </p>
       </div>

--- a/packages/app-finance/src/pages/InventoryPage.tsx
+++ b/packages/app-finance/src/pages/InventoryPage.tsx
@@ -242,8 +242,8 @@ export function InventoryPage() {
 
   if (error) {
     return (
-      <div className="p-6 space-y-6">
-        <h1 className="text-3xl font-bold">Home Inventory</h1>
+      <div className="space-y-6">
+        <h1 className="text-2xl md:text-3xl font-bold">Home Inventory</h1>
         <Alert variant="destructive">
           <p className="font-semibold">Failed to load inventory</p>
           <p className="text-sm">{error.message}</p>
@@ -256,10 +256,10 @@ export function InventoryPage() {
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">Home Inventory</h1>
+          <h1 className="text-2xl md:text-3xl font-bold">Home Inventory</h1>
           <p className="text-muted-foreground">
             {data && `${data.pagination.total} total items`}
           </p>

--- a/packages/app-finance/src/pages/TransactionsPage.tsx
+++ b/packages/app-finance/src/pages/TransactionsPage.tsx
@@ -188,8 +188,8 @@ export function TransactionsPage() {
 
   if (error) {
     return (
-      <div className="p-6 space-y-6">
-        <h1 className="text-3xl font-bold">Transactions</h1>
+      <div className="space-y-6">
+        <h1 className="text-2xl md:text-3xl font-bold">Transactions</h1>
         <Alert variant="destructive">
           <p className="font-semibold">Failed to load transactions</p>
           <p className="text-sm">{error.message}</p>
@@ -202,10 +202,10 @@ export function TransactionsPage() {
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">Transactions</h1>
+          <h1 className="text-2xl md:text-3xl font-bold">Transactions</h1>
           <p className="text-muted-foreground">
             {data && `${data.pagination.total} total transactions`}
           </p>

--- a/packages/app-finance/src/pages/WishlistPage.tsx
+++ b/packages/app-finance/src/pages/WishlistPage.tsx
@@ -171,8 +171,8 @@ export function WishlistPage() {
 
   if (error) {
     return (
-      <div className="p-6 space-y-6">
-        <h1 className="text-3xl font-bold">Wish List</h1>
+      <div className="space-y-6">
+        <h1 className="text-2xl md:text-3xl font-bold">Wish List</h1>
         <Alert variant="destructive">
           <p className="font-semibold">Failed to load wish list</p>
           <p className="text-sm">{error.message}</p>
@@ -185,10 +185,10 @@ export function WishlistPage() {
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">Wish List</h1>
+          <h1 className="text-2xl md:text-3xl font-bold">Wish List</h1>
           <p className="text-muted-foreground">
             {data && `${data.pagination.total} total items`}
           </p>

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -258,7 +258,7 @@ export function DataTable<TData, TValue>({
       )}
 
       {/* Table */}
-      <div className="rounded-md border">
+      <div className="rounded-md border overflow-x-auto">
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (


### PR DESCRIPTION
## Summary
- **Fix double padding**: All 8 pages had `p-6` stacking with RootLayout's `p-4 md:p-6`, wasting 40px per side on mobile (21% of a 375px screen). Stripped page-level padding so RootLayout is the single source of content padding.
- **Responsive headings**: `text-3xl` -> `text-2xl md:text-3xl` on all page titles for better mobile sizing
- **Dashboard mobile**: Hide account badge and "Online" tag on small screens to prevent description truncation. Tighter padding (`p-3 sm:p-4`) and `tabular-nums` on amounts.
- **DataTable scroll**: Add `overflow-x-auto` to table container so wide tables scroll horizontally on mobile instead of breaking layout
- **PWA manifest**: Add `manifest.json` with standalone display mode and `apple-mobile-web-app` meta tags for proper iPad/iPhone home screen installation
- **ImportPage cleanup**: Replace hardcoded `text-gray-600` with semantic `text-muted-foreground`

## Test plan
- [ ] Open on a 375px viewport — verify no double padding, content fills width properly
- [ ] Check page headings scale down on mobile (`text-2xl`) and up on desktop (`text-3xl`)
- [ ] Dashboard transaction list: account badge hidden on mobile, amounts right-aligned
- [ ] DataTable pages (Transactions, Budgets, etc.): table scrolls horizontally on narrow screens
- [ ] Add to home screen on iPad/iPhone — verify standalone mode launches
- [ ] Desktop layout unchanged (RootLayout padding + no page padding = same as before)