### PR TITLE
infra: add TMDB and TheTVDB API keys to secrets pipeline

### DIFF
--- a/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
+++ b/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
@@ -19,6 +19,8 @@ services:
       - up_webhook_secret
       - finance_api_key
       - claude_api_key
+      - tmdb_api_key
+      - thetvdb_api_key
     environment:
       NODE_ENV: production
       SQLITE_PATH: /data/sqlite/pops.db
@@ -160,6 +162,10 @@ secrets:
     file: {{ secrets_dir }}/telegram_bot_token
   finance_api_key:
     file: {{ secrets_dir }}/finance_api_key
+  tmdb_api_key:
+    file: {{ secrets_dir }}/tmdb_api_key
+  thetvdb_api_key:
+    file: {{ secrets_dir }}/thetvdb_api_key
   paperless_secret_key:
     file: {{ secrets_dir }}/paperless_secret_key
   paperless_admin_password:

--- a/infra/ansible/roles/secrets/defaults/main.yml
+++ b/infra/ansible/roles/secrets/defaults/main.yml
@@ -14,6 +14,10 @@ pops_secrets:
     value: "{{ vault_finance_api_key }}"
   - name: cloudflare_tunnel_token
     value: "{{ vault_cloudflare_tunnel_token }}"
+  - name: tmdb_api_key
+    value: "{{ vault_tmdb_api_key }}"
+  - name: thetvdb_api_key
+    value: "{{ vault_thetvdb_api_key }}"
   - name: paperless_secret_key
     value: "{{ vault_paperless_secret_key }}"
   - name: paperless_admin_password

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - up_webhook_secret
       - finance_api_key
       - claude_api_key
+      - tmdb_api_key
+      - thetvdb_api_key
     environment:
       NODE_ENV: production
       SQLITE_PATH: /data/sqlite/pops.db
@@ -183,6 +185,10 @@ secrets:
     file: ../secrets/telegram_bot_token
   finance_api_key:
     file: ../secrets/finance_api_key
+  tmdb_api_key:
+    file: ../secrets/tmdb_api_key
+  thetvdb_api_key:
+    file: ../secrets/thetvdb_api_key
   paperless_secret_key:
     file: ../secrets/paperless_secret_key
   paperless_admin_password:


### PR DESCRIPTION
## Summary

Add `tmdb_api_key` and `thetvdb_api_key` to the full secrets pipeline:
- Ansible secrets role
- Docker Compose (local + production template)
- pops-api service secret declarations

**Action required:** Add `vault_tmdb_api_key` and `vault_thetvdb_api_key` to the Ansible Vault before deploying.

## Test plan

- [ ] `ansible-playbook playbooks/site.yml --syntax-check` passes
- [ ] `docker compose config` validates without errors