### PR TITLE
feat: item form gaps — purchase price, conditions, notes preview [tb-581]

### DIFF
--- a/apps/pops-api/src/modules/inventory/items/types.ts
+++ b/apps/pops-api/src/modules/inventory/items/types.ts
@@ -20,6 +20,7 @@ export interface InventoryItem {
   warrantyExpires: string | null;
   replacementValue: number | null;
   resaleValue: number | null;
+  purchasePrice: number | null;
   purchaseTransactionId: string | null;
   purchasedFromId: string | null;
   purchasedFromName: string | null;
@@ -47,6 +48,7 @@ export function toInventoryItem(row: InventoryRow): InventoryItem {
     warrantyExpires: row.warrantyExpires,
     replacementValue: row.replacementValue,
     resaleValue: row.resaleValue,
+    purchasePrice: row.purchasePrice,
     purchaseTransactionId: row.purchaseTransactionId,
     purchasedFromId: row.purchasedFromId,
     purchasedFromName: row.purchasedFromName,
@@ -73,6 +75,7 @@ export const CreateInventoryItemSchema = z.object({
   warrantyExpires: z.string().nullable().optional(),
   replacementValue: z.number().nullable().optional(),
   resaleValue: z.number().nullable().optional(),
+  purchasePrice: z.number().nullable().optional(),
   purchaseTransactionId: z.string().nullable().optional(),
   purchasedFromId: z.string().nullable().optional(),
   purchasedFromName: z.string().nullable().optional(),
@@ -98,6 +101,7 @@ export const UpdateInventoryItemSchema = z.object({
   warrantyExpires: z.string().nullable().optional(),
   replacementValue: z.number().nullable().optional(),
   resaleValue: z.number().nullable().optional(),
+  purchasePrice: z.number().nullable().optional(),
   purchaseTransactionId: z.string().nullable().optional(),
   purchasedFromId: z.string().nullable().optional(),
   purchasedFromName: z.string().nullable().optional(),

--- a/packages/app-inventory/src/pages/ItemFormPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { extractPrefix } from "./ItemFormPage";
 
@@ -110,6 +110,16 @@ vi.mock("../lib/trpc", () => ({
           useMutation: () => ({ mutateAsync: mockConnectMutate }),
         },
       },
+      locations: {
+        tree: { useQuery: () => ({ data: { data: [] } }) },
+        create: {
+          useMutation: (opts?: Record<string, unknown>) => ({
+            mutate: vi.fn(),
+            isPending: false,
+            ...(opts || {}),
+          }),
+        },
+      },
       photos: {
         listForItem: {
           useQuery: (...args: unknown[]) => {
@@ -147,9 +157,21 @@ vi.mock("../lib/trpc", () => ({
           searchByAssetId: { fetch: mockSearchByAssetIdFetch },
           countByAssetPrefix: { fetch: mockCountByAssetPrefixFetch },
         },
+        locations: {
+          tree: { invalidate: vi.fn() },
+        },
       },
     }),
   },
+}));
+
+// Mock react-markdown
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown-preview">{children}</div>,
+}));
+
+vi.mock("rehype-sanitize", () => ({
+  default: {},
 }));
 
 // Mock useImageProcessor
@@ -267,6 +289,7 @@ describe("ItemFormPage — Asset ID generation", () => {
           warrantyExpires: null,
           replacementValue: null,
           resaleValue: null,
+          purchasePrice: null,
           assetId: "ELEC01",
           notes: null,
           locationId: null,
@@ -332,6 +355,7 @@ describe("ItemFormPage — Photos section", () => {
           warrantyExpires: null,
           replacementValue: null,
           resaleValue: null,
+          purchasePrice: null,
           assetId: null,
           notes: null,
           locationId: null,
@@ -379,6 +403,7 @@ describe("ItemFormPage — Photos section", () => {
           warrantyExpires: null,
           replacementValue: null,
           resaleValue: null,
+          purchasePrice: null,
           assetId: null,
           notes: null,
           locationId: null,
@@ -425,6 +450,7 @@ describe("ItemFormPage — Photos section", () => {
           warrantyExpires: null,
           replacementValue: null,
           resaleValue: null,
+          purchasePrice: null,
           assetId: null,
           notes: null,
           locationId: null,
@@ -457,5 +483,53 @@ describe("ItemFormPage — Photos section", () => {
   it("renders camera button for mobile photo capture", () => {
     renderCreate();
     expect(screen.getByRole("button", { name: /take photo/i })).toBeInTheDocument();
+  });
+});
+
+describe("ItemFormPage — Form gaps (tb-581)", () => {
+  it("renders Purchase Price field in Dates & Values section", () => {
+    renderCreate();
+    expect(screen.getByText(/purchase price/i)).toBeInTheDocument();
+    // The input is rendered via TextInput with register("purchasePrice")
+    const input = document.querySelector('input[name="purchasePrice"]');
+    expect(input).toBeInTheDocument();
+  });
+
+  it("defaults condition to 'good' in create mode", () => {
+    renderCreate();
+    const conditionSelect = document.querySelector('select[name="condition"]') as HTMLSelectElement;
+    expect(conditionSelect).toBeInTheDocument();
+    expect(conditionSelect.value).toBe("good");
+  });
+
+  it("renders correct condition options (new/good/fair/poor/broken)", () => {
+    renderCreate();
+    const conditionSelect = document.querySelector('select[name="condition"]') as HTMLSelectElement;
+    const options = Array.from(conditionSelect.options).map((o) => o.value);
+    expect(options).toContain("new");
+    expect(options).toContain("good");
+    expect(options).toContain("fair");
+    expect(options).toContain("poor");
+    expect(options).toContain("broken");
+    // Old values should not be present
+    expect(options).not.toContain("Excellent");
+  });
+
+  it("marks Type as required", () => {
+    renderCreate();
+    expect(screen.getByText("Type *")).toBeInTheDocument();
+  });
+
+  it("shows notes preview toggle button", () => {
+    renderCreate();
+    expect(screen.getByRole("button", { name: /preview/i })).toBeInTheDocument();
+  });
+
+  it("toggles notes between edit and preview mode", () => {
+    renderCreate();
+    const previewBtn = screen.getByRole("button", { name: /preview/i });
+    fireEvent.click(previewBtn);
+    expect(screen.getByText(/nothing to preview/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
   });
 });

--- a/packages/app-inventory/src/pages/ItemFormPage.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.tsx
@@ -20,7 +20,9 @@ import {
   Badge,
   PageHeader,
 } from "@pops/ui";
-import { Save, Link2, X, Search, Wand2, Loader2, ImageIcon, Trash2 } from "lucide-react";
+import { Save, Link2, X, Search, Wand2, Loader2, ImageIcon, Trash2, Eye, PenLine } from "lucide-react";
+import Markdown from "react-markdown";
+import rehypeSanitize from "rehype-sanitize";
 import { trpc } from "../lib/trpc";
 import { PhotoUpload, type UploadedFile } from "../components/PhotoUpload";
 import { useImageProcessor } from "../hooks/useImageProcessor";
@@ -44,6 +46,7 @@ interface ItemFormValues {
   deductible: boolean;
   purchaseDate: string;
   warrantyExpires: string;
+  purchasePrice: string;
   replacementValue: string;
   resaleValue: string;
   assetId: string;
@@ -62,7 +65,13 @@ const ITEM_TYPES = [
   "Other",
 ];
 
-const CONDITIONS = ["Excellent", "Good", "Fair", "Poor"];
+const CONDITIONS = [
+  { value: "new", label: "New" },
+  { value: "good", label: "Good" },
+  { value: "fair", label: "Fair" },
+  { value: "poor", label: "Poor" },
+  { value: "broken", label: "Broken" },
+];
 
 const defaultValues: ItemFormValues = {
   itemName: "",
@@ -70,12 +79,13 @@ const defaultValues: ItemFormValues = {
   model: "",
   itemId: "",
   type: "",
-  condition: "",
+  condition: "good",
   locationId: "",
   inUse: false,
   deductible: false,
   purchaseDate: "",
   warrantyExpires: "",
+  purchasePrice: "",
   replacementValue: "",
   resaleValue: "",
   assetId: "",
@@ -129,6 +139,7 @@ export function ItemFormPage() {
   const [assetIdError, setAssetIdError] = useState<string | null>(null);
   const [assetIdChecking, setAssetIdChecking] = useState(false);
   const [generating, setGenerating] = useState(false);
+  const [notesPreview, setNotesPreview] = useState(false);
 
   const validateAssetIdUniqueness = useCallback(
     async (value: string) => {
@@ -356,6 +367,7 @@ export function ItemFormPage() {
         deductible: item.deductible,
         purchaseDate: item.purchaseDate ?? "",
         warrantyExpires: item.warrantyExpires ?? "",
+        purchasePrice: item.purchasePrice?.toString() ?? "",
         replacementValue: item.replacementValue?.toString() ?? "",
         resaleValue: item.resaleValue?.toString() ?? "",
         assetId: item.assetId ?? "",
@@ -440,6 +452,7 @@ export function ItemFormPage() {
       deductible: values.deductible,
       purchaseDate: values.purchaseDate || null,
       warrantyExpires: values.warrantyExpires || null,
+      purchasePrice: values.purchasePrice ? parseFloat(values.purchasePrice) : null,
       replacementValue: values.replacementValue ? parseFloat(values.replacementValue) : null,
       resaleValue: values.resaleValue ? parseFloat(values.resaleValue) : null,
       assetId: values.assetId || null,
@@ -578,9 +591,9 @@ export function ItemFormPage() {
           </h2>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <FormField label="Type">
+            <FormField label="Type *" error={errors.type?.message}>
               <Select
-                {...register("type")}
+                {...register("type", { required: "Type is required" })}
                 options={[
                   { value: "", label: "Select type..." },
                   ...ITEM_TYPES.map((t) => ({ value: t, label: t })),
@@ -592,7 +605,7 @@ export function ItemFormPage() {
                 {...register("condition")}
                 options={[
                   { value: "", label: "Select condition..." },
-                  ...CONDITIONS.map((c) => ({ value: c, label: c })),
+                  ...CONDITIONS,
                 ]}
               />
             </FormField>
@@ -632,7 +645,16 @@ export function ItemFormPage() {
             </FormField>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <FormField label="Purchase Price ($)">
+              <TextInput
+                type="number"
+                step="0.01"
+                min="0"
+                {...register("purchasePrice")}
+                placeholder="0.00"
+              />
+            </FormField>
             <FormField label="Replacement Value ($)">
               <TextInput
                 type="number"
@@ -726,16 +748,41 @@ export function ItemFormPage() {
 
         {/* Notes */}
         <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
-          <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
-            <span className="w-1.5 h-1.5 rounded-full bg-app-accent" />
-            Notes
-          </h2>
-          <Textarea
-            {...register("notes")}
-            rows={4}
-            placeholder="Add notes about this item..."
-            className="w-full bg-transparent"
-          />
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
+              <span className="w-1.5 h-1.5 rounded-full bg-app-accent" />
+              Notes
+            </h2>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setNotesPreview((v) => !v)}
+              className="text-xs text-muted-foreground"
+            >
+              {notesPreview ? (
+                <><PenLine className="h-3.5 w-3.5 mr-1" /> Edit</>
+              ) : (
+                <><Eye className="h-3.5 w-3.5 mr-1" /> Preview</>
+              )}
+            </Button>
+          </div>
+          {notesPreview ? (
+            <div className="prose prose-sm dark:prose-invert max-w-none min-h-[6.5rem] p-3 rounded-md border bg-muted/30">
+              {watch("notes") ? (
+                <Markdown rehypePlugins={[rehypeSanitize]}>{watch("notes")}</Markdown>
+              ) : (
+                <p className="text-muted-foreground italic">Nothing to preview</p>
+              )}
+            </div>
+          ) : (
+            <Textarea
+              {...register("notes")}
+              rows={4}
+              placeholder="Add notes about this item... (supports markdown)"
+              className="w-full bg-transparent"
+            />
+          )}
         </section>
 
         {/* Connected Items (create mode only) */}

--- a/packages/app-inventory/src/test-setup.ts
+++ b/packages/app-inventory/src/test-setup.ts
@@ -1,1 +1,10 @@
 import "@testing-library/jest-dom/vitest";
+
+// Polyfill ResizeObserver for Radix UI components (popover, select, etc.)
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}


### PR DESCRIPTION
## Summary
- **Purchase Price**: Add missing field to form + API schemas (CreateInventoryItemSchema, UpdateInventoryItemSchema, InventoryItem type, toInventoryItem mapper)
- **Condition values**: Fix from `Excellent/Good/Fair/Poor` to `new/good/fair/poor/broken` with labels; default to "good" in create mode
- **Type required**: Add required validation — form cannot submit without selecting a type
- **Notes markdown preview**: Toggle button switches between textarea and rendered markdown (uses react-markdown + rehype-sanitize, already in deps)
- **Test setup**: Add ResizeObserver polyfill for Radix UI components in jsdom
- **6 new tests**: Purchase price field, condition defaults, condition options, type required label, notes preview toggle

Closes #750

## Test plan
- [ ] Create mode: condition defaults to "good", type shows "*" required marker
- [ ] Submit without type selected → validation error
- [ ] Purchase Price field renders in Dates & Values section, value persists on save
- [ ] Condition dropdown shows: New, Good, Fair, Poor, Broken
- [ ] Notes section: click Preview → renders markdown; click Edit → returns to textarea
- [ ] Edit mode: all fields including purchasePrice pre-populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)