### PR TITLE
feat: TV show progress indicators [PRD-012/US-4] (tb-162)

### DIFF
--- a/apps/pops-api/src/modules/media/watch-history/router.ts
+++ b/apps/pops-api/src/modules/media/watch-history/router.ts
@@ -8,6 +8,7 @@ import { paginationMeta } from "../../../shared/pagination.js";
 import {
   LogWatchSchema,
   BatchLogWatchSchema,
+  BatchProgressQuerySchema,
   WatchHistoryQuerySchema,
   ProgressQuerySchema,
   RecentWatchHistoryQuerySchema,
@@ -91,6 +92,11 @@ export const watchHistoryRouter = router({
       }
       throw err;
     }
+  }),
+
+  /** Get watch progress percentages for multiple TV shows (for library grid). */
+  batchProgress: protectedProcedure.input(BatchProgressQuerySchema).query(({ input }) => {
+    return { data: service.getBatchProgress(input.tvShowIds) };
   }),
 
   /** Batch-log watch events for all episodes in a season or show. */

--- a/apps/pops-api/src/modules/media/watch-history/service.ts
+++ b/apps/pops-api/src/modules/media/watch-history/service.ts
@@ -15,7 +15,9 @@ import type {
   WatchHistoryFilters,
   TvShowProgress,
   SeasonProgress,
+  NextEpisode,
   BatchLogWatchInput,
+  BatchProgressEntry,
   RecentWatchHistoryFilters,
   RecentWatchHistoryEntry,
 } from "./types.js";
@@ -359,6 +361,9 @@ export function getProgress(tvShowId: number): TvShowProgress {
   const totalWatched = seasonProgress.reduce((sum, s) => sum + s.watched, 0);
   const totalEpisodes = seasonProgress.reduce((sum, s) => sum + s.total, 0);
 
+  // Find next unwatched episode
+  const nextEpisode = findNextUnwatchedEpisode(db, tvShowId);
+
   return {
     tvShowId,
     overall: {
@@ -367,7 +372,60 @@ export function getProgress(tvShowId: number): TvShowProgress {
       percentage: totalEpisodes > 0 ? Math.round((totalWatched / totalEpisodes) * 100) : 0,
     },
     seasons: seasonProgress,
+    nextEpisode,
   };
+}
+
+function findNextUnwatchedEpisode(
+  db: ReturnType<typeof getDrizzle>,
+  tvShowId: number
+): NextEpisode | null {
+  // Get all episodes for this show, ordered by season then episode
+  const allEpisodes = db
+    .select({
+      episodeId: episodes.id,
+      seasonNumber: seasons.seasonNumber,
+      episodeNumber: episodes.episodeNumber,
+      episodeName: episodes.name,
+    })
+    .from(episodes)
+    .innerJoin(seasons, eq(episodes.seasonId, seasons.id))
+    .where(eq(seasons.tvShowId, tvShowId))
+    .orderBy(seasons.seasonNumber, episodes.episodeNumber)
+    .all();
+
+  if (allEpisodes.length === 0) return null;
+
+  // Get set of watched episode IDs
+  const watchedIds = new Set(
+    db
+      .select({ mediaId: watchHistory.mediaId })
+      .from(watchHistory)
+      .innerJoin(episodes, eq(episodes.id, watchHistory.mediaId))
+      .innerJoin(seasons, eq(seasons.id, episodes.seasonId))
+      .where(
+        and(
+          eq(watchHistory.mediaType, "episode"),
+          eq(watchHistory.completed, 1),
+          eq(seasons.tvShowId, tvShowId)
+        )
+      )
+      .all()
+      .map((r) => r.mediaId)
+  );
+
+  // Find first unwatched
+  for (const ep of allEpisodes) {
+    if (!watchedIds.has(ep.episodeId)) {
+      return {
+        seasonNumber: ep.seasonNumber,
+        episodeNumber: ep.episodeNumber,
+        episodeName: ep.episodeName,
+      };
+    }
+  }
+
+  return null; // All watched
 }
 
 /** Result of a batch log operation. */
@@ -502,6 +560,57 @@ export function batchLogWatch(input: BatchLogWatchInput): BatchLogResult {
     }
 
     return { logged: toLog.length, skipped: alreadyWatched.size };
+  });
+}
+
+/**
+ * Get watch progress percentages for multiple TV shows in a single query.
+ * Returns only the overall percentage per show (lightweight for grid views).
+ */
+export function getBatchProgress(tvShowIds: number[]): BatchProgressEntry[] {
+  if (tvShowIds.length === 0) return [];
+
+  const db = getDrizzle();
+
+  // Get total episode counts per show
+  const totalRows = db
+    .select({
+      tvShowId: seasons.tvShowId,
+      total: count(episodes.id),
+    })
+    .from(episodes)
+    .innerJoin(seasons, eq(episodes.seasonId, seasons.id))
+    .where(inArray(seasons.tvShowId, tvShowIds))
+    .groupBy(seasons.tvShowId)
+    .all();
+
+  // Get watched episode counts per show
+  const watchedRows = db
+    .select({
+      tvShowId: seasons.tvShowId,
+      watched: countDistinct(watchHistory.mediaId),
+    })
+    .from(watchHistory)
+    .innerJoin(episodes, eq(episodes.id, watchHistory.mediaId))
+    .innerJoin(seasons, eq(seasons.id, episodes.seasonId))
+    .where(
+      and(
+        eq(watchHistory.mediaType, "episode"),
+        eq(watchHistory.completed, 1),
+        inArray(seasons.tvShowId, tvShowIds)
+      )
+    )
+    .groupBy(seasons.tvShowId)
+    .all();
+
+  const watchedMap = new Map(watchedRows.map((r) => [r.tvShowId, r.watched]));
+
+  return totalRows.map((row) => {
+    const watched = watchedMap.get(row.tvShowId) ?? 0;
+    return {
+      tvShowId: row.tvShowId,
+      percentage: row.total > 0 ? Math.round((watched / row.total) * 100) : 0,
+    };
   });
 }
 

