### PR TITLE
fix: correct inventory item navigate paths [GH-271] (tb-165)

### DIFF
--- a/packages/app-inventory/src/components/InventoryTable.tsx
+++ b/packages/app-inventory/src/components/InventoryTable.tsx
@@ -143,7 +143,7 @@ export function InventoryTable({
       searchPlaceholder="Search items..."
       paginated
       defaultPageSize={20}
-      onRowClick={(row) => navigate(`/inventory/${row.id}`)}
+      onRowClick={(row) => navigate(`/inventory/items/${row.id}`)}
       emptyState="No inventory items found."
     />
   );

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -240,7 +240,7 @@ export function ItemsPage() {
               assetId={item.assetId}
               type={item.type}
               condition={item.condition as Condition | null}
-              onClick={() => navigate(`/inventory/${item.id}`)}
+              onClick={() => navigate(`/inventory/items/${item.id}`)}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Fix inventory item click crash by correcting navigate paths from `/inventory/${id}` to `/inventory/items/${id}` to match route definitions
- 2-line fix in `ItemsPage.tsx` and `InventoryTable.tsx`

Closes #271

## Test plan
- [ ] Click an inventory item in grid view — navigates to detail page
- [ ] Click an inventory item in table view — navigates to detail page
- [ ] Verify no 404 or crash on navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)