### PR TITLE
fix: resolve WatchlistPage.test.tsx typecheck errors on main

### DIFF
--- a/packages/app-media/src/pages/WatchlistPage.test.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.test.tsx
@@ -10,6 +10,7 @@ const mockRemoveMutate = vi.fn();
 const mockReorderMutate = vi.fn();
 const mockUpdateMutate = vi.fn();
 const mockInvalidate = vi.fn();
+const capturedOpts: Record<string, Record<string, unknown>> = {};
 
 vi.mock("../lib/trpc", () => ({
   trpc: {
@@ -18,19 +19,19 @@ vi.mock("../lib/trpc", () => ({
         list: { useQuery: (...args: unknown[]) => mockWatchlistQuery(...args) },
         remove: {
           useMutation: (opts: Record<string, unknown>) => {
-            mockRemoveMutate._opts = opts;
+            capturedOpts.remove = opts;
             return { mutate: mockRemoveMutate, isPending: false };
           },
         },
         reorder: {
           useMutation: (opts: Record<string, unknown>) => {
-            mockReorderMutate._opts = opts;
+            capturedOpts.reorder = opts;
             return { mutate: mockReorderMutate, isPending: false };
           },
         },
         update: {
           useMutation: (opts: Record<string, unknown>) => {
-            mockUpdateMutate._opts = opts;
+            capturedOpts.update = opts;
             return { mutate: mockUpdateMutate, isPending: false, variables: null };
           },
         },


### PR DESCRIPTION
## Summary
- Fixes `TS2339: Property '_opts' does not exist on type 'Mock<Procedure>'` errors in `WatchlistPage.test.tsx`
- Stores mutation opts in a typed `capturedOpts` record instead of dynamically attaching `_opts` to `vi.fn()` mocks
- This was a merge interaction issue — individual PRs passed CI but combined merges created the type conflict

## Test plan
- [x] `pnpm typecheck` passes (all 10 packages)
- [x] `pnpm --filter @pops/app-media lint` passes
- [x] WatchlistPage tests pass (RankingsPage failures are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)