### PR TITLE
feat: add breadcrumbs to drill-down pages [GH-256] (tb-184)

### DIFF
--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -14,10 +14,15 @@ import {
   Skeleton,
   TypeBadge,
   ConditionBadge,
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+  BreadcrumbPage,
   type Condition,
 } from "@pops/ui";
 import {
-  ArrowLeft,
   Pencil,
   Link2,
   Unlink,
@@ -109,13 +114,23 @@ export function ItemDetailPage() {
 
   return (
     <div className="p-6 max-w-3xl">
+      {/* Breadcrumb */}
+      <Breadcrumb className="mb-4">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/inventory">Inventory</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>{item.itemName}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
       {/* Header */}
       <div className="flex items-center gap-3 mb-8">
-        <Link to="/inventory">
-          <Button variant="ghost" size="icon" className="h-9 w-9 bg-amber-500/10 text-amber-700 hover:bg-amber-500/20 hover:text-amber-800 dark:bg-amber-500/20 dark:text-amber-300 dark:hover:bg-amber-500/30 rounded-full transition-colors">
-            <ArrowLeft className="h-5 w-5" />
-          </Button>
-        </Link>
         <div className="flex-1">
           <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight">{item.itemName}</h1>
           {(item.brand || item.model) && (

--- a/packages/app-inventory/src/pages/ItemFormPage.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.tsx
@@ -18,8 +18,14 @@ import {
   AlertDescription,
   Skeleton,
   Badge,
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+  BreadcrumbPage,
 } from "@pops/ui";
-import { ArrowLeft, Save, Link2, X, Search } from "lucide-react";
+import { Save, Link2, X, Search } from "lucide-react";
 import { trpc } from "../lib/trpc";
 
 interface PendingConnection {
@@ -278,18 +284,42 @@ export function ItemFormPage() {
     );
   }
 
+  const editItemName = itemData?.data?.itemName;
+
   return (
     <div className="p-6 max-w-2xl">
-      <div className="flex items-center gap-3 mb-8">
-        <Link to="/inventory">
-          <Button variant="ghost" size="icon" className="h-9 w-9 bg-amber-500/10 text-amber-700 hover:bg-amber-500/20 hover:text-amber-800 dark:bg-amber-500/20 dark:text-amber-300 dark:hover:bg-amber-500/30 rounded-full transition-colors">
-            <ArrowLeft className="h-5 w-5" />
-          </Button>
-        </Link>
-        <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight">
-          {isEditMode ? "Edit Item" : "New Item"}
-        </h1>
-      </div>
+      {/* Breadcrumb */}
+      <Breadcrumb className="mb-4">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/inventory">Inventory</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          {isEditMode && editItemName ? (
+            <>
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link to={`/inventory/items/${id}`}>{editItemName}</Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Edit</BreadcrumbPage>
+              </BreadcrumbItem>
+            </>
+          ) : (
+            <BreadcrumbItem>
+              <BreadcrumbPage>New Item</BreadcrumbPage>
+            </BreadcrumbItem>
+          )}
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight mb-8">
+        {isEditMode ? "Edit Item" : "New Item"}
+      </h1>
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
         {/* Basic Info */}

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -1,5 +1,17 @@
 import { useParams, Link } from "react-router";
-import { Alert, AlertTitle, AlertDescription, Badge, Skeleton } from "@pops/ui";
+import {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+  Badge,
+  Skeleton,
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+  BreadcrumbPage,
+} from "@pops/ui";
 import { trpc } from "../lib/trpc";
 import { formatCurrency, formatRuntime } from "../lib/format";
 import { WatchlistToggle } from "../components/WatchlistToggle";
@@ -115,6 +127,23 @@ export function MovieDetailPage() {
 
   return (
     <div>
+      {/* Breadcrumb */}
+      <div className="p-6 pb-0">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link to="/media">Media</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>{movie.title}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+
       {/* Hero section — negative margins cancel shell padding for edge-to-edge */}
       <div className="-mx-4 md:-mx-6 lg:-mx-8 -mt-4 md:-mt-6 lg:-mt-8 relative h-64 md:h-96 overflow-hidden bg-muted">
         {backdropSrc && (
@@ -224,13 +253,6 @@ export function MovieDetailPage() {
           </section>
         )}
 
-        {/* Back link */}
-        <Link
-          to="/media"
-          className="inline-block text-sm text-primary underline"
-        >
-          Back to library
-        </Link>
       </div>
     </div>
   );

--- a/packages/app-media/src/pages/PlexSettingsPage.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.tsx
@@ -6,9 +6,19 @@
  */
 import { useState, useEffect } from "react";
 import { Link } from "react-router";
-import { Badge, Button, Skeleton, Input } from "@pops/ui";
 import {
-  ArrowLeft,
+  Badge,
+  Button,
+  Skeleton,
+  Input,
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+  BreadcrumbPage,
+} from "@pops/ui";
+import {
   CheckCircle2,
   XCircle,
   RefreshCw,
@@ -223,14 +233,26 @@ export function PlexSettingsPage() {
 
   return (
     <div className="space-y-6 max-w-4xl mx-auto p-6">
+      {/* Breadcrumb */}
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/media">Media</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Plex Settings</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
       {/* Header */}
       <div className="flex items-center gap-3">
-        <Link to="/media" className="text-muted-foreground hover:text-foreground">
-          <ArrowLeft className="h-5 w-5" />
-        </Link>
         <h1 className="text-2xl font-bold tracking-tight">Plex Settings</h1>
         {status?.configured && <ConnectionBadge connected={connected} />}
-        
+
         <div className="flex-1" />
         {status?.hasToken && (
           <Button

--- a/packages/app-media/src/pages/TvShowDetailPage.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.tsx
@@ -6,6 +6,12 @@ import {
   Badge,
   Button,
   Skeleton,
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+  BreadcrumbPage,
 } from "@pops/ui";
 import { trpc } from "../lib/trpc";
 import { ProgressBar } from "../components/ProgressBar";
@@ -135,6 +141,23 @@ export function TvShowDetailPage() {
 
   return (
     <div>
+      {/* Breadcrumb */}
+      <div className="p-6 pb-0">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link to="/media">Media</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>{show.name}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+
       {/* Hero section — negative margins cancel shell padding for edge-to-edge */}
       <div className="-mx-4 md:-mx-6 lg:-mx-8 -mt-4 md:-mt-6 lg:-mt-8 relative h-64 md:h-96 overflow-hidden bg-muted">
         {backdropSrc && (
@@ -326,13 +349,6 @@ export function TvShowDetailPage() {
           </section>
         )}
 
-        {/* Back link */}
-        <Link
-          to="/media"
-          className="inline-block text-sm text-primary underline"
-        >
-          Back to library
-        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add breadcrumb navigation to **MovieDetailPage**, **TvShowDetailPage**, **PlexSettingsPage**, **ItemDetailPage**, and **ItemFormPage**
- Remove redundant bottom "Back to library" links from movie/TV detail pages
- Replace ArrowLeft back buttons with proper breadcrumb trails
- Uses existing `Breadcrumb` primitives from `@pops/ui` with React Router `Link` + `asChild`

## Test plan
- [ ] MovieDetailPage shows `Media > Movie Title` breadcrumb, no bottom "Back" link
- [ ] TvShowDetailPage shows `Media > Show Name` breadcrumb, no bottom "Back" link
- [ ] PlexSettingsPage shows `Media > Plex Settings` breadcrumb
- [ ] ItemDetailPage shows `Inventory > Item Name` breadcrumb
- [ ] ItemFormPage (new) shows `Inventory > New Item`
- [ ] ItemFormPage (edit) shows `Inventory > Item Name > Edit` with clickable item link
- [ ] SeasonDetailPage breadcrumbs unchanged (already had them)

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)