### PR TITLE
fix: replace text-[10px] with text-2xs across 9 files [tb-053]

### DIFF
--- a/packages/app-finance/src/components/TagEditor.tsx
+++ b/packages/app-finance/src/components/TagEditor.tsx
@@ -204,7 +204,7 @@ export function TagEditor({
                 <Badge
                   key={tag}
                   variant="outline"
-                  className="text-[10px] uppercase tracking-wider font-bold py-0 px-1.5"
+                  className="text-2xs uppercase tracking-wider font-bold py-0 px-1.5"
                   style={style}
                   title={tooltipText}
                 >
@@ -215,7 +215,7 @@ export function TagEditor({
             })
           )}
           {tags.length > 3 && (
-            <Badge variant="secondary" className="text-[10px] py-0 px-1.5 font-normal opacity-70">
+            <Badge variant="secondary" className="text-2xs py-0 px-1.5 font-normal opacity-70">
               +{tags.length - 3}
             </Badge>
           )}

--- a/packages/app-finance/src/pages/DashboardPage.tsx
+++ b/packages/app-finance/src/pages/DashboardPage.tsx
@@ -128,7 +128,7 @@ export function DashboardPage() {
                       {transaction.tags.includes("Online") && (
                         <Badge
                           variant="secondary"
-                          className="hidden sm:inline-flex text-[10px] uppercase tracking-wider px-1.5 py-0"
+                          className="hidden sm:inline-flex text-2xs uppercase tracking-wider px-1.5 py-0"
                         >
                           Online
                         </Badge>
@@ -140,7 +140,7 @@ export function DashboardPage() {
                       </p>
                       {transaction.entityName && (
                         <>
-                          <span className="text-muted-foreground/50 text-[10px]">•</span>
+                          <span className="text-muted-foreground/50 text-2xs">•</span>
                           <p className="text-xs text-muted-foreground truncate">
                             {transaction.entityName}
                           </p>
@@ -151,7 +151,7 @@ export function DashboardPage() {
                   <div className="flex items-center gap-4 shrink-0">
                     <Badge
                       variant="outline"
-                      className="hidden sm:inline-flex text-[10px] uppercase tracking-wider px-1.5 py-0 text-muted-foreground font-normal"
+                      className="hidden sm:inline-flex text-2xs uppercase tracking-wider px-1.5 py-0 text-muted-foreground font-normal"
                     >
                       {transaction.account}
                     </Badge>
@@ -191,12 +191,12 @@ export function DashboardPage() {
               <Card key={budget.id} className="p-5 flex flex-col justify-between h-full">
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <h3 className="font-medium text-muted-foreground uppercase text-[10px] tracking-widest">
+                    <h3 className="font-medium text-muted-foreground uppercase text-2xs tracking-widest">
                       {budget.category}
                     </h3>
                     <Badge
                       variant={budget.active ? "default" : "secondary"}
-                      className="text-[10px] h-5"
+                      className="text-2xs h-5"
                     >
                       {budget.active ? "Active" : "Inactive"}
                     </Badge>

--- a/packages/app-inventory/src/components/InventoryCard.tsx
+++ b/packages/app-inventory/src/components/InventoryCard.tsx
@@ -181,7 +181,7 @@ export function InventoryCard({
         <div>
           <h3 className="text-sm font-semibold leading-tight line-clamp-1">{itemName}</h3>
           {(brand || model) && (
-            <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mt-0.5 opacity-80 line-clamp-1">
+            <p className="text-2xs font-medium uppercase tracking-wider text-muted-foreground mt-0.5 opacity-80 line-clamp-1">
               {brand}
               {brand && model && <span className="mx-1 opacity-50">&bull;</span>}
               {model}

--- a/packages/app-inventory/src/components/SortablePhotoGrid.tsx
+++ b/packages/app-inventory/src/components/SortablePhotoGrid.tsx
@@ -110,7 +110,7 @@ export function SortablePhotoGrid({
             <GripVertical className="h-3.5 w-3.5" />
           </div>
           {index === 0 && (
-            <span className="absolute bottom-1 left-1 text-[10px] font-bold bg-app-accent text-white px-1.5 py-0.5 rounded">
+            <span className="absolute bottom-1 left-1 text-2xs font-bold bg-app-accent text-white px-1.5 py-0.5 rounded">
               Primary
             </span>
           )}

--- a/packages/app-media/src/components/DownloadQueue.tsx
+++ b/packages/app-media/src/components/DownloadQueue.tsx
@@ -36,7 +36,7 @@ export function DownloadQueue() {
             progress: number;
           }) => (
             <div key={item.id} className="flex items-center gap-3 rounded-lg border bg-card p-3">
-              <Badge variant="outline" className="text-[10px] uppercase shrink-0">
+              <Badge variant="outline" className="text-2xs uppercase shrink-0">
                 {item.mediaType === "movie" ? "Movie" : "Episode"}
               </Badge>
 

--- a/packages/app-media/src/components/QuickPickDialog.tsx
+++ b/packages/app-media/src/components/QuickPickDialog.tsx
@@ -185,7 +185,7 @@ function PickCard({
           {genres.length > 0 && (
             <div className="flex flex-wrap gap-1">
               {genres.slice(0, 3).map((g) => (
-                <Badge key={g} variant="secondary" className="text-[10px]">
+                <Badge key={g} variant="secondary" className="text-2xs">
                   {g}
                 </Badge>
               ))}

--- a/packages/app-media/src/components/SearchResultCard.tsx
+++ b/packages/app-media/src/components/SearchResultCard.tsx
@@ -119,7 +119,7 @@ export function SearchResultCard({
         {genres && genres.length > 0 && (
           <div className="flex flex-wrap gap-1">
             {genres.slice(0, 3).map((genre) => (
-              <Badge key={genre} variant="outline" className="text-[10px] px-1.5 py-0">
+              <Badge key={genre} variant="outline" className="text-2xs px-1.5 py-0">
                 {genre}
               </Badge>
             ))}

--- a/packages/app-media/src/pages/CalendarPage.tsx
+++ b/packages/app-media/src/pages/CalendarPage.tsx
@@ -155,7 +155,7 @@ export function CalendarPage() {
                 >
                   {formatDate(dateKey)}
                   {today && (
-                    <Badge variant="default" className="text-[10px]">
+                    <Badge variant="default" className="text-2xs">
                       Today
                     </Badge>
                   )}
@@ -187,7 +187,7 @@ export function CalendarPage() {
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
                           <h3 className="text-sm font-medium truncate">{ep.seriesTitle}</h3>
-                          <Badge variant="outline" className="shrink-0 text-[10px]">
+                          <Badge variant="outline" className="shrink-0 text-2xs">
                             {formatEpisodeCode(ep.seasonNumber, ep.episodeNumber)}
                           </Badge>
                         </div>
@@ -198,13 +198,13 @@ export function CalendarPage() {
                           {ep.hasFile ? (
                             <Badge
                               variant="secondary"
-                              className="gap-0.5 text-[10px] bg-green-600 text-white"
+                              className="gap-0.5 text-2xs bg-green-600 text-white"
                             >
                               <CheckCircle className="h-2.5 w-2.5" />
                               Downloaded
                             </Badge>
                           ) : (
-                            <Badge variant="secondary" className="gap-0.5 text-[10px]">
+                            <Badge variant="secondary" className="gap-0.5 text-2xs">
                               <Clock className="h-2.5 w-2.5" />
                               Missing
                             </Badge>

--- a/packages/app-media/src/pages/HistoryPage.tsx
+++ b/packages/app-media/src/pages/HistoryPage.tsx
@@ -235,7 +235,7 @@ function HistoryCard({
         </Badge>
 
         {/* Watch date badge */}
-        <span className="absolute top-2 right-2 z-10 bg-black/60 text-white text-[10px] font-medium px-1.5 py-0.5 rounded">
+        <span className="absolute top-2 right-2 z-10 bg-black/60 text-white text-2xs font-medium px-1.5 py-0.5 rounded">
           {formatShortDate(entry.watchedAt)}
         </span>
 


### PR DESCRIPTION
## Summary
- Replace 17 instances of `text-[10px]` arbitrary bracket value with `text-2xs` utility class
- `text-2xs` is now defined by tb-036 (PR #1003) as a proper Tailwind utility
- Covers 9 files across app-finance, app-media, and app-inventory packages

## Files changed
- `packages/app-finance/src/pages/DashboardPage.tsx` (5 instances)
- `packages/app-media/src/pages/CalendarPage.tsx` (4 instances)
- `packages/app-finance/src/components/TagEditor.tsx` (2 instances)
- `packages/app-media/src/components/DownloadQueue.tsx` (1 instance)
- `packages/app-inventory/src/components/SortablePhotoGrid.tsx` (1 instance)
- `packages/app-media/src/components/SearchResultCard.tsx` (1 instance)
- `packages/app-media/src/pages/HistoryPage.tsx` (1 instance)
- `packages/app-inventory/src/components/InventoryCard.tsx` (1 instance)
- `packages/app-media/src/components/QuickPickDialog.tsx` (1 instance)

## Test plan
- [x] Prettier check passes
- [x] Zero `text-[10px]` instances remain in packages/
- [ ] Verify text sizing renders the same as before (10px = 0.625rem = text-2xs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)