### PR TITLE
feat(media): submitTierList tRPC mutation [tb-165]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/router.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router.ts
@@ -23,6 +23,7 @@ import {
   GetDebriefOpponentSchema,
   GetDebriefSchema,
   GetTierListMoviesSchema,
+  SubmitTierListSchema,
   toDimension,
   toComparison,
   toMediaScore,
@@ -250,6 +251,22 @@ export const comparisonsRouter = router({
     } catch (err) {
       if (err instanceof NotFoundError) {
         throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      throw err;
+    }
+  }),
+
+  /** Submit a tier list: converts placements to pairwise comparisons + tier overrides. */
+  submitTierList: protectedProcedure.input(SubmitTierListSchema).mutation(({ input }) => {
+    try {
+      const result = service.submitTierList(input);
+      return { data: result, message: "Tier list submitted" };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+      }
+      if (err instanceof ValidationError) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: err.message });
       }
       throw err;
     }

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -29,8 +29,13 @@ import {
   type DebriefOpponent,
   type PendingDebrief,
   type TierListMovie,
+  type SubmitTierListInput,
+  type SubmitTierListResult,
+  type ScoreChange,
+  TIER_RANK_ORDER,
 } from "./types.js";
 import { getStaleness } from "./staleness.js";
+import { setTierOverride } from "./tier-overrides.js";
 
 // ── Dimensions ──
 
@@ -1782,4 +1787,121 @@ function normalizePairOrder(
   const keyB = `${bType}:${bId}`;
   if (keyA <= keyB) return [aType, aId, bType, bId];
   return [bType, bId, aType, aId];
+}
+
+// ── Tier List Submission ──
+
+/**
+ * Submit a tier list: converts tier placements into pairwise comparisons.
+ *
+ * For each pair of placed movies, the higher-tier movie wins.
+ * Movies in the same tier are recorded as a "mid" draw.
+ * Also sets tier overrides for each placement.
+ *
+ * Returns the number of comparisons recorded and score deltas.
+ */
+export function submitTierList(input: SubmitTierListInput): SubmitTierListResult {
+  const rawDb = getDb();
+  const drizzleDb = getDrizzle();
+
+  // Validate dimension exists and is active
+  const dimension = getDimension(input.dimensionId);
+  if (dimension.active !== 1) {
+    throw new ValidationError("Cannot submit tier list for inactive dimension");
+  }
+
+  // Capture old scores for all placed movies
+  const oldScores = new Map<number, number>();
+  for (const placement of input.placements) {
+    const existing = drizzleDb
+      .select()
+      .from(mediaScores)
+      .where(
+        and(
+          eq(mediaScores.mediaType, "movie"),
+          eq(mediaScores.mediaId, placement.movieId),
+          eq(mediaScores.dimensionId, input.dimensionId)
+        )
+      )
+      .get();
+    oldScores.set(placement.movieId, existing?.score ?? 1500.0);
+  }
+
+  // Generate all pairwise comparisons and record in a transaction
+  let comparisonsRecorded = 0;
+
+  rawDb.transaction(() => {
+    const placements = input.placements;
+
+    for (let i = 0; i < placements.length; i++) {
+      for (let j = i + 1; j < placements.length; j++) {
+        const a = placements[i];
+        const b = placements[j];
+        if (!a || !b) continue;
+
+        const rankA = TIER_RANK_ORDER[a.tier];
+        const rankB = TIER_RANK_ORDER[b.tier];
+
+        const comparisonInput: RecordComparisonInput = {
+          dimensionId: input.dimensionId,
+          mediaAType: "movie",
+          mediaAId: a.movieId,
+          mediaBType: "movie",
+          mediaBId: b.movieId,
+          winnerType: "movie",
+          winnerId: rankA < rankB ? a.movieId : rankB < rankA ? b.movieId : 0,
+          drawTier: rankA === rankB ? "mid" : null,
+        };
+
+        // Insert comparison and update ELO
+        const result = drizzleDb
+          .insert(comparisons)
+          .values({
+            dimensionId: comparisonInput.dimensionId,
+            mediaAType: comparisonInput.mediaAType,
+            mediaAId: comparisonInput.mediaAId,
+            mediaBType: comparisonInput.mediaBType,
+            mediaBId: comparisonInput.mediaBId,
+            winnerType: comparisonInput.winnerType,
+            winnerId: comparisonInput.winnerId,
+            drawTier: comparisonInput.drawTier ?? null,
+          })
+          .run();
+
+        if (Number(result.lastInsertRowid) > 0) {
+          updateEloScores(comparisonInput);
+          comparisonsRecorded++;
+        }
+      }
+    }
+
+    // Set tier overrides for each placement
+    for (const placement of placements) {
+      setTierOverride("movie", placement.movieId, input.dimensionId, placement.tier);
+    }
+  })();
+
+  // Collect score changes
+  const scoreChanges: ScoreChange[] = [];
+  for (const placement of input.placements) {
+    const newRow = drizzleDb
+      .select()
+      .from(mediaScores)
+      .where(
+        and(
+          eq(mediaScores.mediaType, "movie"),
+          eq(mediaScores.mediaId, placement.movieId),
+          eq(mediaScores.dimensionId, input.dimensionId)
+        )
+      )
+      .get();
+
+    scoreChanges.push({
+      movieId: placement.movieId,
+      oldScore: oldScores.get(placement.movieId) ?? 1500.0,
+      newScore: newRow?.score ?? 1500.0,
+    });
+  }
+
+  return { comparisonsRecorded, scoreChanges };
 }

