### PR TITLE
feat: quick pick "What to watch tonight" flow (tb-139)

### DIFF
--- a/apps/pops-api/src/modules/media/library/router.ts
+++ b/apps/pops-api/src/modules/media/library/router.ts
@@ -8,7 +8,7 @@ import { getTmdbClient, TmdbClient, TmdbApiError } from "../tmdb/index.js";
 import { NotFoundError } from "../../../shared/errors.js";
 import { toMovie } from "../movies/types.js";
 import { toTvShow, toSeason } from "../tv-shows/types.js";
-import { RefreshMovieSchema } from "./types.js";
+import { RefreshMovieSchema, QuickPickSchema } from "./types.js";
 import * as libraryService from "./service.js";
 import { getTvdbClient } from "../thetvdb/index.js";
 import { TvdbApiError } from "../thetvdb/types.js";
@@ -113,6 +113,15 @@ export const libraryRouter = router({
         throw err;
       }
     }),
+
+  /**
+   * Quick pick — returns random unwatched movies from the library.
+   * Used by the "What should I watch tonight?" flow.
+   */
+  quickPick: protectedProcedure.input(QuickPickSchema).query(({ input }) => {
+    const picks = libraryService.getQuickPicks(input.count);
+    return { data: picks };
+  }),
 
   /** Refresh TV show metadata from TheTVDB. */
   refreshTvShow: protectedProcedure

--- a/apps/pops-api/src/modules/media/library/service.ts
+++ b/apps/pops-api/src/modules/media/library/service.ts
@@ -2,6 +2,9 @@
  * Library service — orchestrates adding media to the local library
  * by fetching metadata from external APIs and inserting records.
  */
+import { sql } from "drizzle-orm";
+import { getDrizzle } from "../../../db.js";
+import { movies, watchHistory } from "@pops/db-types";
 import type { TmdbClient } from "../tmdb/client.js";
 import type { TmdbMovieDetail } from "../tmdb/types.js";
 import { getMovieByTmdbId, getMovie, createMovie, updateMovie } from "../movies/service.js";
@@ -97,4 +100,31 @@ export async function refreshMovie(id: number, tmdbClient: TmdbClient): Promise<
 
   // Update the local record
   return updateMovie(id, updateInput);
+}
+
+/**
+ * Get random unwatched movies from the library.
+ *
+ * Returns movies that have no completed watch_history entries.
+ * Uses SQLite's RANDOM() for ordering.
+ */
+export function getQuickPicks(count: number): Movie[] {
+  const db = getDrizzle();
+
+  const rows = db
+    .select()
+    .from(movies)
+    .where(
+      sql`${movies.id} NOT IN (
+        SELECT DISTINCT ${watchHistory.mediaId}
+        FROM ${watchHistory}
+        WHERE ${watchHistory.mediaType} = 'movie'
+          AND ${watchHistory.completed} = 1
+      )`
+    )
+    .orderBy(sql`RANDOM()`)
+    .limit(count)
+    .all();
+
+  return rows.map(toMovie);
 }

--- a/apps/pops-api/src/modules/media/library/types.ts
+++ b/apps/pops-api/src/modules/media/library/types.ts
@@ -8,3 +8,9 @@ export const RefreshMovieSchema = z.object({
   id: z.number().int().positive(),
 });
 export type RefreshMovieInput = z.infer<typeof RefreshMovieSchema>;
+
+/** Zod schema for the quick-pick query. */
+export const QuickPickSchema = z.object({
+  count: z.coerce.number().int().positive().max(10).optional().default(3),
+});
+export type QuickPickInput = z.infer<typeof QuickPickSchema>;

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -1,5 +1,6 @@
 import { useSearchParams, Link } from "react-router";
