### PR TITLE
fix: increase movie list limit max from 500 to 1000 (#984)

### DIFF
--- a/apps/pops-api/src/modules/media/movies/types.ts
+++ b/apps/pops-api/src/modules/media/movies/types.ts
@@ -151,7 +151,7 @@ export type UpdateMovieInput = z.infer<typeof UpdateMovieSchema>;
 export const MovieQuerySchema = z.object({
   search: z.string().optional(),
   genre: z.string().optional(),
-  limit: z.coerce.number().positive().max(500).optional(),
+  limit: z.coerce.number().positive().max(1000).optional(),
   offset: z.coerce.number().nonnegative().optional(),
 });
 export type MovieQueryRaw = z.infer<typeof MovieQuerySchema>;


### PR DESCRIPTION
## Summary
- Root cause: `SearchPage.tsx` calls `media.movies.list` with `limit: 1000` for "In Library" detection, but `MovieQuerySchema` capped at `max(500)`, returning 400
- Fix: increase max from 500 to 1000 in `MovieQuerySchema` to match `TvShowQuerySchema` (which has no cap)

Closes #984

## Test plan
- [x] Typecheck passes
- [x] Prettier formatting verified
- [ ] QA: verify movie list loads without 400 error
- [ ] QA: verify search page "In Library" detection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)