### PR TITLE
feat: season poster downloads and placeholder generation [tb-605]

### DIFF
--- a/apps/pops-api/src/modules/media/tmdb/image-cache.test.ts
+++ b/apps/pops-api/src/modules/media/tmdb/image-cache.test.ts
@@ -305,3 +305,124 @@ describe("deleteTvShowImages", () => {
     });
   });
 });
+
+describe("downloadSeasonPoster", () => {
+  it("downloads season poster to correct path", async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadSeasonPoster(
+      81189,
+      1,
+      "https://artworks.thetvdb.com/banners/seasons/81189-1.jpg"
+    );
+
+    const tvDir = path.join(IMAGES_DIR, "tv", "81189");
+    expect(fs.mkdir).toHaveBeenCalledWith(tvDir, { recursive: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://artworks.thetvdb.com/banners/seasons/81189-1.jpg"
+    );
+    expect(fs.writeFile).toHaveBeenCalledWith(path.join(tvDir, "season_1.jpg"), expect.any(Buffer));
+  });
+
+  it("stores specials poster as season_0.jpg", async () => {
+    fetchMock.mockResolvedValue(mockImageResponse());
+
+    await service.downloadSeasonPoster(
+      81189,
+      0,
+      "https://artworks.thetvdb.com/banners/seasons/81189-0.jpg"
+    );
+
+    const tvDir = path.join(IMAGES_DIR, "tv", "81189");
+    expect(fs.writeFile).toHaveBeenCalledWith(path.join(tvDir, "season_0.jpg"), expect.any(Buffer));
+  });
+
+  it("skips download when posterUrl is null", async () => {
+    await service.downloadSeasonPoster(81189, 1, null);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(fs.mkdir).not.toHaveBeenCalled();
+  });
+
+  it("skips download if file already exists", async () => {
+    vi.mocked(fs.stat).mockResolvedValueOnce({} as Awaited<ReturnType<typeof fs.stat>>);
+
+    await service.downloadSeasonPoster(
+      81189,
+      1,
+      "https://artworks.thetvdb.com/banners/seasons/81189-1.jpg"
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("handles download failure gracefully", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("Network error"));
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(
+      service.downloadSeasonPoster(
+        81189,
+        1,
+        "https://artworks.thetvdb.com/banners/seasons/81189-1.jpg"
+      )
+    ).resolves.toBeUndefined();
+
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("generatePlaceholder", () => {
+  it("generates SVG placeholder with show name", async () => {
+    const destPath = path.join(IMAGES_DIR, "tv", "81189", "poster.jpg");
+
+    await service.generatePlaceholder("Breaking Bad", destPath);
+
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      destPath,
+      expect.stringContaining("Breaking Bad"),
+      "utf-8"
+    );
+  });
+
+  it("generates valid SVG markup", async () => {
+    const destPath = path.join(IMAGES_DIR, "tv", "81189", "poster.jpg");
+
+    await service.generatePlaceholder("Test Show", destPath);
+
+    const svgContent = vi.mocked(fs.writeFile).mock.calls[0]![1] as string;
+    expect(svgContent).toContain("<svg");
+    expect(svgContent).toContain("<rect");
+    expect(svgContent).toContain("<text");
+    expect(svgContent).toContain("Test Show");
+  });
+
+  it("escapes HTML entities in text", async () => {
+    const destPath = path.join(IMAGES_DIR, "tv", "12345", "poster.jpg");
+
+    await service.generatePlaceholder('Show <"Special">', destPath);
+
+    const svgContent = vi.mocked(fs.writeFile).mock.calls[0]![1] as string;
+    expect(svgContent).toContain("&lt;");
+    expect(svgContent).toContain("&gt;");
+    expect(svgContent).toContain("&quot;");
+    expect(svgContent).not.toContain('<"Special">');
+  });
+
+  it("uses deterministic colour based on text", async () => {
+    const destPath = path.join(IMAGES_DIR, "tv", "81189", "poster.jpg");
+
+    await service.generatePlaceholder("Breaking Bad", destPath);
+    const svg1 = vi.mocked(fs.writeFile).mock.calls[0]![1] as string;
+
+    vi.mocked(fs.writeFile).mockClear();
+
+    await service.generatePlaceholder("Breaking Bad", destPath);
+    const svg2 = vi.mocked(fs.writeFile).mock.calls[0]![1] as string;
+
+    expect(svg1).toBe(svg2);
+  });
+});

--- a/apps/pops-api/src/modules/media/tmdb/image-cache.ts
+++ b/apps/pops-api/src/modules/media/tmdb/image-cache.ts
@@ -116,6 +116,53 @@ export class ImageCacheService {
   }
 
   /**
+   * Download a season poster from TheTVDB to local cache.
+   * Stored at: tv/{tvdbId}/season_{num}.jpg (e.g., season_1.jpg, season_0.jpg for specials).
+   */
+  async downloadSeasonPoster(
+    tvdbId: number,
+    seasonNumber: number,
+    posterUrl: string | null
+  ): Promise<void> {
+    if (!posterUrl) return;
+
+    const tvDir = this.tvShowDir(tvdbId);
+    await mkdir(tvDir, { recursive: true });
+
+    const filename = `season_${seasonNumber}.jpg`;
+    await this.downloadImage(posterUrl, join(tvDir, filename));
+  }
+
+  /**
+   * Generate a placeholder image — coloured rectangle with text.
+   * Creates an SVG and writes it to the destination path.
+   */
+  async generatePlaceholder(text: string, destPath: string): Promise<void> {
+    // Generate a deterministic colour from the text
+    let hash = 0;
+    for (let i = 0; i < text.length; i++) {
+      hash = ((hash << 5) - hash + text.charCodeAt(i)) | 0;
+    }
+    const hue = Math.abs(hash) % 360;
+
+    const escapedText = text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="600" viewBox="0 0 400 600">
+  <rect width="400" height="600" fill="hsl(${hue}, 40%, 30%)" />
+  <text x="200" y="300" text-anchor="middle" dominant-baseline="middle"
+        font-family="sans-serif" font-size="28" font-weight="bold" fill="white">
+    ${escapedText}
+  </text>
+</svg>`;
+
+    await writeFile(destPath, svg, "utf-8");
+  }
+
+  /**
    * Get the absolute path to a cached image file.
    * Returns null if the file doesn't exist.
    */


### PR DESCRIPTION
## Summary
- Add `downloadSeasonPoster()` to `ImageCacheService` — downloads season posters from TheTVDB, stored as `tv/{tvdbId}/season_{num}.jpg`
- Add `generatePlaceholder()` — creates deterministic SVG placeholders with hashed colour and escaped text (no external image deps)
- 9 new tests (29 total): season poster download/skip/failure + placeholder SVG markup, escaping, deterministic colour

## Test plan
- [x] All 29 image-cache tests pass
- [x] TypeScript compiles clean
- [x] Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)