### PR TITLE
fix: add error detail logging to insurance report endpoint [tb-028]

### DIFF
--- a/apps/pops-api/src/modules/inventory/reports/router.ts
+++ b/apps/pops-api/src/modules/inventory/reports/router.ts
@@ -39,9 +39,11 @@ export const reportsRouter = router({
         });
         return { data: result };
       } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        console.error("[insurance-report] Failed:", detail, err);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
-          message: "Failed to generate insurance report",
+          message: `Failed to generate insurance report: ${detail}`,
           cause: err,
         });
       }
@@ -52,9 +54,11 @@ export const reportsRouter = router({
     try {
       return { data: service.getValueByLocation() };
     } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error("[value-by-location] Failed:", detail, err);
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",
-        message: "Failed to load value by location breakdown",
+        message: `Failed to load value by location breakdown: ${detail}`,
         cause: err,
       });
     }
@@ -65,9 +69,11 @@ export const reportsRouter = router({
     try {
       return { data: service.getValueByType() };
     } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error("[value-by-type] Failed:", detail, err);
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",
-        message: "Failed to load value by type breakdown",
+        message: `Failed to load value by type breakdown: ${detail}`,
         cause: err,
       });
     }


### PR DESCRIPTION
## Summary
- Insurance report endpoint (GH-970) returns 500 with no useful error details
- Added `console.error` logging with the actual error message to help debug the root cause
- The TRPC error response now includes the underlying error detail instead of a generic message
- Applied same improvement to `valueByLocation` and `valueByType` endpoints for consistency

## Test plan
- [x] Typecheck passes
- [x] Prettier check passes
- [ ] Trigger the insurance report endpoint and verify error details are now visible in server logs and response

🤖 Generated with [Claude Code](https://claude.com/claude-code)