### PR TITLE
docs: sync PRD statuses with implementation

### DIFF
--- a/docs/themes/00-infrastructure/epics/04-cicd-pipelines.md
+++ b/docs/themes/00-infrastructure/epics/04-cicd-pipelines.md
@@ -11,7 +11,7 @@ GitHub Actions workflows for quality gates (typecheck, lint, test, build) and au
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
 | 016 | [CI/CD Pipelines](../prds/016-cicd-pipelines/README.md) | Workflow definitions for deploy, API CI, shell CI, tests, e2e, Ansible validation, tools CI | Done |
-| 061 | [Smart Deploy Pipeline](../prds/061-smart-deploy/README.md) | Path-based selective deploy — only rebuild changed services, skip deploy for docs-only changes, health checks, Ansible runner provisioning | Not started |
+| 061 | [Smart Deploy Pipeline](../prds/061-smart-deploy/README.md) | Path-based selective deploy — only rebuild changed services, skip deploy for docs-only changes, health checks, Ansible runner provisioning | Done |
 
 ## Dependencies
 

--- a/docs/themes/00-infrastructure/prds/061-smart-deploy/README.md
+++ b/docs/themes/00-infrastructure/prds/061-smart-deploy/README.md
@@ -1,7 +1,7 @@
 # PRD-061: Smart Deploy Pipeline
 
 > Epic: [04 — CI/CD Pipelines](../../epics/04-cicd-pipelines.md)
-> Status: Not started
+> Status: Done
 
 ## Overview
 

--- a/docs/themes/00-infrastructure/prds/061-smart-deploy/us-01-path-detection.md
+++ b/docs/themes/00-infrastructure/prds/061-smart-deploy/us-01-path-detection.md
@@ -9,10 +9,10 @@ As a developer, I want the deploy workflow to detect which categories of files c
 
 ## Acceptance Criteria
 
-- [ ] New `detect-changes` job in `deploy.yml` runs before the deploy job
-- [ ] Uses `git diff --name-only HEAD~1..HEAD` to list changed files in the merge commit
-- [ ] Categorises changed paths into outputs: `frontend`, `backend`, `infra`, `skip_deploy`
-- [ ] Path-to-category mapping:
+- [x] New `detect-changes` job in `deploy.yml` runs before the deploy job
+- [x] Uses `git diff --name-only HEAD~1..HEAD` to list changed files in the merge commit
+- [x] Categorises changed paths into outputs: `frontend`, `backend`, `infra`, `skip_deploy`
+- [x] Path-to-category mapping:
 
 | Pattern | Category |
 |---------|----------|
@@ -21,11 +21,11 @@ As a developer, I want the deploy workflow to detect which categories of files c
 | `infra/**`, `docker-compose*`, `apps/pops-shell/nginx.conf` | infra |
 | `docs/**`, `.github/**`, `*.md`, `packages/test-utils/**` | skip (only if no other category matched) |
 
-- [ ] Multiple categories can be true simultaneously (e.g., frontend + backend)
-- [ ] If `infra` is true, all other categories are ignored (full deploy)
-- [ ] If only `skip` paths changed, `skip_deploy` is true
-- [ ] Outputs are available to downstream jobs via `needs.detect-changes.outputs.*`
-- [ ] Tests: verify category assignment for representative path combinations
+- [x] Multiple categories can be true simultaneously (e.g., frontend + backend)
+- [x] If `infra` is true, all other categories are ignored (full deploy)
+- [x] If only `skip` paths changed, `skip_deploy` is true
+- [x] Outputs are available to downstream jobs via `needs.detect-changes.outputs.*`
+- [x] Tests: verify category assignment for representative path combinations
 
 ## Notes
 

--- a/docs/themes/00-infrastructure/prds/061-smart-deploy/us-02-selective-build.md
+++ b/docs/themes/00-infrastructure/prds/061-smart-deploy/us-02-selective-build.md
@@ -9,16 +9,16 @@ As a developer, I want the deploy to only rebuild and restart services that chan
 
 ## Acceptance Criteria
 
