### PR TITLE
feat: configurable quick pick with poster grid [tb-530]

### DIFF
--- a/packages/app-media/src/pages/QuickPickPage.test.tsx
+++ b/packages/app-media/src/pages/QuickPickPage.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+const mockQuickPickQuery = vi.fn();
+const mockRefetch = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      library: {
+        quickPick: {
+          useQuery: (...args: unknown[]) => {
+            const result = mockQuickPickQuery(...args);
+            return { ...result, refetch: mockRefetch };
+          },
+        },
+      },
+    },
+    useUtils: () => ({}),
+  },
+}));
+
+vi.mock("../components/MediaCard", () => ({
+  MediaCard: ({ title, id }: { title: string; id: number }) => (
+    <div data-testid={`media-card-${id}`}>{title}</div>
+  ),
+}));
+
+import { QuickPickPage } from "./QuickPickPage";
+
+const makeMovie = (id: number, title: string) => ({
+  id,
+  title,
+  releaseDate: "2024-01-01",
+  posterUrl: `/poster-${id}.jpg`,
+  runtime: 120,
+  voteAverage: 7.5,
+  genres: ["Action"],
+  overview: `Overview for ${title}`,
+});
+
+function renderPage(route = "/media/quick-pick") {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <QuickPickPage />
+    </MemoryRouter>
+  );
+}
+
+describe("QuickPickPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("displays the correct number of movies (default 3)", () => {
+    mockQuickPickQuery.mockReturnValue({
+      data: {
+        data: [makeMovie(1, "Movie A"), makeMovie(2, "Movie B"), makeMovie(3, "Movie C")],
+      },
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId("media-card-1")).toBeInTheDocument();
+    expect(screen.getByTestId("media-card-2")).toBeInTheDocument();
+    expect(screen.getByTestId("media-card-3")).toBeInTheDocument();
+  });
+
+  it("passes count from ?count= query param to the query", () => {
+    mockQuickPickQuery.mockReturnValue({
+      data: { data: [makeMovie(1, "A"), makeMovie(2, "B")] },
+      isLoading: false,
+    });
+
+    renderPage("/media/quick-pick?count=2");
+
+    expect(mockQuickPickQuery).toHaveBeenCalledWith(
+      { count: 2 },
+      expect.anything()
+    );
+  });
+
+  it("defaults invalid count param to 3", () => {
+    mockQuickPickQuery.mockReturnValue({
+      data: { data: [makeMovie(1, "A"), makeMovie(2, "B"), makeMovie(3, "C")] },
+      isLoading: false,
+    });
+
+    renderPage("/media/quick-pick?count=99");
+
+    expect(mockQuickPickQuery).toHaveBeenCalledWith(
+      { count: 3 },
+      expect.anything()
+    );
+  });
+
+  it("renders count selector with 2, 3, 4, 5 options", () => {
+    mockQuickPickQuery.mockReturnValue({
+      data: { data: [makeMovie(1, "A")] },
+      isLoading: false,
+    });
+
+    renderPage();
+
+    for (const n of [2, 3, 4, 5]) {
+      expect(screen.getByRole("button", { name: String(n) })).toBeInTheDocument();
+    }
+  });
+
+  it("highlights the active count option", () => {
+    mockQuickPickQuery.mockReturnValue({
+      data: { data: [makeMovie(1, "A")] },
+      isLoading: false,
+    });
+
+    renderPage("/media/quick-pick?count=4");
+
+    const btn4 = screen.getByRole("button", { name: "4" });
+    expect(btn4.getAttribute("aria-pressed")).toBe("true");
+    const btn3 = screen.getByRole("button", { name: "3" });
+    expect(btn3.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("calls refetch when 'Show me others' is clicked", () => {
+    mockQuickPickQuery.mockReturnValue({
+      data: { data: [makeMovie(1, "A")] },
+      isLoading: false,
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /show me others/i }));
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it("renders 'Watch This' button for each movie", () => {
+    mockQuickPickQuery.mockReturnValue({
+      data: {
+        data: [makeMovie(1, "Movie A"), makeMovie(2, "Movie B")],
+      },
+      isLoading: false,
+    });
+
+    renderPage("/media/quick-pick?count=2");
+
+    const watchButtons = screen.getAllByRole("button", { name: /watch this/i });
+    expect(watchButtons).toHaveLength(2);
+  });
+
+  it("renders empty state when no unwatched movies", () => {
+    mockQuickPickQuery.mockReturnValue({
+      data: { data: [] },
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText("Nothing unwatched in your library")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /search for movies/i })).toBeInTheDocument();
+  });
+
+  it("renders partial fill when fewer movies than count", () => {
+    mockQuickPickQuery.mockReturnValue({
+      data: { data: [makeMovie(1, "Only One")] },
+      isLoading: false,
+    });
+
+    renderPage("/media/quick-pick?count=5");
+
+    expect(screen.getByTestId("media-card-1")).toBeInTheDocument();
+    expect(screen.getByText("Only One")).toBeInTheDocument();
+    const watchButtons = screen.getAllByRole("button", { name: /watch this/i });
+    expect(watchButtons).toHaveLength(1);
+  });
+
+  it("shows loading skeletons", () => {
+    mockQuickPickQuery.mockReturnValue({
+      data: null,
+      isLoading: true,
+    });
+
+    renderPage();
+
+    expect(screen.queryByText("Quick Pick")).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-media/src/pages/QuickPickPage.tsx
+++ b/packages/app-media/src/pages/QuickPickPage.tsx
@@ -1,113 +1,46 @@
-import { useState, useCallback, useRef } from "react";
-import { useNavigate } from "react-router";
-import { Button, Badge, Skeleton } from "@pops/ui";
-import { SkipForward, Plus, X, RefreshCw, Sparkles } from "lucide-react";
-import { toast } from "sonner";
+import { useNavigate, useSearchParams } from "react-router";
+import { Button, Skeleton } from "@pops/ui";
+import { RefreshCw, Sparkles } from "lucide-react";
 import { trpc } from "../lib/trpc";
+import { MediaCard } from "../components/MediaCard";
+
+const COUNT_OPTIONS = [2, 3, 4, 5] as const;
+const DEFAULT_COUNT = 3;
+
+function parseCount(raw: string | null): number {
+  const n = Number(raw);
+  if (COUNT_OPTIONS.includes(n as (typeof COUNT_OPTIONS)[number])) return n;
+  return DEFAULT_COUNT;
+}
 
 export function QuickPickPage() {
   const navigate = useNavigate();
-  const utils = trpc.useUtils();
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [addedIds, setAddedIds] = useState<Set<number>>(new Set());
-
-  // Touch/swipe state
-  const touchStart = useRef<{ x: number; y: number } | null>(null);
-  const cardRef = useRef<HTMLDivElement>(null);
-  const [swipeOffset, setSwipeOffset] = useState(0);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const count = parseCount(searchParams.get("count"));
 
   const { data, isLoading, refetch } = trpc.media.library.quickPick.useQuery(
-    { count: 10 },
+    { count },
     { refetchOnWindowFocus: false }
   );
 
-  const addToWatchlist = trpc.media.watchlist.add.useMutation({
-    onSuccess: () => {
-      toast.success("Added to watchlist");
-      utils.media.watchlist.list.invalidate();
-    },
-    onError: (err: { message: string }) => {
-      if (err.message.includes("already")) {
-        toast.info("Already on your watchlist");
-      } else {
-        toast.error("Failed to add to watchlist");
-      }
-    },
-  });
-
   const picks = data?.data ?? [];
-  const currentPick = picks[currentIndex];
-  const isFinished = !isLoading && currentIndex >= picks.length;
 
-  const goNext = useCallback(() => {
-    setCurrentIndex((i) => i + 1);
-    setSwipeOffset(0);
-  }, []);
-
-  const handleAddToWatchlist = useCallback(() => {
-    if (!currentPick || addedIds.has(currentPick.id)) return;
-    addToWatchlist.mutate(
-      { mediaType: "movie", mediaId: currentPick.id },
-      {
-        onSuccess: () => {
-          setAddedIds((prev) => new Set(prev).add(currentPick.id));
-          goNext();
-        },
-      }
-    );
-  }, [currentPick, addedIds, addToWatchlist, goNext]);
-
-  const handleRefresh = useCallback(() => {
-    setCurrentIndex(0);
-    setAddedIds(new Set());
-    refetch();
-  }, [refetch]);
-
-  // Touch handlers for swipe
-  const handleTouchStart = useCallback((e: React.TouchEvent) => {
-    const touch = e.touches[0];
-    if (!touch) return;
-    touchStart.current = { x: touch.clientX, y: touch.clientY };
-  }, []);
-
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    if (!touchStart.current) return;
-    const touch = e.touches[0];
-    if (!touch) return;
-    const dx = touch.clientX - touchStart.current.x;
-    setSwipeOffset(dx);
-  }, []);
-
-  const handleTouchEnd = useCallback(() => {
-    if (!touchStart.current) return;
-    const threshold = 80;
-
-    if (swipeOffset > threshold) {
-      // Swipe right → add to watchlist
-      handleAddToWatchlist();
-    } else if (swipeOffset < -threshold) {
-      // Swipe left → skip
-      goNext();
-    }
-
-    touchStart.current = null;
-    setSwipeOffset(0);
-  }, [swipeOffset, handleAddToWatchlist, goNext]);
-
-  // Swipe indicator colors
-  const swipeIndicator =
-    swipeOffset > 40
-      ? "ring-2 ring-emerald-500/50"
-      : swipeOffset < -40
-        ? "ring-2 ring-rose-500/50"
-        : "";
+  function setCount(n: number) {
+    setSearchParams({ count: String(n) }, { replace: true });
+  }
 
   if (isLoading) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-        <Sparkles className="h-8 w-8 text-app-accent animate-pulse" />
-        <Skeleton className="h-[400px] w-[280px] rounded-xl" />
-        <Skeleton className="h-4 w-40" />
+      <div className="space-y-6">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-5 w-5 text-app-accent animate-pulse" />
+          <Skeleton className="h-8 w-32" />
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+          {Array.from({ length: count }, (_, i) => (
+            <Skeleton key={i} className="aspect-[2/3] rounded-lg" />
+          ))}
+        </div>
       </div>
     );
   }
@@ -116,7 +49,7 @@ export function QuickPickPage() {
     return (
       <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 text-center">
         <Sparkles className="h-10 w-10 text-muted-foreground" />
-        <h2 className="text-xl font-semibold">No unwatched movies</h2>
+        <h2 className="text-xl font-semibold">Nothing unwatched in your library</h2>
         <p className="text-muted-foreground text-sm max-w-xs">
           Add more movies to your library or mark some as unwatched to get picks.
         </p>
@@ -125,153 +58,63 @@ export function QuickPickPage() {
     );
   }
 
-  if (isFinished) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4 text-center">
-        <Sparkles className="h-10 w-10 text-app-accent" />
-        <h2 className="text-xl font-semibold">That's all for now!</h2>
-        <p className="text-muted-foreground text-sm max-w-xs">
-          You've seen all the picks. Refresh for a new set of suggestions.
-        </p>
-        <div className="flex gap-3">
-          <Button onClick={handleRefresh}>
-            <RefreshCw className="h-4 w-4 mr-2" />
-            New picks
-          </Button>
-          <Button variant="outline" onClick={() => navigate("/media")}>
-            Back to Library
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  const movie = currentPick;
-  if (!movie) return null;
-  const year = movie.releaseDate?.slice(0, 4);
-
   return (
-    <div className="flex flex-col items-center gap-6 pb-8">
+    <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between w-full max-w-sm">
+      <div className="flex items-center justify-between flex-wrap gap-3">
         <h1 className="text-lg font-semibold flex items-center gap-2">
           <Sparkles className="h-5 w-5 text-app-accent" />
           Quick Pick
         </h1>
-        <span className="text-xs text-muted-foreground">
-          {currentIndex + 1} / {picks.length}
-        </span>
+        <div className="flex items-center gap-3">
+          {/* Count selector */}
+          <div className="flex items-center gap-1 rounded-lg border p-1" role="group" aria-label="Number of picks">
+            {COUNT_OPTIONS.map((n) => (
+              <button
+                key={n}
+                onClick={() => setCount(n)}
+                className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                  n === count
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted"
+                }`}
+                aria-pressed={n === count}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+          {/* Show me others */}
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            <RefreshCw className="h-4 w-4 mr-1.5" />
+            Show me others
+          </Button>
+        </div>
       </div>
 
-      {/* Card */}
-      <div
-        ref={cardRef}
-        className={`relative w-full max-w-sm rounded-xl overflow-hidden bg-card border shadow-lg transition-transform duration-200 ${swipeIndicator}`}
-        style={{
-          transform: `translateX(${swipeOffset * 0.3}px) rotate(${swipeOffset * 0.05}deg)`,
-        }}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-      >
-        {/* Swipe indicators */}
-        {swipeOffset > 40 && (
-          <div className="absolute top-4 left-4 z-10">
-            <Badge className="bg-emerald-500 text-white text-sm px-3 py-1">+ Watchlist</Badge>
-          </div>
-        )}
-        {swipeOffset < -40 && (
-          <div className="absolute top-4 right-4 z-10">
-            <Badge className="bg-rose-500 text-white text-sm px-3 py-1">Skip</Badge>
-          </div>
-        )}
-
-        {/* Poster */}
-        <div className="aspect-[2/3] bg-muted">
-          {movie.posterUrl ? (
-            <img
-              src={movie.posterUrl}
-              alt={movie.title}
-              className="w-full h-full object-cover"
-              draggable={false}
+      {/* Poster grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+        {picks.map((movie) => (
+          <div key={movie.id} className="space-y-2">
+            <MediaCard
+              id={movie.id}
+              type="movie"
+              title={movie.title}
+              year={movie.releaseDate}
+              posterUrl={movie.posterUrl}
+              showTypeBadge={false}
             />
-          ) : (
-            <div className="w-full h-full flex items-center justify-center text-muted-foreground">
-              No Poster
-            </div>
-          )}
-        </div>
-
-        {/* Info */}
-        <div className="p-4 space-y-3">
-          <div>
-            <h2 className="text-lg font-semibold line-clamp-2">{movie.title}</h2>
-            <div className="flex items-center gap-2 mt-1 text-sm text-muted-foreground">
-              {year && <span>{year}</span>}
-              {movie.runtime && (
-                <>
-                  <span>·</span>
-                  <span>{movie.runtime} min</span>
-                </>
-              )}
-              {movie.voteAverage != null && (
-                <>
-                  <span>·</span>
-                  <span>★ {movie.voteAverage.toFixed(1)}</span>
-                </>
-              )}
-            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full font-medium"
+              onClick={() => navigate(`/media/movies/${movie.id}`)}
+            >
+              Watch This
+            </Button>
           </div>
-
-          {/* Genres */}
-          {movie.genres.length > 0 && (
-            <div className="flex flex-wrap gap-1.5">
-              {movie.genres.slice(0, 4).map((genre: string) => (
-                <Badge key={genre} variant="secondary" className="text-xs">
-                  {genre}
-                </Badge>
-              ))}
-            </div>
-          )}
-
-          {/* Overview */}
-          {movie.overview && (
-            <p className="text-sm text-muted-foreground line-clamp-3">{movie.overview}</p>
-          )}
-        </div>
+        ))}
       </div>
-
-      {/* Swipe hint (mobile only) */}
-      <p className="text-xs text-muted-foreground sm:hidden">
-        Swipe right to add · Swipe left to skip
-      </p>
-
-      {/* Action buttons */}
-      <div className="flex items-center gap-3 w-full max-w-sm">
-        <Button variant="outline" className="flex-1" onClick={goNext}>
-          <SkipForward className="h-4 w-4 mr-2" />
-          Skip
-        </Button>
-        <Button
-          className="flex-1 bg-app-accent hover:bg-app-accent/90"
-          onClick={handleAddToWatchlist}
-          disabled={addToWatchlist.isPending || addedIds.has(movie.id)}
-        >
-          <Plus className="h-4 w-4 mr-2" />
-          Watchlist
-        </Button>
-      </div>
-
-      {/* Close button */}
-      <Button
-        variant="ghost"
-        size="sm"
-        className="text-muted-foreground"
-        onClick={() => navigate("/media")}
-      >
-        <X className="h-4 w-4 mr-1" />
-        Not tonight
-      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace single-card swipe UI with responsive poster grid using MediaCard component
- Add count selector (2, 3, 4, 5) with default of 3, persisted in `?count=` query param
- Add "Show me others" button for fetching new random picks without page reload
- Each movie has a "Watch This" button navigating to `/media/movies/:id`

## Test plan
- [x] 10 tests covering: correct movie count, query param persistence, invalid count defaults, count selector rendering, active highlight, refetch on refresh, Watch This buttons, empty state, partial fill, loading state
- [x] Typecheck clean (pre-existing errors in other test files only)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)