### PR TITLE
feat: add DB-level unique constraint on budgets(category, period)

### DIFF
--- a/apps/pops-api/src/db/migrations/20260326150000_budgets_unique_category_period.sql
+++ b/apps/pops-api/src/db/migrations/20260326150000_budgets_unique_category_period.sql
@@ -1,0 +1,6 @@
+-- Add unique constraint on budgets(category, period) with NULL handling.
+-- SQLite treats NULL != NULL in standard UNIQUE constraints, so two rows
+-- with the same category and NULL period would not conflict. Using COALESCE
+-- with a sentinel value ensures NULL periods are treated as equal.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_budgets_category_period
+  ON budgets(category, COALESCE(period, '__NULL__'));

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -28,6 +28,7 @@ const INCLUDED_MIGRATIONS = [
   "20260322120000_settings.sql",
   "20260324140000_watch_history_unique_index.sql",
   "20260325150000_locations_last_edited_time.sql",
+  "20260326150000_budgets_unique_category_period.sql",
 ];
 
 /**
@@ -91,6 +92,8 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
       notes TEXT,
       last_edited_time TEXT NOT NULL
     );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_budgets_category_period
+      ON budgets(category, COALESCE(period, '__NULL__'));
 
     CREATE TABLE IF NOT EXISTS locations (
       id         TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -122,6 +122,8 @@ export function createTestDb(): Database {
       last_edited_time TEXT NOT NULL
     );
     CREATE INDEX IF NOT EXISTS idx_budgets_category ON budgets(category);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_budgets_category_period
+      ON budgets(category, COALESCE(period, '__NULL__'));
 
     CREATE TABLE IF NOT EXISTS wish_list (
       id               TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),


### PR DESCRIPTION
## Summary
- Adds migration `20260326150000_budgets_unique_category_period.sql` with unique index
- Uses `COALESCE(period, '__NULL__')` to handle SQLite's NULL != NULL behavior
- Previously uniqueness was enforced only in service layer — now enforced at DB level too
- Adds index to `schema.ts` (fresh installs) and `test-utils.ts` (test DB)

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 34 budget tests pass (including duplicate category+null period conflict test)
- [x] Index handles both non-null and null period uniqueness

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)