### PR TITLE
feat: insurance report sub-locations toggle, sort selector, receipt IDs [tb-577]

### DIFF
--- a/apps/pops-api/src/modules/inventory/reports/router.ts
+++ b/apps/pops-api/src/modules/inventory/reports/router.ts
@@ -21,10 +21,22 @@ export const reportsRouter = router({
 
   /** Insurance report: items grouped by location with photo thumbnails and totals. */
   insuranceReport: protectedProcedure
-    .input(z.object({ locationId: z.string().optional() }).optional())
+    .input(
+      z
+        .object({
+          locationId: z.string().optional(),
+          includeChildren: z.boolean().optional(),
+          sortBy: z.enum(["value", "name", "type"]).optional(),
+        })
+        .optional()
+    )
     .query(({ input }) => {
       try {
-        const result = service.getInsuranceReport(input?.locationId);
+        const result = service.getInsuranceReport({
+          locationId: input?.locationId,
+          includeChildren: input?.includeChildren ?? true,
+          sortBy: input?.sortBy ?? "value",
+        });
         return { data: result };
       } catch (err) {
         throw new TRPCError({

--- a/apps/pops-api/src/modules/inventory/reports/service.ts
+++ b/apps/pops-api/src/modules/inventory/reports/service.ts
@@ -3,7 +3,7 @@
  */
 import { isNotNull, asc, sql, desc, and, gte, lte, count, eq } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
-import { homeInventory, locations, itemPhotos } from "@pops/db-types";
+import { homeInventory, locations, itemPhotos, itemDocuments } from "@pops/db-types";
 import type { InventoryRow } from "../items/types.js";
 import type { ValueBreakdownEntry, DashboardSummary, RecentItem } from "./types.js";
 
@@ -85,12 +85,14 @@ export interface InsuranceReportItem {
   itemName: string;
   assetId: string | null;
   brand: string | null;
+  type: string | null;
   condition: string | null;
   warrantyExpires: string | null;
   replacementValue: number | null;
   photoPath: string | null;
   locationId: string | null;
   locationName: string | null;
+  receiptDocumentIds: number[];
 }
 
 export interface InsuranceReportGroup {
@@ -105,21 +107,28 @@ export interface InsuranceReportResult {
   totalValue: number;
 }
 
+interface InsuranceReportOptions {
+  locationId?: string;
+  includeChildren?: boolean;
+  sortBy?: "value" | "name" | "type";
+}
+
 /**
- * Get insurance report data, optionally filtered to a location subtree.
- * Items are grouped by location. Each item includes its first photo path.
+ * Get insurance report data, optionally filtered to a location (with or without subtree).
+ * Items are grouped by location. Each item includes its first photo path and receipt IDs.
  */
-export function getInsuranceReport(locationId?: string): InsuranceReportResult {
+export function getInsuranceReport(options: InsuranceReportOptions = {}): InsuranceReportResult {
+  const { locationId, includeChildren = true, sortBy = "value" } = options;
   const db = getDrizzle();
 
-  // Get all location IDs in the subtree if filtering
+  // Get location IDs to filter by
   let locationIds: Set<string> | null = null;
   if (locationId) {
-    locationIds = getLocationSubtreeIds(locationId);
+    locationIds = includeChildren ? getLocationSubtreeIds(locationId) : new Set([locationId]);
   }
 
-  // Get all items with their location names
-  const allItems = db.select().from(homeInventory).orderBy(asc(homeInventory.itemName)).all();
+  // Get all items
+  const allItems = db.select().from(homeInventory).all();
 
   // Build location name map
   const locationRows = db.select().from(locations).all();
@@ -137,10 +146,37 @@ export function getInsuranceReport(locationId?: string): InsuranceReportResult {
     }
   }
 
+  // Get receipt document IDs per item
+  const docs = db
+    .select()
+    .from(itemDocuments)
+    .where(eq(itemDocuments.documentType, "receipt"))
+    .all();
+  const receiptMap = new Map<string, number[]>();
+  for (const doc of docs) {
+    const existing = receiptMap.get(doc.itemId) ?? [];
+    if (!receiptMap.has(doc.itemId)) {
+      receiptMap.set(doc.itemId, existing);
+    }
+    existing.push(doc.paperlessDocumentId);
+  }
+
   // Filter items
   const filteredItems = allItems.filter((item) => {
     if (!locationIds) return true;
     return item.locationId !== null && locationIds.has(item.locationId);
+  });
+
+  // Sort items
+  filteredItems.sort((a, b) => {
+    switch (sortBy) {
+      case "value":
+        return (b.replacementValue ?? 0) - (a.replacementValue ?? 0);
+      case "name":
+        return a.itemName.localeCompare(b.itemName);
+      case "type":
+        return (a.type ?? "").localeCompare(b.type ?? "");
+    }
   });
 
   // Group by location
@@ -158,14 +194,16 @@ export function getInsuranceReport(locationId?: string): InsuranceReportResult {
       itemName: item.itemName,
       assetId: item.assetId,
       brand: item.brand,
+      type: item.type,
       condition: item.condition,
       warrantyExpires: item.warrantyExpires,
       replacementValue: item.replacementValue,
       photoPath: firstPhotoMap.get(item.id) ?? null,
       locationId: item.locationId,
       locationName: item.locationId ? (locationNameMap.get(item.locationId) ?? "Unknown") : null,
+      receiptDocumentIds: receiptMap.get(item.id) ?? [],
     });
-    if (item.replacementValue) {
+    if (item.replacementValue != null) {
       totalValue += item.replacementValue;
     }
   }

--- a/packages/app-inventory/src/pages/InsuranceReportPage.test.tsx
+++ b/packages/app-inventory/src/pages/InsuranceReportPage.test.tsx
@@ -33,13 +33,26 @@ vi.mock("../lib/trpc", () => ({
 
 // Mock UI badge components to avoid complex dependency chain
 vi.mock("@pops/ui", () => ({
-  Skeleton: ({ className }: { className?: string }) => <div className={`animate-pulse ${className ?? ""}`} />,
-  AssetIdBadge: ({ assetId }: { assetId: string }) => <span data-testid="asset-id-badge">{assetId}</span>,
+  Skeleton: ({ className }: { className?: string }) => (
+    <div className={`animate-pulse ${className ?? ""}`} />
+  ),
+  AssetIdBadge: ({ assetId }: { assetId: string }) => (
+    <span data-testid="asset-id-badge">{assetId}</span>
+  ),
   ConditionBadge: ({ condition }: { condition: string }) => (
     <span data-testid="condition-badge">{condition}</span>
   ),
-  Badge: ({ children, className }: { children: React.ReactNode; variant?: string; className?: string }) => (
-    <span data-testid="badge" className={className}>{children}</span>
+  Badge: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    variant?: string;
+    className?: string;
+  }) => (
+    <span data-testid="badge" className={className}>
+      {children}
+    </span>
   ),
 }));
 
@@ -90,6 +103,7 @@ const sampleReport = {
           photoPath: "tv.jpg",
           locationId: "loc-1",
           locationName: "Living Room",
+          receiptDocumentIds: [1234, 5678],
         },
         {
           id: "item-2",
@@ -102,6 +116,7 @@ const sampleReport = {
           photoPath: null,
           locationId: "loc-1",
           locationName: "Living Room",
+          receiptDocumentIds: [],
         },
       ],
     },
@@ -120,6 +135,7 @@ const sampleReport = {
           photoPath: "toaster.jpg",
           locationId: "loc-2",
           locationName: "Kitchen",
+          receiptDocumentIds: [9999],
         },
       ],
     },
@@ -434,5 +450,68 @@ describe("InsuranceReportPage", () => {
     fireEvent.click(csvBtn);
     expect(createObjectURLSpy).toHaveBeenCalled();
     expect(revokeObjectURLSpy).toHaveBeenCalled();
+  });
+
+  it("shows include sub-locations toggle when location is selected", () => {
+    mockInsuranceReportQuery.mockReturnValue({
+      data: { data: sampleReport },
+      isLoading: false,
+    });
+    renderPage("/inventory/insurance-report?locationId=loc-1");
+    expect(screen.getByLabelText("Include sub-locations")).toBeInTheDocument();
+  });
+
+  it("hides include sub-locations toggle when no location selected", () => {
+    mockInsuranceReportQuery.mockReturnValue({
+      data: { data: sampleReport },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByLabelText("Include sub-locations")).not.toBeInTheDocument();
+  });
+
+  it("renders sort selector with default value", () => {
+    mockInsuranceReportQuery.mockReturnValue({
+      data: { data: sampleReport },
+      isLoading: false,
+    });
+    renderPage();
+    const select = screen.getByDisplayValue("Value (high first)");
+    expect(select).toBeInTheDocument();
+  });
+
+  it("renders sort selector with URL param value", () => {
+    mockInsuranceReportQuery.mockReturnValue({
+      data: { data: sampleReport },
+      isLoading: false,
+    });
+    renderPage("/inventory/insurance-report?sortBy=name");
+    const select = screen.getByDisplayValue("Name");
+    expect(select).toBeInTheDocument();
+  });
+
+  it("renders receipt document IDs for items that have them", () => {
+    mockInsuranceReportQuery.mockReturnValue({
+      data: { data: sampleReport },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("#1234, #5678")).toBeInTheDocument();
+    expect(screen.getByText("#9999")).toBeInTheDocument();
+  });
+
+  it("passes sortBy and includeChildren to query", () => {
+    mockInsuranceReportQuery.mockReturnValue({
+      data: { data: sampleReport },
+      isLoading: false,
+    });
+    renderPage("/inventory/insurance-report?locationId=loc-1&sortBy=name&includeChildren=false");
+    expect(mockInsuranceReportQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        locationId: "loc-1",
+        sortBy: "name",
+        includeChildren: false,
+      })
+    );
   });
 });

--- a/packages/app-inventory/src/pages/InsuranceReportPage.tsx
+++ b/packages/app-inventory/src/pages/InsuranceReportPage.tsx
@@ -12,6 +12,8 @@ import { Skeleton, AssetIdBadge, ConditionBadge, Badge, type Condition } from "@
 import { trpc } from "../lib/trpc";
 import { LocationPicker } from "../components/LocationPicker";
 
+type SortBy = "value" | "name" | "type";
+
 function formatCurrency(value: number): string {
   return new Intl.NumberFormat("en-AU", {
     style: "currency",
@@ -54,6 +56,7 @@ interface ReportItem {
   photoPath: string | null;
   locationId: string | null;
   locationName: string | null;
+  receiptDocumentIds: number[];
 }
 
 interface ReportGroup {
@@ -72,6 +75,7 @@ function buildCsvContent(groups: ReportGroup[]): string {
     "Warranty Expires",
     "Replacement Value",
     "Photo",
+    "Receipts",
   ];
   const rows: string[][] = [headers];
 
@@ -86,6 +90,7 @@ function buildCsvContent(groups: ReportGroup[]): string {
         item.warrantyExpires ?? "",
         item.replacementValue != null ? String(item.replacementValue) : "",
         item.photoPath ? "Yes" : "No",
+        item.receiptDocumentIds.map((id) => `#${id}`).join(", "),
       ]);
     }
   }
@@ -97,10 +102,14 @@ export function InsuranceReportPage(): React.ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const locationId = searchParams.get("locationId") ?? undefined;
+  const includeChildren = searchParams.get("includeChildren") !== "false";
+  const sortBy = (searchParams.get("sortBy") as SortBy) || "value";
 
-  const { data, isLoading } = trpc.inventory.reports.insuranceReport.useQuery(
-    locationId ? { locationId } : undefined
-  );
+  const { data, isLoading } = trpc.inventory.reports.insuranceReport.useQuery({
+    locationId,
+    includeChildren: locationId ? includeChildren : undefined,
+    sortBy,
+  });
 
   const { data: locationsData } = trpc.inventory.locations.tree.useQuery();
   const locationTree = locationsData?.data ?? [];
@@ -115,6 +124,24 @@ export function InsuranceReportPage(): React.ReactElement {
     });
   }, []);
 
+  const updateParam = useCallback(
+    (key: string, value: string | null) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (value) {
+            next.set(key, value);
+          } else {
+            next.delete(key);
+          }
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
   const handleLocationChange = useCallback(
     (id: string | null) => {
       setSearchParams(
@@ -124,6 +151,7 @@ export function InsuranceReportPage(): React.ReactElement {
             next.set("locationId", id);
           } else {
             next.delete("locationId");
+            next.delete("includeChildren");
           }
           return next;
         },
@@ -199,15 +227,42 @@ export function InsuranceReportPage(): React.ReactElement {
         </div>
       </div>
 
-      {/* Location filter */}
-      <div className="mb-6 max-w-xs print:hidden">
-        <label className="block text-sm font-medium mb-1">Filter by location</label>
-        <LocationPicker
-          value={locationId ?? null}
-          onChange={handleLocationChange}
-          locations={locationTree}
-          placeholder="All locations"
-        />
+      {/* Filters */}
+      <div className="flex flex-wrap items-end gap-4 mb-6 print:hidden">
+        <div className="w-64">
+          <label className="block text-sm font-medium mb-1">Filter by location</label>
+          <LocationPicker
+            value={locationId ?? null}
+            onChange={handleLocationChange}
+            locations={locationTree}
+            placeholder="All locations"
+          />
+        </div>
+        {locationId && (
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={includeChildren}
+              onChange={(e) => updateParam("includeChildren", e.target.checked ? null : "false")}
+              className="rounded border-border"
+            />
+            Include sub-locations
+          </label>
+        )}
+        <div>
+          <label className="block text-sm font-medium mb-1">Sort by</label>
+          <select
+            value={sortBy}
+            onChange={(e) =>
+              updateParam("sortBy", e.target.value === "value" ? null : e.target.value)
+            }
+            className="rounded-lg border border-border bg-background px-3 py-2 text-sm"
+          >
+            <option value="value">Value (high first)</option>
+            <option value="name">Name</option>
+            <option value="type">Type</option>
+          </select>
+        </div>
       </div>
 
       {/* Summary */}
@@ -245,13 +300,26 @@ export function InsuranceReportPage(): React.ReactElement {
             <table className="w-full text-sm print:text-[11pt] print:border-collapse print:border print:border-gray-300">
               <thead>
                 <tr className="border-b text-left text-muted-foreground print:border-gray-300">
-                  <th className="py-2 pr-3 w-10 print:border print:border-gray-300 print:p-1">Photo</th>
+                  <th className="py-2 pr-3 w-10 print:border print:border-gray-300 print:p-1">
+                    Photo
+                  </th>
                   <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">Name</th>
-                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">Asset ID</th>
+                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">
+                    Asset ID
+                  </th>
                   <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">Brand</th>
-                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">Condition</th>
-                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">Warranty</th>
-                  <th className="py-2 pr-3 text-right print:border print:border-gray-300 print:p-1">Value</th>
+                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">
+                    Condition
+                  </th>
+                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">
+                    Warranty
+                  </th>
+                  <th className="py-2 pr-3 text-right print:border print:border-gray-300 print:p-1">
+                    Value
+                  </th>
+                  <th className="py-2 pr-3 print:border print:border-gray-300 print:p-1">
+                    Receipts
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -278,7 +346,9 @@ export function InsuranceReportPage(): React.ReactElement {
                           />
                         )}
                       </td>
-                      <td className="py-2 pr-3 font-medium print:border print:border-gray-300 print:p-1 print:text-[12pt]">{item.itemName}</td>
+                      <td className="py-2 pr-3 font-medium print:border print:border-gray-300 print:p-1 print:text-[12pt]">
+                        {item.itemName}
+                      </td>
                       <td className="py-2 pr-3 print:border print:border-gray-300 print:p-1 [&_span]:print:bg-transparent [&_span]:print:text-black">
                         {item.assetId ? (
                           <AssetIdBadge assetId={item.assetId} />
@@ -286,7 +356,9 @@ export function InsuranceReportPage(): React.ReactElement {
                           <span className="text-muted-foreground">—</span>
                         )}
                       </td>
-                      <td className="py-2 pr-3 print:border print:border-gray-300 print:p-1">{item.brand ?? "—"}</td>
+                      <td className="py-2 pr-3 print:border print:border-gray-300 print:p-1">
+                        {item.brand ?? "—"}
+                      </td>
                       <td className="py-2 pr-3 print:border print:border-gray-300 print:p-1 [&_span]:print:bg-transparent [&_span]:print:text-black">
                         {item.condition ? (
                           <ConditionBadge condition={item.condition as Condition} />
@@ -295,10 +367,22 @@ export function InsuranceReportPage(): React.ReactElement {
                         )}
                       </td>
                       <td className="py-2 pr-3 print:border print:border-gray-300 print:p-1">
-                        <Badge variant={warranty.variant} className="print:bg-transparent print:border print:border-gray-400 print:text-black">{warranty.label}</Badge>
+                        <Badge
+                          variant={warranty.variant}
+                          className="print:bg-transparent print:border print:border-gray-400 print:text-black"
+                        >
+                          {warranty.label}
+                        </Badge>
                       </td>
                       <td className="py-2 pr-3 text-right tabular-nums print:border print:border-gray-300 print:p-1">
-                        {item.replacementValue != null ? formatCurrency(item.replacementValue) : "—"}
+                        {item.replacementValue != null
+                          ? formatCurrency(item.replacementValue)
+                          : "—"}
+                      </td>
+                      <td className="py-2 pr-3 text-sm text-muted-foreground print:border print:border-gray-300 print:p-1">
+                        {item.receiptDocumentIds.length > 0
+                          ? item.receiptDocumentIds.map((id) => `#${id}`).join(", ")
+                          : "—"}
                       </td>
                     </tr>
                   );
@@ -307,7 +391,7 @@ export function InsuranceReportPage(): React.ReactElement {
               {group.items.some((i) => i.replacementValue != null) && (
                 <tfoot>
                   <tr className="font-semibold">
-                    <td colSpan={6} className="py-2 pr-3 text-right">
+                    <td colSpan={7} className="py-2 pr-3 text-right">
                       Subtotal
                     </td>
                     <td className="py-2 pr-3 text-right tabular-nums">


### PR DESCRIPTION
## Summary
- Add "Include sub-locations" toggle (visible only when a location is selected) to filter by exact location or include children
- Add sort selector with three options: Value (high first), Name, Type — persisted in URL params
- Add receipt document IDs column showing linked Paperless receipt references per item
- Backend: new `includeChildren`, `sortBy` params on `insuranceReport` endpoint + receipt document lookup via `itemDocuments` table

## Test plan
- [x] 32 frontend tests pass (26 existing + 6 new)
- [x] New tests: toggle visibility, sort selector display, sort URL params, receipt IDs rendering, query param forwarding
- [x] TypeScript compiles cleanly (no new errors)
- [x] Prettier formatting clean
- [ ] Manual: toggle appears only when location selected
- [ ] Manual: sort changes item order within groups
- [ ] Manual: receipt IDs show for items with linked documents

Closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)