### PR TITLE
fix: correct ArrStatusBadge monitored color and hide on error [tb-551]

### DIFF
--- a/packages/app-media/src/components/ArrStatusBadge.test.tsx
+++ b/packages/app-media/src/components/ArrStatusBadge.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ArrStatusBadge } from "./ArrStatusBadge";
+
+const mockGetConfig = vi.fn();
+const mockGetMovieStatus = vi.fn();
+const mockGetShowStatus = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      arr: {
+        getConfig: { useQuery: () => mockGetConfig() },
+        getMovieStatus: {
+          useQuery: (_input: unknown, opts: { enabled: boolean }) =>
+            opts.enabled ? mockGetMovieStatus() : { data: null, isLoading: false, error: null },
+        },
+        getShowStatus: {
+          useQuery: (_input: unknown, opts: { enabled: boolean }) =>
+            opts.enabled ? mockGetShowStatus() : { data: null, isLoading: false, error: null },
+        },
+      },
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConfig.mockReturnValue({
+    data: { data: { radarrConfigured: true, sonarrConfigured: true } },
+  });
+});
+
+describe("ArrStatusBadge", () => {
+  it("renders nothing when service is not configured", () => {
+    mockGetConfig.mockReturnValue({
+      data: { data: { radarrConfigured: false, sonarrConfigured: false } },
+    });
+    const { container } = render(<ArrStatusBadge kind="movie" externalId={123} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when service is unreachable (error)", () => {
+    mockGetMovieStatus.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error("Connection refused"),
+    });
+    const { container } = render(<ArrStatusBadge kind="movie" externalId={123} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing while loading", () => {
+    mockGetMovieStatus.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+    const { container } = render(<ArrStatusBadge kind="movie" externalId={123} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders Available badge with green styling", () => {
+    mockGetMovieStatus.mockReturnValue({
+      data: { data: { status: "available", label: "Available" } },
+      isLoading: false,
+      error: null,
+    });
+    render(<ArrStatusBadge kind="movie" externalId={123} />);
+    const badge = screen.getByText("Available");
+    expect(badge).toBeInTheDocument();
+    expect(badge.className).toContain("bg-green-600");
+  });
+
+  it("renders Downloading badge with yellow styling", () => {
+    mockGetMovieStatus.mockReturnValue({
+      data: { data: { status: "downloading", label: "Downloading" } },
+      isLoading: false,
+      error: null,
+    });
+    render(<ArrStatusBadge kind="movie" externalId={123} />);
+    const badge = screen.getByText("Downloading");
+    expect(badge).toBeInTheDocument();
+    expect(badge.className).toContain("bg-yellow-600");
+  });
+
+  it("renders Monitored badge with blue styling", () => {
+    mockGetMovieStatus.mockReturnValue({
+      data: { data: { status: "monitored", label: "Monitored" } },
+      isLoading: false,
+      error: null,
+    });
+    render(<ArrStatusBadge kind="movie" externalId={123} />);
+    const badge = screen.getByText("Monitored");
+    expect(badge).toBeInTheDocument();
+    expect(badge.className).toContain("bg-blue-600");
+  });
+
+  it("renders Not Monitored badge with grey styling", () => {
+    mockGetMovieStatus.mockReturnValue({
+      data: { data: { status: "unmonitored", label: "Not Monitored" } },
+      isLoading: false,
+      error: null,
+    });
+    render(<ArrStatusBadge kind="movie" externalId={123} />);
+    const badge = screen.getByText("Not Monitored");
+    expect(badge).toBeInTheDocument();
+    expect(badge.className).toContain("bg-muted");
+  });
+
+  it("works for TV shows using sonarr", () => {
+    mockGetShowStatus.mockReturnValue({
+      data: { data: { status: "monitored", label: "Monitored" } },
+      isLoading: false,
+      error: null,
+    });
+    render(<ArrStatusBadge kind="show" externalId={456} />);
+    const badge = screen.getByText("Monitored");
+    expect(badge).toBeInTheDocument();
+    expect(badge.className).toContain("bg-blue-600");
+  });
+});

--- a/packages/app-media/src/components/ArrStatusBadge.tsx
+++ b/packages/app-media/src/components/ArrStatusBadge.tsx
@@ -17,12 +17,11 @@ interface ArrStatusBadgeProps {
 const STATUS_STYLES: Record<string, string> = {
   available: "bg-green-600 text-white",
   complete: "bg-green-600 text-white",
-  monitored: "bg-yellow-600 text-white",
+  monitored: "bg-blue-600 text-white",
   downloading: "bg-yellow-600 text-white",
   partial: "bg-yellow-600 text-white",
   unmonitored: "bg-muted text-muted-foreground",
   not_found: "bg-muted text-muted-foreground",
-  unavailable: "bg-muted text-muted-foreground",
 };
 
 export function ArrStatusBadge({ kind, externalId }: ArrStatusBadgeProps) {
@@ -46,11 +45,8 @@ export function ArrStatusBadge({ kind, externalId }: ArrStatusBadgeProps) {
   const query = kind === "movie" ? movieStatus : showStatus;
   if (query.isLoading) return null;
 
-  // Show unavailable badge when query errors (configured but unreachable)
-  if (query.error) {
-    const label = kind === "movie" ? "Radarr unavailable" : "Sonarr unavailable";
-    return <Badge className={STATUS_STYLES.unavailable}>{label}</Badge>;
-  }
+  // Do not render when service is unreachable
+  if (query.error) return null;
 
   if (!query.data?.data) return null;
 


### PR DESCRIPTION
## Summary
- Fix Monitored badge color from yellow to blue per spec (Available=green, Downloading=yellow, Monitored=blue, Not Monitored=grey)
- Return null when Radarr/Sonarr is unreachable instead of showing "unavailable" badge text
- Add 8 unit tests covering all badge states and edge cases

Closes #786

## Test plan
- [ ] Verify Monitored badge renders with blue background
- [ ] Verify Available=green, Downloading=yellow, Not Monitored=grey
- [ ] Verify no badge renders when service is unreachable
- [ ] Run `pnpm test` in `packages/app-media` — 195 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)