### PR TITLE
refactor(arena): submitTierList delegates to batchRecordComparisons [tb-232]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -1937,12 +1937,6 @@ export function submitTierList(input: SubmitTierListInput): SubmitTierListResult
   const rawDb = getDb();
   const drizzleDb = getDrizzle();
 
-  // Validate dimension exists and is active
-  const dimension = getDimension(input.dimensionId);
-  if (dimension.active !== 1) {
-    throw new ValidationError("Cannot submit tier list for inactive dimension");
-  }
-
   // Capture old scores for all placed movies
   const oldScores = new Map<number, number>();
   for (const placement of input.placements) {
@@ -1960,44 +1954,23 @@ export function submitTierList(input: SubmitTierListInput): SubmitTierListResult
     oldScores.set(placement.movieId, existing?.score ?? 1500.0);
   }
 
-  // Convert placements to pairwise comparisons using the pure function
+  // Convert placements to pairwise comparisons, then to batch items
   const pairwise = convertTierPlacements(input.placements);
-  let comparisonsRecorded = 0;
+  const batchItems: BatchComparisonItem[] = pairwise.map((pair) => ({
+    mediaAType: "movie" as const,
+    mediaAId: pair.mediaAId,
+    mediaBType: "movie" as const,
+    mediaBId: pair.mediaBId,
+    winnerType: "movie" as const,
+    winnerId: pair.winnerId,
+    drawTier: pair.drawTier,
+  }));
 
+  // Batch-record comparisons (validates dimension + inserts + ELO updates)
+  const { count: comparisonsRecorded } = batchRecordComparisons(input.dimensionId, batchItems);
+
+  // Set tier overrides for each placement
   rawDb.transaction(() => {
-    for (const pair of pairwise) {
-      const comparisonInput: RecordComparisonInput = {
-        dimensionId: input.dimensionId,
-        mediaAType: "movie",
-        mediaAId: pair.mediaAId,
-        mediaBType: "movie",
-        mediaBId: pair.mediaBId,
-        winnerType: "movie",
-        winnerId: pair.winnerId,
-        drawTier: pair.drawTier,
-      };
-
-      const result = drizzleDb
-        .insert(comparisons)
-        .values({
-          dimensionId: comparisonInput.dimensionId,
-          mediaAType: comparisonInput.mediaAType,
-          mediaAId: comparisonInput.mediaAId,
-          mediaBType: comparisonInput.mediaBType,
-          mediaBId: comparisonInput.mediaBId,
-          winnerType: comparisonInput.winnerType,
-          winnerId: comparisonInput.winnerId,
-          drawTier: comparisonInput.drawTier ?? null,
-        })
-        .run();
-
-      if (Number(result.lastInsertRowid) > 0) {
-        updateEloScores(comparisonInput);
-        comparisonsRecorded++;
-      }
-    }
-
-    // Set tier overrides for each placement
     for (const placement of input.placements) {
       setTierOverride("movie", placement.movieId, input.dimensionId, placement.tier);
     }


### PR DESCRIPTION
## Summary
- Refactors `submitTierList` to delegate comparison recording to `batchRecordComparisons` instead of duplicating insert + ELO update logic
- Maps `convertTierPlacements` output to `BatchComparisonItem[]` format before batch recording
- Tier overrides still applied in a separate transaction after batch recording
- Net reduction: -41 lines, +14 lines (removes duplicated insert/ELO code)

## Test plan
- [x] All 8 `submit-tier-list.test.ts` tests pass (correct counts, score ordering, draws, tier overrides, validation)
- [x] All 106 `comparisons.test.ts` tests pass (no regression)
- [x] Format, lint, typecheck all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)