### PR TITLE
fix: add missing mock in MovieDetailPage tests [tb-590]

### DIFF
--- a/packages/app-media/src/pages/MovieDetailPage.test.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.test.tsx
@@ -32,6 +32,9 @@ vi.mock("../components/ComparisonScores", () => ({
 vi.mock("../components/ArrStatusBadge", () => ({
   ArrStatusBadge: () => <span>Arr Status</span>,
 }));
+vi.mock("../components/RequestMovieButton", () => ({
+  RequestMovieButton: () => null,
+}));
 
 import { MovieDetailPage } from "./MovieDetailPage";
 


### PR DESCRIPTION
## Summary
- Adds missing `RequestMovieButton` mock to `MovieDetailPage.test.tsx` (GH #725)
- The component uses `trpc.media.arr.getConfig` which wasn't mocked, causing 19 of 23 tests to crash with a render error
- All acceptance criteria (language display as full name, watch history section, comprehensive test coverage) were already implemented — this is a one-line mock fix

## Test plan
- [x] All 23 MovieDetailPage tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)