### PR TITLE
fix: add back button to Plex settings page [GH-338]

### DIFF
--- a/packages/app-media/src/pages/PlexSettingsPage.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.tsx
@@ -19,6 +19,7 @@ import {
   BreadcrumbPage,
 } from "@pops/ui";
 import {
+  ArrowLeft,
   CheckCircle2,
   XCircle,
   RefreshCw,
@@ -250,6 +251,13 @@ export function PlexSettingsPage() {
 
       {/* Header */}
       <div className="flex items-center gap-3">
+        <Link
+          to="/media"
+          className="inline-flex items-center justify-center h-8 w-8 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
+          aria-label="Back to Media"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
         <h1 className="text-2xl font-bold tracking-tight">Plex Settings</h1>
         {status?.configured && <ConnectionBadge connected={connected} />}
 


### PR DESCRIPTION
## Summary
- Adds a prominent back button (ArrowLeft icon) next to the "Plex Settings" page title, linking to `/media`
- Breadcrumbs remain as secondary navigation; the back button provides a more visible/accessible way to navigate back
- Addresses user report that the Plex settings page had no back button

## Test plan
- [ ] Navigate to Media > Plex Settings and verify the back arrow appears next to the title
- [ ] Click the back button and verify it navigates to `/media`
- [ ] Verify breadcrumbs still render correctly above the header
- [ ] Test on mobile viewport to confirm the button is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)