### PR TITLE
fix(discover): exclude dismissed movies from context picks [tb-243]

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/context-picks-service.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/context-picks-service.test.ts
@@ -11,6 +11,10 @@ vi.mock("./context-collections.js", async (importOriginal) => {
   };
 });
 
+vi.mock("./flags.js", () => ({
+  getDismissedTmdbIds: vi.fn().mockReturnValue(new Set()),
+}));
+
 // Mock database access
 vi.mock("../../../db.js", () => ({
   getDrizzle: vi.fn(() => ({

--- a/apps/pops-api/src/modules/media/discovery/context-picks-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/context-picks-service.ts
@@ -7,6 +7,7 @@ import { movies } from "@pops/db-types";
 import type { TmdbClient } from "../tmdb/client.js";
 import type { DiscoverResult } from "./types.js";
 import { getActiveCollections, type ContextCollection } from "./context-collections.js";
+import { getDismissedTmdbIds } from "./flags.js";
 
 /** A context collection result set for the API response. */
 export interface ContextPicksCollection {
@@ -95,8 +96,7 @@ export async function getContextPicks(
   const activeCollections = getActiveCollections(hour, month, dayOfWeek);
   const libraryIds = getLibraryTmdbIds();
 
-  // TODO: Exclude dismissed movies once tb-115 (dismissed_discover schema) lands
-  const dismissedIds = new Set<number>();
+  const dismissedIds = getDismissedTmdbIds();
 
   const collectionResults = await Promise.all(
     activeCollections.map(async (col) => {


### PR DESCRIPTION
## Summary
- Replaces TODO placeholder `new Set<number>()` with `getDismissedTmdbIds()` call in `context-picks-service.ts` (line 99)
- Adds `getDismissedTmdbIds` import from `./flags.js`
- Updates test mock to include `getDismissedTmdbIds` in `vi.mock("./flags.js")`

## Test plan
- [x] All 6 existing `context-picks-service.test.ts` tests pass
- [x] No new lint errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)