### PR TITLE
fix(media): use filtered Radarr endpoint for movie status checks

### DIFF
--- a/apps/pops-api/src/modules/media/arr/radarr-client.ts
+++ b/apps/pops-api/src/modules/media/arr/radarr-client.ts
@@ -78,18 +78,18 @@ export class RadarrClient extends ArrBaseClient {
 
   /**
    * Get the status of a movie by TMDB ID.
-   * Fetches all movies and queue, then matches by tmdbId.
+   * Uses the filtered endpoint to fetch only the matching movie, then checks queue.
    */
   async getMovieStatus(tmdbId: number): Promise<ArrStatusResult> {
-    const [movies, queue] = await Promise.all([this.getMovies(), this.getQueue()]);
-
-    const movie = movies.find((m) => m.tmdbId === tmdbId);
+    const movies = await this.get<RadarrMovie[]>(`/movie?tmdbId=${tmdbId}`);
+    const movie = movies[0];
 
     if (!movie) {
       return { status: "not_found", label: "Not in Radarr" };
     }
 
-    // Check download queue
+    // Check download queue only if the movie exists in Radarr
+    const queue = await this.getQueue();
     const queueItem = queue.records.find((r) => r.movieId === movie.id);
     if (queueItem) {
       const progress =


### PR DESCRIPTION
## Summary
- `getMovieStatus` was fetching **all** movies from Radarr (`/movie`) then filtering client-side, easily exceeding the 10s timeout on larger libraries
- Switched to the filtered endpoint (`/movie?tmdbId=N`) which returns only the matching movie
- Queue check is now deferred until after confirming the movie exists in Radarr

This is why the Arr settings test connection showed "Connected" (hits lightweight `/system/status`) while movie detail pages showed "Radarr unavailable" (heavy `/movie` endpoint timing out).

## Test plan
- [ ] Open Arr Settings, verify test connection still shows connected
- [ ] Open a movie detail page, verify Radarr status badge shows correctly (not "Radarr unavailable")
- [ ] Verify movie not in Radarr shows "Not in Radarr" badge
- [ ] Verify downloading movie shows progress badge