### PR TITLE
fix(media): reset staleness for parent tv_show, not episodes

### DIFF
--- a/apps/pops-api/src/modules/media/watch-history/service.ts
+++ b/apps/pops-api/src/modules/media/watch-history/service.ts
@@ -306,8 +306,27 @@ export function logWatch(input: LogWatchInput): LogWatchResult {
     if (!entry) throw new Error("Watch history entry not found after insert");
 
     // Reset staleness when a completed watch event is logged
+    // (comparisons use movie/tv_show types, so resolve episode → tv_show)
     if (completed === 1) {
-      resetStaleness(input.mediaType, input.mediaId);
+      if (input.mediaType === "movie") {
+        resetStaleness("movie", input.mediaId);
+      } else if (input.mediaType === "episode") {
+        const ep = tx
+          .select({ seasonId: episodes.seasonId })
+          .from(episodes)
+          .where(eq(episodes.id, input.mediaId))
+          .get();
+        if (ep) {
+          const season = tx
+            .select({ tvShowId: seasons.tvShowId })
+            .from(seasons)
+            .where(eq(seasons.id, ep.seasonId))
+            .get();
+          if (season) {
+            resetStaleness("tv_show", season.tvShowId);
+          }
+        }
+      }
     }
 
     // Auto-remove from watchlist (PRD-011 R6) — skip for plex_sync source
@@ -624,16 +643,9 @@ export function batchLogWatch(input: BatchLogWatchInput): BatchLogResult {
         .run();
     }
 
-    // Reset staleness for each newly watched episode
-    if (completed === 1 && toLog.length > 0) {
-      for (const episodeId of toLog) {
-        resetStaleness("episode", episodeId);
-      }
-    }
-
     // Auto-remove from watchlist if all episodes now watched
     if (completed === 1 && toLog.length > 0) {
-      // Determine the TV show ID for watchlist removal
+      // Determine the TV show ID for watchlist removal + staleness reset
       let tvShowId: number | undefined;
 
       if (input.mediaType === "show") {
@@ -646,6 +658,11 @@ export function batchLogWatch(input: BatchLogWatchInput): BatchLogResult {
           .where(eq(seasons.id, input.mediaId))
           .get();
         tvShowId = season?.tvShowId;
+      }
+
+      // Reset staleness for the parent TV show (comparisons use tv_show type)
+      if (tvShowId !== undefined) {
+        resetStaleness("tv_show", tvShowId);
       }
 
       if (tvShowId !== undefined) {


### PR DESCRIPTION
## Summary
- **logWatch**: resolves episode → season → tv_show before calling `resetStaleness`, so the comparison arena's staleness tracking is correctly updated when watching TV episodes
- **batchLogWatch**: resets staleness for the parent TV show instead of individual episodes, since the comparison arena only uses `movie`/`tv_show` media types

Fixes QA feedback on PR #1227 — episode staleness resets had no effect because the comparison arena doesn't track individual episodes.

## Test plan
- [x] All 64 watch-history tests pass
- [x] All 11 staleness tests pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)