### PR TITLE
docs: PRD-063 post-watch debrief + PRD-064 batch tier list

### DIFF
--- a/docs/themes/03-media/epics/04-ratings-comparisons.md
+++ b/docs/themes/03-media/epics/04-ratings-comparisons.md
@@ -12,6 +12,8 @@ Build the pairwise comparison system (per ADR-010). Two movies presented side by
 |---|-----|---------|--------|
 | 037 | [Ratings & Comparisons](../prds/037-ratings-comparisons/README.md) | Compare arena page, dimension management, ELO scoring algorithm, rankings page, radar charts on detail pages, quick-pick flow | Partial |
 | 062 | [Comparison Intelligence](../prds/062-comparison-intelligence/README.md) | Probabilistic pair selection, staleness model, dimension exclusion, watch blacklist, skip cooloff, score confidence, freshness indicators | Not started |
+| 063 | [Post-Watch Debrief](../prds/063-post-watch-debrief/README.md) | Rapid-fire comparison session for newly watched movies — one opponent per dimension, median-score calibration | Not started |
+| 064 | [Batch Tier List](../prds/064-batch-tier-list/README.md) | Drag-and-drop S/A/B/C/D tier ranking for 8 movies per dimension, implied pairwise comparisons | Not started |
 
 ## Dependencies
 
@@ -21,6 +23,4 @@ Build the pairwise comparison system (per ADR-010). Two movies presented side by
 ## Out of Scope
 
 - TV show comparisons (hard UX problem — see ideas/media-ideas.md)
-- Post-watch debrief / rapid-fire review mode (PRD-063, future)
-- Batch comparison / tier list drag-and-drop (PRD-064, future)
 - AI-driven comparison prompts (future enhancement)

