### PR TITLE
feat(navigation): add URI resolver and search result navigation [tb-208]

### DIFF
--- a/packages/navigation/src/hooks.ts
+++ b/packages/navigation/src/hooks.ts
@@ -1,6 +1,8 @@
-import { useContext, useEffect } from "react";
+import { useCallback, useContext, useEffect } from "react";
+import { useNavigate } from "react-router";
 import { AppContextCtx } from "./context.js";
 import type { AppContext, AppContextEntity, AppName } from "./types.js";
+import { resolveUri } from "./uri-resolver.js";
 
 /**
  * Returns the current AppContext.
@@ -53,4 +55,29 @@ export function useCurrentApp(): AppName | null {
 export function useCurrentEntity(): AppContextEntity | null {
   const { pageType, entity } = useAppContext();
   return pageType === "drill-down" && entity ? entity : null;
+}
+
+/**
+ * Returns a navigateTo callback that resolves a POPS URI and navigates to
+ * the corresponding frontend route.
+ *
+ * @returns `navigateTo(uri)` — returns true if navigation succeeded, false if
+ * the URI could not be resolved.
+ */
+export function useSearchResultNavigation(): {
+  navigateTo: (uri: string) => boolean;
+} {
+  const navigate = useNavigate();
+
+  const navigateTo = useCallback(
+    (uri: string): boolean => {
+      const route = resolveUri(uri);
+      if (!route) return false;
+      navigate(route);
+      return true;
+    },
+    [navigate]
+  );
+
+  return { navigateTo };
 }

