### PR TITLE
feat(schema): add blacklisted column to watch_history [tb-130]

### DIFF
--- a/apps/pops-api/src/db/drizzle-migrations/0014_dapper_payback.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0014_dapper_payback.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `watch_history` ADD `blacklisted` integer DEFAULT 0 NOT NULL;

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1775264979050,
       "tag": "0013_worthless_speed",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1775272618156,
+      "tag": "0014_dapper_payback",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/pops-api/src/modules/media/plex/sync-discover-watches.test.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-watches.test.ts
@@ -93,6 +93,7 @@ function logWatchResult(created: boolean): ReturnType<typeof logWatch> {
       mediaId: 1,
       watchedAt: "2026-01-01T00:00:00.000Z",
       completed: 1,
+      blacklisted: 0,
     },
     created,
     watchlistRemoved: false,

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -246,7 +246,8 @@ export function createTestDb(): Database {
       media_type TEXT NOT NULL CHECK(media_type IN ('movie', 'episode')),
       media_id   INTEGER NOT NULL,
       watched_at TEXT NOT NULL DEFAULT (datetime('now')),
-      completed  INTEGER NOT NULL DEFAULT 1
+      completed  INTEGER NOT NULL DEFAULT 1,
+      blacklisted INTEGER NOT NULL DEFAULT 0
     );
     CREATE INDEX IF NOT EXISTS idx_watch_history_media ON watch_history(media_type, media_id);
     CREATE INDEX IF NOT EXISTS idx_watch_history_watched_at ON watch_history(watched_at);
@@ -868,13 +869,14 @@ export function seedWatchHistoryEntry(
     media_id: number;
     watched_at: string;
     completed: number;
+    blacklisted: number;
   }> = {}
 ): number {
   const result = db
     .prepare(
       `
-    INSERT INTO watch_history (media_type, media_id, watched_at, completed)
-    VALUES (@media_type, @media_id, @watched_at, @completed)
+    INSERT INTO watch_history (media_type, media_id, watched_at, completed, blacklisted)
+    VALUES (@media_type, @media_id, @watched_at, @completed, @blacklisted)
   `
     )
     .run({
@@ -882,6 +884,7 @@ export function seedWatchHistoryEntry(
       media_id: overrides.media_id ?? 1,
       watched_at: overrides.watched_at ?? new Date().toISOString(),
       completed: overrides.completed ?? 1,
+      blacklisted: overrides.blacklisted ?? 0,
     });
 
   return Number(result.lastInsertRowid);

--- a/packages/db-types/src/schema/watch-history.ts
+++ b/packages/db-types/src/schema/watch-history.ts
@@ -11,6 +11,7 @@ export const watchHistory = sqliteTable(
       .notNull()
       .default(sql`(datetime('now'))`),
     completed: integer("completed").notNull().default(1),
+    blacklisted: integer("blacklisted").notNull().default(0),
   },
   (table) => [
     index("idx_watch_history_media").on(table.mediaType, table.mediaId),


### PR DESCRIPTION
## Summary
- Adds `blacklisted` INTEGER column (default 0) to `watch_history` Drizzle schema
- Generates migration `0014_dapper_payback.sql`
- Updates `test-utils.ts` `createTestDb()` SQL and seed helper to include the new column
- Fixes type error in `sync-discover-watches.test.ts`

Closes #1189

## Test plan
- [x] Drizzle migration generated and reviewed
- [x] `db-types` rebuilt successfully
- [x] Typecheck passes across all workspace packages
- [x] Test type error fixed in sync-discover-watches

🤖 Generated with [Claude Code](https://claude.com/claude-code)