### PR TITLE
feat(navigation): add AppContextProvider with URL-based app detection [tb-180]

### DIFF
--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -26,6 +26,7 @@
     "@pops/app-inventory": "workspace:*",
     "@pops/app-ai": "workspace:*",
     "@pops/api-client": "workspace:*",
+    "@pops/navigation": "workspace:*",
     "@pops/ui": "workspace:*",
     "lucide-react": "^0.563.0",
     "@tanstack/react-query": "5.90.20",

--- a/apps/pops-shell/src/app/layout/RootLayout.tsx
+++ b/apps/pops-shell/src/app/layout/RootLayout.tsx
@@ -12,6 +12,7 @@ import { AppRail } from "./AppRail";
 import { PageNav } from "./PageNav";
 import { Sidebar } from "./Sidebar";
 import { ErrorBoundary, cn } from "@pops/ui";
+import { AppContextProvider } from "@pops/navigation";
 import { useUIStore } from "@/store/uiStore";
 import { registeredApps } from "@/app/nav/registry";
 import { findActiveApp } from "@/app/nav/path-utils";
@@ -30,49 +31,51 @@ export function RootLayout() {
   }, [location.pathname, setPageNavOpen]);
 
   return (
-    <div className={cn("min-h-screen bg-background relative", appColorClass)}>
-      {/* Ambient background decorative elements */}
-      <div className="fixed top-0 left-0 w-full h-full pointer-events-none overflow-hidden z-0 opacity-20 dark:opacity-10">
-        <div className="absolute top-[-10%] right-[-10%] w-[40%] h-[40%] rounded-full bg-app-accent/20 blur-[120px]" />
-        <div className="absolute bottom-[-5%] left-[-5%] w-[30%] h-[30%] rounded-full bg-app-accent/10 blur-[100px]" />
-      </div>
+    <AppContextProvider>
+      <div className={cn("min-h-screen bg-background relative", appColorClass)}>
+        {/* Ambient background decorative elements */}
+        <div className="fixed top-0 left-0 w-full h-full pointer-events-none overflow-hidden z-0 opacity-20 dark:opacity-10">
+          <div className="absolute top-[-10%] right-[-10%] w-[40%] h-[40%] rounded-full bg-app-accent/20 blur-[120px]" />
+          <div className="absolute bottom-[-5%] left-[-5%] w-[30%] h-[30%] rounded-full bg-app-accent/10 blur-[100px]" />
+        </div>
 
-      <div className="relative z-10 pt-14 md:pt-16">
-        <TopBar />
-        <div className="flex">
-          {/* Desktop + Tablet: app rail always visible at md+ */}
-          <div className="hidden md:flex h-[calc(100vh-4rem)] sticky top-16 shrink-0">
-            <AppRail />
-            {/* Desktop only: permanent PageNav (lg+) */}
-            <div className="hidden lg:block">
-              <PageNav />
-            </div>
-          </div>
-
-          {/* Tablet overlay: PageNav as overlay (md to lg) */}
-          {pageNavOpen && (
-            <div className="hidden md:block lg:hidden">
-              <div
-                className="fixed inset-0 bg-black/50 z-40"
-                onClick={() => setPageNavOpen(false)}
-                aria-hidden="true"
-              />
-              <aside className="fixed left-16 top-16 bottom-0 z-50 shadow-lg">
+        <div className="relative z-10 pt-14 md:pt-16">
+          <TopBar />
+          <div className="flex">
+            {/* Desktop + Tablet: app rail always visible at md+ */}
+            <div className="hidden md:flex h-[calc(100vh-4rem)] sticky top-16 shrink-0">
+              <AppRail />
+              {/* Desktop only: permanent PageNav (lg+) */}
+              <div className="hidden lg:block">
                 <PageNav />
-              </aside>
+              </div>
             </div>
-          )}
 
-          {/* Mobile: overlay sidebar */}
-          <Sidebar open={sidebarOpen} />
+            {/* Tablet overlay: PageNav as overlay (md to lg) */}
+            {pageNavOpen && (
+              <div className="hidden md:block lg:hidden">
+                <div
+                  className="fixed inset-0 bg-black/50 z-40"
+                  onClick={() => setPageNavOpen(false)}
+                  aria-hidden="true"
+                />
+                <aside className="fixed left-16 top-16 bottom-0 z-50 shadow-lg">
+                  <PageNav />
+                </aside>
+              </div>
+            )}
 
-          <main className="flex-1 min-w-0 overflow-x-hidden p-4 md:p-6 lg:p-8 max-w-screen-2xl mx-auto transition-all duration-200">
-            <ErrorBoundary>
-              <Outlet />
-            </ErrorBoundary>
-          </main>
+            {/* Mobile: overlay sidebar */}
+            <Sidebar open={sidebarOpen} />
+
+            <main className="flex-1 min-w-0 overflow-x-hidden p-4 md:p-6 lg:p-8 max-w-screen-2xl mx-auto transition-all duration-200">
+              <ErrorBoundary>
+                <Outlet />
+              </ErrorBoundary>
+            </main>
+          </div>
         </div>
       </div>
-    </div>
+    </AppContextProvider>
   );
 }

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -14,7 +14,8 @@
     "format:fix": "prettier --write \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "react": "^19.0.0"
