### PR TITLE
fix: move view toggle from header to filter bar [GH-267] (tb-188)

### DIFF
--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -124,37 +124,9 @@ export function ItemsPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <h1 className="text-2xl md:text-3xl font-bold">Inventory</h1>
-        <div className="flex items-center gap-1 rounded-lg border bg-muted/30 p-0.5">
-          <button
-            type="button"
-            onClick={() => handleViewChange("table")}
-            aria-label="Table view"
-            aria-pressed={viewMode === "table"}
-            className={`rounded-md p-1.5 transition-all ${
-              viewMode === "table"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            <LayoutList className="h-4 w-4" />
-          </button>
-          <button
-            type="button"
-            onClick={() => handleViewChange("grid")}
-            aria-label="Grid view"
-            aria-pressed={viewMode === "grid"}
-            className={`rounded-md p-1.5 transition-all ${
-              viewMode === "grid"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            <LayoutGrid className="h-4 w-4" />
-          </button>
-        </div>
       </div>
 
-      {/* Search + Filters */}
+      {/* Search + Filters + View Toggle */}
       <div className="flex flex-wrap items-end gap-3">
         <TextInput
           placeholder="Search items or asset IDs..."
@@ -199,6 +171,34 @@ export function ItemsPage() {
             Clear filters
           </Button>
         )}
+        <div className="flex items-center gap-1 rounded-lg border bg-muted/30 p-0.5 ml-auto">
+          <button
+            type="button"
+            onClick={() => handleViewChange("table")}
+            aria-label="Table view"
+            aria-pressed={viewMode === "table"}
+            className={`rounded-md p-1.5 transition-all ${
+              viewMode === "table"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <LayoutList className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => handleViewChange("grid")}
+            aria-label="Grid view"
+            aria-pressed={viewMode === "grid"}
+            className={`rounded-md p-1.5 transition-all ${
+              viewMode === "grid"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <LayoutGrid className="h-4 w-4" />
+          </button>
+        </div>
       </div>
 
       {/* Summary line */}


### PR DESCRIPTION
## Summary
- Move table/grid view toggle from the page header into the search/filter bar
- Toggle is now adjacent to the data it controls, pushed right with `ml-auto`

Closes #267

## Test plan
- [ ] View toggle appears at end of filter bar row
- [ ] Table/grid switching still works and persists to localStorage
- [ ] Layout looks good on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)