### PR TITLE
fix(watchlist): make add endpoint idempotent [tb-089]

### DIFF
--- a/apps/pops-api/src/modules/media/watchlist/router.ts
+++ b/apps/pops-api/src/modules/media/watchlist/router.ts
@@ -50,38 +50,33 @@ export const watchlistRouter = router({
     }
   }),
 
-  /** Add an item to the watchlist. Pushes to Plex if connected (best-effort). */
+  /** Add an item to the watchlist. Idempotent — returns existing entry if already present. */
   add: protectedProcedure.input(AddToWatchlistSchema).mutation(async ({ input }) => {
-    let row;
-    try {
-      row = service.addToWatchlist(input);
-    } catch (err) {
-      if (err instanceof ConflictError) {
-        throw new TRPCError({ code: "CONFLICT", message: err.message });
-      }
-      throw err;
-    }
+    const { row, created } = service.addToWatchlist(input);
 
     // Best-effort push to Plex — failures do not block local operation
-    const plexRatingKey = (row as Record<string, unknown>).plexRatingKey as string | null;
-    if (plexRatingKey) {
-      try {
-        const client = getPlexClient();
-        if (client) {
-          await client.addToWatchlist(plexRatingKey);
-          console.log(`[Plex] Pushed watchlist add for ratingKey=${plexRatingKey}`);
+    if (created) {
+      const plexRatingKey = (row as Record<string, unknown>).plexRatingKey as string | null;
+      if (plexRatingKey) {
+        try {
+          const client = getPlexClient();
+          if (client) {
+            await client.addToWatchlist(plexRatingKey);
+            console.log(`[Plex] Pushed watchlist add for ratingKey=${plexRatingKey}`);
+          }
+        } catch (err) {
+          console.warn(
+            `[Plex] Failed to push watchlist add for ratingKey=${plexRatingKey}:`,
+            err instanceof Error ? err.message : err
+          );
         }
-      } catch (err) {
-        console.warn(
-          `[Plex] Failed to push watchlist add for ratingKey=${plexRatingKey}:`,
-          err instanceof Error ? err.message : err
-        );
       }
     }
 
     return {
       data: toWatchlistEntry(row),
-      message: "Added to watchlist",
+      created,
+      message: created ? "Added to watchlist" : "Already on watchlist",
     };
   }),
 

--- a/apps/pops-api/src/modules/media/watchlist/service.test.ts
+++ b/apps/pops-api/src/modules/media/watchlist/service.test.ts
@@ -59,13 +59,14 @@ describe("getWatchlistEntry", () => {
 
 describe("addToWatchlist", () => {
   it("creates a watchlist entry", () => {
-    const entry = service.addToWatchlist({
+    const { row: entry, created } = service.addToWatchlist({
       mediaType: "movie",
       mediaId: 550,
       priority: 2,
       notes: "Must watch",
     });
 
+    expect(created).toBe(true);
     expect(entry.id).toBeGreaterThan(0);
     expect(entry.mediaType).toBe("movie");
     expect(entry.mediaId).toBe(550);
@@ -74,7 +75,7 @@ describe("addToWatchlist", () => {
   });
 
   it("sets default values for optional fields", () => {
-    const entry = service.addToWatchlist({
+    const { row: entry } = service.addToWatchlist({
       mediaType: "tv_show",
       mediaId: 100,
     });
@@ -83,11 +84,19 @@ describe("addToWatchlist", () => {
     expect(entry.notes).toBeNull();
   });
 
-  it("throws ConflictError on duplicate mediaType+mediaId", () => {
-    service.addToWatchlist({ mediaType: "movie", mediaId: 550 });
-    expect(() => service.addToWatchlist({ mediaType: "movie", mediaId: 550 })).toThrow(
-      "already on the watchlist"
-    );
+  it("returns existing entry on duplicate mediaType+mediaId", () => {
+    const { row: first, created: firstCreated } = service.addToWatchlist({
+      mediaType: "movie",
+      mediaId: 550,
+    });
+    const { row: second, created: secondCreated } = service.addToWatchlist({
+      mediaType: "movie",
+      mediaId: 550,
+    });
+
+    expect(firstCreated).toBe(true);
+    expect(secondCreated).toBe(false);
+    expect(second.id).toBe(first.id);
   });
 });
 

--- a/apps/pops-api/src/modules/media/watchlist/service.ts
+++ b/apps/pops-api/src/modules/media/watchlist/service.ts
@@ -56,8 +56,11 @@ export function getWatchlistEntry(id: number): MediaWatchlistRow {
   return row;
 }
 
-/** Add an item to the watchlist. Returns the created row. Throws ConflictError on duplicate. */
-export function addToWatchlist(input: AddToWatchlistInput): MediaWatchlistRow {
+/** Add an item to the watchlist. Idempotent — returns the existing entry if already present. */
+export function addToWatchlist(input: AddToWatchlistInput): {
+  row: MediaWatchlistRow;
+  created: boolean;
+} {
   const db = getDrizzle();
 
   try {
@@ -71,10 +74,20 @@ export function addToWatchlist(input: AddToWatchlistInput): MediaWatchlistRow {
       })
       .run();
 
-    return getWatchlistEntry(Number(result.lastInsertRowid));
+    return { row: getWatchlistEntry(Number(result.lastInsertRowid)), created: true };
   } catch (err) {
     if (err instanceof Error && err.message.includes("UNIQUE constraint failed")) {
-      throw new ConflictError(`${input.mediaType} ${input.mediaId} is already on the watchlist`);
+      const existing = db
+        .select()
+        .from(mediaWatchlist)
+        .where(
+          and(
+            eq(mediaWatchlist.mediaType, input.mediaType),
+            eq(mediaWatchlist.mediaId, input.mediaId)
+          )
+        )
+        .get();
+      if (existing) return { row: existing, created: false };
     }
     throw err;
   }

--- a/packages/app-media/src/pages/DiscoverPage.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.tsx
@@ -133,27 +133,21 @@ export function DiscoverPage() {
       try {
         // First add to library (idempotent)
         const libResult = await addMovieMutation.mutateAsync({ tmdbId });
-        // Then add to watchlist using the local DB id
-        await addWatchlistMutation.mutateAsync({
+        // Then add to watchlist using the local DB id (idempotent)
+        const watchlistResult = await addWatchlistMutation.mutateAsync({
           mediaType: "movie",
           mediaId: libResult.data.id,
         });
-        toast.success(`Added "${libResult.data.title}" to watchlist`);
+        if (watchlistResult.created) {
+          toast.success(`Added "${libResult.data.title}" to watchlist`);
+        } else {
+          toast.info(`"${libResult.data.title}" is already on watchlist`);
+        }
         void utils.media.watchlist.list.invalidate();
         void utils.media.discovery.trending.invalidate();
         void utils.media.discovery.recommendations.invalidate();
-      } catch (err) {
-        // CONFLICT means already on watchlist — that's fine
-        if (
-          err &&
-          typeof err === "object" &&
-          "data" in err &&
-          (err as { data?: { code?: string } }).data?.code === "CONFLICT"
-        ) {
-          toast.info("Already on watchlist");
-        } else {
-          toast.error("Failed to add to watchlist");
-        }
+      } catch {
+        toast.error("Failed to add to watchlist");
       } finally {
         setAddingToWatchlist((prev) => {
           const next = new Set(prev);


### PR DESCRIPTION
## Summary
- Make `watchlist.add` endpoint idempotent — return existing entry with `created: false` instead of throwing 409 CONFLICT on duplicate
- Update service to catch UNIQUE constraint violation and return existing row
- Update router to pass through `created` flag and skip Plex push on duplicates
- Update DiscoverPage to show appropriate toast based on `created` flag
- Update service tests to verify idempotent behavior

## Test plan
- [x] 18 watchlist service tests pass
- [x] Prettier formatted
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)