### PR TITLE
feat(media): add dimension exclusion service [tb-137]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -8,7 +8,7 @@ import {
   seedWatchHistoryEntry,
   createCaller,
 } from "../../../shared/test-utils.js";
-import { blacklistMovie } from "./service.js";
+import { blacklistMovie, excludeFromDimension, includeInDimension } from "./service.js";
 
 const ctx = setupTestContext();
 let caller: ReturnType<typeof createCaller>;
@@ -1624,5 +1624,123 @@ describe("comparisons.blacklistMovie (tRPC)", () => {
     await expect(
       anonCaller.media.comparisons.blacklistMovie({ mediaType: "movie", mediaId: 1 })
     ).rejects.toThrow(TRPCError);
+  });
+});
+
+describe("dimension exclusion", () => {
+  it("excludeFromDimension sets excluded=1 on media_scores", () => {
+    const dimId = seedDimension(db, { name: "Dim" });
+    const movieId = seedMovie(db, { tmdb_id: 550, title: "Movie A" });
+    db.prepare(
+      "INSERT INTO media_scores (media_type, media_id, dimension_id, score, comparison_count, excluded) VALUES (?, ?, ?, ?, ?, ?)"
+    ).run("movie", movieId, dimId, 1600, 5, 0);
+
+    excludeFromDimension("movie", movieId, dimId);
+
+    const row = db
+      .prepare(
+        "SELECT excluded FROM media_scores WHERE media_type = ? AND media_id = ? AND dimension_id = ?"
+      )
+      .get("movie", movieId, dimId) as { excluded: number };
+    expect(row.excluded).toBe(1);
+  });
+
+  it("excludeFromDimension creates score row with excluded=1 if missing", () => {
+    const dimId = seedDimension(db, { name: "Dim" });
+    const movieId = seedMovie(db, { tmdb_id: 550, title: "Movie A" });
+
+    excludeFromDimension("movie", movieId, dimId);
+
+    const row = db
+      .prepare(
+        "SELECT excluded, score FROM media_scores WHERE media_type = ? AND media_id = ? AND dimension_id = ?"
+      )
+      .get("movie", movieId, dimId) as { excluded: number; score: number };
+    expect(row.excluded).toBe(1);
+    expect(row.score).toBe(1500);
+  });
+
+  it("excludeFromDimension purges comparisons for that dimension only", () => {
+    const dim1 = seedDimension(db, { name: "Dim1" });
+    const dim2 = seedDimension(db, { name: "Dim2" });
+    const m1 = seedMovie(db, { tmdb_id: 550, title: "Movie A" });
+    const m2 = seedMovie(db, { tmdb_id: 551, title: "Movie B" });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m1, completed: 1 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m2, completed: 1 });
+
+    db.prepare(
+      "INSERT INTO comparisons (dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, winner_type, winner_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run(dim1, "movie", m1, "movie", m2, "movie", m1);
+    db.prepare(
+      "INSERT INTO comparisons (dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, winner_type, winner_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run(dim2, "movie", m1, "movie", m2, "movie", m1);
+
+    excludeFromDimension("movie", m1, dim1);
+
+    const dim1Count = db
+      .prepare("SELECT COUNT(*) as c FROM comparisons WHERE dimension_id = ?")
+      .get(dim1) as { c: number };
+    const dim2Count = db
+      .prepare("SELECT COUNT(*) as c FROM comparisons WHERE dimension_id = ?")
+      .get(dim2) as { c: number };
+    expect(dim1Count.c).toBe(0);
+    expect(dim2Count.c).toBe(1); // dim2 untouched
+  });
+
+  it("excludeFromDimension recalculates ELO for affected dimension", () => {
+    const dimId = seedDimension(db, { name: "Dim" });
+    const m1 = seedMovie(db, { tmdb_id: 550, title: "Movie A" });
+    const m2 = seedMovie(db, { tmdb_id: 551, title: "Movie B" });
+    const m3 = seedMovie(db, { tmdb_id: 552, title: "Movie C" });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m1, completed: 1 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m2, completed: 1 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m3, completed: 1 });
+
+    for (const id of [m1, m2, m3]) {
+      db.prepare(
+        "INSERT INTO media_scores (media_type, media_id, dimension_id, score, comparison_count, excluded) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run("movie", id, dimId, 1500, 0, 0);
+    }
+
+    db.prepare(
+      "INSERT INTO comparisons (dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, winner_type, winner_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run(dimId, "movie", m2, "movie", m3, "movie", m2);
+    db.prepare(
+      "INSERT INTO comparisons (dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, winner_type, winner_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run(dimId, "movie", m1, "movie", m2, "movie", m1);
+
+    excludeFromDimension("movie", m1, dimId);
+
+    const scores = db
+      .prepare(
+        "SELECT media_id, score FROM media_scores WHERE dimension_id = ? AND excluded = 0 ORDER BY score DESC"
+      )
+      .all(dimId) as Array<{ media_id: number; score: number }>;
+
+    expect(scores.length).toBe(2);
+    expect(scores[0]!.media_id).toBe(m2);
+    expect(scores[0]!.score).toBeGreaterThan(scores[1]!.score);
+  });
+
+  it("includeInDimension sets excluded=0", () => {
+    const dimId = seedDimension(db, { name: "Dim" });
+    const movieId = seedMovie(db, { tmdb_id: 550, title: "Movie A" });
+    db.prepare(
+      "INSERT INTO media_scores (media_type, media_id, dimension_id, score, comparison_count, excluded) VALUES (?, ?, ?, ?, ?, ?)"
+    ).run("movie", movieId, dimId, 1500, 0, 1);
+
+    includeInDimension("movie", movieId, dimId);
+
+    const row = db
+      .prepare(
+        "SELECT excluded FROM media_scores WHERE media_type = ? AND media_id = ? AND dimension_id = ?"
+      )
+      .get("movie", movieId, dimId) as { excluded: number };
+    expect(row.excluded).toBe(0);
+  });
+
+  it("includeInDimension throws NOT_FOUND when no score row exists", () => {
+    const dimId = seedDimension(db, { name: "Dim" });
+    expect(() => includeInDimension("movie", 999, dimId)).toThrow();
   });
 });

--- a/apps/pops-api/src/modules/media/comparisons/router.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router.ts
@@ -16,6 +16,7 @@ import {
   ScoreQuerySchema,
   RandomPairQuerySchema,
   RankingsQuerySchema,
+  DimensionExclusionSchema,
   StalenessSchema,
   toDimension,
   toComparison,
@@ -156,6 +157,32 @@ export const comparisonsRouter = router({
       data: rows,
       pagination: paginationMeta(total, limit, offset),
     };
+  }),
+
+  /** Exclude a media item from a dimension (removes comparisons, recalculates Elo). */
+  excludeFromDimension: protectedProcedure.input(DimensionExclusionSchema).mutation(({ input }) => {
+    try {
+      service.excludeFromDimension(input.mediaType, input.mediaId, input.dimensionId);
+      return { message: "Media excluded from dimension" };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
+  }),
+
+  /** Re-include a media item in a dimension. */
+  includeInDimension: protectedProcedure.input(DimensionExclusionSchema).mutation(({ input }) => {
+    try {
+      service.includeInDimension(input.mediaType, input.mediaId, input.dimensionId);
+      return { message: "Media included in dimension" };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
   }),
 
   /** Mark a media item as stale (compounds ×0.5 each call, floor 0.01). */

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -341,33 +341,8 @@ export function deleteComparison(id: number): void {
     // Delete the comparison
     drizzleDb.delete(comparisons).where(eq(comparisons.id, id)).run();
 
-    // Reset all scores for this dimension
-    drizzleDb
-      .update(mediaScores)
-      .set({ score: 1500.0, comparisonCount: 0, updatedAt: new Date().toISOString() })
-      .where(eq(mediaScores.dimensionId, dimensionId))
-      .run();
-
-    // Replay all remaining comparisons in chronological order
-    const remaining = drizzleDb
-      .select()
-      .from(comparisons)
-      .where(eq(comparisons.dimensionId, dimensionId))
-      .orderBy(asc(comparisons.comparedAt))
-      .all();
-
-    for (const comp of remaining) {
-      updateEloScores({
-        dimensionId: comp.dimensionId,
-        mediaAType: comp.mediaAType as "movie" | "tv_show",
-        mediaAId: comp.mediaAId,
-        mediaBType: comp.mediaBType as "movie" | "tv_show",
-        mediaBId: comp.mediaBId,
-        winnerType: comp.winnerType as "movie" | "tv_show",
-        winnerId: comp.winnerId,
-        drawTier: comp.drawTier as "high" | "mid" | "low" | null,
-      });
-    }
+    // Recalculate ELO for the affected dimension
+    recalcDimensionElo(dimensionId);
   })();
 }
 
@@ -868,6 +843,141 @@ export function getRankings(
     })),
     total: countResult.total,
   };
