### PR TITLE
fix: compact Recently Added widget with richer content

### DIFF
--- a/apps/pops-api/src/modules/inventory/reports/service.ts
+++ b/apps/pops-api/src/modules/inventory/reports/service.ts
@@ -48,6 +48,7 @@ export function getDashboard(): DashboardSummary {
       id: homeInventory.id,
       itemName: homeInventory.itemName,
       type: homeInventory.type,
+      assetId: homeInventory.assetId,
       lastEditedTime: homeInventory.lastEditedTime,
     })
     .from(homeInventory)

--- a/apps/pops-api/src/modules/inventory/reports/types.ts
+++ b/apps/pops-api/src/modules/inventory/reports/types.ts
@@ -14,6 +14,7 @@ export interface RecentItem {
   id: string;
   itemName: string;
   type: string | null;
+  assetId: string | null;
   lastEditedTime: string;
 }
 

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -21,6 +21,7 @@ import {
   TextInput,
   Card,
   CardContent,
+  TypeBadge,
 } from "@pops/ui";
 import type { Condition } from "@pops/ui";
 import { trpc } from "../lib/trpc";
@@ -67,7 +68,21 @@ const IN_USE_OPTIONS: SelectOption[] = [
   { value: "false", label: "Not In Use" },
 ];
 
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
 function DashboardWidgets() {
+  const navigate = useNavigate();
   const { data, isLoading } = trpc.inventory.reports.dashboard.useQuery();
 
   if (isLoading) {
@@ -96,77 +111,88 @@ function DashboardWidgets() {
   } = data.data;
 
   return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center gap-2 text-muted-foreground mb-1">
-              <Package className="h-4 w-4" />
-              <span className="text-xs font-medium">Items</span>
-            </div>
-            <div className="text-2xl font-bold tabular-nums">{itemCount}</div>
-          </CardContent>
-        </Card>
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex items-center gap-2 text-muted-foreground mb-1">
+            <Package className="h-4 w-4" />
+            <span className="text-xs font-medium">Items</span>
+          </div>
+          <div className="text-2xl font-bold tabular-nums">{itemCount}</div>
+        </CardContent>
+      </Card>
 
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center gap-2 text-muted-foreground mb-1">
-              <DollarSign className="h-4 w-4" />
-              <span className="text-xs font-medium">Replacement</span>
-            </div>
-            <div className="text-2xl font-bold tabular-nums">
-              {formatCurrency(totalReplacementValue)}
-            </div>
-          </CardContent>
-        </Card>
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex items-center gap-2 text-muted-foreground mb-1">
+            <DollarSign className="h-4 w-4" />
+            <span className="text-xs font-medium">Replacement</span>
+          </div>
+          <div className="text-2xl font-bold tabular-nums">
+            {formatCurrency(totalReplacementValue)}
+          </div>
+        </CardContent>
+      </Card>
 
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center gap-2 text-muted-foreground mb-1">
-              <DollarSign className="h-4 w-4" />
-              <span className="text-xs font-medium">Resale</span>
-            </div>
-            <div className="text-2xl font-bold tabular-nums">
-              {formatCurrency(totalResaleValue)}
-            </div>
-          </CardContent>
-        </Card>
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex items-center gap-2 text-muted-foreground mb-1">
+            <DollarSign className="h-4 w-4" />
+            <span className="text-xs font-medium">Resale</span>
+          </div>
+          <div className="text-2xl font-bold tabular-nums">
+            {formatCurrency(totalResaleValue)}
+          </div>
+        </CardContent>
+      </Card>
 
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center gap-2 text-muted-foreground mb-1">
-              <Shield className="h-4 w-4" />
-              <span className="text-xs font-medium">Warranties</span>
-            </div>
-            <div className="text-2xl font-bold tabular-nums">
-              {warrantiesExpiringSoon}
-              <span className="text-sm font-normal text-muted-foreground ml-1">
-                expiring
-              </span>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex items-center gap-2 text-muted-foreground mb-1">
+            <Shield className="h-4 w-4" />
+            <span className="text-xs font-medium">Warranties</span>
+          </div>
+          <div className="text-2xl font-bold tabular-nums">
+            {warrantiesExpiringSoon}
+            <span className="text-sm font-normal text-muted-foreground ml-1">
+              expiring
+            </span>
+          </div>
+        </CardContent>
+      </Card>
 
       {recentlyAdded.length > 0 && (
-        <Card>
+        <Card className="col-span-2">
           <CardContent className="p-4">
             <div className="flex items-center gap-2 text-muted-foreground mb-3">
               <Clock className="h-4 w-4" />
               <span className="text-xs font-medium">Recently Added</span>
             </div>
-            <ul className="space-y-2">
+            <ul className="space-y-1.5">
               {recentlyAdded.map((item) => (
                 <li
                   key={item.id}
-                  className="flex items-center justify-between text-sm"
+                  role="button"
+                  tabIndex={0}
+                  className="flex items-center gap-2 text-sm rounded-md px-2 py-1.5 -mx-2 cursor-pointer hover:bg-muted/50 transition-colors"
+                  onClick={() => navigate(`/inventory/items/${item.id}`)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      navigate(`/inventory/items/${item.id}`);
+                    }
+                  }}
                 >
                   <span className="font-medium truncate">{item.itemName}</span>
-                  {item.type && (
-                    <span className="text-xs text-muted-foreground shrink-0 ml-2">
-                      {item.type}
+                  {item.type && <TypeBadge type={item.type} />}
+                  {item.assetId && (
+                    <span className="text-xs text-muted-foreground shrink-0">
+                      {item.assetId}
                     </span>
                   )}
+                  <span className="text-xs text-muted-foreground shrink-0 ml-auto">
+                    {timeAgo(item.lastEditedTime)}
+                  </span>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- **Backend**: Add `assetId` to dashboard query select and `RecentItem` type
- **Frontend**: Move Recently Added card into the stat grid spanning 2 columns (`col-span-2`) instead of full-width below the grid
- **Frontend**: Enrich row content with `TypeBadge`, asset ID, relative timestamp ("2d ago"), and clickable rows navigating to item detail

## Test plan
- [x] Lint passes on all changed files
- [x] Typecheck passes (pre-existing errors unchanged)
- [x] Widget renders inside the stat grid, not full-width
- [x] Rows show name, type badge, asset ID, and relative time
- [x] Clicking a row navigates to `/inventory/items/:id`
- [ ] Manual QA: verify layout on narrow and wide viewports

Fixes #269
[GH-269] (tb-180)

🤖 Generated with [Claude Code](https://claude.com/claude-code)