### PR TITLE
fix: remove --no-cache from docker build

### DIFF
--- a/infra/ansible/roles/pops-deploy/tasks/main.yml
+++ b/infra/ansible/roles/pops-deploy/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: Build custom service images
   ansible.builtin.command:
-    cmd: docker compose build --no-cache
+    cmd: docker compose build
     chdir: "{{ docker_compose_dir }}"
   changed_when: true
 


### PR DESCRIPTION
Speeds up deploys from ~10min to ~2min by using Docker layer cache. Only changed source files trigger rebuilds.