### PR TITLE
feat(search): add transactions backend search adapter [tb-184]

### DIFF
--- a/apps/pops-api/src/modules/finance/transactions/index.ts
+++ b/apps/pops-api/src/modules/finance/transactions/index.ts
@@ -1,3 +1,6 @@
 export { transactionsRouter } from "./router.js";
 export * from "./types.js";
 export * as transactionsService from "./service.js";
+
+// Side-effect: registers the transactions search adapter
+import "./search-adapter.js";

--- a/apps/pops-api/src/modules/finance/transactions/search-adapter.test.ts
+++ b/apps/pops-api/src/modules/finance/transactions/search-adapter.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database } from "better-sqlite3";
+import BetterSqlite3 from "better-sqlite3";
+import crypto from "crypto";
+import { setDb, closeDb } from "../../../db.js";
+import type { SearchHit } from "../../core/search/index.js";
+import { transactionsSearchAdapter, type TransactionHitData } from "./search-adapter.js";
+
+function createDb(): Database {
+  const db = new BetterSqlite3(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE transactions (
+      id              TEXT PRIMARY KEY,
+      description     TEXT NOT NULL,
+      account         TEXT NOT NULL,
+      amount          REAL NOT NULL,
+      date            TEXT NOT NULL,
+      type            TEXT NOT NULL DEFAULT '',
+      tags            TEXT NOT NULL DEFAULT '[]',
+      entity_id       TEXT,
+      entity_name     TEXT,
+      location        TEXT,
+      country         TEXT,
+      related_transaction_id TEXT,
+      notes           TEXT,
+      checksum        TEXT,
+      raw_row         TEXT,
+      last_edited_time TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+function seedTransaction(
+  db: Database,
+  overrides: Partial<{
+    id: string;
+    description: string;
+    account: string;
+    amount: number;
+    date: string;
+    type: string;
+    entity_name: string | null;
+  }> = {}
+): string {
+  const id = overrides.id ?? crypto.randomUUID();
+  db.prepare(
+    `
+    INSERT INTO transactions (id, description, account, amount, date, type, tags, entity_name, last_edited_time)
+    VALUES (@id, @description, @account, @amount, @date, @type, '[]', @entity_name, @last_edited_time)
+  `
+  ).run({
+    id,
+    description: overrides.description ?? "Test Transaction",
+    account: overrides.account ?? "Test Account",
+    amount: overrides.amount ?? -10.0,
+    date: overrides.date ?? "2026-01-01",
+    type: overrides.type ?? "expense",
+    entity_name: overrides.entity_name ?? null,
+    last_edited_time: new Date().toISOString(),
+  });
+  return id;
+}
+
+let db: Database;
+
+beforeEach(() => {
+  db = createDb();
+  setDb(db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+const adapter = transactionsSearchAdapter;
+
+describe("transactions search adapter", () => {
+  it("is registered with correct domain, icon, and color", () => {
+    expect(adapter.domain).toBe("transactions");
+    expect(adapter.icon).toBe("ArrowRightLeft");
+    expect(adapter.color).toBe("green");
+  });
+
+  it("returns empty array for empty query", () => {
+    const hits = adapter.search({ text: "" }, { app: "finance", page: null });
+    expect(hits).toEqual([]);
+  });
+
+  it("returns empty array when no transactions match", () => {
+    seedTransaction(db, { description: "Woolworths groceries" });
+    const hits = adapter.search({ text: "Netflix" }, { app: "finance", page: null });
+    expect(hits).toEqual([]);
+  });
+
+  it("finds exact match with score 1.0", () => {
+    seedTransaction(db, {
+      description: "Netflix",
+      amount: -15.99,
+      date: "2026-03-01",
+      type: "expense",
+    });
+    const hits = adapter.search(
+      { text: "Netflix" },
+      { app: "finance", page: null }
+    ) as SearchHit<TransactionHitData>[];
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(1.0);
+    expect(hits[0]!.matchType).toBe("exact");
+    expect(hits[0]!.matchField).toBe("description");
+    expect(hits[0]!.data.description).toBe("Netflix");
+    expect(hits[0]!.data.amount).toBe(-15.99);
+    expect(hits[0]!.data.type).toBe("expense");
+  });
+
+  it("finds exact match case-insensitively", () => {
+    seedTransaction(db, { description: "Netflix", type: "expense" });
+    const hits = adapter.search(
+      { text: "netflix" },
+      { app: "finance", page: null }
+    ) as SearchHit<TransactionHitData>[];
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(1.0);
+    expect(hits[0]!.matchType).toBe("exact");
+  });
+
+  it("finds prefix match with score 0.8", () => {
+    seedTransaction(db, { description: "Netflix monthly subscription", type: "expense" });
+    const hits = adapter.search(
+      { text: "Netflix" },
+      { app: "finance", page: null }
+    ) as SearchHit<TransactionHitData>[];
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(0.8);
+    expect(hits[0]!.matchType).toBe("prefix");
+  });
+
+  it("finds contains match with score 0.5", () => {
+    seedTransaction(db, { description: "Payment to Netflix AU", type: "expense" });
+    const hits = adapter.search(
+      { text: "Netflix" },
+      { app: "finance", page: null }
+    ) as SearchHit<TransactionHitData>[];
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(0.5);
+    expect(hits[0]!.matchType).toBe("contains");
+  });
+
+  it("sorts hits by score descending", () => {
+    seedTransaction(db, { description: "Netflix", type: "expense" });
+    seedTransaction(db, { description: "Netflix monthly", type: "expense" });
+    seedTransaction(db, { description: "Payment Netflix", type: "expense" });
+    const hits = adapter.search(
+      { text: "Netflix" },
+      { app: "finance", page: null }
+    ) as SearchHit<TransactionHitData>[];
+
+    expect(hits).toHaveLength(3);
+    expect(hits[0]!.score).toBe(1.0);
+    expect(hits[1]!.score).toBe(0.8);
+    expect(hits[2]!.score).toBe(0.5);
+  });
+
+  it("respects options.limit", () => {
+    seedTransaction(db, { description: "Coffee shop A", type: "expense" });
+    seedTransaction(db, { description: "Coffee shop B", type: "expense" });
+    seedTransaction(db, { description: "Coffee shop C", type: "expense" });
+    const hits = adapter.search({ text: "Coffee" }, { app: "finance", page: null }, { limit: 2 });
+
+    expect(hits).toHaveLength(2);
+  });
+
+  it("returns correct hit data shape with URI", () => {
+    const id = seedTransaction(db, {
+      description: "Woolworths groceries",
+      amount: -85.42,
+      date: "2026-03-15",
+      entity_name: "Woolworths",
+      type: "expense",
+    });
+    const hits = adapter.search(
+      { text: "Woolworths" },
+      { app: "finance", page: null }
+    ) as SearchHit<TransactionHitData>[];
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.uri).toBe(`pops:finance/transaction/${id}`);
+    expect(hits[0]!.data).toEqual({
+      description: "Woolworths groceries",
+      amount: -85.42,
+      date: "2026-03-15",
+      entityName: "Woolworths",
+      type: "expense",
+    });
+  });
+
+  it("returns null entityName when transaction has no entity", () => {
+    seedTransaction(db, { description: "Random purchase", type: "expense" });
+    const hits = adapter.search(
+      { text: "Random" },
+      { app: "finance", page: null }
+    ) as SearchHit<TransactionHitData>[];
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.data.entityName).toBeNull();
+  });
+
+  it("trims whitespace from query", () => {
+    seedTransaction(db, { description: "Netflix", type: "expense" });
+    const hits = adapter.search({ text: "  Netflix  " }, { app: "finance", page: null });
+
+    expect(hits).toHaveLength(1);
+  });
+});

--- a/apps/pops-api/src/modules/finance/transactions/search-adapter.ts
+++ b/apps/pops-api/src/modules/finance/transactions/search-adapter.ts
@@ -1,0 +1,91 @@
+import { like, sql } from "drizzle-orm";
+import { getDrizzle } from "../../../db.js";
+import { transactions } from "@pops/db-types";
+import { registerSearchAdapter } from "../../core/search/index.js";
+import type { SearchAdapter, SearchHit, Query, SearchContext } from "../../core/search/index.js";
+
+export interface TransactionHitData {
+  description: string;
+  amount: number;
+  date: string;
+  entityName: string | null;
+  type: "income" | "expense" | "transfer";
+}
+
+function scoreHit(
+  description: string,
+  queryText: string
+): { score: number; matchType: "exact" | "prefix" | "contains" } | null {
+  const lower = description.toLowerCase();
+  const query = queryText.toLowerCase();
+
+  if (lower === query) {
+    return { score: 1.0, matchType: "exact" };
+  }
+  if (lower.startsWith(query)) {
+    return { score: 0.8, matchType: "prefix" };
+  }
+  if (lower.includes(query)) {
+    return { score: 0.5, matchType: "contains" };
+  }
+  return null;
+}
+
+export const transactionsSearchAdapter: SearchAdapter<TransactionHitData> = {
+  domain: "transactions",
+  icon: "ArrowRightLeft",
+  color: "green",
+
+  search(
+    query: Query,
+    _context: SearchContext,
+    options?: { limit?: number }
+  ): SearchHit<TransactionHitData>[] {
+    const text = query.text.trim();
+    if (!text) return [];
+
+    const db = getDrizzle();
+    const rows = db
+      .select({
+        id: transactions.id,
+        description: transactions.description,
+        amount: transactions.amount,
+        date: transactions.date,
+        entityName: transactions.entityName,
+        type: transactions.type,
+      })
+      .from(transactions)
+      .where(like(sql`lower(${transactions.description})`, `%${text.toLowerCase()}%`))
+      .all();
+
+    const hits: SearchHit<TransactionHitData>[] = [];
+    for (const row of rows) {
+      const match = scoreHit(row.description, text);
+      if (!match) continue;
+
+      hits.push({
+        uri: `pops:finance/transaction/${row.id}`,
+        score: match.score,
+        matchField: "description",
+        matchType: match.matchType,
+        data: {
+          description: row.description,
+          amount: row.amount,
+          date: row.date,
+          entityName: row.entityName,
+          type: row.type as "income" | "expense" | "transfer",
+        },
+      });
+    }
+
+    hits.sort((a, b) => b.score - a.score);
+
+    if (options?.limit && options.limit > 0) {
+      return hits.slice(0, options.limit);
+    }
+
+    return hits;
+  },
+};
+
+registerSearchAdapter(transactionsSearchAdapter);

--- a/docs/themes/01-foundation/prds/057-search-engine/README.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/README.md
@@ -73,7 +73,7 @@ v1 is plain text only. Structured syntax added as v2 USs.
 | 02b | [us-02b-movies-result-component](us-02b-movies-result-component.md) | Movies ResultComponent: poster + title + year + rating + runtime | Not started | Blocked by us-02 |
 | 03 | [us-03-tv-shows-adapter](us-03-tv-shows-adapter.md) | TV shows backend adapter: search by name | Not started | Blocked by us-01 |
 | 03b | [us-03b-tv-shows-result-component](us-03b-tv-shows-result-component.md) | TV shows ResultComponent: poster + name + status + seasons | Not started | Blocked by us-03 |
-| 04 | [us-04-transactions-adapter](us-04-transactions-adapter.md) | Transactions backend adapter: search by description | Not started | Blocked by us-01 |
+| 04 | [us-04-transactions-adapter](us-04-transactions-adapter.md) | Transactions backend adapter: search by description | Done | — |
 | 04b | [us-04b-transactions-result-component](us-04b-transactions-result-component.md) | Transactions ResultComponent: description + colored amount + date | Not started | Blocked by us-04 |
 | 05 | [us-05-entities-adapter](us-05-entities-adapter.md) | Entities backend adapter: search by name | Not started | Blocked by us-01 |
 | 05b | [us-05b-entities-result-component](us-05b-entities-result-component.md) | Entities ResultComponent: name + type badge + aliases | Not started | Blocked by us-05 |

--- a/docs/themes/01-foundation/prds/057-search-engine/us-04-transactions-adapter.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-04-transactions-adapter.md
@@ -1,7 +1,7 @@
 # US-04: Transactions search adapter (backend)
 
 > PRD: [057 — Search Engine](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As the system, I search transactions by description and return typed `SearchHit`
 
 ## Acceptance Criteria
 
-- [ ] Adapter registered with `domain: "transactions"`, icon: `"ArrowRightLeft"`, color: `"green"`
-- [ ] Searches transactions by `description` column (case-insensitive LIKE)
-- [ ] Relevance scoring: exact match (1.0) > prefix (0.8) > contains (0.5)
-- [ ] `matchField: "description"` and `matchType` set correctly per hit
-- [ ] Hit data shape: `{ description, amount, date, entityName, type: "income" | "expense" | "transfer" }`
-- [ ] Respects `options.limit` parameter
-- [ ] Tests: search returns correct hits, scoring correct
+- [x] Adapter registered with `domain: "transactions"`, icon: `"ArrowRightLeft"`, color: `"green"`
+- [x] Searches transactions by `description` column (case-insensitive LIKE)
+- [x] Relevance scoring: exact match (1.0) > prefix (0.8) > contains (0.5)
+- [x] `matchField: "description"` and `matchType` set correctly per hit
+- [x] Hit data shape: `{ description, amount, date, entityName, type: "income" | "expense" | "transfer" }`
+- [x] Respects `options.limit` parameter
+- [x] Tests: search returns correct hits, scoring correct
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Implements `SearchAdapter<TransactionHitData>` for the transactions domain (PRD-057 US-04)
- Searches `description` column with case-insensitive LIKE, scoring: exact=1.0, prefix=0.8, contains=0.5
- Returns hit data: `{ description, amount, date, entityName, type }` with URI `pops:finance/transaction/{id}`
- Registers via side-effect import in transactions module index
- 12 tests covering all match types, scoring, limit, empty results, whitespace trimming

## Test plan
- [x] 12 unit tests pass (exact/prefix/contains scoring, limit, URI format, null entityName, whitespace)
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Prettier format check passes

Closes #1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)