### PR TITLE
fix(media): prevent Arr settings wipe when saving one service

### DIFF
--- a/packages/app-media/src/pages/ArrSettingsPage.tsx
+++ b/packages/app-media/src/pages/ArrSettingsPage.tsx
@@ -158,7 +158,6 @@ export function ArrSettingsPage() {
   const saveSettings = trpc.media.arr.saveSettings.useMutation({
     onSuccess: () => {
       toast.success("Settings saved");
-      settingsQuery.refetch();
     },
     onError: (err: { message: string }) => toast.error(`Failed to save: ${err.message}`),
   });


### PR DESCRIPTION
## Summary
- Removed `settingsQuery.refetch()` from save `onSuccess` callback
- The refetch was triggering the `useEffect` to reset ALL field state, wiping unsaved changes in the other service (e.g., saving Radarr would wipe unsaved Sonarr fields)
- Local state already holds the correct values after save; initial load `useEffect` handles first-time population

Fixes #979

## Test plan
- [ ] Enter Radarr URL + key, then enter Sonarr URL + key (don't save yet)
- [ ] Save Radarr — Sonarr fields should still have their unsaved values
- [ ] Save Sonarr — both services should be saved correctly
- [ ] Refresh page — both saved values should load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)