### PR TITLE
fix: resolve 18 typecheck errors in app-media

### DIFF
--- a/packages/app-media/src/components/RequestMovieModal.test.tsx
+++ b/packages/app-media/src/components/RequestMovieModal.test.tsx
@@ -43,12 +43,14 @@ const folders = [
   { id: 2, path: "/movies2", freeSpace: 100 * 1024 * 1024 * 1024 },
 ];
 
-function setupDefaults(overrides: {
-  profilesLoading?: boolean;
-  foldersLoading?: boolean;
-  profileList?: typeof profiles;
-  folderList?: typeof folders;
-} = {}) {
+function setupDefaults(
+  overrides: {
+    profilesLoading?: boolean;
+    foldersLoading?: boolean;
+    profileList?: typeof profiles;
+    folderList?: typeof folders;
+  } = {}
+) {
   const {
     profilesLoading = false,
     foldersLoading = false,
@@ -105,8 +107,8 @@ describe("RequestMovieModal", () => {
 
     const options = select.querySelectorAll("option");
     expect(options).toHaveLength(2);
-    expect(options[0].textContent).toBe("HD - 720p/1080p");
-    expect(options[1].textContent).toBe("Ultra-HD");
+    expect(options[0]!.textContent).toBe("HD - 720p/1080p");
+    expect(options[1]!.textContent).toBe("Ultra-HD");
   });
 
   it("populates root folder dropdown with free space", () => {
@@ -118,8 +120,8 @@ describe("RequestMovieModal", () => {
 
     const options = select.querySelectorAll("option");
     expect(options).toHaveLength(2);
-    expect(options[0].textContent).toContain("/movies");
-    expect(options[0].textContent).toContain("GB free");
+    expect(options[0]!.textContent).toContain("/movies");
+    expect(options[0]!.textContent).toContain("GB free");
   });
 
   it("sends correct addMovie payload on confirm", () => {

--- a/packages/app-media/src/components/RequestMovieModal.tsx
+++ b/packages/app-media/src/components/RequestMovieModal.tsx
@@ -5,13 +5,7 @@
  * then submits to Radarr's addMovie endpoint.
  */
 import { useState, useEffect } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@pops/ui";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@pops/ui";
 import { Button } from "@pops/ui";
 import { RefreshCw, CheckCircle2 } from "lucide-react";
 import { trpc } from "../lib/trpc";
@@ -47,13 +41,13 @@ export function RequestMovieModal({ open, onClose, tmdbId, title, year }: Reques
   // Default to first option once loaded
   useEffect(() => {
     if (profiles.data?.data?.length && qualityProfileId === null) {
-      setQualityProfileId(profiles.data.data[0].id);
+      setQualityProfileId(profiles.data.data[0]!.id);
     }
   }, [profiles.data?.data, qualityProfileId]);
 
   useEffect(() => {
     if (folders.data?.data?.length && !rootFolderPath) {
-      setRootFolderPath(folders.data.data[0].path);
+      setRootFolderPath(folders.data.data[0]!.path);
     }
   }, [folders.data?.data, rootFolderPath]);
 

--- a/packages/app-media/src/components/RequestSeriesModal.test.tsx
+++ b/packages/app-media/src/components/RequestSeriesModal.test.tsx
@@ -137,8 +137,8 @@ describe("RequestSeriesModal", () => {
     const select = screen.getByLabelText("Quality Profile") as HTMLSelectElement;
     const options = select.querySelectorAll("option");
     expect(options).toHaveLength(2);
-    expect(options[0].textContent).toBe("HD - 720p/1080p");
-    expect(options[1].textContent).toBe("Ultra-HD");
+    expect(options[0]!.textContent).toBe("HD - 720p/1080p");
+    expect(options[1]!.textContent).toBe("Ultra-HD");
   });
 
   it("populates root folder dropdown with free space", () => {
@@ -148,8 +148,8 @@ describe("RequestSeriesModal", () => {
     const select = screen.getByLabelText("Root Folder") as HTMLSelectElement;
     const options = select.querySelectorAll("option");
     expect(options).toHaveLength(2);
-    expect(options[0].textContent).toContain("/tv");
-    expect(options[0].textContent).toContain("GB free");
+    expect(options[0]!.textContent).toContain("/tv");
+    expect(options[0]!.textContent).toContain("GB free");
   });
 
   it("populates language profile dropdown from API", () => {
@@ -159,8 +159,8 @@ describe("RequestSeriesModal", () => {
     const select = screen.getByLabelText("Language Profile") as HTMLSelectElement;
     const options = select.querySelectorAll("option");
     expect(options).toHaveLength(2);
-    expect(options[0].textContent).toBe("English");
-    expect(options[1].textContent).toBe("Any");
+    expect(options[0]!.textContent).toBe("English");
+    expect(options[1]!.textContent).toBe("Any");
   });
 
   it("defaults to first quality profile, root folder, and language profile", () => {
@@ -191,11 +191,11 @@ describe("RequestSeriesModal", () => {
 
     const checkboxes = screen.getAllByRole("checkbox");
     // Toggle Season 1 on
-    fireEvent.click(checkboxes[0]);
-    expect(checkboxes[0]).toBeChecked();
+    fireEvent.click(checkboxes[0]!);
+    expect(checkboxes[0]!).toBeChecked();
     // Toggle Season 3 off
-    fireEvent.click(checkboxes[2]);
-    expect(checkboxes[2]).not.toBeChecked();
+    fireEvent.click(checkboxes[2]!);
+    expect(checkboxes[2]!).not.toBeChecked();
   });
 
   it("shows Select All / Deselect All when more than 3 seasons", () => {

--- a/packages/app-media/src/components/RequestSeriesModal.tsx
+++ b/packages/app-media/src/components/RequestSeriesModal.tsx
@@ -67,19 +67,19 @@ export function RequestSeriesModal({
   // Default to first option once loaded
   useEffect(() => {
     if (profiles.data?.data?.length && qualityProfileId === null) {
-      setQualityProfileId(profiles.data.data[0].id);
+      setQualityProfileId(profiles.data.data[0]!.id);
     }
   }, [profiles.data?.data, qualityProfileId]);
 
   useEffect(() => {
     if (folders.data?.data?.length && !rootFolderPath) {
-      setRootFolderPath(folders.data.data[0].path);
+      setRootFolderPath(folders.data.data[0]!.path);
     }
   }, [folders.data?.data, rootFolderPath]);
 
   useEffect(() => {
     if (languages.data?.data?.length && languageProfileId === null) {
-      setLanguageProfileId(languages.data.data[0].id);
+      setLanguageProfileId(languages.data.data[0]!.id);
     }
   }, [languages.data?.data, languageProfileId]);
 

--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -4,7 +4,9 @@ import { MemoryRouter } from "react-router";
 
 const mockDimensionsQuery = vi.fn();
 const mockPairQuery = vi.fn();
-const mockRecordMutate = vi.fn();
+const mockRecordMutate = vi.fn() as ReturnType<typeof vi.fn> & {
+  _opts?: Record<string, unknown>;
+};
 const mockRefetchPair = vi.fn();
 const mockScoresFetch = vi.fn();
 
@@ -57,7 +59,7 @@ function renderPage() {
   return render(
     <MemoryRouter>
       <CompareArenaPage />
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
@@ -115,7 +117,7 @@ describe("CompareArenaPage", () => {
         mediaAId: 10,
         mediaBId: 20,
         winnerId: 10,
-      }),
+      })
     );
   });
 
@@ -170,7 +172,7 @@ describe("CompareArenaPage", () => {
     const { unmount } = render(
       <MemoryRouter>
         <CompareArenaPage />
-      </MemoryRouter>,
+      </MemoryRouter>
     );
 
     // Simulate pending state by re-mocking
@@ -216,9 +218,7 @@ describe("CompareArenaPage", () => {
 
     // The onSuccess callback advances the dimension
     // We can verify the mutation was called with the first dimension
-    expect(mockRecordMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ dimensionId: 1 }),
-    );
+    expect(mockRecordMutate).toHaveBeenCalledWith(expect.objectContaining({ dimensionId: 1 }));
   });
 
   it("renders loading skeletons when pair is loading", () => {


### PR DESCRIPTION
## Summary
- Fix 18 TypeScript errors on main in `@pops/app-media` introduced by recent RequestModal and CompareArena PRs
- Add non-null assertions (`!`) for array index access after length checks (NodeList items, tRPC query data arrays)
- Extend mock type for `_opts` property on CompareArenaPage test mock

## Test plan
- [x] `pnpm --filter @pops/app-media typecheck` passes (0 errors, down from 18)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)