### PR TITLE
fix: add missing eslint config for app-ai + remove unused function

### DIFF
--- a/packages/app-ai/eslint.config.js
+++ b/packages/app-ai/eslint.config.js
@@ -1,0 +1,20 @@
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: ["node_modules", "dist", "coverage", "*.config.js", "*.config.mjs"],
+  },
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  }
+);

--- a/packages/app-inventory/src/pages/WarrantiesPage.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.tsx
@@ -43,12 +43,6 @@ function daysUntil(dateStr: string): number {
   return Math.ceil((target.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
 }
 
-function urgencyColor(days: number): string {
-  if (days <= 14) return "text-red-600";
-  if (days <= 30) return "text-orange-500";
-  return "text-yellow-600";
-}
-
 function urgencyBadgeVariant(
   days: number,
 ): "destructive" | "secondary" | "outline" {


### PR DESCRIPTION
## Summary
- Add `eslint.config.js` to `@pops/app-ai` — was missing after extraction (PR #304), causing `mise lint` to fail
- Remove unused `urgencyColor` function from `WarrantiesPage.tsx` (lint error)

## Test plan
- [x] `mise lint` passes (9/9 tasks, 0 errors)
- [x] `mise typecheck` passes (10/10 tasks)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)