### PR TITLE
docs: templated search architecture with typed adapters

### DIFF
--- a/docs/ideas/app-ideas.md
+++ b/docs/ideas/app-ideas.md
@@ -32,6 +32,18 @@ Items from the original brainstorm that have been scoped into existing themes or
 - ~~**Subscriptions Tracker**~~ — Removed. No active streaming subscriptions. If needed in the future, lives as a finance feature, not a separate app.
 - ~~**Media Tracker** (original framing)~~ — Evolved from "tracker" to "preference learning and recommendation engine." The tracking is the input, recommendations are the output. See [media theme](../themes/03-media/README.md).
 
+## Search context enrichment (Option B)
+
+Deferred from PRD-057/058 v1 design (2026-04-04).
+
+v1 passes raw `SearchContext` (current app, page, entity, filters) to each adapter. Adapters use what they natively understand and ignore the rest. No cross-domain inference.
+
+The idea for v2: before fan-out, an enrichment layer extracts semantic tags from context. E.g. `location: "bedroom"` → tags: `["bedroom", "furniture", "home"]`. Tags are passed alongside raw context. Adapters can optionally boost results matching tags without understanding other domains' data models. The enrichment step could use Claude for semantic extraction, or a simpler keyword/category mapping.
+
+Use case: viewing bedroom inventory, search "lamp" → finance adapter boosts purchases tagged "furniture" or from home goods retailers. Without enrichment, finance ignores the inventory context entirely.
+
+Build this when the AI overlay (PRD-054) exists — the enrichment layer is a natural consumer of the same AI infrastructure.
+
 ## Cross-communication patterns
 
 These are the links that make POPS more than separate apps:

--- a/docs/themes/01-foundation/prds/056-search-ui/README.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/README.md
@@ -5,31 +5,35 @@
 
 ## Overview
 
-Build the search UI — a TopBar search bar with a results panel that shows context-aware sections. Current app results appear first, then results from other domains. Each result links to its page via universal object URIs (ADR-012).
+Build the search UI — a TopBar search bar with a results panel that shows context-aware sections. The current app's results appear first and are visually distinct. Each domain renders its own results using a registered `ResultComponent` — the search UI has no knowledge of domain-specific layouts.
 
 ## UX Flow
 
-1. User focuses the search bar (or presses keyboard shortcut)
-2. Types a query (e.g., "banana")
-3. Results appear in sections, ordered by relevance to current context:
-   - If on `/media`: Movies section first, then TV Shows, then Inventory, Finance, Entities
-   - If on `/inventory`: Items section first, then Finance, Media, Entities
-4. Each result shows: title, type badge, brief metadata
-5. Clicking a result navigates to that item's page
-6. Recent searches shown when input is empty
+1. User focuses the search bar (or presses `Cmd+K` / `Ctrl+K`)
+2. Types a query (e.g., "lamp")
+3. After 300ms debounce, the engine runs
+4. Results appear in sections:
+   - **Context section** (current app): visually highlighted, first 5 results
+   - **Other sections**: grouped by domain, ordered by relevance, 5 results each
+5. Each section has a header: app icon + domain label + result count
+6. Each result is rendered by the domain's `ResultComponent` — poster thumbnails for media, amount+date for finance, asset badge for inventory
+7. Matched text is highlighted within each result by the `ResultComponent`
+8. Clicking a result navigates to that item's page via URI resolution
+9. Recent searches shown when input is empty
 
 ## User Stories
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-search-bar](us-01-search-bar.md) | TopBar search input with keyboard shortcut, focus management | Not started | Yes |
-| 02 | [us-02-results-panel](us-02-results-panel.md) | Dropdown results panel with context-aware domain sections | Not started | Yes |
-| 03 | [us-03-result-navigation](us-03-result-navigation.md) | Click/keyboard-navigate results, link via URIs | Not started | Yes |
-| 04 | [us-04-recent-searches](us-04-recent-searches.md) | Recent search history shown when input is empty | Not started | Blocked by us-01 |
-| 05 | [us-05-keyboard-nav](us-05-keyboard-nav.md) | Arrow keys navigate results, Enter selects, Escape closes | Not started | Blocked by us-02 |
+| 01 | [us-01-search-bar](us-01-search-bar.md) | TopBar search input with keyboard shortcut, focus management, debounce | Not started | Yes |
+| 02 | [us-02-results-panel](us-02-results-panel.md) | Dropdown results panel rendering domain sections via registered ResultComponents | Not started | Yes |
+| 03 | [us-03-result-navigation](us-03-result-navigation.md) | Click/keyboard-navigate results, resolve URIs to routes | Not started | Yes |
+| 04 | [us-04-recent-searches](us-04-recent-searches.md) | Recent search history in localStorage, shown when input is empty | Not started | Blocked by us-01 |
+| 05 | [us-05-keyboard-nav](us-05-keyboard-nav.md) | Arrow keys navigate results across sections, Enter selects, Escape closes | Not started | Blocked by us-02 |
 
 ## Out of Scope
 
 - Search engine and domain adapters (PRD-057)
 - Contextual intelligence system (PRD-058)
