### PR TITLE
refactor(health): migrate health check from raw SQL to Drizzle ORM

### DIFF
--- a/apps/pops-api/src/routes/health.ts
+++ b/apps/pops-api/src/routes/health.ts
@@ -1,5 +1,6 @@
 import { type Router as ExpressRouter, Router } from "express";
-import { getDb } from "../db.js";
+import { sql } from "drizzle-orm";
+import { getDrizzle } from "../db.js";
 
 const router: ExpressRouter = Router();
 
@@ -10,9 +11,9 @@ const apiVersion =
 
 router.get("/health", (_req, res) => {
   try {
-    const db = getDb();
-    const row = db.prepare("SELECT 1 AS ok").get() as { ok: number } | undefined;
-    if (row?.ok === 1) {
+    const db = getDrizzle();
+    const rows = db.all<{ ok: number }>(sql`SELECT 1 AS ok`);
+    if (rows[0]?.ok === 1) {
       res.json({ status: "ok", version: apiVersion });
     } else {
       res.status(503).json({ status: "unhealthy", reason: "sqlite check failed" });


### PR DESCRIPTION
## Summary

Closes #1115

Migrates the health check endpoint (`/health`) from raw better-sqlite3 (`db.prepare("SELECT 1 AS ok").get()`) to Drizzle ORM (`getDrizzle().all(sql\`SELECT 1 AS ok\`)`).

This was the only Tier 1 item from the audit that actually required migration:

- **`listLibrary()` UNION ALL** — already uses Drizzle's `sql` tag, which is the idiomatic approach since Drizzle has no native UNION support. No change needed.
- **`listLibraryGenres()` json_each()** — already uses Drizzle's `sql` tag, which is the correct pattern for SQLite JSON functions not exposed by the ORM. No change needed.
- **`/health` endpoint** — was the only place using raw better-sqlite3 directly (`db.prepare(...).get()`). Now uses `getDrizzle()` + `sql` tagged template. **Migrated in this PR.**

## Changes

- Replaced `getDb()` (raw better-sqlite3) with `getDrizzle()` (Drizzle ORM wrapper)
- Replaced `db.prepare("SELECT 1 AS ok").get()` with `db.all<{ ok: number }>(sql\`SELECT 1 AS ok\`)`
- Response format and version logic unchanged

## Test plan

- [x] Typecheck passes (`pnpm typecheck`)
- [x] Lint passes (`eslint src/routes/health.ts`)
- [x] Format check passes (`pnpm format --check`)
- [x] Existing test suite unaffected (no health route tests exist; all failures are pre-existing inventory timeouts)