### PR TITLE
docs: audit PRD-052 AI usage & cost tracking [tb-440/441/442]

### DIFF
--- a/docs-v2/themes/05-ai/prds/052-ai-usage-cost-tracking/README.md
+++ b/docs-v2/themes/05-ai/prds/052-ai-usage-cost-tracking/README.md
@@ -1,7 +1,7 @@
 # PRD-052: AI Usage & Cost Tracking
 
 > Epic: [00 — AI Operations App](../../epics/00-ai-operations-app.md)
-> Status: To Review
+> Status: Partial
 
 ## Overview
 
@@ -41,11 +41,11 @@ Uses the existing `ai_usage` table (created in PRD-009):
 
 ## User Stories
 
-| # | Story | Summary | Parallelisable |
-|---|-------|---------|----------------|
-| 01 | [us-01-stats-api](us-01-stats-api.md) | getStats and getHistory procedures with aggregation | No (first) |
-| 02 | [us-02-usage-page](us-02-usage-page.md) | Stats cards, daily chart, date range filter | Blocked by us-01 |
-| 03 | [us-03-app-scaffold](us-03-app-scaffold.md) | `@pops/app-ai` workspace package, shell registration, route at /ai | Yes (parallel with us-01) |
+| # | Story | Summary | Parallelisable | Status |
+|---|-------|---------|----------------|--------|
+| 01 | [us-01-stats-api](us-01-stats-api.md) | getStats and getHistory procedures with aggregation | No (first) | Partial |
+| 02 | [us-02-usage-page](us-02-usage-page.md) | Stats cards, daily chart, date range filter | Blocked by us-01 | Partial |
+| 03 | [us-03-app-scaffold](us-03-app-scaffold.md) | `@pops/app-ai` workspace package, shell registration, route at /ai | Yes (parallel with us-01) | Partial |
 
 ## Out of Scope
 

