### PR TITLE
feat(media): add Not Watched buttons to compare arena [tb-150]

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -14,6 +14,9 @@ const mockWatchlistListQuery = vi.fn();
 const mockWatchlistAddMutate = vi.fn() as ReturnType<typeof vi.fn> & {
   _opts?: Record<string, unknown>;
 };
+const mockBlacklistMutate = vi.fn() as ReturnType<typeof vi.fn> & {
+  _opts?: Record<string, unknown>;
+};
 const mockInvalidateRandomPair = vi.fn();
 const mockInvalidateWatchlistList = vi.fn();
 
@@ -37,6 +40,12 @@ vi.mock("../lib/trpc", () => ({
           },
         },
         scores: { fetch: (...args: unknown[]) => mockScoresFetch(...args) },
+        blacklistMovie: {
+          useMutation: (opts: Record<string, unknown>) => {
+            mockBlacklistMutate._opts = opts;
+            return { mutate: mockBlacklistMutate, isPending: false };
+          },
+        },
       },
       watchlist: {
         list: {
@@ -271,5 +280,55 @@ describe("CompareArenaPage", () => {
 
     expect(screen.queryByText("The Matrix")).toBeNull();
     expect(screen.queryByText("Not enough watched movies")).toBeNull();
+  });
+
+  it("renders Not Watched buttons for both movies", () => {
+    setupArena();
+    renderPage();
+
+    expect(screen.getByLabelText("Not watched The Matrix")).toBeTruthy();
+    expect(screen.getByLabelText("Not watched Inception")).toBeTruthy();
+  });
+
+  it("opens confirmation dialog when Not Watched button is clicked", () => {
+    setupArena();
+    renderPage();
+
+    fireEvent.click(screen.getByLabelText("Not watched The Matrix"));
+
+    expect(screen.getByText("Mark as not watched?")).toBeTruthy();
+    expect(screen.getByText(/All comparisons involving this movie/)).toBeTruthy();
+    expect(screen.getByText("Cancel")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Not Watched" })).toBeTruthy();
+  });
+
+  it("calls blacklistMovie mutation on confirm", () => {
+    setupArena();
+    renderPage();
+
+    // Open dialog
+    fireEvent.click(screen.getByLabelText("Not watched Inception"));
+
+    // Confirm
+    fireEvent.click(screen.getByRole("button", { name: "Not Watched" }));
+
+    expect(mockBlacklistMutate).toHaveBeenCalledWith({
+      mediaType: "movie",
+      mediaId: 20,
+    });
+  });
+
+  it("closes dialog on cancel without calling blacklist", () => {
+    setupArena();
+    renderPage();
+
+    // Open dialog
+    fireEvent.click(screen.getByLabelText("Not watched The Matrix"));
+    expect(screen.getByText("Mark as not watched?")).toBeTruthy();
+
+    // Cancel
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(mockBlacklistMutate).not.toHaveBeenCalled();
   });
 });

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -1,7 +1,22 @@
 import { useState, useCallback, useEffect } from "react";
 import { Link, useNavigate } from "react-router";
-import { Badge, Skeleton, Button, Tooltip, TooltipContent, TooltipTrigger } from "@pops/ui";
-import { ImageOff, Bookmark, ChevronUp, Minus, ChevronDown } from "lucide-react";
+import {
+  Badge,
+  Skeleton,
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@pops/ui";
+import { ImageOff, Bookmark, ChevronUp, Minus, ChevronDown, X } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
 import { DimensionManager } from "../components/DimensionManager";
@@ -146,6 +161,34 @@ export function CompareArenaPage() {
       refetchPair();
     },
   });
