### PR TITLE
feat: listRecent watch history with date range filters [PRD-012/US-0c] (tb-098)

### DIFF
--- a/apps/pops-api/src/modules/media/watch-history/router.ts
+++ b/apps/pops-api/src/modules/media/watch-history/router.ts
@@ -10,8 +10,10 @@ import {
   BatchLogWatchSchema,
   WatchHistoryQuerySchema,
   ProgressQuerySchema,
+  RecentWatchHistoryQuerySchema,
   toWatchHistoryEntry,
   type WatchHistoryFilters,
+  type RecentWatchHistoryFilters,
 } from "./types.js";
 import * as service from "./service.js";
 import { NotFoundError } from "../../../shared/errors.js";
@@ -34,6 +36,25 @@ export const watchHistoryRouter = router({
 
     return {
       data: rows.map(toWatchHistoryEntry),
+      pagination: paginationMeta(total, limit, offset),
+    };
+  }),
+
+  /** List recent watch history with date range filters and enriched media metadata. */
+  listRecent: protectedProcedure.input(RecentWatchHistoryQuerySchema).query(({ input }) => {
+    const limit = input.limit ?? DEFAULT_LIMIT;
+    const offset = input.offset ?? DEFAULT_OFFSET;
+
+    const filters: RecentWatchHistoryFilters = {
+      mediaType: input.mediaType,
+      startDate: input.startDate,
+      endDate: input.endDate,
+    };
+
+    const { rows, total } = service.listRecent(filters, limit, offset);
+
+    return {
+      data: rows,
       pagination: paginationMeta(total, limit, offset),
     };
   }),

--- a/apps/pops-api/src/modules/media/watch-history/service.test.ts
+++ b/apps/pops-api/src/modules/media/watch-history/service.test.ts
@@ -6,6 +6,7 @@ import {
   seedTvShow,
   seedSeason,
   seedEpisode,
+  seedMovie,
 } from "../../../shared/test-utils.js";
 import * as service from "./service.js";
 import * as watchlistService from "../watchlist/service.js";
@@ -65,6 +66,178 @@ describe("listWatchHistory", () => {
     const result = service.listWatchHistory({ mediaType: "movie", mediaId: 550 }, 50, 0);
     expect(result.rows).toHaveLength(1);
     expect(result.rows[0].mediaType).toBe("movie");
+  });
+});
+
+describe("listRecent", () => {
+  it("returns empty list when no entries exist", () => {
+    const result = service.listRecent({}, 50, 0);
+    expect(result.rows).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+
+  it("returns enriched movie entries with title and poster", () => {
+    const movieId = seedMovie(db, { tmdb_id: 550, title: "Fight Club", poster_path: "/fc.jpg" });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieId });
+
+    const result = service.listRecent({}, 50, 0);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].title).toBe("Fight Club");
+    expect(result.rows[0].posterPath).toBe("/fc.jpg");
+    expect(result.rows[0].seasonNumber).toBeNull();
+    expect(result.rows[0].episodeNumber).toBeNull();
+    expect(result.rows[0].showName).toBeNull();
+  });
+
+  it("returns enriched episode entries with show name and season/episode info", () => {
+    const showId = seedTvShow(db, { tvdb_id: 81189, name: "Breaking Bad", poster_path: "/bb.jpg" });
+    const seasonId = seedSeason(db, { tv_show_id: showId, tvdb_id: 3001, season_number: 1 });
+    const epId = seedEpisode(db, {
+      season_id: seasonId,
+      tvdb_id: 5001,
+      episode_number: 1,
+      name: "Pilot",
+    });
+    seedWatchHistoryEntry(db, { media_type: "episode", media_id: epId });
+
+    const result = service.listRecent({}, 50, 0);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].title).toBe("Pilot");
+    expect(result.rows[0].showName).toBe("Breaking Bad");
+    expect(result.rows[0].posterPath).toBe("/bb.jpg");
+    expect(result.rows[0].seasonNumber).toBe(1);
+    expect(result.rows[0].episodeNumber).toBe(1);
+  });
+
+  it("filters by mediaType", () => {
+    const movieId = seedMovie(db, { tmdb_id: 550, title: "Fight Club" });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieId });
+    seedWatchHistoryEntry(db, { media_type: "episode", media_id: 999 });
+
+    const result = service.listRecent({ mediaType: "movie" }, 50, 0);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].mediaType).toBe("movie");
+  });
+
+  it("filters by startDate", () => {
+    const movieId = seedMovie(db, { tmdb_id: 550, title: "Fight Club" });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      watched_at: "2026-01-01T00:00:00.000Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      watched_at: "2026-03-15T00:00:00.000Z",
+    });
+
+    const result = service.listRecent({ startDate: "2026-03-01T00:00:00.000Z" }, 50, 0);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].watchedAt).toBe("2026-03-15T00:00:00.000Z");
+  });
+
+  it("filters by endDate", () => {
+    const movieId = seedMovie(db, { tmdb_id: 550, title: "Fight Club" });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      watched_at: "2026-01-01T00:00:00.000Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      watched_at: "2026-03-15T00:00:00.000Z",
+    });
+
+    const result = service.listRecent({ endDate: "2026-02-01T00:00:00.000Z" }, 50, 0);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].watchedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("filters by date range (startDate + endDate)", () => {
+    const movieId = seedMovie(db, { tmdb_id: 550, title: "Fight Club" });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      watched_at: "2026-01-01T00:00:00.000Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      watched_at: "2026-02-15T00:00:00.000Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      watched_at: "2026-03-15T00:00:00.000Z",
+    });
+
+    const result = service.listRecent(
+      { startDate: "2026-02-01T00:00:00.000Z", endDate: "2026-03-01T00:00:00.000Z" },
+      50,
+      0
+    );
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].watchedAt).toBe("2026-02-15T00:00:00.000Z");
+  });
+
+  it("combines mediaType + date range filters", () => {
+    const movieId = seedMovie(db, { tmdb_id: 550, title: "Fight Club" });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      watched_at: "2026-03-15T00:00:00.000Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "episode",
+      media_id: 999,
+      watched_at: "2026-03-15T00:00:00.000Z",
+    });
+
+    const result = service.listRecent(
+      { mediaType: "movie", startDate: "2026-03-01T00:00:00.000Z" },
+      50,
+      0
+    );
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].mediaType).toBe("movie");
+  });
+
+  it("handles missing media gracefully", () => {
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: 99999 });
+
+    const result = service.listRecent({}, 50, 0);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].title).toBeNull();
+    expect(result.rows[0].posterPath).toBeNull();
+  });
+
+  it("supports pagination", () => {
+    const movieId = seedMovie(db, { tmdb_id: 550, title: "Fight Club" });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      watched_at: "2026-01-01T00:00:00.000Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      watched_at: "2026-02-01T00:00:00.000Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      watched_at: "2026-03-01T00:00:00.000Z",
+    });
+
+    const page1 = service.listRecent({}, 2, 0);
+    expect(page1.rows).toHaveLength(2);
+    expect(page1.total).toBe(3);
+
+    const page2 = service.listRecent({}, 2, 2);
+    expect(page2.rows).toHaveLength(1);
+    expect(page2.total).toBe(3);
   });
 });
 