-- Structured query syntax UI hints (part of PRD-057)
+- Structured query syntax UI hints (part of PRD-057 v2)
+- Context enrichment / semantic tagging (v2 idea — see ideas/app-ideas.md)

--- a/docs/themes/01-foundation/prds/056-search-ui/us-02-results-panel.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/us-02-results-panel.md
@@ -5,19 +5,24 @@
 
 ## Description
 
-As a user, I want search results grouped by domain with the current app's results first so that the most relevant results are immediately visible.
+As a user, I want search results grouped by domain with the current app's results first and visually distinct, each rendered by the domain's own component.
 
 ## Acceptance Criteria
 
 - [ ] Dropdown panel appears below search bar when results exist
-- [ ] Results grouped into domain sections (Movies, TV Shows, Transactions, Items, Entities, etc.)
-- [ ] Current app's domain section(s) appear first
-- [ ] Other domains follow in relevance order
-- [ ] Each section shows domain label + result count
+- [ ] Results grouped into domain sections
+- [ ] Each section header shows: app icon + domain label + total result count, themed with the domain's color
+- [ ] Context section (current app) appears first with a subtle visual distinction (e.g. highlighted background, border accent)
+- [ ] Other sections follow, ordered by highest score in section (descending)
+- [ ] Each hit rendered by the domain's registered `ResultComponent` — the results panel has no domain-specific rendering logic
+- [ ] Frontend maintains a `ResultComponent` registry keyed by domain (populated by each app package)
+- [ ] Default limit: 5 results per section. "Show more" link when `totalCount > 5` loads additional results
 - [ ] Empty sections hidden
-- [ ] "No results" state when query matches nothing
+- [ ] "No results" state when query matches nothing across all domains
 - [ ] Panel closes on outside click or Escape
 
 ## Notes
 
-Context comes from PRD-058. If the user is on `/media/movies/42`, the Movies section leads. If on `/inventory`, Items leads.
+Context comes from PRD-058. If the user is on `/media/movies/42`, the media section leads. If on `/inventory`, inventory leads.
+
+The `ResultComponent` registry is frontend-only — each app package registers its component at load time (same pattern as route registration). The search panel imports the registry and looks up components by domain name. If no component is registered for a domain, fall back to a generic one-line `title + type` display.

--- a/docs/themes/01-foundation/prds/057-search-engine/README.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/README.md
@@ -5,31 +5,49 @@
 
 ## Overview
 
-Build the search engine that powers platform-wide search. Cross-domain query fan-out, domain adapter interface, relevance ranking, and structured query syntax for power users.
+Build the search engine that powers platform-wide search. Cross-domain query fan-out, domain adapter interface with typed result components, relevance ranking, and structured query syntax for power users.
 
 ## Architecture
 
-Each domain registers a search adapter. The engine fans a query out to all adapters, collects results, ranks them, and returns context-ordered sections.
+Each domain registers a search adapter with a typed data shape and a React component for rendering its results. The engine fans a query out to all adapters, collects hits, ranks them, and returns context-ordered sections. The engine never touches result data — it only reads `uri` and `score` for routing and ranking.
 
