### PR TITLE
fix: remove double padding from WishlistPage, SearchPage, ItemDetailPage [GH-318]

### DIFF
--- a/packages/app-finance/src/pages/WishlistPage.tsx
+++ b/packages/app-finance/src/pages/WishlistPage.tsx
@@ -287,7 +287,7 @@ export function WishlistPage() {
 
   if (error) {
     return (
-      <div className="space-y-6 p-6">
+      <div className="space-y-6">
         <h1 className="text-2xl font-bold">Wish List</h1>
         <Alert variant="destructive">
           <p className="font-semibold">Failed to load wish list</p>
@@ -303,7 +303,7 @@ export function WishlistPage() {
   const isSubmitting = createMutation.isPending || updateMutation.isPending;
 
   return (
-    <div className="space-y-6 p-6">
+    <div className="space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl md:text-3xl font-bold">Wish List</h1>

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -75,7 +75,7 @@ export function ItemDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="p-6 space-y-6 max-w-3xl">
+      <div className="space-y-6 max-w-3xl">
         <Skeleton className="h-8 w-48" />
         <Skeleton className="h-6 w-32" />
         <div className="grid grid-cols-2 gap-4">
@@ -91,7 +91,7 @@ export function ItemDetailPage() {
   if (error) {
     const is404 = error.data?.code === "NOT_FOUND";
     return (
-      <div className="p-6">
+      <div>
         <Alert variant="destructive">
           <AlertTitle>{is404 ? "Item not found" : "Error"}</AlertTitle>
           <AlertDescription>
@@ -113,7 +113,7 @@ export function ItemDetailPage() {
   const item = itemData.data;
 
   return (
-    <div className="p-6 max-w-3xl">
+    <div className="max-w-3xl">
       {/* Breadcrumb */}
       <Breadcrumb className="mb-4">
         <BreadcrumbList>

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -178,7 +178,7 @@ export function SearchPage() {
   const noResults = hasQuery && !isSearching && totalResults === 0 && !hasError;
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="space-y-4">
       <div>
         <h1 className="text-2xl font-bold">Search</h1>
         <p className="text-muted-foreground mt-1 text-sm">


### PR DESCRIPTION
## Summary
- Removes explicit `p-6` from root wrapper divs in WishlistPage, SearchPage, and ItemDetailPage
- These pages were doubling up padding with the shell's responsive `p-4 md:p-6 lg:p-8` on `<main>`
- Now all three pages inherit the shell's consistent responsive padding

Fixes GH-318 / tb-194

## Test plan
- [ ] WishlistPage (Finance > Wish List) — padding should match other pages
- [ ] SearchPage (Media > Search) — no extra inner padding
- [ ] ItemDetailPage (Inventory > Items > click item) — consistent with other inventory pages
- [ ] Verify at mobile, tablet, and desktop breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)