### PR TITLE
[tb-244/245/246/247] Audit: PRD-002 Design Tokens & Theming — mixed status

### DIFF
--- a/docs-v2/themes/01-foundation/epics/01-ui-component-library.md
+++ b/docs-v2/themes/01-foundation/epics/01-ui-component-library.md
@@ -10,7 +10,7 @@ Build `@pops/ui` — a workspace package containing all shared UI components, de
 
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
-| 002 | [Design Tokens & Theming](../prds/002-design-tokens-theming/README.md) | Tailwind v4 config, colour system (including app colour variable), spacing, typography, breakpoints | Done |
+| 002 | [Design Tokens & Theming](../prds/002-design-tokens-theming/README.md) | Tailwind v4 config, colour system (including app colour variable), spacing, typography, breakpoints | Partial |
 | 003 | [Components](../prds/003-components/README.md) | Primitive (Shadcn/Radix) and composite components, all consuming design tokens — no hardcoded colours | Done |
 | 004 | [Storybook](../prds/004-storybook/README.md) | Config, story discovery across all packages, co-location pattern | Done |
 

--- a/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/README.md
+++ b/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/README.md
@@ -1,7 +1,7 @@
 # PRD-002: Design Tokens & Theming
 
 > Epic: [01 — UI Component Library](../../epics/01-ui-component-library.md)
-> Status: To Review
+> Status: Partial
 
 ## Overview
 
@@ -106,9 +106,9 @@ These patterns must be eliminated and replaced with token-based classes:
 
 | # | Story | Summary | Parallelisable |
 |---|-------|---------|----------------|
-| 01 | [us-01-globals-css](us-01-globals-css.md) | Create globals.css with Tailwind imports, @theme block, CSS variables, light/dark tokens | No (first) |
+| 01 | [us-01-globals-css](us-01-globals-css.md) | Create globals.css with Tailwind imports, @theme block, CSS variables, light/dark tokens ✅ | No (first) |
 | 02 | [us-02-app-colour-variable](us-02-app-colour-variable.md) | Define the app colour CSS variable system (--app-accent, --app-accent-foreground) with per-colour definitions | Blocked by us-01 |
-| 03 | [us-03-eliminate-arbitrary-values](us-03-eliminate-arbitrary-values.md) | Replace all arbitrary Tailwind values with token-based classes across all components | Blocked by us-01 |
+| 03 | [us-03-eliminate-arbitrary-values](us-03-eliminate-arbitrary-values.md) | Replace all arbitrary Tailwind values with token-based classes across all components (partial) | Blocked by us-01 |
 | 04 | [us-04-eliminate-hardcoded-colours](us-04-eliminate-hardcoded-colours.md) | Replace all hardcoded app colour classes (bg-indigo-600, text-emerald-400, etc.) with app-accent token references | Blocked by us-02 |
 
 ## Verification

