### PR TITLE
feat: add 404 not-found page [tb-174]

### DIFF
--- a/apps/pops-shell/src/app/pages/NotFoundPage.tsx
+++ b/apps/pops-shell/src/app/pages/NotFoundPage.tsx
@@ -1,0 +1,20 @@
+import { Link } from "react-router";
+import { FileQuestion } from "lucide-react";
+
+export function NotFoundPage() {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <FileQuestion className="h-16 w-16 text-muted-foreground/40 mb-6" />
+      <h1 className="text-2xl font-bold mb-2">Page not found</h1>
+      <p className="text-muted-foreground mb-6">
+        The page you're looking for doesn't exist or has been moved.
+      </p>
+      <Link
+        to="/"
+        className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+      >
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/apps/pops-shell/src/app/router.tsx
+++ b/apps/pops-shell/src/app/router.tsx
@@ -5,11 +5,12 @@
  * Finance routes are lazily loaded from @pops/app-finance.
  */
 import { Suspense } from "react";
-import { createBrowserRouter, Navigate } from "react-router";
+import { createBrowserRouter, Link, Navigate } from "react-router";
 import { routes as financeRoutes } from "@pops/app-finance";
 import { routes as mediaRoutes } from "@pops/app-media";
 import { routes as inventoryRoutes } from "@pops/app-inventory";
 import { RootLayout } from "./layout/RootLayout";
+import { NotFoundPage } from "./pages/NotFoundPage";
 
 /**
  * Wrap lazy-loaded routes with Suspense so React can show a fallback
@@ -35,6 +36,20 @@ export const router = createBrowserRouter([
   {
     path: "/",
     element: <RootLayout />,
+    errorElement: (
+      <div className="flex flex-col items-center justify-center min-h-screen text-center px-4">
+        <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
+        <p className="text-muted-foreground mb-6">
+          An unexpected error occurred.
+        </p>
+        <Link
+          to="/"
+          className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          Go home
+        </Link>
+      </div>
+    ),
     children: [
       { index: true, element: <Navigate to="/finance" replace /> },
       {
@@ -49,6 +64,7 @@ export const router = createBrowserRouter([
         path: "inventory",
         children: withSuspense(inventoryRoutes),
       },
+      { path: "*", element: <NotFoundPage /> },
     ],
   },
 ]);


### PR DESCRIPTION
## Summary
- Created `NotFoundPage` component with "Page not found" message, description, and link to home
- Added catch-all `{ path: "*" }` route as last child of root — renders within shell layout
- Added `errorElement` on root route for unexpected errors (renders outside shell)

## Test plan
- [ ] Navigate to a non-existent URL (e.g., `/foo/bar`) — should see NotFoundPage within shell chrome
- [ ] Verify "Go home" link navigates to `/` (redirects to `/finance`)
- [ ] Verify existing routes still work normally

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)