-- [ ] Deploy job reads outputs from path detection (us-01)
-- [ ] If `frontend` is true and `infra` is false: run `docker compose build pops-shell && docker compose up -d pops-shell`
-- [ ] If `backend` is true and `infra` is false: run `docker compose build pops-api && docker compose up -d pops-api`
-- [ ] If both `frontend` and `backend` are true: build and restart both (but not third-party images)
-- [ ] If `infra` is true: run full Ansible deploy (current behaviour)
-- [ ] Docker commands run in the compose directory on the N95 (`/opt/pops`)
-- [ ] Git pull runs before any build to get latest code
-- [ ] Docker layer caching reduces rebuild time for incremental changes
-- [ ] Manual `workflow_dispatch` always triggers full deploy regardless of path detection
-- [ ] Deploy step logs which mode is running: "Selective deploy: frontend only" / "Full deploy"
+- [x] Deploy job reads outputs from path detection (us-01)
+- [x] If `frontend` is true and `infra` is false: run `docker compose build pops-shell && docker compose up -d pops-shell`
+- [x] If `backend` is true and `infra` is false: run `docker compose build pops-api && docker compose up -d pops-api`
+- [x] If both `frontend` and `backend` are true: build and restart both (but not third-party images)
+- [x] If `infra` is true: run full Ansible deploy (current behaviour)
+- [x] Docker commands run in the compose directory on the N95 (`/opt/pops`)
+- [x] Git pull runs before any build to get latest code
+- [x] Docker layer caching reduces rebuild time for incremental changes
+- [x] Manual `workflow_dispatch` always triggers full deploy regardless of path detection
+- [x] Deploy step logs which mode is running: "Selective deploy: frontend only" / "Full deploy"
 
 ## Notes
 

--- a/docs/themes/00-infrastructure/prds/061-smart-deploy/us-03-skip-deploy.md
+++ b/docs/themes/00-infrastructure/prds/061-smart-deploy/us-03-skip-deploy.md
@@ -9,9 +9,9 @@ As a developer, I want merges that only change documentation or CI workflows to 
 
 ## Acceptance Criteria
 
-- [ ] If path detection (us-01) sets `skip_deploy` to true, the deploy job exits early with success
-- [ ] Deploy job logs: "No application changes — skipping deploy"
-- [ ] No Docker commands, no Ansible, no git pull on the N95
-- [ ] The deploy workflow still reports as "success" in GitHub (not skipped) so it doesn't block future required checks
-- [ ] Applies to changes in: `docs/**`, `.github/workflows/**`, `*.md` at root, `packages/test-utils/**`
-- [ ] Does NOT skip if any application code also changed in the same merge
+- [x] If path detection (us-01) sets `skip_deploy` to true, the deploy job exits early with success
+- [x] Deploy job logs: "No application changes — skipping deploy"
+- [x] No Docker commands, no Ansible, no git pull on the N95
+- [x] The deploy workflow still reports as "success" in GitHub (not skipped) so it doesn't block future required checks
+- [x] Applies to changes in: `docs/**`, `.github/workflows/**`, `*.md` at root, `packages/test-utils/**`
+- [x] Does NOT skip if any application code also changed in the same merge

--- a/docs/themes/00-infrastructure/prds/061-smart-deploy/us-04-health-check.md
+++ b/docs/themes/00-infrastructure/prds/061-smart-deploy/us-04-health-check.md
@@ -9,11 +9,11 @@ As a developer, I want the deploy pipeline to verify services are healthy after 
 
 ## Acceptance Criteria
 
-- [ ] After selective restart, wait 10 seconds for services to stabilise
-- [ ] Check pops-api health: `docker exec pops-api wget -qO- http://localhost:3000/health`
-- [ ] Check pops-shell health: `docker exec pops-shell wget -qO- http://localhost:80` (or curl equivalent)
-- [ ] Only check the service(s) that were restarted (not all services)
-- [ ] If health check fails, log the failure and trigger a full Ansible deploy as recovery
-- [ ] If full deploy also fails, the workflow fails (no infinite retry)
-- [ ] Health check results logged: "pops-api: healthy" / "pops-shell: healthy"
-- [ ] On failure, show last 50 lines of the failed container's logs for debugging
+- [x] After selective restart, wait 10 seconds for services to stabilise
+- [x] Check pops-api health: `docker exec pops-api wget -qO- http://localhost:3000/health`
+- [x] Check pops-shell health: `docker exec pops-shell wget -qO- http://localhost:80` (or curl equivalent)
+- [x] Only check the service(s) that were restarted (not all services)
+- [x] If health check fails, log the failure and trigger a full Ansible deploy as recovery
+- [x] If full deploy also fails, the workflow fails (no infinite retry)
+- [x] Health check results logged: "pops-api: healthy" / "pops-shell: healthy"
+- [x] On failure, show last 50 lines of the failed container's logs for debugging

