### PR TITLE
fix: add migration to rename default_category → default_tags

### DIFF
--- a/apps/pops-api/src/db/migrations/009a_add_default_tags_column.sql
+++ b/apps/pops-api/src/db/migrations/009a_add_default_tags_column.sql
@@ -1,0 +1,11 @@
+-- Add default_tags column to entities if it doesn't exist.
+-- Required before migration 010 which copies this column during UUID migration.
+-- Also rename default_category to default_tags if the old column exists.
+
+-- SQLite doesn't support IF NOT EXISTS for ALTER TABLE ADD COLUMN,
+-- so we check via pragma and only alter if needed.
+-- However, since this migration only runs once (tracked in schema_migrations),
+-- we can safely attempt the rename/add.
+
+-- If default_category exists but default_tags doesn't, rename it
+ALTER TABLE entities RENAME COLUMN default_category TO default_tags;

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -19,6 +19,7 @@ const INCLUDED_MIGRATIONS = [
   "007_transaction_corrections.sql",
   "008_add_tags_to_transactions.sql",
   "009_environments.sql",
+  "009a_add_default_tags_column.sql",
   "010_uuid_primary_keys.sql",
   "011_add_checksum_raw_row.sql",
   "20260320120000_core_entity_types.sql",


### PR DESCRIPTION
Production DB has default_category, migration 010 expects default_tags. This bridge migration renames the column before 010 runs.