### PR TITLE
fix(media): invalidate movie status after addMovie [tb-108]

### DIFF
--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -188,6 +188,7 @@ export const arrRouter = router({
       }
       try {
         const movie = await client.addMovie(input);
+        arrService.clearMovieStatusCache(input.tmdbId);
         return { data: movie };
       } catch (err) {
         if (err instanceof ArrApiError) {

--- a/apps/pops-api/src/modules/media/arr/service.ts
+++ b/apps/pops-api/src/modules/media/arr/service.ts
@@ -400,6 +400,11 @@ export async function triggerSeriesSearch(
   return client.triggerSearch(sonarrId, seasonNumber);
 }
 
+/** Clear cached status for a specific movie by tmdbId. */
+export function clearMovieStatusCache(tmdbId: number): void {
+  movieStatusCache.delete(tmdbId);
+}
+
 /** Clear all cached statuses. */
 export function clearStatusCache(): void {
   movieStatusCache.clear();

--- a/packages/app-media/src/components/RequestMovieModal.tsx
+++ b/packages/app-media/src/components/RequestMovieModal.tsx
@@ -51,10 +51,13 @@ export function RequestMovieModal({ open, onClose, tmdbId, title, year }: Reques
     }
   }, [folders.data?.data, rootFolderPath]);
 
+  const utils = trpc.useUtils();
+
   const addMovie = trpc.media.arr.addMovie.useMutation({
     onSuccess: () => {
       setSuccess(true);
       setError(null);
+      utils.media.arr.getMovieStatus.invalidate({ tmdbId });
       setTimeout(() => {
         onClose();
         setSuccess(false);


### PR DESCRIPTION
## Summary
- After adding a movie to Radarr, the RequestMovieButton and ArrStatusBadge showed stale "not found" state until the 5-minute server cache expired
- **Backend**: Added `clearMovieStatusCache(tmdbId)` to `arr/service.ts`, called from the `addMovie` mutation in `arr/router.ts` after success
- **Frontend**: Added `utils.media.arr.getMovieStatus.invalidate({ tmdbId })` in `RequestMovieModal.tsx` `onSuccess` callback

## Test plan
- [x] Typecheck passes (10/10 packages)
- [ ] CI tests pass
- [ ] Manual: add a movie via RequestMovieModal → button/badge should update immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)