### PR TITLE
fix: skip JWT verification when team name not configured

### DIFF
--- a/apps/pops-api/src/middleware/auth.test.ts
+++ b/apps/pops-api/src/middleware/auth.test.ts
@@ -30,9 +30,11 @@ function createMockRes(): Response {
 
 describe("authMiddleware", () => {
   const originalEnv = process.env["NODE_ENV"];
+  const originalTeamName = process.env["CLOUDFLARE_ACCESS_TEAM_NAME"];
 
   afterEach(() => {
     process.env["NODE_ENV"] = originalEnv;
+    process.env["CLOUDFLARE_ACCESS_TEAM_NAME"] = originalTeamName;
     vi.restoreAllMocks();
   });
 
@@ -80,9 +82,28 @@ describe("authMiddleware", () => {
     });
   });
 
-  describe("production mode", () => {
+  describe("production mode (no team name — tunnel trust)", () => {
     beforeEach(() => {
       process.env["NODE_ENV"] = "production";
+      delete process.env["CLOUDFLARE_ACCESS_TEAM_NAME"];
+    });
+
+    it("passes auth with tunnel-authenticated user when team name not set", () => {
+      const req = createMockReq({ headers: {} });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      authMiddleware(req, res, next);
+
+      expect(next).toHaveBeenCalledOnce();
+      expect(res.locals["user"]).toEqual({ email: "tunnel-authenticated@pops.local" });
+    });
+  });
+
+  describe("production mode (with team name — JWT verification)", () => {
+    beforeEach(() => {
+      process.env["NODE_ENV"] = "production";
+      process.env["CLOUDFLARE_ACCESS_TEAM_NAME"] = "test-team";
     });
 
     it("returns 401 when JWT header is missing", () => {

--- a/apps/pops-api/src/middleware/auth.ts
+++ b/apps/pops-api/src/middleware/auth.ts
@@ -31,6 +31,14 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
     return;
   }
 
+  // If Cloudflare Access team name is not configured, trust the tunnel
+  // (Cloudflare Access at the tunnel level already authenticates users)
+  if (!process.env["CLOUDFLARE_ACCESS_TEAM_NAME"]) {
+    res.locals["user"] = { email: "tunnel-authenticated@pops.local" };
+    next();
+    return;
+  }
+
   const token = req.headers["cf-access-jwt-assertion"];
 
   if (typeof token !== "string") {


### PR DESCRIPTION
When CLOUDFLARE_ACCESS_TEAM_NAME is not set, trust the Cloudflare tunnel (Access at tunnel level already authenticates). This allows the API to work immediately without additional Cloudflare configuration.