### PR TITLE
feat: Paperless-ngx API client [PRD-022/US-1] (tb-135)

### DIFF
--- a/apps/pops-api/src/modules/inventory/paperless/client.test.ts
+++ b/apps/pops-api/src/modules/inventory/paperless/client.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Paperless-ngx client unit tests — all HTTP calls mocked via vi.stubGlobal("fetch").
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { PaperlessClient } from "./client.js";
+import { PaperlessApiError } from "./types.js";
+
+function mockResponse(body: unknown, status = 200, statusText = "OK"): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: new Headers(),
+    redirected: false,
+    type: "basic",
+    url: "",
+    clone: () => mockResponse(body, status, statusText),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
+const PAPERLESS_URL = "http://paperless:8000";
+const PAPERLESS_TOKEN = "test-paperless-token";
+
+let client: PaperlessClient;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  client = new PaperlessClient(PAPERLESS_URL, PAPERLESS_TOKEN);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PaperlessClient constructor", () => {
+  it("throws if base URL is empty", () => {
+    expect(() => new PaperlessClient("", PAPERLESS_TOKEN)).toThrow("Paperless URL is required");
+  });
+
+  it("throws if token is empty", () => {
+    expect(() => new PaperlessClient(PAPERLESS_URL, "")).toThrow("Paperless token is required");
+  });
+
+  it("strips trailing slash from base URL", () => {
+    const c = new PaperlessClient("http://paperless:8000/", PAPERLESS_TOKEN);
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ count: 0, next: null, previous: null, results: [] })
+    );
+    void c.searchDocuments("test");
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toMatch(/^http:\/\/paperless:8000\/api/);
+  });
+});
+
+describe("PaperlessClient authentication", () => {
+  it("sends Token auth header", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ count: 0, next: null, previous: null, results: [] })
+    );
+
+    await client.searchDocuments("test");
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>).Authorization).toBe(
+      `Token ${PAPERLESS_TOKEN}`
+    );
+  });
+
+  it("sends Accept: application/json header", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ count: 0, next: null, previous: null, results: [] })
+    );
+
+    await client.searchDocuments("test");
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>).Accept).toBe("application/json");
+  });
+});
+
+describe("searchDocuments", () => {
+  const rawDocuments = {
+    count: 1,
+    next: null,
+    previous: null,
+    results: [
+      {
+        id: 42,
+        correspondent: 3,
+        document_type: 1,
+        title: "Invoice 2026-001",
+        content: "Total: $150.00",
+        tags: [1, 5],
+        created: "2026-01-15T10:30:00Z",
+        created_date: "2026-01-15",
+        modified: "2026-01-15T10:35:00Z",
+        added: "2026-01-15T10:30:00Z",
+        archive_serial_number: 1001,
+        original_file_name: "invoice-001.pdf",
+        archived_file_name: "1001-invoice-001.pdf",
+        notes: [],
+      },
+    ],
+  };
+
+  it("returns mapped search results", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(rawDocuments));
+
+    const result = await client.searchDocuments("invoice");
+
+    expect(result.count).toBe(1);
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0]).toEqual({
+      id: 42,
+      correspondentId: 3,
+      documentTypeId: 1,
+      title: "Invoice 2026-001",
+      content: "Total: $150.00",
+      tagIds: [1, 5],
+      created: "2026-01-15T10:30:00Z",
+      createdDate: "2026-01-15",
+      modified: "2026-01-15T10:35:00Z",
+      added: "2026-01-15T10:30:00Z",
+      archiveSerialNumber: 1001,
+      originalFileName: "invoice-001.pdf",
+      archivedFileName: "1001-invoice-001.pdf",
+    });
+  });
+
+  it("passes query and page as URL parameters", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ count: 0, next: null, previous: null, results: [] })
+    );
+
+    await client.searchDocuments("receipt", 3);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain("query=receipt");
+    expect(url).toContain("page=3");
+  });
+
+  it("defaults page to 1", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ count: 0, next: null, previous: null, results: [] })
+    );
+
+    await client.searchDocuments("test");
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain("page=1");
+  });
+});
+
+describe("getDocument", () => {
+  it("returns mapped document detail", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        id: 42,
+        correspondent: null,
+        document_type: null,
+        title: "Test Doc",
+        content: "Content here",
+        tags: [],
+        created: "2026-01-01T00:00:00Z",
+        created_date: "2026-01-01",
+        modified: "2026-01-01T00:00:00Z",
+        added: "2026-01-01T00:00:00Z",
+        archive_serial_number: null,
+        original_file_name: "test.pdf",
+        archived_file_name: null,
+        notes: [],
+      })
+    );
+
+    const result = await client.getDocument(42);
+
+    expect(result.id).toBe(42);
+    expect(result.title).toBe("Test Doc");
+    expect(result.correspondentId).toBeNull();
+    expect(result.documentTypeId).toBeNull();
+    expect(result.archiveSerialNumber).toBeNull();
+    expect(result.archivedFileName).toBeNull();
+  });
+
+  it("calls correct URL", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        id: 42,
+        correspondent: null,
+        document_type: null,
+        title: "Test",
+        content: "",
+        tags: [],
+        created: "",
+        created_date: "",
+        modified: "",
+        added: "",
+        archive_serial_number: null,
+        original_file_name: "",
+        archived_file_name: null,
+        notes: [],
+      })
+    );
+
+    await client.getDocument(42);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain("/api/documents/42/");
+  });
+});
+
+describe("getDocumentMetadata", () => {
+  it("returns raw metadata", async () => {
+    const metadata = {
+      original_checksum: "abc123",
+      original_size: 12345,
+      original_mime_type: "application/pdf",
+    };
+    fetchMock.mockResolvedValueOnce(mockResponse(metadata));
+
+    const result = await client.getDocumentMetadata(42);
+
+    expect(result.original_checksum).toBe("abc123");
+    expect(result.original_size).toBe(12345);
+  });
+});
+
+describe("getDocumentThumbnailUrl", () => {
+  it("builds correct thumbnail URL", () => {
+    const url = client.getDocumentThumbnailUrl(42);
+    expect(url).toBe(`${PAPERLESS_URL}/api/documents/42/thumb/`);
+  });
+});
+
+describe("getDocumentDownloadUrl", () => {
+  it("builds correct download URL", () => {
+    const url = client.getDocumentDownloadUrl(42);
+    expect(url).toBe(`${PAPERLESS_URL}/api/documents/42/download/`);
+  });
+});
+
+describe("getCorrespondents", () => {
+  it("returns mapped correspondents", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        count: 2,
+        next: null,
+        previous: null,
+        results: [
+          {
+            id: 1,
+            slug: "acme-corp",
+            name: "Acme Corp",
+            match: "",
+            matching_algorithm: 1,
+            is_insensitive: true,
+            document_count: 15,
+          },
+          {
+            id: 2,
+            slug: "insurance-co",
+            name: "Insurance Co",
+            match: "",
+            matching_algorithm: 1,
+            is_insensitive: true,
+            document_count: 8,
+          },
+        ],
+      })
+    );
+
+    const result = await client.getCorrespondents();
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      id: 1,
+      slug: "acme-corp",
+      name: "Acme Corp",
+      documentCount: 15,
+    });
+  });
+});
+
+describe("getTags", () => {
+  it("returns mapped tags", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [
+          {
+            id: 5,
+            slug: "receipt",
+            name: "Receipt",
+            colour: 3,
+            match: "",
+            matching_algorithm: 1,
+            is_insensitive: true,
+            is_inbox_tag: false,
+            document_count: 42,
+          },
+        ],
+      })
+    );
+
+    const result = await client.getTags();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: 5,
+      slug: "receipt",
+      name: "Receipt",
+      colour: 3,
+      isInboxTag: false,
+      documentCount: 42,
+    });
+  });
+});
+
+describe("getDocumentTypes", () => {
+  it("returns mapped document types", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [
+          {
+            id: 1,
+            slug: "invoice",
+            name: "Invoice",
+            match: "",
+            matching_algorithm: 1,
+            is_insensitive: true,
+            document_count: 30,
+          },
+        ],
+      })
+    );
+
+    const result = await client.getDocumentTypes();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: 1,
+      slug: "invoice",
+      name: "Invoice",
+      documentCount: 30,
+    });
+  });
+});
+
+describe("error handling", () => {
+  it("throws PaperlessApiError on 401", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ detail: "Invalid token." }, 401, "Unauthorized")
+    );
+
+    await expect(client.searchDocuments("test")).rejects.toThrow(PaperlessApiError);
+
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ detail: "Invalid token." }, 401, "Unauthorized")
+    );
+
+    try {
+      await client.searchDocuments("test");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PaperlessApiError);
+      expect((err as PaperlessApiError).status).toBe(401);
+      expect((err as PaperlessApiError).message).toBe("Invalid token.");
+    }
+  });
+
+  it("throws PaperlessApiError on 404", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ detail: "Not found." }, 404, "Not Found"));
+
+    await expect(client.getDocument(999)).rejects.toThrow(PaperlessApiError);
+  });
+
+  it("throws PaperlessApiError on network error", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    await expect(client.searchDocuments("test")).rejects.toThrow(PaperlessApiError);
+
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    try {
+      await client.searchDocuments("test");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PaperlessApiError);
+      expect((err as PaperlessApiError).status).toBe(0);
+      expect((err as PaperlessApiError).message).toContain("Network error");
+      expect((err as PaperlessApiError).message).toContain("ECONNREFUSED");
+    }
+  });
+
+  it("uses fallback message when error has no detail", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({}, 500, "Internal Server Error"));
+
+    try {
+      await client.searchDocuments("test");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PaperlessApiError);
+      expect((err as PaperlessApiError).status).toBe(500);
+      expect((err as PaperlessApiError).message).toContain("500");
+    }
+  });
+});

