### PR TITLE
docs: PRD-062 comparison intelligence

### DIFF
--- a/docs/themes/03-media/epics/04-ratings-comparisons.md
+++ b/docs/themes/03-media/epics/04-ratings-comparisons.md
@@ -11,6 +11,7 @@ Build the pairwise comparison system (per ADR-010). Two movies presented side by
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
 | 037 | [Ratings & Comparisons](../prds/037-ratings-comparisons/README.md) | Compare arena page, dimension management, ELO scoring algorithm, rankings page, radar charts on detail pages, quick-pick flow | Partial |
+| 062 | [Comparison Intelligence](../prds/062-comparison-intelligence/README.md) | Probabilistic pair selection, staleness model, dimension exclusion, watch blacklist, skip cooloff, score confidence, freshness indicators | Not started |
 
 ## Dependencies
 
@@ -20,5 +21,6 @@ Build the pairwise comparison system (per ADR-010). Two movies presented side by
 ## Out of Scope
 
 - TV show comparisons (hard UX problem — see ideas/media-ideas.md)
-- Smart pair selection (uncertainty-based — future enhancement)
+- Post-watch debrief / rapid-fire review mode (PRD-063, future)
+- Batch comparison / tier list drag-and-drop (PRD-064, future)
 - AI-driven comparison prompts (future enhancement)

