### PR TITLE
docs: mark PRD-007 US-02 app rail accent as done [tb-479]

### DIFF
--- a/docs-v2/themes/01-foundation/prds/007-app-theme-colour-propagation/us-02-rail-accent.md
+++ b/docs-v2/themes/01-foundation/prds/007-app-theme-colour-propagation/us-02-rail-accent.md
@@ -1,7 +1,7 @@
 # US-02: App rail uses active app's accent colour
 
 > PRD: [007 — App Theme Colour Propagation](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -9,9 +9,9 @@ As a developer, I want the app rail's active indicator to use the active app's a
 
 ## Acceptance Criteria
 
-- [ ] Active app indicator in the app rail uses `--app-accent` colour
+- [x] Active app indicator in the app rail uses `--app-accent` colour
 - [x] Indicator colour updates when switching apps
-- [ ] Works in both light and dark mode
+- [x] Works in both light and dark mode
 - [x] Inactive app icons use `text-muted-foreground` — only the active one uses the accent
 
 ## Notes


### PR DESCRIPTION
## Summary
- Mark PRD-007 US-02 (app rail active indicator uses --app-accent) acceptance criteria as done
- The AppRail component already uses `bg-app-accent` via `.app-{color}` CSS classes (implemented in PR #812)
- Light/dark mode supported through `.dark` variants in globals.css

## Test plan
- [x] Verify AppRail.tsx uses `bg-app-accent` (not hardcoded oklch values)
- [x] Verify `.app-{color}` classes have dark mode variants in globals.css
- [x] Doc-only change — no runtime impact

Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)