--- a/apps/pops-api/src/modules/inventory/paperless/client.ts
+++ b/apps/pops-api/src/modules/inventory/paperless/client.ts
@@ -1,0 +1,178 @@
+/**
+ * Paperless-ngx API HTTP client — typed wrapper around the Paperless-ngx REST API.
+ *
+ * Handles authentication (Token-based), request construction,
+ * response parsing, and error mapping. Contains no business logic.
+ *
+ * Paperless-ngx API docs: https://docs.paperless-ngx.com/api/
+ */
+import {
+  PaperlessApiError,
+  type RawPaperlessPaginatedResponse,
+  type RawPaperlessDocument,
+  type RawPaperlessCorrespondent,
+  type RawPaperlessTag,
+  type RawPaperlessDocumentType,
+  type PaperlessDocument,
+  type PaperlessCorrespondent,
+  type PaperlessTag,
+  type PaperlessDocumentType,
+  type PaperlessSearchResult,
+} from "./types.js";
+
+export class PaperlessClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+
+  constructor(baseUrl: string, token: string) {
+    if (!baseUrl) {
+      throw new Error("Paperless URL is required");
+    }
+    if (!token) {
+      throw new Error("Paperless token is required");
+    }
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.token = token;
+  }
+
+  /** Search documents by query string. */
+  async searchDocuments(query: string, page = 1): Promise<PaperlessSearchResult> {
+    const params = new URLSearchParams({
+      query,
+      page: String(page),
+    });
+    const raw = await this.get<RawPaperlessPaginatedResponse<RawPaperlessDocument>>(
+      `/api/documents/?${params.toString()}`
+    );
+    return {
+      documents: raw.results.map((d) => this.mapDocument(d)),
+      count: raw.count,
+      next: raw.next,
+      previous: raw.previous,
+    };
+  }
+
+  /** Get a single document by ID. */
+  async getDocument(id: number): Promise<PaperlessDocument> {
+    const raw = await this.get<RawPaperlessDocument>(`/api/documents/${id}/`);
+    return this.mapDocument(raw);
+  }
+
+  /** Get document metadata (custom fields, etc). */
+  async getDocumentMetadata(id: number): Promise<Record<string, unknown>> {
+    return this.get<Record<string, unknown>>(`/api/documents/${id}/metadata/`);
+  }
+
+  /** Build the thumbnail URL for a document. */
+  getDocumentThumbnailUrl(id: number): string {
+    return `${this.baseUrl}/api/documents/${id}/thumb/`;
+  }
+
+  /** Build the download URL for a document. */
+  getDocumentDownloadUrl(id: number): string {
+    return `${this.baseUrl}/api/documents/${id}/download/`;
+  }
+
+  /** List all correspondents. */
+  async getCorrespondents(): Promise<PaperlessCorrespondent[]> {
+    const raw = await this.get<RawPaperlessPaginatedResponse<RawPaperlessCorrespondent>>(
+      "/api/correspondents/?page_size=100"
+    );
+    return raw.results.map((c) => ({
+      id: c.id,
+      slug: c.slug,
+      name: c.name,
+      documentCount: c.document_count,
+    }));
+  }
+
+  /** List all tags. */
+  async getTags(): Promise<PaperlessTag[]> {
+    const raw = await this.get<RawPaperlessPaginatedResponse<RawPaperlessTag>>(
+      "/api/tags/?page_size=100"
+    );
+    return raw.results.map((t) => ({
+      id: t.id,
+      slug: t.slug,
+      name: t.name,
+      colour: t.colour,
+      isInboxTag: t.is_inbox_tag,
+      documentCount: t.document_count,
+    }));
+  }
+
+  /** List all document types. */
+  async getDocumentTypes(): Promise<PaperlessDocumentType[]> {
+    const raw = await this.get<RawPaperlessPaginatedResponse<RawPaperlessDocumentType>>(
+      "/api/document_types/?page_size=100"
+    );
+    return raw.results.map((dt) => ({
+      id: dt.id,
+      slug: dt.slug,
+      name: dt.name,
+      documentCount: dt.document_count,
+    }));
+  }
+
+  // -------------------------------------------------------------------------
+  // Mappers
+  // -------------------------------------------------------------------------
+
+  private mapDocument(raw: RawPaperlessDocument): PaperlessDocument {
+    return {
+      id: raw.id,
+      correspondentId: raw.correspondent,
+      documentTypeId: raw.document_type,
+      title: raw.title,
+      content: raw.content,
+      tagIds: raw.tags,
+      created: raw.created,
+      createdDate: raw.created_date,
+      modified: raw.modified,
+      added: raw.added,
+      archiveSerialNumber: raw.archive_serial_number,
+      originalFileName: raw.original_file_name,
+      archivedFileName: raw.archived_file_name,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // HTTP
+  // -------------------------------------------------------------------------
+
+  private async get<T>(path: string): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+
+    let response: Response;
+
+    try {
+      response = await fetch(url, {
+        method: "GET",
+        headers: {
+          Authorization: `Token ${this.token}`,
+          Accept: "application/json",
+        },
+      });
+    } catch (err) {
+      throw new PaperlessApiError(
+        0,
+        `Network error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    if (!response.ok) {
+      let message = `Paperless API error: ${response.status} ${response.statusText}`;
+      try {
+        const body = (await response.json()) as { detail?: string };
+        if (body.detail) {
+          message = body.detail;
+        }
+      } catch {
+        // Ignore parse failures
+      }
+      throw new PaperlessApiError(response.status, message);
+    }
+
+    return (await response.json()) as T;
+  }
+}

--- a/apps/pops-api/src/modules/inventory/paperless/index.ts
+++ b/apps/pops-api/src/modules/inventory/paperless/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Paperless-ngx API client — re-exports and factory.
+ */
+import { PaperlessClient } from "./client.js";
+import { getEnv } from "../../../env.js";
+
+export { PaperlessClient } from "./client.js";
+export {
+  PaperlessApiError,
+  type PaperlessDocument,
+  type PaperlessCorrespondent,
+  type PaperlessTag,
+  type PaperlessDocumentType,
+  type PaperlessSearchResult,
+} from "./types.js";
+
+/**
+ * Shared Paperless client factory.
+ * Returns null if PAPERLESS_URL or PAPERLESS_TOKEN are not set.
+ */
+export function getPaperlessClient(): PaperlessClient | null {
+  const url = getEnv("PAPERLESS_URL");
+  const token = getEnv("PAPERLESS_TOKEN");
+  if (!url || !token) return null;
+  return new PaperlessClient(url, token);
+}

--- a/apps/pops-api/src/modules/inventory/paperless/types.ts
+++ b/apps/pops-api/src/modules/inventory/paperless/types.ts
@@ -1,0 +1,130 @@
+/**
+ * Paperless-ngx API types — raw API responses and mapped domain types.
+ *
+ * Paperless-ngx REST API v3 returns paginated lists and detail objects.
+ * Auth: Token-based via Authorization header.
+ */
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+export class PaperlessApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = "PaperlessApiError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Raw API response types
+// ---------------------------------------------------------------------------
+
+export interface RawPaperlessPaginatedResponse<T> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}
+
+export interface RawPaperlessDocument {
+  id: number;
+  correspondent: number | null;
+  document_type: number | null;
+  title: string;
+  content: string;
+  tags: number[];
+  created: string;
+  created_date: string;
+  modified: string;
+  added: string;
+  archive_serial_number: number | null;
+  original_file_name: string;
+  archived_file_name: string | null;
+  notes: { id: number; note: string; created: string }[];
+}
+
+export interface RawPaperlessCorrespondent {
+  id: number;
+  slug: string;
+  name: string;
+  match: string;
+  matching_algorithm: number;
+  is_insensitive: boolean;
+  document_count: number;
+}
+
+export interface RawPaperlessTag {
+  id: number;
+  slug: string;
+  name: string;
+  colour: number;
+  match: string;
+  matching_algorithm: number;
+  is_insensitive: boolean;
+  is_inbox_tag: boolean;
+  document_count: number;
+}
+
+export interface RawPaperlessDocumentType {
+  id: number;
+  slug: string;
+  name: string;
+  match: string;
+  matching_algorithm: number;
+  is_insensitive: boolean;
+  document_count: number;
+}
+
+// ---------------------------------------------------------------------------
+// Mapped domain types
+// ---------------------------------------------------------------------------
+
+export interface PaperlessDocument {
+  id: number;
+  correspondentId: number | null;
+  documentTypeId: number | null;
+  title: string;
+  content: string;
+  tagIds: number[];
+  created: string;
+  createdDate: string;
+  modified: string;
+  added: string;
+  archiveSerialNumber: number | null;
+  originalFileName: string;
+  archivedFileName: string | null;
+}
+
+export interface PaperlessCorrespondent {
+  id: number;
+  slug: string;
+  name: string;
+  documentCount: number;
+}
+
+export interface PaperlessTag {
+  id: number;
+  slug: string;
+  name: string;
+  colour: number;
+  isInboxTag: boolean;
+  documentCount: number;
+}
+
+export interface PaperlessDocumentType {
+  id: number;
+  slug: string;
+  name: string;
+  documentCount: number;
+}
+
+export interface PaperlessSearchResult {
+  documents: PaperlessDocument[];
+  count: number;
+  next: string | null;
+  previous: string | null;
+}


### PR DESCRIPTION
## Summary
- New `inventory/paperless/` module with typed HTTP client for Paperless-ngx REST API
- Methods: `searchDocuments(query, page)`, `getDocument(id)`, `getDocumentMetadata(id)`, `getDocumentThumbnailUrl(id)`, `getDocumentDownloadUrl(id)`, `getCorrespondents()`, `getTags()`, `getDocumentTypes()`
- Token-based authentication via `Authorization: Token` header
- `getPaperlessClient()` factory returns null when `PAPERLESS_URL`/`PAPERLESS_TOKEN` not configured
- Mapped domain types for documents, correspondents, tags, document types

## Test plan
- [x] 20 unit tests with mocked fetch
- [x] Prettier formatting passes
- [ ] CI checks (quality, backend tests, frontend tests, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)