--- a/packages/navigation/src/index.ts
+++ b/packages/navigation/src/index.ts
@@ -13,8 +13,9 @@ export {
 export type { ResultComponent, ResultComponentProps } from "./result-component-registry";
 
 export { AppContextProvider } from "./AppContextProvider";
-export { useAppContext, useSetPageContext, useCurrentApp, useCurrentEntity } from "./hooks";
+export { useAppContext, useSetPageContext, useCurrentApp, useCurrentEntity, useSearchResultNavigation } from "./hooks";
 export type { SetPageContextOptions } from "./hooks";
+export { resolveUri } from "./uri-resolver";
 export type { AppContext, AppContextEntity, AppName } from "./types";
 export { DEFAULT_APP_CONTEXT } from "./types";
 

--- a/packages/navigation/src/uri-resolver.test.ts
+++ b/packages/navigation/src/uri-resolver.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { resolveUri } from "./uri-resolver";
+
+describe("resolveUri", () => {
+  describe("media URIs", () => {
+    it("resolves movie URI", () => {
+      expect(resolveUri("pops:media/movie/42")).toBe("/media/movies/42");
+    });
+
+    it("resolves tv-show URI", () => {
+      expect(resolveUri("pops:media/tv-show/7")).toBe("/media/tv/7");
+    });
+  });
+
+  describe("finance URIs", () => {
+    it("resolves transaction URI", () => {
+      expect(resolveUri("pops:finance/transaction/123")).toBe("/finance/transactions/123");
+    });
+
+    it("resolves entity URI", () => {
+      expect(resolveUri("pops:finance/entity/5")).toBe("/finance/entities/5");
+    });
+
+    it("resolves budget URI", () => {
+      expect(resolveUri("pops:finance/budget/8")).toBe("/finance/budgets/8");
+    });
+  });
+
+  describe("inventory URIs", () => {
+    it("resolves item URI", () => {
+      expect(resolveUri("pops:inventory/item/99")).toBe("/inventory/items/99");
+    });
+  });
+
+  describe("malformed URIs", () => {
+    it("returns null for non-pops URI", () => {
+      expect(resolveUri("https://example.com")).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(resolveUri("")).toBeNull();
+    });
+
+    it("returns null for unknown domain/type", () => {
+      expect(resolveUri("pops:unknown/thing/1")).toBeNull();
+    });
+
+    it("returns null for missing ID", () => {
+      expect(resolveUri("pops:media/movie/")).toBeNull();
+    });
+
+    it("returns null for URI with no slashes after prefix", () => {
+      expect(resolveUri("pops:media")).toBeNull();
+    });
+
+    it("returns null for pops: with no content", () => {
+      expect(resolveUri("pops:")).toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles string IDs", () => {
+      expect(resolveUri("pops:finance/entity/abc")).toBe("/finance/entities/abc");
+    });
+  });
+});

--- a/packages/navigation/src/uri-resolver.ts
+++ b/packages/navigation/src/uri-resolver.ts
@@ -1,0 +1,40 @@
+/**
+ * Resolves POPS URIs (pops:{app}/{type}/{id}) to frontend routes.
+ *
+ * Each search adapter produces URIs like "pops:media/movie/42". This module
+ * maps those to the correct frontend route ("/media/movies/42") so that
+ * clicking a search result navigates to the right page.
+ */
+
+/** Map of {app}/{type} → route prefix. */
+const URI_ROUTE_MAP: Record<string, string> = {
+  "media/movie": "/media/movies",
+  "media/tv-show": "/media/tv",
+  "finance/transaction": "/finance/transactions",
+  "finance/entity": "/finance/entities",
+  "finance/budget": "/finance/budgets",
+  "inventory/item": "/inventory/items",
+};
+
+/**
+ * Resolve a POPS URI to a frontend route path.
+ *
+ * @param uri - A URI like "pops:media/movie/42"
+ * @returns The frontend route (e.g. "/media/movies/42"), or null if unresolvable.
+ */
+export function resolveUri(uri: string): string | null {
+  if (!uri.startsWith("pops:")) return null;
+
+  const rest = uri.slice(5); // Remove "pops:" prefix
+  const lastSlash = rest.lastIndexOf("/");
+  if (lastSlash === -1) return null;
+
+  const prefix = rest.slice(0, lastSlash); // e.g. "media/movie"
+  const id = rest.slice(lastSlash + 1); // e.g. "42"
+  if (!id) return null;
+
+  const routePrefix = URI_ROUTE_MAP[prefix];
+  if (!routePrefix) return null;
+
+  return `${routePrefix}/${id}`;
+}

--- a/packages/navigation/src/useSearchResultNavigation.test.tsx
+++ b/packages/navigation/src/useSearchResultNavigation.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router";
+import { AppContextProvider } from "./AppContextProvider";
+import { useSearchResultNavigation } from "./hooks";
+
+/** Displays navigation result and current location for assertions. */
+function NavTester({ uri }: { uri: string }) {
+  const { navigateTo } = useSearchResultNavigation();
+  const location = useLocation();
+  return (
+    <div>
+      <span data-testid="pathname">{location.pathname}</span>
+      <button onClick={() => navigateTo(uri)}>navigate</button>
+    </div>
+  );
+}
+
+/** Renders inside MemoryRouter + AppContextProvider. */
+function renderAt(path: string, ui: React.ReactNode) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppContextProvider>{ui}</AppContextProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("useSearchResultNavigation", () => {
+  it("navigates to resolved route on valid URI", async () => {
+    renderAt("/media", <NavTester uri="pops:media/movie/42" />);
+
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/media");
+
+    await act(async () => {
+      screen.getByRole("button", { name: "navigate" }).click();
+    });
+
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/media/movies/42");
+  });
+
+  it("does not navigate on invalid URI", async () => {
+    renderAt("/media", <NavTester uri="invalid:uri" />);
+
+    await act(async () => {
+      screen.getByRole("button", { name: "navigate" }).click();
+    });
+
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/media");
+  });
+
+  it("returns true on successful navigation", () => {
+    let result = false;
+
+    function Tester() {
+      const { navigateTo } = useSearchResultNavigation();
+      return (
+        <button
+          onClick={() => {
+            result = navigateTo("pops:finance/entity/5");
+          }}
+        >
+          go
+        </button>
+      );
+    }
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <AppContextProvider>
+          <Tester />
+        </AppContextProvider>
+      </MemoryRouter>
+    );
+
+    act(() => {
+      screen.getByRole("button", { name: "go" }).click();
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false on failed navigation", () => {
+    let result = true;
+
+    function Tester() {
+      const { navigateTo } = useSearchResultNavigation();
+      return (
+        <button
+          onClick={() => {
+            result = navigateTo("bad:uri");
+          }}
+        >
+          go
+        </button>
+      );
+    }
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <AppContextProvider>
+          <Tester />
+        </AppContextProvider>
+      </MemoryRouter>
+    );
+
+    act(() => {
+      screen.getByRole("button", { name: "go" }).click();
+    });
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `resolveUri(uri)` that maps POPS URIs (`pops:media/movie/42` → `/media/movies/42`) to frontend routes
- Supports 6 domain/type mappings: media/movie, media/tv-show, finance/transaction, finance/entity, finance/budget, inventory/item
- Add `useSearchResultNavigation()` hook with `navigateTo(uri)` callback for search result click handling
- 15 tests covering all domain mappings, malformed URIs, and hook navigation behavior

## Test plan
- [x] Typecheck passes
- [x] Format check passes
- [x] Lint passes
- [ ] Unit tests pass in CI (vitest with jsdom hangs in sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)