### PR TITLE
feat: trending day/week toggle + Load More pagination [tb-532]

### DIFF
--- a/packages/app-media/src/pages/DiscoverPage.test.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+const mockTrendingQuery = vi.fn();
+const mockRecommendationsQuery = vi.fn();
+const mockAddMovieMutateAsync = vi.fn();
+const mockAddWatchlistMutateAsync = vi.fn();
+const mockTrendingRefetch = vi.fn();
+const mockRecommendationsRefetch = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      discovery: {
+        trending: {
+          useQuery: (...args: unknown[]) => {
+            const result = mockTrendingQuery(...args);
+            return { ...result, refetch: mockTrendingRefetch, isFetching: false };
+          },
+        },
+        recommendations: {
+          useQuery: (...args: unknown[]) => {
+            const result = mockRecommendationsQuery(...args);
+            return { ...result, refetch: mockRecommendationsRefetch };
+          },
+        },
+      },
+      library: {
+        addMovie: {
+          useMutation: () => ({ mutateAsync: mockAddMovieMutateAsync }),
+        },
+      },
+      watchlist: {
+        add: {
+          useMutation: () => ({ mutateAsync: mockAddWatchlistMutateAsync }),
+        },
+        list: { invalidate: vi.fn() },
+      },
+    },
+    useUtils: () => ({
+      media: {
+        discovery: {
+          trending: { invalidate: vi.fn() },
+          recommendations: { invalidate: vi.fn() },
+        },
+        watchlist: { list: { invalidate: vi.fn() } },
+      },
+    }),
+  },
+}));
+
+vi.mock("../components/HorizontalScrollRow", () => ({
+  HorizontalScrollRow: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <section>
+      <h2>{title}</h2>
+      <div>{children}</div>
+    </section>
+  ),
+}));
+
+vi.mock("../components/DiscoverCard", () => ({
+  DiscoverCard: ({
+    title,
+    inLibrary,
+    onAddToLibrary,
+    tmdbId,
+  }: {
+    title: string;
+    inLibrary: boolean;
+    onAddToLibrary?: (id: number) => void;
+    tmdbId: number;
+  }) => (
+    <div data-testid={`card-${tmdbId}`}>
+      <span>{title}</span>
+      {inLibrary && <span>Owned</span>}
+      {!inLibrary && onAddToLibrary && (
+        <button onClick={() => onAddToLibrary(tmdbId)}>Add to Library</button>
+      )}
+    </div>
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+import { DiscoverPage } from "./DiscoverPage";
+
+const trendingMovies = [
+  { tmdbId: 100, title: "Dune", releaseDate: "2024-03-01", posterPath: null, posterUrl: null, voteAverage: 8.1, inLibrary: false },
+  { tmdbId: 200, title: "Oppenheimer", releaseDate: "2023-07-21", posterPath: null, posterUrl: null, voteAverage: 8.5, inLibrary: true },
+  { tmdbId: 300, title: "Barbie", releaseDate: "2023-07-21", posterPath: null, posterUrl: null, voteAverage: 7.0, inLibrary: false },
+];
+
+const emptyRecommendations = {
+  data: { results: [], sourceMovies: [] },
+  isLoading: false,
+  error: null,
+};
+
+function setupDefaults() {
+  mockTrendingQuery.mockReturnValue({
+    data: { results: trendingMovies, totalResults: 3, page: 1 },
+    isLoading: false,
+    error: null,
+  });
+  mockRecommendationsQuery.mockReturnValue(emptyRecommendations);
+}
+
+function renderPage(initialEntry = "/media/discover") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <DiscoverPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("DiscoverPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders trending movies in grid", () => {
+    setupDefaults();
+    renderPage();
+
+    expect(screen.getByText("Dune")).toBeTruthy();
+    expect(screen.getByText("Oppenheimer")).toBeTruthy();
+    expect(screen.getByText("Barbie")).toBeTruthy();
+  });
+
+  it("day/week toggle switches query timeWindow", () => {
+    setupDefaults();
+    renderPage();
+
+    // Default is "week"
+    expect(mockTrendingQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ timeWindow: "week" }),
+      expect.anything(),
+    );
+
+    fireEvent.click(screen.getByText("Today"));
+
+    expect(mockTrendingQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ timeWindow: "day" }),
+      expect.anything(),
+    );
+  });
+
+  it("active toggle button is highlighted", () => {
+    setupDefaults();
+    renderPage();
+
+    const weekBtn = screen.getByText("This Week");
+    const todayBtn = screen.getByText("Today");
+
+    // Week is default — should have primary styles
+    expect(weekBtn.className).toContain("bg-primary");
+    expect(todayBtn.className).toContain("bg-muted");
+
+    fireEvent.click(todayBtn);
+
+    expect(todayBtn.className).toContain("bg-primary");
+    expect(weekBtn.className).toContain("bg-muted");
+  });
+
+  it("calls add to library mutation with tmdbId", () => {
+    setupDefaults();
+    mockAddMovieMutateAsync.mockResolvedValue({
+      created: true,
+      data: { id: 1, title: "Dune" },
+    });
+    renderPage();
+
+    fireEvent.click(screen.getAllByText("Add to Library")[0]!);
+
+    expect(mockAddMovieMutateAsync).toHaveBeenCalledWith({ tmdbId: 100 });
+  });
+
+  it("shows Owned badge for movies already in library", () => {
+    setupDefaults();
+    renderPage();
+
+    // Oppenheimer (tmdbId 200) is inLibrary
+    const card = screen.getByTestId("card-200");
+    expect(card.textContent).toContain("Owned");
+  });
+
+  it("shows error state with retry button", () => {
+    mockTrendingQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: { message: "TMDB API error" },
+    });
+    mockRecommendationsQuery.mockReturnValue(emptyRecommendations);
+    renderPage();
+
+    expect(screen.getByText("TMDB API error")).toBeTruthy();
+    fireEvent.click(screen.getByText("Retry"));
+    expect(mockTrendingRefetch).toHaveBeenCalled();
+  });
+
+  it("shows Load More button when more results available", () => {
+    mockTrendingQuery.mockReturnValue({
+      data: { results: trendingMovies, totalResults: 60, page: 1 },
+      isLoading: false,
+      error: null,
+    });
+    mockRecommendationsQuery.mockReturnValue(emptyRecommendations);
+    renderPage();
+
+    expect(screen.getByText("Load More")).toBeTruthy();
+  });
+
+  it("reads time window from URL query param", () => {
+    setupDefaults();
+    renderPage("/media/discover?window=day");
+
+    expect(mockTrendingQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ timeWindow: "day" }),
+      expect.anything(),
+    );
+  });
+});

