### PR TITLE
fix(inventory): swap asset ID and category badge positions on InventoryCard

### DIFF
--- a/packages/app-inventory/src/components/InventoryCard.tsx
+++ b/packages/app-inventory/src/components/InventoryCard.tsx
@@ -101,10 +101,10 @@ export function InventoryCard({
             </div>
           )}
 
-          {/* Type badge overlay */}
-          {type && (
+          {/* Asset ID badge overlay */}
+          {assetId && (
             <div className="absolute top-2 left-2">
-              <TypeBadge type={type} />
+              <AssetIdBadge assetId={assetId} />
             </div>
           )}
         </div>
@@ -113,9 +113,9 @@ export function InventoryCard({
         <div className="flex min-w-0 flex-1 flex-col gap-1 p-3">
           <h3 className="text-sm font-semibold leading-tight line-clamp-2">{itemName}</h3>
 
-          {assetId && (
+          {type && (
             <div className="flex items-center">
-              <AssetIdBadge assetId={assetId} />
+              <TypeBadge type={type} />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Moved AssetIdBadge (e.g. `BIKE-001`) to image overlay position (top-left)
- Moved TypeBadge (category like `Electronics`) to content area below the item name
- Matches the desired visual hierarchy where the item code is prominent on the image

Fixes #975

## Test plan
- [ ] Verify asset ID badge appears as overlay on the card image
- [ ] Verify category/type badge appears in the content area below name
- [ ] Check both vertical and horizontal layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)