### PR TITLE
feat(media): add debrief button to watch history page [tb-167]

### DIFF
--- a/packages/app-media/src/pages/HistoryPage.test.tsx
+++ b/packages/app-media/src/pages/HistoryPage.test.tsx
@@ -14,6 +14,7 @@ vi.mock("sonner", () => ({
 }));
 
 const mockListRecentQuery = vi.fn();
+const mockGetPendingDebriefs = vi.fn();
 const mockDeleteMutate = vi.fn();
 let deleteMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
 let deleteMutationPending = false;
@@ -32,6 +33,9 @@ vi.mock("../lib/trpc", () => ({
             return { mutate: mockDeleteMutate, isPending: deleteMutationPending };
           },
         },
+      },
+      comparisons: {
+        getPendingDebriefs: { useQuery: () => mockGetPendingDebriefs() },
       },
     },
     useUtils: () => ({
@@ -110,6 +114,7 @@ describe("HistoryPage", () => {
       isLoading: false,
       error: null,
     });
+    mockGetPendingDebriefs.mockReturnValue({ data: null });
   });
 
   describe("episode enrichment", () => {
@@ -354,6 +359,61 @@ describe("HistoryPage", () => {
     it("hides Previous button on first page", () => {
       renderPage();
       expect(screen.queryByText("Previous")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("debrief button", () => {
+    it("shows debrief button for movies with pending debriefs", () => {
+      mockGetPendingDebriefs.mockReturnValue({
+        data: {
+          data: [
+            {
+              sessionId: 42,
+              movieId: 99,
+              title: "The Matrix",
+              posterUrl: null,
+              status: "pending",
+              createdAt: "2026-03-20T00:00:00Z",
+              pendingDimensionCount: 3,
+            },
+          ],
+        },
+      });
+      renderPage();
+      const debriefLinks = screen.getAllByLabelText("Debrief");
+      expect(debriefLinks.length).toBeGreaterThan(0);
+      expect(debriefLinks[0]).toHaveAttribute("href", "/media/debrief/42");
+    });
+
+    it("hides debrief button for movies without pending debriefs", () => {
+      mockGetPendingDebriefs.mockReturnValue({ data: { data: [] } });
+      renderPage();
+      expect(screen.queryByLabelText("Debrief")).not.toBeInTheDocument();
+    });
+
+    it("hides debrief button for episodes", () => {
+      mockListRecentQuery.mockReturnValue({
+        data: { data: [episodeEntry], pagination: { total: 1 } },
+        isLoading: false,
+        error: null,
+      });
+      mockGetPendingDebriefs.mockReturnValue({
+        data: {
+          data: [
+            {
+              sessionId: 10,
+              movieId: 42,
+              title: "Pilot",
+              posterUrl: null,
+              status: "pending",
+              createdAt: "2026-03-20T00:00:00Z",
+              pendingDimensionCount: 2,
+            },
+          ],
+        },
+      });
+      renderPage();
+      expect(screen.queryByLabelText("Debrief")).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/app-media/src/pages/HistoryPage.tsx
+++ b/packages/app-media/src/pages/HistoryPage.tsx
@@ -4,7 +4,7 @@
  * Mobile: compact list. Desktop (md+): responsive poster card grid.
  * Each entry has a delete action with confirmation dialog.
  */
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { Link, useNavigate } from "react-router";
 import {
   Alert,
@@ -22,7 +22,7 @@ import {
   Button,
   Skeleton,
 } from "@pops/ui";
-import { Film, Trash2 } from "lucide-react";
+import { ClipboardCheck, Film, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
 import { formatEpisodeCode } from "../lib/format";
@@ -114,10 +114,12 @@ function HistoryItem({
   entry,
   onDelete,
   isDeleting,
+  debriefSessionId,
 }: {
   entry: HistoryEntry;
   onDelete: (id: number) => void;
   isDeleting: boolean;
+  debriefSessionId: number | null;
 }) {
   const href = getHistoryHref(entry);
   const posterSrc = getHistoryPoster(entry);
@@ -170,6 +172,16 @@ function HistoryItem({
             )}
           </div>
           <div className="flex items-center gap-1.5 shrink-0">
+            {debriefSessionId != null && (
+              <Link
+                to={`/media/debrief/${debriefSessionId}`}
+                aria-label="Debrief"
+                className="p-1 h-auto w-auto rounded-sm text-primary hover:bg-primary/10 inline-flex items-center"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <ClipboardCheck className="h-3.5 w-3.5" />
+              </Link>
+            )}
             <Button
               variant="ghost"
               size="icon"
@@ -195,10 +207,12 @@ function HistoryCard({
   entry,
   onDelete,
   isDeleting,
+  debriefSessionId,
 }: {
   entry: HistoryEntry;
   onDelete: (id: number) => void;
   isDeleting: boolean;
+  debriefSessionId: number | null;
 }) {
   const navigate = useNavigate();
   const [imageError, setImageError] = useState(false);
@@ -239,6 +253,18 @@ function HistoryCard({
         <span className="absolute top-2 right-2 z-10 bg-black/60 text-white text-2xs font-medium px-1.5 py-0.5 rounded">
           {formatShortDate(entry.watchedAt)}
         </span>
+
+        {/* Debrief button — visible on hover when pending */}
+        {debriefSessionId != null && (
+          <Link
+            to={`/media/debrief/${debriefSessionId}`}
+            aria-label="Debrief"
+            onClick={(e) => e.stopPropagation()}
+            className="absolute bottom-2 left-2 z-10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity p-1.5 h-auto w-auto rounded-md bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center"
+          >
+            <ClipboardCheck className="h-3.5 w-3.5" />
+          </Link>
+        )}
 
         {/* Delete button — visible on hover */}
         <Button
@@ -307,6 +333,15 @@ export function HistoryPage() {
   };
 
   const { data, isLoading, error } = trpc.media.watchHistory.listRecent.useQuery(queryInput);
+  const { data: pendingDebriefs } = trpc.media.comparisons.getPendingDebriefs.useQuery();
+
+  const debriefByMovieId = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const d of pendingDebriefs?.data ?? []) {
+      map.set(d.movieId, d.sessionId);
+    }
+    return map;
+  }, [pendingDebriefs]);
 
   const entries = data?.data ?? [];
   const total = data?.pagination?.total ?? 0;
@@ -389,6 +424,9 @@ export function HistoryPage() {
                 entry={entry}
                 onDelete={handleDeleteClick}
                 isDeleting={deleteMutation.isPending}
+                debriefSessionId={
+                  entry.mediaType === "movie" ? (debriefByMovieId.get(entry.mediaId) ?? null) : null
+                }
               />
             ))}
           </div>
@@ -401,6 +439,9 @@ export function HistoryPage() {
                 entry={entry}
                 onDelete={handleDeleteClick}
                 isDeleting={deleteMutation.isPending}
+                debriefSessionId={
+                  entry.mediaType === "movie" ? (debriefByMovieId.get(entry.mediaId) ?? null) : null
+                }
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- Adds debrief button (ClipboardCheck icon) to movie tiles in watch history page for movies with pending debrief sessions
- Button links to `/media/debrief/:sessionId`, hidden for episodes and movies without pending debriefs
- Uses `getPendingDebriefs` query with `Map<movieId, sessionId>` for O(1) lookup per tile
- Desktop: bottom-left overlay on poster card (visible on hover). Mobile: inline next to delete button

## Test plan
- [x] 28 tests pass (25 existing + 3 new)
- [x] TypeScript compiles cleanly
- [x] Prettier formatting verified
- New tests cover: button shows for pending debriefs, hidden when no debriefs, hidden for episodes

Closes #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)