### PR TITLE
feat: add settings service and tRPC router

### DIFF
--- a/apps/pops-api/src/modules/core/index.ts
+++ b/apps/pops-api/src/modules/core/index.ts
@@ -8,9 +8,11 @@ import { router } from "../../trpc.js";
 import { entitiesRouter } from "./entities/router.js";
 import { aiUsageRouter } from "./ai-usage/router.js";
 import { correctionsRouter } from "./corrections/router.js";
+import { settingsRouter } from "./settings/router.js";
 
 export const coreRouter = router({
   entities: entitiesRouter,
   aiUsage: aiUsageRouter,
   corrections: correctionsRouter,
+  settings: settingsRouter,
 });

--- a/apps/pops-api/src/modules/core/settings/index.ts
+++ b/apps/pops-api/src/modules/core/settings/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Settings module
+ */
+export { settingsRouter } from "./router.js";
+export type { Setting, SetSettingInput, SettingListInput } from "./types.js";

--- a/apps/pops-api/src/modules/core/settings/router.ts
+++ b/apps/pops-api/src/modules/core/settings/router.ts
@@ -1,0 +1,63 @@
+/**
+ * Settings tRPC router — CRUD for key-value settings
+ */
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { router, protectedProcedure } from "../../../trpc.js";
+import { paginationMeta } from "../../../shared/pagination.js";
+import { SetSettingSchema, SettingListSchema, toSetting } from "./types.js";
+import * as service from "./service.js";
+import { NotFoundError } from "../../../shared/errors.js";
+
+const DEFAULT_LIMIT = 50;
+const DEFAULT_OFFSET = 0;
+
+export const settingsRouter = router({
+  /** List all settings with optional search filter */
+  list: protectedProcedure.input(SettingListSchema).query(({ input }) => {
+    const limit = input.limit ?? DEFAULT_LIMIT;
+    const offset = input.offset ?? DEFAULT_OFFSET;
+
+    const { rows, total } = service.listSettings(input.search, limit, offset);
+
+    return {
+      data: rows.map(toSetting),
+      pagination: paginationMeta(total, limit, offset),
+    };
+  }),
+
+  /** Get a single setting by key */
+  get: protectedProcedure.input(z.object({ key: z.string() })).query(({ input }) => {
+    try {
+      const row = service.getSetting(input.key);
+      return { data: toSetting(row) };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
+  }),
+
+  /** Set a setting value (upsert — creates or updates) */
+  set: protectedProcedure.input(SetSettingSchema).mutation(({ input }) => {
+    const row = service.setSetting(input);
+    return {
+      data: toSetting(row),
+      message: "Setting saved",
+    };
+  }),
+
+  /** Delete a setting by key */
+  delete: protectedProcedure.input(z.object({ key: z.string() })).mutation(({ input }) => {
+    try {
+      service.deleteSetting(input.key);
+      return { message: "Setting deleted" };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
+  }),
+});

--- a/apps/pops-api/src/modules/core/settings/service.ts
+++ b/apps/pops-api/src/modules/core/settings/service.ts
@@ -1,0 +1,69 @@
+/**
+ * Settings service — key-value store for application configuration
+ */
+import { eq, like, count } from "drizzle-orm";
+import { getDrizzle } from "../../../db.js";
+import { settings } from "@pops/db-types";
+import { NotFoundError } from "../../../shared/errors.js";
+import type { SettingRow, SetSettingInput } from "./types.js";
+
+/** Get a single setting by key */
+export function getSetting(key: string): SettingRow {
+  const db = getDrizzle();
+  const [row] = db.select().from(settings).where(eq(settings.key, key)).all();
+
+  if (!row) {
+    throw new NotFoundError("Setting", key);
+  }
+
+  return row;
+}
+
+/** List settings with optional search filter */
+export function listSettings(
+  search: string | undefined,
+  limit: number,
+  offset: number
+): { rows: SettingRow[]; total: number } {
+  const db = getDrizzle();
+
+  const condition = search ? like(settings.key, `%${search}%`) : undefined;
+
+  const [countResult] = db.select({ count: count() }).from(settings).where(condition).all();
+
+  const rows = db
+    .select()
+    .from(settings)
+    .where(condition)
+    .orderBy(settings.key)
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  return { rows, total: countResult.count };
+}
+
+/** Set a setting value (upsert — creates or updates) */
+export function setSetting(input: SetSettingInput): SettingRow {
+  const db = getDrizzle();
+
+  db.insert(settings)
+    .values({ key: input.key, value: input.value })
+    .onConflictDoUpdate({
+      target: settings.key,
+      set: { value: input.value },
+    })
+    .run();
+
+  return getSetting(input.key);
+}
+
+/** Delete a setting by key */
+export function deleteSetting(key: string): void {
+  const db = getDrizzle();
+  const result = db.delete(settings).where(eq(settings.key, key)).run();
+
+  if (result.changes === 0) {
+    throw new NotFoundError("Setting", key);
+  }
+}

--- a/apps/pops-api/src/modules/core/settings/settings.test.ts
+++ b/apps/pops-api/src/modules/core/settings/settings.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import type { Database } from "better-sqlite3";
+import { setupTestContext, seedSetting, createCaller } from "../../../shared/test-utils.js";
+
+const ctx = setupTestContext();
+let caller: ReturnType<typeof createCaller>;
+let db: Database;
+
+beforeEach(() => {
+  ({ caller, db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+describe("settings.list", () => {
+  it("returns empty list when no settings exist", async () => {
+    const result = await caller.core.settings.list({});
+    expect(result.data).toEqual([]);
+    expect(result.pagination.total).toBe(0);
+  });
+
+  it("returns all settings", async () => {
+    seedSetting(db, { key: "plex_url", value: "http://plex:32400" });
+    seedSetting(db, { key: "theme", value: "dark" });
+
+    const result = await caller.core.settings.list({});
+    expect(result.data).toHaveLength(2);
+    expect(result.pagination.total).toBe(2);
+  });
+
+  it("filters by search term", async () => {
+    seedSetting(db, { key: "plex_url", value: "http://plex:32400" });
+    seedSetting(db, { key: "plex_token", value: "abc123" });
+    seedSetting(db, { key: "theme", value: "dark" });
+
+    const result = await caller.core.settings.list({ search: "plex" });
+    expect(result.data).toHaveLength(2);
+    expect(result.data.map((s) => s.key)).toEqual(["plex_token", "plex_url"]);
+  });
+
+  it("paginates results", async () => {
+    seedSetting(db, { key: "a", value: "1" });
+    seedSetting(db, { key: "b", value: "2" });
+    seedSetting(db, { key: "c", value: "3" });
+
+    const result = await caller.core.settings.list({ limit: 2, offset: 0 });
+    expect(result.data).toHaveLength(2);
+    expect(result.pagination.total).toBe(3);
+    expect(result.pagination.hasMore).toBe(true);
+  });
+
+  it("throws UNAUTHORIZED without auth", async () => {
+    const unauthCaller = createCaller(false);
+    await expect(unauthCaller.core.settings.list({})).rejects.toThrow(TRPCError);
+    await expect(unauthCaller.core.settings.list({})).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+});
+
+describe("settings.get", () => {
+  it("returns a setting by key", async () => {
+    seedSetting(db, { key: "theme", value: "dark" });
+
+    const result = await caller.core.settings.get({ key: "theme" });
+    expect(result.data.key).toBe("theme");
+    expect(result.data.value).toBe("dark");
+  });
+
+  it("throws NOT_FOUND for missing key", async () => {
+    await expect(caller.core.settings.get({ key: "nonexistent" })).rejects.toThrow(TRPCError);
+    await expect(caller.core.settings.get({ key: "nonexistent" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+});
+
+describe("settings.set", () => {
+  it("creates a new setting", async () => {
+    const result = await caller.core.settings.set({ key: "theme", value: "dark" });
+    expect(result.message).toBe("Setting saved");
+    expect(result.data.key).toBe("theme");
+    expect(result.data.value).toBe("dark");
+  });
+
+  it("updates an existing setting (upsert)", async () => {
+    seedSetting(db, { key: "theme", value: "light" });
+
+    const result = await caller.core.settings.set({ key: "theme", value: "dark" });
+    expect(result.data.value).toBe("dark");
+
+    // Verify only one row exists
+    const listResult = await caller.core.settings.list({ search: "theme" });
+    expect(listResult.data).toHaveLength(1);
+  });
+
+  it("persists to the database", async () => {
+    await caller.core.settings.set({ key: "new_key", value: "new_value" });
+    const row = db.prepare("SELECT * FROM settings WHERE key = ?").get("new_key") as {
+      key: string;
+      value: string;
+    };
+    expect(row).toBeDefined();
+    expect(row.value).toBe("new_value");
+  });
+
+  it("allows empty string value", async () => {
+    const result = await caller.core.settings.set({ key: "empty", value: "" });
+    expect(result.data.value).toBe("");
+  });
+});
+
+describe("settings.delete", () => {
+  it("deletes an existing setting", async () => {
+    seedSetting(db, { key: "theme", value: "dark" });
+
+    const result = await caller.core.settings.delete({ key: "theme" });
+    expect(result.message).toBe("Setting deleted");
+
+    // Verify it's gone
+    await expect(caller.core.settings.get({ key: "theme" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("throws NOT_FOUND for missing key", async () => {
+    await expect(caller.core.settings.delete({ key: "nonexistent" })).rejects.toThrow(TRPCError);
+    await expect(caller.core.settings.delete({ key: "nonexistent" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+});

--- a/apps/pops-api/src/modules/core/settings/types.ts
+++ b/apps/pops-api/src/modules/core/settings/types.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import type { SettingRow } from "@pops/db-types";
+
+export type { SettingRow };
+
+/** API response shape */
+export interface Setting {
+  key: string;
+  value: string;
+}
+
+/** Map database row to API response */
+export function toSetting(row: SettingRow): Setting {
+  return {
+    key: row.key,
+    value: row.value,
+  };
+}
+
+/** Schema for setting a value (upsert) */
+export const SetSettingSchema = z.object({
+  key: z.string().min(1, "Key is required"),
+  value: z.string(),
+});
+export type SetSettingInput = z.infer<typeof SetSettingSchema>;
+
+/** Schema for list query */
+export const SettingListSchema = z.object({
+  search: z.string().optional(),
+  limit: z.coerce.number().positive().optional(),
+  offset: z.coerce.number().nonnegative().optional(),
+});
+export type SettingListInput = z.infer<typeof SettingListSchema>;

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -333,6 +333,11 @@ export function createTestDb(): Database {
     CREATE UNIQUE INDEX IF NOT EXISTS uq_item_documents_pair ON item_documents(item_id, paperless_document_id);
     CREATE INDEX IF NOT EXISTS idx_item_documents_item ON item_documents(item_id);
     CREATE INDEX IF NOT EXISTS idx_item_documents_doc ON item_documents(paperless_document_id);
+
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY NOT NULL,
+      value TEXT NOT NULL
+    );
   `);
 
   return db;
@@ -657,6 +662,24 @@ export function seedBudget(
   });
 
   return id;
+}
+
+/**
+ * Seed a single setting row into the test DB.
+ * Returns the key.
+ */
+export function seedSetting(
+  db: Database,
+  overrides: Partial<{ key: string; value: string }> = {}
+): string {
+  const key = overrides.key ?? "test_key";
+
+  db.prepare(`INSERT INTO settings (key, value) VALUES (@key, @value)`).run({
+    key,
+    value: overrides.value ?? "test_value",
+  });
+
+  return key;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `modules/core/settings/` with service, tRPC router, types, and tests
- Key-value store for app configuration (Plex URL, sync timestamps, UI preferences)
- CRUD: `list` (with search/pagination), `get`, `set` (upsert), `delete`
- Wired into `coreRouter` as `core.settings`
- Adds `settings` table to test-utils `createTestDb` + `seedSetting` helper
- 13 tests passing

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 13 settings tests pass (list, get, set/upsert, delete, not-found, auth)
- [x] Existing tests still pass

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)