### PR TITLE
feat: page nav panel tablet overlay [tb-600]

### DIFF
--- a/apps/pops-shell/src/app/layout/AppRail.tsx
+++ b/apps/pops-shell/src/app/layout/AppRail.tsx
@@ -5,6 +5,7 @@
  * Single click navigates to the app's basePath.
  * Collapsible via toggle (state persisted in uiStore).
  */
+import { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router";
 import { registeredApps } from "@/app/nav/registry";
 import { iconMap } from "@/app/nav/icon-map";
@@ -17,11 +18,26 @@ interface AppRailProps {
   className?: string;
 }
 
+/** Media query match for tablet range (md but not lg) */
+function useIsTablet(): boolean {
+  const [isTablet, setIsTablet] = useState(false);
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 768px) and (max-width: 1023px)");
+    setIsTablet(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setIsTablet(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+  return isTablet;
+}
+
 export function AppRail({ className }: AppRailProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const railOpen = useUIStore((state) => state.railOpen);
   const toggleRail = useUIStore((state) => state.toggleRail);
+  const setPageNavOpen = useUIStore((state) => state.setPageNavOpen);
+  const isTablet = useIsTablet();
 
   if (!railOpen) {
     return (
@@ -60,7 +76,12 @@ export function AppRail({ className }: AppRailProps) {
           <Tooltip key={app.id}>
             <TooltipTrigger asChild>
               <button
-                onClick={() => navigate(app.basePath)}
+                onClick={() => {
+                  navigate(app.basePath);
+                  if (isTablet) {
+                    setPageNavOpen(true);
+                  }
+                }}
                 className={cn(
                   "relative w-full flex items-center justify-center py-1 transition-colors group",
                   appColorClass

--- a/apps/pops-shell/src/app/layout/RootLayout.tsx
+++ b/apps/pops-shell/src/app/layout/RootLayout.tsx
@@ -1,9 +1,11 @@
 /**
  * Root layout — top bar + two-level navigation + content area
  *
- * Desktop (≥768px): AppRail (icons) + PageNav (page links) push content
+ * Desktop (≥1024px): AppRail (icons) + PageNav (page links) push content
+ * Tablet (768–1023px): AppRail visible, PageNav as overlay on app icon click
  * Mobile (<768px): Hamburger opens Sidebar overlay with all pages
  */
+import { useEffect } from "react";
 import { Outlet, useLocation } from "react-router";
 import { TopBar } from "./TopBar";
 import { AppRail } from "./AppRail";
@@ -16,9 +18,16 @@ import { findActiveApp } from "@/app/nav/path-utils";
 
 export function RootLayout() {
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
+  const pageNavOpen = useUIStore((state) => state.pageNavOpen);
+  const setPageNavOpen = useUIStore((state) => state.setPageNavOpen);
   const location = useLocation();
   const activeApp = findActiveApp(location.pathname, registeredApps);
   const appColorClass = activeApp?.color ? `app-${activeApp.color}` : undefined;
+
+  // Close tablet overlay on navigation
+  useEffect(() => {
+    setPageNavOpen(false);
+  }, [location.pathname, setPageNavOpen]);
 
   return (
     <div className={cn("min-h-screen bg-background relative", appColorClass)}>
@@ -31,11 +40,28 @@ export function RootLayout() {
       <div className="relative z-10 pt-14 md:pt-16">
         <TopBar />
         <div className="flex">
-          {/* Desktop: two-level nav (app rail + page nav) */}
+          {/* Desktop + Tablet: app rail always visible at md+ */}
           <div className="hidden md:flex h-[calc(100vh-4rem)] sticky top-16 shrink-0">
             <AppRail />
-            <PageNav />
+            {/* Desktop only: permanent PageNav (lg+) */}
+            <div className="hidden lg:block">
+              <PageNav />
+            </div>
           </div>
+
+          {/* Tablet overlay: PageNav as overlay (md to lg) */}
+          {pageNavOpen && (
+            <div className="hidden md:block lg:hidden">
+              <div
+                className="fixed inset-0 bg-black/50 z-40"
+                onClick={() => setPageNavOpen(false)}
+                aria-hidden="true"
+              />
+              <aside className="fixed left-16 top-16 bottom-0 z-50 shadow-lg">
+                <PageNav />
+              </aside>
+            </div>
+          )}
 
           {/* Mobile: overlay sidebar */}
           <Sidebar open={sidebarOpen} />

--- a/apps/pops-shell/src/store/uiStore.ts
+++ b/apps/pops-shell/src/store/uiStore.ts
@@ -8,10 +8,13 @@ import { persist } from "zustand/middleware";
 interface UIState {
   sidebarOpen: boolean;
   railOpen: boolean;
+  pageNavOpen: boolean;
   toggleSidebar: () => void;
   setSidebarOpen: (open: boolean) => void;
   toggleRail: () => void;
   setRailOpen: (open: boolean) => void;
+  togglePageNav: () => void;
+  setPageNavOpen: (open: boolean) => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -19,13 +22,20 @@ export const useUIStore = create<UIState>()(
     (set) => ({
       sidebarOpen: true,
       railOpen: true,
+      pageNavOpen: false,
       toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
       setSidebarOpen: (open) => set({ sidebarOpen: open }),
       toggleRail: () => set((state) => ({ railOpen: !state.railOpen })),
       setRailOpen: (open) => set({ railOpen: open }),
+      togglePageNav: () => set((state) => ({ pageNavOpen: !state.pageNavOpen })),
+      setPageNavOpen: (open) => set({ pageNavOpen: open }),
     }),
     {
       name: "pops-ui-storage",
+      partialize: (state) => ({
+        sidebarOpen: state.sidebarOpen,
+        railOpen: state.railOpen,
+      }),
     }
   )
 );


### PR DESCRIPTION
## Summary
- On tablet (768-1023px), PageNav collapses by default and opens as overlay on app icon click
- Desktop (>=1024px) retains permanent sidebar layout unchanged
- Overlay includes backdrop, auto-closes on navigation and backdrop click
- New `pageNavOpen` state in uiStore (not persisted to localStorage)
- `useIsTablet` media query hook in AppRail detects tablet range

Closes #700

## Test plan
- [x] Typecheck clean (no errors in changed files)
- [x] Prettier formatting verified
- [ ] Manual: resize browser to tablet width (768-1023px), verify PageNav is hidden by default
- [ ] Manual: click app icon on tablet, verify overlay opens with page links
- [ ] Manual: click backdrop or nav link, verify overlay closes
- [ ] Manual: verify desktop (>=1024px) behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)