### PR TITLE
feat(arena): watchlist pool depletion message [tb-249]

### DIFF
--- a/docs/themes/03-media/prds/037-ratings-comparisons/us-08-arena-watchlist-filter.md
+++ b/docs/themes/03-media/prds/037-ratings-comparisons/us-08-arena-watchlist-filter.md
@@ -1,7 +1,7 @@
 # US-08: Arena watchlist button and filter
 
 > PRD: [037 — Ratings & Comparisons](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,15 +9,15 @@ As a user, I want to add a movie to my watchlist from the compare arena and have
 
 ## Acceptance Criteria
 
-- [ ] Each movie card in the compare arena shows a small "Add to Watchlist" button (bookmark icon)
-- [ ] Clicking the button adds the movie to the watchlist via `media.watchlist.add`
-- [ ] Success toast confirms: "{Movie title} added to watchlist"
-- [ ] After adding, the button changes to a filled bookmark (already on watchlist) and is disabled
-- [ ] Movies already on the watchlist show the filled bookmark on load (check watchlist status)
-- [ ] `getRandomPair` excludes movies that are on the user's watchlist from the candidate pool
-- [ ] If adding to watchlist reduces the pool below 2 eligible movies, show "Not enough movies — some are on your watchlist" with a link to the watchlist page
-- [ ] Skip button still works independently of the watchlist button
-- [ ] Tests cover: watchlist button adds movie, pair selection excludes watchlisted movies, pool depletion message
+- [x] Each movie card in the compare arena shows a small "Add to Watchlist" button (bookmark icon)
+- [x] Clicking the button adds the movie to the watchlist via `media.watchlist.add`
+- [x] Success toast confirms: "{Movie title} added to watchlist"
+- [x] After adding, the button changes to a filled bookmark (already on watchlist) and is disabled
+- [x] Movies already on the watchlist show the filled bookmark on load (check watchlist status)
+- [x] `getRandomPair` excludes movies that are on the user's watchlist from the candidate pool
+- [x] If adding to watchlist reduces the pool below 2 eligible movies, show "Not enough movies — some are on your watchlist" with a link to the watchlist page
+- [x] Skip button still works independently of the watchlist button
+- [x] Tests cover: watchlist button adds movie, pair selection excludes watchlisted movies, pool depletion message
 
 ## Notes
 

--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -242,10 +242,40 @@ describe("CompareArenaPage", () => {
       isLoading: false,
       error: null,
     });
+    mockWatchlistListQuery.mockReturnValue({
+      data: { data: [] },
+      isLoading: false,
+    });
 
     renderPage();
 
     expect(screen.getByText("Not enough watched movies")).toBeTruthy();
+  });
+
+  it("shows watchlist depletion message when pool is empty and movies are watchlisted", () => {
+    mockDimensionsQuery.mockReturnValue({
+      data: { data: [dim1] },
+      isLoading: false,
+    });
+    mockPairQuery.mockReturnValue({
+      data: { data: null },
+      isLoading: false,
+      error: null,
+    });
+    mockWatchlistListQuery.mockReturnValue({
+      data: {
+        data: [
+          { id: 1, mediaType: "movie", mediaId: 10, title: "The Matrix", addedAt: "2026-01-01" },
+        ],
+      },
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText("Not enough movies")).toBeTruthy();
+    expect(screen.getByText("Some are on your watchlist.")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "View watchlist" })).toBeTruthy();
   });
 
   it("disables cards during pending mutation (double-click prevention)", () => {

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -367,13 +367,27 @@ export function CompareArenaPage() {
         </div>
       ) : pairData?.data === null ? (
         <div className="text-center py-12 text-muted-foreground">
-          <p className="text-lg mb-2">Not enough watched movies</p>
-          <p className="text-sm">
-            Watch at least 2 movies to start comparing.{" "}
-            <Link to="/media" className="text-primary underline">
-              Browse library
-            </Link>
-          </p>
+          {watchlistedMovieIds.size > 0 ? (
+            <>
+              <p className="text-lg mb-2">Not enough movies</p>
+              <p className="text-sm">
+                Some are on your watchlist.{" "}
+                <Link to="/media/watchlist" className="text-primary underline">
+                  View watchlist
+                </Link>
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-lg mb-2">Not enough watched movies</p>
+              <p className="text-sm">
+                Watch at least 2 movies to start comparing.{" "}
+                <Link to="/media" className="text-primary underline">
+                  Browse library
+                </Link>
+              </p>
+            </>
+          )}
         </div>
       ) : pairData?.data ? (
         <>


### PR DESCRIPTION
## Summary

The bookmark button (`Add to Watchlist`) and `getSmartPair` watchlist exclusion were already implemented. This PR adds the missing piece:

- **Pool depletion message**: when `pairData.data === null` and `watchlistedMovieIds.size > 0`, shows "Not enough movies — some are on your watchlist" with a link to `/media/watchlist` instead of the generic "Not enough watched movies" message
- **Test**: verifies the watchlist-specific message renders when movies are watchlisted and the pool is empty

## Test plan
- [ ] CI passes
- [ ] New test: watchlist depletion message renders with link
- [ ] Existing test: generic threshold message still works when no watchlisted movies

🤖 Generated with [Claude Code](https://claude.com/claude-code)