### PR TITLE
fix(media): wrap and center-align rankings filter chips

### DIFF
--- a/packages/app-media/src/pages/RankingsPage.tsx
+++ b/packages/app-media/src/pages/RankingsPage.tsx
@@ -249,7 +249,7 @@ export function RankingsPage() {
         <RankingsSkeleton />
       ) : showTabs ? (
         <Tabs value={dimensionParam} onValueChange={handleTabChange}>
-          <TabsList>
+          <TabsList className="h-auto flex-wrap justify-center">
             <TabsTrigger value="overall">Overall</TabsTrigger>
             {activeDimensions.map((dim: { id: number; name: string }) => (
               <TabsTrigger key={dim.id} value={String(dim.id)}>


### PR DESCRIPTION
## Summary
- Fix filter chips on Rankings page overflowing their container
- Add `h-auto`, `flex-wrap`, and `justify-center` to `TabsList` so dimension chips wrap across multiple lines and stay centered

Closes #1177