### PR TITLE
feat(search): transactions ResultComponent — description, amount, date [tb-193]

### DIFF
--- a/docs/themes/01-foundation/prds/057-search-engine/README.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/README.md
@@ -74,7 +74,7 @@ v1 is plain text only. Structured syntax added as v2 USs.
 | 03 | [us-03-tv-shows-adapter](us-03-tv-shows-adapter.md) | TV shows backend adapter: search by name | Done | — |
 | 03b | [us-03b-tv-shows-result-component](us-03b-tv-shows-result-component.md) | TV shows ResultComponent: poster + name + status + seasons | In progress | — |
 | 04 | [us-04-transactions-adapter](us-04-transactions-adapter.md) | Transactions backend adapter: search by description | Done | — |
-| 04b | [us-04b-transactions-result-component](us-04b-transactions-result-component.md) | Transactions ResultComponent: description + colored amount + date | In progress | — |
+| 04b | [us-04b-transactions-result-component](us-04b-transactions-result-component.md) | Transactions ResultComponent: description + colored amount + date | Done | — |
 | 05 | [us-05-entities-adapter](us-05-entities-adapter.md) | Entities backend adapter: search by name | Done | — |
 | 05b | [us-05b-entities-result-component](us-05b-entities-result-component.md) | Entities ResultComponent: name + type badge + aliases | Done | — |
 | 06 | [us-06-budgets-adapter](us-06-budgets-adapter.md) | Budgets backend adapter: search by category | Done | — |

