### PR TITLE
feat(search): movies ResultComponent [tb-191]

### DIFF
--- a/packages/app-media/package.json
+++ b/packages/app-media/package.json
@@ -18,6 +18,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@pops/api-client": "workspace:*",
+    "@pops/navigation": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.90.20",
     "lucide-react": "^0.563.0",

--- a/packages/app-media/src/components/search/MovieSearchResult.test.tsx
+++ b/packages/app-media/src/components/search/MovieSearchResult.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MovieSearchResult, highlightMatch } from "./MovieSearchResult";
+import { _clearRegistry, getResultComponent, registerResultComponent } from "@pops/navigation";
+
+beforeEach(() => {
+  _clearRegistry();
+});
+
+const baseMovie = {
+  title: "The Dark Knight",
+  year: "2008",
+  posterUrl: "/media/images/movie/155/poster.jpg",
+  voteAverage: 9.0,
+  _query: "dark",
+  _matchType: "contains",
+};
+
+describe("MovieSearchResult", () => {
+  it("renders title, year, and rating", () => {
+    render(<MovieSearchResult data={baseMovie as unknown as Record<string, unknown>} />);
+    expect(screen.getByText(/Dark/)).toBeInTheDocument();
+    expect(screen.getByText("2008")).toBeInTheDocument();
+    expect(screen.getByText("9.0")).toBeInTheDocument();
+  });
+
+  it("renders poster image", () => {
+    render(<MovieSearchResult data={baseMovie as unknown as Record<string, unknown>} />);
+    const img = screen.getByAltText("The Dark Knight poster");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "/media/images/movie/155/poster.jpg");
+  });
+
+  it("renders placeholder when no posterUrl", () => {
+    const data = { ...baseMovie, posterUrl: null };
+    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("renders rating with star icon", () => {
+    render(<MovieSearchResult data={baseMovie as unknown as Record<string, unknown>} />);
+    expect(screen.getByTestId("rating")).toBeInTheDocument();
+    expect(screen.getByText("9.0")).toBeInTheDocument();
+  });
+
+  it("hides rating when null", () => {
+    const data = { ...baseMovie, voteAverage: null };
+    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    expect(screen.queryByTestId("rating")).not.toBeInTheDocument();
+  });
+
+  it("hides year when null", () => {
+    const data = { ...baseMovie, year: null };
+    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    expect(screen.queryByText("2008")).not.toBeInTheDocument();
+  });
+
+  it("hides separator when year is null", () => {
+    const data = { ...baseMovie, year: null };
+    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    expect(screen.queryByText("·")).not.toBeInTheDocument();
+  });
+
+  it("hides separator when rating is null", () => {
+    const data = { ...baseMovie, voteAverage: null };
+    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    expect(screen.queryByText("·")).not.toBeInTheDocument();
+  });
+
+  describe("registration", () => {
+    it("can be registered and retrieved for movies domain", () => {
+      registerResultComponent("movies", MovieSearchResult);
+      const Component = getResultComponent("movies");
+      expect(Component).toBe(MovieSearchResult);
+    });
+  });
+});
+
+describe("highlightMatch", () => {
+  it("highlights exact match", () => {
+    const { container } = render(
+      <span>{highlightMatch("Interstellar", "Interstellar", "exact")}</span>
+    );
+    const mark = container.querySelector("mark");
+    expect(mark).toHaveTextContent("Interstellar");
+  });
+
+  it("highlights prefix match", () => {
+    const { container } = render(
+      <span>{highlightMatch("The Dark Knight", "The Dark", "prefix")}</span>
+    );
+    const mark = container.querySelector("mark");
+    expect(mark).toHaveTextContent("The Dark");
+  });
+
+  it("highlights contains match", () => {
+    const { container } = render(
+      <span>{highlightMatch("The Dark Knight", "Dark", "contains")}</span>
+    );
+    const mark = container.querySelector("mark");
+    expect(mark).toHaveTextContent("Dark");
+  });
+
+  it("returns plain text when query is empty", () => {
+    const { container } = render(<span>{highlightMatch("Interstellar", "", "exact")}</span>);
+    expect(container.querySelector("mark")).toBeNull();
+    expect(container.textContent).toBe("Interstellar");
+  });
+
+  it("returns plain text when no match found", () => {
+    const { container } = render(<span>{highlightMatch("Interstellar", "XYZ", "contains")}</span>);
+    expect(container.querySelector("mark")).toBeNull();
+    expect(container.textContent).toBe("Interstellar");
+  });
+});

--- a/packages/app-media/src/components/search/MovieSearchResult.tsx
+++ b/packages/app-media/src/components/search/MovieSearchResult.tsx
@@ -1,0 +1,99 @@
+/**
+ * MovieSearchResult — ResultComponent for movies search hits.
+ *
+ * Renders poster thumbnail, title (highlighted), year, and vote average.
+ * Registered for domain "movies" in the search result component registry.
+ */
+import { Film, Star } from "lucide-react";
+import type { ResultComponentProps } from "@pops/navigation";
+
+interface MovieHitData {
+  title: string;
+  year: string | null;
+  posterUrl: string | null;
+  voteAverage: number | null;
+}
+
+/**
+ * Highlight the matched portion of text based on query and match type.
+ * Returns React nodes with the matched text wrapped in a <mark>.
+ */
+export function highlightMatch(text: string, query: string, matchType: string): React.ReactNode {
+  if (!query) return text;
+
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  let start = -1;
+
+  if (matchType === "exact" || matchType === "prefix") {
+    start = 0;
+  } else {
+    start = lowerText.indexOf(lowerQuery);
+  }
+
+  if (start === -1) return text;
+
+  const end = start + query.length;
+  return (
+    <>
+      {text.slice(0, start)}
+      <mark className="bg-yellow-200/60 dark:bg-yellow-500/30 rounded-sm px-0.5">
+        {text.slice(start, end)}
+      </mark>
+      {text.slice(end)}
+    </>
+  );
+}
+
+function Rating({ value }: { value: number | null }) {
+  if (value == null) return null;
+
+  return (
+    <span className="flex items-center gap-0.5" data-testid="rating">
+      <Star className="h-3 w-3 fill-yellow-500 text-yellow-500" />
+      <span>{value.toFixed(1)}</span>
+    </span>
+  );
+}
+
+export function MovieSearchResult({ data }: ResultComponentProps) {
+  const hit = data as unknown as MovieHitData & {
+    _query?: string;
+    _matchType?: string;
+  };
+  const { title, year, posterUrl, voteAverage } = hit;
+  const query = hit._query ?? "";
+  const matchType = hit._matchType ?? "contains";
+
+  return (
+    <div className="flex items-center gap-3 py-1" data-testid="movie-search-result">
+      {/* Poster thumbnail */}
+      <div className="relative h-12 w-8 shrink-0 overflow-hidden rounded bg-muted">
+        {posterUrl ? (
+          <img
+            src={posterUrl}
+            alt={`${title} poster`}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <Film className="h-4 w-4 opacity-40" />
+          </div>
+        )}
+      </div>
+
+      {/* Text content */}
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="truncate text-sm font-medium leading-tight">
+          {highlightMatch(title, query, matchType)}
+        </span>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {year && <span>{year}</span>}
+          {year && voteAverage != null && <span>·</span>}
+          <Rating value={voteAverage} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/app-media/src/components/search/register.ts
+++ b/packages/app-media/src/components/search/register.ts
@@ -1,0 +1,8 @@
+/**
+ * Side-effect module that registers media search ResultComponents.
+ * Import this module to register the movies ResultComponent.
+ */
+import { registerResultComponent } from "@pops/navigation";
+import { MovieSearchResult } from "./MovieSearchResult";
+
+registerResultComponent("movies", MovieSearchResult);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,6 +534,9 @@ importers:
       '@pops/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@pops/navigation':
+        specifier: workspace:*
+        version: link:../navigation
       '@pops/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
## Summary
- Add `MovieSearchResult` component rendering movie search hits with poster thumbnail (Film icon fallback), highlighted title, year, and star-rated vote average
- Add `highlightMatch` utility for query-matched text highlighting (exact, prefix, contains)
- Register for `movies` domain via `registerResultComponent` side-effect module
- Comprehensive tests covering rendering, poster fallback, rating display, separator logic, highlight behavior, and registration

## Test plan
- [ ] CI passes (lint, typecheck, tests)
- [ ] Component renders poster image when `posterUrl` provided, Film icon placeholder when null
- [ ] Star rating shown with yellow star icon, hidden when voteAverage is null
- [ ] Separator dot only shown when both year and rating are present
- [ ] Text highlighting works for exact, prefix, and contains match types

🤖 Generated with [Claude Code](https://claude.com/claude-code)