### PR TITLE
feat(media): add recordSkip tRPC mutation [tb-144]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/router.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router.ts
@@ -17,6 +17,7 @@ import {
   RandomPairQuerySchema,
   RankingsQuerySchema,
   StalenessSchema,
+  RecordSkipSchema,
   toDimension,
   toComparison,
   toMediaScore,
@@ -168,5 +169,24 @@ export const comparisonsRouter = router({
   getStaleness: protectedProcedure.input(StalenessSchema).query(({ input }) => {
     const staleness = stalenessService.getStaleness(input.mediaType, input.mediaId);
     return { data: { staleness } };
+  }),
+
+  /** Record a skip (puts pair on cooloff for 10 global comparisons). */
+  recordSkip: protectedProcedure.input(RecordSkipSchema).mutation(({ input }) => {
+    try {
+      const skipUntil = service.recordSkip(
+        input.dimensionId,
+        input.mediaAType,
+        input.mediaAId,
+        input.mediaBType,
+        input.mediaBId
+      );
+      return { data: { skipUntil }, message: "Skip recorded" };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
   }),
 });

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -890,7 +890,7 @@ export function recordSkip(
   mediaAId: number,
   mediaBType: string,
   mediaBId: number
-): void {
+): number {
   const db = getDrizzle();
   const globalCount = getGlobalComparisonCount();
   const skipUntil = globalCount + 10;
@@ -935,6 +935,8 @@ export function recordSkip(
       })
       .run();
   }
+
+  return skipUntil;
 }
 
 /**

--- a/apps/pops-api/src/modules/media/comparisons/skip-cooloff-api.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/skip-cooloff-api.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database } from "better-sqlite3";
+import {
+  setupTestContext,
+  seedDimension,
+  seedMovie,
+  seedWatchHistoryEntry,
+  createCaller,
+} from "../../../shared/test-utils.js";
+
+const ctx = setupTestContext();
+let caller: ReturnType<typeof createCaller>;
+let db: Database;
+
+beforeEach(() => {
+  ({ caller, db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+describe("comparisons.recordSkip", () => {
+  function seedPair() {
+    const dimId = seedDimension(db, { name: "Entertainment" });
+    const movieA = seedMovie(db, { title: "Movie A", tmdb_id: 100 });
+    const movieB = seedMovie(db, { title: "Movie B", tmdb_id: 200 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieA, completed: 1 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieB, completed: 1 });
+    return { dimId, movieA, movieB };
+  }
+
+  it("records a skip and returns skipUntil", async () => {
+    const { dimId, movieA, movieB } = seedPair();
+
+    const result = await caller.media.comparisons.recordSkip({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: movieA,
+      mediaBType: "movie",
+      mediaBId: movieB,
+    });
+
+    expect(result.data.skipUntil).toBe(10);
+    expect(result.message).toBe("Skip recorded");
+  });
+
+  it("extends cooloff on repeated skip", async () => {
+    const { dimId, movieA, movieB } = seedPair();
+
+    // First skip → skipUntil = 10
+    await caller.media.comparisons.recordSkip({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: movieA,
+      mediaBType: "movie",
+      mediaBId: movieB,
+    });
+
+    // Record a comparison to bump global count
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: movieA,
+      mediaBType: "movie",
+      mediaBId: movieB,
+      winnerType: "movie",
+      winnerId: movieA,
+    });
+
+    // Second skip → skipUntil = 11 (global count 1 + 10)
+    const result = await caller.media.comparisons.recordSkip({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: movieA,
+      mediaBType: "movie",
+      mediaBId: movieB,
+    });
+
+    expect(result.data.skipUntil).toBe(11);
+  });
+});

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -211,3 +211,12 @@ export const StalenessSchema = z.object({
   mediaId: z.number().int().positive(),
 });
 export type StalenessInput = z.infer<typeof StalenessSchema>;
+
+export const RecordSkipSchema = z.object({
+  dimensionId: z.number().int().positive(),
+  mediaAType: z.enum(MEDIA_TYPES),
+  mediaAId: z.number().int().positive(),
+  mediaBType: z.enum(MEDIA_TYPES),
+  mediaBId: z.number().int().positive(),
+});
+export type RecordSkipInput = z.infer<typeof RecordSkipSchema>;


### PR DESCRIPTION
## Summary
- Adds `RecordSkipSchema` Zod validation to types.ts
- Changes `recordSkip` service to return `skipUntil` (was `void`) so the API can surface it
- Adds `comparisons.recordSkip` tRPC mutation endpoint that records a pair skip and returns the cooloff threshold
- Adds 2 API-level tests: basic skip recording and cooloff extension on repeated skip

Depends on tb-138 (PR #1229, merged) which added the `recordSkip` service function.

## Test plan
- [x] 2 new API tests pass (record skip, extend cooloff)
- [x] 9 existing skip-cooloff service tests still pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)