### PR TITLE
docs: update PRD-063 + PRD-064 user story statuses [tb-177]

### DIFF
--- a/docs/themes/03-media/epics/04-ratings-comparisons.md
+++ b/docs/themes/03-media/epics/04-ratings-comparisons.md
@@ -12,8 +12,8 @@ Build the pairwise comparison system (per ADR-010). Two movies presented side by
 |---|-----|---------|--------|
 | 037 | [Ratings & Comparisons](../prds/037-ratings-comparisons/README.md) | Compare arena page, dimension management, ELO scoring algorithm, rankings page, radar charts on detail pages, quick-pick flow | Partial |
 | 062 | [Comparison Intelligence](../prds/062-comparison-intelligence/README.md) | Probabilistic pair selection, staleness model, dimension exclusion, watch blacklist, skip cooloff, score confidence, freshness indicators | Not started |
-| 063 | [Post-Watch Debrief](../prds/063-post-watch-debrief/README.md) | Rapid-fire comparison session for newly watched movies — one opponent per dimension, median-score calibration | Not started |
-| 064 | [Batch Tier List](../prds/064-batch-tier-list/README.md) | Drag-and-drop S/A/B/C/D tier ranking for 8 movies per dimension, implied pairwise comparisons | Not started |
+| 063 | [Post-Watch Debrief](../prds/063-post-watch-debrief/README.md) | Rapid-fire comparison session for newly watched movies — one opponent per dimension, median-score calibration | In progress |
+| 064 | [Batch Tier List](../prds/064-batch-tier-list/README.md) | Drag-and-drop S/A/B/C/D tier ranking for 8 movies per dimension, implied pairwise comparisons | In progress |
 
 ## Dependencies
 

--- a/docs/themes/03-media/prds/063-post-watch-debrief/README.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/README.md
@@ -1,7 +1,7 @@
 # PRD-063: Post-Watch Debrief
 
 > Epic: [04 — Ratings & Comparisons](../../epics/04-ratings-comparisons.md)
-> Status: Not started
+> Status: In progress
 
 ## Overview
 
@@ -89,11 +89,11 @@ Rows are created when a watch event is logged — one row per active dimension. 
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-debrief-schema](us-01-debrief-schema.md) | debrief_status table, auto-queue on watch event | Not started | Yes |
-| 02 | [us-02-opponent-selection](us-02-opponent-selection.md) | Median-score opponent selection per dimension | Not started | Yes |
-| 03 | [us-03-debrief-api](us-03-debrief-api.md) | tRPC endpoints: getDebrief, recordDebriefComparison, dismissDimension | Not started | Blocked by us-01, us-02 |
-| 04 | [us-04-debrief-page](us-04-debrief-page.md) | Debrief route with comparison cards, dimension progress, bail-out, summary | Not started | Blocked by us-03 |
-| 05 | [us-05-debrief-notifications](us-05-debrief-notifications.md) | History tile button, library banner, detail page button for pending debriefs | Not started | Blocked by us-03 |
+| 01 | [us-01-debrief-schema](us-01-debrief-schema.md) | debrief_status table, auto-queue on watch event | Done | Yes |
+| 02 | [us-02-opponent-selection](us-02-opponent-selection.md) | Median-score opponent selection per dimension | Done | Yes |
+| 03 | [us-03-debrief-api](us-03-debrief-api.md) | tRPC endpoints: getDebrief, recordDebriefComparison, dismissDimension | Partial | Blocked by us-01, us-02 |
+| 04 | [us-04-debrief-page](us-04-debrief-page.md) | Debrief route with comparison cards, dimension progress, bail-out, summary | Partial | Blocked by us-03 |
+| 05 | [us-05-debrief-notifications](us-05-debrief-notifications.md) | History tile button, library banner, detail page button for pending debriefs | Partial | Blocked by us-03 |
 
 US-01 and US-02 can parallelise. US-04 and US-05 can parallelise once US-03 is done.
 

