### PR TITLE
feat: Radarr/Sonarr graceful degradation [PRD-016/US-5] (tb-158)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,5 +26,9 @@ RADARR_API_KEY=
 SONARR_URL=
 SONARR_API_KEY=
 
+# Paperless-ngx (document management)
+PAPERLESS_URL=
+PAPERLESS_TOKEN=
+
 # Paths
 SQLITE_PATH=./data/pops.db

--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -12,23 +12,15 @@ export const arrRouter = router({
   testRadarr: protectedProcedure.query(async () => {
     const client = arrService.getRadarrClient();
     if (!client) {
-      throw new TRPCError({
-        code: "PRECONDITION_FAILED",
-        message: "Radarr is not configured (RADARR_URL / RADARR_API_KEY not set)",
-      });
+      return { data: null, connected: false, error: "Radarr is not configured" };
     }
 
     try {
       const status = await client.testConnection();
-      return { data: status, message: "Radarr connection successful" };
+      return { data: status, connected: true, message: "Radarr connection successful" };
     } catch (err) {
-      if (err instanceof ArrApiError) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: `Radarr error: ${err.message}`,
-        });
-      }
-      throw err;
+      const message = err instanceof ArrApiError ? err.message : "Connection failed";
+      return { data: null, connected: false, error: message };
     }
   }),
 
@@ -36,23 +28,15 @@ export const arrRouter = router({
   testSonarr: protectedProcedure.query(async () => {
     const client = arrService.getSonarrClient();
     if (!client) {
-      throw new TRPCError({
-        code: "PRECONDITION_FAILED",
-        message: "Sonarr is not configured (SONARR_URL / SONARR_API_KEY not set)",
-      });
+      return { data: null, connected: false, error: "Sonarr is not configured" };
     }
 
     try {
       const status = await client.testConnection();
-      return { data: status, message: "Sonarr connection successful" };
+      return { data: status, connected: true, message: "Sonarr connection successful" };
     } catch (err) {
-      if (err instanceof ArrApiError) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: `Sonarr error: ${err.message}`,
-        });
-      }
-      throw err;
+      const message = err instanceof ArrApiError ? err.message : "Connection failed";
+      return { data: null, connected: false, error: message };
     }
   }),
 
@@ -65,18 +49,8 @@ export const arrRouter = router({
   getMovieStatus: protectedProcedure
     .input(z.object({ tmdbId: z.number().int().positive() }))
     .query(async ({ input }) => {
-      try {
-        const result = await arrService.getMovieStatus(input.tmdbId);
-        return { data: result };
-      } catch (err) {
-        if (err instanceof ArrApiError) {
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: `Radarr error: ${err.message}`,
-          });
-        }
-        throw err;
-      }
+      const result = await arrService.getMovieStatus(input.tmdbId);
+      return { data: result };
     }),
 
   /** Get combined download queue from Radarr + Sonarr. */
@@ -99,17 +73,7 @@ export const arrRouter = router({
   getShowStatus: protectedProcedure
     .input(z.object({ tvdbId: z.number().int().positive() }))
     .query(async ({ input }) => {
-      try {
-        const result = await arrService.getShowStatus(input.tvdbId);
-        return { data: result };
-      } catch (err) {
-        if (err instanceof ArrApiError) {
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: `Sonarr error: ${err.message}`,
-          });
-        }
-        throw err;
-      }
+      const result = await arrService.getShowStatus(input.tvdbId);
+      return { data: result };
     }),
 });

--- a/apps/pops-api/src/modules/media/arr/service.ts
+++ b/apps/pops-api/src/modules/media/arr/service.ts
@@ -39,7 +39,7 @@ export function getArrConfig(): ArrConfig {
   };
 }
 
