### PR TITLE
docs: sync PRD-060 discover page with implementation

### DIFF
--- a/docs/themes/03-media/prds/060-discover-page/README.md
+++ b/docs/themes/03-media/prds/060-discover-page/README.md
@@ -152,25 +152,25 @@ Displayed at the bottom of the page. Shows:
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-dismissed-schema](us-01-dismissed-schema.md) | dismissed_discover SQLite table, Drizzle schema + migration, dismiss/getDismissed tRPC endpoints | Done | Yes |
-| 02 | [us-02-discover-card-actions](us-02-discover-card-actions.md) | Card hover actions (Add, Watchlist, Watched, Request, Dismiss), Owned/Watched badges, loading states | Not started | Blocked by us-01 |
-| 03 | [us-03-recommendation-scoring](us-03-recommendation-scoring.md) | Preference profile scoring service: genre affinity from ELO + watch history fallback, match percentage calculation | Not started | Yes |
+| 02 | [us-02-discover-card-actions](us-02-discover-card-actions.md) | Card hover actions (Add, Watchlist, Watched, Request, Dismiss), Owned/Watched badges, loading states | Partial | Blocked by us-01 |
+| 03 | [us-03-recommendation-scoring](us-03-recommendation-scoring.md) | Preference profile scoring service: genre affinity from ELO + watch history fallback, match percentage calculation | Done | Yes |
 
 ### Section endpoints (all parallelisable after us-01 and us-03)
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 04 | [us-04-trending-tmdb](us-04-trending-tmdb.md) | TMDB trending endpoint + frontend row with day/week toggle, dedup pagination, Load More | Not started | Yes |
-| 05 | [us-05-recommendations-endpoint](us-05-recommendations-endpoint.md) | tRPC endpoint: top 10-100 ELO movies → TMDB recs, merge, deduplicate, score, exclude dismissed/library | Not started | Blocked by us-03 |
+| 04 | [us-04-trending-tmdb](us-04-trending-tmdb.md) | TMDB trending endpoint + frontend row with day/week toggle, dedup pagination, Load More | Done | Yes |
+| 05 | [us-05-recommendations-endpoint](us-05-recommendations-endpoint.md) | tRPC endpoint: top 10-100 ELO movies → TMDB recs, merge, deduplicate, score, exclude dismissed/library | Done | Blocked by us-03 |
 | 06 | [us-06-recommendations-ui](us-06-recommendations-ui.md) | Frontend row: cold start CTA, attribution labels, match % badge, subtitle with source movies | Done | Blocked by us-05 |
