### PR TITLE
feat: movie image cache — download on add, redownloadImages on refresh [tb-608]

### DIFF
--- a/apps/pops-api/src/modules/media/library/library.test.ts
+++ b/apps/pops-api/src/modules/media/library/library.test.ts
@@ -10,6 +10,18 @@ vi.mock("../tmdb/client.js", () => ({
   TmdbClient: vi.fn(),
 }));
 
+// Shared mock image cache instance — stable reference across tests
+const mockImageCache = {
+  downloadMovieImages: vi.fn().mockResolvedValue(undefined),
+  deleteMovieImages: vi.fn().mockResolvedValue(undefined),
+  getImagePath: vi.fn().mockResolvedValue(null),
+};
+
+vi.mock("../tmdb/image-cache.js", () => ({
+  ImageCacheService: vi.fn().mockImplementation(() => mockImageCache),
+  MEDIA_DIR_NAMES: { movie: "movies", tv: "tv" },
+}));
+
 // Set the env var before the router module loads
 vi.stubEnv("TMDB_API_TOKEN", "test-api-key");
 
@@ -44,6 +56,8 @@ const MOCK_TMDB_DETAIL: TmdbMovieDetail = {
 };
 
 beforeEach(async () => {
+  mockImageCache.downloadMovieImages.mockClear();
+  mockImageCache.deleteMovieImages.mockClear();
   ({ caller, db } = ctx.setup());
 
   // Reset the mock for each test
@@ -160,5 +174,57 @@ describe("library.addMovie", () => {
   it("rejects unauthenticated calls", async () => {
     const anonCaller = createCaller(false);
     await expect(anonCaller.media.library.addMovie({ tmdbId: 550 })).rejects.toThrow(TRPCError);
+  });
+
+  it("calls downloadMovieImages after creating a new movie", async () => {
+    await caller.media.library.addMovie({ tmdbId: 550 });
+
+    expect(mockImageCache.downloadMovieImages).toHaveBeenCalledWith(
+      550,
+      MOCK_TMDB_DETAIL.posterPath,
+      MOCK_TMDB_DETAIL.backdropPath,
+      null
+    );
+  });
+
+  it("does not call downloadMovieImages for existing movie (idempotent)", async () => {
+    seedMovie(db, { tmdb_id: 550, title: "Fight Club (existing)", genres: '["Drama"]' });
+
+    await caller.media.library.addMovie({ tmdbId: 550 });
+
+    expect(mockImageCache.downloadMovieImages).not.toHaveBeenCalled();
+  });
+});
+
+describe("library.refreshMovie — image cache", () => {
+  it("re-downloads images when redownloadImages is true", async () => {
+    const movieId = seedMovie(db, {
+      tmdb_id: 550,
+      title: "Fight Club",
+      genres: '["Drama"]',
+    });
+
+    await caller.media.library.refreshMovie({ id: movieId, redownloadImages: true });
+
+    expect(mockImageCache.deleteMovieImages).toHaveBeenCalledWith(550);
+    expect(mockImageCache.downloadMovieImages).toHaveBeenCalledWith(
+      550,
+      MOCK_TMDB_DETAIL.posterPath,
+      MOCK_TMDB_DETAIL.backdropPath,
+      null
+    );
+  });
+
+  it("does not re-download images when redownloadImages is false (default)", async () => {
+    const movieId = seedMovie(db, {
+      tmdb_id: 550,
+      title: "Fight Club",
+      genres: '["Drama"]',
+    });
+
+    await caller.media.library.refreshMovie({ id: movieId });
+
+    expect(mockImageCache.deleteMovieImages).not.toHaveBeenCalled();
+    expect(mockImageCache.downloadMovieImages).not.toHaveBeenCalled();
   });
 });

--- a/apps/pops-api/src/modules/media/library/router.ts
+++ b/apps/pops-api/src/modules/media/library/router.ts
@@ -4,7 +4,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../../../trpc.js";
-import { getTmdbClient, TmdbClient, TmdbApiError } from "../tmdb/index.js";
+import { getTmdbClient, TmdbClient, TmdbApiError, getImageCache } from "../tmdb/index.js";
 import { NotFoundError } from "../../../shared/errors.js";
 import { toMovie } from "../movies/types.js";
 import { toTvShow, toSeason } from "../tv-shows/types.js";
@@ -51,8 +51,9 @@ export const libraryRouter = router({
     .input(z.object({ tmdbId: z.number().int().positive() }))
     .mutation(async ({ input }) => {
       const client = requireTmdbClient();
+      const imageCache = getImageCache();
       try {
-        const { movie, created } = await libraryService.addMovie(input.tmdbId, client);
+        const { movie, created } = await libraryService.addMovie(input.tmdbId, client, imageCache);
         return {
           data: movie,
           created,
@@ -78,8 +79,14 @@ export const libraryRouter = router({
   /** Refresh movie metadata from TMDB. */
   refreshMovie: protectedProcedure.input(RefreshMovieSchema).mutation(async ({ input }) => {
     const tmdbClient = requireTmdbClient();
+    const imageCache = getImageCache();
     try {
-      const row = await libraryService.refreshMovie(input.id, tmdbClient);
+      const row = await libraryService.refreshMovie(
+        input.id,
+        tmdbClient,
+        imageCache,
+        input.redownloadImages
+      );
       return {
         data: toMovie(row),
         message: "Movie metadata refreshed",

--- a/apps/pops-api/src/modules/media/library/service.test.ts
+++ b/apps/pops-api/src/modules/media/library/service.test.ts
@@ -13,6 +13,16 @@ import { listLibrary, listLibraryGenres } from "./service.js";
 import type { TmdbMovieDetail } from "../tmdb/types.js";
 import { TRPCError } from "@trpc/server";
 
+// Mock ImageCacheService so getImageCache() returns a stub
+vi.mock("../tmdb/image-cache.js", () => ({
+  ImageCacheService: vi.fn().mockImplementation(() => ({
+    downloadMovieImages: vi.fn().mockResolvedValue(undefined),
+    deleteMovieImages: vi.fn().mockResolvedValue(undefined),
+    getImagePath: vi.fn().mockResolvedValue(null),
+  })),
+  MEDIA_DIR_NAMES: { movie: "movies", tv: "tv" },
+}));
+
 const ctx = setupTestContext();
 let caller: ReturnType<typeof createCaller>;
 let db: Database;

--- a/apps/pops-api/src/modules/media/library/service.ts
+++ b/apps/pops-api/src/modules/media/library/service.ts
@@ -7,6 +7,7 @@ import { getDrizzle } from "../../../db.js";
 import { getDb } from "../../../db.js";
 import { movies, watchHistory } from "@pops/db-types";
 import type { TmdbClient } from "../tmdb/client.js";
+import type { ImageCacheService } from "../tmdb/image-cache.js";
 import type { TmdbMovieDetail } from "../tmdb/types.js";
 import { getMovieByTmdbId, getMovie, createMovie, updateMovie } from "../movies/service.js";
 import { toMovie } from "../movies/types.js";
@@ -18,13 +19,13 @@ import type { LibraryListInput, LibraryItem, LibrarySortOption } from "./types.j
  * Add a movie to the library by TMDB ID.
  *
  * Idempotent: returns the existing record if the movie is already in the library.
- * Fetches full detail from TMDB, maps fields, and inserts a new record.
- *
- * Image download is deferred until the image cache service is available (tb-058).
+ * Fetches full detail from TMDB, maps fields, inserts a new record,
+ * and downloads poster/backdrop images to the local cache.
  */
 export async function addMovie(
   tmdbId: number,
-  tmdbClient: TmdbClient
+  tmdbClient: TmdbClient,
+  imageCache: ImageCacheService
 ): Promise<{ movie: Movie; created: boolean }> {
   // Idempotency: return existing if already in library
   const existing = getMovieByTmdbId(tmdbId);
@@ -56,7 +57,8 @@ export async function addMovie(
     genres: detail.genres.map((g) => g.name),
   });
 
-  // TODO: download images in background when image cache service is available (tb-058)
+  // Download images to local cache (failures are logged, not thrown)
+  await imageCache.downloadMovieImages(detail.tmdbId, detail.posterPath, detail.backdropPath, null);
 
   return { movie: toMovie(row), created: true };
 }
@@ -89,8 +91,14 @@ function mapTmdbDetailToUpdate(detail: TmdbMovieDetail): UpdateMovieInput {
  *
  * Fetches fresh detail from TMDB and updates the local record.
  * Preserves poster_override_path (user-uploaded override).
+ * When redownloadImages is true, deletes and re-downloads cached images.
  */
-export async function refreshMovie(id: number, tmdbClient: TmdbClient): Promise<MovieRow> {
+export async function refreshMovie(
+  id: number,
+  tmdbClient: TmdbClient,
+  imageCache: ImageCacheService,
+  redownloadImages = false
+): Promise<MovieRow> {
   // Get existing movie (throws NotFoundError if missing)
   const existing = getMovie(id);
 
@@ -101,7 +109,20 @@ export async function refreshMovie(id: number, tmdbClient: TmdbClient): Promise<
   const updateInput = mapTmdbDetailToUpdate(detail);
 
   // Update the local record
-  return updateMovie(id, updateInput);
+  const updated = updateMovie(id, updateInput);
+
+  // Re-download images if requested
+  if (redownloadImages) {
+    await imageCache.deleteMovieImages(existing.tmdbId);
+    await imageCache.downloadMovieImages(
+      existing.tmdbId,
+      detail.posterPath,
+      detail.backdropPath,
+      null
+    );
+  }
+
+  return updated;
 }
 
 /** Map a sort option to SQL ORDER BY clause. */

--- a/apps/pops-api/src/modules/media/library/types.ts
+++ b/apps/pops-api/src/modules/media/library/types.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 /** Zod schema for refreshing movie metadata from TMDB. */
 export const RefreshMovieSchema = z.object({
   id: z.number().int().positive(),
+  redownloadImages: z.boolean().default(false),
 });
 export type RefreshMovieInput = z.infer<typeof RefreshMovieSchema>;
 

--- a/apps/pops-api/src/modules/media/tmdb/index.ts
+++ b/apps/pops-api/src/modules/media/tmdb/index.ts
@@ -1,4 +1,5 @@
 import { TmdbClient } from "./client.js";
+import { ImageCacheService } from "./image-cache.js";
 import { TokenBucketRateLimiter } from "./rate-limiter.js";
 import { getEnv } from "../../../env.js";
 
@@ -23,4 +24,17 @@ export function getTmdbClient(): TmdbClient {
     );
   }
   return new TmdbClient(apiToken, tmdbRateLimiter);
+}
+
+const DEFAULT_IMAGES_DIR = "./data/media/images";
+
+/** Lazy singleton for the image cache service. */
+let imageCache: ImageCacheService | null = null;
+
+export function getImageCache(): ImageCacheService {
+  if (!imageCache) {
+    const dir = process.env.MEDIA_IMAGES_DIR ?? DEFAULT_IMAGES_DIR;
+    imageCache = new ImageCacheService(dir);
+  }
+  return imageCache;
 }


### PR DESCRIPTION
## Summary
- `addMovie()` now downloads poster/backdrop to local cache via `ImageCacheService` after creating the movie record (replaces the TODO comment from tb-058)
- `RefreshMovieSchema` accepts optional `redownloadImages` boolean (defaults to `false`)
- When `redownloadImages` is `true`, `refreshMovie()` deletes existing cached images and re-downloads from TMDB
- Added `getImageCache()` lazy singleton factory in `tmdb/index.ts` using `MEDIA_IMAGES_DIR` env var
- 4 new tests covering download-on-add, idempotent skip, and refresh with/without redownload

Closes #692

## Test plan
- [x] All 492 media module tests pass (28 test files)
- [x] Typecheck clean
- [x] Prettier formatting verified
- [x] New tests: addMovie downloads images, idempotent skip, refreshMovie redownload true/false

🤖 Generated with [Claude Code](https://claude.com/claude-code)