### PR TITLE
fix: make TopBar fixed so it doesn't scroll away [GH-268] (tb-175)

### DIFF
--- a/apps/pops-shell/src/app/layout/RootLayout.tsx
+++ b/apps/pops-shell/src/app/layout/RootLayout.tsx
@@ -16,14 +16,14 @@ export function RootLayout() {
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
 
   return (
-    <div className="min-h-screen bg-background relative overflow-hidden">
+    <div className="min-h-screen bg-background relative">
       {/* Ambient background decorative elements */}
       <div className="fixed top-0 left-0 w-full h-full pointer-events-none overflow-hidden z-0 opacity-20 dark:opacity-10">
         <div className="absolute top-[-10%] right-[-10%] w-[40%] h-[40%] rounded-full bg-primary/20 blur-[120px]" />
         <div className="absolute bottom-[-5%] left-[-5%] w-[30%] h-[30%] rounded-full bg-emerald-500/10 blur-[100px]" />
       </div>
 
-      <div className="relative z-10">
+      <div className="relative z-10 pt-14 md:pt-16">
         <TopBar />
         <div className="flex">
           {/* Desktop: two-level nav (app rail + page nav) */}

--- a/apps/pops-shell/src/app/layout/TopBar.tsx
+++ b/apps/pops-shell/src/app/layout/TopBar.tsx
@@ -14,7 +14,7 @@ export function TopBar() {
   const toggleSidebar = useUIStore((state) => state.toggleSidebar);
 
   return (
-    <header className="bg-card border-b border-border h-14 md:h-16 flex items-center px-3 md:px-4 sticky top-0 z-40">
+    <header className="bg-card border-b border-border h-14 md:h-16 flex items-center px-3 md:px-4 fixed top-0 w-full z-40">
       <button
         onClick={toggleSidebar}
         className="min-w-[44px] min-h-[44px] flex items-center justify-center hover:bg-muted rounded-lg mr-2 md:hidden"


### PR DESCRIPTION
## Summary
- Remove `overflow-hidden` from root div (keep on blur container only)
- Change TopBar from `sticky` to `fixed top-0 w-full` positioning
- Add `pt-14 md:pt-16` offset to content container for fixed header height

Closes #268

## Test plan
- [ ] Scroll down on any page — TopBar stays visible at top
- [ ] Sidebar sticky nav still works on desktop
- [ ] Mobile sidebar overlay still works
- [ ] Blur background effects still contained

🤖 Generated with [Claude Code](https://claude.com/claude-code)