### PR TITLE
fix: warranties page section order + ShieldCheck icon [tb-176]

### DIFF
--- a/.room-agent.json
+++ b/.room-agent.json
@@ -1,0 +1,7 @@
+{
+  "username": "wall-e",
+  "token": "1c5ca489-b564-4317-98b4-278104aee592",
+  "room_id": "dev",
+  "ralph_pid": 574,
+  "personality": "/home/agent/.room/personality-wall-e.txt"
+}

--- a/apps/pops-shell/src/app/nav/icon-map.ts
+++ b/apps/pops-shell/src/app/nav/icon-map.ts
@@ -24,6 +24,7 @@ import {
   Compass,
   Trophy,
   FileText,
+  ShieldCheck,
   type LucideIcon,
 } from "lucide-react";
 
@@ -45,4 +46,5 @@ export const iconMap: Record<string, LucideIcon> = {
   Compass,
   Trophy,
   FileText,
+  ShieldCheck,
 };

--- a/packages/app-inventory/src/pages/WarrantiesPage.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.tsx
@@ -1,7 +1,7 @@
 /**
  * WarrantiesPage — warranty tracking dashboard for inventory items.
  *
- * Sections: expiring soon (90 days), expired, active warranties.
+ * Sections: expiring soon (90 days), active, expired warranties.
  * Color-coded urgency for expiring items. PRD-023/US-2.
  */
 import { useMemo, useState } from "react";
@@ -236,10 +236,14 @@ export function WarrantiesPage() {
             </div>
           )}
 
-          {/* Expired — collapsible */}
-          {expired.length > 0 && (
-            <CollapsibleSection title="Expired" count={expired.length}>
-              {expired.map((item) => (
+          {/* Active — collapsible */}
+          {active.length > 0 && (
+            <CollapsibleSection
+              title="Active"
+              count={active.length}
+              defaultOpen
+            >
+              {active.map((item) => (
                 <WarrantyRow
                   key={item.id}
                   item={item}
@@ -250,14 +254,10 @@ export function WarrantiesPage() {
             </CollapsibleSection>
           )}
 
-          {/* Active — collapsible */}
-          {active.length > 0 && (
-            <CollapsibleSection
-              title="Active"
-              count={active.length}
-              defaultOpen
-            >
-              {active.map((item) => (
+          {/* Expired — collapsible */}
+          {expired.length > 0 && (
+            <CollapsibleSection title="Expired" count={expired.length}>
+              {expired.map((item) => (
                 <WarrantyRow
                   key={item.id}
                   item={item}


### PR DESCRIPTION
## Summary
- Swapped Active and Expired sections in WarrantiesPage so display order is: Expiring Soon → Active → Expired (previously Expired came before Active)
- Added `ShieldCheck` icon to shell `icon-map.ts` so the warranties nav entry resolves correctly

## Test plan
- [ ] Navigate to Inventory → Warranties page — verify sections render in order: Expiring Soon, Active, Expired
- [ ] Verify ShieldCheck icon appears in sidebar/nav for warranties entry
- [ ] Confirm collapsible sections still expand/collapse correctly

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)