### PR TITLE
feat: add Arr settings UI for Radarr/Sonarr configuration [GH-341]

### DIFF
--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -53,6 +53,44 @@ export const arrRouter = router({
     return { data: arrService.getArrConfig() };
   }),
 
+  /** Get current Arr settings (URLs and whether API keys are set). */
+  getSettings: protectedProcedure.query(() => {
+    const s = arrService.getArrSettings();
+    return {
+      data: {
+        radarrUrl: s.radarrUrl ?? "",
+        radarrApiKey: s.radarrApiKey ? "••••••••" : "",
+        sonarrUrl: s.sonarrUrl ?? "",
+        sonarrApiKey: s.sonarrApiKey ? "••••••••" : "",
+        radarrHasKey: !!s.radarrApiKey,
+        sonarrHasKey: !!s.sonarrApiKey,
+      },
+    };
+  }),
+
+  /** Save Arr settings (URLs and API keys). */
+  saveSettings: protectedProcedure
+    .input(
+      z.object({
+        radarrUrl: z.string().optional(),
+        radarrApiKey: z.string().optional(),
+        sonarrUrl: z.string().optional(),
+        sonarrApiKey: z.string().optional(),
+      })
+    )
+    .mutation(({ input }) => {
+      // Don't overwrite API keys with the masked placeholder
+      const config: Parameters<typeof arrService.saveArrSettings>[0] = {};
+      if (input.radarrUrl !== undefined) config.radarrUrl = input.radarrUrl;
+      if (input.radarrApiKey !== undefined && input.radarrApiKey !== "••••••••")
+        config.radarrApiKey = input.radarrApiKey;
+      if (input.sonarrUrl !== undefined) config.sonarrUrl = input.sonarrUrl;
+      if (input.sonarrApiKey !== undefined && input.sonarrApiKey !== "••••••••")
+        config.sonarrApiKey = input.sonarrApiKey;
+      arrService.saveArrSettings(config);
+      return { message: "Arr settings saved" };
+    }),
+
   /** Get Radarr status for a movie by TMDB ID. */
   getMovieStatus: protectedProcedure
     .input(z.object({ tmdbId: z.number().int().positive() }))

--- a/apps/pops-api/src/modules/media/arr/service.test.ts
+++ b/apps/pops-api/src/modules/media/arr/service.test.ts
@@ -2,6 +2,29 @@
  * Arr service tests — tests client factory and status caching.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the database so settings table lookups return nothing by default
