### PR TITLE
feat(media): add comparison history view with delete/undo [tb-043]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/router.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router.ts
@@ -10,6 +10,8 @@ import {
   UpdateDimensionSchema,
   RecordComparisonSchema,
   ComparisonQuerySchema,
+  ComparisonHistoryQuerySchema,
+  DeleteComparisonSchema,
   ScoreQuerySchema,
   RandomPairQuerySchema,
   RankingsQuerySchema,
@@ -88,6 +90,30 @@ export const comparisonsRouter = router({
       data: rows.map(toComparison),
       pagination: paginationMeta(total, limit, offset),
     };
+  }),
+
+  /** List all comparisons (paginated, optional dimension filter). */
+  listAll: protectedProcedure.input(ComparisonHistoryQuerySchema).query(({ input }) => {
+    const limit = input.limit ?? DEFAULT_LIMIT;
+    const offset = input.offset ?? 0;
+    const { rows, total } = service.listAllComparisons(input.dimensionId, limit, offset);
+    return {
+      data: rows.map(toComparison),
+      pagination: paginationMeta(total, limit, offset),
+    };
+  }),
+
+  /** Delete a comparison and recalculate Elo scores. */
+  delete: protectedProcedure.input(DeleteComparisonSchema).mutation(({ input }) => {
+    try {
+      service.deleteComparison(input.id);
+      return { message: "Comparison deleted and scores recalculated" };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
   }),
 
   /** Get a random pair of watched movies for comparison. */

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -297,6 +297,81 @@ export function listComparisonsForMedia(
   return { rows, total };
 }
 
+/**
+ * Delete a comparison and recalculate Elo scores for the affected dimension.
+ * Replays all remaining comparisons in chronological order to ensure accuracy.
+ */
+export function deleteComparison(id: number): void {
+  const drizzleDb = getDrizzle();
+  const rawDb = getDb();
+
+  const comparison = drizzleDb.select().from(comparisons).where(eq(comparisons.id, id)).get();
+  if (!comparison) throw new NotFoundError("Comparison", String(id));
+
+  const dimensionId = comparison.dimensionId;
+
+  rawDb.transaction(() => {
+    // Delete the comparison
+    drizzleDb.delete(comparisons).where(eq(comparisons.id, id)).run();
+
+    // Reset all scores for this dimension
+    drizzleDb
+      .update(mediaScores)
+      .set({ score: 1500.0, comparisonCount: 0, updatedAt: new Date().toISOString() })
+      .where(eq(mediaScores.dimensionId, dimensionId))
+      .run();
+
+    // Replay all remaining comparisons in chronological order
+    const remaining = drizzleDb
+      .select()
+      .from(comparisons)
+      .where(eq(comparisons.dimensionId, dimensionId))
+      .orderBy(asc(comparisons.comparedAt))
+      .all();
+
+    for (const comp of remaining) {
+      updateEloScores({
+        dimensionId: comp.dimensionId,
+        mediaAType: comp.mediaAType as "movie" | "tv_show",
+        mediaAId: comp.mediaAId,
+        mediaBType: comp.mediaBType as "movie" | "tv_show",
+        mediaBId: comp.mediaBId,
+        winnerType: comp.winnerType as "movie" | "tv_show",
+        winnerId: comp.winnerId,
+      });
+    }
+  })();
+}
+
+/**
+ * List all comparisons across all dimensions, ordered by most recent first.
+ */
+export function listAllComparisons(
+  dimensionId: number | undefined,
+  limit: number,
+  offset: number
+): ComparisonListResult {
+  const db = getDrizzle();
+
+  const conditions = dimensionId ? eq(comparisons.dimensionId, dimensionId) : undefined;
+
+  const rows = db
+    .select()
+    .from(comparisons)
+    .where(conditions)
+    .orderBy(desc(comparisons.comparedAt))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const countRow = conditions
+    ? db.select({ total: count() }).from(comparisons).where(conditions).all()[0]
+    : db.select({ total: count() }).from(comparisons).all()[0];
+  const total = countRow?.total ?? 0;
+
+  return { rows, total };
+}
+
 // ── Random Pair ──
 
 /**

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -156,3 +156,15 @@ export const ComparisonQuerySchema = z.object({
   offset: z.coerce.number().nonnegative().optional(),
 });
 export type ComparisonQuery = z.infer<typeof ComparisonQuerySchema>;
+
+export const ComparisonHistoryQuerySchema = z.object({
+  dimensionId: z.number().int().positive().optional(),
+  limit: z.coerce.number().positive().max(100).optional(),
+  offset: z.coerce.number().nonnegative().optional(),
+});
+export type ComparisonHistoryQuery = z.infer<typeof ComparisonHistoryQuerySchema>;
+
+export const DeleteComparisonSchema = z.object({
+  id: z.number().int().positive(),
+});
+export type DeleteComparisonInput = z.infer<typeof DeleteComparisonSchema>;

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -124,6 +124,11 @@ export function CompareArenaPage() {
           <Badge variant="outline" className="text-sm">
             {sessionCount} comparison{sessionCount !== 1 ? "s" : ""} this session
           </Badge>
+          <Link to="/media/compare/history">
+            <Button variant="outline" size="sm">
+              History
+            </Button>
+          </Link>
           <DimensionManager />
         </div>
       </div>

--- a/packages/app-media/src/pages/ComparisonHistoryPage.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.tsx
@@ -1,0 +1,228 @@
+/**
+ * ComparisonHistoryPage — paginated list of all comparisons with delete capability.
+ * Allows users to review past comparisons and undo mistakes.
+ */
+import { useState } from "react";
+import { Link } from "react-router";
+import {
+  Button,
+  Card,
+  CardContent,
+  Skeleton,
+  Select,
+} from "@pops/ui";
+import { Trash2, ChevronLeft, ChevronRight, History } from "lucide-react";
+import { trpc } from "../lib/trpc";
+
+const PAGE_SIZE = 20;
+
+export function ComparisonHistoryPage() {
+  const [page, setPage] = useState(0);
+  const [dimensionFilter, setDimensionFilter] = useState<string>("");
+
+  const { data: dimensionsData } = trpc.media.comparisons.listDimensions.useQuery();
+  const dimensions = dimensionsData?.data ?? [];
+
+  const parsedDimensionId = dimensionFilter ? Number(dimensionFilter) : undefined;
+
+  const { data, isLoading, refetch } = trpc.media.comparisons.listAll.useQuery({
+    dimensionId: parsedDimensionId,
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+  });
+
+  const utils = trpc.useUtils();
+
+  const deleteMutation = trpc.media.comparisons.delete.useMutation({
+    onSuccess: () => {
+      utils.media.comparisons.listAll.invalidate();
+      utils.media.comparisons.scores.invalidate();
+      utils.media.comparisons.rankings.invalidate();
+      refetch();
+    },
+  });
+
+  const comparisons = data?.data ?? [];
+  const totalPages = data?.pagination ? Math.ceil(data.pagination.total / PAGE_SIZE) : 0;
+
+  const dimensionOptions = [
+    { label: "All dimensions", value: "" },
+    ...dimensions.map((d: { id: number; name: string }) => ({
+      label: d.name,
+      value: String(d.id),
+    })),
+  ];
+
+  const dimensionMap = new Map(
+    dimensions.map((d: { id: number; name: string }) => [d.id, d.name])
+  );
+
+  function handleDelete(id: number) {
+    if (!window.confirm("Delete this comparison? Elo scores will be recalculated.")) return;
+    deleteMutation.mutate({ id });
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <History className="h-6 w-6 text-muted-foreground" />
+          <h1 className="text-2xl font-bold">Comparison History</h1>
+        </div>
+        <Link to="/media/compare">
+          <Button variant="outline" size="sm">
+            Back to Compare
+          </Button>
+        </Link>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <Select
+          value={dimensionFilter}
+          onChange={(e) => {
+            setDimensionFilter(e.target.value);
+            setPage(0);
+          }}
+          options={dimensionOptions}
+          className="w-48"
+        />
+        {data?.pagination && (
+          <span className="text-sm text-muted-foreground">
+            {data.pagination.total} comparison{data.pagination.total !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full rounded-lg" />
+          ))}
+        </div>
+      ) : comparisons.length === 0 ? (
+        <Card>
+          <CardContent className="p-8 text-center text-muted-foreground">
+            No comparisons yet. Head to the{" "}
+            <Link to="/media/compare" className="text-primary underline">
+              Compare Arena
+            </Link>{" "}
+            to start comparing movies.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {comparisons.map(
+            (comp: {
+              id: number;
+              dimensionId: number;
+              mediaAType: string;
+              mediaAId: number;
+              mediaBType: string;
+              mediaBId: number;
+              winnerType: string;
+              winnerId: number;
+              comparedAt: string;
+            }) => (
+              <ComparisonRow
+                key={comp.id}
+                comparison={comp}
+                dimensionName={dimensionMap.get(comp.dimensionId) ?? "Unknown"}
+                onDelete={handleDelete}
+                isDeleting={deleteMutation.isPending}
+              />
+            )
+          )}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            Page {page + 1} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            disabled={page >= totalPages - 1}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ComparisonRow({
+  comparison,
+  dimensionName,
+  onDelete,
+  isDeleting,
+}: {
+  comparison: {
+    id: number;
+    mediaAId: number;
+    mediaBId: number;
+    winnerId: number;
+    comparedAt: string;
+  };
+  dimensionName: string;
+  onDelete: (id: number) => void;
+  isDeleting: boolean;
+}) {
+  const winnerId = comparison.winnerId;
+  const loserId =
+    comparison.mediaAId === winnerId ? comparison.mediaBId : comparison.mediaAId;
+
+  return (
+    <Card className="group">
+      <CardContent className="flex items-center justify-between p-3">
+        <div className="flex items-center gap-4 min-w-0">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 text-sm">
+              <MovieTitle mediaId={winnerId} className="font-semibold text-foreground" />
+              <span className="text-muted-foreground">beat</span>
+              <MovieTitle mediaId={loserId} className="text-muted-foreground" />
+            </div>
+            <div className="flex items-center gap-2 mt-0.5">
+              <span className="text-2xs text-muted-foreground uppercase tracking-wider">
+                {dimensionName}
+              </span>
+              <span className="text-2xs text-muted-foreground">
+                {new Date(comparison.comparedAt).toLocaleDateString()}
+              </span>
+            </div>
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onDelete(comparison.id)}
+          disabled={isDeleting}
+          className="opacity-0 group-hover:opacity-100 transition-opacity text-destructive hover:text-destructive"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function MovieTitle({ mediaId, className }: { mediaId: number; className?: string }) {
+  const { data } = trpc.media.movies.get.useQuery({ id: mediaId });
+  const title = data?.data?.title ?? `Movie #${mediaId}`;
+  return (
+    <Link to={`/media/movies/${mediaId}`} className={className}>
+      {title}
+    </Link>
+  );
+}

--- a/packages/app-media/src/routes.tsx
+++ b/packages/app-media/src/routes.tsx
@@ -68,6 +68,11 @@ const HistoryPage = lazy(() =>
     default: m.HistoryPage,
   }))
 );
+const ComparisonHistoryPage = lazy(() =>
+  import("./pages/ComparisonHistoryPage").then((m) => ({
+    default: m.ComparisonHistoryPage,
+  }))
+);
 const CalendarPage = lazy(() =>
   import("./pages/CalendarPage").then((m) => ({
     default: m.CalendarPage,
@@ -118,6 +123,7 @@ export const routes: RouteObject[] = [
   { path: "rankings", element: <RankingsPage /> },
   { path: "search", element: <SearchPage /> },
   { path: "compare", element: <CompareArenaPage /> },
+  { path: "compare/history", element: <ComparisonHistoryPage /> },
   { path: "quick-pick", element: <QuickPickPage /> },
   { path: "plex", element: <PlexSettingsPage /> },
   { path: "arr", element: <ArrSettingsPage /> },


### PR DESCRIPTION
## Summary
- Add paginated comparison history page at `/media/compare/history` with dimension filter, delete capability, and movie title resolution
- Backend: `listAllComparisons` query and `deleteComparison` mutation that replays remaining comparisons to recalculate Elo scores within a transaction
- Add "History" button to Compare Arena page for navigation

Closes #985

## Test plan
- [ ] Navigate to /media/compare/history — page loads with pagination
- [ ] Filter by dimension — list updates, page resets to 0
- [ ] Delete a comparison — confirm dialog appears, scores recalculate after delete
- [ ] Verify Elo scores are correct after deletion (replay logic)
- [ ] Navigate via "History" button from Compare Arena page

🤖 Generated with [Claude Code](https://claude.com/claude-code)