### PR TITLE
feat(media): add recordDebriefComparison tRPC mutation [tb-161]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/debrief-comparison.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/debrief-comparison.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database } from "better-sqlite3";
+import {
+  setupTestContext,
+  seedDimension,
+  seedMovie,
+  seedWatchHistoryEntry,
+  createCaller,
+} from "../../../shared/test-utils.js";
+
+const ctx = setupTestContext();
+let caller: ReturnType<typeof createCaller>;
+let db: Database;
+
+beforeEach(() => {
+  ({ caller, db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+function seedDebriefSession(db: Database, watchHistoryId: number, status = "pending"): number {
+  const result = db
+    .prepare("INSERT INTO debrief_sessions (watch_history_id, status) VALUES (?, ?)")
+    .run(watchHistoryId, status);
+  return Number(result.lastInsertRowid);
+}
+
+describe("comparisons.recordDebriefComparison", () => {
+  it("records comparison and creates debrief_result with comparison_id", async () => {
+    const dim1 = seedDimension(db, { name: "Story" });
+    seedDimension(db, { name: "Visuals" }); // 2 dims so first doesn't auto-complete
+    const movieA = seedMovie(db, { tmdb_id: 100, title: "Debrief Movie" });
+    const movieB = seedMovie(db, { tmdb_id: 101, title: "Opponent Movie" });
+    const whId = seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieA });
+    const sessionId = seedDebriefSession(db, whId);
+
+    const result = await caller.media.comparisons.recordDebriefComparison({
+      sessionId,
+      dimensionId: dim1,
+      opponentType: "movie",
+      opponentId: movieB,
+      winnerId: movieA,
+    });
+
+    expect(result.data.comparisonId).toBeGreaterThan(0);
+    expect(result.data.sessionComplete).toBe(false);
+
+    // Verify debrief_result was created
+    const dr = db
+      .prepare("SELECT * FROM debrief_results WHERE session_id = ? AND dimension_id = ?")
+      .get(sessionId, dim1) as { comparison_id: number };
+    expect(dr.comparison_id).toBe(result.data.comparisonId);
+  });
+
+  it("skip (winnerId=0) creates debrief_result with null comparison_id", async () => {
+    const dimId = seedDimension(db, { name: "Story" });
+    const movieA = seedMovie(db, { tmdb_id: 200, title: "Movie A" });
+    const movieB = seedMovie(db, { tmdb_id: 201, title: "Movie B" });
+    const whId = seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieA });
+    const sessionId = seedDebriefSession(db, whId);
+
+    const result = await caller.media.comparisons.recordDebriefComparison({
+      sessionId,
+      dimensionId: dimId,
+      opponentType: "movie",
+      opponentId: movieB,
+      winnerId: 0,
+    });
+
+    expect(result.data.comparisonId).toBeNull();
+
+    // Verify debrief_result has null comparison_id
+    const dr = db.prepare("SELECT * FROM debrief_results WHERE session_id = ?").get(sessionId) as {
+      comparison_id: number | null;
+    };
+    expect(dr.comparison_id).toBeNull();
+  });
+
+  it("auto-completes session when all active dimensions have results", async () => {
+    const dim1 = seedDimension(db, { name: "Story", active: 1 });
+    const dim2 = seedDimension(db, { name: "Visuals", active: 1 });
+    const movieA = seedMovie(db, { tmdb_id: 300, title: "Movie A" });
+    const movieB = seedMovie(db, { tmdb_id: 301, title: "Movie B" });
+    const whId = seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieA });
+    const sessionId = seedDebriefSession(db, whId);
+
+    // Record first dimension — not complete yet
+    const r1 = await caller.media.comparisons.recordDebriefComparison({
+      sessionId,
+      dimensionId: dim1,
+      opponentType: "movie",
+      opponentId: movieB,
+      winnerId: movieA,
+    });
+    expect(r1.data.sessionComplete).toBe(false);
+
+    // Record second dimension — should complete
+    const r2 = await caller.media.comparisons.recordDebriefComparison({
+      sessionId,
+      dimensionId: dim2,
+      opponentType: "movie",
+      opponentId: movieB,
+      winnerId: movieB,
+    });
+    expect(r2.data.sessionComplete).toBe(true);
+
+    // Verify session status
+    const session = db
+      .prepare("SELECT status FROM debrief_sessions WHERE id = ?")
+      .get(sessionId) as { status: string };
+    expect(session.status).toBe("complete");
+  });
+
+  it("activates pending session on first comparison", async () => {
+    const dimId = seedDimension(db, { name: "Story" });
+    const movieA = seedMovie(db, { tmdb_id: 400, title: "Movie A" });
+    const movieB = seedMovie(db, { tmdb_id: 401, title: "Movie B" });
+    const whId = seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieA });
+    const sessionId = seedDebriefSession(db, whId, "pending");
+
+    await caller.media.comparisons.recordDebriefComparison({
+      sessionId,
+      dimensionId: dimId,
+      opponentType: "movie",
+      opponentId: movieB,
+      winnerId: movieA,
+    });
+
+    const session = db
+      .prepare("SELECT status FROM debrief_sessions WHERE id = ?")
+      .get(sessionId) as { status: string };
+    // With only 1 active dimension, session should be complete
+    expect(session.status).toBe("complete");
+  });
+
+  it("rejects if session is already complete", async () => {
+    const dimId = seedDimension(db, { name: "Story" });
+    const movieA = seedMovie(db, { tmdb_id: 500, title: "Movie A" });
+    const movieB = seedMovie(db, { tmdb_id: 501, title: "Movie B" });
+    const whId = seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieA });
+    const sessionId = seedDebriefSession(db, whId, "complete");
+
+    await expect(
+      caller.media.comparisons.recordDebriefComparison({
+        sessionId,
+        dimensionId: dimId,
+        opponentType: "movie",
+        opponentId: movieB,
+        winnerId: movieA,
+      })
+    ).rejects.toThrow();
+  });
+
+  it("rejects duplicate dimension for same session", async () => {
+    const dimId = seedDimension(db, { name: "Story" });
+    seedDimension(db, { name: "Visuals" }); // 2nd dim so first doesn't auto-complete
+    const movieA = seedMovie(db, { tmdb_id: 600, title: "Movie A" });
+    const movieB = seedMovie(db, { tmdb_id: 601, title: "Movie B" });
+    const whId = seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieA });
+    const sessionId = seedDebriefSession(db, whId);
+
+    await caller.media.comparisons.recordDebriefComparison({
+      sessionId,
+      dimensionId: dimId,
+      opponentType: "movie",
+      opponentId: movieB,
+      winnerId: movieA,
+    });
+
+    await expect(
+      caller.media.comparisons.recordDebriefComparison({
+        sessionId,
+        dimensionId: dimId,
+        opponentType: "movie",
+        opponentId: movieB,
+        winnerId: movieA,
+      })
+    ).rejects.toThrow();
+  });
+
+  it("updates ELO scores when comparison is recorded", async () => {
+    const dimId = seedDimension(db, { name: "Story" });
+    const movieA = seedMovie(db, { tmdb_id: 700, title: "Movie A" });
+    const movieB = seedMovie(db, { tmdb_id: 701, title: "Movie B" });
+    const whId = seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieA });
+    const sessionId = seedDebriefSession(db, whId);
+
+    await caller.media.comparisons.recordDebriefComparison({
+      sessionId,
+      dimensionId: dimId,
+      opponentType: "movie",
+      opponentId: movieB,
+      winnerId: movieA,
+    });
+
+    // Check ELO scores were updated
+    const scores = db
+      .prepare(
+        "SELECT media_id, score FROM media_scores WHERE dimension_id = ? ORDER BY score DESC"
+      )
+      .all(dimId) as Array<{ media_id: number; score: number }>;
+
+    expect(scores).toHaveLength(2);
+    expect(scores[0]!.media_id).toBe(movieA); // winner should have higher score
+    expect(scores[0]!.score).toBeGreaterThan(1500);
+    expect(scores[1]!.score).toBeLessThan(1500);
+  });
+});

