### PR TITLE
feat: filtered value aggregation on inventory list [PRD-023/US-5] (tb-151)

### DIFF
--- a/apps/pops-api/src/modules/inventory/items/router.ts
+++ b/apps/pops-api/src/modules/inventory/items/router.ts
@@ -28,7 +28,7 @@ export const inventoryRouter = router({
     const deductible =
       input.deductible === "true" ? true : input.deductible === "false" ? false : undefined;
 
-    const { rows, total } = service.listInventoryItems(
+    const { rows, total, totalReplacementValue, totalResaleValue } = service.listInventoryItems(
       input.search,
       input.room,
       input.type,
@@ -44,6 +44,8 @@ export const inventoryRouter = router({
     return {
       data: rows.map(toInventoryItem),
       pagination: paginationMeta(total, limit, offset),
+      totalReplacementValue,
+      totalResaleValue,
     };
   }),
 

--- a/apps/pops-api/src/modules/inventory/items/service.ts
+++ b/apps/pops-api/src/modules/inventory/items/service.ts
@@ -3,7 +3,7 @@
  * SQLite is the source of truth. All operations are local.
  */
 import crypto from "crypto";
-import { eq, like, count, and } from "drizzle-orm";
+import { eq, like, count, and, sum } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
 import { homeInventory } from "@pops/db-types";
 import { NotFoundError } from "../../../shared/errors.js";
@@ -13,6 +13,8 @@ import type { InventoryRow, CreateInventoryItemInput, UpdateInventoryItemInput }
 export interface InventoryListResult {
   rows: InventoryRow[];
   total: number;
+  totalReplacementValue: number;
+  totalResaleValue: number;
 }
 
 /** List inventory items with optional filters. */
@@ -32,6 +34,13 @@ export function listInventoryItems(
 
   let query = db.select().from(homeInventory).$dynamic();
   let countQuery = db.select({ total: count() }).from(homeInventory).$dynamic();
+  let aggregateQuery = db
+    .select({
+      totalReplacementValue: sum(homeInventory.replacementValue),
+      totalResaleValue: sum(homeInventory.resaleValue),
+    })
+    .from(homeInventory)
+    .$dynamic();
 
   const conditions = [];
   if (search) {
@@ -63,13 +72,20 @@ export function listInventoryItems(
     const where = conditions.length === 1 ? conditions[0] : and(...conditions);
     query = query.where(where);
     countQuery = countQuery.where(where);
+    aggregateQuery = aggregateQuery.where(where);
   }
 
   const rows = query.orderBy(homeInventory.itemName).limit(limit).offset(offset).all();
 
   const [countResult] = countQuery.all();
+  const [aggregates] = aggregateQuery.all();
 
-  return { rows: rows, total: countResult.total };
+  return {
+    rows,
+    total: countResult.total,
+    totalReplacementValue: Number(aggregates.totalReplacementValue ?? 0),
+    totalResaleValue: Number(aggregates.totalResaleValue ?? 0),
+  };
 }
 
 /** Get a single inventory item by id. Throws NotFoundError if missing. */

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -105,11 +105,8 @@ export function ItemsPage() {
 
   const items = data?.data ?? [];
   const totalCount = data?.pagination?.total ?? 0;
-
-  const totalValue = useMemo(
-    () => items.reduce((sum, item) => sum + (item.replacementValue ?? 0), 0),
-    [items],
-  );
+  const totalReplacementValue = data?.totalReplacementValue ?? 0;
+  const totalResaleValue = data?.totalResaleValue ?? 0;
 
   const handleViewChange = useCallback((mode: ViewMode) => {
     setViewMode(mode);
@@ -208,8 +205,11 @@ export function ItemsPage() {
       {!isLoading && (
         <p className="text-sm text-muted-foreground">
           {totalCount} {totalCount === 1 ? "item" : "items"}
-          {totalValue > 0 && (
-            <span> · Total value: {formatCurrency(totalValue)}</span>
+          {totalReplacementValue > 0 && (
+            <span> · {formatCurrency(totalReplacementValue)} replacement</span>
+          )}
+          {totalResaleValue > 0 && (
+            <span> · {formatCurrency(totalResaleValue)} resale</span>
           )}
         </p>
       )}


### PR DESCRIPTION
## Summary
- Add server-side `SUM(replacement_value)` and `SUM(resale_value)` to inventory list query
- Aggregates respect all active filters (search, type, condition, inUse, location, etc.)
- Pass `totalReplacementValue` and `totalResaleValue` through router response
- ItemsPage summary line shows both values (e.g. "23 items · $12,400 replacement · $5,200 resale")
- Replaces previous client-side reduce computation

## Test plan
- [x] 34 inventory item tests passing
- [x] API typecheck clean
- [ ] Verify aggregates update when filters change
- [ ] Verify values show $0/hidden when no items have values set

🤖 Generated with [Claude Code](https://claude.com/claude-code)