--- a/apps/pops-api/src/modules/media/watch-history/types.ts
+++ b/apps/pops-api/src/modules/media/watch-history/types.ts
@@ -74,6 +74,13 @@ export interface SeasonProgress {
   percentage: number;
 }
 
+/** Next unwatched episode pointer. */
+export interface NextEpisode {
+  seasonNumber: number;
+  episodeNumber: number;
+  episodeName: string | null;
+}
+
 /** Overall + per-season watch progress for a TV show. */
 export interface TvShowProgress {
   tvShowId: number;
@@ -83,7 +90,19 @@ export interface TvShowProgress {
     percentage: number;
   };
   seasons: SeasonProgress[];
+  nextEpisode: NextEpisode | null;
 }
+
+/** Batch progress result — percentage per TV show. */
+export interface BatchProgressEntry {
+  tvShowId: number;
+  percentage: number;
+}
+
+/** Zod schema for batch progress query. */
+export const BatchProgressQuerySchema = z.object({
+  tvShowIds: z.array(z.number().int().positive()).min(1).max(500),
+});
 
 /** Zod schema for listRecent query params with date range and mediaType filters. */
 export const RecentWatchHistoryQuerySchema = z.object({

--- a/packages/app-media/src/hooks/useMediaLibrary.ts
+++ b/packages/app-media/src/hooks/useMediaLibrary.ts
@@ -14,6 +14,8 @@ interface MediaItem {
   voteAverage: number | null;
   createdAt: string;
   releaseDate: string | null;
+  /** Watch progress percentage for TV shows (0–100). */
+  progress: number | null;
 }
 
 export function useMediaLibrary() {
@@ -21,20 +23,31 @@ export function useMediaLibrary() {
   const [genreFilter, setGenreFilter] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<SortOption>("dateAdded");
 
-  const {
-    data: moviesData,
-    isLoading: moviesLoading,
-  } = trpc.media.movies.list.useQuery({ limit: 500 });
+  const { data: moviesData, isLoading: moviesLoading } =
+    trpc.media.movies.list.useQuery({ limit: 500 });
 
-  const {
-    data: tvShowsData,
-    isLoading: tvShowsLoading,
-  } = trpc.media.tvShows.list.useQuery({ limit: 500 });
+  const { data: tvShowsData, isLoading: tvShowsLoading } =
+    trpc.media.tvShows.list.useQuery({ limit: 500 });
+
+  // Fetch batch progress for all TV shows
+  const tvShowIds = useMemo(
+    () => (tvShowsData?.data ?? []).map((s) => s.id),
+    [tvShowsData],
+  );
+
+  const { data: progressData } = trpc.media.watchHistory.batchProgress.useQuery(
+    { tvShowIds },
+    { enabled: tvShowIds.length > 0 },
+  );
 
   const isLoading = moviesLoading || tvShowsLoading;
 
   const allItems = useMemo<MediaItem[]>(() => {
-    const movies: MediaItem[] = (moviesData?.data ?? []).map((m) => ({
+    const progressMap = new Map(
+      (progressData?.data ?? []).map((p) => [p.tvShowId, p.percentage]),
+    );
+
+    const movieItems: MediaItem[] = (moviesData?.data ?? []).map((m) => ({
       id: m.id,
       type: "movie" as const,
       title: m.title,
@@ -44,6 +57,7 @@ export function useMediaLibrary() {
       voteAverage: m.voteAverage,
       createdAt: m.createdAt,
       releaseDate: m.releaseDate,
+      progress: null,
     }));
 
     const shows: MediaItem[] = (tvShowsData?.data ?? []).map((s) => ({
@@ -56,10 +70,11 @@ export function useMediaLibrary() {
       voteAverage: s.voteAverage,
       createdAt: s.createdAt,
       releaseDate: s.firstAirDate,
+      progress: progressMap.get(s.id) ?? null,
     }));
 
-    return [...movies, ...shows];
-  }, [moviesData, tvShowsData]);
+    return [...movieItems, ...shows];
+  }, [moviesData, tvShowsData, progressData]);
 
   const allGenres = useMemo(() => {
     const genres = new Set<string>();

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -47,6 +47,7 @@ function MediaCard({
     title: string;
     year: number | null;
     posterUrl: string | null;
+    progress: number | null;
   };
 }) {
   const href =
@@ -75,6 +76,15 @@ function MediaCard({
         >
           {item.type === "movie" ? "Movie" : "TV"}
         </Badge>
+        {/* Progress bar for TV shows */}
+        {item.progress != null && item.progress > 0 && (
+          <div className="absolute bottom-0 left-0 right-0 h-1 bg-black/30">
+            <div
+              className={`h-full transition-all ${item.progress >= 100 ? "bg-green-500" : "bg-indigo-500"}`}
+              style={{ width: `${Math.min(item.progress, 100)}%` }}
+            />
+          </div>
+        )}
       </div>
       <h3 className="mt-2 text-sm font-medium line-clamp-2 transition-colors group-hover:text-indigo-400">
         {item.title}

--- a/packages/app-media/src/pages/TvShowDetailPage.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.tsx
@@ -1,5 +1,12 @@
 import { useParams, Link } from "react-router";
-import { Alert, AlertTitle, AlertDescription, Badge, Button, Skeleton } from "@pops/ui";
+import {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+  Badge,
+  Button,
+  Skeleton,
+} from "@pops/ui";
 import { trpc } from "../lib/trpc";
 import { ProgressBar } from "../components/ProgressBar";
 import { ArrStatusBadge } from "../components/ArrStatusBadge";
@@ -36,17 +43,17 @@ export function TvShowDetailPage() {
 
   const { data, isLoading, error } = trpc.media.tvShows.get.useQuery(
     { id: showId },
-    { enabled: !Number.isNaN(showId) }
+    { enabled: !Number.isNaN(showId) },
   );
 
   const { data: seasonsData } = trpc.media.tvShows.listSeasons.useQuery(
     { tvShowId: showId },
-    { enabled: !Number.isNaN(showId) }
+    { enabled: !Number.isNaN(showId) },
   );
 
   const { data: progressData } = trpc.media.watchHistory.progress.useQuery(
     { tvShowId: showId },
-    { enabled: !Number.isNaN(showId) }
+    { enabled: !Number.isNaN(showId) },
   );
 
   const utils = trpc.useUtils();
@@ -109,10 +116,7 @@ export function TvShowDetailPage() {
   const seasons = seasonsData?.data ?? [];
   const progress = progressData?.data;
 
-  // Find the next unwatched episode
-  const nextSeason = progress?.seasons?.find(
-    (s: { watched: number; total: number }) => s.watched < s.total
-  );
+  const nextEpisode = progress?.nextEpisode ?? null;
 
   const metadataItems = [
     { label: "Status", value: show.status },
@@ -123,7 +127,10 @@ export function TvShowDetailPage() {
         ? `${show.voteAverage.toFixed(1)} (${show.voteCount} votes)`
         : null,
     },
-    { label: "Seasons", value: seasons.length > 0 ? `${seasons.length}` : null },
+    {
+      label: "Seasons",
+      value: seasons.length > 0 ? `${seasons.length}` : null,
+    },
   ].filter((item) => item.value != null);
 
   return (
@@ -173,12 +180,15 @@ export function TvShowDetailPage() {
             )}
 
             {/* Next episode indicator */}
-            {nextSeason && (
+            {nextEpisode && (
               <Link
-                to={`/media/tv/${show.id}/season/${nextSeason.seasonNumber}`}
+                to={`/media/tv/${show.id}/season/${nextEpisode.seasonNumber}`}
                 className="inline-block mt-2 text-sm text-primary hover:underline"
               >
-                Continue: Season {nextSeason.seasonNumber}
+                Continue watching: S
+                {String(nextEpisode.seasonNumber).padStart(2, "0")}E
+                {String(nextEpisode.episodeNumber).padStart(2, "0")}
+                {nextEpisode.episodeName ? ` — ${nextEpisode.episodeName}` : ""}
               </Link>
             )}
 
@@ -201,8 +211,16 @@ export function TvShowDetailPage() {
                   </Button>
                 ) : (
                   <span className="inline-flex items-center gap-1.5 text-sm text-green-500 font-medium">
-                    <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-                      <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                    <svg
+                      className="w-4 h-4"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clipRule="evenodd"
+                      />
                     </svg>
                     All Watched
                   </span>
@@ -261,39 +279,49 @@ export function TvShowDetailPage() {
           <section>
             <h2 className="text-lg font-semibold mb-3">Seasons</h2>
             <div className="space-y-2">
-              {seasons.map((season: { id: number; seasonNumber: number; name: string | null; episodeCount: number | null }) => {
-                const seasonProg = progress?.seasons?.find(
-                  (s: { seasonNumber: number }) => s.seasonNumber === season.seasonNumber
-                );
-                const label =
-                  season.seasonNumber === 0
-                    ? "Specials"
-                    : season.name ?? `Season ${season.seasonNumber}`;
+              {seasons.map(
+                (season: {
+                  id: number;
+                  seasonNumber: number;
+                  name: string | null;
+                  episodeCount: number | null;
+                }) => {
+                  const seasonProg = progress?.seasons?.find(
+                    (s: { seasonNumber: number }) =>
+                      s.seasonNumber === season.seasonNumber,
+                  );
+                  const label =
+                    season.seasonNumber === 0
+                      ? "Specials"
+                      : (season.name ?? `Season ${season.seasonNumber}`);
 
-                return (
-                  <Link
-                    key={season.id}
-                    to={`/media/tv/${show.id}/season/${season.seasonNumber}`}
-                    className="flex items-center gap-3 p-3 rounded-lg border hover:bg-accent/50 transition-colors"
-                  >
-                    <span className="text-sm font-medium flex-1">{label}</span>
-                    {season.episodeCount != null && (
-                      <span className="text-xs text-muted-foreground">
-                        {season.episodeCount} episodes
+                  return (
+                    <Link
+                      key={season.id}
+                      to={`/media/tv/${show.id}/season/${season.seasonNumber}`}
+                      className="flex items-center gap-3 p-3 rounded-lg border hover:bg-accent/50 transition-colors"
+                    >
+                      <span className="text-sm font-medium flex-1">
+                        {label}
                       </span>
-                    )}
-                    {seasonProg && seasonProg.total > 0 && (
-                      <div className="w-24">
-                        <ProgressBar
-                          watched={seasonProg.watched}
-                          total={seasonProg.total}
-                          showLabel={false}
-                        />
-                      </div>
-                    )}
-                  </Link>
-                );
-              })}
+                      {season.episodeCount != null && (
+                        <span className="text-xs text-muted-foreground">
+                          {season.episodeCount} episodes
+                        </span>
+                      )}
+                      {seasonProg && seasonProg.total > 0 && (
+                        <div className="w-24">
+                          <ProgressBar
+                            watched={seasonProg.watched}
+                            total={seasonProg.total}
+                            showLabel={false}
+                          />
+                        </div>
+                      )}
+                    </Link>
+                  );
+                },
+              )}
             </div>
           </section>
         )}


### PR DESCRIPTION
## Summary
- **Backend**: Add `batchProgress` endpoint for efficient bulk TV show watch percentage queries (2 SQL queries for N shows). Enhance `getProgress` to include `nextEpisode` (first unwatched episode with S/E numbers and name)
- **Frontend**: Wire batch progress into `useMediaLibrary` hook. Add thin progress bar to library grid MediaCard for TV shows (green at 100%, indigo otherwise)
- **Detail page**: Update "Continue" link on TvShowDetailPage to show specific episode: "Continue watching: S02E05 — Episode Name"

## Test plan
- [x] All 47 existing watch history tests pass
- [ ] Verify progress bars appear on TV show cards in library grid
- [ ] Verify progress bar is green when 100% watched
- [ ] Verify "Continue watching: S01E03" shows correct next unwatched episode
- [ ] Verify no progress bar on movie cards
- [ ] Verify batch query handles empty TV show list gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)