### PR TITLE
feat(media): filter excluded movies from rankings [tb-152]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -1414,6 +1414,106 @@ describe("confidence in API responses", () => {
     // overall = min = ~0.29
     expect(movie1!.confidence).toBeCloseTo(1 - 1 / Math.sqrt(2), 3); // count=1 → sqrt(2)
   });
+
+  it("per-dimension rankings exclude excluded movies", async () => {
+    const dimId = seedDimension(db, { name: "Story" });
+
+    // Record comparisons: movie 1 > 2 > 3
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 2,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dimId,
+      mediaAType: "movie",
+      mediaAId: 2,
+      mediaBType: "movie",
+      mediaBId: 3,
+      winnerType: "movie",
+      winnerId: 2,
+    });
+
+    // Exclude movie 1 from this dimension
+    excludeFromDimension("movie", 1, dimId);
+
+    const result = await caller.media.comparisons.rankings({ dimensionId: dimId });
+    expect(result.data.length).toBe(2);
+    expect(result.data.every((r) => r.mediaId !== 1)).toBe(true);
+    expect(result.pagination.total).toBe(2);
+  });
+
+  it("excluded movie still appears in other dimensions rankings", async () => {
+    const dim1 = seedDimension(db, { name: "Story", active: 1 });
+    const dim2 = seedDimension(db, { name: "Visuals", active: 1 });
+
+    // Movie 1 vs 2 in both dimensions
+    await caller.media.comparisons.record({
+      dimensionId: dim1,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 2,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dim2,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 2,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+
+    // Exclude movie 1 from dim1 only
+    excludeFromDimension("movie", 1, dim1);
+
+    const dim1Rankings = await caller.media.comparisons.rankings({ dimensionId: dim1 });
+    expect(dim1Rankings.data.every((r) => r.mediaId !== 1)).toBe(true);
+
+    const dim2Rankings = await caller.media.comparisons.rankings({ dimensionId: dim2 });
+    expect(dim2Rankings.data.some((r) => r.mediaId === 1)).toBe(true);
+  });
+
+  it("overall rankings exclude movies from dimensions where excluded", async () => {
+    const dim1 = seedDimension(db, { name: "Story", active: 1 });
+    const dim2 = seedDimension(db, { name: "Visuals", active: 1 });
+
+    // Movie 1 vs 2 in both dimensions
+    await caller.media.comparisons.record({
+      dimensionId: dim1,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 2,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+    await caller.media.comparisons.record({
+      dimensionId: dim2,
+      mediaAType: "movie",
+      mediaAId: 1,
+      mediaBType: "movie",
+      mediaBId: 2,
+      winnerType: "movie",
+      winnerId: 1,
+    });
+
+    // Exclude movie 1 from dim1 — it should still appear in overall via dim2
+    excludeFromDimension("movie", 1, dim1);
+
+    const result = await caller.media.comparisons.rankings({});
+    // Movie 1 should still appear (has non-excluded score in dim2)
+    expect(result.data.some((r) => r.mediaId === 1)).toBe(true);
+    // Movie 2 should also appear
+    expect(result.data.some((r) => r.mediaId === 2)).toBe(true);
+  });
 });
 
 describe("comparisons auth", () => {

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -688,7 +688,7 @@ export function getRankings(
     const countResult = rawDb
       .prepare(
         `SELECT COUNT(*) as total FROM media_scores ms
-         WHERE ms.dimension_id = ? ${mediaTypeClause}`
+         WHERE ms.dimension_id = ? AND ms.excluded = 0 ${mediaTypeClause}`
       )
       .get(...params) as { total: number };
 
@@ -713,7 +713,7 @@ export function getRankings(
         FROM media_scores ms
         LEFT JOIN movies m ON ms.media_type = 'movie' AND ms.media_id = m.id
         LEFT JOIN tv_shows tv ON ms.media_type = 'tv_show' AND ms.media_id = tv.id
-        WHERE ms.dimension_id = ? ${mediaTypeClause}
+        WHERE ms.dimension_id = ? AND ms.excluded = 0 ${mediaTypeClause}
         ORDER BY
           CASE WHEN ms.comparison_count = 0 THEN 1 ELSE 0 END,
           ms.score DESC,
@@ -776,7 +776,7 @@ export function getRankings(
         SELECT ms.media_type, ms.media_id
         FROM media_scores ms
         JOIN comparison_dimensions cd ON ms.dimension_id = cd.id
-        WHERE cd.active = 1 AND ms.dimension_id IN (${dimensionPlaceholders}) ${mediaTypeClause}
+        WHERE cd.active = 1 AND ms.excluded = 0 AND ms.dimension_id IN (${dimensionPlaceholders}) ${mediaTypeClause}
         GROUP BY ms.media_type, ms.media_id
       )`
     )
@@ -805,7 +805,7 @@ export function getRankings(
       JOIN comparison_dimensions cd ON ms.dimension_id = cd.id
       LEFT JOIN movies m ON ms.media_type = 'movie' AND ms.media_id = m.id
       LEFT JOIN tv_shows tv ON ms.media_type = 'tv_show' AND ms.media_id = tv.id
-      WHERE cd.active = 1 AND ms.dimension_id IN (${dimensionPlaceholders}) ${mediaTypeClause}
+      WHERE cd.active = 1 AND ms.excluded = 0 AND ms.dimension_id IN (${dimensionPlaceholders}) ${mediaTypeClause}
       GROUP BY ms.media_type, ms.media_id
       ORDER BY
         CASE WHEN SUM(ms.comparison_count) = 0 THEN 1 ELSE 0 END,


### PR DESCRIPTION
## Summary
- Adds `AND ms.excluded = 0` filter to all 4 ranking SQL queries in `getRankings()` service
- Per-dimension rankings now omit movies excluded from that dimension
- Overall rankings only include non-excluded dimension scores in weighted average
- Movies excluded in one dimension still appear in other dimensions' rankings

Closes #1215

## Test plan
- [x] 3 new tests: per-dimension exclusion, cross-dimension visibility, overall ranking with partial exclusion
- [x] All 81 existing comparison tests pass
- [x] Typecheck clean, lint clean, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)