+}
+
+// ── Dimension Exclusion ──
+
+/**
+ * Recalculate ELO scores for a dimension by resetting all scores and replaying
+ * all comparisons in chronological order.
+ */
+function recalcDimensionElo(dimensionId: number): void {
+  const drizzleDb = getDrizzle();
+
+  // Reset all scores for this dimension
+  drizzleDb
+    .update(mediaScores)
+    .set({ score: 1500.0, comparisonCount: 0, updatedAt: new Date().toISOString() })
+    .where(eq(mediaScores.dimensionId, dimensionId))
+    .run();
+
+  // Replay all remaining comparisons in chronological order
+  const remaining = drizzleDb
+    .select()
+    .from(comparisons)
+    .where(eq(comparisons.dimensionId, dimensionId))
+    .orderBy(asc(comparisons.comparedAt))
+    .all();
+
+  for (const comp of remaining) {
+    updateEloScores({
+      dimensionId: comp.dimensionId,
+      mediaAType: comp.mediaAType as "movie" | "tv_show",
+      mediaAId: comp.mediaAId,
+      mediaBType: comp.mediaBType as "movie" | "tv_show",
+      mediaBId: comp.mediaBId,
+      winnerType: comp.winnerType as "movie" | "tv_show",
+      winnerId: comp.winnerId,
+      drawTier: comp.drawTier as "high" | "mid" | "low" | null,
+    });
+  }
+}
+
+/**
+ * Exclude a media item from a dimension: sets excluded=1 on the media_scores row
+ * (creates with score 1500 + excluded=1 if missing), deletes all comparisons
+ * involving that item for this dimension, and recalculates ELO.
+ */
+export function excludeFromDimension(
+  mediaType: string,
+  mediaId: number,
+  dimensionId: number
+): void {
+  getDimension(dimensionId); // verify exists
+  const drizzleDb = getDrizzle();
+  const rawDb = getDb();
+
+  rawDb.transaction(() => {
+    // Upsert media_scores row with excluded=1
+    const existing = drizzleDb
+      .select()
+      .from(mediaScores)
+      .where(
+        and(
+          eq(mediaScores.mediaType, mediaType),
+          eq(mediaScores.mediaId, mediaId),
+          eq(mediaScores.dimensionId, dimensionId)
+        )
+      )
+      .get();
+
+    if (existing) {
+      drizzleDb
+        .update(mediaScores)
+        .set({ excluded: 1, updatedAt: new Date().toISOString() })
+        .where(eq(mediaScores.id, existing.id))
+        .run();
+    } else {
+      drizzleDb
+        .insert(mediaScores)
+        .values({
+          mediaType,
+          mediaId,
+          dimensionId,
+          score: 1500.0,
+          comparisonCount: 0,
+          excluded: 1,
+        })
+        .run();
+    }
+
+    // Delete all comparisons involving this media item for this dimension
+    drizzleDb
+      .delete(comparisons)
+      .where(
+        and(
+          eq(comparisons.dimensionId, dimensionId),
+          or(
+            and(eq(comparisons.mediaAType, mediaType), eq(comparisons.mediaAId, mediaId)),
+            and(eq(comparisons.mediaBType, mediaType), eq(comparisons.mediaBId, mediaId))
+          )
+        )
+      )
+      .run();
+
+    // Recalculate ELO for this dimension
+    recalcDimensionElo(dimensionId);
+  })();
+}
+
+/**
+ * Re-include a media item in a dimension: sets excluded=0.
+ */
+export function includeInDimension(mediaType: string, mediaId: number, dimensionId: number): void {
+  getDimension(dimensionId); // verify exists
+  const drizzleDb = getDrizzle();
+
+  const existing = drizzleDb
+    .select()
+    .from(mediaScores)
+    .where(
+      and(
+        eq(mediaScores.mediaType, mediaType),
+        eq(mediaScores.mediaId, mediaId),
+        eq(mediaScores.dimensionId, dimensionId)
+      )
+    )
+    .get();
+
+  if (!existing) {
+    throw new NotFoundError("MediaScore", `${mediaType}:${mediaId}:${dimensionId}`);
+  }
+
+  drizzleDb
+    .update(mediaScores)
+    .set({ excluded: 0, updatedAt: new Date().toISOString() })
+    .where(eq(mediaScores.id, existing.id))
+    .run();
 }
 
 // ── Skip Cooloff ──

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -206,6 +206,13 @@ export interface BlacklistMovieResult {
   dimensionsRecalculated: number;
 }
 
+export const DimensionExclusionSchema = z.object({
+  mediaType: z.enum(MEDIA_TYPES),
+  mediaId: z.number().int().positive(),
+  dimensionId: z.number().int().positive(),
+});
+export type DimensionExclusionInput = z.infer<typeof DimensionExclusionSchema>;
+
 export const StalenessSchema = z.object({
   mediaType: z.enum(MEDIA_TYPES),
   mediaId: z.number().int().positive(),


### PR DESCRIPTION
## Summary
- Add `excludeFromDimension(mediaType, mediaId, dimensionId)` — sets excluded=1 on media_scores, purges comparisons for that dimension, recalculates ELO
- Add `includeInDimension(mediaType, mediaId, dimensionId)` — sets excluded=0 to re-include
- Add tRPC endpoints: `excludeFromDimension` and `includeInDimension` mutations
- Refactor `deleteComparison` to reuse shared `recalcDimensionElo` helper
- 6 new tests covering: exclude sets column, creates row if missing, purges only affected dimension, recalc correct, re-include works, NOT_FOUND on missing

Depends on: #1190 (tb-131: excluded column on media_scores)
Closes #1195

## Test plan
- [x] Typecheck passes
- [x] 6 dimension exclusion tests
- [ ] CI full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)