### PR TITLE
refactor: convert core module raw SQL to Drizzle patterns [tb-216]

### DIFF
--- a/apps/pops-api/src/modules/core/ai-usage/service.ts
+++ b/apps/pops-api/src/modules/core/ai-usage/service.ts
@@ -1,7 +1,7 @@
 /**
  * AI usage analytics service — Drizzle ORM
  */
-import { sql, gte, lte, and } from "drizzle-orm";
+import { sql, gte, lte, and, desc } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
 import { aiUsage } from "@pops/db-types";
 import type { AiUsageStatsOutput, AiUsageHistoryOutput, AiUsageHistoryRecord } from "./types.js";
@@ -98,7 +98,7 @@ export function getHistory(startDate?: string, endDate?: string): AiUsageHistory
     .from(aiUsage)
     .where(where)
     .groupBy(sql`DATE(${aiUsage.createdAt})`)
-    .orderBy(sql`DATE(${aiUsage.createdAt}) DESC`)
+    .orderBy(desc(sql`DATE(${aiUsage.createdAt})`))
     .all();
 
   // Calculate summary

--- a/apps/pops-api/src/modules/core/corrections/service.ts
+++ b/apps/pops-api/src/modules/core/corrections/service.ts
@@ -168,7 +168,7 @@ export function createOrUpdateCorrection(input: CreateCorrectionInput): Correcti
       .set({
         confidence: newConfidence,
         timesApplied: newTimesApplied,
-        lastUsedAt: sql`datetime('now')`,
+        lastUsedAt: new Date().toISOString(),
         entityId: input.entityId ?? existing.entityId,
         entityName: input.entityName ?? existing.entityName,
         location: input.location ?? existing.location,
@@ -274,7 +274,7 @@ export function incrementCorrectionUsage(id: string): void {
   db.update(transactionCorrections)
     .set({
       timesApplied: sql`${transactionCorrections.timesApplied} + 1`,
-      lastUsedAt: sql`datetime('now')`,
+      lastUsedAt: new Date().toISOString(),
     })
     .where(eq(transactionCorrections.id, id))
     .run();


### PR DESCRIPTION
## Summary
- Replace `datetime('now')` with `new Date().toISOString()` in corrections service (2 occurrences)
- Wrap DATE() orderBy in Drizzle `desc()` helper in ai-usage service
- Remaining `sql` template usages are Drizzle-native patterns that cannot be expressed otherwise:
  - CASE WHEN aggregations (no Drizzle API)
  - DATE() SQLite function (no Drizzle equivalent)
  - Reversed LIKE pattern (value LIKE column, not column LIKE value)
  - rowid lookup (SQLite-specific)
  - Field increment (no Drizzle helper)

## Test plan
- [ ] AI usage stats page loads correctly
- [ ] Corrections auto-matching works (entity matcher uses corrections)
- [ ] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)