### PR TITLE
feat: watchlist reorder with up/down controls [PRD-011/US-3] (tb-087)

### DIFF
--- a/apps/pops-api/src/modules/media/watchlist/router.ts
+++ b/apps/pops-api/src/modules/media/watchlist/router.ts
@@ -88,6 +88,33 @@ export const watchlistRouter = router({
       }
     }),
 
+  /** Batch-reorder watchlist items by setting new priorities. */
+  reorder: protectedProcedure
+    .input(
+      z.object({
+        items: z.array(
+          z.object({
+            id: z.number(),
+            priority: z.number().int().min(0),
+          })
+        ),
+      })
+    )
+    .mutation(({ input }) => {
+      try {
+        service.reorderWatchlist(input.items);
+        return { message: "Watchlist reordered" };
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+        }
+        if (err instanceof ConflictError) {
+          throw new TRPCError({ code: "CONFLICT", message: err.message });
+        }
+        throw err;
+      }
+    }),
+
   /** Remove an entry from the watchlist. */
   remove: protectedProcedure.input(z.object({ id: z.number() })).mutation(({ input }) => {
     try {

--- a/apps/pops-api/src/modules/media/watchlist/service.test.ts
+++ b/apps/pops-api/src/modules/media/watchlist/service.test.ts
@@ -110,6 +110,70 @@ describe("updateWatchlistEntry", () => {
   });
 });
 
+describe("listWatchlist ordering", () => {
+  it("orders by priority ASC then addedAt DESC", () => {
+    seedWatchlistEntry(db, { media_type: "movie", media_id: 1, priority: 2 });
+    seedWatchlistEntry(db, { media_type: "movie", media_id: 2, priority: 0 });
+    seedWatchlistEntry(db, { media_type: "movie", media_id: 3, priority: 1 });
+
+    const result = service.listWatchlist({}, 50, 0);
+    expect(result.rows.map((r) => r.mediaId)).toEqual([2, 3, 1]);
+  });
+});
+
+describe("reorderWatchlist", () => {
+  it("batch-updates priorities for all items", () => {
+    const id1 = seedWatchlistEntry(db, { media_type: "movie", media_id: 1, priority: 0 });
+    const id2 = seedWatchlistEntry(db, { media_type: "movie", media_id: 2, priority: 1 });
+    const id3 = seedWatchlistEntry(db, { media_type: "movie", media_id: 3, priority: 2 });
+
+    service.reorderWatchlist([
+      { id: id3, priority: 0 },
+      { id: id1, priority: 1 },
+      { id: id2, priority: 2 },
+    ]);
+
+    const result = service.listWatchlist({}, 50, 0);
+    expect(result.rows.map((r) => r.mediaId)).toEqual([3, 1, 2]);
+  });
+
+  it("does nothing for empty array", () => {
+    service.reorderWatchlist([]);
+    // Should not throw
+  });
+
+  it("throws NotFoundError for missing IDs", () => {
+    expect(() => service.reorderWatchlist([{ id: 999, priority: 0 }])).toThrow("WatchlistEntry");
+  });
+
+  it("throws ConflictError for duplicate priorities", () => {
+    const id1 = seedWatchlistEntry(db, { media_type: "movie", media_id: 1, priority: 0 });
+    const id2 = seedWatchlistEntry(db, { media_type: "movie", media_id: 2, priority: 1 });
+
+    expect(() =>
+      service.reorderWatchlist([
+        { id: id1, priority: 0 },
+        { id: id2, priority: 0 },
+      ])
+    ).toThrow("Duplicate priorities");
+  });
+
+  it("persists reorder across reads", () => {
+    const id1 = seedWatchlistEntry(db, { media_type: "movie", media_id: 1, priority: 0 });
+    const id2 = seedWatchlistEntry(db, { media_type: "movie", media_id: 2, priority: 1 });
+
+    service.reorderWatchlist([
+      { id: id2, priority: 0 },
+      { id: id1, priority: 1 },
+    ]);
+
+    const entry1 = service.getWatchlistEntry(id1);
+    const entry2 = service.getWatchlistEntry(id2);
+    expect(entry1.priority).toBe(1);
+    expect(entry2.priority).toBe(0);
+  });
+});
+
 describe("removeFromWatchlist", () => {
   it("removes an existing entry", () => {
     const id = seedWatchlistEntry(db, { media_type: "movie", media_id: 550 });

--- a/apps/pops-api/src/modules/media/watchlist/service.ts
+++ b/apps/pops-api/src/modules/media/watchlist/service.ts
@@ -1,8 +1,8 @@
 /**
  * Watchlist service — CRUD operations against SQLite via Drizzle ORM.
  */
-import { count, desc, eq, and, type SQL } from "drizzle-orm";
-import { getDrizzle } from "../../../db.js";
+import { asc, count, desc, eq, and, type SQL } from "drizzle-orm";
+import { getDb, getDrizzle } from "../../../db.js";
 import { mediaWatchlist } from "@pops/db-types";
 import { NotFoundError, ConflictError } from "../../../shared/errors.js";
 import type {
@@ -37,7 +37,7 @@ export function listWatchlist(
     .select()
     .from(mediaWatchlist)
     .where(where)
-    .orderBy(desc(mediaWatchlist.addedAt))
+    .orderBy(asc(mediaWatchlist.priority), desc(mediaWatchlist.addedAt))
     .limit(limit)
     .offset(offset)
     .all();
@@ -102,6 +102,35 @@ export function removeFromWatchlist(id: number): void {
 
   const result = getDrizzle().delete(mediaWatchlist).where(eq(mediaWatchlist.id, id)).run();
   if (result.changes === 0) throw new NotFoundError("WatchlistEntry", String(id));
+}
+
+/** Batch-update priorities for reordering. */
+export function reorderWatchlist(items: { id: number; priority: number }[]): void {
+  if (items.length === 0) return;
+
+  const db = getDrizzle();
+
+  // Validate all IDs exist
+  for (const item of items) {
+    const row = db.select().from(mediaWatchlist).where(eq(mediaWatchlist.id, item.id)).get();
+    if (!row) throw new NotFoundError("WatchlistEntry", String(item.id));
+  }
+
+  // Check for duplicate priorities
+  const priorities = items.map((i) => i.priority);
+  if (new Set(priorities).size !== priorities.length) {
+    throw new ConflictError("Duplicate priorities in reorder request");
+  }
+
+  // Update all priorities in a transaction
+  getDb().transaction(() => {
+    for (const item of items) {
+      db.update(mediaWatchlist)
+        .set({ priority: item.priority })
+        .where(eq(mediaWatchlist.id, item.id))
+        .run();
+    }
+  })();
 }
 
 /**

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -1,7 +1,37 @@
-import { useState, useRef, useEffect, useMemo } from "react";
+/**
+ * WatchlistPage — displays the user's watchlist with reorder controls and inline notes.
+ *
+ * Items are ordered by priority (lower = higher in list).
+ * Up/down buttons allow reordering, which persists via the reorder mutation.
+ */
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { Link } from "react-router";
-import { Alert, AlertTitle, AlertDescription, Badge, Skeleton, Textarea } from "@pops/ui";
+import {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+  Badge,
+  Skeleton,
+  Textarea,
+} from "@pops/ui";
+import { Button } from "@pops/ui";
+import { ArrowUp, ArrowDown } from "lucide-react";
+import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
+
+interface WatchlistEntry {
+  id: number;
+  mediaType: string;
+  mediaId: number;
+  priority: number | null;
+  notes: string | null;
+  addedAt: string;
+}
+
+interface MediaMeta {
+  title: string;
+  year: number | null;
+}
 
 function WatchlistSkeleton() {
   return (
@@ -21,18 +51,16 @@ function WatchlistSkeleton() {
 }
 
 interface WatchlistItemProps {
-  entry: {
-    id: number;
-    mediaType: string;
-    mediaId: number;
-    priority: number | null;
-    notes: string | null;
-    addedAt: string;
-  };
+  entry: WatchlistEntry;
   title: string;
   year: number | null;
+  isFirst: boolean;
+  isLast: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
   onRemove: (id: number) => void;
   isRemoving: boolean;
+  isReordering: boolean;
   onUpdateNotes: (id: number, notes: string | null) => void;
   isUpdating: boolean;
   updateError: string | null;
@@ -42,8 +70,13 @@ function WatchlistItem({
   entry,
   title,
   year,
+  isFirst,
+  isLast,
+  onMoveUp,
+  onMoveDown,
   onRemove,
   isRemoving,
+  isReordering,
   onUpdateNotes,
   isUpdating,
   updateError,
@@ -103,7 +136,31 @@ function WatchlistItem({
   };
 
   return (
-    <div className="flex gap-4 p-3 rounded-lg border">
+    <div className="flex gap-4 p-3 rounded-lg border" role="listitem">
+      {/* Reorder controls */}
+      <div className="flex flex-col justify-center gap-1 shrink-0">
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-6 w-6 p-0"
+          disabled={isFirst || isReordering}
+          onClick={onMoveUp}
+          aria-label={`Move ${title} up`}
+        >
+          <ArrowUp className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-6 w-6 p-0"
+          disabled={isLast || isReordering}
+          onClick={onMoveDown}
+          aria-label={`Move ${title} down`}
+        >
+          <ArrowDown className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
       <Link to={href} className="shrink-0">
         <img
           src={posterSrc}
@@ -125,11 +182,6 @@ function WatchlistItem({
               </Badge>
               {year && (
                 <span className="text-xs text-muted-foreground">{year}</span>
-              )}
-              {entry.priority != null && entry.priority > 0 && (
-                <span className="text-xs text-muted-foreground">
-                  Priority: {entry.priority}
-                </span>
               )}
             </div>
           </div>
@@ -210,10 +262,15 @@ function WatchlistItem({
 }
 
 export function WatchlistPage() {
+  const [isReordering, setIsReordering] = useState(false);
+  const [removingId, setRemovingId] = useState<number | null>(null);
+  const [updateErrorId, setUpdateErrorId] = useState<number | null>(null);
+  const [updateErrorMsg, setUpdateErrorMsg] = useState<string | null>(null);
+
   const {
     data: watchlistData,
     isLoading,
-    error,
+    error: watchlistError,
   } = trpc.media.watchlist.list.useQuery({ limit: 500 });
 
   const {
@@ -226,11 +283,8 @@ export function WatchlistPage() {
     isLoading: tvShowsLoading,
   } = trpc.media.tvShows.list.useQuery({ limit: 500 });
 
-  const [removingId, setRemovingId] = useState<number | null>(null);
-  const [updateErrorId, setUpdateErrorId] = useState<number | null>(null);
-  const [updateErrorMsg, setUpdateErrorMsg] = useState<string | null>(null);
-
   const utils = trpc.useUtils();
+
   const removeMutation = trpc.media.watchlist.remove.useMutation({
     onSuccess: () => {
       setRemovingId(null);
@@ -240,6 +294,7 @@ export function WatchlistPage() {
       setRemovingId(null);
     },
   });
+
   const updateMutation = trpc.media.watchlist.update.useMutation({
     onSuccess: () => {
       setUpdateErrorId(null);
@@ -251,63 +306,102 @@ export function WatchlistPage() {
     },
   });
 
+  const reorderMutation = trpc.media.watchlist.reorder.useMutation({
+    onSuccess: () => {
+      void utils.media.watchlist.list.invalidate();
+    },
+    onError: (err: { message: string }) => {
+      toast.error(`Failed to reorder: ${err.message}`);
+    },
+    onSettled: () => {
+      setIsReordering(false);
+    },
+  });
+
   const loading = isLoading || moviesLoading || tvShowsLoading;
   const entries = watchlistData?.data ?? [];
 
-  // Build lookup maps for movie/TV metadata
-  interface MediaMeta {
-    title: string;
-    year: number | null;
-  }
-
+  // Build lookup maps for movie/TV metadata (memoized)
   const movieMap = useMemo(
     () =>
       new Map<number, MediaMeta>(
-        (moviesData?.data ?? []).map((m: { id: number; title: string; releaseDate: string | null }) => [
-          m.id,
-          {
-            title: m.title,
-            year: m.releaseDate ? new Date(m.releaseDate).getFullYear() : null,
-          },
-        ])
+        (moviesData?.data ?? []).map(
+          (m: { id: number; title: string; releaseDate: string | null }) => [
+            m.id,
+            {
+              title: m.title,
+              year: m.releaseDate
+                ? new Date(m.releaseDate).getFullYear()
+                : null,
+            },
+          ],
+        ),
       ),
-    [moviesData?.data]
+    [moviesData?.data],
   );
 
   const tvMap = useMemo(
     () =>
       new Map<number, MediaMeta>(
-        (tvShowsData?.data ?? []).map((s: { id: number; name: string; firstAirDate: string | null }) => [
-          s.id,
-          {
-            title: s.name,
-            year: s.firstAirDate
-              ? new Date(s.firstAirDate).getFullYear()
-              : null,
-          },
-        ])
+        (tvShowsData?.data ?? []).map(
+          (s: { id: number; name: string; firstAirDate: string | null }) => [
+            s.id,
+            {
+              title: s.name,
+              year: s.firstAirDate
+                ? new Date(s.firstAirDate).getFullYear()
+                : null,
+            },
+          ],
+        ),
       ),
-    [tvShowsData?.data]
+    [tvShowsData?.data],
   );
 
-  // Sort by priority (higher first), then by addedAt (newest first)
-  const sortedEntries = [...entries].sort((a, b) => {
-    const aPriority = a.priority ?? 0;
-    const bPriority = b.priority ?? 0;
-    if (bPriority !== aPriority) return bPriority - aPriority;
-    return b.addedAt.localeCompare(a.addedAt);
-  });
+  // Already sorted by priority ASC from the API
+  const sortedEntries = entries;
+
+  const handleMove = useCallback(
+    (index: number, direction: "up" | "down") => {
+      if (isReordering) return;
+      const newIndex = direction === "up" ? index - 1 : index + 1;
+      if (newIndex < 0 || newIndex >= sortedEntries.length) return;
+
+      // Build new priority list by swapping
+      const reordered = [...sortedEntries];
+      const [moved] = reordered.splice(index, 1);
+      reordered.splice(newIndex, 0, moved);
+
+      // Assign sequential priorities
+      const items = reordered.map((entry: WatchlistEntry, i: number) => ({
+        id: entry.id,
+        priority: i,
+      }));
+
+      setIsReordering(true);
+      reorderMutation.mutate({ items });
+    },
+    [sortedEntries, reorderMutation, isReordering],
+  );
+
+  if (watchlistError) {
+    return (
+      <div className="p-4 md:p-6">
+        <Alert variant="destructive">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>
+            Failed to load watchlist. Please try again.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
 
   return (
     <div className="p-4 md:p-6 space-y-6 max-w-3xl">
       <h1 className="text-2xl font-bold">Watchlist</h1>
 
-      {error ? (
-        <Alert variant="destructive">
-          <AlertTitle>Error</AlertTitle>
-          <AlertDescription>{error.message}</AlertDescription>
-        </Alert>
-      ) : loading ? (
+      {loading ? (
         <WatchlistSkeleton />
       ) : entries.length === 0 ? (
         <div className="text-center py-16">
@@ -316,10 +410,7 @@ export function WatchlistPage() {
             to watch.
           </p>
           <div className="flex justify-center gap-4 mt-4">
-            <Link
-              to="/media"
-              className="text-sm text-primary underline"
-            >
+            <Link to="/media" className="text-sm text-primary underline">
               Browse library
             </Link>
             <Link
@@ -331,8 +422,8 @@ export function WatchlistPage() {
           </div>
         </div>
       ) : (
-        <div className="space-y-3">
-          {sortedEntries.map((entry) => {
+        <div className="space-y-3" role="list" aria-label="Watchlist items">
+          {sortedEntries.map((entry: WatchlistEntry, index: number) => {
             const meta =
               entry.mediaType === "movie"
                 ? movieMap.get(entry.mediaId)
@@ -344,11 +435,16 @@ export function WatchlistPage() {
                 entry={entry}
                 title={meta?.title ?? "Unknown"}
                 year={meta?.year ?? null}
+                isFirst={index === 0}
+                isLast={index === sortedEntries.length - 1}
+                onMoveUp={() => handleMove(index, "up")}
+                onMoveDown={() => handleMove(index, "down")}
                 onRemove={(id) => {
                   setRemovingId(id);
                   removeMutation.mutate({ id });
                 }}
                 isRemoving={removingId === entry.id}
+                isReordering={isReordering}
                 onUpdateNotes={(id, notes) => {
                   setUpdateErrorId(id);
                   setUpdateErrorMsg(null);


### PR DESCRIPTION
## Summary
- **Backend**: Add `media.watchlist.reorder` batch mutation — accepts array of `{id, priority}` pairs, validates all IDs, updates in single SQLite transaction
- **Backend**: Fix `listWatchlist` ordering from `addedAt DESC` to `priority ASC, addedAt DESC` so list respects priority order
- **Frontend**: WatchlistPage with up/down arrow buttons for mobile-friendly reordering (per spec R4)
- On move, recomputes sequential priorities (0,1,2,...) and calls reorder mutation
- 5 new service tests (ordering, batch reorder, persistence, empty array, missing ID)

## Dependencies
- PR #138 (WatchlistPage by samantha, tb-085) — will have merge conflict on WatchlistPage.tsx and routes.tsx, needs rebase after #138 merges

## Test plan
- [ ] Verify watchlist list returns items ordered by priority ASC
- [ ] Verify reorder mutation updates all priorities in transaction
- [ ] Verify reorder throws NOT_FOUND for invalid IDs
- [ ] Verify up/down buttons disabled at list boundaries
- [ ] Verify reorder persists across page reload
- [ ] Verify empty watchlist shows CTA links
- [ ] Verify error state shown on query failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)