### PR TITLE
feat(comparisons): batchRecordComparisons service + tRPC endpoint [tb-229]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -15,6 +15,7 @@ import {
   getDebriefOpponent,
   getPendingDebriefs,
   getTierListMovies,
+  batchRecordComparisons,
 } from "./service.js";
 
 const ctx = setupTestContext();
@@ -2182,5 +2183,199 @@ describe("getTierListMovies", () => {
     expect(result.data).toHaveLength(1);
     expect(result.data[0]!.title).toBe("API Movie");
     expect(result.data[0]!.score).toBe(1500);
+  });
+});
+
+describe("batchRecordComparisons", () => {
+  it("records multiple comparisons in a single batch", () => {
+    const dimId = seedDimension(db, { name: "Batch Dim" });
+    const m1 = seedMovie(db, { title: "Batch A", tmdb_id: 970 });
+    const m2 = seedMovie(db, { title: "Batch B", tmdb_id: 971 });
+    const m3 = seedMovie(db, { title: "Batch C", tmdb_id: 972 });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: m1,
+      watched_at: "2025-01-01T00:00:00Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: m2,
+      watched_at: "2025-01-02T00:00:00Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: m3,
+      watched_at: "2025-01-03T00:00:00Z",
+    });
+
+    const result = batchRecordComparisons(dimId, [
+      {
+        mediaAType: "movie",
+        mediaAId: m1,
+        mediaBType: "movie",
+        mediaBId: m2,
+        winnerType: "movie",
+        winnerId: m1,
+      },
+      {
+        mediaAType: "movie",
+        mediaAId: m2,
+        mediaBType: "movie",
+        mediaBId: m3,
+        winnerType: "movie",
+        winnerId: m3,
+      },
+    ]);
+
+    expect(result.count).toBe(2);
+
+    // Verify comparisons were inserted
+    const rows = db
+      .prepare("SELECT COUNT(*) as cnt FROM comparisons WHERE dimension_id = ?")
+      .get(dimId) as { cnt: number };
+    expect(rows.cnt).toBe(2);
+  });
+
+  it("updates ELO scores for all comparisons", () => {
+    const dimId = seedDimension(db, { name: "ELO Dim" });
+    const m1 = seedMovie(db, { title: "ELO A", tmdb_id: 975 });
+    const m2 = seedMovie(db, { title: "ELO B", tmdb_id: 976 });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: m1,
+      watched_at: "2025-02-01T00:00:00Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: m2,
+      watched_at: "2025-02-02T00:00:00Z",
+    });
+
+    batchRecordComparisons(dimId, [
+      {
+        mediaAType: "movie",
+        mediaAId: m1,
+        mediaBType: "movie",
+        mediaBId: m2,
+        winnerType: "movie",
+        winnerId: m1,
+      },
+    ]);
+
+    // Winner should have score > 1500, loser < 1500
+    const scores = db
+      .prepare("SELECT media_id, score FROM media_scores WHERE dimension_id = ? ORDER BY media_id")
+      .all(dimId) as Array<{ media_id: number; score: number }>;
+
+    const winnerScore = scores.find((s) => s.media_id === m1)?.score ?? 0;
+    const loserScore = scores.find((s) => s.media_id === m2)?.score ?? 0;
+    expect(winnerScore).toBeGreaterThan(1500);
+    expect(loserScore).toBeLessThan(1500);
+  });
+
+  it("records draws with correct drawTier", () => {
+    const dimId = seedDimension(db, { name: "Draw Dim" });
+    const m1 = seedMovie(db, { title: "Draw A", tmdb_id: 980 });
+    const m2 = seedMovie(db, { title: "Draw B", tmdb_id: 981 });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: m1,
+      watched_at: "2025-03-01T00:00:00Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: m2,
+      watched_at: "2025-03-02T00:00:00Z",
+    });
+
+    const result = batchRecordComparisons(dimId, [
+      {
+        mediaAType: "movie",
+        mediaAId: m1,
+        mediaBType: "movie",
+        mediaBId: m2,
+        winnerType: "movie",
+        winnerId: 0,
+        drawTier: "high",
+      },
+    ]);
+
+    expect(result.count).toBe(1);
+    const row = db
+      .prepare("SELECT draw_tier FROM comparisons WHERE dimension_id = ?")
+      .get(dimId) as { draw_tier: string };
+    expect(row.draw_tier).toBe("high");
+  });
+
+  it("throws for inactive dimension", () => {
+    const dimId = seedDimension(db, { name: "Inactive", active: 0 });
+    const m1 = seedMovie(db, { title: "Err A", tmdb_id: 985 });
+    const m2 = seedMovie(db, { title: "Err B", tmdb_id: 986 });
+
+    expect(() =>
+      batchRecordComparisons(dimId, [
+        {
+          mediaAType: "movie",
+          mediaAId: m1,
+          mediaBType: "movie",
+          mediaBId: m2,
+          winnerType: "movie",
+          winnerId: m1,
+        },
+      ])
+    ).toThrow();
+  });
+
+  it("rolls back all on failure (non-existent dimension)", () => {
+    expect(() =>
+      batchRecordComparisons(99999, [
+        {
+          mediaAType: "movie",
+          mediaAId: 1,
+          mediaBType: "movie",
+          mediaBId: 2,
+          winnerType: "movie",
+          winnerId: 1,
+        },
+      ])
+    ).toThrow();
+
+    const rows = db
+      .prepare("SELECT COUNT(*) as cnt FROM comparisons WHERE dimension_id = 99999")
+      .get() as { cnt: number };
+    expect(rows.cnt).toBe(0);
+  });
+
+  it("works via tRPC endpoint", async () => {
+    const dimId = seedDimension(db, { name: "tRPC Batch Dim" });
+    const m1 = seedMovie(db, { title: "tRPC A", tmdb_id: 990 });
+    const m2 = seedMovie(db, { title: "tRPC B", tmdb_id: 991 });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: m1,
+      watched_at: "2025-04-01T00:00:00Z",
+    });
+    seedWatchHistoryEntry(db, {
+      media_type: "movie",
+      media_id: m2,
+      watched_at: "2025-04-02T00:00:00Z",
+    });
+
+    const result = await caller.media.comparisons.batchRecordComparisons({
+      dimensionId: dimId,
+      comparisons: [
+        {
+          mediaAType: "movie",
+          mediaAId: m1,
+          mediaBType: "movie",
+          mediaBId: m2,
+          winnerType: "movie",
+          winnerId: m1,
+        },
+      ],
+    });
+
+    expect(result.data.count).toBe(1);
+    expect(result.message).toBe("1 comparisons recorded");
   });
 });

