### PR TITLE
docs: add US-07 dimension weights for overall ranking

### DIFF
--- a/docs-v2/themes/03-media/prds/037-ratings-comparisons/README.md
+++ b/docs-v2/themes/03-media/prds/037-ratings-comparisons/README.md
@@ -86,7 +86,7 @@ Build a pairwise comparison system per [ADR-010](../../../../architecture/adr-01
 - Arena rotates through all active dimensions — one dimension per comparison
 - Recently compared pairs are avoided (default: last 10 pairs)
 - Both Elo scores (winner and loser) update in a single database transaction
-- "Overall" ranking is the average score across all active dimensions for each movie
+- "Overall" ranking is the weighted average across all active dimensions: `SUM(score × weight) / SUM(weight)`. Default weight 1.0 (equal weighting = simple average)
 - Movies with zero comparisons start at 1500.0 and sort alphabetically in rankings
 - Dimensions can be added, edited, or deactivated — deactivated dimensions are excluded from overall calculations
 - Deactivated dimensions retain their comparison history and scores (not deleted)
@@ -104,6 +104,8 @@ Build a pairwise comparison system per [ADR-010](../../../../architecture/adr-01
 | Rankings with no comparisons | All movies at 1500.0, sorted alphabetically by title |
 | Movie deleted from library | Comparisons and scores for that movie remain (orphaned but harmless) |
 | Same pair for multiple dimensions | Allowed — each dimension is independent |
+| All dimension weights equal | Weighted average = simple average (backward compatible) |
+| Weight changed | Rankings update instantly (query-time, no recalculation) |
 
 ## User Stories
 
@@ -115,8 +117,9 @@ Build a pairwise comparison system per [ADR-010](../../../../architecture/adr-01
 | 04 | [us-04-dimension-management](us-04-dimension-management.md) | CRUD for comparison dimensions, active/inactive toggle, sort order | Partial | Yes |
 | 05 | [us-05-quick-pick](us-05-quick-pick.md) | Quick pick page with random unwatched movies, configurable count, "Watch This" action | Partial | Yes |
 | 06 | [us-06-comparison-history](us-06-comparison-history.md) | Comparison history list, delete with Elo recalculation, undo toast, dimension filter | Not started | Yes |
+| 07 | [us-07-dimension-weights](us-07-dimension-weights.md) | Per-dimension weight for overall ranking, weight slider in dimension management UI | Not started | Yes |
 
-US-01 depends on US-02 (arena needs Elo scoring to record comparisons). US-03, US-04, US-05, and US-06 can all be built in parallel.
+US-01 depends on US-02 (arena needs Elo scoring to record comparisons). US-03 through US-07 can all be built in parallel.
 
 ## Verification
 

--- a/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-07-dimension-weights.md
+++ b/docs-v2/themes/03-media/prds/037-ratings-comparisons/us-07-dimension-weights.md
@@ -1,0 +1,31 @@
+# US-07: Dimension weights for overall ranking
+
+> PRD: [037 — Ratings & Comparisons](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want to assign a weight to each comparison dimension so that the overall ranking reflects which dimensions matter most to me (e.g., Entertainment matters more than Cinematography).
+
+## Acceptance Criteria
+
+- [ ] `weight` column added to `comparison_dimensions` table (REAL, DEFAULT 1.0)
+- [ ] Weights are positive numbers (minimum 0.1, no upper cap — but UI slider goes 0.1 to 3.0)
+- [ ] `updateDimension` procedure accepts optional `weight` parameter
+- [ ] `listDimensions` response includes `weight` for each dimension
+- [ ] Overall ranking calculation changes from simple average to weighted average: `SUM(score × weight) / SUM(weight)` across active dimensions
+- [ ] Inactive dimensions are excluded from weighted average (same as before)
+- [ ] Rankings page "Overall" view reflects weighted scores
+- [ ] Dimension management UI shows weight slider (or number input) per dimension
+- [ ] Weight changes take effect immediately on the rankings page (no recalculation needed — it's a query-time computation)
+- [ ] Default weight is 1.0 for all dimensions (backward compatible — existing behaviour unchanged)
+- [ ] If all weights are equal, result is identical to the current simple average
+- [ ] Tests cover: weighted overall ranking, equal weights = simple average, zero-comparison movies still sort last, inactive dimensions excluded from weighted calc
+
+## Notes
+
+The weight is applied at **query time** in the overall ranking SQL, not stored per-movie. This means changing a weight instantly re-ranks all movies without replaying comparisons or updating scores. The per-dimension Elo scores are unchanged — only how they combine into "overall" changes.
+
+Example: if Entertainment has weight 2.0 and Cinematography has weight 1.0, a movie that scores 1600 in Entertainment and 1400 in Cinematography gets overall = (1600×2 + 1400×1) / (2+1) = 1533, not the simple average of 1500.
+
+The UI should make it clear that weights affect "Overall" ranking only — per-dimension rankings are unaffected.


### PR DESCRIPTION
## Summary

New US-07 for PRD-037: per-dimension weight for overall ranking calculation.

**How it works:**
- Each dimension gets a `weight` column (REAL, default 1.0)
- Overall ranking changes from `AVG(score)` to `SUM(score × weight) / SUM(weight)`
- Weight is applied at query time — changing it instantly re-ranks without recalculation
- UI: slider (0.1 to 3.0) in dimension management
- Equal weights = same result as current simple average (backward compatible)

## Changes
- New US-07 file with 12 acceptance criteria
- PRD-037 README: updated business rule, added edge cases, added US to table