### PR TITLE
feat(media): arena skip button with cooloff + recordSkip endpoint [tb-148/tb-144]

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -14,6 +14,9 @@ const mockWatchlistListQuery = vi.fn();
 const mockWatchlistAddMutate = vi.fn() as ReturnType<typeof vi.fn> & {
   _opts?: Record<string, unknown>;
 };
+const mockSkipMutate = vi.fn() as ReturnType<typeof vi.fn> & {
+  _opts?: Record<string, unknown>;
+};
 const mockMarkStaleMutate = vi.fn() as ReturnType<typeof vi.fn> & {
   _opts?: Record<string, unknown>;
 };
@@ -44,6 +47,12 @@ vi.mock("../lib/trpc", () => ({
           useMutation: (opts: Record<string, unknown>) => {
             mockRecordMutate._opts = opts;
             return { mutate: mockRecordMutate, isPending: false };
+          },
+        },
+        recordSkip: {
+          useMutation: (opts: Record<string, unknown>) => {
+            mockSkipMutate._opts = opts;
+            return { mutate: mockSkipMutate, isPending: false };
           },
         },
         scores: { fetch: (...args: unknown[]) => mockScoresFetch(...args) },
@@ -179,7 +188,7 @@ describe("CompareArenaPage", () => {
     );
   });
 
-  it("skip button advances dimension without recording", () => {
+  it("skip button calls recordSkip mutation with correct pair details", () => {
     setupArena();
     renderPage();
 
@@ -189,13 +198,16 @@ describe("CompareArenaPage", () => {
 
     fireEvent.click(screen.getByText("Skip this pair"));
 
-    // No recording should be made
+    // No winner recording should be made
     expect(mockRecordMutate).not.toHaveBeenCalled();
-    // refetchPair should NOT be called — dimension index change triggers automatic refetch
-    expect(mockRefetchPair).not.toHaveBeenCalled();
-    // Dimension should advance to Entertainment (dim2)
-    const tabsAfter = screen.getAllByRole("tab");
-    expect(tabsAfter[1]?.getAttribute("aria-selected")).toBe("true");
+    // Skip mutation should be called with correct args
+    expect(mockSkipMutate).toHaveBeenCalledWith({
+      dimensionId: 1,
+      mediaAType: "movie",
+      mediaAId: 10,
+      mediaBType: "movie",
+      mediaBId: 20,
+    });
   });
 
   it("shows minimum threshold message when pair data is null", () => {

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -219,6 +219,28 @@ export function CompareArenaPage() {
     [pairData, dimensionId, recordMutation]
   );
 
+  // Skip pair with cooloff mutation
+  const skipMutation = trpc.media.comparisons.recordSkip.useMutation({
+    onSuccess: () => {
+      toast.success("Pair skipped for 10 comparisons");
+      setDimensionIndex((i) => i + 1);
+      utils.media.comparisons.getRandomPair.invalidate();
+    },
+  });
+
+  const handleSkip = useCallback(() => {
+    if (!pairData?.data || !dimensionId || skipMutation.isPending) return;
+
+    const { movieA, movieB } = pairData.data;
+    skipMutation.mutate({
+      dimensionId,
+      mediaAType: "movie" as const,
+      mediaAId: movieA.id,
+      mediaBType: "movie" as const,
+      mediaBId: movieB.id,
+    });
+  }, [pairData, dimensionId, skipMutation]);
+
   const handleDraw = useCallback(
     (tier: "high" | "mid" | "low") => {
       if (!pairData?.data || !dimensionId || recordMutation.isPending) return;
@@ -453,12 +475,10 @@ export function CompareArenaPage() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => {
-                utils.media.comparisons.getRandomPair.invalidate();
-                setDimensionIndex((i) => i + 1);
-              }}
+              onClick={handleSkip}
+              disabled={skipMutation.isPending}
             >
-              Skip this pair
+              {skipMutation.isPending ? "Skipping…" : "Skip this pair"}
             </Button>
             <Button
               variant="outline"


### PR DESCRIPTION
## Summary
- Wire Skip button in CompareArenaPage to `recordSkip` tRPC mutation instead of inline handler
- Add `RecordSkipSchema` and `recordSkip` mutation to comparisons router (unblocks tb-148, covers tb-144)
- Button shows pending state during mutation, toast on success, rotates dimension + invalidates pair cache
- Update test to verify `skipMutate` is called with correct pair details

## Changes
- `packages/app-media/src/pages/CompareArenaPage.tsx` — skipMutation + handleSkip callback + button wiring
- `packages/app-media/src/pages/CompareArenaPage.test.tsx` — mock recordSkip, assert mutation args
- `apps/pops-api/src/modules/media/comparisons/types.ts` — RecordSkipSchema
- `apps/pops-api/src/modules/media/comparisons/router.ts` — recordSkip mutation endpoint

## Test plan
- [ ] Skip button calls recordSkip mutation with dimensionId + pair details
- [ ] Button disabled during pending mutation
- [ ] Toast shown on success
- [ ] Dimension rotates and pair cache invalidated after skip
- [ ] Typecheck passes for both pops-api and pops-shell

Closes #1209
Closes #1204

🤖 Generated with [Claude Code](https://claude.com/claude-code)