### PR TITLE
fix(media): TvShowDetailPage crashes with hooks order error [tb-061]

### DIFF
--- a/packages/app-media/src/pages/TvShowDetailPage.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.tsx
@@ -149,6 +149,18 @@ export function TvShowDetailPage() {
     },
   });
 
+  const rawSeasons = seasonsData?.data ?? [];
+  // Sort seasons ascending by number, specials (season 0) last
+  const seasons = useMemo(
+    () =>
+      [...rawSeasons].sort((a: { seasonNumber: number }, b: { seasonNumber: number }) => {
+        if (a.seasonNumber === 0) return 1;
+        if (b.seasonNumber === 0) return -1;
+        return a.seasonNumber - b.seasonNumber;
+      }),
+    [rawSeasons]
+  );
+
   if (Number.isNaN(showId)) {
     return (
       <div className="p-6">
@@ -189,17 +201,6 @@ export function TvShowDetailPage() {
   const posterSrc = show.posterUrl ?? "";
   const backdropSrc = show.backdropUrl ?? null;
 
-  const rawSeasons = seasonsData?.data ?? [];
-  // Sort seasons ascending by number, specials (season 0) last
-  const seasons = useMemo(
-    () =>
-      [...rawSeasons].sort((a: { seasonNumber: number }, b: { seasonNumber: number }) => {
-        if (a.seasonNumber === 0) return 1;
-        if (b.seasonNumber === 0) return -1;
-        return a.seasonNumber - b.seasonNumber;
-      }),
-    [rawSeasons]
-  );
   const progress = progressData?.data;
 
   const nextEpisode = progress?.nextEpisode ?? null;


### PR DESCRIPTION
## Summary
- Fix React Rules of Hooks violation in `TvShowDetailPage` that crashed the page when opening a TV show
- Root cause: `useMemo` (season sorting) was called **after** early returns for loading/error/NaN states
- When transitioning from loading → loaded, React saw more hooks than the previous render
- Fix: moved `useMemo` + `rawSeasons` derivation above the conditional early returns

## Test plan
- [x] TypeScript compiles cleanly
- [ ] Open any TV show detail page — no crash
- [ ] Navigate between shows — no hooks error

🤖 Generated with [Claude Code](https://claude.com/claude-code)