### PR TITLE
feat: entity CRUD UI — create/edit/delete dialogs

### DIFF
--- a/docs-v2/themes/02-finance/prds/023-entities/README.md
+++ b/docs-v2/themes/02-finance/prds/023-entities/README.md
@@ -64,7 +64,7 @@ Build the entity registry — the merchant/payee database that transactions and 
 |---|-------|---------|----------------|
 | 01 | [us-01-schema-api](us-01-schema-api.md) | Entity table, CRUD procedures, alias/tag serialization | No (first) |
 | 02 | [us-02-entities-page](us-02-entities-page.md) | DataTable with search, type filter, alias/tag display | Blocked by us-01 |
-| 03 | [us-03-entity-crud-ui](us-03-entity-crud-ui.md) | Create/edit/delete dialogs on the entities page | Blocked by us-02 |
+| 03 | [us-03-entity-crud-ui](us-03-entity-crud-ui.md) | Create/edit/delete dialogs on the entities page | Done |
 
 ## Verification
 

--- a/docs-v2/themes/02-finance/prds/023-entities/us-03-entity-crud-ui.md
+++ b/docs-v2/themes/02-finance/prds/023-entities/us-03-entity-crud-ui.md
@@ -1,7 +1,7 @@
 # US-03: Entity CRUD UI
 
 > PRD: [023 — Entities](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user, I want to create, edit, and delete entities from the entities page so
 
 ## Acceptance Criteria
 
-- [ ] "Add Entity" button opens create dialog
-- [ ] Create form: name (required), type (select), ABN (text), aliases (chip input), default transaction type (select), default tags (chip input), notes (textarea)
-- [ ] Edit: row action opens same form pre-filled
-- [ ] Delete: row action with confirmation dialog
-- [ ] Duplicate name shows error message suggesting the existing entity
-- [ ] Toast confirmation on create/update/delete
-- [ ] DataTable refreshes after mutations
+- [x] "Add Entity" button opens create dialog
+- [x] Create form: name (required), type (select), ABN (text), aliases (chip input), default transaction type (select), default tags (chip input), notes (textarea)
+- [x] Edit: row action opens same form pre-filled
+- [x] Delete: row action with confirmation dialog
+- [x] Duplicate name shows error message suggesting the existing entity
+- [x] Toast confirmation on create/update/delete
+- [x] DataTable refreshes after mutations
 
 ## Notes
 

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -1,13 +1,43 @@
 /**
- * Entities page - manage merchants/payees
+ * Entities page - manage merchants/payees with CRUD
  */
+import { useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
 import { trpc } from "../lib/trpc";
-import { DataTable, SortableHeader } from "@pops/ui";
-import { Badge } from "@pops/ui";
-import { Alert } from "@pops/ui";
-import { Skeleton } from "@pops/ui";
+import {
+  DataTable,
+  SortableHeader,
+  Badge,
+  Alert,
+  Skeleton,
+  Button,
+  TextInput,
+  Textarea,
+  Select,
+  ChipInput,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DropdownMenu,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@pops/ui";
 import type { ColumnFilter } from "@pops/ui";
+import { MoreHorizontal, Plus, Pencil, Trash2, Loader2 } from "lucide-react";
+import { toast } from "sonner";
 
 interface Entity {
   id: string;
@@ -21,10 +51,117 @@ interface Entity {
   lastEditedTime: string;
 }
 
+const ENTITY_TYPES = ["company", "person", "place", "brand", "organisation"] as const;
+
+const TRANSACTION_TYPES = [
+  { label: "None", value: "" },
+  { label: "Purchase", value: "purchase" },
+  { label: "Transfer", value: "transfer" },
+  { label: "Income", value: "income" },
+];
+
+const EntityFormSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  type: z.string(),
+  abn: z.string(),
+  aliases: z.array(z.string()),
+  defaultTransactionType: z.string(),
+  defaultTags: z.array(z.string()),
+  notes: z.string(),
+});
+
+type EntityFormValues = z.infer<typeof EntityFormSchema>;
+
+const DEFAULT_FORM_VALUES: EntityFormValues = {
+  name: "",
+  type: "company",
+  abn: "",
+  aliases: [],
+  defaultTransactionType: "",
+  defaultTags: [],
+  notes: "",
+};
+
 export function EntitiesPage() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingEntity, setEditingEntity] = useState<Entity | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const utils = trpc.useUtils();
   const { data, isLoading, error, refetch } = trpc.core.entities.list.useQuery({
     limit: 100,
   });
+
+  const createMutation = trpc.core.entities.create.useMutation({
+    onSuccess: () => {
+      toast.success("Entity created");
+      utils.core.entities.list.invalidate();
+      setIsDialogOpen(false);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const updateMutation = trpc.core.entities.update.useMutation({
+    onSuccess: () => {
+      toast.success("Entity updated");
+      utils.core.entities.list.invalidate();
+      setIsDialogOpen(false);
+      setEditingEntity(null);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const deleteMutation = trpc.core.entities.delete.useMutation({
+    onSuccess: () => {
+      toast.success("Entity deleted");
+      utils.core.entities.list.invalidate();
+      setDeletingId(null);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const form = useForm<EntityFormValues>({
+    resolver: zodResolver(EntityFormSchema),
+    defaultValues: DEFAULT_FORM_VALUES,
+  });
+
+  const handleAdd = () => {
+    setEditingEntity(null);
+    form.reset(DEFAULT_FORM_VALUES);
+    setIsDialogOpen(true);
+  };
+
+  const handleEdit = (entity: Entity) => {
+    setEditingEntity(entity);
+    form.reset({
+      name: entity.name,
+      type: entity.type || "company",
+      abn: entity.abn || "",
+      aliases: entity.aliases,
+      defaultTransactionType: entity.defaultTransactionType || "",
+      defaultTags: entity.defaultTags,
+      notes: entity.notes || "",
+    });
+    setIsDialogOpen(true);
+  };
+
+  const onSubmit = (values: EntityFormValues) => {
+    const payload = {
+      name: values.name,
+      type: values.type as (typeof ENTITY_TYPES)[number],
+      abn: values.abn || null,
+      aliases: values.aliases,
+      defaultTransactionType: values.defaultTransactionType || null,
+      defaultTags: values.defaultTags,
+      notes: values.notes || null,
+    };
+
+    if (editingEntity) {
+      updateMutation.mutate({ id: editingEntity.id, data: payload });
+    } else {
+      createMutation.mutate(payload);
+    }
+  };
 
   const columns: ColumnDef<Entity>[] = [
     {
@@ -41,7 +178,7 @@ export function EntitiesPage() {
           return <span className="text-muted-foreground">—</span>;
         }
         return (
-          <Badge variant="outline" className="text-xs">
+          <Badge variant="outline" className="text-xs capitalize">
             {type}
           </Badge>
         );
@@ -125,6 +262,32 @@ export function EntitiesPage() {
         );
       },
     },
+    {
+      id: "actions",
+      cell: ({ row }) => (
+        <div className="text-right">
+          <DropdownMenu
+            trigger={
+              <Button variant="ghost" size="icon" className="h-8 w-8 p-0" aria-label="Actions">
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            }
+            align="end"
+          >
+            <DropdownMenuItem onClick={() => handleEdit(row.original)}>
+              <Pencil className="mr-2 h-4 w-4" /> Edit
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              onClick={() => setDeletingId(row.original.id)}
+            >
+              <Trash2 className="mr-2 h-4 w-4" /> Delete
+            </DropdownMenuItem>
+          </DropdownMenu>
+        </div>
+      ),
+    },
   ];
 
   const tableFilters: ColumnFilter[] = [
@@ -134,13 +297,7 @@ export function EntitiesPage() {
       label: "Type",
       options: [
         { label: "All Types", value: "" },
-        { label: "Supermarket", value: "Supermarket" },
-        { label: "Subscription", value: "Subscription" },
-        { label: "Fuel Station", value: "Fuel Station" },
-        { label: "Retailer", value: "Retailer" },
-        { label: "Employer", value: "Employer" },
-        { label: "Technology", value: "Technology" },
-        { label: "Hardware", value: "Hardware" },
+        ...ENTITY_TYPES.map((t) => ({ label: t.charAt(0).toUpperCase() + t.slice(1), value: t })),
       ],
     },
   ];
@@ -152,23 +309,28 @@ export function EntitiesPage() {
         <Alert variant="destructive">
           <p className="font-semibold">Failed to load entities</p>
           <p className="text-sm">{error.message}</p>
-          <button onClick={() => refetch()} className="mt-2 text-sm underline">
+          <Button variant="outline" size="sm" onClick={() => refetch()} className="mt-4">
             Try again
-          </button>
+          </Button>
         </Alert>
       </div>
     );
   }
 
+  const isSubmitting = createMutation.isPending || updateMutation.isPending;
+
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl md:text-3xl font-bold">Entities</h1>
-          <p className="text-muted-foreground">
-            {data && `${data.pagination.total} total entities`}
+          <p className="text-muted-foreground text-sm">
+            {data ? `${data.pagination.total} total entities` : "Manage merchants and payees"}
           </p>
         </div>
+        <Button onClick={handleAdd}>
+          <Plus className="mr-2 h-4 w-4" /> Add Entity
+        </Button>
       </div>
 
       {isLoading ? (
@@ -176,10 +338,10 @@ export function EntitiesPage() {
           <Skeleton className="h-10 w-full" />
           <Skeleton className="h-64 w-full" />
         </div>
-      ) : data ? (
+      ) : (
         <DataTable
           columns={columns}
-          data={data.data}
+          data={data?.data ?? []}
           searchable
           searchColumn="name"
           searchPlaceholder="Search entities..."
@@ -188,7 +350,115 @@ export function EntitiesPage() {
           pageSizeOptions={[25, 50, 100]}
           filters={tableFilters}
         />
-      ) : null}
+      )}
+
+      {/* Add/Edit Dialog */}
+      <Dialog open={isDialogOpen} onOpenChange={(open) => !isSubmitting && setIsDialogOpen(open)}>
+        <DialogContent className="sm:max-w-[500px]">
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <DialogHeader>
+              <DialogTitle>{editingEntity ? "Edit Entity" : "New Entity"}</DialogTitle>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <TextInput
+                label="Name"
+                placeholder="e.g. Woolworths, Netflix"
+                {...form.register("name")}
+                error={form.formState.errors.name?.message}
+              />
+              <div className="grid grid-cols-2 gap-4">
+                <Select
+                  label="Type"
+                  options={ENTITY_TYPES.map((t) => ({
+                    label: t.charAt(0).toUpperCase() + t.slice(1),
+                    value: t,
+                  }))}
+                  {...form.register("type")}
+                />
+                <TextInput
+                  label="ABN (Optional)"
+                  placeholder="00 000 000 000"
+                  {...form.register("abn")}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Aliases</label>
+                <Controller
+                  control={form.control}
+                  name="aliases"
+                  render={({ field }) => (
+                    <ChipInput
+                      placeholder="Type and press Enter..."
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  )}
+                />
+              </div>
+              <Select
+                label="Default Transaction Type (Optional)"
+                options={TRANSACTION_TYPES}
+                {...form.register("defaultTransactionType")}
+              />
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Default Tags</label>
+                <Controller
+                  control={form.control}
+                  name="defaultTags"
+                  render={({ field }) => (
+                    <ChipInput
+                      placeholder="Type and press Enter..."
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  )}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Notes (Optional)</label>
+                <Textarea placeholder="Additional details..." {...form.register("notes")} />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setIsDialogOpen(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {editingEntity ? "Update" : "Create"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation */}
+      <AlertDialog open={!!deletingId} onOpenChange={() => setDeletingId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete this entity. Transactions referencing it will retain the
+              entity name but lose the link.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => deletingId && deleteMutation.mutate({ id: deletingId })}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add Entity button opens create dialog with name, type, ABN, aliases (ChipInput), default transaction type, default tags (ChipInput), and notes (Textarea)
- Row action dropdown with Edit (pre-fills form) and Delete (confirmation AlertDialog)
- tRPC mutations with cache invalidation and toast notifications
- Conflict errors (duplicate name) surfaced via toast
- Fixed type filter dropdown to use correct ENTITY_TYPES (company/person/place/brand/organisation)

Closes #718 — PRD-023/US-03

## Test plan
- [ ] Click "Add Entity" → create dialog opens with empty form
- [ ] Fill form with name + aliases + tags, submit → entity appears in table, success toast
- [ ] Click row action → Edit → form pre-filled with existing values including aliases/tags
- [ ] Update and save → table refreshes, success toast
- [ ] Click row action → Delete → confirmation dialog → confirm → entity removed
- [ ] Create entity with duplicate name → conflict error toast
- [ ] Verify type filter shows correct options (company/person/place/brand/organisation)
- [ ] Verify form validation (empty name rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)