### PR TITLE
docs: mark PRD-040 Arr Status Display as Done [tb-253]

### DIFF
--- a/docs/themes/03-media/epics/07-radarr-sonarr.md
+++ b/docs/themes/03-media/epics/07-radarr-sonarr.md
@@ -10,7 +10,7 @@ Integrate with Radarr (movies) and Sonarr (TV) for status display and request ma
 
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
-| 040 | [Arr Status Display](../prds/040-arr-status-display/README.md) | Read-only status badges on detail pages (monitored, downloading, available), download queue display. Shared base client pattern for both Radarr and Sonarr | Partial |
+| 040 | [Arr Status Display](../prds/040-arr-status-display/README.md) | Read-only status badges on detail pages (monitored, downloading, available), download queue display. Shared base client pattern for both Radarr and Sonarr | Done |
 | 041 | [Radarr Request Management](../prds/041-radarr-request-management/README.md) | Request movies from within POPS, quality profile selection, search triggers, monitoring management | Partial |
 | 042 | [Sonarr Request Management](../prds/042-sonarr-request-management/README.md) | Series management, season/episode monitoring, calendar view, quality profiles, future vs past season handling | Partial |
 

--- a/docs/themes/03-media/prds/040-arr-status-display/README.md
+++ b/docs/themes/03-media/prds/040-arr-status-display/README.md
@@ -1,7 +1,7 @@
 # PRD-040: Arr Status Display
 
 > Epic: [07 — Radarr & Sonarr](../../epics/07-radarr-sonarr.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -89,7 +89,7 @@ Both Radarr and Sonarr expose similar REST APIs. Build a shared HTTP client fact
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-arr-base-client](us-01-arr-base-client.md) | Shared HTTP client factory for Radarr/Sonarr, in-memory cache with 30s TTL, graceful degradation, config storage | Partial | Yes |
+| 01 | [us-01-arr-base-client](us-01-arr-base-client.md) | Shared HTTP client factory for Radarr/Sonarr, in-memory cache with 30s TTL, graceful degradation, config storage | Done | Yes |
 | 02 | [us-02-status-badges](us-02-status-badges.md) | Status badges on movie/TV detail pages — monitored, downloading, available, not monitored — colour-coded with conditional display | Done | Blocked by us-01 |
 | 03 | [us-03-arr-settings](us-03-arr-settings.md) | Settings page at `/media/arr` with URL/API key inputs, test connection, status indicators, masked key display | Done | Blocked by us-01 |
 

--- a/docs/themes/03-media/prds/040-arr-status-display/us-01-arr-base-client.md
+++ b/docs/themes/03-media/prds/040-arr-status-display/us-01-arr-base-client.md
@@ -1,7 +1,7 @@
 # US-01: Arr base client
 
 > PRD: [040 — Arr Status Display](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -11,16 +11,16 @@ As a developer, I want a shared HTTP client factory for Radarr and Sonarr with i
 
 - [x] `createArrClient(baseUrl, apiKey)` factory function returns a configured HTTP client that sets the `X-Api-Key` header on all requests — implemented as `ArrBaseClient` class (not factory function, but functionally equivalent)
 - [x] Client exposes `get<T>(path)` method for typed GET requests against the service API
-- [ ] In-memory cache with 30-second TTL — cache exists at service level (`service.ts`); movie/show status uses 5-minute TTL, download queue uses 30s TTL; not a client-level cache
-- [ ] Cache is keyed by full URL (base URL + path) so Radarr and Sonarr caches do not collide — service caches keyed by tmdbId/tvdbId, not full URL
-- [ ] `clearCache()` method flushes all cached entries for a client instance — `clearStatusCache()` exists in service but not on client; not called on settings save
+- [x] In-memory cache with 30-second TTL — 30s TTL constant at client level (`CACHE_TTL_MS = 30_000`)
+- [x] Cache is keyed by full URL (base URL + path) so Radarr and Sonarr caches do not collide — each client instance caches by full URL string
+- [x] `clearCache()` method flushes all cached entries for a client instance
 - [x] Client handles connection errors gracefully — returns stale cache on connection failure; never throws unhandled exceptions
-- [ ] Connection timeout configurable per service (default 10s) — current implementation has no timeout on `fetch()`
+- [x] Connection timeout configurable per service (default 10s) — `AbortSignal.timeout(10_000)` on all fetch calls
 - [x] `radarr_url`, `radarr_api_key`, `sonarr_url`, `sonarr_api_key` entries stored in the `settings` table
 - [x] tRPC procedures: `media.arr.getConfig()` returns configured/connected status
 - [x] tRPC procedure: `media.arr.getSettings()` returns URLs and whether API keys are set, never actual key values
 - [x] tRPC procedure: `media.arr.saveSettings(input)` accepts partial updates — masked placeholder value (`••••••••`) not overwritten
-- [ ] Saving settings clears the in-memory cache for the affected service — `clearStatusCache()` defined but not called in `saveSettings` mutation
+- [x] Saving settings clears the in-memory cache for the affected service — `arrService.clearStatusCache()` called in `saveSettings` mutation
 - [x] Tests verify: cache behavior, graceful error handling, partial settings update, API key never returned
 
 ## Notes


### PR DESCRIPTION
## Summary

- Ticked all 5 remaining acceptance criteria in US-01 (arr base client) — all were already implemented
- Marked US-01 Done → PRD-040 Done (all 3 user stories: US-01, US-02, US-03 now Done)
- Updated Epic 07 table: PRD-040 Partial → Done

No code changes — docs-only PR.

## Verification

All 5 criteria confirmed in code:
- `clearCache()` — `ArrBaseClient.clearCache()` at base-client.ts:77
- `clearStatusCache()` on save — router.ts:125 `arrService.clearStatusCache()`
- 10s timeout — `AbortSignal.timeout(10_000)` at base-client.ts:58
- Full-URL cache key — base-client.ts:45/71
- 30s TTL — `CACHE_TTL_MS = 30_000` at base-client.ts:17

## Test plan

- [ ] Docs changes only — no functional tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)