+
+  // Blacklist ("Not Watched") state + mutation
+  const [blacklistTarget, setBlacklistTarget] = useState<{
+    id: number;
+    title: string;
+  } | null>(null);
+
+  const blacklistMutation = trpc.media.comparisons.blacklistMovie.useMutation({
+    onSuccess: (_data: unknown, variables: { mediaType: string; mediaId: number }) => {
+      const movie =
+        variables.mediaId === movieAId ? pairData?.data?.movieA : pairData?.data?.movieB;
+      toast.success(`${movie?.title ?? "Movie"} marked as not watched`);
+      setBlacklistTarget(null);
+      utils.media.comparisons.getRandomPair.invalidate();
+    },
+  });
+
+  const handleBlacklist = useCallback((movie: { id: number; title: string }) => {
+    setBlacklistTarget(movie);
+  }, []);
+
+  const confirmBlacklist = useCallback(() => {
+    if (!blacklistTarget) return;
+    blacklistMutation.mutate({
+      mediaType: "movie",
+      mediaId: blacklistTarget.id,
+    });
+  }, [blacklistTarget, blacklistMutation]);
 
   const handleAddToWatchlist = useCallback(
     (movieId: number) => {
@@ -304,6 +347,8 @@ export function CompareArenaPage() {
               onAddToWatchlist={() => handleAddToWatchlist(pairData.data.movieA.id)}
               isOnWatchlist={watchlistedMovieIds.has(pairData.data.movieA.id)}
               watchlistPending={addToWatchlistMutation.isPending}
+              onBlacklist={() => handleBlacklist(pairData.data.movieA)}
+              blacklistPending={blacklistMutation.isPending}
             />
 
             {/* Draw tier buttons — centered between cards */}
@@ -361,6 +406,8 @@ export function CompareArenaPage() {
               onAddToWatchlist={() => handleAddToWatchlist(pairData.data.movieB.id)}
               isOnWatchlist={watchlistedMovieIds.has(pairData.data.movieB.id)}
               watchlistPending={addToWatchlistMutation.isPending}
+              onBlacklist={() => handleBlacklist(pairData.data.movieB)}
+              blacklistPending={blacklistMutation.isPending}
             />
           </div>
         </>
@@ -384,6 +431,35 @@ export function CompareArenaPage() {
           </Button>
         </div>
       )}
+
+      {/* Blacklist confirmation dialog */}
+      <AlertDialog
+        open={blacklistTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setBlacklistTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Mark as not watched?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will mark{" "}
+              <span className="font-medium text-foreground">{blacklistTarget?.title}</span> as not
+              watched. All comparisons involving this movie will be deleted and scores recalculated.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={confirmBlacklist}
+              disabled={blacklistMutation.isPending}
+            >
+              {blacklistMutation.isPending ? "Removing…" : "Not Watched"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -397,6 +473,8 @@ function MovieCard({
   onAddToWatchlist,
   isOnWatchlist,
   watchlistPending,
+  onBlacklist,
+  blacklistPending,
 }: {
   movie: { id: number; title: string; posterPath: string | null; posterUrl: string | null };
   onPick: () => void;
@@ -406,6 +484,8 @@ function MovieCard({
   onAddToWatchlist?: () => void;
   isOnWatchlist?: boolean;
   watchlistPending?: boolean;
+  onBlacklist?: () => void;
+  blacklistPending?: boolean;
 }) {
   const posterSrc = movie.posterUrl ?? undefined;
   const [imgError, setImgError] = useState(false);
@@ -459,6 +539,21 @@ function MovieCard({
           aria-label={isOnWatchlist ? "On watchlist" : `Add ${movie.title} to watchlist`}
         >
           <Bookmark className={`h-4 w-4 ${isOnWatchlist ? "fill-current" : ""}`} />
+        </button>
+      )}
+
+      {/* Not Watched button */}
+      {onBlacklist && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onBlacklist();
+          }}
+          disabled={blacklistPending}
+          className="absolute bottom-2 left-2 p-1.5 rounded-full transition-colors bg-background/80 text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 border border-red-200 dark:border-red-800"
+          aria-label={`Not watched ${movie.title}`}
+        >
+          <X className="h-4 w-4" />
         </button>
       )}
 


### PR DESCRIPTION
## Summary
- Add destructive "Not Watched" (X icon) buttons to each movie card in the compare arena
- Clicking opens AlertDialog confirmation with movie title + purge warning
- On confirm: calls `blacklistMovie` mutation, invalidates pair cache, loads next pair
- On cancel: closes dialog, no action taken
- 4 new tests: button renders, dialog opens, confirm calls mutation, cancel does nothing

## Test plan
- [x] 13 CompareArenaPage tests pass (9 existing + 4 new)
- [x] Typecheck clean (app-media + pops-api)
- [x] Prettier formatted

Closes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)