### PR TITLE
feat(media): add Not Watched buttons to compare arena [tb-150]

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -17,6 +17,9 @@ const mockWatchlistAddMutate = vi.fn() as ReturnType<typeof vi.fn> & {
 const mockMarkStaleMutate = vi.fn() as ReturnType<typeof vi.fn> & {
   _opts?: Record<string, unknown>;
 };
+const mockBlacklistMutate = vi.fn() as ReturnType<typeof vi.fn> & {
+  _opts?: Record<string, unknown>;
+};
 const mockInvalidateRandomPair = vi.fn();
 const mockInvalidateWatchlistList = vi.fn();
 
@@ -44,6 +47,12 @@ vi.mock("../lib/trpc", () => ({
           useMutation: (opts: Record<string, unknown>) => {
             mockMarkStaleMutate._opts = opts;
             return { mutate: mockMarkStaleMutate, isPending: false };
+          },
+        },
+        blacklistMovie: {
+          useMutation: (opts: Record<string, unknown>) => {
+            mockBlacklistMutate._opts = opts;
+            return { mutate: mockBlacklistMutate, isPending: false };
           },
         },
       },
@@ -361,5 +370,39 @@ describe("CompareArenaPage", () => {
     fireEvent.click(screen.getByLabelText("Mark The Matrix as stale"));
 
     expect(mockRecordMutate).not.toHaveBeenCalled();
+  });
+
+  it("renders Not Watched buttons for both movies", () => {
+    setupArena();
+    renderPage();
+    expect(screen.getByLabelText("Not watched The Matrix")).toBeTruthy();
+    expect(screen.getByLabelText("Not watched Inception")).toBeTruthy();
+  });
+
+  it("opens confirmation dialog when Not Watched button is clicked", () => {
+    setupArena();
+    renderPage();
+    fireEvent.click(screen.getByLabelText("Not watched The Matrix"));
+    expect(screen.getByText("Mark as not watched?")).toBeTruthy();
+    expect(screen.getByText(/All comparisons involving this movie/)).toBeTruthy();
+    expect(screen.getByText("Cancel")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Not Watched" })).toBeTruthy();
+  });
+
+  it("calls blacklistMovie mutation on confirm", () => {
+    setupArena();
+    renderPage();
+    fireEvent.click(screen.getByLabelText("Not watched Inception"));
+    fireEvent.click(screen.getByRole("button", { name: "Not Watched" }));
+    expect(mockBlacklistMutate).toHaveBeenCalledWith({ mediaType: "movie", mediaId: 20 });
+  });
+
+  it("closes dialog on cancel without calling blacklist", () => {
+    setupArena();
+    renderPage();
+    fireEvent.click(screen.getByLabelText("Not watched The Matrix"));
+    expect(screen.getByText("Mark as not watched?")).toBeTruthy();
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(mockBlacklistMutate).not.toHaveBeenCalled();
   });
 });

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -1,7 +1,22 @@
 import { useState, useCallback, useEffect } from "react";
 import { Link, useNavigate } from "react-router";
-import { Badge, Skeleton, Button, Tooltip, TooltipContent, TooltipTrigger } from "@pops/ui";
-import { ImageOff, Bookmark, ChevronUp, Minus, ChevronDown, Clock } from "lucide-react";
+import {
+  Badge,
+  Skeleton,
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@pops/ui";
+import { ImageOff, Bookmark, ChevronUp, Minus, ChevronDown, Clock, X } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
 import { DimensionManager } from "../components/DimensionManager";
@@ -170,6 +185,34 @@ export function CompareArenaPage() {
     [markStaleMutation]
   );
 
+  // Blacklist ("Not Watched") state + mutation
+  const [blacklistTarget, setBlacklistTarget] = useState<{
+    id: number;
+    title: string;
+  } | null>(null);
+
+  const blacklistMutation = trpc.media.comparisons.blacklistMovie.useMutation({
+    onSuccess: (_data: unknown, variables: { mediaType: string; mediaId: number }) => {
+      const movie =
+        variables.mediaId === movieAId ? pairData?.data?.movieA : pairData?.data?.movieB;
+      toast.success(`${movie?.title ?? "Movie"} marked as not watched`);
+      setBlacklistTarget(null);
+      utils.media.comparisons.getRandomPair.invalidate();
+    },
+  });
+
+  const handleBlacklist = useCallback((movie: { id: number; title: string }) => {
+    setBlacklistTarget(movie);
+  }, []);
+
+  const confirmBlacklist = useCallback(() => {
+    if (!blacklistTarget) return;
+    blacklistMutation.mutate({
+      mediaType: "movie",
+      mediaId: blacklistTarget.id,
+    });
+  }, [blacklistTarget, blacklistMutation]);
+
   const handleAddToWatchlist = useCallback(
     (movieId: number) => {
       addToWatchlistMutation.mutate({
@@ -327,6 +370,8 @@ export function CompareArenaPage() {
               onAddToWatchlist={() => handleAddToWatchlist(pairData.data.movieA.id)}
               isOnWatchlist={watchlistedMovieIds.has(pairData.data.movieA.id)}
               watchlistPending={addToWatchlistMutation.isPending}
+              onBlacklist={() => handleBlacklist(pairData.data.movieA)}
+              blacklistPending={blacklistMutation.isPending}
             />
 
             {/* Draw tier buttons — centered between cards */}
@@ -384,6 +429,8 @@ export function CompareArenaPage() {
               onAddToWatchlist={() => handleAddToWatchlist(pairData.data.movieB.id)}
               isOnWatchlist={watchlistedMovieIds.has(pairData.data.movieB.id)}
               watchlistPending={addToWatchlistMutation.isPending}
+              onBlacklist={() => handleBlacklist(pairData.data.movieB)}
+              blacklistPending={blacklistMutation.isPending}
             />
           </div>
         </>
@@ -445,6 +492,35 @@ export function CompareArenaPage() {
           </div>
         </div>
       )}
+
+      {/* Blacklist confirmation dialog */}
+      <AlertDialog
+        open={blacklistTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setBlacklistTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Mark as not watched?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will mark{" "}
+              <span className="font-medium text-foreground">{blacklistTarget?.title}</span> as not
+              watched. All comparisons involving this movie will be deleted and scores recalculated.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={confirmBlacklist}
+              disabled={blacklistMutation.isPending}
+            >
+              {blacklistMutation.isPending ? "Removing…" : "Not Watched"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -458,6 +534,8 @@ function MovieCard({
   onAddToWatchlist,
   isOnWatchlist,
   watchlistPending,
+  onBlacklist,
+  blacklistPending,
 }: {
   movie: { id: number; title: string; posterPath: string | null; posterUrl: string | null };
   onPick: () => void;
@@ -467,6 +545,8 @@ function MovieCard({
   onAddToWatchlist?: () => void;
   isOnWatchlist?: boolean;
   watchlistPending?: boolean;
+  onBlacklist?: () => void;
+  blacklistPending?: boolean;
 }) {
   const posterSrc = movie.posterUrl ?? undefined;
   const [imgError, setImgError] = useState(false);
@@ -520,6 +600,21 @@ function MovieCard({
           aria-label={isOnWatchlist ? "On watchlist" : `Add ${movie.title} to watchlist`}
         >
           <Bookmark className={`h-4 w-4 ${isOnWatchlist ? "fill-current" : ""}`} />
+        </button>
+      )}
+
+      {/* Not Watched button */}
+      {onBlacklist && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onBlacklist();
+          }}
+          disabled={blacklistPending}
+          className="absolute bottom-2 left-2 p-1.5 rounded-full transition-colors bg-background/80 text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 border border-red-200 dark:border-red-800"
+          aria-label={`Not watched ${movie.title}`}
+        >
+          <X className="h-4 w-4" />
         </button>
       )}
 


### PR DESCRIPTION
## Summary
- Adds "Not Watched" (X) buttons on each movie card in the compare arena
- Clicking triggers an AlertDialog confirmation before blacklisting
- On confirm, calls `blacklistMovie` mutation to remove watch events, purge comparisons, and recalculate Elo scores
- Supersedes #1294 (rebased cleanly on current main)

## Test plan
- [x] 4 new test cases: render buttons, dialog open, confirm calls mutation, cancel closes dialog
- [x] All 18 CompareArenaPage tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)