### PR TITLE
fix(app-media): Arr settings — remove reveal toggle, add URL validation

### DIFF
--- a/packages/app-media/src/pages/ArrSettingsPage.test.tsx
+++ b/packages/app-media/src/pages/ArrSettingsPage.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockSettingsQuery = vi.fn();
+const mockSaveMutate = vi.fn();
+const mockTestRadarrQuery = vi.fn();
+const mockTestSonarrQuery = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      arr: {
+        getSettings: { useQuery: (...args: unknown[]) => mockSettingsQuery(...args) },
+        saveSettings: {
+          useMutation: () => ({ mutate: mockSaveMutate, isPending: false }),
+        },
+        testRadarr: { useQuery: (...args: unknown[]) => mockTestRadarrQuery(...args) },
+        testSonarr: { useQuery: (...args: unknown[]) => mockTestSonarrQuery(...args) },
+      },
+    },
+  },
+}));
+
+vi.mock("@pops/ui", async () => {
+  const React = await import("react");
+  return {
+    Badge: ({ children, className }: { children: React.ReactNode; className?: string }) =>
+      React.createElement("span", { "data-testid": "badge", className }, children),
+    Button: ({ children, onClick, disabled, ...rest }: Record<string, unknown>) =>
+      React.createElement("button", { onClick: onClick as () => void, disabled, ...rest }, children as React.ReactNode),
+    Skeleton: ({ className }: { className?: string }) =>
+      React.createElement("div", { className: `animate-pulse ${className ?? ""}` }),
+    Input: ({ value, onChange, placeholder, disabled, type, className }: Record<string, unknown>) =>
+      React.createElement("input", { value: value as string, onChange: onChange as () => void, placeholder: placeholder as string, disabled, type, className }),
+    Breadcrumb: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("nav", null, children),
+    BreadcrumbList: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("ol", null, children),
+    BreadcrumbItem: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("li", null, children),
+    BreadcrumbLink: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("span", null, children),
+    BreadcrumbSeparator: () => React.createElement("span", null, "/"),
+    BreadcrumbPage: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("span", null, children),
+  };
+});
+
+import { ArrSettingsPage } from "./ArrSettingsPage";
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/media/arr"]}>
+      <ArrSettingsPage />
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSettingsQuery.mockReturnValue({
+    data: {
+      data: {
+        radarrUrl: "http://192.168.1.100:7878",
+        radarrApiKey: "••••••••",
+        radarrHasKey: true,
+        sonarrUrl: "http://192.168.1.100:8989",
+        sonarrApiKey: "••••••••",
+        sonarrHasKey: true,
+      },
+    },
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+  mockTestRadarrQuery.mockReturnValue({ data: null, isFetching: false, refetch: vi.fn() });
+  mockTestSonarrQuery.mockReturnValue({ data: null, isFetching: false, refetch: vi.fn() });
+});
+
+describe("ArrSettingsPage", () => {
+  it("renders page heading", () => {
+    renderPage();
+    expect(screen.getByRole("heading", { name: "Radarr & Sonarr Settings" })).toBeTruthy();
+  });
+
+  it("renders Radarr and Sonarr sections", () => {
+    renderPage();
+    expect(screen.getByText("Radarr")).toBeTruthy();
+    expect(screen.getByText("Sonarr")).toBeTruthy();
+  });
+
+  it("API key inputs are type=password with no reveal toggle", () => {
+    renderPage();
+    const passwordInputs = document.querySelectorAll('input[type="password"]');
+    expect(passwordInputs.length).toBe(2);
+    // No Eye/EyeOff toggle buttons
+    expect(screen.queryByLabelText("Show API key")).toBeNull();
+    expect(screen.queryByLabelText("Hide API key")).toBeNull();
+  });
+
+  it("renders loading skeleton", () => {
+    mockSettingsQuery.mockReturnValue({ data: null, isLoading: true, refetch: vi.fn() });
+    renderPage();
+    expect(document.querySelector(".animate-pulse")).toBeTruthy();
+  });
+
+  it("shows URL validation error for invalid URL", async () => {
+    mockSettingsQuery.mockReturnValue({
+      data: {
+        data: {
+          radarrUrl: "",
+          radarrApiKey: "",
+          radarrHasKey: false,
+          sonarrUrl: "",
+          sonarrApiKey: "",
+          sonarrHasKey: false,
+        },
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    const urlInputs = screen.getAllByPlaceholderText(/192\.168/);
+    await user.type(urlInputs[0]!, "ftp://bad-url");
+
+    expect(screen.getByText("URL must start with http:// or https://")).toBeTruthy();
+  });
+
+  it("does not show validation error for valid URL", async () => {
+    mockSettingsQuery.mockReturnValue({
+      data: {
+        data: {
+          radarrUrl: "",
+          radarrApiKey: "",
+          radarrHasKey: false,
+          sonarrUrl: "",
+          sonarrApiKey: "",
+          sonarrHasKey: false,
+        },
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    const urlInputs = screen.getAllByPlaceholderText(/192\.168/);
+    await user.type(urlInputs[0]!, "http://localhost:7878");
+
+    expect(screen.queryByText("URL must start with http:// or https://")).toBeNull();
+  });
+
+  it("renders save and test connection buttons", () => {
+    renderPage();
+    const saveButtons = screen.getAllByText("Save");
+    expect(saveButtons.length).toBe(2);
+    const testButtons = screen.getAllByText("Test Connection");
+    expect(testButtons.length).toBe(2);
+  });
+});

--- a/packages/app-media/src/pages/ArrSettingsPage.tsx
+++ b/packages/app-media/src/pages/ArrSettingsPage.tsx
@@ -26,8 +26,6 @@ import {
   Film,
   Tv,
   Save,
-  Eye,
-  EyeOff,
 } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
@@ -73,8 +71,8 @@ function ServiceCard({
   testing: boolean;
   testResult: { configured: boolean; connected: boolean; version?: string; error?: string } | null;
 }) {
-  const [showKey, setShowKey] = useState(false);
   const configured = !!(url && (hasKey || (apiKey && apiKey !== "••••••••")));
+  const urlInvalid = url.length > 0 && !url.startsWith("http://") && !url.startsWith("https://");
 
   return (
     <div className="rounded-lg border bg-card p-6 space-y-4">
@@ -93,34 +91,25 @@ function ServiceCard({
             onChange={(e) => onUrlChange(e.target.value)}
             disabled={saving}
           />
+          {urlInvalid && (
+            <p className="text-xs text-red-400">URL must start with http:// or https://</p>
+          )}
         </div>
 
         <div className="space-y-1.5">
           <label className="text-sm font-medium text-muted-foreground">API Key</label>
-          <div className="flex gap-2">
-            <Input
-              type={showKey ? "text" : "password"}
-              placeholder="Enter API key"
-              value={apiKey}
-              onChange={(e) => onApiKeyChange(e.target.value)}
-              disabled={saving}
-              className="flex-1"
-            />
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-9 w-9 shrink-0"
-              onClick={() => setShowKey(!showKey)}
-              aria-label={showKey ? "Hide API key" : "Show API key"}
-            >
-              {showKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-            </Button>
-          </div>
+          <Input
+            type="password"
+            placeholder="Enter API key"
+            value={apiKey}
+            onChange={(e) => onApiKeyChange(e.target.value)}
+            disabled={saving}
+          />
         </div>
       </div>
 
       <div className="flex gap-2">
-        <Button variant="outline" size="sm" onClick={onSave} disabled={saving}>
+        <Button variant="outline" size="sm" onClick={onSave} disabled={saving || urlInvalid}>
           {saving ? (
             <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" />
           ) : (


### PR DESCRIPTION
## Summary
- Remove Eye/EyeOff show/hide toggle from API key password fields (per spec: masked with no reveal)
- Add URL validation: error text + disabled save when URL doesn't start with `http://` or `https://`
- 7 component tests: masked inputs, no reveal toggle, URL validation, sections, save/test buttons

Closes tb-552 / GH#787 PRD-040 US-03

## Test plan
- [ ] Verify API key fields are masked and have no show/hide toggle
- [ ] Enter invalid URL (e.g. `ftp://` or just `localhost`) and verify error message appears
- [ ] Enter valid URL (`http://...`) and verify no error, save enabled
- [ ] Verify both Radarr and Sonarr sections render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)