### PR TITLE
fix(media): arr test connection uses form data [tb-097]

### DIFF
--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -5,16 +5,32 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../../../trpc.js";
 import { ArrApiError } from "./types.js";
+import { RadarrClient } from "./radarr-client.js";
+import { SonarrClient } from "./sonarr-client.js";
 import * as arrService from "./service.js";
 
-export const arrRouter = router({
-  /** Test Radarr connection and return server version. Safe to call when not configured. */
-  testRadarr: protectedProcedure.query(async () => {
-    const client = arrService.getRadarrClient();
-    if (!client) {
-      return { data: { configured: false, connected: false, error: "Radarr is not configured" } };
-    }
+const TestConnectionInput = z.object({
+  url: z.string().min(1),
+  apiKey: z.string().min(1),
+});
 
+const MASKED_KEY = "••••••••";
+
+/** If the API key is still masked, resolve the saved key from DB. */
+function resolveApiKey(formKey: string, service: "radarr" | "sonarr"): string | null {
+  if (formKey !== MASKED_KEY) return formKey;
+  const settings = arrService.getArrSettings();
+  return (service === "radarr" ? settings.radarrApiKey : settings.sonarrApiKey) ?? null;
+}
+
+export const arrRouter = router({
+  /** Test Radarr connection using provided form values. */
+  testRadarr: protectedProcedure.input(TestConnectionInput).mutation(async ({ input }) => {
+    const apiKey = resolveApiKey(input.apiKey, "radarr");
+    if (!apiKey) {
+      return { data: { configured: false, connected: false, error: "No API key provided" } };
+    }
+    const client = new RadarrClient(input.url, apiKey);
     try {
       const status = await client.testConnection();
       return {
@@ -28,13 +44,13 @@ export const arrRouter = router({
     }
   }),
 
-  /** Test Sonarr connection and return server version. Safe to call when not configured. */
-  testSonarr: protectedProcedure.query(async () => {
-    const client = arrService.getSonarrClient();
-    if (!client) {
-      return { data: { configured: false, connected: false, error: "Sonarr is not configured" } };
+  /** Test Sonarr connection using provided form values. */
+  testSonarr: protectedProcedure.input(TestConnectionInput).mutation(async ({ input }) => {
+    const apiKey = resolveApiKey(input.apiKey, "sonarr");
+    if (!apiKey) {
+      return { data: { configured: false, connected: false, error: "No API key provided" } };
     }
-
+    const client = new SonarrClient(input.url, apiKey);
     try {
       const status = await client.testConnection();
       return {

--- a/packages/app-media/src/pages/ArrSettingsPage.tsx
+++ b/packages/app-media/src/pages/ArrSettingsPage.tsx
@@ -150,12 +150,8 @@ export function ArrSettingsPage() {
     onError: (err: { message: string }) => toast.error(`Failed to save: ${err.message}`),
   });
 
-  const testRadarr = trpc.media.arr.testRadarr.useQuery(undefined, {
-    enabled: false,
-  });
-  const testSonarr = trpc.media.arr.testSonarr.useQuery(undefined, {
-    enabled: false,
-  });
+  const testRadarr = trpc.media.arr.testRadarr.useMutation();
+  const testSonarr = trpc.media.arr.testSonarr.useMutation();
 
   if (settingsQuery.isLoading) {
     return (
@@ -218,9 +214,9 @@ export function ArrSettingsPage() {
               radarrApiKey,
             });
           }}
-          onTest={() => testRadarr.refetch()}
+          onTest={() => testRadarr.mutate({ url: ensureProtocol(radarrUrl), apiKey: radarrApiKey })}
           saving={saveSettings.isPending}
-          testing={testRadarr.isFetching}
+          testing={testRadarr.isPending}
           testResult={testRadarr.data?.data ?? null}
         />
 
@@ -240,9 +236,9 @@ export function ArrSettingsPage() {
               sonarrApiKey,
             });
           }}
-          onTest={() => testSonarr.refetch()}
+          onTest={() => testSonarr.mutate({ url: ensureProtocol(sonarrUrl), apiKey: sonarrApiKey })}
           saving={saveSettings.isPending}
-          testing={testSonarr.isFetching}
+          testing={testSonarr.isPending}
           testResult={testSonarr.data?.data ?? null}
         />
       </div>


### PR DESCRIPTION
## Summary
- Changed `testRadarr`/`testSonarr` from parameterless queries (that read saved DB settings) to mutations that accept `url` + `apiKey` from the form
- Users can now test credentials before saving — test runs against the form values, not the DB
- Masked API keys (`••••••••`) automatically resolve to the saved key from DB

## Test plan
- [ ] Open Arr Settings, change URL, click Test Connection — should test against the new URL
- [ ] Change API key, click Test Connection — should use the new key
- [ ] Leave API key unchanged (masked), change URL, click Test Connection — should resolve saved key

🤖 Generated with [Claude Code](https://claude.com/claude-code)