### PR TITLE
docs: mark PRD-062 Comparison Intelligence as Done [tb-178]

### DIFF
--- a/docs/themes/03-media/epics/04-ratings-comparisons.md
+++ b/docs/themes/03-media/epics/04-ratings-comparisons.md
@@ -11,7 +11,7 @@ Build the pairwise comparison system (per ADR-010). Two movies presented side by
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
 | 037 | [Ratings & Comparisons](../prds/037-ratings-comparisons/README.md) | Compare arena page, dimension management, ELO scoring algorithm, rankings page, radar charts on detail pages, quick-pick flow | Partial |
-| 062 | [Comparison Intelligence](../prds/062-comparison-intelligence/README.md) | Probabilistic pair selection, staleness model, dimension exclusion, watch blacklist, skip cooloff, score confidence, freshness indicators | Not started |
+| 062 | [Comparison Intelligence](../prds/062-comparison-intelligence/README.md) | Probabilistic pair selection, staleness model, dimension exclusion, watch blacklist, skip cooloff, score confidence, freshness indicators | Done |
 | 063 | [Post-Watch Debrief](../prds/063-post-watch-debrief/README.md) | Rapid-fire comparison session for newly watched movies — one opponent per dimension, median-score calibration | In progress |
 | 064 | [Batch Tier List](../prds/064-batch-tier-list/README.md) | Drag-and-drop S/A/B/C/D tier ranking for 8 movies per dimension, implied pairwise comparisons | In progress |
 

--- a/docs/themes/03-media/prds/062-comparison-intelligence/README.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/README.md
@@ -1,7 +1,7 @@
 # PRD-062: Comparison Intelligence
 
 > Epic: [04 — Ratings & Comparisons](../../epics/04-ratings-comparisons.md)
-> Status: Not started
+> Status: Done
 
 ## Overview
 