-/** Get movie status from Radarr with caching. */
+/** Get movie status from Radarr with caching. Serves stale cache on failure. */
 export async function getMovieStatus(tmdbId: number): Promise<ArrStatusResult> {
   const cached = movieStatusCache.get(tmdbId);
   if (cached && cached.expiresAt > Date.now()) {
@@ -51,16 +51,24 @@ export async function getMovieStatus(tmdbId: number): Promise<ArrStatusResult> {
     return { status: "not_found", label: "Radarr not configured" };
   }
 
-  const result = await client.getMovieStatus(tmdbId);
-  movieStatusCache.set(tmdbId, {
-    result,
-    expiresAt: Date.now() + CACHE_TTL_MS,
-  });
-
-  return result;
+  try {
+    const result = await client.getMovieStatus(tmdbId);
+    movieStatusCache.set(tmdbId, {
+      result,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    });
+    return result;
+  } catch (err) {
+    console.warn(
+      `Radarr connection failed for tmdbId=${tmdbId}:`,
+      err instanceof Error ? err.message : err
+    );
+    if (cached) return cached.result;
+    return { status: "not_found", label: "Radarr unavailable" };
+  }
 }
 
-/** Get TV show status from Sonarr with caching. */
+/** Get TV show status from Sonarr with caching. Serves stale cache on failure. */
 export async function getShowStatus(tvdbId: number): Promise<ArrStatusResult> {
   const cached = showStatusCache.get(tvdbId);
   if (cached && cached.expiresAt > Date.now()) {
@@ -72,13 +80,21 @@ export async function getShowStatus(tvdbId: number): Promise<ArrStatusResult> {
     return { status: "not_found", label: "Sonarr not configured" };
   }
 
-  const result = await client.getShowStatus(tvdbId);
-  showStatusCache.set(tvdbId, {
-    result,
-    expiresAt: Date.now() + CACHE_TTL_MS,
-  });
-
-  return result;
+  try {
+    const result = await client.getShowStatus(tvdbId);
+    showStatusCache.set(tvdbId, {
+      result,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    });
+    return result;
+  } catch (err) {
+    console.warn(
+      `Sonarr connection failed for tvdbId=${tvdbId}:`,
+      err instanceof Error ? err.message : err
+    );
+    if (cached) return cached.result;
+    return { status: "not_found", label: "Sonarr unavailable" };
+  }
 }
 
 const QUEUE_CACHE_TTL_MS = 30 * 1000; // 30 seconds

--- a/packages/app-media/src/components/ArrStatusBadge.tsx
+++ b/packages/app-media/src/components/ArrStatusBadge.tsx
@@ -33,18 +33,30 @@ export function ArrStatusBadge({ kind, externalId }: ArrStatusBadgeProps) {
 
   const movieStatus = trpc.media.arr.getMovieStatus.useQuery(
     { tmdbId: externalId },
-    { enabled: kind === "movie" && isConfigured === true },
+    { enabled: kind === "movie" && isConfigured === true, retry: false },
   );
 
   const showStatus = trpc.media.arr.getShowStatus.useQuery(
     { tvdbId: externalId },
-    { enabled: kind === "show" && isConfigured === true },
+    { enabled: kind === "show" && isConfigured === true, retry: false },
   );
 
   if (!isConfigured) return null;
 
   const query = kind === "movie" ? movieStatus : showStatus;
-  if (query.isLoading || !query.data?.data) return null;
+
+  if (query.isLoading) return null;
+
+  if (query.isError) {
+    const label = kind === "movie" ? "Radarr unavailable" : "Sonarr unavailable";
+    return (
+      <Badge className={STATUS_STYLES.not_found}>
+        {label}
+      </Badge>
+    );
+  }
+
+  if (!query.data?.data) return null;
 
   const result = query.data.data;
   const colorClass = STATUS_STYLES[result.status] ?? STATUS_STYLES.not_found;


### PR DESCRIPTION
## Summary
- Service layer catches connection failures, serves stale cache when available, logs warnings via `console.warn`
- Router `testRadarr`/`testSonarr` return `{ connected: false, error }` instead of throwing `PRECONDITION_FAILED`
- `ArrStatusBadge` shows muted "Radarr/Sonarr unavailable" badge on query error instead of hiding
- Added `PAPERLESS_URL`/`PAPERLESS_TOKEN` to `.env.example`

## Test plan
- [ ] Verify no errors when RADARR_URL/SONARR_URL not set — badges hidden
- [ ] Verify "unavailable" badge shown when configured but unreachable
- [ ] Verify stale cache served when connection drops after initial success
- [ ] Verify download queue works when one service is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)