### PR TITLE
fix(media): invalidate arr.getConfig cache after saving settings

### DIFF
--- a/packages/app-media/src/pages/ArrSettingsPage.tsx
+++ b/packages/app-media/src/pages/ArrSettingsPage.tsx
@@ -151,6 +151,7 @@ export function ArrSettingsPage() {
   const [sonarrUrl, setSonarrUrl] = useState("");
   const [sonarrApiKey, setSonarrApiKey] = useState("");
 
+  const utils = trpc.useUtils();
   const settingsQuery = trpc.media.arr.getSettings.useQuery();
 
   useEffect(() => {
@@ -166,6 +167,7 @@ export function ArrSettingsPage() {
   const saveSettings = trpc.media.arr.saveSettings.useMutation({
     onSuccess: () => {
       toast.success("Settings saved");
+      void utils.media.arr.getConfig.invalidate();
     },
     onError: (err: { message: string }) => toast.error(`Failed to save: ${err.message}`),
   });


### PR DESCRIPTION
## Summary
- Added `utils.media.arr.getConfig.invalidate()` to save `onSuccess` handler
- After saving Radarr/Sonarr settings, `ArrStatusBadge` on `MovieDetailPage` was using stale cache (`radarrConfigured: false`), so badges never appeared
- Cache invalidation ensures the badge picks up the new config on next navigation

Fixes #986

## Test plan
- [ ] Configure Radarr settings and save
- [ ] Navigate to a movie detail page — ArrStatusBadge should now render
- [ ] Same for Sonarr on TV show detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)