### PR TITLE
feat(media): add watchlist sync UI to Plex settings page [tb-072]

### DIFF
--- a/packages/app-media/src/pages/PlexSettingsPage.test.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.test.tsx
@@ -8,6 +8,7 @@ const mockGetSyncStatus = vi.fn();
 const mockGetPlexUrl = vi.fn();
 const mockGetSectionIds = vi.fn();
 const mockGetSchedulerStatus = vi.fn();
+const mockGetSyncLogs = vi.fn();
 const mockTestConnection = vi.fn();
 const mockGetLibraries = vi.fn();
 const mockSyncMoviesMutate = vi.fn();
@@ -19,9 +20,11 @@ const mockCheckPinMutate = vi.fn();
 const mockDisconnectMutate = vi.fn();
 const mockStartSchedulerMutate = vi.fn();
 const mockStopSchedulerMutate = vi.fn();
+const mockSyncWatchlistMutate = vi.fn();
 
 let syncMoviesOpts: Record<string, unknown> = {};
 let syncTvOpts: Record<string, unknown> = {};
+let syncWatchlistOpts: Record<string, unknown> = {};
 let getPinOpts: Record<string, unknown> = {};
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
@@ -41,6 +44,9 @@ vi.mock("../lib/trpc", () => ({
         },
         getSchedulerStatus: {
           useQuery: (...args: unknown[]) => mockGetSchedulerStatus(...args),
+        },
+        getSyncLogs: {
+          useQuery: (...args: unknown[]) => mockGetSyncLogs(...args),
         },
         testConnection: {
           useQuery: (...args: unknown[]) => mockTestConnection(...args),
@@ -107,6 +113,12 @@ vi.mock("../lib/trpc", () => ({
             isPending: false,
           }),
         },
+        syncWatchlist: {
+          useMutation: (opts: Record<string, unknown>) => {
+            syncWatchlistOpts = opts;
+            return { mutate: mockSyncWatchlistMutate, isPending: false };
+          },
+        },
       },
     },
   },
@@ -163,6 +175,10 @@ function setupDefaults(overrides: {
     },
     refetch: vi.fn(),
   });
+  mockGetSyncLogs.mockReturnValue({
+    data: { data: [] },
+    refetch: vi.fn(),
+  });
   mockTestConnection.mockReturnValue({
     data: { data: { connected } },
     refetch: vi.fn(),
@@ -192,6 +208,7 @@ describe("PlexSettingsPage", () => {
     mockGetPlexUrl.mockReturnValue({ isLoading: true });
     mockGetSectionIds.mockReturnValue({ data: null });
     mockGetSchedulerStatus.mockReturnValue({ data: null });
+    mockGetSyncLogs.mockReturnValue({ data: null });
     mockTestConnection.mockReturnValue({ data: null });
     mockGetLibraries.mockReturnValue({ data: null });
 
@@ -375,5 +392,90 @@ describe("PlexSettingsPage", () => {
 
     expect(screen.getByText("Connection Failed")).toBeInTheDocument();
     expect(screen.getByText("Connection refused")).toBeInTheDocument();
+  });
+
+  // ── Watchlist Sync ──────────────────────────────────────────────────────
+
+  it("shows Watchlist Sync section when connected", () => {
+    setupDefaults();
+    renderPage();
+
+    expect(screen.getByText("Watchlist Sync")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sync watchlist/i })).toBeInTheDocument();
+  });
+
+  it("hides Watchlist Sync section when not connected", () => {
+    setupDefaults({ connected: false, hasToken: false, configured: false });
+    renderPage();
+
+    expect(screen.queryByText("Watchlist Sync")).not.toBeInTheDocument();
+  });
+
+  it("triggers syncWatchlist mutation on button click", () => {
+    setupDefaults();
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /sync watchlist/i }));
+    expect(mockSyncWatchlistMutate).toHaveBeenCalledOnce();
+  });
+
+  it("displays watchlist sync results after successful sync", () => {
+    setupDefaults();
+    renderPage();
+
+    // Simulate sync success
+    const onSuccess = syncWatchlistOpts.onSuccess as (res: {
+      data: { added: number; removed: number; skipped: number; errors: { title: string; reason: string }[] };
+      message: string;
+    }) => void;
+    onSuccess({
+      data: { added: 3, removed: 1, skipped: 5, errors: [] },
+      message: "Watchlist sync: 3 added, 1 removed, 5 skipped",
+    });
+
+    renderPage();
+
+    expect(screen.getByText("Watchlist Results:")).toBeInTheDocument();
+    expect(screen.getByText("3 added")).toBeInTheDocument();
+    expect(screen.getByText("1 removed")).toBeInTheDocument();
+    expect(screen.getByText("5 skipped")).toBeInTheDocument();
+  });
+
+  it("shows expandable error details for watchlist sync errors", () => {
+    setupDefaults();
+    renderPage();
+
+    const onSuccess = syncWatchlistOpts.onSuccess as (res: {
+      data: { added: number; removed: number; skipped: number; errors: { title: string; reason: string }[] };
+      message: string;
+    }) => void;
+    onSuccess({
+      data: {
+        added: 1,
+        removed: 0,
+        skipped: 0,
+        errors: [{ title: "Unknown Movie", reason: "No TMDB match found" }],
+      },
+      message: "Watchlist sync: 1 added, 0 removed, 0 skipped",
+    });
+
+    renderPage();
+
+    expect(screen.getByText("1 errors")).toBeInTheDocument();
+    // Errors hidden initially
+    expect(screen.queryByText(/No TMDB match found/)).not.toBeInTheDocument();
+
+    // Expand errors — find the one inside the watchlist section
+    const watchlistSection = screen.getByText("Watchlist Sync").closest("div")!;
+    const showBtn = within(watchlistSection).getByText("Show error details");
+    fireEvent.click(showBtn);
+
+    expect(screen.getByText(/Unknown Movie:/)).toBeInTheDocument();
+    expect(screen.getByText(/No TMDB match found/)).toBeInTheDocument();
+
+    // Collapse
+    const hideBtn = within(watchlistSection).getByText("Hide error details");
+    fireEvent.click(hideBtn);
+    expect(screen.queryByText(/No TMDB match found/)).not.toBeInTheDocument();
   });
 });

