### PR TITLE
fix: resolve valueByType/valueByLocation 500 — ORDER BY alias bug

### DIFF
--- a/apps/pops-api/src/modules/inventory/reports/service.ts
+++ b/apps/pops-api/src/modules/inventory/reports/service.ts
@@ -242,7 +242,7 @@ export function getValueByLocation(): ValueBreakdownEntry[] {
     .from(homeInventory)
     .leftJoin(locations, sql`${homeInventory.locationId} = ${locations.id}`)
     .groupBy(sql`COALESCE(${locations.name}, 'Unassigned')`)
-    .orderBy(desc(sql`totalValue`))
+    .orderBy(desc(sql`COALESCE(SUM(${homeInventory.replacementValue}), 0)`))
     .all() as ValueBreakdownEntry[];
 }
 
@@ -260,6 +260,6 @@ export function getValueByType(): ValueBreakdownEntry[] {
     })
     .from(homeInventory)
     .groupBy(sql`COALESCE(${homeInventory.type}, 'Uncategorized')`)
-    .orderBy(desc(sql`totalValue`))
+    .orderBy(desc(sql`COALESCE(SUM(${homeInventory.replacementValue}), 0)`))
     .all() as ValueBreakdownEntry[];
 }


### PR DESCRIPTION
## Summary
- `inventory.reports.valueByType` and `inventory.reports.valueByLocation` endpoints return 500
- Root cause: Drizzle queries use `desc(sql`totalValue`)` which generates `ORDER BY totalValue` — SQLite cannot resolve a SELECT alias via raw sql template
- Fix: replace alias reference with the full aggregate expression `COALESCE(SUM(replacement_value), 0)`

## Test plan
- [ ] `/inventory` page loads Value by Type chart without errors
- [ ] Chart displays correct descending order by value

🤖 Generated with [Claude Code](https://claude.com/claude-code)