### PR TITLE
feat: RequestSeriesModal with Sonarr profile selection [tb-570]

### DIFF
--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -326,6 +326,102 @@ export const arrRouter = router({
       }
     }),
 
+  /** Get Sonarr quality profiles. */
+  getSonarrQualityProfiles: protectedProcedure.query(async () => {
+    const client = arrService.getSonarrClient();
+    if (!client) {
+      throw new TRPCError({ code: "PRECONDITION_FAILED", message: "Sonarr is not configured" });
+    }
+    try {
+      const profiles = await client.getQualityProfiles();
+      return { data: profiles };
+    } catch (err) {
+      if (err instanceof ArrApiError) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Sonarr error: ${err.message}`,
+        });
+      }
+      throw err;
+    }
+  }),
+
+  /** Get Sonarr root folders. */
+  getSonarrRootFolders: protectedProcedure.query(async () => {
+    const client = arrService.getSonarrClient();
+    if (!client) {
+      throw new TRPCError({ code: "PRECONDITION_FAILED", message: "Sonarr is not configured" });
+    }
+    try {
+      const folders = await client.getRootFolders();
+      return { data: folders };
+    } catch (err) {
+      if (err instanceof ArrApiError) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Sonarr error: ${err.message}`,
+        });
+      }
+      throw err;
+    }
+  }),
+
+  /** Get Sonarr language profiles. */
+  getSonarrLanguageProfiles: protectedProcedure.query(async () => {
+    const client = arrService.getSonarrClient();
+    if (!client) {
+      throw new TRPCError({ code: "PRECONDITION_FAILED", message: "Sonarr is not configured" });
+    }
+    try {
+      const profiles = await client.getLanguageProfiles();
+      return { data: profiles };
+    } catch (err) {
+      if (err instanceof ArrApiError) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Sonarr error: ${err.message}`,
+        });
+      }
+      throw err;
+    }
+  }),
+
+  /** Add a series to Sonarr. */
+  addSeries: protectedProcedure
+    .input(
+      z.object({
+        tvdbId: z.number().int().positive(),
+        title: z.string().min(1),
+        qualityProfileId: z.number().int().positive(),
+        rootFolderPath: z.string().min(1),
+        languageProfileId: z.number().int().positive(),
+        seasons: z.array(
+          z.object({
+            seasonNumber: z.number().int().min(0),
+            monitored: z.boolean(),
+          })
+        ),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const client = arrService.getSonarrClient();
+      if (!client) {
+        throw new TRPCError({ code: "PRECONDITION_FAILED", message: "Sonarr is not configured" });
+      }
+      try {
+        const series = await client.addSeries(input);
+        return { data: series };
+      } catch (err) {
+        if (err instanceof ArrApiError) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: `Sonarr error: ${err.message}`,
+          });
+        }
+        throw err;
+      }
+    }),
+
   /** Update season monitoring for a series in Sonarr. */
   updateSeasonMonitoring: protectedProcedure
     .input(

--- a/apps/pops-api/src/modules/media/arr/sonarr-client.ts
+++ b/apps/pops-api/src/modules/media/arr/sonarr-client.ts
@@ -9,6 +9,10 @@ import type {
   ArrStatusResult,
   SonarrCalendarEpisode,
   SonarrEpisodeMonitorInput,
+  SonarrQualityProfile,
+  SonarrRootFolder,
+  SonarrLanguageProfile,
+  SonarrAddSeriesInput,
 } from "./types.js";
 
 export class SonarrClient extends ArrBaseClient {
@@ -130,5 +134,37 @@ export class SonarrClient extends ArrBaseClient {
   async updateEpisodeMonitoring(episodeIds: number[], monitored: boolean): Promise<void> {
     const body: SonarrEpisodeMonitorInput = { episodeIds, monitored };
     await this.put<unknown>("/episode/monitor", body);
+  }
+
+  /** Fetch quality profiles from Sonarr. */
+  async getQualityProfiles(): Promise<SonarrQualityProfile[]> {
+    return this.get<SonarrQualityProfile[]>("/qualityprofile");
+  }
+
+  /** Fetch root folders from Sonarr. */
+  async getRootFolders(): Promise<SonarrRootFolder[]> {
+    return this.get<SonarrRootFolder[]>("/rootfolder");
+  }
+
+  /** Fetch language profiles from Sonarr. */
+  async getLanguageProfiles(): Promise<SonarrLanguageProfile[]> {
+    return this.get<SonarrLanguageProfile[]>("/languageprofile");
+  }
+
+  /** Add a series to Sonarr. */
+  async addSeries(input: SonarrAddSeriesInput): Promise<SonarrSeriesFull> {
+    return this.post<SonarrSeriesFull>("/series", {
+      tvdbId: input.tvdbId,
+      title: input.title,
+      qualityProfileId: input.qualityProfileId,
+      rootFolderPath: input.rootFolderPath,
+      languageProfileId: input.languageProfileId,
+      seasons: input.seasons.map((s) => ({
+        seasonNumber: s.seasonNumber,
+        monitored: s.monitored,
+      })),
+      monitored: true,
+      addOptions: { searchForMissingEpisodes: true },
+    });
   }
 }

--- a/apps/pops-api/src/modules/media/arr/types.ts
+++ b/apps/pops-api/src/modules/media/arr/types.ts
@@ -190,6 +190,33 @@ export interface CalendarEpisode {
   posterUrl: string | null;
 }
 
+// -- Sonarr add-series types --
+
+export interface SonarrQualityProfile {
+  id: number;
+  name: string;
+}
+
+export interface SonarrRootFolder {
+  id: number;
+  path: string;
+  freeSpace: number;
+}
+
+export interface SonarrLanguageProfile {
+  id: number;
+  name: string;
+}
+
+export interface SonarrAddSeriesInput {
+  tvdbId: number;
+  title: string;
+  qualityProfileId: number;
+  rootFolderPath: string;
+  languageProfileId: number;
+  seasons: Array<{ seasonNumber: number; monitored: boolean }>;
+}
+
 /** System status response shared by Radarr and Sonarr. */
 export interface ArrSystemStatus {
   version: string;

--- a/packages/app-media/src/components/RequestSeriesModal.test.tsx
+++ b/packages/app-media/src/components/RequestSeriesModal.test.tsx
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockProfilesQuery = vi.fn();
+const mockFoldersQuery = vi.fn();
+const mockLanguagesQuery = vi.fn();
+const mockAddSeriesMutate = vi.fn();
+let addSeriesOpts: Record<string, unknown> = {};
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      arr: {
+        getSonarrQualityProfiles: {
+          useQuery: (...args: unknown[]) => mockProfilesQuery(...args),
+        },
+        getSonarrRootFolders: {
+          useQuery: (...args: unknown[]) => mockFoldersQuery(...args),
+        },
+        getSonarrLanguageProfiles: {
+          useQuery: (...args: unknown[]) => mockLanguagesQuery(...args),
+        },
+        addSeries: {
+          useMutation: (opts: Record<string, unknown>) => {
+            addSeriesOpts = opts;
+            return { mutate: mockAddSeriesMutate, isPending: false };
+          },
+        },
+      },
+    },
+  },
+}));
+
+import { RequestSeriesModal } from "./RequestSeriesModal";
+import type { SeasonInfo } from "./RequestSeriesModal";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const profiles = [
+  { id: 1, name: "HD - 720p/1080p" },
+  { id: 2, name: "Ultra-HD" },
+];
+
+const folders = [
+  { id: 1, path: "/tv", freeSpace: 800 * 1024 * 1024 * 1024 },
+  { id: 2, path: "/tv2", freeSpace: 200 * 1024 * 1024 * 1024 },
+];
+
+const languageProfiles = [
+  { id: 1, name: "English" },
+  { id: 2, name: "Any" },
+];
+
+const pastSeasons: SeasonInfo[] = [
+  { seasonNumber: 1, firstAirDate: "2020-01-15" },
+  { seasonNumber: 2, firstAirDate: "2021-03-20" },
+];
+
+const futureSeasons: SeasonInfo[] = [
+  { seasonNumber: 3, firstAirDate: "2028-06-01" },
+  { seasonNumber: 4, firstAirDate: null },
+];
+
+const mixedSeasons: SeasonInfo[] = [...pastSeasons, ...futureSeasons];
+
+function setupDefaults(
+  overrides: {
+    profilesLoading?: boolean;
+    foldersLoading?: boolean;
+    languagesLoading?: boolean;
+    profileList?: typeof profiles;
+    folderList?: typeof folders;
+    languageList?: typeof languageProfiles;
+  } = {}
+) {
+  const {
+    profilesLoading = false,
+    foldersLoading = false,
+    languagesLoading = false,
+    profileList = profiles,
+    folderList = folders,
+    languageList = languageProfiles,
+  } = overrides;
+
+  mockProfilesQuery.mockReturnValue({
+    isLoading: profilesLoading,
+    data: profilesLoading ? null : { data: profileList },
+    refetch: vi.fn(),
+  });
+  mockFoldersQuery.mockReturnValue({
+    isLoading: foldersLoading,
+    data: foldersLoading ? null : { data: folderList },
+    refetch: vi.fn(),
+  });
+  mockLanguagesQuery.mockReturnValue({
+    isLoading: languagesLoading,
+    data: languagesLoading ? null : { data: languageList },
+    refetch: vi.fn(),
+  });
+}
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  tvdbId: 81189,
+  title: "Breaking Bad",
+  year: 2008,
+  seasons: mixedSeasons,
+};
+
+function renderModal(props: Partial<typeof defaultProps> = {}) {
+  return render(<RequestSeriesModal {...defaultProps} {...props} />);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  addSeriesOpts = {};
+});
+
+describe("RequestSeriesModal", () => {
+  it("shows series title and year in header", () => {
+    setupDefaults();
+    renderModal();
+
+    expect(screen.getByText("Request Series")).toBeInTheDocument();
+    expect(screen.getByText("Breaking Bad (2008)")).toBeInTheDocument();
+  });
+
+  it("populates quality profile dropdown from API", () => {
+    setupDefaults();
+    renderModal();
+
+    const select = screen.getByLabelText("Quality Profile") as HTMLSelectElement;
+    const options = select.querySelectorAll("option");
+    expect(options).toHaveLength(2);
+    expect(options[0].textContent).toBe("HD - 720p/1080p");
+    expect(options[1].textContent).toBe("Ultra-HD");
+  });
+
+  it("populates root folder dropdown with free space", () => {
+    setupDefaults();
+    renderModal();
+
+    const select = screen.getByLabelText("Root Folder") as HTMLSelectElement;
+    const options = select.querySelectorAll("option");
+    expect(options).toHaveLength(2);
+    expect(options[0].textContent).toContain("/tv");
+    expect(options[0].textContent).toContain("GB free");
+  });
+
+  it("populates language profile dropdown from API", () => {
+    setupDefaults();
+    renderModal();
+
+    const select = screen.getByLabelText("Language Profile") as HTMLSelectElement;
+    const options = select.querySelectorAll("option");
+    expect(options).toHaveLength(2);
+    expect(options[0].textContent).toBe("English");
+    expect(options[1].textContent).toBe("Any");
+  });
+
+  it("defaults to first quality profile, root folder, and language profile", () => {
+    setupDefaults();
+    renderModal();
+
+    expect((screen.getByLabelText("Quality Profile") as HTMLSelectElement).value).toBe("1");
+    expect((screen.getByLabelText("Root Folder") as HTMLSelectElement).value).toBe("/tv");
+    expect((screen.getByLabelText("Language Profile") as HTMLSelectElement).value).toBe("1");
+  });
+
+  it("applies smart season defaults — future checked, past unchecked", () => {
+    setupDefaults();
+    renderModal();
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // Season 1 (2020) and Season 2 (2021) should be unchecked
+    expect(checkboxes[0]).not.toBeChecked(); // Season 1
+    expect(checkboxes[1]).not.toBeChecked(); // Season 2
+    // Season 3 (2028) and Season 4 (null/unannounced) should be checked
+    expect(checkboxes[2]).toBeChecked(); // Season 3
+    expect(checkboxes[3]).toBeChecked(); // Season 4
+  });
+
+  it("allows toggling individual season checkboxes", () => {
+    setupDefaults();
+    renderModal();
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // Toggle Season 1 on
+    fireEvent.click(checkboxes[0]);
+    expect(checkboxes[0]).toBeChecked();
+    // Toggle Season 3 off
+    fireEvent.click(checkboxes[2]);
+    expect(checkboxes[2]).not.toBeChecked();
+  });
+
+  it("shows Select All / Deselect All when more than 3 seasons", () => {
+    setupDefaults();
+    renderModal();
+
+    expect(screen.getByText("Select All")).toBeInTheDocument();
+    expect(screen.getByText("Deselect All")).toBeInTheDocument();
+  });
+
+  it("does not show bulk controls when 3 or fewer seasons", () => {
+    setupDefaults();
+    renderModal({ seasons: pastSeasons });
+
+    expect(screen.queryByText("Select All")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deselect All")).not.toBeInTheDocument();
+  });
+
+  it("Select All checks all seasons", () => {
+    setupDefaults();
+    renderModal();
+
+    fireEvent.click(screen.getByText("Select All"));
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    for (const cb of checkboxes) {
+      expect(cb).toBeChecked();
+    }
+  });
+
+  it("Deselect All unchecks all seasons", () => {
+    setupDefaults();
+    renderModal();
+
+    fireEvent.click(screen.getByText("Deselect All"));
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    for (const cb of checkboxes) {
+      expect(cb).not.toBeChecked();
+    }
+  });
+
+  it("sends correct addSeries payload on confirm", () => {
+    setupDefaults();
+    renderModal();
+
+    fireEvent.click(screen.getByText("Request"));
+
+    expect(mockAddSeriesMutate).toHaveBeenCalledWith({
+      tvdbId: 81189,
+      title: "Breaking Bad",
+      qualityProfileId: 1,
+      rootFolderPath: "/tv",
+      languageProfileId: 1,
+      seasons: [
+        { seasonNumber: 1, monitored: false },
+        { seasonNumber: 2, monitored: false },
+        { seasonNumber: 3, monitored: true },
+        { seasonNumber: 4, monitored: true },
+      ],
+    });
+  });
+
+  it("calls onClose after successful add", () => {
+    vi.useFakeTimers();
+    setupDefaults();
+    const onClose = vi.fn();
+    renderModal({ onClose });
+
+    fireEvent.click(screen.getByText("Request"));
+
+    const onSuccess = addSeriesOpts.onSuccess as () => void;
+    act(() => onSuccess());
+
+    expect(screen.getByText("Series Added")).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(1500));
+    expect(onClose).toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("shows inline error on failure", () => {
+    setupDefaults();
+    renderModal();
+
+    fireEvent.click(screen.getByText("Request"));
+
+    const onError = addSeriesOpts.onError as (err: { message: string }) => void;
+    act(() => onError({ message: "Series already exists in Sonarr" }));
+
+    expect(screen.getByText("Series already exists in Sonarr")).toBeInTheDocument();
+  });
+
+  it("calls onClose on cancel without API call", () => {
+    setupDefaults();
+    const onClose = vi.fn();
+    renderModal({ onClose });
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalled();
+    expect(mockAddSeriesMutate).not.toHaveBeenCalled();
+  });
+
+  it("shows loading state while fetching options", () => {
+    setupDefaults({ profilesLoading: true });
+    renderModal();
+
+    expect(screen.getByText("Loading options...")).toBeInTheDocument();
+  });
+
+  it("shows retry when no profiles available", () => {
+    setupDefaults({ profileList: [] });
+    renderModal();
+
+    expect(screen.getByText(/No quality profiles found/)).toBeInTheDocument();
+    expect(screen.getByText("Retry")).toBeInTheDocument();
+  });
+
+  it("shows retry when no language profiles available", () => {
+    setupDefaults({ languageList: [] });
+    renderModal();
+
+    expect(screen.getByText(/No language profiles found/)).toBeInTheDocument();
+  });
+
+  it("displays season year from firstAirDate", () => {
+    setupDefaults();
+    renderModal();
+
+    expect(screen.getByText("— 2020")).toBeInTheDocument();
+    expect(screen.getByText("— 2028")).toBeInTheDocument();
+  });
+
+  it("displays Specials for season 0", () => {
+    setupDefaults();
+    renderModal({
+      seasons: [{ seasonNumber: 0, firstAirDate: "2019-01-01" }],
+    });
+
+    expect(screen.getByText("Specials")).toBeInTheDocument();
+  });
+});

--- a/packages/app-media/src/components/RequestSeriesModal.tsx
+++ b/packages/app-media/src/components/RequestSeriesModal.tsx
@@ -1,0 +1,361 @@
+/**
+ * RequestSeriesModal — Modal for adding a TV series to Sonarr.
+ *
+ * Presents quality profile, root folder, and language profile dropdowns,
+ * season monitoring checkboxes with smart defaults, then submits to Sonarr.
+ */
+import { useState, useEffect, useMemo } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@pops/ui";
+import { Button } from "@pops/ui";
+import { RefreshCw, CheckCircle2 } from "lucide-react";
+import { trpc } from "../lib/trpc";
+
+export interface SeasonInfo {
+  seasonNumber: number;
+  /** ISO date string for when the season first aired, or null if unannounced. */
+  firstAirDate: string | null;
+}
+
+interface RequestSeriesModalProps {
+  open: boolean;
+  onClose: () => void;
+  tvdbId: number;
+  title: string;
+  year: number;
+  seasons: SeasonInfo[];
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024 * 1024 * 1024) return `${Math.round(bytes / (1024 * 1024))} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+/** Determine if a season is "future" (should be monitored by default). */
+function isFutureSeason(firstAirDate: string | null): boolean {
+  if (!firstAirDate) return true; // unannounced = future
+  return new Date(firstAirDate) > new Date();
+}
+
+export function RequestSeriesModal({
+  open,
+  onClose,
+  tvdbId,
+  title,
+  year,
+  seasons,
+}: RequestSeriesModalProps) {
+  const [qualityProfileId, setQualityProfileId] = useState<number | null>(null);
+  const [rootFolderPath, setRootFolderPath] = useState<string>("");
+  const [languageProfileId, setLanguageProfileId] = useState<number | null>(null);
+  const [seasonMonitored, setSeasonMonitored] = useState<Record<number, boolean>>({});
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const profiles = trpc.media.arr.getSonarrQualityProfiles.useQuery(undefined, {
+    enabled: open,
+    retry: false,
+  });
+  const folders = trpc.media.arr.getSonarrRootFolders.useQuery(undefined, {
+    enabled: open,
+    retry: false,
+  });
+  const languages = trpc.media.arr.getSonarrLanguageProfiles.useQuery(undefined, {
+    enabled: open,
+    retry: false,
+  });
+
+  // Default to first option once loaded
+  useEffect(() => {
+    if (profiles.data?.data?.length && qualityProfileId === null) {
+      setQualityProfileId(profiles.data.data[0].id);
+    }
+  }, [profiles.data?.data, qualityProfileId]);
+
+  useEffect(() => {
+    if (folders.data?.data?.length && !rootFolderPath) {
+      setRootFolderPath(folders.data.data[0].path);
+    }
+  }, [folders.data?.data, rootFolderPath]);
+
+  useEffect(() => {
+    if (languages.data?.data?.length && languageProfileId === null) {
+      setLanguageProfileId(languages.data.data[0].id);
+    }
+  }, [languages.data?.data, languageProfileId]);
+
+  // Set smart season defaults when seasons change
+  useEffect(() => {
+    if (seasons.length > 0 && Object.keys(seasonMonitored).length === 0) {
+      const defaults: Record<number, boolean> = {};
+      for (const s of seasons) {
+        defaults[s.seasonNumber] = isFutureSeason(s.firstAirDate);
+      }
+      setSeasonMonitored(defaults);
+    }
+  }, [seasons, seasonMonitored]);
+
+  const addSeries = trpc.media.arr.addSeries.useMutation({
+    onSuccess: () => {
+      setSuccess(true);
+      setError(null);
+      setTimeout(() => {
+        onClose();
+        resetState();
+      }, 1500);
+    },
+    onError: (err: { message: string }) => {
+      setError(err.message);
+    },
+  });
+
+  function resetState() {
+    setSuccess(false);
+    setQualityProfileId(null);
+    setRootFolderPath("");
+    setLanguageProfileId(null);
+    setSeasonMonitored({});
+    setError(null);
+  }
+
+  const handleClose = () => {
+    if (!addSeries.isPending) {
+      onClose();
+      resetState();
+    }
+  };
+
+  const profileList = profiles.data?.data ?? [];
+  const folderList = folders.data?.data ?? [];
+  const languageList = languages.data?.data ?? [];
+  const isDataLoading = profiles.isLoading || folders.isLoading || languages.isLoading;
+  const canSubmit =
+    qualityProfileId !== null &&
+    rootFolderPath &&
+    languageProfileId !== null &&
+    !addSeries.isPending &&
+    !success;
+
+  const showBulkControls = seasons.length > 3;
+
+  const allChecked = useMemo(
+    () => seasons.length > 0 && seasons.every((s) => seasonMonitored[s.seasonNumber]),
+    [seasons, seasonMonitored]
+  );
+
+  const noneChecked = useMemo(
+    () => seasons.length > 0 && seasons.every((s) => !seasonMonitored[s.seasonNumber]),
+    [seasons, seasonMonitored]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Request Series</DialogTitle>
+          <DialogDescription>
+            {title} ({year})
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 pt-2">
+          {isDataLoading ? (
+            <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
+              <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+              Loading options...
+            </div>
+          ) : profileList.length === 0 || folderList.length === 0 || languageList.length === 0 ? (
+            <div className="text-center py-4 space-y-2">
+              <p className="text-sm text-red-400">
+                {profileList.length === 0
+                  ? "No quality profiles found"
+                  : folderList.length === 0
+                    ? "No root folders found"
+                    : "No language profiles found"}
+                .
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  profiles.refetch();
+                  folders.refetch();
+                  languages.refetch();
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : (
+            <>
+              {/* Quality Profile */}
+              <div className="space-y-1.5">
+                <label htmlFor="quality-profile" className="text-sm font-medium">
+                  Quality Profile
+                </label>
+                <select
+                  id="quality-profile"
+                  value={qualityProfileId ?? ""}
+                  onChange={(e) => setQualityProfileId(Number(e.target.value))}
+                  className="w-full h-9 rounded-md border bg-background px-3 text-sm"
+                  disabled={addSeries.isPending || success}
+                >
+                  {profileList.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Root Folder */}
+              <div className="space-y-1.5">
+                <label htmlFor="root-folder" className="text-sm font-medium">
+                  Root Folder
+                </label>
+                <select
+                  id="root-folder"
+                  value={rootFolderPath}
+                  onChange={(e) => setRootFolderPath(e.target.value)}
+                  className="w-full h-9 rounded-md border bg-background px-3 text-sm"
+                  disabled={addSeries.isPending || success}
+                >
+                  {folderList.map((f) => (
+                    <option key={f.id} value={f.path}>
+                      {f.path} ({formatBytes(f.freeSpace)} free)
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Language Profile */}
+              <div className="space-y-1.5">
+                <label htmlFor="language-profile" className="text-sm font-medium">
+                  Language Profile
+                </label>
+                <select
+                  id="language-profile"
+                  value={languageProfileId ?? ""}
+                  onChange={(e) => setLanguageProfileId(Number(e.target.value))}
+                  className="w-full h-9 rounded-md border bg-background px-3 text-sm"
+                  disabled={addSeries.isPending || success}
+                >
+                  {languageList.map((l) => (
+                    <option key={l.id} value={l.id}>
+                      {l.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Season Monitoring */}
+              {seasons.length > 0 && (
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium">Season Monitoring</span>
+                    {showBulkControls && (
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          className="text-xs text-muted-foreground hover:text-foreground"
+                          disabled={allChecked || addSeries.isPending || success}
+                          onClick={() => {
+                            const all: Record<number, boolean> = {};
+                            for (const s of seasons) all[s.seasonNumber] = true;
+                            setSeasonMonitored(all);
+                          }}
+                        >
+                          Select All
+                        </button>
+                        <button
+                          type="button"
+                          className="text-xs text-muted-foreground hover:text-foreground"
+                          disabled={noneChecked || addSeries.isPending || success}
+                          onClick={() => {
+                            const none: Record<number, boolean> = {};
+                            for (const s of seasons) none[s.seasonNumber] = false;
+                            setSeasonMonitored(none);
+                          }}
+                        >
+                          Deselect All
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <div className="max-h-48 overflow-y-auto space-y-1 rounded-md border p-2">
+                    {seasons.map((s) => (
+                      <label
+                        key={s.seasonNumber}
+                        className="flex items-center gap-2 text-sm cursor-pointer"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={seasonMonitored[s.seasonNumber] ?? false}
+                          onChange={(e) =>
+                            setSeasonMonitored((prev) => ({
+                              ...prev,
+                              [s.seasonNumber]: e.target.checked,
+                            }))
+                          }
+                          disabled={addSeries.isPending || success}
+                        />
+                        {s.seasonNumber === 0 ? "Specials" : `Season ${s.seasonNumber}`}
+                        {s.firstAirDate && (
+                          <span className="text-muted-foreground">
+                            — {s.firstAirDate.slice(0, 4)}
+                          </span>
+                        )}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* Error */}
+          {error && <p className="text-sm text-red-400">{error}</p>}
+
+          {/* Actions */}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" onClick={handleClose} disabled={addSeries.isPending}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                if (qualityProfileId !== null && rootFolderPath && languageProfileId !== null) {
+                  setError(null);
+                  addSeries.mutate({
+                    tvdbId,
+                    title,
+                    qualityProfileId,
+                    rootFolderPath,
+                    languageProfileId,
+                    seasons: seasons.map((s) => ({
+                      seasonNumber: s.seasonNumber,
+                      monitored: seasonMonitored[s.seasonNumber] ?? false,
+                    })),
+                  });
+                }
+              }}
+              disabled={!canSubmit}
+            >
+              {success ? (
+                <>
+                  <CheckCircle2 className="h-4 w-4 mr-1.5" />
+                  Series Added
+                </>
+              ) : addSeries.isPending ? (
+                <>
+                  <RefreshCw className="h-4 w-4 mr-1.5 animate-spin" />
+                  Adding...
+                </>
+              ) : (
+                "Request"
+              )}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Add Sonarr backend endpoints: `getSonarrQualityProfiles`, `getSonarrRootFolders`, `getSonarrLanguageProfiles`, and `addSeries` (client + tRPC router)
- New `RequestSeriesModal` component with three dropdowns (quality profile, root folder, language profile), season monitoring checkboxes with smart defaults (future=checked, past=unchecked), Select All/Deselect All, and loading/success/error states
- 20 tests covering all acceptance criteria

## Test plan
- [ ] Verify dropdowns populate from Sonarr API (quality profiles, root folders, language profiles)
- [ ] Verify smart season defaults: future/unannounced seasons checked, past seasons unchecked
- [ ] Verify Select All / Deselect All controls appear for >3 seasons
- [ ] Verify Request sends correct payload including season monitoring array
- [ ] Verify success auto-closes after 1.5s, error shows inline
- [ ] Verify Cancel closes without API call
- [ ] All 20 unit tests pass

Closes GH#792

🤖 Generated with [Claude Code](https://claude.com/claude-code)