### PR TITLE
test(debrief): debrief_status flags on record/dismiss + tests [tb-245]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/debrief-comparison.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/debrief-comparison.test.ts
@@ -5,6 +5,7 @@ import {
   seedDimension,
   seedMovie,
   seedWatchHistoryEntry,
+  seedDebriefStatus,
   createCaller,
 } from "../../../shared/test-utils.js";
 
@@ -206,5 +207,31 @@ describe("comparisons.recordDebriefComparison", () => {
     expect(scores[0]!.media_id).toBe(movieA); // winner should have higher score
     expect(scores[0]!.score).toBeGreaterThan(1500);
     expect(scores[1]!.score).toBeLessThan(1500);
+  });
+
+  it("sets debriefed=1 on the debrief_status row", async () => {
+    const dimId = seedDimension(db, { name: "Story" });
+    const movieA = seedMovie(db, { tmdb_id: 800, title: "Movie A" });
+    const movieB = seedMovie(db, { tmdb_id: 801, title: "Movie B" });
+    const whId = seedWatchHistoryEntry(db, { media_type: "movie", media_id: movieA });
+    const sessionId = seedDebriefSession(db, whId);
+    seedDebriefStatus(db, { media_type: "movie", media_id: movieA, dimension_id: dimId });
+
+    await caller.media.comparisons.recordDebriefComparison({
+      sessionId,
+      dimensionId: dimId,
+      opponentType: "movie",
+      opponentId: movieB,
+      winnerId: movieA,
+    });
+
+    const row = db
+      .prepare(
+        "SELECT debriefed FROM debrief_status WHERE media_type = 'movie' AND media_id = ? AND dimension_id = ?"
+      )
+      .get(movieA, dimId) as { debriefed: number } | undefined;
+
+    expect(row).toBeTruthy();
+    expect(row!.debriefed).toBe(1);
   });
 });

--- a/apps/pops-api/src/modules/media/comparisons/dismiss-debrief.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/dismiss-debrief.test.ts
@@ -7,6 +7,7 @@ import {
   seedMovie,
   seedWatchHistoryEntry,
   seedDebriefSession,
+  seedDebriefStatus,
   createCaller,
 } from "../../../shared/test-utils.js";
 
@@ -134,5 +135,24 @@ describe("comparisons.dismissDebriefDimension", () => {
     };
 
     expect(compsAfter.cnt).toBe(compsBefore.cnt);
+  });
+
+  it("sets dismissed=1 on the debrief_status row", async () => {
+    const { movieId, dim1, sessionId } = setupDebrief();
+    seedDebriefStatus(db, { media_type: "movie", media_id: movieId, dimension_id: dim1 });
+
+    await caller.media.comparisons.dismissDebriefDimension({
+      sessionId,
+      dimensionId: dim1,
+    });
+
+    const row = db
+      .prepare(
+        "SELECT dismissed FROM debrief_status WHERE media_type = 'movie' AND media_id = ? AND dimension_id = ?"
+      )
+      .get(movieId, dim1) as { dismissed: number } | undefined;
+
+    expect(row).toBeTruthy();
+    expect(row!.dismissed).toBe(1);
   });
 });

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -9,6 +9,7 @@ import {
   comparisonSkipCooloffs,
   debriefResults,
   debriefSessions,
+  debriefStatus,
   mediaScores,
   mediaWatchlist,
   watchHistory,
@@ -1824,6 +1825,25 @@ export function dismissDebriefDimension(sessionId: number, dimensionId: number):
   // Insert debrief_result with null comparison_id (dismissed)
   db.insert(debriefResults).values({ sessionId, dimensionId, comparisonId: null }).run();
 
+  // Mark debrief_status row as dismissed
+  const watchEntry = db
+    .select()
+    .from(watchHistory)
+    .where(eq(watchHistory.id, session.watchHistoryId))
+    .get();
+  if (watchEntry) {
+    db.update(debriefStatus)
+      .set({ dismissed: 1 })
+      .where(
+        and(
+          eq(debriefStatus.mediaType, watchEntry.mediaType),
+          eq(debriefStatus.mediaId, watchEntry.mediaId),
+          eq(debriefStatus.dimensionId, dimensionId)
+        )
+      )
+      .run();
+  }
+
   // Check if all active dimensions now have results → auto-complete
   const activeDims = db
     .select({ id: comparisonDimensions.id })
@@ -2079,6 +2099,19 @@ export function recordDebriefComparison(input: RecordDebriefComparisonInput): {
         dimensionId: input.dimensionId,
         comparisonId,
       })
