### PR TITLE
fix: add missing last_edited_time column to locations table (tb-193)

### DIFF
--- a/apps/pops-api/src/db/migrations/20260320140000_inventory_new_columns.sql
+++ b/apps/pops-api/src/db/migrations/20260320140000_inventory_new_columns.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS locations (
   name       TEXT NOT NULL,
   parent_id  TEXT,
   sort_order INTEGER NOT NULL DEFAULT 0,
+  last_edited_time TEXT NOT NULL DEFAULT (datetime('now')),
   FOREIGN KEY (parent_id) REFERENCES locations(id) ON DELETE CASCADE
 );
 

--- a/apps/pops-api/src/db/migrations/20260325120000_locations_last_edited_time.sql
+++ b/apps/pops-api/src/db/migrations/20260325120000_locations_last_edited_time.sql
@@ -1,0 +1,9 @@
+-- Migration: 20260325120000_locations_last_edited_time.sql
+-- Domain: inventory
+-- Description: Add missing last_edited_time column to locations table.
+--   The Drizzle schema defines this column but the CREATE TABLE SQL omitted it,
+--   causing 500 errors on location tree, insurance report, and value breakdown queries.
+--
+-- Fixes: GH-317, GH-321, GH-322
+
+ALTER TABLE locations ADD COLUMN last_edited_time TEXT NOT NULL DEFAULT (datetime('now'));

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -96,6 +96,7 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
       name       TEXT NOT NULL,
       parent_id  TEXT,
       sort_order INTEGER NOT NULL DEFAULT 0,
+      last_edited_time TEXT NOT NULL DEFAULT (datetime('now')),
       FOREIGN KEY (parent_id) REFERENCES locations(id) ON DELETE CASCADE
     );
 

--- a/apps/pops-api/src/db/seeder.ts
+++ b/apps/pops-api/src/db/seeder.ts
@@ -555,8 +555,8 @@ export function seedDatabase(db: BetterSqlite3.Database): void {
     ];
 
     const insertLocation = db.prepare(`
-      INSERT INTO locations (id, name, parent_id, sort_order)
-      VALUES (?, ?, ?, ?)
+      INSERT INTO locations (id, name, parent_id, sort_order, last_edited_time)
+      VALUES (?, ?, ?, ?, datetime('now'))
     `);
 
     for (const loc of locations) {


### PR DESCRIPTION
## Summary
- Add missing `last_edited_time` column to locations table in `schema.ts` init SQL and migration file
- Add ALTER TABLE migration (`20260325120000`) for existing databases that already have the locations table
- Fix seeder to include `last_edited_time` when inserting location records

Fixes GH-317, GH-321, GH-322 — all caused by the Drizzle ORM schema expecting `last_edited_time` on the locations table but the raw SQL CREATE TABLE omitting it.

## Test plan
- [x] Existing tests pass (30 failures are pre-existing env-context timeout issues unrelated to this change)
- [ ] QA: verify locations tree loads without 500
- [ ] QA: verify insurance report loads without 500
- [ ] QA: verify value by location/type reports load without 500
- [ ] QA: verify `mise db:init && mise db:seed` works cleanly

Closes #317, closes #321, closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)