### PR TITLE
[tb-381/382/384/385] docs: audit PRD-035 US-02/US-03 and PRD-036 US-02/US-03

### DIFF
--- a/docs-v2/themes/03-media/prds/035-watch-history/us-02-episode-enrichment.md
+++ b/docs-v2/themes/03-media/prds/035-watch-history/us-02-episode-enrichment.md
@@ -1,7 +1,7 @@
 # US-02: Episode enrichment
 
 > PRD: [035 — Watch History](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user, I want episode entries in my watch history to show the parent show na
 
 ## Acceptance Criteria
 
-- [ ] Episode entries display the show name above or alongside the episode title
+- [x] Episode entries display the show name above or alongside the episode title
 - [ ] Season and episode numbers render in standard format: "S01E03" (zero-padded to 2 digits)
 - [ ] Subtitle line reads: "{Show Name} — S{XX}E{XX}" (e.g., "Breaking Bad — S02E10")
 - [ ] Show name links to the show detail page (`/media/tv/:showId`)
 - [ ] Season identifier links to the season detail within the show page (`/media/tv/:showId?season=:seasonNumber`)
-- [ ] Movie entries are unaffected — they render title only with no subtitle
-- [ ] When show metadata is missing from the enriched response, the episode renders with its own title only (graceful degradation)
+- [x] Movie entries are unaffected — they render title only with no subtitle
+- [x] When show metadata is missing from the enriched response, the episode renders with its own title only (graceful degradation)
 - [ ] Tests cover: episode subtitle format, show name link URL, season link URL, fallback when show data is missing, movie entries have no subtitle
 
 ## Notes

--- a/docs-v2/themes/03-media/prds/035-watch-history/us-03-delete-watch-event.md
+++ b/docs-v2/themes/03-media/prds/035-watch-history/us-03-delete-watch-event.md
@@ -1,7 +1,7 @@
 # US-03: Delete watch event
 
 > PRD: [035 — Watch History](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 

--- a/docs-v2/themes/03-media/prds/036-watchlist/us-02-reorder.md
+++ b/docs-v2/themes/03-media/prds/036-watchlist/us-02-reorder.md
@@ -1,7 +1,7 @@
 # US-02: Watchlist reorder
 
 > PRD: [036 — Watchlist](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -10,16 +10,16 @@ As a user, I want to reorder my watchlist by dragging items (desktop) or using u
 ## Acceptance Criteria
 
 - [ ] Desktop: drag-and-drop reorder on watchlist items — grab handle visible on hover
-- [ ] Mobile: up/down arrow buttons beside each watchlist entry
+- [x] Mobile: up/down arrow buttons beside each watchlist entry
 - [ ] Dragging an item to a new position updates the visual order immediately (optimistic)
-- [ ] On drop (desktop) or button press (mobile), call `media.watchlist.reorder` with the full ordered list of `{ id, priority }` pairs
-- [ ] Priority values are sequential integers (1, 2, 3...) with no gaps or duplicates
-- [ ] Priority badges update to reflect the new order after reorder
+- [x] On drop (desktop) or button press (mobile), call `media.watchlist.reorder` with the full ordered list of `{ id, priority }` pairs
+- [x] Priority values are sequential integers (1, 2, 3...) with no gaps or duplicates
+- [x] Priority badges update to reflect the new order after reorder
 - [ ] If the reorder API call fails, revert the list to its previous order and show an error toast
 - [ ] Drag-and-drop cancelled mid-drag (escape key or drop outside target) reverts to original order without an API call
 - [ ] Reorder controls are hidden when the list has fewer than 2 items
-- [ ] Up button is hidden/disabled on the first item; down button is hidden/disabled on the last item
-- [ ] Reorder is disabled while a previous reorder request is in flight
+- [x] Up button is hidden/disabled on the first item; down button is hidden/disabled on the last item
+- [x] Reorder is disabled while a previous reorder request is in flight
 - [ ] Tests cover: drag-and-drop changes order, up/down buttons move items, API called with correct priorities, error reverts order, single-item list hides controls
 
 ## Notes

--- a/docs-v2/themes/03-media/prds/036-watchlist/us-03-auto-removal.md
+++ b/docs-v2/themes/03-media/prds/036-watchlist/us-03-auto-removal.md
@@ -1,7 +1,7 @@
 # US-03: Watchlist auto-removal
 
 > PRD: [036 — Watchlist](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,15 +9,15 @@ As a user, I want items to auto-remove from my watchlist when I've finished watc
 
 ## Acceptance Criteria
 
-- [ ] When a movie is logged as watched with `completed=1` via manual action, it is automatically removed from the watchlist
-- [ ] When an episode is logged as watched with `completed=1`, the system checks if ALL episodes across ALL seasons of the parent TV show are now completed
-- [ ] If all episodes of a TV show are completed, the TV show is removed from the watchlist
-- [ ] If any episode of a TV show remains unwatched, the TV show stays on the watchlist
-- [ ] Watch events with `source="plex_sync"` do NOT trigger auto-removal — the watchlist entry is preserved
+- [x] When a movie is logged as watched with `completed=1` via manual action, it is automatically removed from the watchlist
+- [x] When an episode is logged as watched with `completed=1`, the system checks if ALL episodes across ALL seasons of the parent TV show are now completed
+- [x] If all episodes of a TV show are completed, the TV show is removed from the watchlist
+- [x] If any episode of a TV show remains unwatched, the TV show stays on the watchlist
+- [x] Watch events with `source="plex_sync"` do NOT trigger auto-removal — the watchlist entry is preserved
 - [ ] After auto-removal, remaining watchlist items re-sequence priorities (no gaps)
-- [ ] Undo of a mark-as-watched action deletes the watch event but does NOT re-add the item to the watchlist
-- [ ] Auto-removal and watch event logging happen in the same database transaction
-- [ ] If the item is not on the watchlist when marked as watched, no error occurs (no-op for removal)
+- [x] Undo of a mark-as-watched action deletes the watch event but does NOT re-add the item to the watchlist
+- [x] Auto-removal and watch event logging happen in the same database transaction
+- [x] If the item is not on the watchlist when marked as watched, no error occurs (no-op for removal)
 - [ ] Tests cover: movie auto-removal on watch, TV show removal when all episodes watched, TV show retained when partially watched, plex_sync skips removal, priority re-sequencing after removal, undo does not re-add, no-op when item not on watchlist
 
 ## Notes


### PR DESCRIPTION
## Summary

Audited 4 user stories across PRD-035 (Watch History) and PRD-036 (Watchlist). Updated `docs-v2` status and AC checkboxes for each.

## Changes

| Task | GH Issue | US File | Status |
|------|----------|---------|--------|
| tb-381 | GH-527 | PRD-035 US-02 episode enrichment | Partial |
| tb-382 | GH-528 | PRD-035 US-03 delete watch event | Partial |
| tb-384 | GH-530 | PRD-036 US-02 watchlist reorder | Partial |
| tb-385 | GH-531 | PRD-036 US-03 auto-removal | Partial |

## Audit Findings

**GH-527 (Episode enrichment) — Partial**
- ✅ Show name displayed in subtitle, movie entries unaffected, graceful degradation
- ❌ Wrong separator (· not —), no zero-padding (S2E10 not S02E10), no show/season links, no tests

**GH-528 (Delete watch event) — Partial**
- ✅ Backend `media.watchHistory.delete` procedure exists
- ❌ No frontend delete button, no confirmation dialog, no toast, no pagination adjustment, no tests

**GH-530 (Watchlist reorder) — Partial**
- ✅ Mobile up/down buttons, calls `watchlist.reorder` with correct priorities, up/down disabled at edges, disabled while in flight
- ❌ No desktop drag-and-drop, no error revert (just toast), no controls hidden for <2 items, no tests

**GH-531 (Auto-removal) — Partial**
- ✅ Movie/TV auto-removal in transaction, plex_sync skipped, undo doesn't re-add, no-op when not on watchlist
- ❌ Priorities not re-sequenced after auto-removal, no tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)