### PR TITLE
feat: Radarr/Sonarr graceful degradation (tb-158)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,5 +26,13 @@ RADARR_API_KEY=
 SONARR_URL=
 SONARR_API_KEY=
 
+# Plex Media Server (optional — library sync)
+PLEX_URL=
+PLEX_TOKEN=
+
+# Paperless-ngx (optional — document management)
+PAPERLESS_URL=
+PAPERLESS_TOKEN=
+
 # Paths
 SQLITE_PATH=./data/pops.db

--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -8,51 +8,43 @@ import { ArrApiError } from "./types.js";
 import * as arrService from "./service.js";
 
 export const arrRouter = router({
-  /** Test Radarr connection and return server version. */
+  /** Test Radarr connection and return server version. Safe to call when not configured. */
   testRadarr: protectedProcedure.query(async () => {
     const client = arrService.getRadarrClient();
     if (!client) {
-      throw new TRPCError({
-        code: "PRECONDITION_FAILED",
-        message: "Radarr is not configured (RADARR_URL / RADARR_API_KEY not set)",
-      });
+      return { data: { configured: false, connected: false } };
     }
 
     try {
       const status = await client.testConnection();
-      return { data: status, message: "Radarr connection successful" };
+      return {
+        data: { configured: true, connected: true, ...status },
+        message: "Radarr connection successful",
+      };
     } catch (err) {
-      if (err instanceof ArrApiError) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: `Radarr error: ${err.message}`,
-        });
-      }
-      throw err;
+      const errorMsg =
+        err instanceof ArrApiError ? err.message : err instanceof Error ? err.message : String(err);
+      return { data: { configured: true, connected: false, error: errorMsg } };
     }
   }),
 
-  /** Test Sonarr connection and return server version. */
+  /** Test Sonarr connection and return server version. Safe to call when not configured. */
   testSonarr: protectedProcedure.query(async () => {
     const client = arrService.getSonarrClient();
     if (!client) {
-      throw new TRPCError({
-        code: "PRECONDITION_FAILED",
-        message: "Sonarr is not configured (SONARR_URL / SONARR_API_KEY not set)",
-      });
+      return { data: { configured: false, connected: false } };
     }
 
     try {
       const status = await client.testConnection();
-      return { data: status, message: "Sonarr connection successful" };
+      return {
+        data: { configured: true, connected: true, ...status },
+        message: "Sonarr connection successful",
+      };
     } catch (err) {
-      if (err instanceof ArrApiError) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: `Sonarr error: ${err.message}`,
-        });
-      }
-      throw err;
+      const errorMsg =
+        err instanceof ArrApiError ? err.message : err instanceof Error ? err.message : String(err);
+      return { data: { configured: true, connected: false, error: errorMsg } };
     }
   }),
 

--- a/apps/pops-api/src/modules/media/arr/service.ts
+++ b/apps/pops-api/src/modules/media/arr/service.ts
@@ -39,7 +39,7 @@ export function getArrConfig(): ArrConfig {
   };
 }
 
