### PR TITLE
refactor(db): freeze manual SQL migrations, unify on Drizzle [tb-073]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,32 @@ jobs:
         env:
           CLAUDE_API_KEY: test-key
 
+  lint-frozen-migrations:
+    name: Frozen Migrations Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for new SQL migration files
+        run: |
+          NEW_SQL=$(git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD -- 'apps/pops-api/src/db/migrations/*.sql')
+          if [ -n "$NEW_SQL" ]; then
+            echo "::error::Manual SQL migrations are frozen. Use Drizzle instead:"
+            echo "::error::  1. Edit schema in packages/db-types/src/schema/"
+            echo "::error::  2. Run: mise drizzle:generate"
+            echo "::error::  3. Review generated SQL in src/db/drizzle-migrations/"
+            echo ""
+            echo "New .sql files detected:"
+            echo "$NEW_SQL"
+            exit 1
+          fi
+          echo "No new SQL migration files — check passed."
+
   test-frontend:
     name: Frontend Tests
     runs-on: ubuntu-latest

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -54,6 +54,7 @@ src/
 ## Data Patterns
 
 - **SQLite** — source of truth. All access through Drizzle ORM (no raw SQL in new code).
+- **Schema changes go through Drizzle only** — edit the schema file in `packages/db-types/src/schema/`, run `mise drizzle:generate`, review the generated SQL, commit both. Manual SQL migrations in `src/db/migrations/` are frozen (CI enforced).
 - **Integer PKs** for domain tables. **TEXT UUIDs** for cross-domain FKs (finance transactions, entities).
 - **Timestamps** — `createdAt`/`updatedAt` as ISO 8601 TEXT columns.
 - **JSON columns** — stored as TEXT, parsed on read (e.g., tags, genres).

--- a/apps/pops-api/src/db/migrations/MIGRATIONS_FROZEN.md
+++ b/apps/pops-api/src/db/migrations/MIGRATIONS_FROZEN.md
@@ -1,0 +1,18 @@
+# Manual SQL Migrations — FROZEN
+
+**Do not add new `.sql` files to this directory.**
+
+As of March 2026, all schema changes go through Drizzle:
+
+1. Edit the schema in `packages/db-types/src/schema/`
+2. Run `mise drizzle:generate`
+3. Review the generated SQL in `src/db/drizzle-migrations/`
+4. Commit both the schema change and the migration
+
+Existing migrations in this directory are preserved for backward compatibility.
+The `runMigrations()` function in `db.ts` still applies them to databases that
+haven't seen them yet, but no new migrations should be added here.
+
+A CI check enforces this — PRs that add `.sql` files to this directory will fail.
+
+See [PRD-060 US-01](../../../../../docs-v2/themes/00-infrastructure/prds/060-database-operations/us-01-unify-migrations.md) for context.


### PR DESCRIPTION
## Summary
- Added `MIGRATIONS_FROZEN.md` to `src/db/migrations/` documenting the freeze
- Added CI lint job (`lint-frozen-migrations`) to `test.yml` that fails PRs adding new `.sql` files to the migrations directory
- Updated `CONVENTIONS.md` with Drizzle-only schema change workflow

Existing `runMigrations()` continues to apply old migrations for backward compatibility. No code changes to `db.ts` needed — the architecture already supports both systems running in sequence.

## Test plan
- [x] MIGRATIONS_FROZEN.md exists in migrations directory
- [ ] CI lint step catches new .sql files in migrations/ (verified by workflow syntax)
- [x] CONVENTIONS.md documents Drizzle workflow
- [ ] Existing manual migrations still apply on startup (no code change, backward compat preserved)
- [ ] `mise drizzle:generate` workflow documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)