### PR TITLE
feat: Plex TV show import with episode watch matching (tb-145)

### DIFF
--- a/apps/pops-api/src/modules/media/plex/sync-tv.test.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-tv.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for Plex TV show import — batch sync with episode watch matching.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PlexMediaItem, PlexEpisode } from "./types.js";
+import type { PlexClient } from "./client.js";
+
+// Mock dependencies
+vi.mock("../thetvdb/index.js", () => ({
+  getTvdbClient: vi.fn(),
+}));
+
+vi.mock("../library/tv-show-service.js", () => ({
+  addTvShow: vi.fn(),
+}));
+
+vi.mock("../tv-shows/service.js", () => ({
+  getTvShowByTvdbId: vi.fn(),
+}));
+
+vi.mock("../watch-history/service.js", () => ({
+  logWatch: vi.fn(),
+}));
+
+vi.mock("../../../db.js", () => ({
+  getDrizzle: vi.fn(),
+}));
+
+vi.mock("@pops/db-types", () => ({
+  episodes: { seasonId: "seasonId", episodeNumber: "episodeNumber", id: "id" },
+  seasons: { tvShowId: "tvShowId", seasonNumber: "seasonNumber", id: "id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((a, b) => ({ type: "eq", a, b })),
+  and: vi.fn((...args: unknown[]) => ({ type: "and", args })),
+}));
+
+import { importTvShowsFromPlex } from "./sync-tv.js";
+import { getTvdbClient } from "../thetvdb/index.js";
+import * as tvShowService from "../library/tv-show-service.js";
+import { getTvShowByTvdbId } from "../tv-shows/service.js";
+import { logWatch } from "../watch-history/service.js";
+import { getDrizzle } from "../../../db.js";
+
+const mockGetTvdbClient = vi.mocked(getTvdbClient);
+const mockAddTvShow = vi.mocked(tvShowService.addTvShow);
+const mockGetTvShowByTvdbId = vi.mocked(getTvShowByTvdbId);
+const mockLogWatch = vi.mocked(logWatch);
+const mockGetDrizzle = vi.mocked(getDrizzle);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePlexShow(overrides: Partial<PlexMediaItem> = {}): PlexMediaItem {
+  return {
+    ratingKey: "200",
+    type: "show",
+    title: "Breaking Bad",
+    originalTitle: "Breaking Bad",
+    summary: "A chemistry teacher...",
+    tagline: null,
+    year: 2008,
+    thumbUrl: null,
+    artUrl: null,
+    durationMs: null,
+    addedAt: 1711000000,
+    updatedAt: 1711000100,
+    lastViewedAt: 1711500000,
+    viewCount: 1,
+    rating: 9.0,
+    audienceRating: 9.5,
+    contentRating: "TV-MA",
+    externalIds: [
+      { source: "tvdb", id: "81189" },
+      { source: "imdb", id: "tt0903747" },
+    ],
+    genres: ["Drama", "Crime"],
+    directors: [],
+    leafCount: 62,
+    viewedLeafCount: 62,
+    childCount: 5,
+    ...overrides,
+  };
+}
+
+function makePlexEpisode(overrides: Partial<PlexEpisode> = {}): PlexEpisode {
+  return {
+    ratingKey: "300",
+    title: "Pilot",
+    episodeIndex: 1,
+    seasonIndex: 1,
+    summary: "Walter White begins...",
+    thumbUrl: null,
+    durationMs: 3480000,
+    addedAt: 1711000000,
+    updatedAt: 1711000100,
+    lastViewedAt: 1711400000,
+    viewCount: 1,
+    ...overrides,
+  };
+}
+
+function makePlexClient(
+  items: PlexMediaItem[],
+  episodeMap: Record<string, PlexEpisode[]> = {}
+): PlexClient {
+  return {
+    getAllItems: vi.fn().mockResolvedValue(items),
+    getEpisodes: vi.fn().mockImplementation((ratingKey: string) => {
+      return Promise.resolve(episodeMap[ratingKey] ?? []);
+    }),
+  } as unknown as PlexClient;
+}
+
+function makeMockDb(seasonResult: unknown = undefined, episodeResult: unknown = undefined): void {
+  const mockGet = vi.fn().mockReturnValueOnce(seasonResult).mockReturnValueOnce(episodeResult);
+  const mockWhere = vi.fn().mockReturnValue({ get: mockGet });
+  const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+  const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+  mockGetDrizzle.mockReturnValue({ select: mockSelect } as unknown as ReturnType<
+    typeof getDrizzle
+  >);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("importTvShowsFromPlex", () => {
+  it("returns error when TVDB client is not configured", async () => {
+    mockGetTvdbClient.mockReturnValue(null);
+    const client = makePlexClient([]);
+
+    const result = await importTvShowsFromPlex(client, "2");
+
+    expect(result.total).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].reason).toContain("THETVDB_API_KEY");
+    expect(client.getAllItems).not.toHaveBeenCalled();
+  });
+
+  it("syncs show using TVDB ID from Plex Guid", async () => {
+    const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
+    mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
+    mockAddTvShow.mockResolvedValue({
+      show: { id: 1, title: "Breaking Bad" } as unknown as import("@pops/db-types").TvShowRow,
+      seasons: [],
+      created: true,
+    });
+    mockGetTvShowByTvdbId.mockReturnValue(null);
+
+    const show = makePlexShow();
+    const client = makePlexClient([show], { "200": [] });
+
+    const result = await importTvShowsFromPlex(client, "2");
+
+    expect(result.synced).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+    expect(mockAddTvShow).toHaveBeenCalledWith(81189, fakeTvdbClient);
+  });
+
+  it("skips shows without TVDB ID", async () => {
+    const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
+    mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
+
+    const show = makePlexShow({
+      externalIds: [{ source: "imdb", id: "tt0903747" }],
+    });
+    const client = makePlexClient([show]);
+
+    const result = await importTvShowsFromPlex(client, "2");
+
+    expect(result.synced).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(mockAddTvShow).not.toHaveBeenCalled();
+  });
+
+  it("skips shows with non-numeric TVDB ID", async () => {
+    const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
+    mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
+
+    const show = makePlexShow({
+      externalIds: [{ source: "tvdb", id: "invalid" }],
+    });
+    const client = makePlexClient([show]);
+
+    const result = await importTvShowsFromPlex(client, "2");
+
+    expect(result.synced).toBe(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("syncs episode watch history for watched episodes", async () => {
+    const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
+    mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
+    mockAddTvShow.mockResolvedValue({
+      show: { id: 1, title: "Breaking Bad" } as unknown as import("@pops/db-types").TvShowRow,
+      seasons: [],
+      created: true,
+    });
+    mockGetTvShowByTvdbId.mockReturnValue({
+      id: 1,
+    } as unknown as import("@pops/db-types").TvShowRow);
+    makeMockDb({ id: 10 }, { id: 100 });
+
+    const ep = makePlexEpisode({ viewCount: 1, lastViewedAt: 1711400000 });
+    const show = makePlexShow();
+    const client = makePlexClient([show], { "200": [ep] });
+
+    const result = await importTvShowsFromPlex(client, "2");
+
+    expect(result.synced).toBe(1);
+    expect(result.episodesMatched).toBe(1);
+    expect(mockLogWatch).toHaveBeenCalledWith({
+      mediaType: "episode",
+      mediaId: 100,
+      watchedAt: expect.any(String),
+      completed: 1,
+    });
+  });
+
+  it("skips unwatched episodes", async () => {
+    const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
+    mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
+    mockAddTvShow.mockResolvedValue({
+      show: { id: 1, title: "Breaking Bad" } as unknown as import("@pops/db-types").TvShowRow,
+      seasons: [],
+      created: true,
+    });
+    mockGetTvShowByTvdbId.mockReturnValue({
+      id: 1,
+    } as unknown as import("@pops/db-types").TvShowRow);
+
+    const ep = makePlexEpisode({ viewCount: 0, lastViewedAt: null });
+    const show = makePlexShow();
+    const client = makePlexClient([show], { "200": [ep] });
+
+    const result = await importTvShowsFromPlex(client, "2");
+
+    expect(result.synced).toBe(1);
+    expect(result.episodesMatched).toBe(0);
+    expect(mockLogWatch).not.toHaveBeenCalled();
+  });
+
+  it("skips episodes when local season not found", async () => {
+    const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
+    mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
+    mockAddTvShow.mockResolvedValue({
+      show: { id: 1, title: "Breaking Bad" } as unknown as import("@pops/db-types").TvShowRow,
+      seasons: [],
+      created: true,
+    });
+    mockGetTvShowByTvdbId.mockReturnValue({
+      id: 1,
+    } as unknown as import("@pops/db-types").TvShowRow);
+    makeMockDb(undefined, undefined); // No season found
+
+    const ep = makePlexEpisode({ viewCount: 1 });
+    const show = makePlexShow();
+    const client = makePlexClient([show], { "200": [ep] });
+
+    const result = await importTvShowsFromPlex(client, "2");
+
+    expect(result.episodesMatched).toBe(0);
+    expect(mockLogWatch).not.toHaveBeenCalled();
+  });
+
+  it("records errors for failed shows without stopping sync", async () => {
+    const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
+    mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
+    mockGetTvShowByTvdbId.mockReturnValue(null);
+
+    const badShow = makePlexShow({ ratingKey: "1", title: "Bad Show" });
+    const goodShow = makePlexShow({ ratingKey: "2", title: "Good Show" });
+
+    mockAddTvShow.mockRejectedValueOnce(new Error("TVDB timeout")).mockResolvedValueOnce({
+      show: { id: 2, title: "Good Show" } as unknown as import("@pops/db-types").TvShowRow,
+      seasons: [],
+      created: true,
+    });
+
+    const client = makePlexClient([badShow, goodShow], { "2": [] });
+
+    const result = await importTvShowsFromPlex(client, "2");
+
+    expect(result.synced).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].title).toBe("Bad Show");
+    expect(result.errors[0].reason).toContain("TVDB timeout");
+    expect(result.processed).toBe(2);
+  });
+
+  it("calls onProgress callback after each show", async () => {
+    const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
+    mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
+    mockAddTvShow.mockResolvedValue({
+      show: { id: 1, title: "Test" } as unknown as import("@pops/db-types").TvShowRow,
+      seasons: [],
+      created: true,
+    });
+    mockGetTvShowByTvdbId.mockReturnValue(null);
+
+    const shows = [
+      makePlexShow({ ratingKey: "1", title: "Show 1" }),
+      makePlexShow({ ratingKey: "2", title: "Show 2" }),
+    ];
+    const client = makePlexClient(shows, { "1": [], "2": [] });
+    const onProgress = vi.fn();
+
+    await importTvShowsFromPlex(client, "2", { onProgress });
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    const finalProgress = onProgress.mock.calls[1][0];
+    expect(finalProgress.processed).toBe(2);
+    expect(finalProgress.synced).toBe(2);
+    expect(finalProgress.total).toBe(2);
+  });
+
+  it("handles empty library section", async () => {
+    const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
+    mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
+
+    const client = makePlexClient([]);
+
+    const result = await importTvShowsFromPlex(client, "2");
+
+    expect(result.total).toBe(0);
+    expect(result.processed).toBe(0);
+    expect(result.synced).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.episodesMatched).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("ignores duplicate watch history errors", async () => {
+    const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
+    mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
+    mockAddTvShow.mockResolvedValue({
+      show: { id: 1, title: "Breaking Bad" } as unknown as import("@pops/db-types").TvShowRow,
+      seasons: [],
+      created: true,
+    });
+    mockGetTvShowByTvdbId.mockReturnValue({
+      id: 1,
+    } as unknown as import("@pops/db-types").TvShowRow);
+    makeMockDb({ id: 10 }, { id: 100 });
+    mockLogWatch.mockImplementation(() => {
+      throw new Error("UNIQUE constraint failed");
+    });
+
+    const ep = makePlexEpisode({ viewCount: 1, lastViewedAt: 1711400000 });
+    const show = makePlexShow();
+    const client = makePlexClient([show], { "200": [ep] });
+
+    const result = await importTvShowsFromPlex(client, "2");
+
+    // Should still count as synced despite watch history error
+    expect(result.synced).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("handles multiple shows in batch", async () => {
+    const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
+    mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
+    mockGetTvShowByTvdbId.mockReturnValue(null);
+
+    const episodeMap: Record<string, PlexEpisode[]> = {};
+    const shows = Array.from({ length: 4 }, (_, i) => {
+      const show = makePlexShow({
+        ratingKey: String(i + 1),
+        title: `Show ${i + 1}`,
+        externalIds: [{ source: "tvdb", id: String(80000 + i) }],
+      });
+      episodeMap[String(i + 1)] = [];
+      return show;
+    });
+
+    mockAddTvShow.mockResolvedValue({
+      show: { id: 1, title: "Test" } as unknown as import("@pops/db-types").TvShowRow,
+      seasons: [],
+      created: true,
+    });
+
+    const client = makePlexClient(shows, episodeMap);
+
+    const result = await importTvShowsFromPlex(client, "2");
+
+    expect(result.total).toBe(4);
+    expect(result.processed).toBe(4);
+    expect(result.synced).toBe(4);
+    expect(result.errors).toHaveLength(0);
+    expect(mockAddTvShow).toHaveBeenCalledTimes(4);
+  });
+});

--- a/apps/pops-api/src/modules/media/plex/sync-tv.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-tv.ts
@@ -1,0 +1,204 @@
+/**
+ * Plex TV show import — batch sync with progress tracking and episode watch matching.
+ *
+ * Iterates all TV shows in a Plex library section, matches each to a TVDB ID
+ * (via Plex Guid), adds to the local library, fetches episodes from Plex,
+ * and logs watch history for watched episodes.
+ */
+import type { PlexClient } from "./client.js";
+import type { PlexMediaItem, PlexEpisode } from "./types.js";
+import type { TheTvdbClient } from "../thetvdb/client.js";
+import { getTvdbClient } from "../thetvdb/index.js";
+import * as tvShowService from "../library/tv-show-service.js";
+import { getTvShowByTvdbId } from "../tv-shows/service.js";
+import { logWatch } from "../watch-history/service.js";
+import { getDrizzle } from "../../../db.js";
+import { episodes, seasons } from "@pops/db-types";
+import { eq, and } from "drizzle-orm";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TvSyncProgress {
+  total: number;
+  processed: number;
+  synced: number;
+  skipped: number;
+  episodesMatched: number;
+  errors: TvSyncError[];
+}
+
+export interface TvSyncError {
+  title: string;
+  year: number | null;
+  reason: string;
+}
+
+export interface TvSyncOptions {
+  /** Called after each show is processed. */
+  onProgress?: (progress: TvSyncProgress) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Main sync function
+// ---------------------------------------------------------------------------
+
+/**
+ * Import all TV shows from a Plex library section.
+ *
+ * For each Plex TV show:
+ *   1. Extract TVDB ID from Plex Guid array
+ *   2. Add show to library via addTvShow (idempotent)
+ *   3. Fetch episodes from Plex
+ *   4. Match watched episodes to local DB and log watch history
+ */
+export async function importTvShowsFromPlex(
+  plexClient: PlexClient,
+  sectionId: string,
+  options: TvSyncOptions = {}
+): Promise<TvSyncProgress> {
+  const tvdbClient = getTvdbClient();
+  if (!tvdbClient) {
+    return {
+      total: 0,
+      processed: 0,
+      synced: 0,
+      skipped: 0,
+      episodesMatched: 0,
+      errors: [{ title: "Configuration", year: null, reason: "THETVDB_API_KEY not configured" }],
+    };
+  }
+
+  const items = await plexClient.getAllItems(sectionId);
+
+  const progress: TvSyncProgress = {
+    total: items.length,
+    processed: 0,
+    synced: 0,
+    skipped: 0,
+    episodesMatched: 0,
+    errors: [],
+  };
+
+  for (const item of items) {
+    try {
+      await syncSingleShow(item, plexClient, tvdbClient, progress);
+    } catch (err) {
+      progress.errors.push({
+        title: item.title,
+        year: item.year,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    progress.processed++;
+    options.onProgress?.(progress);
+  }
+
+  return progress;
+}
+
+// ---------------------------------------------------------------------------
+// Per-show sync
+// ---------------------------------------------------------------------------
+
+async function syncSingleShow(
+  item: PlexMediaItem,
+  plexClient: PlexClient,
+  tvdbClient: TheTvdbClient,
+  progress: TvSyncProgress
+): Promise<void> {
+  // Step 1: Resolve TVDB ID
+  const tvdbId = resolveTvdbId(item);
+
+  if (!tvdbId) {
+    progress.skipped++;
+    return;
+  }
+
+  // Step 2: Add to library (idempotent)
+  await tvShowService.addTvShow(tvdbId, tvdbClient);
+
+  // Step 3: Sync episode watches
+  const plexEpisodes = await plexClient.getEpisodes(item.ratingKey);
+  const matched = syncEpisodeWatches(tvdbId, plexEpisodes);
+  progress.episodesMatched += matched;
+
+  progress.synced++;
+}
+
+// ---------------------------------------------------------------------------
+// TVDB ID resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract TVDB ID from a Plex media item's Guid array.
+ * Returns null if no TVDB Guid is found or the ID is not numeric.
+ */
+function resolveTvdbId(item: PlexMediaItem): number | null {
+  const tvdbGuid = item.externalIds.find((id) => id.source === "tvdb");
+  if (!tvdbGuid) return null;
+
+  const parsed = Number(tvdbGuid.id);
+  if (Number.isNaN(parsed)) return null;
+
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Episode watch sync
+// ---------------------------------------------------------------------------
+
+/**
+ * Match Plex episodes to local DB episodes by season+episode number
+ * and log watch history for watched episodes.
+ *
+ * Returns the number of episodes matched and logged.
+ */
+function syncEpisodeWatches(tvdbId: number, plexEpisodes: PlexEpisode[]): number {
+  const show = getTvShowByTvdbId(tvdbId);
+  if (!show) return 0;
+
+  const db = getDrizzle();
+  let matched = 0;
+
+  for (const plexEp of plexEpisodes) {
+    if (plexEp.viewCount === 0) continue;
+
+    try {
+      // Find the local season
+      const season = db
+        .select()
+        .from(seasons)
+        .where(and(eq(seasons.tvShowId, show.id), eq(seasons.seasonNumber, plexEp.seasonIndex)))
+        .get();
+      if (!season) continue;
+
+      // Find the local episode
+      const episode = db
+        .select()
+        .from(episodes)
+        .where(
+          and(eq(episodes.seasonId, season.id), eq(episodes.episodeNumber, plexEp.episodeIndex))
+        )
+        .get();
+      if (!episode) continue;
+
+      logWatch({
+        mediaType: "episode",
+        mediaId: episode.id,
+        watchedAt: plexEp.lastViewedAt
+          ? new Date(plexEp.lastViewedAt * 1000).toISOString()
+          : new Date().toISOString(),
+        completed: 1,
+      });
+
+      matched++;
+    } catch {
+      // Ignore duplicate or failed episode watch entries
+    }
+  }
+
+  return matched;
+}


### PR DESCRIPTION
## Summary
- Add `importTvShowsFromPlex()` batch sync function with progress callback tracking
- TVDB ID resolution from Plex Guid array
- Library sync via `addTvShow()` (idempotent), episode fetching from Plex
- Per-episode watch history matching by season+episode number against local DB
- 12 unit tests covering all sync paths (TVDB Guid match, skipped shows, episode watch sync, unwatched episodes, error handling, batch, empty library, duplicate watch entries)

## Test plan
- [x] 12 vitest unit tests pass (`sync-tv.test.ts`)
- [ ] CI green (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)