### PR TITLE
docs: audit PRD-022/023/024 — dedup parsers, entities, corrections [tb-333–345]

### DIFF
--- a/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-01-checksum-dedup.md
+++ b/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-01-checksum-dedup.md
@@ -1,7 +1,7 @@
 # US-01: Checksum-based deduplication
 
 > PRD: [022 — Deduplication & Parsers](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a developer, I want checksum-based deduplication so that re-importing the sam
 
 ## Acceptance Criteria
 
-- [ ] Each ParsedTransaction has a SHA-256 checksum of its raw CSV row (JSON stringified)
-- [ ] Batch query: `SELECT checksum FROM transactions WHERE checksum IN (?)`, batched in groups of 500
-- [ ] Matching checksums → transaction marked as "skipped" with reason "Duplicate transaction (checksum match)"
-- [ ] New checksums → transaction proceeds to entity matching
-- [ ] `transactions.checksum` column has UNIQUE constraint
-- [ ] Test: importing same CSV twice → second import skips all rows
+- [x] Each ParsedTransaction has a SHA-256 checksum of its raw CSV row (JSON stringified)
+- [x] Batch query: `SELECT checksum FROM transactions WHERE checksum IN (?)`, batched in groups of 500
+- [x] Matching checksums → transaction marked as "skipped" with reason "Duplicate transaction (checksum match)"
+- [x] New checksums → transaction proceeds to entity matching
+- [x] `transactions.checksum` column has UNIQUE constraint
+- [x] Test: importing same CSV twice → second import skips all rows
 
 ## Notes
 

--- a/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-02-amex-parser.md
+++ b/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-02-amex-parser.md
@@ -1,7 +1,7 @@
 # US-02: Amex CSV parser
 
 > PRD: [022 — Deduplication & Parsers](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a user, I want to import Amex CSV exports so that my credit card transactions
 
 ## Acceptance Criteria
 
-- [ ] Parses Amex CSV format: Date, Amount, Description, Town/City columns
-- [ ] Date: DD/MM/YYYY → YYYY-MM-DD
-- [ ] Amount: parse float, invert sign (Amex shows charges as positive, should be negative)
-- [ ] Location: extract first line of multiline Town/City, title-case
-- [ ] Account set to "Amex"
-- [ ] Online detection via keyword heuristic
-- [ ] Output: valid ParsedTransaction[] with checksums
-- [ ] Test with sample Amex CSV data
+- [x] Parses Amex CSV format: Date, Amount, Description, Town/City columns
+- [x] Date: DD/MM/YYYY → YYYY-MM-DD
+- [x] Amount: parse float, invert sign (Amex shows charges as positive, should be negative)
+- [x] Location: extract first line of multiline Town/City, title-case
+- [x] Account set to "Amex"
+- [x] Online detection via keyword heuristic
+- [x] Output: valid ParsedTransaction[] with checksums
+- [x] Test with sample Amex CSV data
 
 ## Notes
 

--- a/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-03-anz-parser.md
+++ b/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-03-anz-parser.md
@@ -1,7 +1,7 @@
 # US-03: ANZ CSV parser
 
 > PRD: [022 — Deduplication & Parsers](README.md)
-> Status: To Review
+> Status: Not started
 
 ## Description
 

--- a/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-04-ing-parser.md
+++ b/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-04-ing-parser.md
@@ -1,7 +1,7 @@
 # US-04: ING CSV parser
 
 > PRD: [022 — Deduplication & Parsers](README.md)
-> Status: To Review
+> Status: Not started
 
 ## Description
 

--- a/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-05-up-bank-import.md
+++ b/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-05-up-bank-import.md
@@ -1,7 +1,7 @@
 # US-05: Up Bank API batch import
 
 > PRD: [022 — Deduplication & Parsers](README.md)
-> Status: To Review
+> Status: Not started
 
 ## Description
 

--- a/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-06-common-utils.md
+++ b/docs-v2/themes/02-finance/prds/022-deduplication-parsers/us-06-common-utils.md
@@ -1,7 +1,7 @@
 # US-06: Common parsing utilities
 
 > PRD: [022 — Deduplication & Parsers](README.md)
-> Status: To Review
+> Status: Partial — extractLocation, online detection, and checksum generation not exposed as shared utilities
 
 ## Description
 
@@ -9,13 +9,13 @@ As a developer, I want shared utility functions for date normalization, amount p
 
 ## Acceptance Criteria
 
-- [ ] `normaliseDate(dateStr)`: DD/MM/YYYY → YYYY-MM-DD, validates format
-- [ ] `normaliseAmount(amountStr)`: strip currency symbols ($, AUD), parse float
+- [x] `normaliseDate(dateStr)`: DD/MM/YYYY → YYYY-MM-DD, validates format
+- [x] `normaliseAmount(amountStr)`: strip currency symbols ($, AUD), parse float
 - [ ] `extractLocation(locationStr)`: first line of multiline, title-case
 - [ ] Online detection: checks for keywords (AMAZON, PAYPAL, .COM.AU, NETFLIX, etc.)
 - [ ] Checksum generation: SHA-256 of JSON-stringified raw row
-- [ ] All functions handle edge cases (empty strings, null, malformed input)
-- [ ] Tests for each utility with edge cases
+- [x] All functions handle edge cases (empty strings, null, malformed input)
+- [x] Tests for each utility with edge cases
 
 ## Notes
 

--- a/docs-v2/themes/02-finance/prds/023-entities/us-01-schema-api.md
+++ b/docs-v2/themes/02-finance/prds/023-entities/us-01-schema-api.md
@@ -1,7 +1,7 @@
 # US-01: Entity schema and API
 
 > PRD: [023 — Entities](README.md)
-> Status: To Review
+> Status: Partial — transactions.entity_id has no FK SET NULL constraint
 
 ## Description
 
@@ -9,14 +9,14 @@ As a developer, I want the entity table and CRUD API so that merchants/payees ca
 
 ## Acceptance Criteria
 
-- [ ] `entities` table created with all columns per the data model
-- [ ] CRUD procedures: list (search, type filter, pagination), get, create, update, delete
-- [ ] Unique name enforcement (case-sensitive, returns 409 on conflict)
-- [ ] Aliases: API accepts array, stores as comma-separated, returns as array
-- [ ] Default tags: API accepts array, stores as JSON, returns as array
-- [ ] Type defaults to "company" if not provided
+- [x] `entities` table created with all columns per the data model
+- [x] CRUD procedures: list (search, type filter, pagination), get, create, update, delete
+- [x] Unique name enforcement (case-sensitive, returns 409 on conflict)
+- [x] Aliases: API accepts array, stores as comma-separated, returns as array
+- [x] Default tags: API accepts array, stores as JSON, returns as array
+- [x] Type defaults to "company" if not provided
 - [ ] Deletion: FK SET NULL on all related tables (transactions, inventory)
-- [ ] Tests cover CRUD, duplicate prevention, alias serialization
+- [x] Tests cover CRUD, duplicate prevention, alias serialization
 
 ## Notes
 

--- a/docs-v2/themes/02-finance/prds/023-entities/us-02-entities-page.md
+++ b/docs-v2/themes/02-finance/prds/023-entities/us-02-entities-page.md
@@ -1,7 +1,7 @@
 # US-02: Entities page
 
 > PRD: [023 — Entities](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a user, I want an entities page showing all merchants/payees so that I can br
 
 ## Acceptance Criteria
 
-- [ ] DataTable with columns: Name (sortable), Type (badge), ABN (monospace), Aliases (badges, +N overflow for long lists), Default Type (badge), Default Tags (badges)
-- [ ] Search by name (LIKE filter)
-- [ ] Filter by type (dropdown)
-- [ ] Loading skeleton while data fetches
-- [ ] Empty state when no entities match
-- [ ] Pagination with limit 100
+- [x] DataTable with columns: Name (sortable), Type (badge), ABN (monospace), Aliases (badges, +N overflow for long lists), Default Type (badge), Default Tags (badges)
+- [x] Search by name (LIKE filter)
+- [x] Filter by type (dropdown)
+- [x] Loading skeleton while data fetches
+- [x] Empty state when no entities match
+- [x] Pagination with limit 100
 
 ## Notes
 

--- a/docs-v2/themes/02-finance/prds/023-entities/us-03-entity-crud-ui.md
+++ b/docs-v2/themes/02-finance/prds/023-entities/us-03-entity-crud-ui.md
@@ -1,7 +1,7 @@
 # US-03: Entity CRUD UI
 
 > PRD: [023 — Entities](README.md)
-> Status: To Review
+> Status: Not started
 
 ## Description
 

--- a/docs-v2/themes/02-finance/prds/024-corrections/us-01-schema-api.md
+++ b/docs-v2/themes/02-finance/prds/024-corrections/us-01-schema-api.md
@@ -1,7 +1,7 @@
 # US-01: Corrections schema and API
 
 > PRD: [024 — Corrections](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a developer, I want the corrections table, active view, and CRUD API so that 
 
 ## Acceptance Criteria
 
-- [ ] `transaction_corrections` table with all columns, CHECK constraint on confidence (0-1)
-- [ ] Indexes on description_pattern, confidence, times_applied
-- [ ] `v_active_corrections` view: confidence >= 0.7, ordered by confidence DESC, times_applied DESC
-- [ ] CRUD procedures: list (minConfidence filter), get, createOrUpdate, update, delete
-- [ ] `findMatch` procedure: normalizes input, tries exact then contains, returns best match or null
-- [ ] `adjustConfidence` procedure: clamps [0,1], auto-deletes below 0.3
-- [ ] Tests cover CRUD, findMatch priority, confidence clamping, auto-delete
+- [x] `transaction_corrections` table with all columns, CHECK constraint on confidence (0-1)
+- [x] Indexes on description_pattern, confidence, times_applied
+- [x] `v_active_corrections` view: confidence >= 0.7, ordered by confidence DESC, times_applied DESC
+- [x] CRUD procedures: list (minConfidence filter), get, createOrUpdate, update, delete
+- [x] `findMatch` procedure: normalizes input, tries exact then contains, returns best match or null
+- [x] `adjustConfidence` procedure: clamps [0,1], auto-deletes below 0.3
+- [x] Tests cover CRUD, findMatch priority, confidence clamping, auto-delete
 
 ## Notes
 

--- a/docs-v2/themes/02-finance/prds/024-corrections/us-02-upsert-logic.md
+++ b/docs-v2/themes/02-finance/prds/024-corrections/us-02-upsert-logic.md
@@ -1,7 +1,7 @@
 # US-02: Upsert logic
 
 > PRD: [024 — Corrections](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,10 +9,10 @@ As a developer, I want createOrUpdate to increment confidence on reuse so that f
 
 ## Acceptance Criteria
 
-- [ ] If pattern + matchType combo exists: confidence += 0.1 (capped at 1.0), times_applied += 1, last_used_at updated
-- [ ] Provided fields (entityId, entityName, location, tags, transactionType) merge over existing values
-- [ ] If new: create with confidence 0.5, times_applied 0
-- [ ] Test: create → createOrUpdate with same pattern → verify confidence 0.6, times_applied 1
+- [x] If pattern + matchType combo exists: confidence += 0.1 (capped at 1.0), times_applied += 1, last_used_at updated
+- [x] Provided fields (entityId, entityName, location, tags, transactionType) merge over existing values
+- [x] If new: create with confidence 0.5, times_applied 0
+- [x] Test: create → createOrUpdate with same pattern → verify confidence 0.6, times_applied 1
 
 ## Notes
 

--- a/docs-v2/themes/02-finance/prds/024-corrections/us-03-auto-cleanup.md
+++ b/docs-v2/themes/02-finance/prds/024-corrections/us-03-auto-cleanup.md
@@ -1,7 +1,7 @@
 # US-03: Auto-cleanup on low confidence
 
 > PRD: [024 — Corrections](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,10 +9,10 @@ As a developer, I want corrections auto-deleted when confidence drops below 0.3 
 
 ## Acceptance Criteria
 
-- [ ] `adjustConfidence` clamps result to [0, 1] range
-- [ ] If new confidence < 0.3 after adjustment, correction is deleted
-- [ ] Deletion is immediate (not deferred)
-- [ ] Test: create correction at 0.5, adjust by -0.3 → confidence 0.2 → deleted
+- [x] `adjustConfidence` clamps result to [0, 1] range
+- [x] If new confidence < 0.3 after adjustment, correction is deleted
+- [x] Deletion is immediate (not deferred)
+- [x] Test: create correction at 0.5, adjust by -0.3 → confidence 0.2 → deleted
 
 ## Notes
 

--- a/docs-v2/themes/02-finance/prds/024-corrections/us-04-normalization.md
+++ b/docs-v2/themes/02-finance/prds/024-corrections/us-04-normalization.md
@@ -1,7 +1,7 @@
 # US-04: Description normalization
 
 > PRD: [024 — Corrections](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,11 +9,11 @@ As a developer, I want descriptions normalized consistently so that pattern matc
 
 ## Acceptance Criteria
 
-- [ ] Normalization: uppercase, remove all digits, collapse multiple spaces to single, trim
-- [ ] Applied on both storage (createOrUpdate) and query (findMatch)
-- [ ] "McDonald's North Sydney 2060" → "MCDONALD'S NORTH SYDNEY"
-- [ ] "IKEA TEMPE" and "ikea tempe" produce the same normalized form
-- [ ] Test with various inputs: mixed case, numbers, extra whitespace, special characters
+- [x] Normalization: uppercase, remove all digits, collapse multiple spaces to single, trim
+- [x] Applied on both storage (createOrUpdate) and query (findMatch)
+- [x] "McDonald's North Sydney 2060" → "MCDONALD'S NORTH SYDNEY"
+- [x] "IKEA TEMPE" and "ikea tempe" produce the same normalized form
+- [x] Test with various inputs: mixed case, numbers, extra whitespace, special characters
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Audit findings for 13 user stories across PRD-022 (Deduplication & Parsers), PRD-023 (Entities), and PRD-024 (Corrections).

**PRD-022 — Deduplication & Parsers:**
- **US-01 (tb-333) Done** — SHA-256 checksum in ParsedTransaction, batch dedup queries in groups of 500, UNIQUE index on transactions.checksum, skip reason "Duplicate transaction (checksum match)", service tests
- **US-02 (tb-334) Done** — Full Amex transformer in `pops-api/src/modules/finance/imports/transformers/amex.ts` with date conversion, sign inversion, Town/City extraction, online detection, checksum generation, comprehensive test suite
- **US-03 (tb-335) Not started** — `import-anz.ts` is a TODO stub (migrate from `import_anz.js`)
- **US-04 (tb-336) Not started** — `import-ing.ts` is a TODO stub
- **US-05 (tb-337) Not started** — `import-up-batch.ts` is a TODO stub (migrate from `extract_personal_accounts.js`)
- **US-06 (tb-338) Partial** — `normaliseDate`/`normaliseAmount` are shared in `csv-parser.ts` with tests; `extractLocation`, online detection, and checksum generation exist only as private functions in `amex.ts`

**PRD-023 — Entities:**
- **US-01 (tb-339) Partial** — Full CRUD router and service, aliases stored as comma-separated/returned as array, defaultTags as JSON array, ConflictError→409, deletion/tests all done; gap: `transactions.entity_id` column has no FK SET NULL constraint (corrections and inventory tables do)
- **US-02 (tb-340) Done** — `EntitiesPage.tsx` with DataTable showing all 6 columns (Name/sortable, Type/badge, ABN/monospace, Aliases/+N overflow, Default Type, Default Tags), search, type filter dropdown, loading skeleton, pagination at limit 100
- **US-03 (tb-341) Not started** — No "Add Entity" button on entities page, no edit/delete row actions; `EntityCreateDialog` in import wizard only has a name field (not the full form)

**PRD-024 — Corrections:**
- **US-01 (tb-342) Done** — `transaction_corrections` table with CHECK(confidence 0–1), indexes on description_pattern/confidence/times_applied, `v_active_corrections` view (confidence≥0.7), full CRUD + `findMatchingCorrection` (exact→contains) + `adjustConfidence`
- **US-02 (tb-343) Done** — `createOrUpdateCorrection`: existing pattern increments confidence+0.1 (max 1.0) and times_applied+1, merges provided fields; new rows created at confidence 0.5
- **US-03 (tb-344) Done** — `adjustConfidence` clamps to [0,1], auto-deletes immediately when below 0.3, tests in corrections.test.ts
- **US-04 (tb-345) Done** — `normalizeDescription`: uppercase → strip digits → collapse spaces → trim; applied on both store (`createOrUpdateCorrection`) and query (`findMatchingCorrection`), tested

## Test plan
- [ ] Review status values and checkbox states in updated US files
- [ ] Verify partial findings match referenced code locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)