### PR TITLE
fix(arr): Monitored badge yellow + unavailable service badge [tb-250]

### DIFF
--- a/docs/themes/03-media/prds/040-arr-status-display/README.md
+++ b/docs/themes/03-media/prds/040-arr-status-display/README.md
@@ -90,7 +90,7 @@ Both Radarr and Sonarr expose similar REST APIs. Build a shared HTTP client fact
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-arr-base-client](us-01-arr-base-client.md) | Shared HTTP client factory for Radarr/Sonarr, in-memory cache with 30s TTL, graceful degradation, config storage | Partial | Yes |
-| 02 | [us-02-status-badges](us-02-status-badges.md) | Status badges on movie/TV detail pages — monitored, downloading, available, not monitored — colour-coded with conditional display | Partial | Blocked by us-01 |
+| 02 | [us-02-status-badges](us-02-status-badges.md) | Status badges on movie/TV detail pages — monitored, downloading, available, not monitored — colour-coded with conditional display | Done | Blocked by us-01 |
 | 03 | [us-03-arr-settings](us-03-arr-settings.md) | Settings page at `/media/arr` with URL/API key inputs, test connection, status indicators, masked key display | Partial | Blocked by us-01 |
 
 US-01 is the foundation. US-02 and US-03 can be built in parallel once US-01 is complete.

--- a/docs/themes/03-media/prds/040-arr-status-display/us-02-status-badges.md
+++ b/docs/themes/03-media/prds/040-arr-status-display/us-02-status-badges.md
@@ -1,7 +1,7 @@
 # US-02: Status badges
 
 > PRD: [040 — Arr Status Display](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user, I want to see colour-coded status badges on movie and TV show detail 
 
 ## Acceptance Criteria
 
-- [ ] `ArrStatusBadge` component renders one of four states: "Available" (green), "Downloading" (yellow), "Monitored" (blue), "Not Monitored" (grey) — component exists; "Monitored" is yellow not blue; "Not Monitored" renders as grey ("unmonitored")
+- [x] `ArrStatusBadge` component renders one of four states: "Available" (green), "Downloading" (yellow), "Monitored" (yellow), "Not Monitored" (grey)
 - [x] "Downloading" badge includes a progress percentage when available (e.g., "Downloading 45%")
 - [x] Badge precedence: Available > Downloading > Monitored > Not Monitored — only one badge per item
 - [x] Movie detail page queries Radarr for the movie's status by TMDB ID and renders the badge
 - [x] TV show detail page queries Sonarr for the series' status by TVDB ID and renders the badge
 - [x] Badges do not render when the corresponding service is not configured
-- [ ] Badges do not render when the corresponding service is unreachable — shows "Radarr unavailable" / "Sonarr unavailable" grey badge instead of empty area
+- [x] Badges do not render when the corresponding service is unreachable — shows "Radarr unavailable" / "Sonarr unavailable" grey badge instead of empty area
 - [x] Badge fetches use the cached service (5-min TTL for movie/show status)
 - [x] Badge renders inline within the detail page header area
 - [x] Radarr status mapping implemented correctly

--- a/packages/app-media/src/components/ArrStatusBadge.test.tsx
+++ b/packages/app-media/src/components/ArrStatusBadge.test.tsx
@@ -40,14 +40,24 @@ describe("ArrStatusBadge", () => {
     expect(container.innerHTML).toBe("");
   });
 
-  it("renders nothing when service is unreachable (error)", () => {
+  it("renders Radarr unavailable badge when Radarr is unreachable", () => {
     mockGetMovieStatus.mockReturnValue({
       data: null,
       isLoading: false,
       error: new Error("Connection refused"),
     });
-    const { container } = render(<ArrStatusBadge kind="movie" externalId={123} />);
-    expect(container.innerHTML).toBe("");
+    render(<ArrStatusBadge kind="movie" externalId={123} />);
+    expect(screen.getByText("Radarr unavailable")).toBeInTheDocument();
+  });
+
+  it("renders Sonarr unavailable badge when Sonarr is unreachable", () => {
+    mockGetShowStatus.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error("Connection refused"),
+    });
+    render(<ArrStatusBadge kind="show" externalId={456} />);
+    expect(screen.getByText("Sonarr unavailable")).toBeInTheDocument();
   });
 
   it("renders nothing while loading", () => {
@@ -84,7 +94,7 @@ describe("ArrStatusBadge", () => {
     expect(badge.className).toContain("bg-yellow-600");
   });
 
-  it("renders Monitored badge with blue styling", () => {
+  it("renders Monitored badge with yellow styling", () => {
     mockGetMovieStatus.mockReturnValue({
       data: { data: { status: "monitored", label: "Monitored" } },
       isLoading: false,
@@ -93,7 +103,7 @@ describe("ArrStatusBadge", () => {
     render(<ArrStatusBadge kind="movie" externalId={123} />);
     const badge = screen.getByText("Monitored");
     expect(badge).toBeInTheDocument();
-    expect(badge.className).toContain("bg-blue-600");
+    expect(badge.className).toContain("bg-yellow-600");
   });
 
   it("renders Not Monitored badge with grey styling", () => {
@@ -117,6 +127,6 @@ describe("ArrStatusBadge", () => {
     render(<ArrStatusBadge kind="show" externalId={456} />);
     const badge = screen.getByText("Monitored");
     expect(badge).toBeInTheDocument();
-    expect(badge.className).toContain("bg-blue-600");
+    expect(badge.className).toContain("bg-yellow-600");
   });
 });

--- a/packages/app-media/src/components/ArrStatusBadge.tsx
+++ b/packages/app-media/src/components/ArrStatusBadge.tsx
@@ -17,7 +17,7 @@ interface ArrStatusBadgeProps {
 const STATUS_STYLES: Record<string, string> = {
   available: "bg-green-600 text-white",
   complete: "bg-green-600 text-white",
-  monitored: "bg-blue-600 text-white",
+  monitored: "bg-yellow-600 text-white",
   downloading: "bg-yellow-600 text-white",
   partial: "bg-yellow-600 text-white",
   unmonitored: "bg-muted text-muted-foreground",
@@ -45,8 +45,11 @@ export function ArrStatusBadge({ kind, externalId }: ArrStatusBadgeProps) {
   const query = kind === "movie" ? movieStatus : showStatus;
   if (query.isLoading) return null;
 
-  // Do not render when service is unreachable
-  if (query.error) return null;
+  // Show unavailable badge when service is unreachable
+  if (query.error) {
+    const unavailableLabel = kind === "movie" ? "Radarr unavailable" : "Sonarr unavailable";
+    return <Badge className="bg-muted text-muted-foreground">{unavailableLabel}</Badge>;
+  }
 
   if (!query.data?.data) return null;
 


### PR DESCRIPTION
## Summary

Two fixes for PRD-040 US-02 `ArrStatusBadge`:

- **Monitored color**: `bg-blue-600` → `bg-yellow-600` (spec calls for yellow, not blue)
- **Unavailable service**: replaces `return null` on `query.error` with a grey `"Radarr unavailable"` / `"Sonarr unavailable"` badge

## Test plan
- [ ] CI passes
- [ ] Monitored tests updated (blue → yellow assertions)
- [ ] New Sonarr unreachable test added
- [ ] Existing unreachable test updated to assert badge text

🤖 Generated with [Claude Code](https://claude.com/claude-code)