### PR TITLE
[tb-386/387/388/389/390] docs: audit PRD-037 ratings/comparisons US-01 through US-05

### DIFF
--- a/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-01-compare-arena.md
+++ b/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-01-compare-arena.md
@@ -1,7 +1,7 @@
 # US-01: Compare arena
 
 > PRD: [037 — Ratings & Comparisons](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,19 +9,19 @@ As a user, I want to compare two watched movies side by side across taste dimens
 
 ## Acceptance Criteria
 
-- [ ] Compare arena page renders at `/media/compare`
-- [ ] Page displays two movie poster cards side by side with title, year, and poster image
-- [ ] Current dimension is displayed prominently above the pair: "Which has better {Dimension}?"
-- [ ] Clicking/tapping a movie card selects it as the winner for the current dimension
-- [ ] After picking a winner, the comparison is recorded via `media.comparisons.record` and a new pair loads
+- [x] Compare arena page renders at `/media/compare`
+- [x] Page displays two movie poster cards side by side with title, year, and poster image
+- [x] Current dimension is displayed prominently above the pair: "Which has better {Dimension}?"
+- [x] Clicking/tapping a movie card selects it as the winner for the current dimension
+- [x] After picking a winner, the comparison is recorded via `media.comparisons.record` and a new pair loads
 - [ ] Dimension rotates through all active dimensions in order — one dimension per comparison
-- [ ] "Skip" button below the pair fetches a new random pair without recording a comparison
-- [ ] Random pair is fetched via `media.comparisons.getRandomPair` with the current dimension ID
-- [ ] Recently compared pairs are avoided (last 10 pairs) — pair avoidance is server-side
-- [ ] When fewer than 2 watched movies exist, display "Not enough watched movies" with a CTA linking to the library
-- [ ] Loading state: skeleton pair cards while fetching the next pair
-- [ ] Transition animation between pairs (fade or slide) for visual feedback
-- [ ] Picking a winner disables both cards until the next pair loads (prevent double-submission)
+- [x] "Skip" button below the pair fetches a new random pair without recording a comparison
+- [x] Random pair is fetched via `media.comparisons.getRandomPair` with the current dimension ID
+- [x] Recently compared pairs are avoided (last 10 pairs) — pair avoidance is server-side
+- [x] When fewer than 2 watched movies exist, display "Not enough watched movies" with a CTA linking to the library
+- [x] Loading state: skeleton pair cards while fetching the next pair
+- [x] Transition animation between pairs (fade or slide) for visual feedback
+- [x] Picking a winner disables both cards until the next pair loads (prevent double-submission)
 - [ ] Tests cover: pair renders with correct data, pick winner calls record API, skip fetches new pair, dimension rotates after pick, minimum threshold message renders, double-click prevention
 
 ## Notes

--- a/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-02-elo-scoring.md
+++ b/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-02-elo-scoring.md
@@ -1,7 +1,7 @@
 # US-02: Elo scoring
 
 > PRD: [037 — Ratings & Comparisons](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,19 +9,19 @@ As a system, I want to calculate and update Elo scores when a comparison is reco
 
 ## Acceptance Criteria
 
-- [ ] `media.comparisons.record` validates that the winner ID matches either media A or media B
-- [ ] Both movies have a score record in `media_scores` for the given dimension — created at 1500.0 if not existing
-- [ ] Expected score is calculated as: `1 / (1 + 10^((opponentScore - score) / 400))`
-- [ ] Winner's new score: `oldScore + 32 * (1 - expectedScore)`
-- [ ] Loser's new score: `oldScore + 32 * (0 - expectedScore)`
-- [ ] Both score updates and the comparison record are written in a single database transaction
-- [ ] `comparisonCount` on each movie's score record increments by 1
-- [ ] `updatedAt` on each score record is set to the current timestamp
-- [ ] If the transaction fails, no partial writes occur (neither scores nor comparison saved)
-- [ ] Validation error if winner does not match media A or media B
+- [x] `media.comparisons.record` validates that the winner ID matches either media A or media B
+- [x] Both movies have a score record in `media_scores` for the given dimension — created at 1500.0 if not existing
+- [x] Expected score is calculated as: `1 / (1 + 10^((opponentScore - score) / 400))`
+- [x] Winner's new score: `oldScore + 32 * (1 - expectedScore)`
+- [x] Loser's new score: `oldScore + 32 * (0 - expectedScore)`
+- [x] Both score updates and the comparison record are written in a single database transaction
+- [x] `comparisonCount` on each movie's score record increments by 1
+- [x] `updatedAt` on each score record is set to the current timestamp
+- [x] If the transaction fails, no partial writes occur (neither scores nor comparison saved)
+- [x] Validation error if winner does not match media A or media B
 - [ ] Validation error if dimension ID does not reference an active dimension
-- [ ] Scores are stored as REAL with no rounding — precision preserved across updates
-- [ ] Tests cover: correct Elo calculation for equal-rated movies, lopsided ratings, edge case where one movie has 1500 and opponent has 2000, transaction rollback on failure, validation errors, comparison count increment
+- [x] Scores are stored as REAL with no rounding — precision preserved across updates
+- [x] Tests cover: correct Elo calculation for equal-rated movies, lopsided ratings, edge case where one movie has 1500 and opponent has 2000, transaction rollback on failure, validation errors, comparison count increment
 
 ## Notes
 

--- a/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-03-rankings-page.md
+++ b/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-03-rankings-page.md
@@ -1,7 +1,7 @@
 # US-03: Rankings page
 
 > PRD: [037 — Ratings & Comparisons](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,17 +9,17 @@ As a user, I want to see a leaderboard of my movies ranked by Elo score so that 
 
 ## Acceptance Criteria
 
-- [ ] Rankings page renders at `/media/rankings`
-- [ ] Dimension selector dropdown with "Overall" as default plus each active dimension
+- [x] Rankings page renders at `/media/rankings`
+- [x] Dimension selector dropdown with "Overall" as default plus each active dimension
 - [ ] Selecting a dimension updates the list and persists in `?dimension=` query param
-- [ ] Ranked list displays: rank number, poster thumbnail, title, Elo score (1 decimal place), comparison count
-- [ ] "Overall" ranking calculates the average score across all active dimensions for each movie
+- [x] Ranked list displays: rank number, poster thumbnail, title, Elo score (1 decimal place), comparison count
+- [x] "Overall" ranking calculates the average score across all active dimensions for each movie
 - [ ] Movies are sorted by score descending — ties broken alphabetically by title
 - [ ] Movies with zero comparisons display at 1500.0 and sort alphabetically after scored movies
 - [ ] List is paginated (25 items per page) with page navigation
-- [ ] Empty state: "No comparisons yet — start comparing" with CTA to `/media/compare`
-- [ ] Only movies are shown (TV comparisons are out of scope)
-- [ ] Page calls `media.comparisons.rankings` with optional dimension ID (omitted for overall)
+- [x] Empty state: "No comparisons yet — start comparing" with CTA to `/media/compare`
+- [x] Only movies are shown (TV comparisons are out of scope)
+- [x] Page calls `media.comparisons.rankings` with optional dimension ID (omitted for overall)
 - [ ] Tests cover: ranked order matches scores, overall averages correctly, dimension selector switches list, zero-comparison movies sort last alphabetically, pagination, empty state renders
 
 ## Notes

--- a/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-04-dimension-management.md
+++ b/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-04-dimension-management.md
@@ -1,7 +1,7 @@
 # US-04: Dimension management
 
 > PRD: [037 — Ratings & Comparisons](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,17 +9,17 @@ As a user, I want to manage comparison dimensions (add, edit, deactivate) so tha
 
 ## Acceptance Criteria
 
-- [ ] Dimension management UI accessible from the rankings or compare page (settings/gear icon or dedicated section)
-- [ ] List all dimensions ordered by `sortOrder`, showing name, description, active status
-- [ ] Create new dimension: name (required, unique), description (optional), sortOrder (required)
-- [ ] Edit existing dimension: update name, description, sortOrder
-- [ ] Toggle active/inactive status — deactivated dimensions are greyed out in the list
-- [ ] Deactivated dimensions are excluded from the arena's dimension rotation
-- [ ] Deactivated dimensions are excluded from the "Overall" ranking calculation
-- [ ] Deactivated dimensions retain their comparison history and scores (not deleted)
-- [ ] Cannot delete a dimension — only deactivate (preserves historical data)
-- [ ] Name uniqueness validated — duplicate name shows an error message
-- [ ] Sort order can be updated by reordering the list (similar to watchlist reorder)
+- [x] Dimension management UI accessible from the rankings or compare page (settings/gear icon or dedicated section)
+- [x] List all dimensions ordered by `sortOrder`, showing name, description, active status
+- [x] Create new dimension: name (required, unique), description (optional), sortOrder (required)
+- [x] Edit existing dimension: update name, description, sortOrder
+- [x] Toggle active/inactive status — deactivated dimensions are greyed out in the list
+- [x] Deactivated dimensions are excluded from the arena's dimension rotation
+- [x] Deactivated dimensions are excluded from the "Overall" ranking calculation
+- [x] Deactivated dimensions retain their comparison history and scores (not deleted)
+- [x] Cannot delete a dimension — only deactivate (preserves historical data)
+- [x] Name uniqueness validated — duplicate name shows an error message
+- [x] Sort order can be updated by reordering the list (similar to watchlist reorder)
 - [ ] Default dimensions (Cinematography, Entertainment, Emotional Impact, Rewatchability, Soundtrack) are seeded on first use
 - [ ] Tests cover: create dimension, edit dimension, toggle active status, sort order update, name uniqueness error, deactivated dimension excluded from arena rotation, deactivated excluded from overall ranking
 

--- a/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-05-quick-pick.md
+++ b/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-05-quick-pick.md
@@ -1,7 +1,7 @@
 # US-05: Quick pick
 
 > PRD: [037 — Ratings & Comparisons](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,16 +9,16 @@ As a user, I want a "What should I watch?" page that shows random unwatched movi
 
 ## Acceptance Criteria
 
-- [ ] Quick pick page renders at `/media/quick-pick`
+- [x] Quick pick page renders at `/media/quick-pick`
 - [ ] Displays a configurable number of random unwatched movies (default 3)
-- [ ] "Unwatched" = movies in the library that have no `completed=1` entry in watch_history
+- [x] "Unwatched" = movies in the library that have no `completed=1` entry in watch_history
 - [ ] Each movie displays as a poster card with title, year, and a "Watch This" action button
 - [ ] "Watch This" navigates to the movie's detail page (`/media/movies/:id`)
 - [ ] "Show me others" button fetches a new random set without page reload
 - [ ] Count selector allows choosing how many movies to display (2, 3, 4, or 5)
 - [ ] Count preference persists in `?count=` query param
-- [ ] Empty state: "Nothing unwatched in your library" with CTA to the search page
-- [ ] When fewer unwatched movies exist than the requested count, display all available (no error)
+- [x] Empty state: "Nothing unwatched in your library" with CTA to the search page
+- [x] When fewer unwatched movies exist than the requested count, display all available (no error)
 - [ ] Poster cards use the same MediaCard component or matching styling
 - [ ] Tests cover: correct number of movies displayed, movies are unwatched, "Show me others" refreshes the set, count selector changes count, empty state renders, partial fill when few unwatched movies
 


### PR DESCRIPTION
## Summary

Audited all 5 user stories in PRD-037 (Ratings & Comparisons). Updated `docs-v2` status and AC checkboxes.

## Changes

| Task | GH Issue | US File | Status |
|------|----------|---------|--------|
| tb-386 | GH-532 | US-01 compare arena | Partial |
| tb-387 | GH-533 | US-02 elo scoring | Partial |
| tb-388 | GH-534 | US-03 rankings page | Partial |
| tb-389 | GH-535 | US-04 dimension management | Partial |
| tb-390 | GH-536 | US-05 quick pick | Partial |

## Audit Findings

**GH-532 (Compare arena) — Partial**
- ✅ Arena, pair cards, record/skip, pair avoidance, not-enough-movies message, skeleton, animation, disabled state
- ❌ Dimension auto-rotation missing (uses manual tabs), no frontend tests

**GH-533 (Elo scoring) — Partial**
- ✅ Full Elo formula (K=32), transaction, comparisonCount/updatedAt, REAL precision, winner validation, 28 API tests
- ❌ Inactive dimension not validated on record

**GH-534 (Rankings page) — Partial**
- ✅ Route, dimension tabs, overall avg, empty state, pagination, only movies, calls rankings API
- ❌ `?dimension=` not persisted, no tie-breaking, zero-comparison movies not shown, page size 50 not 25, no frontend tests

**GH-535 (Dimension management) — Partial**
- ✅ CRUD, toggle active, sort order reorder via up/down, accessible from compare page, name uniqueness, cannot delete
- ❌ Default dimensions not seeded on first use (only in test seeder, with different names), no tests

**GH-536 (Quick pick) — Partial**
- ✅ Route, unwatched filter, empty state, partial fill when fewer movies available
- ❌ Swipe-through single-card UX vs spec's multi-card grid, no Watch This nav, no count selector, no `?count=` param, no tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)