### PR TITLE
feat(media): add confidence derivation helper [tb-134]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -1288,6 +1288,133 @@ describe("tiered draws", () => {
   });
 });
 
+describe("calculateConfidence", () => {
+  // Import the pure function directly for unit tests
+  it("returns 0 at count=0", async () => {
+    const { calculateConfidence } = await import("./types.js");
+    expect(calculateConfidence(0)).toBe(0);
+  });
+
+  it("returns ~0.29 at count=1", async () => {
+    const { calculateConfidence } = await import("./types.js");
+    expect(calculateConfidence(1)).toBeCloseTo(0.2929, 3);
+  });
+
+  it("returns ~0.5 at count=3", async () => {
+    const { calculateConfidence } = await import("./types.js");
+    expect(calculateConfidence(3)).toBeCloseTo(0.5, 1);
+  });
+
+  it("returns ~0.82 at count=30", async () => {
+    const { calculateConfidence } = await import("./types.js");
+    expect(calculateConfidence(30)).toBeCloseTo(0.8204, 2);
+  });
+});
+
+describe("confidence in API responses", () => {
+  it("scores endpoint includes confidence per entry", async () => {
+    const dimId = seedDimension(db, { name: "Story" });
+
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 2,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+
+    const result = await caller.media.comparisons.scores({
+      mediaType: "movie",
+      mediaId: 1,
+    });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]!.confidence).toBeCloseTo(0.2929, 3);
+    expect(result.data[0]!.comparisonCount).toBe(1);
+  });
+
+  it("per-dimension rankings include confidence", async () => {
+    const dimId = seedDimension(db, { name: "Visuals" });
+
+    // Do 2 comparisons so movie 1 has comparisonCount=2
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 2,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 3,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+
+    const result = await caller.media.comparisons.rankings({ dimensionId: dimId });
+    // Movie 1 has 2 comparisons
+    const movie1 = result.data.find((r) => r.mediaId === 1);
+    expect(movie1).toBeDefined();
+    expect(movie1!.confidence).toBeCloseTo(1 - 1 / Math.sqrt(3), 3); // count=2 → sqrt(3)
+  });
+
+  it("overall rankings confidence = min confidence across dimensions", async () => {
+    const dim1 = seedDimension(db, { name: "Story", active: 1 });
+    const dim2 = seedDimension(db, { name: "Visuals", active: 1 });
+
+    // Movie 1: 3 comparisons in dim1, 1 comparison in dim2
+    await caller.media.comparisons.record({
+      dimensionId: dim1,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 2,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dim1,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 3,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dim1,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 4,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dim2,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 2,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+
+    const result = await caller.media.comparisons.rankings({});
+    const movie1 = result.data.find((r) => r.mediaId === 1);
+    expect(movie1).toBeDefined();
+    // dim1: 3 comparisons → confidence ~0.5, dim2: 1 comparison → confidence ~0.29
+    // overall = min = ~0.29
+    expect(movie1!.confidence).toBeCloseTo(1 - 1 / Math.sqrt(2), 3); // count=1 → sqrt(2)
+  });
+});
+
 describe("comparisons auth", () => {
   it("rejects unauthenticated calls", async () => {
     const anonCaller = createCaller(false);

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -12,15 +12,16 @@ import {
   movies,
 } from "@pops/db-types";
 import { NotFoundError, ConflictError, ValidationError } from "../../../shared/errors.js";
-import type {
-  ComparisonDimensionRow,
-  ComparisonRow,
-  MediaScoreRow,
-  CreateDimensionInput,
-  UpdateDimensionInput,
-  RecordComparisonInput,
-  RandomPair,
-  RankedMediaEntry,
+import {
+  calculateConfidence,
+  type ComparisonDimensionRow,
+  type ComparisonRow,
+  type MediaScoreRow,
+  type CreateDimensionInput,
+  type UpdateDimensionInput,
+  type RecordComparisonInput,
+  type RandomPair,
+  type RankedMediaEntry,
 } from "./types.js";
 
 // ── Dimensions ──
@@ -682,6 +683,7 @@ export function getRankings(
         posterUrl: resolvePosterUrl(row),
         score: Math.round(row.score * 10) / 10,
         comparisonCount: row.comparisonCount,
+        confidence: calculateConfidence(row.comparisonCount),
       })),
       total: countResult.total,
     };
@@ -725,6 +727,7 @@ export function getRankings(
         ms.media_id as mediaId,
         SUM(ms.score * cd.weight) / SUM(cd.weight) as score,
         SUM(ms.comparison_count) as comparisonCount,
+        MIN(ms.comparison_count) as minComparisonCount,
         COALESCE(m.title, tv.name, 'Unknown') as title,
         CASE
           WHEN ms.media_type = 'movie' THEN CAST(SUBSTR(m.release_date, 1, 4) AS INTEGER)
@@ -753,6 +756,7 @@ export function getRankings(
     mediaId: number;
     score: number;
     comparisonCount: number;
+    minComparisonCount: number;
     title: string;
     year: number | null;
     moviePosterPath: string | null;
@@ -773,6 +777,7 @@ export function getRankings(
       posterUrl: resolvePosterUrl(row),
       score: Math.round(row.score * 10) / 10,
       comparisonCount: row.comparisonCount,
+      confidence: calculateConfidence(row.minComparisonCount),
     })),
     total: countResult.total,
   };

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -57,6 +57,15 @@ export function toComparison(row: ComparisonRow): Comparison {
   };
 }
 
+/**
+ * Derive confidence (0–1) from how many comparisons a media item has undergone.
+ * Formula: 1 - (1 / sqrt(comparisonCount + 1))
+ * At 0 comparisons → 0, at 1 → ~0.29, at 3 → ~0.5, at 30 → ~0.82.
+ */
+export function calculateConfidence(comparisonCount: number): number {
+  return 1 - 1 / Math.sqrt(comparisonCount + 1);
+}
+
 /** API response shape for a media score. */
 export interface MediaScore {
   id: number;
@@ -65,6 +74,7 @@ export interface MediaScore {
   dimensionId: number;
   score: number;
   comparisonCount: number;
+  confidence: number;
   updatedAt: string;
 }
 
@@ -76,6 +86,7 @@ export function toMediaScore(row: MediaScoreRow): MediaScore {
     dimensionId: row.dimensionId,
     score: row.score,
     comparisonCount: row.comparisonCount,
+    confidence: calculateConfidence(row.comparisonCount),
     updatedAt: row.updatedAt,
   };
 }
@@ -151,6 +162,7 @@ export interface RankedMediaEntry {
   posterUrl: string | null;
   score: number;
   comparisonCount: number;
+  confidence: number;
 }
 
 export const RankingsQuerySchema = z.object({


### PR DESCRIPTION
## Summary
- Add `calculateConfidence(comparisonCount)` pure function: `1 - (1 / sqrt(count + 1))`
- Include `confidence` (0–1 float) in both `scores` and `rankings` API responses
- Overall rankings confidence = minimum confidence across active dimensions for each media item

Closes #1197

## Test plan
- [x] Unit tests: confidence at count=0 → 0, count=1 → ~0.29, count=3 → ~0.5, count=30 → ~0.82
- [x] Integration: scores endpoint includes confidence per entry
- [x] Integration: per-dimension rankings include confidence
- [x] Integration: overall rankings confidence = min across dimensions
- [x] All 63 comparison tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)