--- a/apps/pops-api/src/modules/media/comparisons/router.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router.ts
@@ -26,6 +26,7 @@ import {
   SubmitTierListSchema,
   DismissDebriefDimensionSchema,
   RecordDebriefComparisonSchema,
+  BatchRecordComparisonsSchema,
   toDimension,
   toComparison,
   toMediaScore,
@@ -277,6 +278,24 @@ export const comparisonsRouter = router({
       throw err;
     }
   }),
+
+  /** Batch record comparisons in a single transaction with ELO updates. */
+  batchRecordComparisons: protectedProcedure
+    .input(BatchRecordComparisonsSchema)
+    .mutation(({ input }) => {
+      try {
+        const result = service.batchRecordComparisons(input.dimensionId, input.comparisons);
+        return { data: result, message: `${result.count} comparisons recorded` };
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          throw new TRPCError({ code: "NOT_FOUND", message: err.message });
+        }
+        if (err instanceof ValidationError) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: err.message });
+        }
+        throw err;
+      }
+    }),
 
   /** Record a debrief comparison (or skip) for a session + dimension. */
   recordDebriefComparison: protectedProcedure

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -34,6 +34,8 @@ import {
   type ScoreChange,
   TIER_RANK_ORDER,
   type RecordDebriefComparisonInput,
+  type BatchComparisonItem,
+  type BatchRecordResult,
 } from "./types.js";
 import { getStaleness } from "./staleness.js";
 import { setTierOverride } from "./tier-overrides.js";