-| 07 | [us-07-genre-spotlight-endpoint](us-07-genre-spotlight-endpoint.md) | tRPC endpoint: select 2-3 genres with variety, fetch TMDB discover per genre, score results | Not started | Blocked by us-03 |
-| 08 | [us-08-genre-spotlight-ui](us-08-genre-spotlight-ui.md) | Frontend: genre sub-rows ("Best in Action", "Best in Sci-Fi"), Load More per genre | Not started | Blocked by us-07 |
-| 09 | [us-09-watchlist-recs](us-09-watchlist-recs.md) | tRPC endpoint + frontend row: watchlist items → TMDB similar, attribution, exclude owned/dismissed | Not started | Blocked by us-03 |
-| 10 | [us-10-trending-plex](us-10-trending-plex.md) | tRPC endpoint + frontend row: Plex Discover cloud trending, hidden when disconnected | Not started | Yes |
-| 11 | [us-11-rewatch-suggestions](us-11-rewatch-suggestions.md) | tRPC endpoint + frontend row: watched 6+ months ago with high ELO, local-only query | Not started | Yes |
-| 12 | [us-12-from-your-server](us-12-from-your-server.md) | tRPC endpoint + frontend row: unwatched library movies, scored by profile, local-only | Not started | Blocked by us-03 |
-| 13 | [us-13-context-collections](us-13-context-collections.md) | Static collection definitions: genre/keyword mappings + time/date triggers for each context | Not started | Yes |
-| 14 | [us-14-context-endpoint](us-14-context-endpoint.md) | tRPC endpoint: evaluate active collections by server clock, fetch TMDB discover per collection | Not started | Blocked by us-13 |
-| 15 | [us-15-context-ui](us-15-context-ui.md) | Frontend: 1-2 context rows with themed titles, Load More, fallback to "Rainy Day" | Not started | Blocked by us-14 |
+| 07 | [us-07-genre-spotlight-endpoint](us-07-genre-spotlight-endpoint.md) | tRPC endpoint: select 2-3 genres with variety, fetch TMDB discover per genre, score results | Done | Blocked by us-03 |
+| 08 | [us-08-genre-spotlight-ui](us-08-genre-spotlight-ui.md) | Frontend: genre sub-rows ("Best in Action", "Best in Sci-Fi"), Load More per genre | Done | Blocked by us-07 |
+| 09 | [us-09-watchlist-recs](us-09-watchlist-recs.md) | tRPC endpoint + frontend row: watchlist items → TMDB similar, attribution, exclude owned/dismissed | Done | Blocked by us-03 |
+| 10 | [us-10-trending-plex](us-10-trending-plex.md) | tRPC endpoint + frontend row: Plex Discover cloud trending, hidden when disconnected | Done | Yes |
+| 11 | [us-11-rewatch-suggestions](us-11-rewatch-suggestions.md) | tRPC endpoint + frontend row: watched 6+ months ago with high ELO, local-only query | Done | Yes |
+| 12 | [us-12-from-your-server](us-12-from-your-server.md) | tRPC endpoint + frontend row: unwatched library movies, scored by profile, local-only | Done | Blocked by us-03 |
+| 13 | [us-13-context-collections](us-13-context-collections.md) | Static collection definitions: genre/keyword mappings + time/date triggers for each context | Done | Yes |
+| 14 | [us-14-context-endpoint](us-14-context-endpoint.md) | tRPC endpoint: evaluate active collections by server clock, fetch TMDB discover per collection | Done | Blocked by us-13 |
+| 15 | [us-15-context-ui](us-15-context-ui.md) | Frontend: 1-2 context rows with themed titles, Load More, fallback to "Rainy Day" | Done | Blocked by us-14 |
 
 ### Dependency graph
 

--- a/docs/themes/03-media/prds/060-discover-page/us-02-discover-card-actions.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-02-discover-card-actions.md
@@ -1,7 +1,7 @@
 # US-02: Discover card action buttons
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -25,14 +25,14 @@ As a user, I want context-aware action buttons on every discover card that adapt
 - [ ] "Add to Library" disappears immediately after any action that adds the movie (Add, Watchlist, Watched)
 - [ ] Watchlist button toggles: outline bookmark icon = "Add to Watchlist", filled bookmark icon = "Remove from Watchlist"
 - [ ] Watched button changes based on state: Eye icon + "Mark as Watched" when unwatched; RotateCw icon + "Mark as Rewatched" when already watched
-- [ ] "Add to Watchlist" adds to library first (idempotent), then adds to watchlist — one click does both
-- [ ] "Mark as Watched" adds to library first (idempotent), then logs watch event — one click does both
+- [x] "Add to Watchlist" adds to library first (idempotent), then adds to watchlist — one click does both
+- [x] "Mark as Watched" adds to library first (idempotent), then logs watch event — one click does both
 - [ ] "Mark as Rewatched" logs an additional watch event (new timestamp) for an already-watched movie
-- [ ] "Not Interested" calls `media.discovery.dismiss` mutation (backend, not localStorage)
+- [x] "Not Interested" calls `media.discovery.dismiss` mutation (backend, not localStorage)
 
 ### Badges
 
-- [ ] "Owned" badge for movies in the library (top-right corner)
+- [x] "Owned" badge for movies in the library (top-right corner)
 - [ ] "Watched" badge for movies with a watch_history entry (replaces "Owned" when both apply)
 
 ### Data requirements
@@ -44,10 +44,10 @@ As a user, I want context-aware action buttons on every discover card that adapt
 
 ### General
 
