### PR TITLE
feat: tag suggestion source attribution [tb-602]

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/service.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.ts
@@ -92,38 +92,14 @@ function buildSuggestedTags(
   knownTags: string[],
   correctionPattern?: string
 ): SuggestedTag[] {
-  const seen = new Set<string>();
-  const result: SuggestedTag[] = [];
-
-  // 1. Correction rule tags
-  for (const tag of correctionTags) {
-    if (!seen.has(tag)) {
-      seen.add(tag);
-      result.push({ tag, source: "rule", pattern: correctionPattern });
-    }
-  }
-
-  // 2. AI category — only if it case-insensitively matches a tag already in the DB.
-  //    knownTags is loaded once per import batch (not per-transaction).
-  if (aiCategory) {
-    const lowerCategory = aiCategory.toLowerCase();
-    const matched = knownTags.find((t) => t.toLowerCase() === lowerCategory) ?? null;
-    if (matched && !seen.has(matched)) {
-      seen.add(matched);
-      result.push({ tag: matched, source: "ai" });
-    }
-  }
-
-  // 3. Entity default tags + correction tags via suggestTags — anything not already attributed
-  const entitySuggestions = suggestTags(description, entityId);
-  for (const tag of entitySuggestions) {
-    if (!seen.has(tag)) {
-      seen.add(tag);
-      result.push({ tag, source: "entity" });
-    }
-  }
-
-  return result;
+  return suggestTags({
+    description,
+    entityId,
+    aiCategory,
+    knownTags,
+    correctionTags,
+    correctionPattern,
+  });
 }
 
 /**

--- a/apps/pops-api/src/modules/finance/transactions/router.ts
+++ b/apps/pops-api/src/modules/finance/transactions/router.ts
@@ -115,8 +115,11 @@ export const transactionsRouter = router({
       })
     )
     .query(({ input }) => {
-      const tags = suggestTags(input.description, input.entityId ?? null);
-      return { tags };
+      const suggested = suggestTags({
+        description: input.description,
+        entityId: input.entityId ?? null,
+      });
+      return { tags: suggested.map((s) => s.tag) };
     }),
 
   /**

--- a/apps/pops-api/src/shared/tag-suggester.test.ts
+++ b/apps/pops-api/src/shared/tag-suggester.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { suggestTags } from "./tag-suggester.js";
+
+// Mock entity lookup via DB
+const mockEntityGet = vi.fn<() => { defaultTags: string | null } | null>(() => null);
+vi.mock("../db.js", () => ({
+  getDrizzle: vi.fn(() => ({
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          get: (...args: unknown[]) => mockEntityGet(...(args as [])),
+        })),
+      })),
+    })),
+  })),
+}));
+
+// Mock corrections service
+const mockFindAllMatchingCorrections = vi.fn<
+  () => { tags: string; descriptionPattern: string | null }[]
+>(() => []);
+vi.mock("../modules/core/corrections/service.js", () => ({
+  findAllMatchingCorrections: (...args: unknown[]) =>
+    mockFindAllMatchingCorrections(...(args as [])),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFindAllMatchingCorrections.mockReturnValue([]);
+  mockEntityGet.mockReturnValue(null);
+});
+
+describe("suggestTags", () => {
+  it("returns empty array when no matches", () => {
+    const result = suggestTags({ description: "UNKNOWN MERCHANT", entityId: null });
+    expect(result).toEqual([]);
+  });
+
+  describe("correction rule tags (source: rule)", () => {
+    it("returns tags from pre-parsed correctionTags with pattern", () => {
+      const result = suggestTags({
+        description: "WOOLWORTHS",
+        entityId: null,
+        correctionTags: ["groceries", "essentials"],
+        correctionPattern: "WOOLWORTHS%",
+      });
+
+      expect(result).toEqual([
+        { tag: "groceries", source: "rule", pattern: "WOOLWORTHS%" },
+        { tag: "essentials", source: "rule", pattern: "WOOLWORTHS%" },
+      ]);
+    });
+
+    it("falls back to DB corrections when correctionTags not provided", () => {
+      mockFindAllMatchingCorrections.mockReturnValue([
+        { tags: '["groceries"]', descriptionPattern: "COLES%" },
+        { tags: '["food"]', descriptionPattern: "COLES%" },
+      ]);
+
+      const result = suggestTags({ description: "COLES SUPERMARKET", entityId: null });
+
+      expect(mockFindAllMatchingCorrections).toHaveBeenCalledWith("COLES SUPERMARKET");
+      expect(result).toEqual([
+        { tag: "groceries", source: "rule", pattern: "COLES%" },
+        { tag: "food", source: "rule", pattern: "COLES%" },
+      ]);
+    });
+
+    it("handles malformed JSON in correction tags gracefully", () => {
+      mockFindAllMatchingCorrections.mockReturnValue([
+        { tags: "not-json", descriptionPattern: "X" },
+        { tags: '["valid"]', descriptionPattern: "Y" },
+      ]);
+
+      const result = suggestTags({ description: "TEST", entityId: null });
+      expect(result).toEqual([{ tag: "valid", source: "rule", pattern: "Y" }]);
+    });
+  });
+
+  describe("AI category tags (source: ai)", () => {
+    it("adds AI category when it matches a known tag (case-insensitive)", () => {
+      const result = suggestTags({
+        description: "NETFLIX",
+        entityId: null,
+        aiCategory: "entertainment",
+        knownTags: ["Entertainment", "Groceries", "Transport"],
+      });
+
+      expect(result).toEqual([{ tag: "Entertainment", source: "ai" }]);
+    });
+
+    it("skips AI category when it does not match any known tag", () => {
+      const result = suggestTags({
+        description: "NETFLIX",
+        entityId: null,
+        aiCategory: "streaming",
+        knownTags: ["Entertainment", "Groceries"],
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("skips AI category when knownTags not provided", () => {
+      const result = suggestTags({
+        description: "NETFLIX",
+        entityId: null,
+        aiCategory: "entertainment",
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("entity default tags (source: entity)", () => {
+    it("returns entity default tags with source entity", () => {
+      mockEntityGet.mockReturnValue({ defaultTags: '["groceries", "essentials"]' });
+
+      const result = suggestTags({ description: "WOOLWORTHS", entityId: "entity-1" });
+
+      expect(result).toEqual([
+        { tag: "groceries", source: "entity" },
+        { tag: "essentials", source: "entity" },
+      ]);
+    });
+
+    it("handles null entityId", () => {
+      const result = suggestTags({ description: "UNKNOWN", entityId: null });
+      expect(result).toEqual([]);
+      expect(mockEntityGet).not.toHaveBeenCalled();
+    });
+
+    it("handles malformed entity defaultTags JSON", () => {
+      mockEntityGet.mockReturnValue({ defaultTags: "{bad" });
+
+      const result = suggestTags({ description: "TEST", entityId: "entity-1" });
+      expect(result).toEqual([]);
+    });
+
+    it("handles entity with no defaultTags", () => {
+      mockEntityGet.mockReturnValue({ defaultTags: null });
+
+      const result = suggestTags({ description: "TEST", entityId: "entity-1" });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("deduplication and priority", () => {
+    it("correction tags take priority over entity tags", () => {
+      mockEntityGet.mockReturnValue({ defaultTags: '["groceries", "food"]' });
+
+      const result = suggestTags({
+        description: "WOOLWORTHS",
+        entityId: "entity-1",
+        correctionTags: ["groceries"],
+        correctionPattern: "WOOLWORTHS%",
+      });
+
+      expect(result).toEqual([
+        { tag: "groceries", source: "rule", pattern: "WOOLWORTHS%" },
+        { tag: "food", source: "entity" },
+      ]);
+    });
+
+    it("AI category does not duplicate correction tags", () => {
+      const result = suggestTags({
+        description: "COLES",
+        entityId: null,
+        correctionTags: ["Groceries"],
+        correctionPattern: "COLES%",
+        aiCategory: "Groceries",
+        knownTags: ["Groceries"],
+      });
+
+      expect(result).toEqual([{ tag: "Groceries", source: "rule", pattern: "COLES%" }]);
+    });
+
+    it("all three sources work together with deduplication", () => {
+      mockEntityGet.mockReturnValue({ defaultTags: '["essentials", "groceries"]' });
+
+      const result = suggestTags({
+        description: "WOOLWORTHS",
+        entityId: "entity-1",
+        correctionTags: ["groceries"],
+        correctionPattern: "WOOLWORTHS%",
+        aiCategory: "food",
+        knownTags: ["Food", "Groceries"],
+      });
+
+      // groceries from rule (first), Food from AI, essentials from entity
+      // groceries NOT duplicated from entity
+      expect(result).toEqual([
+        { tag: "groceries", source: "rule", pattern: "WOOLWORTHS%" },
+        { tag: "Food", source: "ai" },
+        { tag: "essentials", source: "entity" },
+      ]);
+    });
+  });
+});

--- a/apps/pops-api/src/shared/tag-suggester.ts
+++ b/apps/pops-api/src/shared/tag-suggester.ts
@@ -1,25 +1,70 @@
 /**
- * Suggest tags for a transaction using entity defaults + correction rules.
- * Pure rule-based, synchronous — no LLM call.
+ * Suggest tags for a transaction with source attribution.
+ *
+ * Strategy (order = priority for deduplication):
+ * 1. Correction rules — tags from matching corrections (source: "rule")
+ * 2. AI category — validated against knownTags (source: "ai")
+ * 3. Entity defaults — from entity.default_tags (source: "entity")
+ *
+ * Returns SuggestedTag[] with source attribution and optional pattern.
  */
 import { eq } from "drizzle-orm";
 import { getDrizzle } from "../db.js";
 import { entities } from "@pops/db-types";
 import { findAllMatchingCorrections } from "../modules/core/corrections/service.js";
