### PR TITLE
fix(ui): add explicit text-2xs utility for Tailwind v4

### DIFF
--- a/packages/ui/src/theme/globals.css
+++ b/packages/ui/src/theme/globals.css
@@ -345,6 +345,14 @@
   }
 }
 
+/* Utility: micro-typography (badges, table headers, stat labels)
+ * The @theme --font-size-2xs token is not generating a text-2xs utility
+ * in Tailwind v4.0.14, so we define it explicitly here. */
+@utility text-2xs {
+  font-size: var(--font-size-2xs, 0.625rem);
+  line-height: var(--font-size-2xs--line-height, 0.75rem);
+}
+
 /* Utility: force tabular figures (financial data, counters, dashboards) */
 @utility tabular-nums {
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## Summary
- The `--font-size-2xs` token in `@theme` was not generating a `.text-2xs` utility class in Tailwind v4.0.14 builds
- All 14 usages across badges, table headers, stat labels, and filters were silently falling back to browser defaults, causing oversized typography
- Adds an explicit `@utility text-2xs` definition that references the existing `@theme` variables as a reliable fallback

Closes GH-978

## Test plan
- [x] UI tests pass (18/18)
- [ ] Verify `text-2xs` elements render at 10px in both light and dark mode
- [ ] Check StatCard titles, DataTable headers, filter labels, badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)