### PR TITLE
fix: add error handling to Plex library selection save [GH-337]

### DIFF
--- a/packages/app-media/src/pages/PlexSettingsPage.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.tsx
@@ -121,7 +121,8 @@ export function PlexSettingsPage() {
 
   useEffect(() => {
     if (savedSectionIds.data?.data) {
-      const { movieSectionId: savedMovie, tvSectionId: savedTv } = savedSectionIds.data.data;
+      const { movieSectionId: savedMovie, tvSectionId: savedTv } =
+        savedSectionIds.data.data;
       if (savedMovie) setMovieSectionId(savedMovie);
       if (savedTv) setTvSectionId(savedTv);
     }
@@ -149,7 +150,10 @@ export function PlexSettingsPage() {
     },
     onError: (err) => toast.error(`TV show sync failed: ${err.message}`),
   });
-  const saveSectionIds = trpc.media.plex.saveSectionIds.useMutation();
+  const saveSectionIds = trpc.media.plex.saveSectionIds.useMutation({
+    onError: (err) =>
+      toast.error(`Failed to save library selection: ${err.message}`),
+  });
 
   const saveUrl = trpc.media.plex.setUrl.useMutation({
     onSuccess: () => {
@@ -169,7 +173,7 @@ export function PlexSettingsPage() {
       setPinId(id);
       window.open(
         `https://app.plex.tv/auth#?clientID=${clientId}&code=${code}&context[device][product]=POPS`,
-        "_blank"
+        "_blank",
       );
     },
     onError: (err) => {
@@ -274,7 +278,9 @@ export function PlexSettingsPage() {
             <h2 className="text-lg font-semibold">Server Configuration</h2>
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-muted-foreground">Plex Media Server URL</label>
+            <label className="text-sm font-medium text-muted-foreground">
+              Plex Media Server URL
+            </label>
             <div className="flex gap-2">
               <Input
                 placeholder="http://192.168.1.100:32400"
@@ -283,19 +289,31 @@ export function PlexSettingsPage() {
                 className="flex-1"
                 disabled={saveUrl.isPending}
               />
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 onClick={() => saveUrl.mutate({ url: plexUrl })}
-                disabled={saveUrl.isPending || !plexUrl || (plexUrl === currentUrl.data?.data)}
+                disabled={
+                  saveUrl.isPending ||
+                  !plexUrl ||
+                  plexUrl === currentUrl.data?.data
+                }
               >
-                {saveUrl.isPending ? <RefreshCw className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                {saveUrl.isPending ? (
+                  <RefreshCw className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
               </Button>
             </div>
             {saveUrl.error && (
-              <p className="text-xs text-red-400 mt-1">{saveUrl.error.message}</p>
+              <p className="text-xs text-red-400 mt-1">
+                {saveUrl.error.message}
+              </p>
             )}
             {!status?.hasUrl && (
-              <p className="text-xs text-amber-400">Please set your Plex server URL to enable connection.</p>
+              <p className="text-xs text-amber-400">
+                Please set your Plex server URL to enable connection.
+              </p>
             )}
           </div>
         </div>
@@ -306,14 +324,17 @@ export function PlexSettingsPage() {
             <div className="space-y-2">
               <h2 className="text-lg font-semibold">Plex Account</h2>
               <p className="text-sm text-muted-foreground max-w-md mx-auto">
-                Link your Plex account to enable library syncing and watch history tracking.
+                Link your Plex account to enable library syncing and watch
+                history tracking.
               </p>
             </div>
-            
+
             <div className="pt-2">
               {pinId ? (
                 <div className="space-y-3">
-                  <p className="text-sm text-amber-400 animate-pulse">Waiting for authentication in new tab...</p>
+                  <p className="text-sm text-amber-400 animate-pulse">
+                    Waiting for authentication in new tab...
+                  </p>
                   <Button variant="outline" onClick={() => setPinId(null)}>
                     Cancel
                   </Button>
@@ -326,14 +347,19 @@ export function PlexSettingsPage() {
                   {getPin.isPending ? "Requesting..." : "Connect to Plex"}
                 </Button>
               )}
-              {getPin.error && <p className="text-xs text-red-400 mt-2">{getPin.error.message}</p>}
+              {getPin.error && (
+                <p className="text-xs text-red-400 mt-2">
+                  {getPin.error.message}
+                </p>
+              )}
             </div>
           </div>
         ) : !status?.configured ? (
           <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-4 flex items-center gap-3">
             <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0" />
             <div className="text-sm text-amber-200">
-              Authenticated with Plex account, but server URL is missing. Set the URL above to finish setup.
+              Authenticated with Plex account, but server URL is missing. Set
+              the URL above to finish setup.
             </div>
           </div>
         ) : null}
@@ -345,7 +371,10 @@ export function PlexSettingsPage() {
             <div className="space-y-1">
               <p className="font-semibold">Connection Failed</p>
               <p>{connectionError}</p>
-              <p className="text-xs opacity-70">Verify that the server URL is correct and the server is reachable from this application.</p>
+              <p className="text-xs opacity-70">
+                Verify that the server URL is correct and the server is
+                reachable from this application.
+              </p>
             </div>
           </div>
         )}
@@ -383,7 +412,9 @@ export function PlexSettingsPage() {
                   <Button
                     size="sm"
                     disabled={!movieSectionId || syncMovies.isPending}
-                    onClick={() => syncMovies.mutate({ sectionId: movieSectionId })}
+                    onClick={() =>
+                      syncMovies.mutate({ sectionId: movieSectionId })
+                    }
                     className="w-full"
                   >
                     {syncMovies.isPending ? (
@@ -395,7 +426,9 @@ export function PlexSettingsPage() {
                   </Button>
                 </>
               ) : (
-                <p className="text-xs text-muted-foreground">No movie libraries found</p>
+                <p className="text-xs text-muted-foreground">
+                  No movie libraries found
+                </p>
               )}
             </div>
 
@@ -429,7 +462,9 @@ export function PlexSettingsPage() {
                   <Button
                     size="sm"
                     disabled={!tvSectionId || syncTvShows.isPending}
-                    onClick={() => syncTvShows.mutate({ sectionId: tvSectionId })}
+                    onClick={() =>
+                      syncTvShows.mutate({ sectionId: tvSectionId })
+                    }
                     className="w-full"
                   >
                     {syncTvShows.isPending ? (
@@ -441,7 +476,9 @@ export function PlexSettingsPage() {
                   </Button>
                 </>
               ) : (
-                <p className="text-xs text-muted-foreground">No TV libraries found</p>
+                <p className="text-xs text-muted-foreground">
+                  No TV libraries found
+                </p>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Added error toast notification to the `saveSectionIds` mutation in PlexSettingsPage
- Previously, failures when persisting library selections were silently swallowed
- Note: the persistence mechanism itself (upsert to settings table) is correct — the issue may be related to a stale db-types build not exporting `settings`. Rebuilding `@pops/db-types` resolves the TypeScript error.

## Test plan
- [ ] QA: select a Plex library, navigate away, navigate back — verify selection persists
- [ ] QA: verify error toast appears if save fails

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)