### PR TITLE
feat: add Location Tree page to routes and sidebar [tb-166]

### DIFF
--- a/apps/pops-shell/src/app/nav/icon-map.ts
+++ b/apps/pops-shell/src/app/nav/icon-map.ts
@@ -26,6 +26,7 @@ import {
   Trophy,
   FileText,
   ShieldCheck,
+  MapPin,
   type LucideIcon,
 } from "lucide-react";
 
@@ -49,4 +50,5 @@ export const iconMap: Record<string, LucideIcon> = {
   Trophy,
   FileText,
   ShieldCheck,
+  MapPin,
 };

--- a/packages/app-inventory/src/routes.tsx
+++ b/packages/app-inventory/src/routes.tsx
@@ -28,6 +28,11 @@ const InsuranceReportPage = lazy(() =>
     default: m.InsuranceReportPage,
   })),
 );
+const LocationTreePage = lazy(() =>
+  import("./pages/LocationTreePage").then((m) => ({
+    default: m.LocationTreePage,
+  })),
+);
 
 /** Local type mirror for compile-time safety (shell owns the canonical types). */
 interface AppNavConfigShape {
@@ -48,6 +53,7 @@ export const navConfig = {
   items: [
     { path: "", label: "Items", icon: "Package" },
     { path: "/warranties", label: "Warranties", icon: "ShieldCheck" },
+    { path: "/locations", label: "Locations", icon: "MapPin" },
     { path: "/report", label: "Insurance Report", icon: "FileText" },
   ],
 } satisfies AppNavConfigShape;
@@ -58,5 +64,6 @@ export const routes: RouteObject[] = [
   { path: "items/:id", element: <ItemDetailPage /> },
   { path: "items/:id/edit", element: <ItemFormPage /> },
   { path: "warranties", element: <WarrantiesPage /> },
+  { path: "locations", element: <LocationTreePage /> },
   { path: "report", element: <InsuranceReportPage /> },
 ];


### PR DESCRIPTION
## Summary
- Added lazy-loaded `LocationTreePage` route at `/inventory/locations`
- Added "Locations" nav item with `MapPin` icon to inventory sidebar
- Added `MapPin` to shell `icon-map.ts`

## Test plan
- [ ] Navigate to Inventory section — verify "Locations" appears in sidebar nav
- [ ] Click "Locations" — verify LocationTreePage loads at `/inventory/locations`
- [ ] Verify MapPin icon displays correctly in sidebar

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)