### PR TITLE
feat: quick pick "What to watch tonight" swipeable card UI (tb-139)

### DIFF
--- a/apps/pops-api/src/modules/media/library/router.ts
+++ b/apps/pops-api/src/modules/media/library/router.ts
@@ -8,7 +8,7 @@ import { getTmdbClient, TmdbClient, TmdbApiError } from "../tmdb/index.js";
 import { NotFoundError } from "../../../shared/errors.js";
 import { toMovie } from "../movies/types.js";
 import { toTvShow, toSeason } from "../tv-shows/types.js";
-import { RefreshMovieSchema } from "./types.js";
+import { RefreshMovieSchema, QuickPickSchema } from "./types.js";
 import * as libraryService from "./service.js";
 import { getTvdbClient } from "../thetvdb/index.js";
 import { TvdbApiError } from "../thetvdb/types.js";
@@ -113,6 +113,15 @@ export const libraryRouter = router({
         throw err;
       }
     }),
+
+  /**
+   * Quick pick — returns random unwatched movies from the library.
+   * Used by the "What should I watch tonight?" flow.
+   */
+  quickPick: protectedProcedure.input(QuickPickSchema).query(({ input }) => {
+    const picks = libraryService.getQuickPicks(input.count);
+    return { data: picks };
+  }),
 
   /** Refresh TV show metadata from TheTVDB. */
   refreshTvShow: protectedProcedure

--- a/apps/pops-api/src/modules/media/library/service.ts
+++ b/apps/pops-api/src/modules/media/library/service.ts
@@ -2,6 +2,9 @@
  * Library service — orchestrates adding media to the local library
  * by fetching metadata from external APIs and inserting records.
  */
+import { sql } from "drizzle-orm";
+import { getDrizzle } from "../../../db.js";
+import { movies, watchHistory } from "@pops/db-types";
 import type { TmdbClient } from "../tmdb/client.js";
 import type { TmdbMovieDetail } from "../tmdb/types.js";
 import { getMovieByTmdbId, getMovie, createMovie, updateMovie } from "../movies/service.js";
@@ -97,4 +100,31 @@ export async function refreshMovie(id: number, tmdbClient: TmdbClient): Promise<
 
   // Update the local record
   return updateMovie(id, updateInput);
+}
+
+/**
+ * Get random unwatched movies from the library.
+ *
+ * Returns movies that have no completed watch_history entries.
+ * Uses SQLite's RANDOM() for ordering.
+ */
+export function getQuickPicks(count: number): Movie[] {
+  const db = getDrizzle();
+
+  const rows = db
+    .select()
+    .from(movies)
+    .where(
+      sql`${movies.id} NOT IN (
+        SELECT DISTINCT ${watchHistory.mediaId}
+        FROM ${watchHistory}
+        WHERE ${watchHistory.mediaType} = 'movie'
+          AND ${watchHistory.completed} = 1
+      )`
+    )
+    .orderBy(sql`RANDOM()`)
+    .limit(count)
+    .all();
+
+  return rows.map(toMovie);
 }

--- a/apps/pops-api/src/modules/media/library/types.ts
+++ b/apps/pops-api/src/modules/media/library/types.ts
@@ -8,3 +8,9 @@ export const RefreshMovieSchema = z.object({
   id: z.number().int().positive(),
 });
 export type RefreshMovieInput = z.infer<typeof RefreshMovieSchema>;
+
+/** Zod schema for the quick-pick query. */
+export const QuickPickSchema = z.object({
+  count: z.coerce.number().int().positive().max(10).optional().default(3),
+});
+export type QuickPickInput = z.infer<typeof QuickPickSchema>;

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -213,6 +213,17 @@ export function LibraryPage() {
           ))}
         </MediaGrid>
       )}
+
+      {/* Quick Pick FAB */}
+      <Link
+        to="/media/quick-pick"
+        className="fixed bottom-6 right-6 z-50"
+        aria-label="What should I watch tonight?"
+      >
+        <Button className="h-14 w-14 rounded-full bg-indigo-600 hover:bg-indigo-700 shadow-lg shadow-indigo-500/25 p-0">
+          <Sparkles className="h-6 w-6" />
+        </Button>
+      </Link>
     </div>
   );
 }

--- a/packages/app-media/src/pages/QuickPickPage.tsx
+++ b/packages/app-media/src/pages/QuickPickPage.tsx
@@ -1,206 +1,283 @@
-/**
- * Quick Pick — "What to Watch" decision flow.
- * Shows random unwatched movies one at a time.
- * Skip (left) or Add to Watchlist (right).
- */
-import { useState } from "react";
-import { Link } from "react-router";
+import { useState, useCallback, useRef } from "react";
+import { useNavigate } from "react-router";
+import { Button, Badge, Skeleton } from "@pops/ui";
+import { SkipForward, Plus, X, RefreshCw, Sparkles } from "lucide-react";
 import { toast } from "sonner";
