### PR TITLE
feat(search): TopBar search input with debounce + Cmd+K [tb-204]

### DIFF
--- a/apps/pops-shell/src/app/layout/SearchInput.tsx
+++ b/apps/pops-shell/src/app/layout/SearchInput.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef } from "react";
+import { Search, X } from "lucide-react";
+import { Input, Button } from "@pops/ui";
+import { useSearchStore } from "@/store/searchStore";
+
+const DEBOUNCE_MS = 300;
+
+export function SearchInput() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const query = useSearchStore((s) => s.query);
+  const setQuery = useSearchStore((s) => s.setQuery);
+  const clear = useSearchStore((s) => s.clear);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+
+      if (timerRef.current) clearTimeout(timerRef.current);
+
+      timerRef.current = setTimeout(() => {
+        setQuery(value);
+      }, DEBOUNCE_MS);
+
+      // Update the input immediately for responsiveness
+      // but debounce the store update
+    },
+    [setQuery]
+  );
+
+  const handleClear = useCallback(() => {
+    clear();
+    if (inputRef.current) {
+      inputRef.current.value = "";
+      inputRef.current.focus();
+    }
+  }, [clear]);
+
+  // Cmd+K / Ctrl+K keyboard shortcut
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  // Clean up debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return (
+    <div className="hidden md:flex relative items-center max-w-sm w-full mx-4">
+      <Search className="absolute left-2.5 h-4 w-4 text-muted-foreground pointer-events-none" />
+      <Input
+        ref={inputRef}
+        type="text"
+        placeholder="Search POPS..."
+        defaultValue={query}
+        onChange={handleChange}
+        className="pl-9 pr-9 h-9 bg-muted/50 border-transparent focus:border-border focus:bg-background transition-colors"
+        aria-label="Search POPS"
+      />
+      {query ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleClear}
+          className="absolute right-1 h-7 w-7 text-muted-foreground hover:text-foreground"
+          aria-label="Clear search"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      ) : (
+        <kbd className="absolute right-2.5 hidden lg:inline-flex h-5 items-center gap-0.5 rounded border bg-muted px-1.5 text-[10px] font-medium text-muted-foreground pointer-events-none">
+          ⌘K
+        </kbd>
+      )}
+    </div>
+  );
+}

--- a/apps/pops-shell/src/app/layout/TopBar.tsx
+++ b/apps/pops-shell/src/app/layout/TopBar.tsx
@@ -9,6 +9,7 @@ import { useUIStore } from "@/store/uiStore";
 import { Menu, Sun, Moon } from "lucide-react";
 import { Button } from "@pops/ui";
 import { BuildVersion } from "./BuildVersion";
