### PR TITLE
feat(navigation): add useCurrentApp and useCurrentEntity hooks [tb-189]

### DIFF
--- a/packages/navigation/src/context-consumer-hooks.test.tsx
+++ b/packages/navigation/src/context-consumer-hooks.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { AppContextProvider } from "./AppContextProvider";
+import { useCurrentApp, useCurrentEntity, useSetPageContext } from "./hooks";
+import type { SetPageContextOptions } from "./hooks";
+
+/** Renders children inside a MemoryRouter + AppContextProvider at the given path. */
+function renderAt(path: string, ui: React.ReactNode) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppContextProvider>{ui}</AppContextProvider>
+    </MemoryRouter>
+  );
+}
+
+/** Displays the value of useCurrentApp. */
+function AppDisplay() {
+  const app = useCurrentApp();
+  return <span data-testid="app">{app ?? "null"}</span>;
+}
+
+/** Displays the value of useCurrentEntity. */
+function EntityDisplay() {
+  const entity = useCurrentEntity();
+  return <span data-testid="entity">{entity ? entity.title : "null"}</span>;
+}
+
+/** Sets page context and renders both hook values. */
+function PageWithHooks(props: SetPageContextOptions) {
+  useSetPageContext(props);
+  return (
+    <div>
+      <AppDisplay />
+      <EntityDisplay />
+    </div>
+  );
+}
+
+describe("useCurrentApp", () => {
+  it("returns the app for a finance path", () => {
+    renderAt("/finance/transactions", <AppDisplay />);
+    expect(screen.getByTestId("app")).toHaveTextContent("finance");
+  });
+
+  it("returns the app for a media path", () => {
+    renderAt("/media/library", <AppDisplay />);
+    expect(screen.getByTestId("app")).toHaveTextContent("media");
+  });
+
+  it("returns null at root", () => {
+    renderAt("/", <AppDisplay />);
+    expect(screen.getByTestId("app")).toHaveTextContent("null");
+  });
+
+  it("returns null for unmatched path", () => {
+    renderAt("/settings", <AppDisplay />);
+    expect(screen.getByTestId("app")).toHaveTextContent("null");
+  });
+});
+
+describe("useCurrentEntity", () => {
+  it("returns entity on drill-down page", () => {
+    const entity = { uri: "pops:media/movie/42", type: "movie", title: "Fight Club" };
+    renderAt("/media", <PageWithHooks page="movie-detail" pageType="drill-down" entity={entity} />);
+    expect(screen.getByTestId("entity")).toHaveTextContent("Fight Club");
+  });
+
+  it("returns null on top-level page even with entity set", () => {
+    const entity = { uri: "pops:media/movie/42", type: "movie", title: "Fight Club" };
+    renderAt("/media", <PageWithHooks page="library" pageType="top-level" entity={entity} />);
+    expect(screen.getByTestId("entity")).toHaveTextContent("null");
+  });
+
+  it("returns null when no entity is set", () => {
+    renderAt("/media", <PageWithHooks page="library" />);
+    expect(screen.getByTestId("entity")).toHaveTextContent("null");
+  });
+
+  it("returns null on drill-down page without entity", () => {
+    renderAt("/media", <PageWithHooks page="movie-detail" pageType="drill-down" />);
+    expect(screen.getByTestId("entity")).toHaveTextContent("null");
+  });
+});

--- a/packages/navigation/src/hooks.ts
+++ b/packages/navigation/src/hooks.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect } from "react";
 import { AppContextCtx } from "./context.js";
-import type { AppContext, AppContextEntity } from "./types.js";
+import type { AppContext, AppContextEntity, AppName } from "./types.js";
 
 /**
  * Returns the current AppContext.
@@ -42,4 +42,15 @@ export function useSetPageContext(options: SetPageContextOptions): void {
     };
     // Re-run when any option value changes
   }, [options.page, options.pageType, options.entity, options.filters, setPageContext]);
+}
+
+/** Returns the active app identifier, or null at root / unmatched paths. */
+export function useCurrentApp(): AppName | null {
+  return useAppContext().app;
+}
+
+/** Returns the entity being viewed on a drill-down page, or null otherwise. */
+export function useCurrentEntity(): AppContextEntity | null {
+  const { pageType, entity } = useAppContext();
+  return pageType === "drill-down" && entity ? entity : null;
 }

--- a/packages/navigation/src/index.ts
+++ b/packages/navigation/src/index.ts
@@ -13,7 +13,7 @@ export {
 export type { ResultComponent, ResultComponentProps } from "./result-component-registry";
 
 export { AppContextProvider } from "./AppContextProvider";
-export { useAppContext, useSetPageContext } from "./hooks";
+export { useAppContext, useSetPageContext, useCurrentApp, useCurrentEntity } from "./hooks";
 export type { SetPageContextOptions } from "./hooks";
 export type { AppContext, AppContextEntity, AppName } from "./types";
 export { DEFAULT_APP_CONTEXT } from "./types";


### PR DESCRIPTION
## Summary
- Add `useCurrentApp()` convenience hook — returns `AppName | null` from the current AppContext
- Add `useCurrentEntity()` convenience hook — returns `AppContextEntity | null`, only when on a drill-down page (prevents accidental use of stale entity data on list pages)
- Export both hooks from `@pops/navigation`
- Tests covering app detection, entity on drill-down vs top-level, null cases

## Test plan
- [ ] CI passes (lint, typecheck, tests)
- [ ] `useCurrentApp()` returns correct app for finance/media/inventory/ai paths and null for root/unmatched
- [ ] `useCurrentEntity()` returns entity only on drill-down pages
- [ ] `useCurrentEntity()` returns null on top-level pages even if entity is set in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)