### PR TITLE
feat: download queue widget for Radarr/Sonarr [PRD-016/US-4] (tb-148)

### DIFF
--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -79,6 +79,22 @@ export const arrRouter = router({
       }
     }),
 
+  /** Get combined download queue from Radarr + Sonarr. */
+  getDownloadQueue: protectedProcedure.query(async () => {
+    try {
+      const items = await arrService.getDownloadQueue();
+      return { data: items };
+    } catch (err) {
+      if (err instanceof ArrApiError) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Arr queue error: ${err.message}`,
+        });
+      }
+      throw err;
+    }
+  }),
+
   /** Get Sonarr status for a TV show by TVDB ID. */
   getShowStatus: protectedProcedure
     .input(z.object({ tvdbId: z.number().int().positive() }))

--- a/apps/pops-api/src/modules/media/arr/service.ts
+++ b/apps/pops-api/src/modules/media/arr/service.ts
@@ -3,7 +3,7 @@
  */
 import { RadarrClient } from "./radarr-client.js";
 import { SonarrClient } from "./sonarr-client.js";
-import type { ArrConfig, ArrStatusResult } from "./types.js";
+import type { ArrConfig, ArrStatusResult, DownloadQueueItem } from "./types.js";
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -81,8 +81,74 @@ export async function getShowStatus(tvdbId: number): Promise<ArrStatusResult> {
   return result;
 }
 
+const QUEUE_CACHE_TTL_MS = 30 * 1000; // 30 seconds
+
+interface QueueCacheEntry {
+  items: DownloadQueueItem[];
+  expiresAt: number;
+}
+
+let queueCache: QueueCacheEntry | null = null;
+
+/** Get combined download queue from Radarr + Sonarr with 30s cache. */
+export async function getDownloadQueue(): Promise<DownloadQueueItem[]> {
+  if (queueCache && queueCache.expiresAt > Date.now()) {
+    return queueCache.items;
+  }
+
+  const radarrClient = getRadarrClient();
+  const sonarrClient = getSonarrClient();
+
+  const [radarrQueue, sonarrQueue] = await Promise.all([
+    radarrClient ? radarrClient.getQueue().catch(() => null) : null,
+    sonarrClient ? sonarrClient.getQueue().catch(() => null) : null,
+  ]);
+
+  const items: DownloadQueueItem[] = [];
+
+  if (radarrQueue) {
+    for (const record of radarrQueue.records) {
+      const progress =
+        record.size > 0
+          ? Math.round(((record.size - record.sizeleft) / record.size) * 100)
+          : 0;
+      items.push({
+        id: `radarr-${record.id}`,
+        title: record.title,
+        mediaType: "movie",
+        progress,
+        source: "radarr",
+      });
+    }
+  }
+
+  if (sonarrQueue) {
+    for (const record of sonarrQueue.records) {
+      const progress =
+        record.size > 0
+          ? Math.round(((record.size - record.sizeleft) / record.size) * 100)
+          : 0;
+      const episodeLabel = record.episode
+        ? `S${String(record.episode.seasonNumber).padStart(2, "0")}E${String(record.episode.episodeNumber).padStart(2, "0")}`
+        : undefined;
+      items.push({
+        id: `sonarr-${record.id}`,
+        title: record.title,
+        mediaType: "episode",
+        episodeLabel,
+        progress,
+        source: "sonarr",
+      });
+    }
+  }
+
+  queueCache = { items, expiresAt: Date.now() + QUEUE_CACHE_TTL_MS };
+  return items;
+}
+
 /** Clear all cached statuses. */
 export function clearStatusCache(): void {
   movieStatusCache.clear();
   showStatusCache.clear();
+  queueCache = null;
 }

--- a/apps/pops-api/src/modules/media/arr/types.ts
+++ b/apps/pops-api/src/modules/media/arr/types.ts
@@ -103,3 +103,18 @@ export interface ArrSystemStatus {
   version: string;
   appName: string;
 }
+
+/** Unified download queue item for the frontend. */
+export interface DownloadQueueItem {
+  id: string;
+  title: string;
+  mediaType: "movie" | "episode";
+  /** Episode label, e.g. "S01E05" */
+  episodeLabel?: string;
+  /** Download progress 0–100. */
+  progress: number;
+  /** Human-readable ETA, e.g. "12m", "2h 30m". */
+  eta?: string;
+  /** Source service. */
+  source: "radarr" | "sonarr";
+}

--- a/packages/app-media/src/components/DownloadQueue.tsx
+++ b/packages/app-media/src/components/DownloadQueue.tsx
@@ -1,0 +1,69 @@
+/**
+ * DownloadQueue — shows active downloads from Radarr + Sonarr.
+ *
+ * Auto-refreshes every 30s. Hidden when nothing is downloading
+ * or when neither service is configured.
+ */
+import { Badge } from "@pops/ui";
+import { trpc } from "../lib/trpc";
+
+export function DownloadQueue() {
+  const { data: configData } = trpc.media.arr.getConfig.useQuery();
+  const config = configData?.data;
+
+  const hasAnyService = config?.radarrConfigured || config?.sonarrConfigured;
+
+  const { data } = trpc.media.arr.getDownloadQueue.useQuery(undefined, {
+    enabled: hasAnyService === true,
+    refetchInterval: 30_000,
+  });
+
+  const items = data?.data;
+  if (!items || items.length === 0) return null;
+
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+        Downloading
+      </h2>
+      <div className="space-y-1.5">
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="flex items-center gap-3 rounded-lg border bg-card p-3"
+          >
+            <Badge
+              variant="outline"
+              className="text-[10px] uppercase shrink-0"
+            >
+              {item.mediaType === "movie" ? "Movie" : "Episode"}
+            </Badge>
+
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium truncate">
+                {item.title}
+                {item.episodeLabel && (
+                  <span className="text-muted-foreground ml-1.5">
+                    {item.episodeLabel}
+                  </span>
+                )}
+              </p>
+
+              {/* Progress bar */}
+              <div className="mt-1 h-1.5 rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-indigo-500 transition-all duration-500"
+                  style={{ width: `${item.progress}%` }}
+                />
+              </div>
+            </div>
+
+            <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+              {item.progress}%
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -3,6 +3,7 @@ import { Badge, Button, Skeleton } from "@pops/ui";
 import { useEffect } from "react";
 import { Sparkles } from "lucide-react";
 import { MediaGrid } from "../components/MediaGrid";
+import { DownloadQueue } from "../components/DownloadQueue";
 import {
   useMediaLibrary,
   type MediaType,
@@ -127,6 +128,9 @@ export function LibraryPage() {
           </Link>
         </div>
       </div>
+
+      {/* Download queue */}
+      <DownloadQueue />
 
       {/* Filter bar */}
       <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary
- Added `DownloadQueueItem` type and `getDownloadQueue` service with 30s cache
- New `getDownloadQueue` tRPC query combining Radarr and Sonarr queues
- `DownloadQueue` component with auto-refresh, progress bars, type badges
- Mounted on LibraryPage below header, hidden when empty or unconfigured

## Test plan
- [ ] Verify hidden when RADARR_URL/SONARR_URL not set
- [ ] Verify shows active downloads with progress when configured
- [ ] Verify auto-refreshes every 30s
- [ ] Verify hidden when queue is empty
- [ ] API typecheck passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)