### PR TITLE
fix: default Include sub-locations toggle to true (#971)

### DIFF
--- a/packages/app-inventory/src/components/LocationContentsPanel.tsx
+++ b/packages/app-inventory/src/components/LocationContentsPanel.tsx
@@ -52,7 +52,7 @@ export function LocationContentsPanel({
   node,
 }: LocationContentsPanelProps) {
   const navigate = useNavigate();
-  const [includeSubLocations, setIncludeSubLocations] = useState(false);
+  const [includeSubLocations, setIncludeSubLocations] = useState(true);
 
   const descendantIds = useMemo(() => collectDescendantIds(node), [node]);
   const hasSubLocations = descendantIds.length > 0;


### PR DESCRIPTION
## Summary
- Changes the "Include sub-locations" toggle default from `false` to `true` in `LocationContentsPanel`
- Users expect to see all items including sub-locations when viewing a location

Closes #971

## Test plan
- [x] Typecheck passes
- [x] Prettier formatting verified
- [ ] QA: verify sub-locations toggle is checked by default on Locations page

🤖 Generated with [Claude Code](https://claude.com/claude-code)