--- a/docs/themes/01-foundation/prds/057-search-engine/us-04b-transactions-result-component.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-04b-transactions-result-component.md
@@ -1,7 +1,7 @@
 # US-04b: Transactions result component (frontend)
 
 > PRD: [057 — Search Engine](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,11 +9,11 @@ As a user, I want transaction search results to show description, amount (colore
 
 ## Acceptance Criteria
 
-- [ ] `TransactionsResultComponent` registered in frontend registry for domain `"transactions"`
-- [ ] Renders: description + amount (green for income, red for expense, muted for transfer) + date
-- [ ] Entity name shown if available (subtle, secondary text)
-- [ ] Highlights matched portion of description using `query` prop + `matchField`/`matchType`
-- [ ] Tests: renders correctly for each transaction type, highlighting works
+- [x] `TransactionsResultComponent` registered in frontend registry for domain `"transactions"`
+- [x] Renders: description + amount (green for income, red for expense, muted for transfer) + date
+- [x] Entity name shown if available (subtle, secondary text)
+- [x] Highlights matched portion of description using `query` prop + `matchField`/`matchType`
+- [x] Tests: renders correctly for each transaction type, highlighting works
 
 ## Notes
 

--- a/packages/app-finance/src/components/search/TransactionsResultComponent.test.tsx
+++ b/packages/app-finance/src/components/search/TransactionsResultComponent.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TransactionsResultComponent } from "./TransactionsResultComponent";
+
+function makeData(overrides: Record<string, unknown> = {}) {
+  return {
+    description: "WOOLWORTHS 1234",
+    amount: 42.5,
+    date: "2026-03-15",
+    entityName: "Woolworths",
+    type: "expense",
+    ...overrides,
+  };
+}
+
+describe("TransactionsResultComponent", () => {
+  it("renders description and entity name", () => {
+    render(<TransactionsResultComponent data={makeData()} />);
+    expect(screen.getByText("WOOLWORTHS 1234")).toBeInTheDocument();
+    expect(screen.getByText("Woolworths")).toBeInTheDocument();
+  });
+
+  it("renders expense amount in red with minus sign", () => {
+    render(<TransactionsResultComponent data={makeData({ type: "expense", amount: 99.0 })} />);
+    const amount = screen.getByText("-$99.00");
+    expect(amount).toBeInTheDocument();
+    expect(amount.className).toContain("text-red-600");
+  });
+
+  it("renders income amount in green with plus sign", () => {
+    render(<TransactionsResultComponent data={makeData({ type: "income", amount: 3500 })} />);
+    const amount = screen.getByText("+$3500.00");
+    expect(amount).toBeInTheDocument();
+    expect(amount.className).toContain("text-green-600");
+  });
+
+  it("renders transfer amount in muted color with no sign", () => {
+    render(<TransactionsResultComponent data={makeData({ type: "transfer", amount: 200 })} />);
+    const amount = screen.getByText("$200.00");
+    expect(amount).toBeInTheDocument();
+    expect(amount.className).toContain("text-muted-foreground");
+  });
+
+  it("renders formatted date", () => {
+    render(<TransactionsResultComponent data={makeData({ date: "2026-03-15" })} />);
+    expect(screen.getByText(/15 Mar 2026/)).toBeInTheDocument();
+  });
+
+  it("hides entity name when null", () => {
+    render(<TransactionsResultComponent data={makeData({ entityName: null })} />);
+    expect(screen.getByText("WOOLWORTHS 1234")).toBeInTheDocument();
+    expect(screen.queryByText("Woolworths")).not.toBeInTheDocument();
+  });
+
+  it("highlights matched portion of description", () => {
+    const { container } = render(
+      <TransactionsResultComponent
+        data={makeData({ description: "WOOLWORTHS 1234" })}
+        query="WOOL"
+        matchField="description"
+      />
+    );
+    const mark = container.querySelector("mark");
+    expect(mark).toBeInTheDocument();
+    expect(mark!.textContent).toBe("WOOL");
+  });
+
+  it("does not highlight when matchField is not description", () => {
+    const { container } = render(
+      <TransactionsResultComponent
+        data={makeData({ description: "WOOLWORTHS 1234" })}
+        query="WOOL"
+        matchField="entityName"
+      />
+    );
+    expect(container.querySelector("mark")).not.toBeInTheDocument();
+  });
+
+  it("does not highlight when query is empty", () => {
+    const { container } = render(
+      <TransactionsResultComponent
+        data={makeData({ description: "WOOLWORTHS 1234" })}
+        query=""
+        matchField="description"
+      />
+    );
+    expect(container.querySelector("mark")).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-finance/src/components/search/TransactionsResultComponent.tsx
+++ b/packages/app-finance/src/components/search/TransactionsResultComponent.tsx
@@ -1,0 +1,83 @@
+import { registerResultComponent } from "@pops/navigation";
+import type { ResultComponentProps } from "@pops/navigation";
+
+interface TransactionData {
+  description: string;
+  amount: number;
+  date: string;
+  entityName: string | null;
+  type: "income" | "expense" | "transfer";
+}
+
+function formatAmount(amount: number): string {
+  return `$${Math.abs(amount).toFixed(2)}`;
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function amountColorClass(type: "income" | "expense" | "transfer"): string {
+  switch (type) {
+    case "income":
+      return "text-green-600";
+    case "expense":
+      return "text-red-600";
+    case "transfer":
+      return "text-muted-foreground";
+  }
+}
+
+function highlightMatch(text: string, query: string): React.ReactNode {
+  if (!query) return text;
+
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  const idx = lowerText.indexOf(lowerQuery);
+
+  if (idx === -1) return text;
+
+  const before = text.slice(0, idx);
+  const match = text.slice(idx, idx + query.length);
+  const after = text.slice(idx + query.length);
+
+  return (
+    <>
+      {before}
+      <mark className="bg-yellow-200 dark:bg-yellow-800 rounded-sm px-0.5">{match}</mark>
+      {after}
+    </>
+  );
+}
+
+export function TransactionsResultComponent({ data, query, matchField }: ResultComponentProps) {
+  const tx = data as unknown as TransactionData;
+  const shouldHighlight = matchField === "description" && query;
+
+  return (
+    <div className="flex items-center justify-between gap-2 min-w-0">
+      <div className="flex flex-col min-w-0">
+        <span className="text-sm font-medium truncate">
+          {shouldHighlight ? highlightMatch(tx.description, query!) : tx.description}
+        </span>
+        {tx.entityName && (
+          <span className="text-xs text-muted-foreground truncate">{tx.entityName}</span>
+        )}
+      </div>
+      <div className="flex flex-col items-end shrink-0">
+        <span className={`text-sm font-medium ${amountColorClass(tx.type)}`}>
+          {tx.type === "income" ? "+" : tx.type === "expense" ? "-" : ""}
+          {formatAmount(tx.amount)}
+        </span>
+        <span className="text-xs text-muted-foreground">{formatDate(tx.date)}</span>
+      </div>
+    </div>
+  );
+}
+
+registerResultComponent("transactions", TransactionsResultComponent);

--- a/packages/app-finance/src/index.ts
+++ b/packages/app-finance/src/index.ts
@@ -8,3 +8,4 @@ export { routes, navConfig } from "./routes";
 
 // Side-effect: register search result components
 import "./components/search/EntitiesResultComponent";
+import "./components/search/TransactionsResultComponent";

--- a/packages/navigation/src/result-component-registry.tsx
+++ b/packages/navigation/src/result-component-registry.tsx
@@ -3,6 +3,12 @@ import type { ComponentType } from "react";
 /** Props passed to every result component by the search panel. */
 export interface ResultComponentProps {
   data: Record<string, unknown>;
+  /** Raw query string for match highlighting. */
+  query?: string;
+  /** Which field matched (e.g. "description", "name"). */
+  matchField?: string;
+  /** How the match was found: "exact", "prefix", or "contains". */
+  matchType?: string;
 }
 
 /** A React component that renders a single search result. */


### PR DESCRIPTION
## Summary
- Adds `TransactionsResultComponent` to `@pops/app-finance` — renders transaction search hits with description (match highlighting), colored amount (green/red/muted by type), formatted date, and optional entity name
- Extends `ResultComponentProps` in `@pops/navigation` with `query`, `matchField`, `matchType` props for highlight support
- Registers component via side-effect import in app-finance index
- 9 tests covering all transaction types, highlighting, and edge cases

## Test plan
- [x] Typecheck passes (`tsc --noEmit` in both app-finance and navigation)
- [x] Lint passes (eslint on all changed files)
- [x] Format passes (prettier)
- [ ] Unit tests pass in CI (vitest timed out locally due to resource constraints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)