+vi.mock("../../../db.js", () => ({
+  getDrizzle: vi.fn(() => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          get: () => undefined,
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: () => ({
+        onConflictDoUpdate: () => ({ run: vi.fn() }),
+        onConflictDoNothing: () => ({ run: vi.fn() }),
+      }),
+    }),
+    delete: () => ({
+      where: () => ({ run: vi.fn() }),
+    }),
+  })),
+}));
+
 import { getRadarrClient, getSonarrClient, getArrConfig, clearStatusCache } from "./service.js";
 
 describe("Arr service", () => {

--- a/apps/pops-api/src/modules/media/arr/service.ts
+++ b/apps/pops-api/src/modules/media/arr/service.ts
@@ -1,9 +1,13 @@
 /**
  * Arr service — factory functions and in-memory status cache for Radarr/Sonarr.
  */
+import { eq } from "drizzle-orm";
+import { settings } from "@pops/db-types";
 import { RadarrClient } from "./radarr-client.js";
 import { SonarrClient } from "./sonarr-client.js";
 import type { ArrConfig, ArrStatusResult, DownloadQueueItem } from "./types.js";
+import { getEnv } from "../../../env.js";
+import { getDrizzle } from "../../../db.js";
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -15,27 +19,96 @@ interface CacheEntry {
 const movieStatusCache = new Map<number, CacheEntry>();
 const showStatusCache = new Map<number, CacheEntry>();
 
-/** Create a Radarr client if env vars are configured. */
+// ---------------------------------------------------------------------------
+// Settings helpers (settings table with env var fallback, like Plex)
+// ---------------------------------------------------------------------------
+
+function getSetting(key: string): string | null {
+  const db = getDrizzle();
+  const record = db.select().from(settings).where(eq(settings.key, key)).get();
+  if (record?.value) return record.value;
+  return null;
+}
+
+function getArrSetting(key: string, envName: string): string | null {
+  return getSetting(key) || getEnv(envName) || null;
+}
+
+function saveSetting(key: string, value: string): void {
+  const db = getDrizzle();
+  db.insert(settings)
+    .values({ key, value })
+    .onConflictDoUpdate({ target: settings.key, set: { value } })
+    .run();
+}
+
+function deleteSetting(key: string): void {
+  const db = getDrizzle();
+  db.delete(settings).where(eq(settings.key, key)).run();
+}
+
+/** Get current Arr settings (from settings table or env vars). */
+export function getArrSettings(): {
+  radarrUrl: string | null;
+  radarrApiKey: string | null;
+  sonarrUrl: string | null;
+  sonarrApiKey: string | null;
+} {
+  return {
+    radarrUrl: getArrSetting("radarr_url", "RADARR_URL"),
+    radarrApiKey: getArrSetting("radarr_api_key", "RADARR_API_KEY"),
+    sonarrUrl: getArrSetting("sonarr_url", "SONARR_URL"),
+    sonarrApiKey: getArrSetting("sonarr_api_key", "SONARR_API_KEY"),
+  };
+}
+
+/** Save Arr settings to the settings table. */
+export function saveArrSettings(config: {
+  radarrUrl?: string;
+  radarrApiKey?: string;
+  sonarrUrl?: string;
+  sonarrApiKey?: string;
+}): void {
+  if (config.radarrUrl !== undefined) {
+    if (config.radarrUrl) saveSetting("radarr_url", config.radarrUrl);
+    else deleteSetting("radarr_url");
+  }
+  if (config.radarrApiKey !== undefined) {
+    if (config.radarrApiKey) saveSetting("radarr_api_key", config.radarrApiKey);
+    else deleteSetting("radarr_api_key");
+  }
+  if (config.sonarrUrl !== undefined) {
+    if (config.sonarrUrl) saveSetting("sonarr_url", config.sonarrUrl);
+    else deleteSetting("sonarr_url");
+  }
+  if (config.sonarrApiKey !== undefined) {
+    if (config.sonarrApiKey) saveSetting("sonarr_api_key", config.sonarrApiKey);
+    else deleteSetting("sonarr_api_key");
+  }
+}
+
+/** Create a Radarr client if configured (settings table or env vars). */
 export function getRadarrClient(): RadarrClient | null {
-  const url = process.env["RADARR_URL"];
-  const key = process.env["RADARR_API_KEY"];
+  const url = getArrSetting("radarr_url", "RADARR_URL");
+  const key = getArrSetting("radarr_api_key", "RADARR_API_KEY");
   if (!url || !key) return null;
   return new RadarrClient(url, key);
 }
 
-/** Create a Sonarr client if env vars are configured. */
+/** Create a Sonarr client if configured (settings table or env vars). */
 export function getSonarrClient(): SonarrClient | null {
-  const url = process.env["SONARR_URL"];
-  const key = process.env["SONARR_API_KEY"];
+  const url = getArrSetting("sonarr_url", "SONARR_URL");
+  const key = getArrSetting("sonarr_api_key", "SONARR_API_KEY");
   if (!url || !key) return null;
   return new SonarrClient(url, key);
 }
 
 /** Get configuration state for both services. */
 export function getArrConfig(): ArrConfig {
+  const s = getArrSettings();
   return {
-    radarrConfigured: !!(process.env["RADARR_URL"] && process.env["RADARR_API_KEY"]),
-    sonarrConfigured: !!(process.env["SONARR_URL"] && process.env["SONARR_API_KEY"]),
+    radarrConfigured: !!(s.radarrUrl && s.radarrApiKey),
+    sonarrConfigured: !!(s.sonarrUrl && s.sonarrApiKey),
   };
 }
 

--- a/packages/app-media/src/pages/ArrSettingsPage.tsx
+++ b/packages/app-media/src/pages/ArrSettingsPage.tsx
@@ -1,0 +1,295 @@
+/**
+ * ArrSettingsPage — Radarr/Sonarr connection settings and test UI.
+ *
+ * Allows users to configure Radarr and Sonarr URLs and API keys
+ * via the settings table (replacing env-var-only configuration).
+ */
+import { useState, useEffect } from "react";
+import { Link } from "react-router";
+import {
+  Badge,
+  Button,
+  Skeleton,
+  Input,
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+  BreadcrumbPage,
+} from "@pops/ui";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  XCircle,
+  RefreshCw,
+  Film,
+  Tv,
+  Save,
+  Eye,
+  EyeOff,
+} from "lucide-react";
+import { toast } from "sonner";
+import { trpc } from "../lib/trpc";
+
+function ConnectionBadge({ connected }: { connected: boolean }) {
+  return connected ? (
+    <Badge className="bg-emerald-500/10 text-emerald-400 border-emerald-500/20">
+      <CheckCircle2 className="h-3 w-3 mr-1" />
+      Connected
+    </Badge>
+  ) : (
+    <Badge className="bg-red-500/10 text-red-400 border-red-500/20">
+      <XCircle className="h-3 w-3 mr-1" />
+      Disconnected
+    </Badge>
+  );
+}
+
+function ServiceCard({
+  label,
+  icon: Icon,
+  url,
+  apiKey,
+  hasKey,
+  onUrlChange,
+  onApiKeyChange,
+  onSave,
+  onTest,
+  saving,
+  testing,
+  testResult,
+}: {
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  url: string;
+  apiKey: string;
+  hasKey: boolean;
+  onUrlChange: (v: string) => void;
+  onApiKeyChange: (v: string) => void;
+  onSave: () => void;
+  onTest: () => void;
+  saving: boolean;
+  testing: boolean;
+  testResult: { configured: boolean; connected: boolean; version?: string; error?: string } | null;
+}) {
+  const [showKey, setShowKey] = useState(false);
+  const configured = !!(url && (hasKey || (apiKey && apiKey !== "••••••••")));
+
+  return (
+    <div className="rounded-lg border bg-card p-6 space-y-4">
+      <div className="flex items-center gap-2">
+        <Icon className="h-5 w-5 text-muted-foreground" />
+        <h2 className="text-lg font-semibold">{label}</h2>
+        {testResult && configured && (
+          <ConnectionBadge connected={testResult.connected} />
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-muted-foreground">
+            Server URL
+          </label>
+          <Input
+            placeholder="http://192.168.1.100:7878"
+            value={url}
+            onChange={(e) => onUrlChange(e.target.value)}
+            disabled={saving}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-muted-foreground">
+            API Key
+          </label>
+          <div className="flex gap-2">
+            <Input
+              type={showKey ? "text" : "password"}
+              placeholder="Enter API key"
+              value={apiKey}
+              onChange={(e) => onApiKeyChange(e.target.value)}
+              disabled={saving}
+              className="flex-1"
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-9 w-9 shrink-0"
+              onClick={() => setShowKey(!showKey)}
+              aria-label={showKey ? "Hide API key" : "Show API key"}
+            >
+              {showKey ? (
+                <EyeOff className="h-4 w-4" />
+              ) : (
+                <Eye className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onSave}
+          disabled={saving}
+        >
+          {saving ? (
+            <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+          ) : (
+            <Save className="h-3.5 w-3.5 mr-1.5" />
+          )}
+          Save
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onTest}
+          disabled={testing || !configured}
+        >
+          {testing ? (
+            <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+          ) : (
+            <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+          )}
+          Test Connection
+        </Button>
+      </div>
+
+      {testResult?.connected && testResult.version && (
+        <p className="text-xs text-emerald-400">
+          Connected — v{testResult.version}
+        </p>
+      )}
+      {testResult && !testResult.connected && testResult.error && (
+        <p className="text-xs text-red-400">{testResult.error}</p>
+      )}
+    </div>
+  );
+}
+
+export function ArrSettingsPage() {
+  const [radarrUrl, setRadarrUrl] = useState("");
+  const [radarrApiKey, setRadarrApiKey] = useState("");
+  const [sonarrUrl, setSonarrUrl] = useState("");
+  const [sonarrApiKey, setSonarrApiKey] = useState("");
+
+  const settingsQuery = trpc.media.arr.getSettings.useQuery();
+
+  useEffect(() => {
+    if (settingsQuery.data?.data) {
+      const d = settingsQuery.data.data;
+      setRadarrUrl(d.radarrUrl);
+      setRadarrApiKey(d.radarrApiKey);
+      setSonarrUrl(d.sonarrUrl);
+      setSonarrApiKey(d.sonarrApiKey);
+    }
+  }, [settingsQuery.data?.data]);
+
+  const saveSettings = trpc.media.arr.saveSettings.useMutation({
+    onSuccess: () => {
+      toast.success("Settings saved");
+      settingsQuery.refetch();
+    },
+    onError: (err) => toast.error(`Failed to save: ${err.message}`),
+  });
+
+  const testRadarr = trpc.media.arr.testRadarr.useQuery(undefined, {
+    enabled: false,
+  });
+  const testSonarr = trpc.media.arr.testSonarr.useQuery(undefined, {
+    enabled: false,
+  });
+
+  if (settingsQuery.isLoading) {
+    return (
+      <div className="space-y-6 p-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-48 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-4xl mx-auto p-6">
+      {/* Breadcrumb */}
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/media">Media</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Arr Settings</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Link
+          to="/media"
+          className="inline-flex items-center justify-center h-8 w-8 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
+          aria-label="Back to Media"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
+        <h1 className="text-2xl font-bold tracking-tight">
+          Radarr & Sonarr Settings
+        </h1>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        Configure your Radarr and Sonarr connections to see download status
+        badges on movie and TV show pages.
+      </p>
+
+      <div className="grid gap-6">
+        <ServiceCard
+          label="Radarr"
+          icon={Film}
+          url={radarrUrl}
+          apiKey={radarrApiKey}
+          hasKey={settingsQuery.data?.data.radarrHasKey ?? false}
+          onUrlChange={setRadarrUrl}
+          onApiKeyChange={setRadarrApiKey}
+          onSave={() =>
+            saveSettings.mutate({
+              radarrUrl,
+              radarrApiKey,
+            })
+          }
+          onTest={() => testRadarr.refetch()}
+          saving={saveSettings.isPending}
+          testing={testRadarr.isFetching}
+          testResult={testRadarr.data?.data ?? null}
+        />
+
+        <ServiceCard
+          label="Sonarr"
+          icon={Tv}
+          url={sonarrUrl}
+          apiKey={sonarrApiKey}
+          hasKey={settingsQuery.data?.data.sonarrHasKey ?? false}
+          onUrlChange={setSonarrUrl}
+          onApiKeyChange={setSonarrApiKey}
+          onSave={() =>
+            saveSettings.mutate({
+              sonarrUrl,
+              sonarrApiKey,
+            })
+          }
+          onTest={() => testSonarr.refetch()}
+          saving={saveSettings.isPending}
+          testing={testSonarr.isFetching}
+          testResult={testSonarr.data?.data ?? null}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/app-media/src/routes.tsx
+++ b/packages/app-media/src/routes.tsx
@@ -58,6 +58,11 @@ const PlexSettingsPage = lazy(() =>
     default: m.PlexSettingsPage,
   })),
 );
+const ArrSettingsPage = lazy(() =>
+  import("./pages/ArrSettingsPage").then((m) => ({
+    default: m.ArrSettingsPage,
+  })),
+);
 const HistoryPage = lazy(() =>
   import("./pages/HistoryPage").then((m) => ({
     default: m.HistoryPage,
@@ -110,4 +115,5 @@ export const routes: RouteObject[] = [
   { path: "compare", element: <CompareArenaPage /> },
   { path: "quick-pick", element: <QuickPickPage /> },
   { path: "plex", element: <PlexSettingsPage /> },
+  { path: "arr", element: <ArrSettingsPage /> },
 ];


### PR DESCRIPTION
## Summary
- Adds a new **Arr Settings page** (`/media/arr`) for configuring Radarr and Sonarr connections via the UI
- Backend service now reads from the **settings table** with env var fallback (same pattern as Plex), replacing the env-var-only approach
- Router exposes `getSettings` (with masked API keys) and `saveSettings` endpoints
- Frontend provides URL + API key inputs, eye toggle for key visibility, Save and Test Connection buttons for each service
- Updated service tests to mock the database layer

## Test plan
- [ ] Navigate to `/media/arr` and verify the settings page renders with Radarr and Sonarr cards
- [ ] Enter Radarr URL and API key, click Save, verify toast success
- [ ] Click Test Connection on Radarr, verify connection status badge appears
- [ ] Repeat for Sonarr
- [ ] Reload page and verify saved settings persist (URLs shown, API keys masked)
- [ ] Verify eye icon toggles API key visibility
- [ ] Verify back button and breadcrumbs navigate to `/media`
- [ ] Verify existing env var configuration still works as fallback
- [ ] Run `npx vitest run src/modules/media/arr/` — all 14 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)