### PR TITLE
feat: seed default dimensions on first use + management tests [tb-565]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -22,9 +22,30 @@ afterEach(() => {
 });
 
 describe("comparisons.listDimensions", () => {
-  it("returns empty list when no dimensions exist", async () => {
+  it("seeds 5 default dimensions when none exist", async () => {
     const result = await caller.media.comparisons.listDimensions();
-    expect(result.data).toEqual([]);
+    expect(result.data).toHaveLength(5);
+    expect(result.data.map((d) => d.name)).toEqual([
+      "Cinematography",
+      "Entertainment",
+      "Emotional Impact",
+      "Rewatchability",
+      "Soundtrack",
+    ]);
+  });
+
+  it("returns defaults sorted by sortOrder", async () => {
+    const result = await caller.media.comparisons.listDimensions();
+    for (let i = 0; i < result.data.length; i++) {
+      expect(result.data[i]!.sortOrder).toBe(i);
+    }
+  });
+
+  it("does not re-seed when dimensions already exist", async () => {
+    seedDimension(db, { name: "Custom Only" });
+    const result = await caller.media.comparisons.listDimensions();
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]!.name).toBe("Custom Only");
   });
 
   it("returns dimensions sorted by sortOrder", async () => {
@@ -87,6 +108,35 @@ describe("comparisons.updateDimension", () => {
         data: { name: "X" },
       })
     ).rejects.toThrow(TRPCError);
+  });
+
+  it("toggles active off and back on", async () => {
+    const dimId = seedDimension(db, { name: "Toggle Me", active: 1 });
+
+    const off = await caller.media.comparisons.updateDimension({
+      id: dimId,
+      data: { active: false },
+    });
+    expect(off.data.active).toBe(false);
+
+    const on = await caller.media.comparisons.updateDimension({
+      id: dimId,
+      data: { active: true },
+    });
+    expect(on.data.active).toBe(true);
+  });
+
+  it("swaps sort order between dimensions", async () => {
+    const dimA = seedDimension(db, { name: "First", sort_order: 0 });
+    const dimB = seedDimension(db, { name: "Second", sort_order: 1 });
+
+    // Swap sort orders
+    await caller.media.comparisons.updateDimension({ id: dimA, data: { sortOrder: 1 } });
+    await caller.media.comparisons.updateDimension({ id: dimB, data: { sortOrder: 0 } });
+
+    const result = await caller.media.comparisons.listDimensions();
+    expect(result.data[0]!.name).toBe("Second");
+    expect(result.data[1]!.name).toBe("First");
   });
 });
 

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -24,9 +24,48 @@ import type {
 
 // ── Dimensions ──
 
+const DEFAULT_DIMENSIONS = [
+  { name: "Cinematography", description: "Visual quality, framing, and camera work", sortOrder: 0 },
+  { name: "Entertainment", description: "How engaging and enjoyable to watch", sortOrder: 1 },
+  {
+    name: "Emotional Impact",
+    description: "Depth of feeling and emotional resonance",
+    sortOrder: 2,
+  },
+  { name: "Rewatchability", description: "How well it holds up on repeat viewings", sortOrder: 3 },
+  { name: "Soundtrack", description: "Music, score, and sound design quality", sortOrder: 4 },
+];
+
+/** Seed default dimensions if none exist. Returns true if seeded. */
+export function seedDefaultDimensions(): boolean {
+  const db = getDrizzle();
+  const existing = db.select({ id: comparisonDimensions.id }).from(comparisonDimensions).get();
+  if (existing) return false;
+
+  for (const dim of DEFAULT_DIMENSIONS) {
+    db.insert(comparisonDimensions)
+      .values({ name: dim.name, description: dim.description, active: 1, sortOrder: dim.sortOrder })
+      .run();
+  }
+  return true;
+}
+
 export function listDimensions(): ComparisonDimensionRow[] {
   const db = getDrizzle();
-  return db.select().from(comparisonDimensions).orderBy(asc(comparisonDimensions.sortOrder)).all();
+  const rows = db
+    .select()
+    .from(comparisonDimensions)
+    .orderBy(asc(comparisonDimensions.sortOrder))
+    .all();
+  if (rows.length === 0) {
+    seedDefaultDimensions();
+    return db
+      .select()
+      .from(comparisonDimensions)
+      .orderBy(asc(comparisonDimensions.sortOrder))
+      .all();
+  }
+  return rows;
 }
 
 export function getDimension(id: number): ComparisonDimensionRow {


### PR DESCRIPTION
## Summary
- Add `seedDefaultDimensions()` that inserts 5 default dimensions (Cinematography, Entertainment, Emotional Impact, Rewatchability, Soundtrack) when none exist
- Seeding is lazy — triggered on first `listDimensions()` call when table is empty, skipped if user has already created custom dimensions
- 5 new tests: auto-seed on empty, skip re-seed, sortOrder values, toggle active off/on, sort order swap

## Test plan
- [x] All 36 comparison tests pass (31 existing + 5 new)
- [x] ESLint clean
- [x] Prettier formatted
- [ ] Manual: start fresh DB, verify default dimensions appear in Compare Arena
- [ ] Manual: delete all dimensions, re-open page, verify they re-seed

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)