### PR TITLE
fix: auto-initialize schema on fresh database at startup

### DIFF
--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -135,7 +135,9 @@ function createPreMigrationBackup(
 /** Check if this is a completely fresh database (no tables at all). */
 function isFreshDatabase(database: BetterSqlite3.Database): boolean {
   const row = database
-    .prepare("SELECT COUNT(*) AS cnt FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+    .prepare(
+      "SELECT COUNT(*) AS cnt FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+    )
     .get() as { cnt: number };
   return row.cnt === 0;
 }


### PR DESCRIPTION
Detect empty database (no tables) at startup and run initializeSchema() before attempting migrations. Prevents crash when API creates an empty DB file that the Ansible init task then skips.