### PR TITLE
feat: extract AI Usage page into @pops/app-ai package [tb-181]

### DIFF
--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -24,6 +24,7 @@
     "@pops/app-finance": "workspace:*",
     "@pops/app-media": "workspace:*",
     "@pops/app-inventory": "workspace:*",
+    "@pops/app-ai": "workspace:*",
     "@pops/api": "workspace:*",
     "@pops/ui": "workspace:*",
     "lucide-react": "^0.563.0",

--- a/apps/pops-shell/src/app/nav/icon-map.ts
+++ b/apps/pops-shell/src/app/nav/icon-map.ts
@@ -24,6 +24,7 @@ import {
   Compass,
   Trophy,
   FileText,
+  BarChart3,
   type LucideIcon,
 } from "lucide-react";
 
@@ -45,4 +46,5 @@ export const iconMap: Record<string, LucideIcon> = {
   Compass,
   Trophy,
   FileText,
+  BarChart3,
 };

--- a/apps/pops-shell/src/app/nav/registry.ts
+++ b/apps/pops-shell/src/app/nav/registry.ts
@@ -10,9 +10,15 @@
 import { navConfig as financeNavConfig } from "@pops/app-finance";
 import { navConfig as mediaNavConfig } from "@pops/app-media";
 import { navConfig as inventoryNavConfig } from "@pops/app-inventory";
+import { navConfig as aiNavConfig } from "@pops/app-ai";
 import type { AppNavConfig } from "./types";
 
 /** All registered app nav configs. Order determines display order in the app rail. */
-export const registeredApps: AppNavConfig[] = [financeNavConfig, mediaNavConfig, inventoryNavConfig];
+export const registeredApps: AppNavConfig[] = [
+  financeNavConfig,
+  mediaNavConfig,
+  inventoryNavConfig,
+  aiNavConfig,
+];
 
 export type { AppNavConfig, AppNavItem } from "./types";

--- a/apps/pops-shell/src/app/router.tsx
+++ b/apps/pops-shell/src/app/router.tsx
@@ -9,6 +9,7 @@ import { createBrowserRouter, Navigate } from "react-router";
 import { routes as financeRoutes } from "@pops/app-finance";
 import { routes as mediaRoutes } from "@pops/app-media";
 import { routes as inventoryRoutes } from "@pops/app-inventory";
+import { routes as aiRoutes } from "@pops/app-ai";
 import { RootLayout } from "./layout/RootLayout";
 
 /**
@@ -48,6 +49,10 @@ export const router = createBrowserRouter([
       {
         path: "inventory",
         children: withSuspense(inventoryRoutes),
+      },
+      {
+        path: "ai",
+        children: withSuspense(aiRoutes),
       },
     ],
   },

--- a/packages/app-ai/eslint.config.js
+++ b/packages/app-ai/eslint.config.js
@@ -1,0 +1,26 @@
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: [
+      "node_modules",
+      "dist",
+      "coverage",
+      "*.config.js",
+      "*.config.mjs",
+    ],
+  },
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  },
+);

--- a/packages/app-ai/package.json
+++ b/packages/app-ai/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@pops/app-ai",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts,.tsx",
+    "lint:fix": "eslint src --ext .ts,.tsx --fix"
+  },
+  "dependencies": {
+    "@pops/api": "workspace:*",
+    "@pops/ui": "workspace:*",
+    "@tanstack/react-query": "5.90.20",
+    "@tanstack/react-table": "^8.21.3",
+    "@trpc/client": "11.13.4",
+    "@trpc/react-query": "11.13.4",
+    "lucide-react": "^0.563.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router": "^7.13.1"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "eslint": "^9.39.4",
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.57.1"
+  }
+}

--- a/packages/app-ai/src/index.ts
+++ b/packages/app-ai/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @pops/app-ai — AI app package
+ *
+ * Exports route definitions and navigation config for the shell
+ * to lazily load AI pages under /ai/*.
+ */
+export { routes, navConfig } from "./routes";

--- a/packages/app-ai/src/lib/trpc.ts
+++ b/packages/app-ai/src/lib/trpc.ts
@@ -1,0 +1,10 @@
+/**
+ * tRPC client re-export for app-ai
+ *
+ * Creates typed tRPC hooks for the pops-api backend.
+ * The Provider is owned by the shell (apps/pops-shell).
+ */
+import { createTRPCReact } from "@trpc/react-query";
+import type { AppRouter } from "@pops/api";
+
+export const trpc = createTRPCReact<AppRouter>();

