### PR TITLE
fix: add 0009 to Drizzle journal (weight column migration)

### DIFF
--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1774158551720,
       "tag": "0008_tough_nick_fury",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1774853312000,
+      "tag": "0009_red_quasimodo",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Journal entry for 0009_red_quasimodo.sql was lost during git reset. Without it, Drizzle migrate doesn't know about the migration.