### PR TITLE
feat: add Purchase Date column to inventory table

### DIFF
--- a/docs-v2/themes/04-inventory/prds/044-items-list-page/us-01-table-view.md
+++ b/docs-v2/themes/04-inventory/prds/044-items-list-page/us-01-table-view.md
@@ -18,7 +18,7 @@ As a user, I want a table view of my inventory items with sortable columns so th
 - [ ] Location column shows breadcrumb path (e.g., "Home > Living Room > TV Unit"); truncated with ellipsis if long, full path in tooltip
 - [x] Asset ID column shows the ID or a dash if null
 - [x] Replacement Value column formats as currency; shows dash if null
-- [ ] Purchase Date column formats as locale date; shows dash if null
+- [x] Purchase Date column formats as locale date; shows dash if null
 - [x] Pagination controls below the table with page size selector and page navigation
 - [x] Table calls `inventory.items.list` with current sort, filters, page, and page size
 - [ ] Tests cover: column rendering, sort toggle per column, row click navigation, badge colour mapping, breadcrumb truncation, null field handling, pagination

--- a/packages/app-inventory/src/components/InventoryTable.tsx
+++ b/packages/app-inventory/src/components/InventoryTable.tsx
@@ -25,6 +25,7 @@ export interface InventoryTableItem {
   condition: string | null;
   location: string | null;
   replacementValue: number | null;
+  purchaseDate: string | null;
   inUse: boolean;
   assetId: string | null;
 }
@@ -90,6 +91,15 @@ function createColumns(): ColumnDef<InventoryTableItem>[] {
       cell: ({ row }) => {
         const value = row.original.replacementValue;
         return value != null ? formatCurrency(value) : "—";
+      },
+    },
+    {
+      accessorKey: "purchaseDate",
+      header: ({ column }) => <SortableHeader column={column}>Purchased</SortableHeader>,
+      cell: ({ row }) => {
+        const date = row.original.purchaseDate;
+        if (!date) return <span className="text-muted-foreground">—</span>;
+        return <span className="text-sm tabular-nums">{new Date(date).toLocaleDateString()}</span>;
       },
     },
     {


### PR DESCRIPTION
## Summary
- Add `purchaseDate` to `InventoryTableItem` interface
- Add sortable Purchase Date column with locale date formatting
- Null dates display as dash
- Partial completion of PRD-044/US-01 (location breadcrumb and condition badge mapping blocked by tb-486)

Closes #736 — PRD-044/US-01

## Test plan
- [ ] Purchase Date column visible in inventory table
- [ ] Dates formatted as locale string (e.g., "3/26/2026")
- [ ] Null purchase dates show "—"
- [ ] Column is sortable (click header toggles direction)
- [ ] Existing columns unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)