### PR TITLE
feat(media): add N/A button to compare arena action bar [tb-153]

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -17,6 +17,13 @@ const mockWatchlistAddMutate = vi.fn() as ReturnType<typeof vi.fn> & {
 const mockMarkStaleMutate = vi.fn() as ReturnType<typeof vi.fn> & {
   _opts?: Record<string, unknown>;
 };
+const mockExcludeMutateA = vi.fn() as ReturnType<typeof vi.fn> & {
+  _opts?: Record<string, unknown>;
+};
+const mockExcludeMutateB = vi.fn() as ReturnType<typeof vi.fn> & {
+  _opts?: Record<string, unknown>;
+};
+let excludeCallCount = 0;
 const mockInvalidateRandomPair = vi.fn();
 const mockInvalidateWatchlistList = vi.fn();
 
@@ -44,6 +51,14 @@ vi.mock("../lib/trpc", () => ({
           useMutation: (opts: Record<string, unknown>) => {
             mockMarkStaleMutate._opts = opts;
             return { mutate: mockMarkStaleMutate, isPending: false };
+          },
+        },
+        excludeFromDimension: {
+          useMutation: (opts?: Record<string, unknown>) => {
+            excludeCallCount++;
+            const mockFn = excludeCallCount % 2 === 1 ? mockExcludeMutateA : mockExcludeMutateB;
+            if (opts) mockFn._opts = opts;
+            return { mutate: mockFn, isPending: false };
           },
         },
       },
@@ -115,6 +130,7 @@ function setupArena() {
 describe("CompareArenaPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    excludeCallCount = 0;
     // Default watchlist mock — overridden by setupArena but needed for standalone tests
     mockWatchlistListQuery.mockReturnValue({
       data: { data: [] },
@@ -360,6 +376,32 @@ describe("CompareArenaPage", () => {
 
     fireEvent.click(screen.getByLabelText("Mark The Matrix as stale"));
 
+    expect(mockRecordMutate).not.toHaveBeenCalled();
+  });
+
+  it("renders N/A button in action bar", () => {
+    setupArena();
+    renderPage();
+
+    expect(screen.getByText("N/A")).toBeTruthy();
+  });
+
+  it("N/A button calls excludeFromDimension for both movies", () => {
+    setupArena();
+    renderPage();
+
+    fireEvent.click(screen.getByText("N/A"));
+
+    // Should call exclude for movie A (id: 10) — no options arg
+    expect(mockExcludeMutateA).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaType: "movie", mediaId: 10, dimensionId: 1 })
+    );
+    // Should call exclude for movie B (id: 20) — with onSuccess options
+    expect(mockExcludeMutateB).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaType: "movie", mediaId: 20, dimensionId: 1 }),
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+    // Should NOT record a comparison
     expect(mockRecordMutate).not.toHaveBeenCalled();
   });
 });

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -170,6 +170,27 @@ export function CompareArenaPage() {
     [markStaleMutation]
   );
 
+  // N/A (dimension exclusion) mutation
+  const excludeAMutation = trpc.media.comparisons.excludeFromDimension.useMutation();
+  const excludeBMutation = trpc.media.comparisons.excludeFromDimension.useMutation();
+  const naIsPending = excludeAMutation.isPending || excludeBMutation.isPending;
+
+  const handleNA = useCallback(() => {
+    if (!pairData?.data || !dimensionId || naIsPending) return;
+
+    const { movieA, movieB } = pairData.data;
+    excludeAMutation.mutate({ mediaType: "movie", mediaId: movieA.id, dimensionId });
+    excludeBMutation.mutate(
+      { mediaType: "movie", mediaId: movieB.id, dimensionId },
+      {
+        onSuccess: () => {
+          toast.success("Both movies excluded from this dimension");
+          utils.media.comparisons.getRandomPair.invalidate();
+        },
+      }
+    );
+  }, [pairData, dimensionId, naIsPending, excludeAMutation, excludeBMutation, utils]);
+
   const handleAddToWatchlist = useCallback(
     (movieId: number) => {
       addToWatchlistMutation.mutate({
@@ -389,7 +410,7 @@ export function CompareArenaPage() {
         </>
       ) : null}
 
-      {/* Action bar: Stale buttons + Skip + Done */}
+      {/* Action bar: Stale buttons + Skip + N/A + Done */}
       {pairData?.data && !recordMutation.isPending && !scoreDelta && (
         <div className="flex flex-col items-center gap-3">
           <div className="flex justify-center gap-3">
@@ -438,6 +459,15 @@ export function CompareArenaPage() {
               }}
             >
               Skip this pair
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleNA}
+              disabled={naIsPending}
+              className="text-muted-foreground"
+            >
+              {naIsPending ? "Excluding…" : "N/A"}
             </Button>
             <Button variant="ghost" size="sm" onClick={() => navigate("/media")}>
               Done


### PR DESCRIPTION
## Summary
- Add N/A button to arena action bar (between Skip and Done)
- On click: calls `excludeFromDimension` for both movies in current pair for current dimension
- Does not submit a comparison — loads next pair after exclusion
- Button disabled while mutation pending, shows "Excluding..." text

## Test plan
- [x] 11 CompareArenaPage tests pass (9 existing + 2 new)
- [x] Typecheck clean (app-media)
- [x] Prettier formatted

Closes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)