--- a/docs/themes/03-media/prds/037-ratings-comparisons/README.md
+++ b/docs/themes/03-media/prds/037-ratings-comparisons/README.md
@@ -120,7 +120,7 @@ Build a pairwise comparison system per [ADR-010](../../../../architecture/adr-01
 | 06 | [us-06-comparison-history](us-06-comparison-history.md) | Comparison history list, delete with Elo recalculation, undo toast, dimension filter | Not started | Yes |
 | 07 | [us-07-dimension-weights](us-07-dimension-weights.md) | Per-dimension weight for overall ranking, weight slider in dimension management UI | Done | Yes |
 | 08 | [us-08-arena-watchlist-filter](us-08-arena-watchlist-filter.md) | Add to watchlist from arena, exclude watchlisted movies from pair selection | Not started | Yes |
-| 09 | [us-09-tiered-draws](us-09-tiered-draws.md) | Replace single Equal button with High/Mid/Low draw tiers that affect ELO outcome values (0.7/0.5/0.3) | Not started | Yes |
+| 09 | [us-09-tiered-draws](us-09-tiered-draws.md) | Three draw tier buttons (High/Mid/Low) with ELO outcome values 0.7/0.5/0.3 | Not started | Yes |
 
 US-01 depends on US-02 (arena needs Elo scoring to record comparisons). US-03 through US-08 can all be built in parallel.
 

--- a/docs/themes/03-media/prds/037-ratings-comparisons/us-09-tiered-draws.md
+++ b/docs/themes/03-media/prds/037-ratings-comparisons/us-09-tiered-draws.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-Replace the single "Equal" draw button with three always-visible buttons between the two movie cards: **High**, **Mid**, **Low**. Each tier communicates absolute quality alongside the relative equality — two movies can be equally excellent, equally mediocre, or equally poor.
+As a user, I want three draw tier buttons (High, Mid, Low) between the movie cards so I can express that two movies are equally great, equally average, or equally poor at a dimension.
 
 The draw tier feeds directly into the ELO outcome value:
 
@@ -18,12 +18,11 @@ The draw tier feeds directly into the ELO outcome value:
 ## Acceptance criteria
 
 - [ ] `comparisons` table has a `draw_tier` column: TEXT, nullable, values `'high'` | `'mid'` | `'low'` | null
-- [ ] Drizzle migration generated and applied for the new column
 - [ ] `record` tRPC procedure accepts optional `drawTier` input (validated as enum)
 - [ ] ELO update uses outcome 0.7 (high), 0.5 (mid), 0.3 (low) when `winnerId = 0` and `drawTier` is set
-- [ ] Legacy draws (no tier) continue to use 0.5
+- [ ] Draws without a tier (null) use 0.5 for backward compatibility
 - [ ] Delete + replay recalculation respects stored `draw_tier` values
-- [ ] Compare arena shows three stacked buttons between the two cards: High, Mid, Low (replacing the single Equal button)
+- [ ] Compare arena shows three stacked buttons between the two cards: High, Mid, Low
 - [ ] Each button has a distinct visual treatment (e.g. up-arrow / equals / down-arrow icons, or colour coding)
 - [ ] Score delta animation works for all three tiers
-- [ ] Tests cover: high draw both gain, mid draw neutral, low draw both lose, legacy null draw = 0.5
+- [ ] Tests cover: high draw both gain, mid draw neutral, low draw both lose, null draw = 0.5

--- a/docs/themes/03-media/prds/062-comparison-intelligence/README.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/README.md
@@ -1,0 +1,185 @@
+# PRD-062: Comparison Intelligence
+
+> Epic: [04 — Ratings & Comparisons](../../epics/04-ratings-comparisons.md)
+> Status: Not started
+
+## Overview
+
+A probabilistic pair selection model for the compare arena that maximises information gain per comparison. The arena provides actions for staleness, inapplicability, and data errors that feed back into the model. Score confidence and watch recency ensure rankings reflect current taste, not stale memories.
+
+## Data Model
+
+### watch_history
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `blacklisted` | INTEGER | 0 | 1 = watch event was a data error (e.g. someone else's account). Sync skips blacklisted rows |
+
+### media_scores
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `excluded` | INTEGER | 0 | 1 = movie is not applicable for this dimension. Excluded from rankings and pair selection |
+
+### comparison_staleness
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INTEGER | PK, auto-increment | |
+| `media_type` | TEXT | NOT NULL | `'movie'` |
+| `media_id` | INTEGER | NOT NULL | |
+| `staleness` | REAL | NOT NULL, DEFAULT 1.0 | Multiplier: 1.0 = fresh, 0.5 = marked once, 0.25 = marked twice, etc. |
+| `updated_at` | TEXT | NOT NULL | Last staleness change |
+
+UNIQUE index on `(media_type, media_id)`. Watch event resets `staleness` to 1.0.
+
+### comparison_skip_cooloffs
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INTEGER | PK, auto-increment | |
+| `dimension_id` | INTEGER | NOT NULL, FK | |
+| `media_a_type` | TEXT | NOT NULL | |
+| `media_a_id` | INTEGER | NOT NULL | |
+| `media_b_type` | TEXT | NOT NULL | |
+| `media_b_id` | INTEGER | NOT NULL | |
+| `skip_until` | INTEGER | NOT NULL | Global comparison count at which this pair becomes eligible again |
+| `created_at` | TEXT | NOT NULL | |
+
+UNIQUE index on `(dimension_id, media_a_type, media_a_id, media_b_type, media_b_id)`.
+
+## Pair Selection Algorithm
+
+Each eligible pair `(movieA, movieB)` receives a priority score. A pair is chosen via weighted random sampling (not deterministic top-pick — preserves discovery).
+
+### Priority formula
+
+```
+pairPriority(A, B, dimension) =
+    informationGain(A, B, dimension)
+  × recencyWeight(A) × recencyWeight(B)
+  × stalenessWeight(A) × stalenessWeight(B)
+  × dimensionNeed(dimension)
+  × randomJitter(0.7 .. 1.3)
+```
+
+### Component definitions
+
+| Component | Formula | Purpose |
+|-----------|---------|---------|
+| **informationGain** | `1 / (1 + abs(scoreA - scoreB) / 200) × (1 / (pairComparisonCount + 1))` | Close scores + few head-to-heads = high info. Blowouts and re-treads = low info |
+| **recencyWeight** | `1 / (1 + daysSinceLastWatch / 180)` | Recently watched movies prioritised — opinion is freshest. 6-month half-life |
+| **stalenessWeight** | `comparison_staleness.staleness` (default 1.0) | User-controlled deprioritisation. Compounds: 1.0 → 0.5 → 0.25 → 0.125. Watch resets to 1.0 |
+| **dimensionNeed** | `maxCompCount / (dimensionCompCount + 1)` | Under-sampled dimensions get boosted. Balances the dataset across dimensions |
+| **randomJitter** | Uniform random in `[0.7, 1.3]` | Prevents deterministic loops. Ensures variety even when priorities are similar |
+
+### Exclusions (pair never selected)
+
+- Either movie has `excluded = 1` for the current dimension
+- Either movie has only blacklisted watch events (no valid watches)
+- Pair is in `comparison_skip_cooloffs` and global comparison count < `skip_until`
+- Either movie has zero watch history entries
+
+## Arena Actions
+
+### Button layout
+
+**Left card** — click to pick A as winner
+**Right card** — click to pick B as winner
+
+**Center column (between cards, stacked):**
+- ↑ High draw
+- — Mid draw
+- ↓ Low draw
+
+**Bottom action bar:**
+- **Skip** — per-pair cooloff (10 comparisons), no comparison recorded
+- **Stale (A)** / **Stale (B)** — compound staleness for that movie (×0.5 each press), no comparison recorded, next pair loaded
+- **N/A** — mark both movies as excluded for current dimension, no comparison recorded
+- **Not watched (A)** / **Not watched (B)** — blacklist watch history, purge comparisons, recalc ELO. Destructive action with confirmation dialog
+
+**Watchlist button** — on each card (bookmark icon). Adds to watchlist only. Does NOT submit a comparison. Does NOT change the selection algorithm. Independent of other actions.
+
+## Score Confidence
+
+Each score has an implicit confidence derived from `comparison_count`:
+
+```
+confidence = 1 - (1 / sqrt(comparisonCount + 1))
+```
+
+| Comparisons | Confidence |
+|-------------|------------|
+| 0 | 0% |
+| 1 | 29% |
+| 3 | 50% |
+| 8 | 67% |
+| 15 | 75% |
+| 30 | 82% |
+| 99 | 90% |
+
+Rankings page shows confidence as a subtle bar or percentage next to the score.
+
+## Freshness Indicator
+
+Movies show a freshness badge based on `daysSinceLastWatch` (most recent non-blacklisted watch event):
+
+| Days since watch | Label | Color |
+|-----------------|-------|-------|
+| 0–30 | Fresh | green |
+| 31–90 | Recent | blue |
+| 91–365 | Fading | yellow |
+| 365+ | Stale | red |
+
+If the movie has a `comparison_staleness` row with `staleness < 1.0`, the badge shows "Stale" (red) regardless of watch recency.
+
+## Business Rules
+
+- Pair selection samples from weighted distribution — NOT deterministic top-pick
+- Skip cooloff is per-pair per-dimension: skipping "A vs B" on Cinematography doesn't affect "A vs B" on Entertainment
+- Staleness compounds multiplicatively: 1.0 → 0.5 → 0.25 → 0.125 → 0.0625 (min 0.01, never zero)
+- A watch event (new entry in watch_history for that movie) resets staleness to 1.0
+- "Not applicable" excludes from dimension rankings — score becomes null, not average. Movie doesn't appear in that dimension's ranked list
+- "Not applicable" purges comparisons for that movie+dimension and recalculates ELO
+- "Not watched" blacklists specific watch_history rows (sets `blacklisted = 1`), does not delete them
+- "Not watched" purges all comparisons involving that movie (all dimensions) and recalculates ELO
+- Plex sync checks `blacklisted = 0` when deduplicating — blacklisted events are never re-synced
+- A movie with all watch events blacklisted is treated as unwatched — excluded from comparison pool
+- New watch events for the same movie at a different timestamp are NOT blacklisted (user actually watched it)
+- Confidence is derived (not stored) — calculated from `comparison_count` at query time
+- Dimension rotation uses weighted random by dimension need — under-sampled dimensions appear more often but not exclusively
+
+## Edge Cases
+
+| Case | Behaviour |
+|------|-----------|
+| All pairs exhausted (every combo on cooloff) | Fall back to lowest-cooloff pair. Log warning |
+| Movie marked stale + not applicable for all dimensions | Movie effectively exits the arena. Still appears in library |
+| "Not watched" on a movie with many comparisons | Confirmation dialog warns about comparison count. Recalc may take a moment |
+| Staleness at minimum (0.01) | Movie almost never appears but isn't fully excluded. Watch resets it |
+| New dimension created | All movies start at 1500, confidence 0%, dimensionNeed is highest — new dimension dominates rotation until balanced |
+| Movie watched again after being stale | Staleness resets to 1.0, freshness goes green, movie re-enters normal rotation |
+| "Not applicable" then user changes mind | Un-exclude via movie detail page or dimension management |
+
+## User Stories
+
+| # | Story | Summary | Status | Parallelisable |
+|---|-------|---------|--------|----------------|
+| 01 | [us-01-blacklist-watch-history](us-01-blacklist-watch-history.md) | Blacklisted column on watch_history, "not watched" arena action with comparison purge + ELO recalc, sync protection | Not started | Yes |
+| 02 | [us-02-staleness-model](us-02-staleness-model.md) | Staleness table, compounding multiplier, watch-resets-staleness, arena stale button | Not started | Yes |
+| 03 | [us-03-dimension-exclusion](us-03-dimension-exclusion.md) | "Not applicable" action, excluded column on media_scores, comparison purge + ELO recalc, hide from rankings | Not started | Blocked by us-01 (shares recalc logic) |
+| 04 | [us-04-skip-cooloff](us-04-skip-cooloff.md) | Skip cooloff table, per-pair per-dimension cooloff of 10 comparisons | Not started | Yes |
+| 05 | [us-05-pair-selection-algorithm](us-05-pair-selection-algorithm.md) | Weighted probabilistic pair selection using info gain, recency, staleness, dimension need, jitter | Not started | Blocked by us-02, us-04 |
+| 06 | [us-06-score-confidence](us-06-score-confidence.md) | Derived confidence from comparison_count, displayed on rankings page | Not started | Yes |
+| 07 | [us-07-freshness-indicator](us-07-freshness-indicator.md) | Fresh/Recent/Fading/Stale badge on movies in arena and library | Not started | Blocked by us-02 |
+| 08 | [us-08-arena-action-bar](us-08-arena-action-bar.md) | Bottom action bar with Skip, Stale(A/B), N/A, Not Watched(A/B). Watchlist stays on cards | Not started | Blocked by us-01, us-02, us-03, us-04 |
+
+US-01, US-02, US-04, US-06 can be built in parallel. US-03 shares recalc logic with US-01. US-05 depends on staleness and cooloff tables. US-08 is the UI integration that wires everything together.
+
+## Out of Scope
+
+- Post-watch debrief / rapid-fire review mode (separate PRD-063)
+- Batch comparison / tier list drag-and-drop UI (separate PRD-064)
+- TV show comparisons
+- AI-suggested pairs
+- Score decay over time (soft decay in ELO math — deferred, staleness model handles the user-facing concern)

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-01-blacklist-watch-history.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-01-blacklist-watch-history.md
@@ -1,0 +1,24 @@
+# US-01: Blacklist watch history ("Not watched")
+
+> PRD: [062 — Comparison Intelligence](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want to mark a movie as "not watched" (someone else used my account) so that its watch events are blacklisted, all its comparisons are purged, and ELO scores are recalculated without it.
+
+## Acceptance Criteria
+
+- [ ] `watch_history` table has a `blacklisted` INTEGER column, default 0
+- [ ] `media.comparisons.blacklistMovie` mutation accepts `{ mediaType, mediaId }` and sets `blacklisted = 1` on all watch_history rows for that movie
+- [ ] After blacklisting, all comparisons involving that movie (all dimensions) are deleted
+- [ ] ELO scores are recalculated (reset + replay) for every affected dimension
+- [ ] A movie with all watch events blacklisted is excluded from pair selection
+- [ ] Plex sync (library sync + cloud watch sync) skips inserting a watch event if a matching `(media_type, media_id, watched_at)` row exists with `blacklisted = 1`
+- [ ] New watch events for the same movie with a different `watched_at` are NOT blacklisted — they flow through normally
+- [ ] Arena "Not watched" button shows a confirmation dialog with the count of comparisons that will be purged
+- [ ] Tests: blacklist sets column, comparisons deleted, ELO recalculated, sync respects blacklist, new watch events pass through
+
+## Notes
+
+Blacklisted rows stay in the table — they are not deleted. This is critical for sync dedup: if the row were deleted, the next Plex sync would re-add the watch event.

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-02-staleness-model.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-02-staleness-model.md
@@ -1,0 +1,22 @@
+# US-02: Staleness model
+
+> PRD: [062 — Comparison Intelligence](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want to mark a movie as "stale" (I don't remember it well enough to compare) so that it appears less often in the arena, with the effect compounding each time I press the button.
+
+## Acceptance Criteria
+
+- [ ] `comparison_staleness` table with `(media_type, media_id, staleness, updated_at)` and unique index on `(media_type, media_id)`
+- [ ] `media.comparisons.markStale` mutation accepts `{ mediaType, mediaId }` — inserts with `staleness = 0.5` if no row exists, or multiplies existing staleness by 0.5 (floor at 0.01)
+- [ ] `media.comparisons.getStaleness` query returns staleness for a movie (default 1.0 if no row)
+- [ ] When a new watch event is inserted into `watch_history` for a movie, that movie's staleness resets to 1.0 (or row is deleted)
+- [ ] Arena "Stale" button for a movie does NOT submit a comparison — marks staleness and loads the next pair
+- [ ] Staleness value is available to the pair selection algorithm (US-05)
+- [ ] Tests: initial mark = 0.5, second mark = 0.25, third = 0.125, floor at 0.01, watch resets to 1.0
+
+## Notes
+
+Staleness is per-movie, not per-dimension. If you don't remember a movie, you don't remember it for any dimension. The pair selection algorithm uses this as a multiplier on both movies in a candidate pair.

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-03-dimension-exclusion.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-03-dimension-exclusion.md
@@ -1,0 +1,24 @@
+# US-03: Dimension exclusion ("Not applicable")
+
+> PRD: [062 — Comparison Intelligence](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want to mark a movie as "not applicable" for a specific dimension (e.g. cinematography doesn't apply to Inside Out 2) so that it's excluded from that dimension's rankings and never appears in pairs for that dimension.
+
+## Acceptance Criteria
+
+- [ ] `media_scores` table has an `excluded` INTEGER column, default 0
+- [ ] `media.comparisons.excludeFromDimension` mutation accepts `{ mediaType, mediaId, dimensionId }` — sets `excluded = 1` on the media_scores row (creates it if missing)
+- [ ] After excluding, all comparisons involving that movie for that specific dimension are deleted
+- [ ] ELO scores are recalculated (reset + replay) for that dimension
+- [ ] Excluded movies do not appear in pair selection for that dimension
+- [ ] Excluded movies do not appear in rankings for that dimension
+- [ ] `media.comparisons.includeInDimension` mutation allows undoing the exclusion (sets `excluded = 0`)
+- [ ] Arena "N/A" button excludes BOTH movies in the current pair for the current dimension, loads next pair
+- [ ] Tests: exclude sets column, comparisons purged, recalc correct, pair selection skips excluded, rankings omit excluded, re-include works
+
+## Notes
+
+Exclusion is per-movie per-dimension. A movie can be excluded from Cinematography but still compared on Entertainment. The "N/A" arena button affects both movies since neither is applicable for that dimension in the current matchup. Un-excluding is available from the movie detail page or dimension management UI.

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-04-skip-cooloff.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-04-skip-cooloff.md
@@ -1,0 +1,22 @@
+# US-04: Skip cooloff
+
+> PRD: [062 — Comparison Intelligence](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want "skip" to prevent the same pair from reappearing for the next 10 comparisons in that dimension.
+
+## Acceptance Criteria
+
+- [ ] `comparison_skip_cooloffs` table with `(dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, skip_until, created_at)` and unique index on pair+dimension
+- [ ] When "Skip" is pressed, a cooloff row is inserted with `skip_until = currentGlobalComparisonCount + 10`
+- [ ] Pair selection excludes pairs where `currentGlobalComparisonCount < skip_until`
+- [ ] Cooloff is per-pair per-dimension: skipping "A vs B" on Cinematography doesn't affect "A vs B" on Entertainment
+- [ ] Cooloff is symmetric: skipping "A vs B" also blocks "B vs A" for the same dimension
+- [ ] Expired cooloffs are ignored at query time (no cleanup needed)
+- [ ] Tests: skip inserts cooloff, pair excluded during cooloff, pair eligible after cooloff, symmetry enforced
+
+## Notes
+
+The cooloff count of 10 is a starting point; can be made configurable later. The global comparison count is the total number of rows in the `comparisons` table — a monotonically increasing value.

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-05-pair-selection-algorithm.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-05-pair-selection-algorithm.md
@@ -1,0 +1,29 @@
+# US-05: Pair selection algorithm
+
+> PRD: [062 — Comparison Intelligence](README.md)
+> Status: Not started
+
+## Description
+
+As the system, I select comparison pairs using a weighted probabilistic model so that each comparison maximises information gain about the user's taste.
+
+## Acceptance Criteria
+
+- [ ] Pair selection uses the priority formula from the PRD — not random
+- [ ] **Information gain**: pairs with close scores and few head-to-head comparisons are prioritised. Formula: `1 / (1 + abs(scoreA - scoreB) / 200) × (1 / (pairCount + 1))`
+- [ ] **Recency weight**: recently watched movies appear more often. Formula: `1 / (1 + daysSinceLastWatch / 180)` (6-month half-life)
+- [ ] **Staleness weight**: reads from `comparison_staleness` table. Default 1.0 if no row. Multiplied for both movies in the pair
+- [ ] **Dimension need**: under-sampled dimensions get boosted. Formula: `maxCompCount / (thisDimensionCompCount + 1)`
+- [ ] **Random jitter**: final priority multiplied by uniform random in [0.7, 1.3]
+- [ ] Selection is weighted random sampling from all eligible pairs — NOT deterministic top-pick
+- [ ] Exclusion rules applied before scoring: blacklisted, excluded for dimension, on cooloff, no valid watch events
+- [ ] Dimension selection uses weighted random (by dimension need) instead of round-robin rotation
+- [ ] Falls back to any eligible pair if weighted selection produces no candidates
+- [ ] Performance: pair selection completes in < 200ms for libraries up to 500 movies
+- [ ] Tests: information gain favours close-score pairs, recency favours recent watches, staleness reduces frequency, dimension need favours under-sampled, jitter produces variety across repeated calls
+
+## Notes
+
+The algorithm doesn't need to evaluate every possible pair. Sample a pool of ~50 eligible movies, generate candidate pairs from them, score each pair, then sample proportionally. This keeps it O(n) not O(n²).
+
+Dimension selection happens first (weighted random by need), then pair selection within that dimension. Two-stage process, not a single formula across all dimensions simultaneously.

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-06-score-confidence.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-06-score-confidence.md
@@ -1,0 +1,21 @@
+# US-06: Score confidence
+
+> PRD: [062 — Comparison Intelligence](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want to see how confident the ranking score is so I know which movies are well-established vs barely compared.
+
+## Acceptance Criteria
+
+- [ ] Confidence formula: `confidence = 1 - (1 / sqrt(comparisonCount + 1))` — derived at query time, not stored
+- [ ] Rankings API includes `confidence` (0–1 float) in each ranked entry
+- [ ] Rankings page shows confidence as a subtle visual (e.g. thin bar under the score, or percentage text like "82%")
+- [ ] Low-confidence scores (< 50%, i.e. fewer than 3 comparisons) are visually muted or annotated
+- [ ] Overall rankings confidence is the minimum confidence across active dimensions for that movie
+- [ ] Tests: confidence is 0 at count=0, ~0.29 at count=1, ~0.5 at count=3, ~0.82 at count=30
+
+## Notes
+
+Confidence is purely cosmetic in this US — it tells the user how much to trust a score. The pair selection algorithm (US-05) uses `comparisonCount` directly in its information gain formula, achieving the same prioritisation effect without depending on this number.

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-07-freshness-indicator.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-07-freshness-indicator.md
@@ -1,0 +1,26 @@
+# US-07: Freshness indicator
+
+> PRD: [062 — Comparison Intelligence](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want to see a freshness badge on movies so I know at a glance how recent my watch was and whether I've marked something as stale.
+
+## Acceptance Criteria
+
+- [ ] Freshness badge shows on movie cards in the compare arena (both cards)
+- [ ] Freshness badge shows on the movie detail page
+- [ ] Badge derived from `daysSinceLastWatch` (most recent non-blacklisted watch event):
+  - 0–30 days: "Fresh" (green)
+  - 31–90 days: "Recent" (blue)
+  - 91–365 days: "Fading" (yellow)
+  - 365+ days: "Stale" (red)
+- [ ] If the movie has a `comparison_staleness` row with `staleness < 1.0`, badge shows "Stale" (red) regardless of watch recency
+- [ ] Badge is a small pill/chip near the movie title or poster corner — not intrusive
+- [ ] Library page optionally shows freshness (e.g. as a sort option or filter, not on every card by default)
+- [ ] Tests: correct badge for each time range, stale override, no badge for unwatched movies
+
+## Notes
+
+The freshness badge is informational — it helps the user decide whether to mark something stale in the arena. The pair selection algorithm (US-05) uses `daysSinceLastWatch` for weighting independently, so the badge is the visual representation of the same signal.

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-08-arena-action-bar.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-08-arena-action-bar.md
@@ -1,0 +1,31 @@
+# US-08: Arena action bar
+
+> PRD: [062 — Comparison Intelligence](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want a unified action bar below the comparison cards with all arena actions so I can skip, mark stale, exclude, or purge without leaving the flow.
+
+## Acceptance Criteria
+
+- [ ] Bottom action bar with the following actions:
+  - **Skip** — applies per-pair cooloff (US-04), loads next pair, no comparison recorded
+  - **Stale (A)** — marks movie A as stale (US-02), loads next pair, no comparison recorded
+  - **Stale (B)** — marks movie B as stale (US-02), loads next pair, no comparison recorded
+  - **N/A** — excludes both movies from current dimension (US-03), loads next pair, no comparison recorded
+  - **Not watched (A)** — blacklists movie A's watch history (US-01), confirmation dialog, loads next pair
+  - **Not watched (B)** — blacklists movie B's watch history (US-01), confirmation dialog, loads next pair
+  - **Done** — navigates away from arena
+- [ ] Watchlist bookmark button stays on each movie card. Does NOT submit a comparison or affect the selection algorithm
+- [ ] Center column between cards shows High/Mid/Low draw tier buttons
+- [ ] "Stale" buttons show current staleness level for each movie (e.g. "Stale ×2" if marked before)
+- [ ] "Not watched" buttons use destructive styling (red) and trigger a confirmation dialog showing comparison count to be purged
+- [ ] All action bar buttons are disabled while a mutation is pending
+- [ ] Each action invalidates the pair cache and loads a fresh pair after completing
+- [ ] On mobile, secondary actions (N/A, Not watched) collapse into a "more" menu. Skip and Stale are always visible
+- [ ] Tests: each button calls the correct mutation, confirmation dialog for destructive actions, button states
+
+## Notes
+
+This is the final integration point — build it last. It depends on US-01 (blacklist), US-02 (staleness), US-03 (dimension exclusion), and US-04 (skip cooloff) for the underlying mutations.


### PR DESCRIPTION
## Summary
- PRD-062: Comparison Intelligence — 8 user stories covering probabilistic pair selection, staleness, dimension exclusion, watch blacklist, skip cooloff, score confidence, freshness indicators, arena action bar
- Fix incremental language in US-09 (tiered draws) and PRD-037 summary table
- Epic 04 updated to reference PRD-062

## Test plan
- [ ] Docs only — no code changes