### PR TITLE
docs: fix PRD-039 Plex sync gaps — skip reporting and GUID formats

### DIFF
--- a/docs-v2/themes/03-media/prds/039-plex-sync/README.md
+++ b/docs-v2/themes/03-media/prds/039-plex-sync/README.md
@@ -59,6 +59,7 @@ Build polling-based sync with Plex Media Server. Import library items and watch 
 |---------|--------|
 | Last sync time | Relative time ("2 hours ago") with full timestamp on hover |
 | Results | Synced: N, Skipped: N, Errors: N |
+| Skip details | Expandable list of skipped items with title and reason (e.g., "Breaking Bad — no TheTVDB ID in Plex metadata") |
 | Error details | Expandable list of error messages if errors > 0 |
 
 ## API Dependencies
@@ -138,7 +139,7 @@ Build polling-based sync with Plex Media Server. Import library items and watch 
 - POPS owns the library — Plex is one input source, not the source of truth
 - Sync is additive only — Plex sync never deletes items from the POPS library
 - TMDB ID is the match key for movies; TheTVDB ID is the match key for TV shows
-- If a Plex item has no external ID, it is skipped and counted as an error
+- If a Plex item has no external ID, it is skipped with a descriptive reason (title + why it was skipped)
 - Auth token is stored in the settings table, not in environment variables or config files
 - Scheduler is optional — manual sync is always available
 - Sync results are stored for the most recent run only (not historical)
@@ -148,7 +149,7 @@ Build polling-based sync with Plex Media Server. Import library items and watch 
 | Case | Behaviour |
 |------|-----------|
 | Plex server unreachable | Test connection fails with error message; sync operations fail gracefully |
-| Plex item missing TMDB/TheTVDB ID | Skipped, counted in errors with descriptive message |
+| Plex item missing TMDB/TheTVDB ID | Skipped with reason recorded (title + "no TheTVDB ID in Plex metadata"), visible in skip details UI |
 | Auth token expired | Sync fails with auth error; UI prompts to reconnect |
 | Sync interrupted mid-run | Partial results committed (each item is its own transaction); re-sync is safe |
 | Duplicate movie in Plex (two copies) | Both map to same TMDB ID — second is skipped (unique constraint) |

--- a/docs-v2/themes/03-media/prds/039-plex-sync/us-03-library-sync.md
+++ b/docs-v2/themes/03-media/prds/039-plex-sync/us-03-library-sync.md
@@ -19,14 +19,23 @@ As a user, I want to sync my Plex movie and TV show libraries into POPS so that 
 - [x] TV shows are matched against the POPS library by TheTVDB ID
 - [x] New shows are created with their full season and episode hierarchy
 - [x] Existing shows are checked for new seasons/episodes — new ones are added, existing ones skipped
-- [x] Plex items missing a TMDB ID (movies) or TheTVDB ID (TV shows) are skipped and counted as errors
-- [ ] Each item sync is its own transaction — a failure on one item does not roll back others — errors caught individually but no explicit per-item transactions
+- [x] Plex items missing a TMDB ID (movies) or TheTVDB ID (TV shows) are skipped
+- [ ] Skipped items are tracked with title and reason (e.g., "Breaking Bad — no TheTVDB ID in Plex metadata") — **currently only a counter, no diagnostic info**
+- [ ] Each item sync is its own transaction — a failure on one item does not roll back others — **errors caught individually but no explicit per-item transactions**
 - [x] Both procedures return `{ synced: number, skipped: number, errors: number }`
+- [ ] Return value includes a `skippedItems` array with `{ title, reason }` for each skipped item — **not implemented, only a count is returned**
 - [x] Error results include descriptive messages (e.g., "Movie 'Title' has no TMDB ID")
+- [ ] External ID extraction handles both legacy Plex agents (`com.plexapp.agents.thetvdb://`) and new Plex agent (`plex://show/` with `tvdb://` in Guid array) — **only checks `externalIds` array for `tvdb` source; may miss shows matched by newer Plex metadata agents**
 - [x] Sync is idempotent — running the same sync twice produces identical results
 - [x] Auth token is validated before sync begins — returns auth error if disconnected
 - [x] Tests cover: movie sync creates new records, skips existing, handles missing TMDB ID, TV show sync creates show/season/episode hierarchy, adds new seasons to existing show, idempotent repeated sync, error reporting, auth validation
 
 ## Notes
 
-Plex stores external IDs as GUIDs in the format `com.plexapp.agents.themoviedb://12345` or `plex://movie/5d776...` with linked TMDB/TheTVDB references. Parsing these GUIDs to extract the numeric ID is the critical matching step. If Plex has been configured with a non-standard metadata agent, the GUID format may differ — handle this gracefully by counting it as an error rather than crashing the sync.
+Plex stores external IDs in multiple formats depending on the metadata agent:
+- **Legacy agents:** `com.plexapp.agents.themoviedb://12345`, `com.plexapp.agents.thetvdb://67890`
+- **New Plex agent (default since ~2020):** Primary GUID is `plex://show/5d776...` with external IDs in a separate `Guid` array as `tvdb://67890`, `tmdb://12345`
+
+The extraction code MUST handle both formats. If it only checks one format, all shows from Plex servers using the other agent will silently skip. The new Plex agent is now the default — most users will have it.
+
+Every skipped item must include its title and the reason it was skipped, so the user can diagnose the issue (e.g., "my Plex server uses a different metadata agent").


### PR DESCRIPTION
## Summary

Fixes PRD-039 spec gaps that caused silent TV show skipping during Plex sync.

- Add skip details UI section (title + reason per skipped item)
- Add ACs for `skippedItems` return array with diagnostic info
- Add AC for dual GUID format handling (legacy + new Plex agent)
- Update Notes explaining both Plex GUID formats

## Context

The code fix already landed in 746dcfc8 (`includeGuids=1`), but the PRD still didn't specify skip reporting or GUID format handling. This updates the spec so the pattern is documented for future work.

## Test plan

- [ ] PRD README sync status section includes skip details
- [ ] US-03 has ACs for skippedItems array and GUID format handling