### PR TITLE
fix(ui): replace raw HTML with @pops/ui in app-inventory [tb-110]

### DIFF
--- a/packages/app-inventory/src/components/ConnectDialog.tsx
+++ b/packages/app-inventory/src/components/ConnectDialog.tsx
@@ -102,10 +102,10 @@ export function ConnectDialog({ currentItemId, onConnected }: ConnectDialogProps
             <p className="text-sm text-muted-foreground py-4 text-center">No items found</p>
           ) : (
             results.map((item) => (
-              <button
+              <Button
                 key={item.id}
-                type="button"
-                className="w-full flex items-center justify-between p-2.5 rounded-md hover:bg-accent text-left transition-colors"
+                variant="ghost"
+                className="w-full flex items-center justify-between p-2.5 h-auto text-left"
                 onClick={() => handleConnect(item.id)}
                 disabled={connectMutation.isPending}
               >
@@ -117,7 +117,7 @@ export function ConnectDialog({ currentItemId, onConnected }: ConnectDialogProps
                   </div>
                 </div>
                 <Link2 className="h-4 w-4 text-muted-foreground shrink-0 ml-2" />
-              </button>
+              </Button>
             ))
           )}
         </div>

--- a/packages/app-inventory/src/components/ConnectionsList.tsx
+++ b/packages/app-inventory/src/components/ConnectionsList.tsx
@@ -3,7 +3,7 @@
  * Shows connection count header, list of connected items with badges,
  * and a "Connect to…" button placeholder.
  */
