### PR TITLE
docs: add Epic 07 Database Operations + PRD-060

### DIFF
--- a/docs-v2/themes/00-infrastructure/README.md
+++ b/docs-v2/themes/00-infrastructure/README.md
@@ -27,8 +27,9 @@ Set up a self-hosted production environment on dedicated hardware with zero-trus
 | 4 | [CI/CD Pipelines](epics/04-cicd-pipelines.md) | GitHub Actions workflows for quality gates, deployment, validation | Done |
 | 5 | [Backups](epics/05-backups.md) | Encrypted offsite to Backblaze B2 via rclone | Partial |
 | 6 | [Monitoring](epics/06-monitoring.md) | Health checks, log aggregation, alerting | Done |
+| 7 | [Database Operations](epics/07-database-operations.md) | Unified migration system, production guards, pre-migration backups, go-live runbook | Not started |
 
-Epics 0-2 are sequential (hardware before Docker before networking). Epics 3-6 can be parallelised after 1.
+Epics 0-2 are sequential (hardware before Docker before networking). Epics 3-6 can be parallelised after 1. Epic 7 depends on Epic 5 (backup system).
 
 ## Key Decisions
 

--- a/docs-v2/themes/00-infrastructure/epics/07-database-operations.md
+++ b/docs-v2/themes/00-infrastructure/epics/07-database-operations.md
@@ -1,0 +1,25 @@
+# Epic 07: Database Operations
+
+> Theme: [Infrastructure](../README.md)
+
+## Scope
+
+Establish safe database lifecycle management: unify the migration system, protect production data from accidental destruction, and document the go-live procedure. After this epic, the database can hold real data through any number of schema changes without risk of loss.
+
+## PRDs
+
+| # | PRD | Summary | Status |
+|---|-----|---------|--------|
+| 060 | [Database Operations](../prds/060-database-operations/README.md) | Unify migration system on Drizzle, add production guards, pre-migration backups, migration safety tests, go-live runbook | Not started |
+
+## Dependencies
+
+- **Requires:** Epic 05 (backup system — pre-migration backup relies on the existing rclone/age pipeline)
+- **Unlocks:** Production use with real financial and media data that survives schema changes
+
+## Out of Scope
+
+- Schema design conventions (Foundation Epic 04 / PRD-009)
+- Drizzle ORM adoption for query code (Foundation Epic 06 / PRD-011)
+- Point-in-time recovery or WAL archival
+- Multi-database replication

