### PR TITLE
feat: LocationPicker component [PRD-019/US-c4] (tb-114)

### DIFF
--- a/packages/app-inventory/src/components/LocationPicker.stories.tsx
+++ b/packages/app-inventory/src/components/LocationPicker.stories.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LocationPicker, type LocationTreeNode } from "./LocationPicker";
+
+const mockLocations: LocationTreeNode[] = [
+  {
+    id: "1",
+    name: "House",
+    parentId: null,
+    children: [
+      {
+        id: "2",
+        name: "Living Room",
+        parentId: "1",
+        children: [
+          { id: "6", name: "TV Cabinet", parentId: "2", children: [] },
+          { id: "7", name: "Bookshelf", parentId: "2", children: [] },
+        ],
+      },
+      {
+        id: "3",
+        name: "Office",
+        parentId: "1",
+        children: [
+          { id: "8", name: "Standing Desk", parentId: "3", children: [] },
+          { id: "9", name: "Filing Cabinet", parentId: "3", children: [] },
+        ],
+      },
+      {
+        id: "4",
+        name: "Kitchen",
+        parentId: "1",
+        children: [
+          { id: "10", name: "Pantry", parentId: "4", children: [] },
+        ],
+      },
+      { id: "5", name: "Bedroom", parentId: "1", children: [] },
+    ],
+  },
+  {
+    id: "11",
+    name: "Garage",
+    parentId: null,
+    children: [
+      {
+        id: "12",
+        name: "Storage Shelf",
+        parentId: "11",
+        children: [
+          { id: "13", name: "Top Shelf", parentId: "12", children: [] },
+          { id: "14", name: "Bottom Shelf", parentId: "12", children: [] },
+        ],
+      },
+      { id: "15", name: "Workbench", parentId: "11", children: [] },
+    ],
+  },
+];
+
+const meta: Meta<typeof LocationPicker> = {
+  title: "Inventory/LocationPicker",
+  component: LocationPicker,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="w-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  args: {
+    locations: mockLocations,
+    value: null,
+  },
+};
+
+export const WithSelection: Story = {
+  args: {
+    locations: mockLocations,
+    value: "8",
+  },
+};
+
+export const Interactive: Story = {
+  render: () => {
+    const [value, setValue] = useState<string | null>("6");
+    return (
+      <LocationPicker
+        locations={mockLocations}
+        value={value}
+        onChange={setValue}
+        onCreateLocation={(name, parentId) =>
+          alert(`Create "${name}" under ${parentId ?? "root"}`)
+        }
+      />
+    );
+  },
+};
+
+export const EmptyTree: Story = {
+  args: {
+    locations: [],
+    value: null,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    locations: mockLocations,
+    value: "3",
+    disabled: true,
+  },
+};
+
+export const WithAddLocation: Story = {
+  args: {
+    locations: mockLocations,
+    value: null,
+    onCreateLocation: (name, parentId) =>
+      alert(`Create "${name}" under ${parentId ?? "root"}`),
+  },
+};

