### PR TITLE
fix: define semantic status colour tokens with foreground variants [tb-052]

### DIFF
--- a/packages/ui/src/theme/globals.css
+++ b/packages/ui/src/theme/globals.css
@@ -55,9 +55,12 @@
   --color-input: var(--input);
   --color-ring: var(--ring);
 
-  --color-success: oklch(0.65 0.15 150);
-  --color-warning: oklch(0.75 0.15 70);
-  --color-info: oklch(0.65 0.15 240);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
 
   /* Charts */
   --color-chart-1: var(--chart-1);
@@ -150,6 +153,14 @@
   --chart-4: oklch(0.8 0.15 80);
   --chart-5: oklch(0.6 0.15 330);
 
+  /* Status colours */
+  --success: oklch(0.55 0.15 150);
+  --success-foreground: oklch(0.98 0.01 150);
+  --warning: oklch(0.65 0.15 70);
+  --warning-foreground: oklch(0.2 0.04 70);
+  --info: oklch(0.55 0.15 240);
+  --info-foreground: oklch(0.98 0.01 240);
+
   /* App accent — defaults to primary when no app colour class is applied */
   --app-accent: var(--primary);
   --app-accent-foreground: var(--primary-foreground);
@@ -193,6 +204,14 @@
   --border: oklch(0.25 0.04 260);
   --input: oklch(0.25 0.04 260);
   --ring: oklch(0.6 0.12 260);
+
+  /* Status colours */
+  --success: oklch(0.65 0.15 150);
+  --success-foreground: oklch(0.14 0.02 150);
+  --warning: oklch(0.75 0.15 70);
+  --warning-foreground: oklch(0.14 0.02 70);
+  --info: oklch(0.65 0.15 240);
+  --info-foreground: oklch(0.14 0.02 240);
 
   /* App accent — defaults to primary in dark mode too */
   --app-accent: var(--primary);


### PR DESCRIPTION
## Summary
- Defines `--success`, `--warning`, `--info` CSS variables with foreground variants in both `:root` (light) and `.dark` (dark) mode
- Updates `@theme` to reference CSS vars instead of hardcoded oklch values, matching the pattern used by all other design tokens
- Enables Tailwind utilities: `bg-success`, `text-success-foreground`, `bg-warning`, `text-warning-foreground`, `bg-info`, `text-info-foreground`

## Changes
- `packages/ui/src/theme/globals.css`: 1 file, +22/-3

## Test plan
- [x] Prettier check passes
- [ ] Verify `bg-success`, `text-success`, `bg-warning`, `text-info` etc. work in both light and dark mode
- [ ] Verify opacity modifiers work (e.g. `bg-success/10`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)