### PR TITLE
feat(search): inventory-items ResultComponent [tb-196]

### DIFF
--- a/packages/app-inventory/package.json
+++ b/packages/app-inventory/package.json
@@ -18,6 +18,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@pops/api-client": "workspace:*",
+    "@pops/navigation": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.90.20",
     "@tanstack/react-table": "^8.21.3",

--- a/packages/app-inventory/src/components/search/InventoryItemSearchResult.test.tsx
+++ b/packages/app-inventory/src/components/search/InventoryItemSearchResult.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InventoryItemSearchResult, highlightMatch } from "./InventoryItemSearchResult";
+import { _clearRegistry, getResultComponent, registerResultComponent } from "@pops/navigation";
+
+beforeEach(() => {
+  _clearRegistry();
+});
+
+const baseItem = {
+  itemName: "MacBook Pro 16",
+  location: "Desk",
+  room: "Office",
+  replacementValue: 4299,
+  brand: "Apple",
+  _query: "macbook",
+  _matchType: "prefix",
+};
+
+describe("InventoryItemSearchResult", () => {
+  it("renders name, brand, and location", () => {
+    render(<InventoryItemSearchResult data={baseItem as unknown as Record<string, unknown>} />);
+    expect(screen.getByText(/MacBook/)).toBeInTheDocument();
+    expect(screen.getByText("Apple")).toBeInTheDocument();
+    expect(screen.getByText("Office · Desk")).toBeInTheDocument();
+  });
+
+  it("renders formatted replacement value", () => {
+    render(<InventoryItemSearchResult data={baseItem as unknown as Record<string, unknown>} />);
+    expect(screen.getByTestId("value")).toHaveTextContent("$4,299");
+  });
+
+  it("hides value when null", () => {
+    const data = { ...baseItem, replacementValue: null };
+    render(<InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />);
+    expect(screen.queryByTestId("value")).not.toBeInTheDocument();
+  });
+
+  it("hides brand when null", () => {
+    const data = { ...baseItem, brand: null };
+    render(<InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />);
+    expect(screen.queryByText("Apple")).not.toBeInTheDocument();
+  });
+
+  it("renders location only when room is null", () => {
+    const data = { ...baseItem, room: null };
+    render(<InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />);
+    expect(screen.getByText("Desk")).toBeInTheDocument();
+  });
+
+  it("renders room only when location is null", () => {
+    const data = { ...baseItem, location: null };
+    render(<InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />);
+    expect(screen.getByText("Office")).toBeInTheDocument();
+  });
+
+  it("hides location text when both room and location are null", () => {
+    const data = { ...baseItem, room: null, location: null };
+    render(<InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />);
+    expect(screen.queryByText("Office")).not.toBeInTheDocument();
+    expect(screen.queryByText("Desk")).not.toBeInTheDocument();
+  });
+
+  it("hides separator between brand and location when location is empty", () => {
+    const data = { ...baseItem, room: null, location: null };
+    const { container } = render(
+      <InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />
+    );
+    const dots = container.querySelectorAll("span");
+    const dotTexts = Array.from(dots).map((el) => el.textContent);
+    expect(dotTexts).not.toContain("·");
+  });
+
+  describe("registration", () => {
+    it("can be registered and retrieved for inventory-items domain", () => {
+      registerResultComponent("inventory-items", InventoryItemSearchResult);
+      const Component = getResultComponent("inventory-items");
+      expect(Component).toBe(InventoryItemSearchResult);
+    });
+  });
+});
+
+describe("highlightMatch", () => {
+  it("highlights exact match", () => {
+    const { container } = render(
+      <span>{highlightMatch("MacBook Pro", "MacBook Pro", "exact")}</span>
+    );
+    const mark = container.querySelector("mark");
+    expect(mark).toHaveTextContent("MacBook Pro");
+  });
+
+  it("highlights prefix match", () => {
+    const { container } = render(
+      <span>{highlightMatch("MacBook Pro 16", "MacBook", "prefix")}</span>
+    );
+    const mark = container.querySelector("mark");
+    expect(mark).toHaveTextContent("MacBook");
+  });
+
+  it("highlights contains match", () => {
+    const { container } = render(
+      <span>{highlightMatch("Sony WH-1000XM5", "1000", "contains")}</span>
+    );
+    const mark = container.querySelector("mark");
+    expect(mark).toHaveTextContent("1000");
+  });
+
+  it("returns plain text when query is empty", () => {
+    const { container } = render(<span>{highlightMatch("MacBook Pro", "", "exact")}</span>);
+    expect(container.querySelector("mark")).toBeNull();
+    expect(container.textContent).toBe("MacBook Pro");
+  });
+
+  it("returns plain text when no match found", () => {
+    const { container } = render(<span>{highlightMatch("MacBook Pro", "XYZ", "contains")}</span>);
+    expect(container.querySelector("mark")).toBeNull();
+    expect(container.textContent).toBe("MacBook Pro");
+  });
+});

