### PR TITLE
fix: use getEnv() for TMDB/TVDB API keys (GH-350)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,5 +34,12 @@ PLEX_TOKEN=
 PAPERLESS_URL=
 PAPERLESS_TOKEN=
 
+# Media Metadata Providers
+# TMDB: Get a Read-Access Token (v4 auth) from https://www.themoviedb.org/settings/api
+TMDB_API_KEY=
+
+# TheTVDB: Get an API Key from https://thetvdb.com/dashboard/account/apikey
+THETVDB_API_KEY=
+
 # Paths
 SQLITE_PATH=./data/pops.db

--- a/apps/pops-api/src/modules/media/thetvdb/index.ts
+++ b/apps/pops-api/src/modules/media/thetvdb/index.ts
@@ -1,5 +1,6 @@
 import { TheTvdbAuth } from "./auth.js";
 import { TheTvdbClient } from "./client.js";
+import { getEnv } from "../../../env.js";
 
 export { TheTvdbAuth, TheTvdbClient };
 export { TvdbApiError } from "./types.js";
@@ -21,7 +22,7 @@ let _tvdbClient: TheTvdbClient | null = null;
 
 export function getTvdbClient(): TheTvdbClient | null {
   if (_tvdbClient) return _tvdbClient;
-  const apiKey = process.env["THETVDB_API_KEY"];
+  const apiKey = getEnv("THETVDB_API_KEY");
   if (!apiKey) return null;
   _tvdbClient = new TheTvdbClient(new TheTvdbAuth(apiKey));
   return _tvdbClient;

--- a/apps/pops-api/src/modules/media/tmdb/index.ts
+++ b/apps/pops-api/src/modules/media/tmdb/index.ts
@@ -1,5 +1,6 @@
 import { TmdbClient } from "./client.js";
 import { TokenBucketRateLimiter } from "./rate-limiter.js";
+import { getEnv } from "../../../env.js";
 
 export { GenreCache, getGenreCache, setGenreCache } from "./genre-cache.js";
 export { TmdbClient } from "./client.js";
@@ -15,7 +16,7 @@ const tmdbRateLimiter = new TokenBucketRateLimiter(40, 4);
  * Returns null if TMDB_API_KEY is not set.
  */
 export function getTmdbClient(): TmdbClient | null {
-  const apiKey = process.env["TMDB_API_KEY"];
+  const apiKey = getEnv("TMDB_API_KEY");
   if (!apiKey) return null;
   return new TmdbClient(apiKey, tmdbRateLimiter);
 }


### PR DESCRIPTION
## Summary

- Replace `process.env["TMDB_API_KEY"]` and `process.env["THETVDB_API_KEY"]` with `getEnv()` in both client factories
- `getEnv()` checks Docker secret files first (production), then falls back to `process.env` (dev)
- Add both keys to `.env.example` for local dev setup

## Test plan

- [x] Typecheck passes (`pnpm typecheck` in pops-api)
- [x] `getEnv()` already used by all other API keys in the codebase

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)