### PR TITLE
refactor: deduplicate Plex sync helpers (tb-189)

### DIFF
--- a/apps/pops-api/src/modules/media/plex/service.ts
+++ b/apps/pops-api/src/modules/media/plex/service.ts
@@ -8,19 +8,17 @@
  *   3. For each TV library: iterate items, extract TVDB ID, upsert via library service
  *   4. Sync watch history from Plex viewCount/lastViewedAt
  */
-import { eq, and } from "drizzle-orm";
-import { episodes, seasons, settings } from "@pops/db-types";
+import { eq } from "drizzle-orm";
+import { settings } from "@pops/db-types";
 import { randomUUID } from "node:crypto";
 import { PlexClient } from "./client.js";
-import { type PlexMediaItem, type PlexEpisode } from "./types.js";
+import { extractExternalIdAsNumber, logMovieWatch, syncEpisodeWatches } from "./sync-helpers.js";
 import { getEnv } from "../../../env.js";
 import { getDrizzle } from "../../../db.js";
 import * as libraryService from "../library/service.js";
 import * as tvShowService from "../library/tv-show-service.js";
 import { getTmdbClient } from "../tmdb/index.js";
 import { getTvdbClient } from "../thetvdb/index.js";
-import { getTvShowByTvdbId } from "../tv-shows/service.js";
-import { logWatch } from "../watch-history/service.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -192,24 +190,18 @@ export async function syncMovies(client: PlexClient, sectionId: string): Promise
 
   for (const item of items) {
     try {
-      const tmdbId = extractExternalId(item, "tmdb");
+      const tmdbId = extractExternalIdAsNumber(item, "tmdb");
       if (!tmdbId) {
         result.skipped++;
         continue;
       }
 
-      const tmdbIdNum = Number(tmdbId);
-      if (Number.isNaN(tmdbIdNum)) {
-        result.skipped++;
-        continue;
-      }
-
       // Add movie to library (idempotent)
-      const { movie } = await libraryService.addMovie(tmdbIdNum, tmdbClient);
+      const { movie } = await libraryService.addMovie(tmdbId, tmdbClient);
 
       // Sync watch history if Plex shows it was watched
       if (item.viewCount > 0 && item.lastViewedAt) {
-        syncMovieWatch(movie.id, item.lastViewedAt);
+        logMovieWatch(movie.id, item.lastViewedAt);
       }
 
       result.synced++;
@@ -248,24 +240,18 @@ export async function syncTvShows(client: PlexClient, sectionId: string): Promis
 
   for (const item of items) {
     try {
-      const tvdbId = extractExternalId(item, "tvdb");
+      const tvdbId = extractExternalIdAsNumber(item, "tvdb");
       if (!tvdbId) {
         result.skipped++;
         continue;
       }
 
-      const tvdbIdNum = Number(tvdbId);
-      if (Number.isNaN(tvdbIdNum)) {
-        result.skipped++;
-        continue;
-      }
-
       // Add TV show to library (idempotent)
-      await tvShowService.addTvShow(tvdbIdNum, tvdbClient);
+      await tvShowService.addTvShow(tvdbId, tvdbClient);
 
       // Sync episode watch history
       const plexEpisodes = await client.getEpisodes(item.ratingKey);
-      syncEpisodeWatches(tvdbIdNum, plexEpisodes);
+      syncEpisodeWatches(tvdbId, plexEpisodes);
 
       result.synced++;
     } catch (err) {
@@ -294,81 +280,6 @@ export function getSyncStatus(client: PlexClient | null): PlexSyncStatus {
     lastSyncMovies: lastMovieSync,
     lastSyncTvShows: lastTvSync,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Extract an external ID (tmdb, tvdb, imdb) from a Plex media item. */
-function extractExternalId(item: PlexMediaItem, source: string): string | null {
-  const match = item.externalIds.find((id) => id.source === source);
-  return match?.id ?? null;
-}
-
-/**
- * Log a movie watch event from Plex data.
- * Only logs if the movie doesn't already have a watch history entry.
- */
-function syncMovieWatch(movieId: number, lastViewedAtUnix: number): void {
-  try {
-    logWatch({
-      mediaType: "movie",
-      mediaId: movieId,
-      watchedAt: new Date(lastViewedAtUnix * 1000).toISOString(),
-      completed: 1,
-      source: "plex_sync",
-    });
-  } catch {
-    // Ignore duplicate watch entries
-  }
-}
-
-/**
- * Sync episode watches from Plex episode data.
- * Matches Plex episodes to local episodes by season+episode number.
- */
-function syncEpisodeWatches(tvdbId: number, plexEpisodes: PlexEpisode[]): void {
-  const show = getTvShowByTvdbId(tvdbId);
-  if (!show) return;
-
-  const db = getDrizzle();
-
-  for (const plexEp of plexEpisodes) {
-    if (plexEp.viewCount === 0) continue;
-
-    try {
-      // Find the local season
-      const season = db
-        .select()
-        .from(seasons)
-        .where(and(eq(seasons.tvShowId, show.id), eq(seasons.seasonNumber, plexEp.seasonIndex)))
-        .get();
-      if (!season) continue;
-
-      // Find the local episode
-      const episode = db
-        .select()
-        .from(episodes)
-        .where(
-          and(eq(episodes.seasonId, season.id), eq(episodes.episodeNumber, plexEp.episodeIndex))
-        )
-        .get();
-      if (!episode) continue;
-
-      logWatch({
-        mediaType: "episode",
-        mediaId: episode.id,
-        watchedAt: plexEp.lastViewedAt
-          ? new Date(plexEp.lastViewedAt * 1000).toISOString()
-          : new Date().toISOString(),
-        completed: 1,
-        source: "plex_sync",
-      });
-    } catch {
-      // Ignore duplicate or failed episode watch entries
-    }
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/pops-api/src/modules/media/plex/sync-helpers.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-helpers.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared helpers for Plex sync operations.
+ *
+ * Extracted from service.ts, sync-movies.ts, and sync-tv.ts to eliminate
+ * duplicated watch-history logging and external ID extraction logic.
+ */
+import { eq, and } from "drizzle-orm";
+import { episodes, seasons } from "@pops/db-types";
+import type { PlexMediaItem, PlexEpisode } from "./types.js";
+import { getDrizzle } from "../../../db.js";
+import { getTvShowByTvdbId } from "../tv-shows/service.js";
+import { logWatch } from "../watch-history/service.js";
+
+/**
+ * Extract an external ID (tmdb, tvdb, imdb) from a Plex media item
+ * and parse it as a number. Returns null if not found or not numeric.
+ */
+export function extractExternalIdAsNumber(item: PlexMediaItem, source: string): number | null {
+  const match = item.externalIds.find((id) => id.source === source);
+  if (!match) return null;
+
+  const parsed = Number(match.id);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * Log a movie watch event from Plex data.
+ * Silently ignores duplicate watch entries.
+ */
+export function logMovieWatch(movieId: number, lastViewedAtUnix: number): void {
+  try {
+    logWatch({
+      mediaType: "movie",
+      mediaId: movieId,
+      watchedAt: new Date(lastViewedAtUnix * 1000).toISOString(),
+      completed: 1,
+      source: "plex_sync",
+    });
+  } catch {
+    // Ignore duplicate watch entries
+  }
+}
+
+/**
+ * Match Plex episodes to local DB episodes by season+episode number
+ * and log watch history for watched episodes.
+ *
+ * Returns the number of episodes matched and logged.
+ */
+export function syncEpisodeWatches(tvdbId: number, plexEpisodes: PlexEpisode[]): number {
+  const show = getTvShowByTvdbId(tvdbId);
+  if (!show) return 0;
+
+  const db = getDrizzle();
+  let matched = 0;
+
+  for (const plexEp of plexEpisodes) {
+    if (plexEp.viewCount === 0) continue;
+
+    try {
+      // Find the local season
+      const season = db
+        .select()
+        .from(seasons)
+        .where(and(eq(seasons.tvShowId, show.id), eq(seasons.seasonNumber, plexEp.seasonIndex)))
+        .get();
+      if (!season) continue;
+
+      // Find the local episode
+      const episode = db
+        .select()
+        .from(episodes)
+        .where(
+          and(eq(episodes.seasonId, season.id), eq(episodes.episodeNumber, plexEp.episodeIndex))
+        )
+        .get();
+      if (!episode) continue;
+
+      logWatch({
+        mediaType: "episode",
+        mediaId: episode.id,
+        watchedAt: plexEp.lastViewedAt
+          ? new Date(plexEp.lastViewedAt * 1000).toISOString()
+          : new Date().toISOString(),
+        completed: 1,
+        source: "plex_sync",
+      });
+
+      matched++;
+    } catch {
+      // Ignore duplicate or failed episode watch entries
+    }
+  }
+
+  return matched;
+}

--- a/apps/pops-api/src/modules/media/plex/sync-movies.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-movies.ts
@@ -10,7 +10,7 @@ import type { PlexMediaItem } from "./types.js";
 import type { TmdbClient } from "../tmdb/client.js";
 import { getTmdbClient } from "../tmdb/index.js";
 import * as libraryService from "../library/service.js";
-import { logWatch } from "../watch-history/service.js";
+import { logMovieWatch } from "./sync-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -114,17 +114,7 @@ async function syncSingleMovie(
 
   // Step 3: Sync watch history
   if (item.viewCount > 0 && item.lastViewedAt) {
-    try {
-      logWatch({
-        mediaType: "movie",
-        mediaId: movie.id,
-        watchedAt: new Date(item.lastViewedAt * 1000).toISOString(),
-        completed: 1,
-        source: "plex_sync",
-      });
-    } catch {
-      // Ignore duplicate watch entries
-    }
+    logMovieWatch(movie.id, item.lastViewedAt);
   }
 
   progress.synced++;

--- a/apps/pops-api/src/modules/media/plex/sync-tv.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-tv.ts
@@ -6,15 +6,11 @@
  * and logs watch history for watched episodes.
  */
 import type { PlexClient } from "./client.js";
-import type { PlexMediaItem, PlexEpisode } from "./types.js";
+import type { PlexMediaItem } from "./types.js";
 import type { TheTvdbClient } from "../thetvdb/client.js";
 import { getTvdbClient } from "../thetvdb/index.js";
 import * as tvShowService from "../library/tv-show-service.js";
-import { getTvShowByTvdbId } from "../tv-shows/service.js";
-import { logWatch } from "../watch-history/service.js";
-import { getDrizzle } from "../../../db.js";
-import { episodes, seasons } from "@pops/db-types";
-import { eq, and } from "drizzle-orm";
+import { extractExternalIdAsNumber, syncEpisodeWatches } from "./sync-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -110,7 +106,7 @@ async function syncSingleShow(
   progress: TvSyncProgress
 ): Promise<void> {
   // Step 1: Resolve TVDB ID
-  const tvdbId = resolveTvdbId(item);
+  const tvdbId = extractExternalIdAsNumber(item, "tvdb");
 
   if (!tvdbId) {
     progress.skipped++;
@@ -126,80 +122,4 @@ async function syncSingleShow(
   progress.episodesMatched += matched;
 
   progress.synced++;
-}
-
-// ---------------------------------------------------------------------------
-// TVDB ID resolution
-// ---------------------------------------------------------------------------
-
-/**
- * Extract TVDB ID from a Plex media item's Guid array.
- * Returns null if no TVDB Guid is found or the ID is not numeric.
- */
-function resolveTvdbId(item: PlexMediaItem): number | null {
-  const tvdbGuid = item.externalIds.find((id) => id.source === "tvdb");
-  if (!tvdbGuid) return null;
-
-  const parsed = Number(tvdbGuid.id);
-  if (Number.isNaN(parsed)) return null;
-
-  return parsed;
-}
-
-// ---------------------------------------------------------------------------
-// Episode watch sync
-// ---------------------------------------------------------------------------
-
-/**
- * Match Plex episodes to local DB episodes by season+episode number
- * and log watch history for watched episodes.
- *
- * Returns the number of episodes matched and logged.
- */
-function syncEpisodeWatches(tvdbId: number, plexEpisodes: PlexEpisode[]): number {
-  const show = getTvShowByTvdbId(tvdbId);
-  if (!show) return 0;
-
-  const db = getDrizzle();
-  let matched = 0;
-
-  for (const plexEp of plexEpisodes) {
-    if (plexEp.viewCount === 0) continue;
-
-    try {
-      // Find the local season
-      const season = db
-        .select()
-        .from(seasons)
-        .where(and(eq(seasons.tvShowId, show.id), eq(seasons.seasonNumber, plexEp.seasonIndex)))
-        .get();
-      if (!season) continue;
-
-      // Find the local episode
-      const episode = db
-        .select()
-        .from(episodes)
-        .where(
-          and(eq(episodes.seasonId, season.id), eq(episodes.episodeNumber, plexEp.episodeIndex))
-        )
-        .get();
-      if (!episode) continue;
-
-      logWatch({
-        mediaType: "episode",
-        mediaId: episode.id,
-        watchedAt: plexEp.lastViewedAt
-          ? new Date(plexEp.lastViewedAt * 1000).toISOString()
-          : new Date().toISOString(),
-        completed: 1,
-        source: "plex_sync",
-      });
-
-      matched++;
-    } catch {
-      // Ignore duplicate or failed episode watch entries
-    }
-  }
-
-  return matched;
 }


### PR DESCRIPTION
## Summary
- Extracted duplicated watch-history logging and external ID extraction logic into a new shared `sync-helpers.ts` module
- Replaced 3 inline external ID extraction patterns with `extractExternalIdAsNumber()`
- Replaced 2 identical movie watch logging blocks with `logMovieWatch()`
- Replaced 2 nearly-identical episode sync functions with a single shared `syncEpisodeWatches()`
- Net reduction of ~80 lines of duplicated code across `service.ts`, `sync-movies.ts`, and `sync-tv.ts`

## Test plan
- [ ] Verify typecheck passes (only pre-existing `settings` export error remains)
- [ ] Verify Prettier formatting passes on all changed files
- [ ] Verify movie sync still works end-to-end via Plex settings page
- [ ] Verify TV show sync with episode watch matching still works
- [ ] Verify watch history logging deduplication (no duplicate entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)