### PR TITLE
feat: warranty row brand/model, days-remaining badge, tests [tb-578]

### DIFF
--- a/packages/app-inventory/src/pages/WarrantiesPage.test.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.test.tsx
@@ -32,6 +32,8 @@ function makeItem(
     itemName: string;
     warrantyExpires: string | null;
     assetId: string | null;
+    brand: string | null;
+    model: string | null;
     replacementValue: number | null;
   }> = {}
 ) {
@@ -40,6 +42,8 @@ function makeItem(
     itemName: overrides.itemName ?? "Test Item",
     warrantyExpires: overrides.warrantyExpires ?? null,
     assetId: overrides.assetId ?? null,
+    brand: overrides.brand ?? null,
+    model: overrides.model ?? null,
     replacementValue: overrides.replacementValue ?? null,
   };
 }
@@ -150,5 +154,149 @@ describe("WarrantiesPage", () => {
     // Click to expand Expired section
     fireEvent.click(screen.getByText("Expired"));
     expect(screen.getByText("Old Phone")).toBeInTheDocument();
+  });
+
+  it("shows brand and model in warranty row", () => {
+    mockWarrantiesQuery.mockReturnValue({
+      data: {
+        data: [
+          makeItem({
+            id: "1",
+            itemName: "Laptop",
+            brand: "Apple",
+            model: "MacBook Pro",
+            warrantyExpires: "2030-01-01",
+          }),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText("Laptop")).toBeInTheDocument();
+    expect(screen.getByText("Apple MacBook Pro")).toBeInTheDocument();
+  });
+
+  it("shows brand only when model is null", () => {
+    mockWarrantiesQuery.mockReturnValue({
+      data: {
+        data: [
+          makeItem({
+            id: "1",
+            itemName: "TV",
+            brand: "Samsung",
+            model: null,
+            warrantyExpires: "2030-01-01",
+          }),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText("Samsung")).toBeInTheDocument();
+  });
+
+  it("shows days-remaining badge for active warranties", () => {
+    mockWarrantiesQuery.mockReturnValue({
+      data: {
+        data: [makeItem({ id: "1", itemName: "Active Item", warrantyExpires: "2030-06-01" })],
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    // Active items (>90 days) should show a days-remaining badge
+    expect(screen.getByText("Active Item")).toBeInTheDocument();
+    expect(screen.getByText(/days$/)).toBeInTheDocument();
+  });
+
+  it("shows urgency badge for expiring soon items", () => {
+    // Set warranty to expire in 10 days from now
+    const soon = new Date();
+    soon.setDate(soon.getDate() + 10);
+    const soonStr = soon.toISOString().slice(0, 10);
+
+    mockWarrantiesQuery.mockReturnValue({
+      data: {
+        data: [makeItem({ id: "1", itemName: "Urgent Item", warrantyExpires: soonStr })],
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText("Urgent Item")).toBeInTheDocument();
+    expect(screen.getByText("Expiring Soon")).toBeInTheDocument();
+    expect(screen.getByText("10 days")).toBeInTheDocument();
+  });
+
+  it("shows expired time ago text", () => {
+    mockWarrantiesQuery.mockReturnValue({
+      data: {
+        data: [makeItem({ id: "1", itemName: "Old Item", warrantyExpires: "2020-01-01" })],
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    // Only expired items → section defaults open
+    expect(screen.getByText("Old Item")).toBeInTheDocument();
+    expect(screen.getByText(/d ago$/)).toBeInTheDocument();
+  });
+
+  it("sorts expiring soon section by soonest first", () => {
+    const soon1 = new Date();
+    soon1.setDate(soon1.getDate() + 5);
+    const soon2 = new Date();
+    soon2.setDate(soon2.getDate() + 30);
+
+    mockWarrantiesQuery.mockReturnValue({
+      data: {
+        data: [
+          makeItem({
+            id: "2",
+            itemName: "Later Expiry",
+            warrantyExpires: soon2.toISOString().slice(0, 10),
+          }),
+          makeItem({
+            id: "1",
+            itemName: "Sooner Expiry",
+            warrantyExpires: soon1.toISOString().slice(0, 10),
+          }),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    const buttons = screen.getAllByRole("button").filter((b) => b.textContent?.includes("Expiry"));
+    expect(buttons[0]!.textContent).toContain("Sooner Expiry");
+    expect(buttons[1]!.textContent).toContain("Later Expiry");
+  });
+
+  it("shows asset ID badge when present", () => {
+    mockWarrantiesQuery.mockReturnValue({
+      data: {
+        data: [
+          makeItem({
+            id: "1",
+            itemName: "Tagged Item",
+            assetId: "INV-001",
+            warrantyExpires: "2030-01-01",
+          }),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText("INV-001")).toBeInTheDocument();
   });
 });

--- a/packages/app-inventory/src/pages/WarrantiesPage.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.tsx
@@ -14,6 +14,8 @@ interface WarrantyItem {
   id: string;
   itemName: string;
   assetId: string | null;
+  brand: string | null;
+  model: string | null;
   warrantyExpires: string | null;
   replacementValue: number | null;
 }
@@ -67,21 +69,45 @@ interface WarrantyRowProps {
   onClick: () => void;
 }
 
+function formatDaysRemaining(days: number): string {
+  if (days === 0) return "Today";
+  if (days === 1) return "1 day";
+  return `${days} days`;
+}
+
+function brandModelLabel(brand: string | null, model: string | null): string | null {
+  if (brand && model) return `${brand} ${model}`;
+  return brand ?? model ?? null;
+}
+
 function WarrantyRow({ item, daysRemaining, showUrgency, onClick }: WarrantyRowProps) {
+  const subtitle = brandModelLabel(item.brand, item.model);
+
   return (
     <button
       type="button"
       className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-muted/50"
       onClick={onClick}
     >
-      <span className="font-medium truncate flex-1">{item.itemName}</span>
+      <div className="flex flex-col min-w-0 flex-1">
+        <span className="font-medium truncate">{item.itemName}</span>
+        {subtitle && <span className="text-xs text-muted-foreground truncate">{subtitle}</span>}
+      </div>
       {item.assetId && <AssetIdBadge assetId={item.assetId} />}
       <span className="text-muted-foreground text-xs whitespace-nowrap">
         {item.warrantyExpires && formatDate(item.warrantyExpires)}
       </span>
       {showUrgency && (
         <Badge variant={urgencyBadgeVariant(daysRemaining)} className="text-xs whitespace-nowrap">
-          {daysRemaining === 0 ? "Today" : daysRemaining === 1 ? "1 day" : `${daysRemaining} days`}
+          {formatDaysRemaining(daysRemaining)}
+        </Badge>
+      )}
+      {!showUrgency && daysRemaining >= 0 && (
+        <Badge
+          variant="outline"
+          className="text-xs whitespace-nowrap text-green-600 border-green-200"
+        >
+          {formatDaysRemaining(daysRemaining)}
         </Badge>
       )}
       {!showUrgency && daysRemaining < 0 && (


### PR DESCRIPTION
## Summary
- Show brand/model as secondary text beneath item name in warranty rows
- Add days-remaining badge for active warranties (green outline, >90 days)
- Expiring soon items keep existing urgency badges (red/amber/outline)
- 7 new tests: brand+model display, brand-only, days badge, urgency badge, expired text, sort order, asset ID

## Test plan
- [x] All 13 warranty tests pass (6 existing + 7 new)
- [x] Prettier formatted
- [ ] Manual: verify brand/model appears in warranty rows
- [ ] Manual: verify active items show green days-remaining badge
- [ ] Manual: verify expiring soon items show urgency badges

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)