### PR TITLE
docs: sync search epic/PRD status with implementation

### DIFF
--- a/docs/themes/01-foundation/epics/07-search.md
+++ b/docs/themes/01-foundation/epics/07-search.md
@@ -10,8 +10,8 @@ Build a platform-wide search system accessible from the TopBar. Searches across 
 
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
-| 056 | [Search UI](../prds/056-search-ui/README.md) | TopBar search bar, results panel with context-aware sections (current app first), keyboard navigation, recent searches, result linking via URIs | Not started |
-| 057 | [Search Engine](../prds/057-search-engine/README.md) | Cross-domain query fan-out, domain adapter interface, relevance ranking, context-based ordering. Structured query syntax (`type:movie year:>2000 fight`) as progressive enhancement | Not started |
+| 056 | [Search UI](../prds/056-search-ui/README.md) | TopBar search bar, results panel with context-aware sections (current app first), keyboard navigation, recent searches, result linking via URIs | In progress |
+| 057 | [Search Engine](../prds/057-search-engine/README.md) | Cross-domain query fan-out, domain adapter interface, relevance ranking, context-based ordering. Structured query syntax (`type:movie year:>2000 fight`) as progressive enhancement | In progress |
 | 058 | [Contextual Intelligence](../prds/058-contextual-intelligence/README.md) | Shell tracks active app, page, entity being viewed. Exposes via context/store for Search, AI Overlay, and future consumers | Not started |
 
 PRD-058 first (context system). PRD-057 consumes it (engine uses context for ranking). PRD-056 consumes both (UI displays context-aware results).

--- a/docs/themes/01-foundation/prds/056-search-ui/README.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/README.md
@@ -1,7 +1,7 @@
 # PRD-056: Search UI
 
 > Epic: [07 — Search](../../epics/07-search.md)
-> Status: Not started
+> Status: In progress
 
 ## Overview
 
@@ -25,12 +25,12 @@ Build the search UI — a TopBar search bar with a results panel that shows cont
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-search-bar](us-01-search-bar.md) | TopBar search input with keyboard shortcut, focus management, debounce | Partial | Yes |
-| 02 | [us-02-results-panel](us-02-results-panel.md) | Dropdown panel layout with domain sections, context ordering, close behavior | Not started | Yes |
-| 02b | [us-02b-result-component-registry](us-02b-result-component-registry.md) | Frontend ResultComponent registry, domain lookup, generic fallback, show more | Not started | Blocked by us-02 |
-| 03 | [us-03-result-navigation](us-03-result-navigation.md) | Click/keyboard-navigate results, resolve URIs to routes | Not started | Yes |
-| 04 | [us-04-recent-searches](us-04-recent-searches.md) | Recent search history in localStorage, shown when input is empty | Not started | Blocked by us-01 |
-| 05 | [us-05-keyboard-nav](us-05-keyboard-nav.md) | Arrow keys navigate results across sections, Enter selects, Escape closes | Not started | Blocked by us-02 |
+| 01 | [us-01-search-bar](us-01-search-bar.md) | TopBar search input with keyboard shortcut, focus management, debounce | Done | Yes |
+| 02 | [us-02-results-panel](us-02-results-panel.md) | Dropdown panel layout with domain sections, context ordering, close behavior | In progress | Yes |
+| 02b | [us-02b-result-component-registry](us-02b-result-component-registry.md) | Frontend ResultComponent registry, domain lookup, generic fallback, show more | Partial | Blocked by us-02 |
+| 03 | [us-03-result-navigation](us-03-result-navigation.md) | Click/keyboard-navigate results, resolve URIs to routes | In progress | Yes |
+| 04 | [us-04-recent-searches](us-04-recent-searches.md) | Recent search history in localStorage, shown when input is empty | Done | — |
+| 05 | [us-05-keyboard-nav](us-05-keyboard-nav.md) | Arrow keys navigate results across sections, Enter selects, Escape closes | In progress | — |
 
 ## Out of Scope
 

