### PR TITLE
fix: standardize action icons across pages [GH-259] (tb-183)

### DIFF
--- a/packages/app-finance/src/components/imports/TransactionCard.tsx
+++ b/packages/app-finance/src/components/imports/TransactionCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronRight, Globe, Store, Sparkles, Zap, Edit2 } from "lucide-react";
+import { ChevronRight, Globe, Store, Sparkles, Zap, Pencil } from "lucide-react";
 import { Badge } from "@pops/ui";
 import { Button } from "@pops/ui";
 import {
@@ -121,7 +121,7 @@ export function TransactionCard({
             className="ml-2"
             aria-label={`Edit ${transaction.description}`}
           >
-            <Edit2 className="w-4 h-4" aria-hidden="true" />
+            <Pencil className="w-4 h-4" aria-hidden="true" />
             <span className="sr-only">Edit</span>
           </Button>
         )}

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -15,7 +15,7 @@ import {
   Textarea,
 } from "@pops/ui";
 import { Button } from "@pops/ui";
-import { ArrowUp, ArrowDown } from "lucide-react";
+import { ArrowUp, ArrowDown, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
 
@@ -186,15 +186,16 @@ function WatchlistItem({
             </div>
           </div>
 
-          <button
-            type="button"
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
             onClick={() => onRemove(entry.id)}
             disabled={isRemoving}
             aria-label={`Remove ${title} from watchlist`}
-            className="text-xs text-muted-foreground hover:text-destructive shrink-0 disabled:opacity-50"
           >
-            Remove
-          </button>
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
         </div>
 
         {editing ? (


### PR DESCRIPTION
## Summary
- Replace `Edit2` with `Pencil` icon in TransactionCard
- Replace text "Remove" button with `Trash2` icon button in WatchlistPage

Closes #259

## Test plan
- [ ] TransactionCard edit button shows Pencil icon
- [ ] WatchlistPage remove button shows Trash2 icon and works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)