### PR TITLE
fix: inventory valueByType and valueByLocation 500 errors [GH-351]

### DIFF
--- a/apps/pops-api/src/modules/inventory/reports/service.ts
+++ b/apps/pops-api/src/modules/inventory/reports/service.ts
@@ -232,17 +232,18 @@ function getLocationSubtreeIds(rootId: string): Set<string> {
  */
 export function getValueByLocation(): ValueBreakdownEntry[] {
   const db = getDrizzle();
+  const totalValueExpr = sql<number>`COALESCE(SUM(${homeInventory.replacementValue}), 0)`;
 
   return db
     .select({
       name: sql<string>`COALESCE(${locations.name}, 'Unassigned')`,
-      totalValue: sql<number>`COALESCE(SUM(${homeInventory.replacementValue}), 0)`,
+      totalValue: totalValueExpr,
       itemCount: sql<number>`COUNT(*)`,
     })
     .from(homeInventory)
     .leftJoin(locations, sql`${homeInventory.locationId} = ${locations.id}`)
     .groupBy(sql`COALESCE(${locations.name}, 'Unassigned')`)
-    .orderBy(desc(sql`totalValue`))
+    .orderBy(desc(totalValueExpr))
     .all() as ValueBreakdownEntry[];
 }
 
@@ -251,15 +252,16 @@ export function getValueByLocation(): ValueBreakdownEntry[] {
  */
 export function getValueByType(): ValueBreakdownEntry[] {
   const db = getDrizzle();
+  const totalValueExpr = sql<number>`COALESCE(SUM(${homeInventory.replacementValue}), 0)`;
 
   return db
     .select({
       name: sql<string>`COALESCE(${homeInventory.type}, 'Uncategorized')`,
-      totalValue: sql<number>`COALESCE(SUM(${homeInventory.replacementValue}), 0)`,
+      totalValue: totalValueExpr,
       itemCount: sql<number>`COUNT(*)`,
     })
     .from(homeInventory)
     .groupBy(sql`COALESCE(${homeInventory.type}, 'Uncategorized')`)
-    .orderBy(desc(sql`totalValue`))
+    .orderBy(desc(totalValueExpr))
     .all() as ValueBreakdownEntry[];
 }


### PR DESCRIPTION
## Summary
- `getValueByType()` and `getValueByLocation()` in inventory reports service used `desc(sql`totalValue`)` in ORDER BY, referencing a JS alias that doesn't exist as a SQL column
- SQLite threw "no such column: totalValue" causing 500 errors
- Fix: extract the SUM SQL expression to a variable and reuse it in both `select` and `orderBy`

## Test plan
- [ ] Open inventory dashboard — Value by Type widget should load without errors
- [ ] Verify data shows correct grouping by type with values sorted descending

🤖 Generated with [Claude Code](https://claude.com/claude-code)