### PR TITLE
fix(media): drop immutable cache headers for image responses

### DIFF
--- a/apps/pops-api/src/routes/media/images.ts
+++ b/apps/pops-api/src/routes/media/images.ts
@@ -30,7 +30,9 @@ const CONTENT_TYPES: Record<string, string> = {
   ".png": "image/png",
 };
 
-const CACHE_CONTROL = "public, max-age=31536000, immutable";
+/** Cache for 7 days, revalidate via ETag after that. Never use `immutable` — if a
+ *  corrupt file is ever served, the browser would be stuck for the full max-age. */
+const CACHE_CONTROL = "public, max-age=604800";
 
 /** CDN size presets for TMDB redirect fallback. */
 const TMDB_CDN_SIZES: Record<string, string> = {

--- a/apps/pops-shell/nginx.conf
+++ b/apps/pops-shell/nginx.conf
@@ -31,6 +31,7 @@ server {
 
     # Proxy media images (posters, backdrops) served by pops-api
     # On-demand downloads from TMDB/TVDB may take a few seconds on first request
+    # Cache headers are set by the API — don't override with expires/add_header
     location /media/images/ {
         proxy_pass http://pops-api:3000/media/images/;
         proxy_http_version 1.1;
@@ -38,8 +39,6 @@ server {
         proxy_connect_timeout 10s;
         proxy_read_timeout 30s;
         proxy_send_timeout 30s;
-        expires 7d;
-        add_header Cache-Control "public";
     }
 
     # Proxy health check


### PR DESCRIPTION
## Summary
- SVG placeholders previously served as `.jpg` with `Cache-Control: public, max-age=31536000, immutable` — the browser cached the broken response permanently
- Even after the server-side `removeCorruptedPlaceholder` fix, the browser never re-requested the images because `immutable` tells it to trust the cache for 1 year
- Changed to `max-age=604800` (7 days) without `immutable` so ETags can revalidate after expiry
- Removed conflicting nginx `expires 7d` + `add_header Cache-Control "public"` that created 3 separate Cache-Control headers per response

**Root cause**: poster requests for the 3 failing shows (85002, 280035, 393642) never reached nginx at all — confirmed via access logs. The browser was serving the stale corrupted cache entry.

## Test plan
- [ ] Deploy and verify `/media/images/tv/*/poster.jpg` returns `Cache-Control: public, max-age=604800` (no `immutable`)
- [ ] Hard-refresh browser cache on pops.jmiranda.dev to clear stale entries
- [ ] Confirm the 3 previously broken posters now load