### PR TITLE
feat: drag-and-drop reordering for location tree [tb-615]

### DIFF
--- a/packages/app-inventory/package.json
+++ b/packages/app-inventory/package.json
@@ -12,6 +12,9 @@
     "lint:fix": "eslint src --ext .ts,.tsx --fix"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@pops/api-client": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.90.20",

--- a/packages/app-inventory/src/pages/LocationTreePage.test.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.test.tsx
@@ -1,0 +1,388 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+/* ------------------------------------------------------------------ */
+/*  Mock setup                                                        */
+/* ------------------------------------------------------------------ */
+const mockTreeQuery = vi.fn();
+const mockCreateMutate = vi.fn();
+const mockUpdateMutate = vi.fn();
+const mockDeleteMutate = vi.fn();
+const mockInvalidate = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    inventory: {
+      locations: {
+        tree: {
+          useQuery: (...args: unknown[]) => mockTreeQuery(...args),
+        },
+        create: {
+          useMutation: (opts: Record<string, unknown>) => {
+            (mockCreateMutate as unknown as Record<string, unknown>).__opts = opts;
+            return { mutate: mockCreateMutate, isPending: false };
+          },
+        },
+        update: {
+          useMutation: (opts: Record<string, unknown>) => {
+            (mockUpdateMutate as unknown as Record<string, unknown>).__opts = opts;
+            return { mutate: mockUpdateMutate, isPending: false };
+          },
+        },
+        delete: {
+          useMutation: (opts: Record<string, unknown>) => {
+            (mockDeleteMutate as unknown as Record<string, unknown>).__opts = opts;
+            return { mutate: mockDeleteMutate, isPending: false };
+          },
+        },
+      },
+    },
+    useUtils: () => ({
+      inventory: {
+        locations: {
+          tree: { invalidate: mockInvalidate },
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@pops/ui", () => ({
+  Badge: ({ children, className }: { children: React.ReactNode; variant?: string; className?: string }) => (
+    <span data-testid="badge" className={className}>{children}</span>
+  ),
+  Button: ({ children, onClick, variant, disabled }: { children: React.ReactNode; onClick?: () => void; variant?: string; disabled?: boolean }) => (
+    <button onClick={onClick} data-variant={variant} disabled={disabled}>{children}</button>
+  ),
+  Skeleton: ({ className }: { className?: string }) => (
+    <div className={`animate-pulse ${className ?? ""}`} />
+  ),
+  Collapsible: ({ children, open, onOpenChange }: { children: React.ReactNode; open: boolean; onOpenChange: (v: boolean) => void }) => (
+    <div data-open={open} data-testid="collapsible">{children}</div>
+  ),
+  CollapsibleTrigger: ({ children, asChild, onClick }: { children: React.ReactNode; asChild?: boolean; onClick?: (e: React.MouseEvent) => void }) => (
+    <div onClick={onClick}>{children}</div>
+  ),
+  CollapsibleContent: ({ children, forceMount }: { children: React.ReactNode; forceMount?: boolean }) => (
+    <div>{children}</div>
+  ),
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean; onOpenChange?: (v: boolean) => void }) => (
+    open ? <div data-testid="dialog">{children}</div> : null
+  ),
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../components/LocationContentsPanel", () => ({
+  LocationContentsPanel: ({ locationId, locationName }: { locationId: string; locationName: string }) => (
+    <div data-testid="contents-panel">{locationName}</div>
+  ),
+}));
+
+/* ------------------------------------------------------------------ */
+/*  Mock @dnd-kit to test drag-and-drop logic                        */
+/* ------------------------------------------------------------------ */
+let capturedDragHandlers: {
+  onDragStart?: (event: { active: { id: string } }) => void;
+  onDragEnd?: (event: { active: { id: string }; over: { id: string } | null }) => void;
+} = {};
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children, onDragStart, onDragEnd }: {
+    children: React.ReactNode;
+    sensors?: unknown;
+    collisionDetection?: unknown;
+    onDragStart?: (event: { active: { id: string } }) => void;
+    onDragEnd?: (event: { active: { id: string }; over: { id: string } | null }) => void;
+  }) => {
+    capturedDragHandlers = { onDragStart, onDragEnd };
+    return <div data-testid="dnd-context">{children}</div>;
+  },
+  DragOverlay: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="drag-overlay">{children}</div>
+  ),
+  closestCenter: vi.fn(),
+  PointerSensor: vi.fn(),
+  useSensor: vi.fn(() => ({})),
+  useSensors: vi.fn(() => []),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode; items: string[]; strategy?: unknown }) => (
+    <div data-testid="sortable-context">{children}</div>
+  ),
+  useSortable: ({ id }: { id: string }) => ({
+    attributes: { "data-sortable-id": id },
+    listeners: {},
+    setNodeRef: vi.fn(),
+    setActivatorNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+    isOver: false,
+  }),
+  verticalListSortingStrategy: vi.fn(),
+  arrayMove: <T,>(arr: T[], from: number, to: number): T[] => {
+    const result = [...arr];
+    const [item] = result.splice(from, 1);
+    result.splice(to, 0, item!);
+    return result;
+  },
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}));
+
+import { LocationTreePage } from "./LocationTreePage";
+
+/* ------------------------------------------------------------------ */
+/*  Fixtures                                                          */
+/* ------------------------------------------------------------------ */
+const treeData = [
+  {
+    id: "home",
+    name: "Home",
+    parentId: null,
+    sortOrder: 0,
+    children: [
+      {
+        id: "bedroom",
+        name: "Bedroom",
+        parentId: "home",
+        sortOrder: 0,
+        children: [],
+      },
+      {
+        id: "kitchen",
+        name: "Kitchen",
+        parentId: "home",
+        sortOrder: 1,
+        children: [],
+      },
+    ],
+  },
+  {
+    id: "office",
+    name: "Office",
+    parentId: null,
+    sortOrder: 1,
+    children: [
+      {
+        id: "desk",
+        name: "Desk",
+        parentId: "office",
+        sortOrder: 0,
+        children: [],
+      },
+    ],
+  },
+];
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <LocationTreePage />
+    </MemoryRouter>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                             */
+/* ------------------------------------------------------------------ */
+describe("LocationTreePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedDragHandlers = {};
+    mockTreeQuery.mockReturnValue({
+      data: { data: treeData },
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  /* --- Basic rendering --- */
+
+  it("renders location tree with all nodes", () => {
+    renderPage();
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("Office")).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton", () => {
+    mockTreeQuery.mockReturnValue({ data: undefined, isLoading: true, error: null });
+    renderPage();
+    expect(document.querySelector(".animate-pulse")).toBeInTheDocument();
+  });
+
+  it("renders error state", () => {
+    mockTreeQuery.mockReturnValue({ data: undefined, isLoading: false, error: new Error("fail") });
+    renderPage();
+    expect(screen.getByText("Failed to load locations.")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no locations", () => {
+    mockTreeQuery.mockReturnValue({ data: { data: [] }, isLoading: false, error: null });
+    renderPage();
+    expect(screen.getByText(/No locations yet/)).toBeInTheDocument();
+  });
+
+  /* --- Drag-and-drop infrastructure --- */
+
+  it("wraps tree in DndContext", () => {
+    renderPage();
+    expect(screen.getByTestId("dnd-context")).toBeInTheDocument();
+  });
+
+  it("wraps tree in SortableContext", () => {
+    renderPage();
+    const contexts = screen.getAllByTestId("sortable-context");
+    expect(contexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders drag handles with correct aria-labels", () => {
+    renderPage();
+    expect(screen.getByLabelText("Drag Home")).toBeInTheDocument();
+    expect(screen.getByLabelText("Drag Office")).toBeInTheDocument();
+  });
+
+  it("renders DragOverlay container", () => {
+    renderPage();
+    expect(screen.getByTestId("drag-overlay")).toBeInTheDocument();
+  });
+
+  /* --- Arrow buttons hidden on desktop --- */
+
+  it("arrow buttons have md:hidden class", () => {
+    renderPage();
+    const moveUpButtons = screen.getAllByTitle("Move up");
+    moveUpButtons.forEach((btn) => {
+      expect(btn.className).toContain("md:hidden");
+    });
+    const moveDownButtons = screen.getAllByTitle("Move down");
+    moveDownButtons.forEach((btn) => {
+      expect(btn.className).toContain("md:hidden");
+    });
+  });
+
+  /* --- Drag handle styling --- */
+
+  it("drag handle has cursor-grab and touch-none classes", () => {
+    renderPage();
+    const handle = screen.getByLabelText("Drag Home");
+    expect(handle.className).toContain("cursor-grab");
+    expect(handle.className).toContain("touch-none");
+  });
+
+  it("drag handle is hidden on mobile (hidden md:flex)", () => {
+    renderPage();
+    const handle = screen.getByLabelText("Drag Home");
+    expect(handle.className).toContain("hidden");
+    expect(handle.className).toContain("md:flex");
+  });
+
+  /* --- Drag-and-drop: reorder within siblings --- */
+
+  it("reorders siblings when dropped on same-parent node", () => {
+    renderPage();
+    expect(capturedDragHandlers.onDragEnd).toBeDefined();
+
+    // Simulate dragging "Office" (sortOrder=1) onto "Home" (sortOrder=0)
+    // Both are root-level (parentId=null), so this is a reorder
+    capturedDragHandlers.onDragEnd!({
+      active: { id: "office" },
+      over: { id: "home" },
+    });
+
+    // Should call updateMutation to reassign sort orders
+    // arrayMove([home, office], 1, 0) → [office, home]
+    // office: sortOrder was 1, now should be 0 → mutate
+    // home: sortOrder was 0, now should be 1 → mutate
+    expect(mockUpdateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "office", data: { sortOrder: 0 } })
+    );
+    expect(mockUpdateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "home", data: { sortOrder: 1 } })
+    );
+  });
+
+  /* --- Drag-and-drop: reparent --- */
+
+  it("reparents when dropped on node with different parent", () => {
+    renderPage();
+    expect(capturedDragHandlers.onDragEnd).toBeDefined();
+
+    // Simulate dragging "desk" (parentId=office) onto "home" (parentId=null)
+    // Different parents → reparent: make desk a child of home
+    capturedDragHandlers.onDragEnd!({
+      active: { id: "desk" },
+      over: { id: "home" },
+    });
+
+    expect(mockUpdateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "desk", data: { parentId: "home" } })
+    );
+  });
+
+  /* --- Drag-and-drop: prevent descendant drop --- */
+
+  it("prevents dropping on own descendant", () => {
+    renderPage();
+    expect(capturedDragHandlers.onDragEnd).toBeDefined();
+
+    // Simulate dragging "home" onto "bedroom" (bedroom is a child of home)
+    capturedDragHandlers.onDragEnd!({
+      active: { id: "home" },
+      over: { id: "bedroom" },
+    });
+
+    // Should NOT call updateMutation
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+  });
+
+  /* --- Drag-and-drop: no-op cases --- */
+
+  it("does nothing when dropped on self", () => {
+    renderPage();
+    capturedDragHandlers.onDragEnd!({
+      active: { id: "home" },
+      over: { id: "home" },
+    });
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when dropped on null (cancelled)", () => {
+    renderPage();
+    capturedDragHandlers.onDragEnd!({
+      active: { id: "home" },
+      over: null,
+    });
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+  });
+
+  /* --- Selection --- */
+
+  it("selects a location on click", () => {
+    renderPage();
+    fireEvent.click(screen.getByText("Home"));
+    expect(screen.getByTestId("contents-panel")).toHaveTextContent("Home");
+  });
+
+  it("deselects on second click", () => {
+    renderPage();
+    const treeItems = screen.getAllByRole("treeitem");
+    const homeItem = treeItems.find((el) => el.textContent?.includes("Home"))!;
+    fireEvent.click(homeItem);
+    expect(screen.getByTestId("contents-panel")).toBeInTheDocument();
+    fireEvent.click(homeItem);
+    expect(screen.queryByTestId("contents-panel")).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-inventory/src/pages/LocationTreePage.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.tsx
@@ -22,6 +22,23 @@ import {
   DialogFooter,
 } from "@pops/ui";
 import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragStartEvent,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
   MapPin,
   ChevronRight,
   ChevronDown,
@@ -34,6 +51,7 @@ import {
   MoveRight,
   Trash2,
   FileText,
+  GripVertical,
 } from "lucide-react";
 import { Link } from "react-router";
 import { trpc } from "../lib/trpc";
@@ -211,6 +229,22 @@ function MoveTargetPicker({
   );
 }
 
+/** Lightweight node preview shown while dragging. */
+function DragOverlayNode({ node }: { node: LocationTreeNode }) {
+  return (
+    <div className="flex items-center gap-2 bg-background border rounded-md px-3 py-2 shadow-lg">
+      <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
+      <Folder className="h-4 w-4 text-muted-foreground" />
+      <span className="text-sm font-medium">{node.name}</span>
+      {node.children.length > 0 && (
+        <Badge variant="secondary" className="text-xs">
+          {countDescendants(node) + 1}
+        </Badge>
+      )}
+    </div>
+  );
+}
+
 interface LocationNodeProps {
   node: LocationTreeNode;
   depth: number;
@@ -250,19 +284,39 @@ function LocationNode({
   const isSelected = selectedId === node.id;
   const isAddingChild = addingChildOf === node.id;
 
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+    isOver,
+  } = useSortable({ id: node.id });
+
+  const sortableStyle = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  const dropIndicator = isOver && !isDragging;
+
   // Auto-expand when adding a child
   useEffect(() => {
     if (isAddingChild && !open) setOpen(true);
   }, [isAddingChild, open]);
 
   return (
+    <div ref={setNodeRef} style={sortableStyle}>
     <Collapsible open={open} onOpenChange={setOpen}>
       <div
         className={`group flex items-center gap-1.5 py-1.5 px-2 rounded-md cursor-pointer transition-colors hover:bg-app-accent/10 ${
           isSelected
             ? "bg-app-accent/20 text-foreground font-bold border-l-2 border-app-accent rounded-l-none ml-[-2px]"
             : ""
-        }`}
+        } ${dropIndicator ? "ring-2 ring-app-accent/50 bg-app-accent/5" : ""}`}
         style={{ paddingLeft: `${depth * 20 + 8}px` }}
         onClick={() => onSelect(node.id)}
         onDoubleClick={(e) => {
@@ -273,6 +327,19 @@ function LocationNode({
         aria-selected={isSelected}
         aria-expanded={hasChildren ? open : undefined}
       >
+        {/* Drag handle — desktop only, visible on hover */}
+        <button
+          ref={setActivatorNodeRef}
+          {...attributes}
+          {...listeners}
+          type="button"
+          className="p-0.5 rounded hover:bg-muted cursor-grab active:cursor-grabbing hidden md:flex opacity-0 group-hover:opacity-100 transition-opacity touch-none"
+          aria-label={`Drag ${node.name}`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
+        </button>
+
         {hasChildren ? (
           <CollapsibleTrigger
             asChild
@@ -319,7 +386,7 @@ function LocationNode({
           {siblingCount > 1 && siblingIndex > 0 && (
             <button
               type="button"
-              className="p-0.5 rounded hover:bg-muted"
+              className="p-0.5 rounded hover:bg-muted md:hidden"
               onClick={(e) => {
                 e.stopPropagation();
                 onReorder(node.id, "up");
@@ -333,7 +400,7 @@ function LocationNode({
           {siblingCount > 1 && siblingIndex < siblingCount - 1 && (
             <button
               type="button"
-              className="p-0.5 rounded hover:bg-muted"
+              className="p-0.5 rounded hover:bg-muted md:hidden"
               onClick={(e) => {
                 e.stopPropagation();
                 onReorder(node.id, "down");
@@ -399,44 +466,50 @@ function LocationNode({
 
       {(hasChildren || isAddingChild) && (
         <CollapsibleContent forceMount={isAddingChild ? true : undefined}>
-          <div role="group">
-            {node.children.map((child, i) => (
-              <LocationNode
-                key={child.id}
-                node={child}
-                depth={depth + 1}
-                selectedId={selectedId}
-                onSelect={onSelect}
-                onAddChild={onAddChild}
-                onRename={onRename}
-                onMoveStart={onMoveStart}
-                onReorder={onReorder}
-                onDelete={onDelete}
-                addingChildOf={addingChildOf}
-                onNewChildSave={onNewChildSave}
-                onNewChildCancel={onNewChildCancel}
-                siblingIndex={i}
-                siblingCount={node.children.length}
-              />
-            ))}
-            {isAddingChild && (
-              <div
-                className="flex items-center gap-1.5 py-1.5 px-2"
-                style={{ paddingLeft: `${(depth + 1) * 20 + 8}px` }}
-              >
-                <span className="w-[22px]" />
-                <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
-                <InlineInput
-                  onSave={onNewChildSave}
-                  onCancel={onNewChildCancel}
-                  placeholder="Location name"
+          <SortableContext
+            items={node.children.map((c) => c.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div role="group">
+              {node.children.map((child, i) => (
+                <LocationNode
+                  key={child.id}
+                  node={child}
+                  depth={depth + 1}
+                  selectedId={selectedId}
+                  onSelect={onSelect}
+                  onAddChild={onAddChild}
+                  onRename={onRename}
+                  onMoveStart={onMoveStart}
+                  onReorder={onReorder}
+                  onDelete={onDelete}
+                  addingChildOf={addingChildOf}
+                  onNewChildSave={onNewChildSave}
+                  onNewChildCancel={onNewChildCancel}
+                  siblingIndex={i}
+                  siblingCount={node.children.length}
                 />
-              </div>
-            )}
-          </div>
+              ))}
+              {isAddingChild && (
+                <div
+                  className="flex items-center gap-1.5 py-1.5 px-2"
+                  style={{ paddingLeft: `${(depth + 1) * 20 + 8}px` }}
+                >
+                  <span className="w-[22px]" />
+                  <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <InlineInput
+                    onSave={onNewChildSave}
+                    onCancel={onNewChildCancel}
+                    placeholder="Location name"
+                  />
+                </div>
+              )}
+            </div>
+          </SortableContext>
         </CollapsibleContent>
       )}
     </Collapsible>
+    </div>
   );
 }
 
@@ -445,6 +518,12 @@ export function LocationTreePage() {
   const [addingChildOf, setAddingChildOf] = useState<string | null>(null);
   const [addingRoot, setAddingRoot] = useState(false);
   const [movingId, setMovingId] = useState<string | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+  );
+
   const [deleteConfirm, setDeleteConfirm] = useState<{
     id: string;
     name: string;
@@ -617,6 +696,51 @@ export function LocationTreePage() {
     [treeNodes, nodeMap, updateMutation]
   );
 
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveId(null);
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const activeNode = nodeMap.get(active.id as string);
+      const overNode = nodeMap.get(over.id as string);
+      if (!activeNode || !overNode) return;
+
+      // Prevent dropping on own descendants
+      if (isDescendant(active.id as string, over.id as string, nodeMap)) {
+        toast.error("Cannot move a location into its own sub-location");
+        return;
+      }
+
+      if (activeNode.parentId === overNode.parentId) {
+        // Reorder within same parent
+        const siblings = getSiblings(active.id as string, treeNodes, nodeMap);
+        const oldIndex = siblings.findIndex((s) => s.id === active.id);
+        const newIndex = siblings.findIndex((s) => s.id === over.id);
+        if (oldIndex < 0 || newIndex < 0) return;
+
+        const reordered = arrayMove(siblings, oldIndex, newIndex);
+        reordered.forEach((n, index) => {
+          if (n.sortOrder !== index) {
+            updateMutation.mutate({ id: n.id, data: { sortOrder: index } });
+          }
+        });
+      } else {
+        // Different parent → reparent: make active a child of over
+        updateMutation.mutate({
+          id: activeNode.id,
+          data: { parentId: overNode.id },
+        });
+      }
+    },
+    [nodeMap, treeNodes, updateMutation]
+  );
+
+  const activeNode = activeId ? nodeMap.get(activeId) : null;
   const movingNode = movingId ? nodeMap.get(movingId) : null;
 
   if (error) {
@@ -671,26 +795,37 @@ export function LocationTreePage() {
         </div>
       ) : (
         <div className="flex flex-col md:flex-row gap-6">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          >
           <div className="md:w-2/5 border rounded-lg py-2" role="tree" aria-label="Location tree">
-            {treeNodes.map((node, i) => (
-              <LocationNode
-                key={node.id}
-                node={node}
-                depth={0}
-                selectedId={selectedId}
-                onSelect={handleSelect}
-                onAddChild={handleAddChild}
-                onRename={handleRename}
-                onMoveStart={handleMoveStart}
-                onReorder={handleReorder}
-                onDelete={handleDelete}
-                addingChildOf={addingChildOf}
-                onNewChildSave={handleNewChildSave}
-                onNewChildCancel={handleNewChildCancel}
-                siblingIndex={i}
-                siblingCount={treeNodes.length}
-              />
-            ))}
+            <SortableContext
+              items={treeNodes.map((n) => n.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {treeNodes.map((node, i) => (
+                <LocationNode
+                  key={node.id}
+                  node={node}
+                  depth={0}
+                  selectedId={selectedId}
+                  onSelect={handleSelect}
+                  onAddChild={handleAddChild}
+                  onRename={handleRename}
+                  onMoveStart={handleMoveStart}
+                  onReorder={handleReorder}
+                  onDelete={handleDelete}
+                  addingChildOf={addingChildOf}
+                  onNewChildSave={handleNewChildSave}
+                  onNewChildCancel={handleNewChildCancel}
+                  siblingIndex={i}
+                  siblingCount={treeNodes.length}
+                />
+              ))}
+            </SortableContext>
             {addingRoot && (
               <div className="flex items-center gap-1.5 py-1.5 px-2" style={{ paddingLeft: "8px" }}>
                 <span className="w-[22px]" />
@@ -703,6 +838,10 @@ export function LocationTreePage() {
               </div>
             )}
           </div>
+          <DragOverlay>
+            {activeNode ? <DragOverlayNode node={activeNode} /> : null}
+          </DragOverlay>
+          </DndContext>
 
           <div className="md:w-3/5">
             {selectedId && nodeMap.get(selectedId) ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,15 @@ importers:
 
   packages/app-inventory:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@pops/api-client':
         specifier: workspace:*
         version: link:../api-client


### PR DESCRIPTION
## Summary
- Add @dnd-kit (core, sortable, utilities) for drag-and-drop support in LocationTreePage
- Desktop: GripVertical drag handle on hover; drag between siblings to reorder, onto non-sibling to reparent
- Mobile: arrow buttons preserved (hidden on desktop via `md:hidden`), drag handles hidden on mobile
- Descendant drops blocked to prevent circular references
- DragOverlay shows a lightweight preview of the dragged node
- 18 new tests covering DnD context rendering, reorder logic, reparent logic, descendant prevention, and selection

## Test plan
- [x] 18 new LocationTreePage tests pass (reorder, reparent, descendant block, no-ops, UI rendering)
- [x] All pre-existing app-inventory tests unaffected (37 pre-existing failures in ItemDetailPage/ItemFormPage/WarrantiesPage unchanged)
- [x] TypeScript compiles clean (no new errors)
- [ ] Manual: drag a location between siblings on desktop — sort order updates
- [ ] Manual: drag a location onto a non-sibling — reparents correctly
- [ ] Manual: verify arrow buttons still work on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)