### PR TITLE
feat: download queue widget for Radarr/Sonarr [PRD-016/US-4] (tb-148)

### DIFF
--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -61,6 +61,22 @@ export const arrRouter = router({
     return { data: arrService.getArrConfig() };
   }),
 
+  /** Get combined download queue from Radarr + Sonarr. */
+  getDownloadQueue: protectedProcedure.query(async () => {
+    try {
+      const items = await arrService.getDownloadQueue();
+      return { data: items };
+    } catch (err) {
+      if (err instanceof ArrApiError) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Queue error: ${err.message}`,
+        });
+      }
+      throw err;
+    }
+  }),
+
   /** Get Radarr status for a movie by TMDB ID. */
   getMovieStatus: protectedProcedure
     .input(z.object({ tmdbId: z.number().int().positive() }))

--- a/apps/pops-api/src/modules/media/arr/service.ts
+++ b/apps/pops-api/src/modules/media/arr/service.ts
@@ -3,9 +3,10 @@
  */
 import { RadarrClient } from "./radarr-client.js";
 import { SonarrClient } from "./sonarr-client.js";
-import type { ArrConfig, ArrStatusResult } from "./types.js";
+import type { ArrConfig, ArrStatusResult, DownloadQueueItem } from "./types.js";
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const QUEUE_CACHE_TTL_MS = 30 * 1000; // 30 seconds
 
 interface CacheEntry {
   result: ArrStatusResult;
@@ -81,8 +82,69 @@ export async function getShowStatus(tvdbId: number): Promise<ArrStatusResult> {
   return result;
 }
 
+// -- Download queue cache --
+
+interface QueueCacheEntry {
+  items: DownloadQueueItem[];
+  expiresAt: number;
+}
+
+let queueCache: QueueCacheEntry | null = null;
+
+/** Get combined download queue from Radarr + Sonarr. */
+export async function getDownloadQueue(): Promise<DownloadQueueItem[]> {
+  if (queueCache && queueCache.expiresAt > Date.now()) {
+    return queueCache.items;
+  }
+
+  const radarrClient = getRadarrClient();
+  const sonarrClient = getSonarrClient();
+
+  if (!radarrClient && !sonarrClient) return [];
+
+  const [radarrQueue, sonarrQueue] = await Promise.all([
+    radarrClient?.getQueue().catch(() => null),
+    sonarrClient?.getQueue().catch(() => null),
+  ]);
+
+  const items: DownloadQueueItem[] = [];
+
+  if (radarrQueue) {
+    for (const r of radarrQueue.records) {
+      const progress = r.size > 0 ? Math.round(((r.size - r.sizeleft) / r.size) * 100) : 0;
+      items.push({
+        id: `radarr-${r.id}`,
+        title: r.title,
+        mediaType: "movie",
+        progress,
+        statusLabel: `${progress}%`,
+      });
+    }
+  }
+
+  if (sonarrQueue) {
+    for (const r of sonarrQueue.records) {
+      const progress = r.size > 0 ? Math.round(((r.size - r.sizeleft) / r.size) * 100) : 0;
+      const episodeLabel = r.episode
+        ? `S${String(r.episode.seasonNumber).padStart(2, "0")}E${String(r.episode.episodeNumber).padStart(2, "0")}`
+        : "";
+      items.push({
+        id: `sonarr-${r.id}`,
+        title: episodeLabel ? `${r.title} — ${episodeLabel}` : r.title,
+        mediaType: "episode",
+        progress,
+        statusLabel: `${progress}%`,
+      });
+    }
+  }
+
+  queueCache = { items, expiresAt: Date.now() + QUEUE_CACHE_TTL_MS };
+  return items;
+}
+
 /** Clear all cached statuses. */
 export function clearStatusCache(): void {
   movieStatusCache.clear();
   showStatusCache.clear();
+  queueCache = null;
 }

--- a/apps/pops-api/src/modules/media/arr/types.ts
+++ b/apps/pops-api/src/modules/media/arr/types.ts
@@ -98,6 +98,19 @@ export interface SonarrQueueResponse {
   records: SonarrQueueRecord[];
 }
 
+/** Unified download queue item for frontend. */
+export interface DownloadQueueItem {
+  id: string;
+  title: string;
+  mediaType: "movie" | "episode";
+  /** Progress percentage (0-100). */
+  progress: number;
+  /** Estimated time of arrival, if available. */
+  eta?: string;
+  /** Human-readable status label. */
+  statusLabel: string;
+}
+
 /** System status response shared by Radarr and Sonarr. */
 export interface ArrSystemStatus {
   version: string;

--- a/packages/app-media/src/components/DownloadQueue.tsx
+++ b/packages/app-media/src/components/DownloadQueue.tsx
@@ -1,0 +1,45 @@
+import { Badge } from "@pops/ui";
+import { trpc } from "../lib/trpc";
+
+export function DownloadQueue() {
+  const { data } = trpc.media.arr.getDownloadQueue.useQuery(undefined, {
+    refetchInterval: 30_000,
+  });
+
+  const items = data?.data ?? [];
+
+  if (items.length === 0) return null;
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-3">Downloading</h2>
+      <div className="space-y-2">
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="flex items-center gap-3 rounded-lg border p-3"
+          >
+            <Badge
+              variant="outline"
+              className="shrink-0 text-[10px] uppercase tracking-wider"
+            >
+              {item.mediaType === "movie" ? "Movie" : "Episode"}
+            </Badge>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium truncate">{item.title}</p>
+              <div className="mt-1 h-1.5 rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-indigo-500 transition-all duration-500"
+                  style={{ width: `${item.progress}%` }}
+                />
+              </div>
+            </div>
+            <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+              {item.statusLabel}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -3,6 +3,7 @@ import { Badge, Button, Skeleton } from "@pops/ui";
 import { useEffect } from "react";
 import { Sparkles } from "lucide-react";
 import { MediaGrid } from "../components/MediaGrid";
+import { DownloadQueue } from "../components/DownloadQueue";
 import {
   useMediaLibrary,
   type MediaType,
@@ -127,6 +128,9 @@ export function LibraryPage() {
           </Link>
         </div>
       </div>
+
+      {/* Download queue */}
+      <DownloadQueue />
 
       {/* Filter bar */}
       <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary
- New `DownloadQueueItem` type in arr/types.ts with unified queue item shape
- `getDownloadQueue()` service function merges Radarr + Sonarr queues with 30s cache TTL
- `getDownloadQueue` tRPC endpoint on arr router
- `DownloadQueue` component on LibraryPage — shows title, type badge (Movie/Episode), progress bar with %, auto-refreshes every 30s
- Hidden when queue is empty (component returns null)

## Test plan
- [x] 14 existing arr tests still passing
- [x] Typecheck clean (pops-api + app-media)
- [ ] Verify widget shows when items are downloading in Radarr/Sonarr
- [ ] Verify widget hidden when queue is empty
- [ ] Verify 30s auto-refresh works

🤖 Generated with [Claude Code](https://claude.com/claude-code)