### PR TITLE
ci: make quality checks always report status on PRs [tb-084]

### DIFF
--- a/.github/workflows/pops-api-ci.yml
+++ b/.github/workflows/pops-api-ci.yml
@@ -2,10 +2,6 @@ name: Finance API CI
 
 on:
   pull_request:
-    paths:
-      - "apps/pops-api/**"
-      - "packages/db-types/**"
-      - ".github/workflows/pops-api-ci.yml"
   push:
     branches:
       - main
@@ -15,9 +11,30 @@ on:
       - ".github/workflows/pops-api-ci.yml"
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.api }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            api:
+              - 'apps/pops-api/**'
+              - 'packages/db-types/**'
+              - '.github/workflows/pops-api-ci.yml'
+
   quality-checks:
     name: Quality Checks
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: |
+      always() &&
+      (github.event_name == 'push' || needs.changes.outputs.relevant == 'true')
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/shell-ci.yml
+++ b/.github/workflows/shell-ci.yml
@@ -12,18 +12,35 @@ on:
       - "packages/navigation/**"
       - ".github/workflows/shell-ci.yml"
   pull_request:
-    paths:
-      - "apps/pops-shell/**"
-      - "packages/app-*/**"
-      - "packages/db-types/**"
-      - "packages/ui/**"
-      - "packages/widgets/**"
-      - "packages/navigation/**"
-      - ".github/workflows/shell-ci.yml"
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.shell }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shell:
+              - 'apps/pops-shell/**'
+              - 'packages/app-*/**'
+              - 'packages/db-types/**'
+              - 'packages/ui/**'
+              - 'packages/widgets/**'
+              - 'packages/navigation/**'
+              - '.github/workflows/shell-ci.yml'
+
   quality:
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: |
+      always() &&
+      (github.event_name == 'push' || needs.changes.outputs.relevant == 'true')
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Use `dorny/paths-filter` in pops-api-ci.yml and shell-ci.yml to detect relevant file changes
- Workflows now always trigger on PRs but skip actual work when no relevant files changed
- This ensures required status checks (Quality Checks, quality) always report a result, fixing branch protection on CI-only PRs
- Push-to-main behavior unchanged (still path-filtered)

## Test plan
- [ ] Open a PR touching only `.github/` files — verify Quality Checks and quality jobs show as skipped (not missing)
- [ ] Open a PR touching `apps/pops-api/` — verify Quality Checks runs normally
- [ ] Open a PR touching `apps/pops-shell/` — verify quality runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)