--- a/apps/pops-api/src/modules/media/watch-history/service.ts
+++ b/apps/pops-api/src/modules/media/watch-history/service.ts
@@ -5,9 +5,9 @@
  *   - Movie: removed from watchlist when marked as watched.
  *   - Episode: TV show removed from watchlist when all episodes are watched.
  */
-import { count, countDistinct, desc, eq, and, inArray, type SQL } from "drizzle-orm";
+import { count, countDistinct, desc, eq, and, inArray, gte, lte, type SQL } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
-import { watchHistory, mediaWatchlist, episodes, seasons } from "@pops/db-types";
+import { watchHistory, mediaWatchlist, episodes, seasons, movies, tvShows } from "@pops/db-types";
 import { NotFoundError } from "../../../shared/errors.js";
 import type {
   WatchHistoryRow,
@@ -16,8 +16,9 @@ import type {
   TvShowProgress,
   SeasonProgress,
   BatchLogWatchInput,
+  RecentWatchHistoryFilters,
+  RecentWatchHistoryEntry,
 } from "./types.js";
-import { tvShows } from "@pops/db-types";
 
 /** Count + rows for a paginated list. */
 export interface WatchHistoryListResult {
@@ -53,6 +54,127 @@ export function listWatchHistory(
     .all();
 
   const [countRow] = db.select({ total: count() }).from(watchHistory).where(where).all();
+
+  return { rows, total: countRow.total };
+}
+
+/** Count + enriched rows for a paginated recent history list. */
+export interface RecentWatchHistoryListResult {
+  rows: RecentWatchHistoryEntry[];
+  total: number;
+}
+
+/**
+ * List recent watch history entries with date range and mediaType filters.
+ * Joins media metadata (title, poster) for display on the history page.
+ */
+export function listRecent(
+  filters: RecentWatchHistoryFilters,
+  limit: number,
+  offset: number
+): RecentWatchHistoryListResult {
+  const db = getDrizzle();
+  const conditions: SQL[] = [];
+
+  if (filters.mediaType) {
+    conditions.push(eq(watchHistory.mediaType, filters.mediaType as "movie" | "episode"));
+  }
+  if (filters.startDate) {
+    conditions.push(gte(watchHistory.watchedAt, filters.startDate));
+  }
+  if (filters.endDate) {
+    conditions.push(lte(watchHistory.watchedAt, filters.endDate));
+  }
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  // Get raw watch history rows first
+  const rawRows = db
+    .select()
+    .from(watchHistory)
+    .where(where)
+    .orderBy(desc(watchHistory.watchedAt))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [countRow] = db.select({ total: count() }).from(watchHistory).where(where).all();
+
+  // Enrich with media metadata
+  const rows: RecentWatchHistoryEntry[] = rawRows.map((row) => {
+    if (row.mediaType === "movie") {
+      const movie = db
+        .select({ title: movies.title, posterPath: movies.posterPath })
+        .from(movies)
+        .where(eq(movies.id, row.mediaId))
+        .get();
+      return {
+        id: row.id,
+        mediaType: row.mediaType,
+        mediaId: row.mediaId,
+        watchedAt: row.watchedAt,
+        completed: row.completed,
+        title: movie?.title ?? null,
+        posterPath: movie?.posterPath ?? null,
+        seasonNumber: null,
+        episodeNumber: null,
+        showName: null,
+      };
+    }
+    // episode — look up episode → season → tv show
+    const episode = db
+      .select({
+        name: episodes.name,
+        episodeNumber: episodes.episodeNumber,
+        seasonId: episodes.seasonId,
+        stillPath: episodes.stillPath,
+      })
+      .from(episodes)
+      .where(eq(episodes.id, row.mediaId))
+      .get();
+
+    if (!episode) {
+      return {
+        id: row.id,
+        mediaType: row.mediaType,
+        mediaId: row.mediaId,
+        watchedAt: row.watchedAt,
+        completed: row.completed,
+        title: null,
+        posterPath: null,
+        seasonNumber: null,
+        episodeNumber: null,
+        showName: null,
+      };
+    }
+
+    const season = db
+      .select({ tvShowId: seasons.tvShowId, seasonNumber: seasons.seasonNumber })
+      .from(seasons)
+      .where(eq(seasons.id, episode.seasonId))
+      .get();
+
+    const show = season
+      ? db
+          .select({ name: tvShows.name, posterPath: tvShows.posterPath })
+          .from(tvShows)
+          .where(eq(tvShows.id, season.tvShowId))
+          .get()
+      : null;
+
+    return {
+      id: row.id,
+      mediaType: row.mediaType,
+      mediaId: row.mediaId,
+      watchedAt: row.watchedAt,
+      completed: row.completed,
+      title: episode.name ?? null,
+      posterPath: show?.posterPath ?? episode.stillPath ?? null,
+      seasonNumber: season?.seasonNumber ?? null,
+      episodeNumber: episode.episodeNumber,
+      showName: show?.name ?? null,
+    };
+  });
 
   return { rows, total: countRow.total };
 }

--- a/apps/pops-api/src/modules/media/watch-history/types.ts
+++ b/apps/pops-api/src/modules/media/watch-history/types.ts
@@ -84,3 +84,35 @@ export interface TvShowProgress {
   };
   seasons: SeasonProgress[];
 }
+
+/** Zod schema for listRecent query params with date range and mediaType filters. */
+export const RecentWatchHistoryQuerySchema = z.object({
+  mediaType: z.enum(WATCH_MEDIA_TYPES).optional(),
+  startDate: z.string().datetime().optional(),
+  endDate: z.string().datetime().optional(),
+  limit: z.coerce.number().positive().max(500).optional(),
+  offset: z.coerce.number().nonnegative().optional(),
+});
+export type RecentWatchHistoryQuery = z.infer<typeof RecentWatchHistoryQuerySchema>;
+
+/** Parsed filter params for listRecent. */
+export interface RecentWatchHistoryFilters {
+  mediaType?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+/** Enriched watch history entry with media metadata for the history page. */
+export interface RecentWatchHistoryEntry {
+  id: number;
+  mediaType: string;
+  mediaId: number;
+  watchedAt: string;
+  completed: number;
+  title: string | null;
+  posterPath: string | null;
+  /** For episodes: season/episode info */
+  seasonNumber: number | null;
+  episodeNumber: number | null;
+  showName: string | null;
+}


### PR DESCRIPTION
## Summary
- Add `listRecent` service method to watch-history with `startDate`, `endDate`, and `mediaType` filters
- Enrich results with joined media metadata (title, poster path, season/episode info for episodes, show name for TV shows)
- Add corresponding `listRecent` tRPC query procedure
- Add 9 tests covering all filter combinations, pagination, enrichment, and missing media handling

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] 9 new unit tests for listRecent (empty list, movie enrichment, episode enrichment, mediaType filter, startDate filter, endDate filter, date range, combined filters, missing media, pagination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)