--- a/apps/pops-api/src/modules/media/comparisons/router.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router.ts
@@ -25,6 +25,7 @@ import {
   GetTierListMoviesSchema,
   SubmitTierListSchema,
   DismissDebriefDimensionSchema,
+  RecordDebriefComparisonSchema,
   toDimension,
   toComparison,
   toMediaScore,
@@ -272,6 +273,27 @@ export const comparisonsRouter = router({
       throw err;
     }
   }),
+
+  /** Record a debrief comparison (or skip) for a session + dimension. */
+  recordDebriefComparison: protectedProcedure
+    .input(RecordDebriefComparisonSchema)
+    .mutation(({ input }) => {
+      try {
+        const result = service.recordDebriefComparison(input);
+        return { data: result, message: "Debrief comparison recorded" };
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+        }
+        if (err instanceof ValidationError) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: err.message });
+        }
+        if (err instanceof ConflictError) {
+          throw new TRPCError({ code: "CONFLICT", message: err.message });
+        }
+        throw err;
+      }
+    }),
 
   /** Record a skip (puts pair on cooloff for 10 global comparisons). */
   recordSkip: protectedProcedure.input(RecordSkipSchema).mutation(({ input }) => {

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -33,6 +33,7 @@ import {
   type SubmitTierListResult,
   type ScoreChange,
   TIER_RANK_ORDER,
+  type RecordDebriefComparisonInput,
 } from "./types.js";
 import { getStaleness } from "./staleness.js";
 import { setTierOverride } from "./tier-overrides.js";
@@ -1966,4 +1967,123 @@ export function submitTierList(input: SubmitTierListInput): SubmitTierListResult
   }
 
   return { comparisonsRecorded, scoreChanges };
+}
+
+// ── Debrief Comparison ──
+
+/**
+ * Record a debrief comparison for a session + dimension.
+ * If winnerId > 0, records a real comparison via recordComparison and links it.
+ * If winnerId = 0, creates a debrief_result with null comparison_id (skip).
+ * Auto-completes the session when all active dimensions have results.
+ */
+export function recordDebriefComparison(input: RecordDebriefComparisonInput): {
+  comparisonId: number | null;
+  sessionComplete: boolean;
+} {
+  const drizzleDb = getDrizzle();
+  const rawDb = getDb();
+
+  // Validate session exists and is not complete
+  const session = drizzleDb
+    .select()
+    .from(debriefSessions)
+    .where(eq(debriefSessions.id, input.sessionId))
+    .get();
+  if (!session) throw new NotFoundError("Debrief session", String(input.sessionId));
+  if (session.status === "complete") {
+    throw new ValidationError("Debrief session is already complete");
+  }
+
+  // Get the debrief movie from watch_history
+  const watchEntry = drizzleDb
+    .select()
+    .from(watchHistory)
+    .where(eq(watchHistory.id, session.watchHistoryId))
+    .get();
+  if (!watchEntry) throw new NotFoundError("Watch history entry", String(session.watchHistoryId));
+
+  // Check dimension hasn't already been recorded for this session
+  const existingResult = drizzleDb
+    .select()
+    .from(debriefResults)
+    .where(
+      and(
+        eq(debriefResults.sessionId, input.sessionId),
+        eq(debriefResults.dimensionId, input.dimensionId)
+      )
+    )
+    .get();
+  if (existingResult) {
+    throw new ConflictError("Dimension already recorded for this session");
+  }
+
+  return rawDb.transaction(() => {
+    let comparisonId: number | null = null;
+
+    if (input.winnerId > 0) {
+      // Record a real comparison
+      const compRow = recordComparison({
+        dimensionId: input.dimensionId,
+        mediaAType: watchEntry.mediaType as "movie" | "tv_show",
+        mediaAId: watchEntry.mediaId,
+        mediaBType: input.opponentType,
+        mediaBId: input.opponentId,
+        winnerType:
+          input.winnerId === watchEntry.mediaId
+            ? (watchEntry.mediaType as "movie" | "tv_show")
+            : input.opponentType,
+        winnerId: input.winnerId,
+        drawTier: input.drawTier ?? null,
+      });
+      comparisonId = compRow.id;
+    }
+
+    // Create debrief_result
+    drizzleDb
+      .insert(debriefResults)
+      .values({
+        sessionId: input.sessionId,
+        dimensionId: input.dimensionId,
+        comparisonId,
+      })
+      .run();
+
+    // Activate session if still pending
+    if (session.status === "pending") {
+      drizzleDb
+        .update(debriefSessions)
+        .set({ status: "active" })
+        .where(eq(debriefSessions.id, input.sessionId))
+        .run();
+    }
+
+    // Check if session is complete (all active dimensions have results)
+    const activeDimCount = drizzleDb
+      .select({ cnt: count() })
+      .from(comparisonDimensions)
+      .where(eq(comparisonDimensions.active, 1))
+      .get();
+
+    const resultCount = drizzleDb
+      .select({ cnt: count() })
+      .from(debriefResults)
+      .where(eq(debriefResults.sessionId, input.sessionId))
+      .get();
+
+    const sessionComplete =
+      activeDimCount !== undefined &&
+      resultCount !== undefined &&
+      resultCount.cnt >= activeDimCount.cnt;
+
+    if (sessionComplete) {
+      drizzleDb
+        .update(debriefSessions)
+        .set({ status: "complete" })
+        .where(eq(debriefSessions.id, input.sessionId))
+        .run();
+    }
+
+    return { comparisonId, sessionComplete };
+  })();
 }

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -312,3 +312,13 @@ export interface SubmitTierListResult {
 
 /** Tier rank ordering — lower index = higher tier. */
 export const TIER_RANK_ORDER: Record<Tier, number> = { S: 0, A: 1, B: 2, C: 3, D: 4 };
+
+export const RecordDebriefComparisonSchema = z.object({
+  sessionId: z.number().int().positive(),
+  dimensionId: z.number().int().positive(),
+  opponentType: z.enum(MEDIA_TYPES),
+  opponentId: z.number().int().positive(),
+  winnerId: z.number().int().nonnegative(), // 0 = skip (no comparison)
+  drawTier: z.enum(DRAW_TIERS).nullable().optional(),
+});
+export type RecordDebriefComparisonInput = z.infer<typeof RecordDebriefComparisonSchema>;


### PR DESCRIPTION
## Summary
- Adds `recordDebriefComparison` tRPC mutation for recording debrief comparisons
- Records comparison via existing `recordComparison` when winner specified (updates ELO)
- Skips create debrief_result with null comparison_id when winnerId=0
- Auto-completes session when all active dimensions have results
- Validates: session exists, not complete, dimension not already recorded

Closes #1272

## Test plan
- [x] 7 tests: record with comparison, skip, auto-complete, session activation, reject complete, reject duplicate, ELO update
- [x] Typecheck clean, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)