### PR TITLE
fix: use tvdbId for TV show poster URL construction [tb-204]

### DIFF
--- a/packages/app-media/src/pages/TvShowDetailPage.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.tsx
@@ -114,8 +114,10 @@ export function TvShowDetailPage() {
     ? new Date(show.firstAirDate).getFullYear()
     : null;
 
-  const posterSrc = show.posterUrl ?? "";
-  const backdropSrc = show.backdropUrl ?? null;
+  const posterSrc = `/media/images/tv/${show.tvdbId}/poster.jpg`;
+  const backdropSrc = show.backdropPath
+    ? `/media/images/tv/${show.tvdbId}/backdrop.jpg`
+    : null;
 
   const seasons = seasonsData?.data ?? [];
   const progress = progressData?.data;


### PR DESCRIPTION
## Summary
- Follow-up to PR #346 — uses `show.tvdbId` instead of `show.id` for constructing image proxy URLs in TvShowDetailPage
- The image proxy expects external IDs (tvdbId for TV shows, tmdbId for movies)
- Also correctly checks `show.backdropPath` before constructing backdrop URL

## Test plan
- [ ] TV show detail pages display posters and backdrops correctly
- [ ] MovieDetailPage still works (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)