### PR TITLE
feat: inventory badge components [PRD-019/US-c5] (tb-111)

### DIFF
--- a/packages/ui/src/components/AssetIdBadge.stories.tsx
+++ b/packages/ui/src/components/AssetIdBadge.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AssetIdBadge } from "./AssetIdBadge";
+
+const meta: Meta<typeof AssetIdBadge> = {
+  title: "Inventory/AssetIdBadge",
+  component: AssetIdBadge,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { assetId: "INV-001" },
+};
+
+export const LongId: Story = {
+  args: { assetId: "ASSET-2026-0042" },
+};
+
+export const NumericId: Story = {
+  args: { assetId: "00847" },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <AssetIdBadge assetId="INV-001" />
+      <AssetIdBadge assetId="INV-042" />
+      <AssetIdBadge assetId="ASSET-2026-0100" />
+      <AssetIdBadge assetId="00123" />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/AssetIdBadge.tsx
+++ b/packages/ui/src/components/AssetIdBadge.tsx
@@ -1,0 +1,23 @@
+import type { ComponentProps } from "react";
+import { Badge } from "../primitives/badge";
+import { cn } from "../lib/utils";
+
+export interface AssetIdBadgeProps
+  extends Omit<ComponentProps<typeof Badge>, "variant" | "children"> {
+  assetId: string;
+}
+
+export function AssetIdBadge({ assetId, className, ...props }: AssetIdBadgeProps) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "font-mono text-[10px] tracking-wider px-1.5 py-0 h-5",
+        className
+      )}
+      {...props}
+    >
+      {assetId}
+    </Badge>
+  );
+}

--- a/packages/ui/src/components/ConditionBadge.stories.tsx
+++ b/packages/ui/src/components/ConditionBadge.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ConditionBadge } from "./ConditionBadge";
+
+const meta: Meta<typeof ConditionBadge> = {
+  title: "Inventory/ConditionBadge",
+  component: ConditionBadge,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Excellent: Story = {
+  args: { condition: "Excellent" },
+};
+
+export const Good: Story = {
+  args: { condition: "Good" },
+};
+
+export const Fair: Story = {
+  args: { condition: "Fair" },
+};
+
+export const Poor: Story = {
+  args: { condition: "Poor" },
+};
+
+export const AllConditions: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <ConditionBadge condition="Excellent" />
+      <ConditionBadge condition="Good" />
+      <ConditionBadge condition="Fair" />
+      <ConditionBadge condition="Poor" />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/ConditionBadge.tsx
+++ b/packages/ui/src/components/ConditionBadge.tsx
@@ -1,0 +1,38 @@
+import type { ComponentProps } from "react";
+import { Badge } from "../primitives/badge";
+import { cn } from "../lib/utils";
+
+export type Condition = "Excellent" | "Good" | "Fair" | "Poor";
+
+const conditionStyles: Record<Condition, string> = {
+  Excellent:
+    "bg-emerald-500/10 text-emerald-700 border-emerald-500/20 dark:text-emerald-400",
+  Good: "bg-blue-500/10 text-blue-700 border-blue-500/20 dark:text-blue-400",
+  Fair: "bg-amber-500/10 text-amber-700 border-amber-500/20 dark:text-amber-400",
+  Poor: "bg-red-500/10 text-red-700 border-red-500/20 dark:text-red-400",
+};
+
+export interface ConditionBadgeProps
+  extends Omit<ComponentProps<typeof Badge>, "variant" | "children"> {
+  condition: Condition;
+}
+
+export function ConditionBadge({
+  condition,
+  className,
+  ...props
+}: ConditionBadgeProps) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "text-[10px] uppercase tracking-wider font-semibold py-0 px-1.5 h-5",
+        conditionStyles[condition],
+        className
+      )}
+      {...props}
+    >
+      {condition}
+    </Badge>
+  );
+}

