### PR TITLE
fix: correct watchlist table name in quick pick query [GH-314]

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/service.ts
+++ b/apps/pops-api/src/modules/media/discovery/service.ts
@@ -133,7 +133,7 @@ export function getQuickPickMovies(count: number): QuickPickMovie[] {
          SELECT DISTINCT media_id FROM watch_history WHERE media_type = 'movie'
        )
        AND m.id NOT IN (
-         SELECT media_id FROM media_watchlist WHERE media_type = 'movie'
+         SELECT media_id FROM watchlist WHERE media_type = 'movie'
        )
        ORDER BY RANDOM()
        LIMIT ?`


### PR DESCRIPTION
## Summary
- Fixed `getQuickPickMovies` query referencing non-existent `media_watchlist` table — changed to `watchlist`
- This was causing a 500 error when clicking the "Tonight" quick pick button

## Test plan
- [x] Existing test suite passes (no DB-level test for this raw SQL query existed)
- [ ] QA: verify "Tonight" quick pick no longer returns 500

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)