--- a/packages/app-media/src/pages/DiscoverPage.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.tsx
@@ -2,9 +2,10 @@
  * DiscoverPage — personalized movie discovery with trending and recommendations.
  * Three horizontal scroll sections: Recommended for You, Trending, Similar to Top Rated.
  */
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
+import { useSearchParams } from "react-router";
 import { Alert, Button } from "@pops/ui";
-import { Compass, AlertCircle, RefreshCw } from "lucide-react";
+import { Compass, AlertCircle, RefreshCw, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
 import { HorizontalScrollRow } from "../components/HorizontalScrollRow";
@@ -12,12 +13,63 @@ import { DiscoverCard } from "../components/DiscoverCard";
 
 export function DiscoverPage() {
   const utils = trpc.useUtils();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Trending time window from URL (default "week")
+  const timeWindow = (searchParams.get("window") === "day" ? "day" : "week") as "day" | "week";
+
+  // Trending pagination — accumulate results across pages
+  const [trendingPage, setTrendingPage] = useState(1);
+  const [accumulatedResults, setAccumulatedResults] = useState<
+    Array<{
+      tmdbId: number;
+      title: string;
+      releaseDate: string | null;
+      posterPath: string | null;
+      posterUrl: string | null;
+      voteAverage: number | null;
+      inLibrary: boolean;
+    }>
+  >([]);
 
   // Queries
   const trending = trpc.media.discovery.trending.useQuery(
-    { timeWindow: "week", page: 1 },
+    { timeWindow, page: trendingPage },
     { staleTime: 5 * 60 * 1000 }
   );
+
+  // Accumulate trending results when new data arrives
+  useEffect(() => {
+    if (trending.data?.results) {
+      if (trendingPage === 1) {
+        setAccumulatedResults(trending.data.results);
+      } else {
+        setAccumulatedResults((prev) => [...prev, ...trending.data!.results]);
+      }
+    }
+  }, [trending.data, trendingPage]);
+
+  // Reset pagination when time window changes
+  const setTimeWindow = useCallback(
+    (window: "day" | "week") => {
+      setTrendingPage(1);
+      setAccumulatedResults([]);
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        if (window === "week") {
+          next.delete("window");
+        } else {
+          next.set("window", window);
+        }
+        return next;
+      }, { replace: true });
+    },
+    [setSearchParams]
+  );
+
+  const hasMoreTrending = trending.data
+    ? accumulatedResults.length < trending.data.totalResults
+    : false;
 
   const recommendations = trpc.media.discovery.recommendations.useQuery(
     { sampleSize: 3 },
@@ -170,26 +222,45 @@ export function DiscoverPage() {
       </HorizontalScrollRow>
 
       {/* Trending */}
-      <HorizontalScrollRow title="Trending This Week" isLoading={trending.isLoading}>
-        {trending.error && (
-          <Alert variant="destructive" className="flex items-center gap-3">
-            <AlertCircle className="h-4 w-4 shrink-0" />
-            <p className="flex-1 text-sm">{trending.error.message}</p>
-            <Button variant="outline" size="sm" onClick={() => trending.refetch()}>
-              <RefreshCw className="mr-1 h-3 w-3" /> Retry
-            </Button>
-          </Alert>
-        )}
-        {trending.data?.results.map(
-          (item: {
-            tmdbId: number;
-            title: string;
-            releaseDate: string | null;
-            posterPath: string | null;
-            posterUrl: string | null;
-            voteAverage: number | null;
-            inLibrary: boolean;
-          }) => (
+      <div className="space-y-3">
+        {/* Time window toggle */}
+        <div className="flex items-center gap-2 px-1">
+          <button
+            onClick={() => setTimeWindow("day")}
+            className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+              timeWindow === "day"
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground hover:bg-muted/80"
+            }`}
+          >
+            Today
+          </button>
+          <button
+            onClick={() => setTimeWindow("week")}
+            className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+              timeWindow === "week"
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground hover:bg-muted/80"
+            }`}
+          >
+            This Week
+          </button>
+        </div>
+
+        <HorizontalScrollRow
+          title={timeWindow === "day" ? "Trending Today" : "Trending This Week"}
+          isLoading={trending.isLoading && trendingPage === 1}
+        >
+          {trending.error && (
+            <Alert variant="destructive" className="flex items-center gap-3">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <p className="flex-1 text-sm">{trending.error.message}</p>
+              <Button variant="outline" size="sm" onClick={() => trending.refetch()}>
+                <RefreshCw className="mr-1 h-3 w-3" /> Retry
+              </Button>
+            </Alert>
+          )}
+          {accumulatedResults.map((item) => (
             <DiscoverCard
               key={item.tmdbId}
               tmdbId={item.tmdbId}
@@ -204,9 +275,29 @@ export function DiscoverPage() {
               onAddToLibrary={handleAddToLibrary}
               onAddToWatchlist={handleAddToWatchlist}
             />
-          )
+          ))}
+        </HorizontalScrollRow>
+
+        {/* Load More */}
+        {hasMoreTrending && (
+          <div className="flex justify-center">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setTrendingPage((p) => p + 1)}
+              disabled={trending.isFetching}
+            >
+              {trending.isFetching ? (
+                <>
+                  <Loader2 className="mr-1 h-3 w-3 animate-spin" /> Loading…
+                </>
+              ) : (
+                "Load More"
+              )}
+            </Button>
+          </div>
         )}
-      </HorizontalScrollRow>
+      </div>
 
       {/* Similar to Your Top Rated */}
       <HorizontalScrollRow


### PR DESCRIPTION
## Summary
- Add "Today" / "This Week" toggle buttons to the trending section with active highlight styling
- Persist time window selection in `?window=day` URL query param (default: week)
- Add "Load More" button for paginated trending results with accumulated display
- Add 8 tests covering toggle, pagination, error retry, library actions, and URL reading

## Test plan
- [x] 8 unit tests pass for DiscoverPage
- [x] All 182 app-media tests pass
- [x] ESLint clean
- [ ] CI green

Closes GH#769
PRD: [038 — Discovery & Recommendations](docs-v2/themes/03-media/prds/038-discovery-recommendations/README.md) US-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)