### PR TITLE
fix: search page 500 + error state (tb-169)

### DIFF
--- a/apps/pops-api/src/modules/media/search/router.ts
+++ b/apps/pops-api/src/modules/media/search/router.ts
@@ -36,13 +36,17 @@ export const searchRouter = router({
         page: response.page,
       };
     } catch (err) {
-      if (err instanceof TmdbApiError) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: `TMDB API error: ${err.message}`,
-        });
-      }
-      throw err;
+      if (err instanceof TRPCError) throw err;
+      const message =
+        err instanceof TmdbApiError
+          ? `TMDB API error: ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : "Unknown error searching movies";
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message,
+      });
     }
   }),
 
@@ -59,13 +63,17 @@ export const searchRouter = router({
       const results = await client.searchSeries(input.query);
       return { results };
     } catch (err) {
-      if (err instanceof TvdbApiError) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: `TheTVDB API error: ${err.message}`,
-        });
-      }
-      throw err;
+      if (err instanceof TRPCError) throw err;
+      const message =
+        err instanceof TvdbApiError
+          ? `TheTVDB API error: ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : "Unknown error searching TV shows";
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message,
+      });
     }
   }),
 });

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -6,8 +6,8 @@
  * "In Library" badge for items already in the collection.
  */
 import { useState, useEffect, useCallback } from "react";
-import { Input, Skeleton, Tabs, TabsList, TabsTrigger } from "@pops/ui";
-import { Search } from "lucide-react";
+import { Button, Input, Skeleton, Tabs, TabsList, TabsTrigger } from "@pops/ui";
+import { AlertTriangle, Search } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
 import {
@@ -159,6 +159,16 @@ export function SearchPage() {
   const hasQuery = debouncedQuery.length > 0;
   const hasError = movieSearch.error || tvSearch.error;
 
+  // Toast actual error message on failure
+  useEffect(() => {
+    if (movieSearch.error) {
+      toast.error(`Movie search failed: ${movieSearch.error.message}`);
+    }
+    if (tvSearch.error) {
+      toast.error(`TV search failed: ${tvSearch.error.message}`);
+    }
+  }, [movieSearch.error, tvSearch.error]);
+
   // Merge results
   const movieResults = shouldSearchMovies
     ? (movieSearch.data?.results ?? [])
@@ -202,9 +212,24 @@ export function SearchPage() {
 
       {/* Error state */}
       {hasError && (
-        <p className="text-sm text-destructive">
-          Search failed. Please try again.
-        </p>
+        <div className="flex flex-col items-center justify-center py-12 space-y-4">
+          <AlertTriangle className="h-10 w-10 text-destructive opacity-60" />
+          <div className="text-center space-y-1">
+            <p className="font-semibold">Search failed</p>
+            <p className="text-sm text-muted-foreground">
+              Something went wrong. Check your connection and try again.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            onClick={() => {
+              if (movieSearch.error) movieSearch.refetch();
+              if (tvSearch.error) tvSearch.refetch();
+            }}
+          >
+            Retry
+          </Button>
+        </div>
       )}
 
       {/* Loading skeletons */}


### PR DESCRIPTION
## Summary
- **Backend:** Catch all errors in `search/router.ts` catch blocks (not just `TmdbApiError`/`TvdbApiError`), converting them to `TRPCError` — prevents raw 500s from unhandled exceptions
- **Frontend:** Replace bare red text error with centered error state (AlertTriangle icon, message, retry button) + toast with actual error message

Closes #264

## Test plan
- [x] Search router tests pass (12/12)
- [x] Lint clean on both files
- [x] No new typecheck errors (pre-existing plex errors unrelated)
- [ ] Verify error state renders with icon, message, retry button when search fails
- [ ] Verify toast shows actual error message
- [ ] Verify retry button re-fetches failed queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)