### PR TITLE
feat(media): POPS-to-Plex watchlist push sync [tb-071]

### DIFF
--- a/apps/pops-api/src/modules/media/plex/client.test.ts
+++ b/apps/pops-api/src/modules/media/plex/client.test.ts
@@ -512,6 +512,54 @@ describe("error handling", () => {
   });
 });
 
+describe("addToWatchlist", () => {
+  it("calls Plex Discover API with PUT and correct ratingKey", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(null, 200));
+
+    await client.addToWatchlist("5d776830880197001ec955e8");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("discover.provider.plex.tv/actions/addToWatchlist");
+    expect(url).toContain("ratingKey=5d776830880197001ec955e8");
+    expect(url).toContain(`X-Plex-Token=${PLEX_TOKEN}`);
+    expect(options.method).toBe("PUT");
+  });
+
+  it("throws PlexApiError on API failure", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse("Server Error", 500, "Internal Server Error"));
+
+    await expect(client.addToWatchlist("bad-key")).rejects.toThrow(PlexApiError);
+  });
+
+  it("throws PlexApiError on network error", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    await expect(client.addToWatchlist("key")).rejects.toThrow(PlexApiError);
+  });
+});
+
+describe("removeFromWatchlist", () => {
+  it("calls Plex Discover API with PUT and correct ratingKey", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(null, 200));
+
+    await client.removeFromWatchlist("5d776830880197001ec955e8");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("discover.provider.plex.tv/actions/removeFromWatchlist");
+    expect(url).toContain("ratingKey=5d776830880197001ec955e8");
+    expect(url).toContain(`X-Plex-Token=${PLEX_TOKEN}`);
+    expect(options.method).toBe("PUT");
+  });
+
+  it("throws PlexApiError on API failure", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse("Not Found", 404, "Not Found"));
+
+    await expect(client.removeFromWatchlist("bad-key")).rejects.toThrow(PlexApiError);
+  });
+});
+
 describe("external ID parsing", () => {
   it("handles malformed guid strings gracefully", async () => {
     fetchMock.mockResolvedValueOnce(

--- a/apps/pops-api/src/modules/media/plex/client.ts
+++ b/apps/pops-api/src/modules/media/plex/client.ts
@@ -86,6 +86,24 @@ export class PlexClient {
   }
 
   // -------------------------------------------------------------------------
+  // Plex Discover (cloud) watchlist API
+  // -------------------------------------------------------------------------
+
+  /** Add an item to the Plex cloud watchlist by discover ratingKey. */
+  async addToWatchlist(ratingKey: string): Promise<void> {
+    await this.put(
+      `https://discover.provider.plex.tv/actions/addToWatchlist?ratingKey=${ratingKey}`
+    );
+  }
+
+  /** Remove an item from the Plex cloud watchlist by discover ratingKey. */
+  async removeFromWatchlist(ratingKey: string): Promise<void> {
+    await this.put(
+      `https://discover.provider.plex.tv/actions/removeFromWatchlist?ratingKey=${ratingKey}`
+    );
+  }
+
+  // -------------------------------------------------------------------------
   // Mappers
   // -------------------------------------------------------------------------
 
@@ -184,5 +202,40 @@ export class PlexClient {
     }
 
     return (await response.json()) as T;
+  }
+
+  /** Generic PUT for cloud API endpoints (absolute URLs). */
+  private async put(absoluteUrl: string): Promise<void> {
+    const separator = absoluteUrl.includes("?") ? "&" : "?";
+    const url = `${absoluteUrl}${separator}X-Plex-Token=${this.token}`;
+
+    let response: Response;
+
+    try {
+      response = await fetch(url, {
+        method: "PUT",
+        headers: {
+          Accept: "application/json",
+        },
+      });
+    } catch (err) {
+      throw new PlexApiError(
+        0,
+        `Network error: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    if (!response.ok) {
+      let message = `Plex API error: ${response.status} ${response.statusText}`;
+      try {
+        const text = await response.text();
+        if (text) {
+          message = text;
+        }
+      } catch {
+        // Ignore parse failures
+      }
+      throw new PlexApiError(response.status, message);
+    }
   }
 }

--- a/apps/pops-api/src/modules/media/watchlist/router.ts
+++ b/apps/pops-api/src/modules/media/watchlist/router.ts
@@ -14,6 +14,7 @@ import {
 } from "./types.js";
 import * as service from "./service.js";
 import { NotFoundError, ConflictError } from "../../../shared/errors.js";
+import { getPlexClient } from "../plex/service.js";
 
 const DEFAULT_LIMIT = 50;
 const DEFAULT_OFFSET = 0;
@@ -49,20 +50,39 @@ export const watchlistRouter = router({
     }
   }),
 
-  /** Add an item to the watchlist. */
-  add: protectedProcedure.input(AddToWatchlistSchema).mutation(({ input }) => {
+  /** Add an item to the watchlist. Pushes to Plex if connected (best-effort). */
+  add: protectedProcedure.input(AddToWatchlistSchema).mutation(async ({ input }) => {
+    let row;
     try {
-      const row = service.addToWatchlist(input);
-      return {
-        data: toWatchlistEntry(row),
-        message: "Added to watchlist",
-      };
+      row = service.addToWatchlist(input);
     } catch (err) {
       if (err instanceof ConflictError) {
         throw new TRPCError({ code: "CONFLICT", message: err.message });
       }
       throw err;
     }
+
+    // Best-effort push to Plex — failures do not block local operation
+    const plexRatingKey = (row as Record<string, unknown>).plexRatingKey as string | null;
+    if (plexRatingKey) {
+      try {
+        const client = getPlexClient();
+        if (client) {
+          await client.addToWatchlist(plexRatingKey);
+          console.log(`[Plex] Pushed watchlist add for ratingKey=${plexRatingKey}`);
+        }
+      } catch (err) {
+        console.warn(
+          `[Plex] Failed to push watchlist add for ratingKey=${plexRatingKey}:`,
+          err instanceof Error ? err.message : err
+        );
+      }
+    }
+
+    return {
+      data: toWatchlistEntry(row),
+      message: "Added to watchlist",
+    };
   }),
 
   /** Update a watchlist entry. */
@@ -115,16 +135,45 @@ export const watchlistRouter = router({
       }
     }),
 
-  /** Remove an entry from the watchlist. */
-  remove: protectedProcedure.input(z.object({ id: z.number() })).mutation(({ input }) => {
+  /** Remove an entry from the watchlist. Pushes removal to Plex if connected (best-effort). */
+  remove: protectedProcedure.input(z.object({ id: z.number() })).mutation(async ({ input }) => {
+    // Fetch entry before removing to get plexRatingKey
+    let plexRatingKey: string | null = null;
     try {
-      service.removeFromWatchlist(input.id);
-      return { message: "Removed from watchlist" };
+      const entry = service.getWatchlistEntry(input.id);
+      plexRatingKey = (entry as Record<string, unknown>).plexRatingKey as string | null;
     } catch (err) {
       if (err instanceof NotFoundError) {
         throw new TRPCError({ code: "NOT_FOUND", message: err.message });
       }
       throw err;
     }
+
+    try {
+      service.removeFromWatchlist(input.id);
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
+
+    // Best-effort push removal to Plex
+    if (plexRatingKey) {
+      try {
+        const client = getPlexClient();
+        if (client) {
+          await client.removeFromWatchlist(plexRatingKey);
+          console.log(`[Plex] Pushed watchlist removal for ratingKey=${plexRatingKey}`);
+        }
+      } catch (err) {
+        console.warn(
+          `[Plex] Failed to push watchlist removal for ratingKey=${plexRatingKey}:`,
+          err instanceof Error ? err.message : err
+        );
+      }
+    }
+
+    return { message: "Removed from watchlist" };
   }),
 });


### PR DESCRIPTION
## Summary
- Add `addToWatchlist()` and `removeFromWatchlist()` methods to PlexClient targeting the Plex Discover cloud API (`discover.provider.plex.tv`)
- Extend watchlist router `add` and `remove` mutations with best-effort Plex push — failures are logged but never block the local operation
- Add 5 new client tests covering the Discover API methods

## Dependency
**Blocked by tb-069** (schema migration adding `source` and `plexRatingKey` columns to watchlist table). The push logic safely handles the `plexRatingKey` field being absent until the migration lands — it simply skips the Plex call when no ratingKey is available.

## Changes
- `client.ts`: New `addToWatchlist(ratingKey)` and `removeFromWatchlist(ratingKey)` + private `put()` HTTP method
- `router.ts`: `add` and `remove` mutations now async, with try/catch Plex push after local operation
- `client.test.ts`: 5 new tests for watchlist Discover API calls

## Test plan
- [x] Client tests pass (30/30, was 25)
- [x] Typecheck passes
- [ ] Rebase on tb-069 once merged to verify plexRatingKey access
- [ ] Manual test: add to watchlist with Plex connected, verify Plex API called

🤖 Generated with [Claude Code](https://claude.com/claude-code)