### PR TITLE
fix(ci): quote YAML step name containing colon in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,7 +131,7 @@ jobs:
             --connection=local \
             -v
 
-      - name: Selective deploy: Build + Restart
+      - name: "Selective deploy: Build + Restart"
         if: steps.mode.outputs.type == 'selective'
         id: selective
         run: |


### PR DESCRIPTION
## Summary
- Quotes the `Selective deploy: Build + Restart` step name in deploy.yml — the unquoted colon caused a YAML parse error (invalid mapping) on line 134

## Test plan
- [x] `yaml-lint` passes on deploy.yml