### PR TITLE
feat(media): add skip cooloff service functions [tb-138]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -6,6 +6,7 @@ import { getDb, getDrizzle } from "../../../db.js";
 import {
   comparisonDimensions,
   comparisons,
+  comparisonSkipCooloffs,
   mediaScores,
   mediaWatchlist,
   watchHistory,
@@ -867,4 +868,128 @@ export function getRankings(
     })),
     total: countResult.total,
   };
+}
+
+// ── Skip Cooloff ──
+
+/** Get the total number of comparisons across all dimensions. */
+export function getGlobalComparisonCount(): number {
+  const db = getDrizzle();
+  const result = db.select({ total: count() }).from(comparisons).get();
+  return result?.total ?? 0;
+}
+
+/**
+ * Record a skip cooloff for a pair of media items in a dimension.
+ * Sets skip_until = current global comparison count + 10.
+ * Upserts if the pair already has a cooloff (extends it).
+ */
+export function recordSkip(
+  dimensionId: number,
+  mediaAType: string,
+  mediaAId: number,
+  mediaBType: string,
+  mediaBId: number
+): void {
+  const db = getDrizzle();
+  const globalCount = getGlobalComparisonCount();
+  const skipUntil = globalCount + 10;
+
+  // Normalize pair ordering for consistent storage (lower id first)
+  const [normAType, normAId, normBType, normBId] = normalizePairOrder(
+    mediaAType,
+    mediaAId,
+    mediaBType,
+    mediaBId
+  );
+
+  // Upsert: insert or update skip_until if pair already exists
+  const existing = db
+    .select()
+    .from(comparisonSkipCooloffs)
+    .where(
+      and(
+        eq(comparisonSkipCooloffs.dimensionId, dimensionId),
+        eq(comparisonSkipCooloffs.mediaAType, normAType),
+        eq(comparisonSkipCooloffs.mediaAId, normAId),
+        eq(comparisonSkipCooloffs.mediaBType, normBType),
+        eq(comparisonSkipCooloffs.mediaBId, normBId)
+      )
+    )
+    .get();
+
+  if (existing) {
+    db.update(comparisonSkipCooloffs)
+      .set({ skipUntil })
+      .where(eq(comparisonSkipCooloffs.id, existing.id))
+      .run();
+  } else {
+    db.insert(comparisonSkipCooloffs)
+      .values({
+        dimensionId,
+        mediaAType: normAType,
+        mediaAId: normAId,
+        mediaBType: normBType,
+        mediaBId: normBId,
+        skipUntil,
+      })
+      .run();
+  }
+}
+
+/**
+ * Check if a pair is currently on cooloff for a dimension.
+ * Returns true if global comparison count < skip_until.
+ * Symmetric: A-vs-B matches B-vs-A.
+ */
+export function isPairOnCooloff(
+  dimensionId: number,
+  mediaAType: string,
+  mediaAId: number,
+  mediaBType: string,
+  mediaBId: number
+): boolean {
+  const db = getDrizzle();
+  const globalCount = getGlobalComparisonCount();
+
+  // Normalize pair ordering for consistent lookup
+  const [normAType, normAId, normBType, normBId] = normalizePairOrder(
+    mediaAType,
+    mediaAId,
+    mediaBType,
+    mediaBId
+  );
+
+  const cooloff = db
+    .select()
+    .from(comparisonSkipCooloffs)
+    .where(
+      and(
+        eq(comparisonSkipCooloffs.dimensionId, dimensionId),
+        eq(comparisonSkipCooloffs.mediaAType, normAType),
+        eq(comparisonSkipCooloffs.mediaAId, normAId),
+        eq(comparisonSkipCooloffs.mediaBType, normBType),
+        eq(comparisonSkipCooloffs.mediaBId, normBId)
+      )
+    )
+    .get();
+
+  if (!cooloff) return false;
+  return globalCount < cooloff.skipUntil;
+}
+
+/**
+ * Normalize pair ordering so A-vs-B and B-vs-A map to the same row.
+ * Sorts by (mediaType, mediaId) to ensure consistent key.
+ */
+function normalizePairOrder(
+  aType: string,
+  aId: number,
+  bType: string,
+  bId: number
+): [string, number, string, number] {
+  const keyA = `${aType}:${aId}`;
+  const keyB = `${bType}:${bId}`;
+  if (keyA <= keyB) return [aType, aId, bType, bId];
+  return [bType, bId, aType, aId];
 }