--- a/docs/themes/03-media/prds/063-post-watch-debrief/us-01-debrief-schema.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/us-01-debrief-schema.md
@@ -1,7 +1,7 @@
 # US-01: Debrief schema and auto-queue
 
 > PRD: [063 — Post-Watch Debrief](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,8 +9,8 @@ As the system, I create debrief rows when a watch event is logged so the user is
 
 ## Acceptance Criteria
 
-- [ ] `debrief_status` table with columns: id, media_type, media_id, dimension_id, debriefed (default 0), dismissed (default 0), created_at
-- [ ] UNIQUE index on (media_type, media_id, dimension_id)
-- [ ] When a watch event is logged, insert one debrief row per active dimension for that movie
-- [ ] If rows already exist (re-watch), reset debriefed and dismissed to 0
-- [ ] Tests: watch event creates rows, re-watch resets rows, correct number of dimensions
+- [x] `debrief_status` table with columns: id, media_type, media_id, dimension_id, debriefed (default 0), dismissed (default 0), created_at
+- [x] UNIQUE index on (media_type, media_id, dimension_id)
+- [x] When a watch event is logged, insert one debrief row per active dimension for that movie
+- [x] If rows already exist (re-watch), reset debriefed and dismissed to 0
+- [x] Tests: watch event creates rows, re-watch resets rows, correct number of dimensions

--- a/docs/themes/03-media/prds/063-post-watch-debrief/us-02-opponent-selection.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/us-02-opponent-selection.md
@@ -1,7 +1,7 @@
 # US-02: Median-score opponent selection
 
 > PRD: [063 — Post-Watch Debrief](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,8 +9,8 @@ As the system, I select a debrief opponent near the median score for each dimens
 
 ## Acceptance Criteria
 
-- [ ] `getDebriefOpponent(mediaType, mediaId, dimensionId)` returns a single opponent movie
-- [ ] Opponent is the scored movie closest to the median score for that dimension
-- [ ] Excludes: the debrief movie itself, excluded-for-dimension movies, blacklisted movies, movies already compared against in this dimension
-- [ ] If no eligible opponent exists, returns null (dimension will be skipped)
-- [ ] Tests: selects median-range opponent, respects exclusions, returns null when exhausted
+- [x] `getDebriefOpponent(mediaType, mediaId, dimensionId)` returns a single opponent movie
+- [x] Opponent is the scored movie closest to the median score for that dimension
+- [x] Excludes: the debrief movie itself, excluded-for-dimension movies, blacklisted movies, movies already compared against in this dimension
+- [x] If no eligible opponent exists, returns null (dimension will be skipped)
+- [x] Tests: selects median-range opponent, respects exclusions, returns null when exhausted

--- a/docs/themes/03-media/prds/063-post-watch-debrief/us-03-debrief-api.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/us-03-debrief-api.md
@@ -1,7 +1,7 @@
 # US-03: Debrief tRPC endpoints
 
 > PRD: [063 — Post-Watch Debrief](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -9,9 +9,9 @@ As a developer, I want tRPC endpoints for the debrief flow: get pending debrief,
 
 ## Acceptance Criteria
 
-- [ ] `media.comparisons.getDebrief({ mediaType, mediaId })` returns: movie info, list of dimensions with status (pending/debriefed/dismissed), opponent per pending dimension
-- [ ] `media.comparisons.recordDebriefComparison({ mediaType, mediaId, dimensionId, winnerId, drawTier? })` records comparison via standard path, sets debriefed=1 on the debrief row
-- [ ] `media.comparisons.dismissDebriefDimension({ mediaType, mediaId, dimensionId })` sets dismissed=1
-- [ ] `media.comparisons.getPendingDebriefs()` returns list of movies with incomplete debriefs (for notifications)
-- [ ] All protected procedures
+- [x] `media.comparisons.getDebrief({ mediaType, mediaId })` returns: movie info, list of dimensions with status (pending/debriefed/dismissed), opponent per pending dimension
+- [x] `media.comparisons.recordDebriefComparison({ mediaType, mediaId, dimensionId, winnerId, drawTier? })` records comparison via standard path, sets debriefed=1 on the debrief row
+- [x] `media.comparisons.dismissDebriefDimension({ mediaType, mediaId, dimensionId })` sets dismissed=1
+- [x] `media.comparisons.getPendingDebriefs()` returns list of movies with incomplete debriefs (for notifications)
+- [x] All protected procedures
 - [ ] Tests: get returns correct status, record updates row + ELO, dismiss sets flag, pending list correct

--- a/docs/themes/03-media/prds/063-post-watch-debrief/us-04-debrief-page.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/us-04-debrief-page.md
@@ -1,7 +1,7 @@
 # US-04: Debrief page
 
 > PRD: [063 — Post-Watch Debrief](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -15,7 +15,7 @@ As a user, I want a dedicated debrief page where I rapidly compare a just-watche
 - [ ] Comparison layout: debrief movie (left) vs opponent (right)
 - [ ] Pick A / Pick B / High / Mid / Low draw buttons (same as arena)
 - [ ] After pick, advance to next pending dimension
-- [ ] "Skip this dimension" button dismisses current dimension
-- [ ] "Done for now" button exits, completed dimensions saved
-- [ ] Completion summary: per-dimension result + new score
+- [x] "Skip this dimension" button dismisses current dimension
+- [x] "Done for now" button exits, completed dimensions saved
+- [x] Completion summary: per-dimension result + new score
 - [ ] Tests: renders, pick advances, skip dismisses, bail-out saves progress, summary shows

--- a/docs/themes/03-media/prds/063-post-watch-debrief/us-05-debrief-notifications.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/us-05-debrief-notifications.md
@@ -1,7 +1,7 @@
 # US-05: Debrief notifications
 
 > PRD: [063 — Post-Watch Debrief](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -9,10 +9,10 @@ As a user, I want to see debrief prompts on the history page, library page, and 
 
 ## Acceptance Criteria
 
-- [ ] History page: "Debrief" button on movie tiles with pending debriefs
+- [x] History page: "Debrief" button on movie tiles with pending debriefs
 - [ ] Library page: notification banner "N movies to debrief" — links to first pending, dismissible
-- [ ] Movie detail page: "Debrief this movie" button when debrief is pending
-- [ ] All buttons link to `/media/debrief/:movieId`
+- [x] Movie detail page: "Debrief this movie" button when debrief is pending
+- [x] All buttons link to `/media/debrief/:movieId`
 - [ ] Buttons/banner hidden once all dimensions are debriefed or dismissed
 - [ ] Dismissing the library banner does not dismiss individual debrief rows (just hides the banner for the session)
 - [ ] Tests: button shows for pending, hidden for complete, banner shows count, dismiss works

--- a/docs/themes/03-media/prds/064-batch-tier-list/README.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/README.md
@@ -1,7 +1,7 @@
 # PRD-064: Batch Tier List
 
 > Epic: [04 — Ratings & Comparisons](../../epics/04-ratings-comparisons.md)
-> Status: Not started
+> Status: In progress
 
 ## Overview
 
@@ -102,11 +102,11 @@ No new tables. Tier list submissions generate standard `comparisons` rows via th
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-tier-conversion](us-01-tier-conversion.md) | Convert tier placements to implied pairwise comparisons with correct winners and draw tiers | Not started | Yes |
-| 02 | [us-02-batch-record](us-02-batch-record.md) | Batch record implied comparisons in a single transaction | Not started | Yes |
-| 03 | [us-03-movie-selection](us-03-movie-selection.md) | Select 8 movies to maximise information gain for the chosen dimension | Not started | Yes |
-| 04 | [us-04-tier-list-api](us-04-tier-list-api.md) | tRPC endpoints: getTierListMovies, submitTierList | Not started | Blocked by us-01, us-02, us-03 |
-| 05 | [us-05-drag-drop-ui](us-05-drag-drop-ui.md) | Drag-and-drop tier list page with S/A/B/C/D rows, movie cards, unranked pool | Not started | Blocked by us-04 |
+| 01 | [us-01-tier-conversion](us-01-tier-conversion.md) | Convert tier placements to implied pairwise comparisons with correct winners and draw tiers | Done | Yes |
+| 02 | [us-02-batch-record](us-02-batch-record.md) | Batch record implied comparisons in a single transaction | Done | Yes |
+| 03 | [us-03-movie-selection](us-03-movie-selection.md) | Select 8 movies to maximise information gain for the chosen dimension | Done | Yes |
+| 04 | [us-04-tier-list-api](us-04-tier-list-api.md) | tRPC endpoints: getTierListMovies, submitTierList | Done | Blocked by us-01, us-02, us-03 |
+| 05 | [us-05-drag-drop-ui](us-05-drag-drop-ui.md) | Drag-and-drop tier list page with S/A/B/C/D rows, movie cards, unranked pool | Partial | Blocked by us-04 |
 | 06 | [us-06-submission-summary](us-06-submission-summary.md) | Post-submit summary showing implied comparison count and ELO changes | Done | Blocked by us-05 |
 
 US-01, US-02, US-03 can parallelise. US-05 and US-06 can parallelise once US-04 is done.

--- a/docs/themes/03-media/prds/064-batch-tier-list/us-01-tier-conversion.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/us-01-tier-conversion.md
@@ -1,7 +1,7 @@
 # US-01: Tier-to-comparison conversion
 
 > PRD: [064 — Batch Tier List](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,9 +9,9 @@ As the system, I convert a set of tier placements into implied pairwise comparis
 
 ## Acceptance Criteria
 
-- [ ] `convertTierPlacements(placements: Array<{ movieId, tier }>)` returns `Array<{ mediaAId, mediaBId, winnerId, drawTier }>`
-- [ ] Same tier → draw. Draw tier mapped: S=high, A=high, B=mid, C=low, D=low
-- [ ] Different tiers → higher tier wins (winnerId = higher-tier movie)
-- [ ] Unranked movies produce no comparisons
-- [ ] For N placed movies, generates exactly C(N,2) comparisons
-- [ ] Tests: same tier draws correct, cross-tier wins correct, unranked excluded, count is C(N,2)
+- [x] `convertTierPlacements(placements: Array<{ movieId, tier }>)` returns `Array<{ mediaAId, mediaBId, winnerId, drawTier }>`
+- [x] Same tier → draw. Draw tier mapped: S=high, A=high, B=mid, C=low, D=low
+- [x] Different tiers → higher tier wins (winnerId = higher-tier movie)
+- [x] Unranked movies produce no comparisons
+- [x] For N placed movies, generates exactly C(N,2) comparisons
+- [x] Tests: same tier draws correct, cross-tier wins correct, unranked excluded, count is C(N,2)

--- a/docs/themes/03-media/prds/064-batch-tier-list/us-02-batch-record.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/us-02-batch-record.md
@@ -1,7 +1,7 @@
 # US-02: Batch record comparisons
 
 > PRD: [064 — Batch Tier List](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,8 +9,8 @@ As the system, I record a batch of implied comparisons from a tier list submissi
 
 ## Acceptance Criteria
 
-- [ ] `batchRecordComparisons(dimensionId, comparisons: Array<{ mediaAId, mediaBId, winnerId, drawTier }>)` records all in one transaction
-- [ ] Each comparison goes through standard ELO update logic (same as `recordComparison`)
-- [ ] All or nothing — if any insert fails, entire batch rolls back
-- [ ] Returns count of comparisons recorded
-- [ ] Tests: batch inserts all, ELO updated for each, rollback on failure
+- [x] `batchRecordComparisons(dimensionId, comparisons: Array<{ mediaAId, mediaBId, winnerId, drawTier }>)` records all in one transaction
+- [x] Each comparison goes through standard ELO update logic (same as `recordComparison`)
+- [x] All or nothing — if any insert fails, entire batch rolls back
+- [x] Returns count of comparisons recorded
+- [x] Tests: batch inserts all, ELO updated for each, rollback on failure

--- a/docs/themes/03-media/prds/064-batch-tier-list/us-03-movie-selection.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/us-03-movie-selection.md
@@ -1,7 +1,7 @@
 # US-03: Tier list movie selection
 
 > PRD: [064 — Batch Tier List](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,10 +9,10 @@ As the system, I select 8 movies for a tier list session that maximise informati
 
 ## Acceptance Criteria
 
-- [ ] `getTierListMovies(dimensionId)` returns up to 8 movies
-- [ ] Prefers movies with few comparisons in this dimension (high uncertainty)
-- [ ] Mix of score ranges — not all top-ranked or all bottom-ranked
-- [ ] Excludes: blacklisted, excluded-for-dimension, staleness < 0.3
-- [ ] Returns fewer than 8 if not enough eligible (minimum 2)
-- [ ] Includes poster URL and title for each movie
-- [ ] Tests: returns 8 when available, respects exclusions, mixed score ranges
+- [x] `getTierListMovies(dimensionId)` returns up to 8 movies
+- [x] Prefers movies with few comparisons in this dimension (high uncertainty)
+- [x] Mix of score ranges — not all top-ranked or all bottom-ranked
+- [x] Excludes: blacklisted, excluded-for-dimension, staleness < 0.3
+- [x] Returns fewer than 8 if not enough eligible (minimum 2)
+- [x] Includes poster URL and title for each movie
+- [x] Tests: returns 8 when available, respects exclusions, mixed score ranges

--- a/docs/themes/03-media/prds/064-batch-tier-list/us-04-tier-list-api.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/us-04-tier-list-api.md
@@ -1,7 +1,7 @@
 # US-04: Tier list tRPC endpoints
 
 > PRD: [064 — Batch Tier List](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,9 +9,9 @@ As a developer, I want tRPC endpoints for fetching tier list movies and submitti
 
 ## Acceptance Criteria
 
-- [ ] `media.comparisons.getTierListMovies({ dimensionId })` returns up to 8 movies with poster + title + current score
-- [ ] `media.comparisons.submitTierList({ dimensionId, placements: Array<{ movieId, tier }> })` converts to implied comparisons and batch-records them
-- [ ] Submit returns: { comparisonsRecorded, scoreChanges: Array<{ movieId, oldScore, newScore }> }
-- [ ] Validates: minimum 2 placed movies, valid tier values (S/A/B/C/D), valid dimension
-- [ ] Both protected procedures
-- [ ] Tests: get returns movies, submit records correct count, validation rejects bad input
+- [x] `media.comparisons.getTierListMovies({ dimensionId })` returns up to 8 movies with poster + title + current score
+- [x] `media.comparisons.submitTierList({ dimensionId, placements: Array<{ movieId, tier }> })` converts to implied comparisons and batch-records them
+- [x] Submit returns: { comparisonsRecorded, scoreChanges: Array<{ movieId, oldScore, newScore }> }
+- [x] Validates: minimum 2 placed movies, valid tier values (S/A/B/C/D), valid dimension
+- [x] Both protected procedures
+- [x] Tests: get returns movies, submit records correct count, validation rejects bad input

--- a/docs/themes/03-media/prds/064-batch-tier-list/us-05-drag-drop-ui.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/us-05-drag-drop-ui.md
@@ -1,7 +1,7 @@
 # US-05: Drag-and-drop tier list UI
 
 > PRD: [064 — Batch Tier List](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -9,12 +9,12 @@ As a user, I want to drag movies into S/A/B/C/D tier rows to rank them quickly o
 
 ## Acceptance Criteria
 
-- [ ] Route: `/media/tier-list`
-- [ ] Dimension selector at top (dropdown or chip selector)
-- [ ] 5 tier rows (S/A/B/C/D) as horizontal drop zones with tier label on the left
-- [ ] Unranked pool at the bottom with the 8 movie cards
-- [ ] Movie cards show poster thumbnail + title, draggable
-- [ ] Drag between tiers to reposition, drag back to unranked to remove
-- [ ] "Refresh" button to get a different set of 8 movies
-- [ ] "Submit" button disabled when fewer than 2 movies placed
+- [x] Route: `/media/tier-list`
+- [x] Dimension selector at top (dropdown or chip selector)
+- [x] 5 tier rows (S/A/B/C/D) as horizontal drop zones with tier label on the left
+- [x] Unranked pool at the bottom with the 8 movie cards
+- [x] Movie cards show poster thumbnail + title, draggable
+- [x] Drag between tiers to reposition, drag back to unranked to remove
+- [x] "Refresh" button to get a different set of 8 movies
+- [x] "Submit" button disabled when fewer than 2 movies placed
 - [ ] Tests: drag and drop works, tier assignment persists, submit enables at 2+


### PR DESCRIPTION
## Summary
- Updated acceptance criteria checkboxes and user story statuses for PRD-063 (Post-Watch Debrief) and PRD-064 (Batch Tier List) to reflect all merged PRs on main
- PRD-063: 2 Done, 3 Partial (of 5 user stories)
- PRD-064: 5 Done, 1 Partial (of 6 user stories)
- Updated Epic 04 PRD table with new PRD statuses (both In progress)

## Test plan
- [ ] Verify acceptance criteria checkboxes match actual merged implementations
- [ ] Verify PRD README tables match individual US statuses
- [ ] Verify Epic 04 table reflects correct PRD statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)