### PR TITLE
feat: getRandomPair for movie comparisons [PRD-013/US-0a] (tb-105)

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { TRPCError } from "@trpc/server";
 import type { Database } from "better-sqlite3";
-import { setupTestContext, seedDimension, createCaller } from "../../../shared/test-utils.js";
+import {
+  setupTestContext,
+  seedDimension,
+  seedMovie,
+  seedWatchHistoryEntry,
+  createCaller,
+} from "../../../shared/test-utils.js";
 
 const ctx = setupTestContext();
 let caller: ReturnType<typeof createCaller>;
@@ -266,6 +272,98 @@ describe("comparisons.scores", () => {
     });
     expect(visualScores.data).toHaveLength(1);
     expect(visualScores.data[0].score).toBeLessThan(1500);
+  });
+});
+
+describe("comparisons.getRandomPair", () => {
+  it("returns a pair of watched movies", async () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const m1 = seedMovie(db, { tmdb_id: 550, title: "Fight Club", poster_path: "/fc.jpg" });
+    const m2 = seedMovie(db, { tmdb_id: 551, title: "The Matrix", poster_path: "/mx.jpg" });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m1 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m2 });
+
+    const result = await caller.media.comparisons.getRandomPair({ dimensionId: dimId });
+    expect(result.data.movieA).toHaveProperty("id");
+    expect(result.data.movieA).toHaveProperty("title");
+    expect(result.data.movieA).toHaveProperty("posterPath");
+    expect(result.data.movieB).toHaveProperty("id");
+    expect(result.data.movieB).toHaveProperty("title");
+    expect(result.data.movieA.id).not.toBe(result.data.movieB.id);
+  });
+
+  it("throws NOT_FOUND when fewer than 2 watched movies", async () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const m1 = seedMovie(db, { tmdb_id: 550, title: "Fight Club" });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m1 });
+
+    await expect(caller.media.comparisons.getRandomPair({ dimensionId: dimId })).rejects.toThrow(
+      TRPCError
+    );
+  });
+
+  it("throws NOT_FOUND when no watched movies exist", async () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+
+    await expect(caller.media.comparisons.getRandomPair({ dimensionId: dimId })).rejects.toThrow(
+      TRPCError
+    );
+  });
+
+  it("throws NOT_FOUND for missing dimension", async () => {
+    await expect(caller.media.comparisons.getRandomPair({ dimensionId: 999 })).rejects.toThrow(
+      TRPCError
+    );
+  });
+
+  it("avoids recently compared pairs", async () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    // Create 3 movies so there are multiple possible pairs
+    const m1 = seedMovie(db, { tmdb_id: 550, title: "Fight Club" });
+    const m2 = seedMovie(db, { tmdb_id: 551, title: "The Matrix" });
+    const m3 = seedMovie(db, { tmdb_id: 552, title: "Inception" });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m1 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m2 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m3 });
+
+    // Record comparison between m1 and m2
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: m1,
+      mediaBType: "movie",
+      mediaBId: m2,
+      winnerType: "movie",
+      winnerId: m1,
+    });
+
+    // With avoidRecent=1, the pair (m1, m2) should be avoided
+    // Run several times — the pair should involve m3
+    let sawM3 = false;
+    for (let i = 0; i < 20; i++) {
+      const result = await caller.media.comparisons.getRandomPair({
+        dimensionId: dimId,
+        avoidRecent: 1,
+      });
+      const ids = [result.data.movieA.id, result.data.movieB.id].sort();
+      if (ids.includes(m3)) sawM3 = true;
+      // The recently compared pair (m1, m2) should not appear
+      expect(ids).not.toEqual([m1, m2].sort());
+    }
+    expect(sawM3).toBe(true);
+  });
+
+  it("only considers completed watches", async () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const m1 = seedMovie(db, { tmdb_id: 550, title: "Fight Club" });
+    const m2 = seedMovie(db, { tmdb_id: 551, title: "The Matrix" });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m1, completed: 1 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m2, completed: 0 }); // incomplete
+
+    // Only 1 completed watch → not enough
+    await expect(caller.media.comparisons.getRandomPair({ dimensionId: dimId })).rejects.toThrow(
+      TRPCError
+    );
   });
 });
 

--- a/apps/pops-api/src/modules/media/comparisons/router.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router.ts
@@ -11,6 +11,7 @@ import {
   RecordComparisonSchema,
   ComparisonQuerySchema,
   ScoreQuerySchema,
+  RandomPairQuerySchema,
   toDimension,
   toComparison,
   toMediaScore,
@@ -86,6 +87,25 @@ export const comparisonsRouter = router({
       data: rows.map(toComparison),
       pagination: paginationMeta(total, limit, offset),
     };
+  }),
+
+  /** Get a random pair of watched movies for comparison. */
+  getRandomPair: protectedProcedure.input(RandomPairQuerySchema).query(({ input }) => {
+    try {
+      const pair = service.getRandomPair(input.dimensionId, input.avoidRecent);
+      if (!pair) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Not enough watched movies to create a comparison pair (need at least 2)",
+        });
+      }
+      return { data: pair };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
   }),
 
   /** Get scores for a media item (optionally filtered by dimension). */

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -3,7 +3,13 @@
  */
 import { eq, and, or, asc, count, desc } from "drizzle-orm";
 import { getDb, getDrizzle } from "../../../db.js";
