### PR TITLE
feat(media): add blacklistMovie service function [tb-135]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -8,6 +8,7 @@ import {
   seedWatchHistoryEntry,
   createCaller,
 } from "../../../shared/test-utils.js";
+import { blacklistMovie } from "./service.js";
 
 const ctx = setupTestContext();
 let caller: ReturnType<typeof createCaller>;
@@ -1419,5 +1420,174 @@ describe("comparisons auth", () => {
   it("rejects unauthenticated calls", async () => {
     const anonCaller = createCaller(false);
     await expect(anonCaller.media.comparisons.listDimensions()).rejects.toThrow(TRPCError);
+  });
+});
+
+describe("blacklistMovie", () => {
+  it("sets blacklisted=1 on matching watch_history rows", () => {
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: 10 });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: 10,
+      watched_at: "2026-01-02T00:00:00Z",
+    });
+
+    const result = blacklistMovie("movie", 10);
+    expect(result.blacklistedCount).toBe(2);
+
+    const rows = db.prepare("SELECT blacklisted FROM watch_history WHERE media_id = 10").all() as {
+      blacklisted: number;
+    }[];
+    expect(rows.every((r) => r.blacklisted === 1)).toBe(true);
+  });
+
+  it("does not blacklist unrelated movies", () => {
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: 10 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: 20 });
+
+    blacklistMovie("movie", 10);
+
+    const unrelated = db
+      .prepare("SELECT blacklisted FROM watch_history WHERE media_id = 20")
+      .get() as { blacklisted: number };
+    expect(unrelated.blacklisted).toBe(0);
+  });
+
+  it("deletes all comparisons involving the blacklisted movie", async () => {
+    const dimId = seedDimension(db, { name: "Story" });
+
+    // movie 10 vs 20, movie 10 vs 30, movie 20 vs 30
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: 10,
+      mediaBType: "movie",
+      mediaBId: 20,
+      winnerType: "movie",
+      winnerId: 10,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: 10,
+      mediaBType: "movie",
+      mediaBId: 30,
+      winnerType: "movie",
+      winnerId: 30,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: 20,
+      mediaBType: "movie",
+      mediaBId: 30,
+      winnerType: "movie",
+      winnerId: 20,
+    });
+
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: 10 });
+
+    const result = blacklistMovie("movie", 10);
+    expect(result.comparisonsDeleted).toBe(2); // 10v20 and 10v30
+
+    // Only the 20v30 comparison remains
+    const remaining = await caller.media.comparisons.listAll({});
+    expect(remaining.pagination.total).toBe(1);
+    expect(remaining.data[0]!.mediaAId).toBe(20);
+    expect(remaining.data[0]!.mediaBId).toBe(30);
+  });
+
+  it("recalculates ELO for affected dimensions", async () => {
+    const dimId = seedDimension(db, { name: "Story" });
+
+    // movie 10 beats 20, movie 20 beats 30
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: 10,
+      mediaBType: "movie",
+      mediaBId: 20,
+      winnerType: "movie",
+      winnerId: 10,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: 20,
+      mediaBType: "movie",
+      mediaBId: 30,
+      winnerType: "movie",
+      winnerId: 20,
+    });
+
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: 10 });
+
+    const result = blacklistMovie("movie", 10);
+    expect(result.dimensionsRecalculated).toBe(1);
+
+    // After blacklisting movie 10, only "20 beats 30" remains
+    // Both should be recalculated from 1500: winner gets 1516, loser gets 1484
+    const scores20 = await caller.media.comparisons.scores({ mediaType: "movie", mediaId: 20 });
+    const scores30 = await caller.media.comparisons.scores({ mediaType: "movie", mediaId: 30 });
+    expect(scores20.data[0]!.score).toBe(1516);
+    expect(scores30.data[0]!.score).toBe(1484);
+    expect(scores20.data[0]!.comparisonCount).toBe(1);
+
+    // Movie 10 scores should be reset to 1500 with 0 comparisons
+    const scores10 = await caller.media.comparisons.scores({ mediaType: "movie", mediaId: 10 });
+    expect(scores10.data[0]!.score).toBe(1500);
+    expect(scores10.data[0]!.comparisonCount).toBe(0);
+  });
+
+  it("handles multiple dimensions", async () => {
+    const dim1 = seedDimension(db, { name: "Story" });
+    const dim2 = seedDimension(db, { name: "Visuals" });
+
+    // Movie 10 vs 20 in both dimensions
+    await caller.media.comparisons.record({
+      dimensionId: dim1,
+      mediaAType: "movie",
+      mediaAId: 10,
+      mediaBType: "movie",
+      mediaBId: 20,
+      winnerType: "movie",
+      winnerId: 10,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dim2,
+      mediaAType: "movie",
+      mediaAId: 10,
+      mediaBType: "movie",
+      mediaBId: 20,
+      winnerType: "movie",
+      winnerId: 20,
+    });
+
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: 10 });
+
+    const result = blacklistMovie("movie", 10);
+    expect(result.comparisonsDeleted).toBe(2);
+    expect(result.dimensionsRecalculated).toBe(2);
+
+    // All comparisons gone
+    const remaining = await caller.media.comparisons.listAll({});
+    expect(remaining.pagination.total).toBe(0);
+  });
+
+  it("returns zero counts when movie has no watch history or comparisons", () => {
+    const result = blacklistMovie("movie", 999);
+    expect(result.blacklistedCount).toBe(0);
+    expect(result.comparisonsDeleted).toBe(0);
+    expect(result.dimensionsRecalculated).toBe(0);
+  });
+
+  it("is idempotent — re-blacklisting does not double-count", () => {
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: 10 });
+
+    const first = blacklistMovie("movie", 10);
+    expect(first.blacklistedCount).toBe(1);
+
+    const second = blacklistMovie("movie", 10);
+    expect(second.blacklistedCount).toBe(0); // already blacklisted
   });
 });

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -22,6 +22,7 @@ import {
   type RecordComparisonInput,
   type RandomPair,
   type RankedMediaEntry,
+  type BlacklistMovieResult,
 } from "./types.js";
 
 // ── Dimensions ──