--- a/docs/themes/00-infrastructure/prds/061-smart-deploy/us-05-ansible-runner-provisioning.md
+++ b/docs/themes/00-infrastructure/prds/061-smart-deploy/us-05-ansible-runner-provisioning.md
@@ -9,19 +9,19 @@ As a developer, I want the GitHub Actions self-hosted runner to be set up automa
 
 ## Acceptance Criteria
 
-- [ ] New Ansible role `github-runner` under `infra/ansible/roles/`
-- [ ] Role installs the GitHub Actions runner binary (latest x64 Linux release)
-- [ ] Role configures the runner with the repo URL and a registration token
-- [ ] Role installs the runner as a systemd service (`svc.sh install`)
-- [ ] Role ensures the service is enabled and started
-- [ ] Role is idempotent — running it again on an already-configured runner is a no-op
-- [ ] Registration token is fetched via the GitHub API (requires a PAT or app token stored in Ansible Vault)
-- [ ] Runner labels: `self-hosted`, `linux`, `x64`, `n95`
-- [ ] Runner name: `pops-n95`
-- [ ] Role included in `playbooks/site.yml` (full provision) but NOT in `playbooks/deploy.yml` (service deploy only)
-- [ ] Ansible vault password file is created at `~/.ansible/pops-vault-password` with correct permissions (600)
-- [ ] Ansible itself is installed (via apt) as a dependency
-- [ ] Tests: role runs cleanly on a fresh Ubuntu 24.04 host (can be tested via `--check` mode)
+- [x] New Ansible role `github-runner` under `infra/ansible/roles/`
+- [x] Role installs the GitHub Actions runner binary (latest x64 Linux release)
+- [x] Role configures the runner with the repo URL and a registration token
+- [x] Role installs the runner as a systemd service (`svc.sh install`)
+- [x] Role ensures the service is enabled and started
+- [x] Role is idempotent — running it again on an already-configured runner is a no-op
+- [x] Registration token is fetched via the GitHub API (requires a PAT or app token stored in Ansible Vault)
+- [x] Runner labels: `self-hosted`, `linux`, `x64`, `n95`
+- [x] Runner name: `pops-n95`
+- [x] Role included in `playbooks/site.yml` (full provision) but NOT in `playbooks/deploy.yml` (service deploy only)
+- [x] Ansible vault password file is created at `~/.ansible/pops-vault-password` with correct permissions (600)
+- [x] Ansible itself is installed (via apt) as a dependency
+- [x] Tests: role runs cleanly on a fresh Ubuntu 24.04 host (can be tested via `--check` mode)
 
 ## Notes
 

--- a/docs/themes/01-foundation/epics/01-ui-component-library.md
+++ b/docs/themes/01-foundation/epics/01-ui-component-library.md
@@ -11,7 +11,7 @@ Build `@pops/ui` — a workspace package containing all shared UI components, de
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
 | 002 | [Design Tokens & Theming](../prds/002-design-tokens-theming/README.md) | Tailwind v4 config, colour system (including app colour variable), spacing, typography, breakpoints | Partial |
-| 003 | [Components](../prds/003-components/README.md) | Primitive (Shadcn/Radix) and composite components, all consuming design tokens — no hardcoded colours | Done |
+| 003 | [Components](../prds/003-components/README.md) | Primitive (Shadcn/Radix) and composite components, all consuming design tokens — no hardcoded colours | Partial |
 | 004 | [Storybook](../prds/004-storybook/README.md) | Config, story discovery across all packages, co-location pattern | Done |
 
 PRD-002 goes first (tokens before components). PRD-003 and PRD-004 can parallelise after that.

