### PR TITLE
feat(media): add DebriefComparisonCard component [tb-176]

### DIFF
--- a/packages/app-media/src/components/DebriefComparisonCard.test.tsx
+++ b/packages/app-media/src/components/DebriefComparisonCard.test.tsx
@@ -20,10 +20,7 @@ vi.mock("../lib/trpc", () => ({
   },
 }));
 
-import {
-  DebriefComparisonCard,
-  DebriefComparisonCardSkeleton,
-} from "./DebriefComparisonCard";
+import { DebriefComparisonCard, DebriefComparisonCardSkeleton } from "./DebriefComparisonCard";
 
 const movieA = {
   id: 1,

--- a/packages/app-media/src/components/DebriefComparisonCard.tsx
+++ b/packages/app-media/src/components/DebriefComparisonCard.tsx
@@ -37,11 +37,8 @@ export function DebriefComparisonCard({
 }: DebriefComparisonCardProps) {
   const [winnerId, setWinnerId] = useState<number | null>(null);
 
-  // recordDebriefComparison is added by tb-161 (PR #1313) — cast until merged
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const comparisons = trpc.media.comparisons as any;
-  const mutation = comparisons.recordDebriefComparison.useMutation({
-    onSuccess: (data: { data: { comparisonId: number | null; sessionComplete: boolean } }) => {
+  const mutation = trpc.media.comparisons.recordDebriefComparison.useMutation({
+    onSuccess: (data) => {
       onResult(data.data);
     },
   });


### PR DESCRIPTION
## Summary
- Add `DebriefComparisonCard` component showing two movie posters side by side for debrief comparisons
- User taps one poster to select the winner, which calls `recordDebriefComparison` mutation (tb-161)
- Includes `DebriefComparisonCardSkeleton` for loading state, poster fallback with `ImageOff` icon
- Props: `{ movieA, movieB, dimensionId, sessionId, onResult }`
- Winner/loser visual feedback (green border + scale for winner, red + fade for loser)

## Dependencies
- Depends on tb-161 (PR #1313) for `recordDebriefComparison` mutation — uses `any` cast until merged

## Test plan
- [x] Renders both movie posters side by side with titles and years
- [x] Calls `recordDebriefComparison` with correct params on pick
- [x] Fires `onResult` callback after successful mutation
- [x] Shows placeholder when posterUrl is null
- [x] Accessible pick buttons with aria-labels
- [x] Skeleton component renders two placeholder cards
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)