### PR TITLE
refactor: convert discovery/service.ts from raw SQL to Drizzle [tb-214]

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/service.ts
+++ b/apps/pops-api/src/modules/media/discovery/service.ts
@@ -44,10 +44,7 @@ function getGenreAffinities(): GenreAffinity[] {
     .innerJoin(sql`json_each(${movies.genres}) g`, sql`1=1`)
     .innerJoin(
       mediaScores,
-      and(
-        eq(mediaScores.mediaType, "movie"),
-        eq(mediaScores.mediaId, movies.id),
-      ),
+      and(eq(mediaScores.mediaType, "movie"), eq(mediaScores.mediaId, movies.id))
     )
     .groupBy(sql`g.value`)
     .orderBy(desc(sql`ROUND(AVG(${mediaScores.score}), 1)`))
@@ -105,7 +102,7 @@ function getGenreDistribution(): { genres: GenreDistribution[]; totalWatched: nu
     .from(watchHistory)
     .innerJoin(
       movies,
-      and(eq(movies.id, watchHistory.mediaId), eq(watchHistory.mediaType, "movie")),
+      and(eq(movies.id, watchHistory.mediaId), eq(watchHistory.mediaType, "movie"))
     )
     .innerJoin(sql`json_each(${movies.genres}) g`, sql`1=1`)
     .groupBy(sql`g.value`)
@@ -163,12 +160,7 @@ export function getQuickPickMovies(count_: number): QuickPickMovie[] {
       runtime: movies.runtime,
     })
     .from(movies)
-    .where(
-      and(
-        notInArray(movies.id, watchedIds),
-        notInArray(movies.id, watchlistIds),
-      ),
-    )
+    .where(and(notInArray(movies.id, watchedIds), notInArray(movies.id, watchlistIds)))
     .orderBy(sql`RANDOM()`)
     .limit(count_)
     .all();


### PR DESCRIPTION
## Summary
- Converted all 5 `db.prepare()` raw SQL queries to Drizzle query builder
- Replaced `getDb()` (raw better-sqlite3) with `getDrizzle()` throughout
- Pure Drizzle for simple queries: `getTotalComparisons`, `getDimensionWeights`, `getQuickPickMovies`
- `sql` template literals for `json_each()` queries: `getGenreAffinities`, `getGenreDistribution`
- All 6 existing tests pass unchanged

## Test plan
- [x] `vitest run service.test.ts` — 6/6 tests pass
- [ ] Typecheck passes
- [ ] Discovery page loads preference profile, quick pick, and scored recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)