### PR TITLE
fix: add /trpc reverse proxy to nginx for production

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -15,6 +15,21 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # Proxy tRPC API requests to pops-api
+    location /trpc {
+        proxy_pass http://pops-api:3000/trpc;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy health check
+    location /health {
+        proxy_pass http://pops-api:3000/health;
+    }
+
     # SPA fallback — serve index.html for all routes
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Frontend sends /trpc requests to nginx which has no proxy — returns HTML instead of JSON. Add reverse proxy to pops-api:3000.