### PR TITLE
feat: quick pick What to Watch flow [PRD-014/US-3] (tb-139)

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/router.ts
+++ b/apps/pops-api/src/modules/media/discovery/router.ts
@@ -1,6 +1,7 @@
 /**
- * Discovery tRPC router — preference profile queries.
+ * Discovery tRPC router — preference profile and quick pick queries.
  */
+import { z } from "zod";
 import { router, protectedProcedure } from "../../../trpc.js";
 import * as service from "./service.js";
 
@@ -9,4 +10,11 @@ export const discoveryRouter = router({
   profile: protectedProcedure.query(() => {
     return { data: service.getPreferenceProfile() };
   }),
+
+  /** Get random unwatched movies for the quick pick flow. */
+  quickPick: protectedProcedure
+    .input(z.object({ count: z.number().int().positive().max(10).default(3) }))
+    .query(({ input }) => {
+      return { data: service.getQuickPickMovies(input.count) };
+    }),
 });

--- a/apps/pops-api/src/modules/media/discovery/service.ts
+++ b/apps/pops-api/src/modules/media/discovery/service.ts
@@ -8,6 +8,7 @@ import type {
   DimensionWeight,
   GenreDistribution,
   PreferenceProfile,
+  QuickPickMovie,
 } from "./types.js";
 
 /**
@@ -110,6 +111,31 @@ function getTotalComparisons(): number {
   const result = db.prepare(`SELECT COUNT(*) AS cnt FROM comparisons`).get() as { cnt: number };
 
   return result.cnt;
+}
+
+/**
+ * Get random unwatched movies from the library for quick pick.
+ * Excludes movies already on the watchlist or already watched.
+ */
+export function getQuickPickMovies(count: number): QuickPickMovie[] {
+  const db = getDb();
+
+  return db
+    .prepare(
+      `SELECT m.id, m.tmdb_id AS tmdbId, m.title, m.release_date AS releaseDate,
+              m.poster_path AS posterPath, m.backdrop_path AS backdropPath,
+              m.overview, m.vote_average AS voteAverage, m.genres, m.runtime
+       FROM movies m
+       WHERE m.id NOT IN (
+         SELECT DISTINCT media_id FROM watch_history WHERE media_type = 'movie'
+       )
+       AND m.id NOT IN (
+         SELECT media_id FROM media_watchlist WHERE media_type = 'movie'
+       )
+       ORDER BY RANDOM()
+       LIMIT ?`
+    )
+    .all(count) as QuickPickMovie[];
 }
 
 /**

--- a/apps/pops-api/src/modules/media/discovery/types.ts
+++ b/apps/pops-api/src/modules/media/discovery/types.ts
@@ -29,3 +29,16 @@ export interface PreferenceProfile {
   totalMoviesWatched: number;
   totalComparisons: number;
 }
+
+export interface QuickPickMovie {
+  id: number;
+  tmdbId: number;
+  title: string;
+  releaseDate: string | null;
+  posterPath: string | null;
+  backdropPath: string | null;
+  overview: string | null;
+  voteAverage: number | null;
+  genres: string;
+  runtime: number | null;
+}

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -1,6 +1,7 @@
 import { useSearchParams, Link } from "react-router";
-import { Badge, Skeleton } from "@pops/ui";
+import { Badge, Button, Skeleton } from "@pops/ui";
 import { useEffect } from "react";
+import { Sparkles } from "lucide-react";
 import { MediaGrid } from "../components/MediaGrid";
 import {
   useMediaLibrary,
@@ -47,9 +48,7 @@ function MediaCard({
   };
 }) {
   const href =
-    item.type === "movie"
-      ? `/media/movies/${item.id}`
-      : `/media/tv/${item.id}`;
+    item.type === "movie" ? `/media/movies/${item.id}` : `/media/tv/${item.id}`;
   const posterSrc = item.posterUrl ?? "";
 
   return (
@@ -75,7 +74,9 @@ function MediaCard({
           {item.type === "movie" ? "Movie" : "TV"}
         </Badge>
       </div>
-      <h3 className="mt-2 text-sm font-medium line-clamp-2 transition-colors group-hover:text-indigo-400">{item.title}</h3>
+      <h3 className="mt-2 text-sm font-medium line-clamp-2 transition-colors group-hover:text-indigo-400">
+        {item.title}
+      </h3>
       {item.year && (
         <p className="text-xs text-muted-foreground">{item.year}</p>
       )}
@@ -111,18 +112,30 @@ export function LibraryPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">Library</h1>
-        <Link
-          to="/media/search"
-          className="text-sm font-medium text-indigo-400 hover:text-indigo-300 transition-colors"
-        >
-          Search
-        </Link>
+        <div className="flex items-center gap-3">
+          <Link to="/media/quick-pick">
+            <Button variant="outline" size="sm">
+              <Sparkles className="h-4 w-4 mr-1.5" />
+              Quick Pick
+            </Button>
+          </Link>
+          <Link
+            to="/media/search"
+            className="text-sm font-medium text-indigo-400 hover:text-indigo-300 transition-colors"
+          >
+            Search
+          </Link>
+        </div>
       </div>
 
       {/* Filter bar */}
       <div className="flex flex-wrap items-center gap-3">
         {/* Type toggle */}
