### PR TITLE
fix(ui): address QA feedback on genre spotlight UI [tb-127]

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/genre-spotlight-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/genre-spotlight-service.ts
@@ -50,10 +50,19 @@ export interface GenreSpotlightEntry {
   genreId: number;
   genreName: string;
   results: ScoredDiscoverResult[];
+  totalPages: number;
 }
 
 export interface GenreSpotlightResponse {
   genres: GenreSpotlightEntry[];
+}
+
+export interface GenreSpotlightPageResponse {
+  genreId: number;
+  genreName: string;
+  results: ScoredDiscoverResult[];
+  page: number;
+  totalPages: number;
 }
 
 /**
@@ -144,11 +153,62 @@ export async function getGenreSpotlight(
         genreId,
         genreName,
         results: scored,
+        totalPages: response.totalPages,
       };
     })
   );
 
   return {
     genres: entries.filter((e): e is GenreSpotlightEntry => e != null),
+  };
+}
+
+/**
+ * Fetch additional page of genre spotlight results for a specific genre.
+ */
+export async function getGenreSpotlightPage(
+  client: TmdbClient,
+  profile: PreferenceProfile,
+  libraryIds: Set<number>,
+  genreId: number,
+  page: number
+): Promise<GenreSpotlightPageResponse> {
+  const genreName = TMDB_GENRE_MAP[genreId] ?? "Unknown";
+
+  const response = await client.discoverMovies({
+    genreIds: [genreId],
+    sortBy: "vote_average.desc",
+    voteCountGte: 100,
+    page,
+  });
+
+  const results: DiscoverResult[] = response.results
+    .filter((r) => !libraryIds.has(r.tmdbId))
+    .map((r) => {
+      const inLibrary = false;
+      return {
+        tmdbId: r.tmdbId,
+        title: r.title,
+        overview: r.overview,
+        releaseDate: r.releaseDate,
+        posterPath: r.posterPath,
+        posterUrl: buildPosterUrl(r.posterPath, r.tmdbId, inLibrary),
+        backdropPath: r.backdropPath,
+        voteAverage: r.voteAverage,
+        voteCount: r.voteCount,
+        genreIds: r.genreIds,
+        popularity: r.popularity,
+        inLibrary,
+      };
+    });
+
+  const scored = scoreDiscoverResults(results, profile);
+
+  return {
+    genreId,
+    genreName,
+    results: scored,
+    page: response.page,
+    totalPages: response.totalPages,
   };
 }

--- a/apps/pops-api/src/modules/media/discovery/router.ts
+++ b/apps/pops-api/src/modules/media/discovery/router.ts
@@ -168,4 +168,36 @@ export const discoveryRouter = router({
       });
     }
   }),
+
+  /** Load more results for a specific genre spotlight row. */
+  genreSpotlightPage: protectedProcedure
+    .input(
+      z.object({
+        genreId: z.number().int().positive(),
+        page: z.number().int().positive().min(2),
+      })
+    )
+    .query(async ({ input }) => {
+      try {
+        const client = getTmdbClient();
+        const profile = service.getPreferenceProfile();
+        const db = getDrizzle();
+        const rows = db.select({ tmdbId: movies.tmdbId }).from(movies).all();
+        const libraryIds = new Set(rows.map((r) => r.tmdbId));
+        return await genreSpotlightService.getGenreSpotlightPage(
+          client,
+          profile,
+          libraryIds,
+          input.genreId,
+          input.page
+        );
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message:
+            err instanceof Error ? err.message : "Unknown error fetching genre spotlight page",
+        });
+      }
+    }),
 });