--- a/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/us-01-globals-css.md
+++ b/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/us-01-globals-css.md
@@ -1,7 +1,7 @@
 # US-01: Create globals.css with design tokens
 
 > PRD: [002 — Design Tokens & Theming](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a developer, I want a single `globals.css` file in `@pops/ui/theme` that defi
 
 ## Acceptance Criteria
 
-- [ ] `packages/ui/src/theme/globals.css` exists
-- [ ] Contains `@import "tailwindcss"`
-- [ ] Contains `@theme` block with breakpoints, shadows, radii, and any custom spacing tokens
-- [ ] Contains CSS variables for all colours in `:root` (light mode) and `.dark` (dark mode)
-- [ ] Uses oklch colour space for all colour values
-- [ ] Shell entry point imports `@pops/ui/theme`
-- [ ] Light mode and dark mode both render correctly
-- [ ] No theme-related CSS exists outside this file
+- [x] `packages/ui/src/theme/globals.css` exists
+- [x] Contains `@import "tailwindcss"`
+- [x] Contains `@theme` block with breakpoints, shadows, radii, and any custom spacing tokens
+- [x] Contains CSS variables for all colours in `:root` (light mode) and `.dark` (dark mode)
+- [x] Uses oklch colour space for all colour values
+- [x] Shell entry point imports `@pops/ui/theme`
+- [x] Light mode and dark mode both render correctly
+- [x] No theme-related CSS exists outside this file
 
 ## Notes
 

--- a/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/us-02-app-colour-variable.md
+++ b/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/us-02-app-colour-variable.md
@@ -1,7 +1,7 @@
 # US-02: Define app colour variable system
 
 > PRD: [002 — Design Tokens & Theming](README.md)
-> Status: To Review
+> Status: Not started
 
 ## Description
 

--- a/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/us-03-eliminate-arbitrary-values.md
+++ b/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/us-03-eliminate-arbitrary-values.md
@@ -1,7 +1,7 @@
 # US-03: Eliminate arbitrary Tailwind values
 
 > PRD: [002 — Design Tokens & Theming](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -12,7 +12,7 @@ As a developer, I want all arbitrary Tailwind values replaced with token-based c
 - [ ] All `w-[Npx]`, `h-[Npx]`, `min-w-[Npx]`, `max-h-[Npx]` replaced with Tailwind scale values
 - [ ] All centering hacks (`top-[50%]`, `translate-x-[-50%]`) replaced with built-in utilities
 - [ ] Arbitrary padding/margin (`p-[3px]`, `bottom-[-5px]`) replaced with closest token or custom token added to `@theme`
-- [ ] Radix CSS variable bindings (`w-[var(--radix-*)]`) documented as permitted exception and left in place
+- [x] Radix CSS variable bindings (`w-[var(--radix-*)]`) documented as permitted exception and left in place
 - [ ] `grep` for arbitrary value patterns returns only permitted Radix exceptions
 - [ ] No visual regressions — components render identically before and after
 
@@ -26,3 +26,5 @@ Specific replacements from the audit:
 - `max-h-[300px]` → `max-h-75`
 
 If a value doesn't have a close Tailwind equivalent, add a custom token to `@theme` — don't approximate.
+
+Remaining arbitrary values (as of audit): `packages/ui/src/primitives/` still contains `bottom-[-5px]` (tabs.tsx), `translate-y-[calc(-50%_-_2px)]` and `rounded-[2px]` (tooltip.tsx), `min-w-[44px]` and `min-h-[44px]` (dialog.tsx — accessibility touch targets).

--- a/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/us-04-eliminate-hardcoded-colours.md
+++ b/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/us-04-eliminate-hardcoded-colours.md
@@ -1,7 +1,7 @@
 # US-04: Eliminate hardcoded app colours
 
 > PRD: [002 — Design Tokens & Theming](README.md)
-> Status: To Review
+> Status: Not started
 
 ## Description
 


### PR DESCRIPTION
## Summary

Audited PRD-002 US-01 through US-04 (Design Tokens & Theming) against implementation.

| US | Status | Finding |
|----|--------|---------|
| US-01: globals.css | ✅ Done | File exists with all required elements |
| US-02: App colour variable | ❌ Not started | No `--app-accent` variables found |
| US-03: Eliminate arbitrary values | ⚠️ Partial | Some remain in ui primitives |
| US-04: Eliminate hardcoded colours | ❌ Not started | Hardcoded colours in app packages; blocked by US-02 |

## US-01 Verification (Done)
- ✅ `packages/ui/src/theme/globals.css` exists (272 lines)
- ✅ `@import "tailwindcss"` present
- ✅ `@theme` block with breakpoints, radii, animations
- ✅ CSS variables in `:root` (light) and `.dark` using oklch throughout
- ✅ `apps/pops-shell/src/main.tsx` imports `@pops/ui/theme`
- ✅ Only one CSS file in the whole ui package

## US-02 Finding (Not started)
No `--app-accent` or `--app-accent-foreground` CSS variables found anywhere in the codebase. App colour variable system has not been implemented.

## US-03 Finding (Partial)
Remaining arbitrary values in `packages/ui/src/primitives/`:
- `bottom-[-5px]` in tabs.tsx
- `translate-y-[calc(-50%_-_2px)]`, `rounded-[2px]` in tooltip.tsx
- `min-w-[44px]`, `min-h-[44px]` in dialog.tsx (accessibility touch targets)

## US-04 Finding (Not started)
Hardcoded app colour classes still present: `app-media` (6 files), `app-finance` (1 file), `app-inventory` (2 files). Blocked by US-02 — needs `app-accent` system first.

Closes #390
Closes #391
Closes #392
Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)