--- a/docs/themes/01-foundation/prds/057-search-engine/README.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/README.md
@@ -1,7 +1,7 @@
 # PRD-057: Search Engine
 
 > Epic: [07 — Search](../../epics/07-search.md)
-> Status: Not started
+> Status: In progress
 
 ## Overview
 
@@ -68,22 +68,22 @@ v1 is plain text only. Structured syntax added as v2 USs.
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-adapter-interface](us-01-adapter-interface.md) | SearchAdapter, SearchHit, Query, SearchContext interfaces and adapter registry | Not started | No (first) |
-| 02 | [us-02-movies-adapter](us-02-movies-adapter.md) | Movies backend adapter: search by title | Not started | Blocked by us-01 |
-| 02b | [us-02b-movies-result-component](us-02b-movies-result-component.md) | Movies ResultComponent: poster + title + year + rating + runtime | Not started | Blocked by us-02 |
-| 03 | [us-03-tv-shows-adapter](us-03-tv-shows-adapter.md) | TV shows backend adapter: search by name | Not started | Blocked by us-01 |
-| 03b | [us-03b-tv-shows-result-component](us-03b-tv-shows-result-component.md) | TV shows ResultComponent: poster + name + status + seasons | Not started | Blocked by us-03 |
+| 01 | [us-01-adapter-interface](us-01-adapter-interface.md) | SearchAdapter, SearchHit, Query, SearchContext interfaces and adapter registry | Done | No (first) |
+| 02 | [us-02-movies-adapter](us-02-movies-adapter.md) | Movies backend adapter: search by title | Done | — |
+| 02b | [us-02b-movies-result-component](us-02b-movies-result-component.md) | Movies ResultComponent: poster + title + year + rating + runtime | Done | — |
+| 03 | [us-03-tv-shows-adapter](us-03-tv-shows-adapter.md) | TV shows backend adapter: search by name | Done | — |
+| 03b | [us-03b-tv-shows-result-component](us-03b-tv-shows-result-component.md) | TV shows ResultComponent: poster + name + status + seasons | In progress | — |
 | 04 | [us-04-transactions-adapter](us-04-transactions-adapter.md) | Transactions backend adapter: search by description | Done | — |
-| 04b | [us-04b-transactions-result-component](us-04b-transactions-result-component.md) | Transactions ResultComponent: description + colored amount + date | Not started | Blocked by us-04 |
-| 05 | [us-05-entities-adapter](us-05-entities-adapter.md) | Entities backend adapter: search by name | Done | Blocked by us-01 |
+| 04b | [us-04b-transactions-result-component](us-04b-transactions-result-component.md) | Transactions ResultComponent: description + colored amount + date | In progress | — |
+| 05 | [us-05-entities-adapter](us-05-entities-adapter.md) | Entities backend adapter: search by name | Done | — |
 | 05b | [us-05b-entities-result-component](us-05b-entities-result-component.md) | Entities ResultComponent: name + type badge + aliases | Done | — |