-        <div className="flex rounded-lg border bg-muted/30 p-0.5" role="group" aria-label="Filter by type">
+        <div
+          className="flex rounded-lg border bg-muted/30 p-0.5"
+          role="group"
+          aria-label="Filter by type"
+        >
           {TYPE_OPTIONS.map((opt) => (
             <button
               key={opt.value}

--- a/packages/app-media/src/pages/QuickPickPage.tsx
+++ b/packages/app-media/src/pages/QuickPickPage.tsx
@@ -1,0 +1,206 @@
+/**
+ * Quick Pick — "What to Watch" decision flow.
+ * Shows random unwatched movies one at a time.
+ * Skip (left) or Add to Watchlist (right).
+ */
+import { useState } from "react";
+import { Link } from "react-router";
+import { toast } from "sonner";
+import { Button, Skeleton, Badge } from "@pops/ui";
+import { ArrowLeft, SkipForward, Plus, Sparkles } from "lucide-react";
+import { trpc } from "../lib/trpc";
+
+const TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/w500";
+
+function buildPosterUrl(posterPath: string | null): string | null {
+  if (!posterPath) return null;
+  if (posterPath.startsWith("/")) return `${TMDB_IMAGE_BASE}${posterPath}`;
+  return posterPath;
+}
+
+export function QuickPickPage() {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const utils = trpc.useUtils();
+
+  const { data, isLoading, error, refetch } =
+    trpc.media.discovery.quickPick.useQuery({ count: 10 });
+
+  const addToWatchlist = trpc.media.watchlist.add.useMutation({
+    onSuccess: () => {
+      toast.success("Added to watchlist!");
+      void utils.media.watchlist.list.invalidate();
+      nextCard();
+    },
+    onError: (err) => {
+      if (err.data?.code === "CONFLICT") {
+        toast.info("Already on watchlist");
+        nextCard();
+      } else {
+        toast.error(`Failed to add: ${err.message}`);
+      }
+    },
+  });
+
+  const movies = data?.data ?? [];
+  const currentMovie = movies[currentIndex];
+  const isFinished = currentIndex >= movies.length && movies.length > 0;
+
+  const nextCard = () => {
+    setCurrentIndex((i) => i + 1);
+  };
+
+  const handleSkip = () => {
+    nextCard();
+  };
+
+  const handleAdd = () => {
+    if (!currentMovie) return;
+    addToWatchlist.mutate({ mediaType: "movie", mediaId: currentMovie.id });
+  };
+
+  const handleRefresh = () => {
+    setCurrentIndex(0);
+    void refetch();
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center p-6 max-w-md mx-auto">
+        <Skeleton className="aspect-[2/3] w-full max-w-sm rounded-xl" />
+        <Skeleton className="h-8 w-48 mt-4" />
+        <Skeleton className="h-4 w-32 mt-2" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 text-center">
+        <p className="text-destructive mb-4">Failed to load recommendations</p>
+        <Button onClick={() => void refetch()}>Try Again</Button>
+      </div>
+    );
+  }
+
+  if (movies.length === 0) {
+    return (
+      <div className="p-6 text-center max-w-md mx-auto">
+        <Sparkles className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+        <h2 className="text-xl font-bold mb-2">No picks available</h2>
+        <p className="text-muted-foreground mb-4">
+          All movies in your library are either watched or on your watchlist.
+          Add more movies to get recommendations!
+        </p>
+        <Link to="/media">
+          <Button>Back to Library</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  if (isFinished) {
+    return (
+      <div className="p-6 text-center max-w-md mx-auto">
+        <Sparkles className="h-12 w-12 mx-auto text-primary mb-4" />
+        <h2 className="text-xl font-bold mb-2">All done!</h2>
+        <p className="text-muted-foreground mb-4">
+          You&apos;ve gone through all the picks. Want more?
+        </p>
+        <div className="flex gap-3 justify-center">
+          <Button onClick={handleRefresh}>Get More Picks</Button>
+          <Link to="/media">
+            <Button variant="outline">Back to Library</Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const posterUrl = buildPosterUrl(currentMovie.posterPath);
+  const year = currentMovie.releaseDate?.slice(0, 4);
+  const genres: string[] = currentMovie.genres
+    ? JSON.parse(currentMovie.genres)
+    : [];
+
+  return (
+    <div className="p-6 max-w-md mx-auto">
+      <div className="flex items-center gap-3 mb-6">
+        <Link to="/media">
+          <Button variant="ghost" size="icon" className="h-8 w-8">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <h1 className="text-xl font-bold flex items-center gap-2">
+          <Sparkles className="h-5 w-5" />
+          Quick Pick
+        </h1>
+        <span className="text-sm text-muted-foreground ml-auto">
+          {currentIndex + 1} / {movies.length}
+        </span>
+      </div>
+
+      {/* Movie Card */}
+      <div className="rounded-xl overflow-hidden border shadow-lg mb-6">
+        {posterUrl ? (
+          <img
+            src={posterUrl}
+            alt={currentMovie.title}
+            className="w-full aspect-[2/3] object-cover"
+          />
+        ) : (
+          <div className="w-full aspect-[2/3] bg-muted flex items-center justify-center">
+            <span className="text-muted-foreground">No poster</span>
+          </div>
+        )}
+
+        <div className="p-4 space-y-2">
+          <h2 className="text-lg font-bold">{currentMovie.title}</h2>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            {year && <span>{year}</span>}
+            {currentMovie.runtime && <span>· {currentMovie.runtime} min</span>}
+            {currentMovie.voteAverage !== null && (
+              <span>· ★ {currentMovie.voteAverage.toFixed(1)}</span>
+            )}
+          </div>
+          {genres.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {genres.slice(0, 3).map((g) => (
+                <Badge key={g} variant="secondary" className="text-xs">
+                  {g}
+                </Badge>
+              ))}
+            </div>
+          )}
+          {currentMovie.overview && (
+            <p className="text-sm text-muted-foreground line-clamp-3">
+              {currentMovie.overview}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex gap-3">
+        <Button
+          variant="outline"
+          className="flex-1"
+          onClick={handleSkip}
+          size="lg"
+        >
+          <SkipForward className="h-4 w-4 mr-2" />
+          Skip
+        </Button>
+        <Button
+          className="flex-1"
+          onClick={handleAdd}
+          loading={addToWatchlist.isPending}
+          loadingText="Adding..."
+          size="lg"
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          Watchlist
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-media/src/routes.tsx
+++ b/packages/app-media/src/routes.tsx
@@ -8,30 +8,35 @@ import { lazy } from "react";
 import type { RouteObject } from "react-router";
 
 const LibraryPage = lazy(() =>
-  import("./pages/LibraryPage").then((m) => ({ default: m.LibraryPage }))
+  import("./pages/LibraryPage").then((m) => ({ default: m.LibraryPage })),
 );
 const MovieDetailPage = lazy(() =>
   import("./pages/MovieDetailPage").then((m) => ({
     default: m.MovieDetailPage,
-  }))
+  })),
 );
 const TvShowDetailPage = lazy(() =>
   import("./pages/TvShowDetailPage").then((m) => ({
     default: m.TvShowDetailPage,
-  }))
+  })),
 );
 const SeasonDetailPage = lazy(() =>
   import("./pages/SeasonDetailPage").then((m) => ({
     default: m.SeasonDetailPage,
-  }))
+  })),
 );
 const SearchPage = lazy(() =>
-  import("./pages/SearchPage").then((m) => ({ default: m.SearchPage }))
+  import("./pages/SearchPage").then((m) => ({ default: m.SearchPage })),
 );
 const WatchlistPage = lazy(() =>
   import("./pages/WatchlistPage").then((m) => ({
     default: m.WatchlistPage,
-  }))
+  })),
+);
+const QuickPickPage = lazy(() =>
+  import("./pages/QuickPickPage").then((m) => ({
+    default: m.QuickPickPage,
+  })),
 );
 const CompareArenaPage = lazy(() =>
   import("./pages/CompareArenaPage").then((m) => ({
@@ -77,4 +82,5 @@ export const routes: RouteObject[] = [
   { path: "watchlist", element: <WatchlistPage /> },
   { path: "search", element: <SearchPage /> },
   { path: "compare", element: <CompareArenaPage /> },
+  { path: "quick-pick", element: <QuickPickPage /> },
 ];


### PR DESCRIPTION
## Summary
- Add `quickPick` endpoint to discovery router — returns random unwatched/unwatchlisted movies from library
- Create `QuickPickPage` with card-based decision flow (poster, title, year, rating, genres, overview)
- Skip or Add to Watchlist buttons per movie card
- Add Quick Pick button (Sparkles icon) on LibraryPage header
- Also fixes pre-existing `createdAt`→`linkedAt` typo in item documents types

## Test plan
- [ ] Navigate to `/media/quick-pick` — shows a movie card with poster and details
- [ ] Click Skip — advances to next movie
- [ ] Click Watchlist — adds to watchlist with toast, advances to next
- [ ] Go through all picks — "All done" screen with "Get More Picks" button
- [ ] Empty state when all library movies are watched/watchlisted
- [ ] Quick Pick button visible on Library page header

🤖 Generated with [Claude Code](https://claude.com/claude-code)