### PR TITLE
feat(db): add pre-migration automatic backup with VACUUM INTO [tb-075]

### DIFF
--- a/apps/pops-api/src/db-backup.test.ts
+++ b/apps/pops-api/src/db-backup.test.ts
@@ -12,10 +12,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 /** Minimal reproduction of the backup logic from db.ts for testability. */
-function getPendingMigrations(
-  database: BetterSqlite3.Database,
-  migrationsDir: string
-): string[] {
+function getPendingMigrations(database: BetterSqlite3.Database, migrationsDir: string): string[] {
   database.exec(`
     CREATE TABLE IF NOT EXISTS schema_migrations (
       version TEXT PRIMARY KEY,
@@ -46,9 +43,9 @@ function getPendingMigrations(
 
 function hasData(database: BetterSqlite3.Database): boolean {
   try {
-    const row = database
-      .prepare("SELECT COUNT(*) AS cnt FROM transactions")
-      .get() as { cnt: number } | undefined;
+    const row = database.prepare("SELECT COUNT(*) AS cnt FROM transactions").get() as
+      | { cnt: number }
+      | undefined;
     return (row?.cnt ?? 0) > 0;
   } catch {
     return false;

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -101,9 +101,9 @@ function getPendingMigrations(database: BetterSqlite3.Database): string[] {
 /** Check if the database has any data (not a fresh install). */
 function hasData(database: BetterSqlite3.Database): boolean {
   try {
-    const row = database
-      .prepare("SELECT COUNT(*) AS cnt FROM transactions")
-      .get() as { cnt: number } | undefined;
+    const row = database.prepare("SELECT COUNT(*) AS cnt FROM transactions").get() as
+      | { cnt: number }
+      | undefined;
     return (row?.cnt ?? 0) > 0;
   } catch {
     // Table may not exist on fresh install


### PR DESCRIPTION
## Summary
- Adds automatic SQLite backup (via `VACUUM INTO`) before running pending migrations in `openDatabase()`
- Backup is deleted on success, preserved with logged path on failure
- Skipped for fresh installs (no data) and when no migrations are pending
- 5 test cases covering: backup created, deleted on success, preserved on failure, skipped when no pending, skipped when no data

Implements PRD-060 US-03 acceptance criteria.

## Test plan
- [x] `vitest run src/db-backup.test.ts` — all 5 tests pass
- [x] TypeScript compiles cleanly
- [ ] Reviewer verifies VACUUM INTO backup logic in `db.ts`
- [ ] Reviewer verifies backup cleanup on success / preservation on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)