### PR TITLE
refactor(ui): migrate pages to shared PageHeader component

### DIFF
--- a/packages/app-ai/src/pages/AiUsagePage.tsx
+++ b/packages/app-ai/src/pages/AiUsagePage.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
 import { DataTable, SortableHeader, StatCard, DateInput } from "@pops/ui";
 import { Badge, Button } from "@pops/ui";
-import { Alert } from "@pops/ui";
+import { Alert, PageHeader } from "@pops/ui";
 import { Skeleton } from "@pops/ui";
 import { Card } from "@pops/ui";
 import {
@@ -221,10 +221,7 @@ export function AiUsagePage() {
   if (statsLoading || historyLoading) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">AI Usage</h1>
-          <p className="text-muted-foreground">Track AI categorization costs and usage</p>
-        </div>
+        <PageHeader title="AI Usage" description="Track AI categorization costs and usage" />
 
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
           {[...Array(4)].map((_, i) => (
@@ -241,7 +238,7 @@ export function AiUsagePage() {
   if (statsError || historyError) {
     return (
       <div className="space-y-6">
-        <h1 className="text-2xl md:text-3xl font-bold tracking-tight">AI Usage</h1>
+        <PageHeader title="AI Usage" />
         <Alert variant="destructive">
           <h3 className="font-semibold">Failed to load AI usage data</h3>
           <p className="text-sm mt-1">
@@ -354,13 +351,10 @@ export function AiUsagePage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl md:text-3xl font-bold tracking-tight">AI Usage</h1>
-        <p className="text-muted-foreground">
-          Track AI categorization costs and usage across all imports
-        </p>
-      </div>
+      <PageHeader
+        title="AI Usage"
+        description="Track AI categorization costs and usage across all imports"
+      />
 
       {/* Stats Cards */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">

--- a/packages/app-ai/src/pages/ModelConfigPage.tsx
+++ b/packages/app-ai/src/pages/ModelConfigPage.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
-import { Select, Button, Skeleton, Alert, StatCard } from "@pops/ui";
+import { Select, Button, Skeleton, Alert, StatCard, PageHeader } from "@pops/ui";
 import { TextInput } from "@pops/ui";
 
 const SETTING_KEYS = {
@@ -99,12 +99,7 @@ export function ModelConfigPage() {
   if (isLoading) {
     return (
       <div className="space-y-6 max-w-2xl">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight">
-            Model Configuration
-          </h1>
-          <p className="text-muted-foreground text-sm">Configure AI model and spending limits</p>
-        </div>
+        <PageHeader title="Model Configuration" description="Configure AI model and spending limits" />
         <Skeleton className="h-48" />
         <Skeleton className="h-32" />
       </div>
@@ -113,10 +108,7 @@ export function ModelConfigPage() {
 
   return (
     <div className="space-y-6 max-w-2xl">
-      <div>
-        <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight">Model Configuration</h1>
-        <p className="text-muted-foreground text-sm">Configure AI model and spending limits</p>
-      </div>
+      <PageHeader title="Model Configuration" description="Configure AI model and spending limits" />
 
       {/* Usage vs Budget */}
       <div className="grid gap-4 md:grid-cols-2">

--- a/packages/app-ai/src/pages/PromptViewerPage.tsx
+++ b/packages/app-ai/src/pages/PromptViewerPage.tsx
@@ -4,6 +4,7 @@
  * Shows the current prompt templates used for transaction categorisation
  * and rule generation, with model attribution. PRD-053/US-04.
  */
+import { PageHeader } from "@pops/ui";
 
 const PROMPTS = [
   {
@@ -46,13 +47,10 @@ Return ONLY the JSON array, no markdown, no explanation.`,
 export function PromptViewerPage() {
   return (
     <div className="space-y-6 max-w-3xl">
-      <div className="flex items-center gap-3">
-        <h1 className="text-2xl md:text-3xl font-extrabold tracking-tight">Prompt Templates</h1>
-      </div>
-      <p className="text-muted-foreground text-sm">
-        Read-only view of the AI prompt templates used in this application. Prompts are defined in
-        code and cannot be edited here.
-      </p>
+      <PageHeader
+        title="Prompt Templates"
+        description="Read-only view of the AI prompt templates used in this application. Prompts are defined in code and cannot be edited here."
+      />
 
       <div className="space-y-8">
         {PROMPTS.map((prompt) => (

--- a/packages/app-ai/src/pages/RulesBrowserPage.tsx
+++ b/packages/app-ai/src/pages/RulesBrowserPage.tsx
@@ -23,6 +23,7 @@ import {
   DialogDescription,
   DialogFooter,
   DialogClose,
+  PageHeader,
 } from "@pops/ui";
 import { trpc } from "../lib/trpc";
 
@@ -250,10 +251,7 @@ export function RulesBrowserPage(): React.ReactElement {
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">Categorisation Rules</h1>
-          <p className="text-muted-foreground">Browse and manage AI categorisation rules</p>
-        </div>
+        <PageHeader title="Categorisation Rules" description="Browse and manage AI categorisation rules" />
         <div className="space-y-4">
           {Array.from({ length: 6 }).map((_, i) => (
             <Skeleton key={i} className="h-12 w-full" />
@@ -266,10 +264,7 @@ export function RulesBrowserPage(): React.ReactElement {
   if (isError) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">Categorisation Rules</h1>
-          <p className="text-muted-foreground">Browse and manage AI categorisation rules</p>
-        </div>
+        <PageHeader title="Categorisation Rules" description="Browse and manage AI categorisation rules" />
         <Alert variant="destructive">
           <h3 className="font-semibold">Failed to load rules</h3>
           <p className="text-sm mt-1">Something went wrong loading categorisation rules.</p>
@@ -286,11 +281,7 @@ export function RulesBrowserPage(): React.ReactElement {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl md:text-3xl font-bold tracking-tight">Categorisation Rules</h1>
-        <p className="text-muted-foreground">Browse and manage AI categorisation rules</p>
-      </div>
+      <PageHeader title="Categorisation Rules" description="Browse and manage AI categorisation rules" />
 
       {/* Filters */}
       <div className="flex flex-wrap items-end gap-3">

--- a/packages/app-finance/src/pages/BudgetsPage.tsx
+++ b/packages/app-finance/src/pages/BudgetsPage.tsx
@@ -34,6 +34,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  PageHeader,
 } from "@pops/ui";
 import type { ColumnFilter } from "@pops/ui";
 import { MoreHorizontal, Plus, Pencil, Trash2, Loader2 } from "lucide-react";
@@ -275,7 +276,7 @@ export function BudgetsPage() {
   if (error) {
     return (
       <div className="space-y-6">
-        <h1 className="text-2xl md:text-3xl font-bold">Budgets</h1>
+        <PageHeader title="Budgets" />
         <Alert variant="destructive">
           <p className="font-semibold">Failed to load budgets</p>
           <p className="text-sm">{error.message}</p>
@@ -291,17 +292,15 @@ export function BudgetsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold">Budgets</h1>
-          <p className="text-muted-foreground text-sm">
-            {data ? `${data.pagination.total} total budgets` : "Manage spending targets"}
-          </p>
-        </div>
-        <Button onClick={handleAdd}>
-          <Plus className="mr-2 h-4 w-4" /> Add Budget
-        </Button>
-      </div>
+      <PageHeader
+        title="Budgets"
+        description={data ? `${data.pagination.total} total budgets` : "Manage spending targets"}
+        actions={
+          <Button onClick={handleAdd}>
+            <Plus className="mr-2 h-4 w-4" /> Add Budget
+          </Button>
+        }
+      />
 
       {isLoading ? (
         <div className="space-y-4">

--- a/packages/app-finance/src/pages/DashboardPage.tsx
+++ b/packages/app-finance/src/pages/DashboardPage.tsx
@@ -2,7 +2,7 @@
  * Dashboard page - overview of finances
  */
 import { trpc } from "../lib/trpc";
-import { Card, StatCard, Alert, AlertTitle, AlertDescription, Skeleton, Badge } from "@pops/ui";
+import { Card, StatCard, Alert, AlertTitle, AlertDescription, Skeleton, Badge, PageHeader } from "@pops/ui";
 
 export function DashboardPage() {
   // Fetch recent transactions
@@ -36,7 +36,7 @@ export function DashboardPage() {
   if (transactionsError) {
     return (
       <div className="container mx-auto py-8">
-        <h1 className="text-3xl font-bold mb-6">Dashboard</h1>
+        <PageHeader title="Dashboard" className="mb-6" />
         <Alert variant="destructive">
           <AlertTitle>Unable to load dashboard</AlertTitle>
           <AlertDescription>
@@ -59,10 +59,10 @@ export function DashboardPage() {
 
   return (
     <div className="max-w-7xl mx-auto space-y-8 pb-10">
-      <header>
-        <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-        <p className="text-muted-foreground mt-1">Welcome back! Here's your financial overview.</p>
-      </header>
+      <PageHeader
+        title="Dashboard"
+        description="Welcome back! Here's your financial overview."
+      />
 
       {/* Stats Grid */}
       <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -34,6 +34,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  PageHeader,
 } from "@pops/ui";
 import type { ColumnFilter } from "@pops/ui";
 import { MoreHorizontal, Plus, Pencil, Trash2, Loader2 } from "lucide-react";
@@ -305,7 +306,7 @@ export function EntitiesPage() {
   if (error) {
     return (
       <div className="space-y-6">
-        <h1 className="text-2xl md:text-3xl font-bold">Entities</h1>
+        <PageHeader title="Entities" />
         <Alert variant="destructive">
           <p className="font-semibold">Failed to load entities</p>
           <p className="text-sm">{error.message}</p>
@@ -321,17 +322,15 @@ export function EntitiesPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold">Entities</h1>
-          <p className="text-muted-foreground text-sm">
-            {data ? `${data.pagination.total} total entities` : "Manage merchants and payees"}
-          </p>
-        </div>
-        <Button onClick={handleAdd}>
-          <Plus className="mr-2 h-4 w-4" /> Add Entity
-        </Button>
-      </div>
+      <PageHeader
+        title="Entities"
+        description={data ? `${data.pagination.total} total entities` : "Manage merchants and payees"}
+        actions={
+          <Button onClick={handleAdd}>
+            <Plus className="mr-2 h-4 w-4" /> Add Entity
+          </Button>
+        }
+      />
 
       {isLoading ? (
         <div className="space-y-4">

--- a/packages/app-finance/src/pages/TransactionsPage.tsx
+++ b/packages/app-finance/src/pages/TransactionsPage.tsx
@@ -6,7 +6,7 @@ import { useCallback } from "react";
 import { trpc } from "../lib/trpc";
 import { DataTable, SortableHeader } from "@pops/ui";
 import { Badge } from "@pops/ui";
-import { Alert } from "@pops/ui";
+import { Alert, PageHeader } from "@pops/ui";
 import { Skeleton } from "@pops/ui";
 import { TagEditor } from "../components/TagEditor";
 import type { ColumnFilter } from "@pops/ui";
@@ -185,7 +185,7 @@ export function TransactionsPage() {
   if (error) {
     return (
       <div className="space-y-6">
-        <h1 className="text-2xl md:text-3xl font-bold">Transactions</h1>
+        <PageHeader title="Transactions" />
         <Alert variant="destructive">
           <p className="font-semibold">Failed to load transactions</p>
           <p className="text-sm">{error.message}</p>
@@ -199,14 +199,10 @@ export function TransactionsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold">Transactions</h1>
-          <p className="text-muted-foreground">
-            {data && `${data.pagination.total} total transactions`}
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        title="Transactions"
+        description={data ? `${data.pagination.total} total transactions` : undefined}
+      />
 
       {isLoading ? (
         <div className="space-y-4">

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -24,6 +24,7 @@ import {
   CardContent,
   TypeBadge,
   ViewToggleGroup,
+  PageHeader,
 } from "@pops/ui";
 import type { Condition } from "@pops/ui";
 import { trpc } from "../lib/trpc";
@@ -336,10 +337,7 @@ export function ItemsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl md:text-3xl font-bold">Inventory</h1>
-      </div>
+      <PageHeader title="Inventory" />
 
       {!hasActiveFilters && !search && <DashboardWidgets />}
 

--- a/packages/ui/src/components/PageHeader.stories.tsx
+++ b/packages/ui/src/components/PageHeader.stories.tsx
@@ -18,10 +18,26 @@ export const TopLevel: Story = {
   },
 };
 
+export const TopLevelWithDescription: Story = {
+  args: {
+    title: "Budgets",
+    description: "12 total budgets",
+  },
+};
+
 export const TopLevelWithActions: Story = {
   args: {
     title: "Movies",
     actions: <Button size="sm">Add Movie</Button>,
+  },
+};
+
+export const TopLevelFull: Story = {
+  name: "Top Level (title + description + actions)",
+  args: {
+    title: "Entities",
+    description: "Manage merchants and payees",
+    actions: <Button size="sm">Add Entity</Button>,
   },
 };
 

--- a/packages/ui/src/components/PageHeader.tsx
+++ b/packages/ui/src/components/PageHeader.tsx
@@ -28,6 +28,8 @@ export interface BreadcrumbSegment {
 export interface PageHeaderProps {
   /** Page title displayed as heading */
   title: ReactNode;
+  /** Optional description shown below the title */
+  description?: ReactNode;
   /** URL of the logical parent page — shows back button when provided */
   backHref?: string;
   /** Breadcrumb segments — last segment is the current page (not clickable) */
@@ -146,6 +148,7 @@ function BreadcrumbItems({
 
 export function PageHeader({
   title,
+  description,
   backHref,
   breadcrumbs,
   actions,
@@ -158,9 +161,14 @@ export function PageHeader({
   if (isTopLevel) {
     return (
       <header className={cn("space-y-1", className)}>
-        <div className="flex items-center justify-between gap-4">
-          <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
-          {actions && <div className="flex items-center gap-2">{actions}</div>}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl md:text-3xl font-bold tracking-tight">{title}</h1>
+            {description && (
+              <p className="text-muted-foreground text-sm mt-1">{description}</p>
+            )}
+          </div>
+          {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
         </div>
       </header>
     );
@@ -186,9 +194,14 @@ export function PageHeader({
           </Breadcrumb>
         )}
       </div>
-      <div className="flex items-center justify-between gap-4">
-        <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
-        {actions && <div className="flex items-center gap-2">{actions}</div>}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">{title}</h1>
+          {description && (
+            <p className="text-muted-foreground text-sm mt-1">{description}</p>
+          )}
+        </div>
+        {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- Added `description` prop to the shared `PageHeader` component in `@pops/ui` for subtitle text below the title
- Standardized h1 sizing to responsive `text-2xl md:text-3xl font-bold tracking-tight` with flex layout for actions
- Migrated 9 pages to use `<PageHeader>`: BudgetsPage, EntitiesPage, TransactionsPage, DashboardPage, AiUsagePage, RulesBrowserPage, ModelConfigPage, PromptViewerPage, ItemsPage
- Eliminated ~17 inline h1+description+action patterns across loading, error, and main states
- Added Storybook stories for description and full (title+description+actions) variants

## Test plan
- [ ] Typecheck passes across all packages (verified)
- [ ] Visual check: page headers render correctly with title, description, and action buttons
- [ ] Responsive: h1 scales from text-2xl to text-3xl at md breakpoint
- [ ] Pages with action buttons (Budgets, Entities) show button right-aligned on sm+
- [ ] Error/loading states still show correct header text

Closes GH-992

🤖 Generated with [Claude Code](https://claude.com/claude-code)