-/** Get movie status from Radarr with caching. */
+/** Get movie status from Radarr with caching. Returns stale cache on connection failure. */
 export async function getMovieStatus(tmdbId: number): Promise<ArrStatusResult> {
   const cached = movieStatusCache.get(tmdbId);
   if (cached && cached.expiresAt > Date.now()) {
@@ -51,16 +51,24 @@ export async function getMovieStatus(tmdbId: number): Promise<ArrStatusResult> {
     return { status: "not_found", label: "Radarr not configured" };
   }
 
-  const result = await client.getMovieStatus(tmdbId);
-  movieStatusCache.set(tmdbId, {
-    result,
-    expiresAt: Date.now() + CACHE_TTL_MS,
-  });
-
-  return result;
+  try {
+    const result = await client.getMovieStatus(tmdbId);
+    movieStatusCache.set(tmdbId, {
+      result,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    });
+    return result;
+  } catch (err) {
+    console.warn(
+      `Radarr connection failure for tmdbId=${tmdbId}:`,
+      err instanceof Error ? err.message : err
+    );
+    if (cached) return cached.result;
+    return { status: "unavailable", label: "Radarr unavailable" };
+  }
 }
 
-/** Get TV show status from Sonarr with caching. */
+/** Get TV show status from Sonarr with caching. Returns stale cache on connection failure. */
 export async function getShowStatus(tvdbId: number): Promise<ArrStatusResult> {
   const cached = showStatusCache.get(tvdbId);
   if (cached && cached.expiresAt > Date.now()) {
@@ -72,13 +80,21 @@ export async function getShowStatus(tvdbId: number): Promise<ArrStatusResult> {
     return { status: "not_found", label: "Sonarr not configured" };
   }
 
-  const result = await client.getShowStatus(tvdbId);
-  showStatusCache.set(tvdbId, {
-    result,
-    expiresAt: Date.now() + CACHE_TTL_MS,
-  });
-
-  return result;
+  try {
+    const result = await client.getShowStatus(tvdbId);
+    showStatusCache.set(tvdbId, {
+      result,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    });
+    return result;
+  } catch (err) {
+    console.warn(
+      `Sonarr connection failure for tvdbId=${tvdbId}:`,
+      err instanceof Error ? err.message : err
+    );
+    if (cached) return cached.result;
+    return { status: "unavailable", label: "Sonarr unavailable" };
+  }
 }
 
 const QUEUE_CACHE_TTL_MS = 30 * 1000; // 30 seconds
@@ -109,9 +125,7 @@ export async function getDownloadQueue(): Promise<DownloadQueueItem[]> {
   if (radarrQueue) {
     for (const record of radarrQueue.records) {
       const progress =
-        record.size > 0
-          ? Math.round(((record.size - record.sizeleft) / record.size) * 100)
-          : 0;
+        record.size > 0 ? Math.round(((record.size - record.sizeleft) / record.size) * 100) : 0;
       items.push({
         id: `radarr-${record.id}`,
         title: record.title,
@@ -125,9 +139,7 @@ export async function getDownloadQueue(): Promise<DownloadQueueItem[]> {
   if (sonarrQueue) {
     for (const record of sonarrQueue.records) {
       const progress =
-        record.size > 0
-          ? Math.round(((record.size - record.sizeleft) / record.size) * 100)
-          : 0;
+        record.size > 0 ? Math.round(((record.size - record.sizeleft) / record.size) * 100) : 0;
       const episodeLabel = record.episode
         ? `S${String(record.episode.seasonNumber).padStart(2, "0")}E${String(record.episode.episodeNumber).padStart(2, "0")}`
         : undefined;

--- a/apps/pops-api/src/modules/media/arr/types.ts
+++ b/apps/pops-api/src/modules/media/arr/types.ts
@@ -10,7 +10,8 @@ export type ArrStatus =
   | "unmonitored"
   | "complete"
   | "partial"
-  | "not_found";
+  | "not_found"
+  | "unavailable";
 
 /** Status result returned to the frontend. */
 export interface ArrStatusResult {

--- a/packages/app-media/src/components/ArrStatusBadge.tsx
+++ b/packages/app-media/src/components/ArrStatusBadge.tsx
@@ -22,6 +22,7 @@ const STATUS_STYLES: Record<string, string> = {
   partial: "bg-yellow-600 text-white",
   unmonitored: "bg-muted text-muted-foreground",
   not_found: "bg-muted text-muted-foreground",
+  unavailable: "bg-muted text-muted-foreground",
 };
 
 export function ArrStatusBadge({ kind, externalId }: ArrStatusBadgeProps) {
@@ -44,14 +45,19 @@ export function ArrStatusBadge({ kind, externalId }: ArrStatusBadgeProps) {
   if (!isConfigured) return null;
 
   const query = kind === "movie" ? movieStatus : showStatus;
-  if (query.isLoading || !query.data?.data) return null;
+  if (query.isLoading) return null;
+
+  // Show unavailable badge when query errors (configured but unreachable)
+  if (query.error) {
+    const label =
+      kind === "movie" ? "Radarr unavailable" : "Sonarr unavailable";
+    return <Badge className={STATUS_STYLES.unavailable}>{label}</Badge>;
+  }
+
+  if (!query.data?.data) return null;
 
   const result = query.data.data;
   const colorClass = STATUS_STYLES[result.status] ?? STATUS_STYLES.not_found;
 
-  return (
-    <Badge className={colorClass}>
-      {result.label}
-    </Badge>
-  );
+  return <Badge className={colorClass}>{result.label}</Badge>;
 }


### PR DESCRIPTION
## Summary
- Service layer wraps `getMovieStatus`/`getShowStatus` in try/catch — returns stale cache on connection failure, logs via `console.warn`, returns `"unavailable"` status when no cache available
- `testRadarr`/`testSonarr` router endpoints return `{ configured, connected }` instead of throwing `PRECONDITION_FAILED` when not configured — safe to call unconditionally
- `ArrStatusBadge` shows muted "Radarr unavailable" / "Sonarr unavailable" badge when query errors instead of silently hiding
- Added `"unavailable"` to `ArrStatus` union type
- Added `PLEX_URL`, `PLEX_TOKEN`, `PAPERLESS_URL`, `PAPERLESS_TOKEN` to `.env.example`

## Test plan
- [ ] Without Radarr/Sonarr env vars set, verify media pages load without errors
- [ ] With env vars set but services unreachable, verify "unavailable" badges appear
- [ ] With services running, verify existing badge behavior unchanged
- [ ] Verify `getConfig` still correctly reports configured state
- [ ] Verify download queue handles connection failures gracefully (already did before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)