### PR TITLE
feat: item_documents schema + tRPC routes for Paperless document linking (tb-136)

### DIFF
--- a/apps/pops-api/src/db/migrations/20260321140000_item_documents.sql
+++ b/apps/pops-api/src/db/migrations/20260321140000_item_documents.sql
@@ -1,0 +1,17 @@
+-- Domain: inventory
+-- Description: Create item_documents junction table for linking Paperless-ngx documents to inventory items
+-- Rollback: DROP TABLE IF EXISTS item_documents;
+
+CREATE TABLE IF NOT EXISTS item_documents (
+  id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+  item_id                TEXT NOT NULL,
+  paperless_document_id  INTEGER NOT NULL,
+  document_type          TEXT NOT NULL,
+  title                  TEXT,
+  created_at             TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (item_id) REFERENCES home_inventory(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_item_documents_pair ON item_documents(item_id, paperless_document_id);
+CREATE INDEX IF NOT EXISTS idx_item_documents_item ON item_documents(item_id);
+CREATE INDEX IF NOT EXISTS idx_item_documents_doc ON item_documents(paperless_document_id);

--- a/apps/pops-api/src/modules/inventory/documents/documents.test.ts
+++ b/apps/pops-api/src/modules/inventory/documents/documents.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Item documents router tests.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database } from "better-sqlite3";
+import { TRPCError } from "@trpc/server";
+import {
+  setupTestContext,
+  createCaller,
+  seedInventoryItem,
+  seedItemDocument,
+} from "../../../shared/test-utils.js";
+
+const ctx = setupTestContext();
+let caller: ReturnType<typeof createCaller>;
+let db: Database;
+
+beforeEach(() => {
+  ({ caller, db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+describe("inventory.documents.link", () => {
+  it("links a document to an item and returns the link", async () => {
+    const itemId = seedInventoryItem(db, { item_name: "Test Item" });
+
+    const result = await caller.inventory.documents.link({
+      itemId,
+      paperlessDocumentId: 42,
+      documentType: "receipt",
+      title: "Purchase Receipt",
+    });
+
+    expect(result.data).toMatchObject({
+      itemId,
+      paperlessDocumentId: 42,
+      documentType: "receipt",
+      title: "Purchase Receipt",
+    });
+    expect(result.data.id).toBeTypeOf("number");
+    expect(result.data.createdAt).toBeTypeOf("string");
+    expect(result.message).toBe("Document linked");
+  });
+
+  it("links without title", async () => {
+    const itemId = seedInventoryItem(db, { item_name: "Test Item" });
+
+    const result = await caller.inventory.documents.link({
+      itemId,
+      paperlessDocumentId: 10,
+      documentType: "warranty",
+    });
+
+    expect(result.data.title).toBeNull();
+  });
+
+  it("throws CONFLICT when linking same document twice", async () => {
+    const itemId = seedInventoryItem(db, { item_name: "Test Item" });
+
+    await caller.inventory.documents.link({
+      itemId,
+      paperlessDocumentId: 42,
+      documentType: "receipt",
+    });
+
+    await expect(
+      caller.inventory.documents.link({
+        itemId,
+        paperlessDocumentId: 42,
+        documentType: "receipt",
+      })
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await caller.inventory.documents.link({
+        itemId,
+        paperlessDocumentId: 42,
+        documentType: "receipt",
+      });
+    } catch (err) {
+      expect((err as TRPCError).code).toBe("CONFLICT");
+    }
+  });
+
+  it("throws NOT_FOUND when item does not exist", async () => {
+    await expect(
+      caller.inventory.documents.link({
+        itemId: "nonexistent",
+        paperlessDocumentId: 42,
+        documentType: "receipt",
+      })
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await caller.inventory.documents.link({
+        itemId: "nonexistent",
+        paperlessDocumentId: 42,
+        documentType: "receipt",
+      });
+    } catch (err) {
+      expect((err as TRPCError).code).toBe("NOT_FOUND");
+    }
+  });
+
+  it("allows same document linked to different items", async () => {
+    const itemA = seedInventoryItem(db, { item_name: "Item A" });
+    const itemB = seedInventoryItem(db, { item_name: "Item B" });
+
+    const resultA = await caller.inventory.documents.link({
+      itemId: itemA,
+      paperlessDocumentId: 42,
+      documentType: "receipt",
+    });
+
+    const resultB = await caller.inventory.documents.link({
+      itemId: itemB,
+      paperlessDocumentId: 42,
+      documentType: "receipt",
+    });
+
+    expect(resultA.data.itemId).toBe(itemA);
+    expect(resultB.data.itemId).toBe(itemB);
+  });
+
+  it("persists to the database", async () => {
+    const itemId = seedInventoryItem(db, { item_name: "Test Item" });
+
+    await caller.inventory.documents.link({
+      itemId,
+      paperlessDocumentId: 42,
+      documentType: "manual",
+      title: "User Manual",
+    });
+
+    const row = db
+      .prepare("SELECT * FROM item_documents WHERE item_id = ? AND paperless_document_id = ?")
+      .get(itemId, 42) as
+      | { item_id: string; paperless_document_id: number; document_type: string; title: string }
+      | undefined;
+
+    expect(row).toBeDefined();
+    expect(row!.item_id).toBe(itemId);
+    expect(row!.paperless_document_id).toBe(42);
+    expect(row!.document_type).toBe("manual");
+    expect(row!.title).toBe("User Manual");
+  });
+});
+
+describe("inventory.documents.unlink", () => {
+  it("removes an existing document link", async () => {
+    const itemId = seedInventoryItem(db, { item_name: "Test Item" });
+    const linkId = seedItemDocument(db, { item_id: itemId, paperless_document_id: 42 });
+
+    const result = await caller.inventory.documents.unlink({ id: linkId });
+
+    expect(result.message).toBe("Document unlinked");
+
+    const row = db.prepare("SELECT * FROM item_documents WHERE id = ?").get(linkId);
+    expect(row).toBeUndefined();
+  });
+
+  it("throws NOT_FOUND for nonexistent link", async () => {
+    await expect(caller.inventory.documents.unlink({ id: 999 })).rejects.toThrow(TRPCError);
+
+    try {
+      await caller.inventory.documents.unlink({ id: 999 });
+    } catch (err) {
+      expect((err as TRPCError).code).toBe("NOT_FOUND");
+    }
+  });
+});
+
+describe("inventory.documents.listForItem", () => {
+  it("returns empty list when no documents linked", async () => {
+    const itemId = seedInventoryItem(db, { item_name: "Lonely Item" });
+
+    const result = await caller.inventory.documents.listForItem({ itemId });
+
+    expect(result.data).toEqual([]);
+    expect(result.pagination.total).toBe(0);
+  });
+
+  it("returns linked documents for an item", async () => {
+    const itemId = seedInventoryItem(db, { item_name: "Test Item" });
+    seedItemDocument(db, { item_id: itemId, paperless_document_id: 10, document_type: "receipt" });
+    seedItemDocument(db, { item_id: itemId, paperless_document_id: 20, document_type: "warranty" });
+
+    const result = await caller.inventory.documents.listForItem({ itemId });
+
+    expect(result.data).toHaveLength(2);
+    expect(result.pagination.total).toBe(2);
+  });
+
+  it("does not return documents from other items", async () => {
+    const itemA = seedInventoryItem(db, { item_name: "Item A" });
+    const itemB = seedInventoryItem(db, { item_name: "Item B" });
+    seedItemDocument(db, { item_id: itemA, paperless_document_id: 10 });
+    seedItemDocument(db, { item_id: itemB, paperless_document_id: 20 });
+
+    const result = await caller.inventory.documents.listForItem({ itemId: itemA });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].paperlessDocumentId).toBe(10);
+  });
+
+  it("paginates results", async () => {
+    const itemId = seedInventoryItem(db, { item_name: "Test Item" });
+
+    for (let i = 0; i < 3; i++) {
+      seedItemDocument(db, { item_id: itemId, paperless_document_id: i + 1 });
+    }
+
+    const page1 = await caller.inventory.documents.listForItem({
+      itemId,
+      limit: 2,
+      offset: 0,
+    });
+
+    expect(page1.data).toHaveLength(2);
+    expect(page1.pagination.total).toBe(3);
+    expect(page1.pagination.hasMore).toBe(true);
+
+    const page2 = await caller.inventory.documents.listForItem({
+      itemId,
+      limit: 2,
+      offset: 2,
+    });
+
+    expect(page2.data).toHaveLength(1);
+    expect(page2.pagination.hasMore).toBe(false);
+  });
+});
+
+describe("inventory.documents auth", () => {
+  it("throws UNAUTHORIZED without auth on link", async () => {
+    const unauthCaller = createCaller(false);
+    await expect(
+      unauthCaller.inventory.documents.link({
+        itemId: "a",
+        paperlessDocumentId: 1,
+        documentType: "receipt",
+      })
+    ).rejects.toThrow(TRPCError);
+  });
+
+  it("throws UNAUTHORIZED without auth on unlink", async () => {
+    const unauthCaller = createCaller(false);
+    await expect(unauthCaller.inventory.documents.unlink({ id: 1 })).rejects.toThrow(TRPCError);
+  });
+
+  it("throws UNAUTHORIZED without auth on listForItem", async () => {
+    const unauthCaller = createCaller(false);
+    await expect(unauthCaller.inventory.documents.listForItem({ itemId: "a" })).rejects.toThrow(
+      TRPCError
+    );
+  });
+});

--- a/apps/pops-api/src/modules/inventory/documents/index.ts
+++ b/apps/pops-api/src/modules/inventory/documents/index.ts
@@ -1,0 +1,1 @@
+export { documentsRouter } from "./router.js";

--- a/apps/pops-api/src/modules/inventory/documents/router.ts
+++ b/apps/pops-api/src/modules/inventory/documents/router.ts
@@ -1,0 +1,67 @@
+/**
+ * Item documents tRPC router — link/unlink Paperless-ngx documents to inventory items.
+ */
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { router, protectedProcedure } from "../../../trpc.js";
+import { paginationMeta } from "../../../shared/pagination.js";
+import { LinkDocumentSchema, DocumentQuerySchema, toItemDocument } from "./types.js";
+import * as service from "./service.js";
+import { NotFoundError, ConflictError } from "../../../shared/errors.js";
+
+const DEFAULT_LIMIT = 50;
+const DEFAULT_OFFSET = 0;
+
+export const documentsRouter = router({
+  /** Link a Paperless-ngx document to an inventory item. */
+  link: protectedProcedure.input(LinkDocumentSchema).mutation(({ input }) => {
+    try {
+      const row = service.linkDocument(
+        input.itemId,
+        input.paperlessDocumentId,
+        input.documentType,
+        input.title
+      );
+      return {
+        data: toItemDocument(row),
+        message: "Document linked",
+      };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      if (err instanceof ConflictError) {
+        throw new TRPCError({ code: "CONFLICT", message: err.message });
+      }
+      throw err;
+    }
+  }),
+
+  /** Unlink a document from an item by link ID. */
+  unlink: protectedProcedure
+    .input(z.object({ id: z.number().int().positive() }))
+    .mutation(({ input }) => {
+      try {
+        service.unlinkDocument(input.id);
+        return { message: "Document unlinked" };
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+        }
+        throw err;
+      }
+    }),
+
+  /** List all documents linked to an item. */
+  listForItem: protectedProcedure.input(DocumentQuerySchema).query(({ input }) => {
+    const limit = input.limit ?? DEFAULT_LIMIT;
+    const offset = input.offset ?? DEFAULT_OFFSET;
+
+    const { rows, total } = service.listDocumentsForItem(input.itemId, limit, offset);
+
+    return {
+      data: rows.map(toItemDocument),
+      pagination: paginationMeta(total, limit, offset),
+    };
+  }),
+});

--- a/apps/pops-api/src/modules/inventory/documents/service.ts
+++ b/apps/pops-api/src/modules/inventory/documents/service.ts
@@ -1,0 +1,107 @@
+/**
+ * Item documents service — link/unlink Paperless-ngx documents to inventory items.
+ */
+import { eq, and, count } from "drizzle-orm";
+import { getDrizzle } from "../../../db.js";
+import { itemDocuments, homeInventory } from "@pops/db-types";
+import { NotFoundError, ConflictError } from "../../../shared/errors.js";
+import type { ItemDocumentRow } from "./types.js";
+
+export interface DocumentListResult {
+  rows: ItemDocumentRow[];
+  total: number;
+}
+
+/**
+ * Link a Paperless-ngx document to an inventory item.
+ * Validates the item exists and the pair is not already linked.
+ */
+export function linkDocument(
+  itemId: string,
+  paperlessDocumentId: number,
+  documentType: string,
+  title?: string
+): ItemDocumentRow {
+  const db = getDrizzle();
+
+  // Validate item exists
+  const [item] = db
+    .select({ id: homeInventory.id })
+    .from(homeInventory)
+    .where(eq(homeInventory.id, itemId))
+    .all();
+
+  if (!item) throw new NotFoundError("Inventory item", itemId);
+
+  // Check for existing link
+  const [existing] = db
+    .select({ id: itemDocuments.id })
+    .from(itemDocuments)
+    .where(
+      and(
+        eq(itemDocuments.itemId, itemId),
+        eq(itemDocuments.paperlessDocumentId, paperlessDocumentId)
+      )
+    )
+    .all();
+
+  if (existing) {
+    throw new ConflictError(
+      `Document '${paperlessDocumentId}' is already linked to item '${itemId}'`
+    );
+  }
+
+  db.insert(itemDocuments)
+    .values({ itemId, paperlessDocumentId, documentType, title: title ?? null })
+    .run();
+
+  // Fetch the created row
+  const [created] = db
+    .select()
+    .from(itemDocuments)
+    .where(
+      and(
+        eq(itemDocuments.itemId, itemId),
+        eq(itemDocuments.paperlessDocumentId, paperlessDocumentId)
+      )
+    )
+    .all();
+
+  return created;
+}
+
+/**
+ * Unlink a document from an item by link ID.
+ */
+export function unlinkDocument(id: number): void {
+  const db = getDrizzle();
+
+  const [row] = db
+    .select({ id: itemDocuments.id })
+    .from(itemDocuments)
+    .where(eq(itemDocuments.id, id))
+    .all();
+
+  if (!row) throw new NotFoundError("Item document link", String(id));
+
+  db.delete(itemDocuments).where(eq(itemDocuments.id, id)).run();
+}
+
+/**
+ * List all documents linked to a given item.
+ */
+export function listDocumentsForItem(
+  itemId: string,
+  limit: number,
+  offset: number
+): DocumentListResult {
+  const db = getDrizzle();
+
+  const condition = eq(itemDocuments.itemId, itemId);
+
+  const rows = db.select().from(itemDocuments).where(condition).limit(limit).offset(offset).all();
+
+  const [countResult] = db.select({ total: count() }).from(itemDocuments).where(condition).all();
+
+  return { rows, total: countResult.total };
+}

--- a/apps/pops-api/src/modules/inventory/documents/types.ts
+++ b/apps/pops-api/src/modules/inventory/documents/types.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import type { ItemDocumentRow } from "@pops/db-types";
+
+export type { ItemDocumentRow };
+
+export const DOCUMENT_TYPES = ["receipt", "warranty", "manual", "invoice", "other"] as const;
+export type DocumentType = (typeof DOCUMENT_TYPES)[number];
+
+/** API response shape for an item document link. */
+export interface ItemDocument {
+  id: number;
+  itemId: string;
+  paperlessDocumentId: number;
+  documentType: string;
+  title: string | null;
+  createdAt: string;
+}
+
+/** Map a DB row to the API response shape. */
+export function toItemDocument(row: ItemDocumentRow): ItemDocument {
+  return {
+    id: row.id,
+    itemId: row.itemId,
+    paperlessDocumentId: row.paperlessDocumentId,
+    documentType: row.documentType,
+    title: row.title,
+    createdAt: row.createdAt,
+  };
+}
+
+/** Zod schema for linking a document to an item. */
+export const LinkDocumentSchema = z.object({
+  itemId: z.string().min(1, "Item ID is required"),
+  paperlessDocumentId: z.number().int().positive("Document ID must be a positive integer"),
+  documentType: z.enum(DOCUMENT_TYPES),
+  title: z.string().optional(),
+});
+export type LinkDocumentInput = z.infer<typeof LinkDocumentSchema>;
+
+/** Zod schema for listing documents for an item. */
+export const DocumentQuerySchema = z.object({
+  itemId: z.string().min(1, "Item ID is required"),
+  limit: z.coerce.number().positive().max(500).optional(),
+  offset: z.coerce.number().nonnegative().optional(),
+});
+export type DocumentQuery = z.infer<typeof DocumentQuerySchema>;

--- a/apps/pops-api/src/modules/inventory/index.ts
+++ b/apps/pops-api/src/modules/inventory/index.ts
@@ -6,10 +6,12 @@ import { inventoryRouter as itemsRouter } from "./items/router.js";
 import { locationsRouter } from "./locations/router.js";
 import { connectionsRouter } from "./connections/index.js";
 import { photosRouter } from "./photos/index.js";
+import { documentsRouter } from "./documents/index.js";
 
 export const inventoryRouter = router({
   items: itemsRouter,
   locations: locationsRouter,
   connections: connectionsRouter,
   photos: photosRouter,
+  documents: documentsRouter,
 });

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -320,6 +320,19 @@ export function createTestDb(): Database {
       FOREIGN KEY (item_id) REFERENCES home_inventory(id) ON DELETE CASCADE
     );
     CREATE INDEX IF NOT EXISTS idx_item_photos_item ON item_photos(item_id);
+
+    CREATE TABLE IF NOT EXISTS item_documents (
+      id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+      item_id                TEXT NOT NULL,
+      paperless_document_id  INTEGER NOT NULL,
+      document_type          TEXT NOT NULL,
+      title                  TEXT,
+      created_at             TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (item_id) REFERENCES home_inventory(id) ON DELETE CASCADE
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_item_documents_pair ON item_documents(item_id, paperless_document_id);
+    CREATE INDEX IF NOT EXISTS idx_item_documents_item ON item_documents(item_id);
+    CREATE INDEX IF NOT EXISTS idx_item_documents_doc ON item_documents(paperless_document_id);
   `);
 
   return db;
@@ -575,6 +588,36 @@ export function seedItemPhoto(
       file_path: overrides.file_path ?? "items/test/photo_001.jpg",
       caption: overrides.caption ?? null,
       sort_order: overrides.sort_order ?? 0,
+    });
+
+  return Number(result.lastInsertRowid);
+}
+
+/**
+ * Seed an item document link row into the test DB.
+ * Returns the auto-incremented id.
+ */
+export function seedItemDocument(
+  db: Database,
+  overrides: {
+    item_id: string;
+    paperless_document_id: number;
+    document_type?: string;
+    title?: string | null;
+  }
+): number {
+  const result = db
+    .prepare(
+      `
+    INSERT INTO item_documents (item_id, paperless_document_id, document_type, title)
+    VALUES (@item_id, @paperless_document_id, @document_type, @title)
+  `
+    )
+    .run({
+      item_id: overrides.item_id,
+      paperless_document_id: overrides.paperless_document_id,
+      document_type: overrides.document_type ?? "receipt",
+      title: overrides.title ?? null,
     });
 
   return Number(result.lastInsertRowid);

--- a/packages/db-types/src/index.ts
+++ b/packages/db-types/src/index.ts
@@ -26,6 +26,7 @@ import type { mediaScores } from "./schema/media-scores.js";
 import type { locations } from "./schema/locations.js";
 import type { itemConnections } from "./schema/item-connections.js";
 import type { itemPhotos } from "./schema/item-photos.js";
+import type { itemDocuments } from "./schema/item-documents.js";
 
 // Re-export Drizzle table objects for use in queries
 export {
@@ -49,6 +50,7 @@ export {
   locations,
   itemConnections,
   itemPhotos,
+  itemDocuments,
 } from "./schema/index.js";
 
 // Select types (what you get back from a SELECT query)
@@ -57,7 +59,9 @@ export type EntityRow = InferSelectModel<typeof entities>;
 export type BudgetRow = InferSelectModel<typeof budgets>;
 export type InventoryRow = InferSelectModel<typeof homeInventory>;
 export type WishListRow = InferSelectModel<typeof wishList>;
-export type TransactionCorrectionRow = InferSelectModel<typeof transactionCorrections>;
+export type TransactionCorrectionRow = InferSelectModel<
+  typeof transactionCorrections
+>;
 export type AiUsageRow = InferSelectModel<typeof aiUsage>;
 export type EnvironmentRow = InferSelectModel<typeof environments>;
 export type MovieRow = InferSelectModel<typeof movies>;
@@ -66,12 +70,15 @@ export type SeasonRow = InferSelectModel<typeof seasons>;
 export type EpisodeRow = InferSelectModel<typeof episodes>;
 export type MediaWatchlistRow = InferSelectModel<typeof mediaWatchlist>;
 export type WatchHistoryRow = InferSelectModel<typeof watchHistory>;
-export type ComparisonDimensionRow = InferSelectModel<typeof comparisonDimensions>;
+export type ComparisonDimensionRow = InferSelectModel<
+  typeof comparisonDimensions
+>;
 export type ComparisonRow = InferSelectModel<typeof comparisons>;
 export type MediaScoreRow = InferSelectModel<typeof mediaScores>;
 export type LocationRow = InferSelectModel<typeof locations>;
 export type ItemConnectionRow = InferSelectModel<typeof itemConnections>;
 export type ItemPhotoRow = InferSelectModel<typeof itemPhotos>;
+export type ItemDocumentRow = InferSelectModel<typeof itemDocuments>;
 
 // Insert types (what you pass to an INSERT statement)
 export type TransactionInsert = InferInsertModel<typeof transactions>;
@@ -79,7 +86,9 @@ export type EntityInsert = InferInsertModel<typeof entities>;
 export type BudgetInsert = InferInsertModel<typeof budgets>;
 export type InventoryInsert = InferInsertModel<typeof homeInventory>;
 export type WishListInsert = InferInsertModel<typeof wishList>;
-export type TransactionCorrectionInsert = InferInsertModel<typeof transactionCorrections>;
+export type TransactionCorrectionInsert = InferInsertModel<
+  typeof transactionCorrections
+>;
 export type AiUsageInsert = InferInsertModel<typeof aiUsage>;
 export type EnvironmentInsert = InferInsertModel<typeof environments>;
 export type MovieInsert = InferInsertModel<typeof movies>;
@@ -88,12 +97,15 @@ export type SeasonInsert = InferInsertModel<typeof seasons>;
 export type EpisodeInsert = InferInsertModel<typeof episodes>;
 export type MediaWatchlistInsert = InferInsertModel<typeof mediaWatchlist>;
 export type WatchHistoryInsert = InferInsertModel<typeof watchHistory>;
-export type ComparisonDimensionInsert = InferInsertModel<typeof comparisonDimensions>;
+export type ComparisonDimensionInsert = InferInsertModel<
+  typeof comparisonDimensions
+>;
 export type ComparisonInsert = InferInsertModel<typeof comparisons>;
 export type MediaScoreInsert = InferInsertModel<typeof mediaScores>;
 export type LocationInsert = InferInsertModel<typeof locations>;
 export type ItemConnectionInsert = InferInsertModel<typeof itemConnections>;
 export type ItemPhotoInsert = InferInsertModel<typeof itemPhotos>;
+export type ItemDocumentInsert = InferInsertModel<typeof itemDocuments>;
 
 // Constants
 export const ENTITY_TYPES = [
@@ -105,7 +117,12 @@ export const ENTITY_TYPES = [
 ] as const;
 export type EntityType = (typeof ENTITY_TYPES)[number];
 
-export const WISH_LIST_PRIORITIES = ["Needing", "Soon", "One Day", "Dreaming"] as const;
+export const WISH_LIST_PRIORITIES = [
+  "Needing",
+  "Soon",
+  "One Day",
+  "Dreaming",
+] as const;
 export type WishListPriority = (typeof WISH_LIST_PRIORITIES)[number];
 
 export const MEDIA_TYPES = ["movie", "tv_show"] as const;

--- a/packages/db-types/src/schema/index.ts
+++ b/packages/db-types/src/schema/index.ts
@@ -18,3 +18,4 @@ export { mediaScores } from "./media-scores.js";
 export { locations } from "./locations.js";
 export { itemConnections } from "./item-connections.js";
 export { itemPhotos } from "./item-photos.js";
+export { itemDocuments } from "./item-documents.js";

--- a/packages/db-types/src/schema/item-documents.ts
+++ b/packages/db-types/src/schema/item-documents.ts
@@ -1,0 +1,33 @@
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  unique,
+} from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { homeInventory } from "./inventory.js";
+
+export const itemDocuments = sqliteTable(
+  "item_documents",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    itemId: text("item_id")
+      .notNull()
+      .references(() => homeInventory.id, { onDelete: "cascade" }),
+    paperlessDocumentId: integer("paperless_document_id").notNull(),
+    documentType: text("document_type").notNull(),
+    title: text("title"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    unique("uq_item_documents_pair").on(
+      table.itemId,
+      table.paperlessDocumentId,
+    ),
+    index("idx_item_documents_item").on(table.itemId),
+    index("idx_item_documents_doc").on(table.paperlessDocumentId),
+  ],
+);


### PR DESCRIPTION
## Summary
- **New Drizzle schema** `item_documents` in `@pops/db-types` — junction table linking inventory items to Paperless-ngx documents (item_id, paperless_document_id, document_type, title)
- **New tRPC router** at `inventory.documents` with `link`, `unlink`, and `listForItem` procedures — validates item existence, prevents duplicate links, supports pagination
- **Migration** `20260321140000_item_documents.sql` with unique constraint on (item_id, paperless_document_id)
- **15 tests** covering link/unlink/list operations, conflict detection, NOT_FOUND errors, pagination, and auth guards

## Test plan
- [x] All 15 tests pass (`pnpm vitest run documents.test.ts`)
- [x] TypeScript compiles cleanly (`pnpm typecheck`)
- [x] Prettier formatting verified
- [x] Lockfile integrity verified (`pnpm install --frozen-lockfile`)
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)