--- a/docs-v2/themes/05-ai/prds/052-ai-usage-cost-tracking/us-01-stats-api.md
+++ b/docs-v2/themes/05-ai/prds/052-ai-usage-cost-tracking/us-01-stats-api.md
@@ -1,7 +1,7 @@
 # US-01: Usage stats API
 
 > PRD: [052 — AI Usage & Cost Tracking](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,13 +9,15 @@ As a developer, I want API procedures for AI usage statistics so that the usage 
 
 ## Acceptance Criteria
 
-- [ ] `core.aiUsage.getStats` returns: totalCost (excluding cache hits), totalApiCalls, totalCacheHits, cacheHitRate (0-1), avgCostPerCall, totalInputTokens, totalOutputTokens
-- [ ] Includes `last30Days` sub-summary if data exists in that window
-- [ ] `core.aiUsage.getHistory` returns daily aggregation with optional date range filter
-- [ ] History ordered by date DESC
-- [ ] Both handle empty table gracefully (zeros, not errors)
-- [ ] Tests cover: empty data, single entry, date range filtering
+- [x] `core.aiUsage.getStats` returns: totalCost (excluding cache hits), totalApiCalls, totalCacheHits, cacheHitRate (0-1), avgCostPerCall, totalInputTokens, totalOutputTokens
+- [x] Includes `last30Days` sub-summary if data exists in that window
+- [x] `core.aiUsage.getHistory` returns daily aggregation with optional date range filter
+- [x] History ordered by date DESC
+- [x] Both handle empty table gracefully (zeros, not errors)
+- [ ] Tests cover: empty data, single entry, date range filtering — no test file exists for ai-usage module
 
 ## Notes
 
 Stats separate cached (cached=1, zero cost) from API calls (cached=0, real cost). Cache hit rate = cacheHits / (cacheHits + apiCalls).
+
+**Audit findings** (`apps/pops-api/src/modules/core/ai-usage/`): `getStats` and `getHistory` tRPC procedures exist with all required output fields. No test file — `apps/pops-api/src/modules/core/ai-usage/*.test.ts` does not exist.

--- a/docs-v2/themes/05-ai/prds/052-ai-usage-cost-tracking/us-02-usage-page.md
+++ b/docs-v2/themes/05-ai/prds/052-ai-usage-cost-tracking/us-02-usage-page.md
@@ -1,7 +1,7 @@
 # US-02: AI usage page
 
 > PRD: [052 — AI Usage & Cost Tracking](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,14 +9,16 @@ As a user, I want an AI usage page showing costs, token counts, and trends so th
 
 ## Acceptance Criteria
 
-- [ ] Stats cards: total cost, API calls, cache hits, cache hit rate, avg cost per call
-- [ ] Last 30 days section with cost, calls, cache hits
-- [ ] Daily history chart (line/bar chart showing cost over time)
-- [ ] Date range filter (start/end date pickers)
-- [ ] Loading skeletons while data fetches
-- [ ] Empty state when no AI usage exists
-- [ ] Cost formatted as USD with appropriate precision
+- [x] Stats cards: total cost, API calls, cache hits, cache hit rate, avg cost per call
+- [x] Last 30 days section with cost, calls, cache hits
+- [ ] Daily history chart (line/bar chart showing cost over time) — no chart component; history data is fetched but displayed as a DataTable, not a chart
+- [ ] Date range filter (start/end date pickers) — no date range filter UI
+- [x] Loading skeletons while data fetches
+- [x] Empty state when no AI usage exists
+- [x] Cost formatted as USD with appropriate precision
 
 ## Notes
 
 Chart uses Recharts (already available in the project). Cost trends help identify if AI spend is growing unexpectedly.
+
+**Audit findings** (`packages/app-ai/src/pages/AiUsagePage.tsx`): Stats cards, last 30 days, loading skeleton, and empty state are all implemented. No Recharts chart — history shown as DataTable instead. No date range filter (date inputs not present).

--- a/docs-v2/themes/05-ai/prds/052-ai-usage-cost-tracking/us-03-app-scaffold.md
+++ b/docs-v2/themes/05-ai/prds/052-ai-usage-cost-tracking/us-03-app-scaffold.md
@@ -1,7 +1,7 @@
 # US-03: AI app scaffold
 
 > PRD: [052 — AI Usage & Cost Tracking](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,13 +9,15 @@ As a developer, I want `@pops/app-ai` as a workspace package registered in the s
 
 ## Acceptance Criteria
 
-- [ ] `packages/app-ai/` exists with package.json, tsconfig, routes.tsx
-- [ ] NavConfig exported: id "ai", label "AI", icon "Brain", color "violet", basePath "/ai"
-- [ ] Registered in shell router at `/ai/*`
-- [ ] Lazy-loaded from the shell
-- [ ] AI usage page accessible at `/ai`
-- [ ] App appears in the app rail with violet accent
+- [x] `packages/app-ai/` exists with package.json, tsconfig, routes.tsx
+- [ ] NavConfig exported: id "ai", label "AI", icon "Brain", color "violet", basePath "/ai" — id/label/color/basePath correct; icon is "BarChart3" not "Brain"
+- [x] Registered in shell router at `/ai/*`
+- [x] Lazy-loaded from the shell (via `withSuspense`)
+- [x] AI usage page accessible at `/ai`
+- [x] App appears in the app rail with violet accent
 
 ## Notes
 
 Minimal app — starts with just the usage page. Future PRDs (053) add configuration and rules pages.
+
+**Audit findings** (`packages/app-ai/`, `apps/pops-shell/src/app/`): Package exists, registered in shell at `/ai/*` with lazy loading. NavConfig uses icon "BarChart3" instead of "Brain".


### PR DESCRIPTION
## Summary
- Audited PRD-052 (AI Usage & Cost Tracking) user stories against implementation
- All three US files updated from "To Review" → Partial with specific gap notes

## Findings
- **US-01 (stats API):** All tRPC procedures exist with correct output fields; missing test file
- **US-02 (usage page):** Stats cards, skeleton, empty state implemented; no Recharts chart (DataTable instead), no date range filter
- **US-03 (app scaffold):** Package registered in shell at `/ai/*`; NavConfig icon is `BarChart3` not `Brain`

## Test plan
- [ ] Verify docs render correctly in docs-v2
- [ ] Confirm audit findings against `packages/app-ai/` and `apps/pops-api/src/modules/core/ai-usage/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)