### PR TITLE
fix(ui): use CSS variable for AiUsagePage bar chart color [tb-102]

### DIFF
--- a/packages/app-ai/src/pages/AiUsagePage.tsx
+++ b/packages/app-ai/src/pages/AiUsagePage.tsx
@@ -180,7 +180,7 @@ function DailyCostChart({ data }: { data: AiUsageRecord[] }) {
               );
             }}
           />
-          <Bar dataKey="cost" fill="hsl(38, 92%, 50%)" radius={[4, 4, 0, 0]} />
+          <Bar dataKey="cost" fill="var(--color-chart-1)" radius={[4, 4, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
     </Card>


### PR DESCRIPTION
## Summary
- Replace hardcoded `hsl(38, 92%, 50%)` bar fill color with `var(--color-chart-1)` CSS variable in AiUsagePage daily cost chart
- Chart now adapts to dark mode and respects the theme's chart color palette
- Matches the pattern used in other recharts components (e.g. PreferenceProfile)

## Test plan
- [ ] Verify bar chart renders correctly in light mode
- [ ] Verify bar chart renders correctly in dark mode
- [ ] Verify chart color matches theme palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)