### PR TITLE
fix: allow winnerId=0 in record schema for draws

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -124,7 +124,7 @@ export const RecordComparisonSchema = z.object({
   mediaBType: z.enum(MEDIA_TYPES),
   mediaBId: z.number().int().positive(),
   winnerType: z.enum(MEDIA_TYPES),
-  winnerId: z.number().int().positive(),
+  winnerId: z.number().int().nonnegative(), // 0 = draw
 });
 export type RecordComparisonInput = z.infer<typeof RecordComparisonSchema>;
 


### PR DESCRIPTION
Zod schema had .positive() on winnerId, rejecting 0 (draw). Changed to .nonnegative().