### PR TITLE
feat: inventory filters, search, and empty state [tb-498]

### DIFF
--- a/apps/pops-api/src/modules/inventory/items/inventory.test.ts
+++ b/apps/pops-api/src/modules/inventory/items/inventory.test.ts
@@ -438,3 +438,61 @@ describe("inventory.delete", () => {
     });
   });
 });
+
+describe("inventory.searchByAssetId", () => {
+  it("returns item when exact asset ID matches", async () => {
+    seedInventoryItem(db, { item_name: "MacBook Pro", asset_id: "ASSET-001" });
+    seedInventoryItem(db, { item_name: "Desk", asset_id: "ASSET-002" });
+
+    const result = await caller.inventory.items.searchByAssetId({ assetId: "ASSET-001" });
+    expect(result.data).not.toBeNull();
+    expect(result.data!.itemName).toBe("MacBook Pro");
+    expect(result.data!.assetId).toBe("ASSET-001");
+  });
+
+  it("returns null when no asset ID matches", async () => {
+    seedInventoryItem(db, { item_name: "MacBook Pro", asset_id: "ASSET-001" });
+
+    const result = await caller.inventory.items.searchByAssetId({ assetId: "NONEXISTENT" });
+    expect(result.data).toBeNull();
+  });
+
+  it("matches case-insensitively", async () => {
+    seedInventoryItem(db, { item_name: "MacBook Pro", asset_id: "HDMI-01" });
+
+    const result = await caller.inventory.items.searchByAssetId({ assetId: "hdmi-01" });
+    expect(result.data).not.toBeNull();
+    expect(result.data!.itemName).toBe("MacBook Pro");
+  });
+
+  it("rejects empty asset ID", async () => {
+    await expect(caller.inventory.items.searchByAssetId({ assetId: "" })).rejects.toThrow(
+      TRPCError
+    );
+  });
+});
+
+describe("inventory.distinctTypes", () => {
+  it("returns empty array when no items exist", async () => {
+    const result = await caller.inventory.items.distinctTypes();
+    expect(result.data).toEqual([]);
+  });
+
+  it("returns distinct types sorted alphabetically", async () => {
+    seedInventoryItem(db, { item_name: "MacBook", type: "Electronics" });
+    seedInventoryItem(db, { item_name: "iPhone", type: "Electronics" });
+    seedInventoryItem(db, { item_name: "Desk", type: "Furniture" });
+    seedInventoryItem(db, { item_name: "Jacket", type: "Clothing" });
+
+    const result = await caller.inventory.items.distinctTypes();
+    expect(result.data).toEqual(["Clothing", "Electronics", "Furniture"]);
+  });
+
+  it("excludes items with null type", async () => {
+    seedInventoryItem(db, { item_name: "MacBook", type: "Electronics" });
+    seedInventoryItem(db, { item_name: "Mystery Item", type: null });
+
+    const result = await caller.inventory.items.distinctTypes();
+    expect(result.data).toEqual(["Electronics"]);
+  });
+});

--- a/apps/pops-api/src/modules/inventory/items/router.ts
+++ b/apps/pops-api/src/modules/inventory/items/router.ts
@@ -49,6 +49,19 @@ export const inventoryRouter = router({
     };
   }),
 
+  /** Search for an item by exact asset ID (case-insensitive). Returns null if not found. */
+  searchByAssetId: protectedProcedure
+    .input(z.object({ assetId: z.string().min(1) }))
+    .query(({ input }) => {
+      const row = service.searchByAssetId(input.assetId);
+      return { data: row ? toInventoryItem(row) : null };
+    }),
+
+  /** Return distinct item types from the database. */
+  distinctTypes: protectedProcedure.query(() => {
+    return { data: service.getDistinctTypes() };
+  }),
+
   /** Get a single inventory item by ID. */
   get: protectedProcedure.input(z.object({ id: z.string() })).query(({ input }) => {
     try {
@@ -92,14 +105,6 @@ export const inventoryRouter = router({
         }
         throw err;
       }
-    }),
-
-  /** Search for an item by asset ID (case-insensitive exact match). */
-  searchByAssetId: protectedProcedure
-    .input(z.object({ assetId: z.string().min(1) }))
-    .query(({ input }) => {
-      const row = service.searchByAssetId(input.assetId);
-      return { data: row ? toInventoryItem(row) : null };
     }),
 
   /** Delete an inventory item. */

--- a/apps/pops-api/src/modules/inventory/items/service.ts
+++ b/apps/pops-api/src/modules/inventory/items/service.ts
@@ -3,7 +3,7 @@
  * SQLite is the source of truth. All operations are local.
  */
 import crypto from "crypto";
-import { eq, like, count, and, sum, inArray, sql } from "drizzle-orm";
+import { eq, like, count, and, sum, inArray, sql, isNotNull } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
 import { homeInventory } from "@pops/db-types";
 import { NotFoundError } from "../../../shared/errors.js";
@@ -93,6 +93,32 @@ export function listInventoryItems(
     totalReplacementValue: Number(sumResult?.replacementSum) || 0,
     totalResaleValue: Number(sumResult?.resaleSum) || 0,
   };
+}
+
+/**
+ * Search for an inventory item by exact asset ID (case-insensitive).
+ * Returns the item or null if not found.
+ */
+export function searchByAssetId(assetId: string): InventoryRow | null {
+  const db = getDrizzle();
+  const [row] = db
+    .select()
+    .from(homeInventory)
+    .where(sql`LOWER(${homeInventory.assetId}) = LOWER(${assetId})`)
+    .all();
+  return row ?? null;
+}
+
+/** Return distinct item types that exist in the database. */
+export function getDistinctTypes(): string[] {
+  const db = getDrizzle();
+  const rows = db
+    .selectDistinct({ type: homeInventory.type })
+    .from(homeInventory)
+    .where(isNotNull(homeInventory.type))
+    .orderBy(homeInventory.type)
+    .all();
+  return rows.map((r) => r.type).filter((t): t is string => t !== null);
 }
 
 /** Get a single inventory item by id. Throws NotFoundError if missing. */
