### PR TITLE
fix(media): prevent empty img src warnings [tb-094]

### DIFF
--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -97,9 +97,9 @@ export function MovieDetailPage() {
 
   const year = movie.releaseDate ? new Date(movie.releaseDate).getFullYear() : null;
 
-  const posterSrc = movie.posterUrl ?? "";
-  const backdropSrc = movie.backdropUrl ?? "";
-  const logoSrc = movie.logoUrl ?? "";
+  const posterSrc = movie.posterUrl ?? undefined;
+  const backdropSrc = movie.backdropUrl ?? undefined;
+  const logoSrc = movie.logoUrl ?? undefined;
 
   const metadataItems = [
     { label: "Status", value: movie.status },
@@ -153,11 +153,15 @@ export function MovieDetailPage() {
         </div>
 
         <div className="relative h-full flex flex-col md:flex-row items-end p-6 gap-4 md:gap-6">
-          <img
-            src={posterSrc}
-            alt={`${movie.title} poster`}
-            className="w-28 md:w-44 aspect-[2/3] rounded-lg object-cover shadow-lg shrink-0"
-          />
+          {posterSrc ? (
+            <img
+              src={posterSrc}
+              alt={`${movie.title} poster`}
+              className="w-28 md:w-44 aspect-[2/3] rounded-lg object-cover shadow-lg shrink-0"
+            />
+          ) : (
+            <div className="w-28 md:w-44 aspect-[2/3] rounded-lg bg-muted shadow-lg shrink-0" />
+          )}
 
           <div className="flex-1 pb-1">
             <h1 className="text-2xl md:text-4xl font-bold text-foreground">

--- a/packages/app-media/src/pages/RankingsPage.tsx
+++ b/packages/app-media/src/pages/RankingsPage.tsx
@@ -62,8 +62,6 @@ function RankingRow({
   posterUrl,
 }: RankingRowProps) {
   const href = mediaType === "movie" ? `/media/movies/${mediaId}` : `/media/tv/${mediaId}`;
-  const posterSrc = posterUrl ?? "";
-
   return (
     <div className="flex items-center gap-4 p-3 rounded-lg border hover:bg-muted/50 transition-colors">
       <span className="w-8 text-right text-sm font-bold text-muted-foreground tabular-nums">
@@ -81,12 +79,16 @@ function RankingRow({
       </span>
 
       <Link to={href} className="shrink-0">
-        <img
-          src={posterSrc}
-          alt={`${title} poster`}
-          className="w-10 aspect-[2/3] rounded object-cover bg-muted"
-          loading="lazy"
-        />
+        {posterUrl ? (
+          <img
+            src={posterUrl}
+            alt={`${title} poster`}
+            className="w-10 aspect-[2/3] rounded object-cover bg-muted"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-10 aspect-[2/3] rounded bg-muted" />
+        )}
       </Link>
 
       <div className="flex-1 min-w-0">

--- a/packages/app-media/src/pages/TvShowDetailPage.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.tsx
@@ -198,7 +198,7 @@ export function TvShowDetailPage() {
 
   const yearRange = formatYearRange(show.firstAirDate, show.lastAirDate, show.status);
 
-  const posterSrc = show.posterUrl ?? "";
+  const posterSrc = show.posterUrl ?? undefined;
   const backdropSrc = show.backdropUrl ?? null;
 
   const progress = progressData?.data;
@@ -251,11 +251,15 @@ export function TvShowDetailPage() {
         </div>
 
         <div className="relative h-full flex flex-col md:flex-row items-end p-6 gap-4 md:gap-6">
-          <img
-            src={posterSrc}
-            alt={`${show.name} poster`}
-            className="w-28 md:w-44 aspect-[2/3] rounded-lg object-cover shadow-lg shrink-0"
-          />
+          {posterSrc ? (
+            <img
+              src={posterSrc}
+              alt={`${show.name} poster`}
+              className="w-28 md:w-44 aspect-[2/3] rounded-lg object-cover shadow-lg shrink-0"
+            />
+          ) : (
+            <div className="w-28 md:w-44 aspect-[2/3] rounded-lg bg-muted shadow-lg shrink-0" />
+          )}
 
           <div className="flex-1 pb-1">
             <h1 className="text-2xl md:text-4xl font-bold text-foreground">{show.name}</h1>

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -132,8 +132,6 @@ function WatchlistItem({
 
   const href =
     entry.mediaType === "movie" ? `/media/movies/${entry.mediaId}` : `/media/tv/${entry.mediaId}`;
-  const posterSrc = posterUrl ?? "";
-
   // Sync draft when server data changes
   useEffect(() => {
     if (!editing) {
@@ -206,12 +204,16 @@ function WatchlistItem({
       )}
 
       <Link to={href} className="shrink-0">
-        <img
-          src={posterSrc}
-          alt={`${title} poster`}
-          className="w-16 aspect-[2/3] rounded object-cover bg-muted"
-          loading="lazy"
-        />
+        {posterUrl ? (
+          <img
+            src={posterUrl}
+            alt={`${title} poster`}
+            className="w-16 aspect-[2/3] rounded object-cover bg-muted"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-16 aspect-[2/3] rounded bg-muted" />
+        )}
       </Link>
 
       <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- Fix React warning about empty string passed to img src attribute
- Conditionally render poster images (show muted placeholder when URL missing)
- Affects RankingsPage, WatchlistPage, MovieDetailPage, TvShowDetailPage

## Test plan
- [ ] Visit rankings page — movies without posters show placeholder instead of broken img
- [ ] Visit movie/TV detail pages — no console warnings about empty src
- [ ] Discover page cards already handled correctly (no change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)