### PR TITLE
fix: show error details when Arr test connection fails [tb-038]

### DIFF
--- a/apps/pops-api/src/modules/media/arr/base-client.ts
+++ b/apps/pops-api/src/modules/media/arr/base-client.ts
@@ -15,7 +15,7 @@ interface CacheEntry {
 }
 
 const CACHE_TTL_MS = 30_000;
-const CONNECTION_TIMEOUT_MS = 5_000;
+const CONNECTION_TIMEOUT_MS = 10_000;
 
 export class ArrBaseClient {
   protected readonly baseUrl: string;

--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -12,7 +12,7 @@ export const arrRouter = router({
   testRadarr: protectedProcedure.query(async () => {
     const client = arrService.getRadarrClient();
     if (!client) {
-      return { data: { configured: false, connected: false } };
+      return { data: { configured: false, connected: false, error: "Radarr is not configured" } };
     }
 
     try {
@@ -32,7 +32,7 @@ export const arrRouter = router({
   testSonarr: protectedProcedure.query(async () => {
     const client = arrService.getSonarrClient();
     if (!client) {
-      return { data: { configured: false, connected: false } };
+      return { data: { configured: false, connected: false, error: "Sonarr is not configured" } };
     }
 
     try {

--- a/packages/app-media/src/pages/ArrSettingsPage.tsx
+++ b/packages/app-media/src/pages/ArrSettingsPage.tsx
@@ -18,15 +18,7 @@ import {
   BreadcrumbSeparator,
   BreadcrumbPage,
 } from "@pops/ui";
-import {
-  ArrowLeft,
-  CheckCircle2,
-  XCircle,
-  RefreshCw,
-  Film,
-  Tv,
-  Save,
-} from "lucide-react";
+import { ArrowLeft, CheckCircle2, XCircle, RefreshCw, Film, Tv, Save } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
 
@@ -132,8 +124,8 @@ function ServiceCard({
       {testResult?.connected && testResult.version && (
         <p className="text-xs text-emerald-400">Connected — v{testResult.version}</p>
       )}
-      {testResult && !testResult.connected && testResult.error && (
-        <p className="text-xs text-red-400">{testResult.error}</p>
+      {testResult && !testResult.connected && (
+        <p className="text-xs text-red-400">{testResult.error ?? "Connection failed"}</p>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Backend: return descriptive error messages when Radarr/Sonarr is not configured (previously returned no `error` field)
- Frontend: always show error text when disconnected, with "Connection failed" fallback if error is undefined
- Increased connection timeout from 5s to 10s for slower network setups (helix reported Sonarr hitting the 5s timeout)

## Root cause
The `testRadarr`/`testSonarr` endpoints returned `{ configured: false, connected: false }` with no `error` field when not configured. The frontend only rendered the error text if `testResult.error` was truthy, so users saw "Disconnected" with no explanation.

## Test plan
- [x] Prettier check passes
- [ ] Test with configured Radarr/Sonarr — should show "Connected — vX.X.X"
- [ ] Test with unconfigured service — should show "Radarr is not configured"
- [ ] Test with wrong API key — should show the actual error message
- [ ] Test with slow/unreachable URL — should timeout at 10s instead of 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)