+    "react": "^19.0.0",
+    "react-router": "^7.13.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/navigation/src/AppContextProvider.test.tsx
+++ b/packages/navigation/src/AppContextProvider.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { MemoryRouter, useNavigate } from "react-router";
+import { AppContextProvider } from "./AppContextProvider";
+import { useAppContext } from "./hooks";
+
+/** Renders children inside a MemoryRouter + AppContextProvider at the given path. */
+function renderAt(path: string, ui: React.ReactNode) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppContextProvider>{ui}</AppContextProvider>
+    </MemoryRouter>
+  );
+}
+
+/** Simple consumer that renders all context fields as testable elements. */
+function ContextDisplay() {
+  const ctx = useAppContext();
+  return (
+    <div>
+      <span data-testid="app">{ctx.app ?? "null"}</span>
+      <span data-testid="page">{ctx.page ?? "null"}</span>
+      <span data-testid="pageType">{ctx.pageType}</span>
+      <span data-testid="entity">{ctx.entity ? ctx.entity.title : "none"}</span>
+    </div>
+  );
+}
+
+describe("AppContextProvider", () => {
+  describe("URL-based app detection", () => {
+    it("returns null app at root /", () => {
+      renderAt("/", <ContextDisplay />);
+      expect(screen.getByTestId("app")).toHaveTextContent("null");
+    });
+
+    it("detects finance app from /finance", () => {
+      renderAt("/finance", <ContextDisplay />);
+      expect(screen.getByTestId("app")).toHaveTextContent("finance");
+    });
+
+    it("detects finance app from a nested path /finance/transactions", () => {
+      renderAt("/finance/transactions", <ContextDisplay />);
+      expect(screen.getByTestId("app")).toHaveTextContent("finance");
+    });
+
+    it("detects media app from /media", () => {
+      renderAt("/media", <ContextDisplay />);
+      expect(screen.getByTestId("app")).toHaveTextContent("media");
+    });
+
+    it("detects media app from a nested path /media/library/42", () => {
+      renderAt("/media/library/42", <ContextDisplay />);
+      expect(screen.getByTestId("app")).toHaveTextContent("media");
+    });
+
+    it("detects inventory app from /inventory", () => {
+      renderAt("/inventory", <ContextDisplay />);
+      expect(screen.getByTestId("app")).toHaveTextContent("inventory");
+    });
+
+    it("detects ai app from /ai", () => {
+      renderAt("/ai", <ContextDisplay />);
+      expect(screen.getByTestId("app")).toHaveTextContent("ai");
+    });
+
+    it("returns null app for an unmatched path", () => {
+      renderAt("/unknown", <ContextDisplay />);
+      expect(screen.getByTestId("app")).toHaveTextContent("null");
+    });
+
+    it("does not match /finances as /finance (boundary check)", () => {
+      renderAt("/finances", <ContextDisplay />);
+      expect(screen.getByTestId("app")).toHaveTextContent("null");
+    });
+  });
+
+  describe("default context values", () => {
+    it("has null page by default", () => {
+      renderAt("/finance", <ContextDisplay />);
+      expect(screen.getByTestId("page")).toHaveTextContent("null");
+    });
+
+    it("has top-level pageType by default", () => {
+      renderAt("/finance", <ContextDisplay />);
+      expect(screen.getByTestId("pageType")).toHaveTextContent("top-level");
+    });
+
+    it("has no entity by default", () => {
+      renderAt("/finance", <ContextDisplay />);
+      expect(screen.getByTestId("entity")).toHaveTextContent("none");
+    });
+  });
+
+  describe("navigation updates", () => {
+    /** Component that navigates programmatically so we can test context updates. */
+    function NavTester() {
+      const ctx = useAppContext();
+      const navigate = useNavigate();
+      return (
+        <div>
+          <span data-testid="app">{ctx.app ?? "null"}</span>
+          <button onClick={() => navigate("/media")}>go to media</button>
+          <button onClick={() => navigate("/")}>go to root</button>
+        </div>
+      );
+    }
+
+    it("updates app when navigating to a different app", async () => {
+      render(
+        <MemoryRouter initialEntries={["/finance"]}>
+          <AppContextProvider>
+            <NavTester />
+          </AppContextProvider>
+        </MemoryRouter>
+      );
+
+      expect(screen.getByTestId("app")).toHaveTextContent("finance");
+
+      await act(async () => {
+        screen.getByRole("button", { name: "go to media" }).click();
+      });
+
+      expect(screen.getByTestId("app")).toHaveTextContent("media");
+    });
+
+    it("resets to null app when navigating to root", async () => {
+      render(
+        <MemoryRouter initialEntries={["/finance"]}>
+          <AppContextProvider>
+            <NavTester />
+          </AppContextProvider>
+        </MemoryRouter>
+      );
+
+      await act(async () => {
+        screen.getByRole("button", { name: "go to root" }).click();
+      });
+
+      expect(screen.getByTestId("app")).toHaveTextContent("null");
+    });
+  });
+});