--- a/docs/themes/03-media/prds/063-post-watch-debrief/README.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/README.md
@@ -1,0 +1,104 @@
+# PRD-063: Post-Watch Debrief
+
+> Epic: [04 — Ratings & Comparisons](../../epics/04-ratings-comparisons.md)
+> Status: Not started
+
+## Overview
+
+A focused rapid-fire comparison session for a movie the user just watched. One comparison per active dimension, each against a well-chosen opponent near the median score for that dimension. The debrief quickly calibrates the new movie's position across all dimensions while the user's opinion is freshest.
+
+## Trigger & Notification
+
+The debrief is manual but prompted:
+
+- **History page**: a "Debrief" button appears on the movie tile for any recently watched movie that hasn't been debriefed
+- **Library page**: a notification badge/banner shows unwatched debriefs (e.g. "3 movies to debrief"). Dismissible per movie
+- **Movie detail page**: "Debrief this movie" button when the movie has watch history but no debrief record
+
+A movie is considered "debriefed" once it has at least one comparison per active dimension. The debrief button disappears after completion (or manual dismissal).
+
+## Debrief Flow
+
+Route: `/media/debrief/:movieId`
+
+1. **Header**: movie poster, title, year. "Debrief: {Movie Title}" heading
+2. **Dimension indicator**: shows current dimension name + progress (e.g. "3 of 10")
+3. **Comparison card**: the debrief movie on the left, opponent on the right. Standard pick-A / pick-B / draw-tier buttons
+4. **One comparison per dimension**: after the user picks, advance to the next dimension
+5. **Order**: dimensions presented sequentially (by sort_order), or user can skip a dimension
+6. **Bail out**: "Done for now" button at any point. Completed dimensions are saved. Remaining dimensions still show the debrief prompt
+7. **Completion**: after all dimensions, show a summary: per-dimension result (won/lost/draw tier) and new score for each
+
+## Opponent Selection
+
+For each dimension, select an opponent near the **median score** (~60th percentile on a 0–100 normalized scale). The question is: "Is this movie roughly better or worse than average?"
+
+Selection algorithm:
+1. Get all scored movies for this dimension (exclude the debrief movie itself)
+2. Find the median score
+3. Select the movie closest to the median that the debrief movie hasn't been compared against in this dimension
+4. If all median-range movies are exhausted, expand the search range outward
+5. If no eligible opponent exists, skip this dimension
+
+The opponent should NOT be:
+- The same movie
+- Excluded from this dimension
+- A movie with all watch events blacklisted
+- A movie the debrief movie was already compared against in this dimension during the current debrief
+
+## Data Model
+
+### debrief_status
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INTEGER | PK, auto-increment | |
+| `media_type` | TEXT | NOT NULL | `'movie'` |
+| `media_id` | INTEGER | NOT NULL | |
+| `dimension_id` | INTEGER | NOT NULL, FK | |
+| `debriefed` | INTEGER | NOT NULL, DEFAULT 0 | 1 = comparison recorded for this dimension |
+| `dismissed` | INTEGER | NOT NULL, DEFAULT 0 | 1 = user dismissed without comparing |
+| `created_at` | TEXT | NOT NULL | When the debrief was queued (usually = watch event time) |
+
+UNIQUE index on `(media_type, media_id, dimension_id)`.
+
+Rows are created when a watch event is logged — one row per active dimension. The debrief is "complete" when all rows for a movie have `debriefed = 1` or `dismissed = 1`.
+
+## Business Rules
+
+- A debrief is queued automatically when a new watch event is logged for a movie (one row per active dimension)
+- Completing a comparison in the debrief records it via the standard `comparisons.record` path — same ELO update logic
+- Draw tiers (High/Mid/Low) are available in the debrief, same as the arena
+- The debrief movie's staleness is 0 (just watched)
+- Dismissing a debrief dimension sets `dismissed = 1` — the prompt disappears, no comparison recorded
+- Dismissing all dimensions (or the entire debrief) hides the notification
+- If a new dimension is added after a movie was debriefed, a new debrief row is NOT created retroactively
+- The debrief route is accessible even for movies watched long ago — the "Debrief" button is on any movie with incomplete debrief rows
+
+## Edge Cases
+
+| Case | Behaviour |
+|------|-----------|
+| Movie has no eligible opponents for a dimension | Skip that dimension, mark as dismissed with reason |
+| All dimensions debriefed already | Debrief button hidden, notification absent |
+| User watches the same movie again | New debrief rows created (reset debriefed/dismissed to 0) |
+| Dimension deactivated after debrief queued | Row stays but is ignored by the UI (only show active dimensions) |
+| User navigates away mid-debrief | Completed dimensions saved, remaining still pending |
+
+## User Stories
+
+| # | Story | Summary | Status | Parallelisable |
+|---|-------|---------|--------|----------------|
+| 01 | [us-01-debrief-schema](us-01-debrief-schema.md) | debrief_status table, auto-queue on watch event | Not started | Yes |
+| 02 | [us-02-opponent-selection](us-02-opponent-selection.md) | Median-score opponent selection per dimension | Not started | Yes |
+| 03 | [us-03-debrief-api](us-03-debrief-api.md) | tRPC endpoints: getDebrief, recordDebriefComparison, dismissDimension | Not started | Blocked by us-01, us-02 |
+| 04 | [us-04-debrief-page](us-04-debrief-page.md) | Debrief route with comparison cards, dimension progress, bail-out, summary | Not started | Blocked by us-03 |
+| 05 | [us-05-debrief-notifications](us-05-debrief-notifications.md) | History tile button, library banner, detail page button for pending debriefs | Not started | Blocked by us-03 |
+
+US-01 and US-02 can parallelise. US-04 and US-05 can parallelise once US-03 is done.
+
+## Out of Scope
+
+- TV show debriefs (movie-only for now)
+- Auto-starting debrief on watch event (manual trigger, prompted by notification)
+- Debrief analytics or progress tracking beyond the badge/banner

--- a/docs/themes/03-media/prds/063-post-watch-debrief/us-01-debrief-schema.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/us-01-debrief-schema.md
@@ -1,0 +1,16 @@
+# US-01: Debrief schema and auto-queue
+
+> PRD: [063 — Post-Watch Debrief](README.md)
+> Status: Not started
+
+## Description
+
+As the system, I create debrief rows when a watch event is logged so the user is prompted to debrief that movie.
+
+## Acceptance Criteria
+
+- [ ] `debrief_status` table with columns: id, media_type, media_id, dimension_id, debriefed (default 0), dismissed (default 0), created_at
+- [ ] UNIQUE index on (media_type, media_id, dimension_id)
+- [ ] When a watch event is logged, insert one debrief row per active dimension for that movie
+- [ ] If rows already exist (re-watch), reset debriefed and dismissed to 0
+- [ ] Tests: watch event creates rows, re-watch resets rows, correct number of dimensions