-- [ ] Each action shows loading spinner during mutation, button disabled to prevent double-clicks
-- [ ] Toast notification confirms each action with movie title
-- [ ] After any action, relevant discover queries are invalidated so badges and button states update
-- [ ] Remove existing localStorage-based dismiss logic from DiscoverCard
+- [x] Each action shows loading spinner during mutation, button disabled to prevent double-clicks
+- [x] Toast notification confirms each action with movie title
+- [x] After any action, relevant discover queries are invalidated so badges and button states update
+- [x] Remove existing localStorage-based dismiss logic from DiscoverCard
 - [ ] Tests cover: each button state combination from the table above, toggle behaviours, badge display, loading states
 
 ## Notes

--- a/docs/themes/03-media/prds/060-discover-page/us-03-recommendation-scoring.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-03-recommendation-scoring.md
@@ -1,7 +1,7 @@
 # US-03: Recommendation scoring service
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,16 +9,16 @@ As a developer, I want a reusable scoring service that rates movies against the 
 
 ## Acceptance Criteria
 
-- [ ] `scoreDiscoverResults(results, profile)` function in the discovery service
-- [ ] Accepts an array of `DiscoverResult` and a `PreferenceProfile`
-- [ ] Maps TMDB genre IDs to genre names via `TMDB_GENRE_MAP`
-- [ ] Computes match percentage from genre affinity scores (ELO-based)
-- [ ] Falls back to watch history genre distribution when no comparison data exists
-- [ ] Match percentage scaled to 50-98% range
-- [ ] Returns `ScoredDiscoverResult[]` with `matchPercentage` and `matchReason` (top 3 matching genres)
-- [ ] Sorted by matchPercentage descending
-- [ ] Reusable by: recommendations, genre spotlight, watchlist recs, from-your-server sections
-- [ ] Tests cover: scoring with ELO data, fallback to watch history, empty profile returns 0%, genre mapping
+- [x] `scoreDiscoverResults(results, profile)` function in the discovery service
+- [x] Accepts an array of `DiscoverResult` and a `PreferenceProfile`
+- [x] Maps TMDB genre IDs to genre names via `TMDB_GENRE_MAP`
+- [x] Computes match percentage from genre affinity scores (ELO-based)
+- [x] Falls back to watch history genre distribution when no comparison data exists
+- [x] Match percentage scaled to 50-98% range
+- [x] Returns `ScoredDiscoverResult[]` with `matchPercentage` and `matchReason` (top 3 matching genres)
+- [x] Sorted by matchPercentage descending
+- [x] Reusable by: recommendations, genre spotlight, watchlist recs, from-your-server sections
+- [x] Tests cover: scoring with ELO data, fallback to watch history, empty profile returns 0%, genre mapping
 
 ## Notes
 

--- a/docs/themes/03-media/prds/060-discover-page/us-04-trending-tmdb.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-04-trending-tmdb.md
@@ -1,7 +1,7 @@
 # US-04: Trending on TMDB section
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a user, I want to browse globally trending movies from TMDB with day/week tog
 
 ## Acceptance Criteria
 
-- [ ] "Trending" `HorizontalScrollRow` with day/week pill toggle
-- [ ] Time window persists in URL `?window=day` (week is default, omitted)
-- [ ] "Load More" appends next page, deduplicated by tmdbId
-- [ ] Cards show poster, title, year, TMDB rating badge
-- [ ] Calls `media.discovery.trending` with `{ timeWindow, page }`
-- [ ] Excluded: dismissed movies
-- [ ] Error: retry button, other sections unaffected
-- [ ] Loading skeleton on first page
-- [ ] Tests cover: toggle, dedup, load more, error retry
+- [x] "Trending" `HorizontalScrollRow` with day/week pill toggle
+- [x] Time window persists in URL `?window=day` (week is default, omitted)
+- [x] "Load More" appends next page, deduplicated by tmdbId
+- [x] Cards show poster, title, year, TMDB rating badge
+- [x] Calls `media.discovery.trending` with `{ timeWindow, page }`
+- [x] Excluded: dismissed movies
+- [x] Error: retry button, other sections unaffected
+- [x] Loading skeleton on first page
+- [x] Tests cover: toggle, dedup, load more, error retry

--- a/docs/themes/03-media/prds/060-discover-page/us-05-recommendations-endpoint.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-05-recommendations-endpoint.md
@@ -1,7 +1,7 @@
 # US-05: Recommendations backend endpoint
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a developer, I want a recommendations endpoint that uses a larger source pool
 
 ## Acceptance Criteria
 