+      .run();
+
+    // Mark debrief_status row as debriefed
+    drizzleDb
+      .update(debriefStatus)
+      .set({ debriefed: 1 })
+      .where(
+        and(
+          eq(debriefStatus.mediaType, watchEntry.mediaType),
+          eq(debriefStatus.mediaId, watchEntry.mediaId),
+          eq(debriefStatus.dimensionId, input.dimensionId)
+        )
+      )
       .run();
 
     // Activate session if still pending

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -1237,6 +1237,34 @@ export function seedDebriefSession(
 }
 
 /**
+ * Seed a debrief_status row. Returns the id.
+ */
+export function seedDebriefStatus(
+  db: Database,
+  overrides: {
+    media_type: string;
+    media_id: number;
+    dimension_id: number;
+    debriefed?: number;
+    dismissed?: number;
+  }
+): number {
+  const result = db
+    .prepare(
+      `INSERT INTO debrief_status (media_type, media_id, dimension_id, debriefed, dismissed)
+     VALUES (@media_type, @media_id, @dimension_id, @debriefed, @dismissed)`
+    )
+    .run({
+      media_type: overrides.media_type,
+      media_id: overrides.media_id,
+      dimension_id: overrides.dimension_id,
+      debriefed: overrides.debriefed ?? 0,
+      dismissed: overrides.dismissed ?? 0,
+    });
+  return Number(result.lastInsertRowid);
+}
+
+/**
  * Seed a debrief result. Returns the id.
  */
 export function seedDebriefResult(

--- a/docs/themes/03-media/prds/063-post-watch-debrief/README.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/README.md
@@ -91,7 +91,7 @@ Rows are created when a watch event is logged — one row per active dimension. 
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-debrief-schema](us-01-debrief-schema.md) | debrief_status table, auto-queue on watch event | Done | Yes |
 | 02 | [us-02-opponent-selection](us-02-opponent-selection.md) | Median-score opponent selection per dimension | Done | Yes |
-| 03 | [us-03-debrief-api](us-03-debrief-api.md) | tRPC endpoints: getDebrief, recordDebriefComparison, dismissDimension | Partial | Blocked by us-01, us-02 |
+| 03 | [us-03-debrief-api](us-03-debrief-api.md) | tRPC endpoints: getDebrief, recordDebriefComparison, dismissDimension | Done | Blocked by us-01, us-02 |
 | 04 | [us-04-debrief-page](us-04-debrief-page.md) | Debrief route with comparison cards, dimension progress, bail-out, summary | Partial | Blocked by us-03 |
 | 05 | [us-05-debrief-notifications](us-05-debrief-notifications.md) | History tile button, library banner, detail page button for pending debriefs | Partial | Blocked by us-03 |
 

--- a/docs/themes/03-media/prds/063-post-watch-debrief/us-03-debrief-api.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/us-03-debrief-api.md
@@ -1,7 +1,7 @@
 # US-03: Debrief tRPC endpoints
 
 > PRD: [063 — Post-Watch Debrief](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -14,4 +14,4 @@ As a developer, I want tRPC endpoints for the debrief flow: get pending debrief,
 - [x] `media.comparisons.dismissDebriefDimension({ mediaType, mediaId, dimensionId })` sets dismissed=1
 - [x] `media.comparisons.getPendingDebriefs()` returns list of movies with incomplete debriefs (for notifications)
 - [x] All protected procedures
-- [ ] Tests: get returns correct status, record updates row + ELO, dismiss sets flag, pending list correct
+- [x] Tests: get returns correct status, record updates row + ELO, dismiss sets flag, pending list correct


### PR DESCRIPTION
## Summary

- Implements `debriefed=1` update on `debrief_status` when `recordDebriefComparison` is called
- Implements `dismissed=1` update on `debrief_status` when `dismissDebriefDimension` is called
- Adds `seedDebriefStatus` helper to shared test-utils
- Adds test: `recordDebriefComparison sets debriefed=1 on the debrief_status row`
- Adds test: `dismissDebriefDimension sets dismissed=1 on the debrief_status row`
- Updates US-03 acceptance criteria: all criteria now Done

## Test plan

- [x] `debrief-comparison.test.ts` — 8 tests pass (including new debriefed=1 test)
- [x] `dismiss-debrief.test.ts` — 7 tests pass (including new dismissed=1 test)
- [x] `debrief.test.ts` — 16 tests pass
- [x] `comparisons.test.ts` — 106 tests pass
- [x] Format, lint, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)