### PR TITLE
fix(api): increase vitest hookTimeout for slow environments [tb-083]

### DIFF
--- a/apps/pops-api/vitest.config.ts
+++ b/apps/pops-api/vitest.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: {},
+  test: {
+    hookTimeout: 30_000,
+  },
 });


### PR DESCRIPTION
## Summary
- Increase vitest `hookTimeout` from default 10s to 30s in pops-api
- Root cause: `env-context.test.ts` and `envs/router.test.ts` create full SQLite databases (25+ tables, indexes, seed data) per test in `beforeEach`. On resource-constrained environments (sandboxes), this exceeds the 10s default
- `ai-categorizer-disk.test.ts` also affected — uses dynamic `import()` per test which is slow in constrained envs

## Test plan
- [ ] CI passes (all existing tests still green)
- [ ] Previously-timing-out tests now have adequate time for setup/teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)