### PR TITLE
feat: rankings page gaps — tie-breaking, URL dimension tabs [tb-528]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -567,6 +567,100 @@ describe("comparisons.rankings", () => {
     expect(result.data[0]!.mediaId).toBe(1);
     expect(result.data[0]!.score).toBeGreaterThan(1500);
   });
+
+  it("breaks ties by title alphabetically (per-dimension)", async () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const mZebra = seedMovie(db, { tmdb_id: 601, title: "Zebra Movie" });
+    const mAlpha = seedMovie(db, { tmdb_id: 602, title: "Alpha Movie" });
+
+    // Each movie wins once -> scores return to ~1500
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: mZebra,
+      mediaBType: "movie",
+      mediaBId: mAlpha,
+      winnerType: "movie",
+      winnerId: mZebra,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: mZebra,
+      mediaBType: "movie",
+      mediaBId: mAlpha,
+      winnerType: "movie",
+      winnerId: mAlpha,
+    });
+
+    const result = await caller.media.comparisons.rankings({ dimensionId: dimId });
+    expect(result.data.length).toBe(2);
+    // Equal scores -> alphabetical: Alpha before Zebra
+    expect(result.data[0]!.mediaId).toBe(mAlpha);
+    expect(result.data[1]!.mediaId).toBe(mZebra);
+  });
+
+  it("sorts zero-comparison items after scored items (per-dimension)", async () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const mScored1 = seedMovie(db, { tmdb_id: 701, title: "Scored Movie" });
+    const mScored2 = seedMovie(db, { tmdb_id: 702, title: "Another Scored" });
+    const mUnscored = seedMovie(db, { tmdb_id: 703, title: "Aardvark Unscored" });
+
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: mScored1,
+      mediaBType: "movie",
+      mediaBId: mScored2,
+      winnerType: "movie",
+      winnerId: mScored1,
+    });
+
+    // Insert an unscored entry (comparison_count = 0, score = 1500)
+    db.prepare(
+      `INSERT INTO media_scores (media_type, media_id, dimension_id, score, comparison_count)
+       VALUES ('movie', ?, ?, 1500.0, 0)`
+    ).run(mUnscored, dimId);
+
+    const result = await caller.media.comparisons.rankings({ dimensionId: dimId });
+    expect(result.data.length).toBe(3);
+    // Unscored item should be last despite alphabetically first title
+    expect(result.data[2]!.mediaId).toBe(mUnscored);
+    expect(result.data[2]!.comparisonCount).toBe(0);
+  });
+
+  it("breaks ties by title in overall rankings", async () => {
+    const dim1 = seedDimension(db, { name: "Story", active: 1 });
+    const dim2 = seedDimension(db, { name: "Visuals", active: 1 });
+    const mZebra = seedMovie(db, { tmdb_id: 801, title: "Zebra Film" });
+    const mAlpha = seedMovie(db, { tmdb_id: 802, title: "Alpha Film" });
+
+    // Each movie wins one dimension -> average scores should be equal
+    await caller.media.comparisons.record({
+      dimensionId: dim1,
+      mediaAType: "movie",
+      mediaAId: mZebra,
+      mediaBType: "movie",
+      mediaBId: mAlpha,
+      winnerType: "movie",
+      winnerId: mZebra,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dim2,
+      mediaAType: "movie",
+      mediaAId: mZebra,
+      mediaBType: "movie",
+      mediaBId: mAlpha,
+      winnerType: "movie",
+      winnerId: mAlpha,
+    });
+
+    const result = await caller.media.comparisons.rankings({});
+    expect(result.data.length).toBe(2);
+    // Equal average scores -> alphabetical: Alpha before Zebra
+    expect(result.data[0]!.mediaId).toBe(mAlpha);
+    expect(result.data[1]!.mediaId).toBe(mZebra);
+  });
 });
 
 describe("comparisons auth", () => {

--- a/packages/app-media/src/pages/RankingsPage.test.tsx
+++ b/packages/app-media/src/pages/RankingsPage.test.tsx
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+
+const mockRankingsQuery = vi.fn();
+const mockDimensionsQuery = vi.fn();
+const mockMoviesQuery = vi.fn();
+const mockTvShowsQuery = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      comparisons: {
+        rankings: { useQuery: (...args: unknown[]) => mockRankingsQuery(...args) },
+        listDimensions: { useQuery: () => mockDimensionsQuery() },
+      },
+      movies: {
+        list: { useQuery: (...args: unknown[]) => mockMoviesQuery(...args) },
+      },
+      tvShows: {
+        list: { useQuery: (...args: unknown[]) => mockTvShowsQuery(...args) },
+      },
+    },
+  },
+}));
+
+import { RankingsPage } from "./RankingsPage";
+
+function renderPage(initialRoute = "/media/rankings") {
+  return render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <RankingsPage />
+    </MemoryRouter>
+  );
+}
+
+const movieA = { id: 1, title: "Alpha Movie", releaseDate: "2020-01-01", posterUrl: "/a.jpg" };
+const movieB = { id: 2, title: "Beta Movie", releaseDate: "2021-06-15", posterUrl: "/b.jpg" };
+const tvShow = { id: 10, name: "Gamma Show", firstAirDate: "2019-03-10", posterUrl: "/g.jpg" };
+
+const rankedEntries = [
+  { rank: 1, mediaType: "movie", mediaId: 1, score: 1532, comparisonCount: 5 },
+  { rank: 2, mediaType: "movie", mediaId: 2, score: 1468, comparisonCount: 5 },
+];
+
+const dimensions = [
+  {
+    id: 1,
+    name: "Story",
+    active: true,
+    sortOrder: 0,
+    description: null,
+    createdAt: "2026-01-01",
+  },
+  {
+    id: 2,
+    name: "Visuals",
+    active: true,
+    sortOrder: 1,
+    description: null,
+    createdAt: "2026-01-01",
+  },
+];
+
+function setupDefaults() {
+  mockDimensionsQuery.mockReturnValue({
+    data: { data: dimensions },
+    isLoading: false,
+  });
+  mockMoviesQuery.mockReturnValue({
+    data: { data: [movieA, movieB] },
+  });
+  mockTvShowsQuery.mockReturnValue({
+    data: { data: [tvShow] },
+  });
+  mockRankingsQuery.mockReturnValue({
+    data: {
+      data: rankedEntries,
+      pagination: { total: 2, limit: 25, offset: 0, hasMore: false },
+    },
+    isLoading: false,
+    error: null,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupDefaults();
+});
+
+describe("RankingsPage", () => {
+  it("renders the page heading", () => {
+    renderPage();
+    expect(screen.getByRole("heading", { name: "Rankings" })).toBeInTheDocument();
+  });
+
+  it("shows loading skeleton when dimensions are loading", () => {
+    mockDimensionsQuery.mockReturnValue({ data: undefined, isLoading: true });
+    renderPage();
+    expect(screen.queryByRole("list", { name: "Rankings" })).not.toBeInTheDocument();
+  });
+
+  it("renders ranked items in order", () => {
+    renderPage();
+    const list = screen.getByRole("list", { name: "Rankings" });
+    const items = within(list).getAllByText(/Movie/);
+    expect(items.length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("Alpha Movie")).toBeInTheDocument();
+    expect(screen.getByText("Beta Movie")).toBeInTheDocument();
+  });
+
+  it("displays dimension tabs", () => {
+    renderPage();
+    expect(screen.getByRole("tab", { name: "Overall" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Story" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Visuals" })).toBeInTheDocument();
+  });
+
+  it("switches dimension on tab click", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const storyTab = screen.getByRole("tab", { name: "Story" });
+    await user.click(storyTab);
+
+    // After clicking Story, the rankings query should have been called with dimensionId: 1
+    expect(mockRankingsQuery).toHaveBeenCalledWith(expect.objectContaining({ dimensionId: 1 }));
+  });
+
+  it("shows empty state when no rankings", () => {
+    mockRankingsQuery.mockReturnValue({
+      data: {
+        data: [],
+        pagination: { total: 0, limit: 25, offset: 0, hasMore: false },
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+    expect(screen.getByText(/No rankings yet/)).toBeInTheDocument();
+  });
+
+  it("shows error alert on query failure", () => {
+    mockRankingsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("fail"),
+    });
+
+    renderPage();
+    expect(screen.getByText("Failed to load rankings.")).toBeInTheDocument();
+  });
+
+  it("renders score and match count", () => {
+    renderPage();
+    expect(screen.getByText("1532")).toBeInTheDocument();
+    expect(screen.getAllByText("5 matches")).toHaveLength(2);
+  });
+
+  it("shows pagination when total exceeds page size", () => {
+    const manyEntries = Array.from({ length: 25 }, (_, i) => ({
+      rank: i + 1,
+      mediaType: "movie",
+      mediaId: i + 1,
+      score: 1600 - i * 4,
+      comparisonCount: 3,
+    }));
+
+    mockRankingsQuery.mockReturnValue({
+      data: {
+        data: manyEntries,
+        pagination: { total: 30, limit: 25, offset: 0, hasMore: true },
+      },
+      isLoading: false,
+      error: null,
+    });
+    mockMoviesQuery.mockReturnValue({
+      data: {
+        data: manyEntries.map((e) => ({
+          id: e.mediaId,
+          title: `Movie ${e.mediaId}`,
+          releaseDate: "2020-01-01",
+          posterUrl: null,
+        })),
+      },
+    });
+
+    renderPage();
+    expect(screen.getByText(/Showing 1–25 of 30/)).toBeInTheDocument();
+    expect(screen.getByText("Next")).toBeInTheDocument();
+  });
+
+  it("hides tabs when no active dimensions", () => {
+    mockDimensionsQuery.mockReturnValue({
+      data: { data: [] },
+      isLoading: false,
+    });
+
+    renderPage();
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+  });
+
+  it("selects Visuals tab when URL has ?dimension=2", () => {
+    renderPage("/media/rankings?dimension=2");
+
+    const visualsTab = screen.getByRole("tab", { name: "Visuals" });
+    expect(visualsTab).toHaveAttribute("aria-selected", "true");
+
+    const overallTab = screen.getByRole("tab", { name: "Overall" });
+    expect(overallTab).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("displays medal colors for top 3 ranks", () => {
+    const top3 = [
+      { rank: 1, mediaType: "movie", mediaId: 1, score: 1600, comparisonCount: 10 },
+      { rank: 2, mediaType: "movie", mediaId: 2, score: 1550, comparisonCount: 10 },
+      { rank: 3, mediaType: "movie", mediaId: 3, score: 1500, comparisonCount: 10 },
+    ];
+
+    mockRankingsQuery.mockReturnValue({
+      data: {
+        data: top3,
+        pagination: { total: 3, limit: 25, offset: 0, hasMore: false },
+      },
+      isLoading: false,
+      error: null,
+    });
+    mockMoviesQuery.mockReturnValue({
+      data: {
+        data: [
+          { id: 1, title: "Gold", releaseDate: null, posterUrl: null },
+          { id: 2, title: "Silver", releaseDate: null, posterUrl: null },
+          { id: 3, title: "Bronze", releaseDate: null, posterUrl: null },
+        ],
+      },
+    });
+
+    renderPage();
+    expect(screen.getByText("#1")).toBeInTheDocument();
+    expect(screen.getByText("#2")).toBeInTheDocument();
+    expect(screen.getByText("#3")).toBeInTheDocument();
+  });
+
+  it("shows 'Unknown' for media without metadata", () => {
+    mockMoviesQuery.mockReturnValue({ data: { data: [] } });
+    mockTvShowsQuery.mockReturnValue({ data: { data: [] } });
+
+    renderPage();
+    const unknowns = screen.getAllByText("Unknown");
+    expect(unknowns.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/app-media/src/pages/RankingsPage.tsx
+++ b/packages/app-media/src/pages/RankingsPage.tsx
@@ -4,8 +4,8 @@
  * Supports per-dimension tabs (Overall + each active dimension).
  * Uses the comparisons.rankings tRPC query with pagination.
  */
-import { useState, useMemo } from "react";
-import { Link } from "react-router";
+import { useState, useMemo, useCallback } from "react";
+import { Link, useSearchParams } from "react-router";
 import {
   Alert,
   AlertTitle,
@@ -20,7 +20,7 @@ import {
 import { Trophy } from "lucide-react";
 import { trpc } from "../lib/trpc";
 
-const PAGE_SIZE = 50;
+const PAGE_SIZE = 25;
 
 function RankingsSkeleton() {
   return (
@@ -262,6 +262,9 @@ function RankingsList({ dimensionId }: { dimensionId?: number }) {
 }
 
 export function RankingsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const dimensionParam = searchParams.get("dimension") ?? "overall";
+
   const { data: dimensionsData, isLoading: dimsLoading } =
     trpc.media.comparisons.listDimensions.useQuery();
 
@@ -271,6 +274,24 @@ export function RankingsPage() {
   );
 
   const showTabs = activeDimensions.length > 0;
+
+  const handleTabChange = useCallback(
+    (value: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (value === "overall") {
+            next.delete("dimension");
+          } else {
+            next.set("dimension", value);
+          }
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
 
   return (
     <div className="space-y-6 max-w-3xl mx-auto">
@@ -282,7 +303,7 @@ export function RankingsPage() {
       {dimsLoading ? (
         <RankingsSkeleton />
       ) : showTabs ? (
-        <Tabs defaultValue="overall">
+        <Tabs value={dimensionParam} onValueChange={handleTabChange}>
           <TabsList>
             <TabsTrigger value="overall">Overall</TabsTrigger>
             {activeDimensions.map((dim: { id: number; name: string }) => (


### PR DESCRIPTION
## Summary
- **Backend**: Rewrite `getRankings` SQL with JOINs on movies/tv_shows for title-based tie-breaking (score DESC, title ASC). Zero-comparison items (unscored at 1500) sort alphabetically after scored items.
- **Frontend**: Reduce `PAGE_SIZE` from 50 to 25. Replace `Tabs defaultValue` with `useSearchParams` for `?dimension=` URL persistence so dimension selection survives page refresh/sharing.
- **Tests**: 3 new backend tests (per-dimension tie-breaking, zero-comparison ordering, overall tie-breaking) + 13 new frontend tests (ranked display, dimension tabs, URL sync, pagination, empty/error states, medal colors).

Closes #761

## Test plan
- [x] Backend: `vitest run comparisons.test.ts` — 32 tests pass
- [x] Frontend: `vitest run RankingsPage.test.tsx` — 13 tests pass
- [x] Prettier formatting verified
- [x] TypeScript: no new type errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)