### PR TITLE
feat(arena): Not Watched buttons in action bar with comparison count [tb-215]

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -30,6 +30,7 @@ let excludeCallCount = 0;
 const mockBlacklistMutate = vi.fn() as ReturnType<typeof vi.fn> & {
   _opts?: Record<string, unknown>;
 };
+const mockListForMediaQuery = vi.fn();
 const mockInvalidateRandomPair = vi.fn();
 const mockInvalidateWatchlistList = vi.fn();
 
@@ -78,6 +79,9 @@ vi.mock("../lib/trpc", () => ({
             mockBlacklistMutate._opts = opts;
             return { mutate: mockBlacklistMutate, isPending: false };
           },
+        },
+        listForMedia: {
+          useQuery: (...args: unknown[]) => mockListForMediaQuery(...args),
         },
       },
       watchlist: {
@@ -143,15 +147,23 @@ function setupArena() {
     data: { data: [] },
     isLoading: false,
   });
+  mockListForMediaQuery.mockReturnValue({
+    data: null,
+    isLoading: false,
+  });
 }
 
 describe("CompareArenaPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     excludeCallCount = 0;
-    // Default watchlist mock — overridden by setupArena but needed for standalone tests
+    // Default mocks — overridden by setupArena but needed for standalone tests
     mockWatchlistListQuery.mockReturnValue({
       data: { data: [] },
+      isLoading: false,
+    });
+    mockListForMediaQuery.mockReturnValue({
+      data: null,
       isLoading: false,
     });
   });
@@ -426,27 +438,48 @@ describe("CompareArenaPage", () => {
     expect(mockRecordMutate).not.toHaveBeenCalled();
   });
 