-import { cn, AssetIdBadge, TypeBadge } from "@pops/ui";
+import { cn, AssetIdBadge, TypeBadge, Button } from "@pops/ui";
 import { Link2, Plus } from "lucide-react";
 
 export interface ConnectedItem {
@@ -67,14 +67,15 @@ export function ConnectionsList({
 
       {/* Connect button */}
       {onConnect && (
-        <button
-          type="button"
-          className="flex w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-border px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full border-dashed text-muted-foreground hover:text-foreground"
+          prefix={<Plus className="h-3.5 w-3.5" />}
           onClick={onConnect}
         >
-          <Plus className="h-3.5 w-3.5" />
           Connect to item…
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/packages/app-inventory/src/components/LinkDocumentDialog.tsx
+++ b/packages/app-inventory/src/components/LinkDocumentDialog.tsx
@@ -14,6 +14,7 @@ import {
   DialogDescription,
   Button,
   TextInput,
+  Select,
   Skeleton,
 } from "@pops/ui";
 import { FileText, Search, Link2 } from "lucide-react";
@@ -112,17 +113,15 @@ export function LinkDocumentDialog({ itemId, onLinked }: LinkDocumentDialogProps
               autoFocus
             />
           </div>
-          <select
+          <Select
             value={docType}
             onChange={(e) => setDocType(e.target.value as typeof docType)}
-            className="h-9 rounded-md border border-input bg-background px-2 text-sm"
-          >
-            {DOCUMENT_TYPES.map((t) => (
-              <option key={t} value={t}>
-                {t.charAt(0).toUpperCase() + t.slice(1)}
-              </option>
-            ))}
-          </select>
+            size="sm"
+            options={DOCUMENT_TYPES.map((t) => ({
+              value: t,
+              label: t.charAt(0).toUpperCase() + t.slice(1),
+            }))}
+          />
         </div>
 
         <div className="max-h-72 overflow-y-auto space-y-1">

--- a/packages/app-inventory/src/components/LocationContentsPanel.tsx
+++ b/packages/app-inventory/src/components/LocationContentsPanel.tsx
@@ -140,15 +140,16 @@ export function LocationContentsPanel({
         <ul className="space-y-1">
           {allItems.map((item) => (
             <li key={item.id}>
-              <button
-                type="button"
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted/50"
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start gap-2 h-auto px-2 py-1.5 text-left"
                 onClick={() => navigate(`/inventory/items/${item.id}`)}
               >
                 <span className="font-medium truncate flex-1">{item.itemName}</span>
                 {item.assetId && <AssetIdBadge assetId={item.assetId} />}
                 {item.type && <TypeBadge type={item.type} />}
-              </button>
+              </Button>
             </li>
           ))}
         </ul>

--- a/packages/app-inventory/src/components/LocationPicker.tsx
+++ b/packages/app-inventory/src/components/LocationPicker.tsx
@@ -263,25 +263,27 @@ export function LocationPicker({
         {/* Footer: Clear + Add */}
         <div className="border-t p-2 flex flex-col gap-1">
           {value && (
-            <button
-              type="button"
-              className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-muted-foreground hover:text-foreground"
+              prefix={<X className="h-3.5 w-3.5" />}
               onClick={handleClear}
             >
-              <X className="h-3.5 w-3.5" />
               Clear selection
-            </button>
+            </Button>
           )}
 
           {onCreateLocation && !showAddForm && (
-            <button
-              type="button"
-              className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-muted-foreground hover:text-foreground"
+              prefix={<Plus className="h-3.5 w-3.5" />}
               onClick={() => setShowAddForm(true)}
             >
-              <Plus className="h-3.5 w-3.5" />
               Add location
-            </button>
+            </Button>
           )}
 
           {onCreateLocation && showAddForm && (

--- a/packages/app-inventory/src/components/PhotoGallery.tsx
+++ b/packages/app-inventory/src/components/PhotoGallery.tsx
@@ -127,17 +127,18 @@ export function PhotoGallery({
                 />
               </button>
               {onDelete && (
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="icon"
                   onClick={(e) => {
                     e.stopPropagation();
                     onDelete(photo.id);
                   }}
-                  className="absolute -top-1 -right-1 p-0.5 rounded-full bg-background/80 text-destructive opacity-0 group-hover:opacity-100 transition-opacity hover:bg-background"
+                  className="absolute -top-1 -right-1 h-5 w-5 rounded-full bg-background/80 text-destructive opacity-0 group-hover:opacity-100 transition-opacity hover:bg-background"
                   aria-label={`Delete photo ${photo.caption ?? index + 1}`}
                 >
                   <Trash2 className="h-3 w-3" />
-                </button>
+                </Button>
               )}
             </div>
           ))}

--- a/packages/app-inventory/src/pages/InsuranceReportPage.tsx
+++ b/packages/app-inventory/src/pages/InsuranceReportPage.tsx
@@ -8,7 +8,7 @@
 import { useMemo, useCallback } from "react";
 import { useSearchParams, useNavigate } from "react-router";
 import { FileText, Printer, Download } from "lucide-react";
-import { Skeleton, AssetIdBadge, ConditionBadge, Badge, PageHeader, type Condition } from "@pops/ui";
+import { Skeleton, AssetIdBadge, ConditionBadge, Badge, PageHeader, Button, Select, CheckboxInput, Label, type Condition } from "@pops/ui";
 import { trpc } from "../lib/trpc";
 import { LocationPicker } from "../components/LocationPicker";
 
@@ -201,22 +201,21 @@ export function InsuranceReportPage(): React.ReactElement {
         icon={<FileText className="h-6 w-6 text-muted-foreground print:hidden" />}
         actions={
           <div className="flex items-center gap-2 print:hidden">
-            <button
-              type="button"
+            <Button
+              variant="outline"
+              size="sm"
+              prefix={<Download className="h-4 w-4" />}
               onClick={handleExportCsv}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg border text-sm font-bold hover:bg-muted/50 transition-colors"
             >
-              <Download className="h-4 w-4" />
               Export CSV
-            </button>
-            <button
-              type="button"
+            </Button>
+            <Button
+              size="sm"
+              prefix={<Printer className="h-4 w-4" />}
               onClick={() => window.print()}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-app-accent text-white text-sm font-bold hover:bg-app-accent/80 transition-colors shadow-sm shadow-app-accent/20"
             >
-              <Printer className="h-4 w-4" />
               Print / PDF
-            </button>
+            </Button>
           </div>
         }
         className="mb-6 print:mb-4"
@@ -231,7 +230,7 @@ export function InsuranceReportPage(): React.ReactElement {
       {/* Filters */}
       <div className="flex flex-wrap items-end gap-4 mb-6 print:hidden">
         <div className="w-64">
-          <label className="block text-sm font-medium mb-1">Filter by location</label>
+          <Label className="block mb-1">Filter by location</Label>
           <LocationPicker
             value={locationId ?? null}
             onChange={handleLocationChange}
@@ -240,30 +239,25 @@ export function InsuranceReportPage(): React.ReactElement {
           />
         </div>
         {locationId && (
-          <label className="flex items-center gap-2 text-sm cursor-pointer">
-            <input
-              type="checkbox"
-              checked={includeChildren}
-              onChange={(e) => updateParam("includeChildren", e.target.checked ? null : "false")}
-              className="rounded border-border"
-            />
-            Include sub-locations
-          </label>
+          <CheckboxInput
+            label="Include sub-locations"
+            checked={includeChildren}
+            onCheckedChange={(checked) => updateParam("includeChildren", checked ? null : "false")}
+          />
         )}
-        <div>
-          <label className="block text-sm font-medium mb-1">Sort by</label>
-          <select
-            value={sortBy}
-            onChange={(e) =>
-              updateParam("sortBy", e.target.value === "value" ? null : e.target.value)
-            }
-            className="rounded-lg border border-border bg-background px-3 py-2 text-sm"
-          >
-            <option value="value">Value (high first)</option>
-            <option value="name">Name</option>
-            <option value="type">Type</option>
-          </select>
-        </div>
+        <Select
+          label="Sort by"
+          size="sm"
+          value={sortBy}
+          onChange={(e) =>
+            updateParam("sortBy", e.target.value === "value" ? null : e.target.value)
+          }
+          options={[
+            { value: "value", label: "Value (high first)" },
+            { value: "name", label: "Name" },
+            { value: "type", label: "Type" },
+          ]}
+        />
       </div>
 
       {/* Summary */}

--- a/packages/app-inventory/src/pages/ItemFormPage.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.tsx
@@ -19,6 +19,7 @@ import {
   Skeleton,
   Badge,
   PageHeader,
+  Label,
 } from "@pops/ui";
 import { Save, Link2, X, Search, Wand2, Loader2, ImageIcon, Trash2, Eye, PenLine } from "lucide-react";
 import Markdown from "react-markdown";
@@ -111,7 +112,7 @@ function FormField({
 }) {
   return (
     <div>
-      <label className="text-sm font-medium mb-1.5 block">{label}</label>
+      <Label className="mb-1.5 block">{label}</Label>
       {children}
       {error && <p className="text-sm text-destructive mt-1">{error}</p>}
     </div>
@@ -699,14 +700,15 @@ export function ItemFormPage() {
                         loading="lazy"
                       />
                     </div>
-                    <button
-                      type="button"
+                    <Button
+                      variant="ghost"
+                      size="icon"
                       onClick={() => handleDeletePhoto(photo.id)}
-                      className="absolute top-1 right-1 p-1 rounded-full bg-background/80 text-destructive opacity-0 group-hover:opacity-100 transition-opacity hover:bg-background"
+                      className="absolute top-1 right-1 h-6 w-6 rounded-full bg-background/80 text-destructive opacity-0 group-hover:opacity-100 transition-opacity hover:bg-background"
                       aria-label={`Delete photo ${photo.caption ?? photo.id}`}
                     >
                       <Trash2 className="h-3.5 w-3.5" />
-                    </button>
+                    </Button>
                   </div>
                 ))}
             </div>
@@ -802,15 +804,16 @@ export function ItemFormPage() {
                     className="flex items-center gap-1.5 pl-3 pr-1.5 py-1 bg-app-accent/10 text-app-accent border-app-accent/20"
                   >
                     {conn.itemName}
-                    <button
-                      type="button"
-                      className="rounded-full p-0.5 hover:bg-app-accent/20"
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-4 w-4 rounded-full hover:bg-app-accent/20"
                       onClick={() =>
                         setPendingConnections((prev) => prev.filter((c) => c.id !== conn.id))
                       }
                     >
                       <X className="h-3 w-3" />
-                    </button>
+                    </Button>
                   </Badge>
                 ))}
               </div>
@@ -844,10 +847,10 @@ export function ItemFormPage() {
                       </p>
                     ) : (
                       filtered.map((item) => (
-                        <button
+                        <Button
                           key={item.id}
-                          type="button"
-                          className="w-full flex items-center justify-between p-2.5 hover:bg-app-accent/5 text-left transition-colors"
+                          variant="ghost"
+                          className="w-full flex items-center justify-between p-2.5 h-auto text-left"
                           onClick={() => {
                             setPendingConnections((prev) => [
                               ...prev,
@@ -864,7 +867,7 @@ export function ItemFormPage() {
                             </div>
                           </div>
                           <Link2 className="h-4 w-4 text-app-accent/50 shrink-0 ml-2" />
-                        </button>
+                        </Button>
                       ))
                     );
                   })()

--- a/packages/app-inventory/src/pages/LocationTreePage.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.tsx
@@ -801,17 +801,18 @@ export function LocationTreePage() {
               <FileText className="h-4 w-4" />
               Insurance Report
             </Link>
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-app-accent hover:text-app-accent/80"
+              prefix={<Plus className="h-4 w-4" />}
               onClick={() => {
                 setAddingRoot(true);
                 setAddingChildOf(null);
               }}
-              className="flex items-center gap-1.5 text-sm font-bold text-app-accent hover:text-app-accent/80 transition-colors"
             >
-              <Plus className="h-4 w-4" />
               Add Root Location
-            </button>
+            </Button>
           </>
         }
       />

--- a/packages/app-inventory/src/pages/WarrantiesPage.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.tsx
@@ -7,7 +7,7 @@
 import { useMemo, useState } from "react";
 import { useNavigate, Link } from "react-router";
 import { ShieldCheck, ChevronDown, ChevronRight, AlertCircle } from "lucide-react";
-import { Skeleton, AssetIdBadge, Badge, PageHeader } from "@pops/ui";
+import { Skeleton, AssetIdBadge, Badge, PageHeader, Button } from "@pops/ui";
 import { trpc } from "../lib/trpc";
 
 interface WarrantyItem {
@@ -221,9 +221,9 @@ function CollapsibleSection({
 
   return (
     <div className="border rounded-lg">
-      <button
-        type="button"
-        className="flex w-full items-center gap-2 px-4 py-3 text-left font-medium transition-colors hover:bg-muted/30"
+      <Button
+        variant="ghost"
+        className="flex w-full items-center gap-2 px-4 py-3 h-auto text-left font-medium"
         onClick={() => setOpen(!open)}
       >
         {open ? (
@@ -235,7 +235,7 @@ function CollapsibleSection({
         <Badge variant="secondary" className="text-xs ml-1">
           {count}
         </Badge>
-      </button>
+      </Button>
       {open && <div className="px-2 pb-2">{children}</div>}
     </div>
   );
@@ -296,13 +296,9 @@ export function WarrantiesPage() {
         <div className="text-center py-16">
           <AlertCircle className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
           <p className="text-muted-foreground mb-4">Could not load warranties — try again</p>
-          <button
-            type="button"
-            className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-            onClick={() => refetch()}
-          >
+          <Button onClick={() => refetch()}>
             Retry
-          </button>
+          </Button>
         </div>
       ) : totalItems === 0 ? (
         <div className="text-center py-16">


### PR DESCRIPTION
## Summary
- Replace raw `<button>`, `<select>`, `<label>`, and `<input>` elements with `@pops/ui` components (`Button`, `Select`, `CheckboxInput`, `Label`) across 10 files in app-inventory
- Preserves existing behavior and visual styling
- Some highly custom elements (tree node action buttons, card layouts, file inputs) intentionally left as raw HTML where the @pops/ui component sizing/styling would not match

### Files changed
- **InsuranceReportPage**: buttons → Button, select → Select, checkbox → CheckboxInput, labels → Label
- **ConnectionsList**: "Connect to item" button → Button outline
- **ConnectDialog**: search result buttons → Button ghost
- **LinkDocumentDialog**: document type select → Select
- **LocationContentsPanel**: item row button → Button ghost
- **LocationPicker**: clear/add buttons → Button ghost
- **PhotoGallery**: delete overlay → Button ghost icon
- **ItemFormPage**: FormField label → Label, photo delete → Button icon, connection buttons → Button ghost
- **LocationTreePage**: "Add Root Location" → Button ghost
- **WarrantiesPage**: retry button → Button, collapsible toggle → Button ghost

Ref: #1111

## Test plan
- [ ] Verify InsuranceReportPage renders correctly (export CSV, print buttons, filters)
- [ ] Verify LocationTreePage tree actions still work (add, rename, move, delete)
- [ ] Verify ItemFormPage create/edit flow works (connections, photos, form fields)
- [ ] Verify dark mode renders correctly across all changed components

🤖 Generated with [Claude Code](https://claude.com/claude-code)