### PR TITLE
fix(api): skip rate limiter for /media/images routes [tb-062]

### DIFF
--- a/apps/pops-api/src/middleware/rate-limit.ts
+++ b/apps/pops-api/src/middleware/rate-limit.ts
@@ -5,6 +5,10 @@ import rateLimit from "express-rate-limit";
  * tRPC endpoints are excluded — they're behind Cloudflare Access auth and
  * include polling-heavy operations (e.g. getImportProgress every 1s) that
  * would exhaust any sensible per-IP window.
+ *
+ * Media image routes are excluded — the library grid loads 24-96 poster
+ * images per page which easily exhausts 100 req/15min. These are read-only
+ * cached files behind Cloudflare Access, so rate-limiting them is unnecessary.
  */
 export const rateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -12,5 +16,5 @@ export const rateLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false,
   message: { error: "Too many requests, try again later" },
-  skip: (req) => req.path.startsWith("/trpc"),
+  skip: (req) => req.path.startsWith("/trpc") || req.path.startsWith("/media/images"),
 });


### PR DESCRIPTION
## Summary
- Skip `/media/images` paths in express-rate-limit middleware, same as `/trpc` paths
- Library grid loads 24-96 poster images per page, easily exhausting the 100 req/15min cap and causing 429 errors
- These are read-only cached files behind Cloudflare Access — rate limiting them is unnecessary

## Root cause
The express-rate-limit middleware (100 requests per 15 minutes) was applied to `/media/images/*` routes. Opening the library page with 24+ items immediately consumes most of the budget on poster image requests, causing subsequent images to fail with 429 Too Many Requests.

## Test plan
- [ ] Open library page with 24+ items — all posters should load
- [ ] Switch to 96 items per page — all should load without 429 errors
- [ ] Verify non-image routes (health, webhooks) are still rate-limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)