### PR TITLE
fix: rename TMDB_API_TOKEN to TMDB_API_KEY (#983)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ CLOUDFLARE_TUNNEL_TOKEN=
 
 # Media Metadata Providers
 # TMDB: Get a Read-Access Token (v4 auth) from https://www.themoviedb.org/settings/api
-TMDB_API_TOKEN=
+TMDB_API_KEY=
 # TheTVDB: Get an API Key from https://thetvdb.com/dashboard/account/apikey
 THETVDB_API_KEY=
 
@@ -34,7 +34,7 @@ PAPERLESS_API_TOKEN=
 
 # Media Metadata Providers
 # TMDB: Get a Read-Access Token (v4 auth) from https://www.themoviedb.org/settings/api
-TMDB_API_TOKEN=
+TMDB_API_KEY=
 
 # TheTVDB: Get an API Key from https://thetvdb.com/dashboard/account/apikey
 THETVDB_API_KEY=

--- a/apps/pops-api/.env.example
+++ b/apps/pops-api/.env.example
@@ -15,7 +15,7 @@ MEDIA_IMAGES_DIR=./data/media/images
 
 # Media Metadata Providers
 # TMDB: Get a Read-Access Token (v4 auth) from https://www.themoviedb.org/settings/api
-TMDB_API_TOKEN=your_tmdb_v4_token_here
+TMDB_API_KEY=your_tmdb_v4_token_here
 
 # TheTVDB: Get an API Key from https://thetvdb.com/dashboard/account/apikey
 THETVDB_API_KEY=your_thetvdb_api_key_here

--- a/apps/pops-api/src/modules/media/library/library.test.ts
+++ b/apps/pops-api/src/modules/media/library/library.test.ts
@@ -23,7 +23,7 @@ vi.mock("../tmdb/image-cache.js", () => ({
 }));
 
 // Set the env var before the router module loads
-vi.stubEnv("TMDB_API_TOKEN", "test-api-key");
+vi.stubEnv("TMDB_API_KEY", "test-api-key");
 
 const ctx = setupTestContext();
 let caller: ReturnType<typeof createCaller>;

--- a/apps/pops-api/src/modules/media/library/service.test.ts
+++ b/apps/pops-api/src/modules/media/library/service.test.ts
@@ -29,8 +29,8 @@ let db: Database;
 
 beforeEach(() => {
   ({ caller, db } = ctx.setup());
-  // Set TMDB_API_TOKEN so the router can create a client
-  vi.stubEnv("TMDB_API_TOKEN", "test-api-key");
+  // Set TMDB_API_KEY so the router can create a client
+  vi.stubEnv("TMDB_API_KEY", "test-api-key");
 });
 
 afterEach(() => {

--- a/apps/pops-api/src/modules/media/plex/sync-movies.test.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-movies.test.ts
@@ -140,11 +140,11 @@ beforeEach(() => {
 describe("importMoviesFromPlex", () => {
   it("throws when TMDB client is not configured", async () => {
     mockGetTmdbClient.mockImplementation(() => {
-      throw new Error("TMDB_API_TOKEN is not configured");
+      throw new Error("TMDB_API_KEY is not configured");
     });
     const client = makePlexClient([]);
 
-    await expect(importMoviesFromPlex(client, "1")).rejects.toThrow("TMDB_API_TOKEN");
+    await expect(importMoviesFromPlex(client, "1")).rejects.toThrow("TMDB_API_KEY");
     expect(client.getAllItems).not.toHaveBeenCalled();
   });
 

--- a/apps/pops-api/src/modules/media/search/router.test.ts
+++ b/apps/pops-api/src/modules/media/search/router.test.ts
@@ -10,7 +10,7 @@ let caller: ReturnType<typeof createCaller>;
 
 beforeEach(() => {
   ({ caller } = ctx.setup());
-  vi.stubEnv("TMDB_API_TOKEN", "test-tmdb-key");
+  vi.stubEnv("TMDB_API_KEY", "test-tmdb-key");
   vi.stubEnv("THETVDB_API_KEY", "test-tvdb-key");
 });
 

--- a/apps/pops-api/src/modules/media/tmdb/index.ts
+++ b/apps/pops-api/src/modules/media/tmdb/index.ts
@@ -14,13 +14,13 @@ const tmdbRateLimiter = new TokenBucketRateLimiter(40, 4);
 
 /**
  * Shared TMDB client factory — reuses a single rate limiter across all routers.
- * Throws immediately with a clear error if TMDB_API_TOKEN is not set.
+ * Throws immediately with a clear error if TMDB_API_KEY is not set.
  */
 export function getTmdbClient(): TmdbClient {
-  const apiToken = getEnv("TMDB_API_TOKEN");
+  const apiToken = getEnv("TMDB_API_KEY");
   if (!apiToken) {
     throw new Error(
-      "TMDB_API_TOKEN is not configured. Set it in .env (development) or Docker secrets (production)."
+      "TMDB_API_KEY is not configured. Set it in .env (development) or Docker secrets (production)."
     );
   }
   return new TmdbClient(apiToken, tmdbRateLimiter);

--- a/docs-v2/themes/03-media/prds/029-tmdb-client/README.md
+++ b/docs-v2/themes/03-media/prds/029-tmdb-client/README.md
@@ -58,7 +58,7 @@ No new tables — uses the `movies` table from PRD-028. Image paths written to `
 - Token bucket algorithm: 50 tokens capacity, refills at 50 tokens per 10 seconds
 - Shared across all TMDB API calls (search, metadata fetch, image download)
 - When bucket is empty, requests queue until tokens are available — no errors thrown for rate limiting
-- TMDB_API_TOKEN environment variable required
+- TMDB_API_KEY environment variable required
 
 ## Business Rules
 


### PR DESCRIPTION
## Summary
- Production Docker secret is `TMDB_API_KEY` but code read `TMDB_API_TOKEN`
- This broke movie search, discovery, and all TMDB features with "TMDB_API_TOKEN is not configured"
- Renamed across: tmdb/index.ts, .env.example (root + api), 4 test files, 1 PRD doc
- Also resolves GH-982 (movie search 500) which had the same root cause

Closes #983

## Test plan
- [x] No remaining TMDB_API_TOKEN references in codebase
- [x] Test stubs updated to use TMDB_API_KEY
- [ ] QA: verify movie search, discovery, and TMDB features work in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)