### PR TITLE
audit: Location tree management + Paperless integration

### DIFF
--- a/docs-v2/themes/04-inventory/prds/047-location-tree-management/README.md
+++ b/docs-v2/themes/04-inventory/prds/047-location-tree-management/README.md
@@ -62,12 +62,12 @@ Build the location tree management UI. Hierarchical browser for creating, editin
 
 ## User Stories
 
-| # | Story | Summary | Parallelisable |
-|---|-------|---------|----------------|
-| 01 | [us-01-tree-browser](us-01-tree-browser.md) | Collapsible tree view with expand/collapse, item count badges, multiple root support | No (first) |
-| 02 | [us-02-location-crud](us-02-location-crud.md) | Add root/child locations, inline rename, delete with cascade confirmation and item orphaning | Blocked by us-01 |
-| 03 | [us-03-drag-and-drop](us-03-drag-and-drop.md) | Drag-and-drop reorder and reparent with circular reference prevention, mobile arrow fallback | Blocked by us-01 |
-| 04 | [us-04-items-at-location](us-04-items-at-location.md) | Items panel for selected location, include sub-locations toggle, item list with navigation | Blocked by us-01 |
+| # | Story | Summary | Status | Parallelisable |
+|---|-------|---------|--------|----------------|
+| 01 | [us-01-tree-browser](us-01-tree-browser.md) | Collapsible tree view with expand/collapse, item count badges, multiple root support | Done | No (first) |
+| 02 | [us-02-location-crud](us-02-location-crud.md) | Add root/child locations, inline rename, delete with cascade confirmation and item orphaning | Done | Blocked by us-01 |
+| 03 | [us-03-drag-and-drop](us-03-drag-and-drop.md) | Drag-and-drop reorder and reparent with circular reference prevention, mobile arrow fallback | Partial | Blocked by us-01 |
+| 04 | [us-04-items-at-location](us-04-items-at-location.md) | Items panel for selected location, include sub-locations toggle, item list with navigation | Done | Blocked by us-01 |
 
 US-02, US-03, and US-04 can parallelise after US-01.
 

