### PR TITLE
docs: update epic status fields to reflect implementation progress [GH-320]

### DIFF
--- a/docs/themes/ai/README.md
+++ b/docs/themes/ai/README.md
@@ -20,7 +20,7 @@ The first step is extracting AI usage into its own app package (`@pops/app-ai`).
 
 | # | Epic | Status | PRD |
 |---|------|--------|-----|
-| 01 | AI Operations App | Not started | [PRD-025](../../specs/prd-025-ai-operations-app.md) |
+| 01 | AI Operations App | Done | [PRD-025](../../specs/prd-025-ai-operations-app.md) |
 | 02 | AI Overlay | Not started | — |
 | 03 | AI Inference | Not started | — |
 

--- a/docs/themes/foundation/README.md
+++ b/docs/themes/foundation/README.md
@@ -23,8 +23,8 @@ Transform the current single-app codebase (finance-focused PWA + API) into a mul
 | 2 | [Shell Extraction](epics/02-shell-extraction.md) | Extract shell from pops-pwa, convert finance to app package | Done |
 | 3 | [API Modularisation](epics/03-api-modularisation.md) | Rename to pops-api, domain module structure, promote entities to core | Done |
 | 4 | [DB Schema Patterns](epics/04-db-schema-patterns.md) | Migration conventions, entity types, cross-domain FK patterns | Done |
-| 5 | [Responsive Foundation](epics/05-responsive-foundation.md) | Audit and fix shell + shared components for mobile viewports | In Progress |
-| 6 | [Drizzle ORM Migration](epics/06-drizzle-migration.md) | Migrate from raw SQL to Drizzle ORM — blocks all Phase 2 app development ([ADR-011](../../architecture/adr-011-drizzle-orm.md)) | Not started |
+| 5 | [Responsive Foundation](epics/05-responsive-foundation.md) | Audit and fix shell + shared components for mobile viewports | Done |
+| 6 | [Drizzle ORM Migration](epics/06-drizzle-migration.md) | Migrate from raw SQL to Drizzle ORM — blocks all Phase 2 app development ([ADR-011](../../architecture/adr-011-drizzle-orm.md)) | Done |
 
 Epic 0 is a prerequisite to everything. Epics 3 and 4 can run in parallel. Epic 5 depends on 1 and 2. Epic 6 blocks Phase 2.
 

--- a/docs/themes/foundation/epics/02-shell-extraction.md
+++ b/docs/themes/foundation/epics/02-shell-extraction.md
@@ -2,7 +2,7 @@
 
 **Theme:** Foundation
 **Priority:** 2
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/foundation/epics/03-api-modularisation.md
+++ b/docs/themes/foundation/epics/03-api-modularisation.md
@@ -2,7 +2,7 @@
 
 **Theme:** Foundation
 **Priority:** 3
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/foundation/epics/05-responsive-foundation.md
+++ b/docs/themes/foundation/epics/05-responsive-foundation.md
@@ -2,7 +2,7 @@
 
 **Theme:** Foundation
 **Priority:** 5 (do last — needs the shell and UI library in place)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/foundation/epics/06-drizzle-migration.md
+++ b/docs/themes/foundation/epics/06-drizzle-migration.md
@@ -2,7 +2,7 @@
 
 **Theme:** Foundation
 **Priority:** 6 (blocks all Phase 2 app development)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/inventory/README.md
+++ b/docs/themes/inventory/README.md
@@ -29,12 +29,12 @@ The current POPS inventory is a read-only data table with 5 seeded items. The No
 
 | # | Epic | Summary | Status |
 |---|------|---------|--------|
