### PR TITLE
feat: add Period badge styling to Budgets DataTable [PRD-025/US-02]

### DIFF
--- a/docs-v2/themes/02-finance/prds/025-budgets/README.md
+++ b/docs-v2/themes/02-finance/prds/025-budgets/README.md
@@ -46,7 +46,7 @@ Build budget tracking — spending categories with monthly or yearly limits. Sho
 | # | Story | Summary | Parallelisable |
 |---|-------|---------|----------------|
 | 01 | [us-01-schema-api](us-01-schema-api.md) | Budget table, unique constraint, CRUD procedures | Partial |
-| 02 | [us-02-budgets-page](us-02-budgets-page.md) | DataTable with search, period/status filters, sorting | Partial |
+| 02 | [us-02-budgets-page](us-02-budgets-page.md) | DataTable with search, period/status filters, sorting | Done |
 | 03 | [us-03-budget-crud-ui](us-03-budget-crud-ui.md) | Create/edit/delete dialogs with form validation | Not started |
 
 ## Out of Scope

--- a/docs-v2/themes/02-finance/prds/025-budgets/us-02-budgets-page.md
+++ b/docs-v2/themes/02-finance/prds/025-budgets/us-02-budgets-page.md
@@ -1,7 +1,7 @@
 # US-02: Budgets page
 
 > PRD: [025 — Budgets](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -9,7 +9,7 @@ As a user, I want a budgets page showing all budget categories so that I can see
 
 ## Acceptance Criteria
 
-- [ ] DataTable with columns: Category (sortable), Period (Monthly/Yearly badge), Amount (sortable, right-aligned), Status (Active/Inactive badge), Notes (truncated) — Period column shows plain text, not a badge
+- [x] DataTable with columns: Category (sortable), Period (Monthly/Yearly badge), Amount (sortable, right-aligned), Status (Active/Inactive badge), Notes (truncated)
 - [x] Search by category
 - [x] Filter by: Period (Monthly/Yearly), Status (Active/Inactive)
 - [x] Pagination with limit 100

--- a/packages/app-finance/src/pages/BudgetsPage.tsx
+++ b/packages/app-finance/src/pages/BudgetsPage.tsx
@@ -33,11 +33,22 @@ export function BudgetsPage() {
     {
       accessorKey: "period",
       header: "Period",
-      cell: ({ row }) => (
-        <span className="text-sm">
-          {row.original.period || <span className="text-muted-foreground">—</span>}
-        </span>
-      ),
+      cell: ({ row }) => {
+        const period = row.original.period;
+        if (!period) return <span className="text-muted-foreground">—</span>;
+        return (
+          <Badge
+            variant="outline"
+            className={
+              period === "Monthly"
+                ? "bg-blue-500/10 text-blue-700 border-blue-500/20 dark:text-blue-400"
+                : "bg-amber-500/10 text-amber-700 border-amber-500/20 dark:text-amber-400"
+            }
+          >
+            {period}
+          </Badge>
+        );
+      },
     },
     {
       accessorKey: "amount",


### PR DESCRIPTION
## Summary
- Replace plain text Period column with styled Badge component
- Monthly shows blue badge, Yearly shows amber badge
- Matches existing Status badge pattern in the same table

## Test plan
- [ ] Monthly budgets show blue badge
- [ ] Yearly budgets show amber badge
- [ ] Null period shows em dash
- [ ] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)