### PR TITLE
fix: inventory dashboard layout — remove Value by Location, rearrange [GH-323]

### DIFF
--- a/packages/app-inventory/src/components/ValueBreakdown.tsx
+++ b/packages/app-inventory/src/components/ValueBreakdown.tsx
@@ -1,9 +1,16 @@
 /**
- * ValueBreakdown — horizontal bar charts showing replacement value
- * grouped by location and by item type.
+ * ValueByTypeCard — horizontal bar chart showing replacement value
+ * grouped by item type.
  */
-import { Alert, AlertDescription, Button, Card, CardContent, Skeleton } from "@pops/ui";
-import { AlertCircle, MapPin, RefreshCw, Tag } from "lucide-react";
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Card,
+  CardContent,
+  Skeleton,
+} from "@pops/ui";
+import { AlertCircle, RefreshCw, Tag } from "lucide-react";
 import {
   BarChart,
   Bar,
@@ -97,41 +104,8 @@ function BreakdownChart({ data, onBarClick }: BreakdownChartProps) {
   );
 }
 
-function BreakdownSkeleton() {
-  return (
-    <Card>
-      <CardContent className="p-4 space-y-2">
-        <Skeleton className="h-4 w-32" />
-        <Skeleton className="h-40 w-full" />
-      </CardContent>
-    </Card>
-  );
-}
-
-function BreakdownError({ message, onRetry }: { message: string; onRetry: () => void }) {
-  return (
-    <Alert variant="destructive">
-      <AlertCircle className="h-4 w-4" />
-      <AlertDescription className="flex items-center justify-between gap-2">
-        <span>{message}</span>
-        <Button variant="outline" size="sm" onClick={onRetry}>
-          <RefreshCw className="h-3 w-3 mr-1" />
-          Retry
-        </Button>
-      </AlertDescription>
-    </Alert>
-  );
-}
-
-export function ValueBreakdown() {
+export function ValueByTypeCard({ className }: { className?: string }) {
   const navigate = useNavigate();
-
-  const {
-    data: locationData,
-    isLoading: locationLoading,
-    isError: locationError,
-    refetch: refetchLocation,
-  } = trpc.inventory.reports.valueByLocation.useQuery();
 
   const {
     data: typeData,
@@ -140,63 +114,46 @@ export function ValueBreakdown() {
     refetch: refetchType,
   } = trpc.inventory.reports.valueByType.useQuery();
 
-  if (locationLoading || typeLoading) {
+  if (typeLoading) {
     return (
-      <div className="grid gap-4 md:grid-cols-2">
-        <BreakdownSkeleton />
-        <BreakdownSkeleton />
-      </div>
+      <Card className={className}>
+        <CardContent className="p-4 space-y-2">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-40 w-full" />
+        </CardContent>
+      </Card>
     );
   }
 
-  const locationEntries = locationData?.data ?? [];
   const typeEntries = typeData?.data ?? [];
 
   return (
-    <div className="grid gap-4 md:grid-cols-2">
-      <Card>
-        <CardContent className="p-4">
-          <div className="flex items-center gap-2 text-muted-foreground mb-3">
-            <MapPin className="h-4 w-4" />
-            <span className="text-xs font-medium">Value by Location</span>
-          </div>
-          {locationError ? (
-            <BreakdownError
-              message="Failed to load location breakdown"
-              onRetry={() => refetchLocation()}
-            />
-          ) : (
-            <BreakdownChart
-              data={locationEntries}
-              onBarClick={(name) =>
-                navigate(`/inventory?location=${encodeURIComponent(name)}`)
-              }
-            />
-          )}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent className="p-4">
-          <div className="flex items-center gap-2 text-muted-foreground mb-3">
-            <Tag className="h-4 w-4" />
-            <span className="text-xs font-medium">Value by Type</span>
-          </div>
-          {typeError ? (
-            <BreakdownError
-              message="Failed to load type breakdown"
-              onRetry={() => refetchType()}
-            />
-          ) : (
-            <BreakdownChart
-              data={typeEntries}
-              onBarClick={(name) =>
-                navigate(`/inventory?type=${encodeURIComponent(name)}`)
-              }
-            />
-          )}
-        </CardContent>
-      </Card>
-    </div>
+    <Card className={className}>
+      <CardContent className="p-4">
+        <div className="flex items-center gap-2 text-muted-foreground mb-3">
+          <Tag className="h-4 w-4" />
+          <span className="text-xs font-medium">Value by Type</span>
+        </div>
+        {typeError ? (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription className="flex items-center justify-between gap-2">
+              <span>Failed to load type breakdown</span>
+              <Button variant="outline" size="sm" onClick={() => refetchType()}>
+                <RefreshCw className="h-3 w-3 mr-1" />
+                Retry
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <BreakdownChart
+            data={typeEntries}
+            onBarClick={(name) =>
+              navigate(`/inventory?type=${encodeURIComponent(name)}`)
+            }
+          />
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -27,7 +27,7 @@ import type { Condition } from "@pops/ui";
 import { trpc } from "../lib/trpc";
 import { InventoryTable } from "../components/InventoryTable";
 import { InventoryCard } from "../components/InventoryCard";
-import { ValueBreakdown } from "../components/ValueBreakdown";
+import { ValueByTypeCard } from "../components/ValueBreakdown";
 import { formatCurrency } from "../lib/utils";
 type ViewMode = "table" | "grid";
 
@@ -199,6 +199,8 @@ function DashboardWidgets() {
           </CardContent>
         </Card>
       )}
+
+      <ValueByTypeCard className="col-span-2" />
     </div>
   );
 }
@@ -264,12 +266,7 @@ export function ItemsPage() {
         <h1 className="text-2xl md:text-3xl font-bold">Inventory</h1>
       </div>
 
-      {!hasActiveFilters && !search && (
-        <>
-          <DashboardWidgets />
-          <ValueBreakdown />
-        </>
-      )}
+      {!hasActiveFilters && !search && <DashboardWidgets />}
 
       {/* Search + Filters + View Toggle */}
       <div className="flex flex-wrap items-end gap-3">
@@ -353,7 +350,10 @@ export function ItemsPage() {
           <p className="text-xs font-semibold text-amber-900 dark:text-amber-200 uppercase tracking-wider">
             {totalCount} {totalCount === 1 ? "item" : "items"}
             {totalReplacementValue > 0 && (
-              <span> — {formatCurrency(totalReplacementValue)} replacement</span>
+              <span>
+                {" "}
+                — {formatCurrency(totalReplacementValue)} replacement
+              </span>
             )}
             {totalResaleValue > 0 && (
               <span> — {formatCurrency(totalResaleValue)} resale</span>


### PR DESCRIPTION
## Summary
- Removed the "Value by Location" widget from the inventory dashboard
- Moved "Value by Type" chart into the main dashboard grid next to "Recently Added"
- Eliminated the separate `ValueBreakdown` row — dashboard is now 2 rows instead of 3
- Layout: Row 1 (4 stat cards) + Row 2 (Recently Added | Value by Type)

## Test plan
- [ ] QA: verify inventory dashboard shows correct 2-row layout
- [ ] QA: verify no empty space next to Recently Added
- [ ] QA: verify Value by Type chart is functional with bar click navigation

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)