### PR TITLE
fix(ui): chart colors invisible in dark mode

### DIFF
--- a/packages/app-inventory/src/components/ValueBreakdown.tsx
+++ b/packages/app-inventory/src/components/ValueBreakdown.tsx
@@ -10,11 +10,11 @@ import { trpc } from "../lib/trpc";
 import { formatCurrency } from "../lib/utils";
 
 const BAR_COLORS = [
-  "hsl(var(--primary))",
-  "hsl(var(--primary) / 0.8)",
-  "hsl(var(--primary) / 0.6)",
-  "hsl(var(--primary) / 0.45)",
-  "hsl(var(--primary) / 0.3)",
+  "var(--primary)",
+  "color-mix(in oklch, var(--primary) 80%, transparent)",
+  "color-mix(in oklch, var(--primary) 60%, transparent)",
+  "color-mix(in oklch, var(--primary) 45%, transparent)",
+  "color-mix(in oklch, var(--primary) 30%, transparent)",
 ];
 
 export interface BreakdownEntry {
@@ -46,7 +46,7 @@ export function BreakdownChart({ data, onBarClick }: BreakdownChartProps) {
         <XAxis
           type="number"
           tickFormatter={(v: number) => formatCurrency(v)}
-          tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 11 }}
+          tick={{ fill: "var(--muted-foreground)", fontSize: 11 }}
           axisLine={false}
           tickLine={false}
         />
@@ -54,7 +54,7 @@ export function BreakdownChart({ data, onBarClick }: BreakdownChartProps) {
           type="category"
           dataKey="name"
           width={100}
-          tick={{ fill: "hsl(var(--foreground))", fontSize: 12 }}
+          tick={{ fill: "var(--foreground)", fontSize: 12 }}
           axisLine={false}
           tickLine={false}
         />

--- a/packages/app-media/src/components/ComparisonScores.tsx
+++ b/packages/app-media/src/components/ComparisonScores.tsx
@@ -94,15 +94,15 @@ export function ComparisonScores({ mediaType, mediaId }: ComparisonScoresProps) 
       <div className="rounded-lg border bg-card p-4">
         <ResponsiveContainer width="100%" height={280}>
           <RadarChart data={radarData} cx="50%" cy="50%" outerRadius="75%">
-            <PolarGrid stroke="hsl(var(--border))" />
+            <PolarGrid stroke="var(--border)" />
             <PolarAngleAxis
               dataKey="dimension"
-              tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
+              tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
             />
             <Radar
               dataKey="score"
-              stroke="hsl(var(--primary))"
-              fill="hsl(var(--primary))"
+              stroke="var(--primary)"
+              fill="var(--primary)"
               fillOpacity={0.2}
               strokeWidth={2}
             />

--- a/packages/app-media/src/components/RadarChart.tsx
+++ b/packages/app-media/src/components/RadarChart.tsx
@@ -104,16 +104,16 @@ export function RadarChart({
       {/* Data polygon */}
       <polygon
         points={dataPoints}
-        fill="hsl(var(--primary))"
+        fill="var(--primary)"
         fillOpacity={0.2}
-        stroke="hsl(var(--primary))"
+        stroke="var(--primary)"
         strokeWidth={2}
       />
 
       {/* Data points */}
       {dimensions.map((d, idx) => {
         const [x, y] = polarToXY(idx, normalize(d.score));
-        return <circle key={`point-${idx}`} cx={x} cy={y} r={3} fill="hsl(var(--primary))" />;
+        return <circle key={`point-${idx}`} cx={x} cy={y} r={3} fill="var(--primary)" />;
       })}
 
       {/* Labels */}


### PR DESCRIPTION
## Summary
- Chart components used `hsl(var(--primary))` but the theme defines colors in oklch space, producing invalid CSS like `hsl(oklch(0.6 0.12 260))`
- This made bars, text, and radar fills invisible in dark mode across 3 chart components
- Fix: replace `hsl(var(--*))` with `var(--*)` directly, and use `color-mix()` for opacity variants

**Files changed:**
- `packages/app-inventory/src/components/ValueBreakdown.tsx` — bar colors + axis tick fills
- `packages/app-media/src/components/ComparisonScores.tsx` — radar stroke/fill + axis ticks
- `packages/app-media/src/components/RadarChart.tsx` — polygon fill/stroke + data points

Closes GH-973

## Test plan
- [ ] Verify Value by Type chart bars visible in dark mode
- [ ] Verify ComparisonScores radar chart visible in dark mode
- [ ] Verify RadarChart (SVG) polygon visible in dark mode
- [ ] Confirm charts still look correct in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)