### PR TITLE
feat(tier-list): navigate to rankings on Done [tb-230]

### DIFF
--- a/packages/app-media/src/pages/TierListPage.tsx
+++ b/packages/app-media/src/pages/TierListPage.tsx
@@ -353,7 +353,7 @@ export function TierListPage() {
   }, [reset]);
 
   const handleDone = useCallback(() => {
-    navigate("/media/compare");
+    navigate("/media/rankings");
   }, [navigate]);
 
   return (


### PR DESCRIPTION
## Summary
- Update TierListPage "Done" button to navigate to `/media/rankings` instead of `/media/compare`
- After submitting a tier list, users naturally want to see how their placements affected rankings

## Changes
- **TierListPage.tsx**: Change `handleDone` navigation from `/media/compare` to `/media/rankings`

## Test plan
- [x] TierListSummary.test.tsx — 8 tests pass (component behavior unchanged, navigation via callback)
- [x] Typecheck passes for `@pops/shell`

🤖 Generated with [Claude Code](https://claude.com/claude-code)