### PR TITLE
fix(shell): use app-accent color for ambient background blurs

### DIFF
--- a/apps/pops-shell/src/app/layout/RootLayout.tsx
+++ b/apps/pops-shell/src/app/layout/RootLayout.tsx
@@ -33,8 +33,8 @@ export function RootLayout() {
     <div className={cn("min-h-screen bg-background relative", appColorClass)}>
       {/* Ambient background decorative elements */}
       <div className="fixed top-0 left-0 w-full h-full pointer-events-none overflow-hidden z-0 opacity-20 dark:opacity-10">
-        <div className="absolute top-[-10%] right-[-10%] w-[40%] h-[40%] rounded-full bg-primary/20 blur-[120px]" />
-        <div className="absolute bottom-[-5%] left-[-5%] w-[30%] h-[30%] rounded-full bg-emerald-500/10 blur-[100px]" />
+        <div className="absolute top-[-10%] right-[-10%] w-[40%] h-[40%] rounded-full bg-app-accent/20 blur-[120px]" />
+        <div className="absolute bottom-[-5%] left-[-5%] w-[30%] h-[30%] rounded-full bg-app-accent/10 blur-[100px]" />
       </div>
 
       <div className="relative z-10 pt-14 md:pt-16">


### PR DESCRIPTION
## Summary
- Replace hardcoded `bg-primary/20` and `bg-emerald-500/10` with `bg-app-accent/20` and `bg-app-accent/10` in `RootLayout.tsx` ambient background decorative blurs
- The per-app accent color system (`.app-emerald`, `.app-indigo`, etc.) sets `--app-accent` per app — these blurs were bypassing it with hardcoded colors

Fixes #993

## Test plan
- [ ] Navigate between apps (Finance, Media, AI, Inventory) and verify the ambient background tint changes to match each app's accent color
- [ ] Verify both light and dark mode show the correct per-app tint

🤖 Generated with [Claude Code](https://claude.com/claude-code)