### PR TITLE
fix: rankings TabsList width + revert AppRail buttons

### DIFF
--- a/apps/pops-shell/src/app/layout/AppRail.tsx
+++ b/apps/pops-shell/src/app/layout/AppRail.tsx
@@ -12,7 +12,7 @@ import { iconMap } from "@/app/nav/icon-map";
 import { matchesAtBoundary } from "@/app/nav/path-utils";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useUIStore } from "@/store/uiStore";
-import { Button, Tooltip, TooltipContent, TooltipTrigger, cn } from "@pops/ui";
+import { Tooltip, TooltipContent, TooltipTrigger, cn } from "@pops/ui";
 
 interface AppRailProps {
   className?: string;
@@ -48,15 +48,13 @@ export function AppRail({ className }: AppRailProps) {
           className
         )}
       >
-        <Button
-          variant="ghost"
-          size="icon"
+        <button
           onClick={toggleRail}
-          className="min-w-9 min-h-9 h-9 w-9"
+          className="min-w-9 min-h-9 flex items-center justify-center hover:bg-muted rounded-lg"
           aria-label="Expand app rail"
         >
           <PanelLeftOpen className="h-4 w-4 text-muted-foreground" />
-        </Button>
+        </button>
       </div>
     );
   }
@@ -77,8 +75,7 @@ export function AppRail({ className }: AppRailProps) {
         return (
           <Tooltip key={app.id}>
             <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
+              <button
                 onClick={() => {
                   navigate(app.basePath);
                   if (isTablet) {
@@ -86,7 +83,7 @@ export function AppRail({ className }: AppRailProps) {
                   }
                 }}
                 className={cn(
-                  "relative w-full h-auto flex items-center justify-center py-1 transition-colors group rounded-none",
+                  "relative w-full flex items-center justify-center py-1 transition-colors group",
                   appColorClass
                 )}
                 aria-label={app.label}
@@ -116,7 +113,7 @@ export function AppRail({ className }: AppRailProps) {
                     <span className="text-lg font-semibold">{app.label[0]}</span>
                   )}
                 </span>
-              </Button>
+              </button>
             </TooltipTrigger>
             <TooltipContent side="right">{app.label}</TooltipContent>
           </Tooltip>
@@ -127,15 +124,13 @@ export function AppRail({ className }: AppRailProps) {
       <div className="mt-auto flex justify-center">
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
+            <button
               onClick={toggleRail}
-              className="min-w-9 min-h-9 h-9 w-9"
+              className="min-w-9 min-h-9 flex items-center justify-center hover:bg-muted rounded-lg"
               aria-label="Collapse app rail"
             >
               <PanelLeftClose className="h-4 w-4 text-muted-foreground" />
-            </Button>
+            </button>
           </TooltipTrigger>
           <TooltipContent side="right">Collapse</TooltipContent>
         </Tooltip>

--- a/packages/app-media/src/pages/RankingsPage.tsx
+++ b/packages/app-media/src/pages/RankingsPage.tsx
@@ -249,7 +249,7 @@ export function RankingsPage() {
         <RankingsSkeleton />
       ) : showTabs ? (
         <Tabs value={dimensionParam} onValueChange={handleTabChange}>
-          <TabsList className="h-auto flex-wrap justify-center">
+          <TabsList className="h-auto w-full flex-wrap justify-center">
             <TabsTrigger value="overall">Overall</TabsTrigger>
             {activeDimensions.map((dim: { id: number; name: string }) => (
               <TabsTrigger key={dim.id} value={String(dim.id)}>


### PR DESCRIPTION
## Summary
Post-merge regression fixes:

- **Rankings page** (#1178 regression): Added `w-full` to `TabsList` — without it, the `inline-flex w-fit` base styles caused wrapped tabs to overflow outside the background container. The second row had no visible background.
- **AppRail buttons** (#1182 regression): Reverted nav icon buttons from `Button variant="ghost"` back to raw `<button>`. The `Button` component adds padding, border-radius, and hover states that break the Discord-style icon layout. These are custom navigation elements, not standard action buttons.
- **Episode counts** (#1181 data fix): Ran direct SQL to update 621 seasons from `episodeCount = 0` to actual episode counts. The code fix only affected new adds/refreshes — existing DB rows needed a one-time correction.

## Test plan
- [ ] Rankings page tabs wrap with visible background on both rows
- [ ] AppRail icons display as clean Discord-style icons without button backgrounds
- [ ] Season detail pages show correct episode counts