### PR TITLE
feat(media): debrief controls — skip, bail, completion [tb-171]

### DIFF
--- a/packages/app-media/src/components/DebriefControls.test.tsx
+++ b/packages/app-media/src/components/DebriefControls.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+
+// Capture mutation options
+let dismissOpts: Record<string, (...args: unknown[]) => unknown> = {};
+const mockDismissMutate = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      comparisons: {
+        dismissDebriefDimension: {
+          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
+            dismissOpts = opts;
+            return { mutate: mockDismissMutate, isPending: false };
+          },
+        },
+      },
+    },
+    useUtils: () => ({
+      media: {
+        comparisons: {
+          getPendingDebriefs: { invalidate: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  SkipDimensionButton,
+  DoneForNowButton,
+  CompletionSummary,
+  DebriefActionBar,
+} from "./DebriefControls";
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("SkipDimensionButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dismissOpts = {};
+  });
+
+  it("renders skip button", () => {
+    renderWithRouter(
+      <SkipDimensionButton sessionId={1} dimensionId={2} dimensionName="Cinematography" />
+    );
+    expect(screen.getByTestId("skip-dimension-btn")).toBeInTheDocument();
+    expect(screen.getByText("Skip this dimension")).toBeInTheDocument();
+  });
+
+  it("calls dismissDebriefDimension mutation on click", async () => {
+    const user = userEvent.setup();
+    renderWithRouter(
+      <SkipDimensionButton sessionId={1} dimensionId={2} dimensionName="Cinematography" />
+    );
+
+    await user.click(screen.getByTestId("skip-dimension-btn"));
+    expect(mockDismissMutate).toHaveBeenCalledWith({ sessionId: 1, dimensionId: 2 });
+  });
+
+  it("calls onSkipped callback on success", () => {
+    const onSkipped = vi.fn();
+    renderWithRouter(
+      <SkipDimensionButton
+        sessionId={1}
+        dimensionId={2}
+        dimensionName="Cinematography"
+        onSkipped={onSkipped}
+      />
+    );
+
+    // Simulate mutation success
+    dismissOpts.onSuccess?.();
+    expect(onSkipped).toHaveBeenCalled();
+  });
+});
+
+describe("DoneForNowButton", () => {
+  it("renders done for now button", () => {
+    renderWithRouter(<DoneForNowButton />);
+    expect(screen.getByTestId("done-for-now-btn")).toBeInTheDocument();
+    expect(screen.getByText("Done for now")).toBeInTheDocument();
+  });
+
+  it("calls onExit callback when provided", async () => {
+    const onExit = vi.fn();
+    const user = userEvent.setup();
+    renderWithRouter(<DoneForNowButton onExit={onExit} />);
+
+    await user.click(screen.getByTestId("done-for-now-btn"));
+    expect(onExit).toHaveBeenCalled();
+  });
+});
+
+describe("CompletionSummary", () => {
+  const summaryData = {
+    sessionId: 1,
+    movieTitle: "The Matrix",
+    dimensions: [
+      { dimensionId: 1, name: "Cinematography", status: "complete" as const, comparisonId: 10 },
+      { dimensionId: 2, name: "Entertainment", status: "complete" as const, comparisonId: null },
+      { dimensionId: 3, name: "Rewatchability", status: "pending" as const, comparisonId: null },
+    ],
+  };
+
+  it("renders completion summary with movie title", () => {
+    renderWithRouter(<CompletionSummary data={summaryData} />);
+    expect(screen.getByTestId("completion-summary")).toBeInTheDocument();
+    expect(screen.getByText("The Matrix")).toBeInTheDocument();
+    expect(screen.getByText("Debrief Complete")).toBeInTheDocument();
+  });
+
+  it("shows compared and skipped counts", () => {
+    renderWithRouter(<CompletionSummary data={summaryData} />);
+    expect(screen.getByText("1 compared, 1 skipped")).toBeInTheDocument();
+  });
+
+  it("shows per-dimension results with badges", () => {
+    renderWithRouter(<CompletionSummary data={summaryData} />);
+    expect(screen.getByText("Cinematography")).toBeInTheDocument();
+    expect(screen.getByText("Compared")).toBeInTheDocument();
+    expect(screen.getByText("Skipped")).toBeInTheDocument();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+
+  it("shows Do Another button when callback provided", () => {
+    const onDoAnother = vi.fn();
+    renderWithRouter(<CompletionSummary data={summaryData} onDoAnother={onDoAnother} />);
+    expect(screen.getByText("Do another")).toBeInTheDocument();
+  });
+
+  it("hides Do Another button when no callback", () => {
+    renderWithRouter(<CompletionSummary data={summaryData} />);
+    expect(screen.queryByText("Do another")).not.toBeInTheDocument();
+  });
+});
+
+describe("DebriefActionBar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows skip and bail buttons when session is active", () => {
+    renderWithRouter(
+      <DebriefActionBar
+        sessionId={1}
+        currentDimension={{ id: 2, name: "Cinematography" }}
+        allComplete={false}
+        summaryData={null}
+      />
+    );
+    expect(screen.getByTestId("debrief-action-bar")).toBeInTheDocument();
+    expect(screen.getByTestId("skip-dimension-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("done-for-now-btn")).toBeInTheDocument();
+  });
+
+  it("shows completion summary when all dimensions are complete", () => {
+    const summaryData = {
+      sessionId: 1,
+      movieTitle: "The Matrix",
+      dimensions: [
+        { dimensionId: 1, name: "Cinematography", status: "complete" as const, comparisonId: 10 },
+      ],
+    };
+
+    renderWithRouter(
+      <DebriefActionBar
+        sessionId={1}
+        currentDimension={null}
+        allComplete={true}
+        summaryData={summaryData}
+      />
+    );
+    expect(screen.getByTestId("completion-summary")).toBeInTheDocument();
+    expect(screen.queryByTestId("debrief-action-bar")).not.toBeInTheDocument();
+  });
+
+  it("hides skip button when no current dimension", () => {
+    renderWithRouter(
+      <DebriefActionBar
+        sessionId={1}
+        currentDimension={null}
+        allComplete={false}
+        summaryData={null}
+      />
+    );
+    expect(screen.queryByTestId("skip-dimension-btn")).not.toBeInTheDocument();
+    expect(screen.getByTestId("done-for-now-btn")).toBeInTheDocument();
+  });
+});

--- a/packages/app-media/src/components/DebriefControls.tsx
+++ b/packages/app-media/src/components/DebriefControls.tsx
@@ -1,0 +1,220 @@
+/**
+ * Debrief session controls: skip dimension, bail out (done for now),
+ * and completion summary.
+ *
+ * Designed as composable components for integration into the DebriefPage.
+ */
+import { useNavigate } from "react-router";
+import { Button, Card, CardContent, CardHeader, CardTitle, Badge } from "@pops/ui";
+import {
+  SkipForward,
+  DoorOpen,
+  Trophy,
+  ArrowRight,
+  CheckCircle,
+  XCircle,
+  Clock,
+} from "lucide-react";
+import { toast } from "sonner";
+import { trpc } from "../lib/trpc";
+
+// ── Types ──
+
+interface DimensionResult {
+  dimensionId: number;
+  name: string;
+  status: "complete" | "pending";
+  /** Non-null if a comparison was recorded (not skipped). */
+  comparisonId: number | null;
+}
+
+interface DebriefSummaryData {
+  sessionId: number;
+  movieTitle: string;
+  dimensions: DimensionResult[];
+}
+
+// ── Skip Dimension Button ──
+
+interface SkipDimensionButtonProps {
+  sessionId: number;
+  dimensionId: number;
+  dimensionName: string;
+  onSkipped?: () => void;
+}
+
+export function SkipDimensionButton({
+  sessionId,
+  dimensionId,
+  dimensionName,
+  onSkipped,
+}: SkipDimensionButtonProps) {
+  const utils = trpc.useUtils();
+
+  const dismissMutation = trpc.media.comparisons.dismissDebriefDimension.useMutation({
+    onSuccess: () => {
+      toast.success(`Skipped ${dimensionName}`);
+      void utils.media.comparisons.getPendingDebriefs.invalidate();
+      onSkipped?.();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      disabled={dismissMutation.isPending}
+      onClick={() => dismissMutation.mutate({ sessionId, dimensionId })}
+      data-testid="skip-dimension-btn"
+    >
+      <SkipForward className="mr-1 h-4 w-4" />
+      {dismissMutation.isPending ? "Skipping…" : "Skip this dimension"}
+    </Button>
+  );
+}
+
+// ── Done For Now (Bail Out) Button ──
+
+interface DoneForNowButtonProps {
+  onExit?: () => void;
+}
+
+export function DoneForNowButton({ onExit }: DoneForNowButtonProps) {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    if (onExit) {
+      onExit();
+    } else {
+      navigate("/media");
+    }
+  };
+
+  return (
+    <Button variant="ghost" size="sm" onClick={handleClick} data-testid="done-for-now-btn">
+      <DoorOpen className="mr-1 h-4 w-4" />
+      Done for now
+    </Button>
+  );
+}
+
+// ── Completion Summary ──
+
+interface CompletionSummaryProps {
+  data: DebriefSummaryData;
+  onDoAnother?: () => void;
+}
+
+export function CompletionSummary({ data, onDoAnother }: CompletionSummaryProps) {
+  const navigate = useNavigate();
+
+  const completed = data.dimensions.filter(
+    (d) => d.status === "complete" && d.comparisonId !== null
+  );
+  const skipped = data.dimensions.filter((d) => d.status === "complete" && d.comparisonId === null);
+
+  return (
+    <Card data-testid="completion-summary">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <Trophy className="h-5 w-5 text-yellow-500" />
+          <CardTitle className="text-lg">Debrief Complete</CardTitle>
+        </div>
+        <p className="text-muted-foreground text-sm">
+          Finished debrief for <strong>{data.movieTitle}</strong>
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="space-y-2">
+          {data.dimensions.map((dim) => (
+            <div key={dim.dimensionId} className="flex items-center justify-between text-sm">
+              <span>{dim.name}</span>
+              {dim.status === "complete" && dim.comparisonId !== null ? (
+                <Badge variant="default" className="gap-1">
+                  <CheckCircle className="h-3 w-3" />
+                  Compared
+                </Badge>
+              ) : dim.status === "complete" && dim.comparisonId === null ? (
+                <Badge variant="secondary" className="gap-1">
+                  <XCircle className="h-3 w-3" />
+                  Skipped
+                </Badge>
+              ) : (
+                <Badge variant="outline" className="gap-1">
+                  <Clock className="h-3 w-3" />
+                  Pending
+                </Badge>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="text-muted-foreground border-t pt-3 text-sm">
+          {completed.length} compared, {skipped.length} skipped
+        </div>
+
+        <div className="flex gap-2 pt-1">
+          {onDoAnother && (
+            <Button variant="outline" size="sm" onClick={onDoAnother}>
+              <ArrowRight className="mr-1 h-4 w-4" />
+              Do another
+            </Button>
+          )}
+          <Button
+            variant="default"
+            size="sm"
+            onClick={() => navigate("/media/compare/rankings")}
+            data-testid="done-btn"
+          >
+            Done
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Debrief Action Bar ──
+
+interface DebriefActionBarProps {
+  sessionId: number;
+  currentDimension: { id: number; name: string } | null;
+  allComplete: boolean;
+  summaryData: DebriefSummaryData | null;
+  onDimensionSkipped?: () => void;
+  onDoAnother?: () => void;
+}
+
+/**
+ * Combined action bar for debrief sessions.
+ * Shows skip + bail buttons during active session, summary when complete.
+ */
+export function DebriefActionBar({
+  sessionId,
+  currentDimension,
+  allComplete,
+  summaryData,
+  onDimensionSkipped,
+  onDoAnother,
+}: DebriefActionBarProps) {
+  if (allComplete && summaryData) {
+    return <CompletionSummary data={summaryData} onDoAnother={onDoAnother} />;
+  }
+
+  return (
+    <div className="flex items-center gap-2" data-testid="debrief-action-bar">
+      {currentDimension && (
+        <SkipDimensionButton
+          sessionId={sessionId}
+          dimensionId={currentDimension.id}
+          dimensionName={currentDimension.name}
+          onSkipped={onDimensionSkipped}
+        />
+      )}
+      <DoneForNowButton />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `SkipDimensionButton` — calls `dismissDebriefDimension` mutation, shows toast, advances to next dimension
- Add `DoneForNowButton` — exits debrief session preserving server-side progress
- Add `CompletionSummary` — shows per-dimension results (compared/skipped/pending) with badges and counts
- Add `DebriefActionBar` — composite component that switches between active controls and completion view
- 13 tests covering rendering, click handlers, mutation calls, callbacks, and conditional display

## Test plan
- [x] 13 unit tests pass
- [ ] CI passes lint + typecheck + tests

Closes #1276

🤖 Generated with [Claude Code](https://claude.com/claude-code)