### PR TITLE
docs: audit PRD-027 AI rule creation (Partial) + PRD-028 media data model/API (Done)

### DIFF
--- a/docs-v2/themes/02-finance/prds/027-ai-rule-creation/README.md
+++ b/docs-v2/themes/02-finance/prds/027-ai-rule-creation/README.md
@@ -1,7 +1,7 @@
 # PRD-027: AI Rule Creation
 
 > Epic: [06 — AI Rule Creation](../../epics/06-ai-categorisation.md)
-> Status: To Review
+> Status: Partial
 
 ## Overview
 
@@ -84,10 +84,10 @@ Each import makes the system smarter:
 
 | # | Story | Summary | Parallelisable |
 |---|-------|---------|----------------|
-| 01 | [us-01-correction-analysis](us-01-correction-analysis.md) | Send user correction to Claude, receive pattern suggestion | No (first) |
-| 02 | [us-02-auto-apply-rules](us-02-auto-apply-rules.md) | High-confidence AI rules auto-saved and applied to remaining import transactions | Blocked by us-01 |
-| 03 | [us-03-confirmation-flow](us-03-confirmation-flow.md) | Low-confidence AI rules shown to user for confirmation before saving | Blocked by us-01 |
-| 04 | [us-04-batch-analysis](us-04-batch-analysis.md) | Batch correction analysis for better pattern suggestions | Blocked by us-01 |
+| 01 | [us-01-correction-analysis](us-01-correction-analysis.md) | Send user correction to Claude, receive pattern suggestion | No (first) | Partial |
+| 02 | [us-02-auto-apply-rules](us-02-auto-apply-rules.md) | High-confidence AI rules auto-saved and applied to remaining import transactions | Blocked by us-01 | Partial |
+| 03 | [us-03-confirmation-flow](us-03-confirmation-flow.md) | Low-confidence AI rules shown to user for confirmation before saving | Blocked by us-01 | Not started |
+| 04 | [us-04-batch-analysis](us-04-batch-analysis.md) | Batch correction analysis for better pattern suggestions | Blocked by us-01 | Partial |
 
 US-02 and US-03 can parallelise after US-01.
 

