### PR TITLE
docs: fill search PRD specification gaps

### DIFF
--- a/docs/themes/01-foundation/prds/057-search-engine/README.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/README.md
@@ -26,7 +26,8 @@ interface SearchResult {
   type: string;                 // "movie"
   domain: string;               // "media"
   metadata?: Record<string, string>; // { year: "1999", rating: "8.8" }
-  score: number;                // relevance score for ranking
+  thumbnailUrl?: string;        // poster/icon URL if available
+  score: number;                // 0.0–1.0 relevance: exact=1.0, starts-with=0.8, contains=0.5
 }
 ```
 
@@ -57,6 +58,14 @@ v1 is plain text only. Structured syntax added as v2 USs.
 | 06 | [us-06-structured-syntax](us-06-structured-syntax.md) | Parse structured query syntax (type:, domain:, year:, value:) and apply filters | Not started | Blocked by us-05 |
 
 US-02, US-03, US-04 can parallelise (independent adapters).
+
+## Business Rules
+
+- Each adapter owns its scoring — the engine does not re-score. Score range is 0.0–1.0
+- Adapter failures are isolated — if one adapter throws, others still return results. Failed section is omitted with a console warning
+- Default result limit: 5 per section. "Show more" returns additional results for a single domain
+- Cross-section ordering: current app's domain first (from PRD-058 context), others alphabetical
+- Adapter registry location: `apps/pops-api/src/modules/core/search/`. Each domain adapter calls `registerSearchAdapter()` at startup
 
 ## Out of Scope
 

--- a/docs/themes/01-foundation/prds/057-search-engine/us-01-adapter-interface.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-01-adapter-interface.md
@@ -19,3 +19,5 @@ As a developer, I want a SearchAdapter interface and registration pattern so tha
 ## Notes
 
 The adapter pattern means the search engine doesn't know about domain internals. Each domain owns its search logic.
+
+The adapter registry lives in a `search` module under the API core: `apps/pops-api/src/modules/core/search/`. The registry is a plain array populated at startup — each domain adapter file calls `registerSearchAdapter()` during module initialization (side-effect import in the API entry point, same pattern as tRPC router composition). No dynamic discovery needed.

--- a/docs/themes/01-foundation/prds/057-search-engine/us-02-finance-adapter.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-02-finance-adapter.md
@@ -9,12 +9,18 @@ As a user, I want finance data searchable so that I can find transactions, entit
 
 ## Acceptance Criteria
 
-- [ ] Searches transactions by description (LIKE)
-- [ ] Searches entities by name (LIKE)
-- [ ] Searches budgets by category (LIKE)
+- [ ] Searches transactions by `description` column (case-insensitive LIKE)
+- [ ] Searches entities by `name` column (case-insensitive LIKE)
+- [ ] Searches budgets by `category` column (case-insensitive LIKE)
 - [ ] Results include: URI, title, type badge, relevant metadata (amount, date, entity type)
-- [ ] Relevance scoring: exact match > starts-with > contains
+- [ ] Relevance scoring: exact match (score 1.0) > starts-with (0.8) > contains (0.5)
+- [ ] Each adapter returns its own `score` field using this formula — the engine does not re-score
 
 ## Notes
 
 Transaction search returns the description + amount + date. Entity search returns name + type. Budget search returns category + period + amount.
+
+Columns searched per type:
+- **Transaction**: `description` only (not memo or tags — those are internal metadata)
+- **Entity**: `name` only
+- **Budget**: `category` only

--- a/docs/themes/01-foundation/prds/057-search-engine/us-03-media-adapter.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-03-media-adapter.md
@@ -9,11 +9,16 @@ As a user, I want media data searchable so that I can find movies and TV shows f
 
 ## Acceptance Criteria
 
-- [ ] Searches movies by title (LIKE)
-- [ ] Searches TV shows by name (LIKE)
+- [ ] Searches movies by `title` column (case-insensitive LIKE)
+- [ ] Searches TV shows by `name` column (case-insensitive LIKE)
 - [ ] Results include: URI, title, type badge, relevant metadata (year, rating)
-- [ ] Poster thumbnail in results if available
+- [ ] Poster thumbnail URL in results if poster_path is set
+- [ ] Relevance scoring: exact match (score 1.0) > starts-with (0.8) > contains (0.5)
 
 ## Notes
 
 Media search queries the local library only — not external APIs (TMDB/TheTVDB). External search is the media app's Search page.
+
+Columns searched per type:
+- **Movie**: `title` only (not `original_title` — user searches in their display language)
+- **TV show**: `name` only

--- a/docs/themes/01-foundation/prds/057-search-engine/us-05-fan-out-ranking.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-05-fan-out-ranking.md
@@ -9,14 +9,17 @@ As a developer, I want query fan-out to all adapters with context-aware ranking 
 
 ## Acceptance Criteria
 
-- [ ] Query sent to all registered adapters in parallel
-- [ ] Results collected and merged
-- [ ] Context from PRD-058 determines section ordering (current app first)
-- [ ] Within a section, results ordered by relevance score
-- [ ] Results limited per section (e.g., top 5 per domain, expandable)
-- [ ] Total result count per section for "show more" UI
-- [ ] Fast: total search time < 200ms for local queries
+- [ ] Query sent to all registered adapters in parallel (`Promise.allSettled`)
+- [ ] If one adapter fails, other results still returned — failed adapter's section omitted with console warning
+- [ ] Results collected and merged into sections (one per domain)
+- [ ] Context from PRD-058 determines section ordering (current app's domain first, others alphabetical)
+- [ ] Within a section, results ordered by `score` (descending) — adapters own their scoring
+- [ ] Results limited to 5 per section by default (configurable via `limit` param)
+- [ ] Response includes `totalCount` per section for "show more" UI
+- [ ] Fast: total search time < 200ms for libraries up to 500 items per domain
 
 ## Notes
 
 Fan-out is parallel — all adapters query simultaneously. The engine collects, sections, ranks, and returns. Context ordering is the key differentiator from a flat search.
+
+Score range is 0.0–1.0 (set by each adapter). The engine does NOT re-score — it trusts adapter scores for within-section ordering. Cross-section ordering is purely by context (current app first).

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/us-01-context-provider.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/us-01-context-provider.md
@@ -13,9 +13,11 @@ As a developer, I want a context provider that tracks the active app and exposes
 - [ ] Active app detected from URL path (`/media/*` → "media", `/finance/*` → "finance")
 - [ ] Updates automatically on navigation
 - [ ] `useAppContext()` hook returns current context
-- [ ] Default context when no app matched (e.g., root `/`)
+- [ ] Default context when no app matched (e.g. root `/`): `{ app: null, page: null, pageType: "top-level" }` — entity and filters are undefined
 - [ ] No re-renders in components that don't consume context
 
 ## Notes
 
 URL-based app detection is the baseline. Page-level context (US-02) adds richer information on top.
+
+The provider and hooks live in `packages/navigation/` (already exists as shared nav config). This avoids circular deps — shell, app packages, and `@pops/ui` can all import from `@pops/navigation` without depending on the shell.

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/us-03-context-consumer-api.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/us-03-context-consumer-api.md
@@ -18,4 +18,4 @@ As a developer, I want a clean API for consumers (Search, AI) to read the curren
 
 ## Notes
 
-Consumers should be able to import hooks from a shared location — either the shell re-exports them or they live in a shared package.
+Consumer hooks are exported from `@pops/navigation` (same package as the context provider, US-01). This means any package in the monorepo can import `useAppContext`, `useCurrentApp`, `useCurrentEntity` without depending on the shell.


### PR DESCRIPTION
## Summary
Fills 5 high-priority specification gaps identified in the search PRD audit:

**PRD-057 (Search Engine):**
- Adapter registry location: `core/search` module, startup registration pattern
- Exact columns per domain: transaction→description, entity→name, budget→category, movie→title, tv→name
- Score range: 0.0–1.0, owned by adapters (exact=1.0, starts-with=0.8, contains=0.5)
- Adapter failure isolation: `Promise.allSettled`, failed sections omitted
- Section ordering: current app first, others alphabetical
- Default limit: 5 per section with totalCount for show-more

**PRD-058 (Contextual Intelligence):**
- Default context: `{ app: null, page: null, pageType: "top-level" }`
- Consumer hooks exported from `@pops/navigation` package

## Test plan
- [ ] Docs only — no code changes