### PR TITLE
fix: add Arr settings navigation link to library page (tb-205)

### DIFF
--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -138,6 +138,12 @@ export function LibraryPage() {
               Plex
             </Button>
           </Link>
+          <Link to="/media/arr">
+            <Button variant="outline" size="sm">
+              <Settings className="h-4 w-4 mr-1.5" />
+              Arr
+            </Button>
+          </Link>
           <Link
             to="/media/search"
             className="text-sm font-medium text-indigo-400 hover:text-indigo-300 transition-colors"


### PR DESCRIPTION
## Summary
- The ArrSettingsPage.tsx and `/media/arr` route already existed from PR #343, but there was no navigation link to reach the page
- Adds an "Arr" button next to the existing "Plex" button in the Library page header

## Test plan
- [ ] Navigate to /media → verify "Arr" button appears next to "Plex" in the header
- [ ] Click "Arr" button → verify it navigates to /media/arr and ArrSettingsPage renders
- [ ] Verify existing "Plex" button still works

Closes GH-345

🤖 Generated with [Claude Code](https://claude.com/claude-code)