### PR TITLE
fix: prevent duplicate watch history from Plex sync [GH-249] (tb-172)

### DIFF
--- a/apps/pops-api/src/db/migrations/20260324140000_watch_history_unique_index.sql
+++ b/apps/pops-api/src/db/migrations/20260324140000_watch_history_unique_index.sql
@@ -1,0 +1,10 @@
+-- Migration: 20260324140000_watch_history_unique_index.sql
+-- Domain: media
+-- Description: Add unique index on (media_type, media_id, watched_at) to prevent
+--   duplicate watch history entries from Plex sync re-runs.
+--
+-- Rollback (manual):
+--   DROP INDEX IF EXISTS idx_watch_history_unique;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_history_unique
+  ON watch_history(media_type, media_id, watched_at);

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -26,6 +26,7 @@ const INCLUDED_MIGRATIONS = [
   "20260320140000_inventory_new_columns.sql",
   "20260321140000_item_documents.sql",
   "20260322120000_settings.sql",
+  "20260324140000_watch_history_unique_index.sql",
 ];
 
 /**
@@ -366,6 +367,7 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
     );
     CREATE INDEX IF NOT EXISTS idx_watch_history_media ON watch_history(media_type, media_id);
     CREATE INDEX IF NOT EXISTS idx_watch_history_watched_at ON watch_history(watched_at);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_history_unique ON watch_history(media_type, media_id, watched_at);
 
     CREATE TABLE IF NOT EXISTS schema_migrations (
       version TEXT PRIMARY KEY,

--- a/apps/pops-api/src/modules/media/watch-history/service.ts
+++ b/apps/pops-api/src/modules/media/watch-history/service.ts
@@ -208,6 +208,7 @@ export function getWatchHistoryEntry(id: number): WatchHistoryRow {
 export function logWatch(input: LogWatchInput): WatchHistoryRow {
   const db = getDrizzle();
   const completed = input.completed ?? 1;
+  const watchedAt = input.watchedAt ?? new Date().toISOString();
 
   return db.transaction((tx) => {
     const result = tx
@@ -215,10 +216,28 @@ export function logWatch(input: LogWatchInput): WatchHistoryRow {
       .values({
         mediaType: input.mediaType,
         mediaId: input.mediaId,
-        watchedAt: input.watchedAt ?? new Date().toISOString(),
+        watchedAt,
         completed,
       })
+      .onConflictDoNothing()
       .run();
+
+    // If duplicate, return the existing row
+    if (result.changes === 0) {
+      const existing = tx
+        .select()
+        .from(watchHistory)
+        .where(
+          and(
+            eq(watchHistory.mediaType, input.mediaType),
+            eq(watchHistory.mediaId, input.mediaId),
+            eq(watchHistory.watchedAt, watchedAt)
+          )
+        )
+        .get();
+      if (!existing) throw new Error("Watch history entry not found after conflict");
+      return existing;
+    }
 
     const entry = tx
       .select()
@@ -508,6 +527,7 @@ export function batchLogWatch(input: BatchLogWatchInput): BatchLogResult {
           watchedAt,
           completed,
         })
+        .onConflictDoNothing()
         .run();
     }
 

--- a/packages/db-types/src/schema/watch-history.ts
+++ b/packages/db-types/src/schema/watch-history.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, index, uniqueIndex } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 
 export const watchHistory = sqliteTable(
@@ -13,5 +13,6 @@ export const watchHistory = sqliteTable(
   (table) => [
     index("idx_watch_history_media").on(table.mediaType, table.mediaId),
     index("idx_watch_history_watched_at").on(table.watchedAt),
+    uniqueIndex("idx_watch_history_unique").on(table.mediaType, table.mediaId, table.watchedAt),
   ]
 );


### PR DESCRIPTION
## Summary
- Add unique index on `(media_type, media_id, watched_at)` to `watch_history` table
- Use `INSERT ON CONFLICT DO NOTHING` in `logWatch()` and `batchLogWatch()` to silently skip duplicates
- `logWatch()` returns the existing row when a duplicate is detected

Closes #249

## Test plan
- [ ] Run Plex sync twice — no duplicate watch history entries created
- [ ] Manual `logWatch()` with same media+timestamp — returns existing entry, no error
- [ ] `batchLogWatch()` with overlapping episodes — no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)