--- a/packages/app-media/src/pages/PlexSettingsPage.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.tsx
@@ -31,6 +31,7 @@ import {
   ChevronDown,
   ChevronUp,
   History,
+  Bookmark,
 } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
@@ -41,6 +42,13 @@ interface SyncResult {
   skipped: number;
   errors: { title: string; reason: string; year: number | null }[];
   skipReasons?: { title: string; reason: string; year: number | null }[];
+}
+
+interface WatchlistSyncResult {
+  added: number;
+  removed: number;
+  skipped: number;
+  errors: { title: string; reason: string }[];
 }
 
 function SyncResultDisplay({ result, label }: { result: SyncResult; label: string }) {
@@ -107,6 +115,45 @@ function SyncResultDisplay({ result, label }: { result: SyncResult; label: strin
   );
 }
 
+function WatchlistSyncResultDisplay({ result }: { result: WatchlistSyncResult }) {
+  const [showErrors, setShowErrors] = useState(false);
+
+  return (
+    <div className="rounded-md border bg-muted/30 p-3 space-y-2 text-sm">
+      <div className="flex items-center gap-3 flex-wrap">
+        <span className="font-medium">Watchlist Results:</span>
+        <span className="text-emerald-400">{result.added} added</span>
+        <span className="text-orange-400">{result.removed} removed</span>
+        <span className="text-muted-foreground">{result.skipped} skipped</span>
+        {result.errors.length > 0 && (
+          <span className="text-red-400">{result.errors.length} errors</span>
+        )}
+      </div>
+      {result.errors.length > 0 && (
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowErrors(!showErrors)}
+            className="flex items-center gap-1 text-xs text-red-400 hover:text-red-300 transition-colors"
+          >
+            {showErrors ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            {showErrors ? "Hide" : "Show"} error details
+          </button>
+          {showErrors && (
+            <div className="mt-2 space-y-1 text-xs text-red-400/80">
+              {result.errors.map((err, i) => (
+                <p key={i}>
+                  <span className="font-medium">{err.title}:</span> {err.reason}
+                </p>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function PlexSettingsPage() {
   const [movieSectionId, setMovieSectionId] = useState<string>("");
   const [tvSectionId, setTvSectionId] = useState<string>("");
@@ -115,6 +162,7 @@ export function PlexSettingsPage() {
   const [plexUrl, setPlexUrl] = useState<string>("");
   const [movieSyncResult, setMovieSyncResult] = useState<SyncResult | null>(null);
   const [tvSyncResult, setTvSyncResult] = useState<SyncResult | null>(null);
+  const [watchlistSyncResult, setWatchlistSyncResult] = useState<WatchlistSyncResult | null>(null);
   const [schedulerHours, setSchedulerHours] = useState<number>(6);
 
   const syncStatus = trpc.media.plex.getSyncStatus.useQuery();
@@ -169,6 +217,13 @@ export function PlexSettingsPage() {
       syncLogs.refetch();
     },
     onError: (err: { message: string }) => toast.error(`TV show sync failed: ${err.message}`),
+  });
+  const syncWatchlist = trpc.media.plex.syncWatchlist.useMutation({
+    onSuccess: (res: { data: WatchlistSyncResult; message: string }) => {
+      setWatchlistSyncResult(res.data);
+      toast.success(res.message);
+    },
+    onError: (err: { message: string }) => toast.error(`Watchlist sync failed: ${err.message}`),
   });
   const saveSectionIds = trpc.media.plex.saveSectionIds.useMutation({
     onError: (err: { message: string }) =>
@@ -553,6 +608,38 @@ export function PlexSettingsPage() {
                 <p className="text-xs text-muted-foreground">No TV libraries found</p>
               )}
             </div>
+          </div>
+        )}
+
+        {/* Watchlist Sync */}
+        {connected && (
+          <div className="rounded-lg border bg-card p-6 space-y-4">
+            <div className="flex items-center gap-2">
+              <Bookmark className="h-5 w-5 text-muted-foreground" />
+              <h2 className="text-lg font-semibold">Watchlist Sync</h2>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Sync your Plex watchlist to POPS. Items added or removed on Plex will be reflected
+              locally.
+            </p>
+            <Button
+              size="sm"
+              disabled={syncWatchlist.isPending}
+              onClick={() => {
+                setWatchlistSyncResult(null);
+                syncWatchlist.mutate();
+              }}
+            >
+              {syncWatchlist.isPending ? (
+                <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+              )}
+              {syncWatchlist.isPending ? "Syncing..." : "Sync Watchlist"}
+            </Button>
+            {watchlistSyncResult && (
+              <WatchlistSyncResultDisplay result={watchlistSyncResult} />
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Add "Watchlist Sync" section to PlexSettingsPage with manual sync trigger button
- Display sync results inline (added/removed/skipped counts) with expandable error details
- Section only visible when Plex is connected
- 5 new tests covering visibility, mutation trigger, results display, and error expansion

**Depends on:** PR #1049 (tb-070 — syncWatchlist tRPC mutation)

## Test plan
- [ ] CI passes (typecheck + tests)
- [ ] Watchlist Sync section appears when Plex is connected
- [ ] Section hidden when disconnected
- [ ] Sync button triggers mutation and shows results
- [ ] Error details expand/collapse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)