--- a/docs/themes/03-media/prds/063-post-watch-debrief/us-02-opponent-selection.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/us-02-opponent-selection.md
@@ -1,0 +1,16 @@
+# US-02: Median-score opponent selection
+
+> PRD: [063 — Post-Watch Debrief](README.md)
+> Status: Not started
+
+## Description
+
+As the system, I select a debrief opponent near the median score for each dimension so the comparison calibrates whether the movie is above or below average.
+
+## Acceptance Criteria
+
+- [ ] `getDebriefOpponent(mediaType, mediaId, dimensionId)` returns a single opponent movie
+- [ ] Opponent is the scored movie closest to the median score for that dimension
+- [ ] Excludes: the debrief movie itself, excluded-for-dimension movies, blacklisted movies, movies already compared against in this dimension
+- [ ] If no eligible opponent exists, returns null (dimension will be skipped)
+- [ ] Tests: selects median-range opponent, respects exclusions, returns null when exhausted

--- a/docs/themes/03-media/prds/063-post-watch-debrief/us-03-debrief-api.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/us-03-debrief-api.md
@@ -1,0 +1,17 @@
+# US-03: Debrief tRPC endpoints
+
+> PRD: [063 — Post-Watch Debrief](README.md)
+> Status: Not started
+
+## Description
+
+As a developer, I want tRPC endpoints for the debrief flow: get pending debrief, record a debrief comparison, dismiss a dimension.
+
+## Acceptance Criteria
+
+- [ ] `media.comparisons.getDebrief({ mediaType, mediaId })` returns: movie info, list of dimensions with status (pending/debriefed/dismissed), opponent per pending dimension
+- [ ] `media.comparisons.recordDebriefComparison({ mediaType, mediaId, dimensionId, winnerId, drawTier? })` records comparison via standard path, sets debriefed=1 on the debrief row
+- [ ] `media.comparisons.dismissDebriefDimension({ mediaType, mediaId, dimensionId })` sets dismissed=1
+- [ ] `media.comparisons.getPendingDebriefs()` returns list of movies with incomplete debriefs (for notifications)
+- [ ] All protected procedures
+- [ ] Tests: get returns correct status, record updates row + ELO, dismiss sets flag, pending list correct