--- a/apps/pops-api/src/modules/media/comparisons/skip-cooloff.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/skip-cooloff.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database } from "better-sqlite3";
+import {
+  setupTestContext,
+  seedDimension,
+  seedMovie,
+  seedWatchHistoryEntry,
+} from "../../../shared/test-utils.js";
+import {
+  recordSkip,
+  isPairOnCooloff,
+  getGlobalComparisonCount,
+  recordComparison,
+} from "./service.js";
+
+const ctx = setupTestContext();
+let db: Database;
+
+beforeEach(() => {
+  ({ db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+describe("skip cooloff", () => {
+  function seedComparisonPair() {
+    const dimId = seedDimension(db, { name: "Entertainment" });
+    const movieA = seedMovie(db, { title: "Movie A", tmdb_id: 100 });
+    const movieB = seedMovie(db, { title: "Movie B", tmdb_id: 200 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieA, completed: 1 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieB, completed: 1 });
+    return { dimId, movieA, movieB };
+  }
+
+  describe("getGlobalComparisonCount", () => {
+    it("returns 0 when no comparisons exist", () => {
+      expect(getGlobalComparisonCount()).toBe(0);
+    });
+
+    it("counts all comparisons across dimensions", () => {
+      const { dimId, movieA, movieB } = seedComparisonPair();
+      recordComparison({
+        dimensionId: dimId,
+        mediaAType: "movie",
+        mediaAId: movieA,
+        mediaBType: "movie",
+        mediaBId: movieB,
+        winnerType: "movie",
+        winnerId: movieA,
+      });
+      expect(getGlobalComparisonCount()).toBe(1);
+    });
+  });
+
+  describe("recordSkip", () => {
+    it("creates a cooloff entry for a skipped pair", () => {
+      const { dimId, movieA, movieB } = seedComparisonPair();
+      recordSkip(dimId, "movie", movieA, "movie", movieB);
+
+      const onCooloff = isPairOnCooloff(dimId, "movie", movieA, "movie", movieB);
+      expect(onCooloff).toBe(true);
+    });
+
+    it("upsert extends cooloff when pair already has one", () => {
+      const { dimId, movieA, movieB } = seedComparisonPair();
+
+      // First skip at global count 0 → skip_until = 10
+      recordSkip(dimId, "movie", movieA, "movie", movieB);
+
+      // Add 5 comparisons
+      const movieC = seedMovie(db, { title: "Movie C", tmdb_id: 300 });
+      seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieC, completed: 1 });
+      for (let i = 0; i < 5; i++) {
+        recordComparison({
+          dimensionId: dimId,
+          mediaAType: "movie",
+          mediaAId: movieA,
+          mediaBType: "movie",
+          mediaBId: movieC,
+          winnerType: "movie",
+          winnerId: movieA,
+        });
+      }
+      expect(getGlobalComparisonCount()).toBe(5);
+
+      // Second skip at global count 5 → skip_until = 15
+      recordSkip(dimId, "movie", movieA, "movie", movieB);
+
+      // Still on cooloff (5 < 15)
+      expect(isPairOnCooloff(dimId, "movie", movieA, "movie", movieB)).toBe(true);
+    });
+  });
+
+  describe("isPairOnCooloff", () => {
+    it("returns false when no cooloff exists", () => {
+      const { dimId, movieA, movieB } = seedComparisonPair();
+      expect(isPairOnCooloff(dimId, "movie", movieA, "movie", movieB)).toBe(false);
+    });
+
+    it("returns true during cooloff period", () => {
+      const { dimId, movieA, movieB } = seedComparisonPair();
+      recordSkip(dimId, "movie", movieA, "movie", movieB);
+
+      // Global count is 0, skip_until is 10
+      expect(isPairOnCooloff(dimId, "movie", movieA, "movie", movieB)).toBe(true);
+    });
+
+    it("returns false after 10 more comparisons", () => {
+      const { dimId, movieA, movieB } = seedComparisonPair();
+      recordSkip(dimId, "movie", movieA, "movie", movieB);
+      // skip_until = 10
+
+      // Add 10 comparisons to reach global count = 10
+      const movieC = seedMovie(db, { title: "Movie C", tmdb_id: 300 });
+      seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieC, completed: 1 });
+      for (let i = 0; i < 10; i++) {
+        recordComparison({
+          dimensionId: dimId,
+          mediaAType: "movie",
+          mediaAId: movieA,
+          mediaBType: "movie",
+          mediaBId: movieC,
+          winnerType: "movie",
+          winnerId: movieA,
+        });
+      }
+
+      expect(getGlobalComparisonCount()).toBe(10);
+      // Global count 10 is NOT < skip_until 10 → cooloff expired
+      expect(isPairOnCooloff(dimId, "movie", movieA, "movie", movieB)).toBe(false);
+    });
+
+    it("symmetry: checking B-vs-A matches A-vs-B", () => {
+      const { dimId, movieA, movieB } = seedComparisonPair();
+      // Skip with A, B order
+      recordSkip(dimId, "movie", movieA, "movie", movieB);
+
+      // Check with B, A order — should still be on cooloff
+      expect(isPairOnCooloff(dimId, "movie", movieB, "movie", movieA)).toBe(true);
+    });
+
+    it("symmetry: skip recorded as B-vs-A is found when checking A-vs-B", () => {
+      const { dimId, movieA, movieB } = seedComparisonPair();
+      // Skip with B, A order
+      recordSkip(dimId, "movie", movieB, "movie", movieA);
+
+      // Check with A, B order
+      expect(isPairOnCooloff(dimId, "movie", movieA, "movie", movieB)).toBe(true);
+    });
+  });
+});

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -239,6 +239,18 @@ export function createTestDb(): Database {
     );
     CREATE UNIQUE INDEX IF NOT EXISTS idx_comparison_staleness_unique ON comparison_staleness(media_type, media_id);
 