--- a/packages/ui/src/components/LocationBreadcrumb.stories.tsx
+++ b/packages/ui/src/components/LocationBreadcrumb.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LocationBreadcrumb } from "./LocationBreadcrumb";
+
+const meta: Meta<typeof LocationBreadcrumb> = {
+  title: "Inventory/LocationBreadcrumb",
+  component: LocationBreadcrumb,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SingleLevel: Story = {
+  args: {
+    segments: [{ id: "1", name: "Living Room" }],
+  },
+};
+
+export const TwoLevels: Story = {
+  args: {
+    segments: [
+      { id: "1", name: "Living Room" },
+      { id: "2", name: "TV Cabinet" },
+    ],
+  },
+};
+
+export const ThreeLevels: Story = {
+  args: {
+    segments: [
+      { id: "1", name: "Garage" },
+      { id: "2", name: "Shelf Unit A" },
+      { id: "3", name: "Top Shelf" },
+    ],
+  },
+};
+
+export const Clickable: Story = {
+  args: {
+    segments: [
+      { id: "1", name: "House" },
+      { id: "2", name: "Office" },
+      { id: "3", name: "Desk Drawer" },
+    ],
+    onNavigate: (segment) => alert(`Navigate to: ${segment.name} (${segment.id})`),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    segments: [],
+  },
+};

--- a/packages/ui/src/components/LocationBreadcrumb.tsx
+++ b/packages/ui/src/components/LocationBreadcrumb.tsx
@@ -1,0 +1,59 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "../primitives/breadcrumb";
+import { cn } from "../lib/utils";
+
+export interface LocationSegment {
+  id: string;
+  name: string;
+}
+
+export interface LocationBreadcrumbProps {
+  segments: LocationSegment[];
+  onNavigate?: (segment: LocationSegment) => void;
+  className?: string;
+}
+
+export function LocationBreadcrumb({
+  segments,
+  onNavigate,
+  className,
+}: LocationBreadcrumbProps) {
+  if (segments.length === 0) {
+    return <span className="text-muted-foreground/50">—</span>;
+  }
+
+  return (
+    <Breadcrumb className={cn("text-xs", className)}>
+      <BreadcrumbList className="flex-nowrap text-xs gap-1 sm:gap-1">
+        {segments.map((segment, index) => {
+          const isLast = index === segments.length - 1;
+          return (
+            <BreadcrumbItem key={segment.id}>
+              {isLast ? (
+                <BreadcrumbPage className="text-xs font-medium">
+                  {segment.name}
+                </BreadcrumbPage>
+              ) : (
+                <>
+                  <BreadcrumbLink
+                    className="text-xs cursor-pointer"
+                    onClick={() => onNavigate?.(segment)}
+                  >
+                    {segment.name}
+                  </BreadcrumbLink>
+                  <BreadcrumbSeparator className="[&>svg]:size-3" />
+                </>
+              )}
+            </BreadcrumbItem>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/packages/ui/src/components/TypeBadge.stories.tsx
+++ b/packages/ui/src/components/TypeBadge.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TypeBadge } from "./TypeBadge";
+
+const meta: Meta<typeof TypeBadge> = {
+  title: "Inventory/TypeBadge",
+  component: TypeBadge,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Electronics: Story = {
+  args: { type: "Electronics" },
+};
+
+export const Furniture: Story = {
+  args: { type: "Furniture" },
+};
+
+export const Appliance: Story = {
+  args: { type: "Appliance" },
+};
+
+export const Tool: Story = {
+  args: { type: "Tool" },
+};
+
+export const AllTypes: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <TypeBadge type="Electronics" />
+      <TypeBadge type="Furniture" />
+      <TypeBadge type="Appliance" />
+      <TypeBadge type="Tool" />
+      <TypeBadge type="Kitchen" />
+      <TypeBadge type="Clothing" />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/TypeBadge.tsx
+++ b/packages/ui/src/components/TypeBadge.tsx
@@ -1,0 +1,23 @@
+import type { ComponentProps } from "react";
+import { Badge } from "../primitives/badge";
+import { cn } from "../lib/utils";
+
+export interface TypeBadgeProps
+  extends Omit<ComponentProps<typeof Badge>, "variant" | "children"> {
+  type: string;
+}
+
+export function TypeBadge({ type, className, ...props }: TypeBadgeProps) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "text-[10px] uppercase tracking-wider font-semibold py-0 px-1.5 h-5",
+        className
+      )}
+      {...props}
+    >
+      {type}
+    </Badge>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -82,3 +82,9 @@ export * from "./components/RadioInput";
 export * from "./components/Select";
 export * from "./components/StatCard";
 export * from "./components/TextInput";
+
+// Inventory composites
+export * from "./components/AssetIdBadge";
+export * from "./components/ConditionBadge";
+export * from "./components/TypeBadge";
+export * from "./components/LocationBreadcrumb";


### PR DESCRIPTION
## Summary
- Add **AssetIdBadge** — monospace outline badge for displaying asset IDs
- Add **ConditionBadge** — color-coded badge (Excellent=emerald, Good=blue, Fair=amber, Poor=red)
- Add **TypeBadge** — uppercase outline badge for inventory item types
- Add **LocationBreadcrumb** — clickable breadcrumb path for location hierarchy
- All components include Storybook stories and are exported from `@pops/ui`

## Test plan
- [ ] Verify Storybook stories render correctly for all 4 components
- [ ] Verify typecheck passes (`pnpm typecheck`)
- [ ] Verify lint passes (`pnpm lint`)
- [ ] Verify ConditionBadge shows correct colors for each condition
- [ ] Verify LocationBreadcrumb handles empty segments gracefully
- [ ] Verify LocationBreadcrumb onNavigate callback fires on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)