### PR TITLE
feat(search): entities backend adapter [tb-185]

### DIFF
--- a/apps/pops-api/src/modules/core/entities/index.ts
+++ b/apps/pops-api/src/modules/core/entities/index.ts
@@ -1,3 +1,6 @@
 export { entitiesRouter } from "./router.js";
 export * from "./types.js";
 export * as entitiesService from "./service.js";
+
+// Side-effect: registers the entities search adapter
+import "./search-adapter.js";

--- a/apps/pops-api/src/modules/core/entities/search-adapter.test.ts
+++ b/apps/pops-api/src/modules/core/entities/search-adapter.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SearchContext } from "../search/types.js";
+
+const mockAll = vi.fn().mockReturnValue([]);
+
+vi.mock("../../../db.js", () => ({
+  getDrizzle: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({ all: mockAll }),
+        all: mockAll,
+      }),
+    }),
+  }),
+}));
+
+// Prevent side-effect registration from throwing in subsequent imports
+vi.mock("../search/registry.js", () => ({
+  registerSearchAdapter: vi.fn(),
+  getAdapters: vi.fn(),
+  resetRegistry: vi.fn(),
+}));
+
+import { entitiesSearchAdapter, type EntityHitData } from "./search-adapter.js";
+import { registerSearchAdapter } from "../search/registry.js";
+import type { SearchHit } from "../search/types.js";
+
+const ctx: SearchContext = { app: "finance", page: "entities" };
+
+/** Helper — adapter is synchronous so we can safely cast. */
+function search(text: string, options?: { limit?: number }): SearchHit<EntityHitData>[] {
+  return entitiesSearchAdapter.search({ text }, ctx, options) as SearchHit<EntityHitData>[];
+}
+
+beforeEach(() => {
+  mockAll.mockReset().mockReturnValue([]);
+});
+
+describe("entities search adapter", () => {
+  it("registers with correct domain, icon, and color", () => {
+    expect(entitiesSearchAdapter.domain).toBe("entities");
+    expect(entitiesSearchAdapter.icon).toBe("Building2");
+    expect(entitiesSearchAdapter.color).toBe("green");
+    expect(registerSearchAdapter).toHaveBeenCalledWith(entitiesSearchAdapter);
+  });
+
+  it("returns empty array for empty query", () => {
+    const hits = search("  ");
+    expect(hits).toEqual([]);
+    expect(mockAll).not.toHaveBeenCalled();
+  });
+
+  it("returns exact match with score 1.0", () => {
+    mockAll.mockReturnValueOnce([{ id: "e1", name: "Woolworths", type: "company", aliases: null }]);
+
+    const hits = search("Woolworths");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      uri: "pops:finance/entity/e1",
+      score: 1.0,
+      matchField: "name",
+      matchType: "exact",
+      data: { name: "Woolworths", type: "company", aliases: [] },
+    });
+  });
+
+  it("returns prefix match with score 0.8", () => {
+    mockAll.mockReturnValueOnce([
+      { id: "e2", name: "Woolworths Group", type: "company", aliases: "Woolies" },
+    ]);
+
+    const hits = search("Woolworths");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      score: 0.8,
+      matchType: "prefix",
+      data: { name: "Woolworths Group", type: "company", aliases: ["Woolies"] },
+    });
+  });
+
+  it("returns contains match with score 0.5", () => {
+    mockAll.mockReturnValueOnce([
+      { id: "e3", name: "JB Hi-Fi", type: "company", aliases: "JB, Hi-Fi" },
+    ]);
+
+    const hits = search("Hi-Fi");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      score: 0.5,
+      matchType: "contains",
+      data: { name: "JB Hi-Fi", aliases: ["JB", "Hi-Fi"] },
+    });
+  });
+
+  it("sorts hits by score descending", () => {
+    mockAll.mockReturnValueOnce([
+      { id: "e4", name: "Shell Energy", type: "company", aliases: null },
+      { id: "e5", name: "Shell", type: "company", aliases: null },
+    ]);
+
+    const hits = search("Shell");
+    expect(hits).toHaveLength(2);
+    expect(hits[0]!.score).toBeGreaterThan(hits[1]!.score);
+    expect(hits[0]!.data).toMatchObject({ name: "Shell" });
+    expect(hits[1]!.data).toMatchObject({ name: "Shell Energy" });
+  });
+
+  it("respects limit option", () => {
+    mockAll.mockReturnValueOnce([
+      { id: "e6", name: "Amazon AU", type: "company", aliases: null },
+      { id: "e7", name: "Amazon US", type: "company", aliases: null },
+      { id: "e8", name: "Amazon UK", type: "company", aliases: null },
+    ]);
+
+    const hits = search("Amazon", { limit: 2 });
+    expect(hits).toHaveLength(2);
+  });
+
+  it("uses correct URI format", () => {
+    mockAll.mockReturnValueOnce([
+      { id: "abc-123", name: "Netflix", type: "company", aliases: null },
+    ]);
+
+    const hits = search("Netflix");
+    expect(hits[0]!.uri).toBe("pops:finance/entity/abc-123");
+  });
+});

