### PR TITLE
feat(media): watchlist status endpoint + WatchlistToggle + MAW tests [tb-251]

### DIFF
--- a/apps/pops-api/src/modules/media/watchlist/router.ts
+++ b/apps/pops-api/src/modules/media/watchlist/router.ts
@@ -38,6 +38,18 @@ export const watchlistRouter = router({
     };
   }),
 
+  /** Check if a specific media item is on the watchlist. */
+  status: protectedProcedure
+    .input(
+      z.object({
+        mediaType: z.enum(["movie", "tv_show"]),
+        mediaId: z.number().int().positive(),
+      })
+    )
+    .query(({ input }) => {
+      return service.getWatchlistStatus(input.mediaType, input.mediaId);
+    }),
+
   /** Get a single watchlist entry by ID. */
   get: protectedProcedure.input(z.object({ id: z.number() })).query(({ input }) => {
     try {

--- a/apps/pops-api/src/modules/media/watchlist/service.ts
+++ b/apps/pops-api/src/modules/media/watchlist/service.ts
@@ -79,6 +79,20 @@ export function listWatchlist(
   return { rows, total: countRow?.total ?? 0 };
 }
 
+/** Check whether a specific media item is on the watchlist. Returns entry ID if present. */
+export function getWatchlistStatus(
+  mediaType: "movie" | "tv_show",
+  mediaId: number
+): { onWatchlist: boolean; entryId: number | null } {
+  const db = getDrizzle();
+  const row = db
+    .select({ id: mediaWatchlist.id })
+    .from(mediaWatchlist)
+    .where(and(eq(mediaWatchlist.mediaType, mediaType), eq(mediaWatchlist.mediaId, mediaId)))
+    .get();
+  return row ? { onWatchlist: true, entryId: row.id } : { onWatchlist: false, entryId: null };
+}
+
 /** Get a single watchlist entry by id. Throws NotFoundError if missing. */
 export function getWatchlistEntry(id: number): MediaWatchlistRow {
   const db = getDrizzle();

--- a/docs/themes/03-media/prds/033-movie-detail-page/README.md
+++ b/docs/themes/03-media/prds/033-movie-detail-page/README.md
@@ -105,8 +105,8 @@ Build the movie detail page — a full metadata view with hero backdrop, poster,
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-movie-hero-metadata](us-01-movie-hero-metadata.md) | Hero layout with backdrop, poster, title/year/runtime/genres, overview, metadata grid | Partial | No (first) |
-| 02 | [us-02-watchlist-toggle](us-02-watchlist-toggle.md) | WatchlistToggle component with optimistic add/remove, state detection | Partial | Yes (parallel with us-01) |
-| 03 | [us-03-mark-as-watched](us-03-mark-as-watched.md) | MarkAsWatchedButton with watch logging, undo toast, watchlist auto-removal | Partial | Yes (parallel with us-01) |
+| 02 | [us-02-watchlist-toggle](us-02-watchlist-toggle.md) | WatchlistToggle component with optimistic add/remove, state detection | Done | Yes (parallel with us-01) |
+| 03 | [us-03-mark-as-watched](us-03-mark-as-watched.md) | MarkAsWatchedButton with watch logging, undo toast, watchlist auto-removal | Done | Yes (parallel with us-01) |
 | 04 | [us-04-comparison-scores](us-04-comparison-scores.md) | ComparisonScores radar chart, conditional display, score normalisation | Partial | Yes (parallel with us-01) |
 
 US-01 builds the page shell. US-02, US-03, and US-04 are independent components that can all be built in parallel with each other and integrated into the page.

--- a/docs/themes/03-media/prds/033-movie-detail-page/us-02-watchlist-toggle.md
+++ b/docs/themes/03-media/prds/033-movie-detail-page/us-02-watchlist-toggle.md
@@ -1,7 +1,7 @@
 # US-02: WatchlistToggle component
 
 > PRD: [033 — Movie Detail Page](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -12,13 +12,13 @@ As a user, I want to add or remove a movie from my watchlist with a single click
 - [x] WatchlistToggle is a standalone component that accepts a movie ID and renders the appropriate state
 - [x] When the movie is not on the watchlist: renders "Add to Watchlist" button (e.g., bookmark outline icon + text)
 - [x] When the movie is on the watchlist: renders "In Watchlist" button with a filled/active style (e.g., filled bookmark icon + text)
-- [ ] Clicking "Add to Watchlist" optimistically switches to the "In Watchlist" state immediately, then calls `media.watchlist.add` — no optimistic update; state changes after API success
-- [ ] Clicking "In Watchlist" optimistically switches to the "Add to Watchlist" state immediately, then calls `media.watchlist.remove` — no optimistic update; state changes after API success
-- [ ] If the API call fails, the UI reverts to the previous state and an error toast is displayed — error toast shown but no state revert (state wasn't changed optimistically)
-- [ ] Initial state is determined by calling `media.watchlist.status` with the movie ID — uses `media.watchlist.list` + `find()` instead; `media.watchlist.status` endpoint does not exist
+- [x] Clicking "Add to Watchlist" optimistically switches to the "In Watchlist" state immediately, then calls `media.watchlist.add`
+- [x] Clicking "In Watchlist" optimistically switches to the "Add to Watchlist" state immediately, then calls `media.watchlist.remove`
+- [x] If the API call fails, the UI reverts to the previous state and an error toast is displayed
+- [x] Initial state is determined by calling `media.watchlist.status` with the movie ID
 - [x] Button is disabled during the initial status check (prevents action before state is known)
 - [x] The component is reusable — it can be mounted on any page that has a movie ID (detail page, list items, etc.)
-- [ ] Tests cover: initial state loading, optimistic add, optimistic remove, revert on API failure, error toast on failure
+- [x] Tests cover: initial state loading, optimistic add, optimistic remove, revert on API failure, error toast on failure
 
 ## Notes
 

--- a/docs/themes/03-media/prds/033-movie-detail-page/us-03-mark-as-watched.md
+++ b/docs/themes/03-media/prds/033-movie-detail-page/us-03-mark-as-watched.md
@@ -1,7 +1,7 @@
 # US-03: MarkAsWatchedButton component
 
 > PRD: [033 — Movie Detail Page](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 

--- a/packages/app-media/src/components/MarkAsWatchedButton.test.tsx
+++ b/packages/app-media/src/components/MarkAsWatchedButton.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { MarkAsWatchedButton } from "./MarkAsWatchedButton";
+
+// Capture mutation options
+let logMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
+let _deleteMutationOpts: Record<string, (...args: unknown[]) => unknown> = {};
+const mockLogMutate = vi.fn();
+const mockDeleteMutate = vi.fn();
+const mockWatchlistAddMutate = vi.fn();
+const mockInvalidateHistory = vi.fn();
+const mockInvalidateWatchlist = vi.fn();
+
+const mockHistoryQuery = vi.fn();
+
+vi.mock("../lib/trpc", () => ({
+  trpc: {
+    media: {
+      watchHistory: {
+        list: {
+          useQuery: (...args: unknown[]) => mockHistoryQuery(...args),
+        },
+        log: {
+          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
+            logMutationOpts = opts;
+            return { mutate: mockLogMutate, isPending: false };
+          },
+        },
+        delete: {
+          useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
+            _deleteMutationOpts = opts;
+            return { mutate: mockDeleteMutate, isPending: false };
+          },
+        },
+      },
+      watchlist: {
+        add: {
+          useMutation: () => ({ mutate: mockWatchlistAddMutate, isPending: false }),
+        },
+      },
+    },
+    useUtils: () => ({
+      media: {
+        watchHistory: {
+          list: { invalidate: mockInvalidateHistory },
+        },
+        watchlist: {
+          list: { invalidate: mockInvalidateWatchlist },
+        },
+      },
+    }),
+  },
+}));
+
+// Mock sonner
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+function setupEmpty() {
+  mockHistoryQuery.mockReturnValue({
+    data: { data: [], pagination: { total: 0 } },
+    isLoading: false,
+  });
+}
+
+function setupWatched(count = 1) {
+  mockHistoryQuery.mockReturnValue({
+    data: {
+      data: Array.from({ length: count }, (_, i) => ({
+        id: i + 1,
+        watchedAt: "2026-01-01T00:00:00Z",
+      })),
+    },
+    isLoading: false,
+  });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  logMutationOpts = {};
+  _deleteMutationOpts = {};
+  setupEmpty();
+});
+
+describe("MarkAsWatchedButton", () => {
+  it("renders 'Mark as Watched' button for unwatched movie", () => {
+    render(<MarkAsWatchedButton mediaId={550} />);
+    expect(screen.getByLabelText("Mark as watched")).toBeInTheDocument();
+    expect(screen.getByText("Mark as Watched")).toBeInTheDocument();
+  });
+
+  it("shows watched count when already watched", () => {
+    setupWatched(2);
+    render(<MarkAsWatchedButton mediaId={550} />);
+    expect(screen.getByText("Watched (2)")).toBeInTheDocument();
+  });
+
+  it("calls log mutation with correct payload on click", () => {
+    render(<MarkAsWatchedButton mediaId={550} />);
+
+    fireEvent.click(screen.getByLabelText("Mark as watched"));
+
+    expect(mockLogMutate).toHaveBeenCalledWith({
+      mediaType: "movie",
+      mediaId: 550,
+      completed: 1,
+    });
+  });
+
+  it("shows success toast with Undo action on log success", () => {
+    render(<MarkAsWatchedButton mediaId={550} />);
+
+    logMutationOpts.onSuccess!({ data: { id: 99 }, watchlistRemoved: false });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "Marked as watched",
+      expect.objectContaining({
+        duration: 5000,
+        action: expect.objectContaining({ label: "Undo" }),
+      })
+    );
+  });
+
+  it("invalidates watch history on log success", () => {
+    render(<MarkAsWatchedButton mediaId={550} />);
+
+    logMutationOpts.onSuccess!({ data: { id: 99 }, watchlistRemoved: false });
+
+    expect(mockInvalidateHistory).toHaveBeenCalled();
+  });
+
+  it("shows error toast on log failure", () => {
+    render(<MarkAsWatchedButton mediaId={550} />);
+
+    logMutationOpts.onError!({ message: "DB error" });
+
+    expect(mockToastError).toHaveBeenCalledWith("Failed to log watch: DB error");
+  });
+
+  it("undo calls delete with entry ID", () => {
+    render(<MarkAsWatchedButton mediaId={550} />);
+
+    logMutationOpts.onSuccess!({ data: { id: 99 }, watchlistRemoved: false });
+
+    const toastCall = mockToastSuccess.mock.calls[0];
+    const opts = toastCall?.[1] as { action?: { onClick: () => void } };
+    opts?.action?.onClick();
+
+    expect(mockDeleteMutate).toHaveBeenCalledWith({ id: 99 }, expect.any(Object));
+  });
+
+  it("undo re-adds to watchlist when watchlistRemoved=true", () => {
+    render(<MarkAsWatchedButton mediaId={550} />);
+
+    logMutationOpts.onSuccess!({ data: { id: 99 }, watchlistRemoved: true });
+
+    const toastCall = mockToastSuccess.mock.calls[0];
+    const opts = toastCall?.[1] as { action?: { onClick: () => void } };
+    opts?.action?.onClick();
+
+    // Call the onSuccess of the delete mutation
+    const deleteCall = mockDeleteMutate.mock.calls[0];
+    const deleteOpts = deleteCall?.[1] as { onSuccess?: () => void };
+    deleteOpts?.onSuccess?.();
+
+    expect(mockWatchlistAddMutate).toHaveBeenCalledWith(
+      { mediaType: "movie", mediaId: 550 },
+      expect.any(Object)
+    );
+  });
+
+  it("undo does not re-add to watchlist when watchlistRemoved=false", () => {
+    render(<MarkAsWatchedButton mediaId={550} />);
+
+    logMutationOpts.onSuccess!({ data: { id: 99 }, watchlistRemoved: false });
+
+    const toastCall = mockToastSuccess.mock.calls[0];
+    const opts = toastCall?.[1] as { action?: { onClick: () => void } };
+    opts?.action?.onClick();
+
+    const deleteCall = mockDeleteMutate.mock.calls[0];
+    const deleteOpts = deleteCall?.[1] as { onSuccess?: () => void };
+    deleteOpts?.onSuccess?.();
+
+    expect(mockWatchlistAddMutate).not.toHaveBeenCalled();
+  });
+
+  it("button remains usable after logging (can log multiple watches)", () => {
+    setupWatched(1);
+    render(<MarkAsWatchedButton mediaId={550} />);
+
+    const button = screen.getByLabelText("Mark as watched");
+    expect(button).not.toBeDisabled();
+    fireEvent.click(button);
+    expect(mockLogMutate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app-media/src/components/WatchlistToggle.test.tsx
+++ b/packages/app-media/src/components/WatchlistToggle.test.tsx
@@ -13,14 +13,14 @@ const mockCancel = vi.fn().mockResolvedValue(undefined);
 const mockGetData = vi.fn();
 const mockSetData = vi.fn();
 
-const mockListQuery = vi.fn();
+const mockStatusQuery = vi.fn();
 
 vi.mock("../lib/trpc", () => ({
   trpc: {
     media: {
       watchlist: {
-        list: {
-          useQuery: (...args: unknown[]) => mockListQuery(...args),
+        status: {
+          useQuery: (...args: unknown[]) => mockStatusQuery(...args),
         },
         add: {
           useMutation: (opts: Record<string, (...args: unknown[]) => unknown>) => {
@@ -39,7 +39,7 @@ vi.mock("../lib/trpc", () => ({
     useUtils: () => ({
       media: {
         watchlist: {
-          list: {
+          status: {
             invalidate: mockInvalidate,
             cancel: mockCancel,
             getData: mockGetData,
@@ -63,34 +63,22 @@ vi.mock("sonner", () => ({
   },
 }));
 
-const PAGINATION_EMPTY = { total: 0, limit: 50, offset: 0, hasMore: false };
-const PAGINATION_ONE = { total: 1, limit: 50, offset: 0, hasMore: false };
-
-const WATCHLIST_ENTRY = {
-  id: 42,
-  mediaType: "movie",
-  mediaId: 550,
-  priority: null,
-  notes: null,
-  addedAt: "2026-01-01T00:00:00Z",
-};
-
 function setupNotOnWatchlist() {
-  mockListQuery.mockReturnValue({
-    data: { data: [], pagination: PAGINATION_EMPTY },
+  mockStatusQuery.mockReturnValue({
+    data: { onWatchlist: false, entryId: null },
     isLoading: false,
   });
 }
 
 function setupOnWatchlist() {
-  mockListQuery.mockReturnValue({
-    data: { data: [WATCHLIST_ENTRY], pagination: PAGINATION_ONE },
+  mockStatusQuery.mockReturnValue({
+    data: { onWatchlist: true, entryId: 42 },
     isLoading: false,
   });
 }
 
 function setupLoading() {
-  mockListQuery.mockReturnValue({
+  mockStatusQuery.mockReturnValue({
     data: undefined,
     isLoading: true,
   });
@@ -143,27 +131,28 @@ describe("WatchlistToggle", () => {
       expect(mockAddMutate).toHaveBeenCalledWith({ mediaType: "movie", mediaId: 550 });
     });
 
-    it("onMutate cancels queries, snapshots cache, and adds optimistic entry", async () => {
+    it("onMutate cancels queries, snapshots cache, and sets optimistic state", async () => {
       setupNotOnWatchlist();
       render(<WatchlistToggle mediaType="movie" mediaId={550} />);
 
-      const previousData = { data: [], pagination: PAGINATION_EMPTY };
+      const previousData = { onWatchlist: false, entryId: null };
       mockGetData.mockReturnValue(previousData);
 
       const context = await addMutationOpts.onMutate!();
 
-      expect(mockCancel).toHaveBeenCalled();
-      expect(mockGetData).toHaveBeenCalledWith({ mediaType: "movie" });
-      expect(mockSetData).toHaveBeenCalledWith({ mediaType: "movie" }, expect.any(Function));
+      expect(mockCancel).toHaveBeenCalledWith({ mediaType: "movie", mediaId: 550 });
+      expect(mockGetData).toHaveBeenCalledWith({ mediaType: "movie", mediaId: 550 });
+      expect(mockSetData).toHaveBeenCalledWith(
+        { mediaType: "movie", mediaId: 550 },
+        expect.any(Function)
+      );
       expect(context).toEqual({ previous: previousData });
 
-      // Verify the updater function adds the optimistic entry
+      // Verify the updater sets onWatchlist: true
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const updater = mockSetData.mock.calls[0]![1] as any;
-      const result = updater({ data: [], pagination: PAGINATION_EMPTY });
-      expect(result.data).toHaveLength(1);
-      expect(result.pagination.total).toBe(1);
-      expect((result.data[0] as { mediaId: number }).mediaId).toBe(550);
+      const result = updater(previousData);
+      expect(result.onWatchlist).toBe(true);
     });
 
     it("onSuccess shows success toast", () => {
@@ -179,10 +168,10 @@ describe("WatchlistToggle", () => {
       setupNotOnWatchlist();
       render(<WatchlistToggle mediaType="movie" mediaId={550} />);
 
-      const previous = { data: [], pagination: PAGINATION_EMPTY };
+      const previous = { onWatchlist: false, entryId: null };
       addMutationOpts.onError!({ message: "Server error", data: null }, {}, { previous });
 
-      expect(mockSetData).toHaveBeenCalledWith({ mediaType: "movie" }, previous);
+      expect(mockSetData).toHaveBeenCalledWith({ mediaType: "movie", mediaId: 550 }, previous);
       expect(mockToastError).toHaveBeenCalledWith("Failed to add: Server error");
     });
 
@@ -193,7 +182,7 @@ describe("WatchlistToggle", () => {
       addMutationOpts.onError!(
         { message: "Conflict", data: { code: "CONFLICT" } },
         {},
-        { previous: { data: [], pagination: PAGINATION_EMPTY } }
+        { previous: { onWatchlist: false, entryId: null } }
       );
 
       expect(mockToastInfo).toHaveBeenCalledWith("Already on watchlist");
@@ -205,7 +194,7 @@ describe("WatchlistToggle", () => {
 
       addMutationOpts.onSettled!();
 
-      expect(mockInvalidate).toHaveBeenCalled();
+      expect(mockInvalidate).toHaveBeenCalledWith({ mediaType: "movie", mediaId: 550 });
     });
   });
 
@@ -220,24 +209,24 @@ describe("WatchlistToggle", () => {
       expect(mockRemoveMutate).toHaveBeenCalledWith({ id: 42 });
     });
 
-    it("onMutate cancels queries, snapshots cache, and removes entry", async () => {
+    it("onMutate cancels queries, snapshots cache, and clears status", async () => {
       setupOnWatchlist();
       render(<WatchlistToggle mediaType="movie" mediaId={550} />);
 
-      const previousData = { data: [WATCHLIST_ENTRY], pagination: PAGINATION_ONE };
+      const previousData = { onWatchlist: true, entryId: 42 };
       mockGetData.mockReturnValue(previousData);
 
       const context = await removeMutationOpts.onMutate!();
 
-      expect(mockCancel).toHaveBeenCalled();
+      expect(mockCancel).toHaveBeenCalledWith({ mediaType: "movie", mediaId: 550 });
       expect(context).toEqual({ previous: previousData });
 
-      // Verify the updater function removes the entry
+      // Verify the updater clears the status
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const updater = mockSetData.mock.calls[0]![1] as any;
-      const result = updater({ data: [WATCHLIST_ENTRY], pagination: PAGINATION_ONE });
-      expect(result.data).toHaveLength(0);
-      expect(result.pagination.total).toBe(0);
+      const result = updater(previousData);
+      expect(result.onWatchlist).toBe(false);
+      expect(result.entryId).toBeNull();
     });
 
     it("onSuccess shows success toast", () => {
@@ -253,10 +242,10 @@ describe("WatchlistToggle", () => {
       setupOnWatchlist();
       render(<WatchlistToggle mediaType="movie" mediaId={550} />);
 
-      const previous = { data: [WATCHLIST_ENTRY], pagination: PAGINATION_ONE };
+      const previous = { onWatchlist: true, entryId: 42 };
       removeMutationOpts.onError!({ message: "Network error" }, {}, { previous });
 
-      expect(mockSetData).toHaveBeenCalledWith({ mediaType: "movie" }, previous);
+      expect(mockSetData).toHaveBeenCalledWith({ mediaType: "movie", mediaId: 550 }, previous);
       expect(mockToastError).toHaveBeenCalledWith("Failed to remove: Network error");
     });
 
@@ -266,19 +255,22 @@ describe("WatchlistToggle", () => {
 
       removeMutationOpts.onSettled!();
 
-      expect(mockInvalidate).toHaveBeenCalled();
+      expect(mockInvalidate).toHaveBeenCalledWith({ mediaType: "movie", mediaId: 550 });
     });
   });
 
   describe("media type conversion", () => {
     it("converts 'tv' to 'tv_show' for API calls", () => {
-      mockListQuery.mockReturnValue({
-        data: { data: [], pagination: PAGINATION_EMPTY },
+      mockStatusQuery.mockReturnValue({
+        data: { onWatchlist: false, entryId: null },
         isLoading: false,
       });
       render(<WatchlistToggle mediaType="tv" mediaId={100} />);
 
-      expect(mockListQuery).toHaveBeenCalledWith({ mediaType: "tv_show" }, expect.any(Object));
+      expect(mockStatusQuery).toHaveBeenCalledWith(
+        { mediaType: "tv_show", mediaId: 100 },
+        expect.any(Object)
+      );
     });
   });
 });

--- a/packages/app-media/src/components/WatchlistToggle.tsx
+++ b/packages/app-media/src/components/WatchlistToggle.tsx
@@ -18,40 +18,22 @@ export function WatchlistToggle({ mediaType, mediaId, className }: WatchlistTogg
   const utils = trpc.useUtils();
   const apiMediaType = toApiMediaType(mediaType);
 
-  const { data: watchlistData, isLoading: isChecking } = trpc.media.watchlist.list.useQuery(
-    { mediaType: apiMediaType },
+  const { data: statusData, isLoading: isChecking } = trpc.media.watchlist.status.useQuery(
+    { mediaType: apiMediaType, mediaId },
     { staleTime: 30_000 }
   );
 
-  const watchlistEntry = watchlistData?.data?.find(
-    (entry: { mediaId: number }) => entry.mediaId === mediaId
-  );
-  const isOnWatchlist = !!watchlistEntry;
+  const isOnWatchlist = statusData?.onWatchlist ?? false;
+  const watchlistEntryId = statusData?.entryId ?? null;
 
   const addMutation = trpc.media.watchlist.add.useMutation({
     onMutate: async () => {
-      await utils.media.watchlist.list.cancel();
-      const previous = utils.media.watchlist.list.getData({ mediaType: apiMediaType });
-      utils.media.watchlist.list.setData({ mediaType: apiMediaType }, (old) => {
-        if (!old) return old;
-        const optimisticEntry = {
-          id: -1,
-          mediaType: apiMediaType,
-          mediaId,
-          priority: null,
-          notes: null,
-          source: null,
-          plexRatingKey: null,
-          addedAt: new Date().toISOString(),
-          title: null,
-          posterUrl: null,
-        };
-        return {
-          ...old,
-          data: [...old.data, optimisticEntry],
-          pagination: { ...old.pagination, total: old.pagination.total + 1 },
-        };
-      });
+      await utils.media.watchlist.status.cancel({ mediaType: apiMediaType, mediaId });
+      const previous = utils.media.watchlist.status.getData({ mediaType: apiMediaType, mediaId });
+      utils.media.watchlist.status.setData({ mediaType: apiMediaType, mediaId }, () => ({
+        onWatchlist: true,
+        entryId: -1,
+      }));
       return { previous };
     },
     onSuccess: () => {
@@ -59,7 +41,10 @@ export function WatchlistToggle({ mediaType, mediaId, className }: WatchlistTogg
     },
     onError: (err: { message: string; data?: { code?: string } | null }, _vars, context) => {
       if (context?.previous !== undefined) {
-        utils.media.watchlist.list.setData({ mediaType: apiMediaType }, context.previous);
+        utils.media.watchlist.status.setData(
+          { mediaType: apiMediaType, mediaId },
+          context.previous
+        );
       }
       if (err.data?.code === "CONFLICT") {
         toast.info("Already on watchlist");
@@ -68,22 +53,18 @@ export function WatchlistToggle({ mediaType, mediaId, className }: WatchlistTogg
       }
     },
     onSettled: () => {
-      void utils.media.watchlist.list.invalidate();
+      void utils.media.watchlist.status.invalidate({ mediaType: apiMediaType, mediaId });
     },
   });
 
   const removeMutation = trpc.media.watchlist.remove.useMutation({
     onMutate: async () => {
-      await utils.media.watchlist.list.cancel();
-      const previous = utils.media.watchlist.list.getData({ mediaType: apiMediaType });
-      utils.media.watchlist.list.setData({ mediaType: apiMediaType }, (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          data: old.data.filter((entry) => entry.mediaId !== mediaId),
-          pagination: { ...old.pagination, total: Math.max(0, old.pagination.total - 1) },
-        };
-      });
+      await utils.media.watchlist.status.cancel({ mediaType: apiMediaType, mediaId });
+      const previous = utils.media.watchlist.status.getData({ mediaType: apiMediaType, mediaId });
+      utils.media.watchlist.status.setData({ mediaType: apiMediaType, mediaId }, () => ({
+        onWatchlist: false,
+        entryId: null,
+      }));
       return { previous };
     },
     onSuccess: () => {
@@ -91,12 +72,15 @@ export function WatchlistToggle({ mediaType, mediaId, className }: WatchlistTogg
     },
     onError: (err: { message: string }, _vars, context) => {
       if (context?.previous !== undefined) {
-        utils.media.watchlist.list.setData({ mediaType: apiMediaType }, context.previous);
+        utils.media.watchlist.status.setData(
+          { mediaType: apiMediaType, mediaId },
+          context.previous
+        );
       }
       toast.error(`Failed to remove: ${err.message}`);
     },
     onSettled: () => {
-      void utils.media.watchlist.list.invalidate();
+      void utils.media.watchlist.status.invalidate({ mediaType: apiMediaType, mediaId });
     },
   });
 
@@ -105,8 +89,8 @@ export function WatchlistToggle({ mediaType, mediaId, className }: WatchlistTogg
   const handleToggle = () => {
     if (isMutating) return;
 
-    if (isOnWatchlist && watchlistEntry) {
-      removeMutation.mutate({ id: watchlistEntry.id });
+    if (isOnWatchlist && watchlistEntryId !== null) {
+      removeMutation.mutate({ id: watchlistEntryId });
     } else {
       addMutation.mutate({ mediaType: apiMediaType, mediaId });
     }


### PR DESCRIPTION
## Summary
- Add `media.watchlist.status` tRPC endpoint for per-item watchlist status lookup (returns `{ onWatchlist, entryId }`)
- Rewrite `WatchlistToggle` to use per-item status query with optimistic cache updates instead of full list fetch
- Add `MarkAsWatchedButton.test.tsx` (10 tests: payload, success toast, undo flow, watchlist re-add on undo, button re-enable)
- Update `WatchlistToggle.test.tsx` for new status mock (15 tests)
- Mark US-02 and US-03 Done in PRD-033 docs

## Test plan
- [ ] WatchlistToggle tests pass (15 tests)
- [ ] MarkAsWatchedButton tests pass (10 tests)
- [ ] pops-api typecheck passes
- [ ] app-media typecheck passes
- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)