### PR TITLE
feat(search): add structured query parser [tb-211]

### DIFF
--- a/apps/pops-api/src/modules/core/search/index.ts
+++ b/apps/pops-api/src/modules/core/search/index.ts
@@ -2,3 +2,4 @@ export type { SearchAdapter, SearchHit, Query, SearchContext, StructuredFilter }
 export { registerSearchAdapter, getAdapters, resetRegistry } from "./registry.js";
 export { searchAll, showMore } from "./engine.js";
 export type { SearchSection, SearchAllResult, ShowMoreResult } from "./engine.js";
+export { parseQuery } from "./query-parser.js";

--- a/apps/pops-api/src/modules/core/search/query-parser.test.ts
+++ b/apps/pops-api/src/modules/core/search/query-parser.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { parseQuery } from "./query-parser.js";
+
+describe("parseQuery", () => {
+  it("returns plain text when no filters present", () => {
+    const result = parseQuery("fight club");
+    expect(result.text).toBe("fight club");
+    expect(result.filters).toBeUndefined();
+  });
+
+  it("extracts type: filter", () => {
+    const result = parseQuery("type:movie fight");
+    expect(result.text).toBe("fight");
+    expect(result.filters).toEqual([{ key: "type", value: "movie" }]);
+  });
+
+  it("extracts domain: filter", () => {
+    const result = parseQuery("domain:media severance");
+    expect(result.text).toBe("severance");
+    expect(result.filters).toEqual([{ key: "domain", value: "media" }]);
+  });
+
+  it("extracts year:> filter", () => {
+    const result = parseQuery("year:>2000 action");
+    expect(result.text).toBe("action");
+    expect(result.filters).toEqual([{ key: "year", value: ">2000" }]);
+  });
+
+  it("extracts year:< filter", () => {
+    const result = parseQuery("year:<1990 classic");
+    expect(result.text).toBe("classic");
+    expect(result.filters).toEqual([{ key: "year", value: "<1990" }]);
+  });
+
+  it("extracts year: without operator", () => {
+    const result = parseQuery("year:2024 new");
+    expect(result.text).toBe("new");
+    expect(result.filters).toEqual([{ key: "year", value: "2024" }]);
+  });
+
+  it("extracts value:> filter", () => {
+    const result = parseQuery("value:>100 electronics");
+    expect(result.text).toBe("electronics");
+    expect(result.filters).toEqual([{ key: "value", value: ">100" }]);
+  });
+
+  it("extracts value:< filter", () => {
+    const result = parseQuery("value:<50 budget");
+    expect(result.text).toBe("budget");
+    expect(result.filters).toEqual([{ key: "value", value: "<50" }]);
+  });
+
+  it("extracts warranty:expiring filter", () => {
+    const result = parseQuery("warranty:expiring laptop");
+    expect(result.text).toBe("laptop");
+    expect(result.filters).toEqual([{ key: "warranty", value: "expiring" }]);
+  });
+
+  it("extracts multiple filters", () => {
+    const result = parseQuery("type:movie year:>2000 fight");
+    expect(result.text).toBe("fight");
+    expect(result.filters).toEqual([
+      { key: "type", value: "movie" },
+      { key: "year", value: ">2000" },
+    ]);
+  });
+
+  it("treats unknown key:value as plain text", () => {
+    const result = parseQuery("foo:bar test");
+    expect(result.text).toBe("foo:bar test");
+    expect(result.filters).toBeUndefined();
+  });
+
+  it("mixes known and unknown filters correctly", () => {
+    const result = parseQuery("type:movie foo:bar dark knight");
+    expect(result.text).toBe("foo:bar dark knight");
+    expect(result.filters).toEqual([{ key: "type", value: "movie" }]);
+  });
+
+  it("handles filter at end of query", () => {
+    const result = parseQuery("dark knight type:movie");
+    expect(result.text).toBe("dark knight");
+    expect(result.filters).toEqual([{ key: "type", value: "movie" }]);
+  });
+
+  it("handles only filters, no text", () => {
+    const result = parseQuery("type:movie domain:media");
+    expect(result.text).toBe("");
+    expect(result.filters).toEqual([
+      { key: "type", value: "movie" },
+      { key: "domain", value: "media" },
+    ]);
+  });
+
+  it("handles empty input", () => {
+    const result = parseQuery("");
+    expect(result.text).toBe("");
+    expect(result.filters).toBeUndefined();
+  });
+
+  it("handles whitespace-only input", () => {
+    const result = parseQuery("   ");
+    expect(result.text).toBe("");
+    expect(result.filters).toBeUndefined();
+  });
+
+  it("preserves extra spaces in text portion as single spaces", () => {
+    const result = parseQuery("  dark   knight  type:movie  ");
+    expect(result.text).toBe("dark knight");
+    expect(result.filters).toEqual([{ key: "type", value: "movie" }]);
+  });
+});

--- a/apps/pops-api/src/modules/core/search/query-parser.ts
+++ b/apps/pops-api/src/modules/core/search/query-parser.ts
@@ -1,0 +1,51 @@
+/**
+ * Structured query parser — extracts typed filter tokens from search input.
+ *
+ * Supported filters:
+ *   type:<value>     — entity/content type
+ *   domain:<value>   — search domain
+ *   year:>N, year:<N — year range
+ *   value:>N, value:<N — value range
+ *   warranty:expiring — warranty status
+ *
+ * Unrecognised key:value tokens are treated as plain text.
+ */
+import type { Query, StructuredFilter } from "./types.js";
+
+const KNOWN_KEYS = new Set(["type", "domain", "year", "value", "warranty"]);
+
+/**
+ * Matches tokens like `key:value`, `key:>value`, `key:<value`.
+ * Captures: key, optional operator (> or <), value (no spaces).
+ */
+const FILTER_PATTERN = /(\w+):([><]?)(\S+)/g;
+
+export function parseQuery(input: string): Query {
+  const filters: StructuredFilter[] = [];
+  const textParts: string[] = [];
+
+  // Split by whitespace, process each token
+  const tokens = input.trim().split(/\s+/);
+
+  for (const token of tokens) {
+    if (!token) continue;
+
+    // Reset regex state
+    FILTER_PATTERN.lastIndex = 0;
+    const match = FILTER_PATTERN.exec(token);
+
+    if (match && match.index === 0 && match[0] === token && KNOWN_KEYS.has(match[1] ?? "")) {
+      const key = match[1] ?? "";
+      const operator = match[2] || "";
+      const value = match[3] ?? "";
+      filters.push({ key, value: `${operator}${value}` });
+    } else {
+      textParts.push(token);
+    }
+  }
+
+  return {
+    text: textParts.join(" "),
+    filters: filters.length > 0 ? filters : undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `parseQuery(input)` that extracts typed filter tokens from search input
- Supported filters: `type:`, `domain:`, `year:>/<`, `value:>/<`, `warranty:expiring`
- Unrecognised `key:value` tokens treated as plain text
- Returns `{ text, filters }` matching existing `Query` interface

Closes #1265

## Test plan
- [x] 17 tests: single/multiple filters, operators, unknown filters passthrough, edge cases
- [x] Format, lint, typecheck all clean
- [ ] QA review

🤖 Generated with [Claude Code](https://claude.com/claude-code)