### PR TITLE
feat(search): add fan-out engine (searchAll) [tb-198]

### DIFF
--- a/apps/pops-api/src/modules/core/search/engine.test.ts
+++ b/apps/pops-api/src/modules/core/search/engine.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SearchAdapter, SearchHit, Query, SearchContext } from "./types.js";
+import { searchAll } from "./engine.js";
+import { registerSearchAdapter, resetRegistry } from "./registry.js";
+
+const defaultContext: SearchContext = { app: "media", page: "search" };
+
+function makeHit(overrides: Partial<SearchHit> = {}): SearchHit {
+  return {
+    uri: overrides.uri ?? "pops:test/1",
+    score: overrides.score ?? 0.5,
+    matchField: overrides.matchField ?? "name",
+    matchType: overrides.matchType ?? "contains",
+    data: overrides.data ?? {},
+  };
+}
+
+function makeAdapter(
+  domain: string,
+  hits: SearchHit[] = [],
+  overrides: Partial<SearchAdapter> = {}
+): SearchAdapter {
+  return {
+    domain,
+    icon: overrides.icon ?? "Circle",
+    color: overrides.color ?? "gray",
+    search: vi.fn().mockResolvedValue(hits),
+  };
+}
+
+function makeFailingAdapter(domain: string): SearchAdapter {
+  return {
+    domain,
+    icon: "Circle",
+    color: "gray",
+    search: vi.fn().mockRejectedValue(new Error(`${domain} adapter failed`)),
+  };
+}
+
+beforeEach(() => {
+  resetRegistry();
+});
+
+describe("searchAll", () => {
+  it("returns empty sections when no adapters registered", async () => {
+    const result = await searchAll({ text: "test" }, defaultContext);
+    expect(result.sections).toEqual([]);
+  });
+
+  it("fans query to all registered adapters", async () => {
+    const adapter1 = makeAdapter("movies", [makeHit({ uri: "pops:media/movie/1" })]);
+    const adapter2 = makeAdapter("tv-shows", [makeHit({ uri: "pops:media/tv-show/1" })]);
+    registerSearchAdapter(adapter1);
+    registerSearchAdapter(adapter2);
+
+    const query: Query = { text: "test" };
+    await searchAll(query, defaultContext);
+
+    expect(adapter1.search).toHaveBeenCalledWith(query, defaultContext);
+    expect(adapter2.search).toHaveBeenCalledWith(query, defaultContext);
+  });
+
+  it("returns sections for each adapter with results", async () => {
+    registerSearchAdapter(makeAdapter("movies", [makeHit()], { icon: "Film", color: "purple" }));
+    registerSearchAdapter(makeAdapter("tv-shows", [makeHit()], { icon: "Tv", color: "purple" }));
+
+    const result = await searchAll({ text: "test" }, defaultContext);
+    expect(result.sections).toHaveLength(2);
+    expect(result.sections.map((s) => s.domain)).toContain("movies");
+    expect(result.sections.map((s) => s.domain)).toContain("tv-shows");
+  });
+
+  it("omits sections with no results", async () => {
+    registerSearchAdapter(makeAdapter("movies", [makeHit()]));
+    registerSearchAdapter(makeAdapter("tv-shows", []));
+
+    const result = await searchAll({ text: "test" }, defaultContext);
+    expect(result.sections).toHaveLength(1);
+    expect(result.sections[0]!.domain).toBe("movies");
+  });
+
+  it("includes correct section metadata", async () => {
+    registerSearchAdapter(makeAdapter("movies", [makeHit()], { icon: "Film", color: "purple" }));
+
+    const result = await searchAll({ text: "test" }, defaultContext);
+    const section = result.sections[0]!;
+    expect(section.domain).toBe("movies");
+    expect(section.icon).toBe("Film");
+    expect(section.color).toBe("purple");
+  });
+
+  describe("failure isolation", () => {
+    it("omits failed adapter and returns others", async () => {
+      registerSearchAdapter(makeFailingAdapter("movies"));
+      registerSearchAdapter(makeAdapter("tv-shows", [makeHit()]));
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const result = await searchAll({ text: "test" }, defaultContext);
+      warnSpy.mockRestore();
+
+      expect(result.sections).toHaveLength(1);
+      expect(result.sections[0]!.domain).toBe("tv-shows");
+    });
+
+    it("logs warning for failed adapter", async () => {
+      registerSearchAdapter(makeFailingAdapter("movies"));
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await searchAll({ text: "test" }, defaultContext);
+
+      expect(warnSpy).toHaveBeenCalledWith("Search adapter failed:", expect.any(Error));
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("context ordering", () => {
+    it("marks context sections with isContextSection=true", async () => {
+      registerSearchAdapter(makeAdapter("movies", [makeHit()]));
+      registerSearchAdapter(makeAdapter("transactions", [makeHit()]));
+
+      const result = await searchAll({ text: "test" }, { app: "media", page: "search" });
+      const moviesSection = result.sections.find((s) => s.domain === "movies")!;
+      const txSection = result.sections.find((s) => s.domain === "transactions")!;
+
+      expect(moviesSection.isContextSection).toBe(true);
+      expect(txSection.isContextSection).toBe(false);
+    });
+
+    it("sorts context sections before non-context sections", async () => {
+      registerSearchAdapter(makeAdapter("transactions", [makeHit({ score: 1.0 })]));
+      registerSearchAdapter(makeAdapter("movies", [makeHit({ score: 0.5 })]));
+
+      const result = await searchAll({ text: "test" }, { app: "media", page: "search" });
+      expect(result.sections[0]!.domain).toBe("movies");
+      expect(result.sections[0]!.isContextSection).toBe(true);
+      expect(result.sections[1]!.domain).toBe("transactions");
+      expect(result.sections[1]!.isContextSection).toBe(false);
+    });
+
+    it("sorts non-context sections by highest score descending", async () => {
+      registerSearchAdapter(makeAdapter("transactions", [makeHit({ score: 0.5 })]));
+      registerSearchAdapter(makeAdapter("budgets", [makeHit({ score: 0.8 })]));
+
+      const result = await searchAll({ text: "test" }, { app: "media", page: "search" });
+      // Both are non-context (app is "media"), sorted by score
+      expect(result.sections[0]!.domain).toBe("budgets");
+      expect(result.sections[1]!.domain).toBe("transactions");
+    });
+
+    it("handles null app context gracefully", async () => {
+      registerSearchAdapter(makeAdapter("movies", [makeHit()]));
+
+      const result = await searchAll({ text: "test" }, { app: null, page: null });
+      expect(result.sections[0]!.isContextSection).toBe(false);
+    });
+  });
+
+  describe("section limiting", () => {
+    it("limits hits to 5 per section", async () => {
+      const hits = Array.from({ length: 10 }, (_, i) =>
+        makeHit({ uri: `pops:test/${i}`, score: 1.0 - i * 0.05 })
+      );
+      registerSearchAdapter(makeAdapter("movies", hits));
+
+      const result = await searchAll({ text: "test" }, defaultContext);
+      expect(result.sections[0]!.hits).toHaveLength(5);
+    });
+
+    it("includes totalCount with full count", async () => {
+      const hits = Array.from({ length: 10 }, (_, i) => makeHit({ uri: `pops:test/${i}` }));
+      registerSearchAdapter(makeAdapter("movies", hits));
+
+      const result = await searchAll({ text: "test" }, defaultContext);
+      expect(result.sections[0]!.totalCount).toBe(10);
+      expect(result.sections[0]!.hits).toHaveLength(5);
+    });
+
+    it("sorts hits within section by score descending", async () => {
+      const hits = [
+        makeHit({ uri: "pops:test/1", score: 0.5 }),
+        makeHit({ uri: "pops:test/2", score: 1.0 }),
+        makeHit({ uri: "pops:test/3", score: 0.8 }),
+      ];
+      registerSearchAdapter(makeAdapter("movies", hits));
+
+      const result = await searchAll({ text: "test" }, defaultContext);
+      const sectionHits = result.sections[0]!.hits;
+      expect(sectionHits[0]!.score).toBe(1.0);
+      expect(sectionHits[1]!.score).toBe(0.8);
+      expect(sectionHits[2]!.score).toBe(0.5);
+    });
+  });
+});

--- a/apps/pops-api/src/modules/core/search/engine.ts
+++ b/apps/pops-api/src/modules/core/search/engine.ts
@@ -1,0 +1,70 @@
+/**
+ * Search fan-out engine — fans a query to all registered adapters via
+ * Promise.allSettled, groups results into sections, and orders context
+ * sections (current app) first.
+ */
+import type { Query, SearchContext, SearchHit } from "./types.js";
+import { getAdapters } from "./registry.js";
+import { isContextDomain } from "./domain-app-mapping.js";
+
+export interface SearchSection {
+  domain: string;
+  icon: string;
+  color: string;
+  isContextSection: boolean;
+  hits: SearchHit[];
+  totalCount: number;
+}
+
+export interface SearchAllResult {
+  sections: SearchSection[];
+}
+
+const HITS_PER_SECTION = 5;
+
+export async function searchAll(query: Query, context: SearchContext): Promise<SearchAllResult> {
+  const adapters = getAdapters();
+  const currentApp = context.app;
+
+  const results = await Promise.allSettled(
+    adapters.map(async (adapter) => {
+      const hits = await adapter.search(query, context);
+      return { adapter, hits };
+    })
+  );
+
+  const sections: SearchSection[] = [];
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      console.warn("Search adapter failed:", result.reason);
+      continue;
+    }
+
+    const { adapter, hits } = result.value;
+    if (hits.length === 0) continue;
+
+    const sorted = [...hits].sort((a, b) => b.score - a.score);
+
+    sections.push({
+      domain: adapter.domain,
+      icon: adapter.icon,
+      color: adapter.color,
+      isContextSection: currentApp ? isContextDomain(adapter.domain, currentApp) : false,
+      hits: sorted.slice(0, HITS_PER_SECTION),
+      totalCount: sorted.length,
+    });
+  }
+
+  // Sort: context sections first, then by highest score descending
+  sections.sort((a, b) => {
+    if (a.isContextSection !== b.isContextSection) {
+      return a.isContextSection ? -1 : 1;
+    }
+    const aTopScore = a.hits[0]?.score ?? 0;
+    const bTopScore = b.hits[0]?.score ?? 0;
+    return bTopScore - aTopScore;
+  });
+
+  return { sections };
+}

--- a/apps/pops-api/src/modules/core/search/index.ts
+++ b/apps/pops-api/src/modules/core/search/index.ts
@@ -1,2 +1,4 @@
 export type { SearchAdapter, SearchHit, Query, SearchContext, StructuredFilter } from "./types.js";
 export { registerSearchAdapter, getAdapters, resetRegistry } from "./registry.js";
+export { searchAll } from "./engine.js";
+export type { SearchSection, SearchAllResult } from "./engine.js";


### PR DESCRIPTION
## Summary
- Add `searchAll(query, context)` engine that fans queries to all registered search adapters via `Promise.allSettled`
- Failed adapters are omitted with `console.warn`, other results still returned
- Results grouped into sections: `{ domain, icon, color, isContextSection, hits, totalCount }`
- Context sections (current app domains) sorted first with `isContextSection: true`
- Non-context sections sorted by highest hit score descending
- 5 hits per section, `totalCount` includes all matches

Closes #1249

## Test plan
- [x] 14 unit tests covering fan-out, failure isolation, context ordering, section limiting
- [x] Format, lint, typecheck all clean
- [ ] QA review

🤖 Generated with [Claude Code](https://claude.com/claude-code)