-- [ ] `media.discovery.recommendations` tRPC query accepts `{ sampleSize: number }` (default 20, max 100)
-- [ ] Source: top N library movies by overall ELO score
-- [ ] For each source, fetch TMDB `/movie/{id}/recommendations` (page 1)
-- [ ] Merge all results, deduplicate by tmdbId (keep first occurrence)
-- [ ] Exclude: movies already in library, dismissed movies (from `dismissed_discover` table)
-- [ ] Score using `scoreDiscoverResults` from us-03
-- [ ] Return `{ results: ScoredDiscoverResult[], sourceMovies: string[], totalComparisons: number }`
-- [ ] Returns empty results with `totalComparisons < 5` (cold start signal for frontend)
-- [ ] Tests cover: source selection, deduplication, library exclusion, dismissed exclusion, scoring, cold start
+- [x] `media.discovery.recommendations` tRPC query accepts `{ sampleSize: number }` (default 20, max 100)
+- [x] Source: top N library movies by overall ELO score
+- [x] For each source, fetch TMDB `/movie/{id}/recommendations` (page 1)
+- [x] Merge all results, deduplicate by tmdbId (keep first occurrence)
+- [x] Exclude: movies already in library, dismissed movies (from `dismissed_discover` table)
+- [x] Score using `scoreDiscoverResults` from us-03
+- [x] Return `{ results: ScoredDiscoverResult[], sourceMovies: string[], totalComparisons: number }`
+- [x] Returns empty results with `totalComparisons < 5` (cold start signal for frontend)
+- [x] Tests cover: source selection, deduplication, library exclusion, dismissed exclusion, scoring, cold start

--- a/docs/themes/03-media/prds/060-discover-page/us-07-genre-spotlight-endpoint.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-07-genre-spotlight-endpoint.md
@@ -1,7 +1,7 @@
 # US-07: Genre Spotlight backend endpoint
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a developer, I want an endpoint that selects the user's top genres with varie
 
 ## Acceptance Criteria
 
-- [ ] `media.discovery.genreSpotlight` tRPC query
-- [ ] Selects 2-3 genres from the user's genre affinity data (ELO-based)
-- [ ] Selection avoids closely related genres (e.g., not "Action" and "Adventure" together)
-- [ ] Falls back to watch history genre distribution if no comparison data
-- [ ] For each genre, fetch TMDB `/discover/movie?with_genres={id}&sort_by=vote_average.desc&vote_count.gte=100`
-- [ ] Exclude: library movies, dismissed movies
-- [ ] Score results using `scoreDiscoverResults`
-- [ ] Return `{ genres: Array<{ genreId: number, genreName: string, results: ScoredDiscoverResult[] }> }`
-- [ ] Returns empty when no genre data available (empty library + no comparisons)
-- [ ] Tests cover: genre variety selection, fallback, exclusions, empty state
+- [x] `media.discovery.genreSpotlight` tRPC query
+- [x] Selects 2-3 genres from the user's genre affinity data (ELO-based)
+- [x] Selection avoids closely related genres (e.g., not "Action" and "Adventure" together)
+- [x] Falls back to watch history genre distribution if no comparison data
+- [x] For each genre, fetch TMDB `/discover/movie?with_genres={id}&sort_by=vote_average.desc&vote_count.gte=100`
+- [x] Exclude: library movies, dismissed movies
+- [x] Score results using `scoreDiscoverResults`
+- [x] Return `{ genres: Array<{ genreId: number, genreName: string, results: ScoredDiscoverResult[] }> }`
+- [x] Returns empty when no genre data available (empty library + no comparisons)
+- [x] Tests cover: genre variety selection, fallback, exclusions, empty state

--- a/docs/themes/03-media/prds/060-discover-page/us-08-genre-spotlight-ui.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-08-genre-spotlight-ui.md
@@ -1,7 +1,7 @@
 # US-08: Genre Spotlight frontend rows
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,9 +9,9 @@ As a user, I want to see genre-specific rows of top movies so I can explore genr
 
 ## Acceptance Criteria
 
