### PR TITLE
fix: use correct poster URLs on WatchlistPage and HistoryPage [GH-350]

### DIFF
--- a/packages/app-media/src/pages/HistoryPage.tsx
+++ b/packages/app-media/src/pages/HistoryPage.tsx
@@ -95,18 +95,9 @@ function getHistoryHref(entry: HistoryEntry): string {
   return `/media/movies/${entry.mediaId}`;
 }
 
-function getHistoryPoster(entry: HistoryEntry): string | null {
-  if (!entry.posterPath) return null;
-  const isEpisode = entry.mediaType === "episode";
-  if (isEpisode && entry.tvShowId) {
-    return `/media/images/tv/${entry.tvShowId}/poster.jpg`;
-  }
-  return `/media/images/movie/${entry.mediaId}/poster.jpg`;
-}
-
 function HistoryItem({ entry }: { entry: HistoryEntry }) {
   const href = getHistoryHref(entry);
-  const posterSrc = getHistoryPoster(entry);
+  const posterSrc = entry.posterUrl;
   const isEpisode = entry.mediaType === "episode";
 
   const title = entry.title ?? "Unknown";
@@ -158,7 +149,7 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
   const navigate = useNavigate();
   const [imageError, setImageError] = useState(false);
   const href = getHistoryHref(entry);
-  const posterSrc = getHistoryPoster(entry);
+  const posterSrc = entry.posterUrl;
   const isEpisode = entry.mediaType === "episode";
 
   const title = entry.title ?? "Unknown";

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -283,6 +283,7 @@ interface WatchlistCardProps {
   entry: WatchlistEntry;
   title: string;
   year: number | null;
+  posterUrl: string | null;
   priority: number;
   onRemove: (id: number) => void;
   isRemoving: boolean;
@@ -292,6 +293,7 @@ function WatchlistCard({
   entry,
   title,
   year,
+  posterUrl,
   priority,
   onRemove,
   isRemoving,
@@ -303,7 +305,7 @@ function WatchlistCard({
     entry.mediaType === "movie"
       ? `/media/movies/${entry.mediaId}`
       : `/media/tv/${entry.mediaId}`;
-  const posterSrc = `/media/images/${entry.mediaType === "movie" ? "movie" : "tv"}/${entry.mediaId}/poster.jpg`;
+  const posterSrc = posterUrl;
 
   return (
     <div className="group flex flex-col gap-2">
@@ -347,7 +349,7 @@ function WatchlistCard({
           <Trash2 className="h-3.5 w-3.5" />
         </button>
 
-        {imageError ? (
+        {!posterSrc || imageError ? (
           <div className="flex h-full w-full items-center justify-center bg-muted text-muted-foreground">
             <Film className="h-10 w-10 opacity-40" />
           </div>
@@ -609,6 +611,7 @@ export function WatchlistPage() {
                   entry={entry}
                   title={meta?.title ?? "Unknown"}
                   year={meta?.year ?? null}
+                  posterUrl={meta?.posterUrl ?? null}
                   priority={index + 1}
                   onRemove={(id) => {
                     setRemovingId(id);


### PR DESCRIPTION
## Summary
- WatchlistPage desktop card was using database IDs to construct poster URLs; now uses `posterUrl` from metadata maps (which have correct TMDB/TVDB IDs)
- HistoryPage had a `getHistoryPoster()` helper constructing URLs from database IDs; removed it and use `entry.posterUrl` from the API (which already resolves external IDs correctly)
- Both pages now show poster images correctly

## Test plan
- [ ] Open Watchlist page on desktop — poster images should load
- [ ] Open Watch History page — poster images should load for both movies and episodes
- [ ] Verify mobile watchlist still works (was already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)