### PR TITLE
ci(e2e): cache Playwright browsers [tb-080]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,10 +30,24 @@ jobs:
       - name: Build shared packages
         run: cd packages/db-types && pnpm build
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: |
           cd apps/pops-shell
           npx playwright install --with-deps
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: |
+          cd apps/pops-shell
+          npx playwright install-deps
 
       - name: Initialize pops-api database
         run: cd apps/pops-api && pnpm dev:init


### PR DESCRIPTION
## Summary
- Add `actions/cache` step to cache `~/.cache/ms-playwright` between E2E CI runs
- On cache hit, only install system dependencies (`playwright install-deps`) — skips ~50s browser download
- On cache miss, full `playwright install --with-deps` runs as before
- Cache key uses `pnpm-lock.yaml` hash so it invalidates when Playwright version changes

## Test plan
- [ ] First CI run: cache miss, full install (same behavior as before)
- [ ] Subsequent CI runs: cache hit, only system deps installed (~50s saved)
- [ ] Playwright version bump in lockfile: cache invalidates, re-downloads browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)