--- a/packages/app-media/src/pages/DiscoverPage.test.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.test.tsx
@@ -89,6 +89,8 @@ vi.mock("../lib/trpc", () => ({
           trending: { invalidate: vi.fn() },
           recommendations: { invalidate: vi.fn() },
           rewatchSuggestions: { invalidate: vi.fn() },
+          genreSpotlight: { invalidate: vi.fn() },
+          genreSpotlightPage: { fetch: vi.fn().mockResolvedValue({ results: [] }) },
           contextPicks: { invalidate: vi.fn() },
           getDismissed: { invalidate: vi.fn() },
         },
@@ -431,8 +433,24 @@ describe("DiscoverPage", () => {
     defaultGenreSpotlight();
 
     const page2Movies = [
-      { tmdbId: 200, title: "Oppenheimer", releaseDate: "2023-07-21", posterPath: null, posterUrl: null, voteAverage: 8.5, inLibrary: true }, // duplicate
-      { tmdbId: 400, title: "Interstellar", releaseDate: "2014-11-07", posterPath: null, posterUrl: null, voteAverage: 8.7, inLibrary: false }, // new
+      {
+        tmdbId: 200,
+        title: "Oppenheimer",
+        releaseDate: "2023-07-21",
+        posterPath: null,
+        posterUrl: null,
+        voteAverage: 8.5,
+        inLibrary: true,
+      }, // duplicate
+      {
+        tmdbId: 400,
+        title: "Interstellar",
+        releaseDate: "2014-11-07",
+        posterPath: null,
+        posterUrl: null,
+        voteAverage: 8.7,
+        inLibrary: false,
+      }, // new
     ];
 
     // Start with page 1
@@ -870,5 +888,133 @@ describe("DiscoverPage — context picks", () => {
     // The contextPicks query is called with pages param
     const lastCall = mockContextPicksQuery.mock.calls[mockContextPicksQuery.mock.calls.length - 1];
     expect(lastCall).toBeDefined();
+  });
+});
+
+const genreSpotlightData = {
+  genres: [
+    {
+      genreId: 28,
+      genreName: "Action",
+      totalPages: 5,
+      results: [
+        {
+          tmdbId: 900,
+          title: "Mad Max: Fury Road",
+          releaseDate: "2015-05-15",
+          posterPath: null,
+          posterUrl: null,
+          voteAverage: 7.6,
+          inLibrary: false,
+          matchPercentage: 88,
+          matchReason: "Action",
+        },
+      ],
+    },
+    {
+      genreId: 35,
+      genreName: "Comedy",
+      totalPages: 3,
+      results: [
+        {
+          tmdbId: 901,
+          title: "The Grand Budapest Hotel",
+          releaseDate: "2014-03-28",
+          posterPath: null,
+          posterUrl: null,
+          voteAverage: 8.1,
+          inLibrary: false,
+          matchPercentage: 76,
+          matchReason: "Comedy",
+        },
+      ],
+    },
+  ],
+};
+
+describe("DiscoverPage — genre spotlight", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaults();
+  });
+
+  it("renders genre spotlight rows with correct titles", () => {
+    mockGenreSpotlightQuery.mockReturnValue({
+      data: genreSpotlightData,
+      isLoading: false,
+      error: null,
+    });
+    renderPage();
+
+    expect(screen.getByText("Best in Action")).toBeTruthy();
+    expect(screen.getByText("Best in Comedy")).toBeTruthy();
+  });
+
+  it("renders cards within genre spotlight rows", () => {
+    mockGenreSpotlightQuery.mockReturnValue({
+      data: genreSpotlightData,
+      isLoading: false,
+      error: null,
+    });
+    renderPage();
+
+    expect(screen.getByText("Mad Max: Fury Road")).toBeTruthy();
+    expect(screen.getByText("The Grand Budapest Hotel")).toBeTruthy();
+  });
+
+  it("shows match percentage on genre spotlight cards", () => {
+    mockGenreSpotlightQuery.mockReturnValue({
+      data: genreSpotlightData,
+      isLoading: false,
+      error: null,
+    });
+    renderPage();
+
+    expect(screen.getByText("88% Match")).toBeTruthy();
+    expect(screen.getByText("76% Match")).toBeTruthy();
+  });
+
+  it("hides genre spotlight when no genres returned", () => {
+    defaultGenreSpotlight();
+    renderPage();
+
+    expect(screen.queryByText(/Best in /)).toBeNull();
+  });
+
+  it("shows loading skeleton while genre spotlight is loading", () => {
+    mockGenreSpotlightQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+    renderPage();
+
+    expect(screen.getByText("Best in ...")).toBeTruthy();
+  });
+
+  it("shows Load More buttons for genre rows with multiple pages", () => {
+    mockGenreSpotlightQuery.mockReturnValue({
+      data: genreSpotlightData,
+      isLoading: false,
+      error: null,
+    });
+    renderPage();
+
+    // Both genres have totalPages > 1, so both get Load More
+    const loadMoreButtons = screen.getAllByText("Load More");
+    // At least 2 Load More buttons (one per genre row) plus potentially one from trending
+    expect(loadMoreButtons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows error state with retry button for genre spotlight", () => {
+    mockGenreSpotlightQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: { message: "Genre API error" },
+      refetch: vi.fn(),
+    });
+    renderPage();
+
+    expect(screen.getByText("Genre API error")).toBeTruthy();
   });
 });

