### PR TITLE
fix: add missing generateRules mock to ReviewStep tests

### DIFF
--- a/packages/app-finance/src/components/imports/ReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.test.tsx
@@ -39,6 +39,12 @@ vi.mock("../../lib/trpc", () => ({
             isPending: false,
           }),
         },
+        generateRules: {
+          useMutation: () => ({
+            mutate: vi.fn(),
+            isPending: false,
+          }),
+        },
       },
     },
     useUtils: () => ({


### PR DESCRIPTION
## Summary
- Adds missing `trpc.core.corrections.generateRules.useMutation` mock to `ReviewStep.test.tsx`
- The `useBatchAnalysis` hook (added in a recent PR) calls this tRPC route but the test mock didn't include it, causing 14 test failures on main

## Test plan
- [x] All 34 app-finance tests pass (was 14 failing, 20 passing)
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)