### PR TITLE
feat(media): download season posters during TV show add and refresh

### DIFF
--- a/apps/pops-api/src/modules/media/library/tv-show-service.test.ts
+++ b/apps/pops-api/src/modules/media/library/tv-show-service.test.ts
@@ -301,7 +301,8 @@ describe("addTvShow", () => {
     expect(mockImageCache.downloadTvShowImages).toHaveBeenCalledWith(
       81189,
       "https://artworks.thetvdb.com/poster.jpg",
-      "https://artworks.thetvdb.com/backdrop.jpg"
+      "https://artworks.thetvdb.com/backdrop.jpg",
+      [{ seasonNumber: 1, posterUrl: "https://artworks.thetvdb.com/s1.jpg" }]
     );
   });
 

--- a/apps/pops-api/src/modules/media/library/tv-show-service.ts
+++ b/apps/pops-api/src/modules/media/library/tv-show-service.ts
@@ -149,8 +149,12 @@ export async function addTvShow(
 
   // Download images to local cache (non-blocking — failures are logged)
   if (result.created && imageCache) {
+    const seasonPosters = detail.seasons
+      .filter((s) => s.imageUrl != null)
+      .map((s) => ({ seasonNumber: s.seasonNumber, posterUrl: s.imageUrl }));
+
     imageCache
-      .downloadTvShowImages(tvdbId, posterUrl, backdropUrl)
+      .downloadTvShowImages(tvdbId, posterUrl, backdropUrl, seasonPosters)
       .catch((err) =>
         console.warn(
           `[addTvShow] Image download failed for tvdbId ${tvdbId}: ${err instanceof Error ? err.message : String(err)}`

--- a/apps/pops-api/src/modules/media/thetvdb/service.test.ts
+++ b/apps/pops-api/src/modules/media/thetvdb/service.test.ts
@@ -423,6 +423,16 @@ describe("refreshTvShow", () => {
     seedSeason(db, { tv_show_id: showId, tvdb_id: 30001, season_number: 1 });
 
     const detail = makeShowDetail({
+      seasons: [
+        {
+          tvdbId: 30001,
+          seasonNumber: 1,
+          name: "Season 1",
+          overview: null,
+          imageUrl: "https://artworks.thetvdb.com/s1.jpg",
+          episodeCount: 7,
+        },
+      ],
       artworks: [
         {
           id: 1,
@@ -457,7 +467,8 @@ describe("refreshTvShow", () => {
     expect(mockImageCache.downloadTvShowImages).toHaveBeenCalledWith(
       81189,
       "https://artworks.thetvdb.com/poster.jpg",
-      "https://artworks.thetvdb.com/backdrop.jpg"
+      "https://artworks.thetvdb.com/backdrop.jpg",
+      [{ seasonNumber: 1, posterUrl: "https://artworks.thetvdb.com/s1.jpg" }]
     );
   });
 

--- a/apps/pops-api/src/modules/media/thetvdb/service.ts
+++ b/apps/pops-api/src/modules/media/thetvdb/service.ts
@@ -194,8 +194,12 @@ export async function refreshTvShow(
   // 6. Re-download images if requested
   if (redownloadImages && imageCache) {
     const { posterUrl, backdropUrl } = selectBestArtwork(detail.artworks);
+    const seasonPosters = detail.seasons
+      .filter((s) => s.imageUrl != null)
+      .map((s) => ({ seasonNumber: s.seasonNumber, posterUrl: s.imageUrl }));
+
     await imageCache.deleteTvShowImages(tvdbId);
-    await imageCache.downloadTvShowImages(tvdbId, posterUrl, backdropUrl);
+    await imageCache.downloadTvShowImages(tvdbId, posterUrl, backdropUrl, seasonPosters);
   }
 
   // 7. Return updated show with seasons

--- a/docs-v2/themes/03-media/prds/030-thetvdb-client/us-03-add-to-library.md
+++ b/docs-v2/themes/03-media/prds/030-thetvdb-client/us-03-add-to-library.md
@@ -18,7 +18,7 @@ As a user, I want to add a TV show to my library by TheTVDB ID so that the full 
 - [x] Specials season (seasonNumber 0) included when present
 - [x] All episodes created with: seasonId (FK), tvdbId, episodeNumber, name, overview, airDate, voteAverage, runtime
 - [x] Episodes without an air date are still created (upcoming episodes)
-- [ ] Show poster and all season posters downloaded to local cache — **not downloaded; CDN URLs stored directly in posterPath/backdropPath columns**
+- [x] Show poster and all season posters downloaded to local cache during addTvShow
 - [x] If any image download fails, records are still created with null image paths
 - [x] `createdAt` set on show, all seasons, and all episodes
 - [x] Returns the complete TV show record
@@ -34,7 +34,7 @@ As a user, I want to add a TV show to my library by TheTVDB ID so that the full 
 - [x] New episodes are inserted (not present in DB by tvdbId)
 - [x] Existing episodes are updated with fresh metadata
 - [x] No records are deleted during refresh — existing seasons/episodes are preserved to maintain watch history references
-- [ ] When `redownloadImages` is true, re-downloads show and season posters — **param accepted but has no effect; no image download logic in refresh**
+- [x] When `redownloadImages` is true, re-downloads show and season posters
 - [x] Returns `{ data: TvShow, diff: RefreshDiff }` where diff reports seasonsAdded, seasonsUpdated, episodesAdded, episodesUpdated
 - [x] Returns 404 if show id does not exist in the database
 


### PR DESCRIPTION
## Summary
- Pass season poster URLs to `ImageCacheService.downloadTvShowImages` in both `addTvShow` and `refreshTvShow` flows
- Season posters are now cached locally alongside the show poster and backdrop
- Updated tests to verify season posters are included in download calls

Closes #697

## Test plan
- [x] All 28 tests pass in `tv-show-service.test.ts` and `thetvdb/service.test.ts`
- [x] Typecheck passes with no errors
- [x] Existing `addTvShow` test verifies season posters passed to `downloadTvShowImages`
- [x] Existing `refreshTvShow` test verifies season posters passed when `redownloadImages=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)