### PR TITLE
fix: remove ValueByLocationCard tile from items page [tb-030]

### DIFF
--- a/packages/app-inventory/src/components/ValueBreakdown.test.tsx
+++ b/packages/app-inventory/src/components/ValueBreakdown.test.tsx
@@ -14,7 +14,11 @@ vi.mock("recharts", async () => {
         "div",
         { "data-testid": "bar-chart" },
         data.map((entry: BreakdownEntry) =>
-          React.createElement("div", { key: entry.name, "data-testid": `bar-${entry.name}` }, entry.name)
+          React.createElement(
+            "div",
+            { key: entry.name, "data-testid": `bar-${entry.name}` },
+            entry.name
+          )
         ),
         children
       ),
@@ -29,7 +33,8 @@ vi.mock("recharts", async () => {
         "div",
         {
           "data-testid": "bar",
-          onClick: () => onClick?.({ name: "Electronics", key: "loc-1", totalValue: 5000, itemCount: 10 }),
+          onClick: () =>
+            onClick?.({ name: "Electronics", key: "loc-1", totalValue: 5000, itemCount: 10 }),
         },
         children
       ),
@@ -50,31 +55,23 @@ vi.mock("react-router", async () => {
 });
 
 const mockValueByTypeQuery = vi.fn();
-const mockValueByLocationQuery = vi.fn();
 
 vi.mock("../lib/trpc", () => ({
   trpc: {
     inventory: {
       reports: {
         valueByType: { useQuery: () => mockValueByTypeQuery() },
-        valueByLocation: { useQuery: () => mockValueByLocationQuery() },
       },
     },
   },
 }));
 
 // Import after mocks
-import { ValueByTypeCard, ValueByLocationCard } from "./ValueBreakdown";
+import { ValueByTypeCard } from "./ValueBreakdown";
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockValueByTypeQuery.mockReturnValue({
-    data: { data: [] },
-    isLoading: false,
-    isError: false,
-    refetch: vi.fn(),
-  });
-  mockValueByLocationQuery.mockReturnValue({
     data: { data: [] },
     isLoading: false,
     isError: false,
@@ -103,9 +100,7 @@ describe("BreakdownChart", () => {
   });
 
   it("calls onBarClick when bar is clicked", () => {
-    const data: BreakdownEntry[] = [
-      { name: "Electronics", totalValue: 5000, itemCount: 10 },
-    ];
+    const data: BreakdownEntry[] = [{ name: "Electronics", totalValue: 5000, itemCount: 10 }];
     const onClick = vi.fn();
     renderWithRouter(<BreakdownChart data={data} onBarClick={onClick} />);
     fireEvent.click(screen.getByTestId("bar"));
@@ -179,89 +174,5 @@ describe("ValueByTypeCard", () => {
     renderWithRouter(<ValueByTypeCard />);
     fireEvent.click(screen.getByTestId("bar"));
     expect(mockNavigate).toHaveBeenCalledWith("/inventory?type=Electronics");
-  });
-});
-
-describe("ValueByLocationCard", () => {
-  it("renders 'Value by Location' heading", () => {
-    renderWithRouter(<ValueByLocationCard />);
-    expect(screen.getByText("Value by Location")).toBeInTheDocument();
-  });
-
-  it("renders loading skeleton", () => {
-    mockValueByLocationQuery.mockReturnValue({
-      data: null,
-      isLoading: true,
-      isError: false,
-      refetch: vi.fn(),
-    });
-    renderWithRouter(<ValueByLocationCard />);
-    expect(document.querySelector(".animate-pulse")).toBeInTheDocument();
-  });
-
-  it("shows empty message when no locations have values", () => {
-    renderWithRouter(<ValueByLocationCard />);
-    expect(screen.getByText("No items with replacement values")).toBeInTheDocument();
-  });
-
-  it("renders error state with retry button", () => {
-    const refetch = vi.fn();
-    mockValueByLocationQuery.mockReturnValue({
-      data: null,
-      isLoading: false,
-      isError: true,
-      refetch,
-    });
-    renderWithRouter(<ValueByLocationCard />);
-    expect(screen.getByText("Failed to load location breakdown")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
-    expect(refetch).toHaveBeenCalled();
-  });
-
-  it("renders location entries", () => {
-    mockValueByLocationQuery.mockReturnValue({
-      data: {
-        data: [
-          { name: "Living Room", totalValue: 8000, itemCount: 12, key: "loc-1" },
-          { name: "Office", totalValue: 5000, itemCount: 8, key: "loc-2" },
-        ],
-      },
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    });
-    renderWithRouter(<ValueByLocationCard />);
-    expect(screen.getByTestId("bar-Living Room")).toBeInTheDocument();
-    expect(screen.getByTestId("bar-Office")).toBeInTheDocument();
-  });
-
-  it("navigates to filtered inventory by locationId on bar click", () => {
-    mockValueByLocationQuery.mockReturnValue({
-      data: {
-        data: [{ name: "Living Room", totalValue: 8000, itemCount: 12, key: "loc-1" }],
-      },
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    });
-    renderWithRouter(<ValueByLocationCard />);
-    fireEvent.click(screen.getByTestId("bar"));
-    expect(mockNavigate).toHaveBeenCalledWith("/inventory?locationId=loc-1");
-  });
-
-  it("does not navigate for Unassigned locations (no key)", () => {
-    mockValueByLocationQuery.mockReturnValue({
-      data: {
-        data: [{ name: "Unassigned", totalValue: 2000, itemCount: 3, key: null }],
-      },
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    });
-    renderWithRouter(<ValueByLocationCard />);
-    // The mock Bar click sends key: "loc-1" which is truthy, so this tests the component's
-    // handling. In reality, the entry with key: null would not navigate.
-    // We verify the component renders correctly.
-    expect(screen.getByTestId("bar-Unassigned")).toBeInTheDocument();
   });
 });

--- a/packages/app-inventory/src/components/ValueBreakdown.tsx
+++ b/packages/app-inventory/src/components/ValueBreakdown.tsx
@@ -3,7 +3,7 @@
  * grouped by item type or location.
  */
 import { Alert, AlertDescription, Button, Card, CardContent, Skeleton } from "@pops/ui";
-import { AlertCircle, MapPin, RefreshCw, Tag } from "lucide-react";
+import { AlertCircle, RefreshCw, Tag } from "lucide-react";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts";
 import { useNavigate } from "react-router";
 import { trpc } from "../lib/trpc";
@@ -139,62 +139,6 @@ export function ValueByTypeCard({ className }: { className?: string }) {
           <BreakdownChart
             data={typeEntries}
             onBarClick={(entry) => navigate(`/inventory?type=${encodeURIComponent(entry.name)}`)}
-          />
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-export function ValueByLocationCard({ className }: { className?: string }) {
-  const navigate = useNavigate();
-
-  const {
-    data: locationData,
-    isLoading: locationLoading,
-    isError: locationError,
-    refetch: refetchLocation,
-  } = trpc.inventory.reports.valueByLocation.useQuery();
-
-  if (locationLoading) {
-    return (
-      <Card className={className}>
-        <CardContent className="p-4 space-y-2">
-          <Skeleton className="h-4 w-32" />
-          <Skeleton className="h-40 w-full" />
-        </CardContent>
-      </Card>
-    );
-  }
-
-  const locationEntries: BreakdownEntry[] = locationData?.data ?? [];
-
-  return (
-    <Card className={className}>
-      <CardContent className="p-4">
-        <div className="flex items-center gap-2 text-muted-foreground mb-3">
-          <MapPin className="h-4 w-4" />
-          <span className="text-xs font-medium">Value by Location</span>
-        </div>
-        {locationError ? (
-          <Alert variant="destructive">
-            <AlertCircle className="h-4 w-4" />
-            <AlertDescription className="flex items-center justify-between gap-2">
-              <span>Failed to load location breakdown</span>
-              <Button variant="outline" size="sm" onClick={() => refetchLocation()}>
-                <RefreshCw className="h-3 w-3 mr-1" />
-                Retry
-              </Button>
-            </AlertDescription>
-          </Alert>
-        ) : (
-          <BreakdownChart
-            data={locationEntries}
-            onBarClick={(entry) => {
-              if (entry.key) {
-                navigate(`/inventory?locationId=${encodeURIComponent(entry.key)}`);
-              }
-            }}
           />
         )}
       </CardContent>

--- a/packages/app-inventory/src/pages/ItemsPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.test.tsx
@@ -45,7 +45,6 @@ vi.mock("../components/InventoryCard", () => ({
 
 vi.mock("../components/ValueBreakdown", () => ({
   ValueByTypeCard: () => <div data-testid="value-by-type" />,
-  ValueByLocationCard: () => <div data-testid="value-by-location" />,
 }));
 
 import { ItemsPage } from "./ItemsPage";

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -29,7 +29,7 @@ import type { Condition } from "@pops/ui";
 import { trpc } from "../lib/trpc";
 import { InventoryTable } from "../components/InventoryTable";
 import { InventoryCard } from "../components/InventoryCard";
-import { ValueByTypeCard, ValueByLocationCard } from "../components/ValueBreakdown";
+import { ValueByTypeCard } from "../components/ValueBreakdown";
 import { formatCurrency } from "../lib/utils";
 type ViewMode = "table" | "grid";
 
@@ -204,7 +204,6 @@ function DashboardWidgets() {
       </Card>
 
       <ValueByTypeCard className="col-span-2" />
-      <ValueByLocationCard className="col-span-2" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Removes the "Value by Location" chart card from the inventory items dashboard (GH-972)
- Removes `ValueByLocationCard` component from `ValueBreakdown.tsx`
- Removes associated tests and mocks from `ValueBreakdown.test.tsx` and `ItemsPage.test.tsx`

## Test plan
- [x] Typecheck passes
- [ ] Verify items page renders without the location card
- [ ] Verify remaining "Value by Type" card still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)