### PR TITLE
feat(media): add watchlist recommendations endpoint and UI row [tb-123]

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/router.ts
+++ b/apps/pops-api/src/modules/media/discovery/router.ts
@@ -62,6 +62,21 @@ export const discoveryRouter = router({
     }
   }),
 
+  /** Get recommendations based on watchlist movies via TMDB similar. */
+  watchlistRecommendations: protectedProcedure.query(async () => {
+    try {
+      const client = getTmdbClient();
+      return await tmdbService.getWatchlistRecommendations(client);
+    } catch (err) {
+      if (err instanceof TRPCError) throw err;
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message:
+          err instanceof Error ? err.message : "Unknown error fetching watchlist recommendations",
+      });
+    }
+  }),
+
   /** Get rewatch suggestions — movies watched 6+ months ago with high scores. */
   rewatchSuggestions: protectedProcedure.query(() => {
     try {

--- a/apps/pops-api/src/modules/media/discovery/tmdb-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/tmdb-service.ts
@@ -2,12 +2,13 @@
  * Discovery TMDB service — trending movies and recommendations from TMDB,
  * enriched with library membership status.
  */
-import { desc, isNotNull } from "drizzle-orm";
+import { desc, eq, isNotNull } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
-import { movies } from "@pops/db-types";
+import { movies, mediaWatchlist } from "@pops/db-types";
 import type { TmdbClient } from "../tmdb/client.js";
 import type { TmdbSearchResult } from "../tmdb/types.js";
-import type { DiscoverResult } from "./types.js";
+import type { DiscoverResult, ScoredDiscoverResult } from "./types.js";
+import { getPreferenceProfile, scoreDiscoverResults } from "./service.js";
 
 /** Get all TMDB IDs currently in the library for quick lookup. */
 function getLibraryTmdbIds(): Set<number> {
@@ -143,5 +144,91 @@ export async function getRecommendations(
   return {
     results: merged,
     sourceMovies: topMovies.map((m) => m.title),
+  };
+}
+
+/** Get TMDB IDs of movies on the watchlist for exclusion. */
+function getWatchlistTmdbIds(): Set<number> {
+  const db = getDrizzle();
+  const rows = db
+    .select({ tmdbId: movies.tmdbId })
+    .from(mediaWatchlist)
+    .innerJoin(movies, eq(movies.id, mediaWatchlist.mediaId))
+    .where(eq(mediaWatchlist.mediaType, "movie"))
+    .all();
+  return new Set(rows.map((r) => r.tmdbId));
+}
+
+/**
+ * Get recommendations based on watchlist movies.
+ * Fetches TMDB /movie/{id}/similar for the 10 most recent watchlist items,
+ * merges/deduplicates, excludes library + watchlist + dismissed, scores by preference profile.
+ */
+export async function getWatchlistRecommendations(
+  client: TmdbClient
+): Promise<{ results: ScoredDiscoverResult[]; sourceMovies: string[] }> {
+  const db = getDrizzle();
+
+  // Get up to 10 most recently added movie watchlist items
+  const watchlistItems = db
+    .select({ tmdbId: movies.tmdbId, title: movies.title })
+    .from(mediaWatchlist)
+    .innerJoin(movies, eq(movies.id, mediaWatchlist.mediaId))
+    .where(eq(mediaWatchlist.mediaType, "movie"))
+    .orderBy(desc(mediaWatchlist.addedAt))
+    .limit(10)
+    .all();
+
+  if (watchlistItems.length === 0) {
+    return { results: [], sourceMovies: [] };
+  }
+
+  const libraryIds = getLibraryTmdbIds();
+  const watchlistIds = getWatchlistTmdbIds();
+  const dismissedIds = getDismissedTmdbIds();
+
+  // Fetch similar movies for each watchlist item in parallel
+  const simPromises = watchlistItems.map((m) => client.getMovieSimilar(m.tmdbId, 1));
+  const simResponses = await Promise.all(simPromises);
+
+  // Merge and deduplicate, excluding library, watchlist, and dismissed
+  const seen = new Set<number>();
+  const merged: DiscoverResult[] = [];
+
+  for (const response of simResponses) {
+    for (const result of response.results) {
+      if (
+        seen.has(result.tmdbId) ||
+        libraryIds.has(result.tmdbId) ||
+        watchlistIds.has(result.tmdbId) ||
+        dismissedIds.has(result.tmdbId)
+      ) {
+        continue;
+      }
+      seen.add(result.tmdbId);
+      merged.push({
+        tmdbId: result.tmdbId,
+        title: result.title,
+        overview: result.overview,
+        releaseDate: result.releaseDate,
+        posterPath: result.posterPath,
+        posterUrl: buildPosterUrl(result.posterPath, result.tmdbId, false),
+        backdropPath: result.backdropPath,
+        voteAverage: result.voteAverage,
+        voteCount: result.voteCount,
+        genreIds: result.genreIds,
+        popularity: result.popularity,
+        inLibrary: false,
+      });
+    }
+  }
+
+  // Score using preference profile
+  const profile = getPreferenceProfile();
+  const scored = scoreDiscoverResults(merged, profile);
+
+  return {
+    results: scored,
+    sourceMovies: watchlistItems.map((m) => m.title),
   };
 }

--- a/apps/pops-api/src/modules/media/discovery/watchlist-recommendations.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/watchlist-recommendations.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Watchlist recommendations tests — uses real in-memory SQLite + mocked TMDB client.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Database } from "better-sqlite3";
+import { setupTestContext, seedMovie, seedWatchlistEntry } from "../../../shared/test-utils.js";
+import { getWatchlistRecommendations } from "./tmdb-service.js";
+import type { TmdbClient } from "../tmdb/client.js";
+import type { TmdbSearchResponse, TmdbSearchResult } from "../tmdb/types.js";
+
+const ctx = setupTestContext();
+let db: Database;
+
+beforeEach(() => {
+  ({ db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+  vi.restoreAllMocks();
+});
+
+/** Build a minimal TMDB search result. */
+function makeTmdbResult(overrides: Partial<TmdbSearchResult> = {}): TmdbSearchResult {
+  return {
+    tmdbId: 999,
+    title: "Similar Movie",
+    originalTitle: "Similar Movie",
+    overview: "A similar movie",
+    releaseDate: "2025-01-01",
+    posterPath: "/similar.jpg",
+    backdropPath: null,
+    voteAverage: 7.0,
+    voteCount: 100,
+    genreIds: [28],
+    originalLanguage: "en",
+    popularity: 50,
+    ...overrides,
+  };
+}
+
+/** Build a mock TMDB client. */
+function makeMockClient(similarResponses: Map<number, TmdbSearchResponse> = new Map()): TmdbClient {
+  return {
+    getMovieSimilar: vi.fn(async (tmdbId: number): Promise<TmdbSearchResponse> => {
+      return (
+        similarResponses.get(tmdbId) ?? {
+          results: [],
+          totalResults: 0,
+          totalPages: 0,
+          page: 1,
+        }
+      );
+    }),
+  } as unknown as TmdbClient;
+}
+
+describe("getWatchlistRecommendations", () => {
+  it("returns empty when watchlist is empty", async () => {
+    const client = makeMockClient();
+    const result = await getWatchlistRecommendations(client);
+
+    expect(result.results).toEqual([]);
+    expect(result.sourceMovies).toEqual([]);
+  });
+
+  it("fetches similar movies for watchlist items", async () => {
+    const movieId = seedMovie(db, { tmdb_id: 100, title: "Watchlist Movie" });
+    seedWatchlistEntry(db, { media_id: movieId, media_type: "movie" });
+
+    const responses = new Map<number, TmdbSearchResponse>();
+    responses.set(100, {
+      results: [makeTmdbResult({ tmdbId: 200, title: "Similar A" })],
+      totalResults: 1,
+      totalPages: 1,
+      page: 1,
+    });
+
+    const client = makeMockClient(responses);
+    const result = await getWatchlistRecommendations(client);
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]!.title).toBe("Similar A");
+    expect(result.sourceMovies).toContain("Watchlist Movie");
+  });
+
+  it("deduplicates results across watchlist items", async () => {
+    const movie1 = seedMovie(db, { tmdb_id: 100, title: "Movie A" });
+    const movie2 = seedMovie(db, { tmdb_id: 101, title: "Movie B" });
+    seedWatchlistEntry(db, { media_id: movie1, media_type: "movie" });
+    seedWatchlistEntry(db, { media_id: movie2, media_type: "movie" });
+
+    const sharedResult = makeTmdbResult({ tmdbId: 500, title: "Shared Similar" });
+    const responses = new Map<number, TmdbSearchResponse>();
+    responses.set(100, { results: [sharedResult], totalResults: 1, totalPages: 1, page: 1 });
+    responses.set(101, { results: [sharedResult], totalResults: 1, totalPages: 1, page: 1 });
+
+    const client = makeMockClient(responses);
+    const result = await getWatchlistRecommendations(client);
+
+    expect(result.results).toHaveLength(1);
+  });
+
+  it("excludes library movies from results", async () => {
+    const watchlistMovie = seedMovie(db, { tmdb_id: 100, title: "On Watchlist" });
+    seedWatchlistEntry(db, { media_id: watchlistMovie, media_type: "movie" });
+    // This movie is already in the library
+    seedMovie(db, { tmdb_id: 200, title: "Already Owned" });
+
+    const responses = new Map<number, TmdbSearchResponse>();
+    responses.set(100, {
+      results: [
+        makeTmdbResult({ tmdbId: 200, title: "Already Owned" }),
+        makeTmdbResult({ tmdbId: 300, title: "Not Owned" }),
+      ],
+      totalResults: 2,
+      totalPages: 1,
+      page: 1,
+    });
+
+    const client = makeMockClient(responses);
+    const result = await getWatchlistRecommendations(client);
+
+    const titles = result.results.map((r) => r.title);
+    expect(titles).not.toContain("Already Owned");
+    expect(titles).toContain("Not Owned");
+  });
+
+  it("excludes watchlist movies from results", async () => {
+    const movie1 = seedMovie(db, { tmdb_id: 100, title: "Source" });
+    const movie2 = seedMovie(db, { tmdb_id: 200, title: "Also On Watchlist" });
+    seedWatchlistEntry(db, { media_id: movie1, media_type: "movie" });
+    seedWatchlistEntry(db, { media_id: movie2, media_type: "movie" });
+
+    const responses = new Map<number, TmdbSearchResponse>();
+    responses.set(100, {
+      results: [
+        makeTmdbResult({ tmdbId: 200, title: "Also On Watchlist" }),
+        makeTmdbResult({ tmdbId: 300, title: "New Discovery" }),
+      ],
+      totalResults: 2,
+      totalPages: 1,
+      page: 1,
+    });
+    responses.set(200, { results: [], totalResults: 0, totalPages: 0, page: 1 });
+
+    const client = makeMockClient(responses);
+    const result = await getWatchlistRecommendations(client);
+
+    const titles = result.results.map((r) => r.title);
+    expect(titles).not.toContain("Also On Watchlist");
+    expect(titles).toContain("New Discovery");
+  });
+
+  it("excludes dismissed movies from results", async () => {
+    const watchlistMovie = seedMovie(db, { tmdb_id: 100, title: "Source" });
+    seedWatchlistEntry(db, { media_id: watchlistMovie, media_type: "movie" });
+
+    // Dismiss tmdbId 200
+    db.prepare("INSERT INTO dismissed_discover (tmdb_id) VALUES (?)").run(200);
+
+    const responses = new Map<number, TmdbSearchResponse>();
+    responses.set(100, {
+      results: [
+        makeTmdbResult({ tmdbId: 200, title: "Dismissed Movie" }),
+        makeTmdbResult({ tmdbId: 300, title: "Not Dismissed" }),
+      ],
+      totalResults: 2,
+      totalPages: 1,
+      page: 1,
+    });
+
+    const client = makeMockClient(responses);
+    const result = await getWatchlistRecommendations(client);
+
+    const titles = result.results.map((r) => r.title);
+    expect(titles).not.toContain("Dismissed Movie");
+    expect(titles).toContain("Not Dismissed");
+  });
+
+  it("caps at 10 most recent watchlist items", async () => {
+    // Create 12 movies + watchlist entries
+    for (let i = 0; i < 12; i++) {
+      const id = seedMovie(db, { tmdb_id: 1000 + i, title: `Movie ${i}` });
+      seedWatchlistEntry(db, { media_id: id, media_type: "movie" });
+    }
+
+    const client = makeMockClient();
+    await getWatchlistRecommendations(client);
+
+    // Should only call getMovieSimilar 10 times (capped)
+    expect(client.getMovieSimilar).toHaveBeenCalledTimes(10);
+  });
+
+  it("returns sourceMovies attribution", async () => {
+    const movie1 = seedMovie(db, { tmdb_id: 100, title: "Inception" });
+    const movie2 = seedMovie(db, { tmdb_id: 101, title: "Interstellar" });
+    seedWatchlistEntry(db, { media_id: movie1, media_type: "movie" });
+    seedWatchlistEntry(db, { media_id: movie2, media_type: "movie" });
+
+    const client = makeMockClient();
+    const result = await getWatchlistRecommendations(client);
+
+    expect(result.sourceMovies).toContain("Inception");
+    expect(result.sourceMovies).toContain("Interstellar");
+  });
+});

--- a/apps/pops-api/src/modules/media/tmdb/client.ts
+++ b/apps/pops-api/src/modules/media/tmdb/client.ts
@@ -180,6 +180,38 @@ export class TmdbClient {
     };
   }
 
+  /** Get similar movies based on a specific movie. */
+  async getMovieSimilar(tmdbId: number, page = 1): Promise<TmdbSearchResponse> {
+    const params = new URLSearchParams({
+      page: String(page),
+      language: "en-US",
+    });
+
+    const raw = await this.get<RawTmdbRecommendationsResponse>(
+      `/3/movie/${tmdbId}/similar?${params.toString()}`
+    );
+
+    return {
+      page: raw.page,
+      totalResults: raw.total_results,
+      totalPages: raw.total_pages,
+      results: raw.results.map((r) => ({
+        tmdbId: r.id,
+        title: r.title,
+        originalTitle: r.original_title,
+        overview: r.overview,
+        releaseDate: r.release_date,
+        posterPath: r.poster_path,
+        backdropPath: r.backdrop_path,
+        voteAverage: r.vote_average,
+        voteCount: r.vote_count,
+        genreIds: r.genre_ids,
+        originalLanguage: r.original_language,
+        popularity: r.popularity,
+      })),
+    };
+  }
+
   /** Discover movies by genre IDs and/or keyword IDs, with configurable sort and filters. */
   async discoverMovies(opts: {
     genreIds?: number[];

--- a/packages/app-media/src/pages/DiscoverPage.test.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.test.tsx
@@ -11,6 +11,8 @@ const mockRewatchSuggestionsRefetch = vi.fn();
 const mockGenreSpotlightQuery = vi.fn();
 const mockFromYourServerQuery = vi.fn();
 const mockContextPicksQuery = vi.fn();
+const mockWatchlistRecommendationsQuery = vi.fn();
+const mockWatchlistRecommendationsRefetch = vi.fn();
 const mockGetDismissedQuery = vi.fn();
 const mockAddMovieMutateAsync = vi.fn();
 const mockAddWatchlistMutateAsync = vi.fn();
@@ -59,6 +61,12 @@ vi.mock("../lib/trpc", () => ({
             return { ...result, refetch: vi.fn(), isFetching: false };
           },
         },
+        watchlistRecommendations: {
+          useQuery: (...args: unknown[]) => {
+            const result = mockWatchlistRecommendationsQuery(...args);
+            return { ...result, refetch: mockWatchlistRecommendationsRefetch };
+          },
+        },
         getDismissed: {
           useQuery: (...args: unknown[]) => mockGetDismissedQuery(...args),
         },
@@ -92,6 +100,7 @@ vi.mock("../lib/trpc", () => ({
           genreSpotlight: { invalidate: vi.fn() },
           genreSpotlightPage: { fetch: vi.fn().mockResolvedValue({ results: [] }) },
           contextPicks: { invalidate: vi.fn() },
+          watchlistRecommendations: { invalidate: vi.fn() },
           getDismissed: { invalidate: vi.fn() },
         },
         watchlist: { list: { invalidate: vi.fn() } },
@@ -291,6 +300,14 @@ function defaultContextPicksEmpty() {
   });
 }
 
+function defaultWatchlistRecommendations() {
+  mockWatchlistRecommendationsQuery.mockReturnValue({
+    data: { results: [], sourceMovies: [] },
+    isLoading: false,
+    error: null,
+  });
+}
+
 function defaultDismissed() {
   mockGetDismissedQuery.mockReturnValue({
     data: { data: [] },
@@ -308,6 +325,7 @@ function setupDefaults() {
   defaultGenreSpotlight();
   defaultFromYourServer();
   defaultContextPicksEmpty();
+  defaultWatchlistRecommendations();
   defaultDismissed();
 }
 
@@ -503,6 +521,7 @@ describe("DiscoverPage — recommendations", () => {
     defaultGenreSpotlight();
     defaultFromYourServer();
     defaultContextPicksEmpty();
+    defaultWatchlistRecommendations();
     defaultDismissed();
   });
 
@@ -717,6 +736,7 @@ describe("DiscoverPage — Trending on Plex", () => {
     defaultGenreSpotlight();
     defaultFromYourServer();
     defaultContextPicksEmpty();
+    defaultWatchlistRecommendations();
     defaultDismissed();
   });
 
@@ -774,6 +794,7 @@ describe("DiscoverPage — context picks", () => {
     defaultRewatchSuggestions();
     defaultGenreSpotlight();
     defaultFromYourServer();
+    defaultWatchlistRecommendations();
     defaultDismissed();
   });
 

--- a/packages/app-media/src/pages/DiscoverPage.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.tsx
@@ -220,6 +220,10 @@ export function DiscoverPage() {
     staleTime: 5 * 60 * 1000,
   });
 
+  const watchlistRecs = trpc.media.discovery.watchlistRecommendations.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
+
   const trendingPlex = trpc.media.discovery.trendingPlex.useQuery(
     { limit: 20 },
     { staleTime: 5 * 60 * 1000 }
@@ -297,6 +301,7 @@ export function DiscoverPage() {
         void utils.media.discovery.trending.invalidate();
         void utils.media.discovery.recommendations.invalidate();
         void utils.media.discovery.genreSpotlight.invalidate();
+        void utils.media.discovery.watchlistRecommendations.invalidate();
       } catch {
         toast.error("Failed to add to watchlist");
       } finally {
@@ -769,6 +774,70 @@ export function DiscoverPage() {
             )
           )}
       </HorizontalScrollRow>
+
+      {/* From Your Watchlist — hidden when empty */}
+      {(watchlistRecs.isLoading || (watchlistRecs.data?.results?.length ?? 0) > 0) && (
+        <HorizontalScrollRow
+          title="From Your Watchlist"
+          subtitle={
+            watchlistRecs.data?.sourceMovies?.length
+              ? `Similar to ${watchlistRecs.data.sourceMovies.slice(0, 3).join(", ")}`
+              : undefined
+          }
+          isLoading={watchlistRecs.isLoading}
+        >
+          {watchlistRecs.error && (
+            <Alert variant="destructive" className="flex items-center gap-3">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <p className="flex-1 text-sm">{watchlistRecs.error.message}</p>
+              <Button variant="outline" size="sm" onClick={() => watchlistRecs.refetch()}>
+                <RefreshCw className="mr-1 h-3 w-3" /> Retry
+              </Button>
+            </Alert>
+          )}
+          {!watchlistRecs.error && watchlistRecs.data?.results?.length === 0 && (
+            <p className="py-8 text-sm text-muted-foreground">
+              Add movies to your watchlist to get recommendations here.
+            </p>
+          )}
+          {watchlistRecs.data?.results
+            ?.filter((item) => !isDismissed(item.tmdbId))
+            .map(
+              (item: {
+                tmdbId: number;
+                title: string;
+                releaseDate: string | null;
+                posterPath: string | null;
+                posterUrl: string | null;
+                voteAverage: number | null;
+                inLibrary: boolean;
+                matchPercentage?: number;
+                matchReason?: string;
+              }) => (
+                <DiscoverCard
+                  key={item.tmdbId}
+                  tmdbId={item.tmdbId}
+                  title={item.title}
+                  releaseDate={item.releaseDate ?? ""}
+                  posterPath={item.posterPath}
+                  posterUrl={item.posterUrl}
+                  voteAverage={item.voteAverage ?? 0}
+                  inLibrary={item.inLibrary}
+                  isAddingToLibrary={addingToLibrary.has(item.tmdbId)}
+                  isAddingToWatchlist={addingToWatchlist.has(item.tmdbId)}
+                  onAddToLibrary={handleAddToLibrary}
+                  onAddToWatchlist={handleAddToWatchlist}
+                  onMarkWatched={handleMarkWatched}
+                  isMarkingWatched={markingWatched.has(item.tmdbId)}
+                  onNotInterested={handleNotInterested}
+                  isDismissing={dismissing.has(item.tmdbId)}
+                  matchPercentage={item.matchPercentage}
+                  matchReason={item.matchReason}
+                />
+              )
+            )}
+        </HorizontalScrollRow>
+      )}
 
       {/* Ready to Watch on Your Server — hidden when no results */}
       {(fromYourServer.isLoading || (fromYourServer.data?.results.length ?? 0) > 0) && (


### PR DESCRIPTION
## Summary
- Add `media.discovery.watchlistRecommendations` tRPC query: fetches TMDB `/movie/{id}/similar` for 10 most recent watchlist items, merges/deduplicates, excludes library + watchlist movies, scores via `scoreDiscoverResults`
- Add `getMovieSimilar()` method to TmdbClient
- Add "From Your Watchlist" HorizontalScrollRow to DiscoverPage with source movie attribution, hidden when watchlist empty
- 7 unit tests covering: empty watchlist, similar fetch, deduplication, library exclusion, watchlist exclusion, 10-item cap, attribution

## Test plan
- [x] All 7 new unit tests pass (`watchlist-recommendations.test.ts`)
- [x] Existing discovery service tests still pass (`service.test.ts`)
- [x] No lint errors
- [x] Prettier formatted
- [ ] Manual: verify section hidden when watchlist is empty
- [ ] Manual: verify similar movies shown when watchlist has items

🤖 Generated with [Claude Code](https://claude.com/claude-code)