### PR TITLE
feat(search): add budgets backend search adapter [tb-186]

### DIFF
--- a/apps/pops-api/src/modules/finance/budgets/index.ts
+++ b/apps/pops-api/src/modules/finance/budgets/index.ts
@@ -1,3 +1,4 @@
 export { budgetsRouter } from "./router.js";
 export * from "./types.js";
 export * as budgetsService from "./service.js";
+export { registerBudgetsSearchAdapter } from "./search-adapter.js";

--- a/apps/pops-api/src/modules/finance/budgets/search-adapter.test.ts
+++ b/apps/pops-api/src/modules/finance/budgets/search-adapter.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Database } from "better-sqlite3";
+import { setupTestContext, seedBudget } from "../../../shared/test-utils.js";
+import { resetRegistry } from "../../core/search/index.js";
+import { registerBudgetsSearchAdapter, type BudgetHitData } from "./search-adapter.js";
+import type { SearchHit } from "../../core/search/index.js";
+import { getAdapters } from "../../core/search/index.js";
+
+const ctx = setupTestContext();
+let db: Database;
+
+beforeEach(() => {
+  ({ db } = ctx.setup());
+  resetRegistry();
+  registerBudgetsSearchAdapter();
+});
+
+afterEach(() => {
+  resetRegistry();
+  ctx.teardown();
+});
+
+function search(query: string, limit?: number): SearchHit<BudgetHitData>[] {
+  const adapter = getAdapters().find((a) => a.domain === "budgets")!;
+  return adapter.search(
+    { text: query },
+    { app: "finance", page: "budgets" },
+    limit ? { limit } : undefined
+  ) as SearchHit<BudgetHitData>[];
+}
+
+describe("budgets search adapter", () => {
+  it("registers with correct metadata", () => {
+    const adapter = getAdapters().find((a) => a.domain === "budgets");
+    expect(adapter).toBeDefined();
+    expect(adapter!.icon).toBe("PiggyBank");
+    expect(adapter!.color).toBe("green");
+  });
+
+  it("returns empty results for empty query", () => {
+    seedBudget(db, { category: "Groceries" });
+    expect(search("")).toEqual([]);
+    expect(search("  ")).toEqual([]);
+  });
+
+  it("returns exact match with score 1.0", () => {
+    seedBudget(db, { category: "Groceries", period: "2025-06", amount: 500 });
+
+    const hits = search("Groceries");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(1.0);
+    expect(hits[0]!.matchType).toBe("exact");
+    expect(hits[0]!.matchField).toBe("category");
+    expect(hits[0]!.data).toEqual({
+      category: "Groceries",
+      period: "2025-06",
+      amount: 500,
+    });
+  });
+
+  it("exact match is case-insensitive", () => {
+    seedBudget(db, { category: "Groceries" });
+
+    const hits = search("groceries");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(1.0);
+    expect(hits[0]!.matchType).toBe("exact");
+  });
+
+  it("returns prefix match with score 0.8", () => {
+    seedBudget(db, { category: "Entertainment", period: "2025-06", amount: 200 });
+
+    const hits = search("Enter");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(0.8);
+    expect(hits[0]!.matchType).toBe("prefix");
+    expect(hits[0]!.data.category).toBe("Entertainment");
+  });
+
+  it("returns contains match with score 0.5", () => {
+    seedBudget(db, { category: "Entertainment" });
+
+    const hits = search("tain");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(0.5);
+    expect(hits[0]!.matchType).toBe("contains");
+  });
+
+  it("sorts results by score descending", () => {
+    seedBudget(db, { category: "Transport" });
+    seedBudget(db, { category: "Transportation Costs" });
+    seedBudget(db, { category: "Public Transport" });
+
+    const hits = search("Transport");
+    expect(hits.length).toBeGreaterThanOrEqual(2);
+
+    // "Transport" = exact (1.0), "Transportation Costs" = prefix (0.8), "Public Transport" = contains (0.5)
+    expect(hits[0]!.score).toBe(1.0);
+    expect(hits[0]!.data.category).toBe("Transport");
+    expect(hits[1]!.score).toBe(0.8);
+    expect(hits[1]!.data.category).toBe("Transportation Costs");
+    expect(hits[2]!.score).toBe(0.5);
+    expect(hits[2]!.data.category).toBe("Public Transport");
+  });
+
+  it("includes hit data with category, period, and amount", () => {
+    const id = seedBudget(db, {
+      category: "Dining",
+      period: "2025-07",
+      amount: 300,
+    });
+
+    const hits = search("Dining");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.uri).toBe(`/budgets/${id}`);
+    expect(hits[0]!.data).toEqual({
+      category: "Dining",
+      period: "2025-07",
+      amount: 300,
+    });
+  });
+
+  it("handles null period and amount", () => {
+    seedBudget(db, { category: "Miscellaneous", period: null, amount: null });
+
+    const hits = search("Miscellaneous");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.data.period).toBeNull();
+    expect(hits[0]!.data.amount).toBeNull();
+  });
+
+  it("returns no results when nothing matches", () => {
+    seedBudget(db, { category: "Groceries" });
+    expect(search("zzz-no-match")).toEqual([]);
+  });
+
+  it("respects limit option", () => {
+    for (let i = 0; i < 5; i++) {
+      seedBudget(db, { category: `Cat ${i}` });
+    }
+
+    const hits = search("Cat", 3);
+    expect(hits).toHaveLength(3);
+  });
+});

