### PR TITLE
ci: remove duplicate imports test step from test.yml [tb-079]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,13 +42,6 @@ jobs:
           # Tests use in-memory DB and mocked APIs - no real credentials needed
           CLAUDE_API_KEY: test-key
 
-      - name: Run imports module tests specifically
-        run: |
-          cd apps/pops-api
-          pnpm test src/modules/finance/imports --run --reporter=verbose
-        env:
-          CLAUDE_API_KEY: test-key
-
   lint-frozen-migrations:
     name: Frozen Migrations Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove redundant "Run imports module tests specifically" step from test.yml
- This step re-ran a subset of tests already covered by "Run all backend tests"
- Saves ~4s per CI run

## Test plan
- [ ] Verify CI passes without the duplicate step
- [ ] Confirm imports tests still run as part of the full backend test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)