### PR TITLE
fix(ui): replace hardcoded focus border RGB with --ring token [tb-054]

### DIFF
--- a/packages/ui/src/components/ChipInput.tsx
+++ b/packages/ui/src/components/ChipInput.tsx
@@ -220,7 +220,7 @@ export const ChipInput = forwardRef<HTMLInputElement, ChipInputProps>(
           disabled && "opacity-50 cursor-not-allowed",
           containerClassName
         )}
-        style={isFocused ? { borderColor: "rgb(55, 65, 81)" } : undefined}
+        style={isFocused ? { borderColor: "var(--ring)" } : undefined}
         onClick={handleContainerClick}
       >
         {values.map((value, index) => (

--- a/packages/ui/src/components/DateTimeInput.tsx
+++ b/packages/ui/src/components/DateTimeInput.tsx
@@ -126,7 +126,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
           disabled && "opacity-50 cursor-not-allowed",
           containerClassName
         )}
-        style={isFocused ? { borderColor: "rgb(55, 65, 81)" } : undefined}
+        style={isFocused ? { borderColor: "var(--ring)" } : undefined}
       >
         {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
         <input
@@ -190,7 +190,7 @@ export const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
           disabled && "opacity-50 cursor-not-allowed",
           containerClassName
         )}
-        style={isFocused ? { borderColor: "rgb(55, 65, 81)" } : undefined}
+        style={isFocused ? { borderColor: "var(--ring)" } : undefined}
       >
         {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
         <input
@@ -254,7 +254,7 @@ export const DateTimeInput = forwardRef<HTMLInputElement, DateTimeInputProps>(
           disabled && "opacity-50 cursor-not-allowed",
           containerClassName
         )}
-        style={isFocused ? { borderColor: "rgb(55, 65, 81)" } : undefined}
+        style={isFocused ? { borderColor: "var(--ring)" } : undefined}
       >
         {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
         <input

--- a/packages/ui/src/components/NumberInput.tsx
+++ b/packages/ui/src/components/NumberInput.tsx
@@ -254,7 +254,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
           enableDrag && !disabled && "cursor-ns-resize select-none",
           containerClassName
         )}
-        style={isFocused ? { borderColor: "rgb(55, 65, 81)" } : undefined}
+        style={isFocused ? { borderColor: "var(--ring)" } : undefined}
         onMouseDown={handleMouseDown}
       >
         {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -161,7 +161,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             error && "border-destructive ring-destructive/20",
             containerClassName
           )}
-          style={isFocused && !error ? { borderColor: "rgb(55, 65, 81)" } : undefined}
+          style={isFocused && !error ? { borderColor: "var(--ring)" } : undefined}
         >
           {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
           <select

--- a/packages/ui/src/components/TextInput.tsx
+++ b/packages/ui/src/components/TextInput.tsx
@@ -191,7 +191,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             error && "border-destructive ring-destructive/20",
             containerClassName
           )}
-          style={isFocused && !error ? { borderColor: "rgb(55, 65, 81)" } : undefined}
+          style={isFocused && !error ? { borderColor: "var(--ring)" } : undefined}
         >
           {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
           <input


### PR DESCRIPTION
## Summary
- Replaced hardcoded `rgb(55, 65, 81)` focus border color with `var(--ring)` in 5 UI primitive components (7 instances total)
- Affected: `TextInput`, `ChipInput`, `DateTimeInput` (×3), `Select`, `NumberInput`
- Focus rings now follow the active theme in both light and dark modes

## Test plan
- [ ] Verify focus ring appears correctly on all 5 input types in light mode
- [ ] Verify focus ring appears correctly in dark mode
- [ ] Confirm no visual regression on error-state borders (TextInput, Select)

🤖 Generated with [Claude Code](https://claude.com/claude-code)