### PR TITLE
fix: add pops-pwa network alias for Cloudflare tunnel

### DIFF
--- a/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
+++ b/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
@@ -40,7 +40,9 @@ services:
     container_name: pops-shell
     restart: unless-stopped
     networks:
-      - frontend
+      frontend:
+        aliases:
+          - pops-pwa
     expose:
       - "80"
 


### PR DESCRIPTION
Cloudflare tunnel config references pops-pwa (old name). Shell container is now pops-shell. Added network alias so both names resolve.