### PR TITLE
feat: replace arbitrary values in AppRail with design tokens [PRD-006/US-02]

### DIFF
--- a/apps/pops-shell/src/app/layout/AppRail.tsx
+++ b/apps/pops-shell/src/app/layout/AppRail.tsx
@@ -17,15 +17,6 @@ interface AppRailProps {
   className?: string;
 }
 
-const colorMap = {
-  emerald: "bg-[oklch(0.65_0.15_150)]",
-  indigo: "bg-[oklch(0.6_0.15_260)]",
-  amber: "bg-[oklch(0.7_0.15_70)]",
-  rose: "bg-[oklch(0.65_0.15_25)]",
-  sky: "bg-[oklch(0.65_0.15_220)]",
-  violet: "bg-[oklch(0.65_0.15_290)]",
-} as const;
-
 export function AppRail({ className }: AppRailProps) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -43,7 +34,7 @@ export function AppRail({ className }: AppRailProps) {
       >
         <button
           onClick={toggleRail}
-          className="min-w-[36px] min-h-[36px] flex items-center justify-center hover:bg-muted rounded-lg"
+          className="min-w-9 min-h-9 flex items-center justify-center hover:bg-muted rounded-lg"
           aria-label="Expand app rail"
         >
           <PanelLeftOpen className="h-4 w-4 text-muted-foreground" />
@@ -63,14 +54,17 @@ export function AppRail({ className }: AppRailProps) {
       {registeredApps.map((app) => {
         const isActive = matchesAtBoundary(location.pathname, app.basePath);
         const Icon = iconMap[app.icon];
-        const appColor = app.color ? colorMap[app.color] : "bg-primary";
+        const appColorClass = app.color ? `app-${app.color}` : undefined;
 
         return (
           <Tooltip key={app.id}>
             <TooltipTrigger asChild>
               <button
                 onClick={() => navigate(app.basePath)}
-                className="relative w-full flex items-center justify-center py-1 transition-colors group"
+                className={cn(
+                  "relative w-full flex items-center justify-center py-1 transition-colors group",
+                  appColorClass
+                )}
                 aria-label={app.label}
                 aria-current={isActive ? "page" : undefined}
               >
@@ -79,7 +73,7 @@ export function AppRail({ className }: AppRailProps) {
                   className={cn(
                     "absolute left-0 top-1/2 -translate-y-1/2 w-1 rounded-r-full transition-all duration-300",
                     isActive
-                      ? cn("h-8", appColor)
+                      ? "h-8 bg-app-accent"
                       : "h-0 bg-transparent group-hover:h-4 group-hover:bg-muted-foreground/40"
                   )}
                 />
@@ -88,7 +82,7 @@ export function AppRail({ className }: AppRailProps) {
                   className={cn(
                     "flex items-center justify-center w-12 h-12 rounded-2xl transition-all duration-300",
                     isActive
-                      ? cn(appColor, "text-white shadow-lg shadow-black/20 rounded-xl scale-100")
+                      ? "bg-app-accent text-app-accent-foreground shadow-lg shadow-black/20 rounded-xl scale-100"
                       : "text-muted-foreground hover:bg-muted hover:text-foreground hover:rounded-xl scale-95 hover:scale-100"
                   )}
                 >
@@ -111,7 +105,7 @@ export function AppRail({ className }: AppRailProps) {
           <TooltipTrigger asChild>
             <button
               onClick={toggleRail}
-              className="min-w-[36px] min-h-[36px] flex items-center justify-center hover:bg-muted rounded-lg"
+              className="min-w-9 min-h-9 flex items-center justify-center hover:bg-muted rounded-lg"
               aria-label="Collapse app rail"
             >
               <PanelLeftClose className="h-4 w-4 text-muted-foreground" />

--- a/docs-v2/themes/01-foundation/prds/006-app-switcher/README.md
+++ b/docs-v2/themes/01-foundation/prds/006-app-switcher/README.md
@@ -88,7 +88,7 @@ With only one app registered, the switcher should not feel empty:
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-nav-types-registry](us-01-nav-types-registry.md) | Define AppNavConfig/AppNavItem types and app registry in the shell | Done | No (first) |
-| 02 | [us-02-app-rail](us-02-app-rail.md) | Build vertical app rail with icons, active indicator, collapse toggle | Partial | Blocked by us-01 |
+| 02 | [us-02-app-rail](us-02-app-rail.md) | Build vertical app rail with icons, active indicator, collapse toggle | Done | Blocked by us-01 |
 | 03 | [us-03-page-nav](us-03-page-nav.md) | Build page nav panel showing active app's pages | Partial | Blocked by us-01 |
 | 04 | [us-04-layout-integration](us-04-layout-integration.md) | Integrate app rail + page nav into RootLayout, replace basic sidebar | Partial | Blocked by us-02, us-03 |
 

--- a/docs-v2/themes/01-foundation/prds/006-app-switcher/us-02-app-rail.md
+++ b/docs-v2/themes/01-foundation/prds/006-app-switcher/us-02-app-rail.md
@@ -1,7 +1,7 @@
 # US-02: Build app rail
 
 > PRD: [006 — App Switcher](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -17,7 +17,7 @@ As a developer, I want a vertical app rail showing registered app icons so that 
 - [x] Rail is collapsible via toggle button
 - [x] Collapse state persisted in `uiStore` (survives page reload)
 - [x] Hidden on mobile (<768px)
-- [ ] All styling uses design tokens — no arbitrary values
+- [x] All styling uses design tokens — no arbitrary values
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `colorMap` with arbitrary oklch values from AppRail
- Use `.app-{color}` CSS classes to propagate `--app-accent` variable, replacing `bg-[oklch(...)]` with `bg-app-accent` / `text-app-accent-foreground`
- Replace `min-w-[36px] min-h-[36px]` with `min-w-9 min-h-9`
- Mark US-02 acceptance criterion "All styling uses design tokens" as complete

## Test plan
- [ ] Verify app rail icons display correct colours per app
- [ ] Verify active app indicator uses correct accent colour
- [ ] Verify collapsed rail toggle button sizing unchanged
- [ ] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)