### PR TITLE
feat: inventory schema — UNIQUE asset_id index [tb-019]

### DIFF
--- a/apps/pops-api/src/db/migrations/20260328120000_inventory_asset_id_unique_index.sql
+++ b/apps/pops-api/src/db/migrations/20260328120000_inventory_asset_id_unique_index.sql
@@ -1,0 +1,5 @@
+-- Make idx_inventory_asset_id a UNIQUE index.
+-- The column already has a UNIQUE constraint, so this makes the named index
+-- consistent with the column-level uniqueness enforcement.
+DROP INDEX IF EXISTS idx_inventory_asset_id;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_inventory_asset_id ON home_inventory(asset_id);

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -31,6 +31,7 @@ const INCLUDED_MIGRATIONS = [
   "20260326150000_budgets_unique_category_period.sql",
   "20260326160000_items_locations_schema.sql",
   "20260327120000_sync_logs.sql",
+  "20260328120000_inventory_asset_id_unique_index.sql",
 ];
 
 /**
@@ -141,7 +142,7 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
       FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE SET NULL
     );
 
-    CREATE INDEX IF NOT EXISTS idx_inventory_asset_id ON home_inventory(asset_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_inventory_asset_id ON home_inventory(asset_id);
     CREATE INDEX IF NOT EXISTS idx_inventory_name ON home_inventory(item_name);
     CREATE INDEX IF NOT EXISTS idx_inventory_location ON home_inventory(location_id);
     CREATE INDEX IF NOT EXISTS idx_inventory_type ON home_inventory(type);

--- a/apps/pops-api/src/modules/inventory/items/schema.test.ts
+++ b/apps/pops-api/src/modules/inventory/items/schema.test.ts
@@ -160,6 +160,17 @@ describe("items and locations schema", () => {
       expect(indexNames).toContain("idx_inventory_warranty");
     });
 
+    it("idx_inventory_asset_id is a UNIQUE index", () => {
+      const indexes = db.prepare("PRAGMA index_list(home_inventory)").all() as {
+        name: string;
+        unique: number;
+      }[];
+      const assetIdIndex = indexes.find((i) => i.name === "idx_inventory_asset_id");
+
+      expect(assetIdIndex).toBeDefined();
+      expect(assetIdIndex!.unique).toBe(1);
+    });
+
     it("has all required indexes on locations", () => {
       const indexes = db.prepare("PRAGMA index_list(locations)").all() as { name: string }[];
       const indexNames = indexes.map((i) => i.name);

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -110,7 +110,7 @@ export function createTestDb(): Database {
       FOREIGN KEY (purchased_from_id) REFERENCES entities(id) ON DELETE SET NULL,
       FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE SET NULL
     );
-    CREATE INDEX IF NOT EXISTS idx_inventory_asset_id ON home_inventory(asset_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_inventory_asset_id ON home_inventory(asset_id);
     CREATE INDEX IF NOT EXISTS idx_inventory_name ON home_inventory(item_name);
     CREATE INDEX IF NOT EXISTS idx_inventory_location ON home_inventory(location_id);
     CREATE INDEX IF NOT EXISTS idx_inventory_type ON home_inventory(type);

--- a/packages/db-types/src/schema/inventory.ts
+++ b/packages/db-types/src/schema/inventory.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, real, index } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, index, uniqueIndex } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 import { transactions } from "./transactions.js";
 import { entities } from "./entities.js";
@@ -47,7 +47,7 @@ export const homeInventory = sqliteTable(
     lastEditedTime: text("last_edited_time").notNull(),
   },
   (table) => [
-    index("idx_inventory_asset_id").on(table.assetId),
+    uniqueIndex("idx_inventory_asset_id").on(table.assetId),
     index("idx_inventory_name").on(table.itemName),
     index("idx_inventory_location").on(table.locationId),
     index("idx_inventory_type").on(table.type),


### PR DESCRIPTION
## Summary
- Makes `idx_inventory_asset_id` a UNIQUE index (was regular index; column already had UNIQUE constraint but named index did not)
- Updates schema.ts (raw SQL), test-utils.ts (test schema), and Drizzle ORM definition (inventory.ts)
- Adds migration `20260328120000_inventory_asset_id_unique_index.sql` for existing databases
- Adds test verifying the index is UNIQUE via `PRAGMA index_list`

## Test plan
- [x] All 12 schema tests pass (table creation, defaults, FK cascade, unique constraint, index existence + uniqueness)
- [x] Full test suite passes (0 failures)
- [x] TypeScript typecheck passes
- [ ] QA verify: schema tests cover all acceptance criteria from GH-722

Closes #722

🤖 Generated with [Claude Code](https://claude.ai/code)