### PR TITLE
docs: audit PRD-033/034 movie+tv detail pages [tb-372-379]

### DIFF
--- a/docs-v2/themes/03-media/prds/033-movie-detail-page/us-01-movie-hero-metadata.md
+++ b/docs-v2/themes/03-media/prds/033-movie-detail-page/us-01-movie-hero-metadata.md
@@ -1,7 +1,7 @@
 # US-01: Movie hero and metadata layout
 
 > PRD: [033 — Movie Detail Page](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,21 +9,21 @@ As a user, I want to see a movie's full details — backdrop, poster, title, yea
 
 ## Acceptance Criteria
 
-- [ ] Page renders at `/media/movies/:id` and fetches movie data via `media.library.getMovie`
-- [ ] Hero section displays a full-width backdrop image with a gradient overlay for text readability
-- [ ] If no backdrop image exists, the hero uses a solid colour gradient as fallback
-- [ ] Poster renders overlaid on the hero, using the same 3-tier fallback chain as MediaCard (override → cached → placeholder)
-- [ ] Title renders as a large heading within the hero
-- [ ] Release year renders next to or below the title
-- [ ] Runtime displays formatted as "Xh Ym" (e.g., "2h 15m"); hidden if runtime is null/zero
-- [ ] Genres render as comma-separated text or badge pills
-- [ ] Tagline renders in italic above the overview; hidden if empty or null
-- [ ] Overview section displays the full synopsis text
-- [ ] Metadata grid displays: status, original language (full name, not ISO code), budget (formatted currency), revenue (formatted currency), TMDB rating (vote average + vote count)
-- [ ] Budget and revenue fields are hidden when their value is zero or null
-- [ ] Watch history section lists all watch dates chronologically; shows "Not watched yet" if empty
-- [ ] Page shows a loading state (skeleton) while data is fetching
-- [ ] Page shows a 404 state or redirects to library when the movie ID does not exist
+- [x] Page renders at `/media/movies/:id` and fetches movie data via `media.library.getMovie`
+- [x] Hero section displays a full-width backdrop image with a gradient overlay for text readability
+- [x] If no backdrop image exists, the hero uses a solid colour gradient as fallback
+- [x] Poster renders overlaid on the hero, using the same 3-tier fallback chain as MediaCard (override → cached → placeholder)
+- [x] Title renders as a large heading within the hero
+- [x] Release year renders next to or below the title
+- [x] Runtime displays formatted as "Xh Ym" (e.g., "2h 15m"); hidden if runtime is null/zero
+- [x] Genres render as comma-separated text or badge pills
+- [x] Tagline renders in italic above the overview; hidden if empty or null
+- [x] Overview section displays the full synopsis text
+- [ ] Metadata grid displays: status, original language (full name, not ISO code), budget (formatted currency), revenue (formatted currency), TMDB rating (vote average + vote count) — language shows ISO code uppercased ("EN") not full name ("English")
+- [x] Budget and revenue fields are hidden when their value is zero or null
+- [ ] Watch history section lists all watch dates chronologically; shows "Not watched yet" if empty — section missing entirely
+- [x] Page shows a loading state (skeleton) while data is fetching
+- [x] Page shows a 404 state or redirects to library when the movie ID does not exist
 - [ ] Tests cover: hero renders with backdrop, fallback gradient without backdrop, poster fallback chain, runtime formatting, hidden fields when null/zero, 404 handling, watch history list and empty state
 
 ## Notes

--- a/docs-v2/themes/03-media/prds/033-movie-detail-page/us-02-watchlist-toggle.md
+++ b/docs-v2/themes/03-media/prds/033-movie-detail-page/us-02-watchlist-toggle.md
@@ -1,7 +1,7 @@
 # US-02: WatchlistToggle component
 
 > PRD: [033 — Movie Detail Page](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,15 +9,15 @@ As a user, I want to add or remove a movie from my watchlist with a single click
 
 ## Acceptance Criteria
 
-- [ ] WatchlistToggle is a standalone component that accepts a movie ID and renders the appropriate state
-- [ ] When the movie is not on the watchlist: renders "Add to Watchlist" button (e.g., bookmark outline icon + text)
-- [ ] When the movie is on the watchlist: renders "In Watchlist" button with a filled/active style (e.g., filled bookmark icon + text)
-- [ ] Clicking "Add to Watchlist" optimistically switches to the "In Watchlist" state immediately, then calls `media.watchlist.add`
-- [ ] Clicking "In Watchlist" optimistically switches to the "Add to Watchlist" state immediately, then calls `media.watchlist.remove`
-- [ ] If the API call fails, the UI reverts to the previous state and an error toast is displayed
-- [ ] Initial state is determined by calling `media.watchlist.status` with the movie ID
-- [ ] Button is disabled during the initial status check (prevents action before state is known)
-- [ ] The component is reusable — it can be mounted on any page that has a movie ID (detail page, list items, etc.)
+- [x] WatchlistToggle is a standalone component that accepts a movie ID and renders the appropriate state
+- [x] When the movie is not on the watchlist: renders "Add to Watchlist" button (e.g., bookmark outline icon + text)
+- [x] When the movie is on the watchlist: renders "In Watchlist" button with a filled/active style (e.g., filled bookmark icon + text)
+- [ ] Clicking "Add to Watchlist" optimistically switches to the "In Watchlist" state immediately, then calls `media.watchlist.add` — no optimistic update; state changes after API success
+- [ ] Clicking "In Watchlist" optimistically switches to the "Add to Watchlist" state immediately, then calls `media.watchlist.remove` — no optimistic update; state changes after API success
+- [ ] If the API call fails, the UI reverts to the previous state and an error toast is displayed — error toast shown but no state revert (state wasn't changed optimistically)
+- [ ] Initial state is determined by calling `media.watchlist.status` with the movie ID — uses `media.watchlist.list` + `find()` instead; `media.watchlist.status` endpoint does not exist
+- [x] Button is disabled during the initial status check (prevents action before state is known)
+- [x] The component is reusable — it can be mounted on any page that has a movie ID (detail page, list items, etc.)
 - [ ] Tests cover: initial state loading, optimistic add, optimistic remove, revert on API failure, error toast on failure
 
 ## Notes

--- a/docs-v2/themes/03-media/prds/033-movie-detail-page/us-03-mark-as-watched.md
+++ b/docs-v2/themes/03-media/prds/033-movie-detail-page/us-03-mark-as-watched.md
@@ -1,7 +1,7 @@
 # US-03: MarkAsWatchedButton component
 
 > PRD: [033 — Movie Detail Page](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,15 +9,15 @@ As a user, I want to mark a movie as watched and have the option to undo so that
 
 ## Acceptance Criteria
 
-- [ ] MarkAsWatchedButton is a standalone component that accepts a movie ID
-- [ ] Clicking the button calls `media.watchHistory.log` with the movie ID, `completed=1`, and the current timestamp
-- [ ] Button shows a spinner/loading state while the API call is in flight
-- [ ] On success: a toast notification appears with "Marked as watched" and an "Undo" action button
-- [ ] The undo toast is visible for 5 seconds before auto-dismissing
-- [ ] Clicking "Undo" within the toast window calls `media.watchHistory.delete` to remove the watch event
-- [ ] If the movie was on the watchlist before marking as watched, the server-side auto-removal takes effect; undo re-adds it to the watchlist
-- [ ] After a successful watch log, the watch history section on the page refreshes to include the new entry
-- [ ] The button remains usable after logging a watch (a movie can be watched multiple times — each click logs a new event)
+- [x] MarkAsWatchedButton is a standalone component that accepts a movie ID
+- [x] Clicking the button calls `media.watchHistory.log` with the movie ID, `completed=1`, and the current timestamp
+- [x] Button shows a spinner/loading state while the API call is in flight
+- [x] On success: a toast notification appears with "Marked as watched" and an "Undo" action button
+- [x] The undo toast is visible for 5 seconds before auto-dismissing
+- [x] Clicking "Undo" within the toast window calls `media.watchHistory.delete` to remove the watch event
+- [ ] If the movie was on the watchlist before marking as watched, the server-side auto-removal takes effect; undo re-adds it to the watchlist — undo only deletes the watch event; does not re-add to watchlist. `logWatch` does not return whether watchlist removal occurred.
+- [x] After a successful watch log, the watch history section on the page refreshes to include the new entry
+- [x] The button remains usable after logging a watch (a movie can be watched multiple times — each click logs a new event)
 - [ ] Tests cover: API call with correct payload, success toast with undo action, undo deletes the watch event, button re-enabled after logging, watch history refresh after log
 
 ## Notes

--- a/docs-v2/themes/03-media/prds/033-movie-detail-page/us-04-comparison-scores.md
+++ b/docs-v2/themes/03-media/prds/033-movie-detail-page/us-04-comparison-scores.md
@@ -1,7 +1,7 @@
 # US-04: ComparisonScores radar chart
 
 > PRD: [033 — Movie Detail Page](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,15 +9,15 @@ As a user, I want to see a radar chart of my comparison scores for a movie so th
 
 ## Acceptance Criteria
 
-- [ ] ComparisonScores is a standalone component that accepts a movie ID
-- [ ] Component calls `media.comparisons.scores` to fetch per-dimension Elo scores for the movie
-- [ ] If the movie has been compared at least once, a radar chart renders with one axis per active comparison dimension
-- [ ] If the movie has zero comparisons, the entire component is not rendered (no empty chart, no placeholder)
-- [ ] Elo scores are normalised to a 0-100 scale for radar chart display (map from the expected Elo range, e.g., 800-1600 → 0-100)
-- [ ] Each axis on the radar chart is labelled with the dimension name
-- [ ] The filled area of the radar chart uses the media app's accent colour with transparency
-- [ ] Radar chart is responsive — scales to fit its container without overflowing
-- [ ] A heading or label identifies the section (e.g., "Your Scores" or "Comparison Scores")
+- [x] ComparisonScores is a standalone component that accepts a movie ID
+- [x] Component calls `media.comparisons.scores` to fetch per-dimension Elo scores for the movie
+- [x] If the movie has been compared at least once, a radar chart renders with one axis per active comparison dimension
+- [ ] If the movie has zero comparisons, the entire component is not rendered (no empty chart, no placeholder) — shows placeholder for `totalComparisons < 3` ("Not enough data — at least 3 comparisons needed"); should not render at zero, but may render at 1+
+- [x] Elo scores are normalised to a 0-100 scale for radar chart display (map from the expected Elo range, e.g., 800-1600 → 0-100)
+- [x] Each axis on the radar chart is labelled with the dimension name
+- [x] The filled area of the radar chart uses the media app's accent colour with transparency
+- [x] Radar chart is responsive — scales to fit its container without overflowing
+- [x] A heading or label identifies the section (e.g., "Your Scores" or "Comparison Scores")
 - [ ] Tests cover: chart renders with scores, chart hidden when no comparisons exist, score normalisation maps correctly (e.g., Elo 1200 at midpoint), chart renders correct number of axes matching dimension count
 
 ## Notes

--- a/docs-v2/themes/03-media/prds/034-tv-show-detail-page/us-01-show-hero-metadata.md
+++ b/docs-v2/themes/03-media/prds/034-tv-show-detail-page/us-01-show-hero-metadata.md
@@ -1,7 +1,7 @@
 # US-01: Show hero and metadata layout
 
 > PRD: [034 — TV Show Detail Page](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,18 +9,18 @@ As a user, I want to see a TV show's full details — backdrop, poster, title, y
 
 ## Acceptance Criteria
 
-- [ ] Page renders at `/media/tv/:id` and fetches show data via `media.library.getTvShow`
-- [ ] Hero section displays a full-width backdrop image with a gradient overlay for text readability
-- [ ] If no backdrop image exists, the hero uses a solid colour gradient as fallback
-- [ ] Poster renders overlaid on the hero, using the 3-tier fallback chain (override → cached → placeholder)
-- [ ] Title renders as a large heading within the hero
-- [ ] Year range displays correctly: "Start – End" for ended shows, "Start – Present" for continuing shows, "Start" for single-season ended shows
-- [ ] Status renders as a badge or label (Continuing, Ended, Upcoming)
-- [ ] Genres render as comma-separated text or badge pills
-- [ ] Networks render below or alongside genres (e.g., "HBO", "Netflix")
-- [ ] Overview section displays the full synopsis text below the hero
-- [ ] Page shows a loading state (skeleton) while data is fetching
-- [ ] Page shows a 404 state or redirects to library when the show ID does not exist
+- [x] Page renders at `/media/tv/:id` and fetches show data via `media.library.getTvShow`
+- [x] Hero section displays a full-width backdrop image with a gradient overlay for text readability
+- [x] If no backdrop image exists, the hero uses a solid colour gradient as fallback
+- [x] Poster renders overlaid on the hero, using the 3-tier fallback chain (override → cached → placeholder)
+- [x] Title renders as a large heading within the hero
+- [ ] Year range displays correctly: "Start – End" for ended shows, "Start – Present" for continuing shows, "Start" for single-season ended shows — only shows start year; no end year or "Present" suffix
+- [x] Status renders as a badge or label (Continuing, Ended, Upcoming)
+- [x] Genres render as comma-separated text or badge pills
+- [ ] Networks render below or alongside genres (e.g., "HBO", "Netflix") — not displayed; not present in hero or metadata section
+- [x] Overview section displays the full synopsis text below the hero
+- [x] Page shows a loading state (skeleton) while data is fetching
+- [x] Page shows a 404 state or redirects to library when the show ID does not exist
 - [ ] Tests cover: hero renders with backdrop, fallback gradient, poster fallback chain, year range formatting for all three cases (ended, continuing, single-season), status badge, 404 handling
 
 ## Notes

--- a/docs-v2/themes/03-media/prds/034-tv-show-detail-page/us-02-season-list.md
+++ b/docs-v2/themes/03-media/prds/034-tv-show-detail-page/us-02-season-list.md
@@ -1,7 +1,7 @@
 # US-02: Season list
 
 > PRD: [034 — TV Show Detail Page](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,15 +9,15 @@ As a user, I want to see a list of seasons for a TV show with episode counts and
 
 ## Acceptance Criteria
 
-- [ ] Season list renders below the overview section on the show detail page
-- [ ] Each season card displays: season poster (fallback to show poster if no season poster), season number (e.g., "Season 1"), episode count (e.g., "10 episodes"), per-season watch progress bar with percentage
-- [ ] Progress bar colour is green when 100% watched, accent colour otherwise
-- [ ] Clicking a season card navigates to `/media/tv/:id/season/:num`
-- [ ] Seasons are sorted by season number ascending
-- [ ] Specials (season 0) are listed last, not first
-- [ ] Season progress data comes from `media.watchHistory.progress` (per-season breakdown)
-- [ ] If the show has no seasons, a message renders: "No seasons available"
-- [ ] Season cards have hover/focus state for interactivity feedback
+- [x] Season list renders below the overview section on the show detail page
+- [x] Each season card displays: season poster (fallback to show poster if no season poster), season number (e.g., "Season 1"), episode count (e.g., "10 episodes"), per-season watch progress bar with percentage
+- [x] Progress bar colour is green when 100% watched, accent colour otherwise
+- [x] Clicking a season card navigates to `/media/tv/:id/season/:num`
+- [x] Seasons are sorted by season number ascending
+- [x] Specials (season 0) are listed last, not first
+- [x] Season progress data comes from `media.watchHistory.progress` (per-season breakdown)
+- [x] If the show has no seasons, a message renders: "No seasons available"
+- [x] Season cards have hover/focus state for interactivity feedback
 - [ ] Tests cover: season cards render with correct data, sort order (specials last), click navigation to season detail, progress bar at 0%/50%/100%, empty state when no seasons
 
 ## Notes

--- a/docs-v2/themes/03-media/prds/034-tv-show-detail-page/us-03-season-detail-page.md
+++ b/docs-v2/themes/03-media/prds/034-tv-show-detail-page/us-03-season-detail-page.md
@@ -1,7 +1,7 @@
 # US-03: Season detail page
 
 > PRD: [034 — TV Show Detail Page](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,19 +9,19 @@ As a user, I want to view a season's episodes with individual watch toggles so t
 
 ## Acceptance Criteria
 
-- [ ] Page renders at `/media/tv/:id/season/:num` and fetches season data via `media.library.getSeason`
-- [ ] Season header displays: season poster (fallback to show poster), season name ("Season N" or custom name), overview (hidden if empty), air date
-- [ ] Episode list displays each episode as a row: episode number, name, air date (formatted), runtime (formatted as "Xm"), watch status indicator
-- [ ] Watch status indicator: filled checkmark if watched, empty circle if not watched
-- [ ] Clicking the watch indicator toggles the episode's watched state — calls `media.watchHistory.log` to mark watched or `media.watchHistory.delete` to mark unwatched
-- [ ] Per-episode toggle uses optimistic updates — the indicator changes immediately, reverts on API failure
-- [ ] Episodes that have not aired yet (air date in the future) are visually dimmed with an "Upcoming" label and their watch toggle is disabled
-- [ ] "Mark Season Watched" button calls `media.watchHistory.batchLog` for all unwatched episodes in the season
-- [ ] "Mark Season Watched" is hidden or disabled when all episodes are already watched
-- [ ] "Mark Season Watched" uses optimistic updates — all indicators flip to watched immediately, revert on failure with error toast
-- [ ] Breadcrumb or back link navigates to the parent show detail page (`/media/tv/:id`)
-- [ ] Page shows a loading state while data is fetching
-- [ ] Page shows a 404 state when the season number does not exist for this show
+- [x] Page renders at `/media/tv/:id/season/:num` and fetches season data via `media.library.getSeason`
+- [x] Season header displays: season poster (fallback to show poster), season name ("Season N" or custom name), overview (hidden if empty), air date
+- [x] Episode list displays each episode as a row: episode number, name, air date (formatted), runtime (formatted as "Xm"), watch status indicator
+- [x] Watch status indicator: filled checkmark if watched, empty circle if not watched
+- [x] Clicking the watch indicator toggles the episode's watched state — calls `media.watchHistory.log` to mark watched or `media.watchHistory.delete` to mark unwatched
+- [x] Per-episode toggle uses optimistic updates — the indicator changes immediately, reverts on API failure
+- [ ] Episodes that have not aired yet (air date in the future) are visually dimmed with an "Upcoming" label and their watch toggle is disabled — no air date comparison; all episodes show the same interactive toggle
+- [x] "Mark Season Watched" button calls `media.watchHistory.batchLog` for all unwatched episodes in the season
+- [x] "Mark Season Watched" is hidden or disabled when all episodes are already watched
+- [ ] "Mark Season Watched" uses optimistic updates — all indicators flip to watched immediately, revert on failure with error toast — no optimistic update; no `onError` handler (silent failure)
+- [x] Breadcrumb or back link navigates to the parent show detail page (`/media/tv/:id`)
+- [x] Page shows a loading state while data is fetching
+- [x] Page shows a 404 state when the season number does not exist for this show
 - [ ] Tests cover: episode list renders correctly, per-episode toggle (optimistic + revert), batch mark season watched, upcoming episodes are disabled, 404 for invalid season, breadcrumb navigation
 
 ## Notes

--- a/docs-v2/themes/03-media/prds/034-tv-show-detail-page/us-04-watch-progress.md
+++ b/docs-v2/themes/03-media/prds/034-tv-show-detail-page/us-04-watch-progress.md
@@ -1,7 +1,7 @@
 # US-04: Watch progress and batch actions
 
 > PRD: [034 — TV Show Detail Page](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,16 +9,16 @@ As a user, I want to see my overall watch progress for a TV show and quickly mar
 
 ## Acceptance Criteria
 
-- [ ] Overall watch progress bar renders on the show detail page showing "X of Y episodes watched" with a percentage
-- [ ] Progress bar colour is green when 100%, accent colour when less than 100%
-- [ ] Per-season progress bars on the season cards (from US-02) update in real time after watch events
-- [ ] "Next Episode" indicator displays as a badge or highlight on the next unwatched episode — the first unwatched episode in air-date order across all seasons
-- [ ] If all episodes are watched, the "Next Episode" indicator is hidden
-- [ ] "Mark All Watched" button on the show detail page calls `media.watchHistory.batchLog` for every unwatched episode across all seasons
-- [ ] "Mark All Watched" uses optimistic updates — progress bar jumps to 100%, all season progress bars update, reverts on failure
-- [ ] "Mark All Watched" is hidden or disabled when all episodes are already watched
-- [ ] Watch progress data is fetched via `media.watchHistory.progress(tvShowId)` which returns overall and per-season statistics
-- [ ] Progress bars and next episode indicator refresh after any watch event (single toggle, batch season, batch all)
+- [x] Overall watch progress bar renders on the show detail page showing "X of Y episodes watched" with a percentage
+- [x] Progress bar colour is green when 100%, accent colour when less than 100%
+- [x] Per-season progress bars on the season cards (from US-02) update in real time after watch events
+- [x] "Next Episode" indicator displays as a badge or highlight on the next unwatched episode — the first unwatched episode in air-date order across all seasons
+- [x] If all episodes are watched, the "Next Episode" indicator is hidden
+- [x] "Mark All Watched" button on the show detail page calls `media.watchHistory.batchLog` for every unwatched episode across all seasons
+- [ ] "Mark All Watched" uses optimistic updates — progress bar jumps to 100%, all season progress bars update, reverts on failure — no `onMutate` handler; progress only updates after API success via invalidation; no `onError` / rollback
+- [x] "Mark All Watched" is hidden or disabled when all episodes are already watched
+- [x] Watch progress data is fetched via `media.watchHistory.progress(tvShowId)` which returns overall and per-season statistics
+- [x] Progress bars and next episode indicator refresh after any watch event (single toggle, batch season, batch all)
 - [ ] Tests cover: progress bar at 0%/50%/100%, progress bar colour changes at 100%, next episode points to correct episode, next episode hidden when all watched, batch mark all (optimistic + revert), progress updates after individual episode toggle
 
 ## Notes


### PR DESCRIPTION
## Summary

Audit docs-v2 status updates for PRD-033 (Movie Detail Page) and PRD-034 (TV Show Detail Page) user stories — tasks tb-372 through tb-379.

All 8 user stories updated from `To Review` → `Partial` with individual acceptance criteria marked.

### PRD-033 — Movie Detail Page
- **US-01 Movie hero** (tb-372 / GH-518): Missing watch history section; language shows ISO code not full name
- **US-02 WatchlistToggle** (tb-373 / GH-519): No optimistic updates; uses `watchlist.list` not `watchlist.status` (endpoint missing)
- **US-03 MarkAsWatchedButton** (tb-374 / GH-520): Undo does not re-add to watchlist after auto-removal
- **US-04 ComparisonScores** (tb-375 / GH-521): Shows placeholder for <3 comparisons; spec requires hide at zero

### PRD-034 — TV Show Detail Page
- **US-01 Show hero** (tb-376 / GH-522): Year shows start only (no "Start – End/Present"); networks not displayed
- **US-02 Season list** (tb-377 / GH-523): All ACs implemented; no tests
- **US-03 Season detail** (tb-378 / GH-524): Unaired episodes not dimmed/disabled; batch mark has no `onError`
- **US-04 Watch progress** (tb-379 / GH-525): Mark All Watched lacks optimistic updates and failure revert

All 8 stories missing tests.

## Related issues
GH-518, GH-519, GH-520, GH-521, GH-522, GH-523, GH-524, GH-525

🤖 Generated with [Claude Code](https://claude.com/claude-code)