### PR TITLE
feat(tier-list): add drag-drop and submit tests [tb-227]

### DIFF
--- a/packages/app-media/src/pages/TierListPage.test.tsx
+++ b/packages/app-media/src/pages/TierListPage.test.tsx
@@ -169,4 +169,119 @@ describe("TierListPage", () => {
     expect(screen.queryByText("The Matrix")).toBeNull();
     expect(screen.queryByText("Tier List")).toBeTruthy();
   });
+
+  it("submit button is disabled when fewer than 2 movies placed", () => {
+    setupPage();
+    renderPage();
+
+    const submitBtn = screen.getByRole("button", { name: /Submit Tier List/i });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it("drag-drop: movie moves from pool to tier row", () => {
+    setupPage();
+    renderPage();
+
+    const movieCard = screen.getByLabelText("The Matrix");
+    const tierS = screen.getByLabelText("Tier S");
+
+    const movieData = JSON.stringify(movies[0]);
+    const dataTransfer = {
+      getData: () => movieData,
+      setData: vi.fn(),
+      effectAllowed: "",
+      dropEffect: "",
+    };
+
+    fireEvent.dragStart(movieCard, { dataTransfer });
+    fireEvent.dragOver(tierS, { dataTransfer });
+    fireEvent.drop(tierS, { dataTransfer });
+
+    // Movie should now be in tier S, not in unranked pool
+    expect(screen.getByText("Unranked (2)")).toBeTruthy();
+  });
+
+  it("drag-drop: movie moves between tiers (reposition)", () => {
+    setupPage();
+    renderPage();
+
+    const movieData = JSON.stringify(movies[0]);
+    const dataTransfer = {
+      getData: () => movieData,
+      setData: vi.fn(),
+      effectAllowed: "",
+      dropEffect: "",
+    };
+
+    // Drop into tier S
+    const tierS = screen.getByLabelText("Tier S");
+    fireEvent.drop(tierS, { dataTransfer });
+
+    // Now move from S to A
+    const tierA = screen.getByLabelText("Tier A");
+    fireEvent.drop(tierA, { dataTransfer });
+
+    // Still only 1 movie placed (moved, not duplicated)
+    expect(screen.getByText("Unranked (2)")).toBeTruthy();
+  });
+
+  it("drag-drop: movie removed from tier back to unranked pool", () => {
+    setupPage();
+    renderPage();
+
+    const movieData = JSON.stringify(movies[0]);
+    const dataTransfer = {
+      getData: () => movieData,
+      setData: vi.fn(),
+      effectAllowed: "",
+      dropEffect: "",
+    };
+
+    // Place in tier S
+    const tierS = screen.getByLabelText("Tier S");
+    fireEvent.drop(tierS, { dataTransfer });
+    expect(screen.getByText("Unranked (2)")).toBeTruthy();
+
+    // Drop back to unranked pool
+    const pool = screen.getByLabelText("Unranked movies");
+    fireEvent.dragOver(pool, { dataTransfer });
+    fireEvent.drop(pool, { dataTransfer });
+    expect(screen.getByText("Unranked (3)")).toBeTruthy();
+  });
+
+  it("submit button enables when 2+ movies placed and calls mutate", () => {
+    setupPage();
+    renderPage();
+
+    const dataTransfer1 = {
+      getData: () => JSON.stringify(movies[0]),
+      setData: vi.fn(),
+      effectAllowed: "",
+      dropEffect: "",
+    };
+    const dataTransfer2 = {
+      getData: () => JSON.stringify(movies[1]),
+      setData: vi.fn(),
+      effectAllowed: "",
+      dropEffect: "",
+    };
+
+    const tierS = screen.getByLabelText("Tier S");
+    const tierA = screen.getByLabelText("Tier A");
+
+    fireEvent.drop(tierS, { dataTransfer: dataTransfer1 });
+    fireEvent.drop(tierA, { dataTransfer: dataTransfer2 });
+
+    const submitBtn = screen.getByRole("button", { name: /Submit Tier List/i });
+    expect(submitBtn).not.toBeDisabled();
+
+    fireEvent.click(submitBtn);
+    expect(mockMutate).toHaveBeenCalledWith({
+      dimensionId: 1,
+      placements: expect.arrayContaining([
+        { movieId: 10, tier: "S" },
+        { movieId: 20, tier: "A" },
+      ]),
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add 5 tests covering tier list drag-drop acceptance criteria
- Tests: submit disabled with <2 placements, drag pool→tier, drag between tiers (reposition), drag back to unranked (remove), submit enables with 2+ placements and calls mutation
- Tier list component already fully implements all AC — this PR adds the missing test coverage

Closes #1286

## Test plan
- [x] 13 tests pass (8 existing + 5 new)
- [x] Format, lint clean
- [ ] Note: typecheck has pre-existing errors in search module (unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)