--- a/apps/pops-api/src/modules/media/comparisons/submit-tier-list.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/submit-tier-list.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database } from "better-sqlite3";
+import {
+  setupTestContext,
+  seedDimension,
+  seedMovie,
+  seedWatchHistoryEntry,
+} from "../../../shared/test-utils.js";
+import { submitTierList } from "./service.js";
+import { getTierOverrideForMedia } from "./tier-overrides.js";
+
+const ctx = setupTestContext();
+let db: Database;
+
+beforeEach(() => {
+  ({ db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+/** Seed a movie and mark it as watched so it's eligible for comparisons. */
+function seedWatchedMovie(tmdbId: number, title: string): number {
+  const movieId = seedMovie(db, {
+    tmdb_id: tmdbId,
+    title,
+    poster_path: `/${title.toLowerCase()}.jpg`,
+  });
+  seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieId });
+  return movieId;
+}
+
+describe("submitTierList", () => {
+  it("records correct number of pairwise comparisons", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const m1 = seedWatchedMovie(100, "Movie A");
+    const m2 = seedWatchedMovie(101, "Movie B");
+    const m3 = seedWatchedMovie(102, "Movie C");
+
+    const result = submitTierList({
+      dimensionId: dimId,
+      placements: [
+        { movieId: m1, tier: "S" },
+        { movieId: m2, tier: "A" },
+        { movieId: m3, tier: "B" },
+      ],
+    });
+
+    // 3 movies → 3*(3-1)/2 = 3 pairwise comparisons
+    expect(result.comparisonsRecorded).toBe(3);
+    expect(result.scoreChanges).toHaveLength(3);
+  });
+
+  it("records n*(n-1)/2 comparisons for 4 movies", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const m1 = seedWatchedMovie(100, "Movie A");
+    const m2 = seedWatchedMovie(101, "Movie B");
+    const m3 = seedWatchedMovie(102, "Movie C");
+    const m4 = seedWatchedMovie(103, "Movie D");
+
+    const result = submitTierList({
+      dimensionId: dimId,
+      placements: [
+        { movieId: m1, tier: "S" },
+        { movieId: m2, tier: "A" },
+        { movieId: m3, tier: "C" },
+        { movieId: m4, tier: "D" },
+      ],
+    });
+
+    // 4 movies → 4*3/2 = 6 pairwise comparisons
+    expect(result.comparisonsRecorded).toBe(6);
+  });
+
+  it("higher tier movie gets higher score after submission", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const m1 = seedWatchedMovie(100, "Top Movie");
+    const m2 = seedWatchedMovie(101, "Bottom Movie");
+
+    const result = submitTierList({
+      dimensionId: dimId,
+      placements: [
+        { movieId: m1, tier: "S" },
+        { movieId: m2, tier: "D" },
+      ],
+    });
+
+    const topChange = result.scoreChanges.find((s) => s.movieId === m1);
+    const bottomChange = result.scoreChanges.find((s) => s.movieId === m2);
+
+    expect(topChange?.newScore).toBeDefined();
+    expect(bottomChange?.newScore).toBeDefined();
+    expect((topChange?.newScore ?? 0) > (bottomChange?.newScore ?? 0)).toBe(true);
+  });
+
+  it("same-tier movies get draw comparisons", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const m1 = seedWatchedMovie(100, "Movie A");
+    const m2 = seedWatchedMovie(101, "Movie B");
+
+    const result = submitTierList({
+      dimensionId: dimId,
+      placements: [
+        { movieId: m1, tier: "A" },
+        { movieId: m2, tier: "A" },
+      ],
+    });
+
+    expect(result.comparisonsRecorded).toBe(1);
+
+    // Both should have equal or near-equal scores (mid draw = 0.5)
+    const s1 = result.scoreChanges.find((s) => s.movieId === m1);
+    const s2 = result.scoreChanges.find((s) => s.movieId === m2);
+    expect(s1?.newScore).toBeDefined();
+    expect(s2?.newScore).toBeDefined();
+    expect(Math.abs((s1?.newScore ?? 0) - (s2?.newScore ?? 0))).toBeLessThan(1);
+  });
+
+  it("sets tier overrides for each placement", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const m1 = seedWatchedMovie(100, "Movie A");
+    const m2 = seedWatchedMovie(101, "Movie B");
+
+    submitTierList({
+      dimensionId: dimId,
+      placements: [
+        { movieId: m1, tier: "S" },
+        { movieId: m2, tier: "C" },
+      ],
+    });
+
+    const override1 = getTierOverrideForMedia("movie", m1, dimId);
+    const override2 = getTierOverrideForMedia("movie", m2, dimId);
+
+    expect(override1?.tier).toBe("S");
+    expect(override2?.tier).toBe("C");
+  });
+
+  it("rejects inactive dimension", () => {
+    const dimId = seedDimension(db, { name: "Inactive", active: 0 });
+    const m1 = seedWatchedMovie(100, "Movie A");
+    const m2 = seedWatchedMovie(101, "Movie B");
+
+    expect(() =>
+      submitTierList({
+        dimensionId: dimId,
+        placements: [
+          { movieId: m1, tier: "S" },
+          { movieId: m2, tier: "A" },
+        ],
+      })
+    ).toThrow("Validation failed");
+  });
+
+  it("rejects non-existent dimension", () => {
+    const m1 = seedWatchedMovie(100, "Movie A");
+    const m2 = seedWatchedMovie(101, "Movie B");
+
+    expect(() =>
+      submitTierList({
+        dimensionId: 999,
+        placements: [
+          { movieId: m1, tier: "S" },
+          { movieId: m2, tier: "A" },
+        ],
+      })
+    ).toThrow();
+  });
+
+  it("returns score changes for all placed movies", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const m1 = seedWatchedMovie(100, "Movie A");
+    const m2 = seedWatchedMovie(101, "Movie B");
+
+    const result = submitTierList({
+      dimensionId: dimId,
+      placements: [
+        { movieId: m1, tier: "S" },
+        { movieId: m2, tier: "D" },
+      ],
+    });
+
+    expect(result.scoreChanges).toHaveLength(2);
+    for (const change of result.scoreChanges) {
+      expect(change.oldScore).toBe(1500.0);
+      expect(change.movieId).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -278,3 +278,31 @@ export interface TierListMovie {
   score: number;
   comparisonCount: number;
 }
+
+const TIER_RANKS = ["S", "A", "B", "C", "D"] as const;
+export type Tier = (typeof TIER_RANKS)[number];
+
+export const TierPlacementSchema = z.object({
+  movieId: z.number().int().positive(),
+  tier: z.enum(TIER_RANKS),
+});
+
+export const SubmitTierListSchema = z.object({
+  dimensionId: z.number().int().positive(),
+  placements: z.array(TierPlacementSchema).min(2, "At least 2 placements are required"),
+});
+export type SubmitTierListInput = z.infer<typeof SubmitTierListSchema>;
+
+export interface ScoreChange {
+  movieId: number;
+  oldScore: number;
+  newScore: number;
+}
+
+export interface SubmitTierListResult {
+  comparisonsRecorded: number;
+  scoreChanges: ScoreChange[];
+}
+
+/** Tier rank ordering — lower index = higher tier. */
+export const TIER_RANK_ORDER: Record<Tier, number> = { S: 0, A: 1, B: 2, C: 3, D: 4 };


### PR DESCRIPTION
## Summary
- Add `SubmitTierListSchema` with `dimensionId` + `placements` array (min 2, tiers S/A/B/C/D)
- Add `submitTierList` service function: converts tier placements into n*(n-1)/2 pairwise ELO comparisons (higher tier wins, same tier = mid draw), sets tier overrides, returns comparison count + score deltas
- Add `submitTierList` tRPC mutation to comparisons router with standard error mapping
- 8 tests: pairwise count, 4-movie count, score ordering, draw handling, tier overrides, inactive dimension rejection, non-existent dimension rejection, score change tracking

## Test plan
- [x] 8 unit tests pass
- [ ] CI passes lint + typecheck + tests

Closes #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)