-| 06 | [us-06-budgets-adapter](us-06-budgets-adapter.md) | Budgets backend adapter: search by category | Not started | Blocked by us-01 |
-| 06b | [us-06b-budgets-result-component](us-06b-budgets-result-component.md) | Budgets ResultComponent: category + period + amount | Not started | Blocked by us-06 |
-| 07 | [us-07-inventory-items-adapter](us-07-inventory-items-adapter.md) | Inventory items backend adapter: search by name and asset ID | Not started | Blocked by us-01 |
-| 07b | [us-07b-inventory-items-result-component](us-07b-inventory-items-result-component.md) | Inventory ResultComponent: asset badge + name + location + type | Not started | Blocked by us-07 |
-| 08 | [us-08-fan-out-ranking](us-08-fan-out-ranking.md) | Query fan-out to all adapters, section collection, context ordering | Not started | Blocked by us-02 through us-07 |
-| 08b | [us-08b-show-more-pagination](us-08b-show-more-pagination.md) | Show more pagination within a single domain section | Not started | Blocked by us-08 |
-| 09 | [us-09-structured-syntax](us-09-structured-syntax.md) | Parse structured query syntax (type:, domain:, year:, value:) and apply filters | Not started | Blocked by us-08 |
+| 06 | [us-06-budgets-adapter](us-06-budgets-adapter.md) | Budgets backend adapter: search by category | Done | — |
+| 06b | [us-06b-budgets-result-component](us-06b-budgets-result-component.md) | Budgets ResultComponent: category + period + amount | In progress | — |
+| 07 | [us-07-inventory-items-adapter](us-07-inventory-items-adapter.md) | Inventory items backend adapter: search by name and asset ID | Done | — |
+| 07b | [us-07b-inventory-items-result-component](us-07b-inventory-items-result-component.md) | Inventory ResultComponent: asset badge + name + location + type | Done | — |
+| 08 | [us-08-fan-out-ranking](us-08-fan-out-ranking.md) | Query fan-out to all adapters, section collection, context ordering | Done | — |
+| 08b | [us-08b-show-more-pagination](us-08b-show-more-pagination.md) | Show more pagination within a single domain section | In progress | — |
+| 09 | [us-09-structured-syntax](us-09-structured-syntax.md) | Parse structured query syntax (type:, domain:, year:, value:) and apply filters | In progress | — |
 
 All 6 backend adapters (us-02 through us-07) can parallelise. All 6 frontend components (us-02b through us-07b) can parallelise once their backend counterpart is done.
 

--- a/docs/themes/01-foundation/prds/057-search-engine/us-08-fan-out-ranking.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-08-fan-out-ranking.md
@@ -1,7 +1,7 @@
 # US-08: Fan-out and section ordering
 
 > PRD: [057 — Search Engine](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,15 +9,15 @@ As the system, I fan a query out to all registered adapters in parallel, collect
 
 ## Acceptance Criteria
 
-- [ ] `searchAll(query: Query, context: SearchContext)` fans query + context to all registered adapters in parallel (`Promise.allSettled`)
-- [ ] If one adapter fails, other results still returned — failed section omitted with console warning
-- [ ] Results collected into sections (one per adapter domain)
-- [ ] Context sections: adapters whose domain belongs to the current app appear first, with `isContextSection: true`
-- [ ] Other sections ordered by highest score in section (descending)
-- [ ] Each section limited to 5 hits
-- [ ] Each section includes `totalCount` for "show more" UI
-- [ ] Response shape: `{ sections: Array<{ domain, icon, color, isContextSection, hits: SearchHit[], totalCount }> }`
-- [ ] Tests: fan-out calls all adapters, failure isolation works, context sections first, ordering by max score
+- [x] `searchAll(query: Query, context: SearchContext)` fans query + context to all registered adapters in parallel (`Promise.allSettled`)
+- [x] If one adapter fails, other results still returned — failed section omitted with console warning
+- [x] Results collected into sections (one per adapter domain)
+- [x] Context sections: adapters whose domain belongs to the current app appear first, with `isContextSection: true`
+- [x] Other sections ordered by highest score in section (descending)
+- [x] Each section limited to 5 hits
+- [x] Each section includes `totalCount` for "show more" UI
+- [x] Response shape: `{ sections: Array<{ domain, icon, color, isContextSection, hits: SearchHit[], totalCount }> }`
+- [x] Tests: fan-out calls all adapters, failure isolation works, context sections first, ordering by max score
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Update PRD-056 (Search UI) and PRD-057 (Search Engine) user story status tables to reflect merged PRs
- Mark us-08 (fan-out ranking) as Done with all acceptance criteria checked
- Update Epic 07 (Search) PRD statuses to In progress
- Stories with open PRs marked In progress; stories with merged PRs marked Done

## Test plan
- [ ] Verify status values match merged PR state on main
- [ ] Confirm no content changes, only status field updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)