+    CREATE TABLE IF NOT EXISTS comparison_skip_cooloffs (
+      id               INTEGER PRIMARY KEY AUTOINCREMENT,
+      dimension_id     INTEGER NOT NULL REFERENCES comparison_dimensions(id),
+      media_a_type     TEXT NOT NULL,
+      media_a_id       INTEGER NOT NULL,
+      media_b_type     TEXT NOT NULL,
+      media_b_id       INTEGER NOT NULL,
+      skip_until       INTEGER NOT NULL,
+      created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_comparison_skip_cooloffs_pair ON comparison_skip_cooloffs(dimension_id, media_a_type, media_a_id, media_b_type, media_b_id);
+
     CREATE TABLE IF NOT EXISTS watchlist (
       id               INTEGER PRIMARY KEY AUTOINCREMENT,
       media_type       TEXT NOT NULL CHECK(media_type IN ('movie', 'tv_show')),


### PR DESCRIPTION
## Summary
- Implements recordSkip and isPairOnCooloff for comparison skip cooldowns (PRD-062, US-04)
- recordSkip upserts cooloff with skip_until = globalComparisonCount + 10
- isPairOnCooloff checks if global count < skip_until, with symmetric A/B matching
- Pair normalization ensures A-vs-B and B-vs-A map to same row

Depends on #1224 (tb-133 comparison_skip_cooloffs schema)
Closes #1196

## Test plan
- [x] 9 tests pass: creation, blocking, expiry after 10 comparisons, symmetry, upsert
- [x] Typecheck clean
- [ ] CI passes (after dep PR merges)

Generated with [Claude Code](https://claude.com/claude-code)