### PR TITLE
docs: audit PRD-003/004/005 user stories — components, storybook, shell

### DIFF
--- a/docs-v2/themes/01-foundation/prds/003-components/us-04-data-display.md
+++ b/docs-v2/themes/01-foundation/prds/003-components/us-04-data-display.md
@@ -1,7 +1,21 @@
 # US-04: Build data display composites
 
 > PRD: [003 — Components](README.md)
-> Status: To Review
+> Status: Partial
+
+**GH Issue:** #397
+
+## Audit Findings
+
+**Present:**
+- `DataTable.tsx` — TanStack Table with sorting, filtering, pagination; stories at `DataTable.stories.tsx` and `DataTable.filtering.stories.tsx`
+- `DataTableFilters.tsx` — filter bar component
+- `InfiniteScrollTable.tsx` — scroll-based pagination variant; story at `InfiniteScrollTable.stories.tsx`
+- `EditableCell.tsx` — inline cell editing
+- `StatCard.tsx` — metric card with oklch color variants and trend support; all using design tokens
+
+**Missing:**
+- `ViewToggleGroup` — table/grid toggle persisting to localStorage is not implemented; apps use their own ad-hoc patterns
 
 ## Description
 

--- a/docs-v2/themes/01-foundation/prds/003-components/us-05-utility-components.md
+++ b/docs-v2/themes/01-foundation/prds/003-components/us-05-utility-components.md
@@ -1,7 +1,21 @@
 # US-05: Build utility composites
 
 > PRD: [003 — Components](README.md)
-> Status: To Review
+> Status: Done
+
+**GH Issue:** #398
+
+## Audit Findings
+
+All utility composites are implemented in `packages/ui/src/components/`:
+
+- `Button.tsx` — extends primitive with icon support, loading state (spinner + disabled), shape variants; story present
+- `Chip.tsx` / `ChipInput.tsx` — dismissable tag/label with CVA color variants; keyboard support (Enter/Backspace); stories present
+- `DropdownMenu.tsx` — wrapper around primitive dropdown with standardised menu item patterns; story present
+- `Select.tsx` — wrapper extending the primitive for consistent usage patterns
+- `ErrorBoundary.tsx` — React class component with `fallback` render prop; used in `RootLayout` wrapping `<Outlet />`
+
+All components are exported from the barrel `index.ts` and use design tokens.
 
 ## Description
 

--- a/docs-v2/themes/01-foundation/prds/003-components/us-06-icon-standards.md
+++ b/docs-v2/themes/01-foundation/prds/003-components/us-06-icon-standards.md
@@ -1,7 +1,23 @@
 # US-06: Enforce action icon standards
 
 > PRD: [003 — Components](README.md)
-> Status: To Review
+> Status: Partial
+
+**GH Issue:** #399
+
+## Audit Findings
+
+**Present:**
+- All apps use Lucide React as the single icon library (no mixing with other icon sets)
+- `apps/pops-shell/src/app/nav/icon-map.ts` defines a shared icon registry for navigation icons (Lucide only)
+- No banned icon names (`Edit2`, `Trash`, `PenLine`) found in app packages or `@pops/ui`
+- Destructive actions consistently use `Trash2`
+
+**Missing:**
+- No formal icon standard is documented or enforced in `@pops/ui` (icon choices live in individual app components)
+- Icon-only buttons in table rows/list items are inconsistently labelled — not all have `aria-label`
+- Text-only action labels still exist in some areas (no icon)
+- Full sweep across all packages to verify consistent use of `Plus`, `Pencil`, `X` patterns has not been completed
 
 ## Description
 

--- a/docs-v2/themes/01-foundation/prds/004-storybook/us-02-theme-decorator.md
+++ b/docs-v2/themes/01-foundation/prds/004-storybook/us-02-theme-decorator.md
@@ -1,7 +1,21 @@
 # US-02: Global theme decorator
 
 > PRD: [004 — Storybook](README.md)
-> Status: To Review
+> Status: Partial
+
+**GH Issue:** #401
+
+## Audit Findings
+
+**Present:**
+- `packages/ui/.storybook/preview.ts` imports `../src/theme/globals.css`, so all stories render with the correct design tokens
+- Storybook controls (color matchers, date matchers) configured
+
+**Missing:**
+- No global decorator wrapping stories with a theme provider or dark mode class toggle
+- No Storybook toolbar addon for light/dark mode switching — dark mode can't be previewed without manually setting the `dark` class on `<html>`
+- No app colour variable dropdown (e.g., switching between emerald, indigo, amber themes)
+- The `@storybook/addon-backgrounds` dark background option is not wired to the CSS `dark` class
 
 ## Description
 

--- a/docs-v2/themes/01-foundation/prds/005-shell/us-02-layout.md
+++ b/docs-v2/themes/01-foundation/prds/005-shell/us-02-layout.md
@@ -1,7 +1,21 @@
 # US-02: Build shell layout
 
 > PRD: [005 — Shell](README.md)
-> Status: To Review
+> Status: Done
+
+**GH Issue:** #403
+
+## Audit Findings
+
+Full layout implemented in `apps/pops-shell/src/app/layout/`:
+
+- `RootLayout.tsx` — wraps TopBar + AppRail + PageNav (desktop) + Sidebar (mobile) + `<main>` with `<ErrorBoundary>`; `<Outlet />` renders inside ErrorBoundary
+- `TopBar.tsx` — POPS branding with gradient text, theme toggle (Sun/Moon icons), hamburger for mobile; `fixed top-0 w-full z-40`
+- `AppRail.tsx` — icon-only app switcher for desktop (hidden on mobile)
+- `PageNav.tsx` — page-level nav links for the active app (desktop)
+- `Sidebar.tsx` — mobile overlay with hamburger toggle; controlled via `uiStore`
+
+Content area uses `<main>` with padding, rendered below the fixed TopBar via `pt-14 md:pt-16`. No ancestor has `overflow: hidden` that would trap the fixed TopBar.
 
 ## Description
 

