### PR TITLE
feat(navigation): add useSetPageContext hook [tb-188]

### DIFF
--- a/packages/navigation/src/hooks.ts
+++ b/packages/navigation/src/hooks.ts
@@ -1,6 +1,6 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { AppContextCtx } from "./context.js";
-import type { AppContext } from "./types.js";
+import type { AppContext, AppContextEntity } from "./types.js";
 
 /**
  * Returns the current AppContext.
@@ -9,4 +9,37 @@ import type { AppContext } from "./types.js";
  */
 export function useAppContext(): AppContext {
   return useContext(AppContextCtx).context;
+}
+
+/** Options accepted by useSetPageContext. */
+export interface SetPageContextOptions {
+  page: string;
+  pageType?: AppContext["pageType"];
+  entity?: AppContextEntity;
+  filters?: Record<string, string>;
+}
+
+/**
+ * Sets page-level context on mount and clears it on unmount.
+ *
+ * Call this from any page component to register its identity with the
+ * global AppContext. The provider automatically clears on navigation,
+ * and this hook also clears on unmount for safety.
+ */
+export function useSetPageContext(options: SetPageContextOptions): void {
+  const { setPageContext } = useContext(AppContextCtx);
+
+  useEffect(() => {
+    setPageContext({
+      page: options.page,
+      pageType: options.pageType ?? "top-level",
+      entity: options.entity,
+      filters: options.filters,
+    });
+
+    return () => {
+      setPageContext({ page: null, pageType: "top-level", entity: undefined, filters: undefined });
+    };
+    // Re-run when any option value changes
+  }, [options.page, options.pageType, options.entity, options.filters, setPageContext]);
 }

