### PR TITLE
feat: print layout improvements for insurance report [tb-540]

### DIFF
--- a/packages/app-inventory/src/pages/InsuranceReportPage.test.tsx
+++ b/packages/app-inventory/src/pages/InsuranceReportPage.test.tsx
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router";
+
+const mockReportQuery = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    inventory: {
+      reports: {
+        insuranceReport: {
+          useQuery: (...args: unknown[]) => mockReportQuery(...args),
+        },
+      },
+    },
+  },
+}));
+
+// Mock UI badge components to avoid complex dependency chain
+vi.mock("@pops/ui", () => ({
+  Skeleton: ({ className }: { className?: string }) => <div className={`animate-pulse ${className ?? ""}`} />,
+  AssetIdBadge: ({ assetId }: { assetId: string }) => <span data-testid="asset-id-badge">{assetId}</span>,
+  ConditionBadge: ({ condition }: { condition: string }) => (
+    <span data-testid="condition-badge">{condition}</span>
+  ),
+  Badge: ({ children, className }: { children: React.ReactNode; variant?: string; className?: string }) => (
+    <span data-testid="badge" className={className}>{children}</span>
+  ),
+}));
+
+import { InsuranceReportPage } from "./InsuranceReportPage";
+
+const mockReport = {
+  data: {
+    totalItems: 5,
+    totalValue: 15000,
+    groups: [
+      {
+        locationId: "loc-1",
+        locationName: "Living Room",
+        items: [
+          {
+            id: "item-1",
+            itemName: "MacBook Pro",
+            assetId: "ELEC01",
+            brand: "Apple",
+            condition: "Excellent",
+            warrantyExpires: "2027-06-15",
+            replacementValue: 3500,
+            photoPath: "macbook.jpg",
+            locationId: "loc-1",
+            locationName: "Living Room",
+          },
+          {
+            id: "item-2",
+            itemName: "Monitor",
+            assetId: null,
+            brand: null,
+            condition: null,
+            warrantyExpires: null,
+            replacementValue: null,
+            photoPath: null,
+            locationId: "loc-1",
+            locationName: "Living Room",
+          },
+        ],
+      },
+      {
+        locationId: "loc-2",
+        locationName: "Office",
+        items: [
+          {
+            id: "item-3",
+            itemName: "Desk",
+            assetId: "FURN01",
+            brand: "IKEA",
+            condition: "Good",
+            warrantyExpires: null,
+            replacementValue: 800,
+            photoPath: null,
+            locationId: "loc-2",
+            locationName: "Office",
+          },
+        ],
+      },
+    ],
+  },
+};
+
+function renderPage(locationId?: string) {
+  const path = locationId
+    ? `/inventory/report?locationId=${locationId}`
+    : "/inventory/report";
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/inventory/report" element={<InsuranceReportPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockReportQuery.mockReturnValue({
+    data: mockReport,
+    isLoading: false,
+  });
+});
+
+describe("InsuranceReportPage", () => {
+  it("renders report title", () => {
+    renderPage();
+    expect(screen.getByText("Insurance Report")).toBeInTheDocument();
+  });
+
+  it("renders total items and total value", () => {
+    renderPage();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("renders Print button", () => {
+    renderPage();
+    expect(screen.getByText("Print")).toBeInTheDocument();
+  });
+
+  it("renders location group headers", () => {
+    renderPage();
+    expect(screen.getByText(/Living Room/)).toBeInTheDocument();
+    expect(screen.getByText(/Office/)).toBeInTheDocument();
+  });
+
+  it("renders item names", () => {
+    renderPage();
+    expect(screen.getByText("MacBook Pro")).toBeInTheDocument();
+    expect(screen.getByText("Monitor")).toBeInTheDocument();
+    expect(screen.getByText("Desk")).toBeInTheDocument();
+  });
+
+  it("renders photo thumbnails with print max-width class", () => {
+    renderPage();
+    const img = document.querySelector('img[src*="macbook.jpg"]');
+    expect(img).toBeInTheDocument();
+    expect(img?.className).toContain("print:max-w-[200px]");
+  });
+
+  it("renders photo thumbnails with break-inside-avoid for print", () => {
+    renderPage();
+    const img = document.querySelector('img[src*="macbook.jpg"]');
+    expect(img?.className).toContain("print:break-inside-avoid");
+  });
+
+  it("applies break-inside-avoid to item rows for print", () => {
+    renderPage();
+    const rows = document.querySelectorAll("tbody tr");
+    expect(rows.length).toBe(3); // 2 items in Living Room + 1 in Office
+    rows.forEach((row) => {
+      expect(row.className).toContain("print:break-inside-avoid");
+    });
+  });
+
+  it("applies page-break-before on second location group (not first)", () => {
+    renderPage();
+    // Location groups are divs containing h2 headers
+    const headers = document.querySelectorAll("h2");
+    expect(headers.length).toBe(2);
+    // First group parent should NOT have break-before-page
+    const firstGroup = headers[0]!.parentElement!;
+    expect(firstGroup.className).not.toContain("print:break-before-page");
+    // Second group parent should have break-before-page
+    const secondGroup = headers[1]!.parentElement!;
+    expect(secondGroup.className).toContain("print:break-before-page");
+  });
+
+  it("applies print font sizes to section headers", () => {
+    renderPage();
+    const headers = document.querySelectorAll("h2");
+    headers.forEach((h) => {
+      expect(h.className).toContain("print:text-[14pt]");
+    });
+  });
+
+  it("applies print base font size to container", () => {
+    renderPage();
+    const container = document.querySelector("[class*='print:text-\\[11pt\\]']");
+    expect(container).toBeInTheDocument();
+  });
+
+  it("applies print border classes to table for structure", () => {
+    renderPage();
+    const tables = document.querySelectorAll("table");
+    tables.forEach((table) => {
+      expect(table.className).toContain("print:border");
+      expect(table.className).toContain("print:border-gray-300");
+    });
+  });
+
+  it("removes badge backgrounds for print", () => {
+    renderPage();
+    const badges = screen.getAllByTestId("badge");
+    badges.forEach((badge) => {
+      expect(badge.className).toContain("print:bg-transparent");
+    });
+  });
+
+  it("shows dashes for null values", () => {
+    renderPage();
+    // Monitor has no brand, condition, value — should show dashes
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("shows loading skeleton", () => {
+    mockReportQuery.mockReturnValue({ data: null, isLoading: true });
+    renderPage();
+    expect(document.querySelector(".animate-pulse")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no groups", () => {
+    mockReportQuery.mockReturnValue({
+      data: { data: { totalItems: 0, totalValue: 0, groups: [] } },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No inventory items found.")).toBeInTheDocument();
+  });
+
+  it("shows error state when report fails to load", () => {
+    mockReportQuery.mockReturnValue({ data: null, isLoading: false });
+    renderPage();
+    expect(screen.getByText("Failed to load report.")).toBeInTheDocument();
+  });
+});

--- a/packages/app-inventory/src/pages/InsuranceReportPage.tsx
+++ b/packages/app-inventory/src/pages/InsuranceReportPage.tsx
@@ -80,13 +80,13 @@ export function InsuranceReportPage(): React.ReactElement {
   }
 
   return (
-    <div className="p-6 max-w-5xl mx-auto print:p-0 print:max-w-none">
+    <div className="p-6 max-w-5xl mx-auto print:p-0 print:max-w-none print:text-[11pt]">
       {/* Header */}
       <div className="flex items-center justify-between mb-6 print:mb-4">
         <div>
           <div className="flex items-center gap-2 mb-1">
             <FileText className="h-6 w-6 text-muted-foreground print:hidden" />
-            <h1 className="text-2xl font-bold">Insurance Report</h1>
+            <h1 className="text-2xl font-bold print:text-[14pt]">Insurance Report</h1>
           </div>
           <p className="text-sm text-muted-foreground">
             Generated {today}
@@ -123,12 +123,12 @@ export function InsuranceReportPage(): React.ReactElement {
       </div>
 
       {/* Location Groups */}
-      {report.groups.map((group) => (
+      {report.groups.map((group, groupIndex) => (
         <div
           key={group.locationId ?? "unlocated"}
-          className="mb-8 print:mb-4 print:break-inside-avoid-page"
+          className={`mb-8 print:mb-4 ${groupIndex > 0 ? "print:break-before-page" : ""}`}
         >
-          <h2 className="text-lg font-semibold mb-3 pb-1 border-b">
+          <h2 className="text-lg font-semibold mb-3 pb-1 border-b print:text-[14pt]">
             {group.locationName}
             <span className="ml-2 text-sm font-normal text-muted-foreground">
               ({group.items.length} {group.items.length === 1 ? "item" : "items"})
@@ -136,16 +136,16 @@ export function InsuranceReportPage(): React.ReactElement {
           </h2>
 
           <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+            <table className="w-full text-sm print:text-[11pt] print:border-collapse print:border print:border-gray-300">
               <thead>
-                <tr className="border-b text-left text-muted-foreground">
-                  <th className="py-2 pr-3 w-10">Photo</th>
-                  <th className="py-2 pr-3">Name</th>
-                  <th className="py-2 pr-3">Asset ID</th>
-                  <th className="py-2 pr-3">Brand</th>
-                  <th className="py-2 pr-3">Condition</th>
-                  <th className="py-2 pr-3">Warranty</th>
-                  <th className="py-2 pr-3 text-right">Value</th>
+                <tr className="border-b text-left text-muted-foreground print:border-gray-300">
+                  <th className="py-2 pr-3 w-10 print:border print:border-gray-300 print:p-1">Photo</th>
+                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">Name</th>
+                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">Asset ID</th>
+                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">Brand</th>
+                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">Condition</th>
+                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">Warranty</th>
+                  <th className="py-2 pr-3 text-right print:border print:border-gray-300 print:p-1">Value</th>
                 </tr>
               </thead>
               <tbody>
@@ -154,40 +154,40 @@ export function InsuranceReportPage(): React.ReactElement {
                   return (
                     <tr
                       key={item.id}
-                      className="border-b last:border-0 hover:bg-muted/30 cursor-pointer print:hover:bg-transparent print:cursor-default"
+                      className="border-b last:border-0 hover:bg-muted/30 cursor-pointer print:hover:bg-transparent print:cursor-default print:break-inside-avoid print:border-gray-300"
                       onClick={() => navigate(`/inventory/items/${item.id}`)}
                     >
-                      <td className="py-2 pr-3">
+                      <td className="py-2 pr-3 print:border print:border-gray-300 print:p-1">
                         {item.photoPath ? (
                           <img
                             src={`/inventory/photos/${item.photoPath}`}
                             alt=""
-                            className="w-8 h-8 rounded object-cover"
+                            className="w-8 h-8 rounded object-cover print:w-auto print:h-auto print:max-w-[200px] print:break-inside-avoid"
                           />
                         ) : (
-                          <div className="w-8 h-8 rounded bg-muted" />
+                          <div className="w-8 h-8 rounded bg-muted print:bg-gray-100" />
                         )}
                       </td>
-                      <td className="py-2 pr-3 font-medium">{item.itemName}</td>
-                      <td className="py-2 pr-3">
+                      <td className="py-2 pr-3 font-medium print:border print:border-gray-300 print:p-1 print:text-[12pt]">{item.itemName}</td>
+                      <td className="py-2 pr-3 print:border print:border-gray-300 print:p-1 [&_span]:print:bg-transparent [&_span]:print:text-black">
                         {item.assetId ? (
                           <AssetIdBadge assetId={item.assetId} />
                         ) : (
                           <span className="text-muted-foreground">—</span>
                         )}
                       </td>
-                      <td className="py-2 pr-3">{item.brand ?? "—"}</td>
-                      <td className="py-2 pr-3">
+                      <td className="py-2 pr-3 print:border print:border-gray-300 print:p-1">{item.brand ?? "—"}</td>
+                      <td className="py-2 pr-3 print:border print:border-gray-300 print:p-1 [&_span]:print:bg-transparent [&_span]:print:text-black">
                         {item.condition ? (
                           <ConditionBadge condition={item.condition as Condition} />
                         ) : (
                           <span className="text-muted-foreground">—</span>
                         )}
                       </td>
-                      <td className="py-2 pr-3">
-                        <Badge variant={warranty.variant}>{warranty.label}</Badge>
+                      <td className="py-2 pr-3 print:border print:border-gray-300 print:p-1">
+                        <Badge variant={warranty.variant} className="print:bg-transparent print:border print:border-gray-400 print:text-black">{warranty.label}</Badge>
                       </td>
-                      <td className="py-2 pr-3 text-right tabular-nums">
+                      <td className="py-2 pr-3 text-right tabular-nums print:border print:border-gray-300 print:p-1">
                         {item.replacementValue ? formatCurrency(item.replacementValue) : "—"}
                       </td>
                     </tr>


### PR DESCRIPTION
## Summary
- Add `page-break-before` on location sections (skip first group) so each location starts on a new page
- Fix photo sizing from 8px to max 200px width in print with `break-inside: avoid`
- Add `break-inside: avoid` on item rows to prevent row splitting across pages
- Set print font sizes: 11pt body, 14pt section headers, 12pt item names
- Add print borders (`border-collapse`, `border-gray-300`) for table structure
- Remove background colors on badges/condition indicators for print (transparent bg, border only)
- 17 new tests verifying print classes, layout structure, empty/error states

Closes GH#771 (PRD-051 US-04)

## Test plan
- [ ] Verify 17 InsuranceReportPage tests pass
- [ ] Manual: print preview shows each location on a new page
- [ ] Manual: photos display at max 200px width, not split across pages
- [ ] Manual: item rows don't split across pages
- [ ] Manual: font sizes are readable (11-12pt body, 14pt headers)
- [ ] Manual: badges show borders instead of colored backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)