### PR TITLE
feat(media): add TierListPage with dimension selector and movie pool [tb-169]

### DIFF
--- a/packages/app-media/src/pages/TierListPage.test.tsx
+++ b/packages/app-media/src/pages/TierListPage.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+const mockDimensionsQuery = vi.fn();
+const mockMoviesQuery = vi.fn();
+const mockRefetchMovies = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      comparisons: {
+        listDimensions: {
+          useQuery: (...args: unknown[]) => mockDimensionsQuery(...args),
+        },
+        getTierListMovies: {
+          useQuery: (...args: unknown[]) => {
+            const result = mockMoviesQuery(...args);
+            return { ...result, refetch: mockRefetchMovies, isFetching: false };
+          },
+        },
+      },
+    },
+    useUtils: () => ({}),
+  },
+}));
+
+import { TierListPage } from "./TierListPage";
+
+const DIMENSIONS = [
+  { id: 1, name: "Overall", active: true, sortOrder: 1 },
+  { id: 2, name: "Cinematography", active: true, sortOrder: 2 },
+  { id: 3, name: "Inactive Dim", active: false, sortOrder: 3 },
+];
+
+const MOVIES = [
+  { id: 10, title: "The Matrix", posterUrl: "https://img/matrix.jpg" },
+  { id: 20, title: "Inception", posterUrl: "https://img/inception.jpg" },
+  { id: 30, title: "Interstellar", posterUrl: null },
+];
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <TierListPage />
+    </MemoryRouter>
+  );
+}
+
+function setupDefaults() {
+  mockDimensionsQuery.mockReturnValue({
+    data: { data: DIMENSIONS },
+    isLoading: false,
+  });
+  mockMoviesQuery.mockReturnValue({
+    data: { data: MOVIES },
+    isLoading: false,
+  });
+}
+
+describe("TierListPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaults();
+  });
+
+  it("renders dimension chips for active dimensions only", () => {
+    renderPage();
+    expect(screen.getByText("Overall")).toBeInTheDocument();
+    expect(screen.getByText("Cinematography")).toBeInTheDocument();
+    expect(screen.queryByText("Inactive Dim")).not.toBeInTheDocument();
+  });
+
+  it("auto-selects first active dimension", () => {
+    renderPage();
+    const overallTab = screen.getByText("Overall");
+    expect(overallTab.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("switches dimension on chip click and reloads movies", () => {
+    renderPage();
+    fireEvent.click(screen.getByText("Cinematography"));
+    const cinematographyTab = screen.getByText("Cinematography");
+    expect(cinematographyTab.getAttribute("aria-selected")).toBe("true");
+    expect(mockMoviesQuery).toHaveBeenCalledWith(
+      { dimensionId: 2 },
+      expect.objectContaining({ enabled: true })
+    );
+  });
+
+  it("calls refetch when refresh button is clicked", () => {
+    renderPage();
+    fireEvent.click(screen.getByText("Refresh"));
+    expect(mockRefetchMovies).toHaveBeenCalled();
+  });
+
+  it("shows loading skeletons when movies are loading", () => {
+    mockMoviesQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll(".aspect-\\[2\\/3\\]");
+    expect(skeletons.length).toBe(8);
+  });
+
+  it("shows empty state when no movies available", () => {
+    mockMoviesQuery.mockReturnValue({
+      data: { data: [] },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No movies available for this dimension.")).toBeInTheDocument();
+  });
+
+  it("renders movie cards with posters and titles", () => {
+    renderPage();
+    expect(screen.getByText("The Matrix")).toBeInTheDocument();
+    expect(screen.getByText("Inception")).toBeInTheDocument();
+    expect(screen.getByText("Interstellar")).toBeInTheDocument();
+    expect(screen.getByAltText("The Matrix poster")).toBeInTheDocument();
+    expect(screen.getByAltText("Inception poster")).toBeInTheDocument();
+  });
+
+  it("shows placeholder for movies without poster", () => {
+    renderPage();
+    expect(screen.queryByAltText("Interstellar poster")).not.toBeInTheDocument();
+  });
+
+  it("shows dimension loading skeletons", () => {
+    mockDimensionsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    mockMoviesQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll(".rounded-full");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows no dimensions message when none configured", () => {
+    mockDimensionsQuery.mockReturnValue({
+      data: { data: [] },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No dimensions configured yet.")).toBeInTheDocument();
+  });
+});

--- a/packages/app-media/src/pages/TierListPage.tsx
+++ b/packages/app-media/src/pages/TierListPage.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect } from "react";
+import { Button, Skeleton } from "@pops/ui";
+import { ImageOff, ListOrdered, RefreshCw } from "lucide-react";
+import { trpc } from "../lib/trpc";
+
+export function TierListPage() {
+  const [dimensionId, setDimensionId] = useState<number | null>(null);
+
+  const { data: dimensionsData, isLoading: dimsLoading } =
+    trpc.media.comparisons.listDimensions.useQuery();
+
+  const activeDimensions = dimensionsData?.data?.filter((d: { active: boolean }) => d.active) ?? [];
+
+  // Auto-select first active dimension
+  useEffect(() => {
+    if (dimensionId === null && activeDimensions.length > 0) {
+      setDimensionId(activeDimensions[0]?.id ?? null);
+    }
+  }, [activeDimensions, dimensionId]);
+
+  const {
+    data: moviesData,
+    isLoading: moviesLoading,
+    refetch: refetchMovies,
+    isFetching,
+  } = trpc.media.comparisons.getTierListMovies.useQuery(
+    { dimensionId: dimensionId! },
+    {
+      enabled: dimensionId !== null,
+      refetchOnWindowFocus: false,
+      gcTime: 0,
+      staleTime: 0,
+    }
+  );
+
+  const movies = moviesData?.data ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ListOrdered className="h-6 w-6" />
+          <h1 className="text-2xl font-bold">Tier List</h1>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => refetchMovies()}
+          disabled={isFetching || dimensionId === null}
+        >
+          <RefreshCw className={`h-4 w-4 mr-2 ${isFetching ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Dimension selector chips */}
+      {dimsLoading ? (
+        <div className="flex gap-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-9 w-24 rounded-full" />
+          ))}
+        </div>
+      ) : activeDimensions.length === 0 ? (
+        <p className="text-muted-foreground">No dimensions configured yet.</p>
+      ) : (
+        <div className="flex gap-2 flex-wrap" role="tablist">
+          {activeDimensions.map((dim: { id: number; name: string }) => (
+            <button
+              key={dim.id}
+              role="tab"
+              aria-selected={dim.id === dimensionId}
+              onClick={() => setDimensionId(dim.id)}
+              className={`px-4 py-2 rounded-full text-sm font-medium transition-colors cursor-pointer ${
+                dim.id === dimensionId
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted text-muted-foreground hover:bg-muted/80"
+              }`}
+            >
+              {dim.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Movie pool */}
+      {dimensionId === null ? null : moviesLoading ? (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <Skeleton className="aspect-[2/3] w-full rounded-md" />
+              <Skeleton className="h-4 w-3/4" />
+            </div>
+          ))}
+        </div>
+      ) : movies.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <ListOrdered className="h-12 w-12 mx-auto mb-4 opacity-50" />
+          <p>No movies available for this dimension.</p>
+          <p className="text-sm mt-1">Watch and compare more movies to populate the tier list.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {movies.map((movie: { id: number; title: string; posterUrl: string | null }) => (
+            <MovieCard key={movie.id} movie={movie} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MovieCard({ movie }: { movie: { id: number; title: string; posterUrl: string | null } }) {
+  const [imgError, setImgError] = useState(false);
+
+  return (
+    <div className="flex flex-col items-center text-center rounded-lg border p-3 bg-card">
+      {movie.posterUrl && !imgError ? (
+        <img
+          src={movie.posterUrl}
+          alt={`${movie.title} poster`}
+          className="w-full aspect-[2/3] rounded-md object-cover mb-2"
+          onError={() => setImgError(true)}
+        />
+      ) : (
+        <div className="w-full aspect-[2/3] rounded-md mb-2 bg-muted flex items-center justify-center">
+          <ImageOff className="h-8 w-8 text-muted-foreground" />
+        </div>
+      )}
+      <p className="text-sm font-medium line-clamp-2">{movie.title}</p>
+    </div>
+  );
+}

--- a/packages/app-media/src/routes.tsx
+++ b/packages/app-media/src/routes.tsx
@@ -78,6 +78,11 @@ const CalendarPage = lazy(() =>
     default: m.CalendarPage,
   }))
 );
+const TierListPage = lazy(() =>
+  import("./pages/TierListPage").then((m) => ({
+    default: m.TierListPage,
+  }))
+);
 
 /** Shared navigation types (mirrored from shell to avoid circular dependency) */
 export interface AppNavItem {
@@ -109,6 +114,7 @@ export const navConfig: AppNavConfig = {
     { path: "/rankings", label: "Rankings", icon: "Trophy" },
     { path: "/search", label: "Search", icon: "Search" },
     { path: "/compare", label: "Compare", icon: "ArrowLeftRight" },
+    { path: "/tier-list", label: "Tier List", icon: "ListOrdered" },
   ],
 };
 
@@ -128,4 +134,5 @@ export const routes: RouteObject[] = [
   { path: "plex", element: <PlexSettingsPage /> },
   { path: "arr", element: <ArrSettingsPage /> },
   { path: "arr/calendar", element: <CalendarPage /> },
+  { path: "tier-list", element: <TierListPage /> },
 ];


### PR DESCRIPTION
## Summary
- Adds `/media/tier-list` route with lazy-loaded `TierListPage` component
- Dimension chip selector (pill tabs) filters active dimensions, auto-selects first
- Loads up to 8 movie cards via `getTierListMovies` tRPC query into unranked pool grid
- Movie cards with poster thumbnail + title, fallback placeholder for missing posters
- Refresh button reloads movie set (no caching)
- Loading skeletons, empty state, and no-dimensions state handled
- 9 tests covering renders, dimension switching, refresh, loading, empty states
- Note: frontend tests cannot run locally (jsdom hangs in resource-constrained env) — CI will validate

## Test plan
- [x] Lint clean (app-media)
- [x] Typecheck clean (app-media)
- [x] Prettier formatted
- [ ] 9 tests pass (CI validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)