--- a/packages/navigation/src/AppContextProvider.tsx
+++ b/packages/navigation/src/AppContextProvider.tsx
@@ -1,0 +1,75 @@
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { useLocation } from "react-router";
+import { AppContextCtx } from "./context.js";
+import type { AppContext, AppName } from "./types.js";
+import { DEFAULT_APP_CONTEXT } from "./types.js";
+
+/** Maps URL base paths to their app identifiers. */
+const APP_BASE_PATHS: Array<{ basePath: string; app: AppName }> = [
+  { basePath: "/finance", app: "finance" },
+  { basePath: "/media", app: "media" },
+  { basePath: "/inventory", app: "inventory" },
+  { basePath: "/ai", app: "ai" },
+];
+
+/**
+ * Detect the active app from a URL pathname.
+ *
+ * Matches at a path-segment boundary to avoid false positives
+ * (e.g. /finances should not match /finance).
+ */
+function detectApp(pathname: string): AppName | null {
+  for (const { basePath, app } of APP_BASE_PATHS) {
+    if (pathname === basePath || pathname.startsWith(`${basePath}/`)) {
+      return app;
+    }
+  }
+  return null;
+}
+
+interface AppContextProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * AppContextProvider — wraps the app and tracks the active context.
+ *
+ * - Detects the active app from the URL path (listens to react-router navigation).
+ * - Resets page-level context (page, pageType, entity, filters) on each navigation.
+ * - Exposes context via useAppContext().
+ *
+ * Must be rendered inside a react-router Router (e.g. inside RouterProvider or
+ * a MemoryRouter in tests), since it relies on useLocation().
+ */
+export function AppContextProvider({ children }: AppContextProviderProps) {
+  const { pathname } = useLocation();
+
+  const [pageContext, setPageContextState] = useState<
+    Partial<Pick<AppContext, "page" | "pageType" | "entity" | "filters">>
+  >({});
+
+  // Reset page-level context whenever the user navigates to a new path.
+  useEffect(() => {
+    setPageContextState({});
+  }, [pathname]);
+
+  const context = useMemo<AppContext>(
+    () => ({
+      ...DEFAULT_APP_CONTEXT,
+      ...pageContext,
+      app: detectApp(pathname),
+    }),
+    [pathname, pageContext]
+  );
+
+  const setPageContext = useCallback(
+    (partial: Partial<Pick<AppContext, "page" | "pageType" | "entity" | "filters">>) => {
+      setPageContextState((prev) => ({ ...prev, ...partial }));
+    },
+    []
+  );
+
+  const value = useMemo(() => ({ context, setPageContext }), [context, setPageContext]);
+
+  return <AppContextCtx.Provider value={value}>{children}</AppContextCtx.Provider>;
+}

--- a/packages/navigation/src/context.ts
+++ b/packages/navigation/src/context.ts
@@ -1,0 +1,24 @@
+import { createContext } from "react";
+import type { AppContext } from "./types.js";
+import { DEFAULT_APP_CONTEXT } from "./types.js";
+
+/**
+ * Internal context value shape.
+ *
+ * setPageContext is intentionally not exported from the public API in US-01;
+ * it will be consumed by useSetPageContext in US-02.
+ */
+export interface AppContextValue {
+  context: AppContext;
+  /** Update page-level fields (page, pageType, entity, filters). Called by pages on mount. */
+  setPageContext: (
+    partial: Partial<Pick<AppContext, "page" | "pageType" | "entity" | "filters">>
+  ) => void;
+}
+
+export const AppContextCtx = createContext<AppContextValue>({
+  context: DEFAULT_APP_CONTEXT,
+  setPageContext: () => {},
+});
+
+AppContextCtx.displayName = "AppContext";

--- a/packages/navigation/src/hooks.ts
+++ b/packages/navigation/src/hooks.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+import { AppContextCtx } from "./context.js";
+import type { AppContext } from "./types.js";
+
+/**
+ * Returns the current AppContext.
+ *
+ * Must be used inside an AppContextProvider.
+ */
+export function useAppContext(): AppContext {
+  return useContext(AppContextCtx).context;
+}

