### PR TITLE
feat(media): add getTierListMovies for max info gain selection [tb-159]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -14,6 +14,7 @@ import {
   includeInDimension,
   getDebriefOpponent,
   getPendingDebriefs,
+  getTierListMovies,
 } from "./service.js";
 
 const ctx = setupTestContext();
@@ -2075,5 +2076,151 @@ describe("getPendingDebriefs", () => {
     const result = await caller.media.comparisons.getPendingDebriefs();
     expect(result.data).toHaveLength(1);
     expect(result.data[0]!.title).toBe("Debrief Via API");
+  });
+});
+
+describe("getTierListMovies", () => {
+  function seedScore(
+    mediaType: string,
+    mediaId: number,
+    dimensionId: number,
+    score: number,
+    comparisonCount = 5,
+    excluded = 0
+  ) {
+    db.prepare(
+      `INSERT INTO media_scores (media_type, media_id, dimension_id, score, comparison_count, excluded)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).run(mediaType, mediaId, dimensionId, score, comparisonCount, excluded);
+  }
+
+  function seedStaleness(mediaType: string, mediaId: number, staleness: number) {
+    db.prepare(
+      `INSERT INTO comparison_staleness (media_type, media_id, staleness, updated_at)
+       VALUES (?, ?, ?, datetime('now'))`
+    ).run(mediaType, mediaId, staleness);
+  }
+
+  function seedMovieWithWatch(tmdbId: number, title: string): number {
+    const movieId = seedMovie(db, { tmdb_id: tmdbId, title });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieId, completed: 1 });
+    return movieId;
+  }
+
+  it("returns up to 8 movies", () => {
+    const dimId = seedDimension(db, { name: "Full" });
+    for (let i = 0; i < 12; i++) {
+      const movieId = seedMovieWithWatch(100 + i, `Movie ${i}`);
+      seedScore("movie", movieId, dimId, 1200 + i * 100, 3 + i);
+    }
+
+    const result = getTierListMovies(dimId);
+    expect(result.length).toBeLessThanOrEqual(8);
+    expect(result.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("excludes dimension-excluded movies", () => {
+    const dimId = seedDimension(db, { name: "Exclusion" });
+    const m1 = seedMovieWithWatch(200, "Included");
+    const m2 = seedMovieWithWatch(201, "Excluded");
+    const m3 = seedMovieWithWatch(202, "Also Included");
+    seedScore("movie", m1, dimId, 1600, 5);
+    seedScore("movie", m2, dimId, 1800, 5, 1); // excluded
+    seedScore("movie", m3, dimId, 1400, 5);
+
+    const result = getTierListMovies(dimId);
+    const titles = result.map((m) => m.title);
+    expect(titles).toContain("Included");
+    expect(titles).toContain("Also Included");
+    expect(titles).not.toContain("Excluded");
+  });
+
+  it("excludes blacklisted movies", () => {
+    const dimId = seedDimension(db, { name: "Blacklist" });
+    const m1 = seedMovieWithWatch(300, "Good Movie");
+    const m2 = seedMovie(db, { tmdb_id: 301, title: "Blacklisted Movie" });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m2, completed: 1, blacklisted: 1 });
+    const m3 = seedMovieWithWatch(302, "Another Good");
+    seedScore("movie", m1, dimId, 1600, 5);
+    seedScore("movie", m2, dimId, 1800, 5);
+    seedScore("movie", m3, dimId, 1400, 5);
+
+    const result = getTierListMovies(dimId);
+    const titles = result.map((m) => m.title);
+    expect(titles).toContain("Good Movie");
+    expect(titles).not.toContain("Blacklisted Movie");
+  });
+
+  it("excludes movies with staleness < 0.3", () => {
+    const dimId = seedDimension(db, { name: "Staleness" });
+    const m1 = seedMovieWithWatch(400, "Fresh Movie");
+    const m2 = seedMovieWithWatch(401, "Stale Movie");
+    const m3 = seedMovieWithWatch(402, "OK Movie");
+    seedScore("movie", m1, dimId, 1600, 5);
+    seedScore("movie", m2, dimId, 1800, 5);
+    seedScore("movie", m3, dimId, 1400, 5);
+    seedStaleness("movie", m2, 0.25); // below threshold
+
+    const result = getTierListMovies(dimId);
+    const titles = result.map((m) => m.title);
+    expect(titles).toContain("Fresh Movie");
+    expect(titles).not.toContain("Stale Movie");
+  });
+
+  it("returns mixed score ranges (not all top or bottom)", () => {
+    const dimId = seedDimension(db, { name: "Mixed" });
+    // Seed 10 movies with spread scores, all low comparison counts
+    for (let i = 0; i < 10; i++) {
+      const movieId = seedMovieWithWatch(500 + i, `Range ${i}`);
+      seedScore("movie", movieId, dimId, 1000 + i * 200, 2);
+    }
+
+    const result = getTierListMovies(dimId);
+    expect(result.length).toBe(8);
+
+    // Check that we have a mix — not all from the top or bottom half
+    const scores = result.map((m) => m.score);
+    const maxScore = Math.max(...scores);
+    const minScore = Math.min(...scores);
+    expect(maxScore - minScore).toBeGreaterThan(400);
+  });
+
+  it("returns fewer than 8 when not enough eligible", () => {
+    const dimId = seedDimension(db, { name: "Small" });
+    for (let i = 0; i < 3; i++) {
+      const movieId = seedMovieWithWatch(600 + i, `Small ${i}`);
+      seedScore("movie", movieId, dimId, 1400 + i * 100, 5);
+    }
+
+    const result = getTierListMovies(dimId);
+    expect(result).toHaveLength(3);
+  });
+
+  it("returns empty array when fewer than 2 eligible", () => {
+    const dimId = seedDimension(db, { name: "Tiny" });
+    const movieId = seedMovieWithWatch(700, "Lonely");
+    seedScore("movie", movieId, dimId, 1500, 5);
+
+    const result = getTierListMovies(dimId);
+    expect(result).toEqual([]);
+  });
+
+  it("includes posterUrl and title in response", () => {
+    const dimId = seedDimension(db, { name: "Data" });
+    const m1 = seedMovieWithWatch(800, "Data Movie 1");
+    const m2 = seedMovieWithWatch(801, "Data Movie 2");
+    seedScore("movie", m1, dimId, 1600, 5);
+    seedScore("movie", m2, dimId, 1400, 5);
+
+    const result = getTierListMovies(dimId);
+    expect(result.length).toBe(2);
+    for (const movie of result) {
+      expect(movie).toHaveProperty("title");
+      expect(movie).toHaveProperty("posterUrl");
+      expect(movie).toHaveProperty("mediaType");
+      expect(movie).toHaveProperty("mediaId");
+      expect(movie).toHaveProperty("score");
+      expect(movie).toHaveProperty("comparisonCount");
+    }
   });
 });

--- a/apps/pops-api/src/modules/media/comparisons/router.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router.ts
@@ -21,6 +21,7 @@ import {
   StalenessSchema,
   RecordSkipSchema,
   GetDebriefOpponentSchema,
+  TierListMoviesQuerySchema,
   toDimension,
   toComparison,
   toMediaScore,
@@ -250,6 +251,19 @@ export const comparisonsRouter = router({
         input.mediaBId
       );
       return { data: { skipUntil }, message: "Skip recorded" };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
+  }),
+
+  /** Select up to 8 movies for a tier list placement round. */
+  getTierListMovies: protectedProcedure.input(TierListMoviesQuerySchema).query(({ input }) => {
+    try {
+      const movies = service.getTierListMovies(input.dimensionId);
+      return { data: movies };
     } catch (err) {
       if (err instanceof NotFoundError) {
         throw new TRPCError({ code: "NOT_FOUND", message: err.message });

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -28,6 +28,7 @@ import {
   type BlacklistMovieResult,
   type DebriefOpponent,
   type PendingDebrief,
+  type TierListPlacementMovie,
 } from "./types.js";
 import { getStaleness } from "./staleness.js";
 
@@ -1671,4 +1672,111 @@ function normalizePairOrder(
   const keyB = `${bType}:${bId}`;
   if (keyA <= keyB) return [aType, aId, bType, bId];
   return [bType, bId, aType, aId];
+}
+
+const TIER_LIST_MAX = 8;
+const TIER_LIST_MIN = 2;
+const TIER_LIST_BUFFER_MULTIPLIER = 3;
+const STALENESS_THRESHOLD = 0.3;
+
+/**
+ * Select up to 8 movies for a tier list placement round.
+ *
+ * Strategy: prefer low comparison count (high uncertainty) with a mix of score
+ * ranges (not all top or bottom). Excludes blacklisted, dimension-excluded,
+ * and stale (< 0.3) movies. Returns fewer than 8 if not enough (min 2).
+ */
+export function getTierListMovies(dimensionId: number): TierListPlacementMovie[] {
+  const rawDb = getDb();
+
+  // Verify dimension exists
+  getDimension(dimensionId);
+
+  const rows = rawDb
+    .prepare(
+      `SELECT
+        ms.media_type as mediaType,
+        ms.media_id as mediaId,
+        ms.score as score,
+        ms.comparison_count as comparisonCount,
+        COALESCE(m.title, tv.name, 'Unknown') as title,
+        m.poster_path as moviePosterPath,
+        m.tmdb_id as movieTmdbId,
+        m.poster_override_path as moviePosterOverride,
+        tv.poster_path as tvPosterPath,
+        tv.tvdb_id as tvTvdbId,
+        tv.poster_override_path as tvPosterOverride
+      FROM media_scores ms
+      LEFT JOIN movies m ON ms.media_type = 'movie' AND ms.media_id = m.id
+      LEFT JOIN tv_shows tv ON ms.media_type = 'tv_show' AND ms.media_id = tv.id
+      INNER JOIN watch_history wh
+        ON wh.media_type = ms.media_type AND wh.media_id = ms.media_id
+        AND wh.completed = 1 AND wh.blacklisted = 0
+      LEFT JOIN comparison_staleness cs
+        ON cs.media_type = ms.media_type AND cs.media_id = ms.media_id
+      WHERE ms.dimension_id = ? AND ms.excluded = 0
+        AND COALESCE(cs.staleness, 1.0) >= ?
+      GROUP BY ms.media_type, ms.media_id
+      ORDER BY ms.comparison_count ASC, ms.score DESC`
+    )
+    .all(dimensionId, STALENESS_THRESHOLD) as Array<{
+    mediaType: string;
+    mediaId: number;
+    score: number;
+    comparisonCount: number;
+    title: string;
+    moviePosterPath: string | null;
+    movieTmdbId: number | null;
+    moviePosterOverride: string | null;
+    tvPosterPath: string | null;
+    tvTvdbId: number | null;
+    tvPosterOverride: string | null;
+  }>;
+
+  if (rows.length < TIER_LIST_MIN) return [];
+
+  // Take a buffer of candidates (3x target) sorted by comparison count ASC
+  const candidates = rows.slice(0, TIER_LIST_MAX * TIER_LIST_BUFFER_MULTIPLIER);
+
+  // Stratified sampling: partition by score into 4 quartiles, pick 2 from each
+  const sorted = [...candidates].sort((a, b) => b.score - a.score);
+  const quartileSize = Math.ceil(sorted.length / 4);
+  const quartiles: Array<typeof sorted> = [];
+  for (let i = 0; i < 4; i++) {
+    quartiles.push(sorted.slice(i * quartileSize, (i + 1) * quartileSize));
+  }
+
+  const selected: typeof rows = [];
+  const perQuartile = Math.ceil(TIER_LIST_MAX / 4);
+
+  for (const quartile of quartiles) {
+    // Within each quartile, prefer lowest comparison count
+    const byUncertainty = [...quartile].sort((a, b) => a.comparisonCount - b.comparisonCount);
+    for (const item of byUncertainty) {
+      if (selected.length >= TIER_LIST_MAX) break;
+      if (!selected.some((s) => s.mediaId === item.mediaId && s.mediaType === item.mediaType)) {
+        selected.push(item);
+        if (selected.filter((s) => quartile.includes(s)).length >= perQuartile) break;
+      }
+    }
+  }
+
+  // If still under target, fill from remaining candidates
+  if (selected.length < TIER_LIST_MAX) {
+    for (const item of candidates) {
+      if (selected.length >= TIER_LIST_MAX) break;
+      if (!selected.some((s) => s.mediaId === item.mediaId && s.mediaType === item.mediaType)) {
+        selected.push(item);
+      }
+    }
+  }
+
+  return selected.map((row) => ({
+    mediaType: row.mediaType,
+    mediaId: row.mediaId,
+    title: row.title,
+    posterUrl: resolvePosterUrl(row),
+    score: Math.round(row.score * 10) / 10,
+    comparisonCount: row.comparisonCount,
+  }));
 }

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -259,3 +259,19 @@ export interface PendingDebrief {
   createdAt: string;
   pendingDimensionCount: number;
 }
+
+/** Zod schema for getTierListMovies query. */
+export const TierListMoviesQuerySchema = z.object({
+  dimensionId: z.number().int().positive(),
+});
+export type TierListMoviesQuery = z.infer<typeof TierListMoviesQuerySchema>;
+
+/** API response shape for a tier list placement movie. */
+export interface TierListPlacementMovie {
+  mediaType: string;
+  mediaId: number;
+  title: string;
+  posterUrl: string | null;
+  score: number;
+  comparisonCount: number;
+}


### PR DESCRIPTION
## Summary
- Adds `getTierListMovies(dimensionId)` service function that selects up to 8 movies for tier list placement rounds
- Uses stratified quartile sampling: prefers low comparison count (high uncertainty) with a mix of score ranges
- Excludes blacklisted, dimension-excluded, and stale (< 0.3) movies
- Returns fewer than 8 if not enough (minimum 2, empty if < 2)
- Adds tRPC `getTierListMovies` query endpoint

## Test plan
- [x] 8 new test cases: returns up to 8, exclusions, blacklist, staleness, mixed ranges, fewer than 8, empty when < 2, includes posterUrl+title
- [x] All 8 getTierListMovies tests pass (96/101 total — 5 pre-existing debrief failures)
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)