### PR TITLE
feat: low-confidence rule confirmation flow [tb-585]

### DIFF
--- a/docs-v2/themes/02-finance/prds/027-ai-rule-creation/README.md
+++ b/docs-v2/themes/02-finance/prds/027-ai-rule-creation/README.md
@@ -86,7 +86,7 @@ Each import makes the system smarter:
 |---|-------|---------|----------------|--------|
 | 01 | [us-01-correction-analysis](us-01-correction-analysis.md) | Send user correction to Claude, receive pattern suggestion | No (first) | Partial |
 | 02 | [us-02-auto-apply-rules](us-02-auto-apply-rules.md) | High-confidence AI rules auto-saved and applied to remaining import transactions | Blocked by us-01 | Done |
-| 03 | [us-03-confirmation-flow](us-03-confirmation-flow.md) | Low-confidence AI rules shown to user for confirmation before saving | Blocked by us-01 | Not started |
+| 03 | [us-03-confirmation-flow](us-03-confirmation-flow.md) | Low-confidence AI rules shown to user for confirmation before saving | Blocked by us-01 | Done |
 | 04 | [us-04-batch-analysis](us-04-batch-analysis.md) | Batch correction analysis for better pattern suggestions | Blocked by us-01 | Partial |
 
 US-02 and US-03 can parallelise after US-01.

