### PR TITLE
fix(media): paginate Plex watchlist sync to fetch all items [tb-100]

### DIFF
--- a/apps/pops-api/src/modules/media/plex/sync-watchlist.test.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-watchlist.test.ts
@@ -270,7 +270,7 @@ describe("fetchPlexWatchlist", () => {
     );
   });
 
-  it("sends correct URL with token and client ID", async () => {
+  it("sends correct URL with token, client ID, and pagination params", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ MediaContainer: {} }),
@@ -279,9 +279,79 @@ describe("fetchPlexWatchlist", () => {
     await fetchPlexWatchlist("my-token", "my-client-id");
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://discover.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=my-token&X-Plex-Client-Identifier=my-client-id",
+      "https://discover.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=my-token&X-Plex-Client-Identifier=my-client-id&X-Plex-Container-Start=0&X-Plex-Container-Size=50",
       { method: "GET", headers: { Accept: "application/json" } }
     );
+  });
+
+  it("paginates through multiple pages to fetch all items", async () => {
+    // Page 1: 50 items (full page, triggers next fetch)
+    const page1Items = Array.from({ length: 50 }, (_, i) => ({
+      ratingKey: `key-${i}`,
+      guid: `plex://movie/key-${i}`,
+      type: "movie",
+      title: `Movie ${i}`,
+      year: 2020,
+      Guid: [{ id: `tmdb://${1000 + i}` }],
+    }));
+
+    // Page 2: 10 items (partial page, stops pagination)
+    const page2Items = Array.from({ length: 10 }, (_, i) => ({
+      ratingKey: `key-${50 + i}`,
+      guid: `plex://movie/key-${50 + i}`,
+      type: "movie",
+      title: `Movie ${50 + i}`,
+      year: 2021,
+      Guid: [{ id: `tmdb://${1050 + i}` }],
+    }));
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ MediaContainer: { totalSize: 60, Metadata: page1Items } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ MediaContainer: { totalSize: 60, Metadata: page2Items } }),
+      });
+
+    const items = await fetchPlexWatchlist("test-token", "test-client-id");
+
+    expect(items).toHaveLength(60);
+    expect(items[0]!.title).toBe("Movie 0");
+    expect(items[59]!.title).toBe("Movie 59");
+
+    // Verify pagination params
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const firstUrl = mockFetch.mock.calls[0]![0] as string;
+    const secondUrl = mockFetch.mock.calls[1]![0] as string;
+    expect(firstUrl).toContain("X-Plex-Container-Start=0");
+    expect(firstUrl).toContain("X-Plex-Container-Size=50");
+    expect(secondUrl).toContain("X-Plex-Container-Start=50");
+    expect(secondUrl).toContain("X-Plex-Container-Size=50");
+  });
+
+  it("stops pagination when totalSize is reached", async () => {
+    // Page 1: 50 items with totalSize=50 (no second page needed)
+    const page1Items = Array.from({ length: 50 }, (_, i) => ({
+      ratingKey: `key-${i}`,
+      guid: `plex://movie/key-${i}`,
+      type: "movie",
+      title: `Movie ${i}`,
+      year: 2020,
+      Guid: [{ id: `tmdb://${1000 + i}` }],
+    }));
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ MediaContainer: { totalSize: 50, Metadata: page1Items } }),
+    });
+
+    const items = await fetchPlexWatchlist("test-token", "test-client-id");
+
+    expect(items).toHaveLength(50);
+    // Should only make 1 call since totalSize was reached
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/pops-api/src/modules/media/plex/sync-watchlist.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-watchlist.ts
@@ -58,15 +58,37 @@ export interface WatchlistSyncOptions {
 
 const PLEX_DISCOVER_BASE = "https://discover.provider.plex.tv";
 
+const WATCHLIST_PAGE_SIZE = 50;
+
+interface PlexWatchlistResponse {
+  MediaContainer: {
+    totalSize?: number;
+    Metadata?: Array<{
+      ratingKey: string;
+      guid: string;
+      type: string;
+      title: string;
+      year?: number;
+      Guid?: Array<{ id: string }>;
+    }>;
+  };
+}
+
 /**
- * Fetch all items from the Plex Universal Watchlist (cloud API).
- * Returns the same PlexMediaItem shape as local library items.
+ * Fetch a single page from the Plex Universal Watchlist (cloud API).
  */
-export async function fetchPlexWatchlist(
+async function fetchPlexWatchlistPage(
   token: string,
-  clientId: string
-): Promise<PlexMediaItem[]> {
-  const url = `${PLEX_DISCOVER_BASE}/library/sections/watchlist/all?X-Plex-Token=${token}&X-Plex-Client-Identifier=${clientId}`;
+  clientId: string,
+  start: number,
+  size: number
+): Promise<PlexWatchlistResponse> {
+  const url =
+    `${PLEX_DISCOVER_BASE}/library/sections/watchlist/all` +
+    `?X-Plex-Token=${token}` +
+    `&X-Plex-Client-Identifier=${clientId}` +
+    `&X-Plex-Container-Start=${start}` +
+    `&X-Plex-Container-Size=${size}`;
 
   let response: Response;
   try {
@@ -88,46 +110,66 @@ export async function fetchPlexWatchlist(
     );
   }
 
-  const data = (await response.json()) as {
-    MediaContainer: {
-      Metadata?: Array<{
-        ratingKey: string;
-        guid: string;
-        type: string;
-        title: string;
-        year?: number;
-        Guid?: Array<{ id: string }>;
-      }>;
-    };
-  };
+  return (await response.json()) as PlexWatchlistResponse;
+}
 
-  const items = data.MediaContainer.Metadata ?? [];
+/**
+ * Fetch all items from the Plex Universal Watchlist (cloud API).
+ * Paginates using X-Plex-Container-Start / X-Plex-Container-Size to
+ * retrieve every item (the API defaults to ~20 without these params).
+ * Returns the same PlexMediaItem shape as local library items.
+ */
+export async function fetchPlexWatchlist(
+  token: string,
+  clientId: string
+): Promise<PlexMediaItem[]> {
+  const allItems: PlexMediaItem[] = [];
+  let start = 0;
 
-  return items.map((item) => ({
-    ratingKey: item.ratingKey,
-    type: item.type,
-    title: item.title,
-    originalTitle: null,
-    summary: null,
-    tagline: null,
-    year: item.year ?? null,
-    thumbUrl: null,
-    artUrl: null,
-    durationMs: null,
-    addedAt: 0,
-    updatedAt: 0,
-    lastViewedAt: null,
-    viewCount: 0,
-    rating: null,
-    audienceRating: null,
-    contentRating: null,
-    externalIds: parseGuids(item.Guid),
-    genres: [],
-    directors: [],
-    leafCount: null,
-    viewedLeafCount: null,
-    childCount: null,
-  }));
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const data = await fetchPlexWatchlistPage(token, clientId, start, WATCHLIST_PAGE_SIZE);
+    const pageItems = data.MediaContainer.Metadata ?? [];
+
+    for (const item of pageItems) {
+      allItems.push({
+        ratingKey: item.ratingKey,
+        type: item.type,
+        title: item.title,
+        originalTitle: null,
+        summary: null,
+        tagline: null,
+        year: item.year ?? null,
+        thumbUrl: null,
+        artUrl: null,
+        durationMs: null,
+        addedAt: 0,
+        updatedAt: 0,
+        lastViewedAt: null,
+        viewCount: 0,
+        rating: null,
+        audienceRating: null,
+        contentRating: null,
+        externalIds: parseGuids(item.Guid),
+        genres: [],
+        directors: [],
+        leafCount: null,
+        viewedLeafCount: null,
+        childCount: null,
+      });
+    }
+
+    // Stop if this page returned fewer items than requested (last page)
+    if (pageItems.length < WATCHLIST_PAGE_SIZE) break;
+
+    start += pageItems.length;
+
+    // Safety: stop if we've reached totalSize (when available)
+    const totalSize = data.MediaContainer.totalSize;
+    if (totalSize !== undefined && allItems.length >= totalSize) break;
+  }
+
+  return allItems;
 }
 
 /** Parse Guid array from Plex Discover response. */


### PR DESCRIPTION
## Summary
- `fetchPlexWatchlist()` was making a single API call without pagination params, so the Plex Discover API only returned its default page (~20 items)
- Added pagination loop using `X-Plex-Container-Start` / `X-Plex-Container-Size` (page size 50) to retrieve all watchlist items
- Stops when a page returns fewer items than requested or `totalSize` is reached

## Test plan
- [x] Existing 19 tests still pass
- [x] New test: paginates through multiple pages (60 items across 2 pages)
- [x] New test: stops after single page when totalSize equals page size
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)