### PR TITLE
fix: add leading slash to AI nav item paths (#990)

### DIFF
--- a/packages/app-ai/src/routes.tsx
+++ b/packages/app-ai/src/routes.tsx
@@ -47,9 +47,9 @@ export const navConfig: AppNavConfig = {
   basePath: "/ai",
   items: [
     { path: "", label: "AI Usage", icon: "BarChart3" },
-    { path: "prompts", label: "Prompt Templates", icon: "FileText" },
-    { path: "config", label: "Model Config", icon: "Settings" },
-    { path: "rules", label: "Rules", icon: "BookOpen" },
+    { path: "/prompts", label: "Prompt Templates", icon: "FileText" },
+    { path: "/config", label: "Model Config", icon: "Settings" },
+    { path: "/rules", label: "Rules", icon: "BookOpen" },
   ],
 };
 


### PR DESCRIPTION
## Summary
- AI nav items used paths like `"prompts"` while all other apps use `"/prompts"` with a leading slash
- `PageNav` constructs `fullPath` as `basePath + path`, producing `/aiprompts` instead of `/ai/prompts`
- This caused 404s for Prompt Templates, Model Config, and Rules pages

Closes #990

## Test plan
- [x] Prettier formatting verified
- [ ] QA: navigate to AI > Prompt Templates, Model Config, Rules — all should load
- [ ] QA: verify nav links show correct URLs (`/ai/prompts`, `/ai/config`, `/ai/rules`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)