### PR TITLE
feat(media): add TierListSummary component [tb-173]

### DIFF
--- a/packages/app-media/src/components/TierListSummary.test.tsx
+++ b/packages/app-media/src/components/TierListSummary.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TierListSummary, type ScoreChange } from "./TierListSummary";
+
+const sampleChanges: ScoreChange[] = [
+  { movieId: 1, title: "The Matrix", oldScore: 1200, newScore: 1245 },
+  { movieId: 2, title: "Inception", oldScore: 1300, newScore: 1275 },
+  { movieId: 3, title: "Interstellar", oldScore: 1100, newScore: 1100 },
+];
+
+describe("TierListSummary", () => {
+  it("renders comparison count and movie count", () => {
+    render(
+      <TierListSummary
+        comparisonsRecorded={28}
+        scoreChanges={sampleChanges}
+        onDoAnother={vi.fn()}
+        onDone={vi.fn()}
+      />
+    );
+    expect(screen.getByText("28 comparisons from 3 movies")).toBeInTheDocument();
+  });
+
+  it("renders per-movie score changes", () => {
+    render(
+      <TierListSummary
+        comparisonsRecorded={28}
+        scoreChanges={sampleChanges}
+        onDoAnother={vi.fn()}
+        onDone={vi.fn()}
+      />
+    );
+    expect(screen.getByText("The Matrix")).toBeInTheDocument();
+    expect(screen.getByText("Inception")).toBeInTheDocument();
+    expect(screen.getByText("Interstellar")).toBeInTheDocument();
+  });
+
+  it("shows green delta for positive score changes", () => {
+    render(
+      <TierListSummary
+        comparisonsRecorded={1}
+        scoreChanges={[sampleChanges[0]!]}
+        onDoAnother={vi.fn()}
+        onDone={vi.fn()}
+      />
+    );
+    const delta = screen.getByTestId("delta-1");
+    expect(delta).toHaveTextContent("+45");
+    expect(delta.className).toContain("green");
+  });
+
+  it("shows red delta for negative score changes", () => {
+    render(
+      <TierListSummary
+        comparisonsRecorded={1}
+        scoreChanges={[sampleChanges[1]!]}
+        onDoAnother={vi.fn()}
+        onDone={vi.fn()}
+      />
+    );
+    const delta = screen.getByTestId("delta-2");
+    expect(delta).toHaveTextContent("-25");
+    expect(delta.className).toContain("red");
+  });
+
+  it("shows neutral delta for no change", () => {
+    render(
+      <TierListSummary
+        comparisonsRecorded={1}
+        scoreChanges={[sampleChanges[2]!]}
+        onDoAnother={vi.fn()}
+        onDone={vi.fn()}
+      />
+    );
+    const delta = screen.getByTestId("delta-3");
+    expect(delta).toHaveTextContent("0");
+    expect(delta.className).toContain("muted");
+  });
+
+  it("calls onDoAnother when Do Another is clicked", async () => {
+    const onDoAnother = vi.fn();
+    render(
+      <TierListSummary
+        comparisonsRecorded={28}
+        scoreChanges={sampleChanges}
+        onDoAnother={onDoAnother}
+        onDone={vi.fn()}
+      />
+    );
+    await userEvent.click(screen.getByText("Do Another"));
+    expect(onDoAnother).toHaveBeenCalledOnce();
+  });
+
+  it("calls onDone when Done is clicked", async () => {
+    const onDone = vi.fn();
+    render(
+      <TierListSummary
+        comparisonsRecorded={28}
+        scoreChanges={sampleChanges}
+        onDoAnother={vi.fn()}
+        onDone={onDone}
+      />
+    );
+    await userEvent.click(screen.getByText("Done"));
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+
+  it("handles singular comparison text", () => {
+    render(
+      <TierListSummary
+        comparisonsRecorded={1}
+        scoreChanges={[sampleChanges[0]!]}
+        onDoAnother={vi.fn()}
+        onDone={vi.fn()}
+      />
+    );
+    expect(screen.getByText("1 comparison from 1 movie")).toBeInTheDocument();
+  });
+});

--- a/packages/app-media/src/components/TierListSummary.tsx
+++ b/packages/app-media/src/components/TierListSummary.tsx
@@ -1,0 +1,92 @@
+/**
+ * TierListSummary — shows results after submitting a tier list.
+ *
+ * Displays total comparisons recorded, per-movie score changes with
+ * green/red delta badges, and action buttons.
+ */
+import { Button } from "@pops/ui";
+import { ArrowUpRight, ArrowDownRight, Minus } from "lucide-react";
+
+export interface ScoreChange {
+  movieId: number;
+  title: string;
+  oldScore: number;
+  newScore: number;
+}
+
+interface TierListSummaryProps {
+  comparisonsRecorded: number;
+  scoreChanges: ScoreChange[];
+  onDoAnother: () => void;
+  onDone: () => void;
+}
+
+export function TierListSummary({
+  comparisonsRecorded,
+  scoreChanges,
+  onDoAnother,
+  onDone,
+}: TierListSummaryProps) {
+  const movieCount = scoreChanges.length;
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center space-y-1">
+        <h2 className="text-xl font-bold">Tier List Submitted</h2>
+        <p className="text-muted-foreground">
+          {comparisonsRecorded} comparison{comparisonsRecorded !== 1 ? "s" : ""} from {movieCount}{" "}
+          movie{movieCount !== 1 ? "s" : ""}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {scoreChanges.map((change) => {
+          const delta = Math.round((change.newScore - change.oldScore) * 10) / 10;
+          const isPositive = delta > 0;
+          const isNegative = delta < 0;
+
+          return (
+            <div
+              key={change.movieId}
+              className="flex items-center justify-between gap-3 rounded-lg border p-3"
+            >
+              <span className="text-sm font-medium truncate">{change.title}</span>
+              <div className="flex items-center gap-2 shrink-0">
+                <span className="text-xs text-muted-foreground">{Math.round(change.oldScore)}</span>
+                <span className="text-muted-foreground">→</span>
+                <span className="text-sm font-medium">{Math.round(change.newScore)}</span>
+                <span
+                  className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                    isPositive
+                      ? "bg-green-500/20 text-green-700 dark:text-green-400"
+                      : isNegative
+                        ? "bg-red-500/20 text-red-700 dark:text-red-400"
+                        : "bg-muted text-muted-foreground"
+                  }`}
+                  data-testid={`delta-${change.movieId}`}
+                >
+                  {isPositive ? (
+                    <ArrowUpRight className="h-3 w-3" />
+                  ) : isNegative ? (
+                    <ArrowDownRight className="h-3 w-3" />
+                  ) : (
+                    <Minus className="h-3 w-3" />
+                  )}
+                  {isPositive ? "+" : ""}
+                  {delta}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex gap-3 justify-center">
+        <Button variant="outline" onClick={onDoAnother}>
+          Do Another
+        </Button>
+        <Button onClick={onDone}>Done</Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds standalone `TierListSummary` component showing tier list submission results
- Displays total comparisons recorded and per-movie score changes with green/red/neutral delta badges
- Action buttons: "Do Another" (restart) and "Done" (navigate to rankings)
- Exported for integration into TierListPage (tb-169, in progress)

## Test plan
- [x] 8 tests pass covering: comparison count, score changes, delta styling, callbacks, singular text
- [x] Prettier formatting verified
- CI will run typecheck

Closes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)