### PR TITLE
fix(media): season page shows show name in header + correct episode count [tb-066]

### DIFF
--- a/packages/app-media/src/pages/SeasonDetailPage.test.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.test.tsx
@@ -422,7 +422,7 @@ describe("SeasonDetailPage — monitoring", () => {
       renderPage();
       const headings = screen.getAllByRole("heading", { level: 1 });
       expect(headings.some((h) => h.textContent === "Season 1")).toBe(true);
-      expect(screen.getByText("3 episodes")).toBeInTheDocument();
+      expect(screen.getByText("4 episodes")).toBeInTheDocument();
     });
 
     it("renders episodes section", () => {

--- a/packages/app-media/src/pages/SeasonDetailPage.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.tsx
@@ -450,7 +450,7 @@ export function SeasonDetailPage() {
   return (
     <div className="space-y-6 max-w-4xl mx-auto">
       <PageHeader
-        title={seasonLabel}
+        title={show.name}
         backHref={`/media/tv/${show.id}`}
         breadcrumbs={[
           { label: "Media", href: "/media" },
@@ -474,8 +474,8 @@ export function SeasonDetailPage() {
           <h1 className="text-2xl font-bold">{season.name ?? seasonLabel}</h1>
 
           <div className="flex items-center gap-2 mt-1 text-sm text-muted-foreground">
-            {season.episodeCount != null && <span>{season.episodeCount} episodes</span>}
-            {season.episodeCount != null && season.airDate && <span>·</span>}
+            {episodes.length > 0 && <span>{episodes.length} episodes</span>}
+            {episodes.length > 0 && season.airDate && <span>·</span>}
             {season.airDate && <span>First aired {season.airDate}</span>}
           </div>
 


### PR DESCRIPTION
## Summary
- PageHeader title changed from "Season X" to the TV show name (e.g. "Breaking Bad")
- h1 next to poster still shows the season name — proper hierarchy: show name > season name
- Episode count now uses `episodes.length` (dynamically fetched) instead of `season.episodeCount` (stale DB field that could be 0)
- Updated test assertion to match new episode count source

## Test plan
- [x] TypeScript compiles cleanly
- [x] Test assertion updated for dynamic episode count
- [ ] Open a TV show season page — header shows show name, poster sidebar shows season name
- [ ] Episode count matches actual number of episodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)