-### Domain Adapter Interface
+### Interfaces
 
 ```typescript
-interface SearchAdapter {
-  domain: string;               // "finance", "media", "inventory"
-  types: string[];              // ["transaction", "entity", "budget"]
-  search(query: string, options?: { limit?: number }): SearchResult[];
+interface Query {
+  text: string;                          // raw user input
+  filters?: StructuredFilter[];          // v2: parsed type:, year:, etc.
 }
 
-interface SearchResult {
-  uri: string;                  // "pops:media/movie/42"
-  title: string;                // "Fight Club"
-  type: string;                 // "movie"
-  domain: string;               // "media"
-  metadata?: Record<string, string>; // { year: "1999", rating: "8.8" }
-  thumbnailUrl?: string;        // poster/icon URL if available
-  score: number;                // 0.0–1.0 relevance: exact=1.0, starts-with=0.8, contains=0.5
+interface SearchContext {
+  app: string | null;                    // current app: "media", "finance", etc.
+  page: string | null;                   // "library", "item-detail", etc.
+  entity?: {                             // entity being viewed, if any
+    uri: string;
+    type: string;
+    title: string;
+  };
+  filters?: Record<string, string>;      // active page filters
+}
+
+interface SearchAdapter<T = unknown> {
+  domain: string;                        // "finance", "media", "inventory"
+  icon: string;                          // lucide icon name for section header
+  color: string;                         // app color token for section theming
+  search(query: Query, context: SearchContext, options?: { limit?: number }): SearchHit<T>[];
+  ResultComponent: React.ComponentType<{ hit: SearchHit<T>; query: string }>;
+}
+
+interface SearchHit<T = unknown> {
+  uri: string;                           // "pops:media/movie/42"
+  score: number;                         // 0.0–1.0: exact=1.0, prefix=0.8, contains=0.5
+  matchField: string;                    // which field matched: "title", "description", "assetId"
+  matchType: "exact" | "prefix" | "contains";
+  data: T;                               // domain-specific, opaque to engine
 }
 ```
+
+The engine erases `T` to `unknown` in its internal registry. Each `ResultComponent` knows its own `T` and renders accordingly. Type safety within each domain, type erasure at the engine boundary.
 
 ### Structured Query Syntax (v2)
 
@@ -50,25 +68,29 @@ v1 is plain text only. Structured syntax added as v2 USs.
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-adapter-interface](us-01-adapter-interface.md) | Define SearchAdapter interface and registration pattern | Not started | No (first) |
-| 02 | [us-02-finance-adapter](us-02-finance-adapter.md) | Finance search adapter: transactions, entities, budgets | Not started | Blocked by us-01 |
-| 03 | [us-03-media-adapter](us-03-media-adapter.md) | Media search adapter: movies, TV shows | Not started | Blocked by us-01 |
-| 04 | [us-04-inventory-adapter](us-04-inventory-adapter.md) | Inventory search adapter: items by name, asset ID, type | Not started | Blocked by us-01 |
-| 05 | [us-05-fan-out-ranking](us-05-fan-out-ranking.md) | Query fan-out to all adapters, result collection, relevance ranking, context ordering | Not started | Blocked by us-02, us-03, us-04 |
+| 01 | [us-01-adapter-interface](us-01-adapter-interface.md) | SearchAdapter, SearchHit, Query, SearchContext interfaces and adapter registry | Not started | No (first) |
+| 02 | [us-02-finance-adapter](us-02-finance-adapter.md) | Finance adapter: transactions, entities, budgets with typed hits and ResultComponent | Not started | Blocked by us-01 |
+| 03 | [us-03-media-adapter](us-03-media-adapter.md) | Media adapter: movies, TV shows with poster thumbnails and ResultComponent | Not started | Blocked by us-01 |
+| 04 | [us-04-inventory-adapter](us-04-inventory-adapter.md) | Inventory adapter: items by name, asset ID with location badge and ResultComponent | Not started | Blocked by us-01 |
+| 05 | [us-05-fan-out-ranking](us-05-fan-out-ranking.md) | Query fan-out, context-aware section ordering, result collection | Not started | Blocked by us-02, us-03, us-04 |
 | 06 | [us-06-structured-syntax](us-06-structured-syntax.md) | Parse structured query syntax (type:, domain:, year:, value:) and apply filters | Not started | Blocked by us-05 |
 
 US-02, US-03, US-04 can parallelise (independent adapters).
 
 ## Business Rules
 
-- Each adapter owns its scoring — the engine does not re-score. Score range is 0.0–1.0
-- Adapter failures are isolated — if one adapter throws, others still return results. Failed section is omitted with a console warning
+- Each adapter owns its scoring and match information — the engine does not re-score or re-derive matches
+- Score range is 0.0–1.0 (exact=1.0, prefix=0.8, contains=0.5)
+- Adapter failures are isolated (`Promise.allSettled`) — if one adapter throws, others still return results. Failed section is omitted with a console warning
 - Default result limit: 5 per section. "Show more" returns additional results for a single domain
