### PR TITLE
fix: convert sql templates to Drizzle native patterns [tb-217]

### DIFF
--- a/apps/pops-api/src/modules/inventory/reports/service.ts
+++ b/apps/pops-api/src/modules/inventory/reports/service.ts
@@ -1,7 +1,7 @@
 /**
  * Inventory reports service — warranty tracking and insurance report queries.
  */
-import { isNotNull, asc, sql, desc, and, gte, lte } from "drizzle-orm";
+import { isNotNull, asc, sql, desc, and, gte, lte, count, eq } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
 import { homeInventory, locations, itemPhotos } from "@pops/db-types";
 import type { InventoryRow } from "../items/types.js";
@@ -19,7 +19,7 @@ export function getDashboard(): DashboardSummary {
 
   const [summary] = db
     .select({
-      itemCount: sql<number>`COUNT(*)`,
+      itemCount: count(),
       totalReplacementValue: sql<number>`COALESCE(SUM(${homeInventory.replacementValue}), 0)`,
       totalResaleValue: sql<number>`COALESCE(SUM(${homeInventory.resaleValue}), 0)`,
     })
@@ -32,7 +32,7 @@ export function getDashboard(): DashboardSummary {
   const cutoffIso = cutoff.toISOString().split("T")[0];
 
   const [warrantyResult] = db
-    .select({ cnt: sql<number>`COUNT(*)` })
+    .select({ cnt: count() })
     .from(homeInventory)
     .where(
       and(
@@ -237,10 +237,10 @@ export function getValueByLocation(): ValueBreakdownEntry[] {
     .select({
       name: sql<string>`COALESCE(${locations.name}, 'Unassigned')`,
       totalValue: sql<number>`COALESCE(SUM(${homeInventory.replacementValue}), 0)`,
-      itemCount: sql<number>`COUNT(*)`,
+      itemCount: count(),
     })
     .from(homeInventory)
-    .leftJoin(locations, sql`${homeInventory.locationId} = ${locations.id}`)
+    .leftJoin(locations, eq(homeInventory.locationId, locations.id))
     .groupBy(sql`COALESCE(${locations.name}, 'Unassigned')`)
     .orderBy(desc(sql`COALESCE(SUM(${homeInventory.replacementValue}), 0)`))
     .all() as ValueBreakdownEntry[];
@@ -256,7 +256,7 @@ export function getValueByType(): ValueBreakdownEntry[] {
     .select({
       name: sql<string>`COALESCE(${homeInventory.type}, 'Uncategorized')`,
       totalValue: sql<number>`COALESCE(SUM(${homeInventory.replacementValue}), 0)`,
-      itemCount: sql<number>`COUNT(*)`,
+      itemCount: count(),
     })
     .from(homeInventory)
     .groupBy(sql`COALESCE(${homeInventory.type}, 'Uncategorized')`)

--- a/apps/pops-api/src/modules/media/discovery/tmdb-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/tmdb-service.ts
@@ -2,7 +2,7 @@
  * Discovery TMDB service — trending movies and recommendations from TMDB,
  * enriched with library membership status.
  */
-import { desc, sql } from "drizzle-orm";
+import { desc, isNotNull } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
 import { movies } from "@pops/db-types";
 import type { TmdbClient } from "../tmdb/client.js";
@@ -77,7 +77,7 @@ export async function getRecommendations(
   const topMovies = db
     .select({ tmdbId: movies.tmdbId, title: movies.title })
     .from(movies)
-    .where(sql`${movies.voteAverage} IS NOT NULL`)
+    .where(isNotNull(movies.voteAverage))
     .orderBy(desc(movies.voteAverage))
     .limit(sampleSize)
     .all();


### PR DESCRIPTION
## Summary
- **tmdb-service.ts**: Replace `sql`IS NOT NULL`` with `isNotNull()`, remove unused `sql` import
- **inventory/reports/service.ts**: Replace 3x `sql`COUNT(*)`` with `count()`, replace raw join `sql` condition with `eq()`
- library/service.ts: No changes needed — NOT IN subquery and RANDOM() have no Drizzle equivalent

## Test plan
- [ ] Typecheck passes (`pnpm typecheck`)
- [ ] Lint passes
- [ ] Prettier formatting clean
- [ ] Discovery recommendations still load (tmdb-service change)
- [ ] Inventory dashboard, value-by-location, value-by-type endpoints work

🤖 Generated with [Claude Code](https://claude.com/claude-code)