--- a/docs/themes/03-media/prds/063-post-watch-debrief/us-04-debrief-page.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/us-04-debrief-page.md
@@ -1,0 +1,21 @@
+# US-04: Debrief page
+
+> PRD: [063 — Post-Watch Debrief](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want a dedicated debrief page where I rapidly compare a just-watched movie against one opponent per dimension.
+
+## Acceptance Criteria
+
+- [ ] Route: `/media/debrief/:movieId`
+- [ ] Header: movie poster, title, year, "Debrief: {title}" heading
+- [ ] Dimension progress indicator: "{current} of {total}" with dimension name
+- [ ] Comparison layout: debrief movie (left) vs opponent (right)
+- [ ] Pick A / Pick B / High / Mid / Low draw buttons (same as arena)
+- [ ] After pick, advance to next pending dimension
+- [ ] "Skip this dimension" button dismisses current dimension
+- [ ] "Done for now" button exits, completed dimensions saved
+- [ ] Completion summary: per-dimension result + new score
+- [ ] Tests: renders, pick advances, skip dismisses, bail-out saves progress, summary shows

--- a/docs/themes/03-media/prds/063-post-watch-debrief/us-05-debrief-notifications.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/us-05-debrief-notifications.md
@@ -1,0 +1,18 @@
+# US-05: Debrief notifications
+
+> PRD: [063 — Post-Watch Debrief](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want to see debrief prompts on the history page, library page, and movie detail page so I know which movies need debriefing.
+
+## Acceptance Criteria
+
+- [ ] History page: "Debrief" button on movie tiles with pending debriefs
+- [ ] Library page: notification banner "N movies to debrief" — links to first pending, dismissible
+- [ ] Movie detail page: "Debrief this movie" button when debrief is pending
+- [ ] All buttons link to `/media/debrief/:movieId`
+- [ ] Buttons/banner hidden once all dimensions are debriefed or dismissed
+- [ ] Dismissing the library banner does not dismiss individual debrief rows (just hides the banner for the session)
+- [ ] Tests: button shows for pending, hidden for complete, banner shows count, dismiss works

--- a/docs/themes/03-media/prds/064-batch-tier-list/README.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/README.md
@@ -1,0 +1,119 @@
+# PRD-064: Batch Tier List
+
+> Epic: [04 — Ratings & Comparisons](../../epics/04-ratings-comparisons.md)
+> Status: Not started
+
+## Overview
+
+A drag-and-drop tier list UI for ranking 8 movies at once on a single dimension. Instead of pairwise A-vs-B comparisons, the user arranges movies into tiers (S/A/B/C/D). Each placement implies a set of pairwise results that batch-update ELO scores. Complements the compare arena — faster way to process many movies at once.
+
+## Route
+
+`/media/tier-list`
+
+## UX Flow
+
+1. User selects a dimension (or one is suggested by dimension need)
+2. System presents 8 movies as draggable cards in an unranked pool
+3. User drags movies into tier rows: S (top) / A / B / C / D (bottom)
+4. Movies can remain in the unranked pool (skipped)
+5. User clicks "Submit" to process all implied comparisons
+6. Summary shows: how many comparisons implied, ELO changes
+
+## Tier Layout
+
+```
+┌─────────────────────────────────────┐
+│ S │ [movie] [movie]                 │
+├─────────────────────────────────────┤
+│ A │ [movie] [movie] [movie]         │
+├─────────────────────────────────────┤
+│ B │ [movie]                         │
+├─────────────────────────────────────┤
+│ C │                                 │
+├─────────────────────────────────────┤
+│ D │ [movie] [movie]                 │
+├─────────────────────────────────────┤
+│ Unranked │ [movie]                  │
+└─────────────────────────────────────┘
+```
+
+Each tier row is a horizontal drop zone. Movie cards show poster thumbnail + title. Drag between tiers to reposition.
+
+## Implied Comparisons
+
+Tier placements convert to pairwise results:
+
+| Relationship | Implied result |
+|-------------|---------------|
+| Same tier | Draw — High if S-tier, Mid if B-tier, Low if D-tier |
+| 1 tier apart (e.g. S vs A) | Higher tier wins |
+| 2+ tiers apart (e.g. S vs C) | Higher tier wins |
+| Unranked vs any | No comparison implied (skipped) |
+
+### Draw tier mapping
+
+| Tier | Draw tier when same-tier |
+|------|------------------------|
+| S | High (0.7) — both great |
+| A | High (0.7) — both good |
+| B | Mid (0.5) — both average |
+| C | Low (0.3) — both below average |
+| D | Low (0.3) — both poor |
+
+### Comparison count
+
+For 8 movies all placed in tiers: C(8,2) = 28 implied comparisons. If some remain unranked, fewer comparisons are generated. Each implied comparison goes through the standard `comparisons.record` path with appropriate `winnerId` and `drawTier`.
+
+## Movie Selection
+
+The 8 movies are selected to maximise information gain:
+- Prefer movies with few comparisons in this dimension (high uncertainty)
+- Mix of score ranges (don't show 8 top-ranked movies)
+- Exclude blacklisted, excluded-for-dimension, and stale movies (staleness < 0.3)
+- User can refresh the set ("Show different movies")
+
+## Data Model
+
+No new tables. Tier list submissions generate standard `comparisons` rows via the existing `record` path. The tier-to-comparison conversion is computed client-side and submitted as a batch.
+
+## Business Rules
+
+- Each tier placement generates pairwise comparisons against all other placed movies
+- Unranked movies produce no comparisons
+- All implied comparisons are for the selected dimension only
+- Comparisons are recorded in a single transaction (all or nothing)
+- The tier list is stateless — there's no saved draft. Navigating away loses the arrangement
+- A movie can appear in multiple tier list sessions (different dimensions, or same dimension with different opponents)
+- Existing comparisons between the same pair on the same dimension are NOT overwritten — the new comparison is added alongside (ELO accumulates)
+- Maximum 8 movies per session. Minimum 2 placed in tiers to submit
+
+## Edge Cases
+
+| Case | Behaviour |
+|------|-----------|
+| Fewer than 8 eligible movies | Show as many as available (minimum 2) |
+| All movies placed in same tier | Only same-tier draws generated |
+| Only 2 movies placed | 1 comparison (or 1 draw) |
+| User places none and submits | Submit disabled when fewer than 2 placed |
+| Dimension has no scored movies | All 8 start at 1500, selection is random from watched pool |
+
+## User Stories
+
+| # | Story | Summary | Status | Parallelisable |
+|---|-------|---------|--------|----------------|
+| 01 | [us-01-tier-conversion](us-01-tier-conversion.md) | Convert tier placements to implied pairwise comparisons with correct winners and draw tiers | Not started | Yes |
+| 02 | [us-02-batch-record](us-02-batch-record.md) | Batch record implied comparisons in a single transaction | Not started | Yes |
+| 03 | [us-03-movie-selection](us-03-movie-selection.md) | Select 8 movies to maximise information gain for the chosen dimension | Not started | Yes |
+| 04 | [us-04-tier-list-api](us-04-tier-list-api.md) | tRPC endpoints: getTierListMovies, submitTierList | Not started | Blocked by us-01, us-02, us-03 |
+| 05 | [us-05-drag-drop-ui](us-05-drag-drop-ui.md) | Drag-and-drop tier list page with S/A/B/C/D rows, movie cards, unranked pool | Not started | Blocked by us-04 |
+| 06 | [us-06-submission-summary](us-06-submission-summary.md) | Post-submit summary showing implied comparison count and ELO changes | Not started | Blocked by us-05 |
+
+US-01, US-02, US-03 can parallelise. US-05 and US-06 can parallelise once US-04 is done.
+
+## Out of Scope
+
+- Saved/draft tier lists
+- TV show tier lists
+- Cross-dimension tier lists (one dimension per session)
+- Undo individual implied comparisons after submission (delete the batch via history if needed)

--- a/docs/themes/03-media/prds/064-batch-tier-list/us-01-tier-conversion.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/us-01-tier-conversion.md
@@ -1,0 +1,17 @@
+# US-01: Tier-to-comparison conversion
+
+> PRD: [064 — Batch Tier List](README.md)
+> Status: Not started
+
+## Description
+
+As the system, I convert a set of tier placements into implied pairwise comparisons with correct winners and draw tiers.
+
+## Acceptance Criteria
+
+- [ ] `convertTierPlacements(placements: Array<{ movieId, tier }>)` returns `Array<{ mediaAId, mediaBId, winnerId, drawTier }>`
+- [ ] Same tier → draw. Draw tier mapped: S=high, A=high, B=mid, C=low, D=low
+- [ ] Different tiers → higher tier wins (winnerId = higher-tier movie)
+- [ ] Unranked movies produce no comparisons
+- [ ] For N placed movies, generates exactly C(N,2) comparisons
+- [ ] Tests: same tier draws correct, cross-tier wins correct, unranked excluded, count is C(N,2)

--- a/docs/themes/03-media/prds/064-batch-tier-list/us-02-batch-record.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/us-02-batch-record.md
@@ -1,0 +1,16 @@
+# US-02: Batch record comparisons
+
+> PRD: [064 — Batch Tier List](README.md)
+> Status: Not started
+
+## Description
+
+As the system, I record a batch of implied comparisons from a tier list submission in a single transaction.
+
+## Acceptance Criteria
+
+- [ ] `batchRecordComparisons(dimensionId, comparisons: Array<{ mediaAId, mediaBId, winnerId, drawTier }>)` records all in one transaction
+- [ ] Each comparison goes through standard ELO update logic (same as `recordComparison`)
+- [ ] All or nothing — if any insert fails, entire batch rolls back
+- [ ] Returns count of comparisons recorded
+- [ ] Tests: batch inserts all, ELO updated for each, rollback on failure

--- a/docs/themes/03-media/prds/064-batch-tier-list/us-03-movie-selection.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/us-03-movie-selection.md
@@ -1,0 +1,18 @@
+# US-03: Tier list movie selection
+
+> PRD: [064 — Batch Tier List](README.md)
+> Status: Not started
+
+## Description
+
+As the system, I select 8 movies for a tier list session that maximise information gain for the chosen dimension.
+
+## Acceptance Criteria
+
+- [ ] `getTierListMovies(dimensionId)` returns up to 8 movies
+- [ ] Prefers movies with few comparisons in this dimension (high uncertainty)
+- [ ] Mix of score ranges — not all top-ranked or all bottom-ranked
+- [ ] Excludes: blacklisted, excluded-for-dimension, staleness < 0.3
+- [ ] Returns fewer than 8 if not enough eligible (minimum 2)
+- [ ] Includes poster URL and title for each movie
+- [ ] Tests: returns 8 when available, respects exclusions, mixed score ranges

--- a/docs/themes/03-media/prds/064-batch-tier-list/us-04-tier-list-api.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/us-04-tier-list-api.md
@@ -1,0 +1,17 @@
+# US-04: Tier list tRPC endpoints
+
+> PRD: [064 — Batch Tier List](README.md)
+> Status: Not started
+
+## Description
+
+As a developer, I want tRPC endpoints for fetching tier list movies and submitting a completed tier list.
+
+## Acceptance Criteria
+
+- [ ] `media.comparisons.getTierListMovies({ dimensionId })` returns up to 8 movies with poster + title + current score
+- [ ] `media.comparisons.submitTierList({ dimensionId, placements: Array<{ movieId, tier }> })` converts to implied comparisons and batch-records them
+- [ ] Submit returns: { comparisonsRecorded, scoreChanges: Array<{ movieId, oldScore, newScore }> }
+- [ ] Validates: minimum 2 placed movies, valid tier values (S/A/B/C/D), valid dimension
+- [ ] Both protected procedures
+- [ ] Tests: get returns movies, submit records correct count, validation rejects bad input

--- a/docs/themes/03-media/prds/064-batch-tier-list/us-05-drag-drop-ui.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/us-05-drag-drop-ui.md
@@ -1,0 +1,20 @@
+# US-05: Drag-and-drop tier list UI
+
+> PRD: [064 — Batch Tier List](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want to drag movies into S/A/B/C/D tier rows to rank them quickly on a single dimension.
+
+## Acceptance Criteria
+
+- [ ] Route: `/media/tier-list`
+- [ ] Dimension selector at top (dropdown or chip selector)
+- [ ] 5 tier rows (S/A/B/C/D) as horizontal drop zones with tier label on the left
+- [ ] Unranked pool at the bottom with the 8 movie cards
+- [ ] Movie cards show poster thumbnail + title, draggable
+- [ ] Drag between tiers to reposition, drag back to unranked to remove
+- [ ] "Refresh" button to get a different set of 8 movies
+- [ ] "Submit" button disabled when fewer than 2 movies placed
+- [ ] Tests: drag and drop works, tier assignment persists, submit enables at 2+

--- a/docs/themes/03-media/prds/064-batch-tier-list/us-06-submission-summary.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/us-06-submission-summary.md
@@ -1,0 +1,17 @@
+# US-06: Submission summary
+
+> PRD: [064 — Batch Tier List](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want to see a summary after submitting a tier list showing how many comparisons were implied and how scores changed.
+
+## Acceptance Criteria
+
+- [ ] After submit, show summary overlay or replace the tier list view
+- [ ] Shows: total comparisons recorded (e.g. "28 comparisons from 8 movies")
+- [ ] Per-movie score change: title + old score → new score + delta (colored green/red)
+- [ ] "Do another" button to start a new tier list session (same or different dimension)
+- [ ] "Done" button navigates to rankings page
+- [ ] Tests: summary shows correct count, score changes displayed, navigation works


### PR DESCRIPTION
## Summary
Two new PRDs for the comparison system:

**PRD-063 Post-Watch Debrief** (5 USs): after watching a movie, enter a focused session — one comparison per dimension against a median-score opponent. Queued automatically on watch event, prompted via history/library/detail page notifications.

**PRD-064 Batch Tier List** (6 USs): drag-and-drop S/A/B/C/D tier ranking for 8 movies per dimension. Tier placements imply pairwise comparisons (same tier = tiered draw, different tier = higher wins). Up to 28 comparisons from one session.

## Test plan
- [ ] Docs only