### PR TITLE
fix(ui): standardize ModelConfigPage input component [tb-107]

### DIFF
--- a/packages/app-ai/src/pages/ModelConfigPage.tsx
+++ b/packages/app-ai/src/pages/ModelConfigPage.tsx
@@ -15,6 +15,8 @@ import {
   Skeleton,
   Alert,
   StatCard,
+  Input,
+  Label,
   Breadcrumb,
   BreadcrumbList,
   BreadcrumbItem,
@@ -22,7 +24,6 @@ import {
   BreadcrumbSeparator,
   BreadcrumbPage,
 } from "@pops/ui";
-import { TextInput } from "@pops/ui";
 
 const SETTING_KEYS = {
   model: "ai.model",
@@ -211,14 +212,16 @@ export function ModelConfigPage() {
           onChange={(e) => setModel(e.target.value)}
         />
 
-        <TextInput
-          label="Monthly Token Budget"
-          type="number"
-          placeholder="e.g. 1000000"
-          value={budget}
-          onChange={(e) => setBudget(e.target.value)}
-          min={0}
-        />
+        <div className="space-y-1.5">
+          <Label className="text-muted-foreground">Monthly Token Budget</Label>
+          <Input
+            type="number"
+            placeholder="e.g. 1000000"
+            value={budget}
+            onChange={(e) => setBudget(e.target.value)}
+            min={0}
+          />
+        </div>
 
         <Select
           label="When Budget Exceeded"


### PR DESCRIPTION
## Summary
- Replace `TextInput` with `Input` primitive in ModelConfigPage to match the pattern used in PlexSettingsPage and ArrSettingsPage
- Uses manual `<label>` in a `space-y-1.5` wrapper for consistency across all settings pages

## Test plan
- [x] Typecheck passes
- [x] Visual: label + input renders identically to PlexSettingsPage/ArrSettingsPage pattern
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)