### PR TITLE
fix(media): live progress counts and error details for cloud watch sync

### DIFF
--- a/apps/pops-api/src/modules/media/plex/sync-discover-watches.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-watches.ts
@@ -17,6 +17,10 @@ import { findDiscoverMatch } from "./sync-helpers.js";
 import { logWatch } from "../watch-history/service.js";
 import { getDrizzle } from "../../../db.js";
 
+/** Small delay between items to avoid Plex API rate limits. */
+const RATE_LIMIT_DELAY_MS = 200;
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -26,10 +30,10 @@ export interface DiscoverWatchSyncResult {
   tvShows: DiscoverTvShowResult;
 }
 
-export interface DiscoverMovieResult {
-  /** Total movies in POPS library. */
+export interface DiscoverItemResult {
+  /** Total items in POPS library. */
   total: number;
-  /** Movies found as watched on Plex Discover. */
+  /** Items found as watched on Plex Discover. */
   watched: number;
   /** New watch entries logged. */
   logged: number;
@@ -39,22 +43,13 @@ export interface DiscoverMovieResult {
   notFound: number;
   /** Errors during lookup. */
   errors: number;
+  /** First few error messages for diagnostics (max 5). */
+  errorSamples: string[];
 }
 
-export interface DiscoverTvShowResult {
-  /** Total TV shows in POPS library. */
-  total: number;
-  /** Shows found as watched on Plex Discover. */
-  watched: number;
-  /** New watch entries logged (show-level, not per-episode). */
-  logged: number;
-  /** Already had a watch entry. */
-  alreadyLogged: number;
-  /** Could not find on Plex Discover. */
-  notFound: number;
-  /** Errors during lookup. */
-  errors: number;
-}
+// Keep old names as aliases for backwards compat
+export type DiscoverMovieResult = DiscoverItemResult;
+export type DiscoverTvShowResult = DiscoverItemResult;
 
 // ---------------------------------------------------------------------------
 // Main sync function
@@ -68,7 +63,8 @@ export interface DiscoverTvShowResult {
  */
 export async function syncDiscoverWatches(
   plexClient: PlexClient,
-  onProgress?: (processed: number, total: number) => void
+  onProgress?: (processed: number, total: number) => void,
+  onPartialResult?: (result: DiscoverWatchSyncResult) => void
 ): Promise<DiscoverWatchSyncResult> {
   const db = getDrizzle();
 
@@ -86,7 +82,10 @@ export async function syncDiscoverWatches(
   const totalItems = allMovies.length + allShows.length;
   let processed = 0;
 
-  // Sync movies
+  const MAX_ERROR_SAMPLES = 5;
+
+  // Initialise both result objects up front so partial-result callbacks
+  // can reference tvResult while the movie loop is still running.
   const movieResult: DiscoverMovieResult = {
     total: allMovies.length,
     watched: 0,
@@ -94,8 +93,20 @@ export async function syncDiscoverWatches(
     alreadyLogged: 0,
     notFound: 0,
     errors: 0,
+    errorSamples: [],
   };
 
+  const tvResult: DiscoverTvShowResult = {
+    total: allShows.length,
+    watched: 0,
+    logged: 0,
+    alreadyLogged: 0,
+    notFound: 0,
+    errors: 0,
+    errorSamples: [],
+  };
+
+  // Sync movies
   for (const movie of allMovies) {
     try {
       const synced = await syncSingleMovieWatch(plexClient, movie.id, movie.title, movie.tmdbId);
@@ -106,24 +117,21 @@ export async function syncDiscoverWatches(
       } else movieResult.notFound++;
 
       if (synced === "logged" || synced === "already") movieResult.watched++;
-    } catch {
+    } catch (err) {
       movieResult.errors++;
+      if (movieResult.errorSamples.length < MAX_ERROR_SAMPLES) {
+        const msg = err instanceof Error ? err.message : String(err);
+        movieResult.errorSamples.push(`${movie.title}: ${msg}`);
+      }
     }
 
     processed++;
     onProgress?.(processed, totalItems);
+    onPartialResult?.({ movies: movieResult, tvShows: tvResult });
+    await delay(RATE_LIMIT_DELAY_MS);
   }
 
   // Sync TV shows (show-level watch check only)
-  const tvResult: DiscoverTvShowResult = {
-    total: allShows.length,
-    watched: 0,
-    logged: 0,
-    alreadyLogged: 0,
-    notFound: 0,
-    errors: 0,
-  };
-
   for (const show of allShows) {
     try {
       const synced = await syncSingleTvShowWatch(plexClient, show.id, show.name, show.tvdbId);
@@ -134,12 +142,18 @@ export async function syncDiscoverWatches(
       } else tvResult.notFound++;
 
       if (synced === "logged" || synced === "already") tvResult.watched++;
-    } catch {
+    } catch (err) {
       tvResult.errors++;
+      if (tvResult.errorSamples.length < MAX_ERROR_SAMPLES) {
+        const msg = err instanceof Error ? err.message : String(err);
+        tvResult.errorSamples.push(`${show.name}: ${msg}`);
+      }
     }
 
     processed++;
     onProgress?.(processed, totalItems);
+    onPartialResult?.({ movies: movieResult, tvShows: tvResult });
+    await delay(RATE_LIMIT_DELAY_MS);
   }
 
   return { movies: movieResult, tvShows: tvResult };

--- a/apps/pops-api/src/modules/media/plex/sync-job-manager.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-job-manager.ts
@@ -162,7 +162,7 @@ async function runJob(jobId: string, jobType: SyncJobType, params: SyncJobParams
   const startTime = Date.now();
 
   try {
-    const result = await executeSyncByType(jobType, params, (progress) => {
+    const result = await executeSyncByType(jobId, jobType, params, (progress) => {
       job.progress = progress;
     });
 
@@ -186,6 +186,7 @@ async function runJob(jobId: string, jobType: SyncJobType, params: SyncJobParams
 }
 
 async function executeSyncByType(
+  jobId: string,
   jobType: SyncJobType,
   params: SyncJobParams,
   onProgress: (progress: SyncJobProgress) => void
@@ -221,7 +222,14 @@ async function executeSyncByType(
       );
     }
     case "syncDiscoverWatches": {
-      return syncDiscoverWatches(client, (processed, total) => onProgress({ processed, total }));
+      const job = activeJobs.get(jobId);
+      return syncDiscoverWatches(
+        client,
+        (processed, total) => onProgress({ processed, total }),
+        (partialResult) => {
+          if (job) job.result = partialResult;
+        }
+      );
     }
   }
 }

--- a/packages/app-media/src/hooks/useSyncJob.ts
+++ b/packages/app-media/src/hooks/useSyncJob.ts
@@ -155,7 +155,7 @@ export function useSyncJob(jobType: SyncJobType): UseSyncJobReturn {
     isStarting: startMutation.isPending,
     isRunning,
     progress: isRunning ? (job?.progress ?? null) : null,
-    result: job?.status === "completed" ? job.result : null,
+    result: job?.result ?? null,
     error: job?.status === "failed" ? job.error : null,
     durationMs: job?.durationMs ?? null,
     completedAt: job?.completedAt ?? null,

--- a/packages/app-media/src/pages/PlexSettingsPage.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.tsx
@@ -102,6 +102,7 @@ interface DiscoverMediaResult {
   alreadyLogged: number;
   notFound: number;
   errors: number;
+  errorSamples?: string[];
 }
 
 interface DiscoverWatchSyncResult {
@@ -227,6 +228,69 @@ function WatchlistSyncResultDisplay({ result }: { result: WatchlistSyncResult })
                 <p key={i}>
                   <span className="font-medium">{err.title}:</span> {err.reason}
                 </p>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DiscoverSyncResultDisplay({
+  result,
+  isRunning,
+}: {
+  result: DiscoverWatchSyncResult | null;
+  isRunning: boolean;
+}) {
+  const [showErrors, setShowErrors] = useState(false);
+
+  if (!result) return null;
+
+  const r = result;
+  const allErrors = [...(r.movies.errorSamples ?? []), ...(r.tvShows.errorSamples ?? [])];
+
+  return (
+    <div className="rounded-md border bg-muted/30 p-3 space-y-2 text-sm">
+      <div className="flex items-center gap-3 flex-wrap">
+        <span className="font-medium">
+          {isRunning ? "Cloud Watch Progress:" : "Cloud Watch Results:"}
+        </span>
+        {r.movies.logged > 0 && <span className="text-emerald-400">{r.movies.logged} logged</span>}
+        {r.movies.watched > 0 && (
+          <span className="text-muted-foreground">{r.movies.watched} watched</span>
+        )}
+        {r.movies.alreadyLogged > 0 && (
+          <span className="text-muted-foreground">{r.movies.alreadyLogged} already tracked</span>
+        )}
+        {r.movies.notFound > 0 && (
+          <span className="text-muted-foreground">{r.movies.notFound} not found</span>
+        )}
+        {r.movies.errors + r.tvShows.errors > 0 && (
+          <span className="text-red-400">{r.movies.errors + r.tvShows.errors} errors</span>
+        )}
+      </div>
+      {!isRunning && (
+        <p className="text-xs text-muted-foreground">
+          Checked {r.movies.total} movies, {r.tvShows.total} TV shows against Plex cloud
+        </p>
+      )}
+      {allErrors.length > 0 && (
+        <div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowErrors(!showErrors)}
+            className="flex items-center gap-1 text-xs h-auto p-0 text-red-400 hover:text-red-300"
+          >
+            {showErrors ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            {showErrors ? "Hide" : "Show"} error details
+          </Button>
+          {showErrors && (
+            <div className="mt-2 space-y-1 text-xs text-red-400/80">
+              {allErrors.map((err, i) => (
+                <p key={i}>{err}</p>
               ))}
             </div>
           )}
@@ -901,42 +965,10 @@ export function PlexSettingsPage() {
                 ? `Checking... ${discoverSync.progress.processed}/${discoverSync.progress.total}`
                 : "Sync Cloud Watches"}
             </Button>
-            {discoverSync.result != null &&
-              (() => {
-                const r = discoverSync.result as DiscoverWatchSyncResult;
-                return (
-                  <div className="rounded-md border bg-muted/30 p-3 space-y-2 text-sm">
-                    <div className="flex items-center gap-3 flex-wrap">
-                      <span className="font-medium">Cloud Watch Results:</span>
-                      {r.movies.logged > 0 && (
-                        <span className="text-emerald-400">
-                          {r.movies.logged} movies newly logged
-                        </span>
-                      )}
-                      <span className="text-muted-foreground">
-                        {r.movies.watched} movies watched on Plex
-                      </span>
-                      {r.movies.alreadyLogged > 0 && (
-                        <span className="text-muted-foreground">
-                          ({r.movies.alreadyLogged} already tracked)
-                        </span>
-                      )}
-                    </div>
-                    <div className="text-xs text-muted-foreground space-y-0.5">
-                      <p>
-                        Checked {r.movies.total} movies, {r.tvShows.total} TV shows against Plex
-                        cloud
-                      </p>
-                      {r.movies.notFound > 0 && (
-                        <p>{r.movies.notFound} movies not found on Plex Discover</p>
-                      )}
-                      {r.movies.errors > 0 && (
-                        <p className="text-red-400">{r.movies.errors} errors during lookup</p>
-                      )}
-                    </div>
-                  </div>
-                );
-              })()}
+            <DiscoverSyncResultDisplay
+              result={discoverSync.result as DiscoverWatchSyncResult | null}
+              isRunning={discoverSync.isRunning}
+            />
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- **Error surfacing**: `errorSamples` (first 5 error messages with movie/show titles) added to sync results and shown in expandable UI, matching the pattern used by other sync types
- **Live counts**: partial results streamed to the job manager during sync — UI shows logged/watched/errors counts updating in real-time while running, not just after completion
- **Rate limiting**: 200ms delay between items to avoid Plex API throttling (was causing 100% error rate on bulk syncs — 690/690 errors)
- **New `DiscoverSyncResultDisplay` component** with collapsible error details, consistent with movie/TV/watchlist sync displays

Replaces #1166 (closed due to force-push).

## Test plan
- [x] sync-discover-watches tests passing (10/10)
- [x] PlexSettingsPage tests passing (18/18)
- [ ] Run cloud sync — confirm live counts appear during sync (logged, watched, errors)
- [ ] Confirm error details are expandable when errors occur
- [ ] Confirm rate limiting prevents bulk failures