### PR TITLE
feat(media): decouple watchlist button from comparison flow [tb-151]

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -256,6 +256,46 @@ describe("CompareArenaPage", () => {
     expect(mockRecordMutate).toHaveBeenCalledWith(expect.objectContaining({ dimensionId: 1 }));
   });
 
+  it("watchlist button calls watchlist.add without comparison side effects", () => {
+    setupArena();
+    renderPage();
+
+    // Click the watchlist bookmark button for movie A (The Matrix)
+    const bookmarkButtons = screen.getAllByRole("button", { name: /add .* to watchlist/i });
+    expect(bookmarkButtons.length).toBeGreaterThan(0);
+    fireEvent.click(bookmarkButtons[0]!);
+
+    // Should call watchlist add mutation
+    expect(mockWatchlistAddMutate).toHaveBeenCalledWith({
+      mediaType: "movie",
+      mediaId: 10,
+    });
+
+    // Should NOT call comparison record mutation
+    expect(mockRecordMutate).not.toHaveBeenCalled();
+
+    // Should NOT trigger pair refresh
+    expect(mockRefetchPair).not.toHaveBeenCalled();
+
+    // Should NOT invalidate random pair cache
+    expect(mockInvalidateRandomPair).not.toHaveBeenCalled();
+
+    // Trigger onSuccess to verify it only invalidates watchlist + shows toast
+    const onSuccess = mockWatchlistAddMutate._opts?.onSuccess as (
+      data: unknown,
+      variables: { mediaType: string; mediaId: number }
+    ) => void;
+    onSuccess(undefined, { mediaType: "movie", mediaId: 10 });
+
+    // Should invalidate watchlist cache
+    expect(mockInvalidateWatchlistList).toHaveBeenCalled();
+
+    // Should still NOT refetch pair or record comparison
+    expect(mockRefetchPair).not.toHaveBeenCalled();
+    expect(mockInvalidateRandomPair).not.toHaveBeenCalled();
+    expect(mockRecordMutate).not.toHaveBeenCalled();
+  });
+
   it("renders loading skeletons when pair is loading", () => {
     mockDimensionsQuery.mockReturnValue({
       data: { data: [dim1] },

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -142,8 +142,6 @@ export function CompareArenaPage() {
       const movie =
         variables.mediaId === movieAId ? pairData?.data?.movieA : pairData?.data?.movieB;
       toast.success(`${movie?.title ?? "Movie"} added to watchlist`);
-      // Refetch pair since this movie should now be excluded
-      refetchPair();
     },
   });
 


### PR DESCRIPTION
## Summary
- Remove `refetchPair()` from watchlist add mutation `onSuccess` — the current pair stays visible after adding a movie to watchlist
- Watchlist cache invalidation and success toast remain unchanged
- Add test verifying watchlist button only calls `watchlist.add` with no comparison side effects (no `recordMutation`, no `refetchPair`, no `invalidateRandomPair`)

Closes #1214

## Test plan
- [x] All 10 CompareArenaPage tests pass (including new watchlist isolation test)
- [x] Lint clean
- [x] Typecheck clean
- [ ] Manual: click bookmark in arena → toast appears, pair stays

🤖 Generated with [Claude Code](https://claude.ai/claude-code)