### PR TITLE
feat: linked documents display on item detail page [tb-150]

### DIFF
--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -1,5 +1,5 @@
 /**
- * Item detail page — shows item info and connected items.
+ * Item detail page — shows item info, documents, and connected items.
  * Route: /inventory/items/:id
  */
 import { useParams, Link } from "react-router";


### PR DESCRIPTION
## Summary
- Display linked documents on the item detail page, grouped by document type (receipts, warranties, manuals, invoices, other)
- Each document shows its title (or fallback ID), linked date, and an unlink button
- Documents section appears between Notes and Connected Items sections

## Test plan
- [ ] Navigate to an item detail page with linked documents — verify documents display grouped by type
- [ ] Verify document titles and linked dates render correctly
- [ ] Click unlink button — verify document is removed and list refreshes
- [ ] Navigate to item with no documents — verify "No documents linked yet." message

🤖 Generated with [Claude Code](https://claude.com/claude-code)