### PR TITLE
feat: Plex movie import with progress tracking (tb-144)

### DIFF
--- a/apps/pops-api/src/modules/media/plex/sync-movies.test.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-movies.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Tests for Plex movie import — batch sync with progress tracking and fallback matching.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PlexMediaItem } from "./types.js";
+import type { TmdbClient } from "../tmdb/client.js";
+import type { PlexClient } from "./client.js";
+
+// Mock dependencies
+vi.mock("../tmdb/index.js", () => ({
+  getTmdbClient: vi.fn(),
+}));
+
+vi.mock("../library/service.js", () => ({
+  addMovie: vi.fn(),
+}));
+
+vi.mock("../watch-history/service.js", () => ({
+  logWatch: vi.fn(),
+}));
+
+import { importMoviesFromPlex } from "./sync-movies.js";
+import { getTmdbClient } from "../tmdb/index.js";
+import * as libraryService from "../library/service.js";
+import { logWatch } from "../watch-history/service.js";
+
+const mockGetTmdbClient = vi.mocked(getTmdbClient);
+const mockAddMovie = vi.mocked(libraryService.addMovie);
+const mockLogWatch = vi.mocked(logWatch);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePlexMovie(overrides: Partial<PlexMediaItem> = {}): PlexMediaItem {
+  return {
+    ratingKey: "100",
+    type: "movie",
+    title: "Fight Club",
+    originalTitle: "Fight Club",
+    summary: "An insomniac office worker...",
+    tagline: null,
+    year: 1999,
+    thumbUrl: null,
+    artUrl: null,
+    durationMs: 8340000,
+    addedAt: 1711000000,
+    updatedAt: 1711000100,
+    lastViewedAt: 1711500000,
+    viewCount: 3,
+    rating: 8.0,
+    audienceRating: 8.8,
+    contentRating: "R",
+    externalIds: [
+      { source: "tmdb", id: "550" },
+      { source: "imdb", id: "tt0137523" },
+    ],
+    genres: ["Drama", "Thriller"],
+    directors: ["David Fincher"],
+    leafCount: null,
+    viewedLeafCount: null,
+    childCount: null,
+    ...overrides,
+  };
+}
+
+function makePlexClient(items: PlexMediaItem[]): PlexClient {
+  return {
+    getAllItems: vi.fn().mockResolvedValue(items),
+  } as unknown as PlexClient;
+}
+
+function makeTmdbClient(overrides: Partial<TmdbClient> = {}): TmdbClient {
+  return {
+    searchMovies: vi
+      .fn()
+      .mockResolvedValue({ results: [], totalResults: 0, totalPages: 0, page: 1 }),
+    ...overrides,
+  } as unknown as TmdbClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("importMoviesFromPlex", () => {
+  it("returns error when TMDB client is not configured", async () => {
+    mockGetTmdbClient.mockReturnValue(null);
+    const client = makePlexClient([]);
+
+    const result = await importMoviesFromPlex(client, "1");
+
+    expect(result.total).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].reason).toContain("TMDB_API_KEY");
+    expect(client.getAllItems).not.toHaveBeenCalled();
+  });
+
+  it("syncs movie using TMDB ID from Plex Guid", async () => {
+    const tmdb = makeTmdbClient();
+    mockGetTmdbClient.mockReturnValue(tmdb);
+    mockAddMovie.mockResolvedValue({
+      movie: { id: 1, title: "Fight Club" } as unknown as import("../movies/types.js").Movie,
+      created: true,
+    });
+
+    const movie = makePlexMovie();
+    const client = makePlexClient([movie]);
+
+    const result = await importMoviesFromPlex(client, "1");
+
+    expect(result.synced).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+    expect(mockAddMovie).toHaveBeenCalledWith(550, tmdb);
+    // Should not fall back to search since Guid had TMDB ID
+    expect(tmdb.searchMovies).not.toHaveBeenCalled();
+  });
+
+  it("logs watch history for watched movies", async () => {
+    const tmdb = makeTmdbClient();
+    mockGetTmdbClient.mockReturnValue(tmdb);
+    mockAddMovie.mockResolvedValue({
+      movie: { id: 42, title: "Fight Club" } as unknown as import("../movies/types.js").Movie,
+      created: true,
+    });
+
+    const movie = makePlexMovie({ viewCount: 3, lastViewedAt: 1711500000 });
+    const client = makePlexClient([movie]);
+
+    await importMoviesFromPlex(client, "1");
+
+    expect(mockLogWatch).toHaveBeenCalledWith({
+      mediaType: "movie",
+      mediaId: 42,
+      watchedAt: expect.any(String),
+      completed: 1,
+    });
+  });
+
+  it("does not log watch history for unwatched movies", async () => {
+    const tmdb = makeTmdbClient();
+    mockGetTmdbClient.mockReturnValue(tmdb);
+    mockAddMovie.mockResolvedValue({
+      movie: { id: 1, title: "Fight Club" } as unknown as import("../movies/types.js").Movie,
+      created: true,
+    });
+
+    const movie = makePlexMovie({ viewCount: 0, lastViewedAt: null });
+    const client = makePlexClient([movie]);
+
+    const result = await importMoviesFromPlex(client, "1");
+
+    expect(result.synced).toBe(1);
+    expect(mockLogWatch).not.toHaveBeenCalled();
+  });
+
+  it("skips movies when TMDB ID cannot be resolved", async () => {
+    const tmdb = makeTmdbClient();
+    mockGetTmdbClient.mockReturnValue(tmdb);
+
+    const movie = makePlexMovie({
+      externalIds: [{ source: "imdb", id: "tt0137523" }],
+    });
+    const client = makePlexClient([movie]);
+
+    const result = await importMoviesFromPlex(client, "1");
+
+    expect(result.synced).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(mockAddMovie).not.toHaveBeenCalled();
+  });
+
+  it("falls back to TMDB title+year search when no Guid", async () => {
+    const tmdb = makeTmdbClient({
+      searchMovies: vi.fn().mockResolvedValue({
+        results: [{ tmdbId: 550, title: "Fight Club", releaseDate: "1999-10-15" }],
+        totalResults: 1,
+        totalPages: 1,
+        page: 1,
+      }),
+    } as unknown as Partial<TmdbClient>);
+    mockGetTmdbClient.mockReturnValue(tmdb);
+    mockAddMovie.mockResolvedValue({
+      movie: { id: 1, title: "Fight Club" } as unknown as import("../movies/types.js").Movie,
+      created: true,
+    });
+
+    const movie = makePlexMovie({
+      externalIds: [{ source: "imdb", id: "tt0137523" }],
+    });
+    const client = makePlexClient([movie]);
+
+    const result = await importMoviesFromPlex(client, "1");
+
+    expect(result.synced).toBe(1);
+    expect(tmdb.searchMovies).toHaveBeenCalledWith("Fight Club");
+    expect(mockAddMovie).toHaveBeenCalledWith(550, tmdb);
+  });
+
+  it("skips when TMDB search returns no matching title", async () => {
+    const tmdb = makeTmdbClient({
+      searchMovies: vi.fn().mockResolvedValue({
+        results: [{ tmdbId: 999, title: "Completely Different Movie", releaseDate: "2020-01-01" }],
+        totalResults: 1,
+        totalPages: 1,
+        page: 1,
+      }),
+    } as unknown as Partial<TmdbClient>);
+    mockGetTmdbClient.mockReturnValue(tmdb);
+
+    const movie = makePlexMovie({
+      externalIds: [],
+    });
+    const client = makePlexClient([movie]);
+
+    const result = await importMoviesFromPlex(client, "1");
+
+    expect(result.synced).toBe(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("records errors for failed movies without stopping sync", async () => {
+    const tmdb = makeTmdbClient();
+    mockGetTmdbClient.mockReturnValue(tmdb);
+
+    const goodMovie = makePlexMovie({ ratingKey: "1", title: "Good Movie" });
+    const badMovie = makePlexMovie({ ratingKey: "2", title: "Bad Movie" });
+
+    mockAddMovie.mockRejectedValueOnce(new Error("TMDB 404")).mockResolvedValueOnce({
+      movie: { id: 2, title: "Good Movie" } as unknown as import("../movies/types.js").Movie,
+      created: true,
+    });
+
+    const client = makePlexClient([badMovie, goodMovie]);
+
+    const result = await importMoviesFromPlex(client, "1");
+
+    expect(result.synced).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].title).toBe("Bad Movie");
+    expect(result.errors[0].reason).toContain("TMDB 404");
+    expect(result.processed).toBe(2);
+  });
+
+  it("calls onProgress callback after each item", async () => {
+    const tmdb = makeTmdbClient();
+    mockGetTmdbClient.mockReturnValue(tmdb);
+    mockAddMovie.mockResolvedValue({
+      movie: { id: 1, title: "Test" } as unknown as import("../movies/types.js").Movie,
+      created: true,
+    });
+
+    const movies = [
+      makePlexMovie({ ratingKey: "1", title: "Movie 1" }),
+      makePlexMovie({ ratingKey: "2", title: "Movie 2" }),
+    ];
+    const client = makePlexClient(movies);
+    const onProgress = vi.fn();
+
+    await importMoviesFromPlex(client, "1", { onProgress });
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    // Progress object is passed by reference, so capture the final state
+    const finalProgress = onProgress.mock.calls[1][0];
+    expect(finalProgress.processed).toBe(2);
+    expect(finalProgress.synced).toBe(2);
+    expect(finalProgress.total).toBe(2);
+  });
+
+  it("handles multiple movies in batch", async () => {
+    const tmdb = makeTmdbClient();
+    mockGetTmdbClient.mockReturnValue(tmdb);
+    mockAddMovie.mockResolvedValue({
+      movie: { id: 1, title: "Test" } as unknown as import("../movies/types.js").Movie,
+      created: true,
+    });
+
+    const movies = Array.from({ length: 5 }, (_, i) =>
+      makePlexMovie({
+        ratingKey: String(i + 1),
+        title: `Movie ${i + 1}`,
+        externalIds: [{ source: "tmdb", id: String(100 + i) }],
+        viewCount: 0,
+        lastViewedAt: null,
+      })
+    );
+    const client = makePlexClient(movies);
+
+    const result = await importMoviesFromPlex(client, "1");
+
+    expect(result.total).toBe(5);
+    expect(result.processed).toBe(5);
+    expect(result.synced).toBe(5);
+    expect(result.errors).toHaveLength(0);
+    expect(mockAddMovie).toHaveBeenCalledTimes(5);
+  });
+
+  it("handles empty library section", async () => {
+    const tmdb = makeTmdbClient();
+    mockGetTmdbClient.mockReturnValue(tmdb);
+
+    const client = makePlexClient([]);
+
+    const result = await importMoviesFromPlex(client, "1");
+
+    expect(result.total).toBe(0);
+    expect(result.processed).toBe(0);
+    expect(result.synced).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("ignores duplicate watch history errors", async () => {
+    const tmdb = makeTmdbClient();
+    mockGetTmdbClient.mockReturnValue(tmdb);
+    mockAddMovie.mockResolvedValue({
+      movie: { id: 1, title: "Fight Club" } as unknown as import("../movies/types.js").Movie,
+      created: true,
+    });
+    mockLogWatch.mockImplementation(() => {
+      throw new Error("UNIQUE constraint failed");
+    });
+
+    const movie = makePlexMovie({ viewCount: 2, lastViewedAt: 1711500000 });
+    const client = makePlexClient([movie]);
+
+    const result = await importMoviesFromPlex(client, "1");
+
+    // Should still count as synced despite watch history error
+    expect(result.synced).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("handles non-numeric TMDB ID in Plex Guid gracefully", async () => {
+    const tmdb = makeTmdbClient();
+    mockGetTmdbClient.mockReturnValue(tmdb);
+
+    const movie = makePlexMovie({
+      externalIds: [{ source: "tmdb", id: "invalid" }],
+    });
+    const client = makePlexClient([movie]);
+
+    const result = await importMoviesFromPlex(client, "1");
+
+    // Should fall back to search, which returns empty, so skipped
+    expect(result.skipped).toBe(1);
+  });
+});

--- a/apps/pops-api/src/modules/media/plex/sync-movies.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-movies.ts
@@ -1,0 +1,189 @@
+/**
+ * Plex movie import — batch sync with progress tracking and fallback matching.
+ *
+ * Iterates all movies in a Plex library section, matches each to a TMDB ID
+ * (via Plex Guid or title+year search), adds to the local library, and
+ * logs watch history for watched items.
+ */
+import type { PlexClient } from "./client.js";
+import type { PlexMediaItem } from "./types.js";
+import type { TmdbClient } from "../tmdb/client.js";
+import { getTmdbClient } from "../tmdb/index.js";
+import * as libraryService from "../library/service.js";
+import { logWatch } from "../watch-history/service.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MovieSyncProgress {
+  total: number;
+  processed: number;
+  synced: number;
+  skipped: number;
+  errors: MovieSyncError[];
+}
+
+export interface MovieSyncError {
+  title: string;
+  year: number | null;
+  reason: string;
+}
+
+export interface MovieSyncOptions {
+  /** Called after each item is processed. */
+  onProgress?: (progress: MovieSyncProgress) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Main sync function
+// ---------------------------------------------------------------------------
+
+/**
+ * Import all movies from a Plex library section.
+ *
+ * For each Plex movie:
+ *   1. Try to extract TMDB ID from Plex Guid array
+ *   2. If no TMDB ID, fall back to title+year search via TMDB API
+ *   3. Add movie to library (idempotent)
+ *   4. Log watch history if Plex shows it was watched
+ */
+export async function importMoviesFromPlex(
+  plexClient: PlexClient,
+  sectionId: string,
+  options: MovieSyncOptions = {}
+): Promise<MovieSyncProgress> {
+  const tmdbClient = getTmdbClient();
+  if (!tmdbClient) {
+    return {
+      total: 0,
+      processed: 0,
+      synced: 0,
+      skipped: 0,
+      errors: [{ title: "Configuration", year: null, reason: "TMDB_API_KEY not configured" }],
+    };
+  }
+
+  const items = await plexClient.getAllItems(sectionId);
+
+  const progress: MovieSyncProgress = {
+    total: items.length,
+    processed: 0,
+    synced: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  for (const item of items) {
+    try {
+      await syncSingleMovie(item, tmdbClient, progress);
+    } catch (err) {
+      progress.errors.push({
+        title: item.title,
+        year: item.year,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    progress.processed++;
+    options.onProgress?.(progress);
+  }
+
+  return progress;
+}
+
+// ---------------------------------------------------------------------------
+// Per-movie sync
+// ---------------------------------------------------------------------------
+
+async function syncSingleMovie(
+  item: PlexMediaItem,
+  tmdbClient: TmdbClient,
+  progress: MovieSyncProgress
+): Promise<void> {
+  // Step 1: Resolve TMDB ID
+  const tmdbId = await resolveTmdbId(item, tmdbClient);
+
+  if (!tmdbId) {
+    progress.skipped++;
+    return;
+  }
+
+  // Step 2: Add to library (idempotent)
+  const { movie } = await libraryService.addMovie(tmdbId, tmdbClient);
+
+  // Step 3: Sync watch history
+  if (item.viewCount > 0 && item.lastViewedAt) {
+    try {
+      logWatch({
+        mediaType: "movie",
+        mediaId: movie.id,
+        watchedAt: new Date(item.lastViewedAt * 1000).toISOString(),
+        completed: 1,
+      });
+    } catch {
+      // Ignore duplicate watch entries
+    }
+  }
+
+  progress.synced++;
+}
+
+// ---------------------------------------------------------------------------
+// TMDB ID resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the TMDB ID for a Plex movie.
+ *
+ * Strategy:
+ *   1. Check Plex Guid array for tmdb:// entry
+ *   2. Fall back to TMDB search by title + year
+ */
+async function resolveTmdbId(item: PlexMediaItem, tmdbClient: TmdbClient): Promise<number | null> {
+  // Try Plex Guid array first
+  const plexTmdbId = item.externalIds.find((id) => id.source === "tmdb");
+  if (plexTmdbId) {
+    const parsed = Number(plexTmdbId.id);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+
+  // Fall back to title+year search
+  return searchTmdbByTitleYear(item.title, item.year, tmdbClient);
+}
+
+/**
+ * Search TMDB for a movie by title and optional year.
+ * Returns the first result's TMDB ID if the title is a close match.
+ */
+async function searchTmdbByTitleYear(
+  title: string,
+  year: number | null,
+  tmdbClient: TmdbClient
+): Promise<number | null> {
+  try {
+    const result = await tmdbClient.searchMovies(title);
+    if (result.results.length === 0) return null;
+
+    // Find best match: prefer exact title + matching year
+    for (const r of result.results) {
+      const titleMatch = r.title.toLowerCase() === title.toLowerCase();
+      const yearMatch =
+        year && r.releaseDate ? new Date(r.releaseDate).getFullYear() === year : true;
+
+      if (titleMatch && yearMatch) {
+        return r.tmdbId;
+      }
+    }
+
+    // No exact match — take first result if title is close enough
+    const first = result.results[0];
+    if (first.title.toLowerCase() === title.toLowerCase()) {
+      return first.tmdbId;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `importMoviesFromPlex()` batch sync function with progress callback tracking
- TMDB ID resolution: extracts from Plex Guid array, falls back to TMDB title+year search
- Syncs movies to library and logs watch history for watched items
- 13 unit tests covering all sync paths (Guid match, search fallback, error handling, batch, empty library, duplicate watch entries)

## Test plan
- [x] 13 vitest unit tests pass (`sync-movies.test.ts`)
- [ ] CI green (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)