### PR TITLE
fix(ui): reduce ViewToggleGroup button size and center icons

### DIFF
--- a/packages/ui/src/components/ViewToggleGroup.tsx
+++ b/packages/ui/src/components/ViewToggleGroup.tsx
@@ -88,7 +88,7 @@ export function ViewToggleGroup<T extends string>({
           aria-label={option.label}
           onClick={() => handleChange(option.value)}
           className={cn(
-            "rounded-md p-1.5 min-h-11 min-w-11 transition-all",
+            "flex items-center justify-center rounded-md p-1.5 min-h-8 min-w-8 transition-all",
             activeValue === option.value
               ? "bg-background text-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground",


### PR DESCRIPTION
## Summary
- Reduced ViewToggleGroup button min size from 44px (`min-h-11`/`min-w-11`) to 32px (`min-h-8`/`min-w-8`)
- Added `flex items-center justify-center` to properly center icons within buttons

Fixes #974

## Test plan
- [ ] Verify tile/list toggle buttons are correctly sized on inventory pages
- [ ] Verify icons are centered within toggle buttons
- [ ] Check both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)