--- a/apps/pops-api/src/modules/core/entities/search-adapter.ts
+++ b/apps/pops-api/src/modules/core/entities/search-adapter.ts
@@ -1,0 +1,79 @@
+import { like } from "drizzle-orm";
+import { getDrizzle } from "../../../db.js";
+import { entities } from "@pops/db-types";
+import { registerSearchAdapter } from "../search/registry.js";
+import type { SearchAdapter, SearchHit, Query, SearchContext } from "../search/types.js";
+
+export interface EntityHitData {
+  name: string;
+  type: string;
+  aliases: string[];
+}
+
+function scoreAndClassify(
+  name: string,
+  queryText: string
+): { score: number; matchType: "exact" | "prefix" | "contains" } | null {
+  const lower = name.toLowerCase();
+  const q = queryText.toLowerCase();
+
+  if (lower === q) return { score: 1.0, matchType: "exact" };
+  if (lower.startsWith(q)) return { score: 0.8, matchType: "prefix" };
+  if (lower.includes(q)) return { score: 0.5, matchType: "contains" };
+  return null;
+}
+
+function parseAliases(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export const entitiesSearchAdapter: SearchAdapter<EntityHitData> = {
+  domain: "entities",
+  icon: "Building2",
+  color: "green",
+
+  search(
+    query: Query,
+    _context: SearchContext,
+    options?: { limit?: number }
+  ): SearchHit<EntityHitData>[] {
+    const text = query.text.trim();
+    if (!text) return [];
+
+    const db = getDrizzle();
+    const rows = db
+      .select()
+      .from(entities)
+      .where(like(entities.name, `%${text}%`))
+      .all();
+
+    const limit = options?.limit ?? 20;
+    const hits: SearchHit<EntityHitData>[] = [];
+
+    for (const row of rows) {
+      const match = scoreAndClassify(row.name, text);
+      if (!match) continue;
+
+      hits.push({
+        uri: `pops:finance/entity/${row.id}`,
+        score: match.score,
+        matchField: "name",
+        matchType: match.matchType,
+        data: {
+          name: row.name,
+          type: row.type,
+          aliases: parseAliases(row.aliases),
+        },
+      });
+    }
+
+    hits.sort((a, b) => b.score - a.score);
+    return hits.slice(0, limit);
+  },
+};
+
+registerSearchAdapter(entitiesSearchAdapter);

--- a/docs/themes/01-foundation/prds/057-search-engine/README.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/README.md
@@ -75,7 +75,7 @@ v1 is plain text only. Structured syntax added as v2 USs.
 | 03b | [us-03b-tv-shows-result-component](us-03b-tv-shows-result-component.md) | TV shows ResultComponent: poster + name + status + seasons | Not started | Blocked by us-03 |
 | 04 | [us-04-transactions-adapter](us-04-transactions-adapter.md) | Transactions backend adapter: search by description | Not started | Blocked by us-01 |
 | 04b | [us-04b-transactions-result-component](us-04b-transactions-result-component.md) | Transactions ResultComponent: description + colored amount + date | Not started | Blocked by us-04 |
-| 05 | [us-05-entities-adapter](us-05-entities-adapter.md) | Entities backend adapter: search by name | Not started | Blocked by us-01 |
+| 05 | [us-05-entities-adapter](us-05-entities-adapter.md) | Entities backend adapter: search by name | Done | Blocked by us-01 |
 | 05b | [us-05b-entities-result-component](us-05b-entities-result-component.md) | Entities ResultComponent: name + type badge + aliases | Not started | Blocked by us-05 |
 | 06 | [us-06-budgets-adapter](us-06-budgets-adapter.md) | Budgets backend adapter: search by category | Not started | Blocked by us-01 |
 | 06b | [us-06b-budgets-result-component](us-06b-budgets-result-component.md) | Budgets ResultComponent: category + period + amount | Not started | Blocked by us-06 |

--- a/docs/themes/01-foundation/prds/057-search-engine/us-05-entities-adapter.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-05-entities-adapter.md
@@ -1,7 +1,7 @@
 # US-05: Entities search adapter (backend)
 
 > PRD: [057 — Search Engine](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As the system, I search entities by name and return typed `SearchHit` results wi
 
 ## Acceptance Criteria
 
-- [ ] Adapter registered with `domain: "entities"`, icon: `"Building2"`, color: `"green"`
-- [ ] Searches entities by `name` column (case-insensitive LIKE)
-- [ ] Relevance scoring: exact match (1.0) > prefix (0.8) > contains (0.5)
-- [ ] `matchField: "name"` and `matchType` set correctly per hit
-- [ ] Hit data shape: `{ name, type, aliases }`
-- [ ] Respects `options.limit` parameter
-- [ ] Tests: search returns correct hits, scoring correct
+- [x] Adapter registered with `domain: "entities"`, icon: `"Building2"`, color: `"green"`
+- [x] Searches entities by `name` column (case-insensitive LIKE)
+- [x] Relevance scoring: exact match (1.0) > prefix (0.8) > contains (0.5)
+- [x] `matchField: "name"` and `matchType` set correctly per hit
+- [x] Hit data shape: `{ name, type, aliases }`
+- [x] Respects `options.limit` parameter
+- [x] Tests: search returns correct hits, scoring correct
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Register `entities` search adapter (domain: `entities`, icon: `Building2`, color: `green`)
- Searches `name` column with case-insensitive LIKE, scoring: exact=1.0, prefix=0.8, contains=0.5
- Returns hit data: `{ name, type, aliases }` with URI format `pops:finance/entity/{id}`
- 8 unit tests covering registration, all match types, sorting, limit, and URI format
- Marks US-05 (entities adapter) as Done in PRD-057

Closes #1246

## Test plan
- [x] 8 unit tests pass (exact, prefix, contains scoring, sort order, limit, URI, empty query)
- [x] Format check passes
- [x] TypeScript type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)