### PR TITLE
fix: CI workflows not triggering on stacked PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main, develop]
 
 jobs:
   e2e-tests:

--- a/.github/workflows/shell-ci.yml
+++ b/.github/workflows/shell-ci.yml
@@ -5,12 +5,20 @@ on:
     branches: [main]
     paths:
       - "apps/pops-shell/**"
+      - "packages/app-*/**"
       - "packages/db-types/**"
+      - "packages/ui/**"
+      - "packages/widgets/**"
+      - "packages/navigation/**"
       - ".github/workflows/shell-ci.yml"
   pull_request:
     paths:
       - "apps/pops-shell/**"
+      - "packages/app-*/**"
       - "packages/db-types/**"
+      - "packages/ui/**"
+      - "packages/widgets/**"
+      - "packages/navigation/**"
       - ".github/workflows/shell-ci.yml"
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main, develop]
 
 jobs:
   test-backend:


### PR DESCRIPTION
## Summary
- **test.yml / e2e.yml**: Removed `branches: [main, develop]` filter from `pull_request` trigger — CI now runs on PRs targeting any branch (stacked PRs were silently skipped)
- **shell-ci.yml**: Added `packages/app-*/**`, `packages/ui/**`, `packages/widgets/**`, `packages/navigation/**` to path filters — changes to frontend packages now trigger shell CI

## Context
10 open PRs have zero CI runs. Two root causes:
1. PRs targeting non-main branches (#172, #178, #182, #185) never triggered `test.yml`/`e2e.yml` due to the branch filter
2. PRs touching only `packages/app-inventory/**` or `packages/app-media/**` didn't match any workflow's path filter

An additional 7 PRs targeting main (#159, #163, #171, #177, #183, #186, #188) had CI dropped due to GitHub rate-limiting ~150 workflow triggers from 36 PRs created within 40 minutes. Those will need empty commits or rebases to re-trigger after this merges.

## Test plan
- [ ] Verify this PR itself triggers all CI workflows
- [ ] After merge, push empty commits to rate-limited PRs to confirm CI triggers