-import { Button, Skeleton, Badge } from "@pops/ui";
-import { ArrowLeft, SkipForward, Plus, Sparkles } from "lucide-react";
 import { trpc } from "../lib/trpc";
 
-const TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/w500";
-
-function buildPosterUrl(posterPath: string | null): string | null {
-  if (!posterPath) return null;
-  if (posterPath.startsWith("/")) return `${TMDB_IMAGE_BASE}${posterPath}`;
-  return posterPath;
-}
-
 export function QuickPickPage() {
-  const [currentIndex, setCurrentIndex] = useState(0);
+  const navigate = useNavigate();
   const utils = trpc.useUtils();
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [addedIds, setAddedIds] = useState<Set<number>>(new Set());
 
-  const { data, isLoading, error, refetch } =
-    trpc.media.discovery.quickPick.useQuery({ count: 10 });
+  // Touch/swipe state
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [swipeOffset, setSwipeOffset] = useState(0);
+
+  const { data, isLoading, refetch } = trpc.media.library.quickPick.useQuery(
+    { count: 10 },
+    { refetchOnWindowFocus: false },
+  );
 
   const addToWatchlist = trpc.media.watchlist.add.useMutation({
     onSuccess: () => {
-      toast.success("Added to watchlist!");
-      void utils.media.watchlist.list.invalidate();
-      nextCard();
+      toast.success("Added to watchlist");
+      utils.media.watchlist.list.invalidate();
     },
     onError: (err) => {
-      if (err.data?.code === "CONFLICT") {
-        toast.info("Already on watchlist");
-        nextCard();
+      if (err.message.includes("already")) {
+        toast.info("Already on your watchlist");
       } else {
-        toast.error(`Failed to add: ${err.message}`);
+        toast.error("Failed to add to watchlist");
       }
     },
   });
 
-  const movies = data?.data ?? [];
-  const currentMovie = movies[currentIndex];
-  const isFinished = currentIndex >= movies.length && movies.length > 0;
+  const picks = data?.data ?? [];
+  const currentPick = picks[currentIndex];
+  const isFinished = !isLoading && currentIndex >= picks.length;
 
-  const nextCard = () => {
+  const goNext = useCallback(() => {
     setCurrentIndex((i) => i + 1);
-  };
+    setSwipeOffset(0);
+  }, []);
 
-  const handleSkip = () => {
-    nextCard();
-  };
+  const handleAddToWatchlist = useCallback(() => {
+    if (!currentPick || addedIds.has(currentPick.id)) return;
+    addToWatchlist.mutate(
+      { mediaType: "movie", mediaId: currentPick.id },
+      {
+        onSuccess: () => {
+          setAddedIds((prev) => new Set(prev).add(currentPick.id));
+          goNext();
+        },
+      },
+    );
+  }, [currentPick, addedIds, addToWatchlist, goNext]);
 
-  const handleAdd = () => {
-    if (!currentMovie) return;
-    addToWatchlist.mutate({ mediaType: "movie", mediaId: currentMovie.id });
-  };
-
-  const handleRefresh = () => {
+  const handleRefresh = useCallback(() => {
     setCurrentIndex(0);
-    void refetch();
-  };
+    setAddedIds(new Set());
+    refetch();
+  }, [refetch]);
+
+  // Touch handlers for swipe
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!touchStart.current) return;
+    const dx = e.touches[0].clientX - touchStart.current.x;
+    setSwipeOffset(dx);
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    if (!touchStart.current) return;
+    const threshold = 80;
+
+    if (swipeOffset > threshold) {
+      // Swipe right → add to watchlist
+      handleAddToWatchlist();
+    } else if (swipeOffset < -threshold) {
+      // Swipe left → skip
+      goNext();
+    }
+
+    touchStart.current = null;
+    setSwipeOffset(0);
+  }, [swipeOffset, handleAddToWatchlist, goNext]);
+
+  // Swipe indicator colors
+  const swipeIndicator =
+    swipeOffset > 40
+      ? "ring-2 ring-emerald-500/50"
+      : swipeOffset < -40
+        ? "ring-2 ring-rose-500/50"
+        : "";
 
   if (isLoading) {
     return (
-      <div className="flex flex-col items-center p-6 max-w-md mx-auto">
-        <Skeleton className="aspect-[2/3] w-full max-w-sm rounded-xl" />
-        <Skeleton className="h-8 w-48 mt-4" />
-        <Skeleton className="h-4 w-32 mt-2" />
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <Sparkles className="h-8 w-8 text-indigo-400 animate-pulse" />
+        <Skeleton className="h-[400px] w-[280px] rounded-xl" />
+        <Skeleton className="h-4 w-40" />
       </div>
     );
   }
 
