### PR TITLE
feat(media): add getPendingDebriefs tRPC query [tb-163]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -13,6 +13,7 @@ import {
   excludeFromDimension,
   includeInDimension,
   getDebriefOpponent,
+  getPendingDebriefs,
 } from "./service.js";
 
 const ctx = setupTestContext();
@@ -1968,5 +1969,111 @@ describe("getDebriefOpponent", () => {
     expect(result.data).not.toBeNull();
     expect(result.data!.id).toBe(opponentId);
     expect(result.data!.title).toBe("Opponent");
+  });
+});
+
+describe("getPendingDebriefs", () => {
+  function seedDebriefSession(
+    rawDb: Database,
+    watchHistoryId: number,
+    status: string = "pending"
+  ): number {
+    const result = rawDb
+      .prepare("INSERT INTO debrief_sessions (watch_history_id, status) VALUES (?, ?)")
+      .run(watchHistoryId, status);
+    return Number(result.lastInsertRowid);
+  }
+
+  function seedDebriefResult(
+    rawDb: Database,
+    sessionId: number,
+    dimensionId: number,
+    comparisonId: number | null = null
+  ) {
+    rawDb
+      .prepare(
+        "INSERT INTO debrief_results (session_id, dimension_id, comparison_id) VALUES (?, ?, ?)"
+      )
+      .run(sessionId, dimensionId, comparisonId);
+  }
+
+  it("returns movies with pending debrief sessions", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const movieId = seedMovie(db, { title: "Watched Movie", tmdb_id: 800 });
+    const whId = seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      completed: 1,
+    });
+    seedDebriefSession(db, whId, "pending");
+
+    const results = getPendingDebriefs();
+    expect(results).toHaveLength(1);
+    expect(results[0]!.movieId).toBe(movieId);
+    expect(results[0]!.title).toBe("Watched Movie");
+    expect(results[0]!.status).toBe("pending");
+    expect(results[0]!.pendingDimensionCount).toBe(1); // 1 active dim, 0 results
+    void dimId;
+  });
+
+  it("excludes complete sessions", () => {
+    const movieId = seedMovie(db, { title: "Done Movie", tmdb_id: 801 });
+    const whId = seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      completed: 1,
+    });
+    seedDebriefSession(db, whId, "complete");
+
+    const results = getPendingDebriefs();
+    expect(results).toHaveLength(0);
+  });
+
+  it("includes active sessions", () => {
+    const movieId = seedMovie(db, { title: "Active Movie", tmdb_id: 802 });
+    const whId = seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      completed: 1,
+    });
+    seedDebriefSession(db, whId, "active");
+
+    const results = getPendingDebriefs();
+    expect(results).toHaveLength(1);
+    expect(results[0]!.status).toBe("active");
+  });
+
+  it("counts pending dimensions correctly", () => {
+    const dim1 = seedDimension(db, { name: "Dim A" });
+    const dim2 = seedDimension(db, { name: "Dim B" });
+    const movieId = seedMovie(db, { title: "Partial Movie", tmdb_id: 803 });
+    const whId = seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      completed: 1,
+    });
+    const sessionId = seedDebriefSession(db, whId, "active");
+    // Complete one dimension
+    seedDebriefResult(db, sessionId, dim1, null);
+
+    const results = getPendingDebriefs();
+    expect(results).toHaveLength(1);
+    // 2 active dims - 1 completed result = 1 pending
+    expect(results[0]!.pendingDimensionCount).toBe(1);
+    void dim2;
+  });
+
+  it("returns via tRPC endpoint", async () => {
+    const movieId = seedMovie(db, { title: "Debrief Via API", tmdb_id: 804 });
+    const whId = seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: movieId,
+      completed: 1,
+    });
+    seedDebriefSession(db, whId, "pending");
+
+    const result = await caller.media.comparisons.getPendingDebriefs();
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]!.title).toBe("Debrief Via API");
   });
 });

--- a/apps/pops-api/src/modules/media/comparisons/router.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router.ts
@@ -216,6 +216,12 @@ export const comparisonsRouter = router({
     return { data: { staleness } };
   }),
 
