### PR TITLE
feat: delete watch event from history page [tb-502]

### DIFF
--- a/packages/app-media/package.json
+++ b/packages/app-media/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "eslint": "^9.39.4",

--- a/packages/app-media/src/pages/HistoryPage.test.tsx
+++ b/packages/app-media/src/pages/HistoryPage.test.tsx
@@ -1,16 +1,50 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 
+// Mock sonner toast
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
 const mockListRecentQuery = vi.fn();
+const mockDeleteMutate = vi.fn();
+let deleteMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
+let deleteMutationPending = false;
+const mockInvalidateListRecent = vi.fn();
+const mockInvalidateList = vi.fn();
+const mockInvalidateWatchlist = vi.fn();
 
 vi.mock("../lib/trpc", () => ({
   trpc: {
     media: {
       watchHistory: {
         listRecent: { useQuery: (...args: unknown[]) => mockListRecentQuery(...args) },
+        delete: {
+          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
+            deleteMutationOpts = opts;
+            return { mutate: mockDeleteMutate, isPending: deleteMutationPending };
+          },
+        },
       },
     },
+    useUtils: () => ({
+      media: {
+        watchHistory: {
+          listRecent: { invalidate: mockInvalidateListRecent },
+          list: { invalidate: mockInvalidateList },
+        },
+        watchlist: {
+          list: { invalidate: mockInvalidateWatchlist },
+        },
+      },
+    }),
   },
 }));
 
@@ -69,98 +103,257 @@ const episodeNoShow = {
 describe("HistoryPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it("renders episode subtitle in S02E10 format with em-dash", () => {
+    deleteMutationPending = false;
+    deleteMutationOpts = {};
     mockListRecentQuery.mockReturnValue({
-      data: { data: [episodeEntry], pagination: { total: 1 } },
+      data: { data: [episodeEntry, movieEntry], pagination: { total: 2 } },
       isLoading: false,
       error: null,
     });
-
-    renderPage();
-
-    expect(screen.getAllByText("Breaking Bad").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("S02E10").length).toBeGreaterThan(0);
   });
 
-  it("renders show name as link to show detail page", () => {
-    mockListRecentQuery.mockReturnValue({
-      data: { data: [episodeEntry], pagination: { total: 1 } },
-      isLoading: false,
-      error: null,
+  describe("episode enrichment", () => {
+    it("renders episode subtitle in S02E10 format with em-dash", () => {
+      renderPage();
+      expect(screen.getAllByText("Breaking Bad").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("S02E10").length).toBeGreaterThan(0);
     });
 
-    renderPage();
+    it("renders show name as link to show detail page", () => {
+      renderPage();
+      const showLinks = screen.getAllByText("Breaking Bad");
+      const showLink = showLinks.find(
+        (el) => el.closest("a")?.getAttribute("href") === "/media/tv/7"
+      );
+      expect(showLink).toBeTruthy();
+    });
 
-    const showLinks = screen.getAllByText("Breaking Bad");
-    const showLink = showLinks.find(
-      (el) => el.closest("a")?.getAttribute("href") === "/media/tv/7"
-    );
-    expect(showLink).toBeTruthy();
+    it("renders season code as link to season detail page", () => {
+      renderPage();
+      const codeLinks = screen.getAllByText("S02E10");
+      const seasonLink = codeLinks.find(
+        (el) => el.closest("a")?.getAttribute("href") === "/media/tv/7?season=2"
+      );
+      expect(seasonLink).toBeTruthy();
+    });
+
+    it("renders movie entries with no subtitle", () => {
+      mockListRecentQuery.mockReturnValue({
+        data: { data: [movieEntry], pagination: { total: 1 } },
+        isLoading: false,
+        error: null,
+      });
+      renderPage();
+      expect(screen.getAllByText("The Matrix").length).toBeGreaterThan(0);
+      expect(screen.queryByText(/S\d+E\d+/)).toBeNull();
+    });
+
+    it("renders episode with missing show data as title only (graceful fallback)", () => {
+      mockListRecentQuery.mockReturnValue({
+        data: { data: [episodeNoShow], pagination: { total: 1 } },
+        isLoading: false,
+        error: null,
+      });
+      renderPage();
+      expect(screen.getAllByText("Mystery Episode").length).toBeGreaterThan(0);
+      expect(screen.queryByText(/S\d+E\d+/)).toBeNull();
+    });
+
+    it("renders mixed entries correctly", () => {
+      mockListRecentQuery.mockReturnValue({
+        data: {
+          data: [episodeEntry, movieEntry, episodeNoShow],
+          pagination: { total: 3 },
+        },
+        isLoading: false,
+        error: null,
+      });
+      renderPage();
+      expect(screen.getAllByText("Breaking Bad").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("S02E10").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("The Matrix").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Mystery Episode").length).toBeGreaterThan(0);
+    });
   });
 
-  it("renders season code as link to season detail page", () => {
-    mockListRecentQuery.mockReturnValue({
-      data: { data: [episodeEntry], pagination: { total: 1 } },
-      isLoading: false,
-      error: null,
+  describe("delete button visibility", () => {
+    it("renders delete buttons with correct aria-label", () => {
+      renderPage();
+      const deleteButtons = screen.getAllByLabelText("Delete watch event");
+      expect(deleteButtons.length).toBeGreaterThanOrEqual(2);
     });
-
-    renderPage();
-
-    const codeLinks = screen.getAllByText("S02E10");
-    const seasonLink = codeLinks.find(
-      (el) => el.closest("a")?.getAttribute("href") === "/media/tv/7?season=2"
-    );
-    expect(seasonLink).toBeTruthy();
   });
 
-  it("renders movie entries with no subtitle", () => {
-    mockListRecentQuery.mockReturnValue({
-      data: { data: [movieEntry], pagination: { total: 1 } },
-      isLoading: false,
-      error: null,
+  describe("delete confirmation dialog", () => {
+    it("opens confirmation dialog when delete is clicked", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      const deleteButtons = screen.getAllByLabelText("Delete watch event");
+      await user.click(deleteButtons[0]!);
+      expect(screen.getByText("Remove watch event?")).toBeInTheDocument();
+      expect(screen.getByText(/This cannot be undone/)).toBeInTheDocument();
     });
 
-    renderPage();
+    it("shows cancel and remove buttons in dialog", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      const deleteButtons = screen.getAllByLabelText("Delete watch event");
+      await user.click(deleteButtons[0]!);
+      expect(screen.getByText("Cancel")).toBeInTheDocument();
+      expect(screen.getByText("Remove")).toBeInTheDocument();
+    });
 
-    expect(screen.getAllByText("The Matrix").length).toBeGreaterThan(0);
-    // No episode code or show name should appear
-    expect(screen.queryByText(/S\d+E\d+/)).toBeNull();
+    it("calls delete mutation when confirmed", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      const deleteButtons = screen.getAllByLabelText("Delete watch event");
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByText("Remove"));
+      expect(mockDeleteMutate).toHaveBeenCalledWith({ id: episodeEntry.id });
+    });
+
+    it("closes dialog on cancel without calling delete", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      const deleteButtons = screen.getAllByLabelText("Delete watch event");
+      await user.click(deleteButtons[0]!);
+      await user.click(screen.getByText("Cancel"));
+      expect(mockDeleteMutate).not.toHaveBeenCalled();
+      expect(screen.queryByText("Remove watch event?")).not.toBeInTheDocument();
+    });
   });
 
-  it("renders episode with missing show data as title only (graceful fallback)", () => {
-    mockListRecentQuery.mockReturnValue({
-      data: { data: [episodeNoShow], pagination: { total: 1 } },
-      isLoading: false,
-      error: null,
+  describe("delete success", () => {
+    it("shows success toast on deletion", () => {
+      renderPage();
+      deleteMutationOpts.onSuccess?.();
+      expect(mockToastSuccess).toHaveBeenCalledWith("Watch event removed");
     });
 
-    renderPage();
-
-    expect(screen.getAllByText("Mystery Episode").length).toBeGreaterThan(0);
-    // No subtitle when show data is missing
-    expect(screen.queryByText(/S\d+E\d+/)).toBeNull();
+    it("invalidates queries on success", () => {
+      renderPage();
+      deleteMutationOpts.onSuccess?.();
+      expect(mockInvalidateListRecent).toHaveBeenCalled();
+      expect(mockInvalidateList).toHaveBeenCalled();
+      expect(mockInvalidateWatchlist).toHaveBeenCalled();
+    });
   });
 
-  it("renders mixed entries correctly", () => {
-    mockListRecentQuery.mockReturnValue({
-      data: { data: [episodeEntry, movieEntry, episodeNoShow], pagination: { total: 3 } },
-      isLoading: false,
-      error: null,
+  describe("delete error", () => {
+    it("shows error toast on failure", () => {
+      renderPage();
+      deleteMutationOpts.onError?.({ message: "Server error" });
+      expect(mockToastError).toHaveBeenCalledWith("Failed to delete watch event: Server error");
+    });
+  });
+
+  describe("empty state", () => {
+    it("shows empty state when no entries", () => {
+      mockListRecentQuery.mockReturnValue({
+        data: { data: [], pagination: { total: 0 } },
+        isLoading: false,
+        error: null,
+      });
+      renderPage();
+      expect(
+        screen.getByText("No watch history yet. Start watching something!")
+      ).toBeInTheDocument();
     });
 
-    renderPage();
+    it("shows filtered empty state for movies", async () => {
+      const user = userEvent.setup();
+      mockListRecentQuery.mockReturnValue({
+        data: { data: [], pagination: { total: 0 } },
+        isLoading: false,
+        error: null,
+      });
+      renderPage();
+      await user.click(screen.getByText("Movies"));
+      expect(screen.getByText("No movies in your history.")).toBeInTheDocument();
+    });
 
-    // Episode with full data shows subtitle
-    expect(screen.getAllByText("Breaking Bad").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("S02E10").length).toBeGreaterThan(0);
+    it("shows browse library link in empty state", () => {
+      mockListRecentQuery.mockReturnValue({
+        data: { data: [], pagination: { total: 0 } },
+        isLoading: false,
+        error: null,
+      });
+      renderPage();
+      expect(screen.getByText("Browse library")).toHaveAttribute("href", "/media");
+    });
+  });
 
-    // Movie has no subtitle
-    expect(screen.getAllByText("The Matrix").length).toBeGreaterThan(0);
+  describe("loading state", () => {
+    it("shows skeleton when loading", () => {
+      mockListRecentQuery.mockReturnValue({
+        data: null,
+        isLoading: true,
+        error: null,
+      });
+      const { container } = renderPage();
+      expect(container.querySelectorAll("[data-slot='skeleton']").length).toBeGreaterThan(0);
+    });
+  });
 
-    // Episode without show data has no subtitle
-    expect(screen.getAllByText("Mystery Episode").length).toBeGreaterThan(0);
+  describe("error state", () => {
+    it("shows error alert on query error", () => {
+      mockListRecentQuery.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: { message: "Failed to fetch" },
+      });
+      renderPage();
+      expect(screen.getByText("Error")).toBeInTheDocument();
+      expect(screen.getByText("Failed to fetch")).toBeInTheDocument();
+    });
+  });
+
+  describe("filter tabs", () => {
+    it("passes mediaType filter when Movies tab is selected", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      await user.click(screen.getByText("Movies"));
+      const lastCall = mockListRecentQuery.mock.calls.at(-1);
+      expect(lastCall?.[0]).toMatchObject({ mediaType: "movie" });
+    });
+
+    it("passes mediaType filter when Episodes tab is selected", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      await user.click(screen.getByText("Episodes"));
+      const lastCall = mockListRecentQuery.mock.calls.at(-1);
+      expect(lastCall?.[0]).toMatchObject({ mediaType: "episode" });
+    });
+
+    it("does not pass mediaType filter when All tab is selected", () => {
+      renderPage();
+      const lastCall = mockListRecentQuery.mock.calls.at(-1);
+      expect(lastCall?.[0]).not.toHaveProperty("mediaType");
+    });
+  });
+
+  describe("pagination", () => {
+    it("shows pagination info", () => {
+      renderPage();
+      expect(screen.getByText("Showing 2 of 2")).toBeInTheDocument();
+    });
+
+    it("shows Next button when there are more pages", () => {
+      mockListRecentQuery.mockReturnValue({
+        data: {
+          data: Array.from({ length: 50 }, (_, i) => ({ ...movieEntry, id: i + 1 })),
+          pagination: { total: 100 },
+        },
+        isLoading: false,
+        error: null,
+      });
+      renderPage();
+      expect(screen.getByText("Next")).toBeInTheDocument();
+    });
+
+    it("hides Previous button on first page", () => {
+      renderPage();
+      expect(screen.queryByText("Previous")).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/app-media/src/pages/HistoryPage.tsx
+++ b/packages/app-media/src/pages/HistoryPage.tsx
@@ -1,12 +1,29 @@
 /**
- * HistoryPage — watch history with filter tabs and pagination.
+ * HistoryPage — watch history with filter tabs, pagination, and delete.
  *
  * Mobile: compact list. Desktop (md+): responsive poster card grid.
+ * Each entry has a delete action with confirmation dialog.
  */
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { Link, useNavigate } from "react-router";
-import { Alert, AlertTitle, AlertDescription, Badge, Button, Skeleton } from "@pops/ui";
-import { Film } from "lucide-react";
+import {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  Button,
+  Skeleton,
+} from "@pops/ui";
+import { Film, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
 import { formatEpisodeCode } from "../lib/format";
 
@@ -93,7 +110,15 @@ function getHistoryPoster(entry: HistoryEntry): string | null {
   return entry.posterUrl ?? null;
 }
 
-function HistoryItem({ entry }: { entry: HistoryEntry }) {
+function HistoryItem({
+  entry,
+  onDelete,
+  isDeleting,
+}: {
+  entry: HistoryEntry;
+  onDelete: (id: number) => void;
+  isDeleting: boolean;
+}) {
   const href = getHistoryHref(entry);
   const posterSrc = getHistoryPoster(entry);
   const isEpisode = entry.mediaType === "episode";
@@ -109,7 +134,7 @@ function HistoryItem({ entry }: { entry: HistoryEntry }) {
     : null;
 
   return (
-    <div className="flex gap-3 p-3 rounded-lg border">
+    <div className="group flex gap-3 p-3 rounded-lg border">
       <Link to={href} className="shrink-0">
         {posterSrc ? (
           <img
@@ -144,9 +169,20 @@ function HistoryItem({ entry }: { entry: HistoryEntry }) {
               </p>
             )}
           </div>
-          <Badge variant="secondary" className="text-xs shrink-0">
-            {isEpisode ? "Episode" : "Movie"}
-          </Badge>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <button
+              type="button"
+              aria-label="Delete watch event"
+              disabled={isDeleting}
+              onClick={() => onDelete(entry.id)}
+              className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive disabled:opacity-50"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+            <Badge variant="secondary" className="text-xs">
+              {isEpisode ? "Episode" : "Movie"}
+            </Badge>
+          </div>
         </div>
         <p className="text-xs text-muted-foreground mt-1">{formatWatchDate(entry.watchedAt)}</p>
       </div>
@@ -154,7 +190,15 @@ function HistoryItem({ entry }: { entry: HistoryEntry }) {
   );
 }
 
-function HistoryCard({ entry }: { entry: HistoryEntry }) {
+function HistoryCard({
+  entry,
+  onDelete,
+  isDeleting,
+}: {
+  entry: HistoryEntry;
+  onDelete: (id: number) => void;
+  isDeleting: boolean;
+}) {
   const navigate = useNavigate();
   const [imageError, setImageError] = useState(false);
   const href = getHistoryHref(entry);
@@ -194,6 +238,20 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
         <span className="absolute top-2 right-2 z-10 bg-black/60 text-white text-[10px] font-medium px-1.5 py-0.5 rounded">
           {formatShortDate(entry.watchedAt)}
         </span>
+
+        {/* Delete button — visible on hover */}
+        <button
+          type="button"
+          aria-label="Delete watch event"
+          disabled={isDeleting}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(entry.id);
+          }}
+          className="absolute bottom-2 right-2 z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity p-1.5 rounded-md bg-black/60 hover:bg-destructive text-white disabled:opacity-50"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
 
         {!posterSrc || imageError ? (
           <div className="flex h-full w-full items-center justify-center bg-muted text-muted-foreground">
@@ -236,6 +294,9 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
 export function HistoryPage() {
   const [filter, setFilter] = useState<MediaTypeFilter>("all");
   const [offset, setOffset] = useState(0);
+  const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
+
+  const utils = trpc.useUtils();
 
   const queryInput = {
     ...(filter !== "all" ? { mediaType: filter as "movie" | "episode" } : {}),
@@ -248,6 +309,33 @@ export function HistoryPage() {
   const entries = data?.data ?? [];
   const total = data?.pagination?.total ?? 0;
   const hasMore = offset + PAGE_SIZE < total;
+
+  const deleteMutation = trpc.media.watchHistory.delete.useMutation({
+    onSuccess: () => {
+      toast.success("Watch event removed");
+      void utils.media.watchHistory.listRecent.invalidate();
+      void utils.media.watchHistory.list.invalidate();
+      void utils.media.watchlist.list.invalidate();
+
+      // If we just deleted the last entry on this page, go to previous page
+      if (entries.length === 1 && offset > 0) {
+        setOffset(Math.max(0, offset - PAGE_SIZE));
+      }
+    },
+    onError: (err) => {
+      toast.error(`Failed to delete watch event: ${err.message}`);
+    },
+  });
+
+  const handleDeleteClick = useCallback((id: number) => {
+    setDeleteTarget(id);
+  }, []);
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (deleteTarget === null) return;
+    deleteMutation.mutate({ id: deleteTarget });
+    setDeleteTarget(null);
+  }, [deleteTarget, deleteMutation]);
 
   return (
     <div className="space-y-6">
@@ -297,14 +385,24 @@ export function HistoryPage() {
           {/* Mobile: compact list */}
           <div className="space-y-2 md:hidden">
             {entries.map((entry: HistoryEntry) => (
-              <HistoryItem key={entry.id} entry={entry} />
+              <HistoryItem
+                key={entry.id}
+                entry={entry}
+                onDelete={handleDeleteClick}
+                isDeleting={deleteMutation.isPending}
+              />
             ))}
           </div>
 
           {/* Desktop: poster card grid */}
           <div className="hidden md:grid grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
             {entries.map((entry: HistoryEntry) => (
-              <HistoryCard key={entry.id} entry={entry} />
+              <HistoryCard
+                key={entry.id}
+                entry={entry}
+                onDelete={handleDeleteClick}
+                isDeleting={deleteMutation.isPending}
+              />
             ))}
           </div>
 
@@ -332,6 +430,25 @@ export function HistoryPage() {
           </div>
         </>
       )}
+
+      {/* Delete confirmation dialog */}
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove watch event?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove this entry from your watch history. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDeleteConfirm}>Remove</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,6 +499,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14


### PR DESCRIPTION
## Summary
- Add hover-visible delete button (Trash2 icon) to watch history entries on both mobile (HistoryItem) and desktop (HistoryCard)
- Show AlertDialog confirmation before deletion: "Remove this watch event? This cannot be undone."
- Wire to existing `media.watchHistory.delete` mutation with cache invalidation (listRecent, list, watchlist)
- Error toast on failure, disable button during in-flight request
- Handle pagination edge case: when deleting the last entry on a page, navigate to previous page

Closes #748

## Test plan
- [x] Typecheck passes for app-media
- [x] Existing watch history service tests (47 tests) all pass
- [ ] Manual: hover over entry shows delete icon (desktop)
- [ ] Manual: click delete icon shows confirmation dialog
- [ ] Manual: confirming deletes entry and removes from list
- [ ] Manual: canceling keeps entry
- [ ] Manual: error state shows toast
- [ ] Manual: delete last entry on page 2 navigates to page 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)