### PR TITLE
fix(docs): resolve conflict markers in epic 04 — both PRD-063 and PRD-064 Done

### DIFF
--- a/docs/themes/03-media/epics/04-ratings-comparisons.md
+++ b/docs/themes/03-media/epics/04-ratings-comparisons.md
@@ -12,13 +12,8 @@ Build the pairwise comparison system (per ADR-010). Two movies presented side by
 |---|-----|---------|--------|
 | 037 | [Ratings & Comparisons](../prds/037-ratings-comparisons/README.md) | Compare arena page, dimension management, ELO scoring algorithm, rankings page, radar charts on detail pages, quick-pick flow | Partial |
 | 062 | [Comparison Intelligence](../prds/062-comparison-intelligence/README.md) | Probabilistic pair selection, staleness model, dimension exclusion, watch blacklist, skip cooloff, score confidence, freshness indicators | Done |
-<<<<<<< Updated upstream
 | 063 | [Post-Watch Debrief](../prds/063-post-watch-debrief/README.md) | Rapid-fire comparison session for newly watched movies — one opponent per dimension, median-score calibration | Done |
-| 064 | [Batch Tier List](../prds/064-batch-tier-list/README.md) | Drag-and-drop S/A/B/C/D tier ranking for 8 movies per dimension, implied pairwise comparisons | In progress |
-=======
-| 063 | [Post-Watch Debrief](../prds/063-post-watch-debrief/README.md) | Rapid-fire comparison session for newly watched movies — one opponent per dimension, median-score calibration | In progress |
 | 064 | [Batch Tier List](../prds/064-batch-tier-list/README.md) | Drag-and-drop S/A/B/C/D tier ranking for 8 movies per dimension, implied pairwise comparisons | Done |
->>>>>>> Stashed changes
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- Removes git conflict markers accidentally committed in `docs/themes/03-media/epics/04-ratings-comparisons.md` (lines 15-21 on main)
- Resolves in favor of both PRD-063 (Post-Watch Debrief) and PRD-064 (Batch Tier List) being **Done**

## Cause

PR #1411 was merged with an unresolved `git stash pop` conflict in the epic table.

## Test plan
- [ ] CI passes (docs-only)
- [ ] No conflict markers in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)