### PR TITLE
feat: Plex settings page gaps — PIN display, sync results, scheduler UI [tb-547]

### DIFF
--- a/packages/app-media/src/pages/PlexSettingsPage.test.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.test.tsx
@@ -263,10 +263,10 @@ describe("PlexSettingsPage", () => {
 
     // Simulate success
     const onSuccess = syncMoviesOpts.onSuccess as (res: {
-      data: { synced: number; skipped: number; errors: { title: string; error: string }[] };
+      data: { synced: number; skipped: number; errors: { title: string; reason: string; year: number | null }[] };
     }) => void;
     onSuccess({
-      data: { synced: 5, skipped: 2, errors: [{ title: "Bad Movie", error: "TMDB not found" }] },
+      data: { synced: 5, skipped: 2, errors: [{ title: "Bad Movie", reason: "TMDB not found", year: 2020 }] },
     });
 
     // Re-render to see results
@@ -286,7 +286,7 @@ describe("PlexSettingsPage", () => {
     expect(mockSyncTvMutate).toHaveBeenCalled();
 
     const onSuccess = syncTvOpts.onSuccess as (res: {
-      data: { synced: number; skipped: number; errors: { title: string; error: string }[] };
+      data: { synced: number; skipped: number; errors: { title: string; reason: string; year: number | null }[] };
     }) => void;
     onSuccess({
       data: { synced: 3, skipped: 1, errors: [] },
@@ -303,13 +303,13 @@ describe("PlexSettingsPage", () => {
 
     fireEvent.click(screen.getByText("Sync Movies"));
     const onSuccess = syncMoviesOpts.onSuccess as (res: {
-      data: { synced: number; skipped: number; errors: { title: string; error: string }[] };
+      data: { synced: number; skipped: number; errors: { title: string; reason: string; year: number | null }[] };
     }) => void;
     onSuccess({
       data: {
         synced: 1,
         skipped: 0,
-        errors: [{ title: "Broken Film", error: "No TMDB match" }],
+        errors: [{ title: "Broken Film", reason: "No TMDB match", year: null }],
       },
     });
 

--- a/packages/app-media/src/pages/PlexSettingsPage.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.tsx
@@ -39,7 +39,7 @@ import { trpc } from "../lib/trpc";
 interface SyncResult {
   synced: number;
   skipped: number;
-  errors: { title: string; error: string }[];
+  errors: { title: string; reason: string; year: number | null }[];
 }
 
 function ConnectionBadge({ connected }: { connected: boolean }) {
@@ -86,7 +86,7 @@ function SyncResultDisplay({ result, label }: { result: SyncResult; label: strin
             <div className="mt-2 space-y-1 text-xs text-red-400/80">
               {result.errors.map((err, i) => (
                 <p key={i}>
-                  <span className="font-medium">{err.title}:</span> {err.error}
+                  <span className="font-medium">{err.title}:</span> {err.reason}
                 </p>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- Display PIN code prominently (large mono text) with link to plex.tv/link instead of auto-opening a popup window
- Show inline sync results after manual movie/TV sync: synced, skipped, errors counts
- Add collapsible error details section when sync has failures
- Add auto sync scheduler section with start/stop toggle, configurable interval (hours), and status display (next sync, last sync, totals)
- 13 component tests covering auth flow, sync results, scheduler controls, connection errors

Closes GH#782

## Test plan
- [ ] Verify PIN auth flow shows code prominently with plex.tv/link
- [ ] Verify sync results display inline after movie/TV sync
- [ ] Verify error details expand/collapse
- [ ] Verify scheduler start/stop and interval configuration
- [ ] Run `vitest run PlexSettingsPage.test.tsx` — 13 tests pass

Generated with [Claude Code](https://claude.ai/claude-code)