### PR TITLE
feat(search): keyboard navigation hook [tb-210]

### DIFF
--- a/packages/navigation/src/index.ts
+++ b/packages/navigation/src/index.ts
@@ -20,3 +20,4 @@ export { DEFAULT_APP_CONTEXT } from "./types";
 
 export { useRecentSearches } from "./recent-searches";
 export { RecentSearches } from "./RecentSearches";
+export { useSearchKeyboardNav } from "./search-keyboard-nav";

--- a/packages/navigation/src/search-keyboard-nav.test.tsx
+++ b/packages/navigation/src/search-keyboard-nav.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSearchKeyboardNav } from "./search-keyboard-nav";
+import { useRef } from "react";
+
+function createContainer(resultCount: number): HTMLDivElement {
+  const container = document.createElement("div");
+  for (let i = 0; i < resultCount; i++) {
+    const item = document.createElement("div");
+    item.setAttribute("data-result-index", String(i));
+    item.scrollIntoView = vi.fn();
+    container.appendChild(item);
+  }
+  document.body.appendChild(container);
+  return container;
+}
+
+function fireKey(container: HTMLElement, key: string) {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true });
+  vi.spyOn(event, "preventDefault");
+  container.dispatchEvent(event);
+  return event;
+}
+
+describe("useSearchKeyboardNav", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("starts with selectedIndex -1", () => {
+    container = createContainer(3);
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useSearchKeyboardNav({
+        resultCount: 3,
+        onSelect: vi.fn(),
+        onClose: vi.fn(),
+        containerRef: ref,
+      });
+    });
+    expect(result.current.selectedIndex).toBe(-1);
+  });
+
+  it("ArrowDown moves selection forward", () => {
+    container = createContainer(3);
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useSearchKeyboardNav({
+        resultCount: 3,
+        onSelect: vi.fn(),
+        onClose: vi.fn(),
+        containerRef: ref,
+      });
+    });
+
+    act(() => fireKey(container, "ArrowDown"));
+    expect(result.current.selectedIndex).toBe(0);
+
+    act(() => fireKey(container, "ArrowDown"));
+    expect(result.current.selectedIndex).toBe(1);
+  });
+
+  it("ArrowDown wraps to 0 from last item", () => {
+    container = createContainer(3);
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useSearchKeyboardNav({
+        resultCount: 3,
+        onSelect: vi.fn(),
+        onClose: vi.fn(),
+        containerRef: ref,
+      });
+    });
+
+    // Go to last item
+    act(() => fireKey(container, "ArrowDown")); // 0
+    act(() => fireKey(container, "ArrowDown")); // 1
+    act(() => fireKey(container, "ArrowDown")); // 2
+    act(() => fireKey(container, "ArrowDown")); // wraps to 0
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it("ArrowUp moves selection backward", () => {
+    container = createContainer(3);
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useSearchKeyboardNav({
+        resultCount: 3,
+        onSelect: vi.fn(),
+        onClose: vi.fn(),
+        containerRef: ref,
+      });
+    });
+
+    // Start from -1, ArrowUp goes to last item
+    act(() => fireKey(container, "ArrowUp"));
+    expect(result.current.selectedIndex).toBe(2);
+
+    act(() => fireKey(container, "ArrowUp"));
+    expect(result.current.selectedIndex).toBe(1);
+  });
+
+  it("Enter calls onSelect with current index", () => {
+    container = createContainer(3);
+    const onSelect = vi.fn();
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useSearchKeyboardNav({
+        resultCount: 3,
+        onSelect,
+        onClose: vi.fn(),
+        containerRef: ref,
+      });
+    });
+
+    act(() => fireKey(container, "ArrowDown")); // select 0
+    act(() => fireKey(container, "Enter"));
+    expect(onSelect).toHaveBeenCalledWith(0);
+  });
+
+  it("Enter does nothing when nothing selected", () => {
+    container = createContainer(3);
+    const onSelect = vi.fn();
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useSearchKeyboardNav({
+        resultCount: 3,
+        onSelect,
+        onClose: vi.fn(),
+        containerRef: ref,
+      });
+    });
+
+    act(() => fireKey(container, "Enter"));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("Escape calls onClose", () => {
+    container = createContainer(3);
+    const onClose = vi.fn();
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useSearchKeyboardNav({
+        resultCount: 3,
+        onSelect: vi.fn(),
+        onClose,
+        containerRef: ref,
+      });
+    });
+
+    act(() => fireKey(container, "Escape"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("resets selectedIndex when resultCount changes", () => {
+    container = createContainer(5);
+    let count = 5;
+    const { result, rerender } = renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useSearchKeyboardNav({
+        resultCount: count,
+        onSelect: vi.fn(),
+        onClose: vi.fn(),
+        containerRef: ref,
+      });
+    });
+
+    act(() => fireKey(container, "ArrowDown")); // select 0
+    expect(result.current.selectedIndex).toBe(0);
+
+    count = 3;
+    rerender();
+    expect(result.current.selectedIndex).toBe(-1);
+  });
+
+  it("scrolls selected item into view", () => {
+    container = createContainer(3);
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useSearchKeyboardNav({
+        resultCount: 3,
+        onSelect: vi.fn(),
+        onClose: vi.fn(),
+        containerRef: ref,
+      });
+    });
+
+    act(() => fireKey(container, "ArrowDown")); // select 0
+
+    const item = container.querySelector('[data-result-index="0"]');
+    expect(item?.scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+  });
+
+  it("Escape works even with 0 results", () => {
+    container = createContainer(0);
+    const onClose = vi.fn();
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useSearchKeyboardNav({
+        resultCount: 0,
+        onSelect: vi.fn(),
+        onClose,
+        containerRef: ref,
+      });
+    });
+
+    act(() => fireKey(container, "Escape"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/navigation/src/search-keyboard-nav.ts
+++ b/packages/navigation/src/search-keyboard-nav.ts
@@ -1,0 +1,91 @@
+/**
+ * useSearchKeyboardNav — keyboard navigation for search results.
+ *
+ * Handles ArrowUp/Down to move selection, Enter to select,
+ * Escape to close, and auto-scrolls selected items into view.
+ */
+import { useState, useCallback, useEffect, type RefObject } from "react";
+
+interface UseSearchKeyboardNavOptions {
+  /** Total number of navigable results across all sections. */
+  resultCount: number;
+  /** Called when Enter is pressed on a selected result. */
+  onSelect: (index: number) => void;
+  /** Called when Escape is pressed. */
+  onClose: () => void;
+  /** Ref to the container element that receives keyboard events. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Data attribute used to identify result items for scroll-into-view. Default: "data-result-index". */
+  itemAttribute?: string;
+}
+
+export function useSearchKeyboardNav({
+  resultCount,
+  onSelect,
+  onClose,
+  containerRef,
+  itemAttribute = "data-result-index",
+}: UseSearchKeyboardNavOptions) {
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+
+  // Reset selection when results change
+  useEffect(() => {
+    setSelectedIndex(-1);
+  }, [resultCount]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (selectedIndex < 0 || !containerRef.current) return;
+    const item = containerRef.current.querySelector(`[${itemAttribute}="${selectedIndex}"]`);
+    item?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex, containerRef, itemAttribute]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (resultCount === 0) {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          onClose();
+        }
+        return;
+      }
+
+      switch (event.key) {
+        case "ArrowDown": {
+          event.preventDefault();
+          setSelectedIndex((prev) => (prev < resultCount - 1 ? prev + 1 : 0));
+          break;
+        }
+        case "ArrowUp": {
+          event.preventDefault();
+          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : resultCount - 1));
+          break;
+        }
+        case "Enter": {
+          event.preventDefault();
+          if (selectedIndex >= 0) {
+            onSelect(selectedIndex);
+          }
+          break;
+        }
+        case "Escape": {
+          event.preventDefault();
+          onClose();
+          break;
+        }
+      }
+    },
+    [resultCount, selectedIndex, onSelect, onClose]
+  );
+
+  // Attach keyboard listener to container
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    container.addEventListener("keydown", handleKeyDown);
+    return () => container.removeEventListener("keydown", handleKeyDown);
+  }, [containerRef, handleKeyDown]);
+
+  return { selectedIndex, setSelectedIndex } as const;
+}


### PR DESCRIPTION
## Summary
- Add `useSearchKeyboardNav` hook for arrow key navigation through search results
- ArrowUp/Down moves selection with wrapping, Enter selects highlighted result, Escape closes panel
- Auto-scrolls selected item into view via `scrollIntoView({ block: "nearest" })`
- Resets selection when result count changes (new search triggered)
- Uses `data-result-index` attribute to find items for scroll-into-view
- 10 tests covering all keyboard interactions, wrapping, reset, and scroll behavior

## Test plan
- [ ] CI passes (lint, typecheck, tests)
- [ ] ArrowDown increments selection, wraps from last to first
- [ ] ArrowUp decrements selection, wraps from first to last
- [ ] Enter calls onSelect with current index, no-op when nothing selected
- [ ] Escape calls onClose (works with 0 results too)
- [ ] Selection resets to -1 when resultCount changes
- [ ] Selected item scrolled into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)