### PR TITLE
feat: add shared Prettier config at repo root

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,8 @@
 node_modules
 dist
 coverage
+pnpm-lock.yaml
 package-lock.json
 yarn.lock
-pnpm-lock.yaml
+*.csv
+*.jsonl

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,10 +1,10 @@
 {
   "semi": true,
-  "trailingComma": "es5",
   "singleQuote": false,
   "printWidth": 100,
   "tabWidth": 2,
   "useTabs": false,
+  "trailingComma": "es5",
   "arrowParens": "always",
   "endOfLine": "lf"
 }

--- a/apps/pops-shell/src/app/layout/AppRail.tsx
+++ b/apps/pops-shell/src/app/layout/AppRail.tsx
@@ -78,7 +78,9 @@ export function AppRail({ className }: AppRailProps) {
                 <span
                   className={cn(
                     "absolute left-0 top-1/2 -translate-y-1/2 w-1 rounded-r-full transition-all duration-300",
-                    isActive ? cn("h-8", appColor) : "h-0 bg-transparent group-hover:h-4 group-hover:bg-muted-foreground/40"
+                    isActive
+                      ? cn("h-8", appColor)
+                      : "h-0 bg-transparent group-hover:h-4 group-hover:bg-muted-foreground/40"
                   )}
                 />
 
@@ -93,9 +95,7 @@ export function AppRail({ className }: AppRailProps) {
                   {Icon ? (
                     <Icon className="h-6 w-6" />
                   ) : (
-                    <span className="text-lg font-semibold">
-                      {app.label[0]}
-                    </span>
+                    <span className="text-lg font-semibold">{app.label[0]}</span>
                   )}
                 </span>
               </button>

--- a/apps/pops-shell/src/app/layout/PageNav.test.ts
+++ b/apps/pops-shell/src/app/layout/PageNav.test.ts
@@ -30,9 +30,7 @@ const mockApps: AppNavConfig[] = [
 
 describe("findActiveApp", () => {
   it("returns the app matching the pathname", () => {
-    expect(findActiveApp("/finance/transactions", mockApps)?.id).toBe(
-      "finance",
-    );
+    expect(findActiveApp("/finance/transactions", mockApps)?.id).toBe("finance");
     expect(findActiveApp("/media/watchlist", mockApps)?.id).toBe("media");
   });
 
@@ -64,30 +62,18 @@ describe("isPageActive", () => {
   });
 
   it("matches sub-page by prefix", () => {
-    expect(
-      isPageActive("/finance/transactions", "/finance", "/transactions"),
-    ).toBe(true);
+    expect(isPageActive("/finance/transactions", "/finance", "/transactions")).toBe(true);
   });
 
   it("matches sub-page with deeper path", () => {
-    expect(
-      isPageActive("/finance/transactions/123", "/finance", "/transactions"),
-    ).toBe(true);
+    expect(isPageActive("/finance/transactions/123", "/finance", "/transactions")).toBe(true);
   });
 
   it("does not match unrelated page", () => {
-    expect(isPageActive("/finance/budgets", "/finance", "/transactions")).toBe(
-      false,
-    );
+    expect(isPageActive("/finance/budgets", "/finance", "/transactions")).toBe(false);
   });
 
   it("does not match prefix collisions on sub-pages", () => {
-    expect(
-      isPageActive(
-        "/finance/transactions-pending",
-        "/finance",
-        "/transactions",
-      ),
-    ).toBe(false);
+    expect(isPageActive("/finance/transactions-pending", "/finance", "/transactions")).toBe(false);
   });
 });

--- a/apps/pops-shell/src/app/layout/PageNav.tsx
+++ b/apps/pops-shell/src/app/layout/PageNav.tsx
@@ -57,7 +57,9 @@ export function PageNav() {
       aria-label={`${activeApp.label} pages`}
     >
       <div className="px-4 py-4 border-b border-border">
-        <span className={`text-[10px] font-bold uppercase tracking-[0.15em] ${appColors?.text || "text-muted-foreground"}`}>
+        <span
+          className={`text-[10px] font-bold uppercase tracking-[0.15em] ${appColors?.text || "text-muted-foreground"}`}
+        >
           {activeApp.label}
         </span>
       </div>
@@ -65,11 +67,7 @@ export function PageNav() {
       <div className="p-2 space-y-0.5">
         {activeApp.items.map((item) => {
           const fullPath = `${activeApp.basePath}${item.path}`;
-          const active = isPageActive(
-            location.pathname,
-            activeApp.basePath,
-            item.path,
-          );
+          const active = isPageActive(location.pathname, activeApp.basePath, item.path);
           const Icon = iconMap[item.icon];
 
           return (
@@ -83,9 +81,13 @@ export function PageNav() {
               }`}
             >
               {Icon && (
-                <Icon className={`h-4 w-4 shrink-0 transition-colors ${
-                  active ? "text-white" : `${appColors?.muted || "text-muted-foreground"} group-hover:text-foreground`
-                }`} />
+                <Icon
+                  className={`h-4 w-4 shrink-0 transition-colors ${
+                    active
+                      ? "text-white"
+                      : `${appColors?.muted || "text-muted-foreground"} group-hover:text-foreground`
+                  }`}
+                />
               )}
               <span>{item.label}</span>
             </Link>

--- a/apps/pops-shell/src/app/layout/Sidebar.tsx
+++ b/apps/pops-shell/src/app/layout/Sidebar.tsx
@@ -52,11 +52,7 @@ export function Sidebar({ open }: SidebarProps) {
           {registeredApps.map((app) =>
             app.items.map((item) => {
               const fullPath = `${app.basePath}${item.path}`;
-              const isActive = isPageActive(
-                location.pathname,
-                app.basePath,
-                item.path,
-              );
+              const isActive = isPageActive(location.pathname, app.basePath, item.path);
               const Icon = iconMap[item.icon];
 
               return (
@@ -74,7 +70,7 @@ export function Sidebar({ open }: SidebarProps) {
                   <span>{item.label}</span>
                 </Link>
               );
-            }),
+            })
           )}
         </nav>
       </aside>

--- a/apps/pops-shell/src/app/layout/TopBar.tsx
+++ b/apps/pops-shell/src/app/layout/TopBar.tsx
@@ -40,9 +40,7 @@ export function TopBar() {
           )}
         </button>
 
-        <div className="hidden md:block text-sm text-muted-foreground">
-          user@example.com
-        </div>
+        <div className="hidden md:block text-sm text-muted-foreground">user@example.com</div>
       </div>
     </header>
   );

--- a/apps/pops-shell/src/app/nav/path-utils.ts
+++ b/apps/pops-shell/src/app/nav/path-utils.ts
@@ -7,28 +7,18 @@
 import type { AppNavConfig } from "./types.js";
 
 /** Check if pathname matches a prefix at a path-segment boundary. */
-export function matchesAtBoundary(
-  pathname: string,
-  prefix: string,
-): boolean {
+export function matchesAtBoundary(pathname: string, prefix: string): boolean {
   if (!pathname.startsWith(prefix)) return false;
   return pathname.length === prefix.length || pathname[prefix.length] === "/";
 }
 
 /** Find the active app by matching the current pathname against registered base paths. */
-export function findActiveApp(
-  pathname: string,
-  apps: AppNavConfig[],
-): AppNavConfig | undefined {
+export function findActiveApp(pathname: string, apps: AppNavConfig[]): AppNavConfig | undefined {
   return apps.find((app) => matchesAtBoundary(pathname, app.basePath));
 }
 
 /** Check if a page item is active given the current pathname and its app's basePath. */
-export function isPageActive(
-  pathname: string,
-  basePath: string,
-  itemPath: string,
-): boolean {
+export function isPageActive(pathname: string, basePath: string, itemPath: string): boolean {
   if (itemPath === "") {
     return pathname === basePath || pathname === `${basePath}/`;
   }

--- a/apps/pops-shell/src/app/nav/registry.ts
+++ b/apps/pops-shell/src/app/nav/registry.ts
@@ -14,6 +14,11 @@ import { navConfig as aiNavConfig } from "@pops/app-ai";
 import type { AppNavConfig } from "./types";
 
 /** All registered app nav configs. Order determines display order in the app rail. */
-export const registeredApps: AppNavConfig[] = [financeNavConfig, mediaNavConfig, inventoryNavConfig, aiNavConfig];
+export const registeredApps: AppNavConfig[] = [
+  financeNavConfig,
+  mediaNavConfig,
+  inventoryNavConfig,
+  aiNavConfig,
+];
 
 export type { AppNavConfig, AppNavItem } from "./types";

--- a/apps/pops-shell/src/app/router.tsx
+++ b/apps/pops-shell/src/app/router.tsx
@@ -40,9 +40,7 @@ export const router = createBrowserRouter([
     errorElement: (
       <div className="flex flex-col items-center justify-center min-h-screen text-center px-4">
         <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
-        <p className="text-muted-foreground mb-6">
-          An unexpected error occurred.
-        </p>
+        <p className="text-muted-foreground mb-6">An unexpected error occurred.</p>
         <Link
           to="/"
           className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"

--- a/apps/pops-shell/src/store/uiStore.ts
+++ b/apps/pops-shell/src/store/uiStore.ts
@@ -19,8 +19,7 @@ export const useUIStore = create<UIState>()(
     (set) => ({
       sidebarOpen: true,
       railOpen: true,
-      toggleSidebar: () =>
-        set((state) => ({ sidebarOpen: !state.sidebarOpen })),
+      toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
       setSidebarOpen: (open) => set({ sidebarOpen: open }),
       toggleRail: () => set((state) => ({ railOpen: !state.railOpen })),
       setRailOpen: (open) => set({ railOpen: open }),

--- a/packages/app-ai/src/pages/AiUsagePage.tsx
+++ b/packages/app-ai/src/pages/AiUsagePage.tsx
@@ -39,9 +39,7 @@ export function AiUsagePage() {
       <div className="space-y-6">
         <div>
           <h1 className="text-2xl md:text-3xl font-bold tracking-tight">AI Usage</h1>
-          <p className="text-muted-foreground">
-            Track AI categorization costs and usage
-          </p>
+          <p className="text-muted-foreground">Track AI categorization costs and usage</p>
         </div>
 
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
@@ -74,9 +72,7 @@ export function AiUsagePage() {
   const columns: ColumnDef<AiUsageRecord>[] = [
     {
       accessorKey: "date",
-      header: ({ column }) => (
-        <SortableHeader column={column}>Date</SortableHeader>
-      ),
+      header: ({ column }) => <SortableHeader column={column}>Date</SortableHeader>,
       cell: ({ row }) => {
         const date = new Date(row.original.date);
         return date.toLocaleDateString("en-AU", {
@@ -120,11 +116,7 @@ export function AiUsagePage() {
         const rate = total > 0 ? (row.original.cacheHits / total) * 100 : 0;
         return (
           <div className="text-right">
-            <Badge
-              variant={
-                rate > 80 ? "default" : rate > 50 ? "secondary" : "outline"
-              }
-            >
+            <Badge variant={rate > 80 ? "default" : rate > 50 ? "secondary" : "outline"}>
               {rate.toFixed(1)}%
             </Badge>
           </div>
@@ -173,8 +165,7 @@ export function AiUsagePage() {
   ];
 
   // Calculate cache hit rate
-  const totalRequests =
-    (stats?.totalApiCalls ?? 0) + (stats?.totalCacheHits ?? 0);
+  const totalRequests = (stats?.totalApiCalls ?? 0) + (stats?.totalCacheHits ?? 0);
   const cacheHitRate = totalRequests > 0 ? (stats?.cacheHitRate ?? 0) * 100 : 0;
 
   return (
@@ -192,14 +183,20 @@ export function AiUsagePage() {
         <StatCard
           title="Total Cost"
           value={`$${(stats?.totalCost ?? 0).toFixed(4)}`}
-          description={stats?.last30Days ? `$${stats.last30Days.cost.toFixed(4)} last 30 days` : undefined}
+          description={
+            stats?.last30Days ? `$${stats.last30Days.cost.toFixed(4)} last 30 days` : undefined
+          }
           color="amber"
         />
 
         <StatCard
           title="API Calls"
           value={(stats?.totalApiCalls ?? 0).toLocaleString()}
-          description={stats?.last30Days ? `${stats.last30Days.apiCalls.toLocaleString()} last 30 days` : undefined}
+          description={
+            stats?.last30Days
+              ? `${stats.last30Days.apiCalls.toLocaleString()} last 30 days`
+              : undefined
+          }
           color="indigo"
         />
 
@@ -224,8 +221,7 @@ export function AiUsagePage() {
           <div>
             <h2 className="text-xl font-semibold">Daily Usage History</h2>
             <p className="text-sm text-muted-foreground">
-              Showing {history.records.length} days • Total: $
-              {history.summary.totalCost.toFixed(4)}
+              Showing {history.records.length} days • Total: ${history.summary.totalCost.toFixed(4)}
             </p>
           </div>
           <DataTable columns={columns} data={history.records} />

--- a/packages/app-ai/src/routes.tsx
+++ b/packages/app-ai/src/routes.tsx
@@ -36,6 +36,4 @@ export const navConfig: AppNavConfig = {
   items: [{ path: "", label: "AI Usage", icon: "BarChart3" }],
 };
 
-export const routes: RouteObject[] = [
-  { index: true, element: <AiUsagePage /> },
-];
+export const routes: RouteObject[] = [{ index: true, element: <AiUsagePage /> }];

--- a/packages/app-finance/src/components/TagEditor.stories.tsx
+++ b/packages/app-finance/src/components/TagEditor.stories.tsx
@@ -100,8 +100,7 @@ export const WithSaveLatency: Story = {
         console.log("Saving:", tags);
         setTimeout(resolve, 1200);
       }),
-    onSuggest: () =>
-      new Promise((resolve) => setTimeout(() => resolve(["Subscriptions"]), 800)),
+    onSuggest: () => new Promise((resolve) => setTimeout(() => resolve(["Subscriptions"]), 800)),
   },
 };
 

--- a/packages/app-finance/src/components/TagEditor.tsx
+++ b/packages/app-finance/src/components/TagEditor.tsx
@@ -181,9 +181,7 @@ export function TagEditor({
         <button
           className={cn(
             "flex flex-wrap gap-1 min-h-10 text-left w-full rounded px-2 py-1.5 transition-colors items-center",
-            disabled
-              ? "cursor-default"
-              : "hover:bg-accent/50 cursor-pointer"
+            disabled ? "cursor-default" : "hover:bg-accent/50 cursor-pointer"
           )}
           aria-label="Edit tags"
           disabled={disabled}
@@ -193,11 +191,12 @@ export function TagEditor({
           ) : (
             tags.slice(0, 3).map((tag) => {
               const meta = tagMeta?.get(tag);
-              const tooltipText = meta?.source === "rule" && meta?.pattern
-                ? `Rule: "${meta.pattern}"`
-                : meta?.source
-                ? `${meta.source} suggestion`
-                : undefined;
+              const tooltipText =
+                meta?.source === "rule" && meta?.pattern
+                  ? `Rule: "${meta.pattern}"`
+                  : meta?.source
+                    ? `${meta.source} suggestion`
+                    : undefined;
               const style = getTagStyle(tag);
               return (
                 <Badge

--- a/packages/app-finance/src/components/imports/ColumnMapStep.tsx
+++ b/packages/app-finance/src/components/imports/ColumnMapStep.tsx
@@ -9,15 +9,8 @@ import type { ParsedTransaction } from "@pops/api/modules/finance/imports";
  * Step 2: Map CSV columns to schema fields and validate parsing
  */
 export function ColumnMapStep() {
-  const {
-    headers,
-    rows,
-    columnMap,
-    setColumnMap,
-    setParsedTransactions,
-    nextStep,
-    prevStep,
-  } = useImportStore();
+  const { headers, rows, columnMap, setColumnMap, setParsedTransactions, nextStep, prevStep } =
+    useImportStore();
 
   const [localColumnMap, setLocalColumnMap] = useState(columnMap);
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
@@ -49,11 +42,7 @@ export function ColumnMapStep() {
     const errors: string[] = [];
     const parsedTransactions: ParsedTransaction[] = [];
 
-    if (
-      !localColumnMap.date ||
-      !localColumnMap.description ||
-      !localColumnMap.amount
-    ) {
+    if (!localColumnMap.date || !localColumnMap.description || !localColumnMap.amount) {
       errors.push("Please map all required fields: Date, Description, Amount");
       return { valid: false, errors, parsedTransactions };
     }
@@ -82,9 +71,7 @@ export function ColumnMapStep() {
 
       // Valid row - create ParsedTransaction
       const description = row[localColumnMap.description] ?? "";
-      const location = localColumnMap.location
-        ? row[localColumnMap.location]
-        : undefined;
+      const location = localColumnMap.location ? row[localColumnMap.location] : undefined;
       const rawRow = JSON.stringify(row);
       const checksum = crypto.SHA256(rawRow).toString();
 
@@ -199,10 +186,7 @@ export function ColumnMapStep() {
                 const parsedAmount = parseAmount(amountStr);
 
                 return (
-                  <tr
-                    key={idx}
-                    className="hover:bg-gray-50 dark:hover:bg-gray-800"
-                  >
+                  <tr key={idx} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                     <td className="px-4 py-2 text-gray-500">{idx + 1}</td>
                     <td className="px-4 py-2">
                       <div className="flex items-center gap-2">
@@ -211,19 +195,13 @@ export function ColumnMapStep() {
                         ) : (
                           <AlertCircle className="w-4 h-4 text-red-500" />
                         )}
-                        <span className={parsedDate ? "" : "text-red-600"}>
-                          {dateStr}
-                        </span>
+                        <span className={parsedDate ? "" : "text-red-600"}>{dateStr}</span>
                         {parsedDate && (
-                          <span className="text-xs text-gray-500">
-                            → {parsedDate}
-                          </span>
+                          <span className="text-xs text-gray-500">→ {parsedDate}</span>
                         )}
                       </div>
                     </td>
-                    <td className="px-4 py-2">
-                      {row[localColumnMap.description ?? ""]}
-                    </td>
+                    <td className="px-4 py-2">{row[localColumnMap.description ?? ""]}</td>
                     <td className="px-4 py-2">
                       <div className="flex items-center gap-2">
                         {parsedAmount !== null ? (
@@ -231,24 +209,16 @@ export function ColumnMapStep() {
                         ) : (
                           <AlertCircle className="w-4 h-4 text-red-500" />
                         )}
-                        <span
-                          className={
-                            parsedAmount !== null ? "" : "text-red-600"
-                          }
-                        >
+                        <span className={parsedAmount !== null ? "" : "text-red-600"}>
                           {amountStr}
                         </span>
                         {parsedAmount !== null && (
-                          <span className="text-xs text-gray-500">
-                            → {parsedAmount}
-                          </span>
+                          <span className="text-xs text-gray-500">→ {parsedAmount}</span>
                         )}
                       </div>
                     </td>
                     {localColumnMap.location && (
-                      <td className="px-4 py-2">
-                        {row[localColumnMap.location]}
-                      </td>
+                      <td className="px-4 py-2">{row[localColumnMap.location]}</td>
                     )}
                   </tr>
                 );

--- a/packages/app-finance/src/components/imports/EditableTransactionCard.tsx
+++ b/packages/app-finance/src/components/imports/EditableTransactionCard.tsx
@@ -3,11 +3,7 @@ import { Save, X, ChevronRight } from "lucide-react";
 import { Button } from "@pops/ui";
 import { Input } from "@pops/ui";
 import { Label } from "@pops/ui";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@pops/ui";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@pops/ui";
 import type { ProcessedTransaction } from "@pops/api/modules/finance/imports";
 
 interface EditableTransactionCardProps {
@@ -31,9 +27,7 @@ export function EditableTransactionCard({
   entities,
 }: EditableTransactionCardProps) {
   const [isRawDataExpanded, setIsRawDataExpanded] = useState(false);
-  const [editedFields, setEditedFields] = useState<
-    Partial<ProcessedTransaction>
-  >({
+  const [editedFields, setEditedFields] = useState<Partial<ProcessedTransaction>>({
     description: transaction.description,
     amount: transaction.amount,
     date: transaction.date,
@@ -70,9 +64,7 @@ export function EditableTransactionCard({
     >
       {/* Header */}
       <div className="flex justify-between items-center mb-4 pb-2 border-b border-blue-200 dark:border-blue-800">
-        <h3 className="font-semibold text-blue-900 dark:text-blue-100">
-          Edit Transaction
-        </h3>
+        <h3 className="font-semibold text-blue-900 dark:text-blue-100">Edit Transaction</h3>
         <div className="flex gap-2">
           <Button
             variant="default"
@@ -106,27 +98,20 @@ export function EditableTransactionCard({
           onChange={(e) =>
             setEditedFields({
               ...editedFields,
-              transactionType: e.target.value as
-                | "purchase"
-                | "transfer"
-                | "income",
+              transactionType: e.target.value as "purchase" | "transfer" | "income",
             })
           }
           className="w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-800"
         >
           <option value="purchase">Purchase (requires entity)</option>
-          <option value="transfer">
-            Transfer (between accounts, no entity)
-          </option>
+          <option value="transfer">Transfer (between accounts, no entity)</option>
           <option value="income">Income (salary, refund, etc.)</option>
         </select>
         <p className="text-xs mt-1 text-blue-700 dark:text-blue-300">
           {transactionType === "transfer" &&
             "Transfers don't need an entity - they move money between accounts"}
-          {transactionType === "income" &&
-            "Income transactions: salary, interest, refunds, etc."}
-          {transactionType === "purchase" &&
-            "Purchases require an entity (merchant/payee)"}
+          {transactionType === "income" && "Income transactions: salary, interest, refunds, etc."}
+          {transactionType === "purchase" && "Purchases require an entity (merchant/payee)"}
         </p>
       </div>
 
@@ -138,9 +123,7 @@ export function EditableTransactionCard({
             id="description"
             autoFocus
             value={editedFields.description || ""}
-            onChange={(e) =>
-              setEditedFields({ ...editedFields, description: e.target.value })
-            }
+            onChange={(e) => setEditedFields({ ...editedFields, description: e.target.value })}
             className="bg-white dark:bg-gray-800"
           />
         </div>
@@ -168,9 +151,7 @@ export function EditableTransactionCard({
             id="date"
             type="date"
             value={editedFields.date || ""}
-            onChange={(e) =>
-              setEditedFields({ ...editedFields, date: e.target.value })
-            }
+            onChange={(e) => setEditedFields({ ...editedFields, date: e.target.value })}
             className="bg-white dark:bg-gray-800"
           />
         </div>
@@ -180,9 +161,7 @@ export function EditableTransactionCard({
           <Input
             id="account"
             value={editedFields.account || ""}
-            onChange={(e) =>
-              setEditedFields({ ...editedFields, account: e.target.value })
-            }
+            onChange={(e) => setEditedFields({ ...editedFields, account: e.target.value })}
             className="bg-white dark:bg-gray-800"
           />
         </div>
@@ -192,9 +171,7 @@ export function EditableTransactionCard({
           <Input
             id="location"
             value={editedFields.location || ""}
-            onChange={(e) =>
-              setEditedFields({ ...editedFields, location: e.target.value })
-            }
+            onChange={(e) => setEditedFields({ ...editedFields, location: e.target.value })}
             placeholder="Optional"
             className="bg-white dark:bg-gray-800"
           />
@@ -206,9 +183,7 @@ export function EditableTransactionCard({
               id="online"
               type="checkbox"
               checked={editedFields.online || false}
-              onChange={(e) =>
-                setEditedFields({ ...editedFields, online: e.target.checked })
-              }
+              onChange={(e) => setEditedFields({ ...editedFields, online: e.target.checked })}
               className="w-4 h-4"
             />
             <span>Online transaction</span>
@@ -242,9 +217,8 @@ export function EditableTransactionCard({
       {transactionType === "transfer" && (
         <div className="p-3 bg-gray-100 dark:bg-gray-800 rounded-lg mb-4 text-sm">
           <p className="text-gray-700 dark:text-gray-300">
-            💡 <strong>Transfer transactions</strong> don't require an entity.
-            They represent money moving between your accounts (e.g., credit card
-            payments, savings transfers).
+            💡 <strong>Transfer transactions</strong> don't require an entity. They represent money
+            moving between your accounts (e.g., credit card payments, savings transfers).
           </p>
         </div>
       )}

--- a/packages/app-finance/src/components/imports/EntityCreateDialog.tsx
+++ b/packages/app-finance/src/components/imports/EntityCreateDialog.tsx
@@ -15,10 +15,7 @@ import { Button } from "@pops/ui";
 interface EntityCreateDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onEntityCreated: (entity: {
-    entityId: string;
-    entityName: string;
-  }) => void;
+  onEntityCreated: (entity: { entityId: string; entityName: string }) => void;
   suggestedName?: string;
 }
 
@@ -112,9 +109,7 @@ export function EntityCreateDialog({
                 autoFocus
               />
               {touched && !name.trim() && (
-                <p className="text-xs text-red-600 dark:text-red-400 mt-1">
-                  Name is required
-                </p>
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1">Name is required</p>
               )}
             </div>
 
@@ -143,10 +138,7 @@ export function EntityCreateDialog({
             >
               Cancel
             </Button>
-            <Button
-              type="submit"
-              disabled={!name.trim() || createEntityMutation.isPending}
-            >
+            <Button type="submit" disabled={!name.trim() || createEntityMutation.isPending}>
               {createEntityMutation.isPending ? "Creating..." : "Create Entity"}
             </Button>
           </DialogFooter>

--- a/packages/app-finance/src/components/imports/FileUpload.tsx
+++ b/packages/app-finance/src/components/imports/FileUpload.tsx
@@ -126,9 +126,7 @@ export function FileUpload({
             htmlFor="file-upload"
             className="flex flex-col items-center justify-center cursor-pointer"
           >
-            <Upload
-              className={`w-12 h-12 mb-4 ${error ? "text-red-500" : "text-gray-400"}`}
-            />
+            <Upload className={`w-12 h-12 mb-4 ${error ? "text-red-500" : "text-gray-400"}`} />
             <span className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Drop CSV file here or click to browse
             </span>

--- a/packages/app-finance/src/components/imports/ImportWizard.tsx
+++ b/packages/app-finance/src/components/imports/ImportWizard.tsx
@@ -64,11 +64,7 @@ export function ImportWizard() {
 
       {/* Current step content */}
       <div className="bg-white dark:bg-gray-900 rounded-lg border shadow-sm p-6">
-        {CurrentStepComponent ? (
-          <CurrentStepComponent />
-        ) : (
-          <div>Unknown step</div>
-        )}
+        {CurrentStepComponent ? <CurrentStepComponent /> : <div>Unknown step</div>}
       </div>
     </div>
   );

--- a/packages/app-finance/src/components/imports/LocationField.tsx
+++ b/packages/app-finance/src/components/imports/LocationField.tsx
@@ -1,11 +1,6 @@
 import { MapPin, Info } from "lucide-react";
 import { Badge } from "@pops/ui";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@pops/ui";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@pops/ui";
 import type { ProcessedTransaction } from "@pops/api/modules/finance/imports";
 import { extractLocationDetails } from "../../lib/transaction-utils";
 
@@ -34,10 +29,7 @@ export function LocationField({ transaction }: LocationFieldProps) {
       <span className="text-sm">{details.location}</span>
 
       {details.source && (
-        <Badge
-          variant={details.source === "csv" ? "default" : "secondary"}
-          className="text-xs"
-        >
+        <Badge variant={details.source === "csv" ? "default" : "secondary"} className="text-xs">
           {details.source === "csv" ? "From CSV" : "Matched"}
         </Badge>
       )}
@@ -51,9 +43,7 @@ export function LocationField({ transaction }: LocationFieldProps) {
             <TooltipContent>
               <p className="text-xs">{details.extractedFrom}</p>
               {details.confidence && (
-                <p className="text-xs text-gray-400 mt-1">
-                  Confidence: {details.confidence}
-                </p>
+                <p className="text-xs text-gray-400 mt-1">Confidence: {details.confidence}</p>
               )}
             </TooltipContent>
           </Tooltip>

--- a/packages/app-finance/src/components/imports/ProcessingStep.tsx
+++ b/packages/app-finance/src/components/imports/ProcessingStep.tsx
@@ -3,10 +3,7 @@ import { Loader2, AlertTriangle, CheckCircle, XCircle } from "lucide-react";
 import { useImportStore } from "../../store/importStore";
 import { trpc } from "../../lib/trpc";
 import { Button } from "@pops/ui";
-import type {
-  ProcessImportOutput,
-  ImportWarning,
-} from "@pops/api/modules/finance/imports";
+import type { ProcessImportOutput, ImportWarning } from "@pops/api/modules/finance/imports";
 
 /**
  * Step 3: Process transactions (deduplicate and match entities)
@@ -44,10 +41,7 @@ export function ProcessingStep() {
 
   // Handle completion
   useEffect(() => {
-    if (
-      progressQuery.data?.status === "completed" &&
-      progressQuery.data.result
-    ) {
+    if (progressQuery.data?.status === "completed" && progressQuery.data.result) {
       setPollingEnabled(false);
 
       // Type-cast to ProcessImportOutput since this is the processImport step
@@ -56,15 +50,12 @@ export function ProcessingStep() {
 
       // Check if there are critical errors
       const hasCriticalError = result.warnings?.some(
-        (w: ImportWarning) =>
-          w.type === "AI_API_ERROR"
+        (w: ImportWarning) => w.type === "AI_API_ERROR"
       );
 
       if (hasCriticalError) {
         // Don't auto-advance - let user see the error
-        console.error(
-          "[Import] Processing completed with critical errors - review warnings"
-        );
+        console.error("[Import] Processing completed with critical errors - review warnings");
       } else {
         // No critical errors - proceed to review (deduplication warnings are non-critical)
         nextStep();
@@ -111,12 +102,7 @@ export function ProcessingStep() {
         <div className="w-full max-w-md">
           <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
             <span>Progress</span>
-            <span>
-              {Math.round(
-                (progress.processedCount / progress.totalTransactions) * 100
-              )}
-              %
-            </span>
+            <span>{Math.round((progress.processedCount / progress.totalTransactions) * 100)}%</span>
           </div>
           <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
             <div
@@ -167,15 +153,9 @@ export function ProcessingStep() {
                 key={idx}
                 className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400"
               >
-                {item.status === "processing" && (
-                  <Loader2 className="w-3 h-3 animate-spin" />
-                )}
-                {item.status === "success" && (
-                  <CheckCircle className="w-3 h-3 text-green-500" />
-                )}
-                {item.status === "failed" && (
-                  <XCircle className="w-3 h-3 text-red-500" />
-                )}
+                {item.status === "processing" && <Loader2 className="w-3 h-3 animate-spin" />}
+                {item.status === "success" && <CheckCircle className="w-3 h-3 text-green-500" />}
+                {item.status === "failed" && <XCircle className="w-3 h-3 text-red-500" />}
                 <span className="truncate">{item.description}</span>
               </div>
             ))}
@@ -211,8 +191,7 @@ export function ProcessingStep() {
       {/* Warnings (from completed result) */}
       {progressQuery.data?.result &&
         (progressQuery.data.result as ProcessImportOutput).warnings &&
-        (progressQuery.data.result as ProcessImportOutput).warnings!.length >
-          0 && (
+        (progressQuery.data.result as ProcessImportOutput).warnings!.length > 0 && (
           <div className="w-full max-w-md space-y-2">
             {(progressQuery.data.result as ProcessImportOutput).warnings!.map(
               (warning: ImportWarning, idx: number) => {
@@ -231,16 +210,13 @@ export function ProcessingStep() {
                         </p>
                         <p className="text-xs">{warning.message}</p>
                         {warning.details && (
-                          <p className="text-xs opacity-70 font-mono">
-                            {warning.details}
-                          </p>
+                          <p className="text-xs opacity-70 font-mono">{warning.details}</p>
                         )}
                         {warning.affectedCount && (
                           <p className="text-xs opacity-80">
                             {warning.affectedCount} transaction
-                            {warning.affectedCount !== 1 ? "s" : ""} could not
-                            be automatically categorized. You can manually
-                            categorize them in the review step.
+                            {warning.affectedCount !== 1 ? "s" : ""} could not be automatically
+                            categorized. You can manually categorize them in the review step.
                           </p>
                         )}
                       </div>
@@ -253,24 +229,19 @@ export function ProcessingStep() {
         )}
 
       {/* Fatal errors */}
-      {(processImportMutation.isError ||
-        progressQuery.data?.status === "failed") && (
+      {(processImportMutation.isError || progressQuery.data?.status === "failed") && (
         <div className="p-4 max-w-md text-sm text-red-700 bg-red-100 dark:bg-red-900 dark:text-red-200 rounded-lg">
           <p className="font-medium mb-1">Processing Failed</p>
-          <p>
-            {processImportMutation.error?.message ||
-              "An unexpected error occurred"}
-          </p>
-          {progressQuery.data?.errors &&
-            progressQuery.data.errors.length > 0 && (
-              <div className="mt-2 space-y-1">
-                {progressQuery.data.errors.map((error, idx) => (
-                  <p key={idx} className="text-xs">
-                    • {error.error}
-                  </p>
-                ))}
-              </div>
-            )}
+          <p>{processImportMutation.error?.message || "An unexpected error occurred"}</p>
+          {progressQuery.data?.errors && progressQuery.data.errors.length > 0 && (
+            <div className="mt-2 space-y-1">
+              {progressQuery.data.errors.map((error, idx) => (
+                <p key={idx} className="text-xs">
+                  • {error.error}
+                </p>
+              ))}
+            </div>
+          )}
         </div>
       )}
 
@@ -278,8 +249,7 @@ export function ProcessingStep() {
       {progressQuery.data?.status === "completed" &&
         (progressQuery.data.result as ProcessImportOutput)?.warnings?.some(
           (w: ImportWarning) =>
-            w.type === "AI_CATEGORIZATION_UNAVAILABLE" ||
-            w.type === "AI_API_ERROR"
+            w.type === "AI_CATEGORIZATION_UNAVAILABLE" || w.type === "AI_API_ERROR"
         ) && (
           <Button onClick={nextStep} className="mt-4">
             Continue to Review

--- a/packages/app-finance/src/components/imports/ReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.tsx
@@ -1,12 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
-import {
-  CheckCircle,
-  AlertTriangle,
-  XCircle,
-  AlertCircle,
-  List,
-  Layers,
-} from "lucide-react";
+import { CheckCircle, AlertTriangle, XCircle, AlertCircle, List, Layers } from "lucide-react";
 import { useImportStore } from "../../store/importStore";
 import type { ProcessedTransaction } from "../../store/importStore";
 import { trpc } from "../../lib/trpc";
@@ -26,25 +19,16 @@ type ViewMode = "list" | "grouped";
  * Step 4: Review transactions and resolve uncertain/failed matches
  */
 export function ReviewStep() {
-  const {
-    processedTransactions,
-    setConfirmedTransactions,
-    nextStep,
-    prevStep,
-    findSimilar,
-  } = useImportStore();
+  const { processedTransactions, setConfirmedTransactions, nextStep, prevStep, findSimilar } =
+    useImportStore();
 
-  const [localTransactions, setLocalTransactions] = useState(
-    processedTransactions
-  );
+  const [localTransactions, setLocalTransactions] = useState(processedTransactions);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
-  const [selectedTransaction, setSelectedTransaction] =
-    useState<ProcessedTransaction | null>(null);
+  const [selectedTransaction, setSelectedTransaction] = useState<ProcessedTransaction | null>(null);
   const [pendingBulkTransactions, setPendingBulkTransactions] = useState<
     ProcessedTransaction[] | null
   >(null);
-  const [editingTransaction, setEditingTransaction] =
-    useState<ProcessedTransaction | null>(null);
+  const [editingTransaction, setEditingTransaction] = useState<ProcessedTransaction | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>("grouped");
 
   const { data: entities } = trpc.core.entities.list.useQuery({});
@@ -67,22 +51,14 @@ export function ReviewStep() {
    * Auto-match similar transactions
    */
   const handleAutoMatchSimilar = useCallback(
-    (
-      transactions: ProcessedTransaction[],
-      entityId: string,
-      entityName: string
-    ) => {
+    (transactions: ProcessedTransaction[], entityId: string, entityName: string) => {
       setLocalTransactions((prev) => {
         let updated = { ...prev };
         for (const transaction of transactions) {
           updated = {
             ...updated,
-            uncertain: updated.uncertain.filter(
-              (t: ProcessedTransaction) => t !== transaction
-            ),
-            failed: updated.failed.filter(
-              (t: ProcessedTransaction) => t !== transaction
-            ),
+            uncertain: updated.uncertain.filter((t: ProcessedTransaction) => t !== transaction),
+            failed: updated.failed.filter((t: ProcessedTransaction) => t !== transaction),
             matched: [
               ...updated.matched,
               {
@@ -111,23 +87,15 @@ export function ReviewStep() {
    * Handle entity selection with auto-matching for similar transactions
    */
   const handleEntitySelect = useCallback(
-    (
-      transaction: ProcessedTransaction,
-      entityId: string,
-      entityName: string
-    ) => {
+    (transaction: ProcessedTransaction, entityId: string, entityName: string) => {
       // Find similar transactions before updating
       const similar = findSimilar(transaction);
 
       // Move transaction from uncertain/failed to matched (functional setState avoids stale closure)
       setLocalTransactions((prev) => ({
         ...prev,
-        uncertain: prev.uncertain.filter(
-          (t: ProcessedTransaction) => t !== transaction
-        ),
-        failed: prev.failed.filter(
-          (t: ProcessedTransaction) => t !== transaction
-        ),
+        uncertain: prev.uncertain.filter((t: ProcessedTransaction) => t !== transaction),
+        failed: prev.failed.filter((t: ProcessedTransaction) => t !== transaction),
         matched: [
           ...prev.matched,
           {
@@ -148,8 +116,7 @@ export function ReviewStep() {
         toast.info(
           `Found ${similar.length} similar transaction${similar.length !== 1 ? "s" : ""}`,
           {
-            description:
-              "Would you like to apply this entity to all similar transactions?",
+            description: "Would you like to apply this entity to all similar transactions?",
             action: {
               label: "Apply to All",
               onClick: () => {
@@ -163,13 +130,10 @@ export function ReviewStep() {
     [findSimilar, handleAutoMatchSimilar]
   );
 
-  const handleCreateEntity = useCallback(
-    (transaction: ProcessedTransaction) => {
-      setSelectedTransaction(transaction);
-      setShowCreateDialog(true);
-    },
-    []
-  );
+  const handleCreateEntity = useCallback((transaction: ProcessedTransaction) => {
+    setSelectedTransaction(transaction);
+    setShowCreateDialog(true);
+  }, []);
 
   /**
    * Accept AI suggestion for a single transaction
@@ -182,9 +146,7 @@ export function ReviewStep() {
       let entityId = transaction.entity.entityId;
       if (!entityId && entities?.data) {
         const matchingEntity = entities.data.find(
-          (e) =>
-            e.name.toLowerCase() ===
-            transaction.entity?.entityName?.toLowerCase()
+          (e) => e.name.toLowerCase() === transaction.entity?.entityName?.toLowerCase()
         );
         if (matchingEntity) {
           entityId = matchingEntity.id;
@@ -237,12 +199,8 @@ export function ReviewStep() {
           for (const transaction of transactions) {
             updated = {
               ...updated,
-              uncertain: updated.uncertain.filter(
-                (t: ProcessedTransaction) => t !== transaction
-              ),
-              failed: updated.failed.filter(
-                (t: ProcessedTransaction) => t !== transaction
-              ),
+              uncertain: updated.uncertain.filter((t: ProcessedTransaction) => t !== transaction),
+              failed: updated.failed.filter((t: ProcessedTransaction) => t !== transaction),
               matched: [
                 ...updated.matched,
                 {
@@ -296,12 +254,8 @@ export function ReviewStep() {
           for (const transaction of pendingBulkTransactions) {
             updated = {
               ...updated,
-              uncertain: updated.uncertain.filter(
-                (t: ProcessedTransaction) => t !== transaction
-              ),
-              failed: updated.failed.filter(
-                (t: ProcessedTransaction) => t !== transaction
-              ),
+              uncertain: updated.uncertain.filter((t: ProcessedTransaction) => t !== transaction),
+              failed: updated.failed.filter((t: ProcessedTransaction) => t !== transaction),
               matched: [
                 ...updated.matched,
                 {
@@ -326,11 +280,7 @@ export function ReviewStep() {
         );
       } else if (selectedTransaction) {
         // Handle single transaction assignment
-        handleEntitySelect(
-          selectedTransaction,
-          entity.entityId,
-          entity.entityName
-        );
+        handleEntitySelect(selectedTransaction, entity.entityId, entity.entityName);
         setSelectedTransaction(null);
       }
     },
@@ -341,8 +291,7 @@ export function ReviewStep() {
     setEditingTransaction(transaction);
   }, []);
 
-  const createCorrectionMutation =
-    trpc.core.corrections.createOrUpdate.useMutation();
+  const createCorrectionMutation = trpc.core.corrections.createOrUpdate.useMutation();
 
   const handleSaveEdit = useCallback(
     (
@@ -356,8 +305,7 @@ export function ReviewStep() {
         manuallyEdited: true,
       };
       const isNoEntityType =
-        updatedTx.transactionType === "transfer" ||
-        updatedTx.transactionType === "income";
+        updatedTx.transactionType === "transfer" || updatedTx.transactionType === "income";
 
       setLocalTransactions((prev) => {
         // Transfers and income don't need an entity — promote them straight to matched.
@@ -366,9 +314,7 @@ export function ReviewStep() {
             ...prev,
             matched: prev.matched.some((t) => t === transaction)
               ? prev.matched.map((t) =>
-                  t === transaction
-                    ? { ...updatedTx, status: "matched" as const }
-                    : t
+                  t === transaction ? { ...updatedTx, status: "matched" as const } : t
                 )
               : [...prev.matched, { ...updatedTx, status: "matched" as const }],
             uncertain: prev.uncertain.filter((t) => t !== transaction),
@@ -380,24 +326,16 @@ export function ReviewStep() {
         return {
           ...prev,
           matched: prev.matched.map((t: ProcessedTransaction) =>
-            t === transaction
-              ? { ...t, ...editedFields, manuallyEdited: true }
-              : t
+            t === transaction ? { ...t, ...editedFields, manuallyEdited: true } : t
           ),
           uncertain: prev.uncertain.map((t: ProcessedTransaction) =>
-            t === transaction
-              ? { ...t, ...editedFields, manuallyEdited: true }
-              : t
+            t === transaction ? { ...t, ...editedFields, manuallyEdited: true } : t
           ),
           failed: prev.failed.map((t: ProcessedTransaction) =>
-            t === transaction
-              ? { ...t, ...editedFields, manuallyEdited: true }
-              : t
+            t === transaction ? { ...t, ...editedFields, manuallyEdited: true } : t
           ),
           skipped: prev.skipped.map((t: ProcessedTransaction) =>
-            t === transaction
-              ? { ...t, ...editedFields, manuallyEdited: true }
-              : t
+            t === transaction ? { ...t, ...editedFields, manuallyEdited: true } : t
           ),
         };
       });
@@ -416,29 +354,23 @@ export function ReviewStep() {
         createCorrectionMutation.mutate({
           descriptionPattern: transaction.description,
           matchType: "exact",
-          entityId:
-            editedFields.entity?.entityId ?? transaction.entity?.entityId,
-          entityName:
-            editedFields.entity?.entityName ?? transaction.entity?.entityName,
+          entityId: editedFields.entity?.entityId ?? transaction.entity?.entityId,
+          entityName: editedFields.entity?.entityName ?? transaction.entity?.entityName,
           location: editedFields.location ?? transaction.location,
         });
         toast.success("Correction saved!");
       } else if (hasChanges && !shouldLearn) {
         // Show toast asking if they want to learn
         toast.info("Apply this correction to future imports?", {
-          description:
-            "This will help auto-match similar transactions next time.",
+          description: "This will help auto-match similar transactions next time.",
           action: {
             label: "Learn Pattern",
             onClick: () => {
               createCorrectionMutation.mutate({
                 descriptionPattern: transaction.description,
                 matchType: "exact",
-                entityId:
-                  editedFields.entity?.entityId ?? transaction.entity?.entityId,
-                entityName:
-                  editedFields.entity?.entityName ??
-                  transaction.entity?.entityName,
+                entityId: editedFields.entity?.entityId ?? transaction.entity?.entityId,
+                entityName: editedFields.entity?.entityName ?? transaction.entity?.entityName,
                 location: editedFields.location ?? transaction.location,
               });
               toast.success("Pattern saved!");
@@ -460,8 +392,7 @@ export function ReviewStep() {
   const handleContinueToTagReview = useCallback(() => {
     const confirmed: ConfirmedTransaction[] = localTransactions.matched
       .filter((t: ProcessedTransaction) => {
-        const isNoEntityType =
-          t.transactionType === "transfer" || t.transactionType === "income";
+        const isNoEntityType = t.transactionType === "transfer" || t.transactionType === "income";
         return isNoEntityType || (t.entity?.entityId && t.entity?.entityName);
       })
       .map((t: ProcessedTransaction) => ({
@@ -509,45 +440,40 @@ export function ReviewStep() {
       </div>
 
       {/* Show warnings if present */}
-      {processedTransactions.warnings &&
-        processedTransactions.warnings.length > 0 && (
-          <div className="space-y-2">
-            {processedTransactions.warnings.map((warning, idx: number) => {
-              return (
-                <div
-                  key={idx}
-                  className="p-4 text-sm rounded-lg border text-amber-800 bg-amber-50 dark:bg-amber-900/20 dark:text-amber-200 border-amber-200 dark:border-amber-800"
-                >
-                  <div className="flex items-start gap-3">
-                    <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5" />
-                    <div className="flex-1 space-y-1">
-                      <p className="font-medium">
-                        {warning.type === "AI_CATEGORIZATION_UNAVAILABLE"
-                          ? "AI Categorization Unavailable"
-                          : "AI API Error"}
+      {processedTransactions.warnings && processedTransactions.warnings.length > 0 && (
+        <div className="space-y-2">
+          {processedTransactions.warnings.map((warning, idx: number) => {
+            return (
+              <div
+                key={idx}
+                className="p-4 text-sm rounded-lg border text-amber-800 bg-amber-50 dark:bg-amber-900/20 dark:text-amber-200 border-amber-200 dark:border-amber-800"
+              >
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5" />
+                  <div className="flex-1 space-y-1">
+                    <p className="font-medium">
+                      {warning.type === "AI_CATEGORIZATION_UNAVAILABLE"
+                        ? "AI Categorization Unavailable"
+                        : "AI API Error"}
+                    </p>
+                    <p className="text-xs">{warning.message}</p>
+                    {warning.details && (
+                      <p className="text-xs opacity-70 font-mono">{warning.details}</p>
+                    )}
+                    {warning.affectedCount && (
+                      <p className="text-xs opacity-80">
+                        {warning.affectedCount} transaction
+                        {warning.affectedCount !== 1 ? "s" : ""} could not be automatically
+                        categorized and may appear in the Uncertain or Failed tabs.
                       </p>
-                      <p className="text-xs">{warning.message}</p>
-                      {warning.details && (
-                        <p className="text-xs opacity-70 font-mono">
-                          {warning.details}
-                        </p>
-                      )}
-                      {warning.affectedCount && (
-                        <p className="text-xs opacity-80">
-                          {warning.affectedCount} transaction
-                          {warning.affectedCount !== 1 ? "s" : ""} could not be
-                          automatically categorized and may appear in the
-                          Uncertain or Failed tabs.
-                        </p>
-                      )}
-
-                    </div>
+                    )}
                   </div>
                 </div>
-              );
-            })}
-          </div>
-        )}
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       <Tabs defaultValue="matched" className="w-full">
         <TabsList className="grid w-full grid-cols-4">
@@ -635,10 +561,7 @@ export function ReviewStep() {
               Resolve all uncertain/failed transactions to continue
             </p>
           )}
-          <Button
-            onClick={handleContinueToTagReview}
-            disabled={unresolvedCount > 0}
-          >
+          <Button onClick={handleContinueToTagReview} disabled={unresolvedCount > 0}>
             {`Continue to Tag Review (${localTransactions.matched.length})`}
           </Button>
         </div>
@@ -676,26 +599,15 @@ function MatchedTab({
 }: {
   transactions: ProcessedTransaction[];
   onEdit: (t: ProcessedTransaction) => void;
-  onEntitySelect: (
-    t: ProcessedTransaction,
-    entityId: string,
-    entityName: string
-  ) => void;
+  onEntitySelect: (t: ProcessedTransaction, entityId: string, entityName: string) => void;
   onCreateEntity: (t: ProcessedTransaction) => void;
   editingTransaction: ProcessedTransaction | null;
-  onSaveEdit: (
-    t: ProcessedTransaction,
-    edited: Partial<ProcessedTransaction>
-  ) => void;
+  onSaveEdit: (t: ProcessedTransaction, edited: Partial<ProcessedTransaction>) => void;
   onCancelEdit: () => void;
   entities?: Array<{ id: string; name: string }>;
 }) {
   if (transactions.length === 0) {
-    return (
-      <div className="text-center py-12 text-gray-500">
-        No matched transactions
-      </div>
-    );
+    return <div className="text-center py-12 text-gray-500">No matched transactions</div>;
   }
 
   return (
@@ -750,33 +662,19 @@ function UncertainTab({
   groups: ReturnType<typeof groupTransactionsByEntity>;
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
-  onEntitySelect: (
-    t: ProcessedTransaction,
-    entityId: string,
-    entityName: string
-  ) => void;
+  onEntitySelect: (t: ProcessedTransaction, entityId: string, entityName: string) => void;
   onCreateEntity: (t: ProcessedTransaction) => void;
   onAcceptAiSuggestion: (t: ProcessedTransaction) => void;
   onAcceptAll: (transactions: ProcessedTransaction[]) => void;
-  onCreateAndAssignAll: (
-    transactions: ProcessedTransaction[],
-    entityName: string
-  ) => void;
+  onCreateAndAssignAll: (transactions: ProcessedTransaction[], entityName: string) => void;
   onEdit: (t: ProcessedTransaction) => void;
   editingTransaction: ProcessedTransaction | null;
-  onSaveEdit: (
-    t: ProcessedTransaction,
-    edited: Partial<ProcessedTransaction>
-  ) => void;
+  onSaveEdit: (t: ProcessedTransaction, edited: Partial<ProcessedTransaction>) => void;
   onCancelEdit: () => void;
   entities?: Array<{ id: string; name: string }>;
 }) {
   if (transactions.length === 0) {
-    return (
-      <div className="text-center py-12 text-gray-500">
-        No uncertain transactions
-      </div>
-    );
+    return <div className="text-center py-12 text-gray-500">No uncertain transactions</div>;
   }
 
   return (
@@ -878,33 +776,19 @@ function FailedTab({
   groups: ReturnType<typeof groupTransactionsByEntity>;
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
-  onEntitySelect: (
-    t: ProcessedTransaction,
-    entityId: string,
-    entityName: string
-  ) => void;
+  onEntitySelect: (t: ProcessedTransaction, entityId: string, entityName: string) => void;
   onCreateEntity: (t: ProcessedTransaction) => void;
   onAcceptAiSuggestion: (t: ProcessedTransaction) => void;
   onAcceptAll: (transactions: ProcessedTransaction[]) => void;
-  onCreateAndAssignAll: (
-    transactions: ProcessedTransaction[],
-    entityName: string
-  ) => void;
+  onCreateAndAssignAll: (transactions: ProcessedTransaction[], entityName: string) => void;
   onEdit: (t: ProcessedTransaction) => void;
   editingTransaction: ProcessedTransaction | null;
-  onSaveEdit: (
-    t: ProcessedTransaction,
-    edited: Partial<ProcessedTransaction>
-  ) => void;
+  onSaveEdit: (t: ProcessedTransaction, edited: Partial<ProcessedTransaction>) => void;
   onCancelEdit: () => void;
   entities?: Array<{ id: string; name: string }>;
 }) {
   if (transactions.length === 0) {
-    return (
-      <div className="text-center py-12 text-gray-500">
-        No failed transactions
-      </div>
-    );
+    return <div className="text-center py-12 text-gray-500">No failed transactions</div>;
   }
 
   return (
@@ -986,17 +870,9 @@ function FailedTab({
 /**
  * Skipped tab - read-only list
  */
-function SkippedTab({
-  transactions,
-}: {
-  transactions: ProcessedTransaction[];
-}) {
+function SkippedTab({ transactions }: { transactions: ProcessedTransaction[] }) {
   if (transactions.length === 0) {
-    return (
-      <div className="text-center py-12 text-gray-500">
-        No skipped transactions
-      </div>
-    );
+    return <div className="text-center py-12 text-gray-500">No skipped transactions</div>;
   }
 
   return (

--- a/packages/app-finance/src/components/imports/SummaryStep.tsx
+++ b/packages/app-finance/src/components/imports/SummaryStep.tsx
@@ -14,27 +14,24 @@ export function SummaryStep() {
     return (
       <div className="text-center py-12 space-y-4">
         <p className="text-gray-500">No import results available</p>
-        {processedTransactions.warnings &&
-          processedTransactions.warnings.length > 0 && (
-            <div className="max-w-md mx-auto space-y-2">
-              <p className="text-sm text-gray-600">Import warnings:</p>
-              {processedTransactions.warnings.map((warning, idx) => (
-                <div
-                  key={idx}
-                  className="p-3 text-sm bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded text-left"
-                >
-                  <p className="font-medium text-amber-900 dark:text-amber-100">
-                    {warning.message}
+        {processedTransactions.warnings && processedTransactions.warnings.length > 0 && (
+          <div className="max-w-md mx-auto space-y-2">
+            <p className="text-sm text-gray-600">Import warnings:</p>
+            {processedTransactions.warnings.map((warning, idx) => (
+              <div
+                key={idx}
+                className="p-3 text-sm bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded text-left"
+              >
+                <p className="font-medium text-amber-900 dark:text-amber-100">{warning.message}</p>
+                {warning.details && (
+                  <p className="text-xs text-amber-700 dark:text-amber-300 mt-1 font-mono">
+                    {warning.details}
                   </p>
-                  {warning.details && (
-                    <p className="text-xs text-amber-700 dark:text-amber-300 mt-1 font-mono">
-                      {warning.details}
-                    </p>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     );
   }
@@ -58,9 +55,7 @@ export function SummaryStep() {
           <div className="text-2xl font-semibold text-green-900 dark:text-green-100">
             {importResult.imported}
           </div>
-          <div className="text-xs text-green-700 dark:text-green-300">
-            Imported
-          </div>
+          <div className="text-xs text-green-700 dark:text-green-300">Imported</div>
         </div>
 
         <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-lg p-4 text-center">
@@ -80,9 +75,7 @@ export function SummaryStep() {
           <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
             {importResult.skipped}
           </div>
-          <div className="text-xs text-gray-700 dark:text-gray-300">
-            Skipped
-          </div>
+          <div className="text-xs text-gray-700 dark:text-gray-300">Skipped</div>
         </div>
       </div>
 
@@ -97,9 +90,7 @@ export function SummaryStep() {
             <ul className="divide-y dark:divide-gray-700">
               {importResult.failed.map((result, idx) => (
                 <li key={idx} className="px-4 py-3 text-sm">
-                  <div className="font-medium">
-                    {result.transaction.description}
-                  </div>
+                  <div className="font-medium">{result.transaction.description}</div>
                   <div className="text-xs text-red-600 dark:text-red-400">
                     {result.error ?? "Unknown error"}
                   </div>
@@ -120,9 +111,7 @@ export function SummaryStep() {
         >
           New Import
         </Button>
-        <Button onClick={() => navigate("/transactions")}>
-          View Transactions
-        </Button>
+        <Button onClick={() => navigate("/transactions")}>View Transactions</Button>
       </div>
     </div>
   );

--- a/packages/app-finance/src/components/imports/TagReviewStep.stories.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.stories.tsx
@@ -69,9 +69,7 @@ const shellTransactions: ConfirmedTransaction[] = [
     entityName: "Shell",
     entityId: "shell-id",
     tags: ["Transport"],
-    suggestedTags: [
-      { tag: "Transport", source: "rule", pattern: "shell" },
-    ],
+    suggestedTags: [{ tag: "Transport", source: "rule", pattern: "shell" }],
   }),
   makeTransaction({
     description: "SHELL SERVICE STATION",
@@ -127,8 +125,7 @@ const meta: Meta<typeof TagReviewStep> = {
   },
   decorators: [
     (Story, context) => {
-      const transactions =
-        (context.parameters.transactions as ConfirmedTransaction[]) ?? [];
+      const transactions = (context.parameters.transactions as ConfirmedTransaction[]) ?? [];
       return (
         <StoreSeeder transactions={transactions}>
           <div className="max-w-3xl mx-auto p-6 bg-white dark:bg-gray-900 rounded-lg border shadow-sm">
@@ -150,22 +147,14 @@ type Story = StoryObj<typeof TagReviewStep>;
 /** All transactions have pre-suggested tags with source attribution */
 export const WithSuggestedTags: Story = {
   parameters: {
-    transactions: [
-      ...woolworthsTransactions,
-      ...netflixTransactions,
-      ...shellTransactions,
-    ],
+    transactions: [...woolworthsTransactions, ...netflixTransactions, ...shellTransactions],
   },
 };
 
 /** Some transactions have tags (with sources), one group has none */
 export const Mixed: Story = {
   parameters: {
-    transactions: [
-      ...woolworthsTransactions,
-      ...noTagTransactions,
-      ...netflixTransactions,
-    ],
+    transactions: [...woolworthsTransactions, ...noTagTransactions, ...netflixTransactions],
   },
 };
 

--- a/packages/app-finance/src/components/imports/TagReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.tsx
@@ -85,27 +85,19 @@ export function TagReviewStep() {
 
   // Local tag state keyed by checksum — edits don't touch the store until Import
   const [localTags, setLocalTags] = useState<Record<string, string[]>>(() =>
-    Object.fromEntries(
-      confirmedTransactions.map((t) => [t.checksum, t.tags ?? []])
-    )
+    Object.fromEntries(confirmedTransactions.map((t) => [t.checksum, t.tags ?? []]))
   );
 
   // Immutable snapshot of original suggested tags per checksum — for source badges
   const originalSuggestedTags = useMemo<Record<string, SuggestedTag[]>>(
-    () =>
-      Object.fromEntries(
-        confirmedTransactions.map((t) => [t.checksum, t.suggestedTags ?? []])
-      ),
+    () => Object.fromEntries(confirmedTransactions.map((t) => [t.checksum, t.suggestedTags ?? []])),
     [confirmedTransactions]
   );
 
   const [pollingEnabled, setPollingEnabled] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
 
-  const groups = useMemo(
-    () => groupByEntity(confirmedTransactions),
-    [confirmedTransactions]
-  );
+  const groups = useMemo(() => groupByEntity(confirmedTransactions), [confirmedTransactions]);
 
   const { data: serverTags } = trpc.finance.transactions.availableTags.useQuery();
 
@@ -170,20 +162,17 @@ export function TagReviewStep() {
    * Merge a set of tags into every transaction in a group.
    * Never replaces existing tags — only adds tags the transaction doesn't already have.
    */
-  const handleApplyGroupTags = useCallback(
-    (group: ConfirmedGroup, newTags: string[]) => {
-      setLocalTags((prev) => {
-        const next = { ...prev };
-        for (const t of group.transactions) {
-          const existing = prev[t.checksum] ?? [];
-          const merged = Array.from(new Set([...existing, ...newTags]));
-          next[t.checksum] = merged;
-        }
-        return next;
-      });
-    },
-    []
-  );
+  const handleApplyGroupTags = useCallback((group: ConfirmedGroup, newTags: string[]) => {
+    setLocalTags((prev) => {
+      const next = { ...prev };
+      for (const t of group.transactions) {
+        const existing = prev[t.checksum] ?? [];
+        const merged = Array.from(new Set([...existing, ...newTags]));
+        next[t.checksum] = merged;
+      }
+      return next;
+    });
+  }, []);
 
   const handleImport = useCallback(() => {
     setImportError(null);
@@ -252,7 +241,7 @@ export function TagReviewStep() {
                 <p className="text-sm text-muted-foreground">
                   {progressQuery.data.currentStep === "writing"
                     ? `Writing ${progressQuery.data.processedCount ?? 0} / ${progressQuery.data.totalTransactions ?? confirmedTransactions.length}`
-                    : progressQuery.data.currentStep ?? "Processing…"}
+                    : (progressQuery.data.currentStep ?? "Processing…")}
                 </p>
               )}
             </div>
@@ -263,8 +252,8 @@ export function TagReviewStep() {
       <div>
         <h2 className="text-2xl font-semibold mb-2">Tag Review</h2>
         <p className="text-sm text-muted-foreground">
-          Review and adjust tags before importing. Tags are pre-filled from AI
-          suggestions, learned rules, and entity defaults.
+          Review and adjust tags before importing. Tags are pre-filled from AI suggestions, learned
+          rules, and entity defaults.
         </p>
       </div>
 
@@ -338,17 +327,13 @@ function EntityGroup({
   const [expanded, setExpanded] = useState(true);
 
   // Reactive union of all current tags across this group (updates as user edits)
-  const currentTagsPerTx = group.transactions.map(
-    (t) => localTags[t.checksum] ?? []
-  );
+  const currentTagsPerTx = group.transactions.map((t) => localTags[t.checksum] ?? []);
   const currentUnion = unionTags(currentTagsPerTx);
 
   // Suggested union from original suggestions (for "apply suggestions to all" button)
   const suggestedUnion = useMemo(() => {
     return unionTags(
-      group.transactions.map((t) =>
-        (originalSuggestedTags[t.checksum] ?? []).map((s) => s.tag)
-      )
+      group.transactions.map((t) => (originalSuggestedTags[t.checksum] ?? []).map((s) => s.tag))
     );
   }, [group.transactions, originalSuggestedTags]);
 
@@ -376,11 +361,14 @@ function EntityGroup({
     setGroupStagedTags((prev) => prev.filter((t) => t !== tag));
   }, []);
 
-  const addGroupStagedTag = useCallback((tag: string) => {
-    if (!groupStagedTags.includes(tag)) {
-      setGroupStagedTags((prev) => [...prev, tag]);
-    }
-  }, [groupStagedTags]);
+  const addGroupStagedTag = useCallback(
+    (tag: string) => {
+      if (!groupStagedTags.includes(tag)) {
+        setGroupStagedTags((prev) => [...prev, tag]);
+      }
+    },
+    [groupStagedTags]
+  );
 
   return (
     <div className="border rounded-lg overflow-hidden">
@@ -397,9 +385,7 @@ function EntityGroup({
             <ChevronRight className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
           )}
           <span className="font-medium text-sm">{group.entityName}</span>
-          <span className="text-xs text-muted-foreground">
-            ({group.transactions.length})
-          </span>
+          <span className="text-xs text-muted-foreground">({group.transactions.length})</span>
         </button>
 
         <div className="flex items-center gap-2 flex-shrink-0">
@@ -571,9 +557,7 @@ function GroupTagBar({
             if (e.key === "Enter") {
               e.preventDefault();
               // If there's an exact match in filtered, pick it; else add free-form
-              const exactMatch = filtered.find(
-                (t) => t.toLowerCase() === inputValue.toLowerCase()
-              );
+              const exactMatch = filtered.find((t) => t.toLowerCase() === inputValue.toLowerCase());
               if (exactMatch) {
                 onAddTag(exactMatch);
               } else if (inputValue.trim()) {
@@ -655,10 +639,7 @@ function TransactionTagRow({
   const isNegative = amount < 0;
 
   // Build tagMeta map for source badges in TagEditor
-  const tagMeta = useMemo(
-    () => buildTagMetaMap(originalSuggestedTags),
-    [originalSuggestedTags]
-  );
+  const tagMeta = useMemo(() => buildTagMetaMap(originalSuggestedTags), [originalSuggestedTags]);
 
   return (
     <div className="flex items-center gap-3 px-4 py-2 hover:bg-muted/20 transition-colors">
@@ -672,9 +653,7 @@ function TransactionTagRow({
       <span
         className={cn(
           "text-sm font-mono tabular-nums flex-shrink-0",
-          isNegative
-            ? "text-red-600 dark:text-red-400"
-            : "text-green-600 dark:text-green-400"
+          isNegative ? "text-red-600 dark:text-red-400" : "text-green-600 dark:text-green-400"
         )}
       >
         {isNegative ? "-" : "+"}${Math.abs(amount).toFixed(2)}

--- a/packages/app-finance/src/components/imports/TransactionCard.tsx
+++ b/packages/app-finance/src/components/imports/TransactionCard.tsx
@@ -2,11 +2,7 @@ import { useState } from "react";
 import { ChevronRight, Globe, Store, Sparkles, Zap, Pencil } from "lucide-react";
 import { Badge } from "@pops/ui";
 import { Button } from "@pops/ui";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@pops/ui";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@pops/ui";
 import { LocationField } from "./LocationField";
 import type { ProcessedTransaction } from "@pops/api/modules/finance/imports";
 
@@ -42,22 +38,16 @@ export function TransactionCard({
 }: TransactionCardProps) {
   const [isRawDataExpanded, setIsRawDataExpanded] = useState(false);
 
-  const hasAiSuggestion =
-    transaction.entity?.matchType === "ai" && transaction.entity?.entityName;
+  const hasAiSuggestion = transaction.entity?.matchType === "ai" && transaction.entity?.entityName;
 
   // Check if AI-suggested entity actually exists in the entities list
   const aiSuggestedEntityExists =
     hasAiSuggestion &&
-    entities?.some(
-      (e) =>
-        e.name.toLowerCase() === transaction.entity?.entityName?.toLowerCase()
-    );
+    entities?.some((e) => e.name.toLowerCase() === transaction.entity?.entityName?.toLowerCase());
 
-  const isAutoMatched =
-    transaction.entity?.matchType === ("auto-matched" as never);
-  const isEdited = (
-    transaction as ProcessedTransaction & { manuallyEdited?: boolean }
-  ).manuallyEdited;
+  const isAutoMatched = transaction.entity?.matchType === ("auto-matched" as never);
+  const isEdited = (transaction as ProcessedTransaction & { manuallyEdited?: boolean })
+    .manuallyEdited;
 
   // Parse raw row for display
   let rawData: Record<string, string> = {};
@@ -99,10 +89,7 @@ export function TransactionCard({
               </Badge>
             )}
             {isAutoMatched && (
-              <Badge
-                variant="secondary"
-                className="text-xs flex items-center gap-1"
-              >
+              <Badge variant="secondary" className="text-xs flex items-center gap-1">
                 <Zap className="w-3 h-3" />
                 Auto-matched
               </Badge>
@@ -174,8 +161,7 @@ export function TransactionCard({
                     onClick={() => onAcceptAiSuggestion(transaction)}
                     className="bg-purple-600 hover:bg-purple-700 flex-1"
                   >
-                    {aiSuggestedEntityExists ? "✓" : "+"} Accept "
-                    {transaction.entity.entityName}"
+                    {aiSuggestedEntityExists ? "✓" : "+"} Accept "{transaction.entity.entityName}"
                   </Button>
                 )}
                 {onCreateEntity && (
@@ -207,9 +193,7 @@ export function TransactionCard({
             className="w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-800"
             value={transaction.entity?.entityId || ""}
             onChange={(e) => {
-              const entity = entities?.find(
-                (ent) => ent.id === e.target.value
-              );
+              const entity = entities?.find((ent) => ent.id === e.target.value);
               if (entity && onEntitySelect) {
                 onEntitySelect(transaction, entity.id, entity.name);
               }
@@ -246,9 +230,7 @@ export function TransactionCard({
 
       {/* Error display */}
       {transaction.error && (
-        <div className="text-sm text-red-700 dark:text-red-300 mb-3">
-          {transaction.error}
-        </div>
+        <div className="text-sm text-red-700 dark:text-red-300 mb-3">{transaction.error}</div>
       )}
 
       {/* Collapsible raw data section */}

--- a/packages/app-finance/src/components/imports/TransactionGroup.tsx
+++ b/packages/app-finance/src/components/imports/TransactionGroup.tsx
@@ -2,11 +2,7 @@ import { useState } from "react";
 import { ChevronRight, Sparkles } from "lucide-react";
 import { Button } from "@pops/ui";
 import { Badge } from "@pops/ui";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@pops/ui";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@pops/ui";
 import { TransactionCard } from "./TransactionCard";
 import { EditableTransactionCard } from "./EditableTransactionCard";
 import type { ProcessedTransaction } from "@pops/api/modules/finance/imports";
@@ -15,15 +11,8 @@ import type { TransactionGroup as TransactionGroupType } from "../../lib/transac
 interface TransactionGroupProps {
   group: TransactionGroupType;
   onAcceptAll: (transactions: ProcessedTransaction[]) => void;
-  onCreateAndAssignAll: (
-    transactions: ProcessedTransaction[],
-    entityName: string
-  ) => void;
-  onEntitySelect: (
-    transaction: ProcessedTransaction,
-    entityId: string,
-    entityName: string
-  ) => void;
+  onCreateAndAssignAll: (transactions: ProcessedTransaction[], entityName: string) => void;
+  onEntitySelect: (transaction: ProcessedTransaction, entityId: string, entityName: string) => void;
   onCreateEntity: (transaction: ProcessedTransaction) => void;
   onAcceptAiSuggestion: (transaction: ProcessedTransaction) => void;
   onEdit: (transaction: ProcessedTransaction) => void;
@@ -57,17 +46,12 @@ export function TransactionGroup({
   const [isExpanded, setIsExpanded] = useState(false);
   const [showEntitySelector, setShowEntitySelector] = useState(false);
 
-  const totalAmount = group.transactions.reduce(
-    (sum, t) => sum + Math.abs(t.amount),
-    0
-  );
+  const totalAmount = group.transactions.reduce((sum, t) => sum + Math.abs(t.amount), 0);
 
   // Check if AI-suggested entity exists
   const entityExists =
     group.aiSuggestion &&
-    entities?.some(
-      (e) => e.name.toLowerCase() === group.entityName.toLowerCase()
-    );
+    entities?.some((e) => e.name.toLowerCase() === group.entityName.toLowerCase());
 
   return (
     <div
@@ -81,9 +65,7 @@ export function TransactionGroup({
       <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
         <div
           className={`p-4 ${
-            group.aiSuggestion
-              ? "bg-purple-50 dark:bg-purple-950"
-              : "bg-gray-50 dark:bg-gray-900"
+            group.aiSuggestion ? "bg-purple-50 dark:bg-purple-950" : "bg-gray-50 dark:bg-gray-900"
           }`}
         >
           <div className="flex items-start justify-between">
@@ -130,15 +112,12 @@ export function TransactionGroup({
                     onClick={() => onAcceptAll(group.transactions)}
                     className="bg-purple-600 hover:bg-purple-700"
                   >
-                    {entityExists ? "✓" : "+"} Accept All as "{group.entityName}
-                    "
+                    {entityExists ? "✓" : "+"} Accept All as "{group.entityName}"
                   </Button>
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() =>
-                      onCreateAndAssignAll(group.transactions, group.entityName)
-                    }
+                    onClick={() => onCreateAndAssignAll(group.transactions, group.entityName)}
                   >
                     Create new for all
                   </Button>
@@ -148,9 +127,7 @@ export function TransactionGroup({
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() =>
-                    onCreateAndAssignAll(group.transactions, group.entityName)
-                  }
+                  onClick={() => onCreateAndAssignAll(group.transactions, group.entityName)}
                 >
                   + Create new for all
                 </Button>
@@ -170,23 +147,16 @@ export function TransactionGroup({
         {showEntitySelector && entities && entities.length > 0 && (
           <div className="mt-3 p-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-600">
             <label className="block text-sm font-medium mb-2">
-              Select entity to assign to all {group.transactions.length}{" "}
-              transactions:
+              Select entity to assign to all {group.transactions.length} transactions:
             </label>
             <select
               className="w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-800"
               onChange={(e) => {
-                const selectedEntity = entities.find(
-                  (ent) => ent.id === e.target.value
-                );
+                const selectedEntity = entities.find((ent) => ent.id === e.target.value);
                 if (selectedEntity) {
                   // Apply selected entity to all transactions in group
                   group.transactions.forEach((t) => {
-                    onEntitySelect(
-                      t,
-                      selectedEntity.id,
-                      selectedEntity.name
-                    );
+                    onEntitySelect(t, selectedEntity.id, selectedEntity.name);
                   });
                   setShowEntitySelector(false);
                 }
@@ -206,9 +176,7 @@ export function TransactionGroup({
         <CollapsibleContent>
           <div className="p-4 space-y-3 border-t dark:border-gray-700">
             {group.transactions.map((transaction, idx) =>
-              editingTransaction === transaction &&
-              onSaveEdit &&
-              onCancelEdit ? (
+              editingTransaction === transaction && onSaveEdit && onCancelEdit ? (
                 <EditableTransactionCard
                   key={idx}
                   transaction={transaction}

--- a/packages/app-finance/src/components/imports/UploadStep.tsx
+++ b/packages/app-finance/src/components/imports/UploadStep.tsx
@@ -34,9 +34,7 @@ export function UploadStep() {
       skipEmptyLines: true,
       complete: (results) => {
         if (results.errors.length > 0) {
-          setError(
-            `CSV parsing error: ${results.errors[0]?.message ?? "Unknown error"}`
-          );
+          setError(`CSV parsing error: ${results.errors[0]?.message ?? "Unknown error"}`);
           setIsProcessing(false);
           return;
         }
@@ -87,8 +85,7 @@ export function UploadStep() {
           Bank: American Express (Amex)
         </h3>
         <p className="text-xs text-blue-700 dark:text-blue-300">
-          Download your Amex transactions as CSV from your online banking
-          portal.
+          Download your Amex transactions as CSV from your online banking portal.
         </p>
       </div>
 

--- a/packages/app-finance/src/lib/transaction-utils.ts
+++ b/packages/app-finance/src/lib/transaction-utils.ts
@@ -86,9 +86,7 @@ export interface LocationDetails {
 /**
  * Extract location details from transaction
  */
-export function extractLocationDetails(
-  transaction: ProcessedTransaction
-): LocationDetails {
+export function extractLocationDetails(transaction: ProcessedTransaction): LocationDetails {
   if (!transaction.location) {
     return {
       location: null,
@@ -101,13 +99,7 @@ export function extractLocationDetails(
     const rawRow = JSON.parse(transaction.rawRow) as Record<string, string>;
 
     // Check common CSV location field names
-    const locationFields = [
-      "Town/City",
-      "location",
-      "Location",
-      "City",
-      "city",
-    ];
+    const locationFields = ["Town/City", "location", "Location", "City", "city"];
     for (const field of locationFields) {
       if (rawRow[field] && rawRow[field].trim().length > 0) {
         return {

--- a/packages/app-finance/src/pages/BudgetsPage.tsx
+++ b/packages/app-finance/src/pages/BudgetsPage.tsx
@@ -27,21 +27,15 @@ export function BudgetsPage() {
   const columns: ColumnDef<Budget>[] = [
     {
       accessorKey: "category",
-      header: ({ column }) => (
-        <SortableHeader column={column}>Category</SortableHeader>
-      ),
-      cell: ({ row }) => (
-        <div className="font-medium">{row.original.category}</div>
-      ),
+      header: ({ column }) => <SortableHeader column={column}>Category</SortableHeader>,
+      cell: ({ row }) => <div className="font-medium">{row.original.category}</div>,
     },
     {
       accessorKey: "period",
       header: "Period",
       cell: ({ row }) => (
         <span className="text-sm">
-          {row.original.period || (
-            <span className="text-muted-foreground">—</span>
-          )}
+          {row.original.period || <span className="text-muted-foreground">—</span>}
         </span>
       ),
     },
@@ -58,9 +52,7 @@ export function BudgetsPage() {
           return <div className="text-right text-muted-foreground">—</div>;
         }
         return (
-          <div className="text-right font-mono font-medium tabular-nums">
-            ${amount.toFixed(2)}
-          </div>
+          <div className="text-right font-mono font-medium tabular-nums">${amount.toFixed(2)}</div>
         );
       },
     },
@@ -68,19 +60,12 @@ export function BudgetsPage() {
       accessorKey: "active",
       header: "Status",
       cell: ({ row }) => (
-        <Badge
-          variant={row.original.active ? "default" : "secondary"}
-          className="text-xs"
-        >
+        <Badge variant={row.original.active ? "default" : "secondary"} className="text-xs">
           {row.original.active ? "Active" : "Inactive"}
         </Badge>
       ),
       filterFn: (row, columnId, filterValue) => {
-        if (
-          filterValue === undefined ||
-          filterValue === null ||
-          filterValue === ""
-        ) {
+        if (filterValue === undefined || filterValue === null || filterValue === "") {
           return true;
         }
         const value = row.getValue<boolean>(columnId);
@@ -96,11 +81,7 @@ export function BudgetsPage() {
         if (!notes) {
           return <span className="text-muted-foreground">—</span>;
         }
-        return (
-          <div className="max-w-md text-sm truncate text-muted-foreground">
-            {notes}
-          </div>
-        );
+        return <div className="max-w-md text-sm truncate text-muted-foreground">{notes}</div>;
       },
     },
   ];

--- a/packages/app-finance/src/pages/DashboardPage.tsx
+++ b/packages/app-finance/src/pages/DashboardPage.tsx
@@ -15,10 +15,9 @@ export function DashboardPage() {
   });
 
   // Fetch budgets
-  const { data: budgets, isLoading: budgetsLoading } =
-    trpc.finance.budgets.list.useQuery({
-      limit: 5,
-    });
+  const { data: budgets, isLoading: budgetsLoading } = trpc.finance.budgets.list.useQuery({
+    limit: 5,
+  });
 
   // Calculate stats from transactions
   const stats = transactions?.data
@@ -42,8 +41,7 @@ export function DashboardPage() {
           <AlertTitle>Unable to load dashboard</AlertTitle>
           <AlertDescription>
             <p className="mb-2">
-              The backend API is not responding. Make sure the pops-api
-              server is running.
+              The backend API is not responding. Make sure the pops-api server is running.
             </p>
             <details className="mt-3">
               <summary className="cursor-pointer hover:underline font-medium text-sm">
@@ -63,9 +61,7 @@ export function DashboardPage() {
     <div className="max-w-7xl mx-auto space-y-8 pb-10">
       <header>
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-        <p className="text-muted-foreground mt-1">
-          Welcome back! Here's your financial overview.
-        </p>
+        <p className="text-muted-foreground mt-1">Welcome back! Here's your financial overview.</p>
       </header>
 
       {/* Stats Grid */}
@@ -128,11 +124,12 @@ export function DashboardPage() {
                 >
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
-                      <p className="font-medium truncate text-base">
-                        {transaction.description}
-                      </p>
+                      <p className="font-medium truncate text-base">{transaction.description}</p>
                       {transaction.tags.includes("Online") && (
-                        <Badge variant="secondary" className="hidden sm:inline-flex text-[10px] uppercase tracking-wider px-1.5 py-0">
+                        <Badge
+                          variant="secondary"
+                          className="hidden sm:inline-flex text-[10px] uppercase tracking-wider px-1.5 py-0"
+                        >
                           Online
                         </Badge>
                       )}
@@ -152,7 +149,10 @@ export function DashboardPage() {
                     </div>
                   </div>
                   <div className="flex items-center gap-4 shrink-0">
-                    <Badge variant="outline" className="hidden sm:inline-flex text-[10px] uppercase tracking-wider px-1.5 py-0 text-muted-foreground font-normal">
+                    <Badge
+                      variant="outline"
+                      className="hidden sm:inline-flex text-[10px] uppercase tracking-wider px-1.5 py-0 text-muted-foreground font-normal"
+                    >
                       {transaction.account}
                     </Badge>
                     <p
@@ -162,8 +162,7 @@ export function DashboardPage() {
                           : "text-green-600 dark:text-green-400"
                       }`}
                     >
-                      {transaction.amount < 0 ? "-" : "+"}$
-                      {Math.abs(transaction.amount).toFixed(2)}
+                      {transaction.amount < 0 ? "-" : "+"}${Math.abs(transaction.amount).toFixed(2)}
                     </p>
                   </div>
                 </div>
@@ -192,13 +191,20 @@ export function DashboardPage() {
               <Card key={budget.id} className="p-5 flex flex-col justify-between h-full">
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <h3 className="font-medium text-muted-foreground uppercase text-[10px] tracking-widest">{budget.category}</h3>
-                    <Badge variant={budget.active ? "default" : "secondary"} className="text-[10px] h-5">
+                    <h3 className="font-medium text-muted-foreground uppercase text-[10px] tracking-widest">
+                      {budget.category}
+                    </h3>
+                    <Badge
+                      variant={budget.active ? "default" : "secondary"}
+                      className="text-[10px] h-5"
+                    >
                       {budget.active ? "Active" : "Inactive"}
                     </Badge>
                   </div>
                   <div className="flex items-baseline gap-1">
-                    <span className="text-2xl font-bold">${budget.amount ? budget.amount.toFixed(2) : "0.00"}</span>
+                    <span className="text-2xl font-bold">
+                      ${budget.amount ? budget.amount.toFixed(2) : "0.00"}
+                    </span>
                     <span className="text-xs text-muted-foreground">/ {budget.period}</span>
                   </div>
                 </div>

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -29,9 +29,7 @@ export function EntitiesPage() {
   const columns: ColumnDef<Entity>[] = [
     {
       accessorKey: "name",
-      header: ({ column }) => (
-        <SortableHeader column={column}>Name</SortableHeader>
-      ),
+      header: ({ column }) => <SortableHeader column={column}>Name</SortableHeader>,
       cell: ({ row }) => <div className="font-medium">{row.original.name}</div>,
     },
     {
@@ -90,9 +88,7 @@ export function EntitiesPage() {
         }
         const aliases = row.getValue<string[]>(columnId);
         if (!aliases || aliases.length === 0) return false;
-        return aliases.some((alias) =>
-          alias.toLowerCase().includes(searchTerm)
-        );
+        return aliases.some((alias) => alias.toLowerCase().includes(searchTerm));
       },
     },
     {

--- a/packages/app-finance/src/pages/TransactionsPage.tsx
+++ b/packages/app-finance/src/pages/TransactionsPage.tsx
@@ -63,9 +63,7 @@ export function TransactionsPage() {
   const columns: ColumnDef<Transaction>[] = [
     {
       accessorKey: "date",
-      header: ({ column }) => (
-        <SortableHeader column={column}>Date</SortableHeader>
-      ),
+      header: ({ column }) => <SortableHeader column={column}>Date</SortableHeader>,
       cell: ({ row }) => {
         const date = new Date(row.original.date);
         return date.toLocaleDateString("en-AU", {
@@ -90,9 +88,7 @@ export function TransactionsPage() {
     {
       accessorKey: "account",
       header: "Account",
-      cell: ({ row }) => (
-        <span className="text-sm font-mono">{row.original.account}</span>
-      ),
+      cell: ({ row }) => <span className="text-sm font-mono">{row.original.account}</span>,
     },
     {
       accessorKey: "amount",

--- a/packages/app-finance/src/pages/WishlistPage.tsx
+++ b/packages/app-finance/src/pages/WishlistPage.tsx
@@ -149,9 +149,7 @@ export function WishlistPage() {
   const columns: ColumnDef<WishlistItem>[] = [
     {
       accessorKey: "item",
-      header: ({ column }) => (
-        <SortableHeader column={column}>Item</SortableHeader>
-      ),
+      header: ({ column }) => <SortableHeader column={column}>Item</SortableHeader>,
       cell: ({ row }) => (
         <div className="flex flex-col">
           <span className="font-medium">{row.original.item}</span>
@@ -177,11 +175,7 @@ export function WishlistPage() {
         return (
           <Badge
             variant={
-              priority === "Needing"
-                ? "default"
-                : priority === "Soon"
-                  ? "secondary"
-                  : "outline"
+              priority === "Needing" ? "default" : priority === "Soon" ? "secondary" : "outline"
             }
           >
             {priority}
@@ -201,7 +195,11 @@ export function WishlistPage() {
         if (amount === null) return <div className="text-right text-muted-foreground">—</div>;
         return (
           <div className="text-right font-mono font-medium tabular-nums">
-            ${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            $
+            {amount.toLocaleString(undefined, {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}
           </div>
         );
       },
@@ -218,7 +216,11 @@ export function WishlistPage() {
         if (amount === null) return <div className="text-right text-muted-foreground">—</div>;
         return (
           <div className="text-right font-mono font-medium tabular-nums text-emerald-600 dark:text-emerald-400">
-            ${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            $
+            {amount.toLocaleString(undefined, {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}
           </div>
         );
       },
@@ -235,9 +237,7 @@ export function WishlistPage() {
         return (
           <div className="flex items-center gap-2 min-w-[120px]">
             <Progress value={percentage} className="h-2 flex-1" />
-            <span className="text-xs font-medium tabular-nums w-10 text-right">
-              {percentage}%
-            </span>
+            <span className="text-xs font-medium tabular-nums w-10 text-right">{percentage}%</span>
           </div>
         );
       },
@@ -258,7 +258,7 @@ export function WishlistPage() {
               <Pencil className="mr-2 h-4 w-4" /> Edit
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem 
+            <DropdownMenuItem
               className="text-destructive focus:text-destructive"
               onClick={() => setDeletingId(row.original.id)}
             >
@@ -399,9 +399,9 @@ export function WishlistPage() {
               </div>
             </div>
             <DialogFooter>
-              <Button 
-                type="button" 
-                variant="outline" 
+              <Button
+                type="button"
+                variant="outline"
                 onClick={() => setIsDialogOpen(false)}
                 disabled={isSubmitting}
               >

--- a/packages/app-finance/src/store/importStore.ts
+++ b/packages/app-finance/src/store/importStore.ts
@@ -67,9 +67,7 @@ interface ImportStore {
   setColumnMap: (columnMap: ImportStore["columnMap"]) => void;
   setParsedTransactions: (parsed: ParsedTransaction[]) => void;
   setProcessSessionId: (sessionId: string | null) => void;
-  setProcessedTransactions: (
-    processed: ImportStore["processedTransactions"]
-  ) => void;
+  setProcessedTransactions: (processed: ImportStore["processedTransactions"]) => void;
   setConfirmedTransactions: (confirmed: ConfirmedTransaction[]) => void;
   setExecuteSessionId: (sessionId: string | null) => void;
   setImportResult: (result: ImportStore["importResult"]) => void;
@@ -125,17 +123,13 @@ export const useImportStore = create<ImportStore>((set) => ({
   setColumnMap: (columnMap) => set({ columnMap }),
   setParsedTransactions: (parsedTransactions) => set({ parsedTransactions }),
   setProcessSessionId: (processSessionId) => set({ processSessionId }),
-  setProcessedTransactions: (processedTransactions) =>
-    set({ processedTransactions }),
-  setConfirmedTransactions: (confirmedTransactions) =>
-    set({ confirmedTransactions }),
+  setProcessedTransactions: (processedTransactions) => set({ processedTransactions }),
+  setConfirmedTransactions: (confirmedTransactions) => set({ confirmedTransactions }),
   setExecuteSessionId: (executeSessionId) => set({ executeSessionId }),
   setImportResult: (importResult) => set({ importResult }),
 
-  nextStep: () =>
-    set((state) => ({ currentStep: Math.min(state.currentStep + 1, 6) })),
-  prevStep: () =>
-    set((state) => ({ currentStep: Math.max(state.currentStep - 1, 1) })),
+  nextStep: () => set((state) => ({ currentStep: Math.min(state.currentStep + 1, 6) })),
+  prevStep: () => set((state) => ({ currentStep: Math.max(state.currentStep - 1, 1) })),
   goToStep: (step) => set({ currentStep: step }),
   reset: () => set(initialState),
 

--- a/packages/app-inventory/src/components/ConnectDialog.tsx
+++ b/packages/app-inventory/src/components/ConnectDialog.tsx
@@ -24,16 +24,13 @@ interface ConnectDialogProps {
   onConnected: () => void;
 }
 
-export function ConnectDialog({
-  currentItemId,
-  onConnected,
-}: ConnectDialogProps) {
+export function ConnectDialog({ currentItemId, onConnected }: ConnectDialogProps) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
 
   const { data, isLoading } = trpc.inventory.items.list.useQuery(
     { search, limit: 10 },
-    { enabled: open && search.length >= 2 },
+    { enabled: open && search.length >= 2 }
   );
 
   const connectMutation = trpc.inventory.connections.connect.useMutation({
@@ -76,9 +73,7 @@ export function ConnectDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Connect Item</DialogTitle>
-          <DialogDescription>
-            Search for an item to connect by name or asset ID.
-          </DialogDescription>
+          <DialogDescription>Search for an item to connect by name or asset ID.</DialogDescription>
         </DialogHeader>
 
         <div className="relative">
@@ -104,9 +99,7 @@ export function ConnectDialog({
               <Skeleton className="h-10 w-full" />
             </div>
           ) : results.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">
-              No items found
-            </p>
+            <p className="text-sm text-muted-foreground py-4 text-center">No items found</p>
           ) : (
             results.map((item) => (
               <button
@@ -119,9 +112,8 @@ export function ConnectDialog({
                 <div>
                   <div className="font-medium text-sm">{item.itemName}</div>
                   <div className="text-xs text-muted-foreground">
-                    {[item.brand, item.model, item.assetId]
-                      .filter(Boolean)
-                      .join(" · ") || "No details"}
+                    {[item.brand, item.model, item.assetId].filter(Boolean).join(" · ") ||
+                      "No details"}
                   </div>
                 </div>
                 <Link2 className="h-4 w-4 text-muted-foreground shrink-0 ml-2" />

--- a/packages/app-inventory/src/components/ConnectionGraph.tsx
+++ b/packages/app-inventory/src/components/ConnectionGraph.tsx
@@ -68,9 +68,7 @@ export interface ConnectionGraphProps {
   itemId: string;
 }
 
-export function ConnectionGraph({
-  itemId,
-}: ConnectionGraphProps): React.ReactElement {
+export function ConnectionGraph({ itemId }: ConnectionGraphProps): React.ReactElement {
   const navigate = useNavigate();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -90,28 +88,25 @@ export function ConnectionGraph({
   } | null>(null);
   const { data, isLoading, error } = trpc.inventory.connections.graph.useQuery(
     { itemId },
-    { enabled: !!itemId },
+    { enabled: !!itemId }
   );
 
-  const findNodeAt = useCallback(
-    (canvasX: number, canvasY: number): GraphNode | null => {
-      const t = transformRef.current;
-      const worldX = (canvasX - t.x) / t.k;
-      const worldY = (canvasY - t.y) / t.k;
+  const findNodeAt = useCallback((canvasX: number, canvasY: number): GraphNode | null => {
+    const t = transformRef.current;
+    const worldX = (canvasX - t.x) / t.k;
+    const worldY = (canvasY - t.y) / t.k;
 
-      // Search in reverse so top-drawn nodes are found first
-      for (let i = nodesRef.current.length - 1; i >= 0; i--) {
-        const node = nodesRef.current[i];
-        const dx = (node.x ?? 0) - worldX;
-        const dy = (node.y ?? 0) - worldY;
-        if (dx * dx + dy * dy <= NODE_RADIUS * NODE_RADIUS) {
-          return node;
-        }
+    // Search in reverse so top-drawn nodes are found first
+    for (let i = nodesRef.current.length - 1; i >= 0; i--) {
+      const node = nodesRef.current[i];
+      const dx = (node.x ?? 0) - worldX;
+      const dy = (node.y ?? 0) - worldY;
+      if (dx * dx + dy * dy <= NODE_RADIUS * NODE_RADIUS) {
+        return node;
       }
-      return null;
-    },
-    [],
-  );
+    }
+    return null;
+  }, []);
 
   const draw = useCallback((): void => {
     const canvas = canvasRef.current;
@@ -175,10 +170,7 @@ export function ConnectionGraph({
       ctx.font = `${11 / t.k}px system-ui, sans-serif`;
       ctx.textAlign = "center";
       ctx.textBaseline = "top";
-      const label =
-        node.itemName.length > 20
-          ? node.itemName.slice(0, 18) + "..."
-          : node.itemName;
+      const label = node.itemName.length > 20 ? node.itemName.slice(0, 18) + "..." : node.itemName;
       ctx.fillText(label, nx, ny + LABEL_OFFSET / t.k);
     }
 
@@ -254,7 +246,7 @@ export function ConnectionGraph({
         "link",
         forceLink<GraphNode, GraphLink>(links)
           .id((d) => d.id)
-          .distance(120),
+          .distance(120)
       )
       .force("charge", forceManyBody().strength(-400))
       .force("center", forceCenter(0, 0))
@@ -376,18 +368,12 @@ export function ConnectionGraph({
   }
 
   if (error) {
-    return (
-      <p className="text-sm text-destructive">
-        Failed to load connection graph.
-      </p>
-    );
+    return <p className="text-sm text-destructive">Failed to load connection graph.</p>;
   }
 
   if (!data?.data.nodes.length || data.data.nodes.length < 2) {
     return (
-      <p className="text-sm text-muted-foreground">
-        Not enough connections to display a graph.
-      </p>
+      <p className="text-sm text-muted-foreground">Not enough connections to display a graph.</p>
     );
   }
 
@@ -396,10 +382,7 @@ export function ConnectionGraph({
       ref={containerRef}
       className="relative h-[400px] w-full border rounded-lg bg-muted/20 overflow-hidden"
     >
-      <canvas
-        ref={canvasRef}
-        className="w-full h-full cursor-grab active:cursor-grabbing"
-      />
+      <canvas ref={canvasRef} className="w-full h-full cursor-grab active:cursor-grabbing" />
       <div className="absolute bottom-2 right-2 text-xs text-muted-foreground">
         Scroll to zoom, drag to pan, click node to navigate
       </div>

--- a/packages/app-inventory/src/components/ConnectionTracePanel.tsx
+++ b/packages/app-inventory/src/components/ConnectionTracePanel.tsx
@@ -54,10 +54,7 @@ function TraceNodeRow({ node, depth, currentItemId }: TraceNodeRowProps) {
         aria-expanded={hasChildren ? open : undefined}
       >
         {hasChildren ? (
-          <CollapsibleTrigger
-            asChild
-            onClick={(e: React.MouseEvent) => e.stopPropagation()}
-          >
+          <CollapsibleTrigger asChild onClick={(e: React.MouseEvent) => e.stopPropagation()}>
             <button
               type="button"
               className="p-0.5 rounded hover:bg-muted"
@@ -131,26 +128,18 @@ export interface ConnectionTracePanelProps {
 export function ConnectionTracePanel({ itemId }: ConnectionTracePanelProps) {
   const { data, isLoading, error } = trpc.inventory.connections.trace.useQuery(
     { itemId },
-    { enabled: !!itemId },
+    { enabled: !!itemId }
   );
 
   if (isLoading) return <TraceSkeleton />;
 
   if (error) {
-    return (
-      <p className="text-sm text-destructive">
-        Failed to load connection trace.
-      </p>
-    );
+    return <p className="text-sm text-destructive">Failed to load connection trace.</p>;
   }
 
   const tree = data?.data;
   if (!tree || tree.children.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        No connection chain found.
-      </p>
-    );
+    return <p className="text-sm text-muted-foreground">No connection chain found.</p>;
   }
 
   const totalNodes = countNodes(tree) - 1; // Exclude root

--- a/packages/app-inventory/src/components/ConnectionsList.tsx
+++ b/packages/app-inventory/src/components/ConnectionsList.tsx
@@ -33,17 +33,13 @@ export function ConnectionsList({
         <h4 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
           <Link2 className="h-4 w-4 text-muted-foreground" />
           Connections
-          <span className="text-xs font-normal text-muted-foreground">
-            ({connections.length})
-          </span>
+          <span className="text-xs font-normal text-muted-foreground">({connections.length})</span>
         </h4>
       </div>
 
       {/* List */}
       {connections.length === 0 ? (
-        <p className="py-3 text-center text-sm text-muted-foreground">
-          No connected items
-        </p>
+        <p className="py-3 text-center text-sm text-muted-foreground">No connected items</p>
       ) : (
         <ul className="divide-y divide-border rounded-md border">
           {connections.map((item) => (
@@ -53,14 +49,12 @@ export function ConnectionsList({
                 className={cn(
                   "flex w-full items-center gap-2 px-3 py-2 text-left text-sm",
                   "transition-colors hover:bg-accent/50",
-                  onItemClick && "cursor-pointer",
+                  onItemClick && "cursor-pointer"
                 )}
                 onClick={() => onItemClick?.(item.id)}
                 disabled={!onItemClick}
               >
-                <span className="flex-1 truncate font-medium">
-                  {item.itemName}
-                </span>
+                <span className="flex-1 truncate font-medium">{item.itemName}</span>
                 <div className="flex shrink-0 items-center gap-1">
                   {item.assetId && <AssetIdBadge assetId={item.assetId} />}
                   {item.type && <TypeBadge type={item.type} />}

--- a/packages/app-inventory/src/components/InventoryCard.tsx
+++ b/packages/app-inventory/src/components/InventoryCard.tsx
@@ -59,7 +59,7 @@ export function InventoryCard({
         "border-l-4 border-l-amber-500/50",
         "transition-colors hover:bg-accent/50",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        className,
+        className
       )}
       onClick={() => onClick?.(id)}
     >
@@ -72,7 +72,7 @@ export function InventoryCard({
             loading="lazy"
             className={cn(
               "h-full w-full object-cover transition-opacity duration-200",
-              imageLoaded ? "opacity-100" : "opacity-0",
+              imageLoaded ? "opacity-100" : "opacity-0"
             )}
             onLoad={() => setImageLoaded(true)}
             onError={() => setImageError(true)}
@@ -94,15 +94,11 @@ export function InventoryCard({
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         {/* Item name + subtitle */}
         <div>
-          <h3 className="text-sm font-semibold leading-tight line-clamp-1">
-            {itemName}
-          </h3>
+          <h3 className="text-sm font-semibold leading-tight line-clamp-1">{itemName}</h3>
           {(brand || model) && (
             <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mt-0.5 opacity-80 line-clamp-1">
               {brand}
-              {brand && model && (
-                <span className="mx-1 opacity-50">&bull;</span>
-              )}
+              {brand && model && <span className="mx-1 opacity-50">&bull;</span>}
               {model}
             </p>
           )}
@@ -119,10 +115,7 @@ export function InventoryCard({
 
         {/* Location breadcrumb */}
         {locationSegments.length > 0 && (
-          <LocationBreadcrumb
-            segments={locationSegments}
-            onNavigate={onLocationNavigate}
-          />
+          <LocationBreadcrumb segments={locationSegments} onNavigate={onLocationNavigate} />
         )}
       </div>
     </button>

--- a/packages/app-inventory/src/components/InventoryTable.tsx
+++ b/packages/app-inventory/src/components/InventoryTable.tsx
@@ -52,18 +52,12 @@ function createColumns(): ColumnDef<InventoryTableItem>[] {
     },
     {
       accessorKey: "itemName",
-      header: ({ column }) => (
-        <SortableHeader column={column}>Name</SortableHeader>
-      ),
-      cell: ({ row }) => (
-        <span className="font-medium">{row.original.itemName}</span>
-      ),
+      header: ({ column }) => <SortableHeader column={column}>Name</SortableHeader>,
+      cell: ({ row }) => <span className="font-medium">{row.original.itemName}</span>,
     },
     {
       accessorKey: "brand",
-      header: ({ column }) => (
-        <SortableHeader column={column}>Brand</SortableHeader>
-      ),
+      header: ({ column }) => <SortableHeader column={column}>Brand</SortableHeader>,
       cell: ({ row }) => row.original.brand ?? "—",
     },
     {
@@ -79,27 +73,20 @@ function createColumns(): ColumnDef<InventoryTableItem>[] {
       header: "Condition",
       cell: ({ row }) => {
         const condition = row.original.condition;
-        if (!condition || !VALID_CONDITIONS.has(condition))
-          return condition ?? "—";
+        if (!condition || !VALID_CONDITIONS.has(condition)) return condition ?? "—";
         return <ConditionBadge condition={condition as Condition} />;
       },
     },
     {
       accessorKey: "location",
-      header: ({ column }) => (
-        <SortableHeader column={column}>Location</SortableHeader>
-      ),
+      header: ({ column }) => <SortableHeader column={column}>Location</SortableHeader>,
       cell: ({ row }) => (
-        <span className="text-muted-foreground">
-          {row.original.location ?? "—"}
-        </span>
+        <span className="text-muted-foreground">{row.original.location ?? "—"}</span>
       ),
     },
     {
       accessorKey: "replacementValue",
-      header: ({ column }) => (
-        <SortableHeader column={column}>Value</SortableHeader>
-      ),
+      header: ({ column }) => <SortableHeader column={column}>Value</SortableHeader>,
       cell: ({ row }) => {
         const value = row.original.replacementValue;
         return value != null ? formatCurrency(value) : "—";
@@ -125,11 +112,7 @@ export interface InventoryTableProps {
   searchable?: boolean;
 }
 
-export function InventoryTable({
-  items,
-  loading,
-  searchable = false,
-}: InventoryTableProps) {
+export function InventoryTable({ items, loading, searchable = false }: InventoryTableProps) {
   const navigate = useNavigate();
   const columns = useMemo(() => createColumns(), []);
 

--- a/packages/app-inventory/src/components/LinkDocumentDialog.tsx
+++ b/packages/app-inventory/src/components/LinkDocumentDialog.tsx
@@ -28,32 +28,22 @@ interface PaperlessDocResult {
   thumbnailUrl: string;
 }
 
-const DOCUMENT_TYPES = [
-  "receipt",
-  "warranty",
-  "manual",
-  "invoice",
-  "other",
-] as const;
+const DOCUMENT_TYPES = ["receipt", "warranty", "manual", "invoice", "other"] as const;
 
 interface LinkDocumentDialogProps {
   itemId: string;
   onLinked: () => void;
 }
 
-export function LinkDocumentDialog({
-  itemId,
-  onLinked,
-}: LinkDocumentDialogProps) {
+export function LinkDocumentDialog({ itemId, onLinked }: LinkDocumentDialogProps) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const [docType, setDocType] =
-    useState<(typeof DOCUMENT_TYPES)[number]>("receipt");
+  const [docType, setDocType] = useState<(typeof DOCUMENT_TYPES)[number]>("receipt");
   const [linkingId, setLinkingId] = useState<number | null>(null);
 
   const { data, isLoading } = trpc.inventory.paperless.search.useQuery(
     { query: search },
-    { enabled: open && search.length >= 2 },
+    { enabled: open && search.length >= 2 }
   );
 
   const linkMutation = trpc.inventory.documents.link.useMutation({
@@ -147,9 +137,7 @@ export function LinkDocumentDialog({
               <Skeleton className="h-14 w-full" />
             </div>
           ) : results.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">
-              No documents found
-            </p>
+            <p className="text-sm text-muted-foreground py-4 text-center">No documents found</p>
           ) : (
             results.map((doc) => (
               <div
@@ -168,13 +156,9 @@ export function LinkDocumentDialog({
                   </div>
                 )}
                 <div className="flex-1 min-w-0">
-                  <div className="font-medium text-sm truncate">
-                    {doc.title}
-                  </div>
+                  <div className="font-medium text-sm truncate">{doc.title}</div>
                   <div className="text-xs text-muted-foreground">
-                    {doc.created
-                      ? new Date(doc.created).toLocaleDateString()
-                      : "No date"}
+                    {doc.created ? new Date(doc.created).toLocaleDateString() : "No date"}
                     {doc.originalFileName ? ` · ${doc.originalFileName}` : ""}
                   </div>
                 </div>

--- a/packages/app-inventory/src/components/LocationContentsPanel.tsx
+++ b/packages/app-inventory/src/components/LocationContentsPanel.tsx
@@ -8,14 +8,7 @@
 import { useState, useMemo } from "react";
 import { useNavigate } from "react-router";
 import { Package, Plus } from "lucide-react";
-import {
-  Skeleton,
-  Button,
-  Switch,
-  Label,
-  AssetIdBadge,
-  TypeBadge,
-} from "@pops/ui";
+import { Skeleton, Button, Switch, Label, AssetIdBadge, TypeBadge } from "@pops/ui";
 import { trpc } from "../lib/trpc";
 
 interface LocationTreeNode {
@@ -65,19 +58,16 @@ export function LocationContentsPanel({
   const hasSubLocations = descendantIds.length > 0;
 
   // Query items for this location
-  const { data: directData, isLoading: directLoading } =
-    trpc.inventory.items.list.useQuery({
-      locationId,
-      limit: 200,
-    });
+  const { data: directData, isLoading: directLoading } = trpc.inventory.items.list.useQuery({
+    locationId,
+    limit: 200,
+  });
 
   // Query items for sub-locations (only when toggled on and sub-locations exist)
   const subLocationQueries = trpc.useQueries((t) =>
     includeSubLocations && hasSubLocations
-      ? descendantIds.map((id) =>
-          t.inventory.items.list({ locationId: id, limit: 200 }),
-        )
-      : [],
+      ? descendantIds.map((id) => t.inventory.items.list({ locationId: id, limit: 200 }))
+      : []
   );
 
   const subLocationItems = useMemo(() => {
@@ -87,9 +77,7 @@ export function LocationContentsPanel({
 
   const isLoading =
     directLoading ||
-    (includeSubLocations &&
-      hasSubLocations &&
-      subLocationQueries.some((q) => q.isLoading));
+    (includeSubLocations && hasSubLocations && subLocationQueries.some((q) => q.isLoading));
 
   const allItems = useMemo(() => {
     const direct = directData?.data ?? [];
@@ -99,16 +87,14 @@ export function LocationContentsPanel({
 
   const totalValue = useMemo(
     () => allItems.reduce((sum, item) => sum + (item.replacementValue ?? 0), 0),
-    [allItems],
+    [allItems]
   );
 
   return (
     <div className="border rounded-lg p-4 space-y-4">
       {/* Header */}
       <div>
-        <p className="text-xs text-muted-foreground">
-          {breadcrumb.join(" / ")}
-        </p>
+        <p className="text-xs text-muted-foreground">{breadcrumb.join(" / ")}</p>
         <h2 className="text-lg font-semibold mt-1">{locationName}</h2>
       </div>
 
@@ -159,9 +145,7 @@ export function LocationContentsPanel({
                 className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted/50"
                 onClick={() => navigate(`/inventory/items/${item.id}`)}
               >
-                <span className="font-medium truncate flex-1">
-                  {item.itemName}
-                </span>
+                <span className="font-medium truncate flex-1">{item.itemName}</span>
                 {item.assetId && <AssetIdBadge assetId={item.assetId} />}
                 {item.type && <TypeBadge type={item.type} />}
               </button>
@@ -176,9 +160,7 @@ export function LocationContentsPanel({
         size="sm"
         className="w-full"
         onClick={() =>
-          navigate(
-            `/inventory/items/new?locationId=${encodeURIComponent(locationId)}`,
-          )
+          navigate(`/inventory/items/new?locationId=${encodeURIComponent(locationId)}`)
         }
       >
         <Plus className="h-4 w-4 mr-1.5" />

--- a/packages/app-inventory/src/components/LocationPicker.stories.tsx
+++ b/packages/app-inventory/src/components/LocationPicker.stories.tsx
@@ -30,9 +30,7 @@ const mockLocations: LocationTreeNode[] = [
         id: "4",
         name: "Kitchen",
         parentId: "1",
-        children: [
-          { id: "10", name: "Pantry", parentId: "4", children: [] },
-        ],
+        children: [{ id: "10", name: "Pantry", parentId: "4", children: [] }],
       },
       { id: "5", name: "Bedroom", parentId: "1", children: [] },
     ],
@@ -95,9 +93,7 @@ export const Interactive: Story = {
         locations={mockLocations}
         value={value}
         onChange={setValue}
-        onCreateLocation={(name, parentId) =>
-          alert(`Create "${name}" under ${parentId ?? "root"}`)
-        }
+        onCreateLocation={(name, parentId) => alert(`Create "${name}" under ${parentId ?? "root"}`)}
       />
     );
   },
@@ -122,7 +118,6 @@ export const WithAddLocation: Story = {
   args: {
     locations: mockLocations,
     value: null,
-    onCreateLocation: (name, parentId) =>
-      alert(`Create "${name}" under ${parentId ?? "root"}`),
+    onCreateLocation: (name, parentId) => alert(`Create "${name}" under ${parentId ?? "root"}`),
   },
 };

--- a/packages/app-inventory/src/components/LocationPicker.tsx
+++ b/packages/app-inventory/src/components/LocationPicker.tsx
@@ -4,12 +4,7 @@
  * location tree, type-to-filter, and optional inline create.
  */
 import { useState, useMemo, useCallback } from "react";
-import {
-  cn,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@pops/ui";
+import { cn, Popover, PopoverContent, PopoverTrigger } from "@pops/ui";
 import { Button } from "@pops/ui";
 import { ChevronRight, ChevronDown, MapPin, X, Plus } from "lucide-react";
 
@@ -31,10 +26,7 @@ export interface LocationPickerProps {
 }
 
 /** Build breadcrumb path from root to target node. */
-function buildPath(
-  nodes: LocationTreeNode[],
-  targetId: string
-): LocationTreeNode[] {
+function buildPath(nodes: LocationTreeNode[], targetId: string): LocationTreeNode[] {
   for (const node of nodes) {
     if (node.id === targetId) return [node];
     const childPath = buildPath(node.children, targetId);
@@ -44,10 +36,7 @@ function buildPath(
 }
 
 /** Flatten tree for search, returning nodes that match filter. */
-function filterTree(
-  nodes: LocationTreeNode[],
-  query: string
-): Set<string> {
+function filterTree(nodes: LocationTreeNode[], query: string): Set<string> {
   const matches = new Set<string>();
   const lower = query.toLowerCase();
 
@@ -100,7 +89,7 @@ function TreeNode({
         className={cn(
           "flex w-full items-center gap-1 rounded-md px-2 py-1.5 text-sm",
           "hover:bg-accent/50 transition-colors",
-          isSelected && "bg-accent text-accent-foreground font-medium",
+          isSelected && "bg-accent text-accent-foreground font-medium"
         )}
         style={{ paddingLeft: `${depth * 16 + 8}px` }}
         onClick={() => onSelect(node.id)}
@@ -232,9 +221,7 @@ export function LocationPicker({
         >
           <MapPin className="mr-2 h-4 w-4 shrink-0 opacity-50" />
           {selectedPath.length > 0 ? (
-            <span className="truncate text-sm">
-              {selectedPath.map((n) => n.name).join(" › ")}
-            </span>
+            <span className="truncate text-sm">{selectedPath.map((n) => n.name).join(" › ")}</span>
           ) : (
             <span className="text-sm">{placeholder}</span>
           )}
@@ -256,9 +243,7 @@ export function LocationPicker({
         {/* Tree */}
         <div className="max-h-[240px] overflow-y-auto p-1">
           {locations.length === 0 ? (
-            <p className="py-4 text-center text-sm text-muted-foreground">
-              No locations found
-            </p>
+            <p className="py-4 text-center text-sm text-muted-foreground">No locations found</p>
           ) : (
             locations.map((node) => (
               <TreeNode

--- a/packages/app-inventory/src/components/PhotoGallery.tsx
+++ b/packages/app-inventory/src/components/PhotoGallery.tsx
@@ -40,15 +40,11 @@ export function PhotoGallery({
   }, []);
 
   const goNext = useCallback(() => {
-    setLightboxIndex((prev) =>
-      prev !== null ? (prev + 1) % sorted.length : null,
-    );
+    setLightboxIndex((prev) => (prev !== null ? (prev + 1) % sorted.length : null));
   }, [sorted.length]);
 
   const goPrev = useCallback(() => {
-    setLightboxIndex((prev) =>
-      prev !== null ? (prev - 1 + sorted.length) % sorted.length : null,
-    );
+    setLightboxIndex((prev) => (prev !== null ? (prev - 1 + sorted.length) % sorted.length : null));
   }, [sorted.length]);
 
   // Keyboard navigation
@@ -66,13 +62,10 @@ export function PhotoGallery({
   }, [lightboxIndex, closeLightbox, goNext, goPrev]);
 
   if (photos.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">No photos yet.</p>
-    );
+    return <p className="text-sm text-muted-foreground">No photos yet.</p>;
   }
 
-  const photoSrc = (filePath: string) =>
-    `${baseUrl}/${encodeURIComponent(filePath)}`;
+  const photoSrc = (filePath: string) => `${baseUrl}/${encodeURIComponent(filePath)}`;
 
   const currentPhoto = lightboxIndex !== null ? sorted[lightboxIndex] : null;
 
@@ -158,9 +151,7 @@ export function PhotoGallery({
               className="max-w-full max-h-[80vh] object-contain rounded-md"
             />
             {currentPhoto.caption && (
-              <p className="text-white text-sm text-center">
-                {currentPhoto.caption}
-              </p>
+              <p className="text-white text-sm text-center">{currentPhoto.caption}</p>
             )}
             <p className="text-white/60 text-xs">
               {lightboxIndex! + 1} / {sorted.length}

--- a/packages/app-inventory/src/components/PhotoUpload.tsx
+++ b/packages/app-inventory/src/components/PhotoUpload.tsx
@@ -79,7 +79,7 @@ export function PhotoUpload({
 
       return valid;
     },
-    [maxSizeMb],
+    [maxSizeMb]
   );
 
   const handleFiles = useCallback(
@@ -90,7 +90,7 @@ export function PhotoUpload({
         onFilesSelected(valid);
       }
     },
-    [validateFiles, onFilesSelected],
+    [validateFiles, onFilesSelected]
   );
 
   const handleDrop = useCallback(
@@ -100,7 +100,7 @@ export function PhotoUpload({
       if (disabled) return;
       handleFiles(e.dataTransfer.files);
     },
-    [disabled, handleFiles],
+    [disabled, handleFiles]
   );
 
   const handleDragOver = useCallback(
@@ -108,7 +108,7 @@ export function PhotoUpload({
       e.preventDefault();
       if (!disabled) setIsDragOver(true);
     },
-    [disabled],
+    [disabled]
   );
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
@@ -126,7 +126,7 @@ export function PhotoUpload({
       // Reset input so the same file can be re-selected
       if (inputRef.current) inputRef.current.value = "";
     },
-    [handleFiles],
+    [handleFiles]
   );
 
   const handleCameraChange = useCallback(
@@ -134,7 +134,7 @@ export function PhotoUpload({
       handleFiles(e.target.files);
       if (cameraRef.current) cameraRef.current.value = "";
     },
-    [handleFiles],
+    [handleFiles]
   );
 
   return (
@@ -156,17 +156,14 @@ export function PhotoUpload({
           isDragOver
             ? "border-amber-500 bg-amber-500/10"
             : "border-muted-foreground/25 hover:border-muted-foreground/50",
-          disabled && "opacity-50 cursor-not-allowed",
+          disabled && "opacity-50 cursor-not-allowed"
         )}
       >
         <Upload className="h-8 w-8 text-muted-foreground" />
         <p className="text-sm text-muted-foreground text-center">
-          <span className="font-medium text-foreground">Click to browse</span>{" "}
-          or drag and drop
+          <span className="font-medium text-foreground">Click to browse</span> or drag and drop
         </p>
-        <p className="text-xs text-muted-foreground">
-          Images up to {maxSizeMb}MB
-        </p>
+        <p className="text-xs text-muted-foreground">Images up to {maxSizeMb}MB</p>
       </div>
 
       <input
@@ -202,9 +199,7 @@ export function PhotoUpload({
       </Button>
 
       {/* Validation error */}
-      {validationError && (
-        <p className="text-sm text-destructive">{validationError}</p>
-      )}
+      {validationError && <p className="text-sm text-destructive">{validationError}</p>}
 
       {/* File preview list */}
       {files.length > 0 && (
@@ -239,13 +234,9 @@ export function PhotoUpload({
                       Uploading…
                     </span>
                   )}
-                  {f.status === "done" && (
-                    <span className="text-xs text-green-600">Uploaded</span>
-                  )}
+                  {f.status === "done" && <span className="text-xs text-green-600">Uploaded</span>}
                   {f.status === "error" && (
-                    <span className="text-xs text-destructive">
-                      {f.error ?? "Upload failed"}
-                    </span>
+                    <span className="text-xs text-destructive">{f.error ?? "Upload failed"}</span>
                   )}
                   {f.status === "pending" && (
                     <span className="text-xs text-muted-foreground">Ready</span>

--- a/packages/app-inventory/src/components/ValueBreakdown.tsx
+++ b/packages/app-inventory/src/components/ValueBreakdown.tsx
@@ -2,24 +2,9 @@
  * ValueByTypeCard — horizontal bar chart showing replacement value
  * grouped by item type.
  */
-import {
-  Alert,
-  AlertDescription,
-  Button,
-  Card,
-  CardContent,
-  Skeleton,
-} from "@pops/ui";
+import { Alert, AlertDescription, Button, Card, CardContent, Skeleton } from "@pops/ui";
 import { AlertCircle, RefreshCw, Tag } from "lucide-react";
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Cell,
-} from "recharts";
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts";
 import { useNavigate } from "react-router";
 import { trpc } from "../lib/trpc";
 import { formatCurrency } from "../lib/utils";
@@ -50,11 +35,7 @@ function BreakdownChart({ data, onBarClick }: BreakdownChartProps) {
 
   return (
     <ResponsiveContainer width="100%" height={chartHeight}>
-      <BarChart
-        data={data}
-        layout="vertical"
-        margin={{ left: 0, right: 16, top: 4, bottom: 4 }}
-      >
+      <BarChart data={data} layout="vertical" margin={{ left: 0, right: 16, top: 4, bottom: 4 }}>
         <XAxis
           type="number"
           tickFormatter={(v: number) => formatCurrency(v)}
@@ -73,8 +54,7 @@ function BreakdownChart({ data, onBarClick }: BreakdownChartProps) {
         <Tooltip
           content={({ payload }) => {
             if (!payload?.length) return null;
-            const entry = payload[0]
-              .payload as BreakdownChartProps["data"][number];
+            const entry = payload[0].payload as BreakdownChartProps["data"][number];
             return (
               <div className="rounded-md border bg-popover px-3 py-2 text-sm shadow-md">
                 <p className="font-medium">{entry.name}</p>
@@ -148,9 +128,7 @@ export function ValueByTypeCard({ className }: { className?: string }) {
         ) : (
           <BreakdownChart
             data={typeEntries}
-            onBarClick={(name) =>
-              navigate(`/inventory?type=${encodeURIComponent(name)}`)
-            }
+            onBarClick={(name) => navigate(`/inventory?type=${encodeURIComponent(name)}`)}
           />
         )}
       </CardContent>

--- a/packages/app-inventory/src/pages/InsuranceReportPage.tsx
+++ b/packages/app-inventory/src/pages/InsuranceReportPage.tsx
@@ -8,13 +8,7 @@
 import { useMemo } from "react";
 import { useSearchParams, useNavigate } from "react-router";
 import { FileText, Printer } from "lucide-react";
-import {
-  Skeleton,
-  AssetIdBadge,
-  ConditionBadge,
-  Badge,
-  type Condition,
-} from "@pops/ui";
+import { Skeleton, AssetIdBadge, ConditionBadge, Badge, type Condition } from "@pops/ui";
 import { trpc } from "../lib/trpc";
 
 function formatCurrency(value: number): string {
@@ -42,9 +36,7 @@ function warrantyStatus(expiryStr: string | null): {
   const now = new Date();
   now.setHours(0, 0, 0, 0);
   const expiry = new Date(expiryStr);
-  const days = Math.ceil(
-    (expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24),
-  );
+  const days = Math.ceil((expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
   if (days < 0) return { label: "Expired", variant: "destructive" };
   if (days <= 90) return { label: `${days}d left`, variant: "default" };
   return { label: formatDate(expiryStr), variant: "secondary" };
@@ -56,7 +48,7 @@ export function InsuranceReportPage(): React.ReactElement {
   const locationId = searchParams.get("locationId") ?? undefined;
 
   const { data, isLoading } = trpc.inventory.reports.insuranceReport.useQuery(
-    locationId ? { locationId } : undefined,
+    locationId ? { locationId } : undefined
   );
 
   const report = data?.data;
@@ -98,9 +90,7 @@ export function InsuranceReportPage(): React.ReactElement {
           </div>
           <p className="text-sm text-muted-foreground">
             Generated {today}
-            {locationId && report.groups.length === 1 && (
-              <> — {report.groups[0].locationName}</>
-            )}
+            {locationId && report.groups.length === 1 && <> — {report.groups[0].locationName}</>}
           </p>
         </div>
         <button
@@ -115,8 +105,12 @@ export function InsuranceReportPage(): React.ReactElement {
       {/* Summary */}
       <div className="grid grid-cols-2 gap-6 mb-8 p-6 rounded-2xl bg-amber-500/10 border-2 border-amber-500/10 print:bg-transparent print:border print:border-gray-300 print:rounded-none">
         <div>
-          <p className="text-xs font-bold text-amber-900/60 dark:text-amber-100/60 uppercase tracking-widest mb-1">Total Items</p>
-          <p className="text-3xl font-black text-amber-900 dark:text-amber-50">{report.totalItems}</p>
+          <p className="text-xs font-bold text-amber-900/60 dark:text-amber-100/60 uppercase tracking-widest mb-1">
+            Total Items
+          </p>
+          <p className="text-3xl font-black text-amber-900 dark:text-amber-50">
+            {report.totalItems}
+          </p>
         </div>
         <div className="text-right">
           <p className="text-xs font-bold text-amber-900/60 dark:text-amber-100/60 uppercase tracking-widest mb-1">
@@ -137,8 +131,7 @@ export function InsuranceReportPage(): React.ReactElement {
           <h2 className="text-lg font-semibold mb-3 pb-1 border-b">
             {group.locationName}
             <span className="ml-2 text-sm font-normal text-muted-foreground">
-              ({group.items.length}{" "}
-              {group.items.length === 1 ? "item" : "items"})
+              ({group.items.length} {group.items.length === 1 ? "item" : "items"})
             </span>
           </h2>
 
@@ -186,22 +179,16 @@ export function InsuranceReportPage(): React.ReactElement {
                       <td className="py-2 pr-3">{item.brand ?? "—"}</td>
                       <td className="py-2 pr-3">
                         {item.condition ? (
-                          <ConditionBadge
-                            condition={item.condition as Condition}
-                          />
+                          <ConditionBadge condition={item.condition as Condition} />
                         ) : (
                           <span className="text-muted-foreground">—</span>
                         )}
                       </td>
                       <td className="py-2 pr-3">
-                        <Badge variant={warranty.variant}>
-                          {warranty.label}
-                        </Badge>
+                        <Badge variant={warranty.variant}>{warranty.label}</Badge>
                       </td>
                       <td className="py-2 pr-3 text-right tabular-nums">
-                        {item.replacementValue
-                          ? formatCurrency(item.replacementValue)
-                          : "—"}
+                        {item.replacementValue ? formatCurrency(item.replacementValue) : "—"}
                       </td>
                     </tr>
                   );
@@ -215,10 +202,7 @@ export function InsuranceReportPage(): React.ReactElement {
                     </td>
                     <td className="py-2 pr-3 text-right tabular-nums">
                       {formatCurrency(
-                        group.items.reduce(
-                          (sum, i) => sum + (i.replacementValue ?? 0),
-                          0,
-                        ),
+                        group.items.reduce((sum, i) => sum + (i.replacementValue ?? 0), 0)
                       )}
                     </td>
                   </tr>

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -22,15 +22,7 @@ import {
   BreadcrumbPage,
   type Condition,
 } from "@pops/ui";
-import {
-  Pencil,
-  Link2,
-  Unlink,
-  GitBranch,
-  FileText,
-  X,
-  Network,
-} from "lucide-react";
+import { Pencil, Link2, Unlink, GitBranch, FileText, X, Network } from "lucide-react";
 import { trpc } from "../lib/trpc";
 
 const DOCUMENT_TYPE_LABELS: Record<string, string> = {
@@ -56,10 +48,7 @@ export function ItemDetailPage() {
   } = trpc.inventory.items.get.useQuery({ id: id! }, { enabled: !!id });
 
   const { data: connectionsData, isLoading: connectionsLoading } =
-    trpc.inventory.connections.listForItem.useQuery(
-      { itemId: id! },
-      { enabled: !!id },
-    );
+    trpc.inventory.connections.listForItem.useQuery({ itemId: id! }, { enabled: !!id });
 
   const [showGraph, setShowGraph] = useState(false);
 
@@ -94,9 +83,7 @@ export function ItemDetailPage() {
       <div>
         <Alert variant="destructive">
           <AlertTitle>{is404 ? "Item not found" : "Error"}</AlertTitle>
-          <AlertDescription>
-            {is404 ? "This item doesn't exist." : error.message}
-          </AlertDescription>
+          <AlertDescription>{is404 ? "This item doesn't exist." : error.message}</AlertDescription>
         </Alert>
         <Link
           to="/inventory"
@@ -140,7 +127,11 @@ export function ItemDetailPage() {
           )}
         </div>
         <Link to={`/inventory/items/${id}/edit`}>
-          <Button variant="outline" size="sm" className="font-bold border-amber-500/20 hover:border-amber-500/50 hover:bg-amber-500/5 transition-colors">
+          <Button
+            variant="outline"
+            size="sm"
+            className="font-bold border-amber-500/20 hover:border-amber-500/50 hover:bg-amber-500/5 transition-colors"
+          >
             <Pencil className="h-4 w-4 mr-2 text-amber-600 dark:text-amber-400" />
             Edit
           </Button>
@@ -158,18 +149,43 @@ export function ItemDetailPage() {
             />
           )}
           {item.room && <DetailField label="Room" value={item.room} />}
-          {item.assetId && <DetailField label="Asset ID" value={<Badge variant="outline" className="font-mono bg-muted/50">{item.assetId}</Badge>} />}
-          <DetailField label="Status" value={item.inUse ? 
-            <Badge className="bg-emerald-500/10 text-emerald-700 border-emerald-500/20 hover:bg-emerald-500/15">In Use</Badge> : 
-            <Badge variant="secondary">Stored</Badge>
-          } />
+          {item.assetId && (
+            <DetailField
+              label="Asset ID"
+              value={
+                <Badge variant="outline" className="font-mono bg-muted/50">
+                  {item.assetId}
+                </Badge>
+              }
+            />
+          )}
+          <DetailField
+            label="Status"
+            value={
+              item.inUse ? (
+                <Badge className="bg-emerald-500/10 text-emerald-700 border-emerald-500/20 hover:bg-emerald-500/15">
+                  In Use
+                </Badge>
+              ) : (
+                <Badge variant="secondary">Stored</Badge>
+              )
+            }
+          />
           {item.purchaseDate && (
-            <DetailField label="Purchased" value={new Date(item.purchaseDate).toLocaleDateString("en-AU", { year: 'numeric', month: 'short' })} />
+            <DetailField
+              label="Purchased"
+              value={new Date(item.purchaseDate).toLocaleDateString("en-AU", {
+                year: "numeric",
+                month: "short",
+              })}
+            />
           )}
           {item.replacementValue !== null && (
             <DetailField
               label="Replacement"
-              value={<span className="text-amber-700 dark:text-amber-300 font-bold">{`$${item.replacementValue.toLocaleString()}`}</span>}
+              value={
+                <span className="text-amber-700 dark:text-amber-300 font-bold">{`$${item.replacementValue.toLocaleString()}`}</span>
+              }
             />
           )}
         </div>
@@ -178,9 +194,7 @@ export function ItemDetailPage() {
       {item.notes && (
         <div className="mb-8">
           <h2 className="text-lg font-semibold mb-2">Notes</h2>
-          <p className="text-muted-foreground whitespace-pre-wrap">
-            {item.notes}
-          </p>
+          <p className="text-muted-foreground whitespace-pre-wrap">{item.notes}</p>
         </div>
       )}
 
@@ -211,18 +225,14 @@ export function ItemDetailPage() {
             {connectionsData.data.map((conn) => (
               <ConnectionRow
                 key={conn.id}
-                connectedItemId={
-                  conn.itemAId === id ? conn.itemBId : conn.itemAId
-                }
+                connectedItemId={conn.itemAId === id ? conn.itemBId : conn.itemAId}
                 onDisconnect={() => disconnectMutation.mutate({ id: conn.id })}
                 isDisconnecting={disconnectMutation.isPending}
               />
             ))}
           </div>
         ) : (
-          <p className="text-muted-foreground text-sm">
-            No connected items yet.
-          </p>
+          <p className="text-muted-foreground text-sm">No connected items yet.</p>
         )}
       </section>
 
@@ -234,20 +244,12 @@ export function ItemDetailPage() {
               <GitBranch className="h-5 w-5" />
               Connection Chain
             </h2>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setShowGraph((v) => !v)}
-            >
+            <Button variant="outline" size="sm" onClick={() => setShowGraph((v) => !v)}>
               <Network className="h-4 w-4 mr-1.5" />
               {showGraph ? "Hide Graph" : "View Graph"}
             </Button>
           </div>
-          {showGraph ? (
-            <ConnectionGraph itemId={id!} />
-          ) : (
-            <ConnectionTracePanel itemId={id!} />
-          )}
+          {showGraph ? <ConnectionGraph itemId={id!} /> : <ConnectionTracePanel itemId={id!} />}
         </section>
       ) : null}
 
@@ -257,24 +259,19 @@ export function ItemDetailPage() {
   );
 }
 
-function DetailField({
-  label,
-  value,
-}: {
-  label: string;
-  value: React.ReactNode;
-}) {
+function DetailField({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div>
-      <dt className="text-xs font-bold text-amber-900/60 dark:text-amber-100/60 uppercase tracking-widest mb-1">{label}</dt>
+      <dt className="text-xs font-bold text-amber-900/60 dark:text-amber-100/60 uppercase tracking-widest mb-1">
+        {label}
+      </dt>
       <dd className="font-semibold text-foreground">{value}</dd>
     </div>
   );
 }
 
 function DocumentsSection({ itemId }: { itemId: string }) {
-  const { data: statusData, isLoading: statusLoading } =
-    trpc.inventory.paperless.status.useQuery();
+  const { data: statusData, isLoading: statusLoading } = trpc.inventory.paperless.status.useQuery();
 
   const status = statusData?.data;
 
@@ -302,9 +299,7 @@ function DocumentsSection({ itemId }: { itemId: string }) {
           <FileText className="h-5 w-5" />
           Documents
         </h2>
-        <p className="text-sm text-muted-foreground">
-          Paperless-ngx unavailable
-        </p>
+        <p className="text-sm text-muted-foreground">Paperless-ngx unavailable</p>
       </section>
     );
   }
@@ -340,7 +335,7 @@ function DocumentsList({ itemId }: { itemId: string }) {
 
   const typeOrder = ["receipt", "warranty", "manual", "invoice", "other"];
   const sortedTypes = [...grouped.keys()].sort(
-    (a, b) => (typeOrder.indexOf(a) ?? 99) - (typeOrder.indexOf(b) ?? 99),
+    (a, b) => (typeOrder.indexOf(a) ?? 99) - (typeOrder.indexOf(b) ?? 99)
   );
 
   return (
@@ -350,9 +345,7 @@ function DocumentsList({ itemId }: { itemId: string }) {
           <FileText className="h-5 w-5" />
           Documents
           {docs.length ? (
-            <span className="text-sm font-normal text-muted-foreground">
-              ({docs.length})
-            </span>
+            <span className="text-sm font-normal text-muted-foreground">({docs.length})</span>
           ) : null}
         </h2>
         <LinkDocumentDialog
@@ -408,9 +401,7 @@ function DocumentsList({ itemId }: { itemId: string }) {
           ))}
         </div>
       ) : (
-        <p className="text-muted-foreground text-sm">
-          No documents linked yet.
-        </p>
+        <p className="text-muted-foreground text-sm">No documents linked yet.</p>
       )}
     </section>
   );
@@ -430,16 +421,9 @@ function ConnectionRow({
 
   return (
     <div className="flex items-center justify-between p-3 rounded-lg border">
-      <Link
-        to={`/inventory/items/${connectedItemId}`}
-        className="flex-1 hover:underline"
-      >
+      <Link to={`/inventory/items/${connectedItemId}`} className="flex-1 hover:underline">
         <span className="font-medium">{item?.itemName ?? connectedItemId}</span>
-        {item?.brand && (
-          <span className="text-muted-foreground text-sm ml-2">
-            {item.brand}
-          </span>
-        )}
+        {item?.brand && <span className="text-muted-foreground text-sm ml-2">{item.brand}</span>}
       </Link>
       <Button
         variant="ghost"

--- a/packages/app-inventory/src/pages/ItemFormPage.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.tsx
@@ -115,16 +115,13 @@ export function ItemFormPage() {
   } = useForm<ItemFormValues>({ defaultValues });
 
   // Pending connections for create mode
-  const [pendingConnections, setPendingConnections] = useState<
-    PendingConnection[]
-  >([]);
+  const [pendingConnections, setPendingConnections] = useState<PendingConnection[]>([]);
   const [connectionSearch, setConnectionSearch] = useState("");
 
-  const { data: searchResults, isLoading: searchLoading } =
-    trpc.inventory.items.list.useQuery(
-      { search: connectionSearch, limit: 10 },
-      { enabled: !isEditMode && connectionSearch.length >= 2 },
-    );
+  const { data: searchResults, isLoading: searchLoading } = trpc.inventory.items.list.useQuery(
+    { search: connectionSearch, limit: 10 },
+    { enabled: !isEditMode && connectionSearch.length >= 2 }
+  );
 
   const connectMutation = trpc.inventory.connections.connect.useMutation();
 
@@ -188,9 +185,7 @@ export function ItemFormPage() {
           }
         }
         if (connected > 0) {
-          toast.success(
-            `Item created with ${connected} connection${connected > 1 ? "s" : ""}`,
-          );
+          toast.success(`Item created with ${connected} connection${connected > 1 ? "s" : ""}`);
         } else {
           toast.success("Item created");
         }
@@ -236,9 +231,7 @@ export function ItemFormPage() {
       deductible: values.deductible,
       purchaseDate: values.purchaseDate || null,
       warrantyExpires: values.warrantyExpires || null,
-      replacementValue: values.replacementValue
-        ? parseFloat(values.replacementValue)
-        : null,
+      replacementValue: values.replacementValue ? parseFloat(values.replacementValue) : null,
       resaleValue: values.resaleValue ? parseFloat(values.resaleValue) : null,
       assetId: values.assetId || null,
       notes: values.notes || null,
@@ -270,9 +263,7 @@ export function ItemFormPage() {
       <div className="p-6">
         <Alert variant="destructive">
           <AlertTitle>{is404 ? "Item not found" : "Error"}</AlertTitle>
-          <AlertDescription>
-            {is404 ? "This item doesn't exist." : error.message}
-          </AlertDescription>
+          <AlertDescription>{is404 ? "This item doesn't exist." : error.message}</AlertDescription>
         </Alert>
         <Link
           to="/inventory"
@@ -387,10 +378,7 @@ export function ItemFormPage() {
           </div>
 
           <FormField label="Room">
-            <TextInput
-              {...register("room")}
-              placeholder="e.g. Office, Bedroom"
-            />
+            <TextInput {...register("room")} placeholder="e.g. Office, Bedroom" />
           </FormField>
 
           <div className="flex gap-6 p-4 rounded-xl bg-amber-500/5">
@@ -473,9 +461,7 @@ export function ItemFormPage() {
                       type="button"
                       className="rounded-full p-0.5 hover:bg-amber-500/20"
                       onClick={() =>
-                        setPendingConnections((prev) =>
-                          prev.filter((c) => c.id !== conn.id),
-                        )
+                        setPendingConnections((prev) => prev.filter((c) => c.id !== conn.id))
                       }
                     >
                       <X className="h-3 w-3" />
@@ -504,13 +490,9 @@ export function ItemFormPage() {
                   </div>
                 ) : (
                   (() => {
-                    const pendingIds = new Set(
-                      pendingConnections.map((c) => c.id),
-                    );
+                    const pendingIds = new Set(pendingConnections.map((c) => c.id));
                     const filtered =
-                      searchResults?.data.filter(
-                        (item) => !pendingIds.has(item.id),
-                      ) ?? [];
+                      searchResults?.data.filter((item) => !pendingIds.has(item.id)) ?? [];
                     return filtered.length === 0 ? (
                       <p className="text-sm text-muted-foreground py-3 text-center">
                         No items found
@@ -530,13 +512,10 @@ export function ItemFormPage() {
                           }}
                         >
                           <div>
-                            <div className="font-medium text-sm">
-                              {item.itemName}
-                            </div>
+                            <div className="font-medium text-sm">{item.itemName}</div>
                             <div className="text-xs text-muted-foreground">
-                              {[item.brand, item.model, item.assetId]
-                                .filter(Boolean)
-                                .join(" · ") || "No details"}
+                              {[item.brand, item.model, item.assetId].filter(Boolean).join(" · ") ||
+                                "No details"}
                             </div>
                           </div>
                           <Link2 className="h-4 w-4 text-amber-500/50 shrink-0 ml-2" />
@@ -563,7 +542,12 @@ export function ItemFormPage() {
             {isEditMode ? "Save Changes" : "Create Item"}
           </Button>
           <Link to="/inventory">
-            <Button type="button" variant="outline" size="lg" className="px-8 font-bold border-amber-500/20 hover:bg-amber-500/5">
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className="px-8 font-bold border-amber-500/20 hover:bg-amber-500/5"
+            >
               Cancel
             </Button>
           </Link>

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -4,15 +4,7 @@
  */
 import { useState, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router";
-import {
-  Package,
-  LayoutGrid,
-  LayoutList,
-  Search,
-  DollarSign,
-  Shield,
-  Clock,
-} from "lucide-react";
+import { Package, LayoutGrid, LayoutList, Search, DollarSign, Shield, Clock } from "lucide-react";
 import {
   Skeleton,
   Select,
@@ -140,9 +132,7 @@ function DashboardWidgets() {
             <DollarSign className="h-4 w-4" />
             <span className="text-xs font-medium">Resale</span>
           </div>
-          <div className="text-2xl font-bold tabular-nums">
-            {formatCurrency(totalResaleValue)}
-          </div>
+          <div className="text-2xl font-bold tabular-nums">{formatCurrency(totalResaleValue)}</div>
         </CardContent>
       </Card>
 
@@ -154,9 +144,7 @@ function DashboardWidgets() {
           </div>
           <div className="text-2xl font-bold tabular-nums">
             {warrantiesExpiringSoon}
-            <span className="text-sm font-normal text-muted-foreground ml-1">
-              expiring
-            </span>
+            <span className="text-sm font-normal text-muted-foreground ml-1">expiring</span>
           </div>
         </CardContent>
       </Card>
@@ -186,9 +174,7 @@ function DashboardWidgets() {
                   <span className="font-medium truncate">{item.itemName}</span>
                   {item.type && <TypeBadge type={item.type} />}
                   {item.assetId && (
-                    <span className="text-xs text-muted-foreground shrink-0">
-                      {item.assetId}
-                    </span>
+                    <span className="text-xs text-muted-foreground shrink-0">{item.assetId}</span>
                   )}
                   <span className="text-xs text-muted-foreground shrink-0 ml-auto">
                     {timeAgo(item.lastEditedTime)}
@@ -238,7 +224,7 @@ export function ItemsPage() {
       inUse: (inUseFilter || undefined) as "true" | "false" | undefined,
       limit: 200,
     }),
-    [search, typeFilter, conditionFilter, inUseFilter],
+    [search, typeFilter, conditionFilter, inUseFilter]
   );
 
   const { data, isLoading } = trpc.inventory.items.list.useQuery(queryInput);
@@ -323,14 +309,9 @@ export function ItemsPage() {
             <p className="text-xs font-semibold text-amber-900 dark:text-amber-200 uppercase tracking-wider">
               {totalCount} {totalCount === 1 ? "item" : "items"}
               {totalReplacementValue > 0 && (
-                <span>
-                  {" "}
-                  — {formatCurrency(totalReplacementValue)} replacement
-                </span>
+                <span> — {formatCurrency(totalReplacementValue)} replacement</span>
               )}
-              {totalResaleValue > 0 && (
-                <span> — {formatCurrency(totalResaleValue)} resale</span>
-              )}
+              {totalResaleValue > 0 && <span> — {formatCurrency(totalResaleValue)} resale</span>}
             </p>
           </div>
           <div className="flex items-center gap-1 rounded-lg border bg-muted/30 p-0.5 ml-auto">

--- a/packages/app-inventory/src/pages/LocationTreePage.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.tsx
@@ -64,10 +64,7 @@ function TreeSkeleton() {
   );
 }
 
-function buildBreadcrumb(
-  nodeId: string,
-  nodeMap: Map<string, LocationTreeNode>,
-): string[] {
+function buildBreadcrumb(nodeId: string, nodeMap: Map<string, LocationTreeNode>): string[] {
   const path: string[] = [];
   let current = nodeMap.get(nodeId);
   while (current) {
@@ -77,10 +74,7 @@ function buildBreadcrumb(
   return path;
 }
 
-function buildNodeMap(
-  nodes: LocationTreeNode[],
-  map: Map<string, LocationTreeNode>,
-): void {
+function buildNodeMap(nodes: LocationTreeNode[], map: Map<string, LocationTreeNode>): void {
   for (const node of nodes) {
     map.set(node.id, node);
     buildNodeMap(node.children, map);
@@ -99,7 +93,7 @@ function countDescendants(node: LocationTreeNode): number {
 function isDescendant(
   nodeId: string,
   targetId: string,
-  nodeMap: Map<string, LocationTreeNode>,
+  nodeMap: Map<string, LocationTreeNode>
 ): boolean {
   const node = nodeMap.get(nodeId);
   if (!node) return false;
@@ -115,7 +109,7 @@ function isDescendant(
 function getSiblings(
   nodeId: string,
   treeNodes: LocationTreeNode[],
-  nodeMap: Map<string, LocationTreeNode>,
+  nodeMap: Map<string, LocationTreeNode>
 ): LocationTreeNode[] {
   const node = nodeMap.get(nodeId);
   if (!node) return [];
@@ -194,9 +188,7 @@ function MoveTargetPicker({
                 disabled={disabled}
                 onClick={() => onSelect(node.id)}
                 className={`w-full text-left flex items-center gap-1.5 py-1.5 px-2 rounded-md transition-colors ${
-                  disabled
-                    ? "opacity-40 cursor-not-allowed"
-                    : "hover:bg-muted/50 cursor-pointer"
+                  disabled ? "opacity-40 cursor-not-allowed" : "hover:bg-muted/50 cursor-pointer"
                 }`}
                 style={{ paddingLeft: `${depth * 16 + 8}px` }}
               >
@@ -267,7 +259,9 @@ function LocationNode({
     <Collapsible open={open} onOpenChange={setOpen}>
       <div
         className={`group flex items-center gap-1.5 py-1.5 px-2 rounded-md cursor-pointer transition-colors hover:bg-amber-500/10 ${
-          isSelected ? "bg-amber-500/20 text-amber-900 dark:text-amber-100 font-bold border-l-2 border-amber-500 rounded-l-none ml-[-2px]" : ""
+          isSelected
+            ? "bg-amber-500/20 text-amber-900 dark:text-amber-100 font-bold border-l-2 border-amber-500 rounded-l-none ml-[-2px]"
+            : ""
         }`}
         style={{ paddingLeft: `${depth * 20 + 8}px` }}
         onClick={() => onSelect(node.id)}
@@ -538,7 +532,7 @@ export function LocationTreePage() {
     (id: string, newName: string) => {
       updateMutation.mutate({ id, data: { name: newName } });
     },
-    [updateMutation],
+    [updateMutation]
   );
 
   const handleNewChildSave = useCallback(
@@ -548,7 +542,7 @@ export function LocationTreePage() {
         parentId: addingChildOf,
       });
     },
-    [addingChildOf, createMutation],
+    [addingChildOf, createMutation]
   );
 
   const handleNewChildCancel = useCallback(() => {
@@ -559,7 +553,7 @@ export function LocationTreePage() {
     (name: string) => {
       createMutation.mutate({ name, parentId: null });
     },
-    [createMutation],
+    [createMutation]
   );
 
   const handleNewRootCancel = useCallback(() => {
@@ -574,7 +568,7 @@ export function LocationTreePage() {
       // Try without force first — server will return requiresConfirmation if non-empty
       deleteMutation.mutate({ id });
     },
-    [nodeMap, deleteMutation],
+    [nodeMap, deleteMutation]
   );
 
   const handleDeleteConfirm = useCallback(() => {
@@ -591,10 +585,10 @@ export function LocationTreePage() {
       if (!movingId) return;
       updateMutation.mutate(
         { id: movingId, data: { parentId: newParentId } },
-        { onSuccess: () => setMovingId(null) },
+        { onSuccess: () => setMovingId(null) }
       );
     },
-    [movingId, updateMutation],
+    [movingId, updateMutation]
   );
 
   const handleReorder = useCallback(
@@ -619,7 +613,7 @@ export function LocationTreePage() {
         data: { sortOrder: current.sortOrder },
       });
     },
-    [treeNodes, nodeMap, updateMutation],
+    [treeNodes, nodeMap, updateMutation]
   );
 
   const movingNode = movingId ? nodeMap.get(movingId) : null;
@@ -676,11 +670,7 @@ export function LocationTreePage() {
         </div>
       ) : (
         <div className="flex flex-col md:flex-row gap-6">
-          <div
-            className="md:w-2/5 border rounded-lg py-2"
-            role="tree"
-            aria-label="Location tree"
-          >
+          <div className="md:w-2/5 border rounded-lg py-2" role="tree" aria-label="Location tree">
             {treeNodes.map((node, i) => (
               <LocationNode
                 key={node.id}
@@ -701,10 +691,7 @@ export function LocationTreePage() {
               />
             ))}
             {addingRoot && (
-              <div
-                className="flex items-center gap-1.5 py-1.5 px-2"
-                style={{ paddingLeft: "8px" }}
-              >
+              <div className="flex items-center gap-1.5 py-1.5 px-2" style={{ paddingLeft: "8px" }}>
                 <span className="w-[22px]" />
                 <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
                 <InlineInput
@@ -734,10 +721,7 @@ export function LocationTreePage() {
       )}
 
       {/* Move To dialog */}
-      <Dialog
-        open={!!movingId}
-        onOpenChange={(open) => !open && setMovingId(null)}
-      >
+      <Dialog open={!!movingId} onOpenChange={(open) => !open && setMovingId(null)}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Move &ldquo;{movingNode?.name}&rdquo;</DialogTitle>
@@ -768,28 +752,19 @@ export function LocationTreePage() {
       </Dialog>
 
       {/* Delete confirmation dialog */}
-      <Dialog
-        open={!!deleteConfirm}
-        onOpenChange={(open) => !open && setDeleteConfirm(null)}
-      >
+      <Dialog open={!!deleteConfirm} onOpenChange={(open) => !open && setDeleteConfirm(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>
-              Delete &ldquo;{deleteConfirm?.name}&rdquo;?
-            </DialogTitle>
+            <DialogTitle>Delete &ldquo;{deleteConfirm?.name}&rdquo;?</DialogTitle>
             <DialogDescription>This action cannot be undone.</DialogDescription>
           </DialogHeader>
           {deleteConfirm && (
             <div className="space-y-2 text-sm">
               {deleteConfirm.stats.childCount > 0 && (
                 <p>
-                  This location has{" "}
-                  <strong>{deleteConfirm.stats.childCount}</strong> direct{" "}
-                  {deleteConfirm.stats.childCount === 1
-                    ? "sub-location"
-                    : "sub-locations"}
-                  {deleteConfirm.stats.descendantCount >
-                    deleteConfirm.stats.childCount &&
+                  This location has <strong>{deleteConfirm.stats.childCount}</strong> direct{" "}
+                  {deleteConfirm.stats.childCount === 1 ? "sub-location" : "sub-locations"}
+                  {deleteConfirm.stats.descendantCount > deleteConfirm.stats.childCount &&
                     ` (${deleteConfirm.stats.descendantCount} total)`}
                   . They will all be deleted.
                 </p>
@@ -797,8 +772,8 @@ export function LocationTreePage() {
               {deleteConfirm.stats.totalItemCount > 0 && (
                 <p>
                   <strong>{deleteConfirm.stats.totalItemCount}</strong>{" "}
-                  {deleteConfirm.stats.totalItemCount === 1 ? "item" : "items"}{" "}
-                  will become unlocated.
+                  {deleteConfirm.stats.totalItemCount === 1 ? "item" : "items"} will become
+                  unlocated.
                 </p>
               )}
             </div>

--- a/packages/app-inventory/src/pages/WarrantiesPage.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.tsx
@@ -43,9 +43,7 @@ function daysUntil(dateStr: string): number {
   return Math.ceil((target.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
 }
 
-function urgencyBadgeVariant(
-  days: number,
-): "destructive" | "secondary" | "outline" {
+function urgencyBadgeVariant(days: number): "destructive" | "secondary" | "outline" {
   if (days <= 14) return "destructive";
   if (days <= 30) return "secondary";
   return "outline";
@@ -69,12 +67,7 @@ interface WarrantyRowProps {
   onClick: () => void;
 }
 
-function WarrantyRow({
-  item,
-  daysRemaining,
-  showUrgency,
-  onClick,
-}: WarrantyRowProps) {
+function WarrantyRow({ item, daysRemaining, showUrgency, onClick }: WarrantyRowProps) {
   return (
     <button
       type="button"
@@ -87,15 +80,8 @@ function WarrantyRow({
         {item.warrantyExpires && formatDate(item.warrantyExpires)}
       </span>
       {showUrgency && (
-        <Badge
-          variant={urgencyBadgeVariant(daysRemaining)}
-          className="text-xs whitespace-nowrap"
-        >
-          {daysRemaining === 0
-            ? "Today"
-            : daysRemaining === 1
-              ? "1 day"
-              : `${daysRemaining} days`}
+        <Badge variant={urgencyBadgeVariant(daysRemaining)} className="text-xs whitespace-nowrap">
+          {daysRemaining === 0 ? "Today" : daysRemaining === 1 ? "1 day" : `${daysRemaining} days`}
         </Badge>
       )}
       {!showUrgency && daysRemaining < 0 && (
@@ -201,8 +187,8 @@ export function WarrantiesPage() {
         <div className="text-center py-16">
           <ShieldCheck className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
           <p className="text-muted-foreground">
-            No items with warranty dates. Add warranty expiry dates to your
-            inventory items to track them here.
+            No items with warranty dates. Add warranty expiry dates to your inventory items to track
+            them here.
           </p>
         </div>
       ) : (
@@ -235,11 +221,7 @@ export function WarrantiesPage() {
 
           {/* Active — collapsible */}
           {active.length > 0 && (
-            <CollapsibleSection
-              title="Active"
-              count={active.length}
-              defaultOpen
-            >
+            <CollapsibleSection title="Active" count={active.length} defaultOpen>
               {active.map((item) => (
                 <WarrantyRow
                   key={item.id}

--- a/packages/app-inventory/src/routes.tsx
+++ b/packages/app-inventory/src/routes.tsx
@@ -7,31 +7,29 @@
 import { lazy } from "react";
 import type { RouteObject } from "react-router";
 
-const ItemsPage = lazy(() =>
-  import("./pages/ItemsPage").then((m) => ({ default: m.ItemsPage })),
-);
+const ItemsPage = lazy(() => import("./pages/ItemsPage").then((m) => ({ default: m.ItemsPage })));
 const ItemDetailPage = lazy(() =>
   import("./pages/ItemDetailPage").then((m) => ({
     default: m.ItemDetailPage,
-  })),
+  }))
 );
 const ItemFormPage = lazy(() =>
-  import("./pages/ItemFormPage").then((m) => ({ default: m.ItemFormPage })),
+  import("./pages/ItemFormPage").then((m) => ({ default: m.ItemFormPage }))
 );
 const WarrantiesPage = lazy(() =>
   import("./pages/WarrantiesPage").then((m) => ({
     default: m.WarrantiesPage,
-  })),
+  }))
 );
 const InsuranceReportPage = lazy(() =>
   import("./pages/InsuranceReportPage").then((m) => ({
     default: m.InsuranceReportPage,
-  })),
+  }))
 );
 const LocationTreePage = lazy(() =>
   import("./pages/LocationTreePage").then((m) => ({
     default: m.LocationTreePage,
-  })),
+  }))
 );
 
 /** Local type mirror for compile-time safety (shell owns the canonical types). */

--- a/packages/app-media/src/components/ArrStatusBadge.tsx
+++ b/packages/app-media/src/components/ArrStatusBadge.tsx
@@ -29,17 +29,16 @@ export function ArrStatusBadge({ kind, externalId }: ArrStatusBadgeProps) {
   const { data: configData } = trpc.media.arr.getConfig.useQuery();
   const config = configData?.data;
 
-  const isConfigured =
-    kind === "movie" ? config?.radarrConfigured : config?.sonarrConfigured;
+  const isConfigured = kind === "movie" ? config?.radarrConfigured : config?.sonarrConfigured;
 
   const movieStatus = trpc.media.arr.getMovieStatus.useQuery(
     { tmdbId: externalId },
-    { enabled: kind === "movie" && isConfigured === true },
+    { enabled: kind === "movie" && isConfigured === true }
   );
 
   const showStatus = trpc.media.arr.getShowStatus.useQuery(
     { tvdbId: externalId },
-    { enabled: kind === "show" && isConfigured === true },
+    { enabled: kind === "show" && isConfigured === true }
   );
 
   if (!isConfigured) return null;
@@ -49,8 +48,7 @@ export function ArrStatusBadge({ kind, externalId }: ArrStatusBadgeProps) {
 
   // Show unavailable badge when query errors (configured but unreachable)
   if (query.error) {
-    const label =
-      kind === "movie" ? "Radarr unavailable" : "Sonarr unavailable";
+    const label = kind === "movie" ? "Radarr unavailable" : "Sonarr unavailable";
     return <Badge className={STATUS_STYLES.unavailable}>{label}</Badge>;
   }
 

--- a/packages/app-media/src/components/ComparisonScores.tsx
+++ b/packages/app-media/src/components/ComparisonScores.tsx
@@ -26,8 +26,9 @@ export interface ComparisonScoresProps {
 }
 
 export function ComparisonScores({ mediaType, mediaId }: ComparisonScoresProps) {
-  const { data: scoresResponse, isLoading: scoresLoading } =
-    trpc.media.comparisons.scores.useQuery({ mediaType, mediaId });
+  const { data: scoresResponse, isLoading: scoresLoading } = trpc.media.comparisons.scores.useQuery(
+    { mediaType, mediaId }
+  );
 
   const { data: dimensionsResponse, isLoading: dimensionsLoading } =
     trpc.media.comparisons.listDimensions.useQuery();

--- a/packages/app-media/src/components/DimensionManager.tsx
+++ b/packages/app-media/src/components/DimensionManager.tsx
@@ -45,10 +45,12 @@ export function DimensionManager() {
 
   const utils = trpc.useUtils();
 
-  const { data: dimensionsData, isLoading } =
-    trpc.media.comparisons.listDimensions.useQuery(undefined, {
+  const { data: dimensionsData, isLoading } = trpc.media.comparisons.listDimensions.useQuery(
+    undefined,
+    {
       enabled: open,
-    });
+    }
+  );
 
   const dimensions: Dimension[] = (dimensionsData?.data ?? []).map((d) => ({
     ...d,
@@ -91,7 +93,7 @@ export function DimensionManager() {
         data: { active: !dim.active },
       });
     },
-    [updateMutation],
+    [updateMutation]
   );
 
   const handleStartEdit = useCallback((dim: Dimension) => {
@@ -133,10 +135,10 @@ export function DimensionManager() {
               data: { sortOrder: dim.sortOrder },
             });
           },
-        },
+        }
       );
     },
-    [dimensions, updateMutation],
+    [dimensions, updateMutation]
   );
 
   const sorted = [...dimensions].sort((a, b) => a.sortOrder - b.sortOrder);
@@ -184,9 +186,7 @@ export function DimensionManager() {
 
         {/* Dimension list */}
         {isLoading ? (
-          <p className="text-sm text-muted-foreground py-4 text-center">
-            Loading...
-          </p>
+          <p className="text-sm text-muted-foreground py-4 text-center">Loading...</p>
         ) : sorted.length === 0 ? (
           <p className="text-sm text-muted-foreground py-4 text-center">
             No dimensions yet. Add one above.
@@ -226,9 +226,7 @@ export function DimensionManager() {
                     <div className="space-y-1">
                       <Input
                         value={editing.name}
-                        onChange={(e) =>
-                          setEditing({ ...editing, name: e.target.value })
-                        }
+                        onChange={(e) => setEditing({ ...editing, name: e.target.value })}
                         onKeyDown={(e) => {
                           if (e.key === "Enter") handleSaveEdit();
                           if (e.key === "Escape") setEditing(null);
@@ -238,9 +236,7 @@ export function DimensionManager() {
                       />
                       <Textarea
                         value={editing.description}
-                        onChange={(e) =>
-                          setEditing({ ...editing, description: e.target.value })
-                        }
+                        onChange={(e) => setEditing({ ...editing, description: e.target.value })}
                         rows={1}
                         className="resize-none text-sm"
                         placeholder="Description"
@@ -268,9 +264,7 @@ export function DimensionManager() {
                   ) : (
                     <div>
                       <div className="flex items-center gap-1.5">
-                        <span className="text-sm font-medium truncate">
-                          {dim.name}
-                        </span>
+                        <span className="text-sm font-medium truncate">{dim.name}</span>
                         {!dim.active && (
                           <Badge variant="secondary" className="text-xs">
                             Inactive
@@ -278,9 +272,7 @@ export function DimensionManager() {
                         )}
                       </div>
                       {dim.description && (
-                        <p className="text-xs text-muted-foreground truncate">
-                          {dim.description}
-                        </p>
+                        <p className="text-xs text-muted-foreground truncate">{dim.description}</p>
                       )}
                     </div>
                   )}

--- a/packages/app-media/src/components/DiscoverCard.tsx
+++ b/packages/app-media/src/components/DiscoverCard.tsx
@@ -53,30 +53,19 @@ export function DiscoverCard({
   const year = releaseDate ? releaseDate.slice(0, 4) : null;
 
   return (
-    <div
-      className={cn(
-        "group flex w-36 shrink-0 flex-col gap-1.5 sm:w-40",
-        className,
-      )}
-    >
+    <div className={cn("group flex w-36 shrink-0 flex-col gap-1.5 sm:w-40", className)}>
       {/* Poster */}
       <div className="relative w-full overflow-hidden rounded-md bg-muted aspect-[2/3]">
         {/* Rating badge */}
         {voteAverage > 0 && (
-          <Badge
-            variant="default"
-            className="absolute top-2 left-2 z-10 text-xs"
-          >
+          <Badge variant="default" className="absolute top-2 left-2 z-10 text-xs">
             {voteAverage.toFixed(1)}
           </Badge>
         )}
 
         {/* In Library badge */}
         {inLibrary && (
-          <Badge
-            variant="secondary"
-            className="absolute top-2 right-2 z-10 gap-0.5 text-xs"
-          >
+          <Badge variant="secondary" className="absolute top-2 right-2 z-10 gap-0.5 text-xs">
             <Check className="h-3 w-3" />
             Owned
           </Badge>
@@ -91,7 +80,7 @@ export function DiscoverCard({
             className={cn(
               "h-full w-full object-cover transition-opacity duration-200",
               "group-hover:opacity-80",
-              imageLoaded ? "opacity-100" : "opacity-0",
+              imageLoaded ? "opacity-100" : "opacity-0"
             )}
             onLoad={() => setImageLoaded(true)}
             onError={() => setImageError(true)}
@@ -157,9 +146,7 @@ export function DiscoverCard({
 
       {/* Title + Year + Match info */}
       <div className="space-y-0.5 px-0.5">
-        <h3 className="text-sm font-medium leading-tight line-clamp-2">
-          {title}
-        </h3>
+        <h3 className="text-sm font-medium leading-tight line-clamp-2">{title}</h3>
         {year && <p className="text-xs text-muted-foreground">{year}</p>}
         {matchPercentage != null && matchPercentage > 0 && (
           <div className="flex items-center gap-1">
@@ -170,15 +157,13 @@ export function DiscoverCard({
                   ? "text-green-500"
                   : matchPercentage >= 70
                     ? "text-emerald-500"
-                    : "text-muted-foreground",
+                    : "text-muted-foreground"
               )}
             >
               {matchPercentage}% Match
             </span>
             {matchReason && (
-              <span className="text-xs text-muted-foreground truncate">
-                · {matchReason}
-              </span>
+              <span className="text-xs text-muted-foreground truncate">· {matchReason}</span>
             )}
           </div>
         )}

--- a/packages/app-media/src/components/DownloadQueue.tsx
+++ b/packages/app-media/src/components/DownloadQueue.tsx
@@ -28,14 +28,8 @@ export function DownloadQueue() {
       </h2>
       <div className="space-y-1.5">
         {items.map((item) => (
-          <div
-            key={item.id}
-            className="flex items-center gap-3 rounded-lg border bg-card p-3"
-          >
-            <Badge
-              variant="outline"
-              className="text-[10px] uppercase shrink-0"
-            >
+          <div key={item.id} className="flex items-center gap-3 rounded-lg border bg-card p-3">
+            <Badge variant="outline" className="text-[10px] uppercase shrink-0">
               {item.mediaType === "movie" ? "Movie" : "Episode"}
             </Badge>
 
@@ -43,9 +37,7 @@ export function DownloadQueue() {
               <p className="text-sm font-medium truncate">
                 {item.title}
                 {item.episodeLabel && (
-                  <span className="text-muted-foreground ml-1.5">
-                    {item.episodeLabel}
-                  </span>
+                  <span className="text-muted-foreground ml-1.5">{item.episodeLabel}</span>
                 )}
               </p>
 

--- a/packages/app-media/src/components/EpisodeList.tsx
+++ b/packages/app-media/src/components/EpisodeList.tsx
@@ -99,9 +99,7 @@ function EpisodeRow({
       </div>
 
       {isExpanded && hasOverview && (
-        <p className="mt-2 ml-7 text-sm text-muted-foreground leading-relaxed">
-          {ep.overview}
-        </p>
+        <p className="mt-2 ml-7 text-sm text-muted-foreground leading-relaxed">{ep.overview}</p>
       )}
     </div>
   );
@@ -130,9 +128,7 @@ export function EpisodeList({
   };
 
   if (episodes.length === 0) {
-    return (
-      <p className="text-muted-foreground text-sm">No episodes available.</p>
-    );
+    return <p className="text-muted-foreground text-sm">No episodes available.</p>;
   }
 
   return (

--- a/packages/app-media/src/components/HorizontalScrollRow.tsx
+++ b/packages/app-media/src/components/HorizontalScrollRow.tsx
@@ -46,9 +46,7 @@ export function HorizontalScrollRow({
       <div className="flex items-end justify-between gap-2 px-1">
         <div>
           <h2 className="text-lg font-semibold">{title}</h2>
-          {subtitle && (
-            <p className="text-sm text-muted-foreground">{subtitle}</p>
-          )}
+          {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
         </div>
         <div className="flex gap-1">
           <Button
@@ -73,10 +71,7 @@ export function HorizontalScrollRow({
       </div>
 
       {/* Scrollable content */}
-      <div
-        ref={scrollRef}
-        className="flex gap-4 overflow-x-auto pb-2 scrollbar-thin"
-      >
+      <div ref={scrollRef} className="flex gap-4 overflow-x-auto pb-2 scrollbar-thin">
         {isLoading
           ? Array.from({ length: skeletonCount }, (_, i) => (
               <div key={i} className="w-36 shrink-0 space-y-2 sm:w-40">

--- a/packages/app-media/src/components/MarkAsWatchedButton.tsx
+++ b/packages/app-media/src/components/MarkAsWatchedButton.tsx
@@ -9,17 +9,14 @@ export interface MarkAsWatchedButtonProps {
   className?: string;
 }
 
-export function MarkAsWatchedButton({
-  mediaId,
-  className,
-}: MarkAsWatchedButtonProps) {
+export function MarkAsWatchedButton({ mediaId, className }: MarkAsWatchedButtonProps) {
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [customDate, setCustomDate] = useState("");
   const utils = trpc.useUtils();
 
   const { data: historyData } = trpc.media.watchHistory.list.useQuery(
     { mediaType: "movie", mediaId, limit: 100 },
-    { staleTime: 30_000 },
+    { staleTime: 30_000 }
   );
 
   const watchCount = historyData?.data?.length ?? 0;
@@ -91,11 +88,7 @@ export function MarkAsWatchedButton({
           loading={logMutation.isPending && !showDatePicker}
           loadingText="Logging"
           prefix={
-            watchCount > 0 ? (
-              <CircleCheck className="h-4 w-4" />
-            ) : (
-              <Eye className="h-4 w-4" />
-            )
+            watchCount > 0 ? <CircleCheck className="h-4 w-4" /> : <Eye className="h-4 w-4" />
           }
           aria-label="Mark as watched"
         >
@@ -136,9 +129,7 @@ export function MarkAsWatchedButton({
       )}
 
       {watchCount > 0 && lastWatched && (
-        <p className="text-xs text-muted-foreground mt-1">
-          Last watched {formatDate(lastWatched)}
-        </p>
+        <p className="text-xs text-muted-foreground mt-1">Last watched {formatDate(lastWatched)}</p>
       )}
     </div>
   );

--- a/packages/app-media/src/components/MediaCard.stories.tsx
+++ b/packages/app-media/src/components/MediaCard.stories.tsx
@@ -65,8 +65,7 @@ export const LongTitle: Story = {
   args: {
     id: 3,
     type: "movie",
-    title:
-      "Dr. Strangelove or: How I Learned to Stop Worrying and Love the Bomb",
+    title: "Dr. Strangelove or: How I Learned to Stop Worrying and Love the Bomb",
     year: "1964",
     posterUrl: "/media/images/movie/3/poster.jpg",
     onClick: (id, type) => console.log("Navigate:", type, id),

--- a/packages/app-media/src/components/MediaCard.tsx
+++ b/packages/app-media/src/components/MediaCard.tsx
@@ -58,7 +58,7 @@ export function MediaCard({
       className={cn(
         "group flex w-full cursor-pointer flex-col gap-2 text-left",
         "rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        className,
+        className
       )}
       onClick={handleClick}
     >
@@ -81,7 +81,7 @@ export function MediaCard({
             className={cn(
               "h-full w-full object-cover transition-opacity duration-200",
               "group-hover:opacity-80",
-              imageLoaded ? "opacity-100" : "opacity-0",
+              imageLoaded ? "opacity-100" : "opacity-0"
             )}
             onLoad={() => setImageLoaded(true)}
             onError={() => setImageError(true)}
@@ -106,7 +106,7 @@ export function MediaCard({
             <div
               className={cn(
                 "h-full transition-all",
-                progress >= 100 ? "bg-green-500" : "bg-primary",
+                progress >= 100 ? "bg-green-500" : "bg-primary"
               )}
               style={{ width: `${Math.min(progress, 100)}%` }}
             />
@@ -116,9 +116,7 @@ export function MediaCard({
 
       {/* Title + Year */}
       <div className="space-y-0.5 px-0.5">
-        <h3 className="text-sm font-medium leading-tight line-clamp-2">
-          {title}
-        </h3>
+        <h3 className="text-sm font-medium leading-tight line-clamp-2">{title}</h3>
         {year && (
           <p className="text-xs text-muted-foreground">
             {typeof year === "string" ? year.slice(0, 4) : year}

--- a/packages/app-media/src/components/ProgressBar.tsx
+++ b/packages/app-media/src/components/ProgressBar.tsx
@@ -19,7 +19,7 @@ export function ProgressBar({ watched, total, className, showLabel = true }: Pro
         <div
           className={cn(
             "h-full rounded-full transition-all",
-            isComplete ? "bg-green-500" : "bg-primary",
+            isComplete ? "bg-green-500" : "bg-primary"
           )}
           style={{ width: `${Math.min(percentage, 100)}%` }}
         />

--- a/packages/app-media/src/components/QuickPickDialog.tsx
+++ b/packages/app-media/src/components/QuickPickDialog.tsx
@@ -26,7 +26,7 @@ export function QuickPickDialog() {
 
   const { data, isLoading, refetch } = trpc.media.discovery.quickPick.useQuery(
     { count: 5 },
-    { enabled: open },
+    { enabled: open }
   );
 
   const addToWatchlist = trpc.media.watchlist.add.useMutation({
@@ -57,7 +57,7 @@ export function QuickPickDialog() {
         void refetch();
       }
     },
-    [refetch],
+    [refetch]
   );
 
   const handleSkip = () => setCurrentIndex((i) => i + 1);
@@ -99,16 +99,13 @@ export function QuickPickDialog() {
           ) : movies.length === 0 ? (
             <div className="text-center py-8">
               <p className="text-muted-foreground">
-                No picks available — all movies are watched or on your
-                watchlist.
+                No picks available — all movies are watched or on your watchlist.
               </p>
             </div>
           ) : isFinished ? (
             <div className="text-center py-8 space-y-4">
               <Sparkles className="h-10 w-10 mx-auto text-indigo-400" />
-              <p className="text-muted-foreground">
-                You&apos;ve seen all the picks!
-              </p>
+              <p className="text-muted-foreground">You&apos;ve seen all the picks!</p>
               <Button onClick={handleRefresh} variant="outline">
                 Get More Picks
               </Button>
@@ -183,9 +180,7 @@ function PickCard({
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             {year && <span>{year}</span>}
             {movie.runtime && <span>· {movie.runtime} min</span>}
-            {movie.voteAverage !== null && (
-              <span>· ★ {movie.voteAverage.toFixed(1)}</span>
-            )}
+            {movie.voteAverage !== null && <span>· ★ {movie.voteAverage.toFixed(1)}</span>}
           </div>
           {genres.length > 0 && (
             <div className="flex flex-wrap gap-1">
@@ -197,9 +192,7 @@ function PickCard({
             </div>
           )}
           {movie.overview && (
-            <p className="text-xs text-muted-foreground line-clamp-3">
-              {movie.overview}
-            </p>
+            <p className="text-xs text-muted-foreground line-clamp-3">{movie.overview}</p>
           )}
         </div>
       </div>

--- a/packages/app-media/src/components/RadarChart.tsx
+++ b/packages/app-media/src/components/RadarChart.tsx
@@ -34,10 +34,7 @@ export function RadarChart({
   /** Convert a dimension index + normalized value (0–1) to SVG coordinates. */
   function polarToXY(index: number, value: number): [number, number] {
     const angle = index * angleStep - Math.PI / 2; // Start from top
-    return [
-      cx + radius * value * Math.cos(angle),
-      cy + radius * value * Math.sin(angle),
-    ];
+    return [cx + radius * value * Math.cos(angle), cy + radius * value * Math.sin(angle)];
   }
 
   /** Normalize a score to 0–1 range, clamped. */
@@ -48,9 +45,7 @@ export function RadarChart({
   // Build grid rings
   const gridRings = Array.from({ length: GRID_RINGS }, (_, i) => {
     const fraction = (i + 1) / GRID_RINGS;
-    const points = dimensions
-      .map((_, idx) => polarToXY(idx, fraction).join(","))
-      .join(" ");
+    const points = dimensions.map((_, idx) => polarToXY(idx, fraction).join(",")).join(" ");
     return points;
   });
 
@@ -118,15 +113,7 @@ export function RadarChart({
       {/* Data points */}
       {dimensions.map((d, idx) => {
         const [x, y] = polarToXY(idx, normalize(d.score));
-        return (
-          <circle
-            key={`point-${idx}`}
-            cx={x}
-            cy={y}
-            r={3}
-            fill="hsl(var(--primary))"
-          />
-        );
+        return <circle key={`point-${idx}`} cx={x} cy={y} r={3} fill="hsl(var(--primary))" />;
       })}
 
       {/* Labels */}

--- a/packages/app-media/src/components/SearchResultCard.stories.tsx
+++ b/packages/app-media/src/components/SearchResultCard.stories.tsx
@@ -51,8 +51,7 @@ export const TvShow: Story = {
 export const LongTitle: Story = {
   args: {
     type: "movie",
-    title:
-      "The Lord of the Rings: The Return of the King — Extended Edition Director's Cut",
+    title: "The Lord of the Rings: The Return of the King — Extended Edition Director's Cut",
     year: "2003",
     overview: "Gandalf and Aragorn lead the World of Men against Sauron.",
     voteAverage: 9.0,

--- a/packages/app-media/src/components/SearchResultCard.tsx
+++ b/packages/app-media/src/components/SearchResultCard.tsx
@@ -33,7 +33,7 @@ export interface SearchResultCardProps {
  */
 export function buildPosterUrl(
   posterPath: string | null | undefined,
-  type: SearchResultType,
+  type: SearchResultType
 ): string | null {
   if (!posterPath) return null;
   if (type === "movie" && posterPath.startsWith("/")) {
@@ -64,12 +64,7 @@ export function SearchResultCard({
   const Icon = type === "movie" ? Film : Tv;
 
   return (
-    <div
-      className={cn(
-        "flex gap-4 rounded-lg border bg-card p-3 text-card-foreground",
-        className,
-      )}
-    >
+    <div className={cn("flex gap-4 rounded-lg border bg-card p-3 text-card-foreground", className)}>
       {/* Poster */}
       <div className="relative w-20 shrink-0 overflow-hidden rounded-md bg-muted aspect-[2/3]">
         {!showPlaceholder && (
@@ -77,10 +72,7 @@ export function SearchResultCard({
             src={posterUrl}
             alt={`${title} poster`}
             loading="lazy"
-            className={cn(
-              "h-full w-full object-cover",
-              imageLoaded ? "opacity-100" : "opacity-0",
-            )}
+            className={cn("h-full w-full object-cover", imageLoaded ? "opacity-100" : "opacity-0")}
             onLoad={() => setImageLoaded(true)}
             onError={() => setImageError(true)}
           />
@@ -99,9 +91,7 @@ export function SearchResultCard({
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
-            <h3 className="text-sm font-semibold leading-tight line-clamp-2">
-              {title}
-            </h3>
+            <h3 className="text-sm font-semibold leading-tight line-clamp-2">{title}</h3>
             <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
               {year && <span>{year}</span>}
               {voteAverage != null && voteAverage > 0 && (
@@ -113,18 +103,13 @@ export function SearchResultCard({
             </div>
           </div>
 
-          <Badge
-            variant={type === "movie" ? "default" : "secondary"}
-            className="shrink-0"
-          >
+          <Badge variant={type === "movie" ? "default" : "secondary"} className="shrink-0">
             {type === "movie" ? "Movie" : "TV"}
           </Badge>
         </div>
 
         {overview && (
-          <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed">
-            {overview}
-          </p>
+          <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed">{overview}</p>
         )}
 
         {genres && genres.length > 0 && (

--- a/packages/app-media/src/components/WatchlistToggle.tsx
+++ b/packages/app-media/src/components/WatchlistToggle.tsx
@@ -6,8 +6,7 @@ import { trpc } from "../lib/trpc";
 type DisplayMediaType = "movie" | "tv";
 type ApiMediaType = "movie" | "tv_show";
 
-const toApiMediaType = (type: DisplayMediaType): ApiMediaType =>
-  type === "tv" ? "tv_show" : type;
+const toApiMediaType = (type: DisplayMediaType): ApiMediaType => (type === "tv" ? "tv_show" : type);
 
 export interface WatchlistToggleProps {
   mediaType: DisplayMediaType;
@@ -15,23 +14,16 @@ export interface WatchlistToggleProps {
   className?: string;
 }
 
-export function WatchlistToggle({
-  mediaType,
-  mediaId,
-  className,
-}: WatchlistToggleProps) {
+export function WatchlistToggle({ mediaType, mediaId, className }: WatchlistToggleProps) {
   const utils = trpc.useUtils();
   const apiMediaType = toApiMediaType(mediaType);
 
-  const { data: watchlistData, isLoading: isChecking } =
-    trpc.media.watchlist.list.useQuery(
-      { mediaType: apiMediaType },
-      { staleTime: 30_000 },
-    );
-
-  const watchlistEntry = watchlistData?.data?.find(
-    (entry) => entry.mediaId === mediaId,
+  const { data: watchlistData, isLoading: isChecking } = trpc.media.watchlist.list.useQuery(
+    { mediaType: apiMediaType },
+    { staleTime: 30_000 }
   );
+
+  const watchlistEntry = watchlistData?.data?.find((entry) => entry.mediaId === mediaId);
   const isOnWatchlist = !!watchlistEntry;
 
   const addMutation = trpc.media.watchlist.add.useMutation({
@@ -93,7 +85,9 @@ export function WatchlistToggle({
       onClick={handleToggle}
       loading={isMutating}
       loadingText={isOnWatchlist ? "Removing" : "Adding"}
-      prefix={isOnWatchlist ? <BookmarkCheck className="h-4 w-4" /> : <Bookmark className="h-4 w-4" />}
+      prefix={
+        isOnWatchlist ? <BookmarkCheck className="h-4 w-4" /> : <Bookmark className="h-4 w-4" />
+      }
       aria-label={isOnWatchlist ? "Remove from watchlist" : "Add to watchlist"}
       className={className}
     >

--- a/packages/app-media/src/hooks/useMediaLibrary.ts
+++ b/packages/app-media/src/hooks/useMediaLibrary.ts
@@ -23,29 +23,26 @@ export function useMediaLibrary() {
   const [genreFilter, setGenreFilter] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<SortOption>("dateAdded");
 
-  const { data: moviesData, isLoading: moviesLoading } =
-    trpc.media.movies.list.useQuery({ limit: 500 });
+  const { data: moviesData, isLoading: moviesLoading } = trpc.media.movies.list.useQuery({
+    limit: 500,
+  });
 
-  const { data: tvShowsData, isLoading: tvShowsLoading } =
-    trpc.media.tvShows.list.useQuery({ limit: 500 });
+  const { data: tvShowsData, isLoading: tvShowsLoading } = trpc.media.tvShows.list.useQuery({
+    limit: 500,
+  });
 
   // Fetch batch progress for all TV shows
-  const tvShowIds = useMemo(
-    () => (tvShowsData?.data ?? []).map((s) => s.id),
-    [tvShowsData],
-  );
+  const tvShowIds = useMemo(() => (tvShowsData?.data ?? []).map((s) => s.id), [tvShowsData]);
 
   const { data: progressData } = trpc.media.watchHistory.batchProgress.useQuery(
     { tvShowIds },
-    { enabled: tvShowIds.length > 0 },
+    { enabled: tvShowIds.length > 0 }
   );
 
   const isLoading = moviesLoading || tvShowsLoading;
 
   const allItems = useMemo<MediaItem[]>(() => {
-    const progressMap = new Map(
-      (progressData?.data ?? []).map((p) => [p.tvShowId, p.percentage]),
-    );
+    const progressMap = new Map((progressData?.data ?? []).map((p) => [p.tvShowId, p.percentage]));
 
     const movieItems: MediaItem[] = (moviesData?.data ?? []).map((m) => ({
       id: m.id,

--- a/packages/app-media/src/pages/ArrSettingsPage.tsx
+++ b/packages/app-media/src/pages/ArrSettingsPage.tsx
@@ -81,16 +81,12 @@ function ServiceCard({
       <div className="flex items-center gap-2">
         <Icon className="h-5 w-5 text-muted-foreground" />
         <h2 className="text-lg font-semibold">{label}</h2>
-        {testResult && configured && (
-          <ConnectionBadge connected={testResult.connected} />
-        )}
+        {testResult && configured && <ConnectionBadge connected={testResult.connected} />}
       </div>
 
       <div className="space-y-3">
         <div className="space-y-1.5">
-          <label className="text-sm font-medium text-muted-foreground">
-            Server URL
-          </label>
+          <label className="text-sm font-medium text-muted-foreground">Server URL</label>
           <Input
             placeholder="http://192.168.1.100:7878"
             value={url}
@@ -100,9 +96,7 @@ function ServiceCard({
         </div>
 
         <div className="space-y-1.5">
-          <label className="text-sm font-medium text-muted-foreground">
-            API Key
-          </label>
+          <label className="text-sm font-medium text-muted-foreground">API Key</label>
           <div className="flex gap-2">
             <Input
               type={showKey ? "text" : "password"}
@@ -119,23 +113,14 @@ function ServiceCard({
               onClick={() => setShowKey(!showKey)}
               aria-label={showKey ? "Hide API key" : "Show API key"}
             >
-              {showKey ? (
-                <EyeOff className="h-4 w-4" />
-              ) : (
-                <Eye className="h-4 w-4" />
-              )}
+              {showKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
             </Button>
           </div>
         </div>
       </div>
 
       <div className="flex gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onSave}
-          disabled={saving}
-        >
+        <Button variant="outline" size="sm" onClick={onSave} disabled={saving}>
           {saving ? (
             <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" />
           ) : (
@@ -143,12 +128,7 @@ function ServiceCard({
           )}
           Save
         </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onTest}
-          disabled={testing || !configured}
-        >
+        <Button variant="outline" size="sm" onClick={onTest} disabled={testing || !configured}>
           {testing ? (
             <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" />
           ) : (
@@ -159,9 +139,7 @@ function ServiceCard({
       </div>
 
       {testResult?.connected && testResult.version && (
-        <p className="text-xs text-emerald-400">
-          Connected — v{testResult.version}
-        </p>
+        <p className="text-xs text-emerald-400">Connected — v{testResult.version}</p>
       )}
       {testResult && !testResult.connected && testResult.error && (
         <p className="text-xs text-red-400">{testResult.error}</p>
@@ -239,14 +217,12 @@ export function ArrSettingsPage() {
         >
           <ArrowLeft className="h-4 w-4" />
         </Link>
-        <h1 className="text-2xl font-bold tracking-tight">
-          Radarr & Sonarr Settings
-        </h1>
+        <h1 className="text-2xl font-bold tracking-tight">Radarr & Sonarr Settings</h1>
       </div>
 
       <p className="text-sm text-muted-foreground">
-        Configure your Radarr and Sonarr connections to see download status
-        badges on movie and TV show pages.
+        Configure your Radarr and Sonarr connections to see download status badges on movie and TV
+        show pages.
       </p>
 
       <div className="grid gap-6">

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -15,17 +15,14 @@ interface ScoreDelta {
 export function CompareArenaPage() {
   const navigate = useNavigate();
   const [sessionCount, setSessionCount] = useState(0);
-  const [selectedDimensionId, setSelectedDimensionId] = useState<number | null>(
-    null,
-  );
+  const [selectedDimensionId, setSelectedDimensionId] = useState<number | null>(null);
   const [scoreDelta, setScoreDelta] = useState<ScoreDelta | null>(null);
 
   // Fetch dimensions for tab selector
   const { data: dimensionsData, isLoading: dimsLoading } =
     trpc.media.comparisons.listDimensions.useQuery();
 
-  const activeDimensions =
-    dimensionsData?.data?.filter((d: { active: boolean }) => d.active) ?? [];
+  const activeDimensions = dimensionsData?.data?.filter((d: { active: boolean }) => d.active) ?? [];
 
   // Auto-select first dimension when loaded
   const dimensionId = selectedDimensionId ?? activeDimensions[0]?.id ?? null;
@@ -38,7 +35,7 @@ export function CompareArenaPage() {
     refetch: refetchPair,
   } = trpc.media.comparisons.getRandomPair.useQuery(
     { dimensionId: dimensionId! },
-    { enabled: dimensionId !== null, refetchOnWindowFocus: false },
+    { enabled: dimensionId !== null, refetchOnWindowFocus: false }
   );
 
   const utils = trpc.useUtils();
@@ -48,10 +45,7 @@ export function CompareArenaPage() {
     onSuccess: async (_data, variables) => {
       // Fetch updated scores for both movies to compute delta
       const winnerId = variables.winnerId;
-      const loserId =
-        variables.mediaAId === winnerId
-          ? variables.mediaBId
-          : variables.mediaAId;
+      const loserId = variables.mediaAId === winnerId ? variables.mediaBId : variables.mediaAId;
 
       try {
         const [winnerScores, loserScores] = await Promise.all([
@@ -68,17 +62,14 @@ export function CompareArenaPage() {
         ]);
 
         const winnerScore =
-          winnerScores?.data?.find(
-            (s: { dimensionId: number }) => s.dimensionId === dimensionId,
-          )?.score ?? 1500;
+          winnerScores?.data?.find((s: { dimensionId: number }) => s.dimensionId === dimensionId)
+            ?.score ?? 1500;
         const loserScore =
-          loserScores?.data?.find(
-            (s: { dimensionId: number }) => s.dimensionId === dimensionId,
-          )?.score ?? 1500;
+          loserScores?.data?.find((s: { dimensionId: number }) => s.dimensionId === dimensionId)
+            ?.score ?? 1500;
 
         // Approximate delta from current scores (K=32 Elo)
-        const expectedWinner =
-          1 / (1 + Math.pow(10, (loserScore - winnerScore) / 400));
+        const expectedWinner = 1 / (1 + Math.pow(10, (loserScore - winnerScore) / 400));
         const winnerDelta = Math.round(32 * (1 - expectedWinner));
         const loserDelta = -winnerDelta;
 
@@ -117,7 +108,7 @@ export function CompareArenaPage() {
         winnerId,
       });
     },
-    [pairData, dimensionId, recordMutation],
+    [pairData, dimensionId, recordMutation]
   );
 
   return (
@@ -126,8 +117,7 @@ export function CompareArenaPage() {
         <h1 className="text-2xl font-bold">Compare Arena</h1>
         <div className="flex items-center gap-2">
           <Badge variant="outline" className="text-sm">
-            {sessionCount} comparison{sessionCount !== 1 ? "s" : ""} this
-            session
+            {sessionCount} comparison{sessionCount !== 1 ? "s" : ""} this session
           </Badge>
           <DimensionManager />
         </div>
@@ -141,9 +131,7 @@ export function CompareArenaPage() {
           <Skeleton className="h-8 w-20" />
         </div>
       ) : activeDimensions.length === 0 ? (
-        <p className="text-muted-foreground">
-          No comparison dimensions configured yet.
-        </p>
+        <p className="text-muted-foreground">No comparison dimensions configured yet.</p>
       ) : (
         <div className="flex gap-2 flex-wrap" role="tablist">
           {activeDimensions.map((dim: { id: number; name: string }) => (
@@ -198,9 +186,8 @@ export function CompareArenaPage() {
           <p className="text-center text-muted-foreground text-sm">
             Which movie has better{" "}
             <span className="font-medium text-foreground">
-              {activeDimensions.find(
-                (d: { id: number }) => d.id === dimensionId,
-              )?.name ?? "Overall"}
+              {activeDimensions.find((d: { id: number }) => d.id === dimensionId)?.name ??
+                "Overall"}
             </span>
             ? Click to pick.
           </p>
@@ -298,9 +285,7 @@ function MovieCard({
       {scoreDelta != null && (
         <div
           className={`absolute top-3 right-3 px-2 py-1 rounded-full text-xs font-bold animate-bounce ${
-            scoreDelta > 0
-              ? "bg-green-500/90 text-white"
-              : "bg-red-500/90 text-white"
+            scoreDelta > 0 ? "bg-green-500/90 text-white" : "bg-red-500/90 text-white"
           }`}
         >
           {scoreDelta > 0 ? "+" : ""}

--- a/packages/app-media/src/pages/DiscoverPage.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.tsx
@@ -16,26 +16,22 @@ export function DiscoverPage() {
   // Queries
   const trending = trpc.media.discovery.trending.useQuery(
     { timeWindow: "week", page: 1 },
-    { staleTime: 5 * 60 * 1000 },
+    { staleTime: 5 * 60 * 1000 }
   );
 
   const recommendations = trpc.media.discovery.recommendations.useQuery(
     { sampleSize: 3 },
-    { staleTime: 5 * 60 * 1000 },
+    { staleTime: 5 * 60 * 1000 }
   );
 
   const similarToTopRated = trpc.media.discovery.recommendations.useQuery(
     { sampleSize: 5 },
-    { staleTime: 5 * 60 * 1000 },
+    { staleTime: 5 * 60 * 1000 }
   );
 
   // Track in-progress mutations per tmdbId
-  const [addingToLibrary, setAddingToLibrary] = useState<Set<number>>(
-    new Set(),
-  );
-  const [addingToWatchlist, setAddingToWatchlist] = useState<Set<number>>(
-    new Set(),
-  );
+  const [addingToLibrary, setAddingToLibrary] = useState<Set<number>>(new Set());
+  const [addingToWatchlist, setAddingToWatchlist] = useState<Set<number>>(new Set());
 
   // Mutations
   const addMovieMutation = trpc.media.library.addMovie.useMutation();
@@ -63,7 +59,7 @@ export function DiscoverPage() {
         });
       }
     },
-    [addMovieMutation, utils],
+    [addMovieMutation, utils]
   );
 
   const handleAddToWatchlist = useCallback(
@@ -101,7 +97,7 @@ export function DiscoverPage() {
         });
       }
     },
-    [addMovieMutation, addWatchlistMutation, utils],
+    [addMovieMutation, addWatchlistMutation, utils]
   );
 
   return (
@@ -111,9 +107,7 @@ export function DiscoverPage() {
         <Compass className="h-6 w-6 text-muted-foreground" />
         <div>
           <h1 className="text-2xl font-bold">Discover</h1>
-          <p className="text-sm text-muted-foreground">
-            Find your next favourite movie
-          </p>
+          <p className="text-sm text-muted-foreground">Find your next favourite movie</p>
         </div>
       </div>
 
@@ -162,10 +156,7 @@ export function DiscoverPage() {
       </HorizontalScrollRow>
 
       {/* Trending */}
-      <HorizontalScrollRow
-        title="Trending This Week"
-        isLoading={trending.isLoading}
-      >
+      <HorizontalScrollRow title="Trending This Week" isLoading={trending.isLoading}>
         {trending.error && (
           <Alert variant="destructive" className="flex items-center gap-3">
             <AlertCircle className="h-4 w-4 shrink-0" />

--- a/packages/app-media/src/pages/HistoryPage.tsx
+++ b/packages/app-media/src/pages/HistoryPage.tsx
@@ -5,14 +5,7 @@
  */
 import { useState } from "react";
 import { Link, useNavigate } from "react-router";
-import {
-  Alert,
-  AlertTitle,
-  AlertDescription,
-  Badge,
-  Button,
-  Skeleton,
-} from "@pops/ui";
+import { Alert, AlertTitle, AlertDescription, Badge, Button, Skeleton } from "@pops/ui";
 import { Film } from "lucide-react";
 import { trpc } from "../lib/trpc";
 
@@ -131,19 +124,13 @@ function HistoryItem({ entry }: { entry: HistoryEntry }) {
             <Link to={href} className="hover:underline">
               <h3 className="text-sm font-medium truncate">{title}</h3>
             </Link>
-            {subtitle && (
-              <p className="text-xs text-muted-foreground truncate">
-                {subtitle}
-              </p>
-            )}
+            {subtitle && <p className="text-xs text-muted-foreground truncate">{subtitle}</p>}
           </div>
           <Badge variant="secondary" className="text-xs shrink-0">
             {isEpisode ? "Episode" : "Movie"}
           </Badge>
         </div>
-        <p className="text-xs text-muted-foreground mt-1">
-          {formatWatchDate(entry.watchedAt)}
-        </p>
+        <p className="text-xs text-muted-foreground mt-1">{formatWatchDate(entry.watchedAt)}</p>
       </div>
     </div>
   );
@@ -177,10 +164,7 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
         }}
       >
         {/* Type badge */}
-        <Badge
-          variant={isEpisode ? "secondary" : "default"}
-          className="absolute top-2 left-2 z-10"
-        >
+        <Badge variant={isEpisode ? "secondary" : "default"} className="absolute top-2 left-2 z-10">
           {isEpisode ? "Episode" : "Movie"}
         </Badge>
 
@@ -208,9 +192,7 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
         <Link to={href} className="hover:underline">
           <h3 className="text-sm font-medium leading-tight line-clamp-2">{title}</h3>
         </Link>
-        {subtitle && (
-          <p className="text-xs text-muted-foreground line-clamp-1">{subtitle}</p>
-        )}
+        {subtitle && <p className="text-xs text-muted-foreground line-clamp-1">{subtitle}</p>}
       </div>
     </div>
   );
@@ -226,8 +208,7 @@ export function HistoryPage() {
     offset,
   };
 
-  const { data, isLoading, error } =
-    trpc.media.watchHistory.listRecent.useQuery(queryInput);
+  const { data, isLoading, error } = trpc.media.watchHistory.listRecent.useQuery(queryInput);
 
   const entries = data?.data ?? [];
   const total = data?.pagination?.total ?? 0;
@@ -272,10 +253,7 @@ export function HistoryPage() {
               ? "No watch history yet. Start watching something!"
               : `No ${filter === "movie" ? "movies" : "episodes"} in your history.`}
           </p>
-          <Link
-            to="/media"
-            className="mt-4 inline-block text-sm text-primary underline"
-          >
+          <Link to="/media" className="mt-4 inline-block text-sm text-primary underline">
             Browse library
           </Link>
         </div>
@@ -311,11 +289,7 @@ export function HistoryPage() {
                 </Button>
               )}
               {hasMore && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setOffset(offset + PAGE_SIZE)}
-                >
+                <Button variant="outline" size="sm" onClick={() => setOffset(offset + PAGE_SIZE)}>
                   Next
                 </Button>
               )}

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -5,11 +5,7 @@ import { Sparkles, Settings } from "lucide-react";
 import { MediaGrid } from "../components/MediaGrid";
 import { DownloadQueue } from "../components/DownloadQueue";
 import { QuickPickDialog } from "../components/QuickPickDialog";
-import {
-  useMediaLibrary,
-  type MediaType,
-  type SortOption,
-} from "../hooks/useMediaLibrary";
+import { useMediaLibrary, type MediaType, type SortOption } from "../hooks/useMediaLibrary";
 
 const TYPE_OPTIONS: { value: MediaType; label: string }[] = [
   { value: "all", label: "All" },
@@ -50,8 +46,7 @@ function MediaCard({
     progress: number | null;
   };
 }) {
-  const href =
-    item.type === "movie" ? `/media/movies/${item.id}` : `/media/tv/${item.id}`;
+  const href = item.type === "movie" ? `/media/movies/${item.id}` : `/media/tv/${item.id}`;
   const posterSrc = item.posterUrl ?? "";
 
   return (
@@ -89,9 +84,7 @@ function MediaCard({
       <h3 className="mt-2 text-sm font-medium line-clamp-2 transition-colors group-hover:text-indigo-400">
         {item.title}
       </h3>
-      {item.year && (
-        <p className="text-xs text-muted-foreground">{item.year}</p>
-      )}
+      {item.year && <p className="text-xs text-muted-foreground">{item.year}</p>}
     </Link>
   );
 }
@@ -221,18 +214,13 @@ export function LibraryPage() {
           <p className="text-muted-foreground">
             Your library is empty. Search for movies and shows to get started.
           </p>
-          <Link
-            to="/media/search"
-            className="mt-4 inline-block text-sm text-primary underline"
-          >
+          <Link to="/media/search" className="mt-4 inline-block text-sm text-primary underline">
             Search for media
           </Link>
         </div>
       ) : items.length === 0 ? (
         <div className="text-center py-16">
-          <p className="text-muted-foreground">
-            No results match your filters.
-          </p>
+          <p className="text-muted-foreground">No results match your filters.</p>
         </div>
       ) : (
         <MediaGrid>

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -51,7 +51,7 @@ export function MovieDetailPage() {
 
   const { data, isLoading, error } = trpc.media.movies.get.useQuery(
     { id: movieId },
-    { enabled: !Number.isNaN(movieId) },
+    { enabled: !Number.isNaN(movieId) }
   );
 
   if (Number.isNaN(movieId)) {
@@ -76,15 +76,10 @@ export function MovieDetailPage() {
         <Alert variant="destructive">
           <AlertTitle>{is404 ? "Movie not found" : "Error"}</AlertTitle>
           <AlertDescription>
-            {is404
-              ? "This movie doesn't exist in your library."
-              : error.message}
+            {is404 ? "This movie doesn't exist in your library." : error.message}
           </AlertDescription>
         </Alert>
-        <Link
-          to="/media"
-          className="mt-4 inline-block text-sm text-primary underline"
-        >
+        <Link to="/media" className="mt-4 inline-block text-sm text-primary underline">
           Back to library
         </Link>
       </div>
@@ -94,9 +89,7 @@ export function MovieDetailPage() {
   const movie = data?.data;
   if (!movie) return null;
 
-  const year = movie.releaseDate
-    ? new Date(movie.releaseDate).getFullYear()
-    : null;
+  const year = movie.releaseDate ? new Date(movie.releaseDate).getFullYear() : null;
 
   const posterSrc = movie.posterUrl ?? "";
   const backdropSrc = movie.backdropUrl ?? "";
@@ -130,11 +123,7 @@ export function MovieDetailPage() {
       {/* Hero section — negative margins cancel shell padding for edge-to-edge */}
       <div className="-mx-4 md:-mx-6 lg:-mx-8 -mt-4 md:-mt-6 lg:-mt-8 relative h-64 md:h-96 overflow-hidden bg-muted">
         {backdropSrc && (
-          <img
-            src={backdropSrc}
-            alt=""
-            className="absolute inset-0 w-full h-full object-cover"
-          />
+          <img src={backdropSrc} alt="" className="absolute inset-0 w-full h-full object-cover" />
         )}
         <div className="absolute inset-0 bg-gradient-to-t from-background via-background/80 to-background/20" />
 
@@ -151,9 +140,7 @@ export function MovieDetailPage() {
               </BreadcrumbItem>
               <BreadcrumbSeparator className="text-white/50" />
               <BreadcrumbItem>
-                <BreadcrumbPage className="text-white/90">
-                  {movie.title}
-                </BreadcrumbPage>
+                <BreadcrumbPage className="text-white/90">{movie.title}</BreadcrumbPage>
               </BreadcrumbItem>
             </BreadcrumbList>
           </Breadcrumb>
@@ -170,11 +157,7 @@ export function MovieDetailPage() {
             <h1 className="text-2xl md:text-4xl font-bold text-foreground">
               {logoSrc ? (
                 <>
-                  <img
-                    src={logoSrc}
-                    alt={movie.title}
-                    className="h-12 md:h-16 object-contain"
-                  />
+                  <img src={logoSrc} alt={movie.title} className="h-12 md:h-16 object-contain" />
                   <span className="sr-only">{movie.title}</span>
                 </>
               ) : (
@@ -209,9 +192,7 @@ export function MovieDetailPage() {
         {movie.overview && (
           <section>
             <h2 className="text-lg font-semibold mb-2">Overview</h2>
-            <p className="text-muted-foreground leading-relaxed">
-              {movie.overview}
-            </p>
+            <p className="text-muted-foreground leading-relaxed">{movie.overview}</p>
           </section>
         )}
 
@@ -221,14 +202,8 @@ export function MovieDetailPage() {
             <h2 className="text-lg font-semibold mb-2">Genres</h2>
             <div className="flex flex-wrap gap-2">
               {movie.genres.map((genre) => (
-                <Link
-                  key={genre}
-                  to={`/media?genre=${encodeURIComponent(genre)}`}
-                >
-                  <Badge
-                    variant="secondary"
-                    className="cursor-pointer hover:bg-secondary/80"
-                  >
+                <Link key={genre} to={`/media?genre=${encodeURIComponent(genre)}`}>
+                  <Badge variant="secondary" className="cursor-pointer hover:bg-secondary/80">
                     {genre}
                   </Badge>
                 </Link>
@@ -247,9 +222,7 @@ export function MovieDetailPage() {
             <dl className="grid grid-cols-2 md:grid-cols-3 gap-4">
               {metadataItems.map((item) => (
                 <div key={item.label}>
-                  <dt className="text-sm text-muted-foreground">
-                    {item.label}
-                  </dt>
+                  <dt className="text-sm text-muted-foreground">{item.label}</dt>
                   <dd className="text-sm font-medium">{item.value}</dd>
                 </div>
               ))}

--- a/packages/app-media/src/pages/PlexSettingsPage.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.tsx
@@ -64,8 +64,7 @@ export function PlexSettingsPage() {
 
   useEffect(() => {
     if (savedSectionIds.data?.data) {
-      const { movieSectionId: savedMovie, tvSectionId: savedTv } =
-        savedSectionIds.data.data;
+      const { movieSectionId: savedMovie, tvSectionId: savedTv } = savedSectionIds.data.data;
       if (savedMovie) setMovieSectionId(savedMovie);
       if (savedTv) setTvSectionId(savedTv);
     }
@@ -94,8 +93,7 @@ export function PlexSettingsPage() {
     onError: (err) => toast.error(`TV show sync failed: ${err.message}`),
   });
   const saveSectionIds = trpc.media.plex.saveSectionIds.useMutation({
-    onError: (err) =>
-      toast.error(`Failed to save library selection: ${err.message}`),
+    onError: (err) => toast.error(`Failed to save library selection: ${err.message}`),
   });
 
   const saveUrl = trpc.media.plex.setUrl.useMutation({
@@ -116,7 +114,7 @@ export function PlexSettingsPage() {
       setPinId(id);
       window.open(
         `https://app.plex.tv/auth#?clientID=${clientId}&code=${code}&context[device][product]=POPS`,
-        "_blank",
+        "_blank"
       );
     },
     onError: (err) => {
@@ -242,11 +240,7 @@ export function PlexSettingsPage() {
               <Button
                 variant="outline"
                 onClick={() => saveUrl.mutate({ url: plexUrl })}
-                disabled={
-                  saveUrl.isPending ||
-                  !plexUrl ||
-                  plexUrl === currentUrl.data?.data
-                }
+                disabled={saveUrl.isPending || !plexUrl || plexUrl === currentUrl.data?.data}
               >
                 {saveUrl.isPending ? (
                   <RefreshCw className="h-4 w-4 animate-spin" />
@@ -255,11 +249,7 @@ export function PlexSettingsPage() {
                 )}
               </Button>
             </div>
-            {saveUrl.error && (
-              <p className="text-xs text-red-400 mt-1">
-                {saveUrl.error.message}
-              </p>
-            )}
+            {saveUrl.error && <p className="text-xs text-red-400 mt-1">{saveUrl.error.message}</p>}
             {!status?.hasUrl && (
               <p className="text-xs text-amber-400">
                 Please set your Plex server URL to enable connection.
@@ -274,8 +264,7 @@ export function PlexSettingsPage() {
             <div className="space-y-2">
               <h2 className="text-lg font-semibold">Plex Account</h2>
               <p className="text-sm text-muted-foreground max-w-md mx-auto">
-                Link your Plex account to enable library syncing and watch
-                history tracking.
+                Link your Plex account to enable library syncing and watch history tracking.
               </p>
             </div>
 
@@ -290,26 +279,19 @@ export function PlexSettingsPage() {
                   </Button>
                 </div>
               ) : (
-                <Button
-                  onClick={() => getPin.mutate()}
-                  disabled={getPin.isPending}
-                >
+                <Button onClick={() => getPin.mutate()} disabled={getPin.isPending}>
                   {getPin.isPending ? "Requesting..." : "Connect to Plex"}
                 </Button>
               )}
-              {getPin.error && (
-                <p className="text-xs text-red-400 mt-2">
-                  {getPin.error.message}
-                </p>
-              )}
+              {getPin.error && <p className="text-xs text-red-400 mt-2">{getPin.error.message}</p>}
             </div>
           </div>
         ) : !status?.configured ? (
           <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-4 flex items-center gap-3">
             <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0" />
             <div className="text-sm text-amber-200">
-              Authenticated with Plex account, but server URL is missing. Set
-              the URL above to finish setup.
+              Authenticated with Plex account, but server URL is missing. Set the URL above to
+              finish setup.
             </div>
           </div>
         ) : null}
@@ -322,8 +304,8 @@ export function PlexSettingsPage() {
               <p className="font-semibold">Connection Failed</p>
               <p>{connectionError}</p>
               <p className="text-xs opacity-70">
-                Verify that the server URL is correct and the server is
-                reachable from this application.
+                Verify that the server URL is correct and the server is reachable from this
+                application.
               </p>
             </div>
           </div>
@@ -362,9 +344,7 @@ export function PlexSettingsPage() {
                   <Button
                     size="sm"
                     disabled={!movieSectionId || syncMovies.isPending}
-                    onClick={() =>
-                      syncMovies.mutate({ sectionId: movieSectionId })
-                    }
+                    onClick={() => syncMovies.mutate({ sectionId: movieSectionId })}
                     className="w-full"
                   >
                     {syncMovies.isPending ? (
@@ -376,9 +356,7 @@ export function PlexSettingsPage() {
                   </Button>
                 </>
               ) : (
-                <p className="text-xs text-muted-foreground">
-                  No movie libraries found
-                </p>
+                <p className="text-xs text-muted-foreground">No movie libraries found</p>
               )}
             </div>
 
@@ -412,9 +390,7 @@ export function PlexSettingsPage() {
                   <Button
                     size="sm"
                     disabled={!tvSectionId || syncTvShows.isPending}
-                    onClick={() =>
-                      syncTvShows.mutate({ sectionId: tvSectionId })
-                    }
+                    onClick={() => syncTvShows.mutate({ sectionId: tvSectionId })}
                     className="w-full"
                   >
                     {syncTvShows.isPending ? (
@@ -426,9 +402,7 @@ export function PlexSettingsPage() {
                   </Button>
                 </>
               ) : (
-                <p className="text-xs text-muted-foreground">
-                  No TV libraries found
-                </p>
+                <p className="text-xs text-muted-foreground">No TV libraries found</p>
               )}
             </div>
           </div>

--- a/packages/app-media/src/pages/QuickPickPage.tsx
+++ b/packages/app-media/src/pages/QuickPickPage.tsx
@@ -18,7 +18,7 @@ export function QuickPickPage() {
 
   const { data, isLoading, refetch } = trpc.media.library.quickPick.useQuery(
     { count: 10 },
-    { refetchOnWindowFocus: false },
+    { refetchOnWindowFocus: false }
   );
 
   const addToWatchlist = trpc.media.watchlist.add.useMutation({
@@ -53,7 +53,7 @@ export function QuickPickPage() {
           setAddedIds((prev) => new Set(prev).add(currentPick.id));
           goNext();
         },
-      },
+      }
     );
   }, [currentPick, addedIds, addToWatchlist, goNext]);
 
@@ -114,12 +114,9 @@ export function QuickPickPage() {
         <Sparkles className="h-10 w-10 text-muted-foreground" />
         <h2 className="text-xl font-semibold">No unwatched movies</h2>
         <p className="text-muted-foreground text-sm max-w-xs">
-          Add more movies to your library or mark some as unwatched to get
-          picks.
+          Add more movies to your library or mark some as unwatched to get picks.
         </p>
-        <Button onClick={() => navigate("/media/search")}>
-          Search for movies
-        </Button>
+        <Button onClick={() => navigate("/media/search")}>Search for movies</Button>
       </div>
     );
   }
@@ -175,16 +172,12 @@ export function QuickPickPage() {
         {/* Swipe indicators */}
         {swipeOffset > 40 && (
           <div className="absolute top-4 left-4 z-10">
-            <Badge className="bg-emerald-500 text-white text-sm px-3 py-1">
-              + Watchlist
-            </Badge>
+            <Badge className="bg-emerald-500 text-white text-sm px-3 py-1">+ Watchlist</Badge>
           </div>
         )}
         {swipeOffset < -40 && (
           <div className="absolute top-4 right-4 z-10">
-            <Badge className="bg-rose-500 text-white text-sm px-3 py-1">
-              Skip
-            </Badge>
+            <Badge className="bg-rose-500 text-white text-sm px-3 py-1">Skip</Badge>
           </div>
         )}
 
@@ -207,9 +200,7 @@ export function QuickPickPage() {
         {/* Info */}
         <div className="p-4 space-y-3">
           <div>
-            <h2 className="text-lg font-semibold line-clamp-2">
-              {movie.title}
-            </h2>
+            <h2 className="text-lg font-semibold line-clamp-2">{movie.title}</h2>
             <div className="flex items-center gap-2 mt-1 text-sm text-muted-foreground">
               {year && <span>{year}</span>}
               {movie.runtime && (
@@ -240,9 +231,7 @@ export function QuickPickPage() {
 
           {/* Overview */}
           {movie.overview && (
-            <p className="text-sm text-muted-foreground line-clamp-3">
-              {movie.overview}
-            </p>
+            <p className="text-sm text-muted-foreground line-clamp-3">{movie.overview}</p>
           )}
         </div>
       </div>

--- a/packages/app-media/src/pages/RankingsPage.tsx
+++ b/packages/app-media/src/pages/RankingsPage.tsx
@@ -61,8 +61,7 @@ function RankingRow({
   year,
   posterUrl,
 }: RankingRowProps) {
-  const href =
-    mediaType === "movie" ? `/media/movies/${mediaId}` : `/media/tv/${mediaId}`;
+  const href = mediaType === "movie" ? `/media/movies/${mediaId}` : `/media/tv/${mediaId}`;
   const posterSrc = posterUrl ?? "";
 
   return (
@@ -71,11 +70,7 @@ function RankingRow({
         {rank <= 3 ? (
           <span
             className={
-              rank === 1
-                ? "text-yellow-500"
-                : rank === 2
-                  ? "text-zinc-400"
-                  : "text-amber-700"
+              rank === 1 ? "text-yellow-500" : rank === 2 ? "text-zinc-400" : "text-amber-700"
             }
           >
             #{rank}
@@ -102,9 +97,7 @@ function RankingRow({
           <Badge variant="secondary" className="text-xs">
             {mediaType === "movie" ? "Movie" : "TV"}
           </Badge>
-          {year && (
-            <span className="text-xs text-muted-foreground">{year}</span>
-          )}
+          {year && <span className="text-xs text-muted-foreground">{year}</span>}
         </div>
       </div>
 
@@ -151,15 +144,13 @@ function RankingsList({ dimensionId }: { dimensionId?: number }) {
             m.id,
             {
               title: m.title,
-              year: m.releaseDate
-                ? new Date(m.releaseDate).getFullYear()
-                : null,
+              year: m.releaseDate ? new Date(m.releaseDate).getFullYear() : null,
               posterUrl: m.posterUrl,
             },
-          ],
-        ),
+          ]
+        )
       ),
-    [moviesData?.data],
+    [moviesData?.data]
   );
 
   const tvMap = useMemo(
@@ -175,15 +166,13 @@ function RankingsList({ dimensionId }: { dimensionId?: number }) {
             s.id,
             {
               title: s.name,
-              year: s.firstAirDate
-                ? new Date(s.firstAirDate).getFullYear()
-                : null,
+              year: s.firstAirDate ? new Date(s.firstAirDate).getFullYear() : null,
               posterUrl: s.posterUrl,
             },
-          ],
-        ),
+          ]
+        )
       ),
-    [tvShowsData?.data],
+    [tvShowsData?.data]
   );
 
   if (error) {
@@ -205,8 +194,7 @@ function RankingsList({ dimensionId }: { dimensionId?: number }) {
       <div className="text-center py-16">
         <Trophy className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
         <p className="text-muted-foreground">
-          No rankings yet. Compare some movies to start building your
-          leaderboard.
+          No rankings yet. Compare some movies to start building your leaderboard.
         </p>
       </div>
     );
@@ -217,9 +205,7 @@ function RankingsList({ dimensionId }: { dimensionId?: number }) {
       <div className="space-y-2" role="list" aria-label="Rankings">
         {entries.map((entry) => {
           const meta =
-            entry.mediaType === "movie"
-              ? movieMap.get(entry.mediaId)
-              : tvMap.get(entry.mediaId);
+            entry.mediaType === "movie" ? movieMap.get(entry.mediaId) : tvMap.get(entry.mediaId);
 
           return (
             <RankingRow
@@ -240,8 +226,7 @@ function RankingsList({ dimensionId }: { dimensionId?: number }) {
       {pagination && pagination.total > PAGE_SIZE && (
         <div className="flex items-center justify-between pt-2">
           <span className="text-sm text-muted-foreground">
-            Showing {offset + 1}–
-            {Math.min(offset + PAGE_SIZE, pagination.total)} of{" "}
+            Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, pagination.total)} of{" "}
             {pagination.total}
           </span>
           <div className="flex gap-2">
@@ -274,7 +259,7 @@ export function RankingsPage() {
 
   const activeDimensions = useMemo(
     () => (dimensionsData?.data ?? []).filter((d) => d.active),
-    [dimensionsData?.data],
+    [dimensionsData?.data]
   );
 
   const showTabs = activeDimensions.length > 0;

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -60,37 +60,35 @@ export function SearchPage() {
   // Track items successfully added this session
   const [addedIds, setAddedIds] = useState<Set<string>>(new Set());
 
-  const shouldSearchMovies =
-    debouncedQuery.length > 0 && (mode === "movies" || mode === "both");
-  const shouldSearchTv =
-    debouncedQuery.length > 0 && (mode === "tv" || mode === "both");
+  const shouldSearchMovies = debouncedQuery.length > 0 && (mode === "movies" || mode === "both");
+  const shouldSearchTv = debouncedQuery.length > 0 && (mode === "tv" || mode === "both");
 
   // Search queries
   const movieSearch = trpc.media.search.movies.useQuery(
     { query: debouncedQuery },
-    { enabled: shouldSearchMovies, staleTime: 60_000 },
+    { enabled: shouldSearchMovies, staleTime: 60_000 }
   );
   const tvSearch = trpc.media.search.tvShows.useQuery(
     { query: debouncedQuery },
-    { enabled: shouldSearchTv, staleTime: 60_000 },
+    { enabled: shouldSearchTv, staleTime: 60_000 }
   );
 
   // Library lookups for "In Library" detection
   const libraryMovies = trpc.media.movies.list.useQuery(
     { limit: 1000 },
-    { enabled: shouldSearchMovies, staleTime: 30_000 },
+    { enabled: shouldSearchMovies, staleTime: 30_000 }
   );
   const libraryTvShows = trpc.media.tvShows.list.useQuery(
     { limit: 1000 },
-    { enabled: shouldSearchTv, staleTime: 30_000 },
+    { enabled: shouldSearchTv, staleTime: 30_000 }
   );
 
   // Build lookup sets
   const movieTmdbIds = new Set(
-    (libraryMovies.data?.data ?? []).map((m: { tmdbId: number }) => m.tmdbId),
+    (libraryMovies.data?.data ?? []).map((m: { tmdbId: number }) => m.tmdbId)
   );
   const tvTvdbIds = new Set(
-    (libraryTvShows.data?.data ?? []).map((s: { tvdbId: number }) => s.tvdbId),
+    (libraryTvShows.data?.data ?? []).map((s: { tvdbId: number }) => s.tvdbId)
   );
 
   // Mutations
@@ -120,10 +118,10 @@ export function SearchPage() {
               return next;
             });
           },
-        },
+        }
       );
     },
-    [addMovieMutation],
+    [addMovieMutation]
   );
 
   const handleAddTvShow = useCallback(
@@ -147,15 +145,14 @@ export function SearchPage() {
               return next;
             });
           },
-        },
+        }
       );
     },
-    [addTvShowMutation],
+    [addTvShowMutation]
   );
 
   const isSearching =
-    (shouldSearchMovies && movieSearch.isLoading) ||
-    (shouldSearchTv && tvSearch.isLoading);
+    (shouldSearchMovies && movieSearch.isLoading) || (shouldSearchTv && tvSearch.isLoading);
   const hasQuery = debouncedQuery.length > 0;
   const hasError = movieSearch.error || tvSearch.error;
 
@@ -170,9 +167,7 @@ export function SearchPage() {
   }, [movieSearch.error, tvSearch.error]);
 
   // Merge results
-  const movieResults = shouldSearchMovies
-    ? (movieSearch.data?.results ?? [])
-    : [];
+  const movieResults = shouldSearchMovies ? (movieSearch.data?.results ?? []) : [];
   const tvResults = shouldSearchTv ? (tvSearch.data?.results ?? []) : [];
   const totalResults = movieResults.length + tvResults.length;
   const noResults = hasQuery && !isSearching && totalResults === 0 && !hasError;
@@ -199,10 +194,7 @@ export function SearchPage() {
       </div>
 
       {/* Type toggle */}
-      <Tabs
-        value={mode}
-        onValueChange={(v: string) => setMode(v as SearchMode)}
-      >
+      <Tabs value={mode} onValueChange={(v: string) => setMode(v as SearchMode)}>
         <TabsList>
           <TabsTrigger value="both">Both</TabsTrigger>
           <TabsTrigger value="movies">Movies</TabsTrigger>
@@ -236,10 +228,7 @@ export function SearchPage() {
       {isSearching && (
         <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (
-            <div
-              key={i}
-              className="flex gap-4 rounded-lg border bg-card p-3"
-            >
+            <div key={i} className="flex gap-4 rounded-lg border bg-card p-3">
               <Skeleton className="w-20 shrink-0 rounded-md aspect-[2/3]" />
               <div className="flex flex-1 flex-col gap-2">
                 <Skeleton className="h-4 w-3/4" />
@@ -273,8 +262,7 @@ export function SearchPage() {
               <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
                 {movieResults.map((movie: MovieSearchResult) => {
                   const key = makeKey("movie", movie.tmdbId);
-                  const inLibrary =
-                    movieTmdbIds.has(movie.tmdbId) || addedIds.has(key);
+                  const inLibrary = movieTmdbIds.has(movie.tmdbId) || addedIds.has(key);
                   return (
                     <SearchResultCard
                       key={movie.tmdbId}
@@ -305,8 +293,7 @@ export function SearchPage() {
               <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
                 {tvResults.map((show: TvSearchResult) => {
                   const key = makeKey("tv", show.tvdbId);
-                  const inLibrary =
-                    tvTvdbIds.has(show.tvdbId) || addedIds.has(key);
+                  const inLibrary = tvTvdbIds.has(show.tvdbId) || addedIds.has(key);
                   return (
                     <SearchResultCard
                       key={show.tvdbId}
@@ -332,9 +319,7 @@ export function SearchPage() {
       {!hasQuery && (
         <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
           <Search className="h-12 w-12 opacity-20 mb-4" />
-          <p className="text-sm">
-            Start typing to search for movies and TV shows.
-          </p>
+          <p className="text-sm">Start typing to search for movies and TV shows.</p>
         </div>
       )}
     </div>

--- a/packages/app-media/src/pages/SeasonDetailPage.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.tsx
@@ -49,23 +49,19 @@ export function SeasonDetailPage() {
     data: showData,
     isLoading: showLoading,
     error: showError,
-  } = trpc.media.tvShows.get.useQuery(
-    { id: showId },
-    { enabled: !Number.isNaN(showId) },
-  );
+  } = trpc.media.tvShows.get.useQuery({ id: showId }, { enabled: !Number.isNaN(showId) });
 
-  const { data: seasonsData, isLoading: seasonsLoading } =
-    trpc.media.tvShows.listSeasons.useQuery(
-      { tvShowId: showId },
-      { enabled: !Number.isNaN(showId) },
-    );
+  const { data: seasonsData, isLoading: seasonsLoading } = trpc.media.tvShows.listSeasons.useQuery(
+    { tvShowId: showId },
+    { enabled: !Number.isNaN(showId) }
+  );
 
   const season = seasonsData?.data?.find((s) => s.seasonNumber === seasonNum);
 
   const { data: episodesData, isLoading: episodesLoading } =
     trpc.media.tvShows.listEpisodes.useQuery(
       { seasonId: season?.id ?? 0 },
-      { enabled: !!season?.id },
+      { enabled: !!season?.id }
     );
 
   const episodes = episodesData?.data ?? [];
@@ -74,7 +70,7 @@ export function SeasonDetailPage() {
   // Query watch history for all episodes in this season
   const { data: watchHistoryData } = trpc.media.watchHistory.list.useQuery(
     { mediaType: "episode", limit: 500 },
-    { enabled: episodeIds.length > 0 },
+    { enabled: episodeIds.length > 0 }
   );
 
   const watchedEpisodeIds = useMemo(() => {
@@ -83,7 +79,7 @@ export function SeasonDetailPage() {
     return new Set(
       watchHistoryData.data
         .filter((entry) => episodeIdSet.has(entry.mediaId))
-        .map((entry) => entry.mediaId),
+        .map((entry) => entry.mediaId)
     );
   }, [watchHistoryData, episodeIds]);
 
@@ -138,9 +134,7 @@ export function SeasonDetailPage() {
         logMutation.mutate({ mediaType: "episode", mediaId: episodeId });
       } else {
         // Find the watch history entry to delete
-        const entry = watchHistoryData?.data?.find(
-          (e) => e.mediaId === episodeId,
-        );
+        const entry = watchHistoryData?.data?.find((e) => e.mediaId === episodeId);
         if (entry) {
           deleteEntryToEpisode.current.set(entry.id, episodeId);
           deleteMutation.mutate({ id: entry.id });
@@ -153,23 +147,23 @@ export function SeasonDetailPage() {
         }
       }
     },
-    [logMutation, deleteMutation, watchHistoryData],
+    [logMutation, deleteMutation, watchHistoryData]
   );
 
   const { data: progressData } = trpc.media.watchHistory.progress.useQuery(
     { tvShowId: showId },
-    { enabled: !Number.isNaN(showId) },
+    { enabled: !Number.isNaN(showId) }
   );
 
   const seasonProgress = progressData?.data?.seasons?.find(
-    (s: { seasonNumber: number }) => s.seasonNumber === seasonNum,
+    (s: { seasonNumber: number }) => s.seasonNumber === seasonNum
   );
 
   const batchLogMutation = trpc.media.watchHistory.batchLog.useMutation({
     onSuccess: (result) => {
       utils.media.watchHistory.invalidate();
       toast.success(
-        `Marked ${result.data.logged} episode${result.data.logged !== 1 ? "s" : ""} as watched`,
+        `Marked ${result.data.logged} episode${result.data.logged !== 1 ? "s" : ""} as watched`
       );
     },
     onError: (err) => toast.error(`Failed to mark season: ${err.message}`),
@@ -184,9 +178,7 @@ export function SeasonDetailPage() {
       <div className="p-6">
         <Alert variant="destructive">
           <AlertTitle>Invalid parameters</AlertTitle>
-          <AlertDescription>
-            Show ID and season number must be valid numbers.
-          </AlertDescription>
+          <AlertDescription>Show ID and season number must be valid numbers.</AlertDescription>
         </Alert>
       </div>
     );
@@ -203,15 +195,10 @@ export function SeasonDetailPage() {
         <Alert variant="destructive">
           <AlertTitle>{is404 ? "Show not found" : "Error"}</AlertTitle>
           <AlertDescription>
-            {is404
-              ? "This TV show doesn't exist in your library."
-              : showError.message}
+            {is404 ? "This TV show doesn't exist in your library." : showError.message}
           </AlertDescription>
         </Alert>
-        <Link
-          to="/media"
-          className="mt-4 inline-block text-sm text-primary underline"
-        >
+        <Link to="/media" className="mt-4 inline-block text-sm text-primary underline">
           Back to library
         </Link>
       </div>
@@ -280,25 +267,18 @@ export function SeasonDetailPage() {
           <h1 className="text-2xl font-bold">{season.name ?? seasonLabel}</h1>
 
           <div className="flex items-center gap-2 mt-1 text-sm text-muted-foreground">
-            {season.episodeCount != null && (
-              <span>{season.episodeCount} episodes</span>
-            )}
+            {season.episodeCount != null && <span>{season.episodeCount} episodes</span>}
             {season.episodeCount != null && season.airDate && <span>·</span>}
             {season.airDate && <span>First aired {season.airDate}</span>}
           </div>
 
           {season.overview && (
-            <p className="mt-3 text-sm text-muted-foreground leading-relaxed">
-              {season.overview}
-            </p>
+            <p className="mt-3 text-sm text-muted-foreground leading-relaxed">{season.overview}</p>
           )}
 
           {seasonProgress && seasonProgress.total > 0 && (
             <div className="mt-3">
-              <ProgressBar
-                watched={seasonProgress.watched}
-                total={seasonProgress.total}
-              />
+              <ProgressBar watched={seasonProgress.watched} total={seasonProgress.total} />
             </div>
           )}
 
@@ -320,11 +300,7 @@ export function SeasonDetailPage() {
                 </Button>
               ) : (
                 <span className="inline-flex items-center gap-1.5 text-sm text-green-500 font-medium">
-                  <svg
-                    className="w-4 h-4"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                  >
+                  <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
                     <path
                       fillRule="evenodd"
                       d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"

--- a/packages/app-media/src/pages/TvShowDetailPage.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.tsx
@@ -49,17 +49,17 @@ export function TvShowDetailPage() {
 
   const { data, isLoading, error } = trpc.media.tvShows.get.useQuery(
     { id: showId },
-    { enabled: !Number.isNaN(showId) },
+    { enabled: !Number.isNaN(showId) }
   );
 
   const { data: seasonsData } = trpc.media.tvShows.listSeasons.useQuery(
     { tvShowId: showId },
-    { enabled: !Number.isNaN(showId) },
+    { enabled: !Number.isNaN(showId) }
   );
 
   const { data: progressData } = trpc.media.watchHistory.progress.useQuery(
     { tvShowId: showId },
-    { enabled: !Number.isNaN(showId) },
+    { enabled: !Number.isNaN(showId) }
   );
 
   const utils = trpc.useUtils();
@@ -92,15 +92,10 @@ export function TvShowDetailPage() {
         <Alert variant="destructive">
           <AlertTitle>{is404 ? "Show not found" : "Error"}</AlertTitle>
           <AlertDescription>
-            {is404
-              ? "This TV show doesn't exist in your library."
-              : error.message}
+            {is404 ? "This TV show doesn't exist in your library." : error.message}
           </AlertDescription>
         </Alert>
-        <Link
-          to="/media"
-          className="mt-4 inline-block text-sm text-primary underline"
-        >
+        <Link to="/media" className="mt-4 inline-block text-sm text-primary underline">
           Back to library
         </Link>
       </div>
@@ -110,9 +105,7 @@ export function TvShowDetailPage() {
   const show = data?.data;
   if (!show) return null;
 
-  const year = show.firstAirDate
-    ? new Date(show.firstAirDate).getFullYear()
-    : null;
+  const year = show.firstAirDate ? new Date(show.firstAirDate).getFullYear() : null;
 
   const posterSrc = show.posterUrl ?? "";
   const backdropSrc = show.backdropUrl ?? null;
@@ -127,9 +120,7 @@ export function TvShowDetailPage() {
     { label: "Language", value: show.originalLanguage?.toUpperCase() },
     {
       label: "TMDB Rating",
-      value: show.voteAverage
-        ? `${show.voteAverage.toFixed(1)} (${show.voteCount} votes)`
-        : null,
+      value: show.voteAverage ? `${show.voteAverage.toFixed(1)} (${show.voteCount} votes)` : null,
     },
     {
       label: "Seasons",
@@ -142,11 +133,7 @@ export function TvShowDetailPage() {
       {/* Hero section — negative margins cancel shell padding for edge-to-edge */}
       <div className="-mx-4 md:-mx-6 lg:-mx-8 -mt-4 md:-mt-6 lg:-mt-8 relative h-64 md:h-96 overflow-hidden bg-muted">
         {backdropSrc && (
-          <img
-            src={backdropSrc}
-            alt=""
-            className="absolute inset-0 w-full h-full object-cover"
-          />
+          <img src={backdropSrc} alt="" className="absolute inset-0 w-full h-full object-cover" />
         )}
         <div className="absolute inset-0 bg-gradient-to-t from-background via-background/80 to-background/20" />
 
@@ -163,9 +150,7 @@ export function TvShowDetailPage() {
               </BreadcrumbItem>
               <BreadcrumbSeparator className="text-white/50" />
               <BreadcrumbItem>
-                <BreadcrumbPage className="text-white/90">
-                  {show.name}
-                </BreadcrumbPage>
+                <BreadcrumbPage className="text-white/90">{show.name}</BreadcrumbPage>
               </BreadcrumbItem>
             </BreadcrumbList>
           </Breadcrumb>
@@ -179,9 +164,7 @@ export function TvShowDetailPage() {
           />
 
           <div className="flex-1 pb-1">
-            <h1 className="text-2xl md:text-4xl font-bold text-foreground">
-              {show.name}
-            </h1>
+            <h1 className="text-2xl md:text-4xl font-bold text-foreground">{show.name}</h1>
 
             <div className="flex items-center gap-2 mt-2 text-sm text-muted-foreground">
               {year && <span>{year}</span>}
@@ -197,10 +180,7 @@ export function TvShowDetailPage() {
             {/* Overall progress */}
             {progress && progress.overall.total > 0 && (
               <div className="mt-3 max-w-xs">
-                <ProgressBar
-                  watched={progress.overall.watched}
-                  total={progress.overall.total}
-                />
+                <ProgressBar watched={progress.overall.watched} total={progress.overall.total} />
               </div>
             )}
 
@@ -210,8 +190,7 @@ export function TvShowDetailPage() {
                 to={`/media/tv/${show.id}/season/${nextEpisode.seasonNumber}`}
                 className="inline-block mt-2 text-sm text-primary hover:underline"
               >
-                Continue watching: S
-                {String(nextEpisode.seasonNumber).padStart(2, "0")}E
+                Continue watching: S{String(nextEpisode.seasonNumber).padStart(2, "0")}E
                 {String(nextEpisode.episodeNumber).padStart(2, "0")}
                 {nextEpisode.episodeName ? ` — ${nextEpisode.episodeName}` : ""}
               </Link>
@@ -236,11 +215,7 @@ export function TvShowDetailPage() {
                   </Button>
                 ) : (
                   <span className="inline-flex items-center gap-1.5 text-sm text-green-500 font-medium">
-                    <svg
-                      className="w-4 h-4"
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                    >
+                    <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
                       <path
                         fillRule="evenodd"
                         d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
@@ -262,9 +237,7 @@ export function TvShowDetailPage() {
         {show.overview && (
           <section>
             <h2 className="text-lg font-semibold mb-2">Overview</h2>
-            <p className="text-muted-foreground leading-relaxed">
-              {show.overview}
-            </p>
+            <p className="text-muted-foreground leading-relaxed">{show.overview}</p>
           </section>
         )}
 
@@ -289,9 +262,7 @@ export function TvShowDetailPage() {
             <dl className="grid grid-cols-2 md:grid-cols-3 gap-4">
               {metadataItems.map((item) => (
                 <div key={item.label}>
-                  <dt className="text-sm text-muted-foreground">
-                    {item.label}
-                  </dt>
+                  <dt className="text-sm text-muted-foreground">{item.label}</dt>
                   <dd className="text-sm font-medium">{item.value}</dd>
                 </div>
               ))}
@@ -312,8 +283,7 @@ export function TvShowDetailPage() {
                   episodeCount: number | null;
                 }) => {
                   const seasonProg = progress?.seasons?.find(
-                    (s: { seasonNumber: number }) =>
-                      s.seasonNumber === season.seasonNumber,
+                    (s: { seasonNumber: number }) => s.seasonNumber === season.seasonNumber
                   );
                   const label =
                     season.seasonNumber === 0
@@ -326,9 +296,7 @@ export function TvShowDetailPage() {
                       to={`/media/tv/${show.id}/season/${season.seasonNumber}`}
                       className="flex items-center gap-3 p-3 rounded-lg border hover:bg-accent/50 transition-colors"
                     >
-                      <span className="text-sm font-medium flex-1">
-                        {label}
-                      </span>
+                      <span className="text-sm font-medium flex-1">{label}</span>
                       {season.episodeCount != null && (
                         <span className="text-xs text-muted-foreground">
                           {season.episodeCount} episodes
@@ -345,7 +313,7 @@ export function TvShowDetailPage() {
                       )}
                     </Link>
                   );
-                },
+                }
               )}
             </div>
           </section>

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -7,14 +7,7 @@
  */
 import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { Link, useNavigate } from "react-router";
-import {
-  Alert,
-  AlertTitle,
-  AlertDescription,
-  Badge,
-  Skeleton,
-  Textarea,
-} from "@pops/ui";
+import { Alert, AlertTitle, AlertDescription, Badge, Skeleton, Textarea } from "@pops/ui";
 import { Button } from "@pops/ui";
 import { ArrowUp, ArrowDown, Trash2, Film } from "lucide-react";
 import { toast } from "sonner";
@@ -104,9 +97,7 @@ function WatchlistItem({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const href =
-    entry.mediaType === "movie"
-      ? `/media/movies/${entry.mediaId}`
-      : `/media/tv/${entry.mediaId}`;
+    entry.mediaType === "movie" ? `/media/movies/${entry.mediaId}` : `/media/tv/${entry.mediaId}`;
   const posterSrc = posterUrl ?? "";
 
   // Sync draft when server data changes
@@ -197,9 +188,7 @@ function WatchlistItem({
               <Badge variant="secondary" className="text-xs">
                 {entry.mediaType === "movie" ? "Movie" : "TV"}
               </Badge>
-              {year && (
-                <span className="text-xs text-muted-foreground">{year}</span>
-              )}
+              {year && <span className="text-xs text-muted-foreground">{year}</span>}
             </div>
           </div>
 
@@ -251,9 +240,7 @@ function WatchlistItem({
                 {draft.length}/500 · Ctrl+Enter to save
               </span>
             </div>
-            {updateError && (
-              <p className="text-xs text-destructive">{updateError}</p>
-            )}
+            {updateError && <p className="text-xs text-destructive">{updateError}</p>}
           </div>
         ) : entry.notes ? (
           <button
@@ -302,9 +289,7 @@ function WatchlistCard({
   const [imageError, setImageError] = useState(false);
 
   const href =
-    entry.mediaType === "movie"
-      ? `/media/movies/${entry.mediaId}`
-      : `/media/tv/${entry.mediaId}`;
+    entry.mediaType === "movie" ? `/media/movies/${entry.mediaId}` : `/media/tv/${entry.mediaId}`;
   const posterSrc = posterUrl;
 
   return (
@@ -367,16 +352,10 @@ function WatchlistCard({
       {/* Title + year + notes */}
       <div className="space-y-0.5 px-0.5">
         <Link to={href} className="hover:underline">
-          <h3 className="text-sm font-medium leading-tight line-clamp-2">
-            {title}
-          </h3>
+          <h3 className="text-sm font-medium leading-tight line-clamp-2">{title}</h3>
         </Link>
         {year && <p className="text-xs text-muted-foreground">{year}</p>}
-        {entry.notes && (
-          <p className="text-xs text-muted-foreground line-clamp-1">
-            {entry.notes}
-          </p>
-        )}
+        {entry.notes && <p className="text-xs text-muted-foreground line-clamp-1">{entry.notes}</p>}
       </div>
     </div>
   );
@@ -394,11 +373,13 @@ export function WatchlistPage() {
     error: watchlistError,
   } = trpc.media.watchlist.list.useQuery({ limit: 500 });
 
-  const { data: moviesData, isLoading: moviesLoading } =
-    trpc.media.movies.list.useQuery({ limit: 500 });
+  const { data: moviesData, isLoading: moviesLoading } = trpc.media.movies.list.useQuery({
+    limit: 500,
+  });
 
-  const { data: tvShowsData, isLoading: tvShowsLoading } =
-    trpc.media.tvShows.list.useQuery({ limit: 500 });
+  const { data: tvShowsData, isLoading: tvShowsLoading } = trpc.media.tvShows.list.useQuery({
+    limit: 500,
+  });
 
   const utils = trpc.useUtils();
 
@@ -456,15 +437,13 @@ export function WatchlistPage() {
             m.id,
             {
               title: m.title,
-              year: m.releaseDate
-                ? new Date(m.releaseDate).getFullYear()
-                : null,
+              year: m.releaseDate ? new Date(m.releaseDate).getFullYear() : null,
               posterUrl: m.posterUrl,
             },
-          ],
-        ),
+          ]
+        )
       ),
-    [moviesData?.data],
+    [moviesData?.data]
   );
 
   const tvMap = useMemo(
@@ -480,15 +459,13 @@ export function WatchlistPage() {
             s.id,
             {
               title: s.name,
-              year: s.firstAirDate
-                ? new Date(s.firstAirDate).getFullYear()
-                : null,
+              year: s.firstAirDate ? new Date(s.firstAirDate).getFullYear() : null,
               posterUrl: s.posterUrl,
             },
-          ],
-        ),
+          ]
+        )
       ),
-    [tvShowsData?.data],
+    [tvShowsData?.data]
   );
 
   // Already sorted by priority ASC from the API
@@ -514,16 +491,14 @@ export function WatchlistPage() {
       setIsReordering(true);
       reorderMutation.mutate({ items });
     },
-    [sortedEntries, reorderMutation, isReordering],
+    [sortedEntries, reorderMutation, isReordering]
   );
 
   if (watchlistError) {
     return (
       <Alert variant="destructive">
         <AlertTitle>Error</AlertTitle>
-        <AlertDescription>
-          Failed to load watchlist. Please try again.
-        </AlertDescription>
+        <AlertDescription>Failed to load watchlist. Please try again.</AlertDescription>
       </Alert>
     );
   }
@@ -537,8 +512,7 @@ export function WatchlistPage() {
       ) : entries.length === 0 ? (
         <div className="text-center py-16">
           <p className="text-muted-foreground">
-            Your watchlist is empty. Browse your library or search for something
-            to watch.
+            Your watchlist is empty. Browse your library or search for something to watch.
           </p>
           <div className="flex justify-center gap-4 mt-4">
             <Link to="/media" className="text-sm text-primary underline">
@@ -552,11 +526,7 @@ export function WatchlistPage() {
       ) : (
         <>
           {/* Mobile: compact list with reorder */}
-          <div
-            className="space-y-3 md:hidden"
-            role="list"
-            aria-label="Watchlist items"
-          >
+          <div className="space-y-3 md:hidden" role="list" aria-label="Watchlist items">
             {sortedEntries.map((entry: WatchlistEntry, index: number) => {
               const meta =
                 entry.mediaType === "movie"
@@ -585,13 +555,8 @@ export function WatchlistPage() {
                     setUpdateErrorMsg(null);
                     updateMutation.mutate({ id, data: { notes } });
                   }}
-                  isUpdating={
-                    updateMutation.isPending &&
-                    updateMutation.variables?.id === entry.id
-                  }
-                  updateError={
-                    updateErrorId === entry.id ? updateErrorMsg : null
-                  }
+                  isUpdating={updateMutation.isPending && updateMutation.variables?.id === entry.id}
+                  updateError={updateErrorId === entry.id ? updateErrorMsg : null}
                 />
               );
             })}

--- a/packages/app-media/src/routes.tsx
+++ b/packages/app-media/src/routes.tsx
@@ -8,65 +8,65 @@ import { lazy } from "react";
 import type { RouteObject } from "react-router";
 
 const LibraryPage = lazy(() =>
-  import("./pages/LibraryPage").then((m) => ({ default: m.LibraryPage })),
+  import("./pages/LibraryPage").then((m) => ({ default: m.LibraryPage }))
 );
 const MovieDetailPage = lazy(() =>
   import("./pages/MovieDetailPage").then((m) => ({
     default: m.MovieDetailPage,
-  })),
+  }))
 );
 const TvShowDetailPage = lazy(() =>
   import("./pages/TvShowDetailPage").then((m) => ({
     default: m.TvShowDetailPage,
-  })),
+  }))
 );
 const SeasonDetailPage = lazy(() =>
   import("./pages/SeasonDetailPage").then((m) => ({
     default: m.SeasonDetailPage,
-  })),
+  }))
 );
 const SearchPage = lazy(() =>
-  import("./pages/SearchPage").then((m) => ({ default: m.SearchPage })),
+  import("./pages/SearchPage").then((m) => ({ default: m.SearchPage }))
 );
 const WatchlistPage = lazy(() =>
   import("./pages/WatchlistPage").then((m) => ({
     default: m.WatchlistPage,
-  })),
+  }))
 );
 const QuickPickPage = lazy(() =>
   import("./pages/QuickPickPage").then((m) => ({
     default: m.QuickPickPage,
-  })),
+  }))
 );
 const CompareArenaPage = lazy(() =>
   import("./pages/CompareArenaPage").then((m) => ({
     default: m.CompareArenaPage,
-  })),
+  }))
 );
 const DiscoverPage = lazy(() =>
   import("./pages/DiscoverPage").then((m) => ({
     default: m.DiscoverPage,
-  })),
+  }))
 );
 const RankingsPage = lazy(() =>
   import("./pages/RankingsPage").then((m) => ({
     default: m.RankingsPage,
-  })),
+  }))
 );
 const PlexSettingsPage = lazy(() =>
   import("./pages/PlexSettingsPage").then((m) => ({
     default: m.PlexSettingsPage,
-  })),
+  }))
 );
 const ArrSettingsPage = lazy(() =>
   import("./pages/ArrSettingsPage").then((m) => ({
     default: m.ArrSettingsPage,
-  })),
+  }))
 );
 const HistoryPage = lazy(() =>
   import("./pages/HistoryPage").then((m) => ({
     default: m.HistoryPage,
-  })),
+  }))
 );
 
 /** Shared navigation types (mirrored from shell to avoid circular dependency) */

--- a/packages/db-types/src/index.ts
+++ b/packages/db-types/src/index.ts
@@ -61,9 +61,7 @@ export type EntityRow = InferSelectModel<typeof entities>;
 export type BudgetRow = InferSelectModel<typeof budgets>;
 export type InventoryRow = InferSelectModel<typeof homeInventory>;
 export type WishListRow = InferSelectModel<typeof wishList>;
-export type TransactionCorrectionRow = InferSelectModel<
-  typeof transactionCorrections
->;
+export type TransactionCorrectionRow = InferSelectModel<typeof transactionCorrections>;
 export type AiUsageRow = InferSelectModel<typeof aiUsage>;
 export type EnvironmentRow = InferSelectModel<typeof environments>;
 export type MovieRow = InferSelectModel<typeof movies>;
@@ -72,9 +70,7 @@ export type SeasonRow = InferSelectModel<typeof seasons>;
 export type EpisodeRow = InferSelectModel<typeof episodes>;
 export type MediaWatchlistRow = InferSelectModel<typeof mediaWatchlist>;
 export type WatchHistoryRow = InferSelectModel<typeof watchHistory>;
-export type ComparisonDimensionRow = InferSelectModel<
-  typeof comparisonDimensions
->;
+export type ComparisonDimensionRow = InferSelectModel<typeof comparisonDimensions>;
 export type ComparisonRow = InferSelectModel<typeof comparisons>;
 export type MediaScoreRow = InferSelectModel<typeof mediaScores>;
 export type LocationRow = InferSelectModel<typeof locations>;
@@ -89,9 +85,7 @@ export type EntityInsert = InferInsertModel<typeof entities>;
 export type BudgetInsert = InferInsertModel<typeof budgets>;
 export type InventoryInsert = InferInsertModel<typeof homeInventory>;
 export type WishListInsert = InferInsertModel<typeof wishList>;
-export type TransactionCorrectionInsert = InferInsertModel<
-  typeof transactionCorrections
->;
+export type TransactionCorrectionInsert = InferInsertModel<typeof transactionCorrections>;
 export type AiUsageInsert = InferInsertModel<typeof aiUsage>;
 export type EnvironmentInsert = InferInsertModel<typeof environments>;
 export type MovieInsert = InferInsertModel<typeof movies>;
@@ -100,9 +94,7 @@ export type SeasonInsert = InferInsertModel<typeof seasons>;
 export type EpisodeInsert = InferInsertModel<typeof episodes>;
 export type MediaWatchlistInsert = InferInsertModel<typeof mediaWatchlist>;
 export type WatchHistoryInsert = InferInsertModel<typeof watchHistory>;
-export type ComparisonDimensionInsert = InferInsertModel<
-  typeof comparisonDimensions
->;
+export type ComparisonDimensionInsert = InferInsertModel<typeof comparisonDimensions>;
 export type ComparisonInsert = InferInsertModel<typeof comparisons>;
 export type MediaScoreInsert = InferInsertModel<typeof mediaScores>;
 export type LocationInsert = InferInsertModel<typeof locations>;
@@ -112,21 +104,10 @@ export type ItemDocumentInsert = InferInsertModel<typeof itemDocuments>;
 export type SettingInsert = InferInsertModel<typeof settings>;
 
 // Constants
-export const ENTITY_TYPES = [
-  "company",
-  "person",
-  "place",
-  "brand",
-  "organisation",
-] as const;
+export const ENTITY_TYPES = ["company", "person", "place", "brand", "organisation"] as const;
 export type EntityType = (typeof ENTITY_TYPES)[number];
 
-export const WISH_LIST_PRIORITIES = [
-  "Needing",
-  "Soon",
-  "One Day",
-  "Dreaming",
-] as const;
+export const WISH_LIST_PRIORITIES = ["Needing", "Soon", "One Day", "Dreaming"] as const;
 export type WishListPriority = (typeof WISH_LIST_PRIORITIES)[number];
 
 export const MEDIA_TYPES = ["movie", "tv_show"] as const;

--- a/packages/db-types/src/schema/comparison-dimensions.ts
+++ b/packages/db-types/src/schema/comparison-dimensions.ts
@@ -9,9 +9,9 @@ export const comparisonDimensions = sqliteTable(
     description: text("description"),
     active: integer("active").notNull().default(1),
     sortOrder: integer("sort_order").notNull().default(0),
-    createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
   },
-  (table) => [
-    uniqueIndex("idx_comparison_dimensions_name").on(table.name),
-  ]
+  (table) => [uniqueIndex("idx_comparison_dimensions_name").on(table.name)]
 );

--- a/packages/db-types/src/schema/comparisons.ts
+++ b/packages/db-types/src/schema/comparisons.ts
@@ -15,7 +15,9 @@ export const comparisons = sqliteTable(
     mediaBId: integer("media_b_id").notNull(),
     winnerType: text("winner_type").notNull(),
     winnerId: integer("winner_id").notNull(),
-    comparedAt: text("compared_at").notNull().default(sql`(datetime('now'))`),
+    comparedAt: text("compared_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
   },
   (table) => [
     index("idx_comparisons_dimension_id").on(table.dimensionId),

--- a/packages/db-types/src/schema/episodes.ts
+++ b/packages/db-types/src/schema/episodes.ts
@@ -17,7 +17,9 @@ export const episodes = sqliteTable(
     stillPath: text("still_path"),
     voteAverage: real("vote_average"),
     runtime: integer("runtime"),
-    createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
   },
   (table) => [
     uniqueIndex("idx_episodes_tvdb_id").on(table.tvdbId),

--- a/packages/db-types/src/schema/inventory.ts
+++ b/packages/db-types/src/schema/inventory.ts
@@ -24,10 +24,9 @@ export const homeInventory = sqliteTable(
     warrantyExpires: text("warranty_expires"),
     replacementValue: real("replacement_value"),
     resaleValue: real("resale_value"),
-    purchaseTransactionId: text("purchase_transaction_id").references(
-      () => transactions.id,
-      { onDelete: "set null" }
-    ),
+    purchaseTransactionId: text("purchase_transaction_id").references(() => transactions.id, {
+      onDelete: "set null",
+    }),
     purchasedFromId: text("purchased_from_id").references(() => entities.id, {
       onDelete: "set null",
     }),

--- a/packages/db-types/src/schema/item-documents.ts
+++ b/packages/db-types/src/schema/item-documents.ts
@@ -1,10 +1,4 @@
-import {
-  sqliteTable,
-  text,
-  integer,
-  index,
-  unique,
-} from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, index, unique } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 import { homeInventory } from "./inventory.js";
 
@@ -23,11 +17,8 @@ export const itemDocuments = sqliteTable(
       .default(sql`(datetime('now'))`),
   },
   (table) => [
-    unique("uq_item_documents_pair").on(
-      table.itemId,
-      table.paperlessDocumentId,
-    ),
+    unique("uq_item_documents_pair").on(table.itemId, table.paperlessDocumentId),
     index("idx_item_documents_item").on(table.itemId),
     index("idx_item_documents_doc").on(table.paperlessDocumentId),
-  ],
+  ]
 );

--- a/packages/db-types/src/schema/media-scores.ts
+++ b/packages/db-types/src/schema/media-scores.ts
@@ -13,14 +13,12 @@ export const mediaScores = sqliteTable(
       .references(() => comparisonDimensions.id),
     score: real("score").notNull().default(1500.0),
     comparisonCount: integer("comparison_count").notNull().default(0),
-    updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
   },
   (table) => [
-    uniqueIndex("idx_media_scores_unique").on(
-      table.mediaType,
-      table.mediaId,
-      table.dimensionId,
-    ),
+    uniqueIndex("idx_media_scores_unique").on(table.mediaType, table.mediaId, table.dimensionId),
     index("idx_media_scores_dimension").on(table.dimensionId),
   ]
 );

--- a/packages/db-types/src/schema/media-watchlist.ts
+++ b/packages/db-types/src/schema/media-watchlist.ts
@@ -9,9 +9,9 @@ export const mediaWatchlist = sqliteTable(
     mediaId: integer("media_id").notNull(),
     priority: integer("priority").default(0),
     notes: text("notes"),
-    addedAt: text("added_at").notNull().default(sql`(datetime('now'))`),
+    addedAt: text("added_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
   },
-  (table) => [
-    uniqueIndex("idx_watchlist_media").on(table.mediaType, table.mediaId),
-  ]
+  (table) => [uniqueIndex("idx_watchlist_media").on(table.mediaType, table.mediaId)]
 );

--- a/packages/db-types/src/schema/movies.ts
+++ b/packages/db-types/src/schema/movies.ts
@@ -24,8 +24,12 @@ export const movies = sqliteTable(
     voteAverage: real("vote_average"),
     voteCount: integer("vote_count"),
     genres: text("genres"), // JSON array
-    createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
-    updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
   },
   (table) => [
     uniqueIndex("idx_movies_tmdb_id").on(table.tmdbId),

--- a/packages/db-types/src/schema/seasons.ts
+++ b/packages/db-types/src/schema/seasons.ts
@@ -16,7 +16,9 @@ export const seasons = sqliteTable(
     posterPath: text("poster_path"),
     airDate: text("air_date"),
     episodeCount: integer("episode_count"),
-    createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
   },
   (table) => [
     uniqueIndex("idx_seasons_tvdb_id").on(table.tvdbId),

--- a/packages/db-types/src/schema/tv-shows.ts
+++ b/packages/db-types/src/schema/tv-shows.ts
@@ -24,8 +24,12 @@ export const tvShows = sqliteTable(
     voteCount: integer("vote_count"),
     genres: text("genres"), // JSON array
     networks: text("networks"), // JSON array
-    createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
-    updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
   },
   (table) => [
     uniqueIndex("idx_tv_shows_tvdb_id").on(table.tvdbId),

--- a/packages/db-types/src/schema/watch-history.ts
+++ b/packages/db-types/src/schema/watch-history.ts
@@ -7,7 +7,9 @@ export const watchHistory = sqliteTable(
     id: integer("id").primaryKey({ autoIncrement: true }),
     mediaType: text("media_type", { enum: ["movie", "episode"] }).notNull(),
     mediaId: integer("media_id").notNull(),
-    watchedAt: text("watched_at").notNull().default(sql`(datetime('now'))`),
+    watchedAt: text("watched_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
     completed: integer("completed").notNull().default(1),
   },
   (table) => [

--- a/packages/ui/.prettierrc.json
+++ b/packages/ui/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-  "semi": true,
-  "singleQuote": false,
-  "tabWidth": 2,
-  "trailingComma": "es5",
-  "printWidth": 80
-}

--- a/packages/ui/src/components/AssetIdBadge.tsx
+++ b/packages/ui/src/components/AssetIdBadge.tsx
@@ -2,8 +2,10 @@ import type { ComponentProps } from "react";
 import { Badge } from "../primitives/badge";
 import { cn } from "../lib/utils";
 
-export interface AssetIdBadgeProps
-  extends Omit<ComponentProps<typeof Badge>, "variant" | "children"> {
+export interface AssetIdBadgeProps extends Omit<
+  ComponentProps<typeof Badge>,
+  "variant" | "children"
+> {
   assetId: string;
 }
 
@@ -11,10 +13,7 @@ export function AssetIdBadge({ assetId, className, ...props }: AssetIdBadgeProps
   return (
     <Badge
       variant="outline"
-      className={cn(
-        "font-mono text-[10px] tracking-wider px-1.5 py-0 h-5",
-        className
-      )}
+      className={cn("font-mono text-[10px] tracking-wider px-1.5 py-0 h-5", className)}
       {...props}
     >
       {assetId}

--- a/packages/ui/src/components/Autocomplete.stories.tsx
+++ b/packages/ui/src/components/Autocomplete.stories.tsx
@@ -159,13 +159,6 @@ export const CustomEmpty: Story = {
 export const Disabled: Story = {
   args: {},
   render: () => {
-    return (
-      <Autocomplete
-        suggestions={cities}
-        value="Sydney"
-        disabled
-        placeholder="Disabled..."
-      />
-    );
+    return <Autocomplete suggestions={cities} value="Sydney" disabled placeholder="Disabled..." />;
   },
 };

--- a/packages/ui/src/components/Button.stories.tsx
+++ b/packages/ui/src/components/Button.stories.tsx
@@ -12,14 +12,7 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     variant: {
       control: "select",
-      options: [
-        "default",
-        "destructive",
-        "outline",
-        "secondary",
-        "ghost",
-        "link",
-      ],
+      options: ["default", "destructive", "outline", "secondary", "ghost", "link"],
       description: "Visual style variant of the button",
     },
     size: {

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -12,12 +12,9 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
@@ -139,14 +136,7 @@ function Spinner() {
       viewBox="0 0 24 24"
       aria-hidden="true"
     >
-      <circle
-        className="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        strokeWidth="4"
-      />
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
       <path
         className="opacity-75"
         fill="currentColor"

--- a/packages/ui/src/components/CheckboxInput.stories.tsx
+++ b/packages/ui/src/components/CheckboxInput.stories.tsx
@@ -127,25 +127,19 @@ export const MultipleCheckboxes: Story = {
           label="Email notifications"
           description="Receive updates via email"
           checked={preferences.email}
-          onCheckedChange={(checked) =>
-            setPreferences({ ...preferences, email: checked })
-          }
+          onCheckedChange={(checked) => setPreferences({ ...preferences, email: checked })}
         />
         <CheckboxInput
           label="SMS notifications"
           description="Receive updates via text message"
           checked={preferences.sms}
-          onCheckedChange={(checked) =>
-            setPreferences({ ...preferences, sms: checked })
-          }
+          onCheckedChange={(checked) => setPreferences({ ...preferences, sms: checked })}
         />
         <CheckboxInput
           label="Push notifications"
           description="Receive push notifications in your browser"
           checked={preferences.push}
-          onCheckedChange={(checked) =>
-            setPreferences({ ...preferences, push: checked })
-          }
+          onCheckedChange={(checked) => setPreferences({ ...preferences, push: checked })}
         />
       </div>
     );

--- a/packages/ui/src/components/CheckboxInput.tsx
+++ b/packages/ui/src/components/CheckboxInput.tsx
@@ -93,8 +93,7 @@ export const CheckboxInput = forwardRef<HTMLButtonElement, CheckboxInputProps>(
     },
     ref
   ) => {
-    const generatedId =
-      id || `checkbox-${Math.random().toString(36).substr(2, 9)}`;
+    const generatedId = id || `checkbox-${Math.random().toString(36).substr(2, 9)}`;
 
     return (
       <div className={cn("flex flex-col gap-2", className)}>
@@ -128,15 +127,11 @@ export const CheckboxInput = forwardRef<HTMLButtonElement, CheckboxInputProps>(
                 {label}
                 {required && <span className="text-destructive ml-1">*</span>}
               </label>
-              {description && (
-                <p className="text-sm text-muted-foreground">{description}</p>
-              )}
+              {description && <p className="text-sm text-muted-foreground">{description}</p>}
             </div>
           )}
         </div>
-        {error && errorMessage && (
-          <p className="text-sm text-destructive">{errorMessage}</p>
-        )}
+        {error && errorMessage && <p className="text-sm text-destructive">{errorMessage}</p>}
       </div>
     );
   }

--- a/packages/ui/src/components/Chip.stories.tsx
+++ b/packages/ui/src/components/Chip.stories.tsx
@@ -274,9 +274,7 @@ export const AllRemovableVariants: Story = {
             key={chip.id}
             variant={chip.variant}
             removable
-            onRemove={() =>
-              setChips((prev) => prev.filter((c) => c.id !== chip.id))
-            }
+            onRemove={() => setChips((prev) => prev.filter((c) => c.id !== chip.id))}
           >
             {chip.label}
           </Chip>
@@ -333,9 +331,7 @@ export const FilterChips: Story = {
               key={filter}
               variant="primary"
               removable
-              onRemove={() =>
-                setActiveFilters((prev) => prev.filter((f) => f !== filter))
-              }
+              onRemove={() => setActiveFilters((prev) => prev.filter((f) => f !== filter))}
             >
               {filter}
             </Chip>

--- a/packages/ui/src/components/Chip.tsx
+++ b/packages/ui/src/components/Chip.tsx
@@ -13,13 +13,11 @@ const chipVariants = cva(
       variant: {
         default: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         primary: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         success: "bg-success text-white hover:bg-success/80",
         warning: "bg-warning text-white hover:bg-warning/80",
         info: "bg-info text-white hover:bg-info/80",
-        outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         ghost: "hover:bg-accent hover:text-accent-foreground",
       },
       size: {
@@ -36,9 +34,7 @@ const chipVariants = cva(
 );
 
 export interface ChipProps
-  extends
-    Omit<HTMLAttributes<HTMLDivElement>, "prefix">,
-    VariantProps<typeof chipVariants> {
+  extends Omit<HTMLAttributes<HTMLDivElement>, "prefix">, VariantProps<typeof chipVariants> {
   /**
    * Content to display inside the chip
    */
@@ -88,11 +84,7 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(
     ref
   ) => {
     return (
-      <div
-        ref={ref}
-        className={cn(chipVariants({ variant, size, className }))}
-        {...props}
-      >
+      <div ref={ref} className={cn(chipVariants({ variant, size, className }))} {...props}>
         {prefix && <span className="inline-flex shrink-0">{prefix}</span>}
         <span className="truncate">{children}</span>
         {removable && (

--- a/packages/ui/src/components/ChipInput.stories.tsx
+++ b/packages/ui/src/components/ChipInput.stories.tsx
@@ -137,18 +137,10 @@ export const Controlled: Story = {
     const [values, setValues] = useState(["tag1", "tag2"]);
     return (
       <div className="space-y-4">
-        <ChipInput
-          {...args}
-          value={values}
-          onChange={setValues}
-          placeholder="Add tags..."
-        />
+        <ChipInput {...args} value={values} onChange={setValues} placeholder="Add tags..." />
         <div className="text-sm text-muted-foreground">
           <p>Current values: {values.join(", ")}</p>
-          <button
-            onClick={() => setValues([])}
-            className="mt-2 text-xs underline"
-          >
+          <button onClick={() => setValues([])} className="mt-2 text-xs underline">
             Clear all
           </button>
         </div>
@@ -207,11 +199,7 @@ export const TagEditor: Story = {
       <div className="space-y-4 max-w-lg">
         <div>
           <h3 className="text-lg font-semibold mb-2">Post Tags</h3>
-          <ChipInput
-            value={tags}
-            onChange={setTags}
-            placeholder="Add tags..."
-          />
+          <ChipInput value={tags} onChange={setTags} placeholder="Add tags..." />
         </div>
         <div className="text-sm text-muted-foreground">
           <p>Popular tags:</p>
@@ -238,10 +226,7 @@ export const TagEditor: Story = {
 
 export const CategorySelector: Story = {
   render: () => {
-    const [categories, setCategories] = useState<string[]>([
-      "Food & Dining",
-      "Transportation",
-    ]);
+    const [categories, setCategories] = useState<string[]>(["Food & Dining", "Transportation"]);
 
     const suggestions = [
       "Food & Dining",
@@ -257,9 +242,7 @@ export const CategorySelector: Story = {
     return (
       <div className="space-y-4 max-w-lg">
         <div>
-          <label className="block text-sm font-medium mb-2">
-            Transaction Categories
-          </label>
+          <label className="block text-sm font-medium mb-2">Transaction Categories</label>
           <ChipInput
             value={categories}
             onChange={setCategories}
@@ -296,9 +279,7 @@ export const KeywordInput: Story = {
     return (
       <div className="space-y-4 max-w-lg">
         <div>
-          <label className="block text-sm font-medium mb-2">
-            Search Keywords
-          </label>
+          <label className="block text-sm font-medium mb-2">Search Keywords</label>
           <ChipInput
             value={keywords}
             onChange={setKeywords}
@@ -334,16 +315,7 @@ export const States: Story = {
       <div>
         <p className="text-sm font-medium mb-1">Many values</p>
         <ChipInput
-          defaultValue={[
-            "apple",
-            "banana",
-            "orange",
-            "grape",
-            "kiwi",
-            "mango",
-            "pear",
-            "peach",
-          ]}
+          defaultValue={["apple", "banana", "orange", "grape", "kiwi", "mango", "pear", "peach"]}
         />
       </div>
       <div>
@@ -358,15 +330,8 @@ export const States: Story = {
 export const AllVariants: Story = {
   render: () => (
     <div className="space-y-4">
-      <ChipInput
-        defaultValue={["tag1", "tag2"]}
-        placeholder="Default variant"
-      />
-      <ChipInput
-        defaultValue={["tag1", "tag2"]}
-        placeholder="Ghost variant"
-        variant="ghost"
-      />
+      <ChipInput defaultValue={["tag1", "tag2"]} placeholder="Default variant" />
+      <ChipInput defaultValue={["tag1", "tag2"]} placeholder="Ghost variant" variant="ghost" />
       <ChipInput
         defaultValue={["tag1", "tag2"]}
         placeholder="Underline variant"
@@ -384,9 +349,7 @@ export const PasteMultipleValues: Story = {
     return (
       <div className="space-y-4 max-w-lg">
         <div>
-          <label className="block text-sm font-medium mb-2">
-            Paste Multiple Emails
-          </label>
+          <label className="block text-sm font-medium mb-2">Paste Multiple Emails</label>
           <ChipInput
             value={values}
             onChange={setValues}

--- a/packages/ui/src/components/ChipInput.tsx
+++ b/packages/ui/src/components/ChipInput.tsx
@@ -2,13 +2,7 @@
  * ChipInput component for multi-value input like email tags
  * Similar to Gmail's "To" field where entries become chips
  */
-import {
-  forwardRef,
-  useState,
-  useRef,
-  type InputHTMLAttributes,
-  type KeyboardEvent,
-} from "react";
+import { forwardRef, useState, useRef, type InputHTMLAttributes, type KeyboardEvent } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../lib/utils";
 import { Chip } from "./Chip";
@@ -124,8 +118,7 @@ export const ChipInput = forwardRef<HTMLInputElement, ChipInputProps>(
     },
     ref
   ) => {
-    const [internalValues, setInternalValues] =
-      useState<string[]>(defaultValue);
+    const [internalValues, setInternalValues] = useState<string[]>(defaultValue);
     const [inputValue, setInputValue] = useState("");
     const [isFocused, setIsFocused] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);

--- a/packages/ui/src/components/ComboboxSelect.stories.tsx
+++ b/packages/ui/src/components/ComboboxSelect.stories.tsx
@@ -166,13 +166,6 @@ export const DefaultVariant: Story = {
 export const Disabled: Story = {
   args: {},
   render: () => {
-    return (
-      <ComboboxSelect
-        options={countries}
-        value="us"
-        disabled
-        placeholder="Disabled..."
-      />
-    );
+    return <ComboboxSelect options={countries} value="us" disabled placeholder="Disabled..." />;
   },
 };

--- a/packages/ui/src/components/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect.tsx
@@ -174,16 +174,11 @@ export function ComboboxSelect({
                     >
                       {multiple && (
                         <Check
-                          className={cn(
-                            "mr-2 h-4 w-4",
-                            isSelected ? "opacity-100" : "opacity-0"
-                          )}
+                          className={cn("mr-2 h-4 w-4", isSelected ? "opacity-100" : "opacity-0")}
                         />
                       )}
                       {option.label}
-                      {!multiple && isSelected && (
-                        <Check className="ml-auto h-4 w-4" />
-                      )}
+                      {!multiple && isSelected && <Check className="ml-auto h-4 w-4" />}
                     </CommandItem>
                   );
                 })}
@@ -195,13 +190,7 @@ export function ComboboxSelect({
       {multiple && selectedValues.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
           {selectedValues.map((val) => (
-            <Chip
-              key={val}
-              variant="default"
-              size="sm"
-              removable
-              onRemove={() => removeValue(val)}
-            >
+            <Chip key={val} variant="default" size="sm" removable onRemove={() => removeValue(val)}>
               {getOptionLabel(val)}
             </Chip>
           ))}

--- a/packages/ui/src/components/ConditionBadge.tsx
+++ b/packages/ui/src/components/ConditionBadge.tsx
@@ -5,23 +5,20 @@ import { cn } from "../lib/utils";
 export type Condition = "Excellent" | "Good" | "Fair" | "Poor";
 
 const conditionStyles: Record<Condition, string> = {
-  Excellent:
-    "bg-emerald-500/10 text-emerald-700 border-emerald-500/20 dark:text-emerald-400",
+  Excellent: "bg-emerald-500/10 text-emerald-700 border-emerald-500/20 dark:text-emerald-400",
   Good: "bg-blue-500/10 text-blue-700 border-blue-500/20 dark:text-blue-400",
   Fair: "bg-amber-500/10 text-amber-700 border-amber-500/20 dark:text-amber-400",
   Poor: "bg-red-500/10 text-red-700 border-red-500/20 dark:text-red-400",
 };
 
-export interface ConditionBadgeProps
-  extends Omit<ComponentProps<typeof Badge>, "variant" | "children"> {
+export interface ConditionBadgeProps extends Omit<
+  ComponentProps<typeof Badge>,
+  "variant" | "children"
+> {
   condition: Condition;
 }
 
-export function ConditionBadge({
-  condition,
-  className,
-  ...props
-}: ConditionBadgeProps) {
+export function ConditionBadge({ condition, className, ...props }: ConditionBadgeProps) {
   return (
     <Badge
       variant="outline"

--- a/packages/ui/src/components/DataTable.filtering.stories.tsx
+++ b/packages/ui/src/components/DataTable.filtering.stories.tsx
@@ -2,11 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ColumnDef } from "@tanstack/react-table";
 import { DataTable, SortableHeader } from "./DataTable";
 import type { ColumnFilter } from "./DataTableFilters";
-import {
-  dateRangeFilter,
-  numberRangeFilter,
-  multiSelectFilter,
-} from "./DataTableFilters";
+import { dateRangeFilter, numberRangeFilter, multiSelectFilter } from "./DataTableFilters";
 
 const meta: Meta<typeof DataTable> = {
   title: "Data Display/Table/Filtering",
@@ -31,38 +27,22 @@ interface Transaction {
 }
 
 // Generate sample transactions
-const sampleTransactions: Transaction[] = Array.from(
-  { length: 100 },
-  (_, i) => ({
-    id: `txn-${i + 1}`,
-    date: new Date(2024, Math.floor(i / 10), (i % 10) + 1)
-      .toISOString()
-      .split("T")[0],
-    description: [
-      "Woolworths",
-      "Coles",
-      "Amazon",
-      "Netflix",
-      "Uber",
-      "Spotify",
-      "Apple",
-      "Google",
-    ][i % 8],
-    amount: Math.random() * 400 - 200,
-    category: ["Food", "Shopping", "Entertainment", "Transport", "Bills"][
-      i % 5
-    ],
-    account: ["Checking", "Savings", "Credit Card"][i % 3],
-    status: (["pending", "completed", "failed"] as const)[i % 3],
-  })
-);
+const sampleTransactions: Transaction[] = Array.from({ length: 100 }, (_, i) => ({
+  id: `txn-${i + 1}`,
+  date: new Date(2024, Math.floor(i / 10), (i % 10) + 1).toISOString().split("T")[0],
+  description: ["Woolworths", "Coles", "Amazon", "Netflix", "Uber", "Spotify", "Apple", "Google"][
+    i % 8
+  ],
+  amount: Math.random() * 400 - 200,
+  category: ["Food", "Shopping", "Entertainment", "Transport", "Bills"][i % 5],
+  account: ["Checking", "Savings", "Credit Card"][i % 3],
+  status: (["pending", "completed", "failed"] as const)[i % 3],
+}));
 
 const transactionColumns: ColumnDef<Transaction>[] = [
   {
     accessorKey: "date",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Date</SortableHeader>
-    ),
+    header: ({ column }) => <SortableHeader column={column}>Date</SortableHeader>,
     filterFn: dateRangeFilter,
   },
   {
@@ -71,20 +51,14 @@ const transactionColumns: ColumnDef<Transaction>[] = [
   },
   {
     accessorKey: "amount",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Amount</SortableHeader>
-    ),
+    header: ({ column }) => <SortableHeader column={column}>Amount</SortableHeader>,
     cell: ({ row }) => {
       const amount = row.getValue("amount") as number;
       const formatted = new Intl.NumberFormat("en-AU", {
         style: "currency",
         currency: "AUD",
       }).format(amount);
-      return (
-        <span className={amount < 0 ? "text-red-600" : "text-green-600"}>
-          {formatted}
-        </span>
-      );
+      return <span className={amount < 0 ? "text-red-600" : "text-green-600"}>{formatted}</span>;
     },
     filterFn: numberRangeFilter,
   },
@@ -108,9 +82,7 @@ const transactionColumns: ColumnDef<Transaction>[] = [
         completed: "text-green-600",
         failed: "text-red-600",
       };
-      return (
-        <span className={colors[status as keyof typeof colors]}>{status}</span>
-      );
+      return <span className={colors[status as keyof typeof colors]}>{status}</span>;
     },
     filterFn: multiSelectFilter,
   },

--- a/packages/ui/src/components/DataTable.stories.tsx
+++ b/packages/ui/src/components/DataTable.stories.tsx
@@ -81,38 +81,24 @@ const sampleUsers: User[] = [
   },
 ];
 
-const sampleTransactions: Transaction[] = Array.from(
-  { length: 50 },
-  (_, i) => ({
-    id: `txn-${i + 1}`,
-    date: new Date(2024, 0, i + 1).toISOString().split("T")[0],
-    description: [
-      "Woolworths",
-      "Coles",
-      "Amazon",
-      "Netflix",
-      "Uber",
-      "Spotify",
-    ][i % 6],
-    amount: Math.random() * 200 - 100,
-    category: ["Food", "Shopping", "Entertainment", "Transport"][i % 4],
-    account: ["Checking", "Savings", "Credit Card"][i % 3],
-  })
-);
+const sampleTransactions: Transaction[] = Array.from({ length: 50 }, (_, i) => ({
+  id: `txn-${i + 1}`,
+  date: new Date(2024, 0, i + 1).toISOString().split("T")[0],
+  description: ["Woolworths", "Coles", "Amazon", "Netflix", "Uber", "Spotify"][i % 6],
+  amount: Math.random() * 200 - 100,
+  category: ["Food", "Shopping", "Entertainment", "Transport"][i % 4],
+  account: ["Checking", "Savings", "Credit Card"][i % 3],
+}));
 
 // Basic columns
 const userColumns: ColumnDef<User>[] = [
   {
     accessorKey: "name",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Name</SortableHeader>
-    ),
+    header: ({ column }) => <SortableHeader column={column}>Name</SortableHeader>,
   },
   {
     accessorKey: "email",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Email</SortableHeader>
-    ),
+    header: ({ column }) => <SortableHeader column={column}>Email</SortableHeader>,
   },
   {
     accessorKey: "role",
@@ -124,11 +110,7 @@ const userColumns: ColumnDef<User>[] = [
     cell: ({ row }) => {
       const status = row.getValue("status") as string;
       return (
-        <span
-          className={
-            status === "active" ? "text-green-600" : "text-muted-foreground"
-          }
-        >
+        <span className={status === "active" ? "text-green-600" : "text-muted-foreground"}>
           {status}
         </span>
       );
@@ -136,9 +118,7 @@ const userColumns: ColumnDef<User>[] = [
   },
   {
     accessorKey: "createdAt",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Created</SortableHeader>
-    ),
+    header: ({ column }) => <SortableHeader column={column}>Created</SortableHeader>,
   },
 ];
 
@@ -170,9 +150,7 @@ export const WithPagination: Story = {
     const transactionColumns: ColumnDef<Transaction>[] = [
       {
         accessorKey: "date",
-        header: ({ column }) => (
-          <SortableHeader column={column}>Date</SortableHeader>
-        ),
+        header: ({ column }) => <SortableHeader column={column}>Date</SortableHeader>,
       },
       {
         accessorKey: "description",
@@ -180,9 +158,7 @@ export const WithPagination: Story = {
       },
       {
         accessorKey: "amount",
-        header: ({ column }) => (
-          <SortableHeader column={column}>Amount</SortableHeader>
-        ),
+        header: ({ column }) => <SortableHeader column={column}>Amount</SortableHeader>,
         cell: ({ row }) => {
           const amount = row.getValue("amount") as number;
           const formatted = new Intl.NumberFormat("en-AU", {
@@ -190,9 +166,7 @@ export const WithPagination: Story = {
             currency: "AUD",
           }).format(amount);
           return (
-            <span className={amount < 0 ? "text-red-600" : "text-green-600"}>
-              {formatted}
-            </span>
+            <span className={amount < 0 ? "text-red-600" : "text-green-600"}>{formatted}</span>
           );
         },
       },
@@ -231,9 +205,7 @@ export const WithRowSelection: Story = {
         header: ({ table }) => (
           <Checkbox
             checked={table.getIsAllPageRowsSelected()}
-            onCheckedChange={(value) =>
-              table.toggleAllPageRowsSelected(!!value)
-            }
+            onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
             aria-label="Select all"
           />
         ),
@@ -261,9 +233,7 @@ export const WithRowSelection: Story = {
           searchColumn="name"
         />
         {selectedUsers.length > 0 && (
-          <div className="text-sm">
-            Selected: {selectedUsers.map((u) => u.name).join(", ")}
-          </div>
+          <div className="text-sm">Selected: {selectedUsers.map((u) => u.name).join(", ")}</div>
         )}
       </div>
     );
@@ -275,32 +245,20 @@ export const WithEditableCells: Story = {
   render: () => {
     const [users, setUsers] = useState(sampleUsers);
 
-    const updateUser = (
-      id: number,
-      field: keyof User,
-      value: User[keyof User]
-    ) => {
-      setUsers((prev) =>
-        prev.map((user) =>
-          user.id === id ? { ...user, [field]: value } : user
-        )
-      );
+    const updateUser = (id: number, field: keyof User, value: User[keyof User]) => {
+      setUsers((prev) => prev.map((user) => (user.id === id ? { ...user, [field]: value } : user)));
     };
 
     const editableColumns: ColumnDef<User>[] = [
       {
         accessorKey: "name",
-        header: ({ column }) => (
-          <SortableHeader column={column}>Name</SortableHeader>
-        ),
+        header: ({ column }) => <SortableHeader column={column}>Name</SortableHeader>,
         cell: ({ row }) => (
           <EditableCell
             value={row.original.name}
             type="text"
             onSave={(newValue) => updateUser(row.original.id, "name", newValue)}
-            validate={(val) =>
-              val.length >= 2 || "Name must be at least 2 characters"
-            }
+            validate={(val) => val.length >= 2 || "Name must be at least 2 characters"}
           />
         ),
       },
@@ -311,12 +269,8 @@ export const WithEditableCells: Story = {
           <EditableCell
             value={row.original.email}
             type="text"
-            onSave={(newValue) =>
-              updateUser(row.original.id, "email", newValue)
-            }
-            validate={(val) =>
-              /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val) || "Invalid email"
-            }
+            onSave={(newValue) => updateUser(row.original.id, "email", newValue)}
+            validate={(val) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val) || "Invalid email"}
           />
         ),
       },
@@ -347,9 +301,7 @@ export const WithEditableCells: Story = {
               { label: "Active", value: "active" },
               { label: "Inactive", value: "inactive" },
             ]}
-            onSave={(newValue) =>
-              updateUser(row.original.id, "status", newValue)
-            }
+            onSave={(newValue) => updateUser(row.original.id, "status", newValue)}
           />
         ),
       },
@@ -359,14 +311,7 @@ export const WithEditableCells: Story = {
       },
     ];
 
-    return (
-      <DataTable
-        columns={editableColumns}
-        data={users}
-        searchable
-        searchColumn="name"
-      />
-    );
+    return <DataTable columns={editableColumns} data={users} searchable searchColumn="name" />;
   },
 };
 
@@ -388,18 +333,10 @@ export const WithActions: Story = {
         header: "Actions",
         cell: ({ row }) => (
           <div className="flex gap-2">
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={() => handleEdit(row.original)}
-            >
+            <Button size="sm" variant="ghost" onClick={() => handleEdit(row.original)}>
               Edit
             </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={() => handleDelete(row.original)}
-            >
+            <Button size="sm" variant="ghost" onClick={() => handleDelete(row.original)}>
               Delete
             </Button>
           </div>
@@ -434,9 +371,7 @@ export const EmptyState: Story = {
         emptyState={
           <div className="flex flex-col items-center gap-2">
             <p className="text-lg font-medium">No users found</p>
-            <p className="text-sm text-muted-foreground">
-              Get started by adding your first user
-            </p>
+            <p className="text-sm text-muted-foreground">Get started by adding your first user</p>
             <Button size="sm" className="mt-2">
               Add User
             </Button>

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -20,14 +20,7 @@ import {
 } from "@tanstack/react-table";
 import { ArrowUpDown, ChevronDown, Search } from "lucide-react";
 import { cn } from "../lib/utils";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "../primitives/table";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../primitives/table";
 import { Button } from "./Button";
 import { TextInput } from "./TextInput";
 import {
@@ -158,8 +151,7 @@ export function DataTable<TData, TValue>({
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-  const [columnVisibilityState, setColumnVisibilityState] =
-    useState<VisibilityState>({});
+  const [columnVisibilityState, setColumnVisibilityState] = useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = useState({});
 
   const table = useReactTable({
@@ -191,9 +183,7 @@ export function DataTable<TData, TValue>({
   // Notify parent of selection changes
   useMemo(() => {
     if (onSelectionChange && enableRowSelection) {
-      const selectedRows = table
-        .getFilteredSelectedRowModel()
-        .rows.map((row) => row.original);
+      const selectedRows = table.getFilteredSelectedRowModel().rows.map((row) => row.original);
       onSelectionChange(selectedRows);
     }
   }, [rowSelection, onSelectionChange, enableRowSelection, table]);
@@ -202,10 +192,7 @@ export function DataTable<TData, TValue>({
     <div className={cn("space-y-4", className)}>
       {/* Filters */}
       {filters && filters.length > 0 && (
-        <FilterBar
-          filters={filters}
-          table={table as unknown as TanStackTable<unknown>}
-        />
+        <FilterBar filters={filters} table={table as unknown as TanStackTable<unknown>} />
       )}
 
       {/* Toolbar */}
@@ -215,13 +202,8 @@ export function DataTable<TData, TValue>({
             <TextInput
               placeholder={searchPlaceholder}
               prefix={<Search className="h-4 w-4" />}
-              value={
-                (table.getColumn(searchColumn)?.getFilterValue() as string) ??
-                ""
-              }
-              onChange={(e) =>
-                table.getColumn(searchColumn)?.setFilterValue(e.target.value)
-              }
+              value={(table.getColumn(searchColumn)?.getFilterValue() as string) ?? ""}
+              onChange={(e) => table.getColumn(searchColumn)?.setFilterValue(e.target.value)}
               className="w-full sm:max-w-sm"
               clearable
               onClear={() => table.getColumn(searchColumn)?.setFilterValue("")}
@@ -243,9 +225,7 @@ export function DataTable<TData, TValue>({
                       <DropdownMenuCheckboxItem
                         key={column.id}
                         checked={column.getIsVisible()}
-                        onCheckedChange={(value) =>
-                          column.toggleVisibility(!!value)
-                        }
+                        onCheckedChange={(value) => column.toggleVisibility(!!value)}
                       >
                         {column.id}
                       </DropdownMenuCheckboxItem>
@@ -268,10 +248,7 @@ export function DataTable<TData, TValue>({
                     <TableHead key={header.id}>
                       {header.isPlaceholder
                         ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext()
-                          )}
+                        : flexRender(header.column.columnDef.header, header.getContext())}
                     </TableHead>
                   );
                 })}
@@ -281,10 +258,7 @@ export function DataTable<TData, TValue>({
           <TableBody>
             {loading ? (
               <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-24 text-center"
-                >
+                <TableCell colSpan={columns.length} className="h-24 text-center">
                   Loading...
                 </TableCell>
               </TableRow>
@@ -298,20 +272,14 @@ export function DataTable<TData, TValue>({
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableCell>
                   ))}
                 </TableRow>
               ))
             ) : (
               <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-24 text-center"
-                >
+                <TableCell colSpan={columns.length} className="h-24 text-center">
                   {emptyState || "No results."}
                 </TableCell>
               </TableRow>
@@ -333,9 +301,7 @@ export function DataTable<TData, TValue>({
           </div>
           <div className="flex flex-wrap items-center gap-4 sm:gap-6">
             <div className="flex items-center gap-2">
-              <p className="hidden text-sm font-medium sm:block">
-                Rows per page
-              </p>
+              <p className="hidden text-sm font-medium sm:block">Rows per page</p>
               <select
                 value={table.getState().pagination.pageSize}
                 onChange={(e) => {
@@ -352,8 +318,7 @@ export function DataTable<TData, TValue>({
             </div>
             <div className="flex items-center gap-2">
               <div className="text-sm font-medium">
-                Page {table.getState().pagination.pageIndex + 1} of{" "}
-                {table.getPageCount()}
+                Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
               </div>
               <div className="flex gap-2">
                 <Button

--- a/packages/ui/src/components/DataTableFilters.tsx
+++ b/packages/ui/src/components/DataTableFilters.tsx
@@ -43,11 +43,7 @@ interface SelectFilterProps {
   placeholder?: string;
 }
 
-export function SelectFilter({
-  column,
-  options,
-  placeholder,
-}: SelectFilterProps) {
+export function SelectFilter({ column, options, placeholder }: SelectFilterProps) {
   return (
     <Select
       value={(column.getFilterValue() as string) ?? ""}
@@ -65,11 +61,7 @@ interface MultiSelectFilterProps {
   placeholder?: string;
 }
 
-export function MultiSelectFilter({
-  column,
-  options,
-  placeholder,
-}: MultiSelectFilterProps) {
+export function MultiSelectFilter({ column, options, placeholder }: MultiSelectFilterProps) {
   const filterValue = (column.getFilterValue() as string[]) ?? [];
 
   return (
@@ -77,9 +69,7 @@ export function MultiSelectFilter({
       options={options.map((opt) => ({ label: opt.label, value: opt.value }))}
       value={filterValue}
       onChange={(value) =>
-        column.setFilterValue(
-          Array.isArray(value) && value.length > 0 ? value : undefined
-        )
+        column.setFilterValue(Array.isArray(value) && value.length > 0 ? value : undefined)
       }
       multiple
       placeholder={placeholder || "Select..."}
@@ -100,9 +90,7 @@ export function DateRangeFilter({ column }: DateRangeFilterProps) {
       <TextInput
         type="date"
         value={filterValue[0]}
-        onChange={(e) =>
-          column.setFilterValue([e.target.value, filterValue[1]])
-        }
+        onChange={(e) => column.setFilterValue([e.target.value, filterValue[1]])}
         placeholder="From"
         className="w-full sm:w-38"
       />
@@ -110,9 +98,7 @@ export function DateRangeFilter({ column }: DateRangeFilterProps) {
       <TextInput
         type="date"
         value={filterValue[1]}
-        onChange={(e) =>
-          column.setFilterValue([filterValue[0], e.target.value])
-        }
+        onChange={(e) => column.setFilterValue([filterValue[0], e.target.value])}
         placeholder="To"
         className="w-full sm:w-38"
       />
@@ -131,10 +117,7 @@ export function NumberRangeFilter({
   minPlaceholder = "Min",
   maxPlaceholder = "Max",
 }: NumberRangeFilterProps) {
-  const filterValue = (column.getFilterValue() as [number, number]) ?? [
-    undefined,
-    undefined,
-  ];
+  const filterValue = (column.getFilterValue() as [number, number]) ?? [undefined, undefined];
 
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -194,7 +177,9 @@ export function FilterBar({ filters, table, onClearAll }: FilterBarProps) {
             </span>
           )}
         </Button>
-        <h3 className="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/80 hidden md:block">Filters</h3>
+        <h3 className="text-[10px] font-bold uppercase tracking-[0.15em] text-muted-foreground/80 hidden md:block">
+          Filters
+        </h3>
         {activeFiltersCount > 0 && (
           <Button
             variant="ghost"
@@ -207,7 +192,9 @@ export function FilterBar({ filters, table, onClearAll }: FilterBarProps) {
           </Button>
         )}
       </div>
-      <div className={`grid gap-4 sm:grid-cols-2 lg:grid-cols-3 ${mobileOpen ? "grid" : "hidden"} md:grid`}>
+      <div
+        className={`grid gap-4 sm:grid-cols-2 lg:grid-cols-3 ${mobileOpen ? "grid" : "hidden"} md:grid`}
+      >
         {filters.map((filter) => {
           const column = table.getColumn(filter.id);
           if (!column) return null;
@@ -234,20 +221,15 @@ export function FilterBar({ filters, table, onClearAll }: FilterBarProps) {
                   placeholder={filter.placeholder}
                 />
               )}
-              {filter.type === "daterange" && (
-                <DateRangeFilter column={column} />
-              )}
-              {filter.type === "numberrange" && (
-                <NumberRangeFilter column={column} />
-              )}
+              {filter.type === "daterange" && <DateRangeFilter column={column} />}
+              {filter.type === "numberrange" && <NumberRangeFilter column={column} />}
             </div>
           );
         })}
       </div>
       {activeFiltersCount > 0 && (
         <div className="text-sm text-muted-foreground">
-          {activeFiltersCount} filter{activeFiltersCount !== 1 ? "s" : ""}{" "}
-          active
+          {activeFiltersCount} filter{activeFiltersCount !== 1 ? "s" : ""} active
         </div>
       )}
     </div>
@@ -255,11 +237,7 @@ export function FilterBar({ filters, table, onClearAll }: FilterBarProps) {
 }
 
 // Custom filter functions for TanStack Table
-export const dateRangeFilter = <TData,>(
-  row: TData,
-  columnId: string,
-  filterValue: unknown
-) => {
+export const dateRangeFilter = <TData,>(row: TData, columnId: string, filterValue: unknown) => {
   const [start, end] = filterValue as [string, string];
   const cellValue = (row as Row<unknown>).getValue(columnId) as string;
 
@@ -276,11 +254,7 @@ export const dateRangeFilter = <TData,>(
   return true;
 };
 
-export const numberRangeFilter = <TData,>(
-  row: TData,
-  columnId: string,
-  filterValue: unknown
-) => {
+export const numberRangeFilter = <TData,>(row: TData, columnId: string, filterValue: unknown) => {
   const [min, max] = filterValue as [number, number];
   const cellValue = (row as Row<unknown>).getValue(columnId) as number;
 
@@ -293,11 +267,7 @@ export const numberRangeFilter = <TData,>(
   return true;
 };
 
-export const multiSelectFilter = <TData,>(
-  row: TData,
-  columnId: string,
-  filterValue: unknown
-) => {
+export const multiSelectFilter = <TData,>(row: TData, columnId: string, filterValue: unknown) => {
   const values = filterValue as string[];
   if (!values || values.length === 0) return true;
   const cellValue = (row as Row<unknown>).getValue(columnId);

--- a/packages/ui/src/components/DateTimeInput.stories.tsx
+++ b/packages/ui/src/components/DateTimeInput.stories.tsx
@@ -170,11 +170,7 @@ export const TimeControlled: StoryObj<typeof TimeInput> = {
     const [time, setTime] = useState("14:30");
     return (
       <div className="space-y-4">
-        <TimeInput
-          value={time}
-          onChange={(e) => setTime(e.target.value)}
-          prefix={<ClockIcon />}
-        />
+        <TimeInput value={time} onChange={(e) => setTime(e.target.value)} prefix={<ClockIcon />} />
         <p className="text-sm text-muted-foreground">Selected: {time}</p>
       </div>
     );
@@ -310,9 +306,7 @@ export const AppointmentScheduler: StoryObj = {
         <h3 className="text-lg font-semibold">Book Appointment</h3>
 
         <div className="space-y-2">
-          <label className="block text-sm font-medium">
-            Select Date & Time
-          </label>
+          <label className="block text-sm font-medium">Select Date & Time</label>
           <DateTimeInput
             value={dateTime}
             onChange={(e) => setDateTime(e.target.value)}
@@ -396,11 +390,7 @@ export const AllDateVariants: StoryObj = {
   render: () => (
     <div className="space-y-4">
       <DateInput prefix={<CalendarIcon />} placeholder="Default" />
-      <DateInput
-        variant="ghost"
-        prefix={<CalendarIcon />}
-        placeholder="Ghost"
-      />
+      <DateInput variant="ghost" prefix={<CalendarIcon />} placeholder="Ghost" />
       <DateInput variant="underline" placeholder="Underline" />
     </div>
   ),
@@ -420,11 +410,7 @@ export const AllDateTimeVariants: StoryObj = {
   render: () => (
     <div className="space-y-4">
       <DateTimeInput prefix={<CalendarIcon />} placeholder="Default" />
-      <DateTimeInput
-        variant="ghost"
-        prefix={<CalendarIcon />}
-        placeholder="Ghost"
-      />
+      <DateTimeInput variant="ghost" prefix={<CalendarIcon />} placeholder="Ghost" />
       <DateTimeInput variant="underline" placeholder="Underline" />
     </div>
   ),
@@ -439,11 +425,7 @@ export const States: StoryObj = {
         <div className="space-y-2">
           <DateInput prefix={<CalendarIcon />} placeholder="Empty" />
           <DateInput prefix={<CalendarIcon />} defaultValue="2024-06-15" />
-          <DateInput
-            prefix={<CalendarIcon />}
-            disabled
-            defaultValue="2024-06-15"
-          />
+          <DateInput prefix={<CalendarIcon />} disabled defaultValue="2024-06-15" />
         </div>
       </div>
 
@@ -460,15 +442,8 @@ export const States: StoryObj = {
         <p className="text-sm font-medium">DateTime States</p>
         <div className="space-y-2">
           <DateTimeInput prefix={<CalendarIcon />} placeholder="Empty" />
-          <DateTimeInput
-            prefix={<CalendarIcon />}
-            defaultValue="2024-06-15T14:30"
-          />
-          <DateTimeInput
-            prefix={<CalendarIcon />}
-            disabled
-            defaultValue="2024-06-15T14:30"
-          />
+          <DateTimeInput prefix={<CalendarIcon />} defaultValue="2024-06-15T14:30" />
+          <DateTimeInput prefix={<CalendarIcon />} disabled defaultValue="2024-06-15T14:30" />
         </div>
       </div>
     </div>

--- a/packages/ui/src/components/DateTimeInput.tsx
+++ b/packages/ui/src/components/DateTimeInput.tsx
@@ -2,12 +2,7 @@
  * DateTime input components using native HTML date/time inputs
  * Includes DateInput, TimeInput, and DateTimeInput
  */
-import {
-  forwardRef,
-  useState,
-  type InputHTMLAttributes,
-  type ReactNode,
-} from "react";
+import { forwardRef, useState, type InputHTMLAttributes, type ReactNode } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../lib/utils";
 
@@ -133,9 +128,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
         )}
         style={isFocused ? { borderColor: "rgb(55, 65, 81)" } : undefined}
       >
-        {prefix && (
-          <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>
-        )}
+        {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
         <input
           ref={ref}
           type="date"
@@ -146,9 +139,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
           disabled={disabled}
           {...props}
         />
-        {suffix && (
-          <span className="flex-shrink-0 text-muted-foreground">{suffix}</span>
-        )}
+        {suffix && <span className="flex-shrink-0 text-muted-foreground">{suffix}</span>}
       </div>
     );
   }
@@ -201,9 +192,7 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
         )}
         style={isFocused ? { borderColor: "rgb(55, 65, 81)" } : undefined}
       >
-        {prefix && (
-          <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>
-        )}
+        {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
         <input
           ref={ref}
           type="time"
@@ -214,9 +203,7 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
           disabled={disabled}
           {...props}
         />
-        {suffix && (
-          <span className="flex-shrink-0 text-muted-foreground">{suffix}</span>
-        )}
+        {suffix && <span className="flex-shrink-0 text-muted-foreground">{suffix}</span>}
       </div>
     );
   }
@@ -269,9 +256,7 @@ export const DateTimeInput = forwardRef<HTMLInputElement, DateTimeInputProps>(
         )}
         style={isFocused ? { borderColor: "rgb(55, 65, 81)" } : undefined}
       >
-        {prefix && (
-          <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>
-        )}
+        {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
         <input
           ref={ref}
           type="datetime-local"
@@ -282,9 +267,7 @@ export const DateTimeInput = forwardRef<HTMLInputElement, DateTimeInputProps>(
           disabled={disabled}
           {...props}
         />
-        {suffix && (
-          <span className="flex-shrink-0 text-muted-foreground">{suffix}</span>
-        )}
+        {suffix && <span className="flex-shrink-0 text-muted-foreground">{suffix}</span>}
       </div>
     );
   }

--- a/packages/ui/src/components/DropdownMenu.tsx
+++ b/packages/ui/src/components/DropdownMenu.tsx
@@ -97,9 +97,7 @@ export function DropdownMenu({
           (groups
             ? groups.map((group, groupIndex) => (
                 <div key={groupIndex}>
-                  {group.label && (
-                    <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
-                  )}
+                  {group.label && <DropdownMenuLabel>{group.label}</DropdownMenuLabel>}
                   {group.items.map((item) => (
                     <DropdownMenuItem
                       key={item.value}

--- a/packages/ui/src/components/EditableCell.tsx
+++ b/packages/ui/src/components/EditableCell.tsx
@@ -125,11 +125,7 @@ export function EditableCell<T = unknown>({
     if (validate) {
       const validationResult = validate(value);
       if (validationResult !== true) {
-        setError(
-          typeof validationResult === "string"
-            ? validationResult
-            : "Invalid value"
-        );
+        setError(typeof validationResult === "string" ? validationResult : "Invalid value");
         return;
       }
     }
@@ -165,9 +161,7 @@ export function EditableCell<T = unknown>({
 
   // Display mode
   if (!isEditing) {
-    const displayValue = formatDisplay
-      ? formatDisplay(value)
-      : String(value ?? "");
+    const displayValue = formatDisplay ? formatDisplay(value) : String(value ?? "");
 
     return (
       <div

--- a/packages/ui/src/components/ErrorBoundary.tsx
+++ b/packages/ui/src/components/ErrorBoundary.tsx
@@ -34,12 +34,8 @@ export class ErrorBoundary extends Component<Props, State> {
         this.props.fallback(this.state.error, this.reset)
       ) : (
         <div className="p-6">
-          <h1 className="text-2xl font-bold text-red-600">
-            Something went wrong
-          </h1>
-          <p className="mt-2 text-muted-foreground">
-            {this.state.error.message}
-          </p>
+          <h1 className="text-2xl font-bold text-red-600">Something went wrong</h1>
+          <p className="mt-2 text-muted-foreground">{this.state.error.message}</p>
           <button
             onClick={this.reset}
             className="mt-4 px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90"

--- a/packages/ui/src/components/InfiniteScrollTable.stories.tsx
+++ b/packages/ui/src/components/InfiniteScrollTable.stories.tsx
@@ -29,29 +29,18 @@ const generateTransactions = (count: number, offset: number): Transaction[] => {
   return Array.from({ length: count }, (_, i) => ({
     id: `txn-${offset + i + 1}`,
     date: new Date(2024, 0, offset + i + 1).toISOString().split("T")[0],
-    description: [
-      "Woolworths",
-      "Coles",
-      "Amazon",
-      "Netflix",
-      "Uber",
-      "Spotify",
-      "Apple",
-      "Google",
-    ][(offset + i) % 8],
-    amount: Math.random() * 200 - 100,
-    category: ["Food", "Shopping", "Entertainment", "Transport"][
-      (offset + i) % 4
+    description: ["Woolworths", "Coles", "Amazon", "Netflix", "Uber", "Spotify", "Apple", "Google"][
+      (offset + i) % 8
     ],
+    amount: Math.random() * 200 - 100,
+    category: ["Food", "Shopping", "Entertainment", "Transport"][(offset + i) % 4],
   }));
 };
 
 const transactionColumns: ColumnDef<Transaction>[] = [
   {
     accessorKey: "date",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Date</SortableHeader>
-    ),
+    header: ({ column }) => <SortableHeader column={column}>Date</SortableHeader>,
   },
   {
     accessorKey: "description",
@@ -59,20 +48,14 @@ const transactionColumns: ColumnDef<Transaction>[] = [
   },
   {
     accessorKey: "amount",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Amount</SortableHeader>
-    ),
+    header: ({ column }) => <SortableHeader column={column}>Amount</SortableHeader>,
     cell: ({ row }) => {
       const amount = row.getValue("amount") as number;
       const formatted = new Intl.NumberFormat("en-AU", {
         style: "currency",
         currency: "AUD",
       }).format(amount);
-      return (
-        <span className={amount < 0 ? "text-red-600" : "text-green-600"}>
-          {formatted}
-        </span>
-      );
+      return <span className={amount < 0 ? "text-red-600" : "text-green-600"}>{formatted}</span>;
     },
   },
   {
@@ -84,9 +67,7 @@ const transactionColumns: ColumnDef<Transaction>[] = [
 export const Default: Story = {
   args: {},
   render: () => {
-    const [transactions, setTransactions] = useState<Transaction[]>(
-      generateTransactions(20, 0)
-    );
+    const [transactions, setTransactions] = useState<Transaction[]>(generateTransactions(20, 0));
     const [hasMore, setHasMore] = useState(true);
     const [loading, setLoading] = useState(false);
 
@@ -123,9 +104,7 @@ export const Default: Story = {
 export const WithSearch: Story = {
   args: {},
   render: () => {
-    const [transactions, setTransactions] = useState<Transaction[]>(
-      generateTransactions(20, 0)
-    );
+    const [transactions, setTransactions] = useState<Transaction[]>(generateTransactions(20, 0));
     const [hasMore, setHasMore] = useState(true);
     const [loading, setLoading] = useState(false);
 
@@ -163,9 +142,7 @@ export const WithSearch: Story = {
 export const SmallBatches: Story = {
   args: {},
   render: () => {
-    const [transactions, setTransactions] = useState<Transaction[]>(
-      generateTransactions(5, 0)
-    );
+    const [transactions, setTransactions] = useState<Transaction[]>(generateTransactions(5, 0));
     const [hasMore, setHasMore] = useState(true);
     const [loading, setLoading] = useState(false);
 

--- a/packages/ui/src/components/InfiniteScrollTable.tsx
+++ b/packages/ui/src/components/InfiniteScrollTable.tsx
@@ -155,13 +155,9 @@ export function InfiniteScrollTable<TData, TValue>({
       {/* Infinite scroll trigger */}
       {data.length > 0 && (
         <div ref={observerTarget} className="py-4 text-center">
-          {loading && (
-            <div className="text-sm text-muted-foreground">Loading more...</div>
-          )}
+          {loading && <div className="text-sm text-muted-foreground">Loading more...</div>}
           {!loading && !hasMore && (
-            <div className="text-sm text-muted-foreground">
-              No more items to load
-            </div>
+            <div className="text-sm text-muted-foreground">No more items to load</div>
           )}
         </div>
       )}

--- a/packages/ui/src/components/LocationBreadcrumb.tsx
+++ b/packages/ui/src/components/LocationBreadcrumb.tsx
@@ -19,11 +19,7 @@ export interface LocationBreadcrumbProps {
   className?: string;
 }
 
-export function LocationBreadcrumb({
-  segments,
-  onNavigate,
-  className,
-}: LocationBreadcrumbProps) {
+export function LocationBreadcrumb({ segments, onNavigate, className }: LocationBreadcrumbProps) {
   if (segments.length === 0) {
     return <span className="text-muted-foreground/50">—</span>;
   }
@@ -36,9 +32,7 @@ export function LocationBreadcrumb({
           return (
             <BreadcrumbItem key={segment.id}>
               {isLast ? (
-                <BreadcrumbPage className="text-xs font-medium">
-                  {segment.name}
-                </BreadcrumbPage>
+                <BreadcrumbPage className="text-xs font-medium">{segment.name}</BreadcrumbPage>
               ) : (
                 <>
                   <BreadcrumbLink

--- a/packages/ui/src/components/NumberInput.stories.tsx
+++ b/packages/ui/src/components/NumberInput.stories.tsx
@@ -183,11 +183,7 @@ export const Controlled: Story = {
     const [value, setValue] = useState(25);
     return (
       <div className="space-y-4">
-        <NumberInput
-          {...args}
-          value={value}
-          onChange={(e) => setValue(Number(e.target.value))}
-        />
+        <NumberInput {...args} value={value} onChange={(e) => setValue(Number(e.target.value))} />
         <p className="text-sm text-muted-foreground">Current value: {value}</p>
       </div>
     );
@@ -228,13 +224,7 @@ export const PercentageInput: Story = {
   render: () => (
     <div className="space-y-2 max-w-xs">
       <label className="block text-sm font-medium">Discount</label>
-      <NumberInput
-        suffix={<PercentIcon />}
-        defaultValue={0}
-        min={0}
-        max={100}
-        step={5}
-      />
+      <NumberInput suffix={<PercentIcon />} defaultValue={0} min={0} max={100} step={5} />
     </div>
   ),
 };
@@ -254,11 +244,7 @@ export const AllVariants: Story = {
     <div className="space-y-4">
       <NumberInput placeholder="Default" defaultValue={10} />
       <NumberInput placeholder="Ghost" variant="ghost" defaultValue={10} />
-      <NumberInput
-        placeholder="Underline"
-        variant="underline"
-        defaultValue={10}
-      />
+      <NumberInput placeholder="Underline" variant="underline" defaultValue={10} />
     </div>
   ),
 };
@@ -311,9 +297,7 @@ export const FeaturesShowcase: Story = {
         <NumberInput defaultValue={50} showSteppers />
       </div>
       <div>
-        <p className="text-sm font-medium mb-2">
-          Drag to change (hover and drag)
-        </p>
+        <p className="text-sm font-medium mb-2">Drag to change (hover and drag)</p>
         <NumberInput defaultValue={50} enableDrag />
       </div>
       <div>

--- a/packages/ui/src/components/NumberInput.tsx
+++ b/packages/ui/src/components/NumberInput.tsx
@@ -145,9 +145,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     },
     ref
   ) => {
-    const [internalValue, setInternalValue] = useState<number>(
-      Number(defaultValue) || 0
-    );
+    const [internalValue, setInternalValue] = useState<number>(Number(defaultValue) || 0);
     const [isFocused, setIsFocused] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
     const dragStartY = useRef<number>(0);
@@ -258,9 +256,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
         style={isFocused ? { borderColor: "rgb(55, 65, 81)" } : undefined}
         onMouseDown={handleMouseDown}
       >
-        {prefix && (
-          <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>
-        )}
+        {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
         {showSteppers && (
           <button
             type="button"
@@ -298,9 +294,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
             <ChevronUpIcon />
           </button>
         )}
-        {suffix && (
-          <span className="flex-shrink-0 text-muted-foreground">{suffix}</span>
-        )}
+        {suffix && <span className="flex-shrink-0 text-muted-foreground">{suffix}</span>}
       </div>
     );
   }

--- a/packages/ui/src/components/RadioInput.tsx
+++ b/packages/ui/src/components/RadioInput.tsx
@@ -114,9 +114,7 @@ export const RadioInput = forwardRef<HTMLDivElement, RadioInputProps>(
                 {required && <span className="text-destructive ml-1">*</span>}
               </label>
             )}
-            {description && (
-              <p className="text-sm text-muted-foreground">{description}</p>
-            )}
+            {description && <p className="text-sm text-muted-foreground">{description}</p>}
           </div>
         )}
         <RadioGroup
@@ -128,9 +126,7 @@ export const RadioInput = forwardRef<HTMLDivElement, RadioInputProps>(
           required={required}
           aria-invalid={error}
           className={cn(
-            orientation === "horizontal"
-              ? "grid gap-3 sm:flex sm:flex-row sm:gap-4"
-              : "grid gap-3"
+            orientation === "horizontal" ? "grid gap-3 sm:flex sm:flex-row sm:gap-4" : "grid gap-3"
           )}
           {...props}
         >
@@ -147,24 +143,19 @@ export const RadioInput = forwardRef<HTMLDivElement, RadioInputProps>(
                   htmlFor={`radio-${option.value}`}
                   className={cn(
                     "text-sm font-medium leading-none cursor-pointer select-none",
-                    (option.disabled || disabled) &&
-                      "opacity-50 cursor-not-allowed"
+                    (option.disabled || disabled) && "opacity-50 cursor-not-allowed"
                   )}
                 >
                   {option.label}
                 </label>
                 {option.description && (
-                  <p className="text-sm text-muted-foreground">
-                    {option.description}
-                  </p>
+                  <p className="text-sm text-muted-foreground">{option.description}</p>
                 )}
               </div>
             </div>
           ))}
         </RadioGroup>
-        {error && errorMessage && (
-          <p className="text-sm text-destructive">{errorMessage}</p>
-        )}
+        {error && errorMessage && <p className="text-sm text-destructive">{errorMessage}</p>}
       </div>
     );
   }

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -2,12 +2,7 @@
  * Select component - styled dropdown for choosing from options
  * Native select with custom styling to match design system
  */
-import {
-  forwardRef,
-  useState,
-  type SelectHTMLAttributes,
-  type ReactNode,
-} from "react";
+import { forwardRef, useState, type SelectHTMLAttributes, type ReactNode } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../lib/utils";
 
@@ -168,9 +163,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           )}
           style={isFocused && !error ? { borderColor: "rgb(55, 65, 81)" } : undefined}
         >
-          {prefix && (
-            <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>
-          )}
+          {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
           <select
             ref={ref}
             className={cn(selectVariants({ size, centered, className }))}
@@ -187,22 +180,14 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
               </option>
             )}
             {options.map((option) => (
-              <option
-                key={option.value}
-                value={option.value}
-                disabled={option.disabled}
-              >
+              <option key={option.value} value={option.value} disabled={option.disabled}>
                 {option.label}
               </option>
             ))}
           </select>
           <ChevronDownIcon />
         </div>
-        {error && (
-          <p className="text-[10px] font-medium text-destructive ml-1">
-            {error}
-          </p>
-        )}
+        {error && <p className="text-[10px] font-medium text-destructive ml-1">{error}</p>}
       </div>
     );
   }

--- a/packages/ui/src/components/StatCard.tsx
+++ b/packages/ui/src/components/StatCard.tsx
@@ -61,13 +61,7 @@ export interface StatCardProps {
  * StatCard — a high-impact card for displaying key metrics.
  * Features domain-specific coloring and subtle glow effects.
  */
-export function StatCard({
-  title,
-  value,
-  description,
-  color = "slate",
-  className,
-}: StatCardProps) {
+export function StatCard({ title, value, description, color = "slate", className }: StatCardProps) {
   const styles = statCardColorMap[color];
 
   return (
@@ -89,14 +83,7 @@ export function StatCard({
         <h3 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">
           {title}
         </h3>
-        <p
-          className={cn(
-            "text-3xl font-bold tabular-nums tracking-tight",
-            styles.text
-          )}
-        >
-          {value}
-        </p>
+        <p className={cn("text-3xl font-bold tabular-nums tracking-tight", styles.text)}>{value}</p>
       </div>
       {description && (
         <div className="text-[10px] text-muted-foreground font-medium uppercase tracking-tighter opacity-70 relative z-10">

--- a/packages/ui/src/components/TextInput.stories.tsx
+++ b/packages/ui/src/components/TextInput.stories.tsx
@@ -261,19 +261,12 @@ export const SearchBar: Story = {
 
 export const EmailInput: Story = {
   render: () => (
-    <TextInput
-      type="email"
-      placeholder="Enter your email"
-      prefix={<MailIcon />}
-      clearable
-    />
+    <TextInput type="email" placeholder="Enter your email" prefix={<MailIcon />} clearable />
   ),
 };
 
 export const AmountInput: Story = {
-  render: () => (
-    <TextInput type="number" placeholder="0.00" prefix={<DollarIcon />} />
-  ),
+  render: () => <TextInput type="number" placeholder="0.00" prefix={<DollarIcon />} />,
 };
 
 export const DatePicker: Story = {
@@ -285,21 +278,11 @@ export const FormFields: Story = {
     <div className="space-y-4 max-w-md">
       <div>
         <label className="block text-sm font-medium mb-1">Email</label>
-        <TextInput
-          type="email"
-          placeholder="you@example.com"
-          prefix={<MailIcon />}
-          clearable
-        />
+        <TextInput type="email" placeholder="you@example.com" prefix={<MailIcon />} clearable />
       </div>
       <div>
         <label className="block text-sm font-medium mb-1">Search</label>
-        <TextInput
-          placeholder="Search..."
-          prefix={<SearchIcon />}
-          variant="ghost"
-          clearable
-        />
+        <TextInput placeholder="Search..." prefix={<SearchIcon />} variant="ghost" clearable />
       </div>
       <div>
         <label className="block text-sm font-medium mb-1">Amount</label>
@@ -378,34 +361,16 @@ export const VariantComparison: Story = {
         <p className="text-sm font-medium mb-2">Ghost</p>
         <div className="space-y-2">
           <TextInput placeholder="No icons" variant="ghost" />
-          <TextInput
-            placeholder="With prefix"
-            prefix={<SearchIcon />}
-            variant="ghost"
-          />
-          <TextInput
-            placeholder="Clearable"
-            clearable
-            defaultValue="Text"
-            variant="ghost"
-          />
+          <TextInput placeholder="With prefix" prefix={<SearchIcon />} variant="ghost" />
+          <TextInput placeholder="Clearable" clearable defaultValue="Text" variant="ghost" />
         </div>
       </div>
       <div>
         <p className="text-sm font-medium mb-2">Underline</p>
         <div className="space-y-2">
           <TextInput placeholder="No icons" variant="underline" />
-          <TextInput
-            placeholder="With prefix"
-            prefix={<SearchIcon />}
-            variant="underline"
-          />
-          <TextInput
-            placeholder="Clearable"
-            clearable
-            defaultValue="Text"
-            variant="underline"
-          />
+          <TextInput placeholder="With prefix" prefix={<SearchIcon />} variant="underline" />
+          <TextInput placeholder="Clearable" clearable defaultValue="Text" variant="underline" />
         </div>
       </div>
     </div>

--- a/packages/ui/src/components/TextInput.tsx
+++ b/packages/ui/src/components/TextInput.tsx
@@ -2,12 +2,7 @@
  * TextInput component with variants, prefix/suffix, and clear functionality
  * Supports controlled and uncontrolled modes
  */
-import {
-  forwardRef,
-  useState,
-  type InputHTMLAttributes,
-  type ReactNode,
-} from "react";
+import { forwardRef, useState, type InputHTMLAttributes, type ReactNode } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../lib/utils";
 
@@ -198,9 +193,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           )}
           style={isFocused && !error ? { borderColor: "rgb(55, 65, 81)" } : undefined}
         >
-          {prefix && (
-            <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>
-          )}
+          {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
           <input
             ref={ref}
             className={cn(inputVariants({ size, centered, className }))}
@@ -228,11 +221,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             <span className="flex-shrink-0 text-muted-foreground">{suffix}</span>
           )}
         </div>
-        {error && (
-          <p className="text-[10px] font-medium text-destructive ml-1">
-            {error}
-          </p>
-        )}
+        {error && <p className="text-[10px] font-medium text-destructive ml-1">{error}</p>}
       </div>
     );
   }

--- a/packages/ui/src/components/TypeBadge.tsx
+++ b/packages/ui/src/components/TypeBadge.tsx
@@ -2,8 +2,7 @@ import type { ComponentProps } from "react";
 import { Badge } from "../primitives/badge";
 import { cn } from "../lib/utils";
 
-export interface TypeBadgeProps
-  extends Omit<ComponentProps<typeof Badge>, "variant" | "children"> {
+export interface TypeBadgeProps extends Omit<ComponentProps<typeof Badge>, "variant" | "children"> {
   type: string;
 }
 
@@ -18,7 +17,7 @@ const typeStyles: Record<string, string> = {
 
 export function TypeBadge({ type, className, ...props }: TypeBadgeProps) {
   const style = typeStyles[type] || "bg-muted text-muted-foreground border-transparent";
-  
+
   return (
     <Badge
       variant="outline"

--- a/packages/ui/src/primitives/Accordion.stories.tsx
+++ b/packages/ui/src/primitives/Accordion.stories.tsx
@@ -1,10 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "./accordion";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "./accordion";
 
 const meta: Meta = {
   title: "Layout/Accordion",
@@ -23,26 +18,24 @@ export const Single: Story = {
       <AccordionItem value="item-1">
         <AccordionTrigger>What is POPS?</AccordionTrigger>
         <AccordionContent>
-          POPS (Personal Operations System) is a self-hosted financial tracking
-          and automation platform that uses SQLite as the source of truth for
-          all data.
+          POPS (Personal Operations System) is a self-hosted financial tracking and automation
+          platform that uses SQLite as the source of truth for all data.
         </AccordionContent>
       </AccordionItem>
 
       <AccordionItem value="item-2">
         <AccordionTrigger>How does it work?</AccordionTrigger>
         <AccordionContent>
-          Bank data is imported via CSV or API, matched with entities using a
-          5-stage pipeline, and written directly to SQLite for fast queries.
+          Bank data is imported via CSV or API, matched with entities using a 5-stage pipeline, and
+          written directly to SQLite for fast queries.
         </AccordionContent>
       </AccordionItem>
 
       <AccordionItem value="item-3">
         <AccordionTrigger>Is my data secure?</AccordionTrigger>
         <AccordionContent>
-          Yes, POPS is self-hosted on your own infrastructure with Cloudflare
-          Access for authentication. All secrets are managed via Docker secrets
-          and Ansible Vault.
+          Yes, POPS is self-hosted on your own infrastructure with Cloudflare Access for
+          authentication. All secrets are managed via Docker secrets and Ansible Vault.
         </AccordionContent>
       </AccordionItem>
     </Accordion>
@@ -93,17 +86,11 @@ export const Multiple: Story = {
 
 export const DefaultOpen: Story = {
   render: () => (
-    <Accordion
-      type="single"
-      collapsible
-      defaultValue="item-1"
-      className="w-full max-w-2xl"
-    >
+    <Accordion type="single" collapsible defaultValue="item-1" className="w-full max-w-2xl">
       <AccordionItem value="item-1">
         <AccordionTrigger>Getting Started</AccordionTrigger>
         <AccordionContent>
-          This section is open by default. Follow the setup guide to configure
-          your POPS instance.
+          This section is open by default. Follow the setup guide to configure your POPS instance.
         </AccordionContent>
       </AccordionItem>
 
@@ -122,9 +109,7 @@ export const FAQ: Story = {
     <div className="w-full max-w-2xl space-y-6">
       <div>
         <h2 className="text-2xl font-bold">Frequently Asked Questions</h2>
-        <p className="text-muted-foreground">
-          Find answers to common questions about using POPS
-        </p>
+        <p className="text-muted-foreground">Find answers to common questions about using POPS</p>
       </div>
 
       <Accordion type="single" collapsible>
@@ -143,38 +128,33 @@ export const FAQ: Story = {
         <AccordionItem value="q2">
           <AccordionTrigger>Can I track multiple accounts?</AccordionTrigger>
           <AccordionContent>
-            Yes, POPS supports unlimited accounts including checking, savings,
-            credit cards, and investment accounts. Each transaction is tagged
-            with its source account.
+            Yes, POPS supports unlimited accounts including checking, savings, credit cards, and
+            investment accounts. Each transaction is tagged with its source account.
           </AccordionContent>
         </AccordionItem>
 
         <AccordionItem value="q3">
-          <AccordionTrigger>
-            How accurate is AI categorization?
-          </AccordionTrigger>
+          <AccordionTrigger>How accurate is AI categorization?</AccordionTrigger>
           <AccordionContent>
-            The AI categorization achieves 95-100% accuracy with the 5-stage
-            entity matching pipeline: manual aliases → exact match → prefix
-            match → contains match → AI fallback. Results are cached for
-            consistency.
+            The AI categorization achieves 95-100% accuracy with the 5-stage entity matching
+            pipeline: manual aliases → exact match → prefix match → contains match → AI fallback.
+            Results are cached for consistency.
           </AccordionContent>
         </AccordionItem>
 
         <AccordionItem value="q4">
           <AccordionTrigger>Can I export my data?</AccordionTrigger>
           <AccordionContent>
-            Yes, SQLite is the source of truth, so you can export your data at
-            any time in CSV or other formats via the API.
+            Yes, SQLite is the source of truth, so you can export your data at any time in CSV or
+            other formats via the API.
           </AccordionContent>
         </AccordionItem>
 
         <AccordionItem value="q5">
           <AccordionTrigger>Is there a mobile app?</AccordionTrigger>
           <AccordionContent>
-            POPS includes a Progressive Web App (PWA) that works on mobile
-            devices through your browser. You can install it to your home screen
-            for an app-like experience.
+            POPS includes a Progressive Web App (PWA) that works on mobile devices through your
+            browser. You can install it to your home screen for an app-like experience.
           </AccordionContent>
         </AccordionItem>
       </Accordion>
@@ -210,10 +190,7 @@ export const BudgetCategories: Story = {
                 <span className="font-medium">$150</span>
               </div>
               <div className="h-2 w-full rounded-full bg-muted">
-                <div
-                  className="h-full rounded-full bg-blue-600"
-                  style={{ width: "75%" }}
-                />
+                <div className="h-full rounded-full bg-blue-600" style={{ width: "75%" }} />
               </div>
             </div>
           </AccordionContent>
@@ -241,10 +218,7 @@ export const BudgetCategories: Story = {
                 <span className="font-medium">$60</span>
               </div>
               <div className="h-2 w-full rounded-full bg-muted">
-                <div
-                  className="h-full rounded-full bg-pink-600"
-                  style={{ width: "85%" }}
-                />
+                <div className="h-full rounded-full bg-pink-600" style={{ width: "85%" }} />
               </div>
             </div>
           </AccordionContent>
@@ -272,10 +246,7 @@ export const BudgetCategories: Story = {
                 <span className="font-medium text-red-600">$45</span>
               </div>
               <div className="h-2 w-full rounded-full bg-red-200">
-                <div
-                  className="h-full rounded-full bg-red-600"
-                  style={{ width: "100%" }}
-                />
+                <div className="h-full rounded-full bg-red-600" style={{ width: "100%" }} />
               </div>
             </div>
           </AccordionContent>

--- a/packages/ui/src/primitives/Alert.stories.tsx
+++ b/packages/ui/src/primitives/Alert.stories.tsx
@@ -1,11 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Alert, AlertDescription, AlertTitle } from "./alert";
-import {
-  InfoIcon,
-  TriangleAlertIcon,
-  OctagonXIcon,
-  CircleCheckIcon,
-} from "lucide-react";
+import { InfoIcon, TriangleAlertIcon, OctagonXIcon, CircleCheckIcon } from "lucide-react";
 
 const meta: Meta<typeof Alert> = {
   title: "Feedback/Alert",
@@ -51,9 +46,7 @@ export const Success: Story = {
     <Alert className="border-green-500 text-green-700 dark:text-green-400">
       <CircleCheckIcon />
       <AlertTitle>Success</AlertTitle>
-      <AlertDescription>
-        All transactions have been successfully imported.
-      </AlertDescription>
+      <AlertDescription>All transactions have been successfully imported.</AlertDescription>
     </Alert>
   ),
 };
@@ -65,8 +58,7 @@ export const Warning: Story = {
       <TriangleAlertIcon />
       <AlertTitle>Warning</AlertTitle>
       <AlertDescription>
-        Your budget for groceries is 85% spent. Consider reducing spending in
-        this category.
+        Your budget for groceries is 85% spent. Consider reducing spending in this category.
       </AlertDescription>
     </Alert>
   ),
@@ -78,8 +70,7 @@ export const WithoutIcon: Story = {
     <Alert>
       <AlertTitle>System Maintenance</AlertTitle>
       <AlertDescription>
-        Scheduled maintenance will occur on Saturday, March 15th from 2:00 AM to
-        4:00 AM EST.
+        Scheduled maintenance will occur on Saturday, March 15th from 2:00 AM to 4:00 AM EST.
       </AlertDescription>
     </Alert>
   ),
@@ -114,23 +105,17 @@ export const MultipleAlerts: Story = {
       <Alert>
         <InfoIcon />
         <AlertTitle>New Feature</AlertTitle>
-        <AlertDescription>
-          Check out the new transaction filters in the sidebar.
-        </AlertDescription>
+        <AlertDescription>Check out the new transaction filters in the sidebar.</AlertDescription>
       </Alert>
       <Alert className="border-yellow-500 text-yellow-700 dark:text-yellow-400">
         <TriangleAlertIcon />
         <AlertTitle>Budget Alert</AlertTitle>
-        <AlertDescription>
-          You're approaching your monthly spending limit.
-        </AlertDescription>
+        <AlertDescription>You're approaching your monthly spending limit.</AlertDescription>
       </Alert>
       <Alert variant="destructive">
         <OctagonXIcon />
         <AlertTitle>Sync Error</AlertTitle>
-        <AlertDescription>
-          Unable to connect to API. Retrying in 5 minutes.
-        </AlertDescription>
+        <AlertDescription>Unable to connect to API. Retrying in 5 minutes.</AlertDescription>
       </Alert>
     </div>
   ),
@@ -143,12 +128,10 @@ export const LongContent: Story = {
       <InfoIcon />
       <AlertTitle>Import Complete</AlertTitle>
       <AlertDescription>
-        Successfully imported 1,247 transactions from ANZ, Amex, and ING. All
-        transactions have been matched with existing entities using the 5-stage
-        matching pipeline. Entity matching achieved a 98% success rate with
-        manual aliases, exact matches, and prefix matching. The remaining 2%
-        were matched using AI-powered entity recognition with cached results for
-        future imports.
+        Successfully imported 1,247 transactions from ANZ, Amex, and ING. All transactions have been
+        matched with existing entities using the 5-stage matching pipeline. Entity matching achieved
+        a 98% success rate with manual aliases, exact matches, and prefix matching. The remaining 2%
+        were matched using AI-powered entity recognition with cached results for future imports.
       </AlertDescription>
     </Alert>
   ),

--- a/packages/ui/src/primitives/Avatar.stories.tsx
+++ b/packages/ui/src/primitives/Avatar.stories.tsx
@@ -283,9 +283,7 @@ export const InTable: Story = {
                 </Avatar>
                 <div>
                   <p className="text-sm font-medium">John Doe</p>
-                  <p className="text-xs text-muted-foreground">
-                    john@example.com
-                  </p>
+                  <p className="text-xs text-muted-foreground">john@example.com</p>
                 </div>
               </div>
             </td>
@@ -305,9 +303,7 @@ export const InTable: Story = {
                 </Avatar>
                 <div>
                   <p className="text-sm font-medium">Alice Brown</p>
-                  <p className="text-xs text-muted-foreground">
-                    alice@example.com
-                  </p>
+                  <p className="text-xs text-muted-foreground">alice@example.com</p>
                 </div>
               </div>
             </td>
@@ -323,9 +319,7 @@ export const InTable: Story = {
                 </Avatar>
                 <div>
                   <p className="text-sm font-medium">Charlie Davis</p>
-                  <p className="text-xs text-muted-foreground">
-                    charlie@example.com
-                  </p>
+                  <p className="text-xs text-muted-foreground">charlie@example.com</p>
                 </div>
               </div>
             </td>

--- a/packages/ui/src/primitives/Breadcrumb.stories.tsx
+++ b/packages/ui/src/primitives/Breadcrumb.stories.tsx
@@ -130,9 +130,7 @@ export const TransactionDetail: Story = {
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <BreadcrumbLink href="/transactions/2026/02">
-            February 2026
-          </BreadcrumbLink>
+          <BreadcrumbLink href="/transactions/2026/02">February 2026</BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
@@ -184,9 +182,7 @@ export const AccountHierarchy: Story = {
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <BreadcrumbLink href="/accounts/anz/checking">
-            Everyday Account
-          </BreadcrumbLink>
+          <BreadcrumbLink href="/accounts/anz/checking">Everyday Account</BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
@@ -210,9 +206,7 @@ export const ReportsNavigation: Story = {
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <BreadcrumbLink href="/reports/spending">
-            Spending Analysis
-          </BreadcrumbLink>
+          <BreadcrumbLink href="/reports/spending">Spending Analysis</BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
@@ -238,9 +232,7 @@ export const SettingsPath: Story = {
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <BreadcrumbLink href="/settings/notifications">
-            Notifications
-          </BreadcrumbLink>
+          <BreadcrumbLink href="/settings/notifications">Notifications</BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
@@ -270,15 +262,11 @@ export const DeepHierarchy: Story = {
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <BreadcrumbLink href="/inventory/electronics">
-            Electronics
-          </BreadcrumbLink>
+          <BreadcrumbLink href="/inventory/electronics">Electronics</BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <BreadcrumbLink href="/inventory/electronics/computers">
-            Computers
-          </BreadcrumbLink>
+          <BreadcrumbLink href="/inventory/electronics/computers">Computers</BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
@@ -311,9 +299,7 @@ export const InPageHeader: Story = {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">February 2026 Transactions</h1>
-          <p className="text-muted-foreground">
-            Review and manage your transactions
-          </p>
+          <p className="text-muted-foreground">Review and manage your transactions</p>
         </div>
         <button className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground">
           Add Transaction
@@ -321,9 +307,7 @@ export const InPageHeader: Story = {
       </div>
 
       <div className="rounded-lg border p-4">
-        <p className="text-sm text-muted-foreground">
-          Transaction list would appear here
-        </p>
+        <p className="text-sm text-muted-foreground">Transaction list would appear here</p>
       </div>
     </div>
   ),
@@ -350,9 +334,7 @@ export const WithActions: Story = {
 
       <div className="flex gap-2">
         <button className="rounded-md border px-3 py-1 text-sm">Edit</button>
-        <button className="rounded-md border px-3 py-1 text-sm text-red-600">
-          Delete
-        </button>
+        <button className="rounded-md border px-3 py-1 text-sm text-red-600">Delete</button>
       </div>
     </div>
   ),
@@ -375,9 +357,7 @@ export const Responsive: Story = {
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>
-            <BreadcrumbLink href="/accounts/anz">
-              ANZ Banking Group
-            </BreadcrumbLink>
+            <BreadcrumbLink href="/accounts/anz">ANZ Banking Group</BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>

--- a/packages/ui/src/primitives/Card.stories.tsx
+++ b/packages/ui/src/primitives/Card.stories.tsx
@@ -11,11 +11,7 @@ import {
 import { Button } from "../components/Button";
 import { Badge } from "./badge";
 import { Progress } from "./progress";
-import {
-  MoreVerticalIcon,
-  TrendingUpIcon,
-  TrendingDownIcon,
-} from "lucide-react";
+import { MoreVerticalIcon, TrendingUpIcon, TrendingDownIcon } from "lucide-react";
 
 const meta: Meta<typeof Card> = {
   title: "Layout/Card",
@@ -51,9 +47,7 @@ export const WithFooter: Story = {
         <CardDescription>This action cannot be undone</CardDescription>
       </CardHeader>
       <CardContent>
-        <p className="text-sm">
-          Are you sure you want to delete this transaction?
-        </p>
+        <p className="text-sm">Are you sure you want to delete this transaction?</p>
       </CardContent>
       <CardFooter className="gap-2">
         <Button variant="outline" className="flex-1">
@@ -80,9 +74,7 @@ export const WithAction: Story = {
         </CardAction>
       </CardHeader>
       <CardContent>
-        <p className="text-sm text-muted-foreground">
-          You have 42 transactions in the last 7 days
-        </p>
+        <p className="text-sm text-muted-foreground">You have 42 transactions in the last 7 days</p>
       </CardContent>
     </Card>
   ),
@@ -284,8 +276,8 @@ export const NotificationCard: Story = {
       </CardHeader>
       <CardContent>
         <p className="text-sm">
-          You've reached 85% of your Shopping budget for February. Consider
-          reducing spending in this category.
+          You've reached 85% of your Shopping budget for February. Consider reducing spending in
+          this category.
         </p>
       </CardContent>
       <CardFooter className="gap-2">
@@ -350,9 +342,7 @@ export const DashboardGrid: Story = {
       <Card className="col-span-4">
         <CardHeader>
           <CardTitle>Overview</CardTitle>
-          <CardDescription>
-            Your financial summary for February 2026
-          </CardDescription>
+          <CardDescription>Your financial summary for February 2026</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="h-50 flex items-center justify-center text-muted-foreground">
@@ -377,9 +367,7 @@ export const DashboardGrid: Story = {
                 <span>{txn.desc}</span>
                 <span
                   className={
-                    txn.amount.startsWith("+")
-                      ? "text-green-600 font-medium"
-                      : "text-red-600"
+                    txn.amount.startsWith("+") ? "text-green-600 font-medium" : "text-red-600"
                   }
                 >
                   {txn.amount}

--- a/packages/ui/src/primitives/Dialog.stories.tsx
+++ b/packages/ui/src/primitives/Dialog.stories.tsx
@@ -37,16 +37,12 @@ export const Basic: Story = {
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Transaction Details</DialogTitle>
-          <DialogDescription>
-            View the full details of this transaction.
-          </DialogDescription>
+          <DialogDescription>View the full details of this transaction.</DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
           <div>
             <p className="text-sm font-medium">Description</p>
-            <p className="text-sm text-muted-foreground">
-              WOOLWORTHS 1234 SYDNEY AU
-            </p>
+            <p className="text-sm text-muted-foreground">WOOLWORTHS 1234 SYDNEY AU</p>
           </div>
           <div>
             <p className="text-sm font-medium">Amount</p>
@@ -76,8 +72,7 @@ export const Confirmation: Story = {
           <DialogHeader>
             <DialogTitle>Are you sure?</DialogTitle>
             <DialogDescription>
-              This will permanently delete this transaction. This action cannot
-              be undone.
+              This will permanently delete this transaction. This action cannot be undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -120,18 +115,14 @@ export const Form: Story = {
         <DialogContent className="sm:max-w-125">
           <DialogHeader>
             <DialogTitle>New Transaction</DialogTitle>
-            <DialogDescription>
-              Add a new transaction to your balance sheet.
-            </DialogDescription>
+            <DialogDescription>Add a new transaction to your balance sheet.</DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div>
               <label className="text-sm font-medium">Description</label>
               <TextInput
                 value={formData.description}
-                onChange={(e) =>
-                  setFormData({ ...formData, description: e.target.value })
-                }
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                 placeholder="Enter transaction description"
               />
             </div>
@@ -139,9 +130,7 @@ export const Form: Story = {
               <label className="text-sm font-medium">Amount</label>
               <NumberInput
                 value={formData.amount}
-                onChange={(e) =>
-                  setFormData({ ...formData, amount: Number(e.target.value) })
-                }
+                onChange={(e) => setFormData({ ...formData, amount: Number(e.target.value) })}
                 placeholder="0.00"
                 prefix="$"
               />
@@ -150,18 +139,14 @@ export const Form: Story = {
               <label className="text-sm font-medium">Date</label>
               <DateTimeInput
                 value={formData.date}
-                onChange={(e) =>
-                  setFormData({ ...formData, date: e.target.value })
-                }
+                onChange={(e) => setFormData({ ...formData, date: e.target.value })}
               />
             </div>
             <div>
               <label className="text-sm font-medium">Category</label>
               <Select
                 value={formData.category}
-                onChange={(e) =>
-                  setFormData({ ...formData, category: e.target.value })
-                }
+                onChange={(e) => setFormData({ ...formData, category: e.target.value })}
                 options={[
                   { label: "Food", value: "food" },
                   { label: "Shopping", value: "shopping" },
@@ -176,9 +161,7 @@ export const Form: Story = {
               <label className="text-sm font-medium">Account</label>
               <Select
                 value={formData.account}
-                onChange={(e) =>
-                  setFormData({ ...formData, account: e.target.value })
-                }
+                onChange={(e) => setFormData({ ...formData, account: e.target.value })}
                 options={[
                   { label: "Checking", value: "checking" },
                   { label: "Savings", value: "savings" },
@@ -218,8 +201,7 @@ export const NoCloseButton: Story = {
         <DialogHeader>
           <DialogTitle>Processing Transaction</DialogTitle>
           <DialogDescription>
-            Please wait while we process your transaction. This may take a few
-            moments.
+            Please wait while we process your transaction. This may take a few moments.
           </DialogDescription>
         </DialogHeader>
         <div className="flex justify-center py-8">
@@ -240,36 +222,32 @@ export const LongContent: Story = {
       <DialogContent className="max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Terms and Conditions</DialogTitle>
-          <DialogDescription>
-            Please review our terms and conditions carefully.
-          </DialogDescription>
+          <DialogDescription>Please review our terms and conditions carefully.</DialogDescription>
         </DialogHeader>
         <div className="space-y-4 text-sm">
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
-            euismod, nisl eget ultricies aliquam, nunc nisl aliquet nunc, vitae
-            aliquam nisl nunc vitae nisl. Nullam euismod, nisl eget ultricies
-            aliquam, nunc nisl aliquet nunc, vitae aliquam nisl nunc vitae nisl.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam euismod, nisl eget
+            ultricies aliquam, nunc nisl aliquet nunc, vitae aliquam nisl nunc vitae nisl. Nullam
+            euismod, nisl eget ultricies aliquam, nunc nisl aliquet nunc, vitae aliquam nisl nunc
+            vitae nisl.
           </p>
           <p>
-            Sed ut perspiciatis unde omnis iste natus error sit voluptatem
-            accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
-            quae ab illo inventore veritatis et quasi architecto beatae vitae
-            dicta sunt explicabo.
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque
+            laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi
+            architecto beatae vitae dicta sunt explicabo.
           </p>
           <p>
-            Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut
-            fugit, sed quia consequuntur magni dolores eos qui ratione
-            voluptatem sequi nesciunt.
+            Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia
+            consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
           </p>
           <p>
-            Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet,
-            consectetur, adipisci velit, sed quia non numquam eius modi tempora
-            incidunt ut labore et dolore magnam aliquam quaerat voluptatem.
+            Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci
+            velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam
+            aliquam quaerat voluptatem.
           </p>
           <p>
-            Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis
-            suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur?
+            Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit
+            laboriosam, nisi ut aliquid ex ea commodi consequatur?
           </p>
         </div>
         <DialogFooter showCloseButton>
@@ -294,9 +272,7 @@ export const NestedDialog: Story = {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Outer Dialog</DialogTitle>
-            <DialogDescription>
-              This dialog contains another dialog.
-            </DialogDescription>
+            <DialogDescription>This dialog contains another dialog.</DialogDescription>
           </DialogHeader>
           <div className="py-4">
             <Dialog open={innerOpen} onOpenChange={setInnerOpen}>
@@ -306,13 +282,10 @@ export const NestedDialog: Story = {
               <DialogContent>
                 <DialogHeader>
                   <DialogTitle>Inner Dialog</DialogTitle>
-                  <DialogDescription>
-                    This is a nested dialog.
-                  </DialogDescription>
+                  <DialogDescription>This is a nested dialog.</DialogDescription>
                 </DialogHeader>
                 <p className="text-sm">
-                  Dialogs can be nested when needed, though it should be used
-                  sparingly.
+                  Dialogs can be nested when needed, though it should be used sparingly.
                 </p>
                 <DialogFooter>
                   <Button onClick={() => setInnerOpen(false)}>Close</Button>

--- a/packages/ui/src/primitives/Progress.stories.tsx
+++ b/packages/ui/src/primitives/Progress.stories.tsx
@@ -59,16 +59,11 @@ export const BudgetTracking: Story = {
             <div key={budget.category} className="space-y-2">
               <div className="flex items-center justify-between text-sm">
                 <span className="font-medium">{budget.category}</span>
-                <span
-                  className={isOverBudget ? "text-destructive font-medium" : ""}
-                >
+                <span className={isOverBudget ? "text-destructive font-medium" : ""}>
                   ${budget.spent} / ${budget.total}
                 </span>
               </div>
-              <Progress
-                value={percentage}
-                className={isOverBudget ? "bg-red-200" : ""}
-              />
+              <Progress value={percentage} className={isOverBudget ? "bg-red-200" : ""} />
               <div className="flex justify-between text-xs text-muted-foreground">
                 <span>{percentage.toFixed(0)}% spent</span>
                 {isOverBudget && (
@@ -104,9 +99,7 @@ export const Animated: Story = {
     return (
       <div className="space-y-4">
         <Progress value={progress} />
-        <p className="text-center text-sm text-muted-foreground">
-          {progress}% complete
-        </p>
+        <p className="text-center text-sm text-muted-foreground">{progress}% complete</p>
       </div>
     );
   },
@@ -211,9 +204,7 @@ export const SavingsGoal: Story = {
         </div>
         <Progress value={percentage} className="h-3" />
         <div className="flex justify-between text-sm">
-          <span className="text-muted-foreground">
-            {percentage.toFixed(1)}% of goal
-          </span>
+          <span className="text-muted-foreground">{percentage.toFixed(1)}% of goal</span>
           <span className="font-medium">Goal: ${goal.toLocaleString()}</span>
         </div>
         <p className="text-sm text-muted-foreground">
@@ -253,14 +244,10 @@ export const MultipleGoals: Story = {
               <div className="flex justify-between text-sm">
                 <span className="font-medium">{goal.name}</span>
                 <span className="text-muted-foreground">
-                  ${goal.current.toLocaleString()} / $
-                  {goal.target.toLocaleString()}
+                  ${goal.current.toLocaleString()} / ${goal.target.toLocaleString()}
                 </span>
               </div>
-              <Progress
-                value={percentage}
-                className={`[&>div]:${goal.color}`}
-              />
+              <Progress value={percentage} className={`[&>div]:${goal.color}`} />
             </div>
           );
         })}

--- a/packages/ui/src/primitives/Separator.stories.tsx
+++ b/packages/ui/src/primitives/Separator.stories.tsx
@@ -116,10 +116,7 @@ export const BetweenSections: Story = {
             { desc: "Netflix Subscription", date: "Feb 09", amount: "-$22.99" },
             { desc: "Salary Deposit", date: "Feb 05", amount: "+$3,500.00" },
           ].map((txn, i) => (
-            <div
-              key={i}
-              className="flex items-center justify-between rounded-lg border p-3"
-            >
+            <div key={i} className="flex items-center justify-between rounded-lg border p-3">
               <div>
                 <p className="text-sm font-medium">{txn.desc}</p>
                 <p className="text-xs text-muted-foreground">{txn.date}</p>
@@ -201,9 +198,7 @@ export const WithLabel: Story = {
           <Separator />
         </div>
         <div className="relative flex justify-center text-xs uppercase">
-          <span className="bg-background px-2 text-muted-foreground">
-            Account Settings
-          </span>
+          <span className="bg-background px-2 text-muted-foreground">Account Settings</span>
         </div>
       </div>
 

--- a/packages/ui/src/primitives/Slider.stories.tsx
+++ b/packages/ui/src/primitives/Slider.stories.tsx
@@ -29,9 +29,7 @@ export const Controlled: Story = {
     return (
       <div className="space-y-4">
         <Slider value={value} onValueChange={setValue} max={100} step={1} />
-        <p className="text-center text-sm text-muted-foreground">
-          Value: {value[0]}
-        </p>
+        <p className="text-center text-sm text-muted-foreground">Value: {value[0]}</p>
       </div>
     );
   },
@@ -65,9 +63,7 @@ export const Steps: Story = {
     return (
       <div className="space-y-4">
         <Slider value={value} onValueChange={setValue} max={100} step={25} />
-        <p className="text-center text-sm text-muted-foreground">
-          Value: {value[0]} (steps of 25)
-        </p>
+        <p className="text-center text-sm text-muted-foreground">Value: {value[0]} (steps of 25)</p>
       </div>
     );
   },
@@ -84,13 +80,7 @@ export const BudgetLimit: Story = {
             <label className="text-sm font-medium">Monthly Budget</label>
             <span className="text-sm font-semibold">${budget[0]}</span>
           </div>
-          <Slider
-            value={budget}
-            onValueChange={setBudget}
-            min={0}
-            max={2000}
-            step={50}
-          />
+          <Slider value={budget} onValueChange={setBudget} min={0} max={2000} step={50} />
           <div className="flex justify-between text-xs text-muted-foreground">
             <span>$0</span>
             <span>$2,000</span>
@@ -145,13 +135,7 @@ export const MultipleBudgets: Story = {
             <label className="text-sm font-medium">Food & Dining</label>
             <span className="text-sm font-semibold">${food[0]}</span>
           </div>
-          <Slider
-            value={food}
-            onValueChange={setFood}
-            min={0}
-            max={1000}
-            step={50}
-          />
+          <Slider value={food} onValueChange={setFood} min={0} max={1000} step={50} />
         </div>
 
         <div className="space-y-2">
@@ -159,13 +143,7 @@ export const MultipleBudgets: Story = {
             <label className="text-sm font-medium">Shopping</label>
             <span className="text-sm font-semibold">${shopping[0]}</span>
           </div>
-          <Slider
-            value={shopping}
-            onValueChange={setShopping}
-            min={0}
-            max={1000}
-            step={50}
-          />
+          <Slider value={shopping} onValueChange={setShopping} min={0} max={1000} step={50} />
         </div>
 
         <div className="space-y-2">
@@ -187,13 +165,7 @@ export const MultipleBudgets: Story = {
             <label className="text-sm font-medium">Transport</label>
             <span className="text-sm font-semibold">${transport[0]}</span>
           </div>
-          <Slider
-            value={transport}
-            onValueChange={setTransport}
-            min={0}
-            max={1000}
-            step={50}
-          />
+          <Slider value={transport} onValueChange={setTransport} min={0} max={1000} step={50} />
         </div>
 
         <div className="pt-4 flex justify-between border-t">
@@ -215,9 +187,7 @@ export const DateRange: Story = {
     return (
       <div className="space-y-6 w-96">
         <div className="space-y-2">
-          <label className="text-sm font-medium">
-            Transaction History Range
-          </label>
+          <label className="text-sm font-medium">Transaction History Range</label>
           <Slider
             value={days}
             onValueChange={setDays}
@@ -247,17 +217,13 @@ export const SavingsGoal: Story = {
       <div className="space-y-6 w-96 rounded-lg border p-6">
         <div>
           <h3 className="text-lg font-semibold">Savings Goal Calculator</h3>
-          <p className="text-sm text-muted-foreground">
-            Goal: ${goal.toLocaleString()}
-          </p>
+          <p className="text-sm text-muted-foreground">Goal: ${goal.toLocaleString()}</p>
         </div>
 
         <div className="space-y-2">
           <div className="flex justify-between">
             <label className="text-sm font-medium">Monthly Contribution</label>
-            <span className="text-sm font-semibold">
-              ${monthlyContribution[0]}
-            </span>
+            <span className="text-sm font-semibold">${monthlyContribution[0]}</span>
           </div>
           <Slider
             value={monthlyContribution}
@@ -335,26 +301,15 @@ export const WithLabels: Story = {
       <div className="space-y-6 w-96">
         <div className="space-y-4">
           <label className="text-sm font-medium">Risk Tolerance</label>
-          <Slider
-            value={value}
-            onValueChange={setValue}
-            min={0}
-            max={4}
-            step={1}
-          />
+          <Slider value={value} onValueChange={setValue} min={0} max={4} step={1} />
           <div className="flex justify-between text-xs text-muted-foreground">
             {labels.map((label, i) => (
-              <span
-                key={i}
-                className={value[0] === i ? "font-medium text-foreground" : ""}
-              >
+              <span key={i} className={value[0] === i ? "font-medium text-foreground" : ""}>
                 {label}
               </span>
             ))}
           </div>
-          <p className="text-center text-sm font-medium">
-            Current: {labels[value[0]]}
-          </p>
+          <p className="text-center text-sm font-medium">Current: {labels[value[0]]}</p>
         </div>
       </div>
     );

--- a/packages/ui/src/primitives/Switch.stories.tsx
+++ b/packages/ui/src/primitives/Switch.stories.tsx
@@ -78,11 +78,7 @@ export const WithLabel: Story = {
     const [checked, setChecked] = useState(false);
     return (
       <div className="flex items-center space-x-2">
-        <Switch
-          id="airplane-mode"
-          checked={checked}
-          onCheckedChange={setChecked}
-        />
+        <Switch id="airplane-mode" checked={checked} onCheckedChange={setChecked} />
         <label
           htmlFor="airplane-mode"
           className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
@@ -113,10 +109,7 @@ export const Settings: Story = {
                 Receive notifications about account activity
               </p>
             </div>
-            <Switch
-              checked={notifications}
-              onCheckedChange={setNotifications}
-            />
+            <Switch checked={notifications} onCheckedChange={setNotifications} />
           </div>
 
           <div className="flex items-center justify-between">
@@ -132,9 +125,7 @@ export const Settings: Story = {
           <div className="flex items-center justify-between">
             <div className="space-y-0.5">
               <label className="text-sm font-medium">Security Alerts</label>
-              <p className="text-xs text-muted-foreground">
-                Get notified about security events
-              </p>
+              <p className="text-xs text-muted-foreground">Get notified about security events</p>
             </div>
             <Switch checked={security} onCheckedChange={setSecurity} />
           </div>
@@ -178,10 +169,7 @@ export const BudgetToggles: Story = {
               <div className="h-3 w-3 rounded-full bg-orange-600" />
               <span className="text-sm font-medium">Entertainment</span>
             </div>
-            <Switch
-              checked={entertainment}
-              onCheckedChange={setEntertainment}
-            />
+            <Switch checked={entertainment} onCheckedChange={setEntertainment} />
           </div>
 
           <div className="flex items-center justify-between rounded-lg border p-3">
@@ -209,9 +197,7 @@ export const AccountFeatures: Story = {
       <div className="space-y-6 w-96">
         <div>
           <h3 className="text-lg font-semibold">Smart Features</h3>
-          <p className="text-sm text-muted-foreground">
-            Automate your financial tracking
-          </p>
+          <p className="text-sm text-muted-foreground">Automate your financial tracking</p>
         </div>
 
         <div className="space-y-4">
@@ -222,23 +208,15 @@ export const AccountFeatures: Story = {
                 Automatically categorize transactions using AI
               </p>
             </div>
-            <Switch
-              checked={autoCategorize}
-              onCheckedChange={setAutoCategorize}
-            />
+            <Switch checked={autoCategorize} onCheckedChange={setAutoCategorize} />
           </div>
 
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-1">
               <label className="text-sm font-medium">Recurring Detection</label>
-              <p className="text-xs text-muted-foreground">
-                Identify and track recurring expenses
-              </p>
+              <p className="text-xs text-muted-foreground">Identify and track recurring expenses</p>
             </div>
-            <Switch
-              checked={recurringDetect}
-              onCheckedChange={setRecurringDetect}
-            />
+            <Switch checked={recurringDetect} onCheckedChange={setRecurringDetect} />
           </div>
 
           <div className="flex items-start justify-between gap-4">
@@ -258,10 +236,7 @@ export const AccountFeatures: Story = {
                 Receive personalized savings suggestions
               </p>
             </div>
-            <Switch
-              checked={aiSuggestions}
-              onCheckedChange={setAiSuggestions}
-            />
+            <Switch checked={aiSuggestions} onCheckedChange={setAiSuggestions} />
           </div>
         </div>
       </div>
@@ -290,9 +265,7 @@ export const InForm: Story = {
               type="text"
               className="w-full rounded-md border px-3 py-2 text-sm"
               value={formData.name}
-              onChange={(e) =>
-                setFormData({ ...formData, name: e.target.value })
-              }
+              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
             />
           </div>
 
@@ -302,33 +275,23 @@ export const InForm: Story = {
               type="email"
               className="w-full rounded-md border px-3 py-2 text-sm"
               value={formData.email}
-              onChange={(e) =>
-                setFormData({ ...formData, email: e.target.value })
-              }
+              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
             />
           </div>
 
           <div className="flex items-center justify-between">
-            <label className="text-sm font-medium">
-              Subscribe to newsletter
-            </label>
+            <label className="text-sm font-medium">Subscribe to newsletter</label>
             <Switch
               checked={formData.subscribe}
-              onCheckedChange={(checked) =>
-                setFormData({ ...formData, subscribe: checked })
-              }
+              onCheckedChange={(checked) => setFormData({ ...formData, subscribe: checked })}
             />
           </div>
 
           <div className="flex items-center justify-between">
-            <label className="text-sm font-medium">
-              Accept terms & conditions
-            </label>
+            <label className="text-sm font-medium">Accept terms & conditions</label>
             <Switch
               checked={formData.terms}
-              onCheckedChange={(checked) =>
-                setFormData({ ...formData, terms: checked })
-              }
+              onCheckedChange={(checked) => setFormData({ ...formData, terms: checked })}
             />
           </div>
         </div>

--- a/packages/ui/src/primitives/Tabs.stories.tsx
+++ b/packages/ui/src/primitives/Tabs.stories.tsx
@@ -1,12 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "./tabs";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "./card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./card";
 
 const meta: Meta = {
   title: "Navigation/Tabs",
@@ -152,9 +146,7 @@ export const AccountsTabs: Story = {
             <div className="space-y-2">
               <div className="flex justify-between">
                 <span className="text-sm">Balance</span>
-                <span className="text-lg font-bold text-red-600">
-                  -$1,234.56
-                </span>
+                <span className="text-lg font-bold text-red-600">-$1,234.56</span>
               </div>
               <div className="flex justify-between text-sm">
                 <span className="text-muted-foreground">Available Credit</span>
@@ -213,19 +205,13 @@ export const ReportsTabs: Story = {
         </div>
       </TabsContent>
       <TabsContent value="spending" className="pt-4">
-        <p className="text-sm text-muted-foreground">
-          Spending breakdown by category
-        </p>
+        <p className="text-sm text-muted-foreground">Spending breakdown by category</p>
       </TabsContent>
       <TabsContent value="income" className="pt-4">
-        <p className="text-sm text-muted-foreground">
-          Income sources and history
-        </p>
+        <p className="text-sm text-muted-foreground">Income sources and history</p>
       </TabsContent>
       <TabsContent value="trends" className="pt-4">
-        <p className="text-sm text-muted-foreground">
-          Spending trends over time
-        </p>
+        <p className="text-sm text-muted-foreground">Spending trends over time</p>
       </TabsContent>
     </Tabs>
   ),
@@ -270,14 +256,10 @@ export const SettingsTabs: Story = {
         <Card>
           <CardHeader>
             <CardTitle>Notification Preferences</CardTitle>
-            <CardDescription>
-              Configure how you receive notifications
-            </CardDescription>
+            <CardDescription>Configure how you receive notifications</CardDescription>
           </CardHeader>
           <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Notification settings would go here
-            </p>
+            <p className="text-sm text-muted-foreground">Notification settings would go here</p>
           </CardContent>
         </Card>
       </TabsContent>
@@ -288,9 +270,7 @@ export const SettingsTabs: Story = {
             <CardDescription>Manage your account security</CardDescription>
           </CardHeader>
           <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Security settings would go here
-            </p>
+            <p className="text-sm text-muted-foreground">Security settings would go here</p>
           </CardContent>
         </Card>
       </TabsContent>
@@ -298,14 +278,10 @@ export const SettingsTabs: Story = {
         <Card>
           <CardHeader>
             <CardTitle>Connected Integrations</CardTitle>
-            <CardDescription>
-              Manage your connected accounts and services
-            </CardDescription>
+            <CardDescription>Manage your connected accounts and services</CardDescription>
           </CardHeader>
           <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Integration settings would go here
-            </p>
+            <p className="text-sm text-muted-foreground">Integration settings would go here</p>
           </CardContent>
         </Card>
       </TabsContent>
@@ -362,9 +338,7 @@ export const VerticalTabs: Story = {
               <CardTitle>Account Overview</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-sm text-muted-foreground">
-                Dashboard overview
-              </p>
+              <p className="text-sm text-muted-foreground">Dashboard overview</p>
             </CardContent>
           </Card>
         </TabsContent>
@@ -374,9 +348,7 @@ export const VerticalTabs: Story = {
               <CardTitle>Recent Transactions</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-sm text-muted-foreground">
-                Transaction history
-              </p>
+              <p className="text-sm text-muted-foreground">Transaction history</p>
             </CardContent>
           </Card>
         </TabsContent>
@@ -396,9 +368,7 @@ export const VerticalTabs: Story = {
               <CardTitle>Financial Reports</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-sm text-muted-foreground">
-                Reports and analytics
-              </p>
+              <p className="text-sm text-muted-foreground">Reports and analytics</p>
             </CardContent>
           </Card>
         </TabsContent>

--- a/packages/ui/src/primitives/Textarea.stories.tsx
+++ b/packages/ui/src/primitives/Textarea.stories.tsx
@@ -71,14 +71,8 @@ export const WithError: Story = {
   render: () => (
     <div className="space-y-2 w-96">
       <label className="text-sm font-medium">Message</label>
-      <Textarea
-        placeholder="Enter your message..."
-        aria-invalid="true"
-        defaultValue="Too short"
-      />
-      <p className="text-xs text-destructive">
-        Message must be at least 10 characters
-      </p>
+      <Textarea placeholder="Enter your message..." aria-invalid="true" defaultValue="Too short" />
+      <p className="text-xs text-destructive">Message must be at least 10 characters</p>
     </div>
   ),
 };
@@ -92,9 +86,7 @@ export const TransactionNote: Story = {
       <div className="space-y-4 w-96 rounded-lg border p-6">
         <div>
           <h3 className="text-sm font-semibold">Transaction Details</h3>
-          <p className="text-xs text-muted-foreground">
-            Woolworths Sydney • $87.45
-          </p>
+          <p className="text-xs text-muted-foreground">Woolworths Sydney • $87.45</p>
         </div>
 
         <div className="space-y-2">
@@ -155,9 +147,7 @@ export const Feedback: Story = {
       <div className="space-y-4 w-96 rounded-lg border p-6">
         <div>
           <h3 className="text-lg font-semibold">Send Feedback</h3>
-          <p className="text-sm text-muted-foreground">
-            We'd love to hear your thoughts
-          </p>
+          <p className="text-sm text-muted-foreground">We'd love to hear your thoughts</p>
         </div>
 
         <div className="space-y-2">
@@ -203,9 +193,7 @@ export const AutoGrowing: Story = {
           rows={2}
           className="resize-none"
         />
-        <p className="text-xs text-muted-foreground">
-          Uses field-sizing: content (CSS feature)
-        </p>
+        <p className="text-xs text-muted-foreground">Uses field-sizing: content (CSS feature)</p>
       </div>
     );
   },
@@ -253,9 +241,7 @@ export const Form: Story = {
             className="w-full rounded-md border px-3 py-2 text-sm"
             placeholder="e.g., Emergency Fund"
             value={formData.title}
-            onChange={(e) =>
-              setFormData({ ...formData, title: e.target.value })
-            }
+            onChange={(e) => setFormData({ ...formData, title: e.target.value })}
           />
         </div>
 
@@ -264,9 +250,7 @@ export const Form: Story = {
           <Textarea
             placeholder="What is this goal for?"
             value={formData.description}
-            onChange={(e) =>
-              setFormData({ ...formData, description: e.target.value })
-            }
+            onChange={(e) => setFormData({ ...formData, description: e.target.value })}
             rows={3}
           />
         </div>
@@ -276,17 +260,13 @@ export const Form: Story = {
           <Textarea
             placeholder="Any other details... (optional)"
             value={formData.notes}
-            onChange={(e) =>
-              setFormData({ ...formData, notes: e.target.value })
-            }
+            onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
             rows={2}
           />
         </div>
 
         <div className="flex gap-2">
-          <button className="flex-1 rounded-md border px-4 py-2 text-sm font-medium">
-            Cancel
-          </button>
+          <button className="flex-1 rounded-md border px-4 py-2 text-sm font-medium">Cancel</button>
           <button className="flex-1 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground">
             Create Goal
           </button>

--- a/packages/ui/src/primitives/Toast.stories.tsx
+++ b/packages/ui/src/primitives/Toast.stories.tsx
@@ -105,9 +105,7 @@ export const PromiseToast: Story = {
   render: () => (
     <Button
       onClick={() => {
-        const promise = new Promise<void>((resolve) =>
-          setTimeout(resolve, 2000)
-        );
+        const promise = new Promise<void>((resolve) => setTimeout(resolve, 2000));
 
         toast.promise(promise, {
           loading: "Saving transaction...",

--- a/packages/ui/src/primitives/Tooltip.stories.tsx
+++ b/packages/ui/src/primitives/Tooltip.stories.tsx
@@ -1,10 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "./tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip";
 import { Button } from "../components/Button";
 import { InfoIcon, HelpCircleIcon } from "lucide-react";
 
@@ -110,9 +105,7 @@ export const FormField: Story = {
           <HelpCircleIcon className="h-4 w-4 text-muted-foreground cursor-help" />
         </TooltipTrigger>
         <TooltipContent>
-          <p>
-            The current balance of your account including pending transactions
-          </p>
+          <p>The current balance of your account including pending transactions</p>
         </TooltipContent>
       </Tooltip>
     </div>
@@ -128,9 +121,9 @@ export const LongText: Story = {
       </TooltipTrigger>
       <TooltipContent className="max-w-xs">
         <p>
-          Entity matching uses a 5-stage pipeline: manual aliases, exact match,
-          prefix match, contains match, and punctuation stripping. Achieves
-          95-100% hit rate with aliases, with AI fallback for remaining cases.
+          Entity matching uses a 5-stage pipeline: manual aliases, exact match, prefix match,
+          contains match, and punctuation stripping. Achieves 95-100% hit rate with aliases, with AI
+          fallback for remaining cases.
         </p>
       </TooltipContent>
     </Tooltip>
@@ -243,20 +236,18 @@ export const Multiple: Story = {
   args: {},
   render: () => (
     <div className="flex flex-wrap gap-2">
-      {["Food", "Shopping", "Entertainment", "Transport", "Bills"].map(
-        (category) => (
-          <Tooltip key={category}>
-            <TooltipTrigger asChild>
-              <Button variant="outline" size="sm">
-                {category}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Filter transactions by {category.toLowerCase()} category</p>
-            </TooltipContent>
-          </Tooltip>
-        )
-      )}
+      {["Food", "Shopping", "Entertainment", "Transport", "Bills"].map((category) => (
+        <Tooltip key={category}>
+          <TooltipTrigger asChild>
+            <Button variant="outline" size="sm">
+              {category}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Filter transactions by {category.toLowerCase()} category</p>
+          </TooltipContent>
+        </Tooltip>
+      ))}
     </div>
   ),
 };

--- a/packages/ui/src/primitives/accordion.tsx
+++ b/packages/ui/src/primitives/accordion.tsx
@@ -4,9 +4,7 @@ import * as AccordionPrimitive from "@radix-ui/react-accordion";
 
 import { cn } from "../lib/utils";
 
-function Accordion({
-  ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+function Accordion({ ...props }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
   return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
 }
 

--- a/packages/ui/src/primitives/alert-dialog.tsx
+++ b/packages/ui/src/primitives/alert-dialog.tsx
@@ -4,26 +4,18 @@ import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 import { cn } from "../lib/utils";
 import { Button } from "./button";
 
-function AlertDialog({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
   return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
 }
 
 function AlertDialogTrigger({
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
-  return (
-    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
-  );
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
 }
 
-function AlertDialogPortal({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
-  return (
-    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
-  );
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
 }
 
 function AlertDialogOverlay({
@@ -65,10 +57,7 @@ function AlertDialogContent({
   );
 }
 
-function AlertDialogHeader({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-dialog-header"
@@ -81,10 +70,7 @@ function AlertDialogHeader({
   );
 }
 
-function AlertDialogFooter({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-dialog-footer"
@@ -126,10 +112,7 @@ function AlertDialogDescription({
   );
 }
 
-function AlertDialogMedia({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function AlertDialogMedia({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-dialog-media"

--- a/packages/ui/src/primitives/alert.tsx
+++ b/packages/ui/src/primitives/alert.tsx
@@ -38,19 +38,13 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-title"
-      className={cn(
-        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
-        className
-      )}
+      className={cn("col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight", className)}
       {...props}
     />
   );
 }
 
-function AlertDescription({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function AlertDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-description"

--- a/packages/ui/src/primitives/avatar.tsx
+++ b/packages/ui/src/primitives/avatar.tsx
@@ -25,10 +25,7 @@ function Avatar({
   );
 }
 
-function AvatarImage({
-  className,
-  ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+function AvatarImage({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
@@ -83,10 +80,7 @@ function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function AvatarGroupCount({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function AvatarGroupCount({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="avatar-group-count"
@@ -99,11 +93,4 @@ function AvatarGroupCount({
   );
 }
 
-export {
-  Avatar,
-  AvatarImage,
-  AvatarFallback,
-  AvatarBadge,
-  AvatarGroup,
-  AvatarGroupCount,
-};
+export { Avatar, AvatarImage, AvatarFallback, AvatarBadge, AvatarGroup, AvatarGroupCount };

--- a/packages/ui/src/primitives/badge.tsx
+++ b/packages/ui/src/primitives/badge.tsx
@@ -10,8 +10,7 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
-        secondary:
-          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        secondary: "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
           "bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
@@ -31,8 +30,7 @@ function Badge({
   variant = "default",
   asChild = false,
   ...props
-}: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
   const Comp = asChild ? Slot : "span";
 
   return (

--- a/packages/ui/src/primitives/breadcrumb.tsx
+++ b/packages/ui/src/primitives/breadcrumb.tsx
@@ -62,11 +62,7 @@ function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
   );
 }
 
-function BreadcrumbSeparator({
-  children,
-  className,
-  ...props
-}: React.ComponentProps<"li">) {
+function BreadcrumbSeparator({ children, className, ...props }: React.ComponentProps<"li">) {
   return (
     <li
       data-slot="breadcrumb-separator"
@@ -80,10 +76,7 @@ function BreadcrumbSeparator({
   );
 }
 
-function BreadcrumbEllipsis({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       data-slot="breadcrumb-ellipsis"

--- a/packages/ui/src/primitives/button.tsx
+++ b/packages/ui/src/primitives/button.tsx
@@ -14,10 +14,8 @@ const buttonVariants = cva(
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/packages/ui/src/primitives/card.tsx
+++ b/packages/ui/src/primitives/card.tsx
@@ -52,23 +52,14 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-action"
-      className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
-      )}
+      className={cn("col-start-2 row-span-2 row-start-1 self-start justify-self-end", className)}
       {...props}
     />
   );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-content"
-      className={cn("px-6", className)}
-      {...props}
-    />
-  );
+  return <div data-slot="card-content" className={cn("px-6", className)} {...props} />;
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -81,12 +72,4 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-export {
-  Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
-  CardAction,
-  CardDescription,
-  CardContent,
-};
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/packages/ui/src/primitives/checkbox.tsx
+++ b/packages/ui/src/primitives/checkbox.tsx
@@ -4,10 +4,7 @@ import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 
 import { cn } from "../lib/utils";
 
-function Checkbox({
-  className,
-  ...props
-}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"

--- a/packages/ui/src/primitives/collapsible.tsx
+++ b/packages/ui/src/primitives/collapsible.tsx
@@ -1,31 +1,19 @@
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
 
-function Collapsible({
-  ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+function Collapsible({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
   return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
 }
 
 function CollapsibleTrigger({
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
-  return (
-    <CollapsiblePrimitive.CollapsibleTrigger
-      data-slot="collapsible-trigger"
-      {...props}
-    />
-  );
+  return <CollapsiblePrimitive.CollapsibleTrigger data-slot="collapsible-trigger" {...props} />;
 }
 
 function CollapsibleContent({
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
-  return (
-    <CollapsiblePrimitive.CollapsibleContent
-      data-slot="collapsible-content"
-      {...props}
-    />
-  );
+  return <CollapsiblePrimitive.CollapsibleContent data-slot="collapsible-content" {...props} />;
 }
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/packages/ui/src/primitives/command.tsx
+++ b/packages/ui/src/primitives/command.tsx
@@ -5,18 +5,9 @@ import { Command as CommandPrimitive } from "cmdk";
 import { SearchIcon } from "lucide-react";
 
 import { cn } from "../lib/utils";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "./dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./dialog";
 
-function Command({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive>) {
+function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
   return (
     <CommandPrimitive
       data-slot="command"
@@ -65,10 +56,7 @@ function CommandInput({
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
-    <div
-      data-slot="command-input-wrapper"
-      className="flex h-9 items-center gap-2 border-b px-3"
-    >
+    <div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b px-3">
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         data-slot="command-input"
@@ -82,25 +70,17 @@ function CommandInput({
   );
 }
 
-function CommandList({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.List>) {
+function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
   return (
     <CommandPrimitive.List
       data-slot="command-list"
-      className={cn(
-        "max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto",
-        className
-      )}
+      className={cn("max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto", className)}
       {...props}
     />
   );
 }
 
-function CommandEmpty({
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
   return (
     <CommandPrimitive.Empty
       data-slot="command-empty"
@@ -139,10 +119,7 @@ function CommandSeparator({
   );
 }
 
-function CommandItem({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+function CommandItem({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
   return (
     <CommandPrimitive.Item
       data-slot="command-item"
@@ -155,17 +132,11 @@ function CommandItem({
   );
 }
 
-function CommandShortcut({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function CommandShortcut({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       data-slot="command-shortcut"
-      className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
-        className
-      )}
+      className={cn("text-muted-foreground ml-auto text-xs tracking-widest", className)}
       {...props}
     />
   );

--- a/packages/ui/src/primitives/dialog.tsx
+++ b/packages/ui/src/primitives/dialog.tsx
@@ -5,27 +5,19 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { cn } from "../lib/utils";
 import { Button } from "./button";
 
-function Dialog({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
-function DialogTrigger({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
@@ -100,10 +92,7 @@ function DialogFooter({
   return (
     <div
       data-slot="dialog-footer"
-      className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
-      )}
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
       {...props}
     >
       {children}
@@ -116,10 +105,7 @@ function DialogFooter({
   );
 }
 
-function DialogTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"

--- a/packages/ui/src/primitives/dropdown-menu.tsx
+++ b/packages/ui/src/primitives/dropdown-menu.tsx
@@ -4,29 +4,20 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 
 import { cn } from "../lib/utils";
 
-function DropdownMenu({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
 function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-  return (
-    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
-  );
+  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
 }
 
 function DropdownMenuTrigger({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
-  return (
-    <DropdownMenuPrimitive.Trigger
-      data-slot="dropdown-menu-trigger"
-      {...props}
-    />
-  );
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
 }
 
 function DropdownMenuContent({
@@ -49,12 +40,8 @@ function DropdownMenuContent({
   );
 }
 
-function DropdownMenuGroup({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
-  return (
-    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
-  );
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
 }
 
 function DropdownMenuItem({
@@ -109,12 +96,7 @@ function DropdownMenuCheckboxItem({
 function DropdownMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
-  return (
-    <DropdownMenuPrimitive.RadioGroup
-      data-slot="dropdown-menu-radio-group"
-      {...props}
-    />
-  );
+  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
 }
 
 function DropdownMenuRadioItem({
@@ -152,10 +134,7 @@ function DropdownMenuLabel({
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
-      className={cn(
-        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
-        className
-      )}
+      className={cn("px-2 py-1.5 text-sm font-medium data-[inset]:pl-8", className)}
       {...props}
     />
   );
@@ -174,25 +153,17 @@ function DropdownMenuSeparator({
   );
 }
 
-function DropdownMenuShortcut({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       data-slot="dropdown-menu-shortcut"
-      className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
-        className
-      )}
+      className={cn("text-muted-foreground ml-auto text-xs tracking-widest", className)}
       {...props}
     />
   );
 }
 
-function DropdownMenuSub({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
   return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
 }
 

--- a/packages/ui/src/primitives/popover.tsx
+++ b/packages/ui/src/primitives/popover.tsx
@@ -3,15 +3,11 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 
 import { cn } from "../lib/utils";
 
-function Popover({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
-function PopoverTrigger({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
@@ -37,9 +33,7 @@ function PopoverContent({
   );
 }
 
-function PopoverAnchor({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 
@@ -54,19 +48,10 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
-  return (
-    <div
-      data-slot="popover-title"
-      className={cn("font-medium", className)}
-      {...props}
-    />
-  );
+  return <div data-slot="popover-title" className={cn("font-medium", className)} {...props} />;
 }
 
-function PopoverDescription({
-  className,
-  ...props
-}: React.ComponentProps<"p">) {
+function PopoverDescription({ className, ...props }: React.ComponentProps<"p">) {
   return (
     <p
       data-slot="popover-description"

--- a/packages/ui/src/primitives/progress.tsx
+++ b/packages/ui/src/primitives/progress.tsx
@@ -11,10 +11,7 @@ function Progress({
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
-      className={cn(
-        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
-        className
-      )}
+      className={cn("bg-primary/20 relative h-2 w-full overflow-hidden rounded-full", className)}
       {...props}
     >
       <ProgressPrimitive.Indicator

--- a/packages/ui/src/primitives/select.tsx
+++ b/packages/ui/src/primitives/select.tsx
@@ -4,21 +4,15 @@ import * as SelectPrimitive from "@radix-ui/react-select";
 
 import { cn } from "../lib/utils";
 
-function Select({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
   return <SelectPrimitive.Root data-slot="select" {...props} />;
 }
 
-function SelectGroup({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
-function SelectValue({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
   return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
@@ -85,10 +79,7 @@ function SelectContent({
   );
 }
 
-function SelectLabel({
-  className,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
@@ -145,10 +136,7 @@ function SelectScrollUpButton({
   return (
     <SelectPrimitive.ScrollUpButton
       data-slot="select-scroll-up-button"
-      className={cn(
-        "flex cursor-default items-center justify-center py-1",
-        className
-      )}
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
       {...props}
     >
       <ChevronUpIcon className="size-4" />
@@ -163,10 +151,7 @@ function SelectScrollDownButton({
   return (
     <SelectPrimitive.ScrollDownButton
       data-slot="select-scroll-down-button"
-      className={cn(
-        "flex cursor-default items-center justify-center py-1",
-        className
-      )}
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
       {...props}
     >
       <ChevronDownIcon className="size-4" />

--- a/packages/ui/src/primitives/slider.tsx
+++ b/packages/ui/src/primitives/slider.tsx
@@ -14,12 +14,7 @@ function Slider({
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
   const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
+    () => (Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min, max]),
     [value, defaultValue, min, max]
   );
 

--- a/packages/ui/src/primitives/table.tsx
+++ b/packages/ui/src/primitives/table.tsx
@@ -4,10 +4,7 @@ import { cn } from "../lib/utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
-    <div
-      data-slot="table-container"
-      className="relative w-full overflow-x-auto"
-    >
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
       <table
         data-slot="table"
         className={cn("w-full caption-bottom text-sm", className)}
@@ -41,10 +38,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
   return (
     <tfoot
       data-slot="table-footer"
-      className={cn(
-        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
-        className
-      )}
+      className={cn("bg-muted/50 border-t font-medium [&>tr]:last:border-b-0", className)}
       {...props}
     />
   );
@@ -89,10 +83,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   );
 }
 
-function TableCaption({
-  className,
-  ...props
-}: React.ComponentProps<"caption">) {
+function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
   return (
     <caption
       data-slot="table-caption"
@@ -102,13 +93,4 @@ function TableCaption({
   );
 }
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-};
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/packages/ui/src/primitives/tabs.tsx
+++ b/packages/ui/src/primitives/tabs.tsx
@@ -14,10 +14,7 @@ function Tabs({
       data-slot="tabs"
       data-orientation={orientation}
       orientation={orientation}
-      className={cn(
-        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
-        className
-      )}
+      className={cn("group/tabs flex gap-2 data-[orientation=horizontal]:flex-col", className)}
       {...props}
     />
   );
@@ -42,8 +39,7 @@ function TabsList({
   className,
   variant = "default",
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.List> &
-  VariantProps<typeof tabsListVariants>) {
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
@@ -54,10 +50,7 @@ function TabsList({
   );
 }
 
-function TabsTrigger({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
@@ -73,10 +66,7 @@ function TabsTrigger({
   );
 }
 
-function TabsContent({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"

--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -16,15 +16,11 @@ function TooltipProvider({
   );
 }
 
-function Tooltip({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
-function TooltipTrigger({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 

--- a/packages/ui/src/theme/globals.css
+++ b/packages/ui/src/theme/globals.css
@@ -110,9 +110,7 @@
   --background: oklch(
     0.975 0.01 260
   ); /* Slightly deeper background for better contrast with cards */
-  --foreground: oklch(
-    0.2 0.02 260
-  ); /* Darker foreground for better text contrast */
+  --foreground: oklch(0.2 0.02 260); /* Darker foreground for better text contrast */
 
   --card: oklch(1 0 0); /* Pure white cards to pop */
   --card-foreground: oklch(0.2 0.02 260);


### PR DESCRIPTION
## Summary
- Adds root `.prettierrc` with shared formatting rules: double quotes, printWidth 100, tabWidth 2, trailing commas, LF line endings
- Adds root `.prettierignore` for node_modules, dist, coverage, lockfiles, CSVs
- Removes per-package configs from `pops-api` and `ui` (they now inherit from root)
- Keeps `import-tools/.prettierrc` since it is standalone (yarn, not in pnpm workspace)
- Reformats all 168 workspace source files to match the shared config

## Config
```json
{
  "semi": true,
  "singleQuote": false,
  "printWidth": 100,
  "tabWidth": 2,
  "trailingComma": "es5",
  "arrowParens": "always",
  "endOfLine": "lf"
}
```

## Test plan
- [x] `pnpm typecheck` passes for pops-api and pops-shell
- [x] Tests pass (3 pre-existing timeout failures unrelated to formatting)
- [x] `prettier --check` returns clean on all workspace files
- [ ] Verify import-tools still formats independently

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)