### PR TITLE
[tb-383] docs: mark PRD-036 US-01 watchlist page as Partial

### DIFF
--- a/docs-v2/themes/03-media/prds/036-watchlist/us-01-watchlist-page.md
+++ b/docs-v2/themes/03-media/prds/036-watchlist/us-01-watchlist-page.md
@@ -1,7 +1,7 @@
 # US-01: Watchlist page
 
 > PRD: [036 — Watchlist](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,17 +9,17 @@ As a user, I want a prioritised watchlist page that shows movies and TV shows I 
 
 ## Acceptance Criteria
 
-- [ ] Watchlist page renders at `/media/watchlist`
-- [ ] Desktop layout: poster grid with numbered priority badges in the top-left corner of each card
+- [x] Watchlist page renders at `/media/watchlist`
+- [x] Desktop layout: poster grid with numbered priority badges in the top-left corner of each card
 - [ ] Mobile layout: compact list with poster thumbnail, title, and priority number
-- [ ] Priority badges display sequential numbers (1, 2, 3...) matching the current sort order
+- [x] Priority badges display sequential numbers (1, 2, 3...) matching the current sort order
 - [ ] Filter tabs: "All", "Movies", "TV Shows" — active tab updates `?type=` query param
 - [ ] Filter tabs update the displayed list without a full page reload
-- [ ] Each item shows optional notes text below the poster/title (truncated with expand on click)
+- [x] Each item shows optional notes text below the poster/title (truncated with expand on click)
 - [ ] Page calls `media.watchlist.list` with type filter parameter
-- [ ] Items are ordered by priority ASC, then addedAt DESC
-- [ ] Empty state: "Your watchlist is empty" with links to the library page and search page
-- [ ] Loading state: skeleton matching the active layout (grid for desktop, list for mobile)
+- [x] Items are ordered by priority ASC, then addedAt DESC
+- [x] Empty state: "Your watchlist is empty" with links to the library page and search page
+- [x] Loading state: skeleton matching the active layout (grid for desktop, list for mobile)
 - [ ] Filter-specific empty state: "No movies on your watchlist" or "No TV shows on your watchlist"
 - [ ] Tests cover: grid layout renders on desktop viewport, list layout renders on mobile viewport, filter tabs switch content, priority badges show correct numbers, notes display and truncation, empty state renders
 


### PR DESCRIPTION
## Summary

- Audited GH-529: PRD-036 US-01 Watchlist page
- Updated `docs-v2/themes/03-media/prds/036-watchlist/us-01-watchlist-page.md` status from `To Review` → `Partial`
- Marked implemented ACs as `[x]`, gaps as `[ ]`

## Audit Findings

**Implemented ✅**
- Route `/media/watchlist` renders `WatchlistPage`
- Desktop: poster card grid with `#N` numbered priority badges
- Mobile: compact list with poster, title, notes, reorder arrows
- Notes field with truncation and click-to-expand editor
- Items ordered by priority ASC
- Empty state with library/search links
- Loading skeleton (mobile list + desktop grid)

**Missing ❌**
- Filter tabs (All / Movies / TV Shows) — not present
- Mobile layout missing priority number (shows reorder arrows only)
- `media.watchlist.list` not called with type filter param (no filter UI)
- Filter-specific empty states missing
- No tests

See GH-529 comment for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)