### PR TITLE
fix(ui): replace raw HTML with @pops/ui in app-finance [tb-112]

### DIFF
--- a/packages/app-finance/src/components/TagEditor.tsx
+++ b/packages/app-finance/src/components/TagEditor.tsx
@@ -6,7 +6,7 @@
  * This component is tRPC-agnostic — callers wire up the API.
  */
 import { useState, useRef, useEffect } from "react";
-import { Chip, Popover, PopoverContent, PopoverTrigger, Badge } from "@pops/ui";
+import { Button, Chip, Popover, PopoverContent, PopoverTrigger, Badge } from "@pops/ui";
 import { cn } from "../lib/utils";
 
 /** Source attribution for a tag — from AI, correction rule, or entity defaults. */
@@ -180,9 +180,10 @@ export function TagEditor({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <button
+        <Button
+          variant="ghost"
           className={cn(
-            "flex flex-wrap gap-1 min-h-10 text-left w-full rounded px-2 py-1.5 transition-colors items-center",
+            "flex flex-wrap gap-1 min-h-10 text-left w-full rounded px-2 py-1.5 transition-colors items-center h-auto",
             disabled ? "cursor-default" : "hover:bg-accent/50 cursor-pointer"
           )}
           aria-label="Edit tags"
@@ -219,7 +220,7 @@ export function TagEditor({
               +{tags.length - 3}
             </Badge>
           )}
-        </button>
+        </Button>
       </PopoverTrigger>
       <PopoverContent className="w-80 p-3" align="start">
         <div className="space-y-3">
@@ -264,17 +265,16 @@ export function TagEditor({
               {filteredSuggestions.slice(0, 8).map((tag) => {
                 const style = getTagStyle(tag);
                 return (
-                  <button
+                  <Button
                     key={tag}
+                    variant="outline"
+                    size="sm"
                     onClick={() => addTag(tag)}
-                    className={cn(
-                      "text-xs px-3 py-2 border rounded-full transition-colors",
-                      "hover:brightness-110"
-                    )}
+                    className="text-xs px-3 py-2 rounded-full h-auto hover:brightness-110"
                     style={style}
                   >
                     + {tag}
-                  </button>
+                  </Button>
                 );
               })}
             </div>
@@ -283,30 +283,35 @@ export function TagEditor({
           {/* Actions */}
           <div className="flex items-center justify-between pt-1">
             {onSuggest ? (
-              <button
+              <Button
+                variant="link"
+                size="sm"
                 onClick={handleSuggest}
                 disabled={isSuggesting}
-                className="text-xs text-muted-foreground hover:text-foreground underline disabled:opacity-50 py-2"
+                className="text-xs text-muted-foreground hover:text-foreground px-0 h-auto"
               >
                 {isSuggesting ? "Suggesting…" : "Suggest"}
-              </button>
+              </Button>
             ) : (
               <span />
             )}
             <div className="flex gap-2">
-              <button
+              <Button
+                variant="outline"
+                size="sm"
                 onClick={handleCancel}
-                className="text-xs px-3 py-2 border border-border rounded hover:bg-accent transition-colors"
+                className="text-xs px-3 h-auto py-2"
               >
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
+                size="sm"
                 onClick={handleSave}
                 disabled={isSaving}
-                className="text-xs px-3 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                className="text-xs px-3 h-auto py-2"
               >
                 {isSaving ? "Saving…" : "Save"}
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/packages/app-finance/src/components/imports/BatchProposalsPanel.tsx
+++ b/packages/app-finance/src/components/imports/BatchProposalsPanel.tsx
@@ -49,9 +49,10 @@ export function BatchProposalsPanel({
 
   return (
     <div className="border border-border rounded-lg bg-muted/30 mt-4">
-      <button
+      <Button
+        variant="ghost"
         onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-left hover:bg-muted/50 transition-colors"
+        className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-left hover:bg-muted/50 h-auto justify-start rounded-none"
       >
         {expanded ? (
           <ChevronDown className="h-4 w-4 text-muted-foreground" />
@@ -68,7 +69,7 @@ export function BatchProposalsPanel({
           )}
         </span>
         {isAnalyzing && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground ml-auto" />}
-      </button>
+      </Button>
 
       {expanded && (
         <div className="px-4 pb-3 space-y-2">

--- a/packages/app-finance/src/components/imports/ColumnMapStep.tsx
+++ b/packages/app-finance/src/components/imports/ColumnMapStep.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import crypto from "crypto-js";
 import { useImportStore } from "../../store/importStore";
-import { Button } from "@pops/ui";
+import { Button, Label, Select as UiSelect } from "@pops/ui";
 import { AlertCircle, CheckCircle } from "lucide-react";
 import type { ParsedTransaction } from "@pops/api/modules/finance/imports";
 
@@ -140,24 +140,22 @@ export function ColumnMapStep() {
           const isInvalid = field.required && !localColumnMap[field.key];
           return (
             <div key={field.key} className="flex items-center gap-4">
-              <label className="w-40 text-sm font-medium">
+              <Label className="w-40">
                 {field.label}
                 {field.required && <span className="text-red-500 ml-1">*</span>}
-              </label>
-              <select
+              </Label>
+              <UiSelect
                 name={field.key}
                 value={localColumnMap[field.key] ?? ""}
                 onChange={(e) => handleColumnChange(field.key, e.target.value)}
                 aria-invalid={isInvalid}
-                className="flex-1 px-3 py-2 border rounded-md"
-              >
-                <option value="">Select column...</option>
-                {headers.map((header) => (
-                  <option key={header} value={header}>
-                    {header}
-                  </option>
-                ))}
-              </select>
+                placeholder="Select column..."
+                options={headers.map((header) => ({
+                  label: header,
+                  value: header,
+                }))}
+                containerClassName="flex-1"
+              />
             </div>
           );
         })}

--- a/packages/app-finance/src/components/imports/EditableTransactionCard.tsx
+++ b/packages/app-finance/src/components/imports/EditableTransactionCard.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { Save, X, ChevronRight } from "lucide-react";
-import { Button } from "@pops/ui";
+import { Button, CheckboxInput } from "@pops/ui";
 import { Input } from "@pops/ui";
 import { Label } from "@pops/ui";
+import { Select as UiSelect } from "@pops/ui";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@pops/ui";
 import { EntitySelect } from "./EntitySelect";
 import type { ProcessedTransaction } from "@pops/api/modules/finance/imports";
@@ -92,7 +93,7 @@ export function EditableTransactionCard({
         <Label htmlFor="transactionType" className="block mb-2 font-semibold">
           Transaction Type
         </Label>
-        <select
+        <UiSelect
           id="transactionType"
           name="type"
           value={transactionType}
@@ -102,12 +103,12 @@ export function EditableTransactionCard({
               transactionType: e.target.value as "purchase" | "transfer" | "income",
             })
           }
-          className="w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-800"
-        >
-          <option value="purchase">Purchase (requires entity)</option>
-          <option value="transfer">Transfer (between accounts, no entity)</option>
-          <option value="income">Income (salary, refund, etc.)</option>
-        </select>
+          options={[
+            { label: "Purchase (requires entity)", value: "purchase" },
+            { label: "Transfer (between accounts, no entity)", value: "transfer" },
+            { label: "Income (salary, refund, etc.)", value: "income" },
+          ]}
+        />
         <p className="text-xs mt-1 text-blue-700 dark:text-blue-300">
           {transactionType === "transfer" &&
             "Transfers don't need an entity - they move money between accounts"}
@@ -179,16 +180,14 @@ export function EditableTransactionCard({
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="online" className="flex items-center gap-2">
-            <input
-              id="online"
-              type="checkbox"
-              checked={editedFields.online || false}
-              onChange={(e) => setEditedFields({ ...editedFields, online: e.target.checked })}
-              className="w-4 h-4"
-            />
-            <span>Online transaction</span>
-          </Label>
+          <CheckboxInput
+            id="online"
+            label="Online transaction"
+            checked={editedFields.online || false}
+            onCheckedChange={(checked) =>
+              setEditedFields({ ...editedFields, online: checked === true })
+            }
+          />
         </div>
       </div>
 

--- a/packages/app-finance/src/components/imports/FileUpload.tsx
+++ b/packages/app-finance/src/components/imports/FileUpload.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { Upload, FileText, X } from "lucide-react";
+import { Button, Label } from "@pops/ui";
 
 interface FileUploadProps {
   onFileSelect: (file: File | null) => void;
@@ -122,7 +123,7 @@ export function FileUpload({
             ${error ? "border-red-500 bg-red-50 dark:bg-red-950" : ""}
           `}
         >
-          <label
+          <Label
             htmlFor="file-upload"
             className="flex flex-col items-center justify-center cursor-pointer"
           >
@@ -142,7 +143,7 @@ export function FileUpload({
               className="absolute inset-0 w-full h-full opacity-0 cursor-pointer z-10"
               aria-label="Upload CSV file"
             />
-          </label>
+          </Label>
         </div>
       ) : (
         <div className="flex items-center justify-between p-4 border-2 border-green-500 bg-green-50 dark:bg-green-950 rounded-lg">
@@ -157,13 +158,15 @@ export function FileUpload({
               </p>
             </div>
           </div>
-          <button
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={handleRemove}
-            className="p-2 text-gray-500 hover:text-red-600 transition-colors"
+            className="text-gray-500 hover:text-red-600"
             aria-label="Remove file"
           >
             <X className="w-5 h-5" />
-          </button>
+          </Button>
         </div>
       )}
 

--- a/packages/app-finance/src/components/imports/TagReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.tsx
@@ -374,8 +374,9 @@ function EntityGroup({
     <div className="border rounded-lg overflow-hidden">
       {/* Group header */}
       <div className="flex items-center justify-between gap-3 px-4 py-3 bg-muted/40">
-        <button
-          className="flex items-center gap-2 flex-1 text-left"
+        <Button
+          variant="ghost"
+          className="flex items-center gap-2 flex-1 text-left h-auto p-0 hover:bg-transparent"
           onClick={() => setExpanded((prev) => !prev)}
           aria-expanded={expanded}
         >
@@ -386,7 +387,7 @@ function EntityGroup({
           )}
           <span className="font-medium text-sm">{group.entityName}</span>
           <span className="text-xs text-muted-foreground">({group.transactions.length})</span>
-        </button>
+        </Button>
 
         <div className="flex items-center gap-2 flex-shrink-0">
           {/* Current tag union preview (reactive to edits) */}
@@ -407,16 +408,15 @@ function EntityGroup({
 
           {/* Apply original suggestions to all (if any exist) */}
           {suggestedUnion.length > 0 && (
-            <button
+            <Button
+              variant="outline"
+              size="sm"
               onClick={handleApplySuggestions}
-              className={cn(
-                "text-xs px-2 py-1 rounded border transition-colors whitespace-nowrap",
-                "border-border hover:bg-accent hover:border-accent-foreground/20"
-              )}
+              className="text-xs px-2 py-1 h-auto whitespace-nowrap"
               title={`Apply suggestions: ${suggestedUnion.join(", ")}`}
             >
               Apply suggestions
-            </button>
+            </Button>
           )}
         </div>
       </div>
@@ -527,13 +527,15 @@ function GroupTagBar({
           className="inline-flex items-center gap-0.5 px-1.5 py-0.5 bg-background border border-border rounded-full"
         >
           {tag}
-          <button
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={() => onRemoveTag(tag)}
-            className="text-muted-foreground hover:text-foreground transition-colors ml-0.5"
+            className="text-muted-foreground hover:text-foreground ml-0.5 h-4 w-4 p-0"
             aria-label={`Remove ${tag}`}
           >
             <X className="w-3 h-3" />
-          </button>
+          </Button>
         </span>
       ))}
 
@@ -596,18 +598,18 @@ function GroupTagBar({
       </div>
 
       {/* Apply button — disabled when no staged tags */}
-      <button
+      <Button
+        variant="outline"
+        size="sm"
         onClick={onApply}
         disabled={stagedTags.length === 0}
         className={cn(
-          "px-2 py-0.5 rounded border text-xs transition-colors whitespace-nowrap",
-          stagedTags.length === 0
-            ? "border-border text-muted-foreground cursor-not-allowed opacity-50"
-            : "border-primary text-primary hover:bg-primary/10"
+          "px-2 py-0.5 h-auto text-xs whitespace-nowrap",
+          stagedTags.length > 0 && "border-primary text-primary hover:bg-primary/10"
         )}
       >
         Merge into all
-      </button>
+      </Button>
     </div>
   );
 }

--- a/packages/app-finance/src/components/imports/TransactionGroup.tsx
+++ b/packages/app-finance/src/components/imports/TransactionGroup.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ChevronRight, Sparkles } from "lucide-react";
-import { Button } from "@pops/ui";
+import { Button, Label, Select as UiSelect } from "@pops/ui";
 import { Badge } from "@pops/ui";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@pops/ui";
 import { TransactionCard } from "./TransactionCard";
@@ -146,15 +146,18 @@ export function TransactionGroup({
         {/* Entity selector for bulk assignment */}
         {showEntitySelector && entities && entities.length > 0 && (
           <div className="mt-3 p-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-600">
-            <label className="block text-sm font-medium mb-2">
+            <Label className="block mb-2">
               Select entity to assign to all {group.transactions.length} transactions:
-            </label>
-            <select
-              className="w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-800"
+            </Label>
+            <UiSelect
+              placeholder="Choose entity..."
+              options={entities.map((entity) => ({
+                label: entity.name,
+                value: entity.id,
+              }))}
               onChange={(e) => {
                 const selectedEntity = entities.find((ent) => ent.id === e.target.value);
                 if (selectedEntity) {
-                  // Apply selected entity to all transactions in group
                   group.transactions.forEach((t) => {
                     onEntitySelect(t, selectedEntity.id, selectedEntity.name);
                   });
@@ -162,14 +165,7 @@ export function TransactionGroup({
                 }
               }}
               defaultValue=""
-            >
-              <option value="">Choose entity...</option>
-              {entities.map((entity) => (
-                <option key={entity.id} value={entity.id}>
-                  {entity.name}
-                </option>
-              ))}
-            </select>
+            />
           </div>
         )}
 

--- a/packages/app-finance/src/pages/BudgetsPage.tsx
+++ b/packages/app-finance/src/pages/BudgetsPage.tsx
@@ -35,6 +35,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   PageHeader,
+  Label,
 } from "@pops/ui";
 import type { ColumnFilter } from "@pops/ui";
 import { MoreHorizontal, Plus, Pencil, Trash2, Loader2 } from "lucide-react";
@@ -364,7 +365,7 @@ export function BudgetsPage() {
                 )}
               />
               <div className="space-y-2">
-                <label className="text-sm font-medium">Notes (Optional)</label>
+                <Label>Notes (Optional)</Label>
                 <Textarea placeholder="Additional details..." {...form.register("notes")} />
               </div>
             </div>

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -35,6 +35,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   PageHeader,
+  Label,
 } from "@pops/ui";
 import type { ColumnFilter } from "@pops/ui";
 import { MoreHorizontal, Plus, Pencil, Trash2, Loader2 } from "lucide-react";
@@ -324,7 +325,9 @@ export function EntitiesPage() {
     <div className="space-y-6">
       <PageHeader
         title="Entities"
-        description={data ? `${data.pagination.total} total entities` : "Manage merchants and payees"}
+        description={
+          data ? `${data.pagination.total} total entities` : "Manage merchants and payees"
+        }
         actions={
           <Button onClick={handleAdd}>
             <Plus className="mr-2 h-4 w-4" /> Add Entity
@@ -381,7 +384,7 @@ export function EntitiesPage() {
                 />
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium">Aliases</label>
+                <Label>Aliases</Label>
                 <Controller
                   control={form.control}
                   name="aliases"
@@ -400,7 +403,7 @@ export function EntitiesPage() {
                 {...form.register("defaultTransactionType")}
               />
               <div className="space-y-2">
-                <label className="text-sm font-medium">Default Tags</label>
+                <Label>Default Tags</Label>
                 <Controller
                   control={form.control}
                   name="defaultTags"
@@ -414,7 +417,7 @@ export function EntitiesPage() {
                 />
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium">Notes (Optional)</label>
+                <Label>Notes (Optional)</Label>
                 <Textarea placeholder="Additional details..." {...form.register("notes")} />
               </div>
             </div>

--- a/packages/app-finance/src/pages/TransactionsPage.tsx
+++ b/packages/app-finance/src/pages/TransactionsPage.tsx
@@ -6,7 +6,7 @@ import { useCallback } from "react";
 import { trpc } from "../lib/trpc";
 import { DataTable, SortableHeader } from "@pops/ui";
 import { Badge } from "@pops/ui";
-import { Alert, PageHeader } from "@pops/ui";
+import { Alert, Button, PageHeader } from "@pops/ui";
 import { Skeleton } from "@pops/ui";
 import { TagEditor } from "../components/TagEditor";
 import type { ColumnFilter } from "@pops/ui";
@@ -189,9 +189,9 @@ export function TransactionsPage() {
         <Alert variant="destructive">
           <p className="font-semibold">Failed to load transactions</p>
           <p className="text-sm">{error.message}</p>
-          <button onClick={() => refetch()} className="mt-2 text-sm underline">
+          <Button variant="link" size="sm" onClick={() => refetch()} className="mt-2 px-0">
             Try again
-          </button>
+          </Button>
         </Alert>
       </div>
     );


### PR DESCRIPTION
## Summary
- Replace ~20 raw HTML elements (`<button>`, `<select>`, `<input>`, `<label>`) with their `@pops/ui` equivalents (`Button`, `Select`, `CheckboxInput`, `Label`) across 10 files in `app-finance`
- Tables and custom autocomplete dropdown items kept as raw elements where the UI library would add unnecessary wrapper structure
- Preserves all existing behavior and visual appearance

## Files Changed
- `TagEditor.tsx` — 5 buttons → `Button`
- `TransactionsPage.tsx` — 1 button → `Button`
- `BatchProposalsPanel.tsx` — 1 button → `Button`
- `FileUpload.tsx` — 1 button → `Button`, 1 label → `Label`
- `TagReviewStep.tsx` — 3 buttons → `Button`
- `EditableTransactionCard.tsx` — 1 select → `Select`, 1 checkbox → `CheckboxInput`
- `TransactionGroup.tsx` — 1 select → `Select`, 1 label → `Label`
- `ColumnMapStep.tsx` — 1 select → `Select`, 1 label → `Label`
- `EntitiesPage.tsx` — 3 labels → `Label`
- `BudgetsPage.tsx` — 1 label → `Label`

## Test plan
- [ ] Typecheck passes (verified locally)
- [ ] Verify TagEditor popover still opens/closes and tag editing works
- [ ] Verify transaction type selector in import flow works
- [ ] Verify column mapping dropdowns work
- [ ] Verify entity bulk assignment selector works
- [ ] Visual regression check on dark mode

Ref: #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)