### PR TITLE
test(media): add deleteComparison + Elo recalculation tests [tb-059]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -895,7 +895,7 @@ describe("comparisons.delete (Elo recalculation)", () => {
 
     // Record a fresh single comparison to get the expected scores
     // First, build the chain: A beats B, B beats C, A beats C
-    const comp1 = await caller.media.comparisons.record({
+    await caller.media.comparisons.record({
       dimensionId: dimId,
       mediaAType: "movie",
       mediaAId: 1,
@@ -913,7 +913,7 @@ describe("comparisons.delete (Elo recalculation)", () => {
       winnerType: "movie",
       winnerId: 2,
     });
-    const comp3 = await caller.media.comparisons.record({
+    await caller.media.comparisons.record({
       dimensionId: dimId,
       mediaAType: "movie",
       mediaAId: 1,


### PR DESCRIPTION
## Summary
- Add 25 new tests for `deleteComparison` service function, Elo score replay logic, and `listAll` endpoint
- Covers basic delete, NOT_FOUND errors, auth rejection, score reset on single delete, multi-comparison replay, cross-dimension isolation, chain delete with replay verification, and fresh-recording equivalence
- Validates `listAll` with cross-dimension listing, dimension filtering, and pagination

Closes #1034

## Test plan
- [x] All 47 tests pass (22 existing + 25 new)
- [x] TypeScript compiles cleanly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)