### PR TITLE
fix(shell): add Settings and BookOpen icons to nav icon map

### DIFF
--- a/apps/pops-shell/src/app/nav/icon-map.ts
+++ b/apps/pops-shell/src/app/nav/icon-map.ts
@@ -28,6 +28,8 @@ import {
   FileText,
   ShieldCheck,
   MapPin,
+  Settings,
+  BookOpen,
   type LucideIcon,
 } from "lucide-react";
 
@@ -53,4 +55,6 @@ export const iconMap: Record<string, LucideIcon> = {
   FileText,
   ShieldCheck,
   MapPin,
+  Settings,
+  BookOpen,
 };


### PR DESCRIPTION
## Summary
- Added `Settings` and `BookOpen` Lucide icons to the shell's `icon-map.ts`
- AI app nav items for "Model Config" (`Settings`) and "Rules" (`BookOpen`) were referencing these icons but they weren't in the map, so no icons were rendering

Fixes #991

## Test plan
- [ ] Verify Model Config menu item now shows a gear/settings icon
- [ ] Verify Rules menu item now shows a book icon
- [ ] Verify all other nav icons still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)