### PR TITLE
fix: mount sqlite volume read-write for pops-api

### DIFF
--- a/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
+++ b/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
@@ -12,7 +12,7 @@ services:
       - frontend
       - backend
     volumes:
-      - sqlite-data:/data/sqlite:ro
+      - sqlite-data:/data/sqlite
     secrets:
       - notion_api_token
       - up_bank_token

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - frontend
       - backend
     volumes:
-      - sqlite-data:/data/sqlite:ro
+      - sqlite-data:/data/sqlite
     secrets:
       - notion_api_token
       - up_bank_token


### PR DESCRIPTION
API needs write access for migrations, inserts, updates. Was mounted :ro causing SQLITE_READONLY crash.