-import { Badge, Skeleton } from "@pops/ui";
+import { Badge, Skeleton, Button } from "@pops/ui";
+import { Sparkles } from "lucide-react";
 import { useEffect } from "react";
 import { MediaGrid } from "../components/MediaGrid";
 import {
@@ -47,9 +48,7 @@ function MediaCard({
   };
 }) {
   const href =
-    item.type === "movie"
-      ? `/media/movies/${item.id}`
-      : `/media/tv/${item.id}`;
+    item.type === "movie" ? `/media/movies/${item.id}` : `/media/tv/${item.id}`;
   const posterSrc = item.posterUrl ?? "";
 
   return (
@@ -75,7 +74,9 @@ function MediaCard({
           {item.type === "movie" ? "Movie" : "TV"}
         </Badge>
       </div>
-      <h3 className="mt-2 text-sm font-medium line-clamp-2 transition-colors group-hover:text-indigo-400">{item.title}</h3>
+      <h3 className="mt-2 text-sm font-medium line-clamp-2 transition-colors group-hover:text-indigo-400">
+        {item.title}
+      </h3>
       {item.year && (
         <p className="text-xs text-muted-foreground">{item.year}</p>
       )}
@@ -122,7 +123,11 @@ export function LibraryPage() {
       {/* Filter bar */}
       <div className="flex flex-wrap items-center gap-3">
         {/* Type toggle */}
-        <div className="flex rounded-lg border bg-muted/30 p-0.5" role="group" aria-label="Filter by type">
+        <div
+          className="flex rounded-lg border bg-muted/30 p-0.5"
+          role="group"
+          aria-label="Filter by type"
+        >
           {TYPE_OPTIONS.map((opt) => (
             <button
               key={opt.value}
@@ -200,6 +205,17 @@ export function LibraryPage() {
           ))}
         </MediaGrid>
       )}
+
+      {/* Quick Pick FAB */}
+      <Link
+        to="/media/quick-pick"
+        className="fixed bottom-6 right-6 z-50"
+        aria-label="What should I watch tonight?"
+      >
+        <Button className="h-14 w-14 rounded-full bg-indigo-600 hover:bg-indigo-700 shadow-lg shadow-indigo-500/25 p-0">
+          <Sparkles className="h-6 w-6" />
+        </Button>
+      </Link>
     </div>
   );
 }

--- a/packages/app-media/src/pages/QuickPickPage.tsx
+++ b/packages/app-media/src/pages/QuickPickPage.tsx
@@ -1,0 +1,283 @@
+import { useState, useCallback, useRef } from "react";
+import { useNavigate } from "react-router";
+import { Button, Badge, Skeleton } from "@pops/ui";
+import { SkipForward, Plus, X, RefreshCw, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+import { trpc } from "../lib/trpc";
+
+export function QuickPickPage() {
+  const navigate = useNavigate();
+  const utils = trpc.useUtils();
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [addedIds, setAddedIds] = useState<Set<number>>(new Set());
+
+  // Touch/swipe state
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [swipeOffset, setSwipeOffset] = useState(0);
+
+  const { data, isLoading, refetch } = trpc.media.library.quickPick.useQuery(
+    { count: 10 },
+    { refetchOnWindowFocus: false },
+  );
+
+  const addToWatchlist = trpc.media.watchlist.add.useMutation({
+    onSuccess: () => {
+      toast.success("Added to watchlist");
+      utils.media.watchlist.list.invalidate();
+    },
+    onError: (err) => {
+      if (err.message.includes("already")) {
+        toast.info("Already on your watchlist");
+      } else {
+        toast.error("Failed to add to watchlist");
+      }
+    },
+  });
+
+  const picks = data?.data ?? [];
+  const currentPick = picks[currentIndex];
+  const isFinished = !isLoading && currentIndex >= picks.length;
+
+  const goNext = useCallback(() => {
+    setCurrentIndex((i) => i + 1);
+    setSwipeOffset(0);
+  }, []);
+
+  const handleAddToWatchlist = useCallback(() => {
+    if (!currentPick || addedIds.has(currentPick.id)) return;
+    addToWatchlist.mutate(
+      { mediaType: "movie", mediaId: currentPick.id },
+      {
+        onSuccess: () => {
+          setAddedIds((prev) => new Set(prev).add(currentPick.id));
+          goNext();
+        },
+      },
+    );
+  }, [currentPick, addedIds, addToWatchlist, goNext]);
+
+  const handleRefresh = useCallback(() => {
+    setCurrentIndex(0);
+    setAddedIds(new Set());
+    refetch();
+  }, [refetch]);
+
+  // Touch handlers for swipe
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!touchStart.current) return;
+    const dx = e.touches[0].clientX - touchStart.current.x;
+    setSwipeOffset(dx);
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    if (!touchStart.current) return;
+    const threshold = 80;
+
+    if (swipeOffset > threshold) {
+      // Swipe right → add to watchlist
+      handleAddToWatchlist();
+    } else if (swipeOffset < -threshold) {
+      // Swipe left → skip
+      goNext();
+    }
+
+    touchStart.current = null;
+    setSwipeOffset(0);
+  }, [swipeOffset, handleAddToWatchlist, goNext]);
+
+  // Swipe indicator colors
+  const swipeIndicator =
+    swipeOffset > 40
+      ? "ring-2 ring-emerald-500/50"
+      : swipeOffset < -40
+        ? "ring-2 ring-rose-500/50"
+        : "";
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <Sparkles className="h-8 w-8 text-indigo-400 animate-pulse" />
+        <Skeleton className="h-[400px] w-[280px] rounded-xl" />
+        <Skeleton className="h-4 w-40" />
+      </div>
+    );
+  }
+
+  if (picks.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 text-center">
+        <Sparkles className="h-10 w-10 text-muted-foreground" />
+        <h2 className="text-xl font-semibold">No unwatched movies</h2>
+        <p className="text-muted-foreground text-sm max-w-xs">
+          Add more movies to your library or mark some as unwatched to get
+          picks.
+        </p>
+        <Button onClick={() => navigate("/media/search")}>
+          Search for movies
+        </Button>
+      </div>
+    );
+  }
+
+  if (isFinished) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 text-center">
+        <Sparkles className="h-10 w-10 text-indigo-400" />
+        <h2 className="text-xl font-semibold">That's all for now!</h2>
+        <p className="text-muted-foreground text-sm max-w-xs">
+          You've seen all the picks. Refresh for a new set of suggestions.
+        </p>
+        <div className="flex gap-3">
+          <Button onClick={handleRefresh}>
+            <RefreshCw className="h-4 w-4 mr-2" />
+            New picks
+          </Button>
+          <Button variant="outline" onClick={() => navigate("/media")}>
+            Back to Library
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const movie = currentPick;
+  const year = movie.releaseDate?.slice(0, 4);
+
+  return (
+    <div className="flex flex-col items-center gap-6 pb-8">
+      {/* Header */}
+      <div className="flex items-center justify-between w-full max-w-sm">
+        <h1 className="text-lg font-semibold flex items-center gap-2">
+          <Sparkles className="h-5 w-5 text-indigo-400" />
+          Quick Pick
+        </h1>
+        <span className="text-xs text-muted-foreground">
+          {currentIndex + 1} / {picks.length}
+        </span>
+      </div>
+
+      {/* Card */}
+      <div
+        ref={cardRef}
+        className={`relative w-full max-w-sm rounded-xl overflow-hidden bg-card border shadow-lg transition-transform duration-200 ${swipeIndicator}`}
+        style={{
+          transform: `translateX(${swipeOffset * 0.3}px) rotate(${swipeOffset * 0.05}deg)`,
+        }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* Swipe indicators */}
+        {swipeOffset > 40 && (
+          <div className="absolute top-4 left-4 z-10">
+            <Badge className="bg-emerald-500 text-white text-sm px-3 py-1">
+              + Watchlist
+            </Badge>
+          </div>
+        )}
+        {swipeOffset < -40 && (
+          <div className="absolute top-4 right-4 z-10">
+            <Badge className="bg-rose-500 text-white text-sm px-3 py-1">
+              Skip
+            </Badge>
+          </div>
+        )}
+
+        {/* Poster */}
+        <div className="aspect-[2/3] bg-muted">
+          {movie.posterUrl ? (
+            <img
+              src={movie.posterUrl}
+              alt={movie.title}
+              className="w-full h-full object-cover"
+              draggable={false}
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-muted-foreground">
+              No Poster
+            </div>
+          )}
+        </div>
+
+        {/* Info */}
+        <div className="p-4 space-y-3">
+          <div>
+            <h2 className="text-lg font-semibold line-clamp-2">
+              {movie.title}
+            </h2>
+            <div className="flex items-center gap-2 mt-1 text-sm text-muted-foreground">
+              {year && <span>{year}</span>}
+              {movie.runtime && (
+                <>
+                  <span>·</span>
+                  <span>{movie.runtime} min</span>
+                </>
+              )}
+              {movie.voteAverage != null && (
+                <>
+                  <span>·</span>
+                  <span>★ {movie.voteAverage.toFixed(1)}</span>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Genres */}
+          {movie.genres.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {movie.genres.slice(0, 4).map((genre) => (
+                <Badge key={genre} variant="secondary" className="text-xs">
+                  {genre}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          {/* Overview */}
+          {movie.overview && (
+            <p className="text-sm text-muted-foreground line-clamp-3">
+              {movie.overview}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Swipe hint (mobile only) */}
+      <p className="text-xs text-muted-foreground sm:hidden">
+        Swipe right to add · Swipe left to skip
+      </p>
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-3 w-full max-w-sm">
+        <Button variant="outline" className="flex-1" onClick={goNext}>
+          <SkipForward className="h-4 w-4 mr-2" />
+          Skip
+        </Button>
+        <Button
+          className="flex-1 bg-indigo-600 hover:bg-indigo-700"
+          onClick={handleAddToWatchlist}
+          disabled={addToWatchlist.isPending || addedIds.has(movie.id)}
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          Watchlist
+        </Button>
+      </div>
+
+      {/* Close button */}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground"
+        onClick={() => navigate("/media")}
+      >
+        <X className="h-4 w-4 mr-1" />
+        Not tonight
+      </Button>
+    </div>
+  );
+}

--- a/packages/app-media/src/routes.tsx
+++ b/packages/app-media/src/routes.tsx
@@ -8,30 +8,35 @@ import { lazy } from "react";
 import type { RouteObject } from "react-router";
 
 const LibraryPage = lazy(() =>
-  import("./pages/LibraryPage").then((m) => ({ default: m.LibraryPage }))
+  import("./pages/LibraryPage").then((m) => ({ default: m.LibraryPage })),
 );
 const MovieDetailPage = lazy(() =>
   import("./pages/MovieDetailPage").then((m) => ({
     default: m.MovieDetailPage,
-  }))
+  })),
 );
 const TvShowDetailPage = lazy(() =>
   import("./pages/TvShowDetailPage").then((m) => ({
     default: m.TvShowDetailPage,
-  }))
+  })),
 );
 const SeasonDetailPage = lazy(() =>
   import("./pages/SeasonDetailPage").then((m) => ({
     default: m.SeasonDetailPage,
-  }))
+  })),
 );
 const SearchPage = lazy(() =>
-  import("./pages/SearchPage").then((m) => ({ default: m.SearchPage }))
+  import("./pages/SearchPage").then((m) => ({ default: m.SearchPage })),
 );
 const WatchlistPage = lazy(() =>
   import("./pages/WatchlistPage").then((m) => ({
     default: m.WatchlistPage,
-  }))
+  })),
+);
+const QuickPickPage = lazy(() =>
+  import("./pages/QuickPickPage").then((m) => ({
+    default: m.QuickPickPage,
+  })),
 );
 
 /** Shared navigation types (mirrored from shell to avoid circular dependency) */
@@ -70,4 +75,5 @@ export const routes: RouteObject[] = [
   { path: "tv/:id/season/:num", element: <SeasonDetailPage /> },
   { path: "watchlist", element: <WatchlistPage /> },
   { path: "search", element: <SearchPage /> },
+  { path: "quick-pick", element: <QuickPickPage /> },
 ];


### PR DESCRIPTION
## Summary
- **Backend**: `library.quickPick` tRPC query returns random unwatched movies from the library (filters out movies with completed watch_history entries via NOT IN subquery)
- **Frontend**: `QuickPickPage` at `/media/quick-pick` — swipeable card UI showing movie poster, title, year, runtime, rating, genres, overview. Actions: Skip (next card), Add to Watchlist (mutation + next), Not Tonight (navigate back)
- **Touch gestures**: Swipe right = add to watchlist, swipe left = skip, with visual indicators (green/red ring + badge overlay)
- **FAB**: Sparkles floating action button on LibraryPage linking to quick-pick flow
- **Route**: Added lazy-loaded route in app-media routes.tsx

## Test plan
- [x] All 28 library tests pass
- [x] TypeScript compiles cleanly (both `@pops/api` and `@pops/app-media`)
- [x] Prettier formatting verified
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)