--- a/docs-v2/themes/04-inventory/prds/047-location-tree-management/us-01-tree-browser.md
+++ b/docs-v2/themes/04-inventory/prds/047-location-tree-management/us-01-tree-browser.md
@@ -1,7 +1,7 @@
 # US-01: Tree browser
 
 > PRD: [047 — Location Tree Management](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,17 +9,17 @@ As a user, I want a collapsible hierarchical tree view of all locations so that 
 
 ## Acceptance Criteria
 
-- [ ] Tree view renders all locations hierarchically from the `inventory.locations.list` endpoint (fetches full tree in one call)
-- [ ] Each node displays: location name, item count badge, expand/collapse chevron
-- [ ] Chevron only appears on nodes that have children
-- [ ] Click chevron to expand/collapse a node's children
-- [ ] Multiple root nodes supported (locations with `parentId = NULL`)
-- [ ] Expand/collapse state persisted in session storage (survives page navigation, not browser close)
-- [ ] Selected node highlighted visually
-- [ ] Click node name to select it (triggers item panel load — wired in US-04)
-- [ ] Loading skeleton while tree data fetches
-- [ ] Empty state when no locations exist: "No locations — create your first location to organise items"
-- [ ] Tree handles arbitrary nesting depth without layout breakage
+- [x] Tree view renders all locations hierarchically from the `inventory.locations.list` endpoint (fetches full tree in one call)
+- [x] Each node displays: location name, item count badge, expand/collapse chevron
+- [x] Chevron only appears on nodes that have children
+- [x] Click chevron to expand/collapse a node's children
+- [x] Multiple root nodes supported (locations with `parentId = NULL`)
+- [x] Expand/collapse state persisted in session storage (survives page navigation, not browser close)
+- [x] Selected node highlighted visually
+- [x] Click node name to select it (triggers item panel load — wired in US-04)
+- [x] Loading skeleton while tree data fetches
+- [x] Empty state when no locations exist: "No locations — create your first location to organise items"
+- [x] Tree handles arbitrary nesting depth without layout breakage
 
 ## Notes
 

--- a/docs-v2/themes/04-inventory/prds/047-location-tree-management/us-02-location-crud.md
+++ b/docs-v2/themes/04-inventory/prds/047-location-tree-management/us-02-location-crud.md
@@ -1,7 +1,7 @@
 # US-02: Location CRUD
 
 > PRD: [047 — Location Tree Management](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,20 +9,20 @@ As a user, I want to create, rename, and delete locations from the tree view so 
 
 ## Acceptance Criteria
 
-- [ ] "Add root location" button at the top of the tree — opens inline text input at the tree root
-- [ ] "+" button on each node to add a child location — opens inline text input nested under the parent
-- [ ] Submitting the inline input calls `inventory.locations.create` with the name and parentId (null for root)
-- [ ] New location appears in the tree immediately after creation (optimistic or refetch)
-- [ ] Double-click a node name to enter inline rename mode — text becomes an editable input
-- [ ] Pressing Enter or blurring the rename input saves via `inventory.locations.update`
-- [ ] Pressing Escape cancels rename and reverts to original text
-- [ ] Context menu (right-click or kebab icon) with options: Add child, Rename, Delete
-- [ ] Delete opens a confirmation modal showing: "Delete [name]? This will also delete X child locations. Y items will be unassigned."
-- [ ] Confirmation modal fetches descendant count and affected item count before displaying
-- [ ] Confirming delete calls `inventory.locations.delete` — server cascade-deletes children and sets `locationId = NULL` on affected items
-- [ ] Tree updates after delete (removed node and all descendants disappear)
-- [ ] Toast confirmation on successful create, rename, and delete
-- [ ] Validation: location name cannot be empty or whitespace-only
+- [x] "Add root location" button at the top of the tree — opens inline text input at the tree root
+- [x] "+" button on each node to add a child location — opens inline text input nested under the parent
+- [x] Submitting the inline input calls `inventory.locations.create` with the name and parentId (null for root)
+- [x] New location appears in the tree immediately after creation (optimistic or refetch)
+- [x] Double-click a node name to enter inline rename mode — text becomes an editable input
+- [x] Pressing Enter or blurring the rename input saves via `inventory.locations.update`
+- [x] Pressing Escape cancels rename and reverts to original text
+- [x] Context menu (right-click or kebab icon) with options: Add child, Rename, Delete — **implemented as hover action buttons (same actions, different UI pattern)**
+- [x] Delete opens a confirmation modal showing: "Delete [name]? This will also delete X child locations. Y items will be unassigned."
+- [x] Confirmation modal fetches descendant count and affected item count before displaying
+- [x] Confirming delete calls `inventory.locations.delete` — server cascade-deletes children and sets `locationId = NULL` on affected items
+- [x] Tree updates after delete (removed node and all descendants disappear)
+- [x] Toast confirmation on successful create, rename, and delete
+- [x] Validation: location name cannot be empty or whitespace-only
 
 ## Notes
 

--- a/docs-v2/themes/04-inventory/prds/047-location-tree-management/us-03-drag-and-drop.md
+++ b/docs-v2/themes/04-inventory/prds/047-location-tree-management/us-03-drag-and-drop.md
@@ -1,7 +1,7 @@
 # US-03: Drag-and-drop reorder
 
 > PRD: [047 — Location Tree Management](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,18 +9,18 @@ As a user, I want to drag-and-drop locations to reorder siblings and move nodes 
 
 ## Acceptance Criteria
 
-- [ ] Drag handle visible on each tree node (desktop only)
-- [ ] Dragging a node between siblings reorders them — updates `sortOrder` via `inventory.locations.reorder`
-- [ ] Dragging a node onto another node moves it as a child of the target — updates `parentId` via `inventory.locations.move`
-- [ ] Drop indicator shows where the node will land (between siblings vs. inside a node)
-- [ ] Dragging a node onto itself is a no-op
-- [ ] Circular reference prevention: cannot drop a node onto any of its own descendants — drop target highlights as invalid
-- [ ] Moving a node to a new parent places it at the end of that parent's children
-- [ ] Tree state updates optimistically on drop; reverts on API error with toast
-- [ ] Mobile fallback: up/down arrow buttons appear on each node instead of drag handles
-- [ ] Up arrow moves node one position earlier among siblings; down arrow moves it one position later
-- [ ] Arrow buttons disabled at the boundary (first child can't go up, last child can't go down)
-- [ ] Mobile detection: arrow buttons shown when `pointer: coarse` media query matches
+- [ ] Drag handle visible on each tree node (desktop only) — **not implemented; no drag-and-drop library (e.g. dnd-kit) present**
+- [ ] Dragging a node between siblings reorders them — updates `sortOrder` via `inventory.locations.reorder` — **reorder implemented via up/down arrow buttons, not drag-and-drop**
+- [ ] Dragging a node onto another node moves it as a child of the target — updates `parentId` via `inventory.locations.move` — **move implemented via "Move To" dialog, not drag-and-drop**
+- [ ] Drop indicator shows where the node will land (between siblings vs. inside a node) — **not implemented**
+- [x] Dragging a node onto itself is a no-op — **Move To dialog prevents self-selection**
+- [x] Circular reference prevention: cannot drop a node onto any of its own descendants — drop target highlights as invalid — **descendants disabled in Move To dialog**
+- [x] Moving a node to a new parent places it at the end of that parent's children
+- [x] Tree state updates optimistically on drop; reverts on API error with toast
+- [x] Mobile fallback: up/down arrow buttons appear on each node instead of drag handles — **arrows are the only mechanism (shown always, not as mobile fallback)**
+- [x] Up arrow moves node one position earlier among siblings; down arrow moves it one position later
+- [x] Arrow buttons disabled at the boundary (first child can't go up, last child can't go down)
+- [ ] Mobile detection: arrow buttons shown when `pointer: coarse` media query matches — **arrows shown on all devices, not conditionally on coarse pointer**
 
 ## Notes
 

--- a/docs-v2/themes/04-inventory/prds/047-location-tree-management/us-04-items-at-location.md
+++ b/docs-v2/themes/04-inventory/prds/047-location-tree-management/us-04-items-at-location.md
@@ -1,7 +1,7 @@
 # US-04: Items at location
 
 > PRD: [047 — Location Tree Management](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,16 +9,16 @@ As a user, I want to see which items are at a selected location so that I can br
 
 ## Acceptance Criteria
 
-- [ ] Selecting a tree node loads items for that location in a side panel (desktop) or below the tree (mobile)
-- [ ] Panel header shows location name and breadcrumb path (e.g., "Home > Office > Desk")
-- [ ] Item list displays: name, asset ID, type badge — one row per item
-- [ ] "Include sub-locations" toggle — when enabled, shows items from the selected location and all its descendants
-- [ ] Toggle state persisted in session storage
-- [ ] Items fetched via `inventory.items.list` with `locationId` filter (and `includeChildren` flag for sub-locations)
-- [ ] Clicking an item row navigates to the item detail page
-- [ ] Loading state while items fetch
-- [ ] Empty state: "No items at this location" (or "No items at this location or its sub-locations" when toggle is on)
-- [ ] Item count in panel header updates to reflect the current list (matches the badge on the tree node when toggle is off)
+- [x] Selecting a tree node loads items for that location in a side panel (desktop) or below the tree (mobile)
+- [x] Panel header shows location name and breadcrumb path (e.g., "Home > Office > Desk")
+- [x] Item list displays: name, asset ID, type badge — one row per item
+- [x] "Include sub-locations" toggle — when enabled, shows items from the selected location and all its descendants
+- [x] Toggle state persisted in session storage
+- [x] Items fetched via `inventory.items.list` with `locationId` filter (and `includeChildren` flag for sub-locations)
+- [x] Clicking an item row navigates to the item detail page
+- [x] Loading state while items fetch
+- [x] Empty state: "No items at this location" (or "No items at this location or its sub-locations" when toggle is on)
+- [x] Item count in panel header updates to reflect the current list (matches the badge on the tree node when toggle is off)
 
 ## Notes
 

--- a/docs-v2/themes/04-inventory/prds/049-paperless-integration/README.md
+++ b/docs-v2/themes/04-inventory/prds/049-paperless-integration/README.md
@@ -72,11 +72,11 @@ Auth header: `Authorization: Token XXX` — token stored in settings table or en
 
 ## User Stories
 
-| # | Story | Summary | Parallelisable |
-|---|-------|---------|----------------|
-| 01 | [us-01-paperless-client](us-01-paperless-client.md) | Paperless API client (search, thumbnail, metadata), token auth, health check, graceful degradation | No (first) |
-| 02 | [us-02-link-documents](us-02-link-documents.md) | Document search modal, select + tag, link storage, unlink action | Blocked by us-01 |
-| 03 | [us-03-document-display](us-03-document-display.md) | Documents section on item detail, grouped by tag, thumbnails, "View in Paperless" links | Blocked by us-01 |
+| # | Story | Summary | Status | Parallelisable |
+|---|-------|---------|--------|----------------|
+| 01 | [us-01-paperless-client](us-01-paperless-client.md) | Paperless API client (search, thumbnail, metadata), token auth, health check, graceful degradation | Partial | No (first) |
+| 02 | [us-02-link-documents](us-02-link-documents.md) | Document search modal, select + tag, link storage, unlink action | Done | Blocked by us-01 |
+| 03 | [us-03-document-display](us-03-document-display.md) | Documents section on item detail, grouped by tag, thumbnails, "View in Paperless" links | Partial | Blocked by us-01 |
 
 US-02 and US-03 can parallelise after US-01.
 

--- a/docs-v2/themes/04-inventory/prds/049-paperless-integration/us-01-paperless-client.md
+++ b/docs-v2/themes/04-inventory/prds/049-paperless-integration/us-01-paperless-client.md
@@ -1,7 +1,7 @@
 # US-01: Paperless API client
 
 > PRD: [049 — Paperless-ngx Integration](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,20 +9,20 @@ As a developer, I want a Paperless-ngx API client service so that POPS can searc
 
 ## Acceptance Criteria
 
-- [ ] `PaperlessClient` service created with methods: `search(query)`, `getThumbnail(docId)`, `getDocument(docId)`, `healthCheck()`
-- [ ] Base URL and API token read from env vars (`PAPERLESS_BASE_URL`, `PAPERLESS_API_TOKEN`)
-- [ ] `search(query)` calls `GET /api/documents/?query=X` — returns array of `{ id, title, created, correspondent, thumbnailUrl }`
-- [ ] `getThumbnail(docId)` calls `GET /api/documents/:id/thumb/` — returns binary image data
-- [ ] `getDocument(docId)` calls `GET /api/documents/:id/` — returns full document metadata
-- [ ] `healthCheck()` calls `GET /api/documents/?page_size=1` — returns `{ available: true }` on 200, `{ available: false }` on any error
-- [ ] All requests include `Authorization: Token XXX` header
-- [ ] Request timeout: 5 seconds — slow Paperless responses do not block POPS
-- [ ] Connection errors caught and returned as `{ available: false }` — never thrown to callers
-- [ ] `item_documents` table created with columns per the data model
-- [ ] CRUD procedures created: `inventory.documents.link`, `inventory.documents.unlink`, `inventory.documents.listForItem`
-- [ ] Thumbnail proxy endpoint: `inventory.documents.thumbnail` — fetches from Paperless and serves to client (avoids CORS)
-- [ ] Health endpoint: `inventory.documents.health` — returns Paperless availability
-- [ ] Tests cover: successful search, search with no results, Paperless unavailable, invalid token, timeout handling
+- [x] `PaperlessClient` service created with methods: `search(query)`, `getThumbnail(docId)`, `getDocument(docId)`, `healthCheck()`
+- [ ] Base URL and API token read from env vars (`PAPERLESS_BASE_URL`, `PAPERLESS_API_TOKEN`) — **env vars are `PAPERLESS_URL` and `PAPERLESS_TOKEN`, not the names specified**
+- [x] `search(query)` calls `GET /api/documents/?query=X` — returns array of `{ id, title, created, correspondent, thumbnailUrl }`
+- [x] `getThumbnail(docId)` calls `GET /api/documents/:id/thumb/` — returns binary image data
+- [x] `getDocument(docId)` calls `GET /api/documents/:id/` — returns full document metadata
+- [x] `healthCheck()` calls `GET /api/documents/?page_size=1` — returns `{ available: true }` on 200, `{ available: false }` on any error
+- [x] All requests include `Authorization: Token XXX` header
+- [ ] Request timeout: 5 seconds — slow Paperless responses do not block POPS — **no explicit timeout set; uses default Node.js fetch (indefinite)**
+- [x] Connection errors caught and returned as `{ available: false }` — never thrown to callers
+- [x] `item_documents` table created with columns per the data model
+- [x] CRUD procedures created: `inventory.documents.link`, `inventory.documents.unlink`, `inventory.documents.listForItem`
+- [x] Thumbnail proxy endpoint: `inventory.documents.thumbnail` — fetches from Paperless and serves to client (avoids CORS)
+- [x] Health endpoint: `inventory.documents.health` — returns Paperless availability
+- [x] Tests cover: successful search, search with no results, Paperless unavailable, invalid token, timeout handling
 
 ## Notes
 

--- a/docs-v2/themes/04-inventory/prds/049-paperless-integration/us-02-link-documents.md
+++ b/docs-v2/themes/04-inventory/prds/049-paperless-integration/us-02-link-documents.md
@@ -1,7 +1,7 @@
 # US-02: Link documents
 
 > PRD: [049 — Paperless-ngx Integration](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,19 +9,19 @@ As a user, I want to search Paperless-ngx documents and link them to inventory i
 
 ## Acceptance Criteria
 
-- [ ] "Link Document" button on item detail page — only visible when Paperless health check returns `available: true`
-- [ ] Clicking "Link Document" opens a search modal
-- [ ] Search input with debounced query (300ms) — calls `inventory.documents.search`
-- [ ] Search results show: thumbnail, title, created date, correspondent — one row per document
-- [ ] Selecting a document shows a tag selector: "Receipt", "Warranty", "Manual"
-- [ ] Confirming selection calls `inventory.documents.link` with itemId, paperlessDocId, and tag
-- [ ] Duplicate link attempt shows toast error ("This document is already linked to this item")
-- [ ] Document appears in the item's document section immediately after linking
-- [ ] "Unlink" button on each linked document — confirmation: "Unlink [title]?" — calls `inventory.documents.unlink`
-- [ ] Toast confirmation on successful link and unlink
-- [ ] Empty search results: "No documents found in Paperless"
-- [ ] Loading state while search runs
-- [ ] Modal closes after successful link
+- [x] "Link Document" button on item detail page — only visible when Paperless health check returns `available: true`
+- [x] Clicking "Link Document" opens a search modal
+- [x] Search input with debounced query (300ms) — calls `inventory.documents.search`
+- [x] Search results show: thumbnail, title, created date, correspondent — one row per document
+- [x] Selecting a document shows a tag selector: "Receipt", "Warranty", "Manual"
+- [x] Confirming selection calls `inventory.documents.link` with itemId, paperlessDocId, and tag
+- [x] Duplicate link attempt shows toast error ("This document is already linked to this item")
+- [x] Document appears in the item's document section immediately after linking
+- [x] "Unlink" button on each linked document — confirmation: "Unlink [title]?" — calls `inventory.documents.unlink`
+- [x] Toast confirmation on successful link and unlink
+- [x] Empty search results: "No documents found in Paperless"
+- [x] Loading state while search runs
+- [x] Modal closes after successful link
 
 ## Notes
 

--- a/docs-v2/themes/04-inventory/prds/049-paperless-integration/us-03-document-display.md
+++ b/docs-v2/themes/04-inventory/prds/049-paperless-integration/us-03-document-display.md
@@ -1,7 +1,7 @@
 # US-03: Document display
 
 > PRD: [049 — Paperless-ngx Integration](README.md)
-> Status: To Review
+> Status: Partial
 
 ## Description
 
@@ -9,17 +9,17 @@ As a user, I want to see linked documents on the item detail page grouped by typ
 
 ## Acceptance Criteria
 
-- [ ] Documents section on item detail page — only visible when Paperless health check returns `available: true`
-- [ ] Documents fetched via `inventory.documents.listForItem` on page load
-- [ ] Documents grouped by tag: "Receipts", "Warranties", "Manuals" — each group as a subsection
-- [ ] Empty groups hidden (don't show "Warranties" heading if no warranties linked)
-- [ ] Each document card shows: thumbnail (loaded via proxy), title, tag badge, linked date
-- [ ] "View in Paperless" link on each card — opens the Paperless web UI for that document in a new tab (`PAPERLESS_BASE_URL/documents/:id/details`)
-- [ ] "Unlink" action on each card (same as US-02 unlink)
-- [ ] Thumbnail loading: skeleton placeholder while thumbnail fetches
-- [ ] Thumbnail error: "Document unavailable" placeholder if Paperless returns 404 for the thumbnail (document deleted externally)
-- [ ] Section hidden entirely when Paperless is unavailable — no error message, no empty state, just absent
-- [ ] Section hidden when item has no linked documents and Paperless is available — the "Link Document" button (from US-02) is the entry point
+- [x] Documents section on item detail page — only visible when Paperless health check returns `available: true`
+- [x] Documents fetched via `inventory.documents.listForItem` on page load
+- [x] Documents grouped by tag: "Receipts", "Warranties", "Manuals" — each group as a subsection
+- [x] Empty groups hidden (don't show "Warranties" heading if no warranties linked)
+- [ ] Each document card shows: thumbnail (loaded via proxy), title, tag badge, linked date — **thumbnails not shown on document cards; only title, tag badge, and linked date displayed**
+- [ ] "View in Paperless" link on each card — opens the Paperless web UI for that document in a new tab (`PAPERLESS_BASE_URL/documents/:id/details`) — **not implemented**
+- [x] "Unlink" action on each card (same as US-02 unlink)
+- [ ] Thumbnail loading: skeleton placeholder while thumbnail fetches — **not applicable since thumbnails not rendered**
+- [ ] Thumbnail error: "Document unavailable" placeholder if Paperless returns 404 for the thumbnail (document deleted externally) — **not applicable since thumbnails not rendered**
+- [x] Section hidden entirely when Paperless is unavailable — no error message, no empty state, just absent
+- [x] Section hidden when item has no linked documents and Paperless is available — the "Link Document" button (from US-02) is the entry point
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Audit results for PRD-047 (Location Tree Management) and PRD-049 (Paperless-ngx Integration).

**PRD-047 Location Tree Management**
- US-01 Tree Browser: **Done** — all ACs met
- US-02 Location CRUD: **Done** — all ACs met (actions accessible via hover buttons)
- US-03 Drag-and-drop Reorder: **Partial** — up/down arrows and move-to-parent dialog work; missing drag handles, dnd-kit library, drop indicator, `pointer:coarse` detection
- US-04 Items at Location: **Done** — all ACs met

**PRD-049 Paperless-ngx Integration**
- US-01 Paperless Client: **Partial** — env vars named `PAPERLESS_URL`/`PAPERLESS_TOKEN` not spec's `PAPERLESS_BASE_URL`/`PAPERLESS_API_TOKEN`; no 5-second request timeout
- US-02 Link Documents: **Done** — all ACs met
- US-03 Document Display: **Partial** — grouping by tag, unlink, health-gating all work; missing document card thumbnails, "View in Paperless" links, thumbnail skeleton/error states

## Issues

Closes #569, #570, #572, #577

Comments added to: #571, #576, #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)