### PR TITLE
fix(media): return title/year/poster from rankings API [tb-093]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -550,6 +550,27 @@ export interface RankingsResult {
  *
  * Supports optional mediaType filter and pagination.
  */
+/** Resolve the best poster URL from a rankings row. */
+function resolvePosterUrl(row: {
+  mediaType: string;
+  moviePosterPath: string | null;
+  movieTmdbId: number | null;
+  moviePosterOverride: string | null;
+  tvPosterPath: string | null;
+  tvTvdbId: number | null;
+  tvPosterOverride: string | null;
+}): string | null {
+  if (row.mediaType === "movie") {
+    if (row.moviePosterOverride) return row.moviePosterOverride;
+    if (row.moviePosterPath && row.movieTmdbId)
+      return `/media/images/movie/${row.movieTmdbId}/poster.jpg`;
+    return null;
+  }
+  if (row.tvPosterOverride) return row.tvPosterOverride;
+  if (row.tvPosterPath && row.tvTvdbId) return `/media/images/tv/${row.tvTvdbId}/poster.jpg`;
+  return null;
+}
+
 export function getRankings(
   dimensionId: number | undefined,
   mediaType: string | undefined,
@@ -577,7 +598,18 @@ export function getRankings(
           ms.media_type as mediaType,
           ms.media_id as mediaId,
           ms.score as score,
-          ms.comparison_count as comparisonCount
+          ms.comparison_count as comparisonCount,
+          COALESCE(m.title, tv.name, 'Unknown') as title,
+          CASE
+            WHEN ms.media_type = 'movie' THEN CAST(SUBSTR(m.release_date, 1, 4) AS INTEGER)
+            ELSE CAST(SUBSTR(tv.first_air_date, 1, 4) AS INTEGER)
+          END as year,
+          m.poster_path as moviePosterPath,
+          m.tmdb_id as movieTmdbId,
+          m.poster_override_path as moviePosterOverride,
+          tv.poster_path as tvPosterPath,
+          tv.tvdb_id as tvTvdbId,
+          tv.poster_override_path as tvPosterOverride
         FROM media_scores ms
         LEFT JOIN movies m ON ms.media_type = 'movie' AND ms.media_id = m.id
         LEFT JOIN tv_shows tv ON ms.media_type = 'tv_show' AND ms.media_id = tv.id
@@ -593,6 +625,14 @@ export function getRankings(
       mediaId: number;
       score: number;
       comparisonCount: number;
+      title: string;
+      year: number | null;
+      moviePosterPath: string | null;
+      movieTmdbId: number | null;
+      moviePosterOverride: string | null;
+      tvPosterPath: string | null;
+      tvTvdbId: number | null;
+      tvPosterOverride: string | null;
     }>;
 
     return {
@@ -600,6 +640,9 @@ export function getRankings(
         rank: offset + i + 1,
         mediaType: row.mediaType,
         mediaId: row.mediaId,
+        title: row.title,
+        year: row.year,
+        posterUrl: resolvePosterUrl(row),
         score: Math.round(row.score * 10) / 10,
         comparisonCount: row.comparisonCount,
       })),
@@ -643,7 +686,18 @@ export function getRankings(
         ms.media_type as mediaType,
         ms.media_id as mediaId,
         AVG(ms.score) as score,
-        SUM(ms.comparison_count) as comparisonCount
+        SUM(ms.comparison_count) as comparisonCount,
+        COALESCE(m.title, tv.name, 'Unknown') as title,
+        CASE
+          WHEN ms.media_type = 'movie' THEN CAST(SUBSTR(m.release_date, 1, 4) AS INTEGER)
+          ELSE CAST(SUBSTR(tv.first_air_date, 1, 4) AS INTEGER)
+        END as year,
+        m.poster_path as moviePosterPath,
+        m.tmdb_id as movieTmdbId,
+        m.poster_override_path as moviePosterOverride,
+        tv.poster_path as tvPosterPath,
+        tv.tvdb_id as tvTvdbId,
+        tv.poster_override_path as tvPosterOverride
       FROM media_scores ms
       LEFT JOIN movies m ON ms.media_type = 'movie' AND ms.media_id = m.id
       LEFT JOIN tv_shows tv ON ms.media_type = 'tv_show' AND ms.media_id = tv.id
@@ -660,6 +714,14 @@ export function getRankings(
     mediaId: number;
     score: number;
     comparisonCount: number;
+    title: string;
+    year: number | null;
+    moviePosterPath: string | null;
+    movieTmdbId: number | null;
+    moviePosterOverride: string | null;
+    tvPosterPath: string | null;
+    tvTvdbId: number | null;
+    tvPosterOverride: string | null;
   }>;
 
   return {
@@ -667,6 +729,9 @@ export function getRankings(
       rank: offset + i + 1,
       mediaType: row.mediaType,
       mediaId: row.mediaId,
+      title: row.title,
+      year: row.year,
+      posterUrl: resolvePosterUrl(row),
       score: Math.round(row.score * 10) / 10,
       comparisonCount: row.comparisonCount,
     })),

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -136,6 +136,9 @@ export interface RankedMediaEntry {
   rank: number;
   mediaType: string;
   mediaId: number;
+  title: string;
+  year: number | null;
+  posterUrl: string | null;
   score: number;
   comparisonCount: number;
 }

--- a/packages/app-media/src/pages/RankingsPage.test.tsx
+++ b/packages/app-media/src/pages/RankingsPage.test.tsx
@@ -5,8 +5,6 @@ import { MemoryRouter } from "react-router";
 
 const mockRankingsQuery = vi.fn();
 const mockDimensionsQuery = vi.fn();
-const mockMoviesQuery = vi.fn();
-const mockTvShowsQuery = vi.fn();
 
 vi.mock("../lib/trpc", () => ({
   trpc: {
@@ -14,12 +12,6 @@ vi.mock("../lib/trpc", () => ({
       comparisons: {
         rankings: { useQuery: (...args: unknown[]) => mockRankingsQuery(...args) },
         listDimensions: { useQuery: () => mockDimensionsQuery() },
-      },
-      movies: {
-        list: { useQuery: (...args: unknown[]) => mockMoviesQuery(...args) },
-      },
-      tvShows: {
-        list: { useQuery: (...args: unknown[]) => mockTvShowsQuery(...args) },
       },
     },
   },
@@ -35,13 +27,27 @@ function renderPage(initialRoute = "/media/rankings") {
   );
 }
 
-const movieA = { id: 1, title: "Alpha Movie", releaseDate: "2020-01-01", posterUrl: "/a.jpg" };
-const movieB = { id: 2, title: "Beta Movie", releaseDate: "2021-06-15", posterUrl: "/b.jpg" };
-const tvShow = { id: 10, name: "Gamma Show", firstAirDate: "2019-03-10", posterUrl: "/g.jpg" };
-
 const rankedEntries = [
-  { rank: 1, mediaType: "movie", mediaId: 1, score: 1532, comparisonCount: 5 },
-  { rank: 2, mediaType: "movie", mediaId: 2, score: 1468, comparisonCount: 5 },
+  {
+    rank: 1,
+    mediaType: "movie",
+    mediaId: 1,
+    title: "Alpha Movie",
+    year: 2020,
+    posterUrl: "/a.jpg",
+    score: 1532,
+    comparisonCount: 5,
+  },
+  {
+    rank: 2,
+    mediaType: "movie",
+    mediaId: 2,
+    title: "Beta Movie",
+    year: 2021,
+    posterUrl: "/b.jpg",
+    score: 1468,
+    comparisonCount: 5,
+  },
 ];
 
 const dimensions = [
@@ -67,12 +73,6 @@ function setupDefaults() {
   mockDimensionsQuery.mockReturnValue({
     data: { data: dimensions },
     isLoading: false,
-  });
-  mockMoviesQuery.mockReturnValue({
-    data: { data: [movieA, movieB] },
-  });
-  mockTvShowsQuery.mockReturnValue({
-    data: { data: [tvShow] },
   });
   mockRankingsQuery.mockReturnValue({
     data: {
@@ -164,6 +164,9 @@ describe("RankingsPage", () => {
       rank: i + 1,
       mediaType: "movie",
       mediaId: i + 1,
+      title: `Movie ${i + 1}`,
+      year: 2020,
+      posterUrl: null,
       score: 1600 - i * 4,
       comparisonCount: 3,
     }));
@@ -175,16 +178,6 @@ describe("RankingsPage", () => {
       },
       isLoading: false,
       error: null,
-    });
-    mockMoviesQuery.mockReturnValue({
-      data: {
-        data: manyEntries.map((e) => ({
-          id: e.mediaId,
-          title: `Movie ${e.mediaId}`,
-          releaseDate: "2020-01-01",
-          posterUrl: null,
-        })),
-      },
     });
 
     renderPage();
@@ -214,9 +207,36 @@ describe("RankingsPage", () => {
 
   it("displays medal colors for top 3 ranks", () => {
     const top3 = [
-      { rank: 1, mediaType: "movie", mediaId: 1, score: 1600, comparisonCount: 10 },
-      { rank: 2, mediaType: "movie", mediaId: 2, score: 1550, comparisonCount: 10 },
-      { rank: 3, mediaType: "movie", mediaId: 3, score: 1500, comparisonCount: 10 },
+      {
+        rank: 1,
+        mediaType: "movie",
+        mediaId: 1,
+        title: "Gold",
+        year: null,
+        posterUrl: null,
+        score: 1600,
+        comparisonCount: 10,
+      },
+      {
+        rank: 2,
+        mediaType: "movie",
+        mediaId: 2,
+        title: "Silver",
+        year: null,
+        posterUrl: null,
+        score: 1550,
+        comparisonCount: 10,
+      },
+      {
+        rank: 3,
+        mediaType: "movie",
+        mediaId: 3,
+        title: "Bronze",
+        year: null,
+        posterUrl: null,
+        score: 1500,
+        comparisonCount: 10,
+      },
     ];
 
     mockRankingsQuery.mockReturnValue({
@@ -227,15 +247,6 @@ describe("RankingsPage", () => {
       isLoading: false,
       error: null,
     });
-    mockMoviesQuery.mockReturnValue({
-      data: {
-        data: [
-          { id: 1, title: "Gold", releaseDate: null, posterUrl: null },
-          { id: 2, title: "Silver", releaseDate: null, posterUrl: null },
-          { id: 3, title: "Bronze", releaseDate: null, posterUrl: null },
-        ],
-      },
-    });
 
     renderPage();
     expect(screen.getByText("#1")).toBeInTheDocument();
@@ -244,8 +255,25 @@ describe("RankingsPage", () => {
   });
 
   it("shows 'Unknown' for media without metadata", () => {
-    mockMoviesQuery.mockReturnValue({ data: { data: [] } });
-    mockTvShowsQuery.mockReturnValue({ data: { data: [] } });
+    mockRankingsQuery.mockReturnValue({
+      data: {
+        data: [
+          {
+            rank: 1,
+            mediaType: "movie",
+            mediaId: 999,
+            title: "Unknown",
+            year: null,
+            posterUrl: null,
+            score: 1500,
+            comparisonCount: 1,
+          },
+        ],
+        pagination: { total: 1, limit: 25, offset: 0, hasMore: false },
+      },
+      isLoading: false,
+      error: null,
+    });
 
     renderPage();
     const unknowns = screen.getAllByText("Unknown");

--- a/packages/app-media/src/pages/RankingsPage.tsx
+++ b/packages/app-media/src/pages/RankingsPage.tsx
@@ -111,12 +111,6 @@ function RankingRow({
   );
 }
 
-interface MediaMeta {
-  title: string;
-  year: number | null;
-  posterUrl: string | null;
-}
-
 function RankingsList({ dimensionId }: { dimensionId?: number }) {
   const [offset, setOffset] = useState(0);
 
@@ -125,55 +119,6 @@ function RankingsList({ dimensionId }: { dimensionId?: number }) {
     limit: PAGE_SIZE,
     offset,
   });
-
-  const { data: moviesData } = trpc.media.movies.list.useQuery({ limit: 500 });
-  const { data: tvShowsData } = trpc.media.tvShows.list.useQuery({
-    limit: 500,
-  });
-
-  const movieMap = useMemo(
-    () =>
-      new Map<number, MediaMeta>(
-        (moviesData?.data ?? []).map(
-          (m: {
-            id: number;
-            title: string;
-            releaseDate: string | null;
-            posterUrl: string | null;
-          }) => [
-            m.id,
-            {
-              title: m.title,
-              year: m.releaseDate ? new Date(m.releaseDate).getFullYear() : null,
-              posterUrl: m.posterUrl,
-            },
-          ]
-        )
-      ),
-    [moviesData?.data]
-  );
-
-  const tvMap = useMemo(
-    () =>
-      new Map<number, MediaMeta>(
-        (tvShowsData?.data ?? []).map(
-          (s: {
-            id: number;
-            name: string;
-            firstAirDate: string | null;
-            posterUrl: string | null;
-          }) => [
-            s.id,
-            {
-              title: s.name,
-              year: s.firstAirDate ? new Date(s.firstAirDate).getFullYear() : null,
-              posterUrl: s.posterUrl,
-            },
-          ]
-        )
-      ),
-    [tvShowsData?.data]
-  );
 
   if (error) {
     return (
@@ -208,26 +153,24 @@ function RankingsList({ dimensionId }: { dimensionId?: number }) {
             mediaType: string;
             mediaId: number;
             rank: number;
+            title: string;
+            year: number | null;
+            posterUrl: string | null;
             score: number;
             comparisonCount: number;
-          }) => {
-            const meta =
-              entry.mediaType === "movie" ? movieMap.get(entry.mediaId) : tvMap.get(entry.mediaId);
-
-            return (
-              <RankingRow
-                key={`${entry.mediaType}-${entry.mediaId}`}
-                rank={entry.rank}
-                mediaType={entry.mediaType}
-                mediaId={entry.mediaId}
-                score={entry.score}
-                comparisonCount={entry.comparisonCount}
-                title={meta?.title ?? "Unknown"}
-                year={meta?.year ?? null}
-                posterUrl={meta?.posterUrl ?? null}
-              />
-            );
-          }
+          }) => (
+            <RankingRow
+              key={`${entry.mediaType}-${entry.mediaId}`}
+              rank={entry.rank}
+              mediaType={entry.mediaType}
+              mediaId={entry.mediaId}
+              score={entry.score}
+              comparisonCount={entry.comparisonCount}
+              title={entry.title}
+              year={entry.year}
+              posterUrl={entry.posterUrl}
+            />
+          )
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Rankings page showed "Unknown" for every other movie due to fragile client-side lookup maps
- Backend rankings SQL already JOINed movies/tv_shows for tie-breaking — now returns title, year, and posterUrl directly
- Removed separate movies.list and tvShows.list queries from RankingsPage, eliminating the ID mismatch issue

## Changes
- **Backend**: Added title, year, posterUrl to `RankedMediaEntry` type and both rankings SQL queries (per-dimension + overall)
- **Frontend**: Simplified `RankingsList` — uses server-provided metadata instead of building client-side lookup maps
- **Tests**: Updated backend (47/47 pass) and frontend test mocks to match new response shape

## Test plan
- [x] Backend comparisons tests pass (47/47)
- [x] TypeScript compiles cleanly (backend + frontend)
- [x] Prettier + ESLint clean
- [ ] CI validates frontend tests (jsdom too slow locally)
- [ ] Verify rankings page shows correct titles for all entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)