### PR TITLE
refactor: convert sql templates to Drizzle query builder (tb-217)

### DIFF
--- a/apps/pops-api/src/modules/inventory/reports/service.ts
+++ b/apps/pops-api/src/modules/inventory/reports/service.ts
@@ -1,7 +1,7 @@
 /**
  * Inventory reports service — warranty tracking and insurance report queries.
  */
-import { isNotNull, asc, sql, desc, and, gte, lte } from "drizzle-orm";
+import { isNotNull, asc, sql, desc, and, gte, lte, count, eq } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
 import { homeInventory, locations, itemPhotos } from "@pops/db-types";
 import type { InventoryRow } from "../items/types.js";
@@ -32,7 +32,7 @@ export function getDashboard(): DashboardSummary {
   const cutoffIso = cutoff.toISOString().split("T")[0];
 
   const [warrantyResult] = db
-    .select({ cnt: sql<number>`COUNT(*)` })
+    .select({ cnt: count() })
     .from(homeInventory)
     .where(
       and(
@@ -237,10 +237,10 @@ export function getValueByLocation(): ValueBreakdownEntry[] {
     .select({
       name: sql<string>`COALESCE(${locations.name}, 'Unassigned')`,
       totalValue: sql<number>`COALESCE(SUM(${homeInventory.replacementValue}), 0)`,
-      itemCount: sql<number>`COUNT(*)`,
+      itemCount: count(),
     })
     .from(homeInventory)
-    .leftJoin(locations, sql`${homeInventory.locationId} = ${locations.id}`)
+    .leftJoin(locations, eq(homeInventory.locationId, locations.id))
     .groupBy(sql`COALESCE(${locations.name}, 'Unassigned')`)
     .orderBy(desc(sql`COALESCE(SUM(${homeInventory.replacementValue}), 0)`))
     .all() as ValueBreakdownEntry[];
@@ -256,7 +256,7 @@ export function getValueByType(): ValueBreakdownEntry[] {
     .select({
       name: sql<string>`COALESCE(${homeInventory.type}, 'Uncategorized')`,
       totalValue: sql<number>`COALESCE(SUM(${homeInventory.replacementValue}), 0)`,
-      itemCount: sql<number>`COUNT(*)`,
+      itemCount: count(),
     })
     .from(homeInventory)
     .groupBy(sql`COALESCE(${homeInventory.type}, 'Uncategorized')`)

--- a/apps/pops-api/src/modules/media/discovery/tmdb-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/tmdb-service.ts
@@ -2,7 +2,7 @@
  * Discovery TMDB service — trending movies and recommendations from TMDB,
  * enriched with library membership status.
  */
-import { desc, sql } from "drizzle-orm";
+import { desc, isNotNull } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
 import { movies } from "@pops/db-types";
 import type { TmdbClient } from "../tmdb/client.js";
@@ -77,7 +77,7 @@ export async function getRecommendations(
   const topMovies = db
     .select({ tmdbId: movies.tmdbId, title: movies.title })
     .from(movies)
-    .where(sql`${movies.voteAverage} IS NOT NULL`)
+    .where(isNotNull(movies.voteAverage))
     .orderBy(desc(movies.voteAverage))
     .limit(sampleSize)
     .all();

--- a/apps/pops-api/src/modules/media/library/service.ts
+++ b/apps/pops-api/src/modules/media/library/service.ts
@@ -2,7 +2,7 @@
  * Library service — orchestrates adding media to the local library
  * by fetching metadata from external APIs and inserting records.
  */
-import { sql } from "drizzle-orm";
+import { and, eq, notInArray, sql } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
 import { movies, watchHistory } from "@pops/db-types";
 import type { TmdbClient } from "../tmdb/client.js";
@@ -111,17 +111,15 @@ export async function refreshMovie(id: number, tmdbClient: TmdbClient): Promise<
 export function getQuickPicks(count: number): Movie[] {
   const db = getDrizzle();
 
+  const watchedIds = db
+    .selectDistinct({ mediaId: watchHistory.mediaId })
+    .from(watchHistory)
+    .where(and(eq(watchHistory.mediaType, "movie"), eq(watchHistory.completed, 1)));
+
   const rows = db
     .select()
     .from(movies)
-    .where(
-      sql`${movies.id} NOT IN (
-        SELECT DISTINCT ${watchHistory.mediaId}
-        FROM ${watchHistory}
-        WHERE ${watchHistory.mediaType} = 'movie'
-          AND ${watchHistory.completed} = 1
-      )`
-    )
+    .where(notInArray(movies.id, watchedIds))
     .orderBy(sql`RANDOM()`)
     .limit(count)
     .all();


### PR DESCRIPTION
## Summary
- **tmdb-service.ts**: Replace `sql`IS NOT NULL`` with `isNotNull(movies.voteAverage)`
- **library/service.ts**: Replace raw NOT IN subquery with `notInArray` + `selectDistinct` subquery
- **inventory/reports/service.ts**: Replace 3x `sql`COUNT(*)`` with `count()`, replace raw join condition with `eq()`

## Test plan
- [x] ESLint passes on all 3 files
- [x] TypeScript compiles with no errors
- [ ] QA review of query equivalence

🤖 Generated with [Claude Code](https://claude.com/claude-code)