@@ -256,18 +282,4 @@ export function deleteInventoryItem(id: string): void {
   const db = getDrizzle();
   const result = db.delete(homeInventory).where(eq(homeInventory.id, id)).run();
   if (result.changes === 0) throw new NotFoundError("Inventory item", id);
-}
-
-/**
- * Search for an inventory item by asset ID (case-insensitive exact match).
- * Returns the item or null if not found.
- */
-export function searchByAssetId(assetId: string): InventoryRow | null {
-  const db = getDrizzle();
-  const row = db
-    .select()
-    .from(homeInventory)
-    .where(sql`LOWER(${homeInventory.assetId}) = LOWER(${assetId})`)
-    .get();
-  return row ?? null;
 }

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -2,9 +2,18 @@
  * ItemsPage — inventory item list with search, filters, table/grid toggle,
  * and summary statistics. PRD-019/US-2.
  */
-import { useState, useMemo } from "react";
-import { useNavigate } from "react-router";
-import { Package, LayoutGrid, LayoutList, Search, DollarSign, Shield, Clock } from "lucide-react";
+import { useState, useMemo, useCallback } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import {
+  Package,
+  LayoutGrid,
+  LayoutList,
+  Search,
+  DollarSign,
+  Shield,
+  Clock,
+  Plus,
+} from "lucide-react";
 import {
   Skeleton,
   Select,
@@ -40,17 +49,6 @@ function getInitialView(): ViewMode {
   }
   return "table";
 }