--- a/packages/app-inventory/src/components/search/InventoryItemSearchResult.tsx
+++ b/packages/app-inventory/src/components/search/InventoryItemSearchResult.tsx
@@ -1,0 +1,96 @@
+/**
+ * InventoryItemSearchResult — ResultComponent for inventory-items search hits.
+ *
+ * Renders item name (highlighted), location, and formatted value.
+ * Registered for domain "inventory-items" in the search result component registry.
+ */
+import { Package } from "lucide-react";
+import type { ResultComponentProps } from "@pops/navigation";
+
+interface InventoryItemHitData {
+  itemName: string;
+  location: string | null;
+  room: string | null;
+  replacementValue: number | null;
+  brand: string | null;
+}
+
+/**
+ * Highlight the matched portion of text based on query and match type.
+ * Returns React nodes with the matched text wrapped in a <mark>.
+ */
+export function highlightMatch(text: string, query: string, matchType: string): React.ReactNode {
+  if (!query) return text;
+
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  let start = -1;
+
+  if (matchType === "exact" || matchType === "prefix") {
+    start = 0;
+  } else {
+    start = lowerText.indexOf(lowerQuery);
+  }
+
+  if (start === -1) return text;
+
+  const end = start + query.length;
+  return (
+    <>
+      {text.slice(0, start)}
+      <mark className="bg-yellow-200/60 dark:bg-yellow-500/30 rounded-sm px-0.5">
+        {text.slice(start, end)}
+      </mark>
+      {text.slice(end)}
+    </>
+  );
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function InventoryItemSearchResult({ data }: ResultComponentProps) {
+  const hit = data as unknown as InventoryItemHitData & {
+    _query?: string;
+    _matchType?: string;
+  };
+  const { itemName, location, room, replacementValue, brand } = hit;
+  const query = hit._query ?? "";
+  const matchType = hit._matchType ?? "contains";
+
+  const locationText = [room, location].filter(Boolean).join(" · ");
+
+  return (
+    <div className="flex items-center gap-3 py-1" data-testid="inventory-item-search-result">
+      {/* Icon */}
+      <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded bg-muted text-muted-foreground">
+        <Package className="h-5 w-5 opacity-50" />
+      </div>
+
+      {/* Text content */}
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="truncate text-sm font-medium leading-tight">
+          {highlightMatch(itemName, query, matchType)}
+        </span>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {brand && <span>{brand}</span>}
+          {brand && locationText && <span>·</span>}
+          {locationText && <span>{locationText}</span>}
+        </div>
+      </div>
+
+      {/* Value */}
+      {replacementValue != null && (
+        <span className="shrink-0 text-xs font-medium text-muted-foreground" data-testid="value">
+          {formatCurrency(replacementValue)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/app-inventory/src/components/search/register.ts
+++ b/packages/app-inventory/src/components/search/register.ts
@@ -1,0 +1,8 @@
+/**
+ * Side-effect module that registers inventory search ResultComponents.
+ * Import this module to register the inventory-items ResultComponent.
+ */
+import { registerResultComponent } from "@pops/navigation";
+import { InventoryItemSearchResult } from "./InventoryItemSearchResult";
+
+registerResultComponent("inventory-items", InventoryItemSearchResult);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       '@pops/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@pops/navigation':
+        specifier: workspace:*
+        version: link:../navigation
       '@pops/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
## Summary
- Add `InventoryItemSearchResult` component rendering inventory item search hits with Package icon, highlighted name, brand, room/location, and formatted replacement value (AUD)
- Add `highlightMatch` utility for query-matched text highlighting (exact, prefix, contains)
- Register for `inventory-items` domain via `registerResultComponent` side-effect module
- Comprehensive tests covering rendering, value formatting, location combinations, brand display, highlight behavior, and registration

## Test plan
- [ ] CI passes (lint, typecheck, tests)
- [ ] Component renders Package icon placeholder
- [ ] Replacement value formatted as AUD currency, hidden when null
- [ ] Room and location combined with separator, individual or hidden when null
- [ ] Brand shown/hidden correctly with separator logic
- [ ] Text highlighting works for exact, prefix, and contains match types

🤖 Generated with [Claude Code](https://claude.com/claude-code)