### PR TITLE
feat(media): add debrief button to movie detail page [tb-170]

### DIFF
--- a/packages/app-media/src/pages/MovieDetailPage.test.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Route, Routes } from "react-router";
 const mockMovieQuery = vi.fn();
 const mockWatchHistoryQuery = vi.fn();
 const mockGetStalenessQuery = vi.fn();
+const mockGetPendingDebriefsQuery = vi.fn();
 
 vi.mock("../lib/trpc", () => ({
   trpc: {
@@ -18,6 +19,9 @@ vi.mock("../lib/trpc", () => ({
       },
       comparisons: {
         getStaleness: { useQuery: (...args: unknown[]) => mockGetStalenessQuery(...args) },
+        getPendingDebriefs: {
+          useQuery: (...args: unknown[]) => mockGetPendingDebriefsQuery(...args),
+        },
       },
     },
   },
@@ -94,6 +98,9 @@ beforeEach(() => {
   });
   mockGetStalenessQuery.mockReturnValue({
     data: { data: { staleness: 1.0 } },
+  });
+  mockGetPendingDebriefsQuery.mockReturnValue({
+    data: { data: [] },
   });
 });
 
@@ -337,6 +344,38 @@ describe("MovieDetailPage", () => {
       expect(
         container.querySelectorAll("[class*='animate-pulse'], [data-slot='skeleton']").length
       ).toBeGreaterThan(0);
+    });
+  });
+
+  describe("debrief button", () => {
+    it("shows debrief button when movie has a pending debrief", () => {
+      mockGetPendingDebriefsQuery.mockReturnValue({
+        data: {
+          data: [
+            {
+              sessionId: 42,
+              movieId: 1,
+              title: "The Shawshank Redemption",
+              posterUrl: null,
+              status: "pending",
+              createdAt: "2026-04-01T00:00:00Z",
+              pendingDimensionCount: 3,
+            },
+          ],
+        },
+      });
+      renderAtRoute("/media/movies/1");
+      const button = screen.getByText("Debrief this movie");
+      expect(button).toBeInTheDocument();
+      expect(button.closest("a")).toHaveAttribute("href", "/media/debrief/42");
+    });
+
+    it("hides debrief button when no pending debrief for this movie", () => {
+      mockGetPendingDebriefsQuery.mockReturnValue({
+        data: { data: [] },
+      });
+      renderAtRoute("/media/movies/1");
+      expect(screen.queryByText("Debrief this movie")).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "@pops/ui";
 import { trpc } from "../lib/trpc";
 import { formatCurrency, formatLanguage, formatRuntime } from "../lib/format";
+import { Button } from "@pops/ui";
 import { WatchlistToggle } from "../components/WatchlistToggle";
 import { ComparisonScores } from "../components/ComparisonScores";
 import { MarkAsWatchedButton } from "../components/MarkAsWatchedButton";
@@ -63,6 +64,11 @@ export function MovieDetailPage() {
 
   const { data: stalenessData } = trpc.media.comparisons.getStaleness.useQuery(
     { mediaType: "movie", mediaId: movieId },
+    { enabled: !Number.isNaN(movieId) }
+  );
+
+  const { data: pendingDebriefData } = trpc.media.comparisons.getPendingDebriefs.useQuery(
+    undefined,
     { enabled: !Number.isNaN(movieId) }
   );
 
@@ -120,6 +126,11 @@ export function MovieDetailPage() {
       )
     : null;
   const staleness = stalenessData?.data?.staleness ?? 1.0;
+
+  const pendingDebrief = (pendingDebriefData?.data ?? []).find(
+    (d: { movieId: number; status: string }) =>
+      d.movieId === movie.id && (d.status === "pending" || d.status === "active")
+  );
 
   const metadataItems = [
     { label: "Status", value: movie.status },
@@ -216,6 +227,13 @@ export function MovieDetailPage() {
               <ArrStatusBadge kind="movie" externalId={movie.tmdbId} />
               <RequestMovieButton tmdbId={movie.tmdbId} title={movie.title} />
               <FreshnessBadge daysSinceWatch={daysSinceWatch} staleness={staleness} />
+              {pendingDebrief && (
+                <Link to={`/media/debrief/${pendingDebrief.sessionId}`}>
+                  <Button variant="outline" size="sm">
+                    Debrief this movie
+                  </Button>
+                </Link>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Shows "Debrief this movie" button on MovieDetailPage when movie has a pending/active debrief
- Button links to `/media/debrief/:sessionId`
- Hidden when no pending debrief exists for the movie
- Queries `getPendingDebriefs` endpoint (merged)

## Test plan
- [x] 2 new test cases: button shows for pending debrief, hidden when none
- [x] All 25 MovieDetailPage tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)