### PR TITLE
fix(ui): fix StatCard kerning — tracking-tighter crammed text-2xs [tb-057]

### DIFF
--- a/packages/ui/src/components/StatCard.tsx
+++ b/packages/ui/src/components/StatCard.tsx
@@ -83,10 +83,12 @@ export function StatCard({ title, value, description, color = "slate", className
         <h3 className="text-2xs font-semibold text-muted-foreground uppercase tracking-widest">
           {title}
         </h3>
-        <p className={cn("text-3xl font-bold tabular-nums tracking-tight", styles.text)}>{value}</p>
+        <p className={cn("text-3xl font-bold tabular-nums tracking-normal", styles.text)}>
+          {value}
+        </p>
       </div>
       {description && (
-        <div className="text-2xs text-muted-foreground font-medium uppercase tracking-tighter opacity-70 relative z-10">
+        <div className="text-2xs text-muted-foreground font-medium uppercase tracking-normal opacity-70 relative z-10">
           {description}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Changed `tracking-tighter` → `tracking-normal` on StatCard description text (line 89)
- Changed `tracking-tight` → `tracking-normal` on StatCard value text (line 86)
- At `text-2xs` (10px), negative letter-spacing made characters unreadable

Closes #1015

## Test plan
- [ ] Verify StatCard tiles on AI Model Config page have readable character spacing
- [ ] Check StatCard usage across other pages (finance dashboard, inventory) for visual consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)