### PR TITLE
feat: batch correction analysis frontend [tb-584]

### DIFF
--- a/packages/app-finance/src/components/imports/BatchProposalsPanel.test.tsx
+++ b/packages/app-finance/src/components/imports/BatchProposalsPanel.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BatchProposalsPanel } from "./BatchProposalsPanel";
+import type { ProposedRule } from "../../lib/useBatchAnalysis";
+
+// Mock trpc
+const mockMutate = vi.fn();
+vi.mock("../../lib/trpc", () => ({
+  trpc: {
+    core: {
+      corrections: {
+        createOrUpdate: {
+          useMutation: () => ({
+            mutate: mockMutate,
+            isPending: false,
+          }),
+        },
+      },
+    },
+  },
+}));
+
+// Mock sonner toast
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const sampleProposals: ProposedRule[] = [
+  {
+    descriptionPattern: "WOOLWORTHS",
+    matchType: "contains",
+    tags: ["Groceries", "Essentials"],
+    reasoning: "Common supermarket chain",
+  },
+  {
+    descriptionPattern: "NETFLIX",
+    matchType: "exact",
+    tags: ["Entertainment"],
+    reasoning: "Streaming subscription",
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("BatchProposalsPanel", () => {
+  it("renders nothing when no proposals and not analyzing", () => {
+    const { container } = render(
+      <BatchProposalsPanel
+        proposals={[]}
+        isAnalyzing={false}
+        onAccept={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows analyzing state when isAnalyzing is true", () => {
+    render(
+      <BatchProposalsPanel
+        proposals={[]}
+        isAnalyzing={true}
+        onAccept={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(screen.getByText("AI-Suggested Rules")).toBeInTheDocument();
+    expect(screen.getByText("Analyzing corrections...")).toBeInTheDocument();
+  });
+
+  it("renders proposals with pattern, matchType, and tags", () => {
+    render(
+      <BatchProposalsPanel
+        proposals={sampleProposals}
+        isAnalyzing={false}
+        onAccept={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("WOOLWORTHS")).toBeInTheDocument();
+    expect(screen.getByText("contains")).toBeInTheDocument();
+    expect(screen.getByText("Groceries")).toBeInTheDocument();
+    expect(screen.getByText("Essentials")).toBeInTheDocument();
+    expect(screen.getByText("Common supermarket chain")).toBeInTheDocument();
+
+    expect(screen.getByText("NETFLIX")).toBeInTheDocument();
+    expect(screen.getByText("exact")).toBeInTheDocument();
+    expect(screen.getByText("Entertainment")).toBeInTheDocument();
+  });
+
+  it("shows proposal count badge", () => {
+    render(
+      <BatchProposalsPanel
+        proposals={sampleProposals}
+        isAnalyzing={false}
+        onAccept={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("calls createOrUpdate on accept", () => {
+    const onAccept = vi.fn();
+    render(
+      <BatchProposalsPanel
+        proposals={sampleProposals}
+        isAnalyzing={false}
+        onAccept={onAccept}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    const acceptButtons = screen.getAllByLabelText("Accept rule");
+    fireEvent.click(acceptButtons[0]!);
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        descriptionPattern: "WOOLWORTHS",
+        matchType: "contains",
+        tags: ["Groceries", "Essentials"],
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      })
+    );
+  });
+
+  it("calls onDismiss when dismiss button clicked", () => {
+    const onDismiss = vi.fn();
+    render(
+      <BatchProposalsPanel
+        proposals={sampleProposals}
+        isAnalyzing={false}
+        onAccept={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    );
+
+    const dismissButtons = screen.getAllByLabelText("Dismiss rule");
+    fireEvent.click(dismissButtons[1]!);
+
+    expect(onDismiss).toHaveBeenCalledWith("NETFLIX");
+  });
+
+  it("collapses and expands the panel", () => {
+    render(
+      <BatchProposalsPanel
+        proposals={sampleProposals}
+        isAnalyzing={false}
+        onAccept={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    // Initially expanded
+    expect(screen.getByText("WOOLWORTHS")).toBeInTheDocument();
+
+    // Collapse
+    fireEvent.click(screen.getByText("AI-Suggested Rules"));
+    expect(screen.queryByText("WOOLWORTHS")).not.toBeInTheDocument();
+
+    // Expand again
+    fireEvent.click(screen.getByText("AI-Suggested Rules"));
+    expect(screen.getByText("WOOLWORTHS")).toBeInTheDocument();
+  });
+});

--- a/packages/app-finance/src/components/imports/BatchProposalsPanel.tsx
+++ b/packages/app-finance/src/components/imports/BatchProposalsPanel.tsx
@@ -1,0 +1,157 @@
+/**
+ * Collapsible panel showing AI-proposed correction rules.
+ * Each proposal can be accepted (saved via createOrUpdate) or dismissed.
+ */
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Sparkles, Check, X, Loader2 } from "lucide-react";
+import { Button, Badge, cn } from "@pops/ui";
+import { trpc } from "../../lib/trpc";
+import { toast } from "sonner";
+import type { ProposedRule } from "../../lib/useBatchAnalysis";
+
+interface BatchProposalsPanelProps {
+  proposals: ProposedRule[];
+  isAnalyzing: boolean;
+  onAccept: (pattern: string) => void;
+  onDismiss: (pattern: string) => void;
+}
+
+export function BatchProposalsPanel({
+  proposals,
+  isAnalyzing,
+  onAccept,
+  onDismiss,
+}: BatchProposalsPanelProps) {
+  const [expanded, setExpanded] = useState(true);
+
+  const createCorrectionMutation = trpc.core.corrections.createOrUpdate.useMutation();
+
+  if (proposals.length === 0 && !isAnalyzing) return null;
+
+  const handleAccept = (proposal: ProposedRule) => {
+    createCorrectionMutation.mutate(
+      {
+        descriptionPattern: proposal.descriptionPattern,
+        matchType: proposal.matchType,
+        tags: proposal.tags,
+      },
+      {
+        onSuccess: () => {
+          toast.success(`Rule saved: "${proposal.descriptionPattern}"`);
+          onAccept(proposal.descriptionPattern);
+        },
+        onError: () => {
+          toast.error("Failed to save rule");
+        },
+      }
+    );
+  };
+
+  return (
+    <div className="border border-border rounded-lg bg-muted/30 mt-4">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-left hover:bg-muted/50 transition-colors"
+      >
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-muted-foreground" />
+        )}
+        <Sparkles className="h-4 w-4 text-amber-500" />
+        <span>
+          AI-Suggested Rules
+          {proposals.length > 0 && (
+            <Badge variant="secondary" className="ml-2">
+              {proposals.length}
+            </Badge>
+          )}
+        </span>
+        {isAnalyzing && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground ml-auto" />}
+      </button>
+
+      {expanded && (
+        <div className="px-4 pb-3 space-y-2">
+          {isAnalyzing && proposals.length === 0 && (
+            <p className="text-sm text-muted-foreground py-2">Analyzing corrections...</p>
+          )}
+
+          {proposals.map((proposal) => (
+            <ProposalCard
+              key={proposal.descriptionPattern}
+              proposal={proposal}
+              onAccept={() => handleAccept(proposal)}
+              onDismiss={() => onDismiss(proposal.descriptionPattern)}
+              isSaving={createCorrectionMutation.isPending}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProposalCard({
+  proposal,
+  onAccept,
+  onDismiss,
+  isSaving,
+}: {
+  proposal: ProposedRule;
+  onAccept: () => void;
+  onDismiss: () => void;
+  isSaving: boolean;
+}) {
+  return (
+    <div className="flex items-start gap-3 p-3 bg-card rounded-md border border-border">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <code className="text-sm font-mono bg-muted px-1.5 py-0.5 rounded">
+            {proposal.descriptionPattern}
+          </code>
+          <Badge
+            variant="outline"
+            className={cn(
+              "text-xs",
+              proposal.matchType === "exact" && "border-green-500/50 text-green-600",
+              proposal.matchType === "contains" && "border-blue-500/50 text-blue-600",
+              proposal.matchType === "regex" && "border-purple-500/50 text-purple-600"
+            )}
+          >
+            {proposal.matchType}
+          </Badge>
+          {proposal.tags.map((tag) => (
+            <Badge key={tag} variant="secondary" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+        {proposal.reasoning && (
+          <p className="text-xs text-muted-foreground mt-1">{proposal.reasoning}</p>
+        )}
+      </div>
+
+      <div className="flex gap-1 shrink-0">
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onAccept}
+          disabled={isSaving}
+          className="h-8 w-8 p-0"
+          aria-label="Accept rule"
+        >
+          <Check className="h-4 w-4 text-green-600" />
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onDismiss}
+          className="h-8 w-8 p-0"
+          aria-label="Dismiss rule"
+        >
+          <X className="h-4 w-4 text-muted-foreground" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-finance/src/components/imports/ReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef } from "react";
+import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { CheckCircle, AlertTriangle, XCircle, AlertCircle, List, Layers } from "lucide-react";
 import { useImportStore } from "../../store/importStore";
 import type { ProcessedTransaction } from "../../store/importStore";
@@ -9,9 +9,12 @@ import { EntityCreateDialog } from "./EntityCreateDialog";
 import { TransactionCard } from "./TransactionCard";
 import { TransactionGroup } from "./TransactionGroup";
 import { EditableTransactionCard } from "./EditableTransactionCard";
+import { BatchProposalsPanel } from "./BatchProposalsPanel";
 import { toast } from "sonner";
 import type { ConfirmedTransaction } from "@pops/api/modules/finance/imports";
 import { groupTransactionsByEntity } from "../../lib/transaction-utils";
+import { useBatchAnalysis } from "../../lib/useBatchAnalysis";
+import type { CorrectionEntry } from "../../lib/useBatchAnalysis";
 
 type ViewMode = "list" | "grouped";
 
@@ -37,6 +40,26 @@ export function ReviewStep() {
 
   // Track rejected patterns so they aren't re-suggested during this import session
   const rejectedPatterns = useRef<Set<string>>(new Set());
+
+  // Batch analysis — accumulate corrections, trigger AI analysis
+  const batchAnalysis = useBatchAnalysis();
+
+  // Seed batch analysis with matched transactions on mount
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current) return;
+    seededRef.current = true;
+    const seed: CorrectionEntry[] = localTransactions.matched
+      .filter((t) => t.entity?.entityName)
+      .map((t) => ({
+        description: t.description,
+        entityName: t.entity?.entityName ?? null,
+        amount: t.amount,
+        account: t.account,
+        currentTags: (t.suggestedTags ?? []).map((s) => s.tag),
+      }));
+    if (seed.length > 0) batchAnalysis.seedTransactions(seed);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Preserve scroll position per tab
   const scrollPositions = useRef<Map<string, number>>(new Map());
@@ -529,6 +552,14 @@ export function ReviewStep() {
           entityName: editedFields.entity?.entityName ?? transaction.entity?.entityName,
           location: editedFields.location ?? transaction.location,
         });
+        // Feed into batch analysis for refined pattern proposals
+        batchAnalysis.addCorrection({
+          description: transaction.description,
+          entityName: editedFields.entity?.entityName ?? transaction.entity?.entityName ?? null,
+          amount: transaction.amount,
+          account: transaction.account,
+          currentTags: (transaction.suggestedTags ?? []).map((s) => s.tag),
+        });
         toast.success("Correction saved!");
       } else if (hasChanges && !shouldLearn) {
         // Show toast asking if they want to learn
@@ -553,7 +584,7 @@ export function ReviewStep() {
         toast.success("Transaction updated");
       }
     },
-    [createCorrectionMutation]
+    [createCorrectionMutation, batchAnalysis]
   );
 
   const handleCancelEdit = useCallback(() => {
@@ -721,6 +752,13 @@ export function ReviewStep() {
           <SkippedTab transactions={localTransactions.skipped} />
         </TabsContent>
       </Tabs>
+
+      <BatchProposalsPanel
+        proposals={batchAnalysis.proposals}
+        isAnalyzing={batchAnalysis.isAnalyzing}
+        onAccept={batchAnalysis.acceptProposal}
+        onDismiss={batchAnalysis.dismissProposal}
+      />
 
       <div className="flex justify-between gap-3 items-center">
         <Button variant="outline" onClick={prevStep}>

--- a/packages/app-finance/src/lib/useBatchAnalysis.test.ts
+++ b/packages/app-finance/src/lib/useBatchAnalysis.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useBatchAnalysis } from "./useBatchAnalysis";
+import type { CorrectionEntry } from "./useBatchAnalysis";
+
+// Mock trpc
+const mockMutate = vi.fn();
+vi.mock("./trpc", () => ({
+  trpc: {
+    core: {
+      corrections: {
+        generateRules: {
+          useMutation: (opts: { onSuccess?: (data: { proposals: unknown[] }) => void }) => {
+            // Store onSuccess so tests can trigger it
+            mockMutate._onSuccess = opts.onSuccess;
+            return {
+              mutate: mockMutate,
+              isPending: false,
+            };
+          },
+        },
+      },
+    },
+  },
+}));
+
+function makeCorrectionEntry(
+  description: string,
+  overrides?: Partial<CorrectionEntry>
+): CorrectionEntry {
+  return {
+    description,
+    entityName: "Test Entity",
+    amount: -50,
+    account: "ANZ",
+    currentTags: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useBatchAnalysis", () => {
+  it("starts with empty state", () => {
+    const { result } = renderHook(() => useBatchAnalysis());
+    expect(result.current.proposals).toEqual([]);
+    expect(result.current.isAnalyzing).toBe(false);
+    expect(result.current.correctionCount).toBe(0);
+  });
+
+  it("tracks added corrections", () => {
+    const { result } = renderHook(() => useBatchAnalysis());
+
+    act(() => {
+      result.current.addCorrection(makeCorrectionEntry("WOOLWORTHS"));
+      result.current.addCorrection(makeCorrectionEntry("COLES"));
+    });
+
+    expect(result.current.correctionCount).toBe(2);
+  });
+
+  it("deduplicates corrections by description", () => {
+    const { result } = renderHook(() => useBatchAnalysis());
+
+    act(() => {
+      result.current.addCorrection(makeCorrectionEntry("WOOLWORTHS"));
+      result.current.addCorrection(makeCorrectionEntry("WOOLWORTHS"));
+    });
+
+    expect(result.current.correctionCount).toBe(1);
+  });
+
+  it("triggers analysis after reaching threshold (5) + debounce (3s)", () => {
+    const { result } = renderHook(() => useBatchAnalysis());
+
+    act(() => {
+      for (let i = 0; i < 5; i++) {
+        result.current.addCorrection(makeCorrectionEntry(`MERCHANT_${i}`));
+      }
+    });
+
+    // Before debounce fires
+    expect(mockMutate).not.toHaveBeenCalled();
+
+    // After debounce
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    expect(mockMutate).toHaveBeenCalledWith({
+      transactions: expect.arrayContaining([
+        expect.objectContaining({ description: "MERCHANT_0" }),
+      ]),
+    });
+  });
+
+  it("does not trigger analysis before threshold", () => {
+    const { result } = renderHook(() => useBatchAnalysis());
+
+    act(() => {
+      for (let i = 0; i < 4; i++) {
+        result.current.addCorrection(makeCorrectionEntry(`MERCHANT_${i}`));
+      }
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("seeds transactions and triggers if above threshold", () => {
+    const { result } = renderHook(() => useBatchAnalysis());
+
+    const seed = Array.from({ length: 6 }, (_, i) => makeCorrectionEntry(`SEED_${i}`));
+
+    act(() => {
+      result.current.seedTransactions(seed);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses proposals", () => {
+    const { result } = renderHook(() => useBatchAnalysis());
+
+    // Simulate proposals arriving via onSuccess callback
+    act(() => {
+      mockMutate._onSuccess?.({
+        proposals: [
+          {
+            descriptionPattern: "WOOLWORTHS",
+            matchType: "contains",
+            tags: ["Groceries"],
+            reasoning: "test",
+          },
+          {
+            descriptionPattern: "COLES",
+            matchType: "contains",
+            tags: ["Groceries"],
+            reasoning: "test",
+          },
+        ],
+      });
+    });
+
+    expect(result.current.proposals).toHaveLength(2);
+
+    act(() => {
+      result.current.dismissProposal("WOOLWORTHS");
+    });
+
+    expect(result.current.proposals).toHaveLength(1);
+    expect(result.current.proposals[0]?.descriptionPattern).toBe("COLES");
+  });
+
+  it("removes accepted proposals", () => {
+    const { result } = renderHook(() => useBatchAnalysis());
+
+    act(() => {
+      mockMutate._onSuccess?.({
+        proposals: [
+          {
+            descriptionPattern: "WOOLWORTHS",
+            matchType: "contains",
+            tags: ["Groceries"],
+            reasoning: "test",
+          },
+        ],
+      });
+    });
+
+    expect(result.current.proposals).toHaveLength(1);
+
+    act(() => {
+      result.current.acceptProposal("WOOLWORTHS");
+    });
+
+    expect(result.current.proposals).toHaveLength(0);
+  });
+});

--- a/packages/app-finance/src/lib/useBatchAnalysis.ts
+++ b/packages/app-finance/src/lib/useBatchAnalysis.ts
@@ -1,0 +1,131 @@
+/**
+ * Hook to accumulate user corrections during import review and
+ * periodically trigger batch analysis via corrections.generateRules.
+ *
+ * Debounces requests — waits 3s after last correction before firing.
+ * Only triggers when threshold (5+ corrections) is reached.
+ */
+import { useState, useCallback, useRef, useEffect } from "react";
+import { trpc } from "./trpc";
+
+export interface CorrectionEntry {
+  description: string;
+  entityName: string | null;
+  amount: number;
+  account: string;
+  currentTags: string[];
+}
+
+export interface ProposedRule {
+  descriptionPattern: string;
+  matchType: "exact" | "contains" | "regex";
+  tags: string[];
+  reasoning: string;
+}
+
+const BATCH_THRESHOLD = 5;
+const DEBOUNCE_MS = 3000;
+
+export function useBatchAnalysis() {
+  const [corrections, setCorrections] = useState<CorrectionEntry[]>([]);
+  const [proposals, setProposals] = useState<ProposedRule[]>([]);
+  const [dismissedPatterns, setDismissedPatterns] = useState<Set<string>>(new Set());
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastAnalyzedCountRef = useRef(0);
+
+  const generateRulesMutation = trpc.core.corrections.generateRules.useMutation({
+    onSuccess: (data) => {
+      if (data.proposals) {
+        setProposals((prev) => {
+          // Merge new proposals, avoiding duplicates by pattern
+          const existingPatterns = new Set(prev.map((p) => p.descriptionPattern));
+          const newOnes = data.proposals.filter(
+            (p: ProposedRule) => !existingPatterns.has(p.descriptionPattern)
+          );
+          return [...prev, ...newOnes];
+        });
+      }
+    },
+  });
+
+  const triggerAnalysis = useCallback(
+    (batch: CorrectionEntry[]) => {
+      if (batch.length === 0) return;
+      const capped = batch.slice(0, 50); // API limit
+      generateRulesMutation.mutate({ transactions: capped });
+      lastAnalyzedCountRef.current = batch.length;
+    },
+    [generateRulesMutation]
+  );
+
+  const addCorrection = useCallback(
+    (entry: CorrectionEntry) => {
+      setCorrections((prev) => {
+        // Deduplicate by description
+        if (prev.some((c) => c.description === entry.description)) return prev;
+        const updated = [...prev, entry];
+
+        // Check threshold against new corrections since last analysis
+        const newSinceLastAnalysis = updated.length - lastAnalyzedCountRef.current;
+        if (newSinceLastAnalysis >= BATCH_THRESHOLD) {
+          // Clear existing debounce
+          if (debounceRef.current) clearTimeout(debounceRef.current);
+          debounceRef.current = setTimeout(() => {
+            triggerAnalysis(updated);
+          }, DEBOUNCE_MS);
+        }
+
+        return updated;
+      });
+    },
+    [triggerAnalysis]
+  );
+
+  const seedTransactions = useCallback(
+    (entries: CorrectionEntry[]) => {
+      setCorrections((prev) => {
+        const existingDescs = new Set(prev.map((c) => c.description));
+        const newEntries = entries.filter((e) => !existingDescs.has(e.description));
+        const updated = [...prev, ...newEntries];
+
+        if (updated.length >= BATCH_THRESHOLD && lastAnalyzedCountRef.current === 0) {
+          if (debounceRef.current) clearTimeout(debounceRef.current);
+          debounceRef.current = setTimeout(() => {
+            triggerAnalysis(updated);
+          }, DEBOUNCE_MS);
+        }
+
+        return updated;
+      });
+    },
+    [triggerAnalysis]
+  );
+
+  const dismissProposal = useCallback((pattern: string) => {
+    setDismissedPatterns((prev) => new Set([...prev, pattern]));
+    setProposals((prev) => prev.filter((p) => p.descriptionPattern !== pattern));
+  }, []);
+
+  const acceptProposal = useCallback((pattern: string) => {
+    setProposals((prev) => prev.filter((p) => p.descriptionPattern !== pattern));
+  }, []);
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const visibleProposals = proposals.filter((p) => !dismissedPatterns.has(p.descriptionPattern));
+
+  return {
+    proposals: visibleProposals,
+    isAnalyzing: generateRulesMutation.isPending,
+    addCorrection,
+    seedTransactions,
+    dismissProposal,
+    acceptProposal,
+    correctionCount: corrections.length,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `useBatchAnalysis` hook that accumulates user corrections during import review and triggers `corrections.generateRules` after threshold (5+ corrections) with 3s debounce
- New `BatchProposalsPanel` component renders AI-proposed correction rules with accept/dismiss per proposal, color-coded matchType badges, and collapsible UI
- ReviewStep seeds batch analysis with matched transactions on mount and feeds corrections from "Save & Learn" actions
- 15 tests: 8 for hook (threshold, debounce, dedup, seed, dismiss, accept) + 7 for component (render, accept, dismiss, collapse/expand, analyzing state)

## Test plan
- [x] 15 unit tests pass (8 hook + 7 component)
- [x] TypeScript compiles cleanly
- [x] Prettier formatting applied
- [ ] Full CI suite
- [ ] Manual verification: import 5+ corrections → panel appears with proposals

🤖 Generated with [Claude Code](https://claude.com/claude-code)