### PR TITLE
fix: remove .room-agent.json from tracked files

### DIFF
--- a/.room-agent.json
+++ b/.room-agent.json
@@ -1,7 +1,0 @@
-{
-  "username": "wall-e",
-  "token": "1c5ca489-b564-4317-98b4-278104aee592",
-  "room_id": "dev",
-  "ralph_pid": 574,
-  "personality": "/home/agent/.room/personality-wall-e.txt"
-}


### PR DESCRIPTION
## Summary
- Removes `.room-agent.json` from git tracking — it was accidentally committed and contains agent tokens
- File is already in `.gitignore`, so this just does `git rm --cached`

## Test plan
- [x] Verify `.room-agent.json` is no longer tracked (`git ls-files .room-agent.json` returns empty)
- [x] Verify file still exists locally (not deleted from disk)
- [x] Verify `.gitignore` already has the entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)