### PR TITLE
ci: auto-deploy to N95 on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy to Production
 
 on:
-  # SECURITY: Disabled automatic deployment on public repo with self-hosted runner
-  # Only allow manual deployment trigger by repo owner
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Self-hosted GitHub Actions runner installed on N95 (pops-n95, systemd service, starts on boot)
- Deploy workflow now triggers on push to main (in addition to manual workflow_dispatch)
- Every PR merge → CI passes → auto-deploy to production

## Setup done on N95

- GitHub Actions runner v2.322.0 installed at ~/actions-runner
- Registered as `pops-n95` with labels: self-hosted, linux, x64, n95
- Running as systemd service (auto-start on boot)
- Ansible installed, vault password configured

## Test plan

- [ ] Merge this PR → deploy workflow should trigger automatically
- [ ] Verify services restart on N95 after deploy completes