-- Cross-section ordering: current app's domain first (from PRD-058 context), others alphabetical
+- Cross-section ordering: current app's domain first (from SearchContext), others by highest-score-in-section descending
+- Each adapter receives `SearchContext` and may use it to boost results (e.g. inventory adapter boosts items in the current location). Adapters may also ignore context entirely
 - Adapter registry location: `apps/pops-api/src/modules/core/search/`. Each domain adapter calls `registerSearchAdapter()` at startup
+- `ResultComponent` is registered alongside the search function — the engine passes `hit` and `query` string, the component owns layout and match highlighting
 
 ## Out of Scope
 
 - Search UI (PRD-056)
 - Contextual intelligence (PRD-058)
 - Full-text search indexing (SQLite FTS5 — future if LIKE queries are too slow)
+- Context enrichment / semantic tagging (v2 idea — see ideas/app-ideas.md)

--- a/docs/themes/01-foundation/prds/057-search-engine/us-01-adapter-interface.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-01-adapter-interface.md
@@ -5,19 +5,21 @@
 
 ## Description
 
-As a developer, I want a SearchAdapter interface and registration pattern so that each domain can make its data searchable.
+As a developer, I want a SearchAdapter interface with typed results and a component registration pattern so that each domain can make its data searchable with its own result layout.
 
 ## Acceptance Criteria
 
-- [ ] `SearchAdapter` interface defined: domain, types, search method
-- [ ] `SearchResult` interface defined: uri, title, type, domain, metadata, score
-- [ ] Registration function: `registerSearchAdapter(adapter)` adds to adapter registry
-- [ ] `searchAll(query, context?)` fans query to all registered adapters
-- [ ] Adding a new domain's search = implement adapter + register it
-- [ ] Tests with mock adapters
+- [ ] `SearchAdapter<T>` interface: `domain`, `icon`, `color`, `search(query, context, options)`, `ResultComponent`
+- [ ] `SearchHit<T>` interface: `uri`, `score`, `matchField`, `matchType`, `data: T`
+- [ ] `Query` interface: `text`, optional `filters` (for v2 structured syntax)
+- [ ] `SearchContext` interface: `app`, `page`, optional `entity` and `filters` — sourced from PRD-058
+- [ ] `registerSearchAdapter(adapter)` adds to an adapter registry
+- [ ] `getAdapters()` returns all registered adapters
+- [ ] Type erasure at the registry boundary — registry stores `SearchAdapter<unknown>`, each adapter is internally typed
+- [ ] Tests with mock adapters: registration, retrieval, search call with query + context
 
 ## Notes
 
-The adapter pattern means the search engine doesn't know about domain internals. Each domain owns its search logic.
+The adapter registry lives in `apps/pops-api/src/modules/core/search/`. Each domain adapter calls `registerSearchAdapter()` during module initialization — same pattern as tRPC router composition (side-effect import in the API entry point).
 
-The adapter registry lives in a `search` module under the API core: `apps/pops-api/src/modules/core/search/`. The registry is a plain array populated at startup — each domain adapter file calls `registerSearchAdapter()` during module initialization (side-effect import in the API entry point, same pattern as tRPC router composition). No dynamic discovery needed.
+The `ResultComponent` lives in the frontend (app packages), not the API. The API-side adapter provides the search function; the frontend-side registration provides the component. Both are keyed by `domain`. The tRPC layer bridges them — the API returns `SearchHit<unknown>[]` per section, the frontend maps `domain → ResultComponent` to render.

--- a/docs/themes/01-foundation/prds/057-search-engine/us-02-finance-adapter.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-02-finance-adapter.md
@@ -5,22 +5,24 @@
 
 ## Description
 
-As a user, I want finance data searchable so that I can find transactions, entities, and budgets from the global search.
+As a user, I want finance data searchable so that I can find transactions, entities, and budgets from the global search, each rendered with finance-specific layout.
 
 ## Acceptance Criteria
 
+- [ ] Adapter registered with `domain: "finance"`, icon: `"DollarSign"`, color: `"green"`
 - [ ] Searches transactions by `description` column (case-insensitive LIKE)
 - [ ] Searches entities by `name` column (case-insensitive LIKE)
 - [ ] Searches budgets by `category` column (case-insensitive LIKE)
