### PR TITLE
fix: add missing @pops/api-client to shell Dockerfile

### DIFF
--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -13,6 +13,7 @@ COPY packages/app-finance/package.json ./packages/app-finance/
 COPY packages/app-media/package.json ./packages/app-media/
 COPY packages/app-inventory/package.json ./packages/app-inventory/
 COPY packages/app-ai/package.json ./packages/app-ai/
+COPY packages/api-client/package.json ./packages/api-client/
 
 # Install pnpm and dependencies (workspace resolution)
 RUN corepack enable && pnpm install --frozen-lockfile
@@ -24,6 +25,7 @@ COPY packages/app-finance/ ./packages/app-finance/
 COPY packages/app-media/ ./packages/app-media/
 COPY packages/app-inventory/ ./packages/app-inventory/
 COPY packages/app-ai/ ./packages/app-ai/
+COPY packages/api-client/ ./packages/api-client/
 COPY apps/pops-api/ ./apps/pops-api/
 COPY apps/pops-shell/ ./apps/pops-shell/
 

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -621,10 +621,10 @@ export function WatchlistPage() {
         return;
       }
 
-      const reordered = arrayMove(currentOrder, oldIndex, newIndex);
+      const reordered = arrayMove(currentOrder, oldIndex, newIndex) as WatchlistEntry[];
       setOptimisticOrder(reordered);
 
-      const items = reordered.map((entry, i) => ({ id: entry.id, priority: i }));
+      const items = reordered.map((entry: WatchlistEntry, i: number) => ({ id: entry.id, priority: i }));
       setIsReordering(true);
       reorderMutation.mutate({ items });
     },
@@ -741,7 +741,7 @@ export function WatchlistPage() {
             onDragCancel={handleDragCancel}
           >
             <SortableContext
-              items={sortedEntries.map((e) => e.id)}
+              items={sortedEntries.map((e: WatchlistEntry) => e.id)}
               strategy={verticalListSortingStrategy}
             >
               <div className="hidden md:grid grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
@@ -784,10 +784,10 @@ export function WatchlistPage() {
             <DragOverlay>
               {activeId != null
                 ? (() => {
-                    const entry = sortedEntries.find((e) => e.id === activeId);
+                    const entry = sortedEntries.find((e: WatchlistEntry) => e.id === activeId);
                     if (!entry) return null;
                     const meta = getMetaForEntry(entry);
-                    const idx = sortedEntries.findIndex((e) => e.id === activeId);
+                    const idx = sortedEntries.findIndex((e: WatchlistEntry) => e.id === activeId);
                     return (
                       <div className="opacity-80 w-48">
                         <WatchlistCard


### PR DESCRIPTION
## Summary

Shell Dockerfile was missing `packages/api-client`. Without it, tRPC types resolve to `any`, causing ~100 `noImplicitAny` errors. Both Docker images verified building locally.

## Test plan

- [x] `docker build -f apps/pops-shell/Dockerfile .` succeeds locally
- [x] `docker build -f apps/pops-api/Dockerfile .` succeeds locally