@@ -366,6 +367,91 @@ export function deleteComparison(id: number): void {
         drawTier: comp.drawTier as "high" | "mid" | "low" | null,
       });
     }
+  })();
+}
+
+/**
+ * Blacklist a movie: mark all its watch_history rows as blacklisted,
+ * delete all comparisons involving it, and recalculate ELO for affected dimensions.
+ */
+export function blacklistMovie(mediaType: string, mediaId: number): BlacklistMovieResult {
+  const drizzleDb = getDrizzle();
+  const rawDb = getDb();
+
+  return rawDb.transaction(() => {
+    // 1. Set blacklisted = 1 on all watch_history rows for this media
+    const blacklistResult = rawDb
+      .prepare(
+        `UPDATE watch_history SET blacklisted = 1
+         WHERE media_type = ? AND media_id = ? AND blacklisted = 0`
+      )
+      .run(mediaType, mediaId);
+    const blacklistedCount = blacklistResult.changes;
+
+    // 2. Find all comparisons involving this media (either side)
+    const affectedComparisons = drizzleDb
+      .select()
+      .from(comparisons)
+      .where(
+        or(
+          and(eq(comparisons.mediaAType, mediaType), eq(comparisons.mediaAId, mediaId)),
+          and(eq(comparisons.mediaBType, mediaType), eq(comparisons.mediaBId, mediaId))
+        )
+      )
+      .all();
+
+    const comparisonsDeleted = affectedComparisons.length;
+
+    // 3. Collect affected dimension IDs (unique)
+    const affectedDimensionIds = [...new Set(affectedComparisons.map((c) => c.dimensionId))];
+
+    // 4. Delete all comparisons involving this media
+    if (comparisonsDeleted > 0) {
+      rawDb
+        .prepare(
+          `DELETE FROM comparisons
+           WHERE (media_a_type = ? AND media_a_id = ?)
+              OR (media_b_type = ? AND media_b_id = ?)`
+        )
+        .run(mediaType, mediaId, mediaType, mediaId);
+    }
+
+    // 5. Replay ELO for each affected dimension
+    for (const dimensionId of affectedDimensionIds) {
+      // Reset all scores in this dimension
+      drizzleDb
+        .update(mediaScores)
+        .set({ score: 1500.0, comparisonCount: 0, updatedAt: new Date().toISOString() })
+        .where(eq(mediaScores.dimensionId, dimensionId))
+        .run();
+
+      // Replay remaining comparisons chronologically
+      const remaining = drizzleDb
+        .select()
+        .from(comparisons)
+        .where(eq(comparisons.dimensionId, dimensionId))
+        .orderBy(asc(comparisons.comparedAt))
+        .all();
+
+      for (const comp of remaining) {
+        updateEloScores({
+          dimensionId: comp.dimensionId,
+          mediaAType: comp.mediaAType as "movie" | "tv_show",
+          mediaAId: comp.mediaAId,
+          mediaBType: comp.mediaBType as "movie" | "tv_show",
+          mediaBId: comp.mediaBId,
+          winnerType: comp.winnerType as "movie" | "tv_show",
+          winnerId: comp.winnerId,
+          drawTier: comp.drawTier as "high" | "mid" | "low" | null,
+        });
+      }
+    }
+
+    return {
+      blacklistedCount,
+      comparisonsDeleted,
+      dimensionsRecalculated: affectedDimensionIds.length,
+    };
   })();
 }
 

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -193,3 +193,15 @@ export const DeleteComparisonSchema = z.object({
   id: z.number().int().positive(),
 });
 export type DeleteComparisonInput = z.infer<typeof DeleteComparisonSchema>;
+
+export const BlacklistMovieSchema = z.object({
+  mediaType: z.enum(MEDIA_TYPES),
+  mediaId: z.number().int().positive(),
+});
+export type BlacklistMovieInput = z.infer<typeof BlacklistMovieSchema>;
+
+export interface BlacklistMovieResult {
+  blacklistedCount: number;
+  comparisonsDeleted: number;
+  dimensionsRecalculated: number;
+}


### PR DESCRIPTION
## Summary
- Add `blacklistMovie(mediaType, mediaId)` to comparisons service — marks watch_history rows as blacklisted, deletes all comparisons involving the movie (both sides), and replays ELO for each affected dimension
- Add `BlacklistMovieSchema` and `BlacklistMovieResult` types
- Add `blacklisted` column to test-utils `createTestDb()` watch_history table
- 7 new tests: blacklists correct rows, deletes comparisons, recalculates ELO, handles multiple dimensions, idempotent re-blacklist, unrelated movies unaffected, zero-count edge case

## Dependencies
- Depends on #1189 (tb-130: `blacklisted` column on watch_history schema) — must merge first

## Test plan
- [x] All 63 comparisons tests pass (56 existing + 7 new)
- [x] TypeScript typecheck clean
- [x] ESLint + Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)