### PR TITLE
feat(media): add debrief opponent selection service [tb-155]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -8,7 +8,12 @@ import {
   seedWatchHistoryEntry,
   createCaller,
 } from "../../../shared/test-utils.js";
-import { blacklistMovie, excludeFromDimension, includeInDimension } from "./service.js";
+import {
+  blacklistMovie,
+  excludeFromDimension,
+  includeInDimension,
+  getDebriefOpponent,
+} from "./service.js";
 
 const ctx = setupTestContext();
 let caller: ReturnType<typeof createCaller>;
@@ -1842,5 +1847,126 @@ describe("dimension exclusion", () => {
   it("includeInDimension throws NOT_FOUND when no score row exists", () => {
     const dimId = seedDimension(db, { name: "Dim" });
     expect(() => includeInDimension("movie", 999, dimId)).toThrow();
+  });
+});
+
+describe("getDebriefOpponent", () => {
+  function seedScore(
+    rawDb: Database,
+    mediaType: string,
+    mediaId: number,
+    dimensionId: number,
+    score: number,
+    excluded = 0
+  ) {
+    rawDb
+      .prepare(
+        "INSERT INTO media_scores (media_type, media_id, dimension_id, score, comparison_count, excluded) VALUES (?, ?, ?, ?, ?, ?)"
+      )
+      .run(mediaType, mediaId, dimensionId, score, 5, excluded);
+  }
+
+  it("selects movie closest to median score", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const debriefMovieId = seedMovie(db, { title: "Debrief Movie", tmdb_id: 100 });
+    const lowId = seedMovie(db, { title: "Low Movie", tmdb_id: 101 });
+    const midId = seedMovie(db, { title: "Mid Movie", tmdb_id: 102 });
+    const highId = seedMovie(db, { title: "High Movie", tmdb_id: 103 });
+
+    seedScore(db, "movie", debriefMovieId, dimId, 1500);
+    seedScore(db, "movie", lowId, dimId, 1200);
+    seedScore(db, "movie", midId, dimId, 1500);
+    seedScore(db, "movie", highId, dimId, 1800);
+
+    const result = getDebriefOpponent("movie", debriefMovieId, dimId);
+    expect(result).not.toBeNull();
+    // Median of [1200, 1500, 1800] (sorted, after excluding debrief) is 1500
+    expect(result!.id).toBe(midId);
+    expect(result!.title).toBe("Mid Movie");
+  });
+
+  it("excludes the debrief movie itself", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const debriefId = seedMovie(db, { title: "Only Movie", tmdb_id: 200 });
+
+    seedScore(db, "movie", debriefId, dimId, 1500);
+
+    const result = getDebriefOpponent("movie", debriefId, dimId);
+    expect(result).toBeNull();
+  });
+
+  it("excludes movies with excluded=1 for the dimension", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const debriefId = seedMovie(db, { title: "Debrief", tmdb_id: 300 });
+    const excludedId = seedMovie(db, { title: "Excluded", tmdb_id: 301 });
+
+    seedScore(db, "movie", debriefId, dimId, 1500);
+    seedScore(db, "movie", excludedId, dimId, 1500, 1); // excluded=1
+
+    const result = getDebriefOpponent("movie", debriefId, dimId);
+    expect(result).toBeNull();
+  });
+
+  it("excludes blacklisted movies", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const debriefId = seedMovie(db, { title: "Debrief", tmdb_id: 400 });
+    const blacklistedId = seedMovie(db, { title: "Blacklisted", tmdb_id: 401 });
+
+    seedScore(db, "movie", debriefId, dimId, 1500);
+    seedScore(db, "movie", blacklistedId, dimId, 1500);
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: blacklistedId,
+      blacklisted: 1,
+    });
+
+    const result = getDebriefOpponent("movie", debriefId, dimId);
+    expect(result).toBeNull();
+  });
+
+  it("excludes movies already compared against in this dimension", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const debriefId = seedMovie(db, { title: "Debrief", tmdb_id: 500 });
+    const comparedId = seedMovie(db, { title: "Compared", tmdb_id: 501 });
+
+    seedScore(db, "movie", debriefId, dimId, 1500);
+    seedScore(db, "movie", comparedId, dimId, 1500);
+
+    // Insert a comparison between them
+    db.prepare(
+      "INSERT INTO comparisons (dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, winner_type, winner_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run(dimId, "movie", debriefId, "movie", comparedId, "movie", debriefId);
+
+    const result = getDebriefOpponent("movie", debriefId, dimId);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no eligible opponents exist", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const debriefId = seedMovie(db, { title: "Debrief", tmdb_id: 600 });
+
+    seedScore(db, "movie", debriefId, dimId, 1500);
+    // No other movies have scores
+
+    const result = getDebriefOpponent("movie", debriefId, dimId);
+    expect(result).toBeNull();
+  });
+
+  it("returns via tRPC endpoint", async () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const debriefId = seedMovie(db, { title: "Debrief", tmdb_id: 700 });
+    const opponentId = seedMovie(db, { title: "Opponent", tmdb_id: 701 });
+
+    seedScore(db, "movie", debriefId, dimId, 1500);
+    seedScore(db, "movie", opponentId, dimId, 1500);
+
+    const result = await caller.media.comparisons.getDebriefOpponent({
+      mediaType: "movie",
+      mediaId: debriefId,
+      dimensionId: dimId,
+    });
+    expect(result.data).not.toBeNull();
+    expect(result.data!.id).toBe(opponentId);
+    expect(result.data!.title).toBe("Opponent");
   });
 });

