### PR TITLE
fix: move pnpm/action-setup before setup-node in CI [P0] (tb-090)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "pnpm"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,14 +16,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pops-api-ci.yml
+++ b/.github/workflows/pops-api-ci.yml
@@ -23,14 +23,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "pnpm"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/shell-ci.yml
+++ b/.github/workflows/shell-ci.yml
@@ -19,13 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "pnpm"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -58,14 +58,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- **Root cause**: `actions/setup-node@v4` with `cache: 'pnpm'` requires pnpm to be installed first to hash the lockfile for cache key generation
- **Fix**: Move `pnpm/action-setup@v4` step before `actions/setup-node@v4` in all 5 pnpm-based workflows
- All PRs were failing with `Unable to locate executable file: pnpm`

## Files changed
- `.github/workflows/test.yml` (2 jobs: backend + frontend)
- `.github/workflows/pops-api-ci.yml`
- `.github/workflows/shell-ci.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/e2e.yml`

## Test plan
- [x] CI should pass on this PR itself (validates the fix)
- [ ] Verify other open PRs pass CI after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)