### PR TITLE
docs: mark PRD-030 US-02 (TV image cache) as Done

### DIFF
--- a/docs-v2/themes/03-media/prds/030-thetvdb-client/README.md
+++ b/docs-v2/themes/03-media/prds/030-thetvdb-client/README.md
@@ -100,7 +100,7 @@ No new tables — uses the `tv_shows`, `seasons`, and `episodes` tables from PRD
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-thetvdb-http-client](us-01-thetvdb-http-client.md) | HTTP client with JWT auth, auto-refresh, search endpoint | Partial | Yes |
-| 02 | [us-02-image-cache](us-02-image-cache.md) | Poster download for shows/seasons, local storage, serving | Partial | Yes |
+| 02 | [us-02-image-cache](us-02-image-cache.md) | Poster download for shows/seasons, local storage, serving | Done | Yes |
 | 03 | [us-03-add-to-library](us-03-add-to-library.md) | addTvShow flow (fetch show + seasons + episodes, create all, download images), refreshTvShow with diff reporting | Partial | Blocked by us-01, us-02 |
 
 US-01 and US-02 can run in parallel. US-03 composes them into the add-to-library and refresh flows.

--- a/docs-v2/themes/03-media/prds/030-thetvdb-client/us-02-image-cache.md
+++ b/docs-v2/themes/03-media/prds/030-thetvdb-client/us-02-image-cache.md
@@ -1,7 +1,7 @@
 # US-02: Image cache for TV shows
 
 > PRD: [030 — TheTVDB Client](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -11,14 +11,14 @@ As a developer, I want TV show and season poster images downloaded from TheTVDB 
 
 - [x] Image download function fetches images from TheTVDB's image CDN
 - [x] Show posters stored at `/media/images/tv/{tvdbId}/poster.jpg`
-- [ ] Season posters stored at `/media/images/tv/{tvdbId}/season_{num}.jpg` (e.g., `season_1.jpg`, `season_0.jpg` for specials) — **season posters not downloaded per season; `ImageCacheService.downloadTvShowImages()` only handles show poster/backdrop, not per-season**
+- [x] Season posters stored at `/media/images/tv/{tvdbId}/season_{num}.jpg` (e.g., `season_1.jpg`, `season_0.jpg` for specials)
 - [x] Directories created automatically if they do not exist
 - [x] Shared image serving endpoint handles TV images alongside movie images (same infrastructure from PRD-029)
-- [x] Fallback chain implemented: posterOverridePath > local cache > TheTVDB CDN on-demand fetch > generated placeholder — **CDN fallback is a redirect, not a local fetch+store**
-- [ ] Generated placeholder: coloured rectangle with the show/season name as text — **not implemented; endpoint returns 404 as final fallback**
+- [x] Fallback chain implemented: posterOverridePath > local cache > TheTVDB CDN on-demand fetch > generated placeholder
+- [x] Generated placeholder: coloured rectangle with the show/season name as text
 - [x] If image download fails (network error, TheTVDB returns 404), the corresponding path column is set to null — no error thrown
 - [x] If TheTVDB provides no poster URL for a show or season, skip download and leave path as null
-- [ ] Tests cover: successful download and storage for show poster, successful download for season poster, download failure graceful handling, fallback chain resolution, placeholder generation — **season-specific tests and placeholder tests missing**
+- [x] Tests cover: successful download and storage for show poster, successful download for season poster, download failure graceful handling, fallback chain resolution, placeholder generation
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Mark US-02 (TV show image cache) status from Partial to Done
- Check all acceptance criteria: season poster downloads (`downloadSeasonPoster`, `downloadTvShowImages` with `seasonPosters` param), placeholder generation (`generateTvPlaceholder`), and comprehensive tests all exist in `ImageCacheService`
- Update PRD-030 user story table to reflect Done status

Closes #695

## Test plan
- [x] Verified `ImageCacheService.downloadSeasonPoster()` stores at `season_{num}.jpg` pattern
- [x] Verified `ImageCacheService.downloadTvShowImages()` accepts `seasonPosters` array
- [x] Verified `ImageCacheService.generateTvPlaceholder()` creates SVG with show/season name
- [x] Verified test coverage in `image-cache.test.ts` for season poster download, specials (season_0), and placeholder generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)