### PR TITLE
feat: add undo toast for Mark as Watched [tb-179]

### DIFF
--- a/packages/app-media/src/components/MarkAsWatchedButton.tsx
+++ b/packages/app-media/src/components/MarkAsWatchedButton.tsx
@@ -25,9 +25,26 @@ export function MarkAsWatchedButton({
   const watchCount = historyData?.data?.length ?? 0;
   const lastWatched = historyData?.data?.[0]?.watchedAt;
 
-  const logMutation = trpc.media.watchHistory.log.useMutation({
+  const deleteMutation = trpc.media.watchHistory.delete.useMutation({
     onSuccess: () => {
-      toast.success("Marked as watched");
+      toast.success("Watch entry undone");
+      void utils.media.watchHistory.list.invalidate();
+      void utils.media.watchlist.list.invalidate();
+    },
+    onError: (err) => {
+      toast.error(`Failed to undo: ${err.message}`);
+    },
+  });
+
+  const logMutation = trpc.media.watchHistory.log.useMutation({
+    onSuccess: (result) => {
+      toast.success("Marked as watched", {
+        duration: 5000,
+        action: {
+          label: "Undo",
+          onClick: () => deleteMutation.mutate({ id: result.data.id }),
+        },
+      });
       void utils.media.watchHistory.list.invalidate();
       void utils.media.watchlist.list.invalidate();
       setShowDatePicker(false);


### PR DESCRIPTION
## Summary
- After marking a movie as watched, toast now shows "Undo" action button
- Clicking "Undo" calls the delete watch history mutation to remove the entry
- Toast duration set to 5 seconds per spec

## Test plan
- [ ] Click "Mark as Watched" on a movie detail page — verify toast with "Undo" button appears
- [ ] Click "Undo" within 5 seconds — verify watch entry is removed and lists refresh
- [ ] Let toast expire without clicking Undo — verify watch entry persists
- [ ] Use custom date picker to log watch — verify same undo behavior

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)