### PR TITLE
[tb-243] Audit: US-06 Vitest and Playwright — status partial

### DIFF
--- a/docs-v2/themes/01-foundation/prds/001-project-bootstrap/us-06-test-frameworks.md
+++ b/docs-v2/themes/01-foundation/prds/001-project-bootstrap/us-06-test-frameworks.md
@@ -1,7 +1,7 @@
 # US-06: Set up Vitest and Playwright
 
 > PRD: [001 — Project Bootstrap](README.md)
-> Status: To Review
+> Status: Partial — MSW not installed
 
 ## Description
 
@@ -9,11 +9,11 @@ As a developer, I want Vitest for unit/integration tests and Playwright for e2e 
 
 ## Acceptance Criteria
 
-- [ ] Vitest configured in each package/app that has tests
-- [ ] `pnpm test` / `mise test` runs all unit/integration tests across packages
-- [ ] `mise test:watch` runs tests in watch mode
-- [ ] Playwright configured for e2e tests
-- [ ] E2e tests can run against dev servers
+- [x] Vitest configured in each package/app that has tests
+- [x] `pnpm test` / `mise test` runs all unit/integration tests across packages
+- [x] `mise test:watch` runs tests in watch mode
+- [x] Playwright configured for e2e tests
+- [x] E2e tests can run against dev servers
 - [ ] MSW (Mock Service Worker) available for API mocking in tests
 
 ## Notes


### PR DESCRIPTION
## Summary

- Audited GH-389: PRD-001 US-06 Set up Vitest and Playwright
- Updated `docs-v2/themes/01-foundation/prds/001-project-bootstrap/us-06-test-frameworks.md` — status: Partial

## Verification

- ✅ Vitest configured in pops-api (`vitest ^3.0.0`, `"test": "vitest run"`, 10+ test files)
- ✅ Vitest configured in pops-shell (via `vite.config.ts` with `/// <reference types="vitest/config" />`)
- ✅ `pnpm test` / `mise test` delegates via Turbo to all packages
- ✅ `mise test:watch` — `[tasks."test:watch"]` configured in `mise.toml`
- ✅ Playwright configured — `apps/pops-shell/playwright.config.ts` with `testDir: ./e2e`
- ✅ E2e tests run against dev servers — `webServer` config starts pops-shell (port 5567) and pops-api (port 3000)
- ❌ MSW not installed — no `msw` package in any `package.json`; tests use Playwright's `page.route()` for mocking instead

GH-389 kept open pending MSW setup.