-  it("renders Not Watched buttons for both movies", () => {
+  it("renders Not Watched buttons for both movies on cards and in action bar", () => {
     setupArena();
     renderPage();
-    expect(screen.getByLabelText("Not watched The Matrix")).toBeTruthy();
-    expect(screen.getByLabelText("Not watched Inception")).toBeTruthy();
+    // Both card buttons and action bar buttons have the same aria-label
+    const matrixButtons = screen.getAllByLabelText("Not watched The Matrix");
+    const inceptionButtons = screen.getAllByLabelText("Not watched Inception");
+    expect(matrixButtons.length).toBe(2); // card + action bar
+    expect(inceptionButtons.length).toBe(2); // card + action bar
   });
 
-  it("opens confirmation dialog when Not Watched button is clicked", () => {
+  it("renders Not Watched action bar buttons with movie titles", () => {
     setupArena();
     renderPage();
-    fireEvent.click(screen.getByLabelText("Not watched The Matrix"));
+    expect(screen.getByText("Not Watched: The Matrix")).toBeTruthy();
+    expect(screen.getByText("Not Watched: Inception")).toBeTruthy();
+  });
+
+  it("opens confirmation dialog when action bar Not Watched button is clicked", () => {
+    setupArena();
+    renderPage();
+    fireEvent.click(screen.getByText("Not Watched: The Matrix"));
     expect(screen.getByText("Mark as not watched?")).toBeTruthy();
-    expect(screen.getByText(/All comparisons involving this movie/)).toBeTruthy();
     expect(screen.getByText("Cancel")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Not Watched" })).toBeTruthy();
+  });
+
+  it("shows comparison count in confirmation dialog", () => {
+    setupArena();
+    mockListForMediaQuery.mockReturnValue({
+      data: { data: [], pagination: { total: 5 } },
+      isLoading: false,
+    });
+    renderPage();
+    fireEvent.click(screen.getByText("Not Watched: The Matrix"));
+    expect(screen.getByText("5")).toBeTruthy();
+    expect(screen.getByText(/comparisons involving/)).toBeTruthy();
   });
 
   it("calls blacklistMovie mutation on confirm", () => {
     setupArena();
     renderPage();
-    fireEvent.click(screen.getByLabelText("Not watched Inception"));
+    fireEvent.click(screen.getByText("Not Watched: Inception"));
     fireEvent.click(screen.getByRole("button", { name: "Not Watched" }));
     expect(mockBlacklistMutate).toHaveBeenCalledWith({ mediaType: "movie", mediaId: 20 });
   });
@@ -454,7 +487,7 @@ describe("CompareArenaPage", () => {
   it("closes dialog on cancel without calling blacklist", () => {
     setupArena();
     renderPage();
-    fireEvent.click(screen.getByLabelText("Not watched The Matrix"));
+    fireEvent.click(screen.getByText("Not Watched: The Matrix"));
     expect(screen.getByText("Mark as not watched?")).toBeTruthy();
     fireEvent.click(screen.getByText("Cancel"));
     expect(mockBlacklistMutate).not.toHaveBeenCalled();

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -212,6 +212,13 @@ export function CompareArenaPage() {
     title: string;
   } | null>(null);
 
+  // Fetch comparison count for the blacklist target (shown in confirmation dialog)
+  const { data: blacklistComparisonData } = trpc.media.comparisons.listForMedia.useQuery(
+    { mediaType: "movie", mediaId: blacklistTarget?.id ?? 0, limit: 1 },
+    { enabled: blacklistTarget !== null }
+  );
+  const comparisonsToPurge = blacklistComparisonData?.pagination?.total ?? null;
+
   const blacklistMutation = trpc.media.comparisons.blacklistMovie.useMutation({
     onSuccess: (_data: unknown, variables: { mediaType: string; mediaId: number }) => {
       const movie =
@@ -516,6 +523,44 @@ export function CompareArenaPage() {
             </Tooltip>
           </div>
           <div className="flex justify-center gap-3">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleBlacklist(pairData.data.movieA)}
+                  disabled={blacklistMutation.isPending}
+                  className="text-red-500 border-red-200 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-950/30 hover:text-red-600"
+                  aria-label={`Not watched ${pairData.data.movieA.title}`}
+                >
+                  <X className="h-3.5 w-3.5 mr-1.5" />
+                  Not Watched: {pairData.data.movieA.title}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Mark as not watched — removes all comparisons for this movie
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleBlacklist(pairData.data.movieB)}
+                  disabled={blacklistMutation.isPending}
+                  className="text-red-500 border-red-200 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-950/30 hover:text-red-600"
+                  aria-label={`Not watched ${pairData.data.movieB.title}`}
+                >
+                  <X className="h-3.5 w-3.5 mr-1.5" />
+                  Not Watched: {pairData.data.movieB.title}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Mark as not watched — removes all comparisons for this movie
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <div className="flex justify-center gap-3">
             <Button
               variant="outline"
               size="sm"
@@ -551,9 +596,20 @@ export function CompareArenaPage() {
           <AlertDialogHeader>
             <AlertDialogTitle>Mark as not watched?</AlertDialogTitle>
             <AlertDialogDescription>
-              All comparisons involving this movie will be deleted and scores recalculated. This
-              marks <span className="font-medium text-foreground">{blacklistTarget?.title}</span> as
-              not watched.
+              {comparisonsToPurge !== null ? (
+                <>
+                  <span className="font-medium text-foreground">{comparisonsToPurge}</span>{" "}
+                  comparison{comparisonsToPurge !== 1 ? "s" : ""} involving{" "}
+                  <span className="font-medium text-foreground">{blacklistTarget?.title}</span> will
+                  be deleted and scores recalculated.
+                </>
+              ) : (
+                <>
+                  All comparisons involving{" "}
+                  <span className="font-medium text-foreground">{blacklistTarget?.title}</span> will
+                  be deleted and scores recalculated.
+                </>
+              )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
## Summary
- Add labeled "Not Watched: Movie A" and "Not Watched: Movie B" buttons to the arena action bar with destructive red styling (red text, red border)
- Enhance confirmation dialog to show the exact number of comparisons that will be purged (fetched via `listForMedia` when dialog opens)
- Add tests for action bar buttons, comparison count display, confirm/cancel flows

## Test plan
- [ ] Action bar shows two red "Not Watched" buttons with movie titles
- [ ] Clicking opens confirmation dialog with movie title and comparison count
- [ ] Confirm calls `blacklistMovie` mutation
- [ ] Cancel closes dialog without side effects
- [ ] Buttons disabled while mutation is pending
- [ ] All 22 tests pass

Closes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)