### PR TITLE
feat: recommendations comparison threshold + CTA [tb-535]

### DIFF
--- a/packages/app-media/src/pages/DiscoverPage.test.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router";
 
 const mockTrendingQuery = vi.fn();
 const mockRecommendationsQuery = vi.fn();
+const mockProfileQuery = vi.fn();
 const mockAddMovieMutateAsync = vi.fn();
 const mockAddWatchlistMutateAsync = vi.fn();
 const mockTrendingRefetch = vi.fn();
@@ -24,6 +25,9 @@ vi.mock("../lib/trpc", () => ({
             const result = mockRecommendationsQuery(...args);
             return { ...result, refetch: mockRecommendationsRefetch };
           },
+        },
+        profile: {
+          useQuery: (...args: unknown[]) => mockProfileQuery(...args),
         },
       },
       library: {
@@ -65,15 +69,21 @@ vi.mock("../components/DiscoverCard", () => ({
     inLibrary,
     onAddToLibrary,
     tmdbId,
+    matchPercentage,
+    matchReason,
   }: {
     title: string;
     inLibrary: boolean;
     onAddToLibrary?: (id: number) => void;
     tmdbId: number;
+    matchPercentage?: number;
+    matchReason?: string;
   }) => (
     <div data-testid={`card-${tmdbId}`}>
       <span>{title}</span>
       {inLibrary && <span>Owned</span>}
+      {matchPercentage != null && <span>{matchPercentage}% Match</span>}
+      {matchReason && <span>{matchReason}</span>}
       {!inLibrary && onAddToLibrary && (
         <button onClick={() => onAddToLibrary(tmdbId)}>Add to Library</button>
       )}
@@ -93,19 +103,52 @@ const trendingMovies = [
   { tmdbId: 300, title: "Barbie", releaseDate: "2023-07-21", posterPath: null, posterUrl: null, voteAverage: 7.0, inLibrary: false },
 ];
 
+const recommendedMovies = [
+  { tmdbId: 400, title: "Blade Runner 2049", releaseDate: "2017-10-06", posterPath: null, posterUrl: null, voteAverage: 7.9, inLibrary: false, matchPercentage: 92, matchReason: "Sci-Fi, Action" },
+  { tmdbId: 500, title: "Arrival", releaseDate: "2016-11-11", posterPath: null, posterUrl: null, voteAverage: 7.6, inLibrary: false, matchPercentage: 85, matchReason: "Sci-Fi" },
+];
+
 const emptyRecommendations = {
   data: { results: [], sourceMovies: [] },
   isLoading: false,
   error: null,
 };
 
-function setupDefaults() {
+function defaultTrending() {
   mockTrendingQuery.mockReturnValue({
     data: { results: trendingMovies, totalResults: 3, page: 1 },
     isLoading: false,
     error: null,
   });
+}
+
+function defaultRecommendations() {
+  mockRecommendationsQuery.mockReturnValue({
+    data: { results: recommendedMovies, sourceMovies: ["Interstellar", "The Matrix"] },
+    isLoading: false,
+    error: null,
+  });
+}
+
+function defaultProfile(totalComparisons: number) {
+  mockProfileQuery.mockReturnValue({
+    data: {
+      data: {
+        totalComparisons,
+        totalMoviesWatched: 10,
+        genreAffinities: [],
+        dimensionWeights: [],
+        genreDistribution: [],
+      },
+    },
+    isLoading: false,
+  });
+}
+
+function setupDefaults() {
+  defaultTrending();
   mockRecommendationsQuery.mockReturnValue(emptyRecommendations);
+  defaultProfile(10);
 }
 
 function renderPage(initialEntry = "/media/discover") {
@@ -188,12 +231,13 @@ describe("DiscoverPage", () => {
   });
 
   it("shows error state with retry button", () => {
+    defaultProfile(10);
+    defaultRecommendations();
     mockTrendingQuery.mockReturnValue({
       data: undefined,
       isLoading: false,
       error: { message: "TMDB API error" },
     });
-    mockRecommendationsQuery.mockReturnValue(emptyRecommendations);
     renderPage();
 
     expect(screen.getByText("TMDB API error")).toBeTruthy();
@@ -202,12 +246,13 @@ describe("DiscoverPage", () => {
   });
 
   it("shows Load More button when more results available", () => {
+    defaultProfile(10);
+    mockRecommendationsQuery.mockReturnValue(emptyRecommendations);
     mockTrendingQuery.mockReturnValue({
       data: { results: trendingMovies, totalResults: 60, page: 1 },
       isLoading: false,
       error: null,
     });
-    mockRecommendationsQuery.mockReturnValue(emptyRecommendations);
     renderPage();
 
     expect(screen.getByText("Load More")).toBeTruthy();
@@ -221,5 +266,68 @@ describe("DiscoverPage", () => {
       expect.objectContaining({ timeWindow: "day" }),
       expect.anything(),
     );
+  });
+});
+
+describe("DiscoverPage — recommendations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    defaultTrending();
+  });
+
+  it("shows cold start CTA when totalComparisons < 5", () => {
+    defaultProfile(2);
+    defaultRecommendations();
+    renderPage();
+
+    expect(screen.getByText("Compare more movies to unlock recommendations")).toBeTruthy();
+    expect(screen.getByText(/you have 2 so far/)).toBeTruthy();
+    expect(screen.queryByText("Recommended for You")).toBeNull();
+  });
+
+  it("CTA links to /media/compare", () => {
+    defaultProfile(0);
+    defaultRecommendations();
+    renderPage();
+
+    const link = screen.getByText("Start Comparing");
+    expect(link.closest("a")?.getAttribute("href")).toBe("/media/compare");
+  });
+
+  it("renders recommendations with attribution when above threshold", () => {
+    defaultProfile(10);
+    defaultRecommendations();
+    renderPage();
+
+    expect(screen.getByText("Recommended for You")).toBeTruthy();
+    expect(screen.getAllByText("Blade Runner 2049").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("92% Match").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows 'no new recommendations' when results empty but above threshold", () => {
+    defaultProfile(10);
+    mockRecommendationsQuery.mockReturnValue({
+      data: { results: [], sourceMovies: [] },
+      isLoading: false,
+      error: null,
+    });
+    renderPage();
+
+    expect(screen.getByText(/No new recommendations/)).toBeTruthy();
+  });
+
+  it("calls add to library on recommendation card", () => {
+    defaultProfile(10);
+    defaultRecommendations();
+    mockAddMovieMutateAsync.mockResolvedValue({
+      created: true,
+      data: { id: 1, title: "Blade Runner 2049" },
+    });
+    renderPage();
+
+    const addButtons = screen.getAllByText("Add to Library");
+    fireEvent.click(addButtons[addButtons.length - 2]!);
+
+    expect(mockAddMovieMutateAsync).toHaveBeenCalledWith({ tmdbId: 400 });
   });
 });

--- a/packages/app-media/src/pages/DiscoverPage.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.tsx
@@ -3,13 +3,15 @@
  * Three horizontal scroll sections: Recommended for You, Trending, Similar to Top Rated.
  */
 import { useState, useCallback, useEffect } from "react";
-import { useSearchParams } from "react-router";
+import { Link, useSearchParams } from "react-router";
 import { Alert, Button } from "@pops/ui";
-import { Compass, AlertCircle, RefreshCw, Loader2 } from "lucide-react";
+import { Compass, AlertCircle, RefreshCw, Loader2, Swords } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
 import { HorizontalScrollRow } from "../components/HorizontalScrollRow";
 import { DiscoverCard } from "../components/DiscoverCard";
+
+const COMPARISON_THRESHOLD = 5;
 
 export function DiscoverPage() {
   const utils = trpc.useUtils();
@@ -80,6 +82,13 @@ export function DiscoverPage() {
     { sampleSize: 5 },
     { staleTime: 5 * 60 * 1000 }
   );
+
+  const profile = trpc.media.discovery.profile.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const totalComparisons = profile.data?.data?.totalComparisons ?? 0;
+  const hasEnoughComparisons = totalComparisons >= COMPARISON_THRESHOLD;
 
   // Track in-progress mutations per tmdbId
   const [addingToLibrary, setAddingToLibrary] = useState<Set<number>>(new Set());
@@ -163,63 +172,79 @@ export function DiscoverPage() {
         </div>
       </div>
 
-      {/* Recommended for You */}
-      <HorizontalScrollRow
-        title="Recommended for You"
-        subtitle={
-          recommendations.data?.sourceMovies.length
-            ? `Based on ${recommendations.data.sourceMovies.join(", ")}`
-            : undefined
-        }
-        isLoading={recommendations.isLoading}
-      >
-        {recommendations.error && (
-          <Alert variant="destructive" className="flex items-center gap-3">
-            <AlertCircle className="h-4 w-4 shrink-0" />
-            <p className="flex-1 text-sm">{recommendations.error.message}</p>
-            <Button variant="outline" size="sm" onClick={() => recommendations.refetch()}>
-              <RefreshCw className="mr-1 h-3 w-3" /> Retry
-            </Button>
-          </Alert>
-        )}
-        {!recommendations.error && recommendations.data?.results.length === 0 && (
-          <p className="py-8 text-sm text-muted-foreground">
-            Add movies to your library to get personalized recommendations.
+      {/* Recommended for You — hidden below comparison threshold */}
+      {!hasEnoughComparisons && !profile.isLoading ? (
+        <section className="rounded-lg border border-dashed border-border p-8 text-center">
+          <Swords className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="text-sm font-medium">Compare more movies to unlock recommendations</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            You need at least {COMPARISON_THRESHOLD} comparisons — you have {totalComparisons} so far.
           </p>
-        )}
-        {recommendations.data?.results
-          .slice(0, 20)
-          .map(
-            (item: {
-              tmdbId: number;
-              title: string;
-              releaseDate: string | null;
-              posterPath: string | null;
-              posterUrl: string | null;
-              voteAverage: number | null;
-              inLibrary: boolean;
-              matchPercentage?: number;
-              matchReason?: string;
-            }) => (
-              <DiscoverCard
-                key={item.tmdbId}
-                tmdbId={item.tmdbId}
-                title={item.title}
-                releaseDate={item.releaseDate ?? ""}
-                posterPath={item.posterPath}
-                posterUrl={item.posterUrl}
-                voteAverage={item.voteAverage ?? 0}
-                inLibrary={item.inLibrary}
-                isAddingToLibrary={addingToLibrary.has(item.tmdbId)}
-                isAddingToWatchlist={addingToWatchlist.has(item.tmdbId)}
-                onAddToLibrary={handleAddToLibrary}
-                onAddToWatchlist={handleAddToWatchlist}
-                matchPercentage={item.matchPercentage}
-                matchReason={item.matchReason}
-              />
-            )
+          <Link
+            to="/media/compare"
+            className="mt-4 inline-flex items-center justify-center rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            Start Comparing
+          </Link>
+        </section>
+      ) : (
+        <HorizontalScrollRow
+          title="Recommended for You"
+          subtitle={
+            recommendations.data?.sourceMovies.length
+              ? `Based on ${recommendations.data.sourceMovies.join(", ")}`
+              : undefined
+          }
+          isLoading={recommendations.isLoading || profile.isLoading}
+        >
+          {recommendations.error && (
+            <Alert variant="destructive" className="flex items-center gap-3">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <p className="flex-1 text-sm">{recommendations.error.message}</p>
+              <Button variant="outline" size="sm" onClick={() => recommendations.refetch()}>
+                <RefreshCw className="mr-1 h-3 w-3" /> Retry
+              </Button>
+            </Alert>
           )}
-      </HorizontalScrollRow>
+          {!recommendations.error && recommendations.data?.results.length === 0 && (
+            <p className="py-8 text-sm text-muted-foreground">
+              No new recommendations — keep comparing to discover more.
+            </p>
+          )}
+          {recommendations.data?.results
+            .slice(0, 20)
+            .map(
+              (item: {
+                tmdbId: number;
+                title: string;
+                releaseDate: string | null;
+                posterPath: string | null;
+                posterUrl: string | null;
+                voteAverage: number | null;
+                inLibrary: boolean;
+                matchPercentage?: number;
+                matchReason?: string;
+              }) => (
+                <DiscoverCard
+                  key={item.tmdbId}
+                  tmdbId={item.tmdbId}
+                  title={item.title}
+                  releaseDate={item.releaseDate ?? ""}
+                  posterPath={item.posterPath}
+                  posterUrl={item.posterUrl}
+                  voteAverage={item.voteAverage ?? 0}
+                  inLibrary={item.inLibrary}
+                  isAddingToLibrary={addingToLibrary.has(item.tmdbId)}
+                  isAddingToWatchlist={addingToWatchlist.has(item.tmdbId)}
+                  onAddToLibrary={handleAddToLibrary}
+                  onAddToWatchlist={handleAddToWatchlist}
+                  matchPercentage={item.matchPercentage}
+                  matchReason={item.matchReason}
+                />
+              )
+            )}
+        </HorizontalScrollRow>
+      )}
 
       {/* Trending */}
       <div className="space-y-3">


### PR DESCRIPTION
## Summary
- Hide "Recommended for You" section when user has < 5 recorded comparisons
- Show CTA card: "Compare more movies to unlock recommendations" linking to /media/compare
- Update empty state message to "No new recommendations — keep comparing" when above threshold but no results
- Add 6 tests covering threshold CTA, link target, recommendations rendering, empty state, add-to-library, and error retry

## Test plan
- [x] 6 unit tests pass for DiscoverPage
- [x] All 170 app-media tests pass
- [x] ESLint clean
- [ ] CI green

Closes GH#772
PRD: [038 — Discovery & Recommendations](docs-v2/themes/03-media/prds/038-discovery-recommendations/README.md) US-02

🤖 Generated with [Claude Code](https://claude.com/claude-code)