+import type { SuggestedTag } from "../modules/finance/imports/types.js";
 
-/**
- * Suggest tags for a transaction.
- *
- * Strategy:
- * 1. If entityId provided: look up entity default_tags
- * 2. Run findAllMatchingCorrections for the description → union all tags arrays
- * 3. Return deduplicated, sorted result
- */
-export function suggestTags(description: string, entityId: string | null): string[] {
+export interface SuggestTagsOptions {
+  description: string;
+  entityId: string | null;
+  /** AI-suggested category string (validated against knownTags). */
+  aiCategory?: string | null;
+  /** All tag strings currently in the transactions table (for AI validation). */
+  knownTags?: string[];
+  /** Pre-parsed correction tags (skips DB lookup when caller already has them). */
+  correctionTags?: string[];
+  /** The description_pattern from the matched correction (for attribution). */
+  correctionPattern?: string;
+}
+
+export function suggestTags(opts: SuggestTagsOptions): SuggestedTag[] {
+  const { description, entityId, aiCategory, knownTags, correctionTags, correctionPattern } = opts;
   const db = getDrizzle();
-  const tagSet = new Set<string>();
+  const seen = new Set<string>();
+  const result: SuggestedTag[] = [];
 
-  // 1. Entity default tags
+  // 1. Correction rule tags (pre-parsed or from DB)
+  if (correctionTags && correctionTags.length > 0) {
+    for (const tag of correctionTags) {
+      if (!seen.has(tag)) {
+        seen.add(tag);
+        result.push({ tag, source: "rule", pattern: correctionPattern });
+      }
+    }
+  } else {
+    const corrections = findAllMatchingCorrections(description);
+    for (const correction of corrections) {
+      const tags = parseJsonTags(correction.tags);
+      for (const tag of tags) {
+        if (!seen.has(tag)) {
+          seen.add(tag);
+          result.push({ tag, source: "rule", pattern: correction.descriptionPattern ?? undefined });
+        }
+      }
+    }
+  }
+
+  // 2. AI category — only if it case-insensitively matches a known tag
+  if (aiCategory && knownTags) {
+    const lowerCategory = aiCategory.toLowerCase();
+    const matched = knownTags.find((t) => t.toLowerCase() === lowerCategory) ?? null;
+    if (matched && !seen.has(matched)) {
+      seen.add(matched);
+      result.push({ tag: matched, source: "ai" });
+    }
+  }
+
+  // 3. Entity default tags
   if (entityId) {
     const entity = db
       .select({ defaultTags: entities.defaultTags })
@@ -28,33 +73,29 @@ export function suggestTags(description: string, entityId: string | null): strin
       .get();
 
     if (entity?.defaultTags) {
-      try {
-        const parsed = JSON.parse(entity.defaultTags) as unknown;
-        if (Array.isArray(parsed)) {
-          for (const tag of parsed) {
-            if (typeof tag === "string") tagSet.add(tag);
-          }
+      const tags = parseJsonTags(entity.defaultTags);
+      for (const tag of tags) {
+        if (!seen.has(tag)) {
+          seen.add(tag);
+          result.push({ tag, source: "entity" });
         }
-      } catch {
-        // malformed JSON — ignore
       }
     }
   }
 
-  // 2. Correction rule tags
-  const corrections = findAllMatchingCorrections(description);
-  for (const correction of corrections) {
-    try {
-      const parsed = JSON.parse(correction.tags) as unknown;
-      if (Array.isArray(parsed)) {
-        for (const tag of parsed) {
-          if (typeof tag === "string") tagSet.add(tag);
-        }
-      }
-    } catch {
-      // malformed JSON — ignore
-    }
-  }
+  return result;
+}
 
-  return [...tagSet].sort();
+/** Parse a JSON string expected to be a string array. Returns [] on failure. */
+function parseJsonTags(json: string | null | undefined): string[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.filter((t): t is string => typeof t === "string");
+    }
+  } catch {
+    // malformed JSON — ignore
+  }
+  return [];
 }


### PR DESCRIPTION
## Summary
- Refactors `suggestTags()` to return `SuggestedTag[]` with source attribution (`rule`/`ai`/`entity`) instead of plain `string[]`
- Accepts optional `aiCategory` + `knownTags` params for AI category validation against existing DB tags
- `buildSuggestedTags()` in service.ts now delegates to the consolidated `suggestTags()` function
- 14 unit tests covering all three tag sources, deduplication priority, and edge cases (malformed JSON, missing data)

## Test plan
- [x] 14 unit tests pass (`tag-suggester.test.ts`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Prettier formatting applied
- [ ] Full pops-api test suite (CI)
- [ ] Verify tag attribution displays correctly in import UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)