### PR TITLE
feat(inventory): pointer media queries for drag-drop + drop indicator [tb-021]

### DIFF
--- a/packages/app-inventory/src/pages/LocationTreePage.test.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 /* ------------------------------------------------------------------ */
@@ -92,18 +92,20 @@ vi.mock("../components/LocationContentsPanel", () => ({
 /* ------------------------------------------------------------------ */
 let capturedDragHandlers: {
   onDragStart?: (event: { active: { id: string } }) => void;
+  onDragOver?: (event: { active: { id: string }; over: { id: string } | null }) => void;
   onDragEnd?: (event: { active: { id: string }; over: { id: string } | null }) => void;
 } = {};
 
 vi.mock("@dnd-kit/core", () => ({
-  DndContext: ({ children, onDragStart, onDragEnd }: {
+  DndContext: ({ children, onDragStart, onDragOver, onDragEnd }: {
     children: React.ReactNode;
     sensors?: unknown;
     collisionDetection?: unknown;
     onDragStart?: (event: { active: { id: string } }) => void;
+    onDragOver?: (event: { active: { id: string }; over: { id: string } | null }) => void;
     onDragEnd?: (event: { active: { id: string }; over: { id: string } | null }) => void;
   }) => {
-    capturedDragHandlers = { onDragStart, onDragEnd };
+    capturedDragHandlers = { onDragStart, onDragOver, onDragEnd };
     return <div data-testid="dnd-context">{children}</div>;
   },
   DragOverlay: ({ children }: { children: React.ReactNode }) => (
@@ -259,17 +261,17 @@ describe("LocationTreePage", () => {
     expect(screen.getByTestId("drag-overlay")).toBeInTheDocument();
   });
 
-  /* --- Arrow buttons hidden on desktop --- */
+  /* --- Arrow buttons for coarse pointers (touch devices) --- */
 
-  it("arrow buttons have md:hidden class", () => {
+  it("arrow buttons use pointer:coarse media query", () => {
     renderPage();
     const moveUpButtons = screen.getAllByTitle("Move up");
     moveUpButtons.forEach((btn) => {
-      expect(btn.className).toContain("md:hidden");
+      expect(btn.className).toContain("[@media(pointer:coarse)]:inline-flex");
     });
     const moveDownButtons = screen.getAllByTitle("Move down");
     moveDownButtons.forEach((btn) => {
-      expect(btn.className).toContain("md:hidden");
+      expect(btn.className).toContain("[@media(pointer:coarse)]:inline-flex");
     });
   });
 
@@ -282,11 +284,11 @@ describe("LocationTreePage", () => {
     expect(handle.className).toContain("touch-none");
   });
 
-  it("drag handle is hidden on mobile (hidden md:flex)", () => {
+  it("drag handle uses pointer:fine media query", () => {
     renderPage();
     const handle = screen.getByLabelText("Drag Home");
     expect(handle.className).toContain("hidden");
-    expect(handle.className).toContain("md:flex");
+    expect(handle.className).toContain("[@media(pointer:fine)]:flex");
   });
 
   /* --- Drag-and-drop: reorder within siblings --- */
@@ -366,6 +368,43 @@ describe("LocationTreePage", () => {
       over: null,
     });
     expect(mockUpdateMutate).not.toHaveBeenCalled();
+  });
+
+  /* --- Drop indicator line --- */
+
+  it("shows drop indicator when dragging over a sibling", () => {
+    renderPage();
+    act(() => {
+      capturedDragHandlers.onDragStart!({ active: { id: "office" } });
+    });
+    act(() => {
+      capturedDragHandlers.onDragOver!({
+        active: { id: "office" },
+        over: { id: "home" },
+      });
+    });
+    expect(screen.getByTestId("drop-indicator")).toBeInTheDocument();
+  });
+
+  it("removes drop indicator on drag end", () => {
+    renderPage();
+    act(() => {
+      capturedDragHandlers.onDragStart!({ active: { id: "office" } });
+    });
+    act(() => {
+      capturedDragHandlers.onDragOver!({
+        active: { id: "office" },
+        over: { id: "home" },
+      });
+    });
+    expect(screen.getByTestId("drop-indicator")).toBeInTheDocument();
+    act(() => {
+      capturedDragHandlers.onDragEnd!({
+        active: { id: "office" },
+        over: { id: "home" },
+      });
+    });
+    expect(screen.queryByTestId("drop-indicator")).not.toBeInTheDocument();
   });
 
   /* --- Selection --- */

--- a/packages/app-inventory/src/pages/LocationTreePage.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.tsx
@@ -30,6 +30,7 @@ import {
   useSensors,
   type DragStartEvent,
   type DragEndEvent,
+  type DragOverEvent,
 } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -245,6 +246,20 @@ function DragOverlayNode({ node }: { node: LocationTreeNode }) {
   );
 }
 
+/** Visual drop indicator line shown between siblings during drag. */
+function DropIndicatorLine({ depth }: { depth: number }) {
+  return (
+    <div
+      className="relative h-0.5 my-[-1px] z-10"
+      style={{ marginLeft: `${depth * 20 + 8}px`, marginRight: "8px" }}
+      data-testid="drop-indicator"
+    >
+      <div className="absolute inset-0 bg-app-accent rounded-full" />
+      <div className="absolute left-0 top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-app-accent -ml-1" />
+    </div>
+  );
+}
+
 interface LocationNodeProps {
   node: LocationTreeNode;
   depth: number;
@@ -260,6 +275,10 @@ interface LocationNodeProps {
   onNewChildCancel: () => void;
   siblingIndex: number;
   siblingCount: number;
+  /** ID of the node currently being dragged over (for drop indicator). */
+  overId: string | null;
+  /** ID of the node currently being dragged. */
+  activeId: string | null;
 }
 
 function LocationNode({
@@ -277,6 +296,8 @@ function LocationNode({
   onNewChildCancel,
   siblingIndex,
   siblingCount,
+  overId,
+  activeId,
 }: LocationNodeProps) {
   const [open, setOpen] = useState(depth < 1);
   const [renaming, setRenaming] = useState(false);
@@ -301,7 +322,8 @@ function LocationNode({
     opacity: isDragging ? 0.4 : 1,
   };
 
-  const dropIndicator = isOver && !isDragging;
+  // Show drop indicator line when this node is the drop target during a same-parent reorder
+  const showDropLine = overId === node.id && activeId !== null && activeId !== node.id && !isDragging;
 
   // Auto-expand when adding a child
   useEffect(() => {
@@ -310,13 +332,14 @@ function LocationNode({
 
   return (
     <div ref={setNodeRef} style={sortableStyle}>
+    {showDropLine && <DropIndicatorLine depth={depth} />}
     <Collapsible open={open} onOpenChange={setOpen}>
       <div
         className={`group flex items-center gap-1.5 py-1.5 px-2 rounded-md cursor-pointer transition-colors hover:bg-app-accent/10 ${
           isSelected
             ? "bg-app-accent/20 text-foreground font-bold border-l-2 border-app-accent rounded-l-none ml-[-2px]"
             : ""
-        } ${dropIndicator ? "ring-2 ring-app-accent/50 bg-app-accent/5" : ""}`}
+        } ${isOver && !isDragging ? "ring-2 ring-app-accent/50 bg-app-accent/5" : ""}`}
         style={{ paddingLeft: `${depth * 20 + 8}px` }}
         onClick={() => onSelect(node.id)}
         onDoubleClick={(e) => {
@@ -327,13 +350,13 @@ function LocationNode({
         aria-selected={isSelected}
         aria-expanded={hasChildren ? open : undefined}
       >
-        {/* Drag handle — desktop only, visible on hover */}
+        {/* Drag handle — fine pointer only (mouse/trackpad), visible on hover */}
         <button
           ref={setActivatorNodeRef}
           {...attributes}
           {...listeners}
           type="button"
-          className="p-0.5 rounded hover:bg-muted cursor-grab active:cursor-grabbing hidden md:flex opacity-0 group-hover:opacity-100 transition-opacity touch-none"
+          className="p-0.5 rounded hover:bg-muted cursor-grab active:cursor-grabbing hidden [@media(pointer:fine)]:flex opacity-0 group-hover:opacity-100 transition-opacity touch-none"
           aria-label={`Drag ${node.name}`}
           onClick={(e) => e.stopPropagation()}
         >
@@ -386,7 +409,7 @@ function LocationNode({
           {siblingCount > 1 && siblingIndex > 0 && (
             <button
               type="button"
-              className="p-0.5 rounded hover:bg-muted md:hidden"
+              className="p-0.5 rounded hover:bg-muted hidden [@media(pointer:coarse)]:inline-flex"
               onClick={(e) => {
                 e.stopPropagation();
                 onReorder(node.id, "up");
@@ -400,7 +423,7 @@ function LocationNode({
           {siblingCount > 1 && siblingIndex < siblingCount - 1 && (
             <button
               type="button"
-              className="p-0.5 rounded hover:bg-muted md:hidden"
+              className="p-0.5 rounded hover:bg-muted hidden [@media(pointer:coarse)]:inline-flex"
               onClick={(e) => {
                 e.stopPropagation();
                 onReorder(node.id, "down");
@@ -488,6 +511,8 @@ function LocationNode({
                   onNewChildCancel={onNewChildCancel}
                   siblingIndex={i}
                   siblingCount={node.children.length}
+                  overId={overId}
+                  activeId={activeId}
                 />
               ))}
               {isAddingChild && (
@@ -519,6 +544,7 @@ export function LocationTreePage() {
   const [addingRoot, setAddingRoot] = useState(false);
   const [movingId, setMovingId] = useState<string | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
@@ -700,9 +726,14 @@ export function LocationTreePage() {
     setActiveId(event.active.id as string);
   }, []);
 
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    setOverId(event.over ? (event.over.id as string) : null);
+  }, []);
+
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       setActiveId(null);
+      setOverId(null);
       const { active, over } = event;
       if (!over || active.id === over.id) return;
 
@@ -799,6 +830,7 @@ export function LocationTreePage() {
             sensors={sensors}
             collisionDetection={closestCenter}
             onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
             onDragEnd={handleDragEnd}
           >
           <div className="md:w-2/5 border rounded-lg py-2" role="tree" aria-label="Location tree">
@@ -823,6 +855,8 @@ export function LocationTreePage() {
                   onNewChildCancel={handleNewChildCancel}
                   siblingIndex={i}
                   siblingCount={treeNodes.length}
+                  overId={overId}
+                  activeId={activeId}
                 />
               ))}
             </SortableContext>


### PR DESCRIPTION
## Summary
- Replace `md:hidden`/`md:flex` breakpoints with `@media(pointer:coarse)` and `@media(pointer:fine)` so touch tablets at desktop width get arrow reorder buttons instead of drag handles
- Add visual drop indicator line (horizontal bar with dot) between siblings during drag operations using dnd-kit `onDragOver` state
- Update tests for new media query classes and add drop indicator tests

Closes #681

## Test plan
- [x] All 20 LocationTreePage tests pass
- [x] TypeScript compiles cleanly
- [ ] Manual: On desktop (mouse), drag handle visible on hover, arrow buttons hidden
- [ ] Manual: On tablet/touch device, arrow buttons visible, drag handle hidden
- [ ] Manual: During drag, blue indicator line appears at drop position

🤖 Generated with [Claude Code](https://claude.com/claude-code)