### PR TITLE
fix(media): season list shows 0 episode counts

### DIFF
--- a/apps/pops-api/src/modules/media/library/tv-show-service.test.ts
+++ b/apps/pops-api/src/modules/media/library/tv-show-service.test.ts
@@ -208,6 +208,75 @@ describe("addTvShow", () => {
     expect(result.show.networks).toBeNull();
   });
 
+  it("sets episodeCount from actual fetched episodes, not TVDB summary", async () => {
+    // TVDB season summary says episodeCount: 99, but only 3 episodes are fetched.
+    // The DB should reflect the actual count (3), not the summary value (99).
+    const detail = makeShowDetail({
+      seasons: [
+        {
+          tvdbId: 30002,
+          seasonNumber: 1,
+          name: "Season 1",
+          overview: null,
+          imageUrl: null,
+          episodeCount: 99,
+        },
+      ],
+    });
+    const episodeMap = new Map([[1, makeEpisodes(1, 3)]]);
+    const client = makeMockClient(detail, episodeMap);
+
+    const result = await addTvShow(81189, client);
+
+    expect(result.seasons).toHaveLength(1);
+    expect(result.seasons[0]!.episodeCount).toBe(3);
+  });
+
+  it("falls back to TVDB summary episodeCount when no episodes are fetched", async () => {
+    const detail = makeShowDetail({
+      seasons: [
+        {
+          tvdbId: 30002,
+          seasonNumber: 1,
+          name: "Season 1",
+          overview: null,
+          imageUrl: null,
+          episodeCount: 8,
+        },
+      ],
+    });
+    // No episodes fetched for this season
+    const episodeMap = new Map<number, TvdbEpisode[]>([[1, []]]);
+    const client = makeMockClient(detail, episodeMap);
+
+    const result = await addTvShow(81189, client);
+
+    expect(result.seasons).toHaveLength(1);
+    expect(result.seasons[0]!.episodeCount).toBe(8);
+  });
+
+  it("sets episodeCount to null when TVDB summary is 0 and no episodes fetched", async () => {
+    const detail = makeShowDetail({
+      seasons: [
+        {
+          tvdbId: 30002,
+          seasonNumber: 1,
+          name: "Season 1",
+          overview: null,
+          imageUrl: null,
+          episodeCount: 0,
+        },
+      ],
+    });
+    const episodeMap = new Map<number, TvdbEpisode[]>([[1, []]]);
+    const client = makeMockClient(detail, episodeMap);
+
+    const result = await addTvShow(81189, client);
+
+    expect(result.seasons).toHaveLength(1);
+    expect(result.seasons[0]!.episodeCount).toBeNull();
+  });
+
   it("inserts episodes with correct data", async () => {
     const detail = makeShowDetail({
       seasons: [

--- a/apps/pops-api/src/modules/media/library/tv-show-service.ts
+++ b/apps/pops-api/src/modules/media/library/tv-show-service.ts
@@ -104,6 +104,11 @@ export async function addTvShow(
     const insertedSeasons: SeasonRow[] = [];
 
     for (const season of detail.seasons) {
+      // Use the actual fetched episode count rather than the TVDB season summary,
+      // which typically returns 0 from the extended endpoint (episodes not included).
+      const eps = seasonEpisodes.get(season.seasonNumber) ?? [];
+      const episodeCount = eps.length > 0 ? eps.length : season.episodeCount || null;
+
       const seasonResult = tx
         .insert(seasons)
         .values({
@@ -113,7 +118,7 @@ export async function addTvShow(
           name: season.name,
           overview: season.overview,
           posterPath: season.imageUrl,
-          episodeCount: season.episodeCount,
+          episodeCount,
         })
         .run();
 
@@ -123,7 +128,6 @@ export async function addTvShow(
       insertedSeasons.push(seasonRow);
 
       // Insert episodes for this season
-      const eps = seasonEpisodes.get(season.seasonNumber) ?? [];
       for (const ep of eps) {
         tx.insert(episodes)
           .values({

--- a/apps/pops-api/src/modules/media/thetvdb/service.test.ts
+++ b/apps/pops-api/src/modules/media/thetvdb/service.test.ts
@@ -302,6 +302,80 @@ describe("refreshTvShow", () => {
     expect(result.show.numberOfSeasons).toBe(1);
   });
 
+  it("updates season episodeCount from actual fetched episodes", async () => {
+    const showId = seedTvShow(db, { tvdb_id: 81189, name: "Breaking Bad" });
+    // Seed a season with episodeCount: 0 (the bug state)
+    seedSeason(db, {
+      tv_show_id: showId,
+      tvdb_id: 5001,
+      season_number: 1,
+      name: "Season 1",
+      episode_count: 0,
+    });
+
+    const detail = makeShowDetail({
+      seasons: [
+        {
+          tvdbId: 5001,
+          seasonNumber: 1,
+          name: "Season 1",
+          overview: null,
+          imageUrl: null,
+          // TVDB summary also says 0 (the root cause of the bug)
+          episodeCount: 0,
+        },
+      ],
+    });
+    const episodesBySeason: Record<number, TvdbEpisode[]> = {
+      1: [
+        makeEpisode({ tvdbId: 6001, episodeNumber: 1, name: "Pilot" }),
+        makeEpisode({ tvdbId: 6002, episodeNumber: 2, name: "Cat's in the Bag..." }),
+        makeEpisode({ tvdbId: 6003, episodeNumber: 3, name: "...And the Bag's in the River" }),
+      ],
+    };
+    const client = createMockClient(detail, episodesBySeason);
+
+    const result = await refreshTvShow(client, { id: showId });
+
+    // The season episodeCount should be corrected to 3 (actual episodes)
+    expect(result.seasons).toHaveLength(1);
+    expect(result.seasons[0]!.episodeCount).toBe(3);
+  });
+
+  it("preserves existing season episodeCount when TVDB summary is 0 and no episodes fetched", async () => {
+    const showId = seedTvShow(db, { tvdb_id: 81189, name: "Breaking Bad" });
+    seedSeason(db, {
+      tv_show_id: showId,
+      tvdb_id: 5001,
+      season_number: 1,
+      name: "Season 1",
+      episode_count: 7,
+    });
+
+    const detail = makeShowDetail({
+      seasons: [
+        {
+          tvdbId: 5001,
+          seasonNumber: 1,
+          name: "Season 1 (Updated)",
+          overview: null,
+          imageUrl: null,
+          // TVDB summary returns 0 (unreliable)
+          episodeCount: 0,
+        },
+      ],
+    });
+    // No episodes returned from the episode endpoint
+    const client = createMockClient(detail, { 1: [] });
+
+    const result = await refreshTvShow(client, { id: showId });
+
+    // The existing episodeCount (7) should be preserved since TVDB summary is 0
+    // and no episodes were fetched to provide an actual count
+    expect(result.seasons).toHaveLength(1);
+    expect(result.seasons[0]!.episodeCount).toBe(7);
+  });
+
   it("throws NotFoundError for invalid show id", async () => {
     const detail = makeShowDetail();
     const client = createMockClient(detail);

--- a/apps/pops-api/src/modules/media/thetvdb/service.ts
+++ b/apps/pops-api/src/modules/media/thetvdb/service.ts
@@ -30,6 +30,10 @@ export interface RefreshTvShowResult {
 /**
  * Upsert a season row — insert if new, update if existing.
  * Returns the local season ID and whether it was newly added.
+ *
+ * Note: episodeCount from the TVDB season summary is unreliable (often 0
+ * because the extended endpoint doesn't include episodes). Use
+ * {@link updateSeasonEpisodeCount} after fetching actual episodes.
  */
 function upsertSeason(
   showId: number,
@@ -38,13 +42,17 @@ function upsertSeason(
   const db = getDrizzle();
   const existing = db.select().from(seasons).where(eq(seasons.tvdbId, seasonSummary.tvdbId)).get();
 
+  // Only use the TVDB summary episodeCount as a fallback (non-zero).
+  const episodeCount = seasonSummary.episodeCount || null;
+
   if (existing) {
     db.update(seasons)
       .set({
         name: seasonSummary.name,
         overview: seasonSummary.overview,
         posterPath: seasonSummary.imageUrl,
-        episodeCount: seasonSummary.episodeCount,
+        // Preserve existing episodeCount if the summary provides 0/null
+        ...(episodeCount != null ? { episodeCount } : {}),
       })
       .where(eq(seasons.id, existing.id))
       .run();
@@ -59,7 +67,7 @@ function upsertSeason(
       name: seasonSummary.name,
       overview: seasonSummary.overview,
       posterPath: seasonSummary.imageUrl,
-      episodeCount: seasonSummary.episodeCount,
+      episodeCount,
     })
     .run();
 
@@ -70,6 +78,15 @@ function upsertSeason(
   }
 
   return { seasonId: newSeason.id, added: true };
+}
+
+/**
+ * Update a season's episodeCount based on actually fetched episode data.
+ */
+function updateSeasonEpisodeCount(seasonId: number, episodeCount: number): void {
+  if (episodeCount <= 0) return;
+  const db = getDrizzle();
+  db.update(seasons).set({ episodeCount }).where(eq(seasons.id, seasonId)).run();
 }
 
 /**
@@ -178,6 +195,9 @@ export async function refreshTvShow(
           episodesAdded++;
         }
       }
+
+      // Update season episodeCount with the actual fetched count
+      updateSeasonEpisodeCount(seasonId, tvdbEpisodes.length);
     }
 
     // Update numberOfEpisodes on the show


### PR DESCRIPTION
## Summary

- Season episode counts on the TV show detail page always showed 0 because the TheTVDB extended series endpoint doesn't include episodes in the season summary
- Fixed `addTvShow` to derive `episodeCount` from the actual fetched episodes instead of the unreliable TVDB season summary
- Fixed `refreshTvShow` to update `episodeCount` after upserting episodes, and to preserve existing counts when the TVDB summary returns 0

## Test plan

- [x] Added 3 new tests in `tv-show-service.test.ts`: verifies actual count overrides summary, fallback when no episodes fetched, null when summary is 0
- [x] Added 2 new tests in `thetvdb/service.test.ts`: verifies refresh updates count from actual episodes, preserves existing count when summary is 0
- [x] All 1477 existing tests pass
- [x] Typecheck passes
- [x] Lint and format checks pass

Closes #1175