### PR TITLE
feat(media): add markStale + getStaleness tRPC endpoints [tb-142]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/router.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router.ts
@@ -15,11 +15,13 @@ import {
   ScoreQuerySchema,
   RandomPairQuerySchema,
   RankingsQuerySchema,
+  StalenessSchema,
   toDimension,
   toComparison,
   toMediaScore,
 } from "./types.js";
 import * as service from "./service.js";
+import * as stalenessService from "./staleness.js";
 import { NotFoundError, ConflictError, ValidationError } from "../../../shared/errors.js";
 
 const DEFAULT_LIMIT = 50;
@@ -147,5 +149,17 @@ export const comparisonsRouter = router({
       data: rows,
       pagination: paginationMeta(total, limit, offset),
     };
+  }),
+
+  /** Mark a media item as stale (compounds ×0.5 each call, floor 0.01). */
+  markStale: protectedProcedure.input(StalenessSchema).mutation(({ input }) => {
+    const staleness = stalenessService.markStale(input.mediaType, input.mediaId);
+    return { data: { staleness } };
+  }),
+
+  /** Get the staleness value for a media item (default 1.0 = fresh). */
+  getStaleness: protectedProcedure.input(StalenessSchema).query(({ input }) => {
+    const staleness = stalenessService.getStaleness(input.mediaType, input.mediaId);
+    return { data: { staleness } };
   }),
 });

--- a/apps/pops-api/src/modules/media/comparisons/staleness-api.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/staleness-api.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database } from "better-sqlite3";
+import {
+  setupTestContext,
+  seedMovie,
+  seedWatchHistoryEntry,
+  createCaller,
+} from "../../../shared/test-utils.js";
+
+const ctx = setupTestContext();
+let caller: ReturnType<typeof createCaller>;
+let db: Database;
+
+beforeEach(() => {
+  ({ caller, db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+describe("comparisons.markStale", () => {
+  it("marks a media item as stale (returns 0.5)", async () => {
+    seedMovie(db, { title: "Test Movie", tmdb_id: 100 });
+
+    const result = await caller.media.comparisons.markStale({
+      mediaType: "movie",
+      mediaId: 1,
+    });
+
+    expect(result.data.staleness).toBe(0.5);
+  });
+
+  it("compounds staleness on second call (0.5 × 0.5 = 0.25)", async () => {
+    seedMovie(db, { title: "Test Movie", tmdb_id: 100 });
+
+    await caller.media.comparisons.markStale({ mediaType: "movie", mediaId: 1 });
+    const result = await caller.media.comparisons.markStale({
+      mediaType: "movie",
+      mediaId: 1,
+    });
+
+    expect(result.data.staleness).toBe(0.25);
+  });
+});
+
+describe("comparisons.getStaleness", () => {
+  it("returns 1.0 for a fresh media item (no staleness row)", async () => {
+    seedMovie(db, { title: "Test Movie", tmdb_id: 100 });
+
+    const result = await caller.media.comparisons.getStaleness({
+      mediaType: "movie",
+      mediaId: 1,
+    });
+
+    expect(result.data.staleness).toBe(1.0);
+  });
+
+  it("returns correct value after marking stale", async () => {
+    seedMovie(db, { title: "Test Movie", tmdb_id: 100 });
+
+    await caller.media.comparisons.markStale({ mediaType: "movie", mediaId: 1 });
+
+    const result = await caller.media.comparisons.getStaleness({
+      mediaType: "movie",
+      mediaId: 1,
+    });
+
+    expect(result.data.staleness).toBe(0.5);
+  });
+
+  it("returns 1.0 after watch resets staleness", async () => {
+    const movieId = seedMovie(db, { title: "Test Movie", tmdb_id: 100 });
+
+    // Mark stale
+    await caller.media.comparisons.markStale({ mediaType: "movie", mediaId: movieId });
+    const stale = await caller.media.comparisons.getStaleness({
+      mediaType: "movie",
+      mediaId: movieId,
+    });
+    expect(stale.data.staleness).toBe(0.5);
+
+    // Simulate watch completing (inserts watch history which resets staleness)
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieId, completed: 1 });
+    // Manually reset staleness (watch-history service does this, but we're testing via tRPC)
+    db.prepare("DELETE FROM comparison_staleness WHERE media_type = ? AND media_id = ?").run(
+      "movie",
+      movieId
+    );
+
+    const fresh = await caller.media.comparisons.getStaleness({
+      mediaType: "movie",
+      mediaId: movieId,
+    });
+    expect(fresh.data.staleness).toBe(1.0);
+  });
+});

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -205,3 +205,9 @@ export interface BlacklistMovieResult {
   comparisonsDeleted: number;
   dimensionsRecalculated: number;
 }
+
+export const StalenessSchema = z.object({
+  mediaType: z.enum(MEDIA_TYPES),
+  mediaId: z.number().int().positive(),
+});
+export type StalenessInput = z.infer<typeof StalenessSchema>;


### PR DESCRIPTION
## Summary
- Adds markStale mutation and getStaleness query to comparisons tRPC router
- markStale compounds staleness x0.5 per call (floor 0.01)
- getStaleness returns staleness float (default 1.0 = fresh)
- Includes comparison_staleness schema + staleness service from tb-132/tb-136

Depends on #1225 (tb-132 staleness schema) and #1227 (tb-136 staleness CRUD)
Closes #1202

## Test plan
- [x] 5 tRPC integration tests pass (mark, compound, get fresh, get stale, reset)
- [x] Typecheck clean
- [ ] CI passes (after dep PRs merge)