### PR TITLE
fix(ui): add missing eslint-plugin-storybook dependency [tb-081]

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,6 +63,7 @@
     "eslint": "^9.0.0",
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^7.0.0",
+    "eslint-plugin-storybook": "^10.3.0",
     "prettier": "^3.0.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,6 +714,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.0
         version: 7.0.1(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-storybook:
+        specifier: ^10.3.0
+        version: 10.3.3(eslint@9.39.4(jiti@2.6.1))(storybook@10.3.1(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       prettier:
         specifier: ^3.0.0
         version: 3.8.1
@@ -3986,6 +3989,12 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       eslint: '>=8'
+
+  eslint-plugin-storybook@10.3.3:
+    resolution: {integrity: sha512-jo8wZvKaJlxxrNvf4hCsROJP3CdlpaLiYewAs5Ww+PJxCrLelIi5XVHWOAgBvvr3H9WDKvUw8xuvqPYqAlpkFg==}
+    peerDependencies:
+      eslint: '>=8'
+      storybook: ^10.3.3
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -9847,6 +9856,15 @@ snapshots:
       '@typescript-eslint/utils': 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       eslint: 10.0.3(jiti@2.6.1)
       ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-plugin-storybook@10.3.3(eslint@9.39.4(jiti@2.6.1))(storybook@10.3.1(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      storybook: 10.3.1(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
## Summary
- `pnpm lint` fails in `@pops/ui` because `eslint-plugin-storybook` is imported in `eslint.config.js` but not listed in `devDependencies`
- Added `eslint-plugin-storybook@^10.3.0` to match the existing `@storybook/react-vite@^10.3.1`

## Test plan
- [ ] CI lint step passes for `@pops/ui`
- [ ] `pnpm lint` no longer errors with "Cannot find package 'eslint-plugin-storybook'"

🤖 Generated with [Claude Code](https://claude.com/claude-code)