-import { comparisonDimensions, comparisons, mediaScores } from "@pops/db-types";
+import {
+  comparisonDimensions,
+  comparisons,
+  mediaScores,
+  watchHistory,
+  movies,
+} from "@pops/db-types";
 import { NotFoundError, ConflictError, ValidationError } from "../../../shared/errors.js";
 import type {
   ComparisonDimensionRow,
@@ -12,6 +18,7 @@ import type {
   CreateDimensionInput,
   UpdateDimensionInput,
   RecordComparisonInput,
+  RandomPair,
 } from "./types.js";
 
 // ── Dimensions ──
@@ -244,6 +251,106 @@ export function listComparisonsForMedia(
   const [{ total }] = db.select({ total: count() }).from(comparisons).where(conditions).all();
 
   return { rows, total };
+}
+
+// ── Random Pair ──
+
+/**
+ * Get a random pair of watched movies for comparison, avoiding recently
+ * compared pairs for the given dimension.
+ *
+ * @param dimensionId - The dimension to compare on
+ * @param avoidRecent - Number of recent comparisons to check for repeat avoidance (default 10)
+ * @returns A pair of movies with metadata, or null if fewer than 2 watched movies exist
+ */
+export function getRandomPair(dimensionId: number, avoidRecent: number = 10): RandomPair | null {
+  getDimension(dimensionId); // verify dimension exists
+
+  const db = getDrizzle();
+
+  // Get distinct watched movie IDs
+  const watchedMovieIds = db
+    .select({ mediaId: watchHistory.mediaId })
+    .from(watchHistory)
+    .where(and(eq(watchHistory.mediaType, "movie"), eq(watchHistory.completed, 1)))
+    .groupBy(watchHistory.mediaId)
+    .all()
+    .map((r) => r.mediaId);
+
+  if (watchedMovieIds.length < 2) return null;
+
+  // Get recent comparison pairs for this dimension to avoid
+  const recentPairs: Set<string> = new Set();
+  if (avoidRecent > 0) {
+    const recent = db
+      .select({
+        mediaAId: comparisons.mediaAId,
+        mediaBId: comparisons.mediaBId,
+      })
+      .from(comparisons)
+      .where(
+        and(
+          eq(comparisons.dimensionId, dimensionId),
+          eq(comparisons.mediaAType, "movie"),
+          eq(comparisons.mediaBType, "movie")
+        )
+      )
+      .orderBy(desc(comparisons.comparedAt))
+      .limit(avoidRecent)
+      .all();
+
+    for (const r of recent) {
+      // Store both orderings so we can check either direction
+      recentPairs.add(`${r.mediaAId}-${r.mediaBId}`);
+      recentPairs.add(`${r.mediaBId}-${r.mediaAId}`);
+    }
+  }
+
+  // Try to find a non-recent pair (with bounded attempts)
+  const maxAttempts = Math.min(watchedMovieIds.length * 3, 100);
+  let movieAId: number | null = null;
+  let movieBId: number | null = null;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const idxA = Math.floor(Math.random() * watchedMovieIds.length);
+    let idxB = Math.floor(Math.random() * (watchedMovieIds.length - 1));
+    if (idxB >= idxA) idxB++;
+
+    const candidateA = watchedMovieIds[idxA];
+    const candidateB = watchedMovieIds[idxB];
+
+    if (!recentPairs.has(`${candidateA}-${candidateB}`)) {
+      movieAId = candidateA;
+      movieBId = candidateB;
+      break;
+    }
+  }
+
+  // Fallback: if all pairs are recent, just pick any random pair
+  if (movieAId === null || movieBId === null) {
+    const idxA = Math.floor(Math.random() * watchedMovieIds.length);
+    let idxB = Math.floor(Math.random() * (watchedMovieIds.length - 1));
+    if (idxB >= idxA) idxB++;
+    movieAId = watchedMovieIds[idxA];
+    movieBId = watchedMovieIds[idxB];
+  }
+
+  // Fetch movie metadata
+  const movieA = db
+    .select({ id: movies.id, title: movies.title, posterPath: movies.posterPath })
+    .from(movies)
+    .where(eq(movies.id, movieAId))
+    .get();
+
+  const movieB = db
+    .select({ id: movies.id, title: movies.title, posterPath: movies.posterPath })
+    .from(movies)
+    .where(eq(movies.id, movieBId))
+    .get();
+
+  if (!movieA || !movieB) return null;
+
+  return { movieA, movieB };
 }
 
 // ── Scores ──

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -76,6 +76,19 @@ export function toMediaScore(row: MediaScoreRow): MediaScore {
   };
 }
 
+/** API response shape for a random pair of movies to compare. */
+export interface RandomPair {
+  movieA: { id: number; title: string; posterPath: string | null };
+  movieB: { id: number; title: string; posterPath: string | null };
+}
+
+/** Zod schema for getRandomPair query. */
+export const RandomPairQuerySchema = z.object({
+  dimensionId: z.number().int().positive(),
+  avoidRecent: z.coerce.number().int().nonnegative().max(100).optional().default(10),
+});
+export type RandomPairQuery = z.infer<typeof RandomPairQuerySchema>;
+
 /** Zod schemas */
 export const CreateDimensionSchema = z.object({
   name: z.string().min(1, "Name is required"),


### PR DESCRIPTION
## Summary
- Add `getRandomPair` service method that selects two random watched movies for comparison
- Avoids recently compared pairs (configurable via `avoidRecent` param, default 10)
- Returns movie metadata (id, title, posterPath) for both candidates
- Add corresponding `getRandomPair` tRPC query procedure
- Add 6 tests: basic pair, insufficient movies, no movies, missing dimension, recent repeat avoidance, completed-only filter

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] 6 new tests covering all edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)