### PR TITLE
feat(media): context collection definitions + getActiveCollections [tb-116]

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/context-collections.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/context-collections.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  CONTEXT_COLLECTIONS,
-  getActiveCollections,
-} from "./context-collections.js";
+import { CONTEXT_COLLECTIONS, getActiveCollections } from "./context-collections.js";
 
 /** Helper — get collection by id. */
 function findCollection(id: string) {

--- a/apps/pops-api/src/modules/media/discovery/context-collections.ts
+++ b/apps/pops-api/src/modules/media/discovery/context-collections.ts
@@ -31,9 +31,7 @@ export const CONTEXT_COLLECTIONS: ContextCollection[] = [
     genreIds: [10749, 35], // Romance + Comedy
     keywordIds: [],
     trigger: (hour, _month, dayOfWeek) =>
-      (dayOfWeek === FRIDAY || dayOfWeek === SATURDAY) &&
-      hour >= 18 &&
-      hour <= 22,
+      (dayOfWeek === FRIDAY || dayOfWeek === SATURDAY) && hour >= 18 && hour <= 22,
   },
   {
     id: "sunday-flicks",
@@ -94,7 +92,7 @@ const MAX_ACTIVE = 2;
 export function getActiveCollections(
   hour: number,
   month: number,
-  dayOfWeek: number,
+  dayOfWeek: number
 ): ContextCollection[] {
   const matched: ContextCollection[] = [];
 

--- a/apps/pops-api/src/modules/media/discovery/index.ts
+++ b/apps/pops-api/src/modules/media/discovery/index.ts
@@ -8,8 +8,5 @@ export type {
   DimensionWeight,
   GenreDistribution,
 } from "./types.js";
-export {
-  CONTEXT_COLLECTIONS,
-  getActiveCollections,
-} from "./context-collections.js";
+export { CONTEXT_COLLECTIONS, getActiveCollections } from "./context-collections.js";
 export type { ContextCollection } from "./context-collections.js";


### PR DESCRIPTION
## Summary
- Define `ContextCollection` type and 7 static collections (date-night, sunday-flicks, late-night, halloween, christmas, oscar-season, rainy-day) with trigger functions and TMDB genre/keyword mappings
- Export `getActiveCollections(hour, month, dayOfWeek)` returning max 2 matching collections, filling with rainy-day fallback when <2 non-fallback match
- 28 unit tests covering every trigger condition, fallback selection, and the max 2 cap

## Test plan
- [x] All 28 unit tests pass (`vitest run context-collections.test.ts`)
- [x] TypeScript compiles without errors in new files
- [ ] QA: verify trigger logic matches PRD table

🤖 Generated with [Claude Code](https://claude.com/claude-code)