### PR TITLE
fix(arr): wrap fetch errors in ArrApiError with descriptive messages [tb-064]

### DIFF
--- a/apps/pops-api/src/modules/media/arr/base-client.ts
+++ b/apps/pops-api/src/modules/media/arr/base-client.ts
@@ -17,6 +17,15 @@ interface CacheEntry {
 const CACHE_TTL_MS = 30_000;
 const CONNECTION_TIMEOUT_MS = 10_000;
 
+/** Convert a network-level fetch error into a descriptive ArrApiError. */
+function toArrApiError(err: unknown, url: string): ArrApiError {
+  if (err instanceof DOMException && err.name === "TimeoutError") {
+    return new ArrApiError(`Connection timed out after ${CONNECTION_TIMEOUT_MS / 1000}s — ${url}`);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return new ArrApiError(`Connection failed: ${message} — ${url}`);
+}
+
 export class ArrBaseClient {
   protected readonly baseUrl: string;
   private readonly apiKey: string;
@@ -38,14 +47,19 @@ export class ArrBaseClient {
       return cached.data as T;
     }
 
-    const response = await fetch(url, {
-      method: "GET",
-      headers: {
-        "X-Api-Key": this.apiKey,
-        Accept: "application/json",
-      },
-      signal: AbortSignal.timeout(CONNECTION_TIMEOUT_MS),
-    });
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "GET",
+        headers: {
+          "X-Api-Key": this.apiKey,
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(CONNECTION_TIMEOUT_MS),
+      });
+    } catch (err) {
+      throw toArrApiError(err, url);
+    }
 
     if (!response.ok) {
       throw new ArrApiError(`${response.status} ${response.statusText} — ${url}`, response.status);
@@ -68,15 +82,21 @@ export class ArrBaseClient {
   protected async post<T>(path: string, body: unknown): Promise<T> {
     const url = `${this.baseUrl}/api/v3${path}`;
 
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "X-Api-Key": this.apiKey,
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify(body),
-    });
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "X-Api-Key": this.apiKey,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(CONNECTION_TIMEOUT_MS),
+      });
+    } catch (err) {
+      throw toArrApiError(err, url);
+    }
 
     if (!response.ok) {
       throw new ArrApiError(`${response.status} ${response.statusText} — ${url}`, response.status);
@@ -89,15 +109,21 @@ export class ArrBaseClient {
   protected async put<T>(path: string, body: unknown): Promise<T> {
     const url = `${this.baseUrl}/api/v3${path}`;
 
-    const response = await fetch(url, {
-      method: "PUT",
-      headers: {
-        "X-Api-Key": this.apiKey,
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify(body),
-    });
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "PUT",
+        headers: {
+          "X-Api-Key": this.apiKey,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(CONNECTION_TIMEOUT_MS),
+      });
+    } catch (err) {
+      throw toArrApiError(err, url);
+    }
 
     if (!response.ok) {
       throw new ArrApiError(`${response.status} ${response.statusText} — ${url}`, response.status);

--- a/apps/pops-api/src/modules/media/arr/types.ts
+++ b/apps/pops-api/src/modules/media/arr/types.ts
@@ -34,7 +34,7 @@ export interface ArrConfig {
 export class ArrApiError extends Error {
   public readonly status: number;
 
-  constructor(message: string, status: number) {
+  constructor(message: string, status = 0) {
     super(message);
     this.name = "ArrApiError";
     this.status = status;


### PR DESCRIPTION
## Summary
- Network-level fetch failures (connection refused, DNS, timeouts) threw raw `TypeError("fetch failed")` bypassing `ArrApiError` handlers → users saw opaque "fetch failed" message
- Wrap all `fetch()` calls in try/catch, converting to `ArrApiError` with URL context and human-readable cause (e.g. "Connection timed out after 10s — https://...")
- Add `AbortSignal.timeout` to POST/PUT methods (previously only GET had timeout protection)
- Make `ArrApiError.status` optional (default 0) for network errors without HTTP status codes
- Fixes both Radarr "fetch failed" (tb-064) and Sonarr timeout (tb-065) since they share the base client

## Test plan
- [x] All 12 base-client tests pass
- [x] TypeScript compiles cleanly
- [ ] Test Radarr connection with invalid URL → descriptive error instead of "fetch failed"
- [ ] Test Sonarr connection when service is down → timeout message with URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)