### PR TITLE
feat: Paperless graceful degradation (tb-157)

### DIFF
--- a/apps/pops-api/src/modules/inventory/index.ts
+++ b/apps/pops-api/src/modules/inventory/index.ts
@@ -8,6 +8,7 @@ import { connectionsRouter } from "./connections/index.js";
 import { photosRouter } from "./photos/index.js";
 import { reportsRouter } from "./reports/index.js";
 import { documentsRouter } from "./documents/index.js";
+import { paperlessRouter } from "./paperless/router.js";
 
 export const inventoryRouter = router({
   items: itemsRouter,
@@ -16,4 +17,5 @@ export const inventoryRouter = router({
   photos: photosRouter,
   reports: reportsRouter,
   documents: documentsRouter,
+  paperless: paperlessRouter,
 });

--- a/apps/pops-api/src/modules/inventory/paperless/router.ts
+++ b/apps/pops-api/src/modules/inventory/paperless/router.ts
@@ -1,0 +1,27 @@
+/**
+ * Paperless tRPC router — connection status for graceful degradation.
+ */
+import { router, protectedProcedure } from "../../../trpc.js";
+import { getEnv } from "../../../env.js";
+
+export const paperlessRouter = router({
+  /** Check if Paperless-ngx is configured and reachable. */
+  status: protectedProcedure.query(async () => {
+    const url = getEnv("PAPERLESS_URL");
+    const token = getEnv("PAPERLESS_TOKEN");
+    if (!url || !token) {
+      return { data: { configured: false, available: false } };
+    }
+
+    try {
+      const baseUrl = url.replace(/\/+$/, "");
+      const response = await fetch(`${baseUrl}/api/`, {
+        headers: { Authorization: `Token ${token}` },
+        signal: AbortSignal.timeout(3000),
+      });
+      return { data: { configured: true, available: response.ok } };
+    } catch {
+      return { data: { configured: true, available: false } };
+    }
+  }),
+});

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -12,7 +12,14 @@ import {
   AlertDescription,
   Skeleton,
 } from "@pops/ui";
-import { ArrowLeft, Pencil, Link2, Unlink } from "lucide-react";
+import {
+  ArrowLeft,
+  Pencil,
+  Link2,
+  Unlink,
+  FileText,
+  AlertTriangle,
+} from "lucide-react";
 import { trpc } from "../lib/trpc";
 import { ConnectDialog } from "../components/ConnectDialog";
 
@@ -194,7 +201,99 @@ export function ItemDetailPage() {
           </p>
         )}
       </section>
+
+      {/* Documents */}
+      <DocumentsSection itemId={id!} />
     </div>
+  );
+}
+
+function DocumentsSection({ itemId }: { itemId: string }) {
+  const { data: statusData, isLoading: statusLoading } =
+    trpc.inventory.paperless.status.useQuery();
+
+  const status = statusData?.data;
+
+  // Not configured — hide entirely
+  if (!statusLoading && (!status || !status.configured)) {
+    return null;
+  }
+
+  // Configured but unavailable
+  if (!statusLoading && status?.configured && !status.available) {
+    return (
+      <section className="mt-8">
+        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
+          <FileText className="h-5 w-5" />
+          Documents
+        </h2>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <AlertTriangle className="h-4 w-4" />
+          Paperless-ngx unavailable
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <DocumentsList
+      itemId={itemId}
+      isReady={!statusLoading && !!status?.available}
+    />
+  );
+}
+
+function DocumentsList({
+  itemId,
+  isReady,
+}: {
+  itemId: string;
+  isReady: boolean;
+}) {
+  const { data, isLoading } = trpc.inventory.documents.listForItem.useQuery(
+    { itemId },
+    { enabled: isReady },
+  );
+
+  const docs = data?.data ?? [];
+
+  return (
+    <section className="mt-8">
+      <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
+        <FileText className="h-5 w-5" />
+        Documents
+      </h2>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+      ) : docs.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No linked documents.</p>
+      ) : (
+        <div className="space-y-2">
+          {docs.map((doc) => (
+            <div
+              key={doc.id}
+              className="flex items-center justify-between p-3 rounded-lg border"
+            >
+              <div className="flex items-center gap-3">
+                <FileText className="h-4 w-4 text-muted-foreground" />
+                <div>
+                  <p className="text-sm font-medium">
+                    {doc.title ?? `Document #${doc.paperlessDocumentId}`}
+                  </p>
+                  <Badge variant="secondary" className="text-xs mt-0.5">
+                    {doc.documentType}
+                  </Badge>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds `inventory.paperless.status` tRPC endpoint that checks if Paperless-ngx is configured (env vars set) and reachable (3s timeout health check)
- Adds Documents section to `ItemDetailPage.tsx` with three states:
  - **Not configured**: section hidden entirely (no errors)
  - **Configured but unreachable**: muted "Paperless-ngx unavailable" message
  - **Available**: lists linked documents from `inventory.documents.listForItem`
- Wires paperless router into inventory module index

## Test plan
- [ ] Without `PAPERLESS_URL`/`PAPERLESS_TOKEN` set, verify Documents section is hidden on item detail page
- [ ] With env vars set but Paperless unreachable, verify "Paperless-ngx unavailable" message appears
- [ ] With Paperless running, verify linked documents are listed with type badges
- [ ] Verify item detail page works fully without documents section (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)