@@ -1858,6 +1860,67 @@ function normalizePairOrder(
   return [bType, bId, aType, aId];
 }
 
+// ── Batch Record Comparisons ──
+
+/**
+ * Record multiple comparisons in a single transaction with ELO updates.
+ *
+ * All-or-nothing: if any comparison fails, the entire batch is rolled back.
+ * Each comparison is inserted and its ELO scores are updated within the
+ * same transaction. Returns the total count of comparisons recorded.
+ */
+export function batchRecordComparisons(
+  dimensionId: number,
+  items: BatchComparisonItem[]
+): BatchRecordResult {
+  const rawDb = getDb();
+  const drizzleDb = getDrizzle();
+
+  // Validate dimension exists and is active
+  const dimension = getDimension(dimensionId);
+  if (dimension.active !== 1) {
+    throw new ValidationError("Cannot record comparisons for inactive dimension");
+  }
+
+  let count = 0;
+
+  rawDb.transaction(() => {
+    for (const item of items) {
+      const comparisonInput: RecordComparisonInput = {
+        dimensionId,
+        mediaAType: item.mediaAType,
+        mediaAId: item.mediaAId,
+        mediaBType: item.mediaBType,
+        mediaBId: item.mediaBId,
+        winnerType: item.winnerType,
+        winnerId: item.winnerId,
+        drawTier: item.drawTier ?? null,
+      };
+
+      const result = drizzleDb
+        .insert(comparisons)
+        .values({
+          dimensionId: comparisonInput.dimensionId,
+          mediaAType: comparisonInput.mediaAType,
+          mediaAId: comparisonInput.mediaAId,
+          mediaBType: comparisonInput.mediaBType,
+          mediaBId: comparisonInput.mediaBId,
+          winnerType: comparisonInput.winnerType,
+          winnerId: comparisonInput.winnerId,
+          drawTier: comparisonInput.drawTier ?? null,
+        })
+        .run();
+
+      if (Number(result.lastInsertRowid) > 0) {
+        updateEloScores(comparisonInput);
+        count++;
+      }
+    }
+  })();
+
+  return { count };
+}
+
 // ── Tier List Submission ──
 
 /**
@@ -1896,51 +1959,60 @@ export function submitTierList(input: SubmitTierListInput): SubmitTierListResult
     oldScores.set(placement.movieId, existing?.score ?? 1500.0);
   }
 
-  // Generate all pairwise comparisons and record in a transaction
+  // Generate pairwise comparisons from tier placements
+  const batchItems: BatchComparisonItem[] = [];
+  const placements = input.placements;
+
+  for (let i = 0; i < placements.length; i++) {
+    for (let j = i + 1; j < placements.length; j++) {
+      const a = placements[i];
+      const b = placements[j];
+      if (!a || !b) continue;
+
+      const rankA = TIER_RANK_ORDER[a.tier];
+      const rankB = TIER_RANK_ORDER[b.tier];
+
+      batchItems.push({
+        mediaAType: "movie",
+        mediaAId: a.movieId,
+        mediaBType: "movie",
+        mediaBId: b.movieId,
+        winnerType: "movie",
+        winnerId: rankA < rankB ? a.movieId : rankB < rankA ? b.movieId : 0,
+        drawTier: rankA === rankB ? "mid" : null,
+      });
+    }
+  }
+
+  // Record comparisons in batch, then set tier overrides in same transaction
   let comparisonsRecorded = 0;
 
   rawDb.transaction(() => {
-    const placements = input.placements;
+    // Insert comparisons and update ELO
+    for (const item of batchItems) {
+      const comparisonInput: RecordComparisonInput = {
+        dimensionId: input.dimensionId,
+        ...item,
+        drawTier: item.drawTier ?? null,
+      };
 
-    for (let i = 0; i < placements.length; i++) {
-      for (let j = i + 1; j < placements.length; j++) {
-        const a = placements[i];
-        const b = placements[j];
-        if (!a || !b) continue;
+      const result = drizzleDb
+        .insert(comparisons)
+        .values({
+          dimensionId: comparisonInput.dimensionId,
+          mediaAType: comparisonInput.mediaAType,
+          mediaAId: comparisonInput.mediaAId,
+          mediaBType: comparisonInput.mediaBType,
+          mediaBId: comparisonInput.mediaBId,
+          winnerType: comparisonInput.winnerType,
+          winnerId: comparisonInput.winnerId,
+          drawTier: comparisonInput.drawTier ?? null,
+        })
+        .run();
 
-        const rankA = TIER_RANK_ORDER[a.tier];
-        const rankB = TIER_RANK_ORDER[b.tier];
-
-        const comparisonInput: RecordComparisonInput = {
-          dimensionId: input.dimensionId,
-          mediaAType: "movie",
-          mediaAId: a.movieId,
-          mediaBType: "movie",
-          mediaBId: b.movieId,
-          winnerType: "movie",
-          winnerId: rankA < rankB ? a.movieId : rankB < rankA ? b.movieId : 0,
-          drawTier: rankA === rankB ? "mid" : null,
-        };
-
-        // Insert comparison and update ELO
-        const result = drizzleDb
-          .insert(comparisons)
-          .values({
-            dimensionId: comparisonInput.dimensionId,
-            mediaAType: comparisonInput.mediaAType,
-            mediaAId: comparisonInput.mediaAId,
-            mediaBType: comparisonInput.mediaBType,
-            mediaBId: comparisonInput.mediaBId,
-            winnerType: comparisonInput.winnerType,
-            winnerId: comparisonInput.winnerId,
-            drawTier: comparisonInput.drawTier ?? null,
-          })
-          .run();
-
-        if (Number(result.lastInsertRowid) > 0) {
-          updateEloScores(comparisonInput);
-          comparisonsRecorded++;
-        }
+      if (Number(result.lastInsertRowid) > 0) {
+        updateEloScores(comparisonInput);
+        comparisonsRecorded++;
       }
     }
 

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -322,3 +322,25 @@ export const RecordDebriefComparisonSchema = z.object({
   drawTier: z.enum(DRAW_TIERS).nullable().optional(),
 });
 export type RecordDebriefComparisonInput = z.infer<typeof RecordDebriefComparisonSchema>;
+
+/** Input for a single comparison in a batch. */
+export const BatchComparisonItemSchema = z.object({
+  mediaAType: z.enum(MEDIA_TYPES),
+  mediaAId: z.number().int().positive(),
+  mediaBType: z.enum(MEDIA_TYPES),
+  mediaBId: z.number().int().positive(),
+  winnerType: z.enum(MEDIA_TYPES),
+  winnerId: z.number().int().nonnegative(), // 0 = draw
+  drawTier: z.enum(DRAW_TIERS).nullable().optional(),
+});
+export type BatchComparisonItem = z.infer<typeof BatchComparisonItemSchema>;
+
+export const BatchRecordComparisonsSchema = z.object({
+  dimensionId: z.number().int().positive(),
+  comparisons: z.array(BatchComparisonItemSchema).min(1, "At least 1 comparison is required"),
+});
+export type BatchRecordComparisonsInput = z.infer<typeof BatchRecordComparisonsSchema>;
+
+export interface BatchRecordResult {
+  count: number;
+}


### PR DESCRIPTION
## Summary
- Add `batchRecordComparisons(dimensionId, comparisons)` service function that records all comparisons in a single SQLite transaction with ELO score updates
- All-or-nothing rollback on failure
- Add `BatchComparisonItem`, `BatchRecordComparisonsSchema` types and `batchRecordComparisons` tRPC protected mutation
- Refactor `submitTierList` to use the same batch pattern internally
- 6 unit tests: batch inserts, ELO updates, draws, inactive dimension, rollback, tRPC endpoint

## Test plan
- [ ] `batchRecordComparisons` records N comparisons in a single transaction
- [ ] ELO scores updated for each comparison
- [ ] Draws with drawTier recorded correctly
- [ ] Throws for inactive dimension
- [ ] Rolls back on failure (no partial writes)
- [ ] tRPC endpoint returns correct count and message
- [ ] Existing `submitTierList` tests still pass (refactored to use batch pattern)

Closes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)