### PR TITLE
fix(plex): add includeGuids=1 to getAllItems so TV sync gets TVDB IDs

### DIFF
--- a/apps/pops-api/src/modules/media/plex/client.test.ts
+++ b/apps/pops-api/src/modules/media/plex/client.test.ts
@@ -185,6 +185,16 @@ describe("getAllItems", () => {
     },
   };
 
+  it("requests includeGuids=1 to get external IDs", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(rawItems));
+
+    await client.getAllItems("1");
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain("/library/sections/1/all");
+    expect(url).toContain("includeGuids=1");
+  });
+
   it("returns mapped media items", async () => {
     fetchMock.mockResolvedValueOnce(mockResponse(rawItems));
 

--- a/apps/pops-api/src/modules/media/plex/client.ts
+++ b/apps/pops-api/src/modules/media/plex/client.ts
@@ -54,10 +54,10 @@ export class PlexClient {
     }));
   }
 
-  /** Get all items in a library section. */
+  /** Get all items in a library section (includes external IDs). */
   async getAllItems(sectionId: string): Promise<PlexMediaItem[]> {
     const raw = await this.get<RawPlexMediaContainer<RawPlexItemsContainer>>(
-      `/library/sections/${sectionId}/all`
+      `/library/sections/${sectionId}/all?includeGuids=1`
     );
     const items = raw.MediaContainer.Metadata ?? [];
     return items.map((item) => this.mapMediaItem(item));

--- a/apps/pops-api/src/modules/media/plex/index.ts
+++ b/apps/pops-api/src/modules/media/plex/index.ts
@@ -12,4 +12,4 @@ export {
 } from "./types.js";
 export { getPlexClient, testConnection, getSyncStatus, type PlexSyncStatus } from "./service.js";
 export { importMoviesFromPlex, type MovieSyncProgress } from "./sync-movies.js";
-export { importTvShowsFromPlex, type TvSyncProgress } from "./sync-tv.js";
+export { importTvShowsFromPlex, type TvSyncProgress, type TvSyncSkip } from "./sync-tv.js";

--- a/apps/pops-api/src/modules/media/plex/scheduler.test.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler.test.ts
@@ -209,6 +209,7 @@ describe("sync execution", () => {
       skipped: 1,
       episodesMatched: 5,
       errors: [],
+      skipReasons: [],
     });
 
     startScheduler({ intervalMs: 5000 });
@@ -245,6 +246,7 @@ describe("sync execution", () => {
       skipped: 0,
       episodesMatched: 3,
       errors: [],
+      skipReasons: [],
     });
 
     startScheduler({ intervalMs: 5000, movieSectionId: "1", tvSectionId: "2" });
@@ -329,6 +331,7 @@ describe("sync execution", () => {
       skipped: 0,
       episodesMatched: 0,
       errors: [],
+      skipReasons: [],
     });
 
     vi.advanceTimersByTime(5000);
@@ -357,6 +360,7 @@ describe("sync execution", () => {
       skipped: 0,
       episodesMatched: 3,
       errors: [],
+      skipReasons: [],
     });
 
     startScheduler({ intervalMs: 1000, movieSectionId: "1", tvSectionId: "2" });
@@ -389,6 +393,7 @@ describe("sync execution", () => {
       skipped: 0,
       episodesMatched: 0,
       errors: [],
+      skipReasons: [],
     });
 
     startScheduler({
@@ -422,6 +427,7 @@ describe("sync execution", () => {
       skipped: 0,
       episodesMatched: 0,
       errors: [],
+      skipReasons: [],
     });
 
     startScheduler({ intervalMs: 5000, movieSectionId: "1", tvSectionId: "2" });
@@ -525,6 +531,7 @@ describe("_triggerSync", () => {
       skipped: 0,
       episodesMatched: 0,
       errors: [],
+      skipReasons: [],
     });
 
     startScheduler({ intervalMs: 60000, movieSectionId: "1", tvSectionId: "2" });

--- a/apps/pops-api/src/modules/media/plex/sync-tv.test.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-tv.test.ts
@@ -171,7 +171,7 @@ describe("importTvShowsFromPlex", () => {
     expect(mockAddTvShow).toHaveBeenCalledWith(81189, fakeTvdbClient);
   });
 
-  it("skips shows without TVDB ID", async () => {
+  it("skips shows without TVDB ID and logs reason", async () => {
     const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
     mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
 
@@ -184,10 +184,13 @@ describe("importTvShowsFromPlex", () => {
 
     expect(result.synced).toBe(0);
     expect(result.skipped).toBe(1);
+    expect(result.skipReasons).toHaveLength(1);
+    expect(result.skipReasons[0]!.title).toBe("Breaking Bad");
+    expect(result.skipReasons[0]!.reason).toBe("No TVDB ID in Plex metadata");
     expect(mockAddTvShow).not.toHaveBeenCalled();
   });
 
-  it("skips shows with non-numeric TVDB ID", async () => {
+  it("skips shows with non-numeric TVDB ID and logs reason", async () => {
     const fakeTvdbClient = {} as ReturnType<typeof getTvdbClient>;
     mockGetTvdbClient.mockReturnValue(fakeTvdbClient);
 
@@ -200,6 +203,8 @@ describe("importTvShowsFromPlex", () => {
 
     expect(result.synced).toBe(0);
     expect(result.skipped).toBe(1);
+    expect(result.skipReasons).toHaveLength(1);
+    expect(result.skipReasons[0]!.reason).toBe("TVDB ID is not a valid number");
   });
 
   it("syncs episode watch history for watched episodes", async () => {
@@ -370,6 +375,7 @@ describe("importTvShowsFromPlex", () => {
     // Should still count as synced despite watch history error
     expect(result.synced).toBe(1);
     expect(result.errors).toHaveLength(0);
+    expect(result.skipReasons).toHaveLength(0);
   });
 
   it("handles multiple shows in batch", async () => {

--- a/apps/pops-api/src/modules/media/plex/sync-tv.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-tv.ts
@@ -24,6 +24,13 @@ export interface TvSyncProgress {
   skipped: number;
   episodesMatched: number;
   errors: TvSyncError[];
+  skipReasons: TvSyncSkip[];
+}
+
+export interface TvSyncSkip {
+  title: string;
+  year: number | null;
+  reason: string;
 }
 
 export interface TvSyncError {
@@ -66,6 +73,7 @@ export async function importTvShowsFromPlex(
     skipped: 0,
     episodesMatched: 0,
     errors: [],
+    skipReasons: [],
   };
 
   for (const item of items) {
@@ -100,7 +108,13 @@ async function syncSingleShow(
   const tvdbId = extractExternalIdAsNumber(item, "tvdb");
 
   if (!tvdbId) {
+    const hasTvdbGuid = item.externalIds.some((id) => id.source === "tvdb");
     progress.skipped++;
+    progress.skipReasons.push({
+      title: item.title,
+      year: item.year,
+      reason: hasTvdbGuid ? "TVDB ID is not a valid number" : "No TVDB ID in Plex metadata",
+    });
     return;
   }
 

--- a/packages/app-media/src/pages/PlexSettingsPage.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.tsx
@@ -41,6 +41,7 @@ interface SyncResult {
   synced: number;
   skipped: number;
   errors: { title: string; reason: string; year: number | null }[];
+  skipReasons?: { title: string; reason: string; year: number | null }[];
 }
 
 function ConnectionBadge({ connected }: { connected: boolean }) {
@@ -59,6 +60,8 @@ function ConnectionBadge({ connected }: { connected: boolean }) {
 
 function SyncResultDisplay({ result, label }: { result: SyncResult; label: string }) {
   const [showErrors, setShowErrors] = useState(false);
+  const [showSkipped, setShowSkipped] = useState(false);
+  const skipReasons = result.skipReasons ?? [];
 
   return (
     <div className="rounded-md border bg-muted/30 p-3 space-y-2 text-sm">
@@ -70,6 +73,30 @@ function SyncResultDisplay({ result, label }: { result: SyncResult; label: strin
           <span className="text-red-400">{result.errors.length} errors</span>
         )}
       </div>
+      {skipReasons.length > 0 && (
+        <div>
+          <button
+            onClick={() => setShowSkipped(!showSkipped)}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {showSkipped ? (
+              <ChevronUp className="h-3 w-3" />
+            ) : (
+              <ChevronDown className="h-3 w-3" />
+            )}
+            {showSkipped ? "Hide" : "Show"} skip reasons
+          </button>
+          {showSkipped && (
+            <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+              {skipReasons.map((skip, i) => (
+                <p key={i}>
+                  <span className="font-medium">{skip.title}:</span> {skip.reason}
+                </p>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
       {result.errors.length > 0 && (
         <div>
           <button


### PR DESCRIPTION
## Summary
- **Root cause**: Plex's `/library/sections/{id}/all` endpoint does not return `Guid` arrays by default, so `externalIds` was always empty for every show, causing all 48 to be silently skipped
- **Fix**: Add `?includeGuids=1` query param to `PlexClient.getAllItems()` so Plex returns external IDs (TVDB, TMDB, IMDB)
- **Improvement**: Add `skipReasons` to `TvSyncProgress` and surface them in the PlexSettingsPage UI so users can see exactly why shows were skipped

Closes #1019

## Test plan
- [x] All 117 plex tests pass (client, sync-tv, sync-movies, scheduler, auth)
- [x] New test verifies `includeGuids=1` is in the request URL
- [x] Skip reason tests verify both "No TVDB ID" and "not a valid number" cases
- [x] TypeScript compiles clean
- [ ] Manual: trigger TV sync in PlexSettingsPage — shows should now sync instead of all being skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)