### PR TITLE
feat(inventory): warranty document link in warranty row [tb-239]

### DIFF
--- a/apps/pops-api/src/modules/inventory/reports/router.ts
+++ b/apps/pops-api/src/modules/inventory/reports/router.ts
@@ -16,7 +16,12 @@ export const reportsRouter = router({
   /** List all items with warranty dates, sorted by expiry. */
   warranties: protectedProcedure.query(() => {
     const rows = service.listWarrantyItems();
-    return { data: rows.map(toInventoryItem) };
+    return {
+      data: rows.map((row) => ({
+        ...toInventoryItem(row),
+        warrantyDocumentId: row.warrantyDocumentId,
+      })),
+    };
   }),
 
   /** Insurance report: items grouped by location with photo thumbnails and totals. */

--- a/apps/pops-api/src/modules/inventory/reports/service.ts
+++ b/apps/pops-api/src/modules/inventory/reports/service.ts
@@ -65,15 +65,27 @@ export function getDashboard(): DashboardSummary {
   };
 }
 
+export interface WarrantyListItem extends InventoryRow {
+  warrantyDocumentId: number | null;
+}
+
 /** List all inventory items that have a warranty expiry date, sorted by expiry. */
-export function listWarrantyItems(): InventoryRow[] {
+export function listWarrantyItems(): WarrantyListItem[] {
   const db = getDrizzle();
-  return db
-    .select()
+  const rows = db
+    .select({
+      item: homeInventory,
+      warrantyDocumentId: itemDocuments.paperlessDocumentId,
+    })
     .from(homeInventory)
+    .leftJoin(
+      itemDocuments,
+      and(eq(itemDocuments.itemId, homeInventory.id), eq(itemDocuments.documentType, "warranty"))
+    )
     .where(isNotNull(homeInventory.warrantyExpires))
     .orderBy(homeInventory.warrantyExpires)
     .all();
+  return rows.map((r) => ({ ...r.item, warrantyDocumentId: r.warrantyDocumentId ?? null }));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/app-inventory/src/pages/WarrantiesPage.test.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 const mockWarrantiesQuery = vi.fn();
+const mockPaperlessStatusQuery = vi.fn();
 
 vi.mock("../lib/trpc", () => ({
   trpc: {
@@ -10,6 +11,11 @@ vi.mock("../lib/trpc", () => ({
       reports: {
         warranties: {
           useQuery: (...args: unknown[]) => mockWarrantiesQuery(...args),
+        },
+      },
+      paperless: {
+        status: {
+          useQuery: (...args: unknown[]) => mockPaperlessStatusQuery(...args),
         },
       },
     },
@@ -35,6 +41,7 @@ function makeItem(
     brand: string | null;
     model: string | null;
     replacementValue: number | null;
+    warrantyDocumentId: number | null;
   }> = {}
 ) {
   return {
@@ -45,6 +52,7 @@ function makeItem(
     brand: overrides.brand ?? null,
     model: overrides.model ?? null,
     replacementValue: overrides.replacementValue ?? null,
+    warrantyDocumentId: overrides.warrantyDocumentId ?? null,
   };
 }
 
@@ -63,6 +71,9 @@ beforeEach(() => {
     isLoading: false,
     isError: false,
     refetch: vi.fn(),
+  });
+  mockPaperlessStatusQuery.mockReturnValue({
+    data: { data: { configured: false, available: false, baseUrl: null } },
   });
 });
 
@@ -438,5 +449,81 @@ describe("WarrantiesPage", () => {
     });
     renderPage();
     expect(screen.getByText("INV-001")).toBeInTheDocument();
+  });
+
+  describe("warranty document link", () => {
+    it("shows View Warranty link when document and Paperless configured", () => {
+      mockWarrantiesQuery.mockReturnValue({
+        data: {
+          data: [
+            makeItem({
+              id: "1",
+              itemName: "MacBook",
+              warrantyExpires: "2030-01-01",
+              warrantyDocumentId: 42,
+            }),
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+      mockPaperlessStatusQuery.mockReturnValue({
+        data: { data: { configured: true, available: true, baseUrl: "https://paperless.example" } },
+      });
+      renderPage();
+      const link = screen.getByText("View Warranty");
+      expect(link).toBeInTheDocument();
+      expect(link.closest("a")).toHaveAttribute(
+        "href",
+        "https://paperless.example/documents/42/details"
+      );
+    });
+
+    it("hides View Warranty link when warrantyDocumentId is null", () => {
+      mockWarrantiesQuery.mockReturnValue({
+        data: {
+          data: [
+            makeItem({
+              id: "1",
+              itemName: "MacBook",
+              warrantyExpires: "2030-01-01",
+              warrantyDocumentId: null,
+            }),
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+      mockPaperlessStatusQuery.mockReturnValue({
+        data: { data: { configured: true, available: true, baseUrl: "https://paperless.example" } },
+      });
+      renderPage();
+      expect(screen.queryByText("View Warranty")).not.toBeInTheDocument();
+    });
+
+    it("hides View Warranty link when Paperless not available", () => {
+      mockWarrantiesQuery.mockReturnValue({
+        data: {
+          data: [
+            makeItem({
+              id: "1",
+              itemName: "MacBook",
+              warrantyExpires: "2030-01-01",
+              warrantyDocumentId: 42,
+            }),
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+      mockPaperlessStatusQuery.mockReturnValue({
+        data: { data: { configured: false, available: false, baseUrl: null } },
+      });
+      renderPage();
+      expect(screen.queryByText("View Warranty")).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/app-inventory/src/pages/WarrantiesPage.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.tsx
@@ -18,6 +18,7 @@ interface WarrantyItem {
   model: string | null;
   warrantyExpires: string | null;
   replacementValue: number | null;
+  warrantyDocumentId: number | null;
 }
 
 function formatCurrency(value: number): string {
@@ -66,6 +67,7 @@ interface WarrantyRowProps {
   item: WarrantyItem;
   daysRemaining: number;
   showUrgency?: boolean;
+  paperlessBaseUrl: string | null;
   onClick: () => void;
 }
 
@@ -80,8 +82,18 @@ function brandModelLabel(brand: string | null, model: string | null): string | n
   return brand ?? model ?? null;
 }
 
-function WarrantyRow({ item, daysRemaining, showUrgency, onClick }: WarrantyRowProps) {
+function WarrantyRow({
+  item,
+  daysRemaining,
+  showUrgency,
+  paperlessBaseUrl,
+  onClick,
+}: WarrantyRowProps) {
   const subtitle = brandModelLabel(item.brand, item.model);
+  const docUrl =
+    item.warrantyDocumentId != null && paperlessBaseUrl != null
+      ? `${paperlessBaseUrl}/documents/${item.warrantyDocumentId}/details`
+      : null;
 
   return (
     <button
@@ -94,6 +106,17 @@ function WarrantyRow({ item, daysRemaining, showUrgency, onClick }: WarrantyRowP
         {subtitle && <span className="text-xs text-muted-foreground truncate">{subtitle}</span>}
       </div>
       {item.assetId && <AssetIdBadge assetId={item.assetId} />}
+      {docUrl && (
+        <a
+          href={docUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-primary whitespace-nowrap hover:underline"
+          onClick={(e) => e.stopPropagation()}
+        >
+          View Warranty
+        </a>
+      )}
       <span className="text-muted-foreground text-xs whitespace-nowrap">
         {item.warrantyExpires && formatDate(item.warrantyExpires)}
       </span>
@@ -171,10 +194,11 @@ const TIER_STYLES: Record<string, TierConfig> = {
 interface ExpiringSectionProps {
   tier: keyof typeof TIER_STYLES;
   items: Array<WarrantyItem & { daysRemaining: number }>;
+  paperlessBaseUrl: string | null;
   onItemClick: (id: string) => void;
 }
 
-function ExpiringSection({ tier, items, onItemClick }: ExpiringSectionProps) {
+function ExpiringSection({ tier, items, paperlessBaseUrl, onItemClick }: ExpiringSectionProps) {
   if (items.length === 0) return null;
   const style = TIER_STYLES[tier]!;
 
@@ -200,6 +224,7 @@ function ExpiringSection({ tier, items, onItemClick }: ExpiringSectionProps) {
             item={item}
             daysRemaining={item.daysRemaining}
             showUrgency
+            paperlessBaseUrl={paperlessBaseUrl}
             onClick={() => onItemClick(item.id)}
           />
         ))}
@@ -248,6 +273,8 @@ function CollapsibleSection({
 export function WarrantiesPage() {
   const navigate = useNavigate();
   const { data, isLoading, isError, refetch } = trpc.inventory.reports.warranties.useQuery();
+  const { data: paperlessData } = trpc.inventory.paperless.status.useQuery();
+  const paperlessBaseUrl = paperlessData?.data?.available ? paperlessData.data.baseUrl : null;
 
   const { critical, warning, caution, active, expired } = useMemo(() => {
     type Entry = WarrantyItem & { daysRemaining: number };
@@ -323,16 +350,19 @@ export function WarrantiesPage() {
           <ExpiringSection
             tier="critical"
             items={critical}
+            paperlessBaseUrl={paperlessBaseUrl}
             onItemClick={(id) => navigate(`/inventory/items/${id}`)}
           />
           <ExpiringSection
             tier="warning"
             items={warning}
+            paperlessBaseUrl={paperlessBaseUrl}
             onItemClick={(id) => navigate(`/inventory/items/${id}`)}
           />
           <ExpiringSection
             tier="caution"
             items={caution}
+            paperlessBaseUrl={paperlessBaseUrl}
             onItemClick={(id) => navigate(`/inventory/items/${id}`)}
           />
 
@@ -344,6 +374,7 @@ export function WarrantiesPage() {
                   key={item.id}
                   item={item}
                   daysRemaining={item.daysRemaining}
+                  paperlessBaseUrl={paperlessBaseUrl}
                   onClick={() => navigate(`/inventory/items/${item.id}`)}
                 />
               ))}
@@ -362,6 +393,7 @@ export function WarrantiesPage() {
                   key={item.id}
                   item={item}
                   daysRemaining={item.daysRemaining}
+                  paperlessBaseUrl={paperlessBaseUrl}
                   onClick={() => navigate(`/inventory/items/${item.id}`)}
                 />
               ))}


### PR DESCRIPTION
## Summary
- Backend: `listWarrantyItems()` left-joins `itemDocuments` (documentType='warranty') to include `warrantyDocumentId` per item
- Frontend: `WarrantyRow` renders a "View Warranty" link (`<a>` targeting Paperless-ngx) when `warrantyDocumentId` is set and Paperless is available; link hidden otherwise
- Fetches `trpc.inventory.paperless.status` for base URL; link only shown when `available: true`

## Test plan
- [ ] `View Warranty` link appears for items with a linked warranty document (Paperless configured)
- [ ] Link href is `{paperlessBaseUrl}/documents/{id}/details` and opens in new tab
- [ ] Link hidden when `warrantyDocumentId` is null
- [ ] Link hidden when Paperless not configured/available
- [ ] Brand/model subtitle still renders correctly (unchanged)
- [ ] All existing tier/collapsible tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)