--- a/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-01-correction-analysis.md
+++ b/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-01-correction-analysis.md
@@ -1,7 +1,7 @@
 # US-01: Send correction to Claude for pattern analysis
 
 > PRD: [027 — AI Rule Creation](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -11,13 +11,17 @@ As a developer, I want user corrections sent to Claude so that the AI can sugges
 
 - [ ] When a user assigns an entity to an uncertain transaction, the correction is sent to Claude
 - [ ] Prompt includes: description, entity name, context (amount, account)
-- [ ] Claude returns: `{ matchType, pattern, confidence }`
-- [ ] matchType is one of: "exact", "prefix", "contains"
-- [ ] Pattern has minimum length of 3 characters
-- [ ] Confidence is 0-1 range
-- [ ] AI failure is non-fatal — correction still works, just no pattern created
-- [ ] Cost tracked in ai_usage table
-- [ ] Named environments skip AI calls
+- [x] Claude returns: `{ matchType, pattern, confidence }`
+- [x] matchType is one of: "exact", "prefix", "contains"
+- [x] Pattern has minimum length of 3 characters
+- [x] Confidence is 0-1 range
+- [x] AI failure is non-fatal — correction still works, just no pattern created
+- [x] Cost tracked in ai_usage table
+- [x] Named environments skip AI calls
+
+## Missing
+
+Per-correction trigger from ReviewStep is not wired up. Only batch mode exists (`corrections.generateRules`). When user assigns entity in ReviewStep, it saves the correction directly without sending to Claude for individual pattern analysis.
 
 ## Notes
 

--- a/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-02-auto-apply-rules.md
+++ b/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-02-auto-apply-rules.md
@@ -1,7 +1,7 @@
 # US-02: Auto-apply high-confidence rules during import
 
 > PRD: [027 — AI Rule Creation](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -14,7 +14,11 @@ As a user, I want high-confidence AI rules automatically applied to remaining im
 - [ ] Newly matched transactions move from uncertain → matched
 - [ ] Toast notification: "Rule created: [pattern]. Applied to N more transactions"
 - [ ] Tab counts update immediately
-- [ ] Rule is persistent — applies to future imports too
+- [x] Rule is persistent — applies to future imports too
+
+## Missing
+
+Backend uses confidence >= 0.9 threshold (not 0.8 as specified). No toast notification after a rule is created. No real-time re-evaluation of uncertain/failed tab after saving a rule. The UI does not show tab count decreasing as rules are applied.
 
 ## Notes
 

--- a/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-03-confirmation-flow.md
+++ b/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-03-confirmation-flow.md
@@ -1,7 +1,7 @@
 # US-03: Confirmation flow for low-confidence rules
 
 > PRD: [027 — AI Rule Creation](README.md)
-> Status: To Review
+> Status: Not started
 
 ## Description
 

--- a/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-04-batch-analysis.md
+++ b/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-04-batch-analysis.md
@@ -1,7 +1,7 @@
 # US-04: Batch correction analysis
 
 > PRD: [027 — AI Rule Creation](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,12 +9,16 @@ As a developer, I want multiple corrections analyzed together so that the AI can
 
 ## Acceptance Criteria
 
-- [ ] `corrections.generateRules` accepts batch of 1-50 transactions with their corrections
-- [ ] Claude analyzes the batch and returns pattern proposals
-- [ ] Batch context helps: two corrections for "IKEA TEMPE" and "IKEA RHODES" → stronger "IKEA" prefix confidence
-- [ ] Proposals are not auto-saved — caller confirms via createOrUpdate
+- [x] `corrections.generateRules` accepts batch of 1-50 transactions with their corrections
+- [x] Claude analyzes the batch and returns pattern proposals
+- [x] Batch context helps: two corrections for "IKEA TEMPE" and "IKEA RHODES" → stronger "IKEA" prefix confidence
+- [x] Proposals are not auto-saved — caller confirms via createOrUpdate
 - [ ] Works alongside per-correction analysis (US-01) — batch runs periodically during review step
-- [ ] Cost tracked as single AI call, not per transaction
+- [x] Cost tracked as single AI call, not per transaction
+
+## Missing
+
+No frontend UI calls `corrections.generateRules`. No component triggers batch analysis from ReviewStep during the review step. Proposals cannot be confirmed through the UI — backend design is correct but UI integration is absent.
 
 ## Notes
 

--- a/docs-v2/themes/03-media/prds/028-media-data-model-api/README.md
+++ b/docs-v2/themes/03-media/prds/028-media-data-model-api/README.md
@@ -1,7 +1,7 @@
 # PRD-028: Media Data Model & API
 
 > Epic: [00 — Data Model & API](../../epics/00-data-model-api.md)
-> Status: To Review
+> Status: Done
 
 ## Overview
 
@@ -262,10 +262,10 @@ Define the media domain schema and build the tRPC routers that all other media f
 
 | # | Story | Summary | Parallelisable |
 |---|-------|---------|----------------|
-| 01 | [us-01-movie-tv-schema](us-01-movie-tv-schema.md) | Tables for movies, tv_shows, seasons, episodes with indexes and FK cascades | Yes |
-| 02 | [us-02-tracking-schema](us-02-tracking-schema.md) | Tables for media_watchlist, watch_history, comparison_dimensions, comparisons, media_scores | Yes |
-| 03 | [us-03-movie-tv-api](us-03-movie-tv-api.md) | CRUD procedures for movies and tvShows (including seasons/episodes) | Blocked by us-01 |
-| 04 | [us-04-tracking-comparison-api](us-04-tracking-comparison-api.md) | Procedures for watchlist, watchHistory, and comparisons (Elo scoring, random pair, rankings) | Blocked by us-01, us-02 |
+| 01 | [us-01-movie-tv-schema](us-01-movie-tv-schema.md) | Tables for movies, tv_shows, seasons, episodes with indexes and FK cascades | Yes | Done |
+| 02 | [us-02-tracking-schema](us-02-tracking-schema.md) | Tables for media_watchlist, watch_history, comparison_dimensions, comparisons, media_scores | Yes | Done |
+| 03 | [us-03-movie-tv-api](us-03-movie-tv-api.md) | CRUD procedures for movies and tvShows (including seasons/episodes) | Blocked by us-01 | Done |
+| 04 | [us-04-tracking-comparison-api](us-04-tracking-comparison-api.md) | Procedures for watchlist, watchHistory, and comparisons (Elo scoring, random pair, rankings) | Blocked by us-01, us-02 | Done |
 
 US-01 and US-02 can run in parallel (independent tables). US-03 needs US-01. US-04 needs both US-01 and US-02.
 

--- a/docs-v2/themes/03-media/prds/028-media-data-model-api/us-01-movie-tv-schema.md
+++ b/docs-v2/themes/03-media/prds/028-media-data-model-api/us-01-movie-tv-schema.md
@@ -1,7 +1,7 @@
 # US-01: Movie and TV schema
 
 > PRD: [028 — Media Data Model & API](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,19 +9,19 @@ As a developer, I want the movies, tv_shows, seasons, and episodes tables with p
 
 ## Acceptance Criteria
 
-- [ ] `movies` table created with all columns per the data model (id, tmdbId, imdbId, title, originalTitle, overview, tagline, releaseDate, runtime, status, originalLanguage, budget, revenue, posterPath, backdropPath, logoPath, posterOverridePath, voteAverage, voteCount, genres, createdAt, updatedAt)
-- [ ] `movies` indexes on: tmdbId (UNIQUE), title, releaseDate
-- [ ] `tv_shows` table created with all columns per the data model (id, tvdbId, name, originalName, overview, firstAirDate, lastAirDate, status, originalLanguage, numberOfSeasons, numberOfEpisodes, episodeRunTime, posterPath, backdropPath, logoPath, posterOverridePath, voteAverage, voteCount, genres, networks, createdAt, updatedAt)
-- [ ] `tv_shows` indexes on: tvdbId (UNIQUE), name, firstAirDate
-- [ ] `seasons` table created with FK to tv_shows(id) ON DELETE CASCADE (id, tvShowId, tvdbId, seasonNumber, name, overview, posterPath, airDate, episodeCount, createdAt)
-- [ ] `seasons` indexes on: tvdbId (UNIQUE), (tvShowId + seasonNumber) UNIQUE composite, tvShowId
-- [ ] `episodes` table created with FK to seasons(id) ON DELETE CASCADE (id, seasonId, tvdbId, episodeNumber, name, overview, airDate, stillPath, voteAverage, runtime, createdAt)
-- [ ] `episodes` indexes on: tvdbId (UNIQUE), (seasonId + episodeNumber) UNIQUE composite, seasonId
-- [ ] Deleting a tv_show cascades to all its seasons and episodes
-- [ ] Deleting a season cascades to all its episodes
-- [ ] `seasonNumber` 0 is allowed (specials)
-- [ ] `genres` column defaults to '[]' and stores valid JSON arrays
-- [ ] Tests verify table creation, FK cascade behaviour, unique constraint enforcement, and index existence
+- [x] `movies` table created with all columns per the data model (id, tmdbId, imdbId, title, originalTitle, overview, tagline, releaseDate, runtime, status, originalLanguage, budget, revenue, posterPath, backdropPath, logoPath, posterOverridePath, voteAverage, voteCount, genres, createdAt, updatedAt)
+- [x] `movies` indexes on: tmdbId (UNIQUE), title, releaseDate
+- [x] `tv_shows` table created with all columns per the data model (id, tvdbId, name, originalName, overview, firstAirDate, lastAirDate, status, originalLanguage, numberOfSeasons, numberOfEpisodes, episodeRunTime, posterPath, backdropPath, logoPath, posterOverridePath, voteAverage, voteCount, genres, networks, createdAt, updatedAt)
+- [x] `tv_shows` indexes on: tvdbId (UNIQUE), name, firstAirDate
+- [x] `seasons` table created with FK to tv_shows(id) ON DELETE CASCADE (id, tvShowId, tvdbId, seasonNumber, name, overview, posterPath, airDate, episodeCount, createdAt)
+- [x] `seasons` indexes on: tvdbId (UNIQUE), (tvShowId + seasonNumber) UNIQUE composite, tvShowId
+- [x] `episodes` table created with FK to seasons(id) ON DELETE CASCADE (id, seasonId, tvdbId, episodeNumber, name, overview, airDate, stillPath, voteAverage, runtime, createdAt)
+- [x] `episodes` indexes on: tvdbId (UNIQUE), (seasonId + episodeNumber) UNIQUE composite, seasonId
+- [x] Deleting a tv_show cascades to all its seasons and episodes
+- [x] Deleting a season cascades to all its episodes
+- [x] `seasonNumber` 0 is allowed (specials)
+- [x] `genres` column defaults to '[]' and stores valid JSON arrays
+- [x] Tests verify table creation, FK cascade behaviour, unique constraint enforcement, and index existence
 
 ## Notes
 

--- a/docs-v2/themes/03-media/prds/028-media-data-model-api/us-02-tracking-schema.md
+++ b/docs-v2/themes/03-media/prds/028-media-data-model-api/us-02-tracking-schema.md
@@ -1,7 +1,7 @@
 # US-02: Tracking and comparison schema
 
 > PRD: [028 — Media Data Model & API](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,26 +9,26 @@ As a developer, I want the media_watchlist, watch_history, comparison_dimensions
 
 ## Acceptance Criteria
 
-- [ ] `media_watchlist` table created (id, mediaType, mediaId, priority, notes, addedAt)
-- [ ] `media_watchlist` unique index on (mediaType + mediaId)
-- [ ] `media_watchlist.mediaType` constrained to "movie" or "tv_show"
-- [ ] `media_watchlist.priority` defaults to 0
-- [ ] `watch_history` table created (id, mediaType, mediaId, watchedAt, completed)
-- [ ] `watch_history` indexes on: (mediaType + mediaId), watchedAt, (mediaType + mediaId + watchedAt) UNIQUE
-- [ ] `watch_history.mediaType` constrained to "movie" or "episode"
-- [ ] `watch_history.completed` defaults to 0
-- [ ] `comparison_dimensions` table created (id, name, description, active, sortOrder, createdAt)
-- [ ] `comparison_dimensions.name` has UNIQUE constraint
-- [ ] `comparison_dimensions.active` defaults to 1
-- [ ] `comparisons` table created (id, dimensionId, mediaAType, mediaAId, mediaBType, mediaBId, winnerType, winnerId, comparedAt)
-- [ ] `comparisons` FK from dimensionId to comparison_dimensions(id)
-- [ ] `comparisons` indexes on: dimensionId, (mediaAType + mediaAId), (mediaBType + mediaBId)
-- [ ] `media_scores` table created (id, mediaType, mediaId, dimensionId, score, comparisonCount, updatedAt)
-- [ ] `media_scores` unique index on (mediaType + mediaId + dimensionId)
-- [ ] `media_scores` FK from dimensionId to comparison_dimensions(id)
-- [ ] `media_scores.score` defaults to 1500.0
-- [ ] `media_scores.comparisonCount` defaults to 0
-- [ ] Tests verify table creation, unique constraints, default values, and FK enforcement
+- [x] `media_watchlist` table created (id, mediaType, mediaId, priority, notes, addedAt)
+- [x] `media_watchlist` unique index on (mediaType + mediaId)
+- [x] `media_watchlist.mediaType` constrained to "movie" or "tv_show"
+- [x] `media_watchlist.priority` defaults to 0
+- [x] `watch_history` table created (id, mediaType, mediaId, watchedAt, completed)
+- [x] `watch_history` indexes on: (mediaType + mediaId), watchedAt, (mediaType + mediaId + watchedAt) UNIQUE
+- [x] `watch_history.mediaType` constrained to "movie" or "episode"
+- [x] `watch_history.completed` defaults to 0
+- [x] `comparison_dimensions` table created (id, name, description, active, sortOrder, createdAt)
+- [x] `comparison_dimensions.name` has UNIQUE constraint
+- [x] `comparison_dimensions.active` defaults to 1
+- [x] `comparisons` table created (id, dimensionId, mediaAType, mediaAId, mediaBType, mediaBId, winnerType, winnerId, comparedAt)
+- [x] `comparisons` FK from dimensionId to comparison_dimensions(id)
+- [x] `comparisons` indexes on: dimensionId, (mediaAType + mediaAId), (mediaBType + mediaBId)
+- [x] `media_scores` table created (id, mediaType, mediaId, dimensionId, score, comparisonCount, updatedAt)
+- [x] `media_scores` unique index on (mediaType + mediaId + dimensionId)
+- [x] `media_scores` FK from dimensionId to comparison_dimensions(id)
+- [x] `media_scores.score` defaults to 1500.0
+- [x] `media_scores.comparisonCount` defaults to 0
+- [x] Tests verify table creation, unique constraints, default values, and FK enforcement
 
 ## Notes
 

--- a/docs-v2/themes/03-media/prds/028-media-data-model-api/us-03-movie-tv-api.md
+++ b/docs-v2/themes/03-media/prds/028-media-data-model-api/us-03-movie-tv-api.md
@@ -1,7 +1,7 @@
 # US-03: Movie and TV show API
 
 > PRD: [028 — Media Data Model & API](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,26 +9,26 @@ As a developer, I want tRPC CRUD procedures for movies and TV shows (including s
 
 ## Acceptance Criteria
 
-- [ ] `media.movies.list` — paginated (limit/offset), filterable by search (title) and genre, ordered by releaseDate DESC
-- [ ] `media.movies.get` — returns single movie by id, 404 if not found
-- [ ] `media.movies.create` — requires tmdbId and title, sets createdAt/updatedAt, returns created movie
-- [ ] `media.movies.update` — partial update by id, updates only provided fields plus updatedAt
-- [ ] `media.movies.delete` — removes movie by id, 404 if not found
-- [ ] `media.tvShows.list` — paginated, filterable by search (name) and status, ordered by name ASC
-- [ ] `media.tvShows.get` — returns single TV show by id, 404 if not found
-- [ ] `media.tvShows.create` — requires tvdbId and name, sets createdAt/updatedAt, returns created show
-- [ ] `media.tvShows.update` — partial update by id, updates only provided fields plus updatedAt
-- [ ] `media.tvShows.delete` — removes show by id (cascades to seasons/episodes), 404 if not found
-- [ ] `media.tvShows.listSeasons` — returns all seasons for a tvShowId, ordered by seasonNumber ASC
-- [ ] `media.tvShows.createSeason` — requires tvShowId, tvdbId, seasonNumber; validates tvShowId exists
-- [ ] `media.tvShows.deleteSeason` — removes season by id (cascades to episodes)
-- [ ] `media.tvShows.listEpisodes` — returns all episodes for a seasonId, ordered by episodeNumber ASC
-- [ ] `media.tvShows.createEpisode` — requires seasonId, tvdbId, episodeNumber; validates seasonId exists
-- [ ] `media.tvShows.deleteEpisode` — removes episode by id
-- [ ] Input validation on all procedures (zod schemas)
-- [ ] Pagination returns total count alongside data
-- [ ] Genres are parsed from JSON on read and serialized on write
-- [ ] Tests cover CRUD operations, filtering, pagination, cascade deletes, and 404 cases
+- [x] `media.movies.list` — paginated (limit/offset), filterable by search (title) and genre, ordered by releaseDate DESC
+- [x] `media.movies.get` — returns single movie by id, 404 if not found
+- [x] `media.movies.create` — requires tmdbId and title, sets createdAt/updatedAt, returns created movie
+- [x] `media.movies.update` — partial update by id, updates only provided fields plus updatedAt
+- [x] `media.movies.delete` — removes movie by id, 404 if not found
+- [x] `media.tvShows.list` — paginated, filterable by search (name) and status, ordered by name ASC
+- [x] `media.tvShows.get` — returns single TV show by id, 404 if not found
+- [x] `media.tvShows.create` — requires tvdbId and name, sets createdAt/updatedAt, returns created show
+- [x] `media.tvShows.update` — partial update by id, updates only provided fields plus updatedAt
+- [x] `media.tvShows.delete` — removes show by id (cascades to seasons/episodes), 404 if not found
+- [x] `media.tvShows.listSeasons` — returns all seasons for a tvShowId, ordered by seasonNumber ASC
+- [x] `media.tvShows.createSeason` — requires tvShowId, tvdbId, seasonNumber; validates tvShowId exists
+- [x] `media.tvShows.deleteSeason` — removes season by id (cascades to episodes)
+- [x] `media.tvShows.listEpisodes` — returns all episodes for a seasonId, ordered by episodeNumber ASC
+- [x] `media.tvShows.createEpisode` — requires seasonId, tvdbId, episodeNumber; validates seasonId exists
+- [x] `media.tvShows.deleteEpisode` — removes episode by id
+- [x] Input validation on all procedures (zod schemas)
+- [x] Pagination returns total count alongside data
+- [x] Genres are parsed from JSON on read and serialized on write
+- [x] Tests cover CRUD operations, filtering, pagination, cascade deletes, and 404 cases
 
 ## Notes
 

--- a/docs-v2/themes/03-media/prds/028-media-data-model-api/us-04-tracking-comparison-api.md
+++ b/docs-v2/themes/03-media/prds/028-media-data-model-api/us-04-tracking-comparison-api.md
@@ -1,7 +1,7 @@
 # US-04: Tracking and comparison API
 
 > PRD: [028 — Media Data Model & API](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -11,54 +11,54 @@ As a developer, I want tRPC procedures for watchlist management, watch history l
 
 ### Watchlist
 
-- [ ] `media.watchlist.list` — returns all entries ordered by priority ASC then addedAt DESC, enriched with media metadata (title, poster)
-- [ ] `media.watchlist.get` — returns single entry by id
-- [ ] `media.watchlist.add` — creates entry with mediaType + mediaId; on CONFLICT (duplicate), returns existing entry unchanged
-- [ ] `media.watchlist.update` — updates priority and/or notes by id
-- [ ] `media.watchlist.reorder` — accepts array of { id, priority }, updates all in a single transaction
-- [ ] `media.watchlist.remove` — deletes entry by id
-- [ ] Watchlist validates mediaType is "movie" or "tv_show"
-- [ ] Watchlist validates that the referenced media item exists
+- [x] `media.watchlist.list` — returns all entries ordered by priority ASC then addedAt DESC, enriched with media metadata (title, poster)
+- [x] `media.watchlist.get` — returns single entry by id
+- [x] `media.watchlist.add` — creates entry with mediaType + mediaId; on CONFLICT (duplicate), returns existing entry unchanged
+- [x] `media.watchlist.update` — updates priority and/or notes by id
+- [x] `media.watchlist.reorder` — accepts array of { id, priority }, updates all in a single transaction
+- [x] `media.watchlist.remove` — deletes entry by id
+- [x] Watchlist validates mediaType is "movie" or "tv_show"
+- [x] Watchlist validates that the referenced media item exists
 
 ### Watch History
 
-- [ ] `media.watchHistory.list` — paginated, filterable by mediaType
-- [ ] `media.watchHistory.listRecent` — returns last N entries enriched with metadata; for episodes includes show name and show poster
-- [ ] `media.watchHistory.get` — returns single entry by id
-- [ ] `media.watchHistory.log` — creates watch history entry; when completed=1 for a movie, auto-removes that movie from watchlist; when completed=1 for an episode, checks if ALL show episodes are watched and auto-removes show from watchlist if so
-- [ ] `media.watchHistory.progress` — for a tvShowId, returns overall completion percentage and per-season completion percentages
-- [ ] `media.watchHistory.batchProgress` — batch version of progress for multiple tvShowIds
-- [ ] `media.watchHistory.batchLog` — marks all episodes in a season or show as watched in one operation
-- [ ] `media.watchHistory.delete` — removes entry by id
-- [ ] Watch history validates mediaType is "movie" or "episode"
+- [x] `media.watchHistory.list` — paginated, filterable by mediaType
+- [x] `media.watchHistory.listRecent` — returns last N entries enriched with metadata; for episodes includes show name and show poster
+- [x] `media.watchHistory.get` — returns single entry by id
+- [x] `media.watchHistory.log` — creates watch history entry; when completed=1 for a movie, auto-removes that movie from watchlist; when completed=1 for an episode, checks if ALL show episodes are watched and auto-removes show from watchlist if so
+- [x] `media.watchHistory.progress` — for a tvShowId, returns overall completion percentage and per-season completion percentages
+- [x] `media.watchHistory.batchProgress` — batch version of progress for multiple tvShowIds
+- [x] `media.watchHistory.batchLog` — marks all episodes in a season or show as watched in one operation
+- [x] `media.watchHistory.delete` — removes entry by id
+- [x] Watch history validates mediaType is "movie" or "episode"
 
 ### Comparisons
 
-- [ ] `media.comparisons.listDimensions` — returns all dimensions ordered by sortOrder
-- [ ] `media.comparisons.createDimension` — creates dimension with name, description, sortOrder
-- [ ] `media.comparisons.updateDimension` — updates dimension fields (name, description, active, sortOrder)
-- [ ] `media.comparisons.record` — validates winnerId matches either A or B; inserts comparison record and updates both items' Elo scores in a single transaction using K=32
-- [ ] `media.comparisons.listForMedia` — returns all comparisons involving a specific media item
-- [ ] `media.comparisons.getRandomPair` — returns two watched movies for a given dimension, avoids recently compared pairs, returns null if fewer than 2 watched movies exist
-- [ ] `media.comparisons.scores` — returns all dimension scores for a specific media item
-- [ ] `media.comparisons.rankings` — returns ranked list per dimension, or overall ranking (average across active dimensions) when no dimension specified
+- [x] `media.comparisons.listDimensions` — returns all dimensions ordered by sortOrder
+- [x] `media.comparisons.createDimension` — creates dimension with name, description, sortOrder
+- [x] `media.comparisons.updateDimension` — updates dimension fields (name, description, active, sortOrder)
+- [x] `media.comparisons.record` — validates winnerId matches either A or B; inserts comparison record and updates both items' Elo scores in a single transaction using K=32
+- [x] `media.comparisons.listForMedia` — returns all comparisons involving a specific media item
+- [x] `media.comparisons.getRandomPair` — returns two watched movies for a given dimension, avoids recently compared pairs, returns null if fewer than 2 watched movies exist
+- [x] `media.comparisons.scores` — returns all dimension scores for a specific media item
+- [x] `media.comparisons.rankings` — returns ranked list per dimension, or overall ranking (average across active dimensions) when no dimension specified
 
 ### Elo Scoring
 
-- [ ] Starting score is 1500.0 for new items
-- [ ] K-factor is 32
-- [ ] Both winner and loser scores update atomically in the same transaction
-- [ ] `comparisonCount` increments for both items on each comparison
-- [ ] Overall ranking averages scores across all active dimensions only
+- [x] Starting score is 1500.0 for new items
+- [x] K-factor is 32
+- [x] Both winner and loser scores update atomically in the same transaction
+- [x] `comparisonCount` increments for both items on each comparison
+- [x] Overall ranking averages scores across all active dimensions only
 
 ### Cross-cutting
 
-- [ ] Input validation via zod schemas on all procedures
-- [ ] Tests cover auto-removal from watchlist on movie completion
-- [ ] Tests cover auto-removal from watchlist when all show episodes are completed
-- [ ] Tests cover Elo score calculation correctness
-- [ ] Tests cover getRandomPair edge cases (no movies, one movie, recently compared)
-- [ ] Tests cover batch operations (reorder, batchLog, batchProgress)
+- [x] Input validation via zod schemas on all procedures
+- [x] Tests cover auto-removal from watchlist on movie completion
+- [x] Tests cover auto-removal from watchlist when all show episodes are completed
+- [x] Tests cover Elo score calculation correctness
+- [x] Tests cover getRandomPair edge cases (no movies, one movie, recently compared)
+- [x] Tests cover batch operations (reorder, batchLog, batchProgress)
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- **PRD-027 AI Rule Creation** (tb-352 to tb-355): Partial — backend infrastructure built but frontend integration missing
  - US-01 Partial: generateRules endpoint exists, but per-correction trigger not wired from ReviewStep
  - US-02 Partial: rules persistent, but confidence threshold is 0.9 (spec says 0.8), no toast/re-eval
  - US-03 Not started: no low-confidence confirmation UI
  - US-04 Partial: backend complete, no frontend UI
  - GH issues 498–501 commented with findings (kept open)

- **PRD-028 Media Data Model & API** (tb-356 to tb-359): All Done
  - US-01: movies/tv_shows/seasons/episodes schema with CASCADE FKs and UNIQUE indexes
  - US-02: media_watchlist/watch_history/comparison_dimensions/comparisons/media_scores schema
  - US-03: Full CRUD API for movies and TV shows (including seasons/episodes hierarchy)
  - US-04: Watchlist, watch history, comparisons with Elo K=32 scoring and auto-remove
  - GH issues 502–505 commented and closed

## Test plan

- [ ] Docs-only change — no code modified, no tests required
- [ ] PRD-027 GH issues 498–501: commented with partial/not-started findings, kept open
- [ ] PRD-028 GH issues 502–505: commented with Done findings, closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)