### PR TITLE
fix: repair DialogClose mock so cancel-delete test passes [tb-574]

### DIFF
--- a/packages/app-ai/src/pages/RulesBrowserPage.test.tsx
+++ b/packages/app-ai/src/pages/RulesBrowserPage.test.tsx
@@ -47,6 +47,8 @@ vi.mock("../lib/trpc", () => ({
 
 vi.mock("@pops/ui", async () => {
   const React = await import("react");
+  // Shared ref so DialogClose can call the Dialog's onOpenChange
+  let dialogCloseRef: (() => void) | null = null;
   return {
     DataTable: ({
       columns,
@@ -141,8 +143,9 @@ vi.mock("@pops/ui", async () => {
       children: React.ReactNode;
       open: boolean;
       onOpenChange: (v: boolean) => void;
-    }) =>
-      open
+    }) => {
+      dialogCloseRef = open ? () => onOpenChange(false) : null;
+      return open
         ? React.createElement(
             "div",
             {
@@ -155,7 +158,8 @@ vi.mock("@pops/ui", async () => {
             },
             children
           )
-        : null,
+        : null;
+    },
     DialogContent: ({ children }: { children: React.ReactNode; showCloseButton?: boolean }) =>
       React.createElement("div", { "data-testid": "dialog-content" }, children),
     DialogHeader: ({ children }: { children: React.ReactNode }) =>
@@ -166,8 +170,19 @@ vi.mock("@pops/ui", async () => {
       React.createElement("p", null, children),
     DialogFooter: ({ children }: { children: React.ReactNode }) =>
       React.createElement("div", null, children),
-    DialogClose: ({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) =>
-      asChild ? (children as React.ReactElement) : React.createElement("button", null, children),
+    DialogClose: ({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) => {
+      if (asChild) {
+        // Wrap the child element to add an onClick that closes the dialog
+        const child = children as React.ReactElement;
+        return React.cloneElement(child, {
+          onClick: (...args: unknown[]) => {
+            dialogCloseRef?.();
+            (child.props as Record<string, unknown>).onClick?.(...args);
+          },
+        } as Record<string, unknown>);
+      }
+      return React.createElement("button", { onClick: () => dialogCloseRef?.() }, children);
+    },
   };
 });
 


### PR DESCRIPTION
## Summary
- The `DialogClose` mock in `RulesBrowserPage.test.tsx` was passing `asChild` children through without wiring up the dialog close handler
- Clicking "Cancel" in the delete confirmation dialog never dismissed it, causing the "cancels delete dialog" test to fail
- Introduced a shared `dialogCloseRef` between the `Dialog` and `DialogClose` mocks so `asChild` buttons correctly call `onOpenChange(false)`

Closes #778

## Test plan
- [x] All 18 RulesBrowserPage tests pass (17 previously passing + 1 fixed)
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)