### PR TITLE
audit: PRD-025 US-02 and US-03 budgets page and CRUD UI [tb-347, tb-348]

### DIFF
--- a/docs-v2/themes/02-finance/epics/04-budgets.md
+++ b/docs-v2/themes/02-finance/epics/04-budgets.md
@@ -10,7 +10,7 @@ Build budget tracking — spending categories with monthly or yearly limits. Sho
 
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
-| 025 | [Budgets](../prds/025-budgets/README.md) | Budget data model, CRUD page, period types (monthly/yearly), spend vs target, active/inactive toggle | Done |
+| 025 | [Budgets](../prds/025-budgets/README.md) | Budget data model, CRUD page, period types (monthly/yearly), spend vs target, active/inactive toggle | Partial |
 
 ## Dependencies
 

--- a/docs-v2/themes/02-finance/prds/025-budgets/README.md
+++ b/docs-v2/themes/02-finance/prds/025-budgets/README.md
@@ -46,8 +46,8 @@ Build budget tracking — spending categories with monthly or yearly limits. Sho
 | # | Story | Summary | Parallelisable |
 |---|-------|---------|----------------|
 | 01 | [us-01-schema-api](us-01-schema-api.md) | Budget table, unique constraint, CRUD procedures | No (first) |
-| 02 | [us-02-budgets-page](us-02-budgets-page.md) | DataTable with search, period/status filters, sorting | Blocked by us-01 |
-| 03 | [us-03-budget-crud-ui](us-03-budget-crud-ui.md) | Create/edit/delete dialogs with form validation | Blocked by us-02 |
+| 02 | [us-02-budgets-page](us-02-budgets-page.md) | DataTable with search, period/status filters, sorting | Partial |
+| 03 | [us-03-budget-crud-ui](us-03-budget-crud-ui.md) | Create/edit/delete dialogs with form validation | Not started |
 
 ## Out of Scope
 

--- a/docs-v2/themes/02-finance/prds/025-budgets/us-02-budgets-page.md
+++ b/docs-v2/themes/02-finance/prds/025-budgets/us-02-budgets-page.md
@@ -1,7 +1,7 @@
 # US-02: Budgets page
 
 > PRD: [025 — Budgets](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,11 +9,11 @@ As a user, I want a budgets page showing all budget categories so that I can see
 
 ## Acceptance Criteria
 
-- [ ] DataTable with columns: Category (sortable), Period (Monthly/Yearly badge), Amount (sortable, right-aligned), Status (Active/Inactive badge), Notes (truncated)
-- [ ] Search by category
-- [ ] Filter by: Period (Monthly/Yearly), Status (Active/Inactive)
-- [ ] Pagination with limit 100
-- [ ] Loading skeleton and empty state
+- [ ] DataTable with columns: Category (sortable), Period (Monthly/Yearly badge), Amount (sortable, right-aligned), Status (Active/Inactive badge), Notes (truncated) — Period column shows plain text, not a badge
+- [x] Search by category
+- [x] Filter by: Period (Monthly/Yearly), Status (Active/Inactive)
+- [x] Pagination with limit 100
+- [x] Loading skeleton and empty state
 
 ## Notes
 

--- a/docs-v2/themes/02-finance/prds/025-budgets/us-03-budget-crud-ui.md
+++ b/docs-v2/themes/02-finance/prds/025-budgets/us-03-budget-crud-ui.md
@@ -1,7 +1,7 @@
 # US-03: Budget CRUD UI
 
 > PRD: [025 — Budgets](README.md)
-> Status: To Review
+> Status: Not started
 
 ## Description
 


### PR DESCRIPTION
## Summary

- **US-02 (Budgets page)**: Partial — Period column uses plain text instead of Monthly/Yearly badge. All other criteria met.
- **US-03 (Budget CRUD UI)**: Not started — `BudgetsPage.tsx` is read-only; API CRUD exists but no UI.

## Changes

- Updated `us-02-budgets-page.md`: status → Partial, checked off met criteria
- Updated `us-03-budget-crud-ui.md`: confirmed status → Not started
- Updated `prds/025-budgets/README.md`: user story table statuses
- Updated `epics/04-budgets.md`: epic status → Partial

## Test plan

- [ ] Verify doc statuses reflect implementation state
- [ ] GH-493 comment added, kept open
- [ ] GH-494 comment added, kept open

🤖 Generated with [Claude Code](https://claude.com/claude-code)