-- [ ] Renders 2-3 `HorizontalScrollRow` components, one per genre
-- [ ] Each row titled: "Best in {Genre}" (e.g., "Best in Action")
-- [ ] Each row supports Load More (fetches next page from TMDB discover)
-- [ ] Hidden when the endpoint returns empty genres
-- [ ] Loading skeleton while genre data loads
-- [ ] Tests cover: multiple genre rows render, titles correct, load more works
+- [x] Renders 2-3 `HorizontalScrollRow` components, one per genre
+- [x] Each row titled: "Best in {Genre}" (e.g., "Best in Action")
+- [x] Each row supports Load More (fetches next page from TMDB discover)
+- [x] Hidden when the endpoint returns empty genres
+- [x] Loading skeleton while genre data loads
+- [x] Tests cover: multiple genre rows render, titles correct, load more works

--- a/docs/themes/03-media/prds/060-discover-page/us-09-watchlist-recs.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-09-watchlist-recs.md
@@ -1,7 +1,7 @@
 # US-09: From Your Watchlist
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a user, I want recommendations based on my watchlist so I can discover movies
 
 ## Acceptance Criteria
 
-- [ ] `media.discovery.watchlistRecommendations` tRPC query
-- [ ] Source: movie-type items from POPS watchlist (cap at 10 most recently added)
-- [ ] For each, fetch TMDB `/movie/{id}/similar` (page 1)
-- [ ] Merge, deduplicate by tmdbId
-- [ ] Exclude: library movies, watchlist items, dismissed movies
-- [ ] Score using `scoreDiscoverResults`
-- [ ] Return `{ results: ScoredDiscoverResult[], sourceMovies: string[] }`
-- [ ] Frontend: `HorizontalScrollRow` with subtitle "Similar to movies on your watchlist"
-- [ ] Hidden when watchlist is empty
-- [ ] Empty state: "Add more movies to your watchlist to get suggestions"
-- [ ] Tests cover: source from watchlist, exclusions, attribution, empty state
+- [x] `media.discovery.watchlistRecommendations` tRPC query
+- [x] Source: movie-type items from POPS watchlist (cap at 10 most recently added)
+- [x] For each, fetch TMDB `/movie/{id}/similar` (page 1)
+- [x] Merge, deduplicate by tmdbId
+- [x] Exclude: library movies, watchlist items, dismissed movies
+- [x] Score using `scoreDiscoverResults`
+- [x] Return `{ results: ScoredDiscoverResult[], sourceMovies: string[] }`
+- [x] Frontend: `HorizontalScrollRow` with subtitle "Similar to movies on your watchlist"
+- [x] Hidden when watchlist is empty
+- [x] Empty state: "Add more movies to your watchlist to get suggestions"
+- [x] Tests cover: source from watchlist, exclusions, attribution, empty state

--- a/docs/themes/03-media/prds/060-discover-page/us-10-trending-plex.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-10-trending-plex.md
@@ -1,7 +1,7 @@
 # US-10: Trending on Plex
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a user, I want to see what's popular across the Plex community so I can disco
 
 ## Acceptance Criteria
 
-- [ ] `media.discovery.trendingPlex` tRPC query
-- [ ] Fetches from Plex Discover cloud API trending/popular endpoint
-- [ ] Returns results as `DiscoverResult[]` with tmdbId matching where possible
-- [ ] Hidden when Plex is not connected (no token)
-- [ ] Graceful fallback: section hidden (not error) if Plex API fails
-- [ ] Frontend: `HorizontalScrollRow` titled "Trending on Plex"
-- [ ] Exclude: dismissed movies
-- [ ] Tests cover: connected rendering, hidden when disconnected, API failure hides section
+- [x] `media.discovery.trendingPlex` tRPC query
+- [x] Fetches from Plex Discover cloud API trending/popular endpoint
+- [x] Returns results as `DiscoverResult[]` with tmdbId matching where possible
+- [x] Hidden when Plex is not connected (no token)
+- [x] Graceful fallback: section hidden (not error) if Plex API fails
+- [x] Frontend: `HorizontalScrollRow` titled "Trending on Plex"
+- [x] Exclude: dismissed movies
+- [x] Tests cover: connected rendering, hidden when disconnected, API failure hides section
 
 ## Notes
 

