### PR TITLE
feat: entity selection dropdown with type badge [tb-609]

### DIFF
--- a/packages/app-finance/src/components/imports/EditableTransactionCard.tsx
+++ b/packages/app-finance/src/components/imports/EditableTransactionCard.tsx
@@ -4,6 +4,7 @@ import { Button } from "@pops/ui";
 import { Input } from "@pops/ui";
 import { Label } from "@pops/ui";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@pops/ui";
+import { EntitySelect } from "./EntitySelect";
 import type { ProcessedTransaction } from "@pops/api/modules/finance/imports";
 
 interface EditableTransactionCardProps {
@@ -14,7 +15,7 @@ interface EditableTransactionCardProps {
     shouldLearn?: boolean
   ) => void;
   onCancel: () => void;
-  entities?: Array<{ id: string; name: string }>;
+  entities?: Array<{ id: string; name: string; type: string }>;
 }
 
 /**
@@ -195,22 +196,11 @@ export function EditableTransactionCard({
       {transactionType === "purchase" && entities && entities.length > 0 && (
         <div className="space-y-2 mb-4">
           <Label htmlFor="entity">Entity (Merchant/Payee)</Label>
-          <select
-            id="entity"
-            className="w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-800"
+          <EntitySelect
+            entities={entities}
             value={transaction.entity?.entityId || ""}
-            onChange={() => {
-              // Entity selection handled separately - this is just for display
-              // The parent component should handle entity changes
-            }}
-          >
-            <option value="">Select entity...</option>
-            {entities.map((entity) => (
-              <option key={entity.id} value={entity.id}>
-                {entity.name}
-              </option>
-            ))}
-          </select>
+            placeholder="Select entity..."
+          />
         </div>
       )}
 

--- a/packages/app-finance/src/components/imports/EntitySelect.tsx
+++ b/packages/app-finance/src/components/imports/EntitySelect.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import {
+  Badge,
+  Button,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@pops/ui";
+
+export interface EntityOption {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface EntitySelectProps {
+  entities: EntityOption[];
+  value?: string;
+  onChange?: (entityId: string, entityName: string) => void;
+  placeholder?: string;
+}
+
+export function EntitySelect({
+  entities,
+  value,
+  onChange,
+  placeholder = "Choose existing entity...",
+}: EntitySelectProps) {
+  const [open, setOpen] = useState(false);
+
+  const selected = entities.find((e) => e.id === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between font-normal"
+        >
+          {selected ? (
+            <span className="flex items-center gap-2 truncate">
+              <span className="truncate">{selected.name}</span>
+              <Badge variant="outline" className="text-xs capitalize shrink-0">
+                {selected.type}
+              </Badge>
+            </span>
+          ) : (
+            <span className="text-muted-foreground">{placeholder}</span>
+          )}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+        <Command>
+          <CommandInput placeholder="Search entities..." />
+          <CommandList>
+            <CommandEmpty>No entities found.</CommandEmpty>
+            <CommandGroup>
+              {entities.map((entity) => (
+                <CommandItem
+                  key={entity.id}
+                  value={`${entity.name} ${entity.type}`}
+                  onSelect={() => {
+                    onChange?.(entity.id, entity.name);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={`mr-2 h-4 w-4 ${value === entity.id ? "opacity-100" : "opacity-0"}`}
+                  />
+                  <span className="truncate">{entity.name}</span>
+                  <Badge variant="outline" className="ml-auto text-xs capitalize shrink-0">
+                    {entity.type}
+                  </Badge>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/app-finance/src/components/imports/ReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.tsx
@@ -626,7 +626,7 @@ function MatchedTab({
   editingTransaction: ProcessedTransaction | null;
   onSaveEdit: (t: ProcessedTransaction, edited: Partial<ProcessedTransaction>) => void;
   onCancelEdit: () => void;
-  entities?: Array<{ id: string; name: string }>;
+  entities?: Array<{ id: string; name: string; type: string }>;
 }) {
   if (transactions.length === 0) {
     return <div className="text-center py-12 text-gray-500">No matched transactions</div>;
@@ -693,7 +693,7 @@ function UncertainTab({
   editingTransaction: ProcessedTransaction | null;
   onSaveEdit: (t: ProcessedTransaction, edited: Partial<ProcessedTransaction>) => void;
   onCancelEdit: () => void;
-  entities?: Array<{ id: string; name: string }>;
+  entities?: Array<{ id: string; name: string; type: string }>;
 }) {
   if (transactions.length === 0) {
     return <div className="text-center py-12 text-gray-500">No uncertain transactions</div>;
@@ -807,7 +807,7 @@ function FailedTab({
   editingTransaction: ProcessedTransaction | null;
   onSaveEdit: (t: ProcessedTransaction, edited: Partial<ProcessedTransaction>) => void;
   onCancelEdit: () => void;
-  entities?: Array<{ id: string; name: string }>;
+  entities?: Array<{ id: string; name: string; type: string }>;
 }) {
   if (transactions.length === 0) {
     return <div className="text-center py-12 text-gray-500">No failed transactions</div>;

--- a/packages/app-finance/src/components/imports/TransactionCard.tsx
+++ b/packages/app-finance/src/components/imports/TransactionCard.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@pops/ui";
 import { Button } from "@pops/ui";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@pops/ui";
 import { LocationField } from "./LocationField";
+import { EntitySelect } from "./EntitySelect";
 import type { ProcessedTransaction } from "@pops/api/modules/finance/imports";
 
 interface TransactionCardProps {
@@ -16,7 +17,7 @@ interface TransactionCardProps {
   onCreateEntity?: (transaction: ProcessedTransaction) => void;
   onAcceptAiSuggestion?: (transaction: ProcessedTransaction) => void;
   onEdit?: (transaction: ProcessedTransaction) => void;
-  entities?: Array<{ id: string; name: string }>;
+  entities?: Array<{ id: string; name: string; type: string }>;
   readonly?: boolean;
   showMatchType?: boolean;
   variant?: "matched" | "uncertain" | "failed";
@@ -189,27 +190,15 @@ export function TransactionCard({
             </Button>
           )}
 
-          <select
-            className="w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-800"
+          <EntitySelect
+            entities={entities ?? []}
             value={transaction.entity?.entityId || ""}
-            onChange={(e) => {
-              const entity = entities?.find((ent) => ent.id === e.target.value);
-              if (entity && onEntitySelect) {
-                onEntitySelect(transaction, entity.id, entity.name);
+            onChange={(entityId, entityName) => {
+              if (onEntitySelect) {
+                onEntitySelect(transaction, entityId, entityName);
               }
             }}
-          >
-            <option value="">Choose existing entity...</option>
-            {entities && entities.length > 0 && (
-              <>
-                {entities.map((entity) => (
-                  <option key={entity.id} value={entity.id}>
-                    {entity.name}
-                  </option>
-                ))}
-              </>
-            )}
-          </select>
+          />
         </div>
       )}
 

--- a/packages/app-finance/src/components/imports/TransactionGroup.tsx
+++ b/packages/app-finance/src/components/imports/TransactionGroup.tsx
@@ -22,7 +22,7 @@ interface TransactionGroupProps {
     editedFields: Partial<ProcessedTransaction>
   ) => void;
   onCancelEdit?: () => void;
-  entities?: Array<{ id: string; name: string }>;
+  entities?: Array<{ id: string; name: string; type: string }>;
   variant?: "uncertain" | "failed";
 }
 


### PR DESCRIPTION
## Summary
- New `EntitySelect` component using Popover + Command primitives with searchable filtering
- Each entity option displays name + type badge (company, person, place, etc.)
- Replaced native `<select>` in `TransactionCard` and `EditableTransactionCard`
- Updated entity prop type across `ReviewStep`, `TransactionGroup` to include `type` field

Closes #691

## Test plan
- [x] Typecheck clean across app-finance
- [x] Prettier formatting verified
- [ ] Manual: open import review, verify entity dropdown shows searchable list with type badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)