### PR TITLE
fix: remove hero backdrop bezel on detail pages [tb-185]

### DIFF
--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -115,8 +115,8 @@ export function MovieDetailPage() {
 
   return (
     <div>
-      {/* Hero section */}
-      <div className="relative h-64 md:h-96 overflow-hidden bg-muted">
+      {/* Hero section — negative margins cancel shell padding for edge-to-edge */}
+      <div className="-mx-4 md:-mx-6 lg:-mx-8 -mt-4 md:-mt-6 lg:-mt-8 relative h-64 md:h-96 overflow-hidden bg-muted">
         {backdropSrc && (
           <img
             src={backdropSrc}

--- a/packages/app-media/src/pages/TvShowDetailPage.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.tsx
@@ -135,8 +135,8 @@ export function TvShowDetailPage() {
 
   return (
     <div>
-      {/* Hero section */}
-      <div className="relative h-64 md:h-96 overflow-hidden bg-muted">
+      {/* Hero section — negative margins cancel shell padding for edge-to-edge */}
+      <div className="-mx-4 md:-mx-6 lg:-mx-8 -mt-4 md:-mt-6 lg:-mt-8 relative h-64 md:h-96 overflow-hidden bg-muted">
         {backdropSrc && (
           <img
             src={backdropSrc}


### PR DESCRIPTION
## Summary
- Added negative margins (`-mx-4 md:-mx-6 lg:-mx-8 -mt-4 md:-mt-6 lg:-mt-8`) to hero sections in MovieDetailPage and TvShowDetailPage
- Hero backdrops now render edge-to-edge, cancelling the shell's main padding
- No shell layout changes needed — avoids breaking other pages
- Coordinates with tb-177 (GH-263) which added mx-auto for content centering

## Test plan
- [ ] Open a movie detail page — verify hero backdrop extends to edges (no padding gap)
- [ ] Open a TV show detail page — verify same edge-to-edge hero
- [ ] Verify content below hero still has proper padding and centering
- [ ] Check on mobile viewports — no horizontal overflow

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)