### PR TITLE
docs: mark PRD-033 Movie Detail Page as Done

### DIFF
--- a/docs/themes/03-media/epics/02-app-package-ui.md
+++ b/docs/themes/03-media/epics/02-app-package-ui.md
@@ -12,7 +12,7 @@ Build `@pops/app-media` — the workspace package with all media UI pages. Libra
 |---|-----|---------|--------|
 | 031 | [Library Page](../prds/031-library-page/README.md) | Grid view of owned media, filter by type (movie/TV), sorting, poster cards | Partial |
 | 032 | [Search Page](../prds/032-search-page/README.md) | Query TMDB/TheTVDB, display results, add-to-library flow with metadata fetch | Partial |
-| 033 | [Movie Detail Page](../prds/033-movie-detail-page/README.md) | Movie metadata display, poster/backdrop, cast, watch status, comparison scores, actions | Partial |
+| 033 | [Movie Detail Page](../prds/033-movie-detail-page/README.md) | Movie metadata display, poster/backdrop, cast, watch status, comparison scores, actions | Done |
 | 034 | [TV Show Detail Page](../prds/034-tv-show-detail-page/README.md) | Show metadata, season list, episode drill-down, per-episode watch tracking, season detail page | Partial |
 
 PRD-031 and PRD-032 can be built in parallel. PRD-033 and PRD-034 can be built in parallel. All four depend on Epic 01 (metadata must be fetchable).

--- a/docs/themes/03-media/prds/033-movie-detail-page/README.md
+++ b/docs/themes/03-media/prds/033-movie-detail-page/README.md
@@ -1,7 +1,7 @@
 # PRD-033: Movie Detail Page
 
 > Epic: [02 — App Package & Core UI](../../epics/02-app-package-ui.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -104,10 +104,10 @@ Build the movie detail page — a full metadata view with hero backdrop, poster,
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-movie-hero-metadata](us-01-movie-hero-metadata.md) | Hero layout with backdrop, poster, title/year/runtime/genres, overview, metadata grid | Partial | No (first) |
+| 01 | [us-01-movie-hero-metadata](us-01-movie-hero-metadata.md) | Hero layout with backdrop, poster, title/year/runtime/genres, overview, metadata grid | Done | No (first) |
 | 02 | [us-02-watchlist-toggle](us-02-watchlist-toggle.md) | WatchlistToggle component with optimistic add/remove, state detection | Done | Yes (parallel with us-01) |
 | 03 | [us-03-mark-as-watched](us-03-mark-as-watched.md) | MarkAsWatchedButton with watch logging, undo toast, watchlist auto-removal | Done | Yes (parallel with us-01) |
-| 04 | [us-04-comparison-scores](us-04-comparison-scores.md) | ComparisonScores radar chart, conditional display, score normalisation | Partial | Yes (parallel with us-01) |
+| 04 | [us-04-comparison-scores](us-04-comparison-scores.md) | ComparisonScores radar chart, conditional display, score normalisation | Done | Yes (parallel with us-01) |
 
 US-01 builds the page shell. US-02, US-03, and US-04 are independent components that can all be built in parallel with each other and integrated into the page.
 


### PR DESCRIPTION
All 4 user stories (US-01 through US-04) have been implemented and their individual files marked Done. The PRD README table was stale — this PR syncs it to reflect current state.

- US-01 (hero metadata): Done
- US-02 (watchlist toggle): Done  
- US-03 (mark as watched): Done
- US-04 (comparison scores): Done

Also updates Epic 02 table to mark PRD-033 as Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)