### PR TITLE
feat(media): add deriveTierList service [tb-157]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -651,7 +651,7 @@ export interface RankingsResult {
  * Supports optional mediaType filter and pagination.
  */
 /** Resolve the best poster URL from a rankings row. */
-function resolvePosterUrl(row: {
+export function resolvePosterUrl(row: {
   mediaType: string;
   moviePosterPath: string | null;
   movieTmdbId: number | null;

--- a/apps/pops-api/src/modules/media/comparisons/tier-list.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/tier-list.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database } from "better-sqlite3";
+import { setupTestContext, seedDimension, seedMovie } from "../../../shared/test-utils.js";
+import { deriveTierList } from "./tier-list.js";
+
+const ctx = setupTestContext();
+let db: Database;
+
+beforeEach(() => {
+  ({ db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+function seedScore(
+  db: Database,
+  mediaType: string,
+  mediaId: number,
+  dimensionId: number,
+  score: number,
+  comparisonCount = 5,
+  excluded = 0
+) {
+  db.prepare(
+    `INSERT INTO media_scores (media_type, media_id, dimension_id, score, comparison_count, excluded)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run(mediaType, mediaId, dimensionId, score, comparisonCount, excluded);
+}
+
+describe("deriveTierList", () => {
+  it("returns empty array for dimension with no scores", () => {
+    const dimId = seedDimension(db, { name: "Empty" });
+    const result = deriveTierList(dimId);
+    expect(result).toEqual([]);
+  });
+
+  it("assigns single movie to S tier", () => {
+    const dimId = seedDimension(db, { name: "Solo" });
+    const movieId = seedMovie(db, { tmdb_id: 100, title: "Only Movie" });
+    seedScore(db, "movie", movieId, dimId, 1600);
+
+    const result = deriveTierList(dimId);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.tier).toBe("S");
+    expect(result[0]!.movies).toHaveLength(1);
+    expect(result[0]!.movies[0]!.title).toBe("Only Movie");
+  });
+
+  it("assigns tiers by percentile for 10 movies", () => {
+    const dimId = seedDimension(db, { name: "Full" });
+
+    // Seed 10 movies with descending scores
+    for (let i = 0; i < 10; i++) {
+      const movieId = seedMovie(db, { tmdb_id: 200 + i, title: `Movie ${i}` });
+      seedScore(db, "movie", movieId, dimId, 2000 - i * 100);
+    }
+
+    const result = deriveTierList(dimId);
+
+    // Top 10% (1 movie) = S
+    const sMovies = result.find((g) => g.tier === "S")?.movies ?? [];
+    expect(sMovies).toHaveLength(1);
+    expect(sMovies[0]!.score).toBe(2000);
+
+    // Next 15% (1-2 movies) = A: positions 2 (20%)
+    // Cumulative: 10%=S, 25%=A → movie at index 1 (20%) is A
+    const aMovies = result.find((g) => g.tier === "A")?.movies ?? [];
+    expect(aMovies.length).toBeGreaterThanOrEqual(1);
+
+    // All tiers accounted for
+    const totalMovies = result.reduce((sum, g) => sum + g.movies.length, 0);
+    expect(totalMovies).toBe(10);
+  });
+
+  it("excludes movies with comparison_count = 0", () => {
+    const dimId = seedDimension(db, { name: "Mixed" });
+    const m1 = seedMovie(db, { tmdb_id: 300, title: "Compared" });
+    const m2 = seedMovie(db, { tmdb_id: 301, title: "Uncompared" });
+    seedScore(db, "movie", m1, dimId, 1600, 5);
+    seedScore(db, "movie", m2, dimId, 1500, 0);
+
+    const result = deriveTierList(dimId);
+    const allMovies = result.flatMap((g) => g.movies);
+    expect(allMovies).toHaveLength(1);
+    expect(allMovies[0]!.title).toBe("Compared");
+  });
+
+  it("excludes movies with excluded = 1", () => {
+    const dimId = seedDimension(db, { name: "Exclusions" });
+    const m1 = seedMovie(db, { tmdb_id: 400, title: "Included" });
+    const m2 = seedMovie(db, { tmdb_id: 401, title: "Excluded" });
+    seedScore(db, "movie", m1, dimId, 1600, 5, 0);
+    seedScore(db, "movie", m2, dimId, 1800, 5, 1);
+
+    const result = deriveTierList(dimId);
+    const allMovies = result.flatMap((g) => g.movies);
+    expect(allMovies).toHaveLength(1);
+    expect(allMovies[0]!.title).toBe("Included");
+  });
+
+  it("returns movies sorted by score descending within tiers", () => {
+    const dimId = seedDimension(db, { name: "Sorted" });
+    const m1 = seedMovie(db, { tmdb_id: 500, title: "Top" });
+    const m2 = seedMovie(db, { tmdb_id: 501, title: "Middle" });
+    const m3 = seedMovie(db, { tmdb_id: 502, title: "Bottom" });
+    seedScore(db, "movie", m1, dimId, 1800, 5);
+    seedScore(db, "movie", m2, dimId, 1500, 5);
+    seedScore(db, "movie", m3, dimId, 1200, 5);
+
+    const result = deriveTierList(dimId);
+    const allMovies = result.flatMap((g) => g.movies);
+    expect(allMovies[0]!.title).toBe("Top");
+    expect(allMovies[allMovies.length - 1]!.title).toBe("Bottom");
+  });
+
+  it("only includes empty tiers that have movies", () => {
+    const dimId = seedDimension(db, { name: "Sparse" });
+    const m1 = seedMovie(db, { tmdb_id: 600, title: "One" });
+    const m2 = seedMovie(db, { tmdb_id: 601, title: "Two" });
+    seedScore(db, "movie", m1, dimId, 1800, 5);
+    seedScore(db, "movie", m2, dimId, 1500, 5);
+
+    const result = deriveTierList(dimId);
+    // With 2 movies, not all 6 tiers should be present
+    expect(result.length).toBeLessThanOrEqual(2);
+    expect(result.every((g) => g.movies.length > 0)).toBe(true);
+  });
+
+  it("includes score and comparisonCount in movie data", () => {
+    const dimId = seedDimension(db, { name: "Data" });
+    const movieId = seedMovie(db, {
+      tmdb_id: 700,
+      title: "Data Movie",
+      release_date: "2024-06-15",
+    });
+    seedScore(db, "movie", movieId, dimId, 1750.5, 12);
+
+    const result = deriveTierList(dimId);
+    const movie = result[0]!.movies[0]!;
+    expect(movie.score).toBe(1750.5);
+    expect(movie.comparisonCount).toBe(12);
+    expect(movie.year).toBe(2024);
+    expect(movie.mediaType).toBe("movie");
+    expect(movie.mediaId).toBe(movieId);
+  });
+});

--- a/apps/pops-api/src/modules/media/comparisons/tier-list.ts
+++ b/apps/pops-api/src/modules/media/comparisons/tier-list.ts
@@ -1,0 +1,109 @@
+/**
+ * Tier list derivation — maps ELO scores to S/A/B/C/D/F tiers by percentile.
+ */
+import { getDb } from "../../../db.js";
+import { resolvePosterUrl } from "./service.js";
+
+export const TIERS = ["S", "A", "B", "C", "D", "F"] as const;
+export type Tier = (typeof TIERS)[number];
+
+/** Cumulative percentile breakpoints for each tier (top → bottom). */
+const TIER_BREAKPOINTS: Array<{ tier: Tier; cumulativePercent: number }> = [
+  { tier: "S", cumulativePercent: 0.1 },
+  { tier: "A", cumulativePercent: 0.25 },
+  { tier: "B", cumulativePercent: 0.5 },
+  { tier: "C", cumulativePercent: 0.75 },
+  { tier: "D", cumulativePercent: 0.9 },
+  { tier: "F", cumulativePercent: 1.0 },
+];
+
+export interface TierMovie {
+  mediaType: string;
+  mediaId: number;
+  title: string;
+  year: number | null;
+  posterUrl: string | null;
+  score: number;
+  comparisonCount: number;
+}
+
+export interface TierGroup {
+  tier: Tier;
+  movies: TierMovie[];
+}
+
+function assignTier(index: number, total: number): Tier {
+  if (total <= 1) return "S";
+  const percentile = index / (total - 1);
+  for (const bp of TIER_BREAKPOINTS) {
+    if (percentile <= bp.cumulativePercent) return bp.tier;
+  }
+  return "F";
+}
+
+export function deriveTierList(dimensionId: number): TierGroup[] {
+  const rawDb = getDb();
+
+  const rows = rawDb
+    .prepare(
+      `SELECT
+        ms.media_type as mediaType,
+        ms.media_id as mediaId,
+        ms.score as score,
+        ms.comparison_count as comparisonCount,
+        COALESCE(m.title, tv.name, 'Unknown') as title,
+        CASE
+          WHEN ms.media_type = 'movie' THEN CAST(SUBSTR(m.release_date, 1, 4) AS INTEGER)
+          ELSE CAST(SUBSTR(tv.first_air_date, 1, 4) AS INTEGER)
+        END as year,
+        m.poster_path as moviePosterPath,
+        m.tmdb_id as movieTmdbId,
+        m.poster_override_path as moviePosterOverride,
+        tv.poster_path as tvPosterPath,
+        tv.tvdb_id as tvTvdbId,
+        tv.poster_override_path as tvPosterOverride
+      FROM media_scores ms
+      LEFT JOIN movies m ON ms.media_type = 'movie' AND ms.media_id = m.id
+      LEFT JOIN tv_shows tv ON ms.media_type = 'tv_show' AND ms.media_id = tv.id
+      WHERE ms.dimension_id = ? AND ms.excluded = 0 AND ms.comparison_count > 0
+      ORDER BY ms.score DESC, COALESCE(m.title, tv.name) ASC`
+    )
+    .all(dimensionId) as Array<{
+    mediaType: string;
+    mediaId: number;
+    score: number;
+    comparisonCount: number;
+    title: string;
+    year: number | null;
+    moviePosterPath: string | null;
+    movieTmdbId: number | null;
+    moviePosterOverride: string | null;
+    tvPosterPath: string | null;
+    tvTvdbId: number | null;
+    tvPosterOverride: string | null;
+  }>;
+
+  if (rows.length === 0) return [];
+
+  const tierMap: Record<Tier, TierMovie[]> = { S: [], A: [], B: [], C: [], D: [], F: [] };
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row) continue;
+    const tier = assignTier(i, rows.length);
+    tierMap[tier].push({
+      mediaType: row.mediaType,
+      mediaId: row.mediaId,
+      title: row.title,
+      year: row.year,
+      posterUrl: resolvePosterUrl(row),
+      score: Math.round(row.score * 10) / 10,
+      comparisonCount: row.comparisonCount,
+    });
+  }
+
+  return TIERS.map((tier) => ({
+    tier,
+    movies: tierMap[tier],
+  })).filter((group) => group.movies.length > 0);
+}


### PR DESCRIPTION
## Summary
- Adds `deriveTierList(dimensionId)` service that maps ELO scores to S/A/B/C/D/F tiers using percentile breakpoints
- Top 10% = S, next 15% = A, next 25% = B, next 25% = C, next 15% = D, bottom 10% = F
- Excludes movies with `comparison_count = 0` or `excluded = 1`
- Exports `resolvePosterUrl` from service.ts for reuse

Closes #1280

## Test plan
- [x] 8 tests: empty dimension, single movie, 10-movie percentile distribution, zero-comparison exclusion, excluded flag, sort order, sparse tiers, data fields
- [x] Typecheck clean, lint clean, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)