### PR TITLE
feat(media): add confidence display to rankings page [tb-145]

### DIFF
--- a/packages/app-media/src/pages/RankingsPage.test.tsx
+++ b/packages/app-media/src/pages/RankingsPage.test.tsx
@@ -37,6 +37,7 @@ const rankedEntries = [
     posterUrl: "/a.jpg",
     score: 1532,
     comparisonCount: 5,
+    confidence: 0.59,
   },
   {
     rank: 2,
@@ -47,6 +48,7 @@ const rankedEntries = [
     posterUrl: "/b.jpg",
     score: 1468,
     comparisonCount: 5,
+    confidence: 0.59,
   },
 ];
 
@@ -169,6 +171,7 @@ describe("RankingsPage", () => {
       posterUrl: null,
       score: 1600 - i * 4,
       comparisonCount: 3,
+      confidence: 0.5,
     }));
 
     mockRankingsQuery.mockReturnValue({
@@ -216,6 +219,7 @@ describe("RankingsPage", () => {
         posterUrl: null,
         score: 1600,
         comparisonCount: 10,
+        confidence: 0.7,
       },
       {
         rank: 2,
@@ -226,6 +230,7 @@ describe("RankingsPage", () => {
         posterUrl: null,
         score: 1550,
         comparisonCount: 10,
+        confidence: 0.7,
       },
       {
         rank: 3,
@@ -236,6 +241,7 @@ describe("RankingsPage", () => {
         posterUrl: null,
         score: 1500,
         comparisonCount: 10,
+        confidence: 0.7,
       },
     ];
 
@@ -254,6 +260,13 @@ describe("RankingsPage", () => {
     expect(screen.getByText("#3")).toBeInTheDocument();
   });
 
+  it("displays confidence percentage for items with comparisons", () => {
+    renderPage();
+    // Both entries have confidence 0.59 → 59% conf
+    const confLabels = screen.getAllByText("59% conf");
+    expect(confLabels).toHaveLength(2);
+  });
+
   it("shows 'Unknown' for media without metadata", () => {
     mockRankingsQuery.mockReturnValue({
       data: {
@@ -267,6 +280,7 @@ describe("RankingsPage", () => {
             posterUrl: null,
             score: 1500,
             comparisonCount: 1,
+            confidence: 0.29,
           },
         ],
         pagination: { total: 1, limit: 25, offset: 0, hasMore: false },

--- a/packages/app-media/src/pages/RankingsPage.tsx
+++ b/packages/app-media/src/pages/RankingsPage.tsx
@@ -45,6 +45,7 @@ interface RankingRowProps {
   mediaId: number;
   score: number;
   comparisonCount: number;
+  confidence: number;
   title: string;
   year: number | null;
   posterUrl: string | null;
@@ -56,6 +57,7 @@ function RankingRow({
   mediaId,
   score,
   comparisonCount,
+  confidence,
   title,
   year,
   posterUrl,
@@ -107,6 +109,20 @@ function RankingRow({
         <div className="text-xs text-muted-foreground">
           {comparisonCount} {comparisonCount === 1 ? "match" : "matches"}
         </div>
+        {comparisonCount > 0 && (
+          <div
+            className={cn(
+              "text-xs tabular-nums",
+              confidence >= 0.7
+                ? "text-green-600 dark:text-green-400"
+                : confidence >= 0.4
+                  ? "text-yellow-600 dark:text-yellow-400"
+                  : "text-red-500 dark:text-red-400"
+            )}
+          >
+            {Math.round(confidence * 100)}% conf
+          </div>
+        )}
       </div>
     </div>
   );
@@ -159,6 +175,7 @@ function RankingsList({ dimensionId }: { dimensionId?: number }) {
             posterUrl: string | null;
             score: number;
             comparisonCount: number;
+            confidence: number;
           }) => (
             <RankingRow
               key={`${entry.mediaType}-${entry.mediaId}`}
@@ -167,6 +184,7 @@ function RankingsList({ dimensionId }: { dimensionId?: number }) {
               mediaId={entry.mediaId}
               score={entry.score}
               comparisonCount={entry.comparisonCount}
+              confidence={entry.confidence}
               title={entry.title}
               year={entry.year}
               posterUrl={entry.posterUrl}


### PR DESCRIPTION
## Summary
- Adds `confidence` field to `RankingRowProps` and inline type in `RankingsPage.tsx`
- Displays confidence as color-coded percentage (green >= 70%, yellow >= 40%, red < 40%)
- Only shown for items with at least 1 comparison
- Updates test mock data to include confidence values
- Adds test verifying confidence display

Closes #1205

## Test plan
- [x] Typecheck passes (pops-api + pops-shell)
- [x] Formatting clean (prettier)
- [x] Test for confidence display added
- [x] Backend already serves confidence in RankedMediaEntry (tb-134)

🤖 Generated with [Claude Code](https://claude.com/claude-code)