### PR TITLE
feat: Arr base client cache, timeout, and save invalidation [tb-550]

### DIFF
--- a/apps/pops-api/src/modules/media/arr/base-client.test.ts
+++ b/apps/pops-api/src/modules/media/arr/base-client.test.ts
@@ -16,6 +16,13 @@ function jsonResponse(data: unknown, status = 200): Response {
   });
 }
 
+// Expose protected get() for cache testing
+class TestableClient extends ArrBaseClient {
+  async fetch<T>(path: string): Promise<T> {
+    return this.get<T>(path);
+  }
+}
+
 describe("ArrBaseClient", () => {
   let client: ArrBaseClient;
 
@@ -90,5 +97,110 @@ describe("ArrBaseClient", () => {
     );
 
     await expect(client.testConnection()).rejects.toThrow(ArrApiError);
+  });
+
+  it("sets AbortSignal timeout on fetch calls", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ version: "1.0", appName: "Test" }));
+
+    await client.testConnection();
+
+    const options = mockFetch.mock.calls[0]![1] as { signal?: AbortSignal };
+    expect(options.signal).toBeDefined();
+  });
+});
+
+describe("ArrBaseClient caching", () => {
+  let client: TestableClient;
+
+  beforeEach(() => {
+    client = new TestableClient("http://localhost:7878", "test-api-key");
+    mockFetch.mockReset();
+  });
+
+  it("returns cached data on second call within TTL", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ movies: [1, 2, 3] }));
+
+    const first = await client.fetch("/movie");
+    const second = await client.fetch("/movie");
+
+    expect(first).toEqual({ movies: [1, 2, 3] });
+    expect(second).toEqual({ movies: [1, 2, 3] });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches again after cache TTL expires", async () => {
+    vi.useFakeTimers();
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ v: 1 }))
+      .mockResolvedValueOnce(jsonResponse({ v: 2 }));
+
+    await client.fetch("/movie");
+    vi.advanceTimersByTime(31_000);
+
+    const result = await client.fetch("/movie");
+    expect(result).toEqual({ v: 2 });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it("clearCache() flushes all cached entries", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ v: 1 }))
+      .mockResolvedValueOnce(jsonResponse({ v: 2 }));
+
+    await client.fetch("/movie");
+    client.clearCache();
+
+    const result = await client.fetch("/movie");
+    expect(result).toEqual({ v: 2 });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("maintains separate caches per client instance", async () => {
+    const radarr = new TestableClient("http://radarr:7878", "key-r");
+    const sonarr = new TestableClient("http://sonarr:8989", "key-s");
+
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ from: "radarr" }))
+      .mockResolvedValueOnce(jsonResponse({ from: "sonarr" }));
+
+    const r = await radarr.fetch("/system/status");
+    const s = await sonarr.fetch("/system/status");
+
+    expect(r).toEqual({ from: "radarr" });
+    expect(s).toEqual({ from: "sonarr" });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches are keyed by full URL (different paths don't collide)", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ type: "movie" }))
+      .mockResolvedValueOnce(jsonResponse({ type: "queue" }));
+
+    const movies = await client.fetch("/movie");
+    const queue = await client.fetch("/queue");
+
+    expect(movies).toEqual({ type: "movie" });
+    expect(queue).toEqual({ type: "queue" });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("clearCache on one instance does not affect another", async () => {
+    const clientA = new TestableClient("http://radarr:7878", "key");
+    const clientB = new TestableClient("http://sonarr:8989", "key");
+
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ v: "a" }))
+      .mockResolvedValueOnce(jsonResponse({ v: "b" }));
+
+    await clientA.fetch("/movie");
+    await clientB.fetch("/series");
+
+    clientA.clearCache();
+
+    // clientB cache should still be intact
+    await clientB.fetch("/series");
+    expect(mockFetch).toHaveBeenCalledTimes(2); // no extra call for clientB
   });
 });

--- a/apps/pops-api/src/modules/media/arr/base-client.ts
+++ b/apps/pops-api/src/modules/media/arr/base-client.ts
@@ -3,12 +3,24 @@
  *
  * Both services share the same API pattern: base URL + /api/v3/ + endpoint,
  * authenticated via X-Api-Key header.
+ *
+ * Each client instance maintains its own in-memory cache keyed by full URL
+ * with a 30-second TTL, so Radarr and Sonarr caches cannot collide.
  */
 import { ArrApiError, type ArrSystemStatus } from "./types.js";
+
+interface CacheEntry {
+  data: unknown;
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 30_000;
+const CONNECTION_TIMEOUT_MS = 5_000;
 
 export class ArrBaseClient {
   protected readonly baseUrl: string;
   private readonly apiKey: string;
+  private readonly cache = new Map<string, CacheEntry>();
 
   constructor(baseUrl: string, apiKey: string) {
     // Strip trailing slash
@@ -20,19 +32,36 @@ export class ArrBaseClient {
   protected async get<T>(path: string): Promise<T> {
     const url = `${this.baseUrl}/api/v3${path}`;
 
+    // Check cache
+    const cached = this.cache.get(url);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.data as T;
+    }
+
     const response = await fetch(url, {
       method: "GET",
       headers: {
         "X-Api-Key": this.apiKey,
         Accept: "application/json",
       },
+      signal: AbortSignal.timeout(CONNECTION_TIMEOUT_MS),
     });
 
     if (!response.ok) {
       throw new ArrApiError(`${response.status} ${response.statusText} — ${url}`, response.status);
     }
 
-    return (await response.json()) as T;
+    const data = (await response.json()) as T;
+
+    // Store in cache
+    this.cache.set(url, { data, expiresAt: Date.now() + CACHE_TTL_MS });
+
+    return data;
+  }
+
+  /** Flush all cached entries for this client instance. */
+  clearCache(): void {
+    this.cache.clear();
   }
 
   /** Test the connection by fetching system status. */

--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -88,6 +88,7 @@ export const arrRouter = router({
       if (input.sonarrApiKey !== undefined && input.sonarrApiKey !== "••••••••")
         config.sonarrApiKey = input.sonarrApiKey;
       arrService.saveArrSettings(config);
+      arrService.clearStatusCache();
       return { message: "Arr settings saved" };
     }),
 


### PR DESCRIPTION
## Summary
- Added URL-keyed in-memory cache (30s TTL) to `ArrBaseClient` so Radarr/Sonarr caches don't collide
- Added `clearCache()` method to flush all cached entries per client instance
- Added 5-second connection timeout via `AbortSignal.timeout()`
- `saveSettings` mutation now calls `clearStatusCache()` to invalidate stale data after config changes
- 12 tests covering cache hits, TTL expiry, clearCache, per-instance isolation, timeout signal

## Test plan
- [x] 12 vitest tests passing
- [x] Lint clean
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)