--- a/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-03-confirmation-flow.md
+++ b/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-03-confirmation-flow.md
@@ -1,7 +1,7 @@
 # US-03: Confirmation flow for low-confidence rules
 
 > PRD: [027 — AI Rule Creation](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,11 +9,11 @@ As a user, I want to review low-confidence AI rule suggestions before they're ap
 
 ## Acceptance Criteria
 
-- [ ] AI suggestions with confidence < 0.8 shown in a confirmation UI (toast or inline prompt)
-- [ ] Shows: proposed pattern, match type, how many transactions it would match
-- [ ] "Accept" saves the rule and applies to remaining transactions
-- [ ] "Reject" discards the suggestion — correction is saved but no rule created
-- [ ] Rejected patterns are not re-suggested for the same description in this import
+- [x] AI suggestions with confidence < 0.8 shown in a confirmation UI (toast or inline prompt)
+- [x] Shows: proposed pattern, match type, how many transactions it would match
+- [x] "Accept" saves the rule and applies to remaining transactions
+- [x] "Reject" discards the suggestion — correction is saved but no rule created
+- [x] Rejected patterns are not re-suggested for the same description in this import
 
 ## Notes
 

--- a/packages/app-finance/src/components/imports/ReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.test.tsx
@@ -18,8 +18,7 @@ vi.mock("../../lib/trpc", () => ({
           useMutation: (opts: Record<string, unknown>) => ({
             mutateAsync: (...args: unknown[]) => {
               const result = mockCreateEntityMutateAsync(...args);
-              if (typeof opts.onSuccess === "function")
-                (opts.onSuccess as () => void)();
+              if (typeof opts.onSuccess === "function") (opts.onSuccess as () => void)();
               return result;
             },
             isPending: false,
@@ -158,7 +157,8 @@ vi.mock("../../lib/transaction-utils", () => ({
     txs.length > 0
       ? [
           {
-            entityName: (txs[0] as { entity?: { entityName?: string } })?.entity?.entityName ?? "Unknown",
+            entityName:
+              (txs[0] as { entity?: { entityName?: string } })?.entity?.entityName ?? "Unknown",
             aiSuggestion: true,
             transactions: txs,
           },
@@ -183,20 +183,10 @@ vi.mock("@pops/ui", async () => {
       ),
     TabsList: ({ children }: { children: React.ReactNode }) =>
       React.createElement("div", { role: "tablist" }, children),
-    TabsTrigger: ({
-      children,
-      value,
-    }: {
-      children: React.ReactNode;
-      value: string;
-    }) => React.createElement("button", { role: "tab", "data-value": value }, children),
-    TabsContent: ({
-      children,
-      value,
-    }: {
-      children: React.ReactNode;
-      value: string;
-    }) => React.createElement("div", { "data-testid": `tab-${value}` }, children),
+    TabsTrigger: ({ children, value }: { children: React.ReactNode; value: string }) =>
+      React.createElement("button", { role: "tab", "data-value": value }, children),
+    TabsContent: ({ children, value }: { children: React.ReactNode; value: string }) =>
+      React.createElement("div", { "data-testid": `tab-${value}` }, children),
   };
 });
 
@@ -204,10 +194,7 @@ import { ReviewStep } from "./ReviewStep";
 
 // --- Helpers ---
 
-function makeTx(
-  description: string,
-  overrides: Record<string, unknown> = {}
-) {
+function makeTx(description: string, overrides: Record<string, unknown> = {}) {
   return {
     date: "2026-01-15",
     description,
@@ -357,5 +344,182 @@ describe("ReviewStep — auto-apply rules", () => {
     expect(mockToastSuccess).toHaveBeenCalledWith(
       expect.stringContaining("Applied to 1 more transaction")
     );
+  });
+});
+
+describe("ReviewStep — low-confidence confirmation flow", () => {
+  it("shows confirmation toast for low-confidence suggestion instead of auto-saving", () => {
+    const tx = makeTx("SPOTIFY PREMIUM", {
+      entity: { entityId: "ent-3", entityName: "Spotify", matchType: "ai", confidence: 0.6 },
+    });
+    mockEntitiesQuery.mockReturnValue({
+      data: {
+        data: [
+          { id: "ent-1", name: "Woolworths", type: "company" },
+          { id: "ent-3", name: "Spotify", type: "company" },
+        ],
+      },
+    });
+    mockProcessedTransactions = {
+      matched: [],
+      uncertain: [tx],
+      failed: [],
+      skipped: [],
+    };
+    render(<ReviewStep />);
+
+    fireEvent.click(screen.getByTestId("accept-SPOTIFY PREMIUM"));
+
+    // Should show info toast with confirmation, not auto-save
+    expect(mockToastInfo).toHaveBeenCalledWith(
+      expect.stringContaining('Create rule: contains "Spotify"'),
+      expect.objectContaining({
+        action: expect.objectContaining({ label: "Accept" }),
+        cancel: expect.objectContaining({ label: "Reject" }),
+      })
+    );
+
+    // Should NOT auto-save correction
+    expect(mockCreateCorrectionMutate).not.toHaveBeenCalled();
+  });
+
+  it("auto-saves rule when confidence >= 0.8 (high confidence path)", () => {
+    const tx = makeTx("WOOLWORTHS 1234 SYDNEY", {
+      entity: { entityId: "ent-1", entityName: "Woolworths", matchType: "ai", confidence: 0.85 },
+    });
+    mockProcessedTransactions = {
+      matched: [],
+      uncertain: [tx],
+      failed: [],
+      skipped: [],
+    };
+    render(<ReviewStep />);
+
+    fireEvent.click(screen.getByTestId("accept-WOOLWORTHS 1234 SYDNEY"));
+
+    // Should auto-save correction (high confidence path)
+    expect(mockCreateCorrectionMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        matchType: "contains",
+        entityId: "ent-1",
+        entityName: "Woolworths",
+      })
+    );
+
+    // Should NOT show confirmation toast
+    expect(mockToastInfo).not.toHaveBeenCalledWith(
+      expect.stringContaining("Create rule"),
+      expect.anything()
+    );
+  });
+
+  it("confirmation toast shows match count when other transactions would match", () => {
+    const tx1 = makeTx("SPOTIFY PREMIUM", {
+      entity: { entityId: "ent-3", entityName: "Spotify", matchType: "ai", confidence: 0.6 },
+    });
+    const tx2 = makeTx("SPOTIFY FAMILY PLAN", {
+      entity: { entityId: "ent-3", entityName: "Spotify", matchType: "ai", confidence: 0.5 },
+    });
+    mockEntitiesQuery.mockReturnValue({
+      data: {
+        data: [{ id: "ent-3", name: "Spotify", type: "company" }],
+      },
+    });
+    mockProcessedTransactions = {
+      matched: [],
+      uncertain: [tx1, tx2],
+      failed: [],
+      skipped: [],
+    };
+    render(<ReviewStep />);
+
+    fireEvent.click(screen.getByTestId("accept-SPOTIFY PREMIUM"));
+
+    // Should mention 1 more transaction that would match
+    expect(mockToastInfo).toHaveBeenCalledWith(
+      expect.stringContaining("Would apply to 1 more transaction"),
+      expect.anything()
+    );
+  });
+
+  it("accept button in confirmation toast saves the rule", () => {
+    const tx = makeTx("SPOTIFY PREMIUM", {
+      entity: { entityId: "ent-3", entityName: "Spotify", matchType: "ai", confidence: 0.6 },
+    });
+    mockEntitiesQuery.mockReturnValue({
+      data: {
+        data: [{ id: "ent-3", name: "Spotify", type: "company" }],
+      },
+    });
+    mockProcessedTransactions = {
+      matched: [],
+      uncertain: [tx],
+      failed: [],
+      skipped: [],
+    };
+    render(<ReviewStep />);
+
+    fireEvent.click(screen.getByTestId("accept-SPOTIFY PREMIUM"));
+
+    // Simulate clicking the Accept button in the toast
+    const infoCall = mockToastInfo.mock.calls[0]!;
+    const actionOnClick = (infoCall[1] as { action: { onClick: () => void } }).action.onClick;
+    actionOnClick();
+
+    // Now the correction should be saved
+    expect(mockCreateCorrectionMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        matchType: "contains",
+        entityId: "ent-3",
+        entityName: "Spotify",
+      })
+    );
+  });
+
+  it("reject button prevents re-suggestion for same pattern", () => {
+    // Both descriptions normalise to "SPOTIFY" (digits + extra spaces stripped)
+    const tx1 = makeTx("SPOTIFY 1234", {
+      entity: { entityId: "ent-3", entityName: "Spotify", matchType: "ai", confidence: 0.6 },
+    });
+    const tx2 = makeTx("SPOTIFY 5678", {
+      entity: { entityId: "ent-3", entityName: "Spotify", matchType: "ai", confidence: 0.5 },
+    });
+    mockEntitiesQuery.mockReturnValue({
+      data: {
+        data: [{ id: "ent-3", name: "Spotify", type: "company" }],
+      },
+    });
+    mockProcessedTransactions = {
+      matched: [],
+      uncertain: [tx1, tx2],
+      failed: [],
+      skipped: [],
+    };
+    const { unmount } = render(<ReviewStep />);
+
+    // Accept first transaction — shows confirmation toast
+    fireEvent.click(screen.getByTestId("accept-SPOTIFY 1234"));
+    expect(mockToastInfo).toHaveBeenCalledTimes(1);
+
+    // Simulate clicking Reject
+    const infoCall = mockToastInfo.mock.calls[0]!;
+    const cancelOnClick = (infoCall[1] as { cancel: { onClick: () => void } }).cancel.onClick;
+    cancelOnClick();
+
+    // No correction should be saved
+    expect(mockCreateCorrectionMutate).not.toHaveBeenCalled();
+
+    // Accept second transaction with same normalised pattern — should NOT show confirmation again
+    mockToastInfo.mockClear();
+    fireEvent.click(screen.getByTestId("accept-SPOTIFY 5678"));
+
+    // The confirmation toast should not appear for the rejected pattern
+    const createRuleCalls = mockToastInfo.mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "string" && (call[0] as string).includes("Create rule")
+    );
+    expect(createRuleCalls).toHaveLength(0);
+
+    unmount();
   });
 });

--- a/packages/app-finance/src/components/imports/ReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.tsx
@@ -35,6 +35,9 @@ export function ReviewStep() {
   const initialTab = localTransactions.uncertain.length > 0 ? "uncertain" : "matched";
   const [activeTab, setActiveTab] = useState(initialTab);
 
+  // Track rejected patterns so they aren't re-suggested during this import session
+  const rejectedPatterns = useRef<Set<string>>(new Set());
+
   // Preserve scroll position per tab
   const scrollPositions = useRef<Map<string, number>>(new Map());
   const handleTabChange = useCallback(
@@ -234,8 +237,30 @@ export function ReviewStep() {
   );
 
   /**
+   * Count how many remaining uncertain/failed transactions would match a pattern.
+   * Excludes the transaction being accepted (identified by checksum).
+   */
+  const countPatternMatches = useCallback(
+    (entityName: string, excludeChecksum: string) => {
+      const normalised = entityName.toUpperCase();
+      let count = 0;
+      for (const t of localTransactions.uncertain) {
+        if (t.checksum !== excludeChecksum && t.description.toUpperCase().includes(normalised))
+          count++;
+      }
+      for (const t of localTransactions.failed) {
+        if (t.checksum !== excludeChecksum && t.description.toUpperCase().includes(normalised))
+          count++;
+      }
+      return count;
+    },
+    [localTransactions.uncertain, localTransactions.failed]
+  );
+
+  /**
    * Accept AI suggestion for a single transaction.
-   * Auto-saves a correction rule and re-evaluates remaining transactions.
+   * High-confidence (>= 0.8): auto-saves a correction rule and re-evaluates.
+   * Low-confidence (< 0.8): shows a confirmation toast for the user to accept or reject.
    */
   const handleAcceptAiSuggestion = useCallback(
     (transaction: ProcessedTransaction) => {
@@ -258,12 +283,51 @@ export function ReviewStep() {
         return;
       }
 
-      handleEntitySelect(transaction, entityId, transaction.entity.entityName);
+      const confidence = transaction.entity.confidence ?? 0;
+      const entityName = transaction.entity.entityName;
+      const pattern = transaction.description
+        .toUpperCase()
+        .replace(/\d+/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
 
-      // Auto-save correction rule and re-evaluate remaining transactions
-      autoSaveRuleAndReEvaluate(transaction.description, entityId, transaction.entity.entityName);
+      // Always accept the transaction itself
+      handleEntitySelect(transaction, entityId, entityName);
+
+      if (confidence >= 0.8) {
+        // High confidence — auto-save rule
+        autoSaveRuleAndReEvaluate(transaction.description, entityId, entityName);
+      } else if (!rejectedPatterns.current.has(pattern)) {
+        // Low confidence — show confirmation toast
+        const matchCount = countPatternMatches(entityName, transaction.checksum);
+        const matchSuffix =
+          matchCount > 0
+            ? `. Would apply to ${matchCount} more transaction${matchCount !== 1 ? "s" : ""}`
+            : "";
+
+        toast.info(`Create rule: contains "${entityName}"?${matchSuffix}`, {
+          action: {
+            label: "Accept",
+            onClick: () => {
+              autoSaveRuleAndReEvaluate(transaction.description, entityId!, entityName);
+            },
+          },
+          cancel: {
+            label: "Reject",
+            onClick: () => {
+              rejectedPatterns.current.add(pattern);
+            },
+          },
+        });
+      }
     },
-    [handleEntitySelect, entities, handleCreateEntity, autoSaveRuleAndReEvaluate]
+    [
+      handleEntitySelect,
+      entities,
+      handleCreateEntity,
+      autoSaveRuleAndReEvaluate,
+      countPatternMatches,
+    ]
   );
 
   /**


### PR DESCRIPTION
## Summary
- When accepting AI suggestions with confidence < 0.8, show a confirmation toast with proposed pattern, match count, and Accept/Reject buttons instead of auto-saving
- Rejected patterns tracked in a session-scoped `useRef<Set>` so they aren't re-suggested during the same import
- High-confidence suggestions (>= 0.8) continue to auto-save as before (tb-586 behaviour)
- 5 new tests covering: confirmation toast shown, high-confidence bypass, match count display, accept saves rule, reject prevents re-suggestion

Closes #734

## Test plan
- [x] 10/10 tests pass (5 existing auto-apply + 5 new confirmation flow)
- [x] TypeScript compiles with no errors
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)