--- a/packages/navigation/src/index.ts
+++ b/packages/navigation/src/index.ts
@@ -11,3 +11,8 @@ export {
   _clearRegistry,
 } from "./result-component-registry";
 export type { ResultComponent, ResultComponentProps } from "./result-component-registry";
+
+export { AppContextProvider } from "./AppContextProvider";
+export { useAppContext } from "./hooks";
+export type { AppContext, AppContextEntity, AppName } from "./types";
+export { DEFAULT_APP_CONTEXT } from "./types";

--- a/packages/navigation/src/result-component-registry.test.tsx
+++ b/packages/navigation/src/result-component-registry.test.tsx
@@ -41,16 +41,12 @@ describe("getResultComponent", () => {
 
 describe("GenericResultComponent", () => {
   it("renders the first string value found in data", () => {
-    const { getByText } = render(
-      <GenericResultComponent data={{ title: "Hello World" }} />
-    );
+    const { getByText } = render(<GenericResultComponent data={{ title: "Hello World" }} />);
     expect(getByText("Hello World")).toBeInTheDocument();
   });
 
   it("renders an empty span when data has no string fields", () => {
-    const { container } = render(
-      <GenericResultComponent data={{ count: 42, active: true }} />
-    );
+    const { container } = render(<GenericResultComponent data={{ count: 42, active: true }} />);
     expect(container.textContent).toBe("");
   });
 

--- a/packages/navigation/src/result-component-registry.tsx
+++ b/packages/navigation/src/result-component-registry.tsx
@@ -10,7 +10,8 @@ export type ResultComponent = ComponentType<ResultComponentProps>;
 
 /** Generic fallback — renders the first string field found in `data`. */
 export function GenericResultComponent({ data }: ResultComponentProps) {
-  const title = (Object.values(data).find((v) => typeof v === "string") as string | undefined) ?? "";
+  const title =
+    (Object.values(data).find((v) => typeof v === "string") as string | undefined) ?? "";
   return <span>{title}</span>;
 }
 

--- a/packages/navigation/src/types.ts
+++ b/packages/navigation/src/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared type definitions for app context and navigation.
+ *
+ * Lives in @pops/navigation so shell, app packages, and @pops/ui can all
+ * import from here without creating circular dependencies.
+ */
+
+/** Known app identifiers. */
+export type AppName = "finance" | "media" | "inventory" | "ai";
+
+/** An entity the user is currently viewing (e.g. a specific movie or transaction). */
+export interface AppContextEntity {
+  /** Namespaced URI, e.g. "pops:media/movie/42". */
+  uri: string;
+  /** Entity type, e.g. "movie", "transaction". */
+  type: string;
+  /** Human-readable title, e.g. "Fight Club". */
+  title: string;
+}
+
+/**
+ * The current contextual state of the shell — which app is active,
+ * which page, what entity (if any) is being viewed, and what filters
+ * are applied.
+ */
+export interface AppContext {
+  /** Active app, or null at root / or unmatched paths. */
+  app: AppName | null;
+  /** Current page identifier set by the active page component, or null. */
+  page: string | null;
+  /** Whether the current page is a top-level list/dashboard or a drill-down detail view. */
+  pageType: "top-level" | "drill-down";
+  /** Set when the user is viewing a specific entity. Cleared on navigation. */
+  entity?: AppContextEntity;
+  /** Active filter state on list pages. Cleared on navigation. */
+  filters?: Record<string, string>;
+}
+
+/** The default context returned when no app is matched (e.g. root /). */
+export const DEFAULT_APP_CONTEXT: AppContext = {
+  app: null,
+  page: null,
+  pageType: "top-level",
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@pops/app-media':
         specifier: workspace:*
         version: link:../../packages/app-media
+      '@pops/navigation':
+        specifier: workspace:*
+        version: link:../../packages/navigation
       '@pops/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -660,6 +663,9 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.4
+      react-router:
+        specifier: ^7.13.1
+        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1


### PR DESCRIPTION
## Summary
- Extracted navigation-only changes from copilot PR #1297 (dropped DB schema already on main, reverted doc changes)
- Adds `AppContextProvider` that detects active app from URL pathname with segment-boundary matching
- Integrates into shell `RootLayout` as top-level wrapper
- 14 tests covering all app paths, boundaries, defaults, and navigation updates

## Changes
- `packages/navigation/`: Added `AppContextProvider`, `useAppContext` hook, `AppContext` types, `context.ts`
- `apps/pops-shell/`: Added `@pops/navigation` dependency, wrapped RootLayout with `AppContextProvider`
- Fixed pre-existing format issues in `result-component-registry` files

## Test plan
- [ ] All 14 navigation tests pass (URL detection, boundary checks, navigation updates)
- [ ] Shell typecheck passes with new import
- [ ] Format and lint clean

Supersedes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)