--- a/docs-v2/themes/00-infrastructure/prds/060-database-operations/README.md
+++ b/docs-v2/themes/00-infrastructure/prds/060-database-operations/README.md
@@ -1,0 +1,94 @@
+# PRD-060: Database Operations
+
+> Epic: [07 — Database Operations](../../epics/07-database-operations.md)
+> Status: Not started
+
+## Overview
+
+Make the database safe for production data. Today, the codebase has two migration systems running in parallel, destructive commands with no environment guards, no pre-migration backups, and no documented procedure for going from dev to production. This PRD unifies the migration system, adds safety rails, and documents the go-live process.
+
+## Current State
+
+### Two Migration Systems
+
+| System | Location | Applied by | Used for |
+|--------|----------|------------|----------|
+| Manual SQL | `src/db/migrations/*.sql` | `runMigrations()` on server startup | Production schema changes |
+| Drizzle | `src/db/drizzle-migrations/` | `drizzle-kit migrate` | New schema changes going forward |
+
+Both systems track applied migrations separately (`schema_migrations` table vs Drizzle's `__drizzle_migrations` table). An agent adding a new table might use either system, leading to drift.
+
+### Destructive Commands
+
+| Command | What it does | Guard |
+|---------|-------------|-------|
+| `mise db:init` | Deletes the entire SQLite file and recreates from scratch | None |
+| `mise db:seed` | Calls `db:clear` (deletes all data) then inserts test data | None |
+| `mise db:clear` | Deletes all rows from all tables (preserves schema) | None |
+
+Running any of these against a production database destroys real data with no warning.
+
+### Missing Safety Layers
+
+- No automatic backup before schema migrations
+- No test that verifies migrations preserve existing data
+- No documentation on when to stop using `db:init` and start relying on migrations only
+
+## Target State
+
+- **One migration system** (Drizzle) — single source of truth for schema changes
+- **Production guards** — destructive commands refuse to run against production databases
+- **Pre-migration backup** — automatic SQLite backup before any migration runs
+- **Migration safety tests** — CI verifies migrations don't lose data
+- **Go-live runbook** — documented procedure for transitioning to real data
+
+## Business Rules
+
+- Drizzle is the only migration system going forward — manual SQL migrations are frozen (no new files)
+- `runMigrations()` continues to apply existing manual migrations for backward compatibility but does not accept new ones
+- `db:init`, `db:seed`, `db:clear` refuse to execute when `NODE_ENV=production` or when the database contains financial transactions
+- Pre-migration backup creates a timestamped copy of the SQLite file before applying any pending migration
+- If a migration fails, the database is restored from the pre-migration backup automatically
+- The go-live runbook is stored in the repo (accessible when the server is down)
+
+## Edge Cases
+
+| Case | Behaviour |
+|------|-----------|
+| No pending migrations | Backup skipped, server starts normally |
+| Migration fails mid-transaction | SQLite transaction rolls back; pre-migration backup available as additional safety net |
+| `db:init` run with `NODE_ENV=production` | Command exits with error, does not delete the database |
+| `db:seed` run against DB with real transactions | Command exits with error explaining why |
+| Both old and new migration systems have pending migrations | Old migrations run first (backward compat), then Drizzle migrations run |
+| Drizzle schema drift (schema file doesn't match DB) | `drizzle-kit generate` detects drift and generates a corrective migration |
+| Agent creates a manual SQL migration file | CI lint step fails — manual migrations are frozen |
+
+## User Stories
+
+| # | Story | Summary | Status | Parallelisable |
+|---|-------|---------|--------|----------------|
+| 01 | [us-01-unify-migrations](us-01-unify-migrations.md) | Freeze manual SQL migrations, make Drizzle the only path for new schema changes | Not started | No (first) |
+| 02 | [us-02-production-guards](us-02-production-guards.md) | Add environment checks to db:init, db:seed, db:clear that refuse to run against production data | Not started | Yes |
+| 03 | [us-03-pre-migration-backup](us-03-pre-migration-backup.md) | Automatic SQLite file backup before any pending migration runs, with auto-restore on failure | Not started | Yes |
+| 04 | [us-04-migration-safety-tests](us-04-migration-safety-tests.md) | CI test that applies migrations to a seeded DB and verifies data integrity | Not started | Blocked by us-01 |
+| 05 | [us-05-go-live-runbook](us-05-go-live-runbook.md) | Document the procedure for transitioning from dev database to production data | Not started | Yes |
+
+US-02, US-03, and US-05 can all parallelise. US-04 depends on US-01 (needs the unified migration system to test against).
+
+## Verification
+
+- Adding a new column via Drizzle schema + `drizzle-kit generate` produces a migration that applies cleanly to an existing DB with data
+- `mise db:init` fails with a clear error when `NODE_ENV=production`
+- `mise db:seed` fails with a clear error when the DB has real transactions
+- Pre-migration backup is created before migrations run, and removed after successful completion
+- A deliberately broken migration triggers auto-restore from the backup
+- CI migration safety test passes on every PR that includes a schema change
+- Go-live runbook exists in the repo and covers: initial import, backup verification, migration workflow
+
+## Out of Scope
+
+- Drizzle ORM adoption for query code (PRD-011)
+- Schema design conventions (PRD-009)
+- WAL archival or point-in-time recovery
+- Database replication or read replicas
+- Automated rollback of Drizzle migrations (Drizzle doesn't support down migrations — restore from backup instead)

--- a/docs-v2/themes/00-infrastructure/prds/060-database-operations/us-01-unify-migrations.md
+++ b/docs-v2/themes/00-infrastructure/prds/060-database-operations/us-01-unify-migrations.md
@@ -1,0 +1,25 @@
+# US-01: Unify migration system on Drizzle
+
+> PRD: [060 — Database Operations](README.md)
+> Status: Not started
+
+## Description
+
+As a developer, I want Drizzle as the single migration system so that there is one way to change the schema and no confusion about which system to use.
+
+## Acceptance Criteria
+
+- [ ] `MIGRATIONS_FROZEN.md` file added to `src/db/migrations/` explaining that manual SQL migrations are frozen — no new files accepted
+- [ ] CI lint step fails if a new `.sql` file is added to `src/db/migrations/` (e.g., a pre-commit hook or GitHub Action check)
+- [ ] `runMigrations()` in `db.ts` still applies existing manual SQL migrations (backward compatibility for databases that have them)
+- [ ] Drizzle migrations in `src/db/drizzle-migrations/` are applied by `drizzle-kit migrate` after manual migrations complete
+- [ ] Server startup sequence: `runMigrations()` (old) → Drizzle migrate (new) → server ready
+- [ ] `mise drizzle:generate` is the documented workflow for schema changes: edit schema in `packages/db-types/src/schema/` → run generate → review SQL → commit
+- [ ] `CONVENTIONS.md` updated: "Schema changes go through Drizzle only — edit the schema file, run `mise drizzle:generate`, review the SQL, commit both"
+- [ ] Existing `drizzle.config.ts` baseline warning preserved (don't re-apply baseline to existing prod DBs)
+
+## Notes
+
+The manual migration system served well during early development but having two systems creates ambiguity. Freezing (not deleting) the old system preserves backward compatibility while ensuring all new work goes through Drizzle.
+
+The CI check can be a simple shell command in the PR workflow: `git diff --name-only origin/main | grep 'src/db/migrations/.*\.sql$' && exit 1 || true`.

--- a/docs-v2/themes/00-infrastructure/prds/060-database-operations/us-02-production-guards.md
+++ b/docs-v2/themes/00-infrastructure/prds/060-database-operations/us-02-production-guards.md
@@ -1,0 +1,25 @@
+# US-02: Production guards on destructive commands
+
+> PRD: [060 — Database Operations](README.md)
+> Status: Not started
+
+## Description
+
+As an operator, I want destructive database commands to refuse to run against production data so that a mistaken `mise db:seed` can never wipe real financial records.
+
+## Acceptance Criteria
+
+- [ ] `scripts/init-db.ts` checks `NODE_ENV` — exits with error message if `NODE_ENV=production`
+- [ ] `scripts/init-db.ts` checks if the database contains any `transactions` rows — exits with error if count > 0, explaining "Database contains real data. Use migrations to modify the schema."
+- [ ] `scripts/clear-db.ts` (or equivalent) applies the same two checks
+- [ ] `scripts/seed-db.ts` (or equivalent) applies the same two checks
+- [ ] Error messages are specific: tell the user what was detected and what to do instead
+- [ ] `mise db:init`, `mise db:seed`, `mise db:clear` all inherit these guards (they call the scripts)
+- [ ] A `--force` flag exists as an escape hatch (e.g., `FORCE=true mise db:init`) for deliberate resets — but prints a warning before proceeding
+- [ ] Tests cover: guard triggers on production env, guard triggers on non-empty transactions table, `--force` bypasses with warning, guard passes on empty dev database
+
+## Notes
+
+The transaction count check is a heuristic — if someone has imported real bank transactions, the database is "production" regardless of `NODE_ENV`. Both checks run: either one failing blocks the operation.
+
+The `--force` flag exists because sometimes you legitimately need to reset a dev database that has leftover test data in the transactions table. The flag should never be used in CI or automated scripts.

--- a/docs-v2/themes/00-infrastructure/prds/060-database-operations/us-03-pre-migration-backup.md
+++ b/docs-v2/themes/00-infrastructure/prds/060-database-operations/us-03-pre-migration-backup.md
@@ -1,0 +1,27 @@
+# US-03: Pre-migration automatic backup
+
+> PRD: [060 — Database Operations](README.md)
+> Status: Not started
+
+## Description
+
+As an operator, I want an automatic backup of the SQLite database before any migration runs so that a bad migration can never cause unrecoverable data loss.
+
+## Acceptance Criteria
+
+- [ ] When `runMigrations()` or Drizzle migrate detects pending migrations, a backup is created BEFORE applying them
+- [ ] Backup is a file copy: `{DB_PATH}.pre-migration-{timestamp}.bak` in the same directory as the database
+- [ ] Backup uses SQLite's `VACUUM INTO` or file copy with WAL checkpoint to ensure consistency
+- [ ] If all migrations succeed, the backup file is deleted (no accumulation of old backups)
+- [ ] If any migration fails, the backup file is preserved and its path is logged: "Migration failed. Backup available at: {path}"
+- [ ] If the database has no data (fresh install), backup is skipped (no point backing up empty schema)
+- [ ] Backup is skipped if there are no pending migrations (server starts normally, no unnecessary I/O)
+- [ ] Log line on backup: `[db] Backing up database before applying N migration(s)...`
+- [ ] Log line on cleanup: `[db] All migrations applied successfully. Backup removed.`
+- [ ] Tests cover: backup created when migrations pending, backup deleted on success, backup preserved on failure, backup skipped when no pending migrations
+
+## Notes
+
+`VACUUM INTO` is preferred over file copy because it creates a consistent snapshot even if WAL mode has uncommitted pages. However, it requires SQLite 3.27+ — verify the `better-sqlite3` version supports it. Fallback: `PRAGMA wal_checkpoint(TRUNCATE)` then file copy.
+
+This is a local safety net, not a replacement for the offsite backup system (PRD-017). The offsite backup runs on a schedule; this runs on every server startup that has pending migrations.

--- a/docs-v2/themes/00-infrastructure/prds/060-database-operations/us-04-migration-safety-tests.md
+++ b/docs-v2/themes/00-infrastructure/prds/060-database-operations/us-04-migration-safety-tests.md
@@ -1,0 +1,26 @@
+# US-04: Migration data safety tests
+
+> PRD: [060 — Database Operations](README.md)
+> Status: Not started
+
+## Description
+
+As a developer, I want CI tests that verify migrations don't lose data so that a schema change can never silently drop rows or columns.
+
+## Acceptance Criteria
+
+- [ ] Test file: `apps/pops-api/src/db/migration-safety.test.ts`
+- [ ] Test creates an in-memory SQLite database with the full schema (via `initializeSchema`)
+- [ ] Test inserts representative seed data into key tables: transactions (with tags JSON, entity FK), movies (with genres JSON), items (with location FK, connections), watchlist, watch_history
+- [ ] Test applies all Drizzle migrations via `drizzle-kit migrate` (or programmatic equivalent)
+- [ ] After migration, test queries each seeded table and verifies: row count unchanged, column values intact, FK relationships valid, JSON columns parse correctly
+- [ ] Test runs in CI on every PR that modifies `packages/db-types/src/schema/` or `src/db/drizzle-migrations/`
+- [ ] Test fails with a clear message if a migration drops rows, nullifies columns, or breaks FK constraints
+- [ ] Test covers a "new column added" migration: existing rows get the default value, no data loss
+- [ ] Test covers a "column renamed" migration: data preserved under the new name (or migration uses ALTER TABLE RENAME COLUMN)
+
+## Notes
+
+SQLite has limited ALTER TABLE support — it can add columns and rename columns, but cannot drop columns (pre-3.35) or change types. Migrations that need to restructure a table must use the "create new → copy data → drop old → rename new" pattern. The safety test catches cases where the copy step is missing.
+
+This test doesn't need to run against every migration individually — it runs the full migration chain against a seeded DB and verifies the end state. If a new migration breaks data, the test fails.

--- a/docs-v2/themes/00-infrastructure/prds/060-database-operations/us-05-go-live-runbook.md
+++ b/docs-v2/themes/00-infrastructure/prds/060-database-operations/us-05-go-live-runbook.md
@@ -1,0 +1,28 @@
+# US-05: Go-live runbook
+
+> PRD: [060 — Database Operations](README.md)
+> Status: Not started
+
+## Description
+
+As an operator, I want a documented go-live procedure so that I know exactly how to transition from a dev database to real production data and never lose it.
+
+## Acceptance Criteria
+
+- [ ] Runbook file created at `docs-v2/runbooks/go-live.md` (accessible from repo when server is down)
+- [ ] Runbook covers: prerequisites (backups working, migrations unified, guards in place)
+- [ ] Runbook covers: initial data import — which import commands to run, in what order, with what flags
+- [ ] Runbook covers: verification — how to confirm data was imported correctly (row counts, spot checks)
+- [ ] Runbook covers: point of no return — after this step, never run `db:init` or `db:seed` again
+- [ ] Runbook covers: ongoing operations — how schema changes work going forward (edit schema → generate → review → commit → deploy → auto-migrate on startup)
+- [ ] Runbook covers: emergency recovery — if something goes wrong, how to restore from backup (references PRD-017 recovery procedure)
+- [ ] Runbook includes a "safe commands" vs "destructive commands" reference table
+- [ ] Runbook is linked from the root `CLAUDE.md` under a "Production" section so agents see it
+
+## Notes
+
+The runbook should be concise enough to follow under stress (server down, need to restore). No prose — use numbered steps, command blocks, and verification checks.
+
+Safe commands (always OK): `mise dev`, `mise test`, `mise build`, `mise typecheck`, `mise lint`.
+Destructive commands (never in production): `mise db:init`, `mise db:seed`, `mise db:clear`.
+Schema change commands (careful): `mise drizzle:generate`, `mise drizzle:migrate`.


### PR DESCRIPTION
## Summary

New infrastructure epic for production data safety. Blocks real data usage.

**Epic 07: Database Operations** — PRD-060 with 5 user stories:
- **US-01**: Unify migrations on Drizzle — freeze manual SQL, single migration path
- **US-02**: Production guards — db:init/seed/clear refuse to run against real data
- **US-03**: Pre-migration backup — automatic SQLite snapshot before any migration, auto-restore on failure
- **US-04**: Migration safety tests — CI verifies schema changes don't lose data
- **US-05**: Go-live runbook — documented procedure for transitioning from dev to production

## Why this blocks go-live

Today, running `mise db:seed` against a database with real bank transactions wipes everything with no warning. There are two competing migration systems. There's no automatic backup before schema changes. No operator would trust this with real financial data.

## Test plan

- [ ] Epic follows template (scope, PRDs table, dependencies, out of scope)
- [ ] PRD follows template (overview, current state, target state, business rules, edge cases, US table)
- [ ] All 5 USs follow template (description, acceptance criteria, notes)
- [ ] US acceptance criteria are testable
- [ ] Parallelisation notes are accurate (US-02/03/05 parallel, US-04 blocked by US-01)