### PR TITLE
refactor(pops-shell): app rail design token styling [tb-601]

### DIFF
--- a/apps/pops-shell/src/app/layout/AppRail.tsx
+++ b/apps/pops-shell/src/app/layout/AppRail.tsx
@@ -82,7 +82,7 @@ export function AppRail({ className }: AppRailProps) {
                   className={cn(
                     "flex items-center justify-center w-12 h-12 rounded-2xl transition-all duration-300",
                     isActive
-                      ? "bg-app-accent text-app-accent-foreground shadow-lg shadow-black/20 rounded-xl scale-100"
+                      ? "bg-app-accent text-app-accent-foreground shadow-lg shadow-foreground/20 rounded-xl scale-100"
                       : "text-muted-foreground hover:bg-muted hover:text-foreground hover:rounded-xl scale-95 hover:scale-100"
                   )}
                 >


### PR DESCRIPTION
## Summary
- Replace `shadow-black/20` with `shadow-foreground/20` on active app icon in the app rail
- This was the only non-token value found in the component — all other styling already uses design tokens (`bg-card`, `border-border`, `bg-app-accent`, `text-muted-foreground`, etc.)
- Using the semantic `foreground` token ensures correct shadow tinting in both light and dark modes

Closes #699

## Test plan
- [ ] Visual: verify active app icon shadow looks correct in light mode
- [ ] Visual: verify active app icon shadow looks correct in dark mode
- [ ] Verify no styling regressions in the app rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)