### PR TITLE
fix: remove duplicate TMDB/THETVDB entries in .env.example [tb-105]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,12 +32,5 @@ PLEX_TOKEN=
 PAPERLESS_BASE_URL=
 PAPERLESS_API_TOKEN=
 
-# Media Metadata Providers
-# TMDB: Get a Read-Access Token (v4 auth) from https://www.themoviedb.org/settings/api
-TMDB_API_KEY=
-
-# TheTVDB: Get an API Key from https://thetvdb.com/dashboard/account/apikey
-THETVDB_API_KEY=
-
 # Paths
 SQLITE_PATH=./data/pops.db


### PR DESCRIPTION
## Summary
- Investigated TMDB env var naming across the entire codebase — **naming is consistent**: `TMDB_API_KEY` is used in all 15+ references (source, tests, `.env.example`, docs)
- No instances of `TMDB_API_TOKEN` or `TMDB_ACCESS_TOKEN` found anywhere
- Removed duplicate Media Metadata Providers block in `.env.example` (lines 35-40 were a copy of lines 21-25)

## Test plan
- [x] Verified no other env var naming inconsistencies exist
- [x] Confirmed `.env.example` still has all required variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)