@@ -165,14 +165,14 @@ If the movie has a `comparison_staleness` row with `staleness < 1.0`, the badge 
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-blacklist-watch-history](us-01-blacklist-watch-history.md) | Blacklisted column on watch_history, "not watched" arena action with comparison purge + ELO recalc, sync protection | Not started | Yes |
-| 02 | [us-02-staleness-model](us-02-staleness-model.md) | Staleness table, compounding multiplier, watch-resets-staleness, arena stale button | Not started | Yes |
-| 03 | [us-03-dimension-exclusion](us-03-dimension-exclusion.md) | "Not applicable" action, excluded column on media_scores, comparison purge + ELO recalc, hide from rankings | Not started | Blocked by us-01 (shares recalc logic) |
-| 04 | [us-04-skip-cooloff](us-04-skip-cooloff.md) | Skip cooloff table, per-pair per-dimension cooloff of 10 comparisons | Not started | Yes |
-| 05 | [us-05-pair-selection-algorithm](us-05-pair-selection-algorithm.md) | Weighted probabilistic pair selection using info gain, recency, staleness, dimension need, jitter | Not started | Blocked by us-02, us-04 |
-| 06 | [us-06-score-confidence](us-06-score-confidence.md) | Derived confidence from comparison_count, displayed on rankings page | Not started | Yes |
-| 07 | [us-07-freshness-indicator](us-07-freshness-indicator.md) | Fresh/Recent/Fading/Stale badge on movies in arena and library | Not started | Blocked by us-02 |
-| 08 | [us-08-arena-action-bar](us-08-arena-action-bar.md) | Bottom action bar with Skip, Stale(A/B), N/A, Not Watched(A/B). Watchlist stays on cards | Not started | Blocked by us-01, us-02, us-03, us-04 |
+| 01 | [us-01-blacklist-watch-history](us-01-blacklist-watch-history.md) | Blacklisted column on watch_history, "not watched" arena action with comparison purge + ELO recalc, sync protection | Done | Yes |
+| 02 | [us-02-staleness-model](us-02-staleness-model.md) | Staleness table, compounding multiplier, watch-resets-staleness, arena stale button | Done | Yes |
+| 03 | [us-03-dimension-exclusion](us-03-dimension-exclusion.md) | "Not applicable" action, excluded column on media_scores, comparison purge + ELO recalc, hide from rankings | Done | Blocked by us-01 (shares recalc logic) |
+| 04 | [us-04-skip-cooloff](us-04-skip-cooloff.md) | Skip cooloff table, per-pair per-dimension cooloff of 10 comparisons | Done | Yes |
+| 05 | [us-05-pair-selection-algorithm](us-05-pair-selection-algorithm.md) | Weighted probabilistic pair selection using info gain, recency, staleness, dimension need, jitter | Done | Blocked by us-02, us-04 |
+| 06 | [us-06-score-confidence](us-06-score-confidence.md) | Derived confidence from comparison_count, displayed on rankings page | Done | Yes |
+| 07 | [us-07-freshness-indicator](us-07-freshness-indicator.md) | Fresh/Recent/Fading/Stale badge on movies in arena and library | Done | Blocked by us-02 |
+| 08 | [us-08-arena-action-bar](us-08-arena-action-bar.md) | Bottom action bar with Skip, Stale(A/B), N/A, Not Watched(A/B). Watchlist stays on cards | Done | Blocked by us-01, us-02, us-03, us-04 |
 
 US-01, US-02, US-04, US-06 can be built in parallel. US-03 shares recalc logic with US-01. US-05 depends on staleness and cooloff tables. US-08 is the UI integration that wires everything together.
 

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-01-blacklist-watch-history.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-01-blacklist-watch-history.md
@@ -1,7 +1,7 @@
 # US-01: Blacklist watch history ("Not watched")
 
 > PRD: [062 — Comparison Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,15 +9,15 @@ As a user, I want to mark a movie as "not watched" (someone else used my account
 
 ## Acceptance Criteria
 
-- [ ] `watch_history` table has a `blacklisted` INTEGER column, default 0
-- [ ] `media.comparisons.blacklistMovie` mutation accepts `{ mediaType, mediaId }` and sets `blacklisted = 1` on all watch_history rows for that movie
-- [ ] After blacklisting, all comparisons involving that movie (all dimensions) are deleted
-- [ ] ELO scores are recalculated (reset + replay) for every affected dimension
-- [ ] A movie with all watch events blacklisted is excluded from pair selection
-- [ ] Plex sync (library sync + cloud watch sync) skips inserting a watch event if a matching `(media_type, media_id, watched_at)` row exists with `blacklisted = 1`
-- [ ] New watch events for the same movie with a different `watched_at` are NOT blacklisted — they flow through normally
-- [ ] Arena "Not watched" button shows a confirmation dialog with the count of comparisons that will be purged
-- [ ] Tests: blacklist sets column, comparisons deleted, ELO recalculated, sync respects blacklist, new watch events pass through
+- [x] `watch_history` table has a `blacklisted` INTEGER column, default 0
+- [x] `media.comparisons.blacklistMovie` mutation accepts `{ mediaType, mediaId }` and sets `blacklisted = 1` on all watch_history rows for that movie
+- [x] After blacklisting, all comparisons involving that movie (all dimensions) are deleted
+- [x] ELO scores are recalculated (reset + replay) for every affected dimension
+- [x] A movie with all watch events blacklisted is excluded from pair selection
+- [x] Plex sync (library sync + cloud watch sync) skips inserting a watch event if a matching `(media_type, media_id, watched_at)` row exists with `blacklisted = 1`
+- [x] New watch events for the same movie with a different `watched_at` are NOT blacklisted — they flow through normally
+- [x] Arena "Not watched" button shows a confirmation dialog with the count of comparisons that will be purged
+- [x] Tests: blacklist sets column, comparisons deleted, ELO recalculated, sync respects blacklist, new watch events pass through
 
 ## Notes
 

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-02-staleness-model.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-02-staleness-model.md
@@ -1,7 +1,7 @@
 # US-02: Staleness model
 
 > PRD: [062 — Comparison Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user, I want to mark a movie as "stale" (I don't remember it well enough to
 
 ## Acceptance Criteria
 
-- [ ] `comparison_staleness` table with `(media_type, media_id, staleness, updated_at)` and unique index on `(media_type, media_id)`
-- [ ] `media.comparisons.markStale` mutation accepts `{ mediaType, mediaId }` — inserts with `staleness = 0.5` if no row exists, or multiplies existing staleness by 0.5 (floor at 0.01)
-- [ ] `media.comparisons.getStaleness` query returns staleness for a movie (default 1.0 if no row)
-- [ ] When a new watch event is inserted into `watch_history` for a movie, that movie's staleness resets to 1.0 (or row is deleted)
-- [ ] Arena "Stale" button for a movie does NOT submit a comparison — marks staleness and loads the next pair
-- [ ] Staleness value is available to the pair selection algorithm (US-05)
-- [ ] Tests: initial mark = 0.5, second mark = 0.25, third = 0.125, floor at 0.01, watch resets to 1.0
+- [x] `comparison_staleness` table with `(media_type, media_id, staleness, updated_at)` and unique index on `(media_type, media_id)`
+- [x] `media.comparisons.markStale` mutation accepts `{ mediaType, mediaId }` — inserts with `staleness = 0.5` if no row exists, or multiplies existing staleness by 0.5 (floor at 0.01)
+- [x] `media.comparisons.getStaleness` query returns staleness for a movie (default 1.0 if no row)
+- [x] When a new watch event is inserted into `watch_history` for a movie, that movie's staleness resets to 1.0 (or row is deleted)
+- [x] Arena "Stale" button for a movie does NOT submit a comparison — marks staleness and loads the next pair
+- [x] Staleness value is available to the pair selection algorithm (US-05)
+- [x] Tests: initial mark = 0.5, second mark = 0.25, third = 0.125, floor at 0.01, watch resets to 1.0
 
 ## Notes
 

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-03-dimension-exclusion.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-03-dimension-exclusion.md
@@ -1,7 +1,7 @@
 # US-03: Dimension exclusion ("Not applicable")
 
 > PRD: [062 — Comparison Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,15 +9,15 @@ As a user, I want to mark a movie as "not applicable" for a specific dimension (
 
 ## Acceptance Criteria
 
-- [ ] `media_scores` table has an `excluded` INTEGER column, default 0
-- [ ] `media.comparisons.excludeFromDimension` mutation accepts `{ mediaType, mediaId, dimensionId }` — sets `excluded = 1` on the media_scores row (creates it if missing)
-- [ ] After excluding, all comparisons involving that movie for that specific dimension are deleted
-- [ ] ELO scores are recalculated (reset + replay) for that dimension
-- [ ] Excluded movies do not appear in pair selection for that dimension
-- [ ] Excluded movies do not appear in rankings for that dimension
-- [ ] `media.comparisons.includeInDimension` mutation allows undoing the exclusion (sets `excluded = 0`)
-- [ ] Arena "N/A" button excludes BOTH movies in the current pair for the current dimension, loads next pair
-- [ ] Tests: exclude sets column, comparisons purged, recalc correct, pair selection skips excluded, rankings omit excluded, re-include works
+- [x] `media_scores` table has an `excluded` INTEGER column, default 0
+- [x] `media.comparisons.excludeFromDimension` mutation accepts `{ mediaType, mediaId, dimensionId }` — sets `excluded = 1` on the media_scores row (creates it if missing)
+- [x] After excluding, all comparisons involving that movie for that specific dimension are deleted
+- [x] ELO scores are recalculated (reset + replay) for that dimension
+- [x] Excluded movies do not appear in pair selection for that dimension
+- [x] Excluded movies do not appear in rankings for that dimension
+- [x] `media.comparisons.includeInDimension` mutation allows undoing the exclusion (sets `excluded = 0`)
+- [x] Arena "N/A" button excludes BOTH movies in the current pair for the current dimension, loads next pair
+- [x] Tests: exclude sets column, comparisons purged, recalc correct, pair selection skips excluded, rankings omit excluded, re-include works
 
 ## Notes
 

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-04-skip-cooloff.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-04-skip-cooloff.md
@@ -1,7 +1,7 @@
 # US-04: Skip cooloff
 
 > PRD: [062 — Comparison Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user, I want "skip" to prevent the same pair from reappearing for the next 
 
 ## Acceptance Criteria
 
-- [ ] `comparison_skip_cooloffs` table with `(dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, skip_until, created_at)` and unique index on pair+dimension
-- [ ] When "Skip" is pressed, a cooloff row is inserted with `skip_until = currentGlobalComparisonCount + 10`
-- [ ] Pair selection excludes pairs where `currentGlobalComparisonCount < skip_until`
-- [ ] Cooloff is per-pair per-dimension: skipping "A vs B" on Cinematography doesn't affect "A vs B" on Entertainment
-- [ ] Cooloff is symmetric: skipping "A vs B" also blocks "B vs A" for the same dimension
-- [ ] Expired cooloffs are ignored at query time (no cleanup needed)
-- [ ] Tests: skip inserts cooloff, pair excluded during cooloff, pair eligible after cooloff, symmetry enforced
+- [x] `comparison_skip_cooloffs` table with `(dimension_id, media_a_type, media_a_id, media_b_type, media_b_id, skip_until, created_at)` and unique index on pair+dimension
+- [x] When "Skip" is pressed, a cooloff row is inserted with `skip_until = currentGlobalComparisonCount + 10`
+- [x] Pair selection excludes pairs where `currentGlobalComparisonCount < skip_until`
+- [x] Cooloff is per-pair per-dimension: skipping "A vs B" on Cinematography doesn't affect "A vs B" on Entertainment
+- [x] Cooloff is symmetric: skipping "A vs B" also blocks "B vs A" for the same dimension
+- [x] Expired cooloffs are ignored at query time (no cleanup needed)
+- [x] Tests: skip inserts cooloff, pair excluded during cooloff, pair eligible after cooloff, symmetry enforced
 
 ## Notes
 

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-05-pair-selection-algorithm.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-05-pair-selection-algorithm.md
@@ -1,7 +1,7 @@
 # US-05: Pair selection algorithm
 
 > PRD: [062 — Comparison Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,18 +9,18 @@ As the system, I select comparison pairs using a weighted probabilistic model so
 
 ## Acceptance Criteria
 
-- [ ] Pair selection uses the priority formula from the PRD — not random
-- [ ] **Information gain**: pairs with close scores and few head-to-head comparisons are prioritised. Formula: `1 / (1 + abs(scoreA - scoreB) / 200) × (1 / (pairCount + 1))`
-- [ ] **Recency weight**: recently watched movies appear more often. Formula: `1 / (1 + daysSinceLastWatch / 180)` (6-month half-life)
-- [ ] **Staleness weight**: reads from `comparison_staleness` table. Default 1.0 if no row. Multiplied for both movies in the pair
-- [ ] **Dimension need**: under-sampled dimensions get boosted. Formula: `maxCompCount / (thisDimensionCompCount + 1)`
-- [ ] **Random jitter**: final priority multiplied by uniform random in [0.7, 1.3]
-- [ ] Selection is weighted random sampling from all eligible pairs — NOT deterministic top-pick
-- [ ] Exclusion rules applied before scoring: blacklisted, excluded for dimension, on cooloff, no valid watch events
-- [ ] Dimension selection uses weighted random (by dimension need) instead of round-robin rotation
-- [ ] Falls back to any eligible pair if weighted selection produces no candidates
-- [ ] Performance: pair selection completes in < 200ms for libraries up to 500 movies
-- [ ] Tests: information gain favours close-score pairs, recency favours recent watches, staleness reduces frequency, dimension need favours under-sampled, jitter produces variety across repeated calls
+- [x] Pair selection uses the priority formula from the PRD — not random
+- [x] **Information gain**: pairs with close scores and few head-to-head comparisons are prioritised. Formula: `1 / (1 + abs(scoreA - scoreB) / 200) × (1 / (pairCount + 1))`
+- [x] **Recency weight**: recently watched movies appear more often. Formula: `1 / (1 + daysSinceLastWatch / 180)` (6-month half-life)
+- [x] **Staleness weight**: reads from `comparison_staleness` table. Default 1.0 if no row. Multiplied for both movies in the pair
+- [x] **Dimension need**: under-sampled dimensions get boosted. Formula: `maxCompCount / (thisDimensionCompCount + 1)`
+- [x] **Random jitter**: final priority multiplied by uniform random in [0.7, 1.3]
+- [x] Selection is weighted random sampling from all eligible pairs — NOT deterministic top-pick
+- [x] Exclusion rules applied before scoring: blacklisted, excluded for dimension, on cooloff, no valid watch events
+- [x] Dimension selection uses weighted random (by dimension need) instead of round-robin rotation
+- [x] Falls back to any eligible pair if weighted selection produces no candidates
+- [x] Performance: pair selection completes in < 200ms for libraries up to 500 movies
+- [x] Tests: information gain favours close-score pairs, recency favours recent watches, staleness reduces frequency, dimension need favours under-sampled, jitter produces variety across repeated calls
 
 ## Notes
 

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-06-score-confidence.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-06-score-confidence.md
@@ -1,7 +1,7 @@
 # US-06: Score confidence
 
 > PRD: [062 — Comparison Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a user, I want to see how confident the ranking score is so I know which movi
 
 ## Acceptance Criteria
 
-- [ ] Confidence formula: `confidence = 1 - (1 / sqrt(comparisonCount + 1))` — derived at query time, not stored
-- [ ] Rankings API includes `confidence` (0–1 float) in each ranked entry
-- [ ] Rankings page shows confidence as a subtle visual (e.g. thin bar under the score, or percentage text like "82%")
-- [ ] Low-confidence scores (< 50%, i.e. fewer than 3 comparisons) are visually muted or annotated
-- [ ] Overall rankings confidence is the minimum confidence across active dimensions for that movie
-- [ ] Tests: confidence is 0 at count=0, ~0.29 at count=1, ~0.5 at count=3, ~0.82 at count=30
+- [x] Confidence formula: `confidence = 1 - (1 / sqrt(comparisonCount + 1))` — derived at query time, not stored
+- [x] Rankings API includes `confidence` (0–1 float) in each ranked entry
+- [x] Rankings page shows confidence as a subtle visual (e.g. thin bar under the score, or percentage text like "82%")
+- [x] Low-confidence scores (< 50%, i.e. fewer than 3 comparisons) are visually muted or annotated
+- [x] Overall rankings confidence is the minimum confidence across active dimensions for that movie
+- [x] Tests: confidence is 0 at count=0, ~0.29 at count=1, ~0.5 at count=3, ~0.82 at count=30
 
 ## Notes
 

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-07-freshness-indicator.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-07-freshness-indicator.md
@@ -1,7 +1,7 @@
 # US-07: Freshness indicator
 
 > PRD: [062 — Comparison Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,17 +9,17 @@ As a user, I want to see a freshness badge on movies so I know at a glance how r
 
 ## Acceptance Criteria
 
-- [ ] Freshness badge shows on movie cards in the compare arena (both cards)
-- [ ] Freshness badge shows on the movie detail page
-- [ ] Badge derived from `daysSinceLastWatch` (most recent non-blacklisted watch event):
+- [x] Freshness badge shows on movie cards in the compare arena (both cards)
+- [x] Freshness badge shows on the movie detail page
+- [x] Badge derived from `daysSinceLastWatch` (most recent non-blacklisted watch event):
   - 0–30 days: "Fresh" (green)
   - 31–90 days: "Recent" (blue)
   - 91–365 days: "Fading" (yellow)
   - 365+ days: "Stale" (red)
-- [ ] If the movie has a `comparison_staleness` row with `staleness < 1.0`, badge shows "Stale" (red) regardless of watch recency
-- [ ] Badge is a small pill/chip near the movie title or poster corner — not intrusive
-- [ ] Library page optionally shows freshness (e.g. as a sort option or filter, not on every card by default)
-- [ ] Tests: correct badge for each time range, stale override, no badge for unwatched movies
+- [x] If the movie has a `comparison_staleness` row with `staleness < 1.0`, badge shows "Stale" (red) regardless of watch recency
+- [x] Badge is a small pill/chip near the movie title or poster corner — not intrusive
+- [x] Library page optionally shows freshness (e.g. as a sort option or filter, not on every card by default)
+- [x] Tests: correct badge for each time range, stale override, no badge for unwatched movies
 
 ## Notes
 

--- a/docs/themes/03-media/prds/062-comparison-intelligence/us-08-arena-action-bar.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/us-08-arena-action-bar.md
@@ -1,7 +1,7 @@
 # US-08: Arena action bar
 
 > PRD: [062 — Comparison Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,7 +9,7 @@ As a user, I want a unified action bar below the comparison cards with all arena
 
 ## Acceptance Criteria
 
-- [ ] Bottom action bar with the following actions:
+- [x] Bottom action bar with the following actions:
   - **Skip** — applies per-pair cooloff (US-04), loads next pair, no comparison recorded
   - **Stale (A)** — marks movie A as stale (US-02), loads next pair, no comparison recorded
   - **Stale (B)** — marks movie B as stale (US-02), loads next pair, no comparison recorded
@@ -17,14 +17,14 @@ As a user, I want a unified action bar below the comparison cards with all arena
   - **Not watched (A)** — blacklists movie A's watch history (US-01), confirmation dialog, loads next pair
   - **Not watched (B)** — blacklists movie B's watch history (US-01), confirmation dialog, loads next pair
   - **Done** — navigates away from arena
-- [ ] Watchlist bookmark button stays on each movie card. Does NOT submit a comparison or affect the selection algorithm
-- [ ] Center column between cards shows High/Mid/Low draw tier buttons
-- [ ] "Stale" buttons show current staleness level for each movie (e.g. "Stale ×2" if marked before)
-- [ ] "Not watched" buttons use destructive styling (red) and trigger a confirmation dialog showing comparison count to be purged
-- [ ] All action bar buttons are disabled while a mutation is pending
-- [ ] Each action invalidates the pair cache and loads a fresh pair after completing
-- [ ] On mobile, secondary actions (N/A, Not watched) collapse into a "more" menu. Skip and Stale are always visible
-- [ ] Tests: each button calls the correct mutation, confirmation dialog for destructive actions, button states
+- [x] Watchlist bookmark button stays on each movie card. Does NOT submit a comparison or affect the selection algorithm
+- [x] Center column between cards shows High/Mid/Low draw tier buttons
+- [x] "Stale" buttons show current staleness level for each movie (e.g. "Stale ×2" if marked before)
+- [x] "Not watched" buttons use destructive styling (red) and trigger a confirmation dialog showing comparison count to be purged
+- [x] All action bar buttons are disabled while a mutation is pending
+- [x] Each action invalidates the pair cache and loads a fresh pair after completing
+- [x] On mobile, secondary actions (N/A, Not watched) collapse into a "more" menu. Skip and Stale are always visible
+- [x] Tests: each button calls the correct mutation, confirmation dialog for destructive actions, button states
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Mark all 8 user stories in PRD-062 (Comparison Intelligence) as Done with all acceptance criteria checked
- Update PRD-062 status to Done in the README user story table
- Update epic 04 (Ratings & Comparisons) PRD table to reflect PRD-062 as Done

All features verified against codebase: blacklist watch history, staleness model, dimension exclusion, skip cooloff, pair selection algorithm, score confidence, freshness indicator, arena action bar.

## Test plan
- [ ] Verify all 8 US files have status: Done and all criteria checked
- [ ] Verify PRD-062 README table shows all stories as Done
- [ ] Verify epic 04 table shows PRD-062 as Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)