### PR TITLE
fix: change AI nav icon from BarChart3 to Brain [tb-536]

### DIFF
--- a/packages/app-ai/src/routes.tsx
+++ b/packages/app-ai/src/routes.tsx
@@ -33,7 +33,7 @@ export const navConfig: AppNavConfig = {
   icon: "Bot",
   color: "violet",
   basePath: "/ai",
-  items: [{ path: "", label: "AI Usage", icon: "BarChart3" }],
+  items: [{ path: "", label: "AI Usage", icon: "Brain" }],
 };
 
 export const routes: RouteObject[] = [{ index: true, element: <AiUsagePage /> }];


### PR DESCRIPTION
## Summary
- One-line change: update AI app navigation icon from `BarChart3` to `Brain` in `packages/app-ai/src/routes.tsx`

## Test plan
- [x] Visual change only — icon name swap in NavConfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)