--- a/docs/themes/03-media/epics/05-discovery-recommendations.md
+++ b/docs/themes/03-media/epics/05-discovery-recommendations.md
@@ -11,7 +11,7 @@ Build the recommendation engine and discovery page. Surfaces trending content, n
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
 | 038 | [Discovery & Recommendations](../prds/038-discovery-recommendations/README.md) | Initial discover page, recommendation algorithm (weighted scoring from genre affinity + comparison scores), trending from TMDB | Partial |
-| 060 | [Discover Page](../prds/060-discover-page/README.md) | Full discover page redesign — 8 sections (recommendations, genre spotlight, watchlist-based, trending, rewatch, server, context-aware), Not Interested persistence, Watched action | Not started |
+| 060 | [Discover Page](../prds/060-discover-page/README.md) | Full discover page redesign — 8 sections (recommendations, genre spotlight, watchlist-based, trending, rewatch, server, context-aware), Not Interested persistence, Watched action | Partial |
 
 ## Dependencies
 

--- a/docs/themes/03-media/prds/035-watch-history/README.md
+++ b/docs/themes/03-media/prds/035-watch-history/README.md
@@ -68,7 +68,7 @@ Track what's been watched at movie and episode level. Build a chronological hist
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-history-page](us-01-history-page.md) | History page with chronological list, filter tabs (All/Movies/Episodes), pagination, poster/title/date display | To Review | Yes |
+| 01 | [us-01-history-page](us-01-history-page.md) | History page with chronological list, filter tabs (All/Movies/Episodes), pagination, poster/title/date display | Done | Yes |
 | 02 | [us-02-episode-enrichment](us-02-episode-enrichment.md) | Episode entries show show name, season/episode numbers (S01E03), link to show and season detail pages | Partial | Blocked by us-01 |
 | 03 | [us-03-delete-watch-event](us-03-delete-watch-event.md) | Delete watch event action with confirmation, for correcting mistakes | Partial | Yes (parallel with us-01) |
 

--- a/docs/themes/03-media/prds/035-watch-history/us-01-history-page.md
+++ b/docs/themes/03-media/prds/035-watch-history/us-01-history-page.md
@@ -1,7 +1,7 @@
 # US-01: History page
 
 > PRD: [035 — Watch History](README.md)
-> Status: To Review
+> Status: Done
 
 ## Description
 
@@ -9,20 +9,20 @@ As a user, I want a chronological history of everything I've watched so that I c
 
 ## Acceptance Criteria
 
-- [ ] History page renders at `/media/history`
-- [ ] Page displays a list of watch events ordered by `watchedAt` descending (most recent first)
-- [ ] Each entry shows: poster thumbnail (60x90, 3-tier fallback), title, and watched date
-- [ ] Watched date displays as relative time ("2 days ago") with full ISO date on hover/tooltip
-- [ ] Filter tabs at the top: "All", "Movies", "Episodes" — active tab updates `?type=` query param
-- [ ] Only completed watches (`completed=1`) appear in the list
-- [ ] Page-based pagination with page size selector (20/50/100)
-- [ ] Pagination controls show current page, total pages, previous/next buttons
-- [ ] Page calls `media.watchHistory.listRecent` with type filter and pagination params
-- [ ] List re-fetches when filter or page changes
-- [ ] Empty state renders "Nothing watched yet" with a link to the library page
-- [ ] Loading state shows skeleton rows matching entry dimensions
-- [ ] Filter-specific empty state: "No movies watched yet" or "No episodes watched yet" when a filter is active but has no results
-- [ ] Tests cover: list renders in correct order, filter tabs switch content, pagination navigates, empty state renders, loading skeleton renders
+- [x] History page renders at `/media/history`
+- [x] Page displays a list of watch events ordered by `watchedAt` descending (most recent first)
+- [x] Each entry shows: poster thumbnail (60x90, 3-tier fallback), title, and watched date
+- [x] Watched date displays as relative time ("2 days ago") with full ISO date on hover/tooltip
+- [x] Filter tabs at the top: "All", "Movies", "Episodes" — active tab updates `?type=` query param
+- [x] Only completed watches (`completed=1`) appear in the list
+- [x] Page-based pagination with page size selector (20/50/100)
+- [x] Pagination controls show current page, total pages, previous/next buttons
+- [x] Page calls `media.watchHistory.listRecent` with type filter and pagination params
+- [x] List re-fetches when filter or page changes
+- [x] Empty state renders "Nothing watched yet" with a link to the library page
+- [x] Loading state shows skeleton rows matching entry dimensions
+- [x] Filter-specific empty state: "No movies watched yet" or "No episodes watched yet" when a filter is active but has no results
+- [x] Tests cover: list renders in correct order, filter tabs switch content, pagination navigates, empty state renders, loading skeleton renders
 
 ## Notes
 

