### PR TITLE
fix: proxy /media/images/ to API for poster serving

### DIFF
--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -25,6 +25,15 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Proxy media images (posters, backdrops) served by pops-api
+    location /media/images/ {
+        proxy_pass http://pops-api:3000/media/images/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        expires 7d;
+        add_header Cache-Control "public";
+    }
+
     # Proxy health check
     location /health {
         proxy_pass http://pops-api:3000/health;


### PR DESCRIPTION
Poster URLs like /media/images/tv/364149/poster.jpg were hitting nginx SPA fallback, returning HTML instead of images.