### PR TITLE
feat: RequestSeriesModal with Sonarr integration [tb-557]

### DIFF
--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -283,4 +283,101 @@ export const arrRouter = router({
         throw err;
       }
     }),
+
+  /** Get Sonarr quality profiles. */
+  getSonarrQualityProfiles: protectedProcedure.query(async () => {
+    const client = arrService.getSonarrClient();
+    if (!client) {
+      throw new TRPCError({ code: "PRECONDITION_FAILED", message: "Sonarr is not configured" });
+    }
+    try {
+      const profiles = await client.getQualityProfiles();
+      return { data: profiles };
+    } catch (err) {
+      if (err instanceof ArrApiError) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Sonarr error: ${err.message}`,
+        });
+      }
+      throw err;
+    }
+  }),
+
+  /** Get Sonarr root folders. */
+  getSonarrRootFolders: protectedProcedure.query(async () => {
+    const client = arrService.getSonarrClient();
+    if (!client) {
+      throw new TRPCError({ code: "PRECONDITION_FAILED", message: "Sonarr is not configured" });
+    }
+    try {
+      const folders = await client.getRootFolders();
+      return { data: folders };
+    } catch (err) {
+      if (err instanceof ArrApiError) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Sonarr error: ${err.message}`,
+        });
+      }
+      throw err;
+    }
+  }),
+
+  /** Get Sonarr language profiles. */
+  getSonarrLanguageProfiles: protectedProcedure.query(async () => {
+    const client = arrService.getSonarrClient();
+    if (!client) {
+      throw new TRPCError({ code: "PRECONDITION_FAILED", message: "Sonarr is not configured" });
+    }
+    try {
+      const profiles = await client.getLanguageProfiles();
+      return { data: profiles };
+    } catch (err) {
+      if (err instanceof ArrApiError) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Sonarr error: ${err.message}`,
+        });
+      }
+      throw err;
+    }
+  }),
+
+  /** Add a series to Sonarr. */
+  addSeries: protectedProcedure
+    .input(
+      z.object({
+        tvdbId: z.number().int().positive(),
+        title: z.string().min(1),
+        qualityProfileId: z.number().int().positive(),
+        rootFolderPath: z.string().min(1),
+        languageProfileId: z.number().int().positive(),
+        seasons: z.array(
+          z.object({
+            seasonNumber: z.number().int().min(0),
+            monitored: z.boolean(),
+          })
+        ),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const client = arrService.getSonarrClient();
+      if (!client) {
+        throw new TRPCError({ code: "PRECONDITION_FAILED", message: "Sonarr is not configured" });
+      }
+      try {
+        const series = await client.addSeries(input);
+        arrService.clearStatusCache();
+        return { data: series };
+      } catch (err) {
+        if (err instanceof ArrApiError) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: `Sonarr error: ${err.message}`,
+          });
+        }
+        throw err;
+      }
+    }),
 });

--- a/apps/pops-api/src/modules/media/arr/sonarr-client.ts
+++ b/apps/pops-api/src/modules/media/arr/sonarr-client.ts
@@ -2,7 +2,15 @@
  * Sonarr API client — extends base *arr client with TV show-specific endpoints.
  */
 import { ArrBaseClient } from "./base-client.js";
-import type { SonarrSeries, SonarrQueueResponse, ArrStatusResult } from "./types.js";
+import type {
+  SonarrSeries,
+  SonarrQueueResponse,
+  ArrStatusResult,
+  SonarrQualityProfile,
+  SonarrRootFolder,
+  SonarrLanguageProfile,
+  SonarrAddSeriesInput,
+} from "./types.js";
 
 export class SonarrClient extends ArrBaseClient {
   /** Fetch all monitored series from Sonarr. */
@@ -65,5 +73,34 @@ export class SonarrClient extends ArrBaseClient {
     }
 
     return { status: "monitored", label: "Monitored" };
+  }
+
+  /** Fetch quality profiles from Sonarr. */
+  async getQualityProfiles(): Promise<SonarrQualityProfile[]> {
+    return this.get<SonarrQualityProfile[]>("/qualityprofile");
+  }
+
+  /** Fetch root folders from Sonarr. */
+  async getRootFolders(): Promise<SonarrRootFolder[]> {
+    return this.get<SonarrRootFolder[]>("/rootfolder");
+  }
+
+  /** Fetch language profiles from Sonarr. */
+  async getLanguageProfiles(): Promise<SonarrLanguageProfile[]> {
+    return this.get<SonarrLanguageProfile[]>("/languageprofile");
+  }
+
+  /** Add a series to Sonarr. */
+  async addSeries(input: SonarrAddSeriesInput): Promise<SonarrSeries> {
+    return this.post<SonarrSeries>("/series", {
+      tvdbId: input.tvdbId,
+      title: input.title,
+      qualityProfileId: input.qualityProfileId,
+      rootFolderPath: input.rootFolderPath,
+      languageProfileId: input.languageProfileId,
+      seasons: input.seasons,
+      monitored: true,
+      addOptions: { searchForMissingEpisodes: false },
+    });
   }
 }

--- a/apps/pops-api/src/modules/media/arr/types.ts
+++ b/apps/pops-api/src/modules/media/arr/types.ts
@@ -95,6 +95,33 @@ export interface RadarrQueueResponse {
   records: RadarrQueueRecord[];
 }
 
+// -- Sonarr request/config types --
+
+export interface SonarrQualityProfile {
+  id: number;
+  name: string;
+}
+
+export interface SonarrRootFolder {
+  id: number;
+  path: string;
+  freeSpace: number;
+}
+
+export interface SonarrLanguageProfile {
+  id: number;
+  name: string;
+}
+
+export interface SonarrAddSeriesInput {
+  tvdbId: number;
+  title: string;
+  qualityProfileId: number;
+  rootFolderPath: string;
+  languageProfileId: number;
+  seasons: { seasonNumber: number; monitored: boolean }[];
+}
+
 // -- Sonarr response types --
 
 export interface SonarrSeries {

--- a/packages/app-media/src/components/RequestSeriesModal.test.tsx
+++ b/packages/app-media/src/components/RequestSeriesModal.test.tsx
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mockQualityProfiles = vi.fn();
+const mockRootFolders = vi.fn();
+const mockLanguageProfiles = vi.fn();
+const mockMutateAsync = vi.fn();
+const mockAddSeries = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      arr: {
+        getSonarrQualityProfiles: { useQuery: () => mockQualityProfiles() },
+        getSonarrRootFolders: { useQuery: () => mockRootFolders() },
+        getSonarrLanguageProfiles: { useQuery: () => mockLanguageProfiles() },
+        addSeries: {
+          useMutation: () => mockAddSeries(),
+        },
+      },
+    },
+  },
+}));
+
+import { RequestSeriesModal, type SeasonInfo } from "./RequestSeriesModal";
+
+const QUALITY_PROFILES = [
+  { id: 1, name: "HD-1080p" },
+  { id: 2, name: "Ultra-HD" },
+];
+
+const ROOT_FOLDERS = [
+  { id: 1, path: "/tv", freeSpace: 500_000_000_000 },
+  { id: 2, path: "/tv-anime", freeSpace: 200_000_000_000 },
+];
+
+const LANGUAGE_PROFILES = [
+  { id: 1, name: "English" },
+  { id: 2, name: "Japanese" },
+];
+
+const SEASONS: SeasonInfo[] = [
+  { seasonNumber: 1, airDate: "2020-01-15" },
+  { seasonNumber: 2, airDate: "2021-06-01" },
+  { seasonNumber: 3, airDate: "2027-09-01" },
+];
+
+function setupMocks(
+  overrides: {
+    isLoading?: boolean;
+    isPending?: boolean;
+  } = {}
+): void {
+  mockQualityProfiles.mockReturnValue({
+    data: overrides.isLoading ? undefined : { data: QUALITY_PROFILES },
+    isLoading: overrides.isLoading ?? false,
+  });
+  mockRootFolders.mockReturnValue({
+    data: overrides.isLoading ? undefined : { data: ROOT_FOLDERS },
+    isLoading: overrides.isLoading ?? false,
+  });
+  mockLanguageProfiles.mockReturnValue({
+    data: overrides.isLoading ? undefined : { data: LANGUAGE_PROFILES },
+    isLoading: overrides.isLoading ?? false,
+  });
+  mockAddSeries.mockReturnValue({
+    mutateAsync: mockMutateAsync,
+    isPending: overrides.isPending ?? false,
+  });
+}
+
+function renderModal(seasonOverrides?: SeasonInfo[]): ReturnType<typeof render> {
+  return render(
+    <RequestSeriesModal
+      open={true}
+      onClose={vi.fn()}
+      tvdbId={12345}
+      title="Breaking Bad"
+      year={2008}
+      seasons={seasonOverrides ?? SEASONS}
+    />
+  );
+}
+
+describe("RequestSeriesModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutateAsync.mockResolvedValue({ data: {} });
+  });
+
+  it("renders title with year", () => {
+    setupMocks();
+    renderModal();
+    expect(screen.getByText("Request Breaking Bad (2008)")).toBeInTheDocument();
+  });
+
+  it("shows loading spinner while data is loading", () => {
+    setupMocks({ isLoading: true });
+    renderModal();
+    expect(screen.queryByText("Quality Profile")).not.toBeInTheDocument();
+  });
+
+  it("populates quality profile dropdown", () => {
+    setupMocks();
+    renderModal();
+    expect(screen.getByText("Quality Profile")).toBeInTheDocument();
+    const select = screen.getByTestId("quality-profile-select") as HTMLSelectElement;
+    const options = Array.from(select.querySelectorAll("option"));
+    expect(options.some((o) => o.textContent === "HD-1080p")).toBe(true);
+    expect(options.some((o) => o.textContent === "Ultra-HD")).toBe(true);
+  });
+
+  it("populates root folder dropdown with free space", () => {
+    setupMocks();
+    renderModal();
+    const container = screen.getByTestId("root-folder-select");
+    const options = Array.from(container.querySelectorAll("option")).map((o) => o.textContent);
+    expect(options.some((o) => o?.includes("/tv") && o?.includes("free"))).toBe(true);
+  });
+
+  it("populates language profile dropdown", () => {
+    setupMocks();
+    renderModal();
+    const container = screen.getByTestId("language-profile-select");
+    const options = Array.from(container.querySelectorAll("option"));
+    expect(options.some((o) => o.textContent === "English")).toBe(true);
+  });
+
+  it("defaults future seasons to checked and past to unchecked", () => {
+    setupMocks();
+    renderModal();
+
+    // Season 1 (2020, past) — unchecked
+    const s1 = screen.getByRole("checkbox", { name: "Season 1" });
+    expect(s1).toHaveAttribute("data-state", "unchecked");
+
+    // Season 2 (2021, past) — unchecked
+    const s2 = screen.getByRole("checkbox", { name: "Season 2" });
+    expect(s2).toHaveAttribute("data-state", "unchecked");
+
+    // Season 3 (2027, future) — checked
+    const s3 = screen.getByRole("checkbox", { name: "Season 3" });
+    expect(s3).toHaveAttribute("data-state", "checked");
+  });
+
+  it("toggles a season checkbox", () => {
+    setupMocks();
+    renderModal();
+
+    const s1 = screen.getByRole("checkbox", { name: "Season 1" });
+    expect(s1).toHaveAttribute("data-state", "unchecked");
+
+    fireEvent.click(s1);
+    expect(s1).toHaveAttribute("data-state", "checked");
+
+    fireEvent.click(s1);
+    expect(s1).toHaveAttribute("data-state", "unchecked");
+  });
+
+  it("shows Select All / Deselect All when more than 3 seasons", () => {
+    setupMocks();
+    const manySeasons: SeasonInfo[] = [
+      { seasonNumber: 1, airDate: "2018-01-01" },
+      { seasonNumber: 2, airDate: "2019-01-01" },
+      { seasonNumber: 3, airDate: "2020-01-01" },
+      { seasonNumber: 4, airDate: "2027-01-01" },
+    ];
+    renderModal(manySeasons);
+
+    expect(screen.getByText("Select All")).toBeInTheDocument();
+    expect(screen.getByText("Deselect All")).toBeInTheDocument();
+  });
+
+  it("does not show Select All / Deselect All for 3 or fewer seasons", () => {
+    setupMocks();
+    renderModal();
+
+    expect(screen.queryByText("Select All")).not.toBeInTheDocument();
+  });
+
+  it("Select All checks all seasons", () => {
+    setupMocks();
+    const seasons: SeasonInfo[] = [
+      { seasonNumber: 1, airDate: "2020-01-01" },
+      { seasonNumber: 2, airDate: "2021-01-01" },
+      { seasonNumber: 3, airDate: "2022-01-01" },
+      { seasonNumber: 4, airDate: "2023-01-01" },
+    ];
+    renderModal(seasons);
+
+    fireEvent.click(screen.getByText("Select All"));
+
+    for (const s of seasons) {
+      expect(screen.getByRole("checkbox", { name: `Season ${s.seasonNumber}` })).toHaveAttribute(
+        "data-state",
+        "checked"
+      );
+    }
+  });
+
+  it("Deselect All unchecks all seasons", () => {
+    setupMocks();
+    const seasons: SeasonInfo[] = [
+      { seasonNumber: 1, airDate: "2027-01-01" },
+      { seasonNumber: 2, airDate: "2027-06-01" },
+      { seasonNumber: 3, airDate: "2028-01-01" },
+      { seasonNumber: 4, airDate: "2028-06-01" },
+    ];
+    renderModal(seasons);
+
+    fireEvent.click(screen.getByText("Deselect All"));
+
+    for (const s of seasons) {
+      expect(screen.getByRole("checkbox", { name: `Season ${s.seasonNumber}` })).toHaveAttribute(
+        "data-state",
+        "unchecked"
+      );
+    }
+  });
+
+  it("sends correct payload on Request click", async () => {
+    setupMocks();
+    renderModal();
+
+    fireEvent.click(screen.getByRole("button", { name: /request/i }));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        tvdbId: 12345,
+        title: "Breaking Bad",
+        qualityProfileId: 1,
+        rootFolderPath: "/tv",
+        languageProfileId: 1,
+        seasons: [
+          { seasonNumber: 1, monitored: false },
+          { seasonNumber: 2, monitored: false },
+          { seasonNumber: 3, monitored: true },
+        ],
+      });
+    });
+  });
+
+  it("shows success message after successful request", async () => {
+    setupMocks();
+    renderModal();
+
+    fireEvent.click(screen.getByRole("button", { name: /request/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Series added successfully!")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message on failure", async () => {
+    mockMutateAsync.mockRejectedValue(new Error("Sonarr returned 500"));
+    setupMocks();
+    renderModal();
+
+    fireEvent.click(screen.getByRole("button", { name: /request/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Sonarr returned 500")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    setupMocks();
+    const onClose = vi.fn();
+    render(
+      <RequestSeriesModal open={true} onClose={onClose} tvdbId={1} title="Test" seasons={SEASONS} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("disables Request button during pending state", () => {
+    setupMocks({ isPending: true });
+    renderModal();
+
+    expect(screen.getByRole("button", { name: /request/i })).toBeDisabled();
+  });
+
+  it("displays season air year", () => {
+    setupMocks();
+    renderModal();
+    expect(screen.getByText(/Season 1 — 2020/)).toBeInTheDocument();
+  });
+});

--- a/packages/app-media/src/components/RequestSeriesModal.tsx
+++ b/packages/app-media/src/components/RequestSeriesModal.tsx
@@ -1,0 +1,290 @@
+/**
+ * RequestSeriesModal — modal for requesting a TV series via Sonarr.
+ *
+ * Shows quality profile, root folder, and language profile dropdowns,
+ * plus season checkboxes with smart defaults (future/current checked, past unchecked).
+ */
+import { useState, useMemo, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  Button,
+  Checkbox,
+  Label,
+  Select,
+} from "@pops/ui";
+import { Loader2 } from "lucide-react";
+import { trpc } from "../lib/trpc";
+
+export interface SeasonInfo {
+  seasonNumber: number;
+  /** Air date string (ISO or year), used for smart defaults. */
+  airDate?: string | null;
+}
+
+export interface RequestSeriesModalProps {
+  open: boolean;
+  onClose: () => void;
+  tvdbId: number;
+  title: string;
+  year?: number | null;
+  seasons: SeasonInfo[];
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+}
+
+function isFutureSeason(airDate?: string | null): boolean {
+  if (!airDate) return true; // Unknown air date → treat as future
+  return new Date(airDate) > new Date();
+}
+
+export function RequestSeriesModal({
+  open,
+  onClose,
+  tvdbId,
+  title,
+  year,
+  seasons,
+}: RequestSeriesModalProps) {
+  const qualityProfiles = trpc.media.arr.getSonarrQualityProfiles.useQuery(undefined, {
+    enabled: open,
+  });
+  const rootFolders = trpc.media.arr.getSonarrRootFolders.useQuery(undefined, { enabled: open });
+  const languageProfiles = trpc.media.arr.getSonarrLanguageProfiles.useQuery(undefined, {
+    enabled: open,
+  });
+
+  const addSeries = trpc.media.arr.addSeries.useMutation();
+
+  // Dropdown selections — default to first option once data loads
+  const [qualityProfileId, setQualityProfileId] = useState<string>("");
+  const [rootFolderPath, setRootFolderPath] = useState<string>("");
+  const [languageProfileId, setLanguageProfileId] = useState<string>("");
+
+  // Auto-select first option when data loads
+  useEffect(() => {
+    const profiles = qualityProfiles.data?.data;
+    if (profiles?.length && !qualityProfileId) {
+      setQualityProfileId(String(profiles[0]!.id));
+    }
+  }, [qualityProfiles.data, qualityProfileId]);
+
+  useEffect(() => {
+    const folders = rootFolders.data?.data;
+    if (folders?.length && !rootFolderPath) {
+      setRootFolderPath(folders[0]!.path);
+    }
+  }, [rootFolders.data, rootFolderPath]);
+
+  useEffect(() => {
+    const profiles = languageProfiles.data?.data;
+    if (profiles?.length && !languageProfileId) {
+      setLanguageProfileId(String(profiles[0]!.id));
+    }
+  }, [languageProfiles.data, languageProfileId]);
+
+  // Season monitoring state — smart defaults
+  const sortedSeasons = useMemo(
+    () => [...seasons].sort((a, b) => a.seasonNumber - b.seasonNumber),
+    [seasons]
+  );
+
+  const [monitoredSeasons, setMonitoredSeasons] = useState<Set<number>>(() => {
+    const initial = new Set<number>();
+    for (const s of seasons) {
+      if (isFutureSeason(s.airDate)) {
+        initial.add(s.seasonNumber);
+      }
+    }
+    return initial;
+  });
+
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const toggleSeason = (seasonNumber: number): void => {
+    setMonitoredSeasons((prev) => {
+      const next = new Set(prev);
+      if (next.has(seasonNumber)) {
+        next.delete(seasonNumber);
+      } else {
+        next.add(seasonNumber);
+      }
+      return next;
+    });
+  };
+
+  const selectAll = (): void => {
+    setMonitoredSeasons(new Set(sortedSeasons.map((s) => s.seasonNumber)));
+  };
+
+  const deselectAll = (): void => {
+    setMonitoredSeasons(new Set());
+  };
+
+  const allSelected = qualityProfileId && rootFolderPath && languageProfileId;
+
+  const handleRequest = async (): Promise<void> => {
+    if (!allSelected) return;
+    setError(null);
+
+    try {
+      await addSeries.mutateAsync({
+        tvdbId,
+        title,
+        qualityProfileId: Number(qualityProfileId),
+        rootFolderPath,
+        languageProfileId: Number(languageProfileId),
+        seasons: sortedSeasons.map((s) => ({
+          seasonNumber: s.seasonNumber,
+          monitored: monitoredSeasons.has(s.seasonNumber),
+        })),
+      });
+      setSuccess(true);
+      setTimeout(() => {
+        onClose();
+      }, 1500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add series");
+    }
+  };
+
+  const qualityOptions =
+    qualityProfiles.data?.data?.map((p) => ({ value: String(p.id), label: p.name })) ?? [];
+  const rootFolderOptions =
+    rootFolders.data?.data?.map((f) => ({
+      value: f.path,
+      label: `${f.path} (${formatBytes(f.freeSpace)} free)`,
+    })) ?? [];
+  const languageOptions =
+    languageProfiles.data?.data?.map((p) => ({ value: String(p.id), label: p.name })) ?? [];
+
+  const isLoading =
+    qualityProfiles.isLoading || rootFolders.isLoading || languageProfiles.isLoading;
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent aria-describedby="request-series-description">
+        <DialogHeader>
+          <DialogTitle>
+            Request {title}
+            {year ? ` (${year})` : ""}
+          </DialogTitle>
+          <DialogDescription id="request-series-description">
+            Add this series to Sonarr for downloading.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <Select
+              label="Quality Profile"
+              options={qualityOptions}
+              value={qualityProfileId}
+              onChange={(e) => setQualityProfileId(e.target.value)}
+              placeholder="Select quality profile..."
+              data-testid="quality-profile-select"
+            />
+
+            <Select
+              label="Root Folder"
+              options={rootFolderOptions}
+              value={rootFolderPath}
+              onChange={(e) => setRootFolderPath(e.target.value)}
+              placeholder="Select root folder..."
+              data-testid="root-folder-select"
+            />
+
+            <Select
+              label="Language Profile"
+              options={languageOptions}
+              value={languageProfileId}
+              onChange={(e) => setLanguageProfileId(e.target.value)}
+              placeholder="Select language profile..."
+              data-testid="language-profile-select"
+            />
+
+            {/* Season monitoring */}
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <Label className="text-xs font-semibold text-muted-foreground uppercase tracking-widest">
+                  Seasons
+                </Label>
+                {sortedSeasons.length > 3 && (
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      className="text-xs text-primary hover:underline"
+                      onClick={selectAll}
+                    >
+                      Select All
+                    </button>
+                    <button
+                      type="button"
+                      className="text-xs text-primary hover:underline"
+                      onClick={deselectAll}
+                    >
+                      Deselect All
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              <div
+                className={
+                  sortedSeasons.length > 10
+                    ? "max-h-60 overflow-y-auto flex flex-col gap-1.5"
+                    : "flex flex-col gap-1.5"
+                }
+              >
+                {sortedSeasons.map((season) => (
+                  <label
+                    key={season.seasonNumber}
+                    className="flex items-center gap-2 cursor-pointer"
+                  >
+                    <Checkbox
+                      checked={monitoredSeasons.has(season.seasonNumber)}
+                      onCheckedChange={() => toggleSeason(season.seasonNumber)}
+                      aria-label={`Season ${season.seasonNumber}`}
+                    />
+                    <span className="text-sm">
+                      Season {season.seasonNumber}
+                      {season.airDate ? ` — ${season.airDate.slice(0, 4)}` : ""}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {success && <p className="text-sm text-green-500">Series added successfully!</p>}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={addSeries.isPending}>
+            Cancel
+          </Button>
+          <Button onClick={handleRequest} disabled={!allSelected || addSeries.isPending || success}>
+            {addSeries.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Request
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `RequestSeriesModal` component for requesting TV series via Sonarr with quality profile, root folder, and language profile dropdowns
- Backend: Sonarr quality profiles, root folders, language profiles query endpoints + `addSeries` mutation with Zod validation
- Season checkboxes with smart defaults (future/current checked, past unchecked), Select All/Deselect All, scrollable list for 10+ seasons
- 17 tests covering dropdowns, season defaults, toggles, payload, success/error states, and cancel behavior

## Test plan
- [x] 17 unit tests passing (RequestSeriesModal.test.tsx)
- [x] TypeScript compiles cleanly (pops-api + app-media)
- [x] Prettier formatting verified
- [ ] Manual: open modal from TV show detail page, verify dropdowns populate from Sonarr
- [ ] Manual: verify season smart defaults and Select All/Deselect All
- [ ] Manual: submit request and verify series appears in Sonarr

Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)