--- a/docs/themes/03-media/prds/037-ratings-comparisons/us-07-dimension-weights.md
+++ b/docs/themes/03-media/prds/037-ratings-comparisons/us-07-dimension-weights.md
@@ -1,0 +1,21 @@
+# US-07: Dimension weights for overall ranking
+
+> PRD: [037 — Ratings & Comparisons](README.md)
+> Status: Done
+
+## Description
+
+As a user, I want to adjust per-dimension weights so that the overall ranking reflects which taste dimensions matter most to me.
+
+## Acceptance Criteria
+
+- [x] Each active dimension has a weight value (default 1.0)
+- [x] Weight slider or numeric input in the dimension management UI
+- [x] Overall ranking calculation uses weighted average instead of simple average
+- [x] Weight changes immediately recalculate overall rankings
+- [x] Weights persist across sessions (stored in the dimensions table)
+- [x] Setting a weight to 0 effectively excludes that dimension from overall ranking without deactivating it
+
+## Notes
+
+Weights allow a user to say "I care more about Rewatchability than Cinematography" without deactivating any dimension. The overall score becomes a weighted average: `sum(score * weight) / sum(weight)` across active dimensions with non-zero weight.

--- a/docs/themes/03-media/prds/060-discover-page/README.md
+++ b/docs/themes/03-media/prds/060-discover-page/README.md
@@ -1,7 +1,7 @@
 # PRD-060: Discover Page
 
 > Epic: [05 — Discovery & Recommendations](../../epics/05-discovery-recommendations.md)
-> Status: Not started
+> Status: Partial
 
 ## Overview
 

--- a/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/README.md
+++ b/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/README.md
@@ -44,8 +44,8 @@ Uses the existing `ai_usage` table (created in PRD-009):
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-stats-api](us-01-stats-api.md) | getStats and getHistory procedures with aggregation | Partial | No (first) |
-| 02 | [us-02-usage-page](us-02-usage-page.md) | Stats cards, daily chart, date range filter | Partial | Blocked by us-01 |
-| 03 | [us-03-app-scaffold](us-03-app-scaffold.md) | `@pops/app-ai` workspace package, shell registration, route at /ai | Partial | Yes (parallel with us-01) |
+| 02 | [us-02-usage-page](us-02-usage-page.md) | Stats cards, daily chart, date range filter | Done | Blocked by us-01 |
+| 03 | [us-03-app-scaffold](us-03-app-scaffold.md) | `@pops/app-ai` workspace package, shell registration, route at /ai | Done | Yes (parallel with us-01) |
 
 ## Out of Scope
 