+import { SearchInput } from "./SearchInput";
 
 export function TopBar() {
   const theme = useThemeStore((state) => state.theme);
@@ -33,6 +34,8 @@ export function TopBar() {
         </h1>
         <BuildVersion />
       </div>
+
+      <SearchInput />
 
       <div className="ml-auto flex items-center gap-1 md:gap-4">
         <Button

--- a/apps/pops-shell/src/store/searchStore.test.ts
+++ b/apps/pops-shell/src/store/searchStore.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useSearchStore } from "@/store/searchStore";
+
+describe("searchStore", () => {
+  beforeEach(() => {
+    useSearchStore.setState({ query: "", isOpen: false });
+  });
+
+  it("defaults to empty query and closed", () => {
+    expect(useSearchStore.getState().query).toBe("");
+    expect(useSearchStore.getState().isOpen).toBe(false);
+  });
+
+  it("setQuery updates query and opens when non-empty", () => {
+    useSearchStore.getState().setQuery("test");
+    expect(useSearchStore.getState().query).toBe("test");
+    expect(useSearchStore.getState().isOpen).toBe(true);
+  });
+
+  it("setQuery closes when empty", () => {
+    useSearchStore.getState().setQuery("test");
+    useSearchStore.getState().setQuery("");
+    expect(useSearchStore.getState().query).toBe("");
+    expect(useSearchStore.getState().isOpen).toBe(false);
+  });
+
+  it("clear resets query and closes", () => {
+    useSearchStore.getState().setQuery("hello");
+    useSearchStore.getState().clear();
+    expect(useSearchStore.getState().query).toBe("");
+    expect(useSearchStore.getState().isOpen).toBe(false);
+  });
+
+  it("setOpen controls isOpen independently", () => {
+    useSearchStore.getState().setOpen(true);
+    expect(useSearchStore.getState().isOpen).toBe(true);
+
+    useSearchStore.getState().setOpen(false);
+    expect(useSearchStore.getState().isOpen).toBe(false);
+  });
+});

--- a/apps/pops-shell/src/store/searchStore.ts
+++ b/apps/pops-shell/src/store/searchStore.ts
@@ -1,0 +1,21 @@
+/**
+ * Search store — manages search input state
+ * Not persisted (search is ephemeral)
+ */
+import { create } from "zustand";
+
+interface SearchState {
+  query: string;
+  isOpen: boolean;
+  setQuery: (query: string) => void;
+  setOpen: (open: boolean) => void;
+  clear: () => void;
+}
+
+export const useSearchStore = create<SearchState>()((set) => ({
+  query: "",
+  isOpen: false,
+  setQuery: (query) => set({ query, isOpen: query.length > 0 }),
+  setOpen: (open) => set({ isOpen: open }),
+  clear: () => set({ query: "", isOpen: false }),
+}));

--- a/docs/themes/01-foundation/prds/056-search-ui/README.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/README.md
@@ -25,7 +25,7 @@ Build the search UI — a TopBar search bar with a results panel that shows cont
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-search-bar](us-01-search-bar.md) | TopBar search input with keyboard shortcut, focus management, debounce | Not started | Yes |
+| 01 | [us-01-search-bar](us-01-search-bar.md) | TopBar search input with keyboard shortcut, focus management, debounce | Partial | Yes |
 | 02 | [us-02-results-panel](us-02-results-panel.md) | Dropdown panel layout with domain sections, context ordering, close behavior | Not started | Yes |
 | 02b | [us-02b-result-component-registry](us-02b-result-component-registry.md) | Frontend ResultComponent registry, domain lookup, generic fallback, show more | Not started | Blocked by us-02 |
 | 03 | [us-03-result-navigation](us-03-result-navigation.md) | Click/keyboard-navigate results, resolve URIs to routes | Not started | Yes |

--- a/docs/themes/01-foundation/prds/056-search-ui/us-01-search-bar.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/us-01-search-bar.md
@@ -1,7 +1,7 @@
 # US-01: TopBar search bar
 
 > PRD: [056 — Search UI](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -9,11 +9,11 @@ As a user, I want a search bar in the TopBar so that I can search the entire pla
 
 ## Acceptance Criteria
 
-- [ ] Search input in the TopBar, always visible on desktop
-- [ ] Keyboard shortcut to focus (Cmd+K or Ctrl+K)
-- [ ] Placeholder text: "Search POPS..."
-- [ ] Debounced input (300ms) before triggering search
-- [ ] Clear button when text is present
+- [x] Search input in the TopBar, always visible on desktop
+- [x] Keyboard shortcut to focus (Cmd+K or Ctrl+K)
+- [x] Placeholder text: "Search POPS..."
+- [x] Debounced input (300ms) before triggering search
+- [x] Clear button when text is present
 - [ ] Mobile: collapses to search icon, expands on tap
 - [ ] Focus trap when results panel is open
 


### PR DESCRIPTION
## Summary
- Adds `SearchInput` component to TopBar — always visible on desktop (hidden on mobile, deferred to tb-205)
- Debounced input (300ms) backed by zustand `searchStore`
- Cmd+K / Ctrl+K keyboard shortcut to focus the search input
- Clear button (X) when query is present, ⌘K hint when empty
- 5 store tests covering query state, open/close, and clear behavior
- Updates US-01 status to Partial (desktop criteria done, mobile + focus trap remain)

Closes #1258

## Test plan
- [ ] Search input visible on desktop, hidden on mobile
- [ ] Typing debounces store update by 300ms
- [ ] Cmd+K focuses the input
- [ ] Clear button resets query and refocuses
- [ ] ⌘K hint shows when input is empty, hidden when query present

🤖 Generated with [Claude Code](https://claude.com/claude-code)