### PR TITLE
fix: use API-provided posterUrl instead of constructing URLs with DB IDs (tb-210)

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -263,7 +263,7 @@ function MovieCard({
   scoreDelta?: number | null;
   isWinner?: boolean;
 }) {
-  const posterSrc = `/media/images/movie/${movie.id}/poster.jpg`;
+  const posterSrc = movie.posterUrl ?? undefined;
   const [imgError, setImgError] = useState(false);
 
   return (

--- a/packages/app-media/src/pages/HistoryPage.tsx
+++ b/packages/app-media/src/pages/HistoryPage.tsx
@@ -96,12 +96,7 @@ function getHistoryHref(entry: HistoryEntry): string {
 }
 
 function getHistoryPoster(entry: HistoryEntry): string | null {
-  if (!entry.posterPath) return null;
-  const isEpisode = entry.mediaType === "episode";
-  if (isEpisode && entry.tvShowId) {
-    return `/media/images/tv/${entry.tvShowId}/poster.jpg`;
-  }
-  return `/media/images/movie/${entry.mediaId}/poster.jpg`;
+  return entry.posterUrl ?? null;
 }
 
 function HistoryItem({ entry }: { entry: HistoryEntry }) {

--- a/packages/app-media/src/pages/SeasonDetailPage.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.tsx
@@ -241,9 +241,7 @@ export function SeasonDetailPage() {
   }
 
   const seasonLabel = seasonNum === 0 ? "Specials" : `Season ${seasonNum}`;
-  const posterSrc = season.posterPath
-    ? `/media/images/tv/${show.id}/season-${seasonNum}-poster.jpg`
-    : null;
+  const posterSrc = season.posterUrl ?? null;
 
   return (
     <div className="space-y-6 max-w-4xl mx-auto">

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -283,6 +283,7 @@ interface WatchlistCardProps {
   entry: WatchlistEntry;
   title: string;
   year: number | null;
+  posterUrl: string | null;
   priority: number;
   onRemove: (id: number) => void;
   isRemoving: boolean;
@@ -292,6 +293,7 @@ function WatchlistCard({
   entry,
   title,
   year,
+  posterUrl,
   priority,
   onRemove,
   isRemoving,
@@ -303,7 +305,7 @@ function WatchlistCard({
     entry.mediaType === "movie"
       ? `/media/movies/${entry.mediaId}`
       : `/media/tv/${entry.mediaId}`;
-  const posterSrc = `/media/images/${entry.mediaType === "movie" ? "movie" : "tv"}/${entry.mediaId}/poster.jpg`;
+  const posterSrc = posterUrl;
 
   return (
     <div className="group flex flex-col gap-2">
@@ -347,7 +349,7 @@ function WatchlistCard({
           <Trash2 className="h-3.5 w-3.5" />
         </button>
 
-        {imageError ? (
+        {!posterSrc || imageError ? (
           <div className="flex h-full w-full items-center justify-center bg-muted text-muted-foreground">
             <Film className="h-10 w-10 opacity-40" />
           </div>
@@ -609,6 +611,7 @@ export function WatchlistPage() {
                   entry={entry}
                   title={meta?.title ?? "Unknown"}
                   year={meta?.year ?? null}
+                  posterUrl={meta?.posterUrl ?? null}
                   priority={index + 1}
                   onRemove={(id) => {
                     setRemovingId(id);


### PR DESCRIPTION
## Summary
- Pages were constructing poster image URLs using database auto-increment IDs instead of the API-provided `posterUrl` (which uses correct tmdbId/tvdbId), causing 404s on the image proxy
- Fixed HistoryPage, WatchlistPage (desktop cards), TvShowDetailPage, SeasonDetailPage, and CompareArenaPage to use API-provided `posterUrl` directly
- Added null handling with Film icon fallback where needed

## Test plan
- [ ] Verify poster images load on the Watch History page (movies + episodes)
- [ ] Verify poster images load on the Watchlist page (both mobile list and desktop grid)
- [ ] Verify poster images load on TV show detail pages
- [ ] Verify season poster loads on season detail pages
- [ ] Verify compare arena movie posters load correctly
- [ ] Verify graceful fallback (Film icon) when posterUrl is null

🤖 Generated with [Claude Code](https://claude.com/claude-code)