### PR TITLE
fix(media): use strong=false for Plex PIN to get 4-digit code

### DIFF
--- a/apps/pops-api/src/modules/media/plex/router.ts
+++ b/apps/pops-api/src/modules/media/plex/router.ts
@@ -215,7 +215,7 @@ export const plexRouter = router({
 
   getAuthPin: protectedProcedure.mutation(async () => {
     const clientId = plexService.getPlexClientId();
-    const res = await fetch("https://plex.tv/api/v2/pins?strong=true", {
+    const res = await fetch("https://plex.tv/api/v2/pins?strong=false", {
       method: "POST",
       headers: {
         Accept: "application/json",


### PR DESCRIPTION
## Summary
- Changed `strong=true` to `strong=false` in Plex PIN creation API call
- `strong=true` returns a long OAuth code (e.g. `ey1cqii00fngmx78hx19h1bl7`) incompatible with `plex.tv/link`
- `strong=false` returns the 4-digit PIN that `plex.tv/link` expects

Fixes #988

## Test plan
- [ ] Click "Connect to Plex" — should receive a 4-digit PIN
- [ ] Enter PIN at plex.tv/link — auth should complete
- [ ] Verify polling detects successful auth and saves token

🤖 Generated with [Claude Code](https://claude.com/claude-code)