### PR TITLE
fix(navigation): use useLayoutEffect in useSetPageContext and AppContextProvider [tb-241]

### DIFF
--- a/packages/navigation/src/AppContextProvider.tsx
+++ b/packages/navigation/src/AppContextProvider.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router";
 import { AppContextCtx } from "./context.js";
 import type { AppContext, AppName } from "./types.js";
@@ -49,7 +49,7 @@ export function AppContextProvider({ children }: AppContextProviderProps) {
   >({});
 
   // Reset page-level context whenever the user navigates to a new path.
-  useEffect(() => {
+  useLayoutEffect(() => {
     setPageContextState({});
   }, [pathname]);
 

--- a/packages/navigation/src/hooks.ts
+++ b/packages/navigation/src/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect } from "react";
+import { useCallback, useContext, useLayoutEffect } from "react";
 import { useNavigate } from "react-router";
 import { AppContextCtx } from "./context.js";
 import type { AppContext, AppContextEntity, AppName } from "./types.js";
@@ -31,7 +31,7 @@ export interface SetPageContextOptions {
 export function useSetPageContext(options: SetPageContextOptions): void {
   const { setPageContext } = useContext(AppContextCtx);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setPageContext({
       page: options.page,
       pageType: options.pageType ?? "top-level",


### PR DESCRIPTION
## Summary
- Replace `useEffect` with `useLayoutEffect` in `useSetPageContext` hook (`hooks.ts`)
- Replace `useEffect` with `useLayoutEffect` in `AppContextProvider` pathname-reset effect

## Why
`useEffect` runs asynchronously after paint. In the test environment (and deploy pipeline), assertions can execute before the effect fires, causing failures. `useLayoutEffect` fires synchronously before paint, so state is always set before any assertions run.

## Test plan
- [ ] CI navigation tests pass (were previously failing due to async timing)
- [ ] No regressions in other navigation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)