--- a/packages/navigation/src/index.ts
+++ b/packages/navigation/src/index.ts
@@ -13,6 +13,7 @@ export {
 export type { ResultComponent, ResultComponentProps } from "./result-component-registry";
 
 export { AppContextProvider } from "./AppContextProvider";
-export { useAppContext } from "./hooks";
+export { useAppContext, useSetPageContext } from "./hooks";
+export type { SetPageContextOptions } from "./hooks";
 export type { AppContext, AppContextEntity, AppName } from "./types";
 export { DEFAULT_APP_CONTEXT } from "./types";

--- a/packages/navigation/src/useSetPageContext.test.tsx
+++ b/packages/navigation/src/useSetPageContext.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { AppContextProvider } from "./AppContextProvider";
+import { useAppContext } from "./hooks";
+import { useSetPageContext } from "./hooks";
+import type { SetPageContextOptions } from "./hooks";
+import { useState } from "react";
+
+/** Renders children inside a MemoryRouter + AppContextProvider at the given path. */
+function renderAt(path: string, ui: React.ReactNode) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppContextProvider>{ui}</AppContextProvider>
+    </MemoryRouter>
+  );
+}
+
+/** Page component that calls useSetPageContext and displays the resulting context. */
+function TestPage(props: SetPageContextOptions) {
+  useSetPageContext(props);
+  const ctx = useAppContext();
+  return (
+    <div>
+      <span data-testid="page">{ctx.page ?? "null"}</span>
+      <span data-testid="pageType">{ctx.pageType}</span>
+      <span data-testid="entity">{ctx.entity ? ctx.entity.title : "none"}</span>
+      <span data-testid="filters">{ctx.filters ? JSON.stringify(ctx.filters) : "none"}</span>
+    </div>
+  );
+}
+
+/** Reads context without setting it — used to verify cleared state after unmount. */
+function ContextReader() {
+  const ctx = useAppContext();
+  return (
+    <div>
+      <span data-testid="page">{ctx.page ?? "null"}</span>
+      <span data-testid="pageType">{ctx.pageType}</span>
+      <span data-testid="entity">{ctx.entity ? ctx.entity.title : "none"}</span>
+      <span data-testid="filters">{ctx.filters ? JSON.stringify(ctx.filters) : "none"}</span>
+    </div>
+  );
+}
+
+describe("useSetPageContext", () => {
+  it("sets page context on mount", () => {
+    renderAt("/media", <TestPage page="library" />);
+
+    expect(screen.getByTestId("page")).toHaveTextContent("library");
+    expect(screen.getByTestId("pageType")).toHaveTextContent("top-level");
+  });
+
+  it("sets pageType when provided", () => {
+    renderAt("/media", <TestPage page="movie-detail" pageType="drill-down" />);
+
+    expect(screen.getByTestId("page")).toHaveTextContent("movie-detail");
+    expect(screen.getByTestId("pageType")).toHaveTextContent("drill-down");
+  });
+
+  it("sets entity on drill-down pages", () => {
+    const entity = { uri: "pops:media/movie/42", type: "movie", title: "Fight Club" };
+    renderAt("/media", <TestPage page="movie-detail" pageType="drill-down" entity={entity} />);
+
+    expect(screen.getByTestId("entity")).toHaveTextContent("Fight Club");
+  });
+
+  it("sets filters on list pages", () => {
+    renderAt(
+      "/finance",
+      <TestPage page="transactions" filters={{ category: "food", month: "2026-03" }} />
+    );
+
+    expect(screen.getByTestId("filters")).toHaveTextContent(
+      JSON.stringify({ category: "food", month: "2026-03" })
+    );
+  });
+
+  it("clears context on unmount", () => {
+    function Toggler() {
+      const [showPage, setShowPage] = useState(true);
+      return (
+        <div>
+          {showPage ? <TestPage page="library" /> : <ContextReader />}
+          <button onClick={() => setShowPage(false)}>unmount</button>
+        </div>
+      );
+    }
+
+    renderAt("/media", <Toggler />);
+
+    // Page is set
+    expect(screen.getByTestId("page")).toHaveTextContent("library");
+
+    // Unmount the page component
+    act(() => {
+      screen.getByRole("button", { name: "unmount" }).click();
+    });
+
+    // Context should be cleared
+    expect(screen.getByTestId("page")).toHaveTextContent("null");
+    expect(screen.getByTestId("pageType")).toHaveTextContent("top-level");
+    expect(screen.getByTestId("entity")).toHaveTextContent("none");
+  });
+
+  it("clears entity and filters on unmount after drill-down", () => {
+    const entity = { uri: "pops:media/movie/42", type: "movie", title: "Fight Club" };
+
+    function Toggler() {
+      const [showPage, setShowPage] = useState(true);
+      return (
+        <div>
+          {showPage ? (
+            <TestPage
+              page="movie-detail"
+              pageType="drill-down"
+              entity={entity}
+              filters={{ tab: "cast" }}
+            />
+          ) : (
+            <ContextReader />
+          )}
+          <button onClick={() => setShowPage(false)}>unmount</button>
+        </div>
+      );
+    }
+
+    renderAt("/media", <Toggler />);
+
+    expect(screen.getByTestId("entity")).toHaveTextContent("Fight Club");
+    expect(screen.getByTestId("filters")).toHaveTextContent(JSON.stringify({ tab: "cast" }));
+
+    act(() => {
+      screen.getByRole("button", { name: "unmount" }).click();
+    });
+
+    expect(screen.getByTestId("entity")).toHaveTextContent("none");
+    expect(screen.getByTestId("filters")).toHaveTextContent("none");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `useSetPageContext` hook to `@pops/navigation` that sets page-level context (`page`, `pageType`, `entity`, `filters`) on mount and clears on unmount
- Export `useSetPageContext` and `SetPageContextOptions` type from package index
- Add 5 tests covering mount, unmount, drill-down entity, and filters scenarios

## Test plan
- [x] Typecheck passes (`tsc --noEmit`)
- [x] Format check passes (`prettier --check`)
- [x] Lint passes (`eslint src`)
- [ ] Unit tests pass in CI (vitest hangs in sandbox due to jsdom resource constraints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)