### PR TITLE
feat: connect/disconnect items with search dialog [PRD-021/US-1] (tb-128)

### DIFF
--- a/packages/app-inventory/package.json
+++ b/packages/app-inventory/package.json
@@ -18,7 +18,8 @@
     "lucide-react": "^0.563.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router": "^7.13.1"
+    "react-router": "^7.13.1",
+    "sonner": "^2.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/packages/app-inventory/src/components/ConnectDialog.tsx
+++ b/packages/app-inventory/src/components/ConnectDialog.tsx
@@ -1,0 +1,171 @@
+/**
+ * ConnectDialog — Search and connect inventory items.
+ *
+ * Dialog with debounced search input that queries inventory items,
+ * displays results, and connects on click. Prevents self-connects
+ * and shows existing connections.
+ */
+import { useState, useCallback, useEffect, useRef } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Badge,
+} from "@pops/ui";
+import { toast } from "sonner";
+import { Search, Link2, Loader2 } from "lucide-react";
+import { trpc } from "../lib/trpc";
+
+interface ConnectDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The item we're connecting from */
+  currentItemId: string;
+  /** IDs of already-connected items (to show as disabled) */
+  connectedIds: string[];
+}
+
+export function ConnectDialog({
+  open,
+  onOpenChange,
+  currentItemId,
+  connectedIds,
+}: ConnectDialogProps) {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const utils = trpc.useUtils();
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  // Reset on open
+  useEffect(() => {
+    if (open) {
+      setSearch("");
+      setDebouncedSearch("");
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [open]);
+
+  const { data: searchResults, isLoading } = trpc.inventory.items.list.useQuery(
+    { search: debouncedSearch, limit: 20 },
+    { enabled: open && debouncedSearch.length >= 1 },
+  );
+
+  const connectMutation = trpc.inventory.connections.connect.useMutation({
+    onSuccess: () => {
+      utils.inventory.connections.listForItem.invalidate({ itemId: currentItemId });
+      toast.success("Items connected");
+      onOpenChange(false);
+    },
+    onError: (err) => {
+      if (err.data?.code === "CONFLICT") {
+        toast.error("These items are already connected");
+      } else {
+        toast.error(err.message || "Failed to connect items");
+      }
+    },
+  });
+
+  const handleConnect = useCallback(
+    (targetId: string) => {
+      if (targetId === currentItemId) return;
+      connectMutation.mutate({
+        itemAId: currentItemId,
+        itemBId: targetId,
+      });
+    },
+    [currentItemId, connectMutation],
+  );
+
+  const connectedSet = new Set(connectedIds);
+  const items = (searchResults?.data ?? []).filter((item) => item.id !== currentItemId);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Connect to Item</DialogTitle>
+        </DialogHeader>
+
+        {/* Search input */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            ref={inputRef}
+            placeholder="Search by name or asset ID..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        {/* Results */}
+        <div className="max-h-64 overflow-y-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : debouncedSearch.length < 1 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              Type to search for items
+            </p>
+          ) : items.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              No items found
+            </p>
+          ) : (
+            <ul className="divide-y divide-border">
+              {items.map((item) => {
+                const isConnected = connectedSet.has(item.id);
+                return (
+                  <li key={item.id}>
+                    <button
+                      type="button"
+                      onClick={() => handleConnect(item.id)}
+                      disabled={isConnected || connectMutation.isPending}
+                      className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm transition-colors hover:bg-accent/50 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <Link2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                      <div className="flex-1 min-w-0">
+                        <span className="font-medium truncate block">
+                          {item.itemName}
+                        </span>
+                        {(item.brand || item.model) && (
+                          <span className="text-xs text-muted-foreground truncate block">
+                            {item.brand}
+                            {item.brand && item.model && " · "}
+                            {item.model}
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-1 shrink-0">
+                        {item.assetId && (
+                          <Badge variant="secondary" className="text-xs">
+                            {item.assetId}
+                          </Badge>
+                        )}
+                        {isConnected && (
+                          <Badge variant="outline" className="text-xs">
+                            Connected
+                          </Badge>
+                        )}
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app-inventory/src/components/ConnectionsList.tsx
+++ b/packages/app-inventory/src/components/ConnectionsList.tsx
@@ -4,7 +4,7 @@
  * and a "Connect to…" button placeholder.
  */
 import { cn, AssetIdBadge, TypeBadge } from "@pops/ui";
-import { Link2, Plus } from "lucide-react";
+import { Link2, Plus, X } from "lucide-react";
 
 export interface ConnectedItem {
   id: string;
@@ -17,6 +17,7 @@ export interface ConnectionsListProps {
   connections: ConnectedItem[];
   onItemClick?: (id: string) => void;
   onConnect?: () => void;
+  onDisconnect?: (itemId: string) => void;
   className?: string;
 }
 
@@ -24,6 +25,7 @@ export function ConnectionsList({
   connections,
   onItemClick,
   onConnect,
+  onDisconnect,
   className,
 }: ConnectionsListProps) {
   return (
@@ -64,6 +66,19 @@ export function ConnectionsList({
                 <div className="flex shrink-0 items-center gap-1">
                   {item.assetId && <AssetIdBadge assetId={item.assetId} />}
                   {item.type && <TypeBadge type={item.type} />}
+                  {onDisconnect && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDisconnect(item.id);
+                      }}
+                      className="ml-1 p-0.5 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                      aria-label={`Disconnect ${item.itemName}`}
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  )}
                 </div>
               </button>
             </li>

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -3,6 +3,7 @@
  * Shows header with badges, photo placeholder, metadata grid,
  * notes section, and connections list.
  */
+import { useState, useCallback } from "react";
 import { useParams, useNavigate, Link } from "react-router";
 import {
   Alert,
@@ -17,9 +18,11 @@ import {
 } from "@pops/ui";
 import type { Condition, LocationSegment } from "@pops/ui";
 import { Button } from "@pops/ui";
+import { toast } from "sonner";
 import { ArrowLeft, Pencil, Trash2, Package, Calendar, DollarSign, ShieldCheck, MapPin } from "lucide-react";
 import { trpc } from "../lib/trpc";
 import { ConnectionsList } from "../components/ConnectionsList";
+import { ConnectDialog } from "../components/ConnectDialog";
 
 function ItemDetailSkeleton() {
   return (
@@ -84,6 +87,9 @@ function formatCurrency(value: number | null): string {
 export function ItemDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const [connectOpen, setConnectOpen] = useState(false);
+
+  const utils = trpc.useUtils();
 
   const { data: itemResponse, isLoading, error } = trpc.inventory.items.get.useQuery(
     { id: id! },
@@ -94,6 +100,27 @@ export function ItemDetailPage() {
   const { data: connectionsData } = trpc.inventory.connections.listForItem.useQuery(
     { itemId: id! },
     { enabled: !!id }
+  );
+
+  const disconnectMutation = trpc.inventory.connections.disconnect.useMutation({
+    onSuccess: () => {
+      utils.inventory.connections.listForItem.invalidate({ itemId: id! });
+      toast.success("Items disconnected");
+    },
+    onError: (err) => toast.error(err.message || "Failed to disconnect"),
+  });
+
+  const handleDisconnect = useCallback(
+    (connectedItemId: string) => {
+      // Find the connection by the connected item's ID
+      const conn = connectionsData?.data.find(
+        (c) => (c.itemAId === id ? c.itemBId : c.itemAId) === connectedItemId,
+      );
+      if (conn) {
+        disconnectMutation.mutate({ id: conn.id });
+      }
+    },
+    [connectionsData, id, disconnectMutation],
   );
 
   // Extract connected item IDs to fetch their details
@@ -292,6 +319,16 @@ export function ItemDetailPage() {
       <ConnectionsList
         connections={connections}
         onItemClick={(itemId) => navigate(`/inventory/items/${itemId}`)}
+        onConnect={() => setConnectOpen(true)}
+        onDisconnect={handleDisconnect}
+      />
+
+      {/* Connect dialog */}
+      <ConnectDialog
+        open={connectOpen}
+        onOpenChange={setConnectOpen}
+        currentItemId={id}
+        connectedIds={connectedItemIds}
       />
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       react-router:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      sonner:
+        specifier: ^2.0.0
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@types/react':
         specifier: ^19.0.0


### PR DESCRIPTION
## Summary
- New ConnectDialog component: debounced search input to find items by name, click to connect. Prevents self-connects and shows already-connected items as disabled.
- ConnectionsList updated with disconnect button (X icon) per connection row
- ItemDetailPage wired with connect dialog (via "Connect to item..." button) and disconnect mutation with toast feedback and query cache invalidation

## Test plan
- [ ] Verify "Connect to item..." button opens ConnectDialog
- [ ] Verify search finds items by name
- [ ] Verify clicking an item connects it (toast confirms)
- [ ] Verify self-connect is prevented (current item excluded from results)
- [ ] Verify already-connected items show "Connected" badge and are disabled
- [ ] Verify duplicate connection shows error toast
- [ ] Verify X button disconnects an item with toast confirmation
- [ ] Verify connection list refreshes after connect/disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)