### PR TITLE
feat(search): show-more in SearchResultsPanel [tb-207]

### DIFF
--- a/packages/navigation/src/SearchResultsPanel.test.tsx
+++ b/packages/navigation/src/SearchResultsPanel.test.tsx
@@ -9,32 +9,34 @@ beforeEach(() => {
 });
 
 function makeSection(overrides: Partial<SearchResultSection> = {}): SearchResultSection {
+  const hits = overrides.hits ?? [
+    {
+      uri: "pops:media/movie/1",
+      score: 0.8,
+      matchField: "title",
+      matchType: "prefix",
+      data: { title: "The Matrix" },
+    },
+  ];
   return {
     domain: "movies",
     label: "Movies",
     icon: <span data-testid="icon">🎬</span>,
     color: "purple",
-    hits: [
-      {
-        uri: "pops:media/movie/1",
-        score: 0.8,
-        matchField: "title",
-        matchType: "prefix",
-        data: { title: "The Matrix" },
-      },
-    ],
+    hits,
+    totalCount: overrides.totalCount ?? hits.length,
     isContext: false,
     ...overrides,
   };
 }
 
 describe("SearchResultsPanel", () => {
-  it("renders sections with headers", () => {
-    const sections = [makeSection()];
+  it("renders sections with headers showing total count", () => {
+    const sections = [makeSection({ totalCount: 12 })];
     render(<SearchResultsPanel sections={sections} query="matrix" onClose={vi.fn()} />);
     expect(screen.getByTestId("search-results-panel")).toBeInTheDocument();
     expect(screen.getByText("Movies")).toBeInTheDocument();
-    expect(screen.getByText("1")).toBeInTheDocument(); // count
+    expect(screen.getByText("12")).toBeInTheDocument(); // totalCount
   });
 
   it("renders no results state when all sections are empty", () => {
@@ -82,7 +84,7 @@ describe("SearchResultsPanel", () => {
       }),
     ];
     render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
-    const sectionElements = screen.getAllByTestId(/^section-/);
+    const sectionElements = screen.getAllByTestId(/^section-(?!header)/);
     expect(sectionElements[0]).toHaveAttribute("data-testid", "section-transactions");
     expect(sectionElements[1]).toHaveAttribute("data-testid", "section-movies");
   });
@@ -109,7 +111,7 @@ describe("SearchResultsPanel", () => {
       }),
     ];
     render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
-    const sectionElements = screen.getAllByTestId(/^section-/);
+    const sectionElements = screen.getAllByTestId(/^section-(?!header)/);
     expect(sectionElements[0]).toHaveAttribute("data-testid", "section-movies");
     expect(sectionElements[1]).toHaveAttribute("data-testid", "section-budgets");
   });
@@ -180,5 +182,40 @@ describe("SearchResultsPanel", () => {
     ];
     render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
     expect(screen.getByText("Fallback Item")).toBeInTheDocument();
+  });
+
+  it("shows 'Show more' link when totalCount exceeds displayed hits", () => {
+    const sections = [makeSection({ totalCount: 15 })];
+    render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
+    expect(screen.getByTestId("show-more-movies")).toBeInTheDocument();
+    expect(screen.getByText("Show more (14 remaining)")).toBeInTheDocument();
+  });
+
+  it("hides 'Show more' link when totalCount equals hits length", () => {
+    const sections = [makeSection({ totalCount: 1 })];
+    render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
+    expect(screen.queryByTestId("show-more-movies")).not.toBeInTheDocument();
+  });
+
+  it("calls onShowMore with domain when 'Show more' is clicked", () => {
+    const onShowMore = vi.fn();
+    const sections = [makeSection({ totalCount: 10 })];
+    render(
+      <SearchResultsPanel
+        sections={sections}
+        query="test"
+        onClose={vi.fn()}
+        onShowMore={onShowMore}
+      />
+    );
+    fireEvent.click(screen.getByTestId("show-more-movies"));
+    expect(onShowMore).toHaveBeenCalledWith("movies");
+    expect(onShowMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show 'Show more' when totalCount is not provided (defaults to hits length)", () => {
+    const sections = [makeSection()]; // totalCount defaults to hits.length
+    render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
+    expect(screen.queryByTestId("show-more-movies")).not.toBeInTheDocument();
   });
 });

--- a/packages/navigation/src/SearchResultsPanel.tsx
+++ b/packages/navigation/src/SearchResultsPanel.tsx
@@ -18,6 +18,7 @@ export interface SearchResultSection {
   icon: ReactNode;
   color: string;
   hits: SearchResultHit[];
+  totalCount: number;
   isContext: boolean;
 }
 
@@ -26,6 +27,7 @@ export interface SearchResultsPanelProps {
   query: string;
   onClose: () => void;
   onResultClick?: (uri: string) => void;
+  onShowMore?: (domain: string) => void;
 }
 
 const COLOR_CLASSES: Record<string, string> = {
@@ -69,6 +71,7 @@ export function SearchResultsPanel({
   query,
   onClose,
   onResultClick,
+  onShowMore,
 }: SearchResultsPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -143,7 +146,7 @@ export function SearchResultsPanel({
             <SectionHeader
               icon={section.icon}
               label={section.label}
-              count={section.hits.length}
+              count={section.totalCount}
               color={section.color}
             />
             <ul className="px-1 pb-1">
@@ -167,6 +170,16 @@ export function SearchResultsPanel({
                 </li>
               ))}
             </ul>
+            {section.totalCount > section.hits.length && (
+              <button
+                type="button"
+                className="w-full px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground text-left hover:bg-accent/50 transition-colors"
+                onClick={() => onShowMore?.(section.domain)}
+                data-testid={`show-more-${section.domain}`}
+              >
+                Show more ({section.totalCount - section.hits.length} remaining)
+              </button>
+            )}
           </div>
         );
       })}


### PR DESCRIPTION
## Summary
- Adds `totalCount` to `SearchResultSection` type so section headers display total available results
- Adds `onShowMore(domain)` callback prop to `SearchResultsPanel` — renders a "Show more (N remaining)" button when `totalCount > hits.length`
- Fixes pre-existing test regex that incorrectly matched `section-header-*` testids

## Test plan
- [x] Show-more link visible when `totalCount > hits.length`
- [x] Show-more link hidden when `totalCount === hits.length`
- [x] `onShowMore` callback fires with correct domain
- [x] Section header displays `totalCount` instead of `hits.length`
- [x] All 16 tests pass (12 existing + 4 new)

Depends on #1353 (tb-206).

🤖 Generated with [Claude Code](https://claude.com/claude-code)