### PR TITLE
feat: TV image cache — season posters and placeholder generation [tb-605]

### DIFF
--- a/apps/pops-api/src/modules/media/tmdb/image-cache.test.ts
+++ b/apps/pops-api/src/modules/media/tmdb/image-cache.test.ts
@@ -457,9 +457,7 @@ describe("downloadTvShowImages — season posters", () => {
   it("skips null season poster URLs", async () => {
     fetchMock.mockResolvedValue(mockImageResponse());
 
-    await service.downloadTvShowImages(81189, null, null, [
-      { seasonNumber: 1, posterUrl: null },
-    ]);
+    await service.downloadTvShowImages(81189, null, null, [{ seasonNumber: 1, posterUrl: null }]);
 
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/apps/pops-api/src/modules/media/tmdb/image-cache.ts
+++ b/apps/pops-api/src/modules/media/tmdb/image-cache.ts
@@ -232,27 +232,18 @@ export class ImageCacheService {
    * For seasons, includes "Season N" in the label.
    * Stored as poster.jpg (show) or season_{num}.jpg (season).
    */
-  async generateTvPlaceholder(
-    tvdbId: number,
-    title: string,
-    seasonNumber?: number
-  ): Promise<void> {
+  async generateTvPlaceholder(tvdbId: number, title: string, seasonNumber?: number): Promise<void> {
     const tvDir = this.tvShowDir(tvdbId);
     await mkdir(tvDir, { recursive: true });
 
     const filename =
       seasonNumber !== undefined ? seasonFilename(seasonNumber) : IMAGE_FILENAMES.poster;
-    const label =
-      seasonNumber !== undefined ? `${title} — Season ${seasonNumber}` : title;
+    const label = seasonNumber !== undefined ? `${title} — Season ${seasonNumber}` : title;
     await this.writePlaceholderSvg(join(tvDir, filename), label, tvdbId);
   }
 
   /** Write an SVG placeholder to destPath unless the file already exists. */
-  private async writePlaceholderSvg(
-    destPath: string,
-    label: string,
-    seed: number
-  ): Promise<void> {
+  private async writePlaceholderSvg(destPath: string, label: string, seed: number): Promise<void> {
     // Skip if file already exists
     try {
       await stat(destPath);


### PR DESCRIPTION
## Summary
- **Season posters**: New `downloadSeasonPoster()` stores per-season posters at `tv/{tvdbId}/season_{num}.jpg` (e.g. `season_1.jpg`, `season_0.jpg` for specials)
- **Bulk season download**: Extended `downloadTvShowImages()` with optional `seasonPosters` array for batch downloading
- **Placeholder generation**: `generateTvPlaceholder()` creates SVG placeholders for shows and seasons; `generateMoviePlaceholder()` for movies — shared `writePlaceholderSvg()` private method
- **Season path lookup**: `getSeasonImagePath()` returns cached season poster paths

## Test plan
- [x] 33 image cache tests pass (22 existing + 11 new)
- [x] TypeScript compiles cleanly
- [ ] Verify season poster filenames match expected naming convention
- [ ] Verify placeholder SVGs render with correct season labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)