### PR TITLE
fix(media): Plex Discover API compat + sync job restore on navigation

### DIFF
--- a/apps/pops-api/src/modules/media/plex/client.ts
+++ b/apps/pops-api/src/modules/media/plex/client.ts
@@ -146,14 +146,16 @@ export class PlexClient {
     try {
       const data = await this.getAbsolute<{
         MediaContainer: {
-          UserState?: Array<{
-            viewCount?: number;
-            lastViewedAt?: number;
-          }>;
+          UserState?:
+            | { viewCount?: number; lastViewedAt?: number }
+            | Array<{ viewCount?: number; lastViewedAt?: number }>;
         };
       }>(url);
 
-      const state = data.MediaContainer.UserState?.[0];
+      // Plex API returns UserState as either an object or an array
+      const raw = data.MediaContainer.UserState;
+      if (!raw) return null;
+      const state = Array.isArray(raw) ? raw[0] : raw;
       if (!state) return null;
 
       return {
@@ -168,14 +170,16 @@ export class PlexClient {
 
   /**
    * Search the Plex Discover API by title and media type.
-   * Returns items with ratingKeys and external IDs (tmdb://, tvdb://).
+   * Returns items with ratingKeys but without external IDs (Guid arrays).
+   * Use getDiscoverMetadata() to fetch Guids for a specific item.
    */
   async searchDiscover(query: string, searchType: "movie" | "show"): Promise<PlexMediaItem[]> {
-    const typeParam = searchType === "movie" ? "1" : "2";
+    const typeParam = searchType === "movie" ? "movies" : "tv";
     const url =
       `https://discover.provider.plex.tv/library/search` +
       `?query=${encodeURIComponent(query)}` +
       `&searchTypes=${typeParam}` +
+      `&searchProviders=discover` +
       `&limit=5` +
       `&X-Plex-Token=${this.token}`;
 
@@ -199,6 +203,30 @@ export class PlexClient {
       }
     }
     return items;
+  }
+
+  /**
+   * Fetch full metadata for a Discover item by its ratingKey.
+   * Includes Guid array (tmdb://, tvdb://, imdb://) for ID matching.
+   */
+  async getDiscoverMetadata(ratingKey: string): Promise<PlexMediaItem | null> {
+    const url =
+      `https://metadata.provider.plex.tv/library/metadata/${ratingKey}` +
+      `?includeGuids=1` +
+      `&X-Plex-Token=${this.token}`;
+
+    try {
+      const data = await this.getAbsolute<{
+        MediaContainer: {
+          Metadata?: RawPlexMediaItem[];
+        };
+      }>(url);
+
+      const item = data.MediaContainer.Metadata?.[0];
+      return item ? this.mapMediaItem(item) : null;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/apps/pops-api/src/modules/media/plex/sync-discover-watches.test.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-watches.test.ts
@@ -53,7 +53,7 @@ function makeDiscoverItem(overrides: Partial<PlexMediaItem> = {}): PlexMediaItem
     rating: null,
     audienceRating: null,
     contentRating: null,
-    externalIds: [{ source: "tmdb", id: "550" }],
+    externalIds: [],
     genres: [],
     directors: [],
     leafCount: null,
@@ -63,13 +63,20 @@ function makeDiscoverItem(overrides: Partial<PlexMediaItem> = {}): PlexMediaItem
   };
 }
 
+/** Make a metadata item with Guids (returned by getDiscoverMetadata). */
+function makeMetadataItem(overrides: Partial<PlexMediaItem> = {}): PlexMediaItem {
+  return makeDiscoverItem(overrides);
+}
+
 function makePlexClient(
   discoverResults: PlexMediaItem[] = [],
-  userState: { viewCount: number; lastViewedAt: number | null } | null = null
+  userState: { viewCount: number; lastViewedAt: number | null } | null = null,
+  metadataItem?: PlexMediaItem | null
 ): PlexClient {
   return {
     searchDiscover: vi.fn().mockResolvedValue(discoverResults),
     getUserState: vi.fn().mockResolvedValue(userState),
+    getDiscoverMetadata: vi.fn().mockResolvedValue(metadataItem ?? null),
   } as unknown as PlexClient;
 }
 
@@ -102,9 +109,16 @@ describe("syncDiscoverWatches", () => {
       watchlistRemoved: false,
     } as unknown as ReturnType<typeof logWatch>);
 
+    // Search returns item without Guids; getDiscoverMetadata returns item with Guids
+    const searchItem = makeDiscoverItem({ ratingKey: "disc-1" });
+    const metaItem = makeMetadataItem({
+      ratingKey: "disc-1",
+      externalIds: [{ source: "tmdb", id: "550" }],
+    });
     const client = makePlexClient(
-      [makeDiscoverItem({ ratingKey: "disc-1", externalIds: [{ source: "tmdb", id: "550" }] })],
-      { viewCount: 3, lastViewedAt: 1711500000 }
+      [searchItem],
+      { viewCount: 3, lastViewedAt: 1711500000 },
+      metaItem
     );
     const result = await syncDiscoverWatches(client);
 
@@ -127,10 +141,12 @@ describe("syncDiscoverWatches", () => {
       watchlistRemoved: false,
     } as unknown as ReturnType<typeof logWatch>);
 
-    const client = makePlexClient(
-      [makeDiscoverItem({ externalIds: [{ source: "tmdb", id: "550" }] })],
-      { viewCount: 1, lastViewedAt: null }
-    );
+    const searchItem = makeDiscoverItem({ ratingKey: "disc-1" });
+    const metaItem = makeMetadataItem({
+      ratingKey: "disc-1",
+      externalIds: [{ source: "tmdb", id: "550" }],
+    });
+    const client = makePlexClient([searchItem], { viewCount: 1, lastViewedAt: null }, metaItem);
     const result = await syncDiscoverWatches(client);
 
     expect(result.movies.watched).toBe(1);
@@ -149,13 +165,31 @@ describe("syncDiscoverWatches", () => {
     expect(result.movies.watched).toBe(0);
   });
 
+  it("counts movies not found when metadata TMDB ID doesn't match", async () => {
+    setupDrizzleMock([{ id: 1, title: "Fight Club", tmdbId: 550 }], []);
+
+    // Search returns a result but metadata has wrong TMDB ID
+    const searchItem = makeDiscoverItem({ ratingKey: "disc-1" });
+    const metaItem = makeMetadataItem({
+      ratingKey: "disc-1",
+      externalIds: [{ source: "tmdb", id: "999" }],
+    });
+    const client = makePlexClient([searchItem], null, metaItem);
+    const result = await syncDiscoverWatches(client);
+
+    expect(result.movies.notFound).toBe(1);
+    expect(result.movies.watched).toBe(0);
+  });
+
   it("skips movies not watched on Plex", async () => {
     setupDrizzleMock([{ id: 1, title: "Fight Club", tmdbId: 550 }], []);
 
-    const client = makePlexClient(
-      [makeDiscoverItem({ externalIds: [{ source: "tmdb", id: "550" }] })],
-      { viewCount: 0, lastViewedAt: null }
-    );
+    const searchItem = makeDiscoverItem({ ratingKey: "disc-1" });
+    const metaItem = makeMetadataItem({
+      ratingKey: "disc-1",
+      externalIds: [{ source: "tmdb", id: "550" }],
+    });
+    const client = makePlexClient([searchItem], { viewCount: 0, lastViewedAt: null }, metaItem);
     const result = await syncDiscoverWatches(client);
 
     expect(result.movies.watched).toBe(0);
@@ -181,9 +215,15 @@ describe("checkAndLogMovieWatch", () => {
       watchlistRemoved: false,
     } as unknown as ReturnType<typeof logWatch>);
 
+    const searchItem = makeDiscoverItem({ ratingKey: "disc-1" });
+    const metaItem = makeMetadataItem({
+      ratingKey: "disc-1",
+      externalIds: [{ source: "tmdb", id: "42" }],
+    });
     const client = makePlexClient(
-      [makeDiscoverItem({ externalIds: [{ source: "tmdb", id: "42" }] })],
-      { viewCount: 1, lastViewedAt: 1711500000 }
+      [searchItem],
+      { viewCount: 1, lastViewedAt: 1711500000 },
+      metaItem
     );
     const result = await checkAndLogMovieWatch(client, 1, "Shrek", 42);
 
@@ -191,10 +231,12 @@ describe("checkAndLogMovieWatch", () => {
   });
 
   it("returns false when movie is not watched", async () => {
-    const client = makePlexClient(
-      [makeDiscoverItem({ externalIds: [{ source: "tmdb", id: "42" }] })],
-      { viewCount: 0, lastViewedAt: null }
-    );
+    const searchItem = makeDiscoverItem({ ratingKey: "disc-1" });
+    const metaItem = makeMetadataItem({
+      ratingKey: "disc-1",
+      externalIds: [{ source: "tmdb", id: "42" }],
+    });
+    const client = makePlexClient([searchItem], { viewCount: 0, lastViewedAt: null }, metaItem);
     const result = await checkAndLogMovieWatch(client, 1, "Shrek", 42);
 
     expect(result).toBe(false);
@@ -211,6 +253,7 @@ describe("checkAndLogMovieWatch", () => {
     const client = {
       searchDiscover: vi.fn().mockRejectedValue(new Error("Network error")),
       getUserState: vi.fn(),
+      getDiscoverMetadata: vi.fn(),
     } as unknown as PlexClient;
 
     const result = await checkAndLogMovieWatch(client, 1, "Shrek", 42);

--- a/apps/pops-api/src/modules/media/plex/sync-discover-watches.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-watches.ts
@@ -13,7 +13,7 @@
  */
 import { movies, tvShows } from "@pops/db-types";
 import type { PlexClient } from "./client.js";
-import { extractExternalIdAsNumber } from "./sync-helpers.js";
+import { findDiscoverMatch } from "./sync-helpers.js";
 import { logWatch } from "../watch-history/service.js";
 import { getDrizzle } from "../../../db.js";
 
@@ -154,7 +154,8 @@ type SyncStatus = "logged" | "already" | "not_watched" | "not_found";
 /**
  * Check a single movie against Plex Discover and log watch if played.
  *
- * Uses a small delay between API calls to avoid rate limiting.
+ * Flow: search by title → fetch metadata for each result to get TMDB ID →
+ * match by TMDB ID → check userState → log watch.
  */
 async function syncSingleMovieWatch(
   client: PlexClient,
@@ -162,18 +163,15 @@ async function syncSingleMovieWatch(
   title: string,
   tmdbId: number
 ): Promise<SyncStatus> {
-  // Search Discover for the movie
+  // Search Discover for the movie and match by TMDB ID
   const results = await client.searchDiscover(title, "movie");
+  if (results.length === 0) return "not_found";
 
-  // Match by TMDB ID
-  const match = results.find((item) => {
-    const id = extractExternalIdAsNumber(item, "tmdb");
-    return id === tmdbId;
-  });
-  if (!match) return "not_found";
+  const matchedRatingKey = await findDiscoverMatch(client, results, "tmdb", tmdbId);
+  if (!matchedRatingKey) return "not_found";
 
   // Check user state
-  const state = await client.getUserState(match.ratingKey);
+  const state = await client.getUserState(matchedRatingKey);
   if (!state || state.viewCount === 0) return "not_watched";
 
   // Log the watch
@@ -208,18 +206,15 @@ async function syncSingleTvShowWatch(
   name: string,
   tvdbId: number
 ): Promise<SyncStatus> {
-  // Search Discover for the show
+  // Search Discover for the show and match by TVDB ID
   const results = await client.searchDiscover(name, "show");
+  if (results.length === 0) return "not_found";
 
-  // Match by TVDB ID
-  const match = results.find((item) => {
-    const id = extractExternalIdAsNumber(item, "tvdb");
-    return id === tvdbId;
-  });
-  if (!match) return "not_found";
+  const matchedRatingKey = await findDiscoverMatch(client, results, "tvdb", tvdbId);
+  if (!matchedRatingKey) return "not_found";
 
   // Check user state — for TV shows this indicates the user has interacted with it
-  const state = await client.getUserState(match.ratingKey);
+  const state = await client.getUserState(matchedRatingKey);
   if (!state || state.viewCount === 0) return "not_watched";
 
   // TV show watch state is tracked but we don't log show-level watch events

--- a/apps/pops-api/src/modules/media/plex/sync-helpers.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-helpers.ts
@@ -6,6 +6,7 @@
  */
 import { eq, and } from "drizzle-orm";
 import { episodes, seasons } from "@pops/db-types";
+import type { PlexClient } from "./client.js";
 import type { PlexMediaItem, PlexEpisode } from "./types.js";
 import { getDrizzle } from "../../../db.js";
 import { getTvShowByTvdbId } from "../tv-shows/service.js";
@@ -45,6 +46,27 @@ export interface EpisodeSyncDiagnostics {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Find the Discover ratingKey whose metadata contains a matching external ID.
+ *
+ * Search results don't include Guid arrays, so this fetches full metadata
+ * for each candidate and compares the given source/ID pair.
+ */
+export async function findDiscoverMatch(
+  client: PlexClient,
+  candidates: PlexMediaItem[],
+  source: string,
+  expectedId: number
+): Promise<string | null> {
+  for (const item of candidates) {
+    const meta = await client.getDiscoverMetadata(item.ratingKey);
+    if (!meta) continue;
+    const id = extractExternalIdAsNumber(meta, source);
+    if (id === expectedId) return item.ratingKey;
+  }
+  return null;
+}
 
 /**
  * Extract an external ID (tmdb, tvdb, imdb) from a Plex media item

--- a/apps/pops-api/src/modules/media/watchlist/plex-push.ts
+++ b/apps/pops-api/src/modules/media/watchlist/plex-push.ts
@@ -5,11 +5,11 @@
 import { eq } from "drizzle-orm";
 import { mediaWatchlist } from "@pops/db-types";
 import { getPlexClient } from "../plex/service.js";
-import { extractExternalIdAsNumber } from "../plex/sync-helpers.js";
+import { findDiscoverMatch } from "../plex/sync-helpers.js";
 import { getMovie } from "../movies/service.js";
 import { getTvShow } from "../tv-shows/service.js";
 import { getDrizzle } from "../../../db.js";
-import type { PlexMediaItem } from "../plex/types.js";
+import type { PlexClient as PlexClientType } from "../plex/client.js";
 
 /**
  * Look up a Plex Discover ratingKey for a local media item by searching the
@@ -32,37 +32,21 @@ export async function lookupPlexRatingKey(
 }
 
 async function lookupMovieRatingKey(
-  client: { searchDiscover: (q: string, t: "movie" | "show") => Promise<PlexMediaItem[]> },
+  client: PlexClientType,
   movieId: number
 ): Promise<string | null> {
   const movie = getMovie(movieId);
   const results = await client.searchDiscover(movie.title, "movie");
-
-  for (const item of results) {
-    const tmdbId = extractExternalIdAsNumber(item, "tmdb");
-    if (tmdbId && tmdbId === movie.tmdbId) {
-      return item.ratingKey;
-    }
-  }
-
-  return null;
+  return findDiscoverMatch(client, results, "tmdb", movie.tmdbId);
 }
 
 async function lookupTvShowRatingKey(
-  client: { searchDiscover: (q: string, t: "movie" | "show") => Promise<PlexMediaItem[]> },
+  client: PlexClientType,
   tvShowId: number
 ): Promise<string | null> {
   const show = getTvShow(tvShowId);
   const results = await client.searchDiscover(show.name, "show");
-
-  for (const item of results) {
-    const tvdbId = extractExternalIdAsNumber(item, "tvdb");
-    if (tvdbId && tvdbId === show.tvdbId) {
-      return item.ratingKey;
-    }
-  }
-
-  return null;
+  return findDiscoverMatch(client, results, "tvdb", show.tvdbId);
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Plex Discover API breaking changes** — three bugs that completely broke cloud watch sync:
  - `searchTypes` param changed from `"1"`/`"2"` to `"movies"`/`"tv"`, and `searchProviders=discover` is now required (every search returned 400)
  - `UserState` response changed from array to object (`UserState?.[0]` on an object returns `undefined`)
  - Search results no longer include `Guid` arrays — added `getDiscoverMetadata()` and extracted `findDiscoverMatch()` helper to DRY the metadata-fetch-and-match loop across 4 call sites
- **Sync job state lost on navigation** — `useSyncJob` now auto-restores running jobs on mount by querying `getActiveSyncJobs` and re-attaching to any running job of its type. No changes needed in PlexSettingsPage. Removed unused `useRestoreActiveSyncJobs` export.

Verified end-to-end against live Plex API: Shrek (TMDB 808) correctly returns `viewCount=3`, `lastViewedAt=2026-03-02`.

## Test plan
- [x] Unit tests updated and passing (10/10 sync-discover-watches, 18/18 PlexSettingsPage)
- [x] End-to-end verification against live Plex Discover API on N95
- [ ] Trigger "Sync Cloud Watches" from Plex Settings, navigate away, navigate back — confirm progress resumes
- [ ] Confirm Shrek appears in watch history after sync completes
- [ ] Confirm watchlist push still works for new additions