### PR TITLE
fix(ci): use local Ansible connection for self-hosted runner deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,7 @@ jobs:
           ansible-playbook playbooks/deploy.yml \
             -i inventory/hosts.yml \
             --vault-password-file ~/.ansible/pops-vault-password \
+            --connection=local \
             -v
 
       - name: Wait for services to stabilize


### PR DESCRIPTION
The runner IS the N95 — Ansible was trying to SSH to itself and failing because the SSH key doesn't exist locally. Use --connection=local instead.