### PR TITLE
fix(media): make search results clickable for items in library [tb-095]

### DIFF
--- a/packages/app-media/src/components/SearchResultCard.stories.tsx
+++ b/packages/app-media/src/components/SearchResultCard.stories.tsx
@@ -2,6 +2,7 @@
  * SearchResultCard stories — search result card variants for movies and TV shows.
  */
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter } from "react-router";
 import { SearchResultCard } from "./SearchResultCard";
 
 const meta: Meta<typeof SearchResultCard> = {
@@ -13,9 +14,11 @@ const meta: Meta<typeof SearchResultCard> = {
   },
   decorators: [
     (Story) => (
-      <div style={{ maxWidth: "400px" }}>
-        <Story />
-      </div>
+      <MemoryRouter>
+        <div style={{ maxWidth: "400px" }}>
+          <Story />
+        </div>
+      </MemoryRouter>
     ),
   ],
 };
@@ -78,6 +81,18 @@ export const InLibrary: Story = {
     posterUrl: "https://image.tmdb.org/t/p/w342/pB8BM7pdSp6B6Ih7QI4S2t015wi.jpg",
     voteAverage: 8.4,
     inLibrary: true,
+  },
+};
+
+export const InLibraryClickable: Story = {
+  args: {
+    type: "movie",
+    title: "Fight Club",
+    year: "1999",
+    posterUrl: "https://image.tmdb.org/t/p/w342/pB8BM7pdSp6B6Ih7QI4S2t015wi.jpg",
+    voteAverage: 8.4,
+    inLibrary: true,
+    href: "/media/movies/1",
   },
 };
 

--- a/packages/app-media/src/components/SearchResultCard.tsx
+++ b/packages/app-media/src/components/SearchResultCard.tsx
@@ -4,6 +4,7 @@
  * and an "Add to Library" / "In Library" action.
  */
 import { useState } from "react";
+import { Link } from "react-router";
 import { cn, Badge, Button, Skeleton } from "@pops/ui";
 import { Film, Tv, Loader2, Check, Plus } from "lucide-react";
 import { RequestMovieButton } from "./RequestMovieButton";
@@ -27,6 +28,8 @@ export interface SearchResultCardProps {
   addDisabledReason?: string;
   isAdding?: boolean;
   onAdd?: () => void;
+  /** When set, the card becomes a clickable link to the detail page. */
+  href?: string;
   className?: string;
 }
 
@@ -59,6 +62,7 @@ export function SearchResultCard({
   addDisabledReason,
   isAdding,
   onAdd,
+  href,
   className,
 }: SearchResultCardProps) {
   const [imageLoaded, setImageLoaded] = useState(false);
@@ -67,8 +71,8 @@ export function SearchResultCard({
   const showPlaceholder = !posterUrl || imageError;
   const Icon = type === "movie" ? Film : Tv;
 
-  return (
-    <div className={cn("flex gap-4 rounded-lg border bg-card p-3 text-card-foreground", className)}>
+  const cardContent = (
+    <>
       {/* Poster */}
       <div className="relative w-20 shrink-0 overflow-hidden rounded-md bg-muted aspect-[2/3]">
         {!showPlaceholder && (
@@ -155,6 +159,22 @@ export function SearchResultCard({
           )}
         </div>
       </div>
-    </div>
+    </>
   );
+
+  const baseClasses = cn(
+    "flex gap-4 rounded-lg border bg-card p-3 text-card-foreground",
+    href && "transition-colors hover:bg-accent/50",
+    className
+  );
+
+  if (href) {
+    return (
+      <Link to={href} className={baseClasses} aria-label={`${title} (${type === "movie" ? "Movie" : "TV"})`}>
+        {cardContent}
+      </Link>
+    );
+  }
+
+  return <div className={baseClasses}>{cardContent}</div>;
 }

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -101,12 +101,18 @@ export function SearchPage() {
     { enabled: shouldSearchTv, staleTime: 30_000 }
   );
 
-  // Build lookup sets
+  // Build lookup sets and ID maps for navigation
   const movieTmdbIds = new Set(
     (libraryMovies.data?.data ?? []).map((m: { tmdbId: number }) => m.tmdbId)
   );
   const tvTvdbIds = new Set(
     (libraryTvShows.data?.data ?? []).map((s: { tvdbId: number }) => s.tvdbId)
+  );
+  const movieTmdbToLocalId = new Map(
+    (libraryMovies.data?.data ?? []).map((m: { id: number; tmdbId: number }) => [m.tmdbId, m.id])
+  );
+  const tvTvdbToLocalId = new Map(
+    (libraryTvShows.data?.data ?? []).map((s: { id: number; tvdbId: number }) => [s.tvdbId, s.id])
   );
 
   // Mutations
@@ -263,6 +269,7 @@ export function SearchPage() {
               {movieResults.map((movie: MovieSearchResult) => {
                 const key = makeKey("movie", movie.tmdbId);
                 const inLibrary = movieTmdbIds.has(movie.tmdbId) || addedIds.has(key);
+                const localId = movieTmdbToLocalId.get(movie.tmdbId);
                 return (
                   <SearchResultCard
                     key={movie.tmdbId}
@@ -276,6 +283,7 @@ export function SearchPage() {
                     inLibrary={inLibrary}
                     isAdding={addingIds.has(key)}
                     onAdd={() => handleAddMovie(movie.tmdbId)}
+                    href={localId != null ? `/media/movies/${localId}` : undefined}
                   />
                 );
               })}
@@ -324,6 +332,7 @@ export function SearchPage() {
               {tvResults.map((show: TvSearchResult) => {
                 const key = makeKey("tv", show.tvdbId);
                 const inLibrary = tvTvdbIds.has(show.tvdbId) || addedIds.has(key);
+                const localId = tvTvdbToLocalId.get(show.tvdbId);
                 return (
                   <SearchResultCard
                     key={show.tvdbId}
@@ -336,6 +345,7 @@ export function SearchPage() {
                     inLibrary={inLibrary}
                     isAdding={addingIds.has(key)}
                     onAdd={() => handleAddTvShow(show.tvdbId)}
+                    href={localId != null ? `/media/tv/${localId}` : undefined}
                   />
                 );
               })}


### PR DESCRIPTION
## Summary
- Search result cards for movies/TV shows already in the library now navigate to their detail pages when clicked
- Builds `tmdbId→localId` and `tvdbId→localId` lookup maps from existing library queries (no additional API calls)
- Cards not yet in library remain non-clickable (just "Add to Library" button)
- Added hover styling and `InLibraryClickable` Storybook story

## Test plan
- [ ] Search for a movie that's already in the library — clicking the card navigates to `/media/movies/{id}`
- [ ] Search for a TV show in the library — clicking navigates to `/media/tv/{id}`
- [ ] Search for a movie NOT in library — card is not clickable, only "Add to Library" button works
- [ ] Add a movie via search, verify it becomes clickable after page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)