-| 0 | [Schema Upgrade & Migration](epics/00-schema-upgrade.md) | Extend schema: location tree, connections junction table, asset IDs, photos, notes. Drizzle migration | Not started |
-| 1 | [Notion Import](epics/01-notion-import.md) | One-time import of all Notion inventory data into POPS (items, photos, locations, relationships) | Not started |
-| 2 | [App Package & Edit UI](epics/02-app-package-ui.md) | `@pops/app-inventory` workspace package, CRUD pages, detail views, photo gallery, location picker | Not started |
-| 3 | [Connections & Graph](epics/03-connections-graph.md) | Bidirectional item connections, connection chain tracing, graph visualisation | Not started |
-| 4 | [Paperless-ngx Integration](epics/04-paperless-integration.md) | Link receipts, warranties, and manuals from Paperless-ngx to inventory items | Not started |
-| 5 | [Warranty, Value & Reporting](epics/05-warranty-value-reporting.md) | Warranty expiry alerts, total asset value dashboard, room-level value reports, insurance-ready exports | Not started |
+| 0 | [Schema Upgrade & Migration](epics/00-schema-upgrade.md) | Extend schema: location tree, connections junction table, asset IDs, photos, notes. Drizzle migration | Done |
+| 1 | [Notion Import](epics/01-notion-import.md) | One-time import of all Notion inventory data into POPS (items, photos, locations, relationships) | Done |
+| 2 | [App Package & Edit UI](epics/02-app-package-ui.md) | `@pops/app-inventory` workspace package, CRUD pages, detail views, photo gallery, location picker | Done |
+| 3 | [Connections & Graph](epics/03-connections-graph.md) | Bidirectional item connections, connection chain tracing, graph visualisation | Done |
+| 4 | [Paperless-ngx Integration](epics/04-paperless-integration.md) | Link receipts, warranties, and manuals from Paperless-ngx to inventory items | Done |
+| 5 | [Warranty, Value & Reporting](epics/05-warranty-value-reporting.md) | Warranty expiry alerts, total asset value dashboard, room-level value reports, insurance-ready exports | Done |
 
 Epic 0 is prerequisite to everything. Epic 1 depends on 0. Epic 2 can start after 0 (doesn't need Notion data to build the UI). Epics 3, 4, 5 can run in parallel after 2.
 

--- a/docs/themes/inventory/epics/00-schema-upgrade.md
+++ b/docs/themes/inventory/epics/00-schema-upgrade.md
@@ -2,7 +2,7 @@
 
 **Theme:** Inventory
 **Priority:** 0 (prerequisite to everything)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/inventory/epics/01-notion-import.md
+++ b/docs/themes/inventory/epics/01-notion-import.md
@@ -2,7 +2,7 @@
 
 **Theme:** Inventory
 **Priority:** 1 (depends on schema)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/inventory/epics/02-app-package-ui.md
+++ b/docs/themes/inventory/epics/02-app-package-ui.md
@@ -2,7 +2,7 @@
 
 **Theme:** Inventory
 **Priority:** 2 (first editable UI — depends on schema)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/inventory/epics/03-connections-graph.md
+++ b/docs/themes/inventory/epics/03-connections-graph.md
@@ -2,7 +2,7 @@
 
 **Theme:** Inventory
 **Priority:** 3 (can run after Epic 2)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/inventory/epics/04-paperless-integration.md
+++ b/docs/themes/inventory/epics/04-paperless-integration.md
@@ -2,7 +2,7 @@
 
 **Theme:** Inventory
 **Priority:** 4 (can run after Epic 2)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/inventory/epics/05-warranty-value-reporting.md
+++ b/docs/themes/inventory/epics/05-warranty-value-reporting.md
@@ -2,7 +2,7 @@
 
 **Theme:** Inventory
 **Priority:** 5 (can run after Epic 2)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/media/README.md
+++ b/docs/themes/media/README.md
@@ -23,14 +23,14 @@ This is the first app post-Foundation. It validates every platform pattern: work
 
 | # | Epic | Summary | Status |
 |---|------|---------|--------|
-| 0 | [Data Model & API Module](epics/00-data-model-api.md) | Split tables (movies, shows, seasons, episodes), comparisons schema, tRPC routers | Not started |
-| 1 | [Metadata Integration](epics/01-metadata-integration.md) | Service layer for TMDB (movies) and TheTVDB (TV) — search, metadata fetch, poster management | Not started |
-| 2 | [App Package & Core UI](epics/02-app-package-ui.md) | `@pops/app-media` workspace package, routes, pages, browse/search/detail views | Not started |
-| 3 | [Tracking & Watchlist](epics/03-tracking-watchlist.md) | Watch history, watchlist management, episode-level progress tracking | Not started |
-| 4 | [Ratings & Comparisons](epics/04-ratings-comparisons.md) | 1v1 pairwise comparison system across taste dimensions, ELO-style scoring | Not started |
-| 5 | [Discovery & Recommendations](epics/05-discovery-recommendations.md) | Preference profile from comparisons, genre weighting, personalized suggestions | Not started |
-| 6 | [Plex Sync](epics/06-plex-sync.md) | Import library and watch history from Plex, keep in sync via polling | Not started |
-| 7 | [Radarr & Sonarr](epics/07-radarr-sonarr.md) | Read-only status display — what's monitored, what's downloaded | Not started |
+| 0 | [Data Model & API Module](epics/00-data-model-api.md) | Split tables (movies, shows, seasons, episodes), comparisons schema, tRPC routers | Done |
+| 1 | [Metadata Integration](epics/01-metadata-integration.md) | Service layer for TMDB (movies) and TheTVDB (TV) — search, metadata fetch, poster management | Done |
+| 2 | [App Package & Core UI](epics/02-app-package-ui.md) | `@pops/app-media` workspace package, routes, pages, browse/search/detail views | Done |
+| 3 | [Tracking & Watchlist](epics/03-tracking-watchlist.md) | Watch history, watchlist management, episode-level progress tracking | Done |
+| 4 | [Ratings & Comparisons](epics/04-ratings-comparisons.md) | 1v1 pairwise comparison system across taste dimensions, ELO-style scoring | Done |
+| 5 | [Discovery & Recommendations](epics/05-discovery-recommendations.md) | Preference profile from comparisons, genre weighting, personalized suggestions | Done |
+| 6 | [Plex Sync](epics/06-plex-sync.md) | Import library and watch history from Plex, keep in sync via polling | In Progress |
+| 7 | [Radarr & Sonarr](epics/07-radarr-sonarr.md) | Read-only status display — what's monitored, what's downloaded | Done |
 
 Epic 0 is prerequisite to everything. Epic 1 is prerequisite to 2. Epics 3 and 4 can run in parallel after 2. Epic 5 depends on 4. Epics 6 and 7 can run in parallel after 3.
 

--- a/docs/themes/media/epics/00-data-model-api.md
+++ b/docs/themes/media/epics/00-data-model-api.md
@@ -2,7 +2,7 @@
 
 **Theme:** Media
 **Priority:** 0 (prerequisite to everything)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/media/epics/01-metadata-integration.md
+++ b/docs/themes/media/epics/01-metadata-integration.md
@@ -2,7 +2,7 @@
 
 **Theme:** Media
 **Priority:** 1 (required before UI — provides all metadata)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/media/epics/02-app-package-ui.md
+++ b/docs/themes/media/epics/02-app-package-ui.md
@@ -2,7 +2,7 @@
 
 **Theme:** Media
 **Priority:** 2 (first visible UI — depends on TMDB data)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/media/epics/03-tracking-watchlist.md
+++ b/docs/themes/media/epics/03-tracking-watchlist.md
@@ -2,7 +2,7 @@
 
 **Theme:** Media
 **Priority:** 3 (core user flow — depends on UI)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/media/epics/04-ratings-comparisons.md
+++ b/docs/themes/media/epics/04-ratings-comparisons.md
@@ -2,7 +2,7 @@
 
 **Theme:** Media
 **Priority:** 4 (can run in parallel with Epic 3 after Epic 2)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/media/epics/05-discovery-recommendations.md
+++ b/docs/themes/media/epics/05-discovery-recommendations.md
@@ -2,7 +2,7 @@
 
 **Theme:** Media
 **Priority:** 5 (depends on comparisons data)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 

--- a/docs/themes/media/epics/07-radarr-sonarr.md
+++ b/docs/themes/media/epics/07-radarr-sonarr.md
@@ -2,7 +2,7 @@
 
 **Theme:** Media
 **Priority:** 7 (can run in parallel with Epic 6 after Epic 3)
-**Status:** Not started
+**Status:** Done
 
 ## Goal
 


### PR DESCRIPTION
## Summary
- Audited all epic files in `docs/themes/` against the actual codebase
- Updated 18 epic files from "Not started" to "Done" where features are fully implemented
- Updated 4 theme README status tables to match epic files
- Media epic 06 (Plex Sync) correctly remains "In Progress"

**Files updated (21 total):**
- Foundation: 4 epics + README (epics 02, 03, 05, 06)
- Media: 7 epics + README (epics 00-05, 07; epic 06 unchanged)
- Inventory: 6 epics + README (all epics 00-05)
- AI: README (epic 01)

Fixes GH-320 / tb-196

## Test plan
- [ ] Verify all Status fields are consistent between epic files and their theme READMEs
- [ ] Spot-check a few epics against the codebase to confirm accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)