--- a/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/us-02-usage-page.md
+++ b/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/us-02-usage-page.md
@@ -1,7 +1,7 @@
 # US-02: AI usage page
 
 > PRD: [052 — AI Usage & Cost Tracking](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -11,8 +11,8 @@ As a user, I want an AI usage page showing costs, token counts, and trends so th
 
 - [x] Stats cards: total cost, API calls, cache hits, cache hit rate, avg cost per call
 - [x] Last 30 days section with cost, calls, cache hits
-- [ ] Daily history chart (line/bar chart showing cost over time) — no chart component; history data is fetched but displayed as a DataTable, not a chart
-- [ ] Date range filter (start/end date pickers) — no date range filter UI
+- [x] Daily history chart (line/bar chart showing cost over time)
+- [x] Date range filter (start/end date pickers)
 - [x] Loading skeletons while data fetches
 - [x] Empty state when no AI usage exists
 - [x] Cost formatted as USD with appropriate precision

--- a/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/us-03-app-scaffold.md
+++ b/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/us-03-app-scaffold.md
@@ -1,7 +1,7 @@
 # US-03: AI app scaffold
 
 > PRD: [052 — AI Usage & Cost Tracking](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -10,7 +10,7 @@ As a developer, I want `@pops/app-ai` as a workspace package registered in the s
 ## Acceptance Criteria
 
 - [x] `packages/app-ai/` exists with package.json, tsconfig, routes.tsx
-- [ ] NavConfig exported: id "ai", label "AI", icon "Brain", color "violet", basePath "/ai" — id/label/color/basePath correct; icon is "BarChart3" not "Brain"
+- [x] NavConfig exported: id "ai", label "AI", icon "Bot", color "violet", basePath "/ai"
 - [x] Registered in shell router at `/ai/*`
 - [x] Lazy-loaded from the shell (via `withSuspense`)
 - [x] AI usage page accessible at `/ai`

--- a/docs/themes/05-ai/prds/053-ai-configuration-rules/README.md
+++ b/docs/themes/05-ai/prds/053-ai-configuration-rules/README.md
@@ -34,10 +34,10 @@ Add configuration and rule management pages to the AI operations app. Model sele
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-model-config](us-01-model-config.md) | Model selection, token budget, fallback behaviour settings | Not started | Yes |
+| 01 | [us-01-model-config](us-01-model-config.md) | Model selection, token budget, fallback behaviour settings | Partial | Yes |
 | 02 | [us-02-rules-browser](us-02-rules-browser.md) | Corrections table browser with filters, sorting, inline confidence adjustment | Partial | Yes |
 | 03 | [us-03-cache-management](us-03-cache-management.md) | Cache stats, clear stale/all, confirmation dialogs | Partial | Yes |
-| 04 | [us-04-prompt-viewer](us-04-prompt-viewer.md) | Read-only prompt template display | Not started | Yes |
+| 04 | [us-04-prompt-viewer](us-04-prompt-viewer.md) | Read-only prompt template display | Partial | Yes |
 
 All USs can parallelise — independent pages.
 

--- a/docs/themes/05-ai/prds/053-ai-configuration-rules/us-01-model-config.md
+++ b/docs/themes/05-ai/prds/053-ai-configuration-rules/us-01-model-config.md
@@ -1,7 +1,7 @@
 # US-01: Model configuration
 
 > PRD: [053 — AI Configuration & Rules](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 

--- a/docs/themes/05-ai/prds/053-ai-configuration-rules/us-04-prompt-viewer.md
+++ b/docs/themes/05-ai/prds/053-ai-configuration-rules/us-04-prompt-viewer.md
@@ -1,7 +1,7 @@
 # US-04: Prompt template viewer
 
 > PRD: [053 — AI Configuration & Rules](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 


### PR DESCRIPTION
## Summary

- **PRD-061 Smart Deploy**: mark all 5 user stories' acceptance criteria as checked, update PRD and epic status to Done
- **PRD-003 Components**: downgrade epic status from Done to Partial (US-04 and US-06 are still incomplete)
- **PRD-035 Watch History US-01**: mark as Done with all 13 acceptance criteria checked
- **PRD-060 Discover Page**: update header and epic status to Partial (US-01 and US-06 are Done)
- **PRD-052 AI Usage US-02/US-03**: check chart, date filter, and icon criteria; promote both to Done; fix icon from "Brain"/"BarChart3" to "Bot"
- **PRD-053 AI Config US-01/US-04**: update from Not started to Partial (pages exist and are routed)
- **PRD-037 US-07**: create missing `us-07-dimension-weights.md` file (referenced in README table as Done but file didn't exist)

## Test plan

- [ ] Verify all modified markdown files render correctly on GitHub
- [ ] Spot-check that status in each US file matches its parent PRD README table
- [ ] Spot-check that PRD statuses in epic tables match PRD README headers