### PR TITLE
fix: use API-provided poster URLs in TvShowDetailPage [tb-204]

### DIFF
--- a/packages/app-media/src/pages/TvShowDetailPage.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.tsx
@@ -114,10 +114,8 @@ export function TvShowDetailPage() {
     ? new Date(show.firstAirDate).getFullYear()
     : null;
 
-  const posterSrc = `/media/images/tv/${show.id}/poster.jpg`;
-  const backdropSrc = show.backdropPath
-    ? `/media/images/tv/${show.id}/backdrop.jpg`
-    : null;
+  const posterSrc = show.posterUrl ?? "";
+  const backdropSrc = show.backdropUrl ?? null;
 
   const seasons = seasonsData?.data ?? [];
   const progress = progressData?.data;


### PR DESCRIPTION
## Summary
- TvShowDetailPage was constructing `/media/images/tv/${show.id}/poster.jpg` using the local DB primary key instead of the external tvdbId
- The image proxy expects tvdbId, so posters/backdrops were broken for all TV shows
- Fix: use the pre-constructed `posterUrl`/`backdropUrl` from the API response (same pattern MovieDetailPage already uses correctly)

## Test plan
- [ ] TV show detail pages display posters and backdrops correctly
- [ ] Movie detail pages still work (no change, already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)