--- a/apps/pops-api/src/modules/finance/budgets/search-adapter.ts
+++ b/apps/pops-api/src/modules/finance/budgets/search-adapter.ts
@@ -1,0 +1,74 @@
+import { like } from "drizzle-orm";
+import { getDrizzle } from "../../../db.js";
+import { budgets } from "@pops/db-types";
+import { registerSearchAdapter } from "../../core/search/index.js";
+import type { SearchAdapter, SearchHit, Query, SearchContext } from "../../core/search/index.js";
+
+export interface BudgetHitData {
+  category: string;
+  period: string | null;
+  amount: number | null;
+}
+
+function scoreHit(
+  category: string,
+  query: string
+): { score: number; matchType: "exact" | "prefix" | "contains" } | null {
+  const lower = category.toLowerCase();
+  const q = query.toLowerCase();
+
+  if (lower === q) return { score: 1.0, matchType: "exact" };
+  if (lower.startsWith(q)) return { score: 0.8, matchType: "prefix" };
+  if (lower.includes(q)) return { score: 0.5, matchType: "contains" };
+  return null;
+}
+
+const budgetsSearchAdapter: SearchAdapter<BudgetHitData> = {
+  domain: "budgets",
+  icon: "PiggyBank",
+  color: "green",
+
+  search(
+    query: Query,
+    _context: SearchContext,
+    options?: { limit?: number }
+  ): SearchHit<BudgetHitData>[] {
+    const text = query.text.trim();
+    if (!text) return [];
+
+    const db = getDrizzle();
+    const limit = options?.limit ?? 20;
+
+    const rows = db
+      .select()
+      .from(budgets)
+      .where(like(budgets.category, `%${text}%`))
+      .limit(limit)
+      .all();
+
+    const hits: SearchHit<BudgetHitData>[] = [];
+
+    for (const row of rows) {
+      const match = scoreHit(row.category, text);
+      if (!match) continue;
+
+      hits.push({
+        uri: `/budgets/${row.id}`,
+        score: match.score,
+        matchField: "category",
+        matchType: match.matchType,
+        data: {
+          category: row.category,
+          period: row.period,
+          amount: row.amount,
+        },
+      });
+    }
+
+    return hits.sort((a, b) => b.score - a.score);
+  },
+};
+
+export function registerBudgetsSearchAdapter(): void {
+  registerSearchAdapter(budgetsSearchAdapter);
+}


### PR DESCRIPTION
## Summary
- Implements `SearchAdapter<BudgetHitData>` for the budgets domain (icon: PiggyBank, color: green)
- Searches `category` column with case-insensitive LIKE, scoring: exact=1.0, prefix=0.8, contains=0.5
- Returns `{ category, period, amount }` in hit data
- 11 tests covering registration, exact/prefix/contains matching, scoring order, null handling, and limit

Closes #1247

## Test plan
- [x] All 11 unit tests pass
- [x] Lint passes (0 errors)
- [x] Typecheck passes
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)