-  if (error) {
+  if (picks.length === 0) {
     return (
-      <div className="p-6 text-center">
-        <p className="text-destructive mb-4">Failed to load recommendations</p>
-        <Button onClick={() => void refetch()}>Try Again</Button>
-      </div>
-    );
-  }
-
-  if (movies.length === 0) {
-    return (
-      <div className="p-6 text-center max-w-md mx-auto">
-        <Sparkles className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-        <h2 className="text-xl font-bold mb-2">No picks available</h2>
-        <p className="text-muted-foreground mb-4">
-          All movies in your library are either watched or on your watchlist.
-          Add more movies to get recommendations!
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 text-center">
+        <Sparkles className="h-10 w-10 text-muted-foreground" />
+        <h2 className="text-xl font-semibold">No unwatched movies</h2>
+        <p className="text-muted-foreground text-sm max-w-xs">
+          Add more movies to your library or mark some as unwatched to get
+          picks.
         </p>
-        <Link to="/media">
-          <Button>Back to Library</Button>
-        </Link>
+        <Button onClick={() => navigate("/media/search")}>
+          Search for movies
+        </Button>
       </div>
     );
   }
 
   if (isFinished) {
     return (
-      <div className="p-6 text-center max-w-md mx-auto">
-        <Sparkles className="h-12 w-12 mx-auto text-primary mb-4" />
-        <h2 className="text-xl font-bold mb-2">All done!</h2>
-        <p className="text-muted-foreground mb-4">
-          You&apos;ve gone through all the picks. Want more?
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 text-center">
+        <Sparkles className="h-10 w-10 text-indigo-400" />
+        <h2 className="text-xl font-semibold">That's all for now!</h2>
+        <p className="text-muted-foreground text-sm max-w-xs">
+          You've seen all the picks. Refresh for a new set of suggestions.
         </p>
-        <div className="flex gap-3 justify-center">
-          <Button onClick={handleRefresh}>Get More Picks</Button>
-          <Link to="/media">
-            <Button variant="outline">Back to Library</Button>
-          </Link>
+        <div className="flex gap-3">
+          <Button onClick={handleRefresh}>
+            <RefreshCw className="h-4 w-4 mr-2" />
+            New picks
+          </Button>
+          <Button variant="outline" onClick={() => navigate("/media")}>
+            Back to Library
+          </Button>
         </div>
       </div>
     );
   }
 
-  const posterUrl = buildPosterUrl(currentMovie.posterPath);
-  const year = currentMovie.releaseDate?.slice(0, 4);
-  const genres: string[] = currentMovie.genres
-    ? JSON.parse(currentMovie.genres)
-    : [];
+  const movie = currentPick;
+  const year = movie.releaseDate?.slice(0, 4);
 
   return (
-    <div className="p-6 max-w-md mx-auto">
-      <div className="flex items-center gap-3 mb-6">
-        <Link to="/media">
-          <Button variant="ghost" size="icon" className="h-8 w-8">
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-        </Link>
-        <h1 className="text-xl font-bold flex items-center gap-2">
-          <Sparkles className="h-5 w-5" />
+    <div className="flex flex-col items-center gap-6 pb-8">
+      {/* Header */}
+      <div className="flex items-center justify-between w-full max-w-sm">
+        <h1 className="text-lg font-semibold flex items-center gap-2">
+          <Sparkles className="h-5 w-5 text-indigo-400" />
           Quick Pick
         </h1>
-        <span className="text-sm text-muted-foreground ml-auto">
-          {currentIndex + 1} / {movies.length}
+        <span className="text-xs text-muted-foreground">
+          {currentIndex + 1} / {picks.length}
         </span>
       </div>
 
-      {/* Movie Card */}
-      <div className="rounded-xl overflow-hidden border shadow-lg mb-6">
-        {posterUrl ? (
-          <img
-            src={posterUrl}
-            alt={currentMovie.title}
-            className="w-full aspect-[2/3] object-cover"
-          />
-        ) : (
-          <div className="w-full aspect-[2/3] bg-muted flex items-center justify-center">
-            <span className="text-muted-foreground">No poster</span>
+      {/* Card */}
+      <div
+        ref={cardRef}
+        className={`relative w-full max-w-sm rounded-xl overflow-hidden bg-card border shadow-lg transition-transform duration-200 ${swipeIndicator}`}
+        style={{
+          transform: `translateX(${swipeOffset * 0.3}px) rotate(${swipeOffset * 0.05}deg)`,
+        }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* Swipe indicators */}
+        {swipeOffset > 40 && (
+          <div className="absolute top-4 left-4 z-10">
+            <Badge className="bg-emerald-500 text-white text-sm px-3 py-1">
+              + Watchlist
+            </Badge>
+          </div>
+        )}
+        {swipeOffset < -40 && (
+          <div className="absolute top-4 right-4 z-10">
+            <Badge className="bg-rose-500 text-white text-sm px-3 py-1">
+              Skip
+            </Badge>
           </div>
         )}
 
-        <div className="p-4 space-y-2">
-          <h2 className="text-lg font-bold">{currentMovie.title}</h2>
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            {year && <span>{year}</span>}
-            {currentMovie.runtime && <span>· {currentMovie.runtime} min</span>}
-            {currentMovie.voteAverage !== null && (
-              <span>· ★ {currentMovie.voteAverage.toFixed(1)}</span>
-            )}
+        {/* Poster */}
+        <div className="aspect-[2/3] bg-muted">
+          {movie.posterUrl ? (
+            <img
+              src={movie.posterUrl}
+              alt={movie.title}
+              className="w-full h-full object-cover"
+              draggable={false}
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-muted-foreground">
+              No Poster
+            </div>
+          )}
+        </div>
+
+        {/* Info */}
+        <div className="p-4 space-y-3">
+          <div>
+            <h2 className="text-lg font-semibold line-clamp-2">
+              {movie.title}
+            </h2>
+            <div className="flex items-center gap-2 mt-1 text-sm text-muted-foreground">
+              {year && <span>{year}</span>}
+              {movie.runtime && (
+                <>
+                  <span>·</span>
+                  <span>{movie.runtime} min</span>
+                </>
+              )}
+              {movie.voteAverage != null && (
+                <>
+                  <span>·</span>
+                  <span>★ {movie.voteAverage.toFixed(1)}</span>
+                </>
+              )}
+            </div>
           </div>
-          {genres.length > 0 && (
-            <div className="flex flex-wrap gap-1">
-              {genres.slice(0, 3).map((g) => (
-                <Badge key={g} variant="secondary" className="text-xs">
-                  {g}
+
+          {/* Genres */}
+          {movie.genres.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {movie.genres.slice(0, 4).map((genre) => (
+                <Badge key={genre} variant="secondary" className="text-xs">
+                  {genre}
                 </Badge>
               ))}
             </div>
           )}
-          {currentMovie.overview && (
+
+          {/* Overview */}
+          {movie.overview && (
             <p className="text-sm text-muted-foreground line-clamp-3">
-              {currentMovie.overview}
+              {movie.overview}
             </p>
           )}
         </div>
       </div>
 
-      {/* Action Buttons */}
-      <div className="flex gap-3">
-        <Button
-          variant="outline"
-          className="flex-1"
-          onClick={handleSkip}
-          size="lg"
-        >
+      {/* Swipe hint (mobile only) */}
+      <p className="text-xs text-muted-foreground sm:hidden">
+        Swipe right to add · Swipe left to skip
+      </p>
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-3 w-full max-w-sm">
+        <Button variant="outline" className="flex-1" onClick={goNext}>
           <SkipForward className="h-4 w-4 mr-2" />
           Skip
         </Button>
         <Button
-          className="flex-1"
-          onClick={handleAdd}
-          loading={addToWatchlist.isPending}
-          loadingText="Adding..."
-          size="lg"
+          className="flex-1 bg-indigo-600 hover:bg-indigo-700"
+          onClick={handleAddToWatchlist}
+          disabled={addToWatchlist.isPending || addedIds.has(movie.id)}
         >
           <Plus className="h-4 w-4 mr-2" />
           Watchlist
         </Button>
       </div>
+
+      {/* Close button */}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground"
+        onClick={() => navigate("/media")}
+      >
+        <X className="h-4 w-4 mr-1" />
+        Not tonight
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Rebased version of #198 with swipeable card UI for the quick pick flow.

- **Frontend**: `QuickPickPage` at `/media/quick-pick` — swipeable card UI showing movie poster, title, year, runtime, rating, genres, overview. Actions: Skip (next card), Add to Watchlist (mutation + next), Not Tonight (navigate back)
- **Touch gestures**: Swipe right = add to watchlist, swipe left = skip, with visual indicators (green/red ring + badge overlay)
- **FAB**: Sparkles floating action button on LibraryPage linking to quick-pick flow
- Uses `library.quickPick` tRPC query (random unwatched movies)

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] CI pipeline passes
- [ ] Swipe gestures work on mobile
- [ ] Skip and Add to Watchlist buttons work