### PR TITLE
feat: RequestMovieButton with Radarr integration [tb-555]

### DIFF
--- a/packages/app-media/src/components/DiscoverCard.tsx
+++ b/packages/app-media/src/components/DiscoverCard.tsx
@@ -5,6 +5,7 @@
 import { useState } from "react";
 import { cn, Badge, Button, Skeleton } from "@pops/ui";
 import { Film, Plus, Bookmark, Check, Loader2, X } from "lucide-react";
+import { RequestMovieButton } from "./RequestMovieButton";
 
 export interface DiscoverCardProps {
   tmdbId: number;
@@ -131,6 +132,7 @@ export function DiscoverCard({
               <Bookmark className="h-3.5 w-3.5" />
             )}
           </Button>
+          <RequestMovieButton tmdbId={tmdbId} title={title} variant="compact" />
           <Button
             size="icon"
             variant="ghost"

--- a/packages/app-media/src/components/RequestMovieButton.test.tsx
+++ b/packages/app-media/src/components/RequestMovieButton.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const mockGetConfigQuery = vi.fn();
+const mockGetMovieStatusQuery = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      arr: {
+        getConfig: {
+          useQuery: () => mockGetConfigQuery(),
+        },
+        getMovieStatus: {
+          useQuery: (_input: unknown, _opts: unknown) => mockGetMovieStatusQuery(),
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+}));
+
+import { RequestMovieButton } from "./RequestMovieButton";
+import { toast } from "sonner";
+
+describe("RequestMovieButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows disabled button when Radarr is not configured (standard)", () => {
+    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: false } } });
+    mockGetMovieStatusQuery.mockReturnValue({ data: null, isLoading: false, error: null });
+
+    render(<RequestMovieButton tmdbId={123} title="Test Movie" />);
+
+    const button = screen.getByRole("button", { name: /request/i });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("title", "Radarr not configured");
+  });
+
+  it("shows disabled compact button when Radarr is not configured", () => {
+    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: false } } });
+    mockGetMovieStatusQuery.mockReturnValue({ data: null, isLoading: false, error: null });
+
+    render(<RequestMovieButton tmdbId={123} title="Test Movie" variant="compact" />);
+
+    const button = screen.getByRole("button", { name: /radarr not configured/i });
+    expect(button).toBeDisabled();
+  });
+
+  it("hides button when movie exists in Radarr (available)", () => {
+    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
+    mockGetMovieStatusQuery.mockReturnValue({
+      data: { data: { status: "available", label: "Available" } },
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = render(<RequestMovieButton tmdbId={123} title="Test Movie" />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("hides button when movie is monitored in Radarr", () => {
+    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
+    mockGetMovieStatusQuery.mockReturnValue({
+      data: { data: { status: "monitored", label: "Monitored" } },
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = render(<RequestMovieButton tmdbId={123} title="Test Movie" />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("hides button when movie is downloading in Radarr", () => {
+    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
+    mockGetMovieStatusQuery.mockReturnValue({
+      data: { data: { status: "downloading", label: "Downloading 45%" } },
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = render(<RequestMovieButton tmdbId={123} title="Test Movie" />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when Radarr is unreachable (query error)", () => {
+    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
+    mockGetMovieStatusQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error("Connection refused"),
+    });
+
+    const { container } = render(<RequestMovieButton tmdbId={123} title="Test Movie" />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows Request button when movie is not found in Radarr (standard)", () => {
+    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
+    mockGetMovieStatusQuery.mockReturnValue({
+      data: { data: { status: "not_found", label: "Not in Radarr" } },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<RequestMovieButton tmdbId={123} title="Test Movie" />);
+    expect(screen.getByRole("button", { name: /request/i })).toBeEnabled();
+  });
+
+  it("shows compact button when movie is not found in Radarr", () => {
+    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
+    mockGetMovieStatusQuery.mockReturnValue({
+      data: { data: { status: "not_found", label: "Not in Radarr" } },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<RequestMovieButton tmdbId={123} title="Test Movie" variant="compact" />);
+    expect(screen.getByRole("button", { name: /request in radarr/i })).toBeEnabled();
+  });
+
+  it("calls onRequest callback when clicked", () => {
+    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
+    mockGetMovieStatusQuery.mockReturnValue({
+      data: { data: { status: "not_found", label: "Not in Radarr" } },
+      isLoading: false,
+      error: null,
+    });
+
+    const onRequest = vi.fn();
+    render(<RequestMovieButton tmdbId={456} title="Test Movie" onRequest={onRequest} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /request/i }));
+    expect(onRequest).toHaveBeenCalledWith(456);
+  });
+
+  it("shows toast when clicked without onRequest callback", () => {
+    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
+    mockGetMovieStatusQuery.mockReturnValue({
+      data: { data: { status: "not_found", label: "Not in Radarr" } },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<RequestMovieButton tmdbId={789} title="Inception" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /request/i }));
+    expect(toast.info).toHaveBeenCalledWith('Request "Inception" — modal coming soon');
+  });
+
+  it("returns null while loading", () => {
+    mockGetConfigQuery.mockReturnValue({ data: { data: { radarrConfigured: true } } });
+    mockGetMovieStatusQuery.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+
+    const { container } = render(<RequestMovieButton tmdbId={123} title="Test Movie" />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/packages/app-media/src/components/RequestMovieButton.tsx
+++ b/packages/app-media/src/components/RequestMovieButton.tsx
@@ -1,0 +1,99 @@
+/**
+ * RequestMovieButton — requests a movie via Radarr.
+ *
+ * Hidden when the movie already exists in Radarr.
+ * Disabled when Radarr is not configured.
+ * Returns null on query error (service unreachable).
+ */
+import { Button } from "@pops/ui";
+import { Download } from "lucide-react";
+import { toast } from "sonner";
+import { trpc } from "../lib/trpc";
+
+type ButtonVariant = "standard" | "compact";
+
+export interface RequestMovieButtonProps {
+  tmdbId: number;
+  title: string;
+  variant?: ButtonVariant;
+  onRequest?: (tmdbId: number) => void;
+}
+
+export function RequestMovieButton({
+  tmdbId,
+  title,
+  variant = "standard",
+  onRequest,
+}: RequestMovieButtonProps) {
+  const { data: configData } = trpc.media.arr.getConfig.useQuery();
+  const config = configData?.data;
+
+  const movieStatus = trpc.media.arr.getMovieStatus.useQuery(
+    { tmdbId },
+    { enabled: config?.radarrConfigured === true }
+  );
+
+  // Not configured — show disabled button
+  if (!config?.radarrConfigured) {
+    if (variant === "compact") {
+      return (
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7 text-white hover:bg-white/20"
+          disabled
+          title="Radarr not configured"
+          aria-label="Request movie (Radarr not configured)"
+        >
+          <Download className="h-3.5 w-3.5" />
+        </Button>
+      );
+    }
+    return (
+      <Button variant="outline" size="sm" disabled title="Radarr not configured">
+        <Download className="h-4 w-4" />
+        Request
+      </Button>
+    );
+  }
+
+  // Loading — show spinner
+  if (movieStatus.isLoading) return null;
+
+  // Error — hide entirely (service unreachable)
+  if (movieStatus.error) return null;
+
+  // Movie exists in Radarr — hide button
+  const status = movieStatus.data?.data?.status;
+  if (status && status !== "not_found") return null;
+
+  const handleClick = () => {
+    if (onRequest) {
+      onRequest(tmdbId);
+    } else {
+      toast.info(`Request "${title}" — modal coming soon`);
+    }
+  };
+
+  if (variant === "compact") {
+    return (
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-7 w-7 text-white hover:bg-white/20"
+        onClick={handleClick}
+        title="Request in Radarr"
+        aria-label="Request in Radarr"
+      >
+        <Download className="h-3.5 w-3.5" />
+      </Button>
+    );
+  }
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleClick}>
+      <Download className="h-4 w-4" />
+      Request
+    </Button>
+  );
+}

--- a/packages/app-media/src/components/SearchResultCard.tsx
+++ b/packages/app-media/src/components/SearchResultCard.tsx
@@ -6,6 +6,7 @@
 import { useState } from "react";
 import { cn, Badge, Button, Skeleton } from "@pops/ui";
 import { Film, Tv, Loader2, Check, Plus } from "lucide-react";
+import { RequestMovieButton } from "./RequestMovieButton";
 
 const TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/w342";
 
@@ -14,6 +15,8 @@ export type SearchResultType = "movie" | "tv";
 export interface SearchResultCardProps {
   type: SearchResultType;
   title: string;
+  /** TMDB ID — required for movie request button. */
+  tmdbId?: number;
   year?: string | null;
   overview?: string | null;
   posterUrl?: string | null;
@@ -45,6 +48,7 @@ export function buildPosterUrl(
 export function SearchResultCard({
   type,
   title,
+  tmdbId,
   year,
   overview,
   posterUrl,
@@ -122,8 +126,8 @@ export function SearchResultCard({
           </div>
         )}
 
-        {/* Action button */}
-        <div className="mt-auto pt-1">
+        {/* Action buttons */}
+        <div className="mt-auto flex items-center gap-2 pt-1">
           {inLibrary ? (
             <Badge variant="secondary" className="gap-1">
               <Check className="h-3 w-3" />
@@ -145,6 +149,9 @@ export function SearchResultCard({
               )}
               {isAdding ? "Adding…" : "Add to Library"}
             </Button>
+          )}
+          {type === "movie" && tmdbId != null && (
+            <RequestMovieButton tmdbId={tmdbId} title={title} />
           )}
         </div>
       </div>

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -18,6 +18,7 @@ import { WatchlistToggle } from "../components/WatchlistToggle";
 import { ComparisonScores } from "../components/ComparisonScores";
 import { MarkAsWatchedButton } from "../components/MarkAsWatchedButton";
 import { ArrStatusBadge } from "../components/ArrStatusBadge";
+import { RequestMovieButton } from "../components/RequestMovieButton";
 
 function MovieDetailSkeleton() {
   return (
@@ -186,6 +187,7 @@ export function MovieDetailPage() {
               <WatchlistToggle mediaType="movie" mediaId={movie.id} />
               <MarkAsWatchedButton mediaId={movie.id} />
               <ArrStatusBadge kind="movie" externalId={movie.tmdbId} />
+              <RequestMovieButton tmdbId={movie.tmdbId} title={movie.title} />
             </div>
           </div>
         </div>

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -267,6 +267,7 @@ export function SearchPage() {
                   <SearchResultCard
                     key={movie.tmdbId}
                     type="movie"
+                    tmdbId={movie.tmdbId}
                     title={movie.title}
                     year={movie.releaseDate?.slice(0, 4) ?? null}
                     overview={movie.overview}


### PR DESCRIPTION
## Summary
- Add `RequestMovieButton` component with two variants (standard/compact) that checks Radarr config and movie status via tRPC
- Hidden when movie exists in Radarr, disabled when not configured, absent on error
- Integrated into MovieDetailPage (hero section), DiscoverCard (hover overlay), and SearchResultCard (action area)
- Added `tmdbId` prop to SearchResultCard for request button support
- 11 unit tests covering all visibility/interaction states
- Uses placeholder toast until RequestMovieModal (tb-554) is ready

## Test plan
- [ ] Verify button hidden when movie already in Radarr (available/monitored/downloading)
- [ ] Verify button disabled when Radarr not configured
- [ ] Verify button absent when Radarr unreachable (query error)
- [ ] Verify button visible and clickable when movie not in Radarr
- [ ] Verify compact variant renders in DiscoverCard hover overlay
- [ ] Verify standard variant renders in MovieDetailPage and SearchResultCard
- [ ] Verify toast shown on click (placeholder for modal)
- [ ] CI passes (typecheck, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)