### PR TITLE
fix: handle inventory dashboard 500s with error boundaries (tb-167)

### DIFF
--- a/apps/pops-api/src/modules/inventory/reports/router.ts
+++ b/apps/pops-api/src/modules/inventory/reports/router.ts
@@ -2,6 +2,7 @@
  * Inventory reports tRPC router — warranty tracking and insurance reports.
  */
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../../../trpc.js";
 import { toInventoryItem } from "../items/types.js";
 import * as service from "./service.js";
@@ -22,17 +23,41 @@ export const reportsRouter = router({
   insuranceReport: protectedProcedure
     .input(z.object({ locationId: z.string().optional() }).optional())
     .query(({ input }) => {
-      const result = service.getInsuranceReport(input?.locationId);
-      return { data: result };
+      try {
+        const result = service.getInsuranceReport(input?.locationId);
+        return { data: result };
+      } catch (err) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to generate insurance report",
+          cause: err,
+        });
+      }
     }),
 
   /** Get replacement value breakdown grouped by location. */
   valueByLocation: protectedProcedure.query(() => {
-    return { data: service.getValueByLocation() };
+    try {
+      return { data: service.getValueByLocation() };
+    } catch (err) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to load value by location breakdown",
+        cause: err,
+      });
+    }
   }),
 
   /** Get replacement value breakdown grouped by item type. */
   valueByType: protectedProcedure.query(() => {
-    return { data: service.getValueByType() };
+    try {
+      return { data: service.getValueByType() };
+    } catch (err) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to load value by type breakdown",
+        cause: err,
+      });
+    }
   }),
 });

--- a/packages/app-inventory/src/components/ValueBreakdown.tsx
+++ b/packages/app-inventory/src/components/ValueBreakdown.tsx
@@ -2,8 +2,8 @@
  * ValueBreakdown — horizontal bar charts showing replacement value
  * grouped by location and by item type.
  */
-import { Card, CardContent, Skeleton } from "@pops/ui";
-import { MapPin, Tag } from "lucide-react";
+import { Alert, AlertDescription, Button, Card, CardContent, Skeleton } from "@pops/ui";
+import { AlertCircle, MapPin, RefreshCw, Tag } from "lucide-react";
 import {
   BarChart,
   Bar,
@@ -108,14 +108,37 @@ function BreakdownSkeleton() {
   );
 }
 
+function BreakdownError({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <Alert variant="destructive">
+      <AlertCircle className="h-4 w-4" />
+      <AlertDescription className="flex items-center justify-between gap-2">
+        <span>{message}</span>
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          <RefreshCw className="h-3 w-3 mr-1" />
+          Retry
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
 export function ValueBreakdown() {
   const navigate = useNavigate();
 
-  const { data: locationData, isLoading: locationLoading } =
-    trpc.inventory.reports.valueByLocation.useQuery();
+  const {
+    data: locationData,
+    isLoading: locationLoading,
+    isError: locationError,
+    refetch: refetchLocation,
+  } = trpc.inventory.reports.valueByLocation.useQuery();
 
-  const { data: typeData, isLoading: typeLoading } =
-    trpc.inventory.reports.valueByType.useQuery();
+  const {
+    data: typeData,
+    isLoading: typeLoading,
+    isError: typeError,
+    refetch: refetchType,
+  } = trpc.inventory.reports.valueByType.useQuery();
 
   if (locationLoading || typeLoading) {
     return (
@@ -137,12 +160,19 @@ export function ValueBreakdown() {
             <MapPin className="h-4 w-4" />
             <span className="text-xs font-medium">Value by Location</span>
           </div>
-          <BreakdownChart
-            data={locationEntries}
-            onBarClick={(name) =>
-              navigate(`/inventory?location=${encodeURIComponent(name)}`)
-            }
-          />
+          {locationError ? (
+            <BreakdownError
+              message="Failed to load location breakdown"
+              onRetry={() => refetchLocation()}
+            />
+          ) : (
+            <BreakdownChart
+              data={locationEntries}
+              onBarClick={(name) =>
+                navigate(`/inventory?location=${encodeURIComponent(name)}`)
+              }
+            />
+          )}
         </CardContent>
       </Card>
 
@@ -152,12 +182,19 @@ export function ValueBreakdown() {
             <Tag className="h-4 w-4" />
             <span className="text-xs font-medium">Value by Type</span>
           </div>
-          <BreakdownChart
-            data={typeEntries}
-            onBarClick={(name) =>
-              navigate(`/inventory?type=${encodeURIComponent(name)}`)
-            }
-          />
+          {typeError ? (
+            <BreakdownError
+              message="Failed to load type breakdown"
+              onRetry={() => refetchType()}
+            />
+          ) : (
+            <BreakdownChart
+              data={typeEntries}
+              onBarClick={(name) =>
+                navigate(`/inventory?type=${encodeURIComponent(name)}`)
+              }
+            />
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- **Backend:** Wrapped `valueByLocation`, `valueByType`, and `insuranceReport` router procedures in try/catch, throwing `TRPCError` with `INTERNAL_SERVER_ERROR` code and descriptive messages instead of unhandled 500s
- **Frontend:** Updated `ValueBreakdown` component to distinguish error vs empty state — shows error alert with retry button on failure, preserves "No data" for successful-but-empty responses

Fixes https://github.com/pops-project/pops/issues/270

## Test plan
- [ ] Verify inventory dashboard loads correctly with seeded data
- [ ] Simulate DB error to confirm error alert appears with retry button
- [ ] Verify retry button triggers refetch
- [ ] Confirm empty state still shows "No data available" when no items exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)