### PR TITLE
fix: copy tsconfig.base.json into Docker images

### DIFF
--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 
 # Copy all workspace packages
 COPY packages/db-types/package.json ./packages/db-types/

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Copy workspace root files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 
 # Copy all workspace package.json files needed by pops-shell
 COPY apps/pops-shell/package.json ./apps/pops-shell/


### PR DESCRIPTION
## Summary

Docker build fails at `pnpm build` in db-types because `tsconfig.base.json` isn't copied into the image. Both pops-api and pops-shell Dockerfiles affected.

## Root cause

`packages/db-types/tsconfig.json` extends `../../tsconfig.base.json`. The Dockerfile copies the package tsconfig but not the base. This causes:
1. `TS5083: Cannot read file '/app/tsconfig.base.json'`
2. All drizzle-orm `.d.ts` type errors (because `skipLibCheck: true` is in the missing base config)

## Fix

Add `tsconfig.base.json` to the `COPY` line in both Dockerfiles.

## Test plan

- [ ] `docker compose build` succeeds for both pops-api and pops-shell