-
-const TYPE_OPTIONS: SelectOption[] = [
-  { value: "", label: "All Types" },
-  { value: "Electronics", label: "Electronics" },
-  { value: "Furniture", label: "Furniture" },
-  { value: "Appliance", label: "Appliance" },
-  { value: "Clothing", label: "Clothing" },
-  { value: "Tools", label: "Tools" },
-  { value: "Sports", label: "Sports" },
-  { value: "Other", label: "Other" },
-];
 
 const CONDITION_OPTIONS: SelectOption[] = [
   { value: "", label: "All Conditions" },
@@ -216,11 +214,89 @@ function ItemsPageSkeleton() {
 
 export function ItemsPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [viewMode, setViewMode] = useState<ViewMode>(getInitialView);
-  const [search, setSearch] = useState("");
-  const [typeFilter, setTypeFilter] = useState("");
-  const [conditionFilter, setConditionFilter] = useState("");
-  const [inUseFilter, setInUseFilter] = useState("");
+
+  const search = searchParams.get("q") ?? "";
+  const typeFilter = searchParams.get("type") ?? "";
+  const conditionFilter = searchParams.get("condition") ?? "";
+  const inUseFilter = searchParams.get("inUse") ?? "";
+  const locationFilter = searchParams.get("locationId") ?? "";
+
+  const setParam = useCallback(
+    (key: string, value: string) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        if (value) {
+          next.set(key, value);
+        } else {
+          next.delete(key);
+        }
+        return next;
+      });
+    },
+    [setSearchParams]
+  );
+
+  const clearFilters = useCallback(() => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete("type");
+      next.delete("condition");
+      next.delete("inUse");
+      next.delete("locationId");
+      return next;
+    });
+  }, [setSearchParams]);
+
+  /** Dynamic type options from the database. */
+  const { data: typesData } = trpc.inventory.items.distinctTypes.useQuery();
+  const typeOptions = useMemo<SelectOption[]>(() => {
+    const opts: SelectOption[] = [{ value: "", label: "All Types" }];
+    for (const t of typesData?.data ?? []) {
+      opts.push({ value: t, label: t });
+    }
+    return opts;
+  }, [typesData]);
+
+  /** Location options from the tree endpoint — indented to show hierarchy. */
+  const { data: locationsData } = trpc.inventory.locations.tree.useQuery();
+  const locationOptions = useMemo<SelectOption[]>(() => {
+    const opts: SelectOption[] = [{ value: "", label: "All Locations" }];
+    function flatten(
+      nodes: Array<{ id: string; name: string; children: Array<unknown> }>,
+      depth: number
+    ) {
+      for (const node of nodes) {
+        const indent = depth > 0 ? "\u00A0\u00A0".repeat(depth) + "└ " : "";
+        opts.push({ value: node.id, label: `${indent}${node.name}` });
+        flatten(node.children as typeof nodes, depth + 1);
+      }
+    }
+    flatten(locationsData?.data ?? [], 0);
+    return opts;
+  }, [locationsData]);
+
+  /** Asset ID exact-match search on Enter key. */
+  const utils = trpc.useUtils();
+  const [assetIdSearching, setAssetIdSearching] = useState(false);
+  const handleSearchKeyDown = useCallback(
+    async (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== "Enter" || !search.trim()) return;
+      setAssetIdSearching(true);
+      try {
+        const result = await utils.inventory.items.searchByAssetId.fetch({
+          assetId: search.trim(),
+        });
+        if (result.data) {
+          navigate(`/inventory/items/${result.data.id}`);
+        }
+      } finally {
+        setAssetIdSearching(false);
+      }
+    },
+    [search, utils, navigate]
+  );
 
   const queryInput = useMemo(
     () => ({
@@ -228,9 +304,10 @@ export function ItemsPage() {
       type: typeFilter || undefined,
       condition: conditionFilter || undefined,
       inUse: (inUseFilter || undefined) as "true" | "false" | undefined,
+      locationId: locationFilter || undefined,
       limit: 200,
     }),
-    [search, typeFilter, conditionFilter, inUseFilter]
+    [search, typeFilter, conditionFilter, inUseFilter, locationFilter]
   );
 
   const { data, isLoading } = trpc.inventory.items.list.useQuery(queryInput);
@@ -242,7 +319,7 @@ export function ItemsPage() {
 
   const handleViewChange = (mode: ViewMode) => setViewMode(mode);
 
-  const hasActiveFilters = !!(typeFilter || conditionFilter || inUseFilter);
+  const hasActiveFilters = !!(typeFilter || conditionFilter || inUseFilter || locationFilter);
 
   return (
     <div className="space-y-6">
@@ -259,42 +336,42 @@ export function ItemsPage() {
           placeholder="Search items or asset IDs..."
           prefix={<Search className="h-4 w-4" />}
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => setParam("q", e.target.value)}
+          onKeyDown={handleSearchKeyDown}
           clearable
-          onClear={() => setSearch("")}
+          onClear={() => setParam("q", "")}
           className="w-full sm:max-w-xs"
         />
         <Select
           value={typeFilter}
-          onChange={(e) => setTypeFilter(e.target.value)}
-          options={TYPE_OPTIONS}
+          onChange={(e) => setParam("type", e.target.value)}
+          options={typeOptions}
           placeholder="All Types"
           className="w-36"
         />
         <Select
           value={conditionFilter}
-          onChange={(e) => setConditionFilter(e.target.value)}
+          onChange={(e) => setParam("condition", e.target.value)}
           options={CONDITION_OPTIONS}
           placeholder="All Conditions"
           className="w-40"
         />
         <Select
           value={inUseFilter}
-          onChange={(e) => setInUseFilter(e.target.value)}
+          onChange={(e) => setParam("inUse", e.target.value)}
           options={IN_USE_OPTIONS}
           placeholder="All"
           className="w-28"
         />
+        <Select
+          value={locationFilter}
+          onChange={(e) => setParam("locationId", e.target.value)}
+          options={locationOptions}
+          placeholder="All Locations"
+          className="w-40"
+        />
         {hasActiveFilters && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              setTypeFilter("");
-              setConditionFilter("");
-              setInUseFilter("");
-            }}
-          >
+          <Button variant="ghost" size="sm" onClick={clearFilters}>
             Clear filters
           </Button>
         )}
@@ -329,11 +406,19 @@ export function ItemsPage() {
       ) : items.length === 0 ? (
         <div className="flex flex-col items-center justify-center h-64 text-muted-foreground gap-4">
           <Package className="h-12 w-12 opacity-40" />
-          <p>
-            {search || hasActiveFilters
-              ? "No items match your filters."
-              : "No inventory items yet."}
-          </p>
+          {search || hasActiveFilters ? (
+            <p>No items match your filters.</p>
+          ) : (
+            <>
+              <p>No inventory items yet.</p>
+              <Button
+                prefix={<Plus className="h-4 w-4" />}
+                onClick={() => navigate("/inventory/items/new")}
+              >
+                Add your first item
+              </Button>
+            </>
+          )}
         </div>
       ) : viewMode === "table" ? (
         <InventoryTable items={items} />


### PR DESCRIPTION
## Summary
- Add search bar with asset ID exact-match on Enter key, type/condition/in-use/location filter dropdowns, and "Clear filters" button
- Location dropdown uses tree endpoint with indented hierarchy display
- Dynamic type options fetched from `distinctTypes` endpoint
- Empty state with contextual message and "Add first item" CTA
- Summary pill showing item count + replacement/resale totals
- Dashboard widgets hidden when filters are active

Replaces #837 (rebased onto main to resolve merge conflicts).

## Test plan
- [x] 41 inventory tests pass (searchByAssetId, distinctTypes, CRUD, filters)
- [x] API typecheck passes
- [x] Prettier formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)