-- [ ] Results include: URI, title, type badge, relevant metadata (amount, date, entity type)
-- [ ] Relevance scoring: exact match (score 1.0) > starts-with (0.8) > contains (0.5)
-- [ ] Each adapter returns its own `score` field using this formula — the engine does not re-score
+- [ ] Relevance scoring: exact match (1.0) > prefix (0.8) > contains (0.5)
+- [ ] `matchField` and `matchType` set correctly per hit
+- [ ] Hit data shapes:
+  - Transaction: `{ description, amount, date, entityName, type: "income" | "expense" | "transfer" }`
+  - Entity: `{ name, type, aliases }`
+  - Budget: `{ category, period, amount }`
+- [ ] `ResultComponent` renders transactions with amount (green for income, red for expense) + date. Entities with type badge. Budgets with period + amount
+- [ ] `ResultComponent` highlights the matched portion of text using `query` prop + `matchField`/`matchType`
+- [ ] Tests: search returns correct hits, scoring is correct, match info is accurate
 
 ## Notes
 
-Transaction search returns the description + amount + date. Entity search returns name + type. Budget search returns category + period + amount.
-
-Columns searched per type:
-- **Transaction**: `description` only (not memo or tags — those are internal metadata)
-- **Entity**: `name` only
-- **Budget**: `category` only
+Transaction search uses `description` only — not memo or tags. Entity search uses `name` only. Budget search uses `category` only.

--- a/docs/themes/01-foundation/prds/057-search-engine/us-03-media-adapter.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-03-media-adapter.md
@@ -5,20 +5,23 @@
 
 ## Description
 
-As a user, I want media data searchable so that I can find movies and TV shows from the global search.
+As a user, I want media data searchable so that I can find movies and TV shows from the global search, each rendered with poster thumbnails.
 
 ## Acceptance Criteria
 
+- [ ] Adapter registered with `domain: "media"`, icon: `"Film"`, color: `"purple"`
 - [ ] Searches movies by `title` column (case-insensitive LIKE)
 - [ ] Searches TV shows by `name` column (case-insensitive LIKE)
-- [ ] Results include: URI, title, type badge, relevant metadata (year, rating)
-- [ ] Poster thumbnail URL in results if poster_path is set
-- [ ] Relevance scoring: exact match (score 1.0) > starts-with (0.8) > contains (0.5)
+- [ ] Relevance scoring: exact match (1.0) > prefix (0.8) > contains (0.5)
+- [ ] `matchField` and `matchType` set correctly per hit
+- [ ] Hit data shapes:
+  - Movie: `{ title, year, posterUrl, voteAverage }`
+  - TV show: `{ name, year, posterUrl, voteAverage, status }`
+- [ ] `ResultComponent` renders poster thumbnail (small, left-aligned) + title + year + rating
+- [ ] `ResultComponent` highlights the matched portion of the title using `query` prop + `matchField`/`matchType`
+- [ ] Poster URL points to local cache (`/media/images/movie/{tmdbId}/poster.jpg`)
+- [ ] Tests: search returns correct hits, poster URLs resolved, scoring correct
 
 ## Notes
 
-Media search queries the local library only — not external APIs (TMDB/TheTVDB). External search is the media app's Search page.
-
-Columns searched per type:
-- **Movie**: `title` only (not `original_title` — user searches in their display language)
-- **TV show**: `name` only
+Media search queries the local library only — not external APIs (TMDB/TheTVDB). External search is the media app's Search page. Only `title` (movies) and `name` (TV shows) are searched — not `original_title` or `original_name`.

--- a/docs/themes/01-foundation/prds/057-search-engine/us-04-inventory-adapter.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-04-inventory-adapter.md
@@ -5,15 +5,22 @@
 
 ## Description
 
-As a user, I want inventory data searchable so that I can find items by name or asset ID from the global search.
+As a user, I want inventory data searchable so that I can find items by name or asset ID from the global search, rendered with asset badges and location.
 
 ## Acceptance Criteria
 