--- a/packages/app-ai/src/pages/AiUsagePage.tsx
+++ b/packages/app-ai/src/pages/AiUsagePage.tsx
@@ -1,0 +1,257 @@
+/**
+ * AI Usage page - view AI categorization costs and usage
+ */
+import type { ColumnDef } from "@tanstack/react-table";
+import { trpc } from "../lib/trpc";
+import { DataTable, SortableHeader, StatCard } from "@pops/ui";
+import { Badge } from "@pops/ui";
+import { Alert } from "@pops/ui";
+import { Skeleton } from "@pops/ui";
+import { Card } from "@pops/ui";
+
+interface AiUsageRecord {
+  date: string;
+  apiCalls: number;
+  cacheHits: number;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number;
+}
+
+export function AiUsagePage() {
+  // Fetch overall stats
+  const {
+    data: stats,
+    isLoading: statsLoading,
+    error: statsError,
+  } = trpc.core.aiUsage.getStats.useQuery();
+
+  // Fetch usage history
+  const {
+    data: history,
+    isLoading: historyLoading,
+    error: historyError,
+  } = trpc.core.aiUsage.getHistory.useQuery({});
+
+  // Loading state
+  if (statsLoading || historyLoading) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
+            AI Usage
+          </h1>
+          <p className="text-muted-foreground">
+            Track AI categorization costs and usage
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {[...Array(4)].map((_, i) => (
+            <Skeleton key={i} className="h-32" />
+          ))}
+        </div>
+
+        <Skeleton className="h-96" />
+      </div>
+    );
+  }
+
+  // Error state
+  if (statsError || historyError) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
+          AI Usage
+        </h1>
+        <Alert variant="destructive">
+          <h3 className="font-semibold">Failed to load AI usage data</h3>
+          <p className="text-sm mt-1">
+            {statsError?.message || historyError?.message || "Unknown error"}
+          </p>
+        </Alert>
+      </div>
+    );
+  }
+
+  // Define table columns
+  const columns: ColumnDef<AiUsageRecord>[] = [
+    {
+      accessorKey: "date",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Date</SortableHeader>
+      ),
+      cell: ({ row }) => {
+        const date = new Date(row.original.date);
+        return date.toLocaleDateString("en-AU", {
+          day: "2-digit",
+          month: "short",
+          year: "numeric",
+        });
+      },
+    },
+    {
+      accessorKey: "apiCalls",
+      header: ({ column }) => (
+        <div className="flex justify-end">
+          <SortableHeader column={column}>API Calls</SortableHeader>
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="text-right font-mono tabular-nums">
+          {row.original.apiCalls.toLocaleString()}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "cacheHits",
+      header: ({ column }) => (
+        <div className="flex justify-end">
+          <SortableHeader column={column}>Cache Hits</SortableHeader>
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="text-right font-mono tabular-nums">
+          {row.original.cacheHits.toLocaleString()}
+        </div>
+      ),
+    },
+    {
+      id: "cacheHitRate",
+      header: () => <div className="text-right">Cache Hit Rate</div>,
+      cell: ({ row }) => {
+        const total = row.original.apiCalls + row.original.cacheHits;
+        const rate = total > 0 ? (row.original.cacheHits / total) * 100 : 0;
+        return (
+          <div className="text-right">
+            <Badge
+              variant={
+                rate > 80 ? "default" : rate > 50 ? "secondary" : "outline"
+              }
+            >
+              {rate.toFixed(1)}%
+            </Badge>
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "inputTokens",
+      header: ({ column }) => (
+        <div className="flex justify-end">
+          <SortableHeader column={column}>Input Tokens</SortableHeader>
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="text-right font-mono text-sm tabular-nums">
+          {row.original.inputTokens.toLocaleString()}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "outputTokens",
+      header: ({ column }) => (
+        <div className="flex justify-end">
+          <SortableHeader column={column}>Output Tokens</SortableHeader>
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="text-right font-mono text-sm tabular-nums">
+          {row.original.outputTokens.toLocaleString()}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "cost",
+      header: ({ column }) => (
+        <div className="flex justify-end">
+          <SortableHeader column={column}>Cost</SortableHeader>
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="text-right font-mono font-medium tabular-nums">
+          ${row.original.cost.toFixed(4)}
+        </div>
+      ),
+    },
+  ];
+
+  // Calculate cache hit rate
+  const totalRequests =
+    (stats?.totalApiCalls ?? 0) + (stats?.totalCacheHits ?? 0);
+  const cacheHitRate = totalRequests > 0 ? (stats?.cacheHitRate ?? 0) * 100 : 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
+          AI Usage
+        </h1>
+        <p className="text-muted-foreground">
+          Track AI categorization costs and usage across all imports
+        </p>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          title="Total Cost"
+          value={`$${(stats?.totalCost ?? 0).toFixed(4)}`}
+          description={
+            stats?.last30Days
+              ? `$${stats.last30Days.cost.toFixed(4)} last 30 days`
+              : undefined
+          }
+          color="amber"
+        />
+
+        <StatCard
+          title="API Calls"
+          value={(stats?.totalApiCalls ?? 0).toLocaleString()}
+          description={
+            stats?.last30Days
+              ? `${stats.last30Days.apiCalls.toLocaleString()} last 30 days`
+              : undefined
+          }
+          color="indigo"
+        />
+
+        <StatCard
+          title="Cache Hit Rate"
+          value={`${cacheHitRate.toFixed(1)}%`}
+          description={`${(stats?.totalCacheHits ?? 0).toLocaleString()} cached results`}
+          color="emerald"
+        />
+
+        <StatCard
+          title="Avg Cost/Call"
+          value={`$${(stats?.avgCostPerCall ?? 0).toFixed(5)}`}
+          description={`${((stats?.totalInputTokens ?? 0) + (stats?.totalOutputTokens ?? 0)).toLocaleString()} total tokens`}
+          color="sky"
+        />
+      </div>
+
+      {/* Usage History Table */}
+      {history && history.records.length > 0 ? (
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-xl font-semibold">Daily Usage History</h2>
+            <p className="text-sm text-muted-foreground">
+              Showing {history.records.length} days • Total: $
+              {history.summary.totalCost.toFixed(4)}
+            </p>
+          </div>
+          <DataTable columns={columns} data={history.records} />
+        </div>
+      ) : (
+        <Card className="p-12 text-center">
+          <p className="text-muted-foreground">No AI usage data yet</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            AI categorization data will appear here after importing transactions
+          </p>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/packages/app-ai/src/routes.tsx
+++ b/packages/app-ai/src/routes.tsx
@@ -1,0 +1,35 @@
+/**
+ * AI app route definitions and navigation config
+ *
+ * Routes are lazy-loaded for code splitting. The shell imports
+ * these via @pops/app-ai and mounts them under /ai/*.
+ */
+import { lazy } from "react";
+import type { RouteObject } from "react-router";
+
+const AiUsagePage = lazy(() =>
+  import("./pages/AiUsagePage").then((m) => ({ default: m.AiUsagePage })),
+);
+
+/** Local type mirror for compile-time safety (shell owns the canonical types). */
+interface AppNavConfigShape {
+  id: string;
+  label: string;
+  icon: string;
+  color?: string;
+  basePath: string;
+  items: { path: string; label: string; icon: string }[];
+}
+
+export const navConfig = {
+  id: "ai",
+  label: "AI",
+  icon: "Bot",
+  color: "violet",
+  basePath: "/ai",
+  items: [{ path: "", label: "Usage", icon: "BarChart3" }],
+} satisfies AppNavConfigShape;
+
+export const routes: RouteObject[] = [
+  { index: true, element: <AiUsagePage /> },
+];

--- a/packages/app-ai/tsconfig.json
+++ b/packages/app-ai/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": []
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.stories.tsx"]
+}

--- a/packages/app-finance/src/routes.tsx
+++ b/packages/app-finance/src/routes.tsx
@@ -8,32 +8,28 @@ import { lazy } from "react";
 import type { RouteObject } from "react-router";
 
 const DashboardPage = lazy(() =>
-  import("./pages/DashboardPage").then((m) => ({ default: m.DashboardPage }))
+  import("./pages/DashboardPage").then((m) => ({ default: m.DashboardPage })),
 );
 const TransactionsPage = lazy(() =>
   import("./pages/TransactionsPage").then((m) => ({
     default: m.TransactionsPage,
-  }))
+  })),
 );
 const EntitiesPage = lazy(() =>
-  import("./pages/EntitiesPage").then((m) => ({ default: m.EntitiesPage }))
+  import("./pages/EntitiesPage").then((m) => ({ default: m.EntitiesPage })),
 );
 const BudgetsPage = lazy(() =>
-  import("./pages/BudgetsPage").then((m) => ({ default: m.BudgetsPage }))
+  import("./pages/BudgetsPage").then((m) => ({ default: m.BudgetsPage })),
 );
 const InventoryPage = lazy(() =>
-  import("./pages/InventoryPage").then((m) => ({ default: m.InventoryPage }))
+  import("./pages/InventoryPage").then((m) => ({ default: m.InventoryPage })),
 );
 const WishlistPage = lazy(() =>
-  import("./pages/WishlistPage").then((m) => ({ default: m.WishlistPage }))
+  import("./pages/WishlistPage").then((m) => ({ default: m.WishlistPage })),
 );
 const ImportPage = lazy(() =>
-  import("./pages/ImportPage").then((m) => ({ default: m.ImportPage }))
+  import("./pages/ImportPage").then((m) => ({ default: m.ImportPage })),
 );
-const AiUsagePage = lazy(() =>
-  import("./pages/AiUsagePage").then((m) => ({ default: m.AiUsagePage }))
-);
-
 /** Shared navigation types (mirrored from shell to avoid circular dependency) */
 export interface AppNavItem {
   path: string;
@@ -64,7 +60,6 @@ export const navConfig: AppNavConfig = {
     { path: "/inventory", label: "Inventory", icon: "Package" },
     { path: "/wishlist", label: "Wish List", icon: "Star" },
     { path: "/import", label: "Import", icon: "Download" },
-    { path: "/ai-usage", label: "AI Usage", icon: "Bot" },
   ],
 };
 
@@ -76,5 +71,4 @@ export const routes: RouteObject[] = [
   { path: "inventory", element: <InventoryPage /> },
   { path: "wishlist", element: <WishlistPage /> },
   { path: "import", element: <ImportPage /> },
-  { path: "ai-usage", element: <AiUsagePage /> },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@pops/api':
         specifier: workspace:*
         version: link:../pops-api
+      '@pops/app-ai':
+        specifier: workspace:*
+        version: link:../../packages/app-ai
       '@pops/app-finance':
         specifier: workspace:*
         version: link:../../packages/app-finance
@@ -190,6 +193,55 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.13(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
+
+  packages/app-ai:
+    dependencies:
+      '@pops/api':
+        specifier: workspace:*
+        version: link:../../apps/pops-api
+      '@pops/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@tanstack/react-query':
+        specifier: 5.90.20
+        version: 5.90.20(react@19.2.4)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@trpc/client':
+        specifier: 11.13.4
+        version: 11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3)
+      '@trpc/react-query':
+        specifier: 11.13.4
+        version: 11.13.4(@tanstack/react-query@5.90.20(react@19.2.4))(@trpc/client@11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.13.4(typescript@5.9.3))(react@19.2.4)(typescript@5.9.3)
+      lucide-react:
+        specifier: ^0.563.0
+        version: 0.563.0(react@19.2.4)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.13.1
+        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.57.1
+        version: 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
 
   packages/app-finance:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,8 @@
 packages:
-  - 'apps/*'
-  - 'packages/app-finance'
-  - 'packages/app-media'
-  - 'packages/app-inventory'
-  - 'packages/db-types'
-  - 'packages/ui'
+  - "apps/*"
+  - "packages/app-finance"
+  - "packages/app-media"
+  - "packages/app-inventory"
+  - "packages/app-ai"
+  - "packages/db-types"
+  - "packages/ui"


### PR DESCRIPTION
## Summary
- Create new `@pops/app-ai` workspace package following the established app package pattern (routes, navConfig, trpc, lazy-loaded pages)
- Move `AiUsagePage` from `app-finance` into `app-ai`, removing the route and nav entry from finance
- Register the AI app in the shell router (`/ai`), nav registry, and icon-map (`BarChart3`) with violet color theme

## Test plan
- [x] `pnpm install` resolves workspace deps
- [x] `tsc --noEmit` passes on pops-shell (no new type errors)
- [x] Prettier formatting applied to all new/modified files
- [ ] Verify `/ai` route loads the AI Usage page in browser
- [ ] Verify AI nav item appears in sidebar with Bot icon and violet color
- [ ] Verify `/finance` no longer shows AI Usage nav item or route

🤖 Generated with [Claude Code](https://claude.com/claude-code)