--- a/packages/app-media/src/pages/DiscoverPage.tsx
+++ b/packages/app-media/src/pages/DiscoverPage.tsx
@@ -98,6 +98,71 @@ export function DiscoverPage() {
     staleTime: 5 * 60 * 1000,
   });
 
+  // Reset per-genre accumulated state when base query data changes (e.g. after invalidation)
+  useEffect(() => {
+    setGenreAccumulated({});
+    setGenrePages({});
+  }, [genreSpotlight.dataUpdatedAt]);
+
+  // Per-genre pagination for Load More
+  const [genrePages, setGenrePages] = useState<Record<number, number>>({});
+  const [genreAccumulated, setGenreAccumulated] = useState<
+    Record<
+      number,
+      Array<{
+        tmdbId: number;
+        title: string;
+        releaseDate: string;
+        posterPath: string | null;
+        posterUrl: string | null;
+        voteAverage: number;
+        inLibrary: boolean;
+        matchPercentage: number;
+        matchReason: string;
+      }>
+    >
+  >({});
+  const [genreLoadingMore, setGenreLoadingMore] = useState<Set<number>>(new Set());
+
+  const handleGenreLoadMore = useCallback(
+    async (genreId: number, totalPages: number) => {
+      const currentPage = genrePages[genreId] ?? 1;
+      const nextPage = currentPage + 1;
+      if (nextPage > totalPages) return;
+
+      // Collect page-1 IDs for dedup
+      const page1Ids = new Set(
+        genreSpotlight.data?.genres
+          ?.find((g: { genreId: number }) => g.genreId === genreId)
+          ?.results.map((r: { tmdbId: number }) => r.tmdbId) ?? []
+      );
+
+      setGenreLoadingMore((prev) => new Set(prev).add(genreId));
+      try {
+        const data = await utils.media.discovery.genreSpotlightPage.fetch({
+          genreId,
+          page: nextPage,
+        });
+        setGenrePages((prev) => ({ ...prev, [genreId]: nextPage }));
+        setGenreAccumulated((prev) => {
+          const existing = prev[genreId] ?? [];
+          const existingIds = new Set([...existing.map((r) => r.tmdbId), ...page1Ids]);
+          const newItems = data.results.filter((r) => !existingIds.has(r.tmdbId));
+          return { ...prev, [genreId]: [...existing, ...newItems] };
+        });
+      } catch {
+        toast.error("Failed to load more results");
+      } finally {
+        setGenreLoadingMore((prev) => {
+          const next = new Set(prev);
+          next.delete(genreId);
+          return next;
+        });
+      }
+    },
+    [genrePages, genreSpotlight.data, utils]
+  );
+
   // Context picks — each collection accumulates results across pages
   const [contextPages, setContextPages] = useState<Record<string, number>>({});
   const [accumulatedContext, setAccumulatedContext] = useState<
@@ -198,6 +263,7 @@ export function DiscoverPage() {
         }
         void utils.media.discovery.trending.invalidate();
         void utils.media.discovery.recommendations.invalidate();
