### PR TITLE
feat: ConnectionsList component [PRD-019/US-c6] (tb-116)

### DIFF
--- a/packages/app-inventory/src/components/ConnectionsList.stories.tsx
+++ b/packages/app-inventory/src/components/ConnectionsList.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ConnectionsList } from "./ConnectionsList";
+
+const meta: Meta<typeof ConnectionsList> = {
+  title: "Inventory/ConnectionsList",
+  component: ConnectionsList,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="w-[360px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithConnections: Story = {
+  args: {
+    connections: [
+      { id: "1", itemName: "USB-C Hub", assetId: "INV-022", type: "Electronics" },
+      { id: "2", itemName: "Monitor Stand", assetId: "INV-015", type: "Furniture" },
+      { id: "3", itemName: "Keyboard", type: "Electronics" },
+    ],
+    onItemClick: (id) => alert(`Navigate to item ${id}`),
+    onConnect: () => alert("Open connect dialog"),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    connections: [],
+    onConnect: () => alert("Open connect dialog"),
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    connections: [
+      { id: "1", itemName: "Charger", assetId: "INV-050", type: "Electronics" },
+      { id: "2", itemName: "Carrying Case", type: "Accessory" },
+    ],
+  },
+};
+
+export const ManyConnections: Story = {
+  args: {
+    connections: [
+      { id: "1", itemName: "MacBook Pro 16″", assetId: "INV-001", type: "Electronics" },
+      { id: "2", itemName: "USB-C Hub", assetId: "INV-022", type: "Electronics" },
+      { id: "3", itemName: "External SSD", assetId: "INV-033", type: "Electronics" },
+      { id: "4", itemName: "Monitor", assetId: "INV-010", type: "Electronics" },
+      { id: "5", itemName: "Desk Mat", type: "Accessory" },
+      { id: "6", itemName: "Webcam", assetId: "INV-041", type: "Electronics" },
+    ],
+    onItemClick: (id) => alert(`Navigate to item ${id}`),
+    onConnect: () => alert("Open connect dialog"),
+  },
+};

--- a/packages/app-inventory/src/components/ConnectionsList.tsx
+++ b/packages/app-inventory/src/components/ConnectionsList.tsx
@@ -1,0 +1,89 @@
+/**
+ * ConnectionsList — displays linked inventory items for a given item.
+ * Shows connection count header, list of connected items with badges,
+ * and a "Connect to…" button placeholder.
+ */
+import { cn, AssetIdBadge, TypeBadge } from "@pops/ui";
+import { Link2, Plus } from "lucide-react";
+
+export interface ConnectedItem {
+  id: string;
+  itemName: string;
+  assetId?: string | null;
+  type?: string | null;
+}
+
+export interface ConnectionsListProps {
+  connections: ConnectedItem[];
+  onItemClick?: (id: string) => void;
+  onConnect?: () => void;
+  className?: string;
+}
+
+export function ConnectionsList({
+  connections,
+  onItemClick,
+  onConnect,
+  className,
+}: ConnectionsListProps) {
+  return (
+    <div className={cn("space-y-2", className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h4 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
+          <Link2 className="h-4 w-4 text-muted-foreground" />
+          Connections
+          <span className="text-xs font-normal text-muted-foreground">
+            ({connections.length})
+          </span>
+        </h4>
+      </div>
+
+      {/* List */}
+      {connections.length === 0 ? (
+        <p className="py-3 text-center text-sm text-muted-foreground">
+          No connected items
+        </p>
+      ) : (
+        <ul className="divide-y divide-border rounded-md border">
+          {connections.map((item) => (
+            <li key={item.id}>
+              <button
+                type="button"
+                className={cn(
+                  "flex w-full items-center gap-2 px-3 py-2 text-left text-sm",
+                  "transition-colors hover:bg-accent/50",
+                  onItemClick && "cursor-pointer",
+                )}
+                onClick={() => onItemClick?.(item.id)}
+                disabled={!onItemClick}
+              >
+                <span className="flex-1 truncate font-medium">
+                  {item.itemName}
+                </span>
+                <div className="flex shrink-0 items-center gap-1">
+                  {item.assetId && <AssetIdBadge assetId={item.assetId} />}
+                  {item.type && <TypeBadge type={item.type} />}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Connect button */}
+      {onConnect && (
+        <button
+          type="button"
+          className="flex w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-border px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+          onClick={onConnect}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Connect to item…
+        </button>
+      )}
+    </div>
+  );
+}
+
+ConnectionsList.displayName = "ConnectionsList";


### PR DESCRIPTION
## Summary
- Add **ConnectionsList** component to `@pops/app-inventory` — displays linked inventory items
- Connection count header with link icon
- Each item shows name, AssetIdBadge, and TypeBadge
- Click navigates to item detail via `onItemClick` callback
- Dashed "Connect to item…" button placeholder via `onConnect` callback
- Empty state for no connections
- Storybook stories covering empty, read-only, clickable, and many connections

**Depends on:** tb-110 (inventory scaffold, PR #158) and tb-111 (badge components, PR #160)

## Test plan
- [ ] Verify Storybook stories render correctly
- [ ] Verify typecheck passes (`pnpm typecheck`)
- [ ] Verify lint passes (`pnpm lint`)
- [ ] Verify click handler fires on item click
- [ ] Verify empty state renders when no connections
- [ ] Verify Connect button shows only when onConnect is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)