### PR TITLE
fix(db): add missing item_documents table to schema [tb-090]

### DIFF
--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -176,6 +176,20 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
 
     CREATE INDEX IF NOT EXISTS idx_item_photos_item ON item_photos(item_id);
 
+    CREATE TABLE IF NOT EXISTS item_documents (
+      id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+      item_id                TEXT NOT NULL,
+      paperless_document_id  INTEGER NOT NULL,
+      document_type          TEXT NOT NULL,
+      title                  TEXT,
+      created_at             TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (item_id) REFERENCES home_inventory(id) ON DELETE CASCADE
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_item_documents_pair ON item_documents(item_id, paperless_document_id);
+    CREATE INDEX IF NOT EXISTS idx_item_documents_item ON item_documents(item_id);
+    CREATE INDEX IF NOT EXISTS idx_item_documents_doc ON item_documents(paperless_document_id);
+
     CREATE TABLE IF NOT EXISTS wish_list (
       id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
       notion_id TEXT UNIQUE,


### PR DESCRIPTION
## Summary
- Add missing `item_documents` CREATE TABLE + indexes to `initializeSchema()` in schema.ts
- The table DDL was never added when the migration was created, but the migration was listed in INCLUDED_MIGRATIONS — so fresh databases had the migration marked as applied but the table never created
- This caused the insurance report to crash with "no such table: item_documents"

## Test plan
- [x] All 11 migration safety tests pass
- [x] Prettier passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)