### PR TITLE
fix: resolve typecheck errors in test files across 3 packages

### DIFF
--- a/packages/app-ai/src/pages/RulesBrowserPage.test.tsx
+++ b/packages/app-ai/src/pages/RulesBrowserPage.test.tsx
@@ -177,7 +177,8 @@ vi.mock("@pops/ui", async () => {
         return React.cloneElement(child, {
           onClick: (...args: unknown[]) => {
             dialogCloseRef?.();
-            (child.props as Record<string, unknown>).onClick?.(...args);
+            const onClick = (child.props as Record<string, (...a: unknown[]) => void>).onClick;
+            onClick?.(...args);
           },
         } as Record<string, unknown>);
       }
@@ -368,7 +369,7 @@ describe("RulesBrowserPage", () => {
     await user.selectOptions(select, "exact");
     // Verify the query was called with matchType param (server-side filter)
     const lastCall = mockListQuery.mock.calls[mockListQuery.mock.calls.length - 1];
-    expect(lastCall[0]).toMatchObject({ matchType: "exact" });
+    expect(lastCall![0]).toMatchObject({ matchType: "exact" });
   });
 
   it("renders clear filters button when filter active", async () => {

--- a/packages/app-finance/src/lib/useBatchAnalysis.test.ts
+++ b/packages/app-finance/src/lib/useBatchAnalysis.test.ts
@@ -5,6 +5,7 @@ import type { CorrectionEntry } from "./useBatchAnalysis";
 
 // Mock trpc
 const mockMutate = vi.fn();
+let capturedOnSuccess: ((data: { proposals: unknown[] }) => void) | undefined;
 vi.mock("./trpc", () => ({
   trpc: {
     core: {
@@ -12,7 +13,7 @@ vi.mock("./trpc", () => ({
         generateRules: {
           useMutation: (opts: { onSuccess?: (data: { proposals: unknown[] }) => void }) => {
             // Store onSuccess so tests can trigger it
-            mockMutate._onSuccess = opts.onSuccess;
+            capturedOnSuccess = opts.onSuccess;
             return {
               mutate: mockMutate,
               isPending: false,
@@ -139,7 +140,7 @@ describe("useBatchAnalysis", () => {
 
     // Simulate proposals arriving via onSuccess callback
     act(() => {
-      mockMutate._onSuccess?.({
+      capturedOnSuccess?.({
         proposals: [
           {
             descriptionPattern: "WOOLWORTHS",
@@ -171,7 +172,7 @@ describe("useBatchAnalysis", () => {
     const { result } = renderHook(() => useBatchAnalysis());
 
     act(() => {
-      mockMutate._onSuccess?.({
+      capturedOnSuccess?.({
         proposals: [
           {
             descriptionPattern: "WOOLWORTHS",

--- a/packages/app-inventory/src/components/SortablePhotoGrid.test.tsx
+++ b/packages/app-inventory/src/components/SortablePhotoGrid.test.tsx
@@ -38,7 +38,7 @@ describe("SortablePhotoGrid", () => {
   });
 
   it("does not render when only one photo", () => {
-    const { container } = render(<SortablePhotoGrid photos={[photos[0]]} onReorder={vi.fn()} />);
+    const { container } = render(<SortablePhotoGrid photos={[photos[0]!]} onReorder={vi.fn()} />);
     expect(container.innerHTML).toBe("");
   });
 
@@ -53,9 +53,9 @@ describe("SortablePhotoGrid", () => {
     const items = screen.getAllByRole("listitem");
 
     // Drag item 0 to position 2
-    fireEvent.dragStart(items[0]);
-    fireEvent.dragOver(items[2], { preventDefault: vi.fn() });
-    fireEvent.drop(items[2], { preventDefault: vi.fn() });
+    fireEvent.dragStart(items[0]!);
+    fireEvent.dragOver(items[2]!, { preventDefault: vi.fn() });
+    fireEvent.drop(items[2]!, { preventDefault: vi.fn() });
 
     expect(onReorder).toHaveBeenCalledWith([2, 3, 1]);
   });
@@ -65,9 +65,9 @@ describe("SortablePhotoGrid", () => {
     render(<SortablePhotoGrid photos={photos} onReorder={onReorder} />);
     const items = screen.getAllByRole("listitem");
 
-    fireEvent.dragStart(items[1]);
-    fireEvent.dragOver(items[1], { preventDefault: vi.fn() });
-    fireEvent.drop(items[1], { preventDefault: vi.fn() });
+    fireEvent.dragStart(items[1]!);
+    fireEvent.dragOver(items[1]!, { preventDefault: vi.fn() });
+    fireEvent.drop(items[1]!, { preventDefault: vi.fn() });
 
     expect(onReorder).not.toHaveBeenCalled();
   });
@@ -91,10 +91,10 @@ describe("SortablePhotoGrid", () => {
     render(<SortablePhotoGrid photos={photos} onReorder={onReorder} />);
     const items = screen.getAllByRole("listitem");
 
-    fireEvent.dragStart(items[0]);
-    expect(items[0].className).toContain("opacity-40");
+    fireEvent.dragStart(items[0]!);
+    expect(items[0]!.className).toContain("opacity-40");
 
-    fireEvent.dragEnd(items[0]);
-    expect(items[0].className).not.toContain("opacity-40");
+    fireEvent.dragEnd(items[0]!);
+    expect(items[0]!.className).not.toContain("opacity-40");
   });
 });

--- a/packages/app-inventory/src/pages/ItemsPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.test.tsx
@@ -201,7 +201,7 @@ describe("ItemsPage", () => {
       });
       renderPage();
 
-      const typeSelect = screen.getAllByRole("combobox")[0];
+      const typeSelect = screen.getAllByRole("combobox")[0]!;
       expect(typeSelect).toBeInTheDocument();
       // Options include: placeholder + "All Types" + 3 dynamic types = 5
       const options = typeSelect.querySelectorAll("option");
@@ -224,7 +224,7 @@ describe("ItemsPage", () => {
 
       // Location select should have: All Locations, Home, └ Office
       const selects = screen.getAllByRole("combobox");
-      const locationSelect = selects[selects.length - 1]; // last select
+      const locationSelect = selects[selects.length - 1]!; // last select
       const options = locationSelect.querySelectorAll("option");
       expect(options.length).toBeGreaterThanOrEqual(3);
     });
@@ -234,7 +234,7 @@ describe("ItemsPage", () => {
 
       const selects = screen.getAllByRole("combobox");
       // Condition select: placeholder + All Conditions + Excellent + Good + Fair + Poor = 6
-      const conditionSelect = selects[1]; // second select
+      const conditionSelect = selects[1]!; // second select
       const options = conditionSelect.querySelectorAll("option");
       expect(options.length).toBe(6);
     });


### PR DESCRIPTION
## Summary
- **app-finance**: `useBatchAnalysis.test.ts` — use a separate `capturedOnSuccess` variable instead of dynamically attaching `_onSuccess` to the vitest mock (which has no such property on its type)
- **app-ai**: `RulesBrowserPage.test.tsx` — fix callable type on dialog close handler mock, add non-null assertion for array access
- **app-inventory**: `SortablePhotoGrid.test.tsx` + `ItemsPage.test.tsx` — add non-null assertions for array element accesses that TypeScript flags as possibly undefined

All errors were pre-existing on `main`. After this fix, `pnpm typecheck` passes across all 10 packages.

## Test plan
- [x] `pnpm typecheck` — all 10 packages pass
- [x] `pnpm --filter @pops/app-finance test` — 20 passing (14 pre-existing failures in ReviewStep unrelated)
- [x] Prettier check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)