### PR TITLE
fix(ci): update repo before selective deploy builds

### DIFF
--- a/.github/workflows/root-deploy.yml
+++ b/.github/workflows/root-deploy.yml
@@ -196,6 +196,15 @@ jobs:
             --connection=local \
             -v
 
+      - name: "Selective deploy: Update repo"
+        if: steps.mode.outputs.type == 'selective'
+        run: |
+          cd /opt/pops/repo
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
+          echo "Repo updated to $(git rev-parse --short HEAD)"
+
       - name: "Selective deploy: Build + Restart"
         if: steps.mode.outputs.type == 'selective'
         id: selective


### PR DESCRIPTION
## Summary
- Selective deploys were building Docker images from `/opt/pops/repo`, which was only updated during full Ansible deploys
- This meant every selective deploy since the last full deploy (run 9) shipped stale code with an incorrect version label — the frontend has been stuck at b12 because runs 13-14 were backend-only, but even runs 10 and 12 built run 9's code
- Adds a `git fetch + reset` step before selective builds so the repo is current

## Test plan
- [ ] Merge and verify the next deploy run updates `/opt/pops/repo` before building
- [ ] Confirm build version increments on next frontend-touching deploy