### PR TITLE
fix(inventory): replace tree indent inline px with CSS variables

### DIFF
--- a/packages/app-inventory/src/components/ConnectionTracePanel.tsx
+++ b/packages/app-inventory/src/components/ConnectionTracePanel.tsx
@@ -46,7 +46,7 @@ function TraceNodeRow({ node, depth, currentItemId }: TraceNodeRowProps) {
             ? "bg-app-accent/10 text-foreground font-bold border-l-2 border-app-accent rounded-l-none ml-[-2px]"
             : "hover:bg-app-accent/5 cursor-pointer"
         }`}
-        style={{ paddingLeft: `${depth * 20 + 8}px` }}
+        style={{ paddingLeft: `calc(${depth} * var(--tree-indent-step) + var(--tree-indent-base))` }}
         onClick={() => {
           if (!isCurrent) navigate(`/inventory/items/${node.id}`);
         }}
@@ -111,7 +111,7 @@ function TraceSkeleton() {
         <div
           key={i}
           className="flex items-center gap-2"
-          style={{ paddingLeft: `${(i % 3) * 20 + 8}px` }}
+          style={{ paddingLeft: `calc(${i % 3} * var(--tree-indent-step) + var(--tree-indent-base))` }}
         >
           <Skeleton className="h-4 w-4" />
           <Skeleton className="h-4 w-32" />

--- a/packages/app-inventory/src/components/LocationPicker.tsx
+++ b/packages/app-inventory/src/components/LocationPicker.tsx
@@ -91,7 +91,7 @@ function TreeNode({
           "hover:bg-accent/50 transition-colors",
           isSelected && "bg-accent text-accent-foreground font-medium"
         )}
-        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        style={{ paddingLeft: `calc(${depth} * var(--tree-picker-step) + var(--tree-indent-base))` }}
         onClick={() => onSelect(node.id)}
       >
         {hasChildren ? (

--- a/packages/app-inventory/src/pages/LocationTreePage.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.tsx
@@ -73,7 +73,7 @@ function TreeSkeleton() {
         <div
           key={i}
           className="flex items-center gap-2"
-          style={{ paddingLeft: `${(i % 3) * 20}px` }}
+          style={{ paddingLeft: `calc(${i % 3} * var(--tree-indent-step))` }}
         >
           <Skeleton className="h-4 w-4" />
           <Skeleton className="h-4 w-32" />
@@ -209,7 +209,7 @@ function MoveTargetPicker({
                 className={`w-full text-left flex items-center gap-1.5 py-1.5 px-2 rounded-md transition-colors ${
                   disabled ? "opacity-40 cursor-not-allowed" : "hover:bg-muted/50 cursor-pointer"
                 }`}
-                style={{ paddingLeft: `${depth * 16 + 8}px` }}
+                style={{ paddingLeft: `calc(${depth} * var(--tree-picker-step) + var(--tree-indent-base))` }}
               >
                 <Folder className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                 <span className="text-sm truncate">{node.name}</span>
@@ -251,7 +251,7 @@ function DropIndicatorLine({ depth }: { depth: number }) {
   return (
     <div
       className="relative h-0.5 my-[-1px] z-10"
-      style={{ marginLeft: `${depth * 20 + 8}px`, marginRight: "8px" }}
+      style={{ marginLeft: `calc(${depth} * var(--tree-indent-step) + var(--tree-indent-base))`, marginRight: "8px" }}
       data-testid="drop-indicator"
     >
       <div className="absolute inset-0 bg-app-accent rounded-full" />
@@ -340,7 +340,7 @@ function LocationNode({
             ? "bg-app-accent/20 text-foreground font-bold border-l-2 border-app-accent rounded-l-none ml-[-2px]"
             : ""
         } ${isOver && !isDragging ? "ring-2 ring-app-accent/50 bg-app-accent/5" : ""}`}
-        style={{ paddingLeft: `${depth * 20 + 8}px` }}
+        style={{ paddingLeft: `calc(${depth} * var(--tree-indent-step) + var(--tree-indent-base))` }}
         onClick={() => onSelect(node.id)}
         onDoubleClick={(e) => {
           e.stopPropagation();
@@ -518,7 +518,7 @@ function LocationNode({
               {isAddingChild && (
                 <div
                   className="flex items-center gap-1.5 py-1.5 px-2"
-                  style={{ paddingLeft: `${(depth + 1) * 20 + 8}px` }}
+                  style={{ paddingLeft: `calc(${depth + 1} * var(--tree-indent-step) + var(--tree-indent-base))` }}
                 >
                   <span className="w-[22px]" />
                   <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
@@ -861,7 +861,7 @@ export function LocationTreePage() {
               ))}
             </SortableContext>
             {addingRoot && (
-              <div className="flex items-center gap-1.5 py-1.5 px-2" style={{ paddingLeft: "8px" }}>
+              <div className="flex items-center gap-1.5 py-1.5 px-2" style={{ paddingLeft: "var(--tree-indent-base)" }}>
                 <span className="w-[22px]" />
                 <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
                 <InlineInput
@@ -908,7 +908,7 @@ export function LocationTreePage() {
               type="button"
               onClick={() => handleMoveTo(null)}
               className="w-full text-left flex items-center gap-1.5 py-1.5 px-2 rounded-md hover:bg-muted/50"
-              style={{ paddingLeft: "8px" }}
+              style={{ paddingLeft: "var(--tree-indent-base)" }}
             >
               <MapPin className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
               <span className="text-sm font-medium">Root level</span>

--- a/packages/ui/src/theme/globals.css
+++ b/packages/ui/src/theme/globals.css
@@ -116,6 +116,11 @@
 :root {
   --radius: 0.625rem;
 
+  /* Tree indentation */
+  --tree-indent-step: 1.25rem;   /* 20px — main tree row indent per depth */
+  --tree-indent-base: 0.5rem;    /* 8px — base left padding at depth 0 */
+  --tree-picker-step: 1rem;      /* 16px — compact picker indent per depth */
+
   /* Light mode - Clean, Warm, Efficient with subtle indigo tint */
   --background: oklch(
     0.975 0.01 260


### PR DESCRIPTION
## Summary
- Defined `--tree-indent-step` (20px), `--tree-indent-base` (8px), `--tree-picker-step` (16px) in globals.css
- Replaced all hardcoded pixel calculations in tree components with `calc()` using CSS variables
- 4 files changed: globals.css, LocationTreePage.tsx, ConnectionTracePanel.tsx, LocationPicker.tsx

Fixes #1009

## Test plan
- [ ] Location tree page — verify indentation looks identical to before
- [ ] Connection trace panel — verify tree indent levels are correct
- [ ] Location picker dropdown — verify compact indent still works
- [ ] Skeleton loading states — verify they still show varying indent levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)