### PR TITLE
docs: mark PRD-027 US-04 batch correction analysis as Done

### DIFF
--- a/docs-v2/themes/02-finance/prds/027-ai-rule-creation/README.md
+++ b/docs-v2/themes/02-finance/prds/027-ai-rule-creation/README.md
@@ -1,7 +1,7 @@
 # PRD-027: AI Rule Creation
 
 > Epic: [06 — AI Rule Creation](../../epics/06-ai-categorisation.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -87,7 +87,7 @@ Each import makes the system smarter:
 | 01 | [us-01-correction-analysis](us-01-correction-analysis.md) | Send user correction to Claude, receive pattern suggestion | No (first) | Done |
 | 02 | [us-02-auto-apply-rules](us-02-auto-apply-rules.md) | High-confidence AI rules auto-saved and applied to remaining import transactions | Blocked by us-01 | Done |
 | 03 | [us-03-confirmation-flow](us-03-confirmation-flow.md) | Low-confidence AI rules shown to user for confirmation before saving | Blocked by us-01 | Done |
-| 04 | [us-04-batch-analysis](us-04-batch-analysis.md) | Batch correction analysis for better pattern suggestions | Blocked by us-01 | Partial |
+| 04 | [us-04-batch-analysis](us-04-batch-analysis.md) | Batch correction analysis for better pattern suggestions | Blocked by us-01 | Done |
 
 US-02 and US-03 can parallelise after US-01.
 

--- a/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-04-batch-analysis.md
+++ b/docs-v2/themes/02-finance/prds/027-ai-rule-creation/us-04-batch-analysis.md
@@ -1,7 +1,7 @@
 # US-04: Batch correction analysis
 
 > PRD: [027 — AI Rule Creation](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -13,12 +13,8 @@ As a developer, I want multiple corrections analyzed together so that the AI can
 - [x] Claude analyzes the batch and returns pattern proposals
 - [x] Batch context helps: two corrections for "IKEA TEMPE" and "IKEA RHODES" → stronger "IKEA" prefix confidence
 - [x] Proposals are not auto-saved — caller confirms via createOrUpdate
-- [ ] Works alongside per-correction analysis (US-01) — batch runs periodically during review step
+- [x] Works alongside per-correction analysis (US-01) — batch runs periodically during review step
 - [x] Cost tracked as single AI call, not per transaction
-
-## Missing
-
-No frontend UI calls `corrections.generateRules`. No component triggers batch analysis from ReviewStep during the review step. Proposals cannot be confirmed through the UI — backend design is correct but UI integration is absent.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Updates US-04 (batch correction analysis) status from Partial to Done
- Checks remaining AC item (batch runs alongside per-correction analysis)
- Removes outdated "Missing" section from US-04 doc
- Updates PRD-027 status from Partial to Done (all 4 user stories now Done)
- Closes #737

All features verified on main via grep:
- `useBatchAnalysis.ts` calls `generateRules` (lines 36, 55)
- `ReviewStep.tsx` integrates hook (line 45) and renders `BatchProposalsPanel` (line 805)
- Backend `generateRules` procedure exists in `router.ts:159`

## Test plan
- [x] Verified all code exists via grep on worktree
- [x] No code changes — docs-only update

🤖 Generated with [Claude Code](https://claude.com/claude-code)