--- a/packages/app-inventory/src/components/LocationPicker.tsx
+++ b/packages/app-inventory/src/components/LocationPicker.tsx
@@ -1,0 +1,336 @@
+/**
+ * LocationPicker — tree-based location selector with search and inline add.
+ * Shows trigger button with breadcrumb path, opens popover with expandable
+ * location tree, type-to-filter, and optional inline create.
+ */
+import { useState, useMemo, useCallback } from "react";
+import {
+  cn,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@pops/ui";
+import { Button } from "@pops/ui";
+import { ChevronRight, ChevronDown, MapPin, X, Plus } from "lucide-react";
+
+export interface LocationTreeNode {
+  id: string;
+  name: string;
+  parentId: string | null;
+  children: LocationTreeNode[];
+}
+
+export interface LocationPickerProps {
+  value?: string | null;
+  onChange?: (locationId: string | null) => void;
+  locations: LocationTreeNode[];
+  onCreateLocation?: (name: string, parentId: string | null) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+/** Build breadcrumb path from root to target node. */
+function buildPath(
+  nodes: LocationTreeNode[],
+  targetId: string
+): LocationTreeNode[] {
+  for (const node of nodes) {
+    if (node.id === targetId) return [node];
+    const childPath = buildPath(node.children, targetId);
+    if (childPath.length > 0) return [node, ...childPath];
+  }
+  return [];
+}
+
+/** Flatten tree for search, returning nodes that match filter. */
+function filterTree(
+  nodes: LocationTreeNode[],
+  query: string
+): Set<string> {
+  const matches = new Set<string>();
+  const lower = query.toLowerCase();
+
+  function walk(node: LocationTreeNode, ancestors: string[]) {
+    const nameMatches = node.name.toLowerCase().includes(lower);
+    const childMatches: boolean[] = [];
+
+    for (const child of node.children) {
+      walk(child, [...ancestors, node.id]);
+      if (matches.has(child.id)) childMatches.push(true);
+    }
+
+    if (nameMatches || childMatches.length > 0) {
+      matches.add(node.id);
+      for (const aid of ancestors) matches.add(aid);
+    }
+  }
+
+  for (const node of nodes) walk(node, []);
+  return matches;
+}
+
+function TreeNode({
+  node,
+  depth,
+  selectedId,
+  expandedIds,
+  visibleIds,
+  onToggle,
+  onSelect,
+}: {
+  node: LocationTreeNode;
+  depth: number;
+  selectedId: string | null;
+  expandedIds: Set<string>;
+  visibleIds: Set<string> | null;
+  onToggle: (id: string) => void;
+  onSelect: (id: string) => void;
+}) {
+  if (visibleIds && !visibleIds.has(node.id)) return null;
+
+  const hasChildren = node.children.length > 0;
+  const isExpanded = expandedIds.has(node.id);
+  const isSelected = node.id === selectedId;
+
+  return (
+    <div>
+      <button
+        type="button"
+        className={cn(
+          "flex w-full items-center gap-1 rounded-md px-2 py-1.5 text-sm",
+          "hover:bg-accent/50 transition-colors",
+          isSelected && "bg-accent text-accent-foreground font-medium",
+        )}
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        onClick={() => onSelect(node.id)}
+      >
+        {hasChildren ? (
+          <span
+            role="button"
+            tabIndex={-1}
+            className="shrink-0 p-0.5 rounded hover:bg-accent"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggle(node.id);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.stopPropagation();
+                onToggle(node.id);
+              }
+            }}
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            )}
+          </span>
+        ) : (
+          <span className="w-[18px] shrink-0" />
+        )}
+        <span className="truncate">{node.name}</span>
+      </button>
+
+      {hasChildren && isExpanded && (
+        <div>
+          {node.children.map((child) => (
+            <TreeNode
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              selectedId={selectedId}
+              expandedIds={expandedIds}
+              visibleIds={visibleIds}
+              onToggle={onToggle}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function LocationPicker({
+  value,
+  onChange,
+  locations,
+  onCreateLocation,
+  placeholder = "Select location…",
+  disabled = false,
+  className,
+}: LocationPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [newLocationName, setNewLocationName] = useState("");
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const selectedPath = useMemo(
+    () => (value ? buildPath(locations, value) : []),
+    [locations, value]
+  );
+
+  const visibleIds = useMemo(
+    () => (search.trim() ? filterTree(locations, search.trim()) : null),
+    [locations, search]
+  );
+
+  // Auto-expand matching nodes when searching
+  const effectiveExpanded = useMemo(() => {
+    if (visibleIds) return visibleIds;
+    return expandedIds;
+  }, [visibleIds, expandedIds]);
+
+  const handleToggle = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      onChange?.(id);
+      setOpen(false);
+      setSearch("");
+    },
+    [onChange]
+  );
+
+  const handleClear = useCallback(() => {
+    onChange?.(null);
+    setOpen(false);
+    setSearch("");
+  }, [onChange]);
+
+  const handleAddLocation = useCallback(() => {
+    const name = newLocationName.trim();
+    if (!name || !onCreateLocation) return;
+    onCreateLocation(name, value ?? null);
+    setNewLocationName("");
+    setShowAddForm(false);
+  }, [newLocationName, onCreateLocation, value]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn(
+            "w-full justify-start text-left font-normal h-9",
+            !value && "text-muted-foreground",
+            className
+          )}
+        >
+          <MapPin className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+          {selectedPath.length > 0 ? (
+            <span className="truncate text-sm">
+              {selectedPath.map((n) => n.name).join(" › ")}
+            </span>
+          ) : (
+            <span className="text-sm">{placeholder}</span>
+          )}
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent className="w-[280px] p-0" align="start">
+        {/* Search */}
+        <div className="border-b px-3 py-2">
+          <input
+            type="text"
+            placeholder="Search locations…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+
+        {/* Tree */}
+        <div className="max-h-[240px] overflow-y-auto p-1">
+          {locations.length === 0 ? (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              No locations found
+            </p>
+          ) : (
+            locations.map((node) => (
+              <TreeNode
+                key={node.id}
+                node={node}
+                depth={0}
+                selectedId={value ?? null}
+                expandedIds={effectiveExpanded}
+                visibleIds={visibleIds}
+                onToggle={handleToggle}
+                onSelect={handleSelect}
+              />
+            ))
+          )}
+        </div>
+
+        {/* Footer: Clear + Add */}
+        <div className="border-t p-2 flex flex-col gap-1">
+          {value && (
+            <button
+              type="button"
+              className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+              onClick={handleClear}
+            >
+              <X className="h-3.5 w-3.5" />
+              Clear selection
+            </button>
+          )}
+
+          {onCreateLocation && !showAddForm && (
+            <button
+              type="button"
+              className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+              onClick={() => setShowAddForm(true)}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Add location
+            </button>
+          )}
+
+          {onCreateLocation && showAddForm && (
+            <div className="flex items-center gap-1">
+              <input
+                type="text"
+                placeholder="Location name…"
+                value={newLocationName}
+                onChange={(e) => setNewLocationName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleAddLocation();
+                  if (e.key === "Escape") {
+                    setShowAddForm(false);
+                    setNewLocationName("");
+                  }
+                }}
+                className="flex-1 rounded-md border border-input bg-background px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-ring"
+                autoFocus
+              />
+              <Button
+                size="sm"
+                variant="default"
+                onClick={handleAddLocation}
+                disabled={!newLocationName.trim()}
+                className="h-7 px-2 text-xs"
+              >
+                Add
+              </Button>
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+LocationPicker.displayName = "LocationPicker";


### PR DESCRIPTION
## Summary
- Add **LocationPicker** component to `@pops/app-inventory` — tree-based location selector
- Popover trigger shows selected location as breadcrumb path (e.g. "House › Office › Standing Desk")
- Expandable tree nodes with chevron toggle
- Type-to-filter search that auto-expands matching branches
- Clear selection button
- Inline "Add Location" form at bottom (optional, via `onCreateLocation` prop)
- Data-agnostic: parent passes `LocationTreeNode[]`, no tRPC dependency
- Storybook stories with mock tree data

**Depends on:** tb-110 (inventory scaffold, PR #158) and tb-111 (badge components, PR #160)

## Test plan
- [ ] Verify Storybook stories render correctly
- [ ] Verify typecheck passes (`pnpm typecheck`)
- [ ] Verify lint passes (`pnpm lint`)
- [ ] Verify tree expands/collapses on chevron click
- [ ] Verify search filters tree and auto-expands matching branches
- [ ] Verify selecting a node updates the trigger button text
- [ ] Verify Clear button resets selection
- [ ] Verify Add Location form creates with correct parentId

🤖 Generated with [Claude Code](https://claude.com/claude-code)