### PR TITLE
fix(media): replace raw HTML elements with @pops/ui components [tb-111]

### DIFF
--- a/packages/app-media/src/components/DimensionManager.tsx
+++ b/packages/app-media/src/components/DimensionManager.tsx
@@ -209,24 +209,26 @@ export function DimensionManager() {
               >
                 {/* Reorder buttons */}
                 <div className="flex flex-col">
-                  <button
-                    type="button"
+                  <Button
+                    variant="ghost"
+                    size="icon"
                     onClick={() => handleReorder(dim, "up")}
                     disabled={idx === 0 || updateMutation.isPending}
-                    className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+                    className="p-0.5 h-auto w-auto text-muted-foreground hover:text-foreground"
                     aria-label={`Move ${dim.name} up`}
                   >
                     <ChevronUp className="h-3 w-3" />
-                  </button>
-                  <button
-                    type="button"
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
                     onClick={() => handleReorder(dim, "down")}
                     disabled={idx === sorted.length - 1 || updateMutation.isPending}
-                    className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+                    className="p-0.5 h-auto w-auto text-muted-foreground hover:text-foreground"
                     aria-label={`Move ${dim.name} down`}
                   >
                     <ChevronDown className="h-3 w-3" />
-                  </button>
+                  </Button>
                 </div>
 
                 {/* Name & description (editable) */}
@@ -289,14 +291,15 @@ export function DimensionManager() {
 
                 {/* Edit button */}
                 {editing?.id !== dim.id && (
-                  <button
-                    type="button"
+                  <Button
+                    variant="ghost"
+                    size="icon"
                     onClick={() => handleStartEdit(dim)}
-                    className="p-1 text-muted-foreground hover:text-foreground"
+                    className="p-1 h-auto w-auto text-muted-foreground hover:text-foreground"
                     aria-label={`Edit ${dim.name}`}
                   >
                     <Pencil className="h-3.5 w-3.5" />
-                  </button>
+                  </Button>
                 )}
 
                 {/* Active toggle */}

--- a/packages/app-media/src/components/RequestMovieModal.tsx
+++ b/packages/app-media/src/components/RequestMovieModal.tsx
@@ -5,7 +5,7 @@
  * then submits to Radarr's addMovie endpoint.
  */
 import { useState, useEffect } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@pops/ui";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Select } from "@pops/ui";
 import { Button } from "@pops/ui";
 import { RefreshCw, CheckCircle2 } from "lucide-react";
 import { trpc } from "../lib/trpc";
@@ -117,44 +117,30 @@ export function RequestMovieModal({ open, onClose, tmdbId, title, year }: Reques
           ) : (
             <>
               {/* Quality Profile */}
-              <div className="space-y-1.5">
-                <label htmlFor="quality-profile" className="text-sm font-medium">
-                  Quality Profile
-                </label>
-                <select
-                  id="quality-profile"
-                  value={qualityProfileId ?? ""}
-                  onChange={(e) => setQualityProfileId(Number(e.target.value))}
-                  className="w-full h-9 rounded-md border bg-background px-3 text-sm"
-                  disabled={addMovie.isPending || success}
-                >
-                  {profileList.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <Select
+                label="Quality Profile"
+                id="quality-profile"
+                value={String(qualityProfileId ?? "")}
+                onChange={(e) => setQualityProfileId(Number(e.target.value))}
+                disabled={addMovie.isPending || success}
+                options={profileList.map((p) => ({
+                  value: String(p.id),
+                  label: p.name,
+                }))}
+              />
 
               {/* Root Folder */}
-              <div className="space-y-1.5">
-                <label htmlFor="root-folder" className="text-sm font-medium">
-                  Root Folder
-                </label>
-                <select
-                  id="root-folder"
-                  value={rootFolderPath}
-                  onChange={(e) => setRootFolderPath(e.target.value)}
-                  className="w-full h-9 rounded-md border bg-background px-3 text-sm"
-                  disabled={addMovie.isPending || success}
-                >
-                  {folderList.map((f) => (
-                    <option key={f.id} value={f.path}>
-                      {f.path} ({formatBytes(f.freeSpace)} free)
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <Select
+                label="Root Folder"
+                id="root-folder"
+                value={rootFolderPath}
+                onChange={(e) => setRootFolderPath(e.target.value)}
+                disabled={addMovie.isPending || success}
+                options={folderList.map((f) => ({
+                  value: f.path,
+                  label: `${f.path} (${formatBytes(f.freeSpace)} free)`,
+                }))}
+              />
             </>
           )}
 

--- a/packages/app-media/src/components/RequestSeriesModal.tsx
+++ b/packages/app-media/src/components/RequestSeriesModal.tsx
@@ -5,7 +5,7 @@
  * season monitoring checkboxes with smart defaults, then submits to Sonarr.
  */
 import { useState, useEffect, useMemo } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@pops/ui";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Select, Label } from "@pops/ui";
 import { Button } from "@pops/ui";
 import { RefreshCw, CheckCircle2 } from "lucide-react";
 import { trpc } from "../lib/trpc";
@@ -188,64 +188,43 @@ export function RequestSeriesModal({
           ) : (
             <>
               {/* Quality Profile */}
-              <div className="space-y-1.5">
-                <label htmlFor="quality-profile" className="text-sm font-medium">
-                  Quality Profile
-                </label>
-                <select
-                  id="quality-profile"
-                  value={qualityProfileId ?? ""}
-                  onChange={(e) => setQualityProfileId(Number(e.target.value))}
-                  className="w-full h-9 rounded-md border bg-background px-3 text-sm"
-                  disabled={addSeries.isPending || success}
-                >
-                  {profileList.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <Select
+                label="Quality Profile"
+                id="quality-profile"
+                value={String(qualityProfileId ?? "")}
+                onChange={(e) => setQualityProfileId(Number(e.target.value))}
+                disabled={addSeries.isPending || success}
+                options={profileList.map((p) => ({
+                  value: String(p.id),
+                  label: p.name,
+                }))}
+              />
 
               {/* Root Folder */}
-              <div className="space-y-1.5">
-                <label htmlFor="root-folder" className="text-sm font-medium">
-                  Root Folder
-                </label>
-                <select
-                  id="root-folder"
-                  value={rootFolderPath}
-                  onChange={(e) => setRootFolderPath(e.target.value)}
-                  className="w-full h-9 rounded-md border bg-background px-3 text-sm"
-                  disabled={addSeries.isPending || success}
-                >
-                  {folderList.map((f) => (
-                    <option key={f.id} value={f.path}>
-                      {f.path} ({formatBytes(f.freeSpace)} free)
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <Select
+                label="Root Folder"
+                id="root-folder"
+                value={rootFolderPath}
+                onChange={(e) => setRootFolderPath(e.target.value)}
+                disabled={addSeries.isPending || success}
+                options={folderList.map((f) => ({
+                  value: f.path,
+                  label: `${f.path} (${formatBytes(f.freeSpace)} free)`,
+                }))}
+              />
 
               {/* Language Profile */}
-              <div className="space-y-1.5">
-                <label htmlFor="language-profile" className="text-sm font-medium">
-                  Language Profile
-                </label>
-                <select
-                  id="language-profile"
-                  value={languageProfileId ?? ""}
-                  onChange={(e) => setLanguageProfileId(Number(e.target.value))}
-                  className="w-full h-9 rounded-md border bg-background px-3 text-sm"
-                  disabled={addSeries.isPending || success}
-                >
-                  {languageList.map((l) => (
-                    <option key={l.id} value={l.id}>
-                      {l.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <Select
+                label="Language Profile"
+                id="language-profile"
+                value={String(languageProfileId ?? "")}
+                onChange={(e) => setLanguageProfileId(Number(e.target.value))}
+                disabled={addSeries.isPending || success}
+                options={languageList.map((l) => ({
+                  value: String(l.id),
+                  label: l.name,
+                }))}
+              />
 
               {/* Season Monitoring */}
               {seasons.length > 0 && (
@@ -254,9 +233,10 @@ export function RequestSeriesModal({
                     <span className="text-sm font-medium">Season Monitoring</span>
                     {showBulkControls && (
                       <div className="flex gap-2">
-                        <button
-                          type="button"
-                          className="text-xs text-muted-foreground hover:text-foreground"
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-xs h-auto p-0 text-muted-foreground hover:text-foreground"
                           disabled={allChecked || addSeries.isPending || success}
                           onClick={() => {
                             const all: Record<number, boolean> = {};
@@ -265,10 +245,11 @@ export function RequestSeriesModal({
                           }}
                         >
                           Select All
-                        </button>
-                        <button
-                          type="button"
-                          className="text-xs text-muted-foreground hover:text-foreground"
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-xs h-auto p-0 text-muted-foreground hover:text-foreground"
                           disabled={noneChecked || addSeries.isPending || success}
                           onClick={() => {
                             const none: Record<number, boolean> = {};
@@ -277,15 +258,15 @@ export function RequestSeriesModal({
                           }}
                         >
                           Deselect All
-                        </button>
+                        </Button>
                       </div>
                     )}
                   </div>
                   <div className="max-h-48 overflow-y-auto space-y-1 rounded-md border p-2">
                     {seasons.map((s) => (
-                      <label
+                      <Label
                         key={s.seasonNumber}
-                        className="flex items-center gap-2 text-sm cursor-pointer"
+                        className="flex items-center gap-2 text-sm cursor-pointer font-normal"
                       >
                         <input
                           type="checkbox"
@@ -304,7 +285,7 @@ export function RequestSeriesModal({
                             — {s.firstAirDate.slice(0, 4)}
                           </span>
                         )}
-                      </label>
+                      </Label>
                     ))}
                   </div>
                 </div>

--- a/packages/app-media/src/pages/ArrSettingsPage.tsx
+++ b/packages/app-media/src/pages/ArrSettingsPage.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect } from "react";
 import { Link } from "react-router";
 import {
   Button,
+  Label,
   Skeleton,
   Input,
   Breadcrumb,
@@ -66,7 +67,7 @@ function ServiceCard({
 
       <div className="space-y-3">
         <div className="space-y-1.5">
-          <label className="text-sm font-medium text-muted-foreground">Server URL</label>
+          <Label className="text-muted-foreground">Server URL</Label>
           <Input
             placeholder="https://192.168.1.100:7878"
             value={url}
@@ -77,7 +78,7 @@ function ServiceCard({
         </div>
 
         <div className="space-y-1.5">
-          <label className="text-sm font-medium text-muted-foreground">API Key</label>
+          <Label className="text-muted-foreground">API Key</Label>
           <Input
             type="password"
             placeholder="Enter API key"

--- a/packages/app-media/src/pages/HistoryPage.tsx
+++ b/packages/app-media/src/pages/HistoryPage.tsx
@@ -170,15 +170,16 @@ function HistoryItem({
             )}
           </div>
           <div className="flex items-center gap-1.5 shrink-0">
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="icon"
               aria-label="Delete watch event"
               disabled={isDeleting}
               onClick={() => onDelete(entry.id)}
-              className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive disabled:opacity-50"
+              className="p-1 h-auto w-auto hover:bg-destructive/10 text-muted-foreground hover:text-destructive"
             >
               <Trash2 className="h-3.5 w-3.5" />
-            </button>
+            </Button>
             <Badge variant="secondary" className="text-xs">
               {isEpisode ? "Episode" : "Movie"}
             </Badge>
@@ -240,18 +241,19 @@ function HistoryCard({
         </span>
 
         {/* Delete button — visible on hover */}
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          size="icon"
           aria-label="Delete watch event"
           disabled={isDeleting}
           onClick={(e) => {
             e.stopPropagation();
             onDelete(entry.id);
           }}
-          className="absolute bottom-2 right-2 z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity p-1.5 rounded-md bg-black/60 hover:bg-destructive text-white disabled:opacity-50"
+          className="absolute bottom-2 right-2 z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity p-1.5 h-auto w-auto rounded-md bg-black/60 hover:bg-destructive text-white"
         >
           <Trash2 className="h-3.5 w-3.5" />
-        </button>
+        </Button>
 
         {!posterSrc || imageError ? (
           <div className="flex h-full w-full items-center justify-center bg-muted text-muted-foreground">
@@ -344,21 +346,18 @@ export function HistoryPage() {
       {/* Type filter tabs */}
       <div className="flex gap-2">
         {FILTER_OPTIONS.map((opt) => (
-          <button
+          <Button
             key={opt.value}
-            type="button"
+            variant={filter === opt.value ? "default" : "secondary"}
+            size="sm"
             onClick={() => {
               setFilter(opt.value);
               setOffset(0);
             }}
-            className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
-              filter === opt.value
-                ? "bg-primary text-primary-foreground"
-                : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
-            }`}
+            shape="pill"
           >
             {opt.label}
-          </button>
+          </Button>
         ))}
       </div>
 

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useSearchParams, Link } from "react-router";
-import { Button, Skeleton, TextInput } from "@pops/ui";
+import { Button, Select, Skeleton, TextInput } from "@pops/ui";
 import { Sparkles, Settings, Search, ChevronLeft, ChevronRight, AlertCircle } from "lucide-react";
 import { MediaGrid } from "../components/MediaGrid";
 import { MediaCard } from "../components/MediaCard";
@@ -76,18 +76,16 @@ function PaginationControls({
         </span>
       </div>
       <div className="flex items-center gap-2">
-        <select
-          value={pageSize}
+        <Select
+          value={String(pageSize)}
           onChange={(e) => onPageSizeChange(Number(e.target.value))}
           aria-label="Items per page"
-          className="h-8 rounded-md border bg-background px-2 text-sm"
-        >
-          {PAGE_SIZE_OPTIONS.map((size) => (
-            <option key={size} value={size}>
-              {size} per page
-            </option>
-          ))}
-        </select>
+          size="sm"
+          options={PAGE_SIZE_OPTIONS.map((size) => ({
+            value: String(size),
+            label: `${size} per page`,
+          }))}
+        />
         <Button
           variant="outline"
           size="sm"
@@ -236,52 +234,48 @@ export function LibraryPage() {
           aria-label="Filter by type"
         >
           {TYPE_OPTIONS.map((opt) => (
-            <button
+            <Button
               key={opt.value}
-              type="button"
+              variant={typeFilter === opt.value ? "default" : "ghost"}
+              size="sm"
               onClick={() => setParam("type", opt.value === "all" ? "" : opt.value)}
               aria-pressed={typeFilter === opt.value}
-              className={`px-3 py-1 text-xs font-semibold uppercase tracking-wider rounded-md transition-all duration-200 ${
+              className={`text-xs font-semibold uppercase tracking-wider ${
                 typeFilter === opt.value
-                  ? "bg-app-accent text-white shadow-sm"
+                  ? "bg-app-accent text-white shadow-sm hover:bg-app-accent/90"
                   : "text-muted-foreground hover:text-foreground"
               }`}
             >
               {opt.label}
-            </button>
+            </Button>
           ))}
         </div>
 
         {/* Genre dropdown */}
         {allGenres.length > 0 && (
-          <select
+          <Select
             value={genreFilter ?? ""}
             onChange={(e) => setParam("genre", e.target.value)}
             aria-label="Filter by genre"
-            className="h-8 rounded-md border bg-background px-2 text-sm"
-          >
-            <option value="">All Genres</option>
-            {allGenres.map((genre) => (
-              <option key={genre} value={genre}>
-                {genre}
-              </option>
-            ))}
-          </select>
+            size="sm"
+            options={[
+              { value: "", label: "All Genres" },
+              ...allGenres.map((genre) => ({ value: genre, label: genre })),
+            ]}
+          />
         )}
 
         {/* Sort dropdown */}
-        <select
+        <Select
           value={sortBy}
           onChange={(e) => setParam("sort", e.target.value)}
           aria-label="Sort by"
-          className="h-8 rounded-md border bg-background px-2 text-sm"
-        >
-          {SORT_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
+          size="sm"
+          options={SORT_OPTIONS.map((opt) => ({
+            value: opt.value,
+            label: opt.label,
+          }))}
+        />
 
         {/* Search input */}
         <TextInput

--- a/packages/app-media/src/pages/PlexSettingsPage.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect } from "react";
 import { Link } from "react-router";
 import {
   Button,
+  Label,
   Skeleton,
   Input,
   Select,
@@ -69,13 +70,15 @@ function SyncResultDisplay({ result, label }: { result: SyncResult; label: strin
       </div>
       {skipReasons.length > 0 && (
         <div>
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => setShowSkipped(!showSkipped)}
-            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            className="flex items-center gap-1 text-xs h-auto p-0 text-muted-foreground hover:text-foreground"
           >
             {showSkipped ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
             {showSkipped ? "Hide" : "Show"} skip reasons
-          </button>
+          </Button>
           {showSkipped && (
             <div className="mt-2 space-y-1 text-xs text-muted-foreground">
               {skipReasons.map((skip, i) => (
@@ -89,14 +92,15 @@ function SyncResultDisplay({ result, label }: { result: SyncResult; label: strin
       )}
       {result.errors.length > 0 && (
         <div>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => setShowErrors(!showErrors)}
-            className="flex items-center gap-1 text-xs text-red-400 hover:text-red-300 transition-colors"
+            className="flex items-center gap-1 text-xs h-auto p-0 text-red-400 hover:text-red-300"
           >
             {showErrors ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
             {showErrors ? "Hide" : "Show"} error details
-          </button>
+          </Button>
           {showErrors && (
             <div className="mt-2 space-y-1 text-xs text-red-400/80">
               {result.errors.map((err, i) => (
@@ -130,14 +134,15 @@ function WatchlistSyncResultDisplay({ result }: { result: WatchlistSyncResult })
       </div>
       {skipReasons.length > 0 && (
         <div>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => setShowSkipped(!showSkipped)}
-            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            className="flex items-center gap-1 text-xs h-auto p-0 text-muted-foreground hover:text-foreground"
           >
             {showSkipped ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
             {showSkipped ? "Hide" : "Show"} skip reasons
-          </button>
+          </Button>
           {showSkipped && (
             <div className="mt-2 space-y-1 text-xs text-muted-foreground">
               {skipReasons.map((skip, i) => (
@@ -151,14 +156,15 @@ function WatchlistSyncResultDisplay({ result }: { result: WatchlistSyncResult })
       )}
       {result.errors.length > 0 && (
         <div>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => setShowErrors(!showErrors)}
-            className="flex items-center gap-1 text-xs text-red-400 hover:text-red-300 transition-colors"
+            className="flex items-center gap-1 text-xs h-auto p-0 text-red-400 hover:text-red-300"
           >
             {showErrors ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
             {showErrors ? "Hide" : "Show"} error details
-          </button>
+          </Button>
           {showErrors && (
             <div className="mt-2 space-y-1 text-xs text-red-400/80">
               {result.errors.map((err, i) => (
@@ -403,9 +409,9 @@ export function PlexSettingsPage() {
             <h2 className="text-lg font-semibold">Server Configuration</h2>
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-muted-foreground">
+            <Label className="text-muted-foreground">
               Plex Media Server URL
-            </label>
+            </Label>
             <div className="flex gap-2">
               <Input
                 placeholder="http://192.168.1.100:32400"
@@ -671,9 +677,9 @@ export function PlexSettingsPage() {
 
             <div className="flex items-center gap-4 flex-wrap">
               <div className="flex items-center gap-2">
-                <label htmlFor="scheduler-hours" className="text-sm text-muted-foreground">
+                <Label htmlFor="scheduler-hours" className="text-muted-foreground font-normal">
                   Sync every
-                </label>
+                </Label>
                 <Input
                   id="scheduler-hours"
                   type="number"

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -256,24 +256,26 @@ function WatchlistItem({
               className="text-xs min-h-0 resize-none"
             />
             <div className="flex items-center gap-2">
-              <button
-                type="button"
+              <Button
+                variant="link"
+                size="sm"
                 onClick={handleSave}
                 disabled={isUpdating}
                 aria-label="Save note"
-                className="text-xs text-primary hover:underline disabled:opacity-50"
+                className="text-xs h-auto p-0 text-primary"
               >
                 {isUpdating ? "Saving..." : "Save"}
-              </button>
-              <button
-                type="button"
+              </Button>
+              <Button
+                variant="link"
+                size="sm"
                 onClick={handleCancel}
                 disabled={isUpdating}
                 aria-label="Cancel editing"
-                className="text-xs text-muted-foreground hover:underline"
+                className="text-xs h-auto p-0 text-muted-foreground"
               >
                 Cancel
-              </button>
+              </Button>
               <span className="text-xs text-muted-foreground ml-auto">
                 {draft.length}/500 · Ctrl+Enter to save
               </span>
@@ -281,23 +283,23 @@ function WatchlistItem({
             {updateError && <p className="text-xs text-destructive">{updateError}</p>}
           </div>
         ) : entry.notes ? (
-          <button
-            type="button"
+          <Button
+            variant="ghost"
             onClick={() => setEditing(true)}
             aria-label={`Edit notes for ${title}`}
-            className="mt-1.5 text-xs text-muted-foreground line-clamp-2 text-left hover:text-foreground transition-colors cursor-pointer"
+            className="mt-1.5 text-xs text-muted-foreground line-clamp-2 text-left hover:text-foreground h-auto p-0 justify-start"
           >
             {entry.notes}
-          </button>
+          </Button>
         ) : (
-          <button
-            type="button"
+          <Button
+            variant="ghost"
             onClick={() => setEditing(true)}
             aria-label={`Add notes for ${title}`}
-            className="mt-1.5 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors cursor-pointer"
+            className="mt-1.5 text-xs text-muted-foreground/60 hover:text-muted-foreground h-auto p-0"
           >
             Add note...
-          </button>
+          </Button>
         )}
       </div>
     </div>
@@ -356,16 +358,17 @@ function WatchlistCard({
 
         {/* Grab handle (desktop hover) */}
         {dragListeners && (
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="icon"
             aria-label={`Drag to reorder ${title}`}
-            className="absolute top-2 left-1/2 -translate-x-1/2 z-10 opacity-0 group-hover:opacity-100 transition-opacity bg-black/60 text-white rounded-md p-1 cursor-grab active:cursor-grabbing"
+            className="absolute top-2 left-1/2 -translate-x-1/2 z-10 opacity-0 group-hover:opacity-100 transition-opacity bg-black/60 text-white rounded-md p-1 h-auto w-auto cursor-grab active:cursor-grabbing hover:bg-black/80"
             onClick={(e) => e.stopPropagation()}
             {...dragListeners}
             {...dragAttributes}
           >
             <GripVertical className="h-4 w-4" />
-          </button>
+          </Button>
         )}
 
         {/* Type badge */}
@@ -377,18 +380,19 @@ function WatchlistCard({
         </Badge>
 
         {/* Remove button (hover) */}
-        <button
-          type="button"
+        <Button
+          variant="destructive"
+          size="icon"
           onClick={(e) => {
             e.stopPropagation();
             onRemove(entry.id);
           }}
           disabled={isRemoving}
           aria-label={`Remove ${title} from watchlist`}
-          className="absolute bottom-2 right-2 z-10 opacity-0 group-hover:opacity-100 transition-opacity bg-destructive text-destructive-foreground rounded-md p-1.5 hover:bg-destructive/90 disabled:opacity-50"
+          className="absolute bottom-2 right-2 z-10 opacity-0 group-hover:opacity-100 transition-opacity h-auto w-auto p-1.5"
         >
           <Trash2 className="h-3.5 w-3.5" />
-        </button>
+        </Button>
 
         {!posterSrc || imageError ? (
           <div className="flex h-full w-full items-center justify-center bg-muted text-muted-foreground">
@@ -658,20 +662,17 @@ export function WatchlistPage() {
       {/* Filter tabs */}
       <div className="flex gap-2" role="tablist" aria-label="Filter watchlist">
         {FILTER_OPTIONS.map((opt) => (
-          <button
+          <Button
             key={opt.value}
-            type="button"
+            variant={filter === opt.value ? "default" : "secondary"}
+            size="sm"
             role="tab"
             aria-selected={filter === opt.value}
             onClick={() => setFilter(opt.value)}
-            className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
-              filter === opt.value
-                ? "bg-primary text-primary-foreground"
-                : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
-            }`}
+            shape="pill"
           >
             {opt.label}
-          </button>
+          </Button>
         ))}
       </div>
 


### PR DESCRIPTION
## Summary
- Replace ~38 raw HTML elements across 8 files in app-media with @pops/ui components
- 20 `<button>` → `Button` (ghost, link, destructive, icon variants as appropriate)
- 8 `<select>` → `Select` with `options` prop
- 9 `<label>` → `Label`
- Files: WatchlistPage, HistoryPage, LibraryPage, PlexSettingsPage, ArrSettingsPage, RequestSeriesModal, RequestMovieModal, DimensionManager

Ref: #1111

## Test plan
- [ ] WatchlistPage: filter tabs, note save/cancel, drag handle, remove button all work
- [ ] HistoryPage: filter tabs and delete buttons work
- [ ] LibraryPage: type toggle, genre/sort dropdowns, page size select work
- [ ] PlexSettingsPage: show/hide skip/error toggles, labels display correctly
- [ ] ArrSettingsPage: labels display correctly
- [ ] RequestMovieModal: quality profile and root folder selects work
- [ ] RequestSeriesModal: all 3 selects + season monitoring checkboxes work
- [ ] DimensionManager: reorder and edit buttons work

🤖 Generated with [Claude Code](https://claude.com/claude-code)