### PR TITLE
docs: mark US-06 recommendations UI as done [tb-128]

### DIFF
--- a/docs/themes/03-media/prds/060-discover-page/README.md
+++ b/docs/themes/03-media/prds/060-discover-page/README.md
@@ -161,7 +161,7 @@ Displayed at the bottom of the page. Shows:
 |---|-------|---------|--------|----------------|
 | 04 | [us-04-trending-tmdb](us-04-trending-tmdb.md) | TMDB trending endpoint + frontend row with day/week toggle, dedup pagination, Load More | Not started | Yes |
 | 05 | [us-05-recommendations-endpoint](us-05-recommendations-endpoint.md) | tRPC endpoint: top 10-100 ELO movies → TMDB recs, merge, deduplicate, score, exclude dismissed/library | Not started | Blocked by us-03 |
-| 06 | [us-06-recommendations-ui](us-06-recommendations-ui.md) | Frontend row: cold start CTA, attribution labels, match % badge, subtitle with source movies | Not started | Blocked by us-05 |
+| 06 | [us-06-recommendations-ui](us-06-recommendations-ui.md) | Frontend row: cold start CTA, attribution labels, match % badge, subtitle with source movies | Done | Blocked by us-05 |
 | 07 | [us-07-genre-spotlight-endpoint](us-07-genre-spotlight-endpoint.md) | tRPC endpoint: select 2-3 genres with variety, fetch TMDB discover per genre, score results | Not started | Blocked by us-03 |
 | 08 | [us-08-genre-spotlight-ui](us-08-genre-spotlight-ui.md) | Frontend: genre sub-rows ("Best in Action", "Best in Sci-Fi"), Load More per genre | Not started | Blocked by us-07 |
 | 09 | [us-09-watchlist-recs](us-09-watchlist-recs.md) | tRPC endpoint + frontend row: watchlist items → TMDB similar, attribution, exclude owned/dismissed | Not started | Blocked by us-03 |

--- a/docs/themes/03-media/prds/060-discover-page/us-06-recommendations-ui.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-06-recommendations-ui.md
@@ -1,7 +1,7 @@
 # US-06: Recommendations frontend row
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,11 +9,11 @@ As a user, I want to see personalised recommendations with match scores and sour
 
 ## Acceptance Criteria
 
-- [ ] "Recommended for You" `HorizontalScrollRow`
-- [ ] Hidden when `totalComparisons < 5`; shows CTA card linking to `/media/compare` instead
-- [ ] Each card shows match percentage badge (colour-coded: green >=85%, emerald >=70%, grey below)
-- [ ] Each card shows match reason: top 3 matching genres
-- [ ] Subtitle: "Based on {source movie 1}, {source movie 2}, ..."
-- [ ] Empty state: "No new recommendations — keep comparing"
-- [ ] Loading skeleton while endpoint resolves
-- [ ] Tests cover: cold start CTA, attribution, match badge, empty state
+- [x] "Recommended for You" `HorizontalScrollRow`
+- [x] Hidden when `totalComparisons < 5`; shows CTA card linking to `/media/compare` instead
+- [x] Each card shows match percentage badge (colour-coded: green >=85%, emerald >=70%, grey below)
+- [x] Each card shows match reason: top 3 matching genres
+- [x] Subtitle: "Based on {source movie 1}, {source movie 2}, ..."
+- [x] Empty state: "No new recommendations — keep comparing"
+- [x] Loading skeleton while endpoint resolves
+- [x] Tests cover: cold start CTA, attribution, match badge, empty state


### PR DESCRIPTION
## Summary
- Mark US-06 acceptance criteria as checked — all already implemented
- Update PRD-060 user stories table: US-06 status → Done

All acceptance criteria verified in existing code:
- DiscoverPage: cold-start CTA, attribution subtitle, loading skeleton, empty state
- DiscoverCard: color-coded match% badges, genre reason display
- DiscoverPage.test.tsx: full test coverage for all scenarios

## Test plan
- [x] No code changes — docs only
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)