### PR TITLE
feat: warranty page empty states and error handling

### DIFF
--- a/packages/app-inventory/src/pages/WarrantiesPage.test.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+const mockWarrantiesQuery = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    inventory: {
+      reports: {
+        warranties: {
+          useQuery: (...args: unknown[]) => mockWarrantiesQuery(...args),
+        },
+      },
+    },
+  },
+}));
+
+import { WarrantiesPage } from "./WarrantiesPage";
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/inventory/warranties"]}>
+      <WarrantiesPage />
+    </MemoryRouter>
+  );
+}
+
+function makeItem(
+  overrides: Partial<{
+    id: string;
+    itemName: string;
+    warrantyExpires: string | null;
+    assetId: string | null;
+    replacementValue: number | null;
+  }> = {}
+) {
+  return {
+    id: overrides.id ?? "item-1",
+    itemName: overrides.itemName ?? "Test Item",
+    warrantyExpires: overrides.warrantyExpires ?? null,
+    assetId: overrides.assetId ?? null,
+    replacementValue: overrides.replacementValue ?? null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: loaded, empty data
+  mockWarrantiesQuery.mockReturnValue({
+    data: { data: [] },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+});
+
+describe("WarrantiesPage", () => {
+  it("shows loading skeleton", () => {
+    mockWarrantiesQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    // Skeleton renders multiple placeholder elements
+    expect(screen.queryByText("No items with warranty dates")).not.toBeInTheDocument();
+    expect(screen.queryByText("Browse Items")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state with Browse Items link", () => {
+    renderPage();
+    expect(screen.getByText(/No items with warranty dates/)).toBeInTheDocument();
+    const link = screen.getByText("Browse Items");
+    expect(link).toBeInTheDocument();
+    expect(link.closest("a")).toHaveAttribute("href", "/inventory/items");
+  });
+
+  it("shows error state with retry button", () => {
+    const mockRefetch = vi.fn();
+    mockWarrantiesQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: mockRefetch,
+    });
+    renderPage();
+    expect(screen.getByText(/Could not load warranties/)).toBeInTheDocument();
+    const retryBtn = screen.getByText("Retry");
+    fireEvent.click(retryBtn);
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("expands Expired section when all warranties are expired", () => {
+    const pastDate = "2020-01-01";
+    mockWarrantiesQuery.mockReturnValue({
+      data: {
+        data: [
+          makeItem({ id: "1", itemName: "Old Laptop", warrantyExpires: pastDate }),
+          makeItem({ id: "2", itemName: "Old Phone", warrantyExpires: "2019-06-15" }),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    // Expired section should be expanded (defaultOpen) — items should be visible
+    expect(screen.getByText("Old Laptop")).toBeInTheDocument();
+    expect(screen.getByText("Old Phone")).toBeInTheDocument();
+  });
+
+  it("collapses Expired section when active items exist", () => {
+    const futureDate = "2030-06-01";
+    const pastDate = "2020-01-01";
+    mockWarrantiesQuery.mockReturnValue({
+      data: {
+        data: [
+          makeItem({ id: "1", itemName: "New Laptop", warrantyExpires: futureDate }),
+          makeItem({ id: "2", itemName: "Old Phone", warrantyExpires: pastDate }),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    // Active item should be visible
+    expect(screen.getByText("New Laptop")).toBeInTheDocument();
+    // Expired section is collapsed by default — items should not be visible
+    expect(screen.queryByText("Old Phone")).not.toBeInTheDocument();
+  });
+
+  it("shows Expired items after expanding collapsed section", () => {
+    const futureDate = "2030-06-01";
+    const pastDate = "2020-01-01";
+    mockWarrantiesQuery.mockReturnValue({
+      data: {
+        data: [
+          makeItem({ id: "1", itemName: "New Laptop", warrantyExpires: futureDate }),
+          makeItem({ id: "2", itemName: "Old Phone", warrantyExpires: pastDate }),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    // Click to expand Expired section
+    fireEvent.click(screen.getByText("Expired"));
+    expect(screen.getByText("Old Phone")).toBeInTheDocument();
+  });
+});

--- a/packages/app-inventory/src/pages/WarrantiesPage.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.tsx
@@ -5,8 +5,8 @@
  * Color-coded urgency for expiring items. PRD-023/US-2.
  */
 import { useMemo, useState } from "react";
-import { useNavigate } from "react-router";
-import { ShieldCheck, ChevronDown, ChevronRight } from "lucide-react";
+import { useNavigate, Link } from "react-router";
+import { ShieldCheck, ChevronDown, ChevronRight, AlertCircle } from "lucide-react";
 import { Skeleton, AssetIdBadge, Badge } from "@pops/ui";
 import { trpc } from "../lib/trpc";
 
@@ -137,7 +137,7 @@ function CollapsibleSection({
 
 export function WarrantiesPage() {
   const navigate = useNavigate();
-  const { data, isLoading } = trpc.inventory.reports.warranties.useQuery();
+  const { data, isLoading, isError, refetch } = trpc.inventory.reports.warranties.useQuery();
 
   const { expiringSoon, expired, active } = useMemo(() => {
     const items = data?.data ?? [];
@@ -183,13 +183,31 @@ export function WarrantiesPage() {
 
       {isLoading ? (
         <WarrantySkeleton />
+      ) : isError ? (
+        <div className="text-center py-16">
+          <AlertCircle className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
+          <p className="text-muted-foreground mb-4">Could not load warranties — try again</p>
+          <button
+            type="button"
+            className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            onClick={() => refetch()}
+          >
+            Retry
+          </button>
+        </div>
       ) : totalItems === 0 ? (
         <div className="text-center py-16">
           <ShieldCheck className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
-          <p className="text-muted-foreground">
+          <p className="text-muted-foreground mb-4">
             No items with warranty dates. Add warranty expiry dates to your inventory items to track
             them here.
           </p>
+          <Link
+            to="/inventory/items"
+            className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Browse Items
+          </Link>
         </div>
       ) : (
         <div className="space-y-4">
@@ -235,7 +253,11 @@ export function WarrantiesPage() {
 
           {/* Expired — collapsible */}
           {expired.length > 0 && (
-            <CollapsibleSection title="Expired" count={expired.length}>
+            <CollapsibleSection
+              title="Expired"
+              count={expired.length}
+              defaultOpen={expiringSoon.length === 0 && active.length === 0}
+            >
               {expired.map((item) => (
                 <WarrantyRow
                   key={item.id}


### PR DESCRIPTION
## Summary
- Add "Browse Items" CTA link to the page-level empty state, navigating to `/inventory/items`
- Auto-expand Expired tier when all warranties are expired (no active or expiring-soon items)
- Add error state with "Could not load warranties — try again" message and Retry button that calls `refetch()`
- 6 new tests covering loading, empty state with CTA, error+retry, all-expired expansion, and collapsed/expanded behavior

Closes #765 (PRD-050 US-03)

## Test plan
- [x] 6/6 WarrantiesPage tests pass
- [x] Prettier check passes
- [x] Pre-existing test failures in ItemDetailPage/ItemFormPage are unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)