--- a/docs/themes/03-media/prds/060-discover-page/us-11-rewatch-suggestions.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-11-rewatch-suggestions.md
@@ -1,7 +1,7 @@
 # US-11: Rewatch Suggestions
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a user, I want suggestions for movies worth rewatching from my watch history 
 
 ## Acceptance Criteria
 
-- [ ] `media.discovery.rewatchSuggestions` tRPC query
-- [ ] Source: POPS watch_history joined with media_scores (ELO)
-- [ ] Only movies watched 6+ months ago
-- [ ] Only movies with above-median ELO score (or top 50% by voteAverage if no ELO)
-- [ ] Sorted by ELO score descending, limit 20
-- [ ] Return includes movie poster, title, year, score
-- [ ] Frontend: `HorizontalScrollRow` with subtitle "Movies you loved — worth another watch"
-- [ ] Cards link to movie detail page (already in library)
-- [ ] Hidden when no watch history older than 6 months
-- [ ] Local-only query — no external API calls
-- [ ] Tests cover: 6-month threshold, score filter, sorting, empty state
+- [x] `media.discovery.rewatchSuggestions` tRPC query
+- [x] Source: POPS watch_history joined with media_scores (ELO)
+- [x] Only movies watched 6+ months ago
+- [x] Only movies with above-median ELO score (or top 50% by voteAverage if no ELO)
+- [x] Sorted by ELO score descending, limit 20
+- [x] Return includes movie poster, title, year, score
+- [x] Frontend: `HorizontalScrollRow` with subtitle "Movies you loved — worth another watch"
+- [x] Cards link to movie detail page (already in library)
+- [x] Hidden when no watch history older than 6 months
+- [x] Local-only query — no external API calls
+- [x] Tests cover: 6-month threshold, score filter, sorting, empty state

--- a/docs/themes/03-media/prds/060-discover-page/us-12-from-your-server.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-12-from-your-server.md
@@ -1,7 +1,7 @@
 # US-12: From Your Server
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user, I want to see unwatched movies from my Plex server ranked by how well
 
 ## Acceptance Criteria
 
-- [ ] `media.discovery.fromYourServer` tRPC query
-- [ ] Source: POPS library movies (all movies imported from Plex sync)
-- [ ] Filter: unwatched only (no watch_history entry)
-- [ ] Score using `scoreDiscoverResults` from us-03
-- [ ] Sorted by match percentage descending, limit 20
-- [ ] Return includes poster URL (local proxy), title, year, match percentage
-- [ ] Frontend: `HorizontalScrollRow` with subtitle "Unwatched movies on your server, ranked for you"
-- [ ] Hidden when Plex not connected or no unwatched movies
-- [ ] Local-only query — no external API calls
-- [ ] Tests cover: unwatched filter, scoring, empty state
+- [x] `media.discovery.fromYourServer` tRPC query
+- [x] Source: POPS library movies (all movies imported from Plex sync)
+- [x] Filter: unwatched only (no watch_history entry)
+- [x] Score using `scoreDiscoverResults` from us-03
+- [x] Sorted by match percentage descending, limit 20
+- [x] Return includes poster URL (local proxy), title, year, match percentage
+- [x] Frontend: `HorizontalScrollRow` with subtitle "Unwatched movies on your server, ranked for you"
+- [x] Hidden when Plex not connected or no unwatched movies
+- [x] Local-only query — no external API calls
+- [x] Tests cover: unwatched filter, scoring, empty state

--- a/docs/themes/03-media/prds/060-discover-page/us-13-context-collections.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-13-context-collections.md
@@ -1,7 +1,7 @@
 # US-13: Context collection definitions
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,9 +9,9 @@ As a developer, I want static context collection definitions so the context-awar
 
 ## Acceptance Criteria
 
-- [ ] `ContextCollection` type: `{ id, title, emoji, genreIds: number[], keywords: string[], trigger: (hour, month, dayOfWeek) => boolean }`
-- [ ] Definitions stored as a constant array in the discovery module (data, not DB)
-- [ ] Collections defined:
+- [x] `ContextCollection` type: `{ id, title, emoji, genreIds: number[], keywords: string[], trigger: (hour, month, dayOfWeek) => boolean }`
+- [x] Definitions stored as a constant array in the discovery module (data, not DB)
+- [x] Collections defined:
 
 | ID | Title | Trigger | TMDB Genres/Keywords |
 |----|-------|---------|---------------------|
