### PR TITLE
fix: add missing toast feedback on mutations (tb-186)

### DIFF
--- a/packages/app-inventory/src/pages/LocationTreePage.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.tsx
@@ -467,16 +467,20 @@ export function LocationTreePage() {
 
   const createMutation = trpc.inventory.locations.create.useMutation({
     onSuccess: () => {
+      toast.success("Location created");
       utils.inventory.locations.tree.invalidate();
       setAddingChildOf(null);
       setAddingRoot(false);
     },
+    onError: (err) => toast.error(`Failed to create location: ${err.message}`),
   });
 
   const updateMutation = trpc.inventory.locations.update.useMutation({
     onSuccess: () => {
+      toast.success("Location updated");
       utils.inventory.locations.tree.invalidate();
     },
+    onError: (err) => toast.error(`Failed to update location: ${err.message}`),
   });
 
   const deleteMutation = trpc.inventory.locations.delete.useMutation({

--- a/packages/app-media/src/pages/PlexSettingsPage.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.tsx
@@ -18,6 +18,7 @@ import {
   Server,
   Save,
 } from "lucide-react";
+import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
 
 function ConnectionBadge({ connected }: { connected: boolean }) {
@@ -116,28 +117,35 @@ export function PlexSettingsPage() {
   });
 
   const syncMovies = trpc.media.plex.syncMovies.useMutation({
-    onSuccess: () => syncStatus.refetch(),
+    onSuccess: () => {
+      toast.success("Movie sync complete");
+      syncStatus.refetch();
+    },
+    onError: (err) => toast.error(`Movie sync failed: ${err.message}`),
   });
   const syncTvShows = trpc.media.plex.syncTvShows.useMutation({
-    onSuccess: () => syncStatus.refetch(),
+    onSuccess: () => {
+      toast.success("TV show sync complete");
+      syncStatus.refetch();
+    },
+    onError: (err) => toast.error(`TV show sync failed: ${err.message}`),
   });
 
   const saveUrl = trpc.media.plex.setUrl.useMutation({
     onSuccess: () => {
-      console.log("[Plex] Server URL saved successfully");
+      toast.success("Server URL saved");
       syncStatus.refetch();
       connectionTest.refetch();
       currentUrl.refetch();
     },
     onError: (err) => {
-      console.error("[Plex] Failed to save URL:", err);
+      toast.error(`Failed to save URL: ${err.message}`);
     },
   });
 
   const getPin = trpc.media.plex.getAuthPin.useMutation({
     onSuccess: (res) => {
       const { id, code, clientId } = res.data;
-      console.log(`[Plex] Obtained PIN ID: ${id}, Code: ${code}`);
       setPinId(id);
       window.open(
         `https://app.plex.tv/auth#?clientID=${clientId}&code=${code}&context[device][product]=POPS`,
@@ -145,29 +153,31 @@ export function PlexSettingsPage() {
       );
     },
     onError: (err) => {
-      console.error("[Plex] Failed to get PIN:", err);
+      toast.error(`Failed to start auth: ${err.message}`);
     },
   });
 
   const checkPin = trpc.media.plex.checkAuthPin.useMutation({
     onSuccess: (res) => {
       if (res.data.connected) {
-        console.log("[Plex] Successfully connected! Refetching status...");
+        toast.success("Plex account connected");
         setPinId(null);
         syncStatus.refetch();
         connectionTest.refetch();
       }
     },
     onError: (err) => {
-      console.error("[Plex] Failed to check PIN:", err);
+      toast.error(`Auth check failed: ${err.message}`);
     },
   });
 
   const disconnect = trpc.media.plex.disconnect.useMutation({
     onSuccess: () => {
+      toast.success("Plex account disconnected");
       syncStatus.refetch();
       connectionTest.refetch();
     },
+    onError: (err) => toast.error(`Failed to disconnect: ${err.message}`),
   });
 
   useEffect(() => {

--- a/packages/app-media/src/pages/SeasonDetailPage.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.tsx
@@ -166,9 +166,11 @@ export function SeasonDetailPage() {
   );
 
   const batchLogMutation = trpc.media.watchHistory.batchLog.useMutation({
-    onSuccess: () => {
+    onSuccess: (result) => {
       utils.media.watchHistory.invalidate();
+      toast.success(`Marked ${result.data.logged} episode${result.data.logged !== 1 ? "s" : ""} as watched`);
     },
+    onError: (err) => toast.error(`Failed to mark season: ${err.message}`),
   });
 
   const isSeasonWatched = seasonProgress

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -288,10 +288,12 @@ export function WatchlistPage() {
   const removeMutation = trpc.media.watchlist.remove.useMutation({
     onSuccess: () => {
       setRemovingId(null);
+      toast.success("Removed from watchlist");
       void utils.media.watchlist.list.invalidate();
     },
-    onError: () => {
+    onError: (err) => {
       setRemovingId(null);
+      toast.error(`Failed to remove: ${err.message}`);
     },
   });
 
@@ -299,10 +301,12 @@ export function WatchlistPage() {
     onSuccess: () => {
       setUpdateErrorId(null);
       setUpdateErrorMsg(null);
+      toast.success("Notes saved");
       void utils.media.watchlist.list.invalidate();
     },
     onError: (error) => {
       setUpdateErrorMsg(error.message ?? "Failed to save notes");
+      toast.error(`Failed to save notes: ${error.message}`);
     },
   });
 


### PR DESCRIPTION
## Summary
- Add success/error toasts to 12 silent mutations across 4 files
- **PlexSettingsPage:** 6 mutations (syncMovies, syncTvShows, saveUrl, getPin, checkPin, disconnect) — replaced console.log/error with toast feedback
- **SeasonDetailPage:** batchLogMutation — added success toast with episode count
- **WatchlistPage:** removeMutation + updateMutation — added success/error toasts
- **LocationTreePage:** createMutation + updateMutation — added success/error toasts

Closes #254

## Test plan
- [x] Lint clean on all 4 files
- [x] No new typecheck errors
- [ ] Verify toasts appear on success/failure for each mutation
- [ ] Verify existing functionality (reorder, delete) not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)