--- a/apps/pops-api/src/modules/media/comparisons/router.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router.ts
@@ -19,6 +19,7 @@ import {
   DimensionExclusionSchema,
   StalenessSchema,
   RecordSkipSchema,
+  GetDebriefOpponentSchema,
   toDimension,
   toComparison,
   toMediaScore,
@@ -196,6 +197,23 @@ export const comparisonsRouter = router({
   getStaleness: protectedProcedure.input(StalenessSchema).query(({ input }) => {
     const staleness = stalenessService.getStaleness(input.mediaType, input.mediaId);
     return { data: { staleness } };
+  }),
+
+  /** Get a debrief opponent — movie closest to median score, excluding ineligible. */
+  getDebriefOpponent: protectedProcedure.input(GetDebriefOpponentSchema).query(({ input }) => {
+    try {
+      const opponent = service.getDebriefOpponent(
+        input.mediaType,
+        input.mediaId,
+        input.dimensionId
+      );
+      return { data: opponent };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
   }),
 
   /** Record a skip (puts pair on cooloff for 10 global comparisons). */

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -24,6 +24,7 @@ import {
   type RandomPair,
   type RankedMediaEntry,
   type BlacklistMovieResult,
+  type DebriefOpponent,
 } from "./types.js";
 
 // ── Dimensions ──
@@ -1088,6 +1089,139 @@ export function isPairOnCooloff(
 
   if (!cooloff) return false;
   return globalCount < cooloff.skipUntil;
+}
+
+// ── Debrief Opponent Selection ──
+
+/**
+ * Select a debrief opponent — the eligible movie closest to the median score
+ * for the given dimension.
+ *
+ * Excludes:
+ *  - The debrief movie itself
+ *  - Movies excluded from the dimension (excluded = 1)
+ *  - Blacklisted movies (watch_history.blacklisted = 1)
+ *  - Movies already compared against the debrief movie in this dimension
+ */
+export function getDebriefOpponent(
+  mediaType: string,
+  mediaId: number,
+  dimensionId: number
+): DebriefOpponent | null {
+  getDimension(dimensionId); // verify dimension exists
+
+  const db = getDrizzle();
+
+  // Get all non-excluded scores for this dimension
+  const allScores = db
+    .select()
+    .from(mediaScores)
+    .where(
+      and(
+        eq(mediaScores.dimensionId, dimensionId),
+        eq(mediaScores.mediaType, mediaType),
+        eq(mediaScores.excluded, 0)
+      )
+    )
+    .orderBy(asc(mediaScores.score))
+    .all();
+
+  // Get blacklisted movie IDs
+  const blacklistedIds = new Set(
+    db
+      .select({ mediaId: watchHistory.mediaId })
+      .from(watchHistory)
+      .where(
+        and(
+          eq(watchHistory.mediaType, mediaType as "movie" | "episode"),
+          eq(watchHistory.blacklisted, 1)
+        )
+      )
+      .all()
+      .map((r) => r.mediaId)
+  );
+
+  // Get IDs of movies already compared against this one in this dimension
+  const comparedAgainstIds = new Set<number>();
+  const compsA = db
+    .select({ mediaBId: comparisons.mediaBId })
+    .from(comparisons)
+    .where(
+      and(
+        eq(comparisons.dimensionId, dimensionId),
+        eq(comparisons.mediaAType, mediaType),
+        eq(comparisons.mediaAId, mediaId)
+      )
+    )
+    .all();
+  for (const c of compsA) comparedAgainstIds.add(c.mediaBId);
+
+  const compsB = db
+    .select({ mediaAId: comparisons.mediaAId })
+    .from(comparisons)
+    .where(
+      and(
+        eq(comparisons.dimensionId, dimensionId),
+        eq(comparisons.mediaBType, mediaType),
+        eq(comparisons.mediaBId, mediaId)
+      )
+    )
+    .all();
+  for (const c of compsB) comparedAgainstIds.add(c.mediaAId);
+
+  // Filter eligible candidates
+  const eligible = allScores.filter(
+    (s) =>
+      s.mediaId !== mediaId && !blacklistedIds.has(s.mediaId) && !comparedAgainstIds.has(s.mediaId)
+  );
+
+  if (eligible.length === 0) return null;
+
+  // Find median score
+  const medianIndex = Math.floor(eligible.length / 2);
+  const medianEntry = eligible[medianIndex];
+  if (!medianEntry) return null;
+  const medianScore = medianEntry.score;
+
+  // Pick the one closest to median
+  let closest = eligible[0];
+  if (!closest) return null;
+  let closestDist = Math.abs(closest.score - medianScore);
+  for (const s of eligible) {
+    const dist = Math.abs(s.score - medianScore);
+    if (dist < closestDist) {
+      closest = s;
+      closestDist = dist;
+    }
+  }
+
+  // Fetch movie metadata
+  const movieRow = db
+    .select({
+      id: movies.id,
+      title: movies.title,
+      posterPath: movies.posterPath,
+      tmdbId: movies.tmdbId,
+      posterOverridePath: movies.posterOverridePath,
+    })
+    .from(movies)
+    .where(eq(movies.id, closest.mediaId))
+    .get();
+
+  if (!movieRow) return null;
+
+  const posterUrl = movieRow.posterOverridePath
+    ? movieRow.posterOverridePath
+    : movieRow.posterPath
+      ? `/media/images/movie/${movieRow.tmdbId}/poster.jpg`
+      : null;
+
+  return {
+    id: movieRow.id,
+    title: movieRow.title,
+    posterPath: movieRow.posterPath,
+    posterUrl,
+  };
 }
 
 /**

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -227,3 +227,18 @@ export const RecordSkipSchema = z.object({
   mediaBId: z.number().int().positive(),
 });
 export type RecordSkipInput = z.infer<typeof RecordSkipSchema>;
+
+export const GetDebriefOpponentSchema = z.object({
+  mediaType: z.enum(MEDIA_TYPES),
+  mediaId: z.number().int().positive(),
+  dimensionId: z.number().int().positive(),
+});
+export type GetDebriefOpponentInput = z.infer<typeof GetDebriefOpponentSchema>;
+
+/** API response shape for a debrief opponent. */
+export interface DebriefOpponent {
+  id: number;
+  title: string;
+  posterPath: string | null;
+  posterUrl: string | null;
+}


### PR DESCRIPTION
## Summary
- Add `getDebriefOpponent(mediaType, mediaId, dimensionId)` service function that selects the eligible movie closest to the median score for a dimension
- Excludes: the debrief movie itself, dimension-excluded movies, blacklisted movies, and movies already compared against in this dimension
- Returns `{id, title, posterPath, posterUrl}` or `null` if no eligible opponents
- Add `getDebriefOpponent` tRPC query endpoint
- Add `DebriefOpponent` type + `GetDebriefOpponentSchema` Zod validation

Closes #1270

## Test plan
- [x] 7 new tests covering: median selection, self-exclusion, dimension exclusion, blacklist exclusion, comparison exclusion, null when exhausted, tRPC endpoint
- [x] All 88 comparison tests pass
- [x] Lint clean
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)