@@ -23,6 +23,6 @@ As a developer, I want static context collection definitions so the context-awar
 | oscar-season | Oscar Winners | Feb-Mar | keyword: oscar, academy award |
 | rainy-day | Rainy Day | Always (fallback) | Comedy (35) + Drama (18) + Animation (16) |
 
-- [ ] Each collection maps to a TMDB `/discover/movie` query with genre IDs and/or keyword IDs
-- [ ] `getActiveCollections(hour, month, dayOfWeek)` returns matching collections (max 2, always includes fallback if <2 match)
-- [ ] Tests cover: time matching for each trigger, fallback selection, max 2 limit
+- [x] Each collection maps to a TMDB `/discover/movie` query with genre IDs and/or keyword IDs
+- [x] `getActiveCollections(hour, month, dayOfWeek)` returns matching collections (max 2, always includes fallback if <2 match)
+- [x] Tests cover: time matching for each trigger, fallback selection, max 2 limit

--- a/docs/themes/03-media/prds/060-discover-page/us-14-context-endpoint.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-14-context-endpoint.md
@@ -1,7 +1,7 @@
 # US-14: Context-aware picks endpoint
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,10 +9,10 @@ As a developer, I want an endpoint that returns movie results for the currently 
 
 ## Acceptance Criteria
 
-- [ ] `media.discovery.contextPicks` tRPC query
-- [ ] Evaluates active collections using server clock (hour, month, day of week)
-- [ ] For each active collection (max 2), fetches TMDB `/discover/movie` with the collection's genre/keyword filters, `sort_by=vote_average.desc`, `vote_count.gte=100`
-- [ ] Exclude: library movies, dismissed movies
-- [ ] Return `{ collections: Array<{ id, title, emoji, results: DiscoverResult[] }> }`
-- [ ] Supports page parameter per collection for Load More
-- [ ] Tests cover: correct collection evaluation, TMDB query construction, exclusions
+- [x] `media.discovery.contextPicks` tRPC query
+- [x] Evaluates active collections using server clock (hour, month, day of week)
+- [x] For each active collection (max 2), fetches TMDB `/discover/movie` with the collection's genre/keyword filters, `sort_by=vote_average.desc`, `vote_count.gte=100`
+- [x] Exclude: library movies, dismissed movies
+- [x] Return `{ collections: Array<{ id, title, emoji, results: DiscoverResult[] }> }`
+- [x] Supports page parameter per collection for Load More
+- [x] Tests cover: correct collection evaluation, TMDB query construction, exclusions

--- a/docs/themes/03-media/prds/060-discover-page/us-15-context-ui.md
+++ b/docs/themes/03-media/prds/060-discover-page/us-15-context-ui.md
@@ -1,7 +1,7 @@
 # US-15: Context-aware picks frontend rows
 
 > PRD: [060 — Discover Page](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,9 +9,9 @@ As a user, I want to see 1-2 themed movie rows that match the current time or se
 
 ## Acceptance Criteria
 
-- [ ] Renders 1-2 `HorizontalScrollRow` components from active context collections
-- [ ] Each row titled with collection title + emoji (e.g., "Date Night")
-- [ ] Each row supports Load More
-- [ ] Hidden when no collections match (should not happen — fallback always matches)
-- [ ] Loading skeleton while endpoint resolves
-- [ ] Tests cover: rows render with themed titles, load more works
+- [x] Renders 1-2 `HorizontalScrollRow` components from active context collections
+- [x] Each row titled with collection title + emoji (e.g., "Date Night")
+- [x] Each row supports Load More
+- [x] Hidden when no collections match (should not happen — fallback always matches)
+- [x] Loading skeleton while endpoint resolves
+- [x] Tests cover: rows render with themed titles, load more works


### PR DESCRIPTION
## Summary
PRD-060 was 13% in docs but 95% in code. Synced all statuses:
- 12 USs → Done (all criteria checked)
- US-02 → Partial (buttons work, state matrix + Watched badge missing)
- PRD overall: Partial (14/15 done)

## Test plan
- [ ] Docs only