-- [ ] Searches items by item_name (LIKE)
-- [ ] Searches items by asset_id (exact match, also partial)
-- [ ] Results include: URI, item name, type badge, asset ID, location
-- [ ] Asset ID matches ranked higher than name matches (exact identifier)
+- [ ] Adapter registered with `domain: "inventory"`, icon: `"Box"`, color: `"amber"`
+- [ ] Searches items by `item_name` column (case-insensitive LIKE)
+- [ ] Searches items by `asset_id` column (exact match first, then prefix match)
+- [ ] Asset ID exact matches score 1.0, prefix matches score 0.9 (higher than name matches — exact identifier)
+- [ ] Relevance scoring for name: exact (1.0) > prefix (0.8) > contains (0.5)
+- [ ] `matchField` set to `"assetId"` or `"itemName"` depending on what matched
+- [ ] If context has an entity with a location, boost items in that location (optional v1 enhancement)
+- [ ] Hit data shape: `{ itemName, assetId, location, type, condition }`
+- [ ] `ResultComponent` renders asset ID badge (monospace, prominent) + item name + location breadcrumb + type
+- [ ] `ResultComponent` highlights the matched portion using `query` prop + `matchField`/`matchType`
+- [ ] Tests: name search works, asset ID exact match ranks highest, scoring correct
 
 ## Notes
 
-Asset ID search is a key use case — look at a cable's tag (HDMI01), type it in search, find the item instantly.
+Asset ID search is a key use case — look at a cable's tag (HDMI01), type it in search, find the item instantly. Asset ID matches should always outrank name substring matches.

--- a/docs/themes/01-foundation/prds/057-search-engine/us-05-fan-out-ranking.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-05-fan-out-ranking.md
@@ -5,21 +5,23 @@
 
 ## Description
 
-As a developer, I want query fan-out to all adapters with context-aware ranking so that results are ordered by relevance.
+As the system, I fan a query out to all registered adapters with the current context and return context-ordered sections for the search UI to render.
 
 ## Acceptance Criteria
 
-- [ ] Query sent to all registered adapters in parallel (`Promise.allSettled`)
+- [ ] `searchAll(query: Query, context: SearchContext)` fans query + context to all registered adapters in parallel (`Promise.allSettled`)
 - [ ] If one adapter fails, other results still returned — failed adapter's section omitted with console warning
-- [ ] Results collected and merged into sections (one per domain)
-- [ ] Context from PRD-058 determines section ordering (current app's domain first, others alphabetical)
-- [ ] Within a section, results ordered by `score` (descending) — adapters own their scoring
-- [ ] Results limited to 5 per section by default (configurable via `limit` param)
-- [ ] Response includes `totalCount` per section for "show more" UI
+- [ ] Results collected into sections (one per domain)
+- [ ] Context section: current app's domain appears first, with visual distinction flag (`isContextSection: true`)
+- [ ] Context section returns first 5 hits
+- [ ] Other sections return first 5 hits each, ordered by highest score in section (descending)
+- [ ] Each section includes `totalCount` for "show more" UI
+- [ ] `showMore(domain, query, context, offset)` returns next page of results for a single domain
 - [ ] Fast: total search time < 200ms for libraries up to 500 items per domain
+- [ ] Response shape: `{ sections: Array<{ domain, icon, color, isContextSection, hits: SearchHit[], totalCount }> }`
 
 ## Notes
 
-Fan-out is parallel — all adapters query simultaneously. The engine collects, sections, ranks, and returns. Context ordering is the key differentiator from a flat search.
+Fan-out is parallel — all adapters query simultaneously. The engine collects, sections, and returns. It does NOT re-score hits — adapters own their scores. The engine only uses `score` for ordering sections relative to each other (by max score in section).
 
-Score range is 0.0–1.0 (set by each adapter). The engine does NOT re-score — it trusts adapter scores for within-section ordering. Cross-section ordering is purely by context (current app first).
+Context comes from PRD-058's `SearchContext`. The engine's only context-aware behavior is putting the matching domain first.


### PR DESCRIPTION
## Summary
Redesigns search interfaces based on design discussion:

- `SearchAdapter<T>` with generic `ResultComponent` — each domain owns its data shape AND its renderer
- `SearchHit<T>` with `matchField`/`matchType` — engine provides match info, components own highlighting
- `Query` + `SearchContext` passed to adapters — context-aware results (v1: adapters use what they understand)
- Engine only touches `uri`/`score` — `data: T` is opaque, rendering fully delegated to domain components
- Type erasure at registry boundary, full type safety within each domain

Also:
- Per-domain hit data shapes defined (finance, media, inventory)
- Context section gets `isContextSection` flag for visual distinction
- Frontend `ResultComponent` registry pattern documented
- Option B (semantic context enrichment) logged in ideas/app-ideas.md for v2

## Test plan
- [ ] Docs only — no code changes