--- a/docs-v2/themes/01-foundation/prds/005-shell/us-03-routing.md
+++ b/docs-v2/themes/01-foundation/prds/005-shell/us-03-routing.md
@@ -1,7 +1,23 @@
 # US-03: Build router with lazy-loaded app registration
 
 > PRD: [005 — Shell](README.md)
-> Status: To Review
+> Status: Done
+
+**GH Issue:** #404
+
+## Audit Findings
+
+`apps/pops-shell/src/app/router.tsx` implements the full routing setup:
+
+- `createBrowserRouter` from React Router v7
+- Root route uses `<RootLayout />` as the wrapper, with a custom `errorElement` for crash recovery
+- `/` redirects to `/finance` via `<Navigate to="/finance" replace />`
+- Registered apps: `/finance/*`, `/media/*`, `/inventory/*`, `/ai/*`
+- Each app exports a `routes` array; page components inside each app use `React.lazy()` for code splitting
+- `withSuspense` helper wraps each route element in `<Suspense>` with a loading fallback
+- `NotFoundPage` rendered inside the root route (within shell layout) for unmatched paths
+
+**Note:** The shell statically imports each app's route registry (`import { routes } from "@pops/app-finance"`), but all page elements within those routes are `React.lazy()` — code splitting happens at the page level.
 
 ## Description
 

--- a/docs-v2/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
+++ b/docs-v2/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
@@ -1,7 +1,21 @@
 # US-04: Build page-level navigation (back button + breadcrumbs)
 
 > PRD: [005 — Shell](README.md)
-> Status: To Review
+> Status: Partial
+
+**GH Issue:** #405
+
+## Audit Findings
+
+**Present:**
+- `Breadcrumb` primitive available in `@pops/ui` (shadcn-based, at `packages/ui/src/primitives/breadcrumb.tsx`)
+- `LocationBreadcrumb.tsx` composite in `@pops/ui` for inventory location hierarchies (with click handlers and segments)
+
+**Missing:**
+- No shared `PageHeader` component or standard page header pattern in `@pops/ui` combining a back button + breadcrumb
+- No drill-down pages in the codebase implement the `ArrowLeft + Breadcrumb` pattern from the spec
+- The `TopBar` does not include a contextual breadcrumb area
+- Mobile collapse behaviour (`…` for middle segments) is not implemented
 
 ## Description
 

--- a/docs-v2/themes/01-foundation/prds/005-shell/us-05-trpc-access.md
+++ b/docs-v2/themes/01-foundation/prds/005-shell/us-05-trpc-access.md
@@ -1,7 +1,22 @@
 # US-05: Set up tRPC client and app package access pattern
 
 > PRD: [005 — Shell](README.md)
-> Status: To Review
+> Status: Partial
+
+**GH Issue:** #406
+
+## Audit Findings
+
+**Present:**
+- `apps/pops-shell/src/lib/trpc.ts` — `createTRPCReact<AppRouter>()` with `httpBatchLink` pointing to `/trpc` (proxied to `localhost:3000` in dev)
+- `trpc.Provider` + `QueryClientProvider` wrap the entire app in `App.tsx`
+- `ReactQueryDevtools` available in development (gated by `!VITE_E2E`)
+- TypeScript resolves `AppRouter` from `@pops/api` — procedure names autocomplete
+- App packages (e.g., `app-finance`) each have their own `lib/trpc.ts` re-creating `createTRPCReact<AppRouter>()` for local `@/` alias resolution
+
+**Missing:**
+- Each app package creates a separate `createTRPCReact` instance rather than sharing the shell's instance; this is architecturally fragile (separate React contexts) — noted in `app-finance/src/lib/trpc.ts` as needing consolidation
+- No shared `@pops/api-client` package as suggested in the notes — tRPC config is duplicated across packages
 
 ## Description
 


### PR DESCRIPTION
## Summary

Audit findings for 8 user stories across PRD-003 (components), PRD-004 (Storybook), and PRD-005 (shell).

| Task | GH Issue | Story | Status |
|------|----------|-------|--------|
| tb-251 | #397 | PRD-003 US-04: Data display composites | **Partial** — ViewToggleGroup missing |
| tb-252 | #398 | PRD-003 US-05: Utility composites | **Done** |
| tb-253 | #399 | PRD-003 US-06: Icon standards | **Partial** — no formal audit/aria-labels incomplete |
| tb-255 | #401 | PRD-004 US-02: Theme decorator | **Partial** — no dark mode toolbar toggle |
| tb-257 | #403 | PRD-005 US-02: Shell layout | **Done** |
| tb-258 | #404 | PRD-005 US-03: Routing | **Done** (page-level lazy loading) |
| tb-259 | #405 | PRD-005 US-04: Breadcrumbs | **Partial** — primitive exists, no PageHeader pattern |
| tb-260 | #406 | PRD-005 US-05: tRPC access | **Partial** — separate instances per app package |

## Test plan

- [ ] Review audit findings match actual code state
- [ ] Verify GH issues for partial/missing items remain open

🤖 Generated with [Claude Code](https://claude.com/claude-code)