### PR TITLE
fix(media): change library default sort to Title A-Z [tb-063]

### DIFF
--- a/apps/pops-api/src/modules/media/library/service.ts
+++ b/apps/pops-api/src/modules/media/library/service.ts
@@ -137,7 +137,7 @@ function sortClause(sort: LibrarySortOption): string {
     case "rating":
       return "vote_average DESC";
     default:
-      return "created_at DESC";
+      return "title COLLATE NOCASE ASC";
   }
 }
 

--- a/apps/pops-api/src/modules/media/library/types.ts
+++ b/apps/pops-api/src/modules/media/library/types.ts
@@ -23,7 +23,7 @@ export type LibrarySortOption = (typeof librarySortOptions)[number];
 /** Zod schema for the unified library list query. */
 export const LibraryListSchema = z.object({
   type: z.enum(["all", "movie", "tv"]).optional().default("all"),
-  sort: z.enum(librarySortOptions).optional().default("dateAdded"),
+  sort: z.enum(librarySortOptions).optional().default("title"),
   search: z.string().optional(),
   genre: z.string().optional(),
   page: z.coerce.number().int().positive().optional().default(1),

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -15,8 +15,8 @@ const TYPE_OPTIONS: { value: MediaType; label: string }[] = [
 ];
 
 const SORT_OPTIONS: { value: SortOption; label: string }[] = [
-  { value: "dateAdded", label: "Date Added" },
   { value: "title", label: "Title (A-Z)" },
+  { value: "dateAdded", label: "Date Added" },
   { value: "releaseDate", label: "Release Date" },
   { value: "rating", label: "Rating" },
 ];
@@ -126,7 +126,7 @@ export function LibraryPage() {
   const rawType = searchParams.get("type");
   const rawSort = searchParams.get("sort");
   const typeFilter: MediaType = isValidMediaType(rawType) ? rawType : "all";
-  const sortBy: SortOption = isValidSort(rawSort) ? rawSort : "dateAdded";
+  const sortBy: SortOption = isValidSort(rawSort) ? rawSort : "title";
   const genreFilter = searchParams.get("genre") || null;
   const searchQuery = searchParams.get("q") ?? "";
   const page = Math.max(1, Number(searchParams.get("page")) || 1);


### PR DESCRIPTION
## Summary
- Change default library sort from "Date Added" to "Title (A-Z)" per user feedback
- Update backend Zod schema default, frontend fallback, sort dropdown order, and `sortClause` default case
- 3 files changed, 4 lines each way — minimal diff

## Changes
- `types.ts`: Zod schema default `"dateAdded"` → `"title"`
- `service.ts`: `sortClause` default case → `title COLLATE NOCASE ASC`
- `LibraryPage.tsx`: Frontend fallback sort → `"title"`, reordered dropdown to put Title first

## Note
Notion PRDs/USs should be updated to reflect A-Z as the default library sort order.

## Test plan
- [ ] Open library page with no sort param — should display A-Z
- [ ] Verify existing sort options still work (Date Added, Release Date, Rating)
- [ ] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)