+  /** Get all movies with pending/active debrief sessions. */
+  getPendingDebriefs: protectedProcedure.query(() => {
+    const debriefs = service.getPendingDebriefs();
+    return { data: debriefs };
+  }),
+
   /** Get a debrief opponent — movie closest to median score, excluding ineligible. */
   getDebriefOpponent: protectedProcedure.input(GetDebriefOpponentSchema).query(({ input }) => {
     try {

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -11,6 +11,8 @@ import {
   mediaWatchlist,
   watchHistory,
   movies,
+  debriefSessions,
+  debriefResults,
 } from "@pops/db-types";
 import { NotFoundError, ConflictError, ValidationError } from "../../../shared/errors.js";
 import {
@@ -25,6 +27,7 @@ import {
   type RankedMediaEntry,
   type BlacklistMovieResult,
   type DebriefOpponent,
+  type PendingDebrief,
 } from "./types.js";
 import { getStaleness } from "./staleness.js";
 
@@ -1559,6 +1562,99 @@ export function getDebriefOpponent(
     posterPath: movieRow.posterPath,
     posterUrl,
   };
+}
+
+// ── Pending Debriefs ──
+
+/**
+ * Get all movies with pending or active debrief sessions.
+ * Joins debrief_sessions → watch_history → movies and counts
+ * how many dimensions still need results per session.
+ */
+export function getPendingDebriefs(): PendingDebrief[] {
+  const db = getDrizzle();
+
+  // Get sessions that are pending or active
+  const sessions = db
+    .select({
+      sessionId: debriefSessions.id,
+      status: debriefSessions.status,
+      watchHistoryId: debriefSessions.watchHistoryId,
+      createdAt: debriefSessions.createdAt,
+    })
+    .from(debriefSessions)
+    .where(or(eq(debriefSessions.status, "pending"), eq(debriefSessions.status, "active")))
+    .orderBy(desc(debriefSessions.createdAt))
+    .all();
+
+  if (sessions.length === 0) return [];
+
+  // Get count of active dimensions
+  const activeDimCount =
+    db
+      .select({ total: count() })
+      .from(comparisonDimensions)
+      .where(eq(comparisonDimensions.active, 1))
+      .all()[0]?.total ?? 0;
+
+  const results: PendingDebrief[] = [];
+
+  for (const session of sessions) {
+    // Get watch history entry to find media info
+    const whEntry = db
+      .select({
+        mediaType: watchHistory.mediaType,
+        mediaId: watchHistory.mediaId,
+      })
+      .from(watchHistory)
+      .where(eq(watchHistory.id, session.watchHistoryId))
+      .get();
+
+    if (!whEntry || whEntry.mediaType !== "movie") continue;
+
+    // Get movie info
+    const movieRow = db
+      .select({
+        id: movies.id,
+        title: movies.title,
+        posterPath: movies.posterPath,
+        tmdbId: movies.tmdbId,
+        posterOverridePath: movies.posterOverridePath,
+      })
+      .from(movies)
+      .where(eq(movies.id, whEntry.mediaId))
+      .get();
+
+    if (!movieRow) continue;
+
+    // Count completed debrief results for this session
+    const completedCount =
+      db
+        .select({ total: count() })
+        .from(debriefResults)
+        .where(eq(debriefResults.sessionId, session.sessionId))
+        .all()[0]?.total ?? 0;
+
+    const pendingDimensionCount = Math.max(0, activeDimCount - completedCount);
+
+    const posterUrl = movieRow.posterOverridePath
+      ? movieRow.posterOverridePath
+      : movieRow.posterPath
+        ? `/media/images/movie/${movieRow.tmdbId}/poster.jpg`
+        : null;
+
+    results.push({
+      sessionId: session.sessionId,
+      movieId: movieRow.id,
+      title: movieRow.title,
+      posterUrl,
+      status: session.status as "pending" | "active",
+      createdAt: session.createdAt,
+      pendingDimensionCount,
+    });
+  }
+
+  return results;
 }
 
 /**

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -248,3 +248,14 @@ export interface DebriefOpponent {
   posterPath: string | null;
   posterUrl: string | null;
 }
+
+/** API response shape for a pending debrief entry. */
+export interface PendingDebrief {
+  sessionId: number;
+  movieId: number;
+  title: string;
+  posterUrl: string | null;
+  status: "pending" | "active";
+  createdAt: string;
+  pendingDimensionCount: number;
+}


### PR DESCRIPTION
## Summary
- Add `getPendingDebriefs()` service function that returns movies with pending/active debrief sessions
- Joins `debrief_sessions` → `watch_history` → `movies` to get movie metadata
- Counts pending dimensions per session (active dimensions minus completed debrief_results)
- Returns `{sessionId, movieId, title, posterUrl, status, createdAt, pendingDimensionCount}`
- Add `getPendingDebriefs` tRPC query endpoint (no input required)
- Add `PendingDebrief` type

Closes #1274

## Test plan
- [x] 5 new tests: returns pending list, excludes complete sessions, includes active sessions, counts pending dimensions correctly, tRPC endpoint integration
- [x] All 93 comparison tests pass
- [x] Lint clean
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)