### PR TITLE
feat: add THETVDB_API_KEY startup validation [tb-606]

### DIFF
--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -9,6 +9,7 @@ import { createApp } from "./app.js";
 import { closeDb } from "./db.js";
 import { startTtlWatcher } from "./modules/core/envs/ttl-watcher.js";
 import { startupCleanup } from "./modules/core/envs/registry.js";
+import { validateTvdbApiKey } from "./modules/media/thetvdb/index.js";
 
 const port = Number(process.env["PORT"] ?? 3000);
 const app = createApp();
@@ -19,6 +20,9 @@ if (expired.length > 0)
   console.log(`[pops-api] Cleaned up ${expired.length} expired env(s): ${expired.join(", ")}`);
 if (orphaned.length > 0)
   console.log(`[pops-api] Removed ${orphaned.length} orphaned env DB(s): ${orphaned.join(", ")}`);
+
+// Validate required environment variables
+validateTvdbApiKey();
 
 const server = app.listen(port, () => {
   console.log(`[pops-api] Listening on port ${port}`);

--- a/apps/pops-api/src/modules/media/thetvdb/index.test.ts
+++ b/apps/pops-api/src/modules/media/thetvdb/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../env.js", () => ({
+  getEnv: vi.fn(),
+}));
+
+import { validateTvdbApiKey, getTvdbClient, setTvdbClient } from "./index.js";
+import { getEnv } from "../../../env.js";
+
+const mockGetEnv = vi.mocked(getEnv);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setTvdbClient(null);
+});
+
+describe("validateTvdbApiKey", () => {
+  it("throws when THETVDB_API_KEY is not set", () => {
+    mockGetEnv.mockReturnValue(undefined);
+
+    expect(() => validateTvdbApiKey()).toThrow("THETVDB_API_KEY is not configured");
+  });
+
+  it("does not throw when THETVDB_API_KEY is set", () => {
+    mockGetEnv.mockReturnValue("test-api-key-123");
+
+    expect(() => validateTvdbApiKey()).not.toThrow();
+  });
+
+  it("throws with helpful message mentioning .env and Docker secrets", () => {
+    mockGetEnv.mockReturnValue(undefined);
+
+    expect(() => validateTvdbApiKey()).toThrow(/\.env.*Docker secrets/);
+  });
+});
+
+describe("getTvdbClient", () => {
+  it("throws when API key is missing", () => {
+    mockGetEnv.mockReturnValue(undefined);
+
+    expect(() => getTvdbClient()).toThrow("THETVDB_API_KEY is not configured");
+  });
+
+  it("creates client when API key is present", () => {
+    mockGetEnv.mockReturnValue("test-api-key-123");
+
+    const client = getTvdbClient();
+    expect(client).toBeDefined();
+  });
+
+  it("returns same client instance on subsequent calls", () => {
+    mockGetEnv.mockReturnValue("test-api-key-123");
+
+    const client1 = getTvdbClient();
+    const client2 = getTvdbClient();
+    expect(client1).toBe(client2);
+  });
+});

--- a/apps/pops-api/src/modules/media/thetvdb/index.ts
+++ b/apps/pops-api/src/modules/media/thetvdb/index.ts
@@ -32,6 +32,19 @@ export function getTvdbClient(): TheTvdbClient {
   return _tvdbClient;
 }
 
+/**
+ * Validate that THETVDB_API_KEY is configured.
+ * Call at server startup to fail fast with a clear error.
+ */
+export function validateTvdbApiKey(): void {
+  const apiKey = getEnv("THETVDB_API_KEY");
+  if (!apiKey) {
+    throw new Error(
+      "THETVDB_API_KEY is not configured. Set it in .env (development) or Docker secrets (production)."
+    );
+  }
+}
+
 /** Reset the shared client (for testing). */
 export function setTvdbClient(client: TheTvdbClient | null): void {
   _tvdbClient = client;


### PR DESCRIPTION
## Summary
- Add `validateTvdbApiKey()` that checks for `THETVDB_API_KEY` at server startup
- Throw clear error message referencing both `.env` and Docker secrets setup
- Call validation in `index.ts` before server starts listening

## Changes
- **Modified**: `apps/pops-api/src/modules/media/thetvdb/index.ts` — add `validateTvdbApiKey()` export
- **Modified**: `apps/pops-api/src/index.ts` — call validation at startup
- **New**: `apps/pops-api/src/modules/media/thetvdb/index.test.ts` — 6 tests

## Test plan
- [x] 6 tests pass (throws when missing, succeeds when present, error message format)
- [ ] Verify server fails to start without THETVDB_API_KEY set
- [ ] Verify server starts normally with THETVDB_API_KEY set

🤖 Generated with [Claude Code](https://claude.com/claude-code)