### PR TITLE
feat: movie detail language names + watch history [PRD-033/US-01]

### DIFF
--- a/docs-v2/themes/03-media/prds/033-movie-detail-page/us-01-movie-hero-metadata.md
+++ b/docs-v2/themes/03-media/prds/033-movie-detail-page/us-01-movie-hero-metadata.md
@@ -1,7 +1,7 @@
 # US-01: Movie hero and metadata layout
 
 > PRD: [033 — Movie Detail Page](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -19,12 +19,12 @@ As a user, I want to see a movie's full details — backdrop, poster, title, yea
 - [x] Genres render as comma-separated text or badge pills
 - [x] Tagline renders in italic above the overview; hidden if empty or null
 - [x] Overview section displays the full synopsis text
-- [ ] Metadata grid displays: status, original language (full name, not ISO code), budget (formatted currency), revenue (formatted currency), TMDB rating (vote average + vote count) — language shows ISO code uppercased ("EN") not full name ("English")
+- [x] Metadata grid displays: status, original language (full name, not ISO code), budget (formatted currency), revenue (formatted currency), TMDB rating (vote average + vote count)
 - [x] Budget and revenue fields are hidden when their value is zero or null
-- [ ] Watch history section lists all watch dates chronologically; shows "Not watched yet" if empty — section missing entirely
+- [x] Watch history section lists all watch dates chronologically; shows "Not watched yet" if empty
 - [x] Page shows a loading state (skeleton) while data is fetching
 - [x] Page shows a 404 state or redirects to library when the movie ID does not exist
-- [ ] Tests cover: hero renders with backdrop, fallback gradient without backdrop, poster fallback chain, runtime formatting, hidden fields when null/zero, 404 handling, watch history list and empty state
+- [x] Tests cover: hero renders with backdrop, fallback gradient without backdrop, poster fallback chain, runtime formatting, hidden fields when null/zero, 404 handling, watch history list and empty state
 
 ## Notes
 

--- a/packages/app-media/package.json
+++ b/packages/app-media/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint src --ext .ts,.tsx --fix"
@@ -21,10 +23,14 @@
     "sonner": "^2.0.7"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "eslint": "^9.39.4",
+    "jsdom": "^29.0.1",
     "typescript": "^5.7.0",
-    "typescript-eslint": "^8.57.1"
+    "typescript-eslint": "^8.57.1",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/app-media/src/lib/format.test.ts
+++ b/packages/app-media/src/lib/format.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { formatRuntime, formatCurrency, formatLanguage } from "./format";
+
+describe("formatRuntime", () => {
+  it("formats hours and minutes", () => {
+    expect(formatRuntime(148)).toBe("2h 28m");
+  });
+
+  it("formats exactly one hour", () => {
+    expect(formatRuntime(60)).toBe("1h 0m");
+  });
+
+  it("formats minutes only when under an hour", () => {
+    expect(formatRuntime(45)).toBe("45m");
+  });
+
+  it("formats zero minutes", () => {
+    expect(formatRuntime(0)).toBe("0m");
+  });
+});
+
+describe("formatCurrency", () => {
+  it("formats large budgets", () => {
+    expect(formatCurrency(150000000)).toBe("$150,000,000");
+  });
+
+  it("formats zero", () => {
+    expect(formatCurrency(0)).toBe("$0");
+  });
+});
+
+describe("formatLanguage", () => {
+  it("maps en to English", () => {
+    expect(formatLanguage("en")).toBe("English");
+  });
+
+  it("maps ja to Japanese", () => {
+    expect(formatLanguage("ja")).toBe("Japanese");
+  });
+
+  it("maps fr to French", () => {
+    expect(formatLanguage("fr")).toBe("French");
+  });
+
+  it("maps ko to Korean", () => {
+    expect(formatLanguage("ko")).toBe("Korean");
+  });
+
+  it("maps zh to Chinese", () => {
+    expect(formatLanguage("zh")).toBe("Chinese");
+  });
+
+  it("is case-insensitive", () => {
+    expect(formatLanguage("EN")).toBe("English");
+    expect(formatLanguage("En")).toBe("English");
+  });
+
+  it("returns uppercased code for unknown languages", () => {
+    expect(formatLanguage("xx")).toBe("XX");
+  });
+});

--- a/packages/app-media/src/lib/format.ts
+++ b/packages/app-media/src/lib/format.ts
@@ -1,3 +1,37 @@
+/** Map ISO 639-1 language codes to full language names. */
+const LANGUAGE_NAMES: Record<string, string> = {
+  ab: "Abkhazian", af: "Afrikaans", am: "Amharic", ar: "Arabic",
+  az: "Azerbaijani", be: "Belarusian", bg: "Bulgarian", bn: "Bengali",
+  bs: "Bosnian", ca: "Catalan", cs: "Czech", cy: "Welsh",
+  da: "Danish", de: "German", el: "Greek", en: "English",
+  es: "Spanish", et: "Estonian", eu: "Basque", fa: "Persian",
+  fi: "Finnish", fr: "French", ga: "Irish", gl: "Galician",
+  gu: "Gujarati", he: "Hebrew", hi: "Hindi", hr: "Croatian",
+  hu: "Hungarian", hy: "Armenian", id: "Indonesian", is: "Icelandic",
+  it: "Italian", ja: "Japanese", ka: "Georgian", kk: "Kazakh",
+  km: "Khmer", kn: "Kannada", ko: "Korean", ku: "Kurdish",
+  ky: "Kyrgyz", la: "Latin", lb: "Luxembourgish", lo: "Lao",
+  lt: "Lithuanian", lv: "Latvian", mk: "Macedonian", ml: "Malayalam",
+  mn: "Mongolian", mr: "Marathi", ms: "Malay", mt: "Maltese",
+  my: "Burmese", nb: "Norwegian Bokmål", ne: "Nepali", nl: "Dutch",
+  no: "Norwegian", pa: "Punjabi", pl: "Polish", ps: "Pashto",
+  pt: "Portuguese", ro: "Romanian", ru: "Russian", si: "Sinhala",
+  sk: "Slovak", sl: "Slovenian", so: "Somali", sq: "Albanian",
+  sr: "Serbian", sv: "Swedish", sw: "Swahili", ta: "Tamil",
+  te: "Telugu", tg: "Tajik", th: "Thai", tl: "Tagalog",
+  tr: "Turkish", uk: "Ukrainian", ur: "Urdu", uz: "Uzbek",
+  vi: "Vietnamese", wo: "Wolof", zh: "Chinese", zu: "Zulu",
+  cn: "Cantonese",
+};
+
+/**
+ * Convert an ISO 639-1 language code to its full name.
+ * Returns the uppercased code if no mapping exists.
+ */
+export function formatLanguage(code: string): string {
+  return LANGUAGE_NAMES[code.toLowerCase()] ?? code.toUpperCase();
+}
+
 export function formatRuntime(minutes: number): string {
   const h = Math.floor(minutes / 60);
   const m = minutes % 60;

--- a/packages/app-media/src/pages/MovieDetailPage.test.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.test.tsx
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+// Mock trpc hooks
+const mockMovieQuery = vi.fn();
+const mockWatchHistoryQuery = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      movies: {
+        get: { useQuery: (...args: unknown[]) => mockMovieQuery(...args) },
+      },
+      watchHistory: {
+        list: { useQuery: (...args: unknown[]) => mockWatchHistoryQuery(...args) },
+      },
+    },
+  },
+}));
+
+// Mock sub-components that need their own tRPC context
+vi.mock("../components/WatchlistToggle", () => ({
+  WatchlistToggle: () => <button>Watchlist</button>,
+}));
+vi.mock("../components/MarkAsWatchedButton", () => ({
+  MarkAsWatchedButton: () => <button>Mark Watched</button>,
+}));
+vi.mock("../components/ComparisonScores", () => ({
+  ComparisonScores: () => <div data-testid="comparison-scores" />,
+}));
+vi.mock("../components/ArrStatusBadge", () => ({
+  ArrStatusBadge: () => <span>Arr Status</span>,
+}));
+
+import { MovieDetailPage } from "./MovieDetailPage";
+
+function renderAtRoute(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/media/movies/:id" element={<MovieDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+const baseMovie = {
+  id: 1,
+  tmdbId: 278,
+  imdbId: "tt0111161",
+  title: "The Shawshank Redemption",
+  originalTitle: "The Shawshank Redemption",
+  overview: "Framed in the 1940s for a double murder.",
+  tagline: "Fear can hold you prisoner. Hope can set you free.",
+  releaseDate: "1994-09-23",
+  runtime: 142,
+  status: "Released",
+  originalLanguage: "en",
+  budget: 25000000,
+  revenue: 58300000,
+  posterPath: "/poster.jpg",
+  posterUrl: "/media/images/movie/278/poster.jpg",
+  backdropPath: "/backdrop.jpg",
+  backdropUrl: "/media/images/movie/278/backdrop.jpg",
+  logoPath: null,
+  logoUrl: null,
+  posterOverridePath: null,
+  voteAverage: 8.7,
+  voteCount: 24000,
+  genres: ["Drama", "Crime"],
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+beforeEach(() => {
+  mockMovieQuery.mockReturnValue({
+    data: { data: baseMovie },
+    isLoading: false,
+    error: null,
+  });
+  mockWatchHistoryQuery.mockReturnValue({
+    data: { data: [] },
+  });
+});
+
+describe("MovieDetailPage", () => {
+  describe("hero with backdrop", () => {
+    it("renders backdrop image when backdropUrl is present", () => {
+      const { container } = renderAtRoute("/media/movies/1");
+      const backdrop = container.querySelector('img[src="/media/images/movie/278/backdrop.jpg"]');
+      expect(backdrop).toBeInTheDocument();
+    });
+
+    it("renders poster image", () => {
+      renderAtRoute("/media/movies/1");
+      expect(screen.getByAltText("The Shawshank Redemption poster")).toBeInTheDocument();
+    });
+
+    it("renders title in h1", () => {
+      renderAtRoute("/media/movies/1");
+      const heading = screen.getByRole("heading", { level: 1 });
+      expect(heading).toHaveTextContent("The Shawshank Redemption");
+    });
+
+    it("renders tagline", () => {
+      renderAtRoute("/media/movies/1");
+      expect(screen.getByText("Fear can hold you prisoner. Hope can set you free.")).toBeInTheDocument();
+    });
+
+    it("renders year and runtime in hero subtitle", () => {
+      renderAtRoute("/media/movies/1");
+      expect(screen.getByText("1994")).toBeInTheDocument();
+      // Runtime appears in both hero and metadata grid
+      expect(screen.getAllByText("2h 22m")).toHaveLength(2);
+    });
+  });
+
+  describe("fallback gradient without backdrop", () => {
+    it("does not render backdrop img when backdropUrl is null", () => {
+      mockMovieQuery.mockReturnValue({
+        data: { data: { ...baseMovie, backdropUrl: null, backdropPath: null } },
+        isLoading: false,
+        error: null,
+      });
+      renderAtRoute("/media/movies/1");
+      // Only poster img should exist, no backdrop
+      const imgs = screen.getAllByRole("img");
+      expect(imgs).toHaveLength(1); // just the poster
+      expect(imgs[0]).toHaveAttribute("alt", "The Shawshank Redemption poster");
+    });
+
+    it("still renders the gradient overlay div", () => {
+      mockMovieQuery.mockReturnValue({
+        data: { data: { ...baseMovie, backdropUrl: null } },
+        isLoading: false,
+        error: null,
+      });
+      const { container } = renderAtRoute("/media/movies/1");
+      const gradient = container.querySelector(".bg-gradient-to-t");
+      expect(gradient).toBeInTheDocument();
+    });
+  });
+
+  describe("poster fallback chain", () => {
+    it("renders poster when posterUrl is present", () => {
+      renderAtRoute("/media/movies/1");
+      const poster = screen.getByAltText("The Shawshank Redemption poster");
+      expect(poster).toHaveAttribute("src", "/media/images/movie/278/poster.jpg");
+    });
+
+    it("still renders poster img element when posterUrl is null (with empty string fallback)", () => {
+      mockMovieQuery.mockReturnValue({
+        data: { data: { ...baseMovie, posterUrl: null } },
+        isLoading: false,
+        error: null,
+      });
+      renderAtRoute("/media/movies/1");
+      const poster = screen.getByAltText("The Shawshank Redemption poster");
+      expect(poster).toBeInTheDocument();
+    });
+  });
+
+  describe("runtime formatting", () => {
+    it("formats runtime as Xh Ym", () => {
+      renderAtRoute("/media/movies/1");
+      // Runtime appears in both hero subtitle and metadata grid
+      expect(screen.getAllByText("2h 22m").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("hides runtime when null", () => {
+      mockMovieQuery.mockReturnValue({
+        data: { data: { ...baseMovie, runtime: null } },
+        isLoading: false,
+        error: null,
+      });
+      renderAtRoute("/media/movies/1");
+      expect(screen.queryByText(/\d+h \d+m/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("hidden fields when null/zero", () => {
+    it("hides budget when zero", () => {
+      mockMovieQuery.mockReturnValue({
+        data: { data: { ...baseMovie, budget: 0 } },
+        isLoading: false,
+        error: null,
+      });
+      renderAtRoute("/media/movies/1");
+      expect(screen.queryByText("Budget")).not.toBeInTheDocument();
+    });
+
+    it("hides revenue when null", () => {
+      mockMovieQuery.mockReturnValue({
+        data: { data: { ...baseMovie, revenue: null } },
+        isLoading: false,
+        error: null,
+      });
+      renderAtRoute("/media/movies/1");
+      expect(screen.queryByText("Revenue")).not.toBeInTheDocument();
+    });
+
+    it("hides tagline when null", () => {
+      mockMovieQuery.mockReturnValue({
+        data: { data: { ...baseMovie, tagline: null } },
+        isLoading: false,
+        error: null,
+      });
+      renderAtRoute("/media/movies/1");
+      expect(screen.queryByText("Fear can hold you prisoner")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("language display", () => {
+    it("shows full language name instead of ISO code", () => {
+      renderAtRoute("/media/movies/1");
+      expect(screen.getByText("English")).toBeInTheDocument();
+      expect(screen.queryByText("EN")).not.toBeInTheDocument();
+    });
+
+    it("shows Japanese for ja", () => {
+      mockMovieQuery.mockReturnValue({
+        data: { data: { ...baseMovie, originalLanguage: "ja" } },
+        isLoading: false,
+        error: null,
+      });
+      renderAtRoute("/media/movies/1");
+      expect(screen.getByText("Japanese")).toBeInTheDocument();
+    });
+  });
+
+  describe("404 handling", () => {
+    it("shows not found message for NOT_FOUND error", () => {
+      mockMovieQuery.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: { data: { code: "NOT_FOUND" }, message: "Not found" },
+      });
+      renderAtRoute("/media/movies/999");
+      expect(screen.getByText("Movie not found")).toBeInTheDocument();
+      expect(screen.getByText("This movie doesn't exist in your library.")).toBeInTheDocument();
+    });
+
+    it("shows generic error for other errors", () => {
+      mockMovieQuery.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: { data: { code: "INTERNAL_SERVER_ERROR" }, message: "Something broke" },
+      });
+      renderAtRoute("/media/movies/1");
+      expect(screen.getByText("Error")).toBeInTheDocument();
+      expect(screen.getByText("Something broke")).toBeInTheDocument();
+    });
+
+    it("shows back to library link on error", () => {
+      mockMovieQuery.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: { data: { code: "NOT_FOUND" }, message: "Not found" },
+      });
+      renderAtRoute("/media/movies/999");
+      expect(screen.getByText("Back to library")).toHaveAttribute("href", "/media");
+    });
+  });
+
+  describe("watch history", () => {
+    it("shows 'Not watched yet' when no watch history", () => {
+      mockWatchHistoryQuery.mockReturnValue({ data: { data: [] } });
+      renderAtRoute("/media/movies/1");
+      expect(screen.getByText("Not watched yet")).toBeInTheDocument();
+    });
+
+    it("shows watch dates chronologically", () => {
+      mockWatchHistoryQuery.mockReturnValue({
+        data: {
+          data: [
+            { id: 2, mediaType: "movie", mediaId: 1, watchedAt: "2026-03-15T00:00:00Z", completed: 1 },
+            { id: 1, mediaType: "movie", mediaId: 1, watchedAt: "2025-12-25T00:00:00Z", completed: 1 },
+          ],
+        },
+      });
+      const { container } = renderAtRoute("/media/movies/1");
+      // Get list items from the watch history ul specifically
+      const watchHistoryList = container.querySelector("ul");
+      expect(watchHistoryList).toBeInTheDocument();
+      const items = watchHistoryList!.querySelectorAll("li");
+      expect(items).toHaveLength(2);
+      // Should be chronological: Dec 2025 first, Mar 2026 second
+      expect(items[0]!.textContent).toContain("December");
+      expect(items[1]!.textContent).toContain("March");
+    });
+
+    it("renders Watch History heading", () => {
+      renderAtRoute("/media/movies/1");
+      expect(screen.getByText("Watch History")).toBeInTheDocument();
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows skeleton when loading", () => {
+      mockMovieQuery.mockReturnValue({
+        data: null,
+        isLoading: true,
+        error: null,
+      });
+      const { container } = renderAtRoute("/media/movies/1");
+      // Skeleton renders multiple placeholder elements
+      expect(container.querySelectorAll("[class*='animate-pulse'], [data-slot='skeleton']").length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -13,7 +13,7 @@ import {
   BreadcrumbPage,
 } from "@pops/ui";
 import { trpc } from "../lib/trpc";
-import { formatCurrency, formatRuntime } from "../lib/format";
+import { formatCurrency, formatLanguage, formatRuntime } from "../lib/format";
 import { WatchlistToggle } from "../components/WatchlistToggle";
 import { ComparisonScores } from "../components/ComparisonScores";
 import { MarkAsWatchedButton } from "../components/MarkAsWatchedButton";
@@ -51,6 +51,11 @@ export function MovieDetailPage() {
 
   const { data, isLoading, error } = trpc.media.movies.get.useQuery(
     { id: movieId },
+    { enabled: !Number.isNaN(movieId) }
+  );
+
+  const { data: watchHistoryData } = trpc.media.watchHistory.list.useQuery(
+    { mediaType: "movie", mediaId: movieId },
     { enabled: !Number.isNaN(movieId) }
   );
 
@@ -97,7 +102,7 @@ export function MovieDetailPage() {
 
   const metadataItems = [
     { label: "Status", value: movie.status },
-    { label: "Language", value: movie.originalLanguage?.toUpperCase() },
+    { label: "Language", value: movie.originalLanguage ? formatLanguage(movie.originalLanguage) : null },
     {
       label: "Budget",
       value: movie.budget ? formatCurrency(movie.budget) : null,
@@ -229,6 +234,28 @@ export function MovieDetailPage() {
             </dl>
           </section>
         )}
+
+        {/* Watch history */}
+        <section>
+          <h2 className="text-lg font-semibold mb-2">Watch History</h2>
+          {watchHistoryData?.data && watchHistoryData.data.length > 0 ? (
+            <ul className="space-y-2">
+              {[...watchHistoryData.data]
+                .sort((a, b) => new Date(a.watchedAt).getTime() - new Date(b.watchedAt).getTime())
+                .map((entry) => (
+                  <li key={entry.id} className="text-sm text-muted-foreground">
+                    {new Date(entry.watchedAt).toLocaleDateString("en-AU", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
+                  </li>
+                ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">Not watched yet</p>
+          )}
+        </section>
       </div>
     </div>
   );

--- a/packages/app-media/src/test-setup.ts
+++ b/packages/app-media/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/packages/app-media/vitest.config.ts
+++ b/packages/app-media/vitest.config.ts
@@ -1,0 +1,10 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test-setup.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,6 +484,12 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -493,12 +499,18 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1(@noble/hashes@1.8.0)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.57.1
         version: 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
 
   packages/db-types:
     dependencies:


### PR DESCRIPTION
## Summary
- Maps ISO 639-1 language codes to full names in metadata grid (e.g., "en" → "English" instead of "EN")
- Adds watch history section showing chronological watch dates, with "Not watched yet" empty state
- Sets up vitest + @testing-library/react test infrastructure in app-media package
- 36 tests covering format utils and MovieDetailPage component

## Test plan
- [x] 36 tests pass (13 format utils + 23 MovieDetailPage component)
- [x] Typecheck clean
- [ ] Visual check: language shows as "English" not "EN" in metadata grid
- [ ] Visual check: watch history section renders below metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)