+        void utils.media.discovery.genreSpotlight.invalidate();
       } catch {
         toast.error("Failed to add to library");
       } finally {
@@ -230,6 +296,7 @@ export function DiscoverPage() {
         void utils.media.watchlist.list.invalidate();
         void utils.media.discovery.trending.invalidate();
         void utils.media.discovery.recommendations.invalidate();
+        void utils.media.discovery.genreSpotlight.invalidate();
       } catch {
         toast.error("Failed to add to watchlist");
       } finally {
@@ -255,6 +322,7 @@ export function DiscoverPage() {
         toast.success(`Marked "${libResult.data.title}" as watched`);
         void utils.media.discovery.trending.invalidate();
         void utils.media.discovery.recommendations.invalidate();
+        void utils.media.discovery.genreSpotlight.invalidate();
         void utils.media.discovery.rewatchSuggestions.invalidate();
       } catch {
         toast.error("Failed to mark as watched");
@@ -477,10 +545,20 @@ export function DiscoverPage() {
           {null}
         </HorizontalScrollRow>
       )}
+      {genreSpotlight.error && !genreSpotlight.data && (
+        <Alert variant="destructive" className="flex items-center gap-3">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          <p className="flex-1 text-sm">{genreSpotlight.error.message}</p>
+          <Button variant="outline" size="sm" onClick={() => genreSpotlight.refetch()}>
+            <RefreshCw className="mr-1 h-3 w-3" /> Retry
+          </Button>
+        </Alert>
+      )}
       {genreSpotlight.data?.genres?.map(
         (genre: {
           genreId: number;
           genreName: string;
+          totalPages: number;
           results: Array<{
             tmdbId: number;
             title: string;
@@ -492,38 +570,66 @@ export function DiscoverPage() {
             matchPercentage: number;
             matchReason: string;
           }>;
-        }) => (
-          <HorizontalScrollRow
-            key={genre.genreId}
-            title={`Best in ${genre.genreName}`}
-            isLoading={genreSpotlight.isLoading}
-          >
-            {genre.results
-              .filter((item) => !isDismissed(item.tmdbId))
-              .map((item) => (
-                <DiscoverCard
-                  key={item.tmdbId}
-                  tmdbId={item.tmdbId}
-                  title={item.title}
-                  releaseDate={item.releaseDate ?? ""}
-                  posterPath={item.posterPath}
-                  posterUrl={item.posterUrl}
-                  voteAverage={item.voteAverage ?? 0}
-                  inLibrary={item.inLibrary}
-                  isAddingToLibrary={addingToLibrary.has(item.tmdbId)}
-                  isAddingToWatchlist={addingToWatchlist.has(item.tmdbId)}
-                  onAddToLibrary={handleAddToLibrary}
-                  onAddToWatchlist={handleAddToWatchlist}
-                  onMarkWatched={handleMarkWatched}
-                  isMarkingWatched={markingWatched.has(item.tmdbId)}
-                  onNotInterested={handleNotInterested}
-                  isDismissing={dismissing.has(item.tmdbId)}
-                  matchPercentage={item.matchPercentage}
-                  matchReason={item.matchReason}
-                />
-              ))}
-          </HorizontalScrollRow>
-        )
+        }) => {
+          const extraResults = genreAccumulated[genre.genreId] ?? [];
+          const page1Ids = new Set(genre.results.map((r) => r.tmdbId));
+          const allResults = [
+            ...genre.results,
+            ...extraResults.filter((r) => !page1Ids.has(r.tmdbId)),
+          ].filter((item) => !isDismissed(item.tmdbId));
+          const currentPage = genrePages[genre.genreId] ?? 1;
+          const hasMore = currentPage < genre.totalPages;
+
+          return (
+            <div key={genre.genreId} className="space-y-3">
+              <HorizontalScrollRow
+                title={`Best in ${genre.genreName}`}
+                isLoading={genreSpotlight.isLoading}
+              >
+                {allResults.map((item) => (
+                  <DiscoverCard
+                    key={item.tmdbId}
+                    tmdbId={item.tmdbId}
+                    title={item.title}
+                    releaseDate={item.releaseDate ?? ""}
+                    posterPath={item.posterPath}
+                    posterUrl={item.posterUrl}
+                    voteAverage={item.voteAverage ?? 0}
+                    inLibrary={item.inLibrary}
+                    isAddingToLibrary={addingToLibrary.has(item.tmdbId)}
+                    isAddingToWatchlist={addingToWatchlist.has(item.tmdbId)}
+                    onAddToLibrary={handleAddToLibrary}
+                    onAddToWatchlist={handleAddToWatchlist}
+                    onMarkWatched={handleMarkWatched}
+                    isMarkingWatched={markingWatched.has(item.tmdbId)}
+                    onNotInterested={handleNotInterested}
+                    isDismissing={dismissing.has(item.tmdbId)}
+                    matchPercentage={item.matchPercentage}
+                    matchReason={item.matchReason}
+                  />
+                ))}
+              </HorizontalScrollRow>
+              {hasMore && (
+                <div className="flex justify-center">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleGenreLoadMore(genre.genreId, genre.totalPages)}
+                    disabled={genreLoadingMore.has(genre.genreId)}
+                  >
+                    {genreLoadingMore.has(genre.genreId) ? (
+                      <>
+                        <Loader2 className="mr-1 h-3 w-3 animate-spin" /> Loading…
+                      </>
+                    ) : (
+                      "Load More"
+                    )}
+                  </Button>
+                </div>
+              )}
+            </div>
+          );
+        }
       )}
 
       {/* Worth Rewatching — hidden when empty */}


### PR DESCRIPTION
## Summary
- Add Load More pagination per genre row (new `genreSpotlightPage` endpoint)
- Add 7 frontend tests for genre spotlight (rows render, titles, match%, empty state, loading, Load More, error)
- Add `genreSpotlight` query invalidation after library/watchlist/watched mutations (fixes stale `inLibrary` state)
- Add error state with Retry button for genre spotlight section

## Test plan
- [x] All 26 DiscoverPage tests pass (7 new genre spotlight tests)
- [x] All 62 backend discovery tests pass
- [x] No new type errors introduced
- [x] Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)