### PR TITLE
docs: fix PRD/US spec gaps found during manual testing

### DIFF
--- a/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/README.md
+++ b/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/README.md
@@ -106,7 +106,7 @@ These patterns must be eliminated and replaced with token-based classes:
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-globals-css](us-01-globals-css.md) | Create globals.css with Tailwind imports, @theme block, CSS variables, light/dark tokens | Done | No (first) |
+| 01 | [us-01-globals-css](us-01-globals-css.md) | Create globals.css with Tailwind imports, @theme block, CSS variables, light/dark tokens | Partial | No (first) |
 | 02 | [us-02-app-colour-variable](us-02-app-colour-variable.md) | Define the app colour CSS variable system (--app-accent, --app-accent-foreground) with per-colour definitions | Not started | Blocked by us-01 |
 | 03 | [us-03-eliminate-arbitrary-values](us-03-eliminate-arbitrary-values.md) | Replace all arbitrary Tailwind values with token-based classes across all components | Partial | Blocked by us-01 |
 | 04 | [us-04-eliminate-hardcoded-colours](us-04-eliminate-hardcoded-colours.md) | Replace all hardcoded app colour classes (bg-indigo-600, text-emerald-400, etc.) with app-accent token references | Not started | Blocked by us-02 |

--- a/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/us-01-globals-css.md
+++ b/docs-v2/themes/01-foundation/prds/002-design-tokens-theming/us-01-globals-css.md
@@ -1,7 +1,7 @@
 # US-01: Create globals.css with design tokens
 
 > PRD: [002 — Design Tokens & Theming](README.md)
-> Status: Done
+> Status: Partial
 
 ## Description
 
@@ -17,6 +17,7 @@ As a developer, I want a single `globals.css` file in `@pops/ui/theme` that defi
 - [x] Shell entry point imports `@pops/ui/theme`
 - [x] Light mode and dark mode both render correctly
 - [x] No theme-related CSS exists outside this file
+- [ ] All custom Tailwind utility classes used across the codebase (e.g., `text-2xs`) are defined in the `@theme` block — no undefined utility classes
 
 ## Notes
 

--- a/docs-v2/themes/01-foundation/prds/005-shell/README.md
+++ b/docs-v2/themes/01-foundation/prds/005-shell/README.md
@@ -1,7 +1,7 @@
 # PRD-005: Shell
 
 > Epic: [02 — Shell & App Switcher](../../epics/02-shell-app-switcher.md)
-> Status: Done
+> Status: Partial
 
 ## Overview
 
@@ -187,7 +187,7 @@ The key rule: app packages depend on `@pops/ui` and shared packages, never on ot
 | 01 | [us-01-shell-scaffold](us-01-shell-scaffold.md) | Create pops-shell with entry point, Vite config, provider stack | Done | No (first) |
 | 02 | [us-02-layout](us-02-layout.md) | Build RootLayout, TopBar with fixed positioning, content area with independent scroll | Done | Blocked by us-01 |
 | 03 | [us-03-routing](us-03-routing.md) | Build router with lazy-loaded app registration, namespaced routes, error handling, NotFoundPage | Done | Blocked by us-01 |
-| 04 | [us-04-breadcrumbs](us-04-breadcrumbs.md) | Build page-level navigation pattern: back button + breadcrumbs for drill-down pages, mobile truncation | Done | Blocked by us-02 |
+| 04 | [us-04-breadcrumbs](us-04-breadcrumbs.md) | Build page-level navigation pattern: back button + breadcrumbs for drill-down pages, mobile truncation | Partial | Blocked by us-02 |
 | 05 | [us-05-trpc-access](us-05-trpc-access.md) | Set up tRPC client in shell and establish the import pattern for app packages | Done | Blocked by us-01 |
 
 US-02 and US-03 can parallelise after US-01. US-04 depends on layout. US-05 can parallelise with US-02/US-03.

--- a/docs-v2/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
+++ b/docs-v2/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
@@ -1,7 +1,7 @@
 # US-04: Build page-level navigation (back button + breadcrumbs)
 
 > PRD: [005 — Shell](README.md)
-> Status: Done
+> Status: Partial
 
 ## Description
 
@@ -19,6 +19,7 @@ As a developer, I want a standard page header pattern with back button and bread
 - [x] On mobile, middle breadcrumb segments collapse to `…` — first and last always visible
 - [x] Top-level pages (sidebar-accessible) show neither back button nor breadcrumbs
 - [x] Back navigation is never placed at the bottom of the page
+- [ ] All drill-down pages across all apps use the shared PageHeader pattern — no inline h1 styling
 
 ## Notes
 

--- a/docs-v2/themes/01-foundation/prds/006-app-switcher/README.md
+++ b/docs-v2/themes/01-foundation/prds/006-app-switcher/README.md
@@ -87,7 +87,7 @@ With only one app registered, the switcher should not feel empty:
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-nav-types-registry](us-01-nav-types-registry.md) | Define AppNavConfig/AppNavItem types and app registry in the shell | Done | No (first) |
+| 01 | [us-01-nav-types-registry](us-01-nav-types-registry.md) | Define AppNavConfig/AppNavItem types and app registry in the shell | Partial | No (first) |
 | 02 | [us-02-app-rail](us-02-app-rail.md) | Build vertical app rail with icons, active indicator, collapse toggle | Done | Blocked by us-01 |
 | 03 | [us-03-page-nav](us-03-page-nav.md) | Build page nav panel showing active app's pages | Partial | Blocked by us-01 |
 | 04 | [us-04-layout-integration](us-04-layout-integration.md) | Integrate app rail + page nav into RootLayout, replace basic sidebar | Done | Blocked by us-02, us-03 |

--- a/docs-v2/themes/01-foundation/prds/006-app-switcher/us-01-nav-types-registry.md
+++ b/docs-v2/themes/01-foundation/prds/006-app-switcher/us-01-nav-types-registry.md
@@ -1,7 +1,7 @@
 # US-01: Define nav types and app registry
 
 > PRD: [006 — App Switcher](README.md)
-> Status: Done
+> Status: Partial
 
 ## Description
 
@@ -14,6 +14,7 @@ As a developer, I want typed nav config interfaces and a central app registry so
 - [x] Registry is the single source of truth — sidebar/rail reads from it, no hardcoded nav lists
 - [x] At least one app (finance) registered with Lucide icon references (not emoji)
 - [x] Adding a new app to the registry is a one-line import + array push
+- [ ] Icon name strings in navConfig resolve to actual icon components — missing mappings fail visibly at dev time (TypeScript error or runtime warning), not silently at render time
 
 ## Notes
 

--- a/docs-v2/themes/01-foundation/prds/007-app-theme-colour-propagation/README.md
+++ b/docs-v2/themes/01-foundation/prds/007-app-theme-colour-propagation/README.md
@@ -1,7 +1,7 @@
 # PRD-007: App Theme Colour Propagation
 
 > Epic: [02 — Shell & App Switcher](../../epics/02-shell-app-switcher.md)
-> Status: Done
+> Status: Partial
 
 ## Overview
 
@@ -74,3 +74,7 @@ No database changes. The colour is declared in the app's `navConfig` (already pa
 - The CSS variable definitions themselves (PRD-002 US-02)
 - Replacing hardcoded colours in app packages (PRD-002 US-04)
 - Per-page colour overrides within an app
+
+## Dependencies
+
+PRD-007 propagation is only effective when PRD-002 US-02 (define `--app-accent` CSS variable values) and PRD-002 US-04 (replace hardcoded colour classes with `bg-app-accent` tokens) are both complete. Without those, the shell sets variables that no component consumes.

--- a/docs-v2/themes/03-media/prds/029-tmdb-client/us-01-tmdb-http-client.md
+++ b/docs-v2/themes/03-media/prds/029-tmdb-client/us-01-tmdb-http-client.md
@@ -13,7 +13,7 @@ As a developer, I want an HTTP client for the TMDB API with a token bucket rate 
 - [ ] Token bucket rate limiter: 50 tokens capacity, refills 50 tokens every 10 seconds — **implementation uses 40 tokens/10s (matches TMDB's real limit); spec number is wrong**
 - [x] All TMDB API calls pass through the rate limiter before executing
 - [x] When the bucket is empty, requests queue and wait for available tokens — no immediate errors
-- [ ] `TMDB_API_TOKEN` read from environment; startup validation fails with a clear error if missing — **env var is `TMDB_API_KEY`; validation is lazy (returns null), not startup**
+- [ ] `TMDB_API_KEY` read from environment (matching PRD-015 secrets inventory); startup validation fails with a clear error if missing — **validation is lazy (returns null), not startup**
 - [x] `media.search.movies(query, page?)` tRPC procedure calls TMDB's `/search/movie` endpoint
 - [x] Search returns `{ results: TmdbSearchResult[], totalResults, totalPages }` with fields mapped from TMDB response
 - [x] Internal `fetchMovieDetails(tmdbId)` method calls TMDB's `/movie/{id}` endpoint with `append_to_response=images`
@@ -24,4 +24,4 @@ As a developer, I want an HTTP client for the TMDB API with a token bucket rate 
 
 ## Notes
 
-TMDB API v3 uses Bearer token auth via the `Authorization` header. The rate limiter is shared across all endpoints — a burst of search calls should delay subsequent metadata fetches if the bucket is depleted. The rate limiter should be a reusable utility, not TMDB-specific, since TheTVDB (PRD-030) needs its own instance.
+TMDB API v3 uses Bearer token auth via the `Authorization` header. The env var name `TMDB_API_KEY` matches the secrets inventory in PRD-015. The rate limiter is shared across all endpoints — a burst of search calls should delay subsequent metadata fetches if the bucket is depleted. The rate limiter should be a reusable utility, not TMDB-specific, since TheTVDB (PRD-030) needs its own instance.

--- a/docs-v2/themes/03-media/prds/037-ratings-comparisons/README.md
+++ b/docs-v2/themes/03-media/prds/037-ratings-comparisons/README.md
@@ -114,8 +114,9 @@ Build a pairwise comparison system per [ADR-010](../../../../architecture/adr-01
 | 03 | [us-03-rankings-page](us-03-rankings-page.md) | Rankings page with dimension selector, ranked list (poster, title, score, count), overall average | Partial | Yes (parallel with us-01) |
 | 04 | [us-04-dimension-management](us-04-dimension-management.md) | CRUD for comparison dimensions, active/inactive toggle, sort order | Partial | Yes |
 | 05 | [us-05-quick-pick](us-05-quick-pick.md) | Quick pick page with random unwatched movies, configurable count, "Watch This" action | Partial | Yes |
+| 06 | [us-06-comparison-history](us-06-comparison-history.md) | Comparison history list, delete with Elo recalculation, undo toast, dimension filter | Not started | Yes |
 
-US-01 depends on US-02 (arena needs Elo scoring to record comparisons). US-03, US-04, and US-05 can all be built in parallel.
+US-01 depends on US-02 (arena needs Elo scoring to record comparisons). US-03, US-04, US-05, and US-06 can all be built in parallel.
 
 ## Verification
 

--- a/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-06-comparison-history.md
+++ b/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-06-comparison-history.md
@@ -1,0 +1,25 @@
+# US-06: Comparison history and delete
+
+> PRD: [037 — Ratings & Comparisons](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want to see my past comparisons and undo mistakes so that a misclick doesn't permanently skew my rankings.
+
+## Acceptance Criteria
+
+- [ ] Comparison history page or section accessible from the compare arena or rankings page
+- [ ] History shows: both items compared (poster + title), winner, dimension, date
+- [ ] History ordered by date DESC (most recent first)
+- [ ] Pagination or infinite scroll for long history
+- [ ] Delete button per comparison with confirmation dialog
+- [ ] On delete, Elo scores are recalculated — both items' scores for that dimension are recomputed from remaining comparisons
+- [ ] Undo toast after delete (5-second window to reverse the deletion before recalculation commits)
+- [ ] Filter by dimension (dropdown matching the rankings dimension selector)
+- [ ] Empty state: "No comparisons yet" with CTA to compare arena
+- [ ] Tests cover: history list, delete with Elo recalculation, undo, filter by dimension
+
+## Notes
+
+Elo recalculation on delete is not trivial — the simplest approach is to replay all remaining comparisons for the affected dimension in chronological order from the starting score (1500). This is acceptable given the expected volume (hundreds, not millions). Alternative: just subtract the Elo delta from the deletion, which is faster but less accurate if many comparisons exist.

--- a/docs-v2/themes/03-media/prds/039-plex-sync/us-01-plex-auth.md
+++ b/docs-v2/themes/03-media/prds/039-plex-sync/us-01-plex-auth.md
@@ -9,7 +9,7 @@ As a user, I want to authenticate with my Plex account using a PIN code so that 
 
 ## Acceptance Criteria
 
-- [x] `media.plex.getAuthPin()` requests a PIN from the Plex API and returns `{ id, code, clientId }`
+- [x] `media.plex.getAuthPin()` requests a PIN from the Plex API with `strong=false` (4-digit numeric code for plex.tv/link) and returns `{ id, code, clientId }`
 - [x] PIN response includes a unique client identifier that persists across sessions
 - [x] `media.plex.checkAuthPin(id)` polls the Plex API to check if the PIN has been claimed
 - [x] When the PIN is claimed, the auth token is extracted from the Plex response
@@ -25,3 +25,5 @@ As a user, I want to authenticate with my Plex account using a PIN code so that 
 ## Notes
 
 The Plex PIN-based OAuth flow uses three Plex API endpoints: POST to create a PIN, GET to check PIN status, and the resulting auth token for subsequent API calls. The client identifier should be a UUID generated once and stored alongside the token — Plex uses it to identify the POPS application. Poll interval for `checkAuthPin` should be ~2 seconds. The token does not expire but can be revoked by the user from their Plex account settings.
+
+Plex offers two PIN flows: `strong=false` returns a 4-digit numeric code for manual entry at plex.tv/link; `strong=true` returns a long alphanumeric code for OAuth redirect flow. Use `strong=false` — the manual entry UX is simpler and doesn't require popup handling.

--- a/docs-v2/themes/03-media/prds/040-arr-status-display/us-01-arr-base-client.md
+++ b/docs-v2/themes/03-media/prds/040-arr-status-display/us-01-arr-base-client.md
@@ -15,7 +15,7 @@ As a developer, I want a shared HTTP client factory for Radarr and Sonarr with i
 - [ ] Cache is keyed by full URL (base URL + path) so Radarr and Sonarr caches do not collide — service caches keyed by tmdbId/tvdbId, not full URL
 - [ ] `clearCache()` method flushes all cached entries for a client instance — `clearStatusCache()` exists in service but not on client; not called on settings save
 - [x] Client handles connection errors gracefully — returns stale cache on connection failure; never throws unhandled exceptions
-- [ ] Connection timeout set to 5 seconds — no timeout configured on `fetch()`
+- [ ] Connection timeout configurable per service (default 10s) — current implementation has no timeout on `fetch()`
 - [x] `radarr_url`, `radarr_api_key`, `sonarr_url`, `sonarr_api_key` entries stored in the `settings` table
 - [x] tRPC procedures: `media.arr.getConfig()` returns configured/connected status
 - [x] tRPC procedure: `media.arr.getSettings()` returns URLs and whether API keys are set, never actual key values

--- a/docs-v2/themes/03-media/prds/040-arr-status-display/us-03-arr-settings.md
+++ b/docs-v2/themes/03-media/prds/040-arr-status-display/us-03-arr-settings.md
@@ -20,7 +20,9 @@ As a user, I want a settings page to configure Radarr and Sonarr connections so 
 - [x] On failed test, displays error message
 - [x] "Save" button calls saveSettings — masked placeholder (`••••••••`) preserved, not overwritten
 - [x] Save provides success feedback
-- [ ] Form validates that URLs start with `http://` or `https://` before allowing save — no URL validation implemented (only placeholder text)
+- [ ] Saving one service preserves unsaved changes in the other — each service section has independent form state
+- [ ] URLs without a protocol prefix are auto-normalized to `https://` on save — not rejected with a validation error
+- [ ] Failed connection test on http suggests trying https
 - [x] Page loads current settings via `getSettings()` on mount
 - [x] Tests verify: load on mount, save payload, key preservation, test connection success/failure
 


### PR DESCRIPTION
## Summary

Fixes spec gaps that caused 15 bugs found during manual testing (GH-979 through GH-993).

- PRD-040: Arr settings independent form state, URL normalization, configurable timeout
- PRD-029: Fix env var name mismatch with secrets inventory
- PRD-039: Specify Plex PIN flow (strong=false for plex.tv/link)
- PRD-002: Require custom Tailwind utilities defined in @theme block
- PRD-005: Require shared PageHeader across all pages
- PRD-006: Require icon name → component mapping with visible failures
- PRD-007: Revert Done → Partial (dependency on PRD-002 US-02/04 not met)
- PRD-037: New US-06 for comparison history with delete and Elo recalculation

## Test plan

- [ ] All modified files follow US/PRD template format
- [ ] New US-06 has testable acceptance criteria
- [ ] Status changes cascade correctly (US → PRD table → PRD status)