### PR TITLE
docs(media): PRD-041 docs audit — US-01 and US-02 Done [tb-254]

### DIFF
--- a/docs/themes/03-media/prds/041-radarr-request-management/README.md
+++ b/docs/themes/03-media/prds/041-radarr-request-management/README.md
@@ -86,9 +86,9 @@ The request action surfaces on existing movie pages, not on a dedicated route.
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-radarr-api-client](us-01-radarr-api-client.md) | Radarr v3 API client — quality profiles, root folders, add movie, check existence, update monitoring, trigger search | Partial | Yes |
-| 02 | [us-02-request-modal](us-02-request-modal.md) | Request modal with quality profile selector, root folder selector, confirm action, search trigger | Not started | Blocked by us-01 |
-| 03 | [us-03-request-integration](us-03-request-integration.md) | "Request" button on movie detail, search results, and discovery; state-aware visibility | Not started | Blocked by us-01, us-02 |
+| 01 | [us-01-radarr-api-client](us-01-radarr-api-client.md) | Radarr v3 API client — quality profiles, root folders, add movie, check existence, update monitoring, trigger search | Done | Yes |
+| 02 | [us-02-request-modal](us-02-request-modal.md) | Request modal with quality profile selector, root folder selector, confirm action, search trigger | Done | Blocked by us-01 |
+| 03 | [us-03-request-integration](us-03-request-integration.md) | "Request" button on movie detail, search results, and discovery; state-aware visibility | Partial | Blocked by us-01, us-02 |
 
 US-01 is the API layer. US-02 builds the modal component. US-03 integrates the button and modal into existing pages.
 

--- a/docs/themes/03-media/prds/041-radarr-request-management/us-01-radarr-api-client.md
+++ b/docs/themes/03-media/prds/041-radarr-request-management/us-01-radarr-api-client.md
@@ -1,7 +1,7 @@
 # US-01: Radarr API client
 
 > PRD: [041 — Radarr Request Management](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -10,19 +10,19 @@ As a developer, I want a Radarr v3 API client built on the shared arr base clien
 ## Acceptance Criteria
 
 - [x] Radarr client extends the base arr client factory from PRD-040
-- [ ] `media.radarr.getQualityProfiles()` returns a typed array of quality profiles from Radarr's `GET /api/v3/qualityprofile` endpoint
-- [ ] Each quality profile includes at minimum: `id`, `name`
-- [ ] `media.radarr.getRootFolders()` returns a typed array of root folders from Radarr's `GET /api/v3/rootfolder` endpoint
-- [ ] Each root folder includes: `id`, `path`, `freeSpace` (in bytes)
-- [ ] `media.radarr.checkMovie(tmdbId)` queries `GET /api/v3/movie?tmdbId=X` and returns `{ exists: boolean, radarrId?: number, monitored?: boolean }`
-- [ ] `checkMovie` returns `{ exists: false }` when Radarr returns an empty array for the TMDB ID
-- [ ] `media.radarr.addMovie(input)` sends `POST /api/v3/movie` with `{ tmdbId, title, qualityProfileId, rootFolderPath, monitored: true, addOptions: { searchForMovie: true } }` and returns the created movie object
-- [ ] `media.radarr.updateMonitoring(radarrId, monitored)` sends `PUT /api/v3/movie/:id` with the updated monitoring flag and returns the updated movie
-- [ ] `media.radarr.triggerSearch(radarrId)` sends `POST /api/v3/command` with `{ name: "MoviesSearch", movieIds: [radarrId] }` and returns a success message
-- [ ] All procedures return structured error objects on failure (network error, 401, 404, etc.) — never throw unhandled exceptions
-- [ ] All procedures require Radarr to be configured — return a clear error if URL or API key is missing from settings
-- [ ] Input validation: `tmdbId` is a positive integer, `qualityProfileId` is a positive integer, `rootFolderPath` is a non-empty string
-- [ ] Tests verify: quality profile fetch, root folder fetch with free space, checkMovie returns exists=true when found, checkMovie returns exists=false when not found, addMovie sends correct payload, updateMonitoring toggles flag, triggerSearch sends correct command, error handling on 401/network failure, validation rejects invalid inputs
+- [x] `media.radarr.getQualityProfiles()` returns a typed array of quality profiles from Radarr's `GET /api/v3/qualityprofile` endpoint
+- [x] Each quality profile includes at minimum: `id`, `name`
+- [x] `media.radarr.getRootFolders()` returns a typed array of root folders from Radarr's `GET /api/v3/rootfolder` endpoint
+- [x] Each root folder includes: `id`, `path`, `freeSpace` (in bytes)
+- [x] `media.radarr.checkMovie(tmdbId)` queries `GET /api/v3/movie?tmdbId=X` and returns `{ exists: boolean, radarrId?: number, monitored?: boolean }`
+- [x] `checkMovie` returns `{ exists: false }` when Radarr returns an empty array for the TMDB ID
+- [x] `media.radarr.addMovie(input)` sends `POST /api/v3/movie` with `{ tmdbId, title, qualityProfileId, rootFolderPath, monitored: true, addOptions: { searchForMovie: true } }` and returns the created movie object
+- [x] `media.radarr.updateMonitoring(radarrId, monitored)` sends `PUT /api/v3/movie/:id` with the updated monitoring flag and returns the updated movie
+- [x] `media.radarr.triggerSearch(radarrId)` sends `POST /api/v3/command` with `{ name: "MoviesSearch", movieIds: [radarrId] }` and returns a success message
+- [x] All procedures return structured error objects on failure (network error, 401, 404, etc.) — never throw unhandled exceptions
+- [x] All procedures require Radarr to be configured — return a clear error if URL or API key is missing from settings
+- [x] Input validation: `tmdbId` is a positive integer, `qualityProfileId` is a positive integer, `rootFolderPath` is a non-empty string
+- [x] Tests verify: quality profile fetch, root folder fetch with free space, checkMovie returns exists=true when found, checkMovie returns exists=false when not found, addMovie sends correct payload, updateMonitoring toggles flag, triggerSearch sends correct command, error handling on 401/network failure, validation rejects invalid inputs
 
 ## Notes
 

--- a/docs/themes/03-media/prds/041-radarr-request-management/us-02-request-modal.md
+++ b/docs/themes/03-media/prds/041-radarr-request-management/us-02-request-modal.md
@@ -1,7 +1,7 @@
 # US-02: Request movie modal
 
 > PRD: [041 — Radarr Request Management](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,23 +9,23 @@ As a user, I want a modal to request movies through Radarr so that I can select 
 
 ## Acceptance Criteria
 
-- [ ] `RequestMovieModal` component accepts a movie (tmdbId, title, year) and an `onClose` callback
-- [ ] Modal header shows the movie title and year for confirmation
-- [ ] Quality profile dropdown is populated by calling `media.radarr.getQualityProfiles()` when the modal opens
-- [ ] Root folder dropdown is populated by calling `media.radarr.getRootFolders()` when the modal opens
-- [ ] Root folder options display the path and human-readable free space (e.g., "/movies — 1.2 TB free")
-- [ ] Both dropdowns default to the first available option
-- [ ] "Request" confirm button is disabled until both quality profile and root folder are selected
-- [ ] "Request" confirm button is disabled while data is loading (profiles/folders fetch in progress)
-- [ ] Clicking "Request" calls `media.radarr.addMovie()` with the selected options
-- [ ] Confirm button shows a loading spinner while the request is in flight
-- [ ] On success: modal shows a brief success message, then closes after 1.5 seconds
-- [ ] On error: modal shows an inline error message below the confirm button (e.g., "Movie already exists in Radarr"), confirm button re-enables
-- [ ] "Cancel" button closes the modal without making any API calls
-- [ ] Clicking the modal backdrop closes the modal (same as cancel)
-- [ ] If quality profiles or root folders fail to load, the modal shows an error state with a retry option
-- [ ] Modal is accessible: focus trapped within modal, Escape key closes it, confirm button is focusable
-- [ ] Tests verify: dropdowns populate from API data, confirm sends correct payload, success flow closes modal, error flow shows message, cancel closes without API call, loading states disable interactions, empty profiles/folders show error
+- [x] `RequestMovieModal` component accepts a movie (tmdbId, title, year) and an `onClose` callback
+- [x] Modal header shows the movie title and year for confirmation
+- [x] Quality profile dropdown is populated by calling `media.radarr.getQualityProfiles()` when the modal opens
+- [x] Root folder dropdown is populated by calling `media.radarr.getRootFolders()` when the modal opens
+- [x] Root folder options display the path and human-readable free space (e.g., "/movies — 1.2 TB free")
+- [x] Both dropdowns default to the first available option
+- [x] "Request" confirm button is disabled until both quality profile and root folder are selected
+- [x] "Request" confirm button is disabled while data is loading (profiles/folders fetch in progress)
+- [x] Clicking "Request" calls `media.radarr.addMovie()` with the selected options
+- [x] Confirm button shows a loading spinner while the request is in flight
+- [x] On success: modal shows a brief success message, then closes after 1.5 seconds
+- [x] On error: modal shows an inline error message below the confirm button (e.g., "Movie already exists in Radarr"), confirm button re-enables
+- [x] "Cancel" button closes the modal without making any API calls
+- [x] Clicking the modal backdrop closes the modal (same as cancel)
+- [x] If quality profiles or root folders fail to load, the modal shows an error state with a retry option
+- [x] Modal is accessible: focus trapped within modal, Escape key closes it, confirm button is focusable
+- [x] Tests verify: dropdowns populate from API data, confirm sends correct payload, success flow closes modal, error flow shows message, cancel closes without API call, loading states disable interactions, empty profiles/folders show error
 
 ## Notes
 

--- a/docs/themes/03-media/prds/041-radarr-request-management/us-03-request-integration.md
+++ b/docs/themes/03-media/prds/041-radarr-request-management/us-03-request-integration.md
@@ -1,7 +1,7 @@
 # US-03: Request button integration
 
 > PRD: [041 — Radarr Request Management](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -9,17 +9,17 @@ As a user, I want a "Request" button on movie detail pages, search results, and 
 
 ## Acceptance Criteria
 
-- [ ] `RequestMovieButton` component accepts a movie (tmdbId, title, year) and renders a "Request" button
-- [ ] Button is hidden (not rendered) when the movie already exists in Radarr — determined by calling `media.radarr.checkMovie(tmdbId)` which returns `exists: true`
-- [ ] Button is disabled with a "Radarr not configured" tooltip when Radarr is not configured — determined by `media.arr.getConfig()` returning `radarr.configured: false`
+- [x] `RequestMovieButton` component accepts a movie (tmdbId, title, year) and renders a "Request" button
+- [x] Button is hidden (not rendered) when the movie already exists in Radarr — determined by calling `media.radarr.checkMovie(tmdbId)` which returns `exists: true`
+- [x] Button is disabled with a "Radarr not configured" tooltip when Radarr is not configured — determined by `media.arr.getConfig()` returning `radarr.configured: false`
 - [ ] Clicking the button opens the `RequestMovieModal`
 - [ ] After a successful request, the button disappears and the arr status badge updates to reflect the new state (Monitored or Downloading)
-- [ ] Movie detail page: button renders in the header/action area alongside other actions
-- [ ] Search results page: button renders as an action on each movie result card
-- [ ] Discovery/recommendations page: button renders as an action on each recommended movie card
-- [ ] Button checks Radarr existence using the cached base client (30s TTL) — navigating between pages does not trigger redundant existence checks
-- [ ] Button renders a compact variant for card contexts (search results, discovery) and a standard variant for the detail page
-- [ ] If `checkMovie` fails (Radarr unreachable), the button does not render — same graceful degradation as status badges
+- [x] Movie detail page: button renders in the header/action area alongside other actions
+- [x] Search results page: button renders as an action on each movie result card
+- [x] Discovery/recommendations page: button renders as an action on each recommended movie card
+- [x] Button checks Radarr existence using the cached base client (30s TTL) — navigating between pages does not trigger redundant existence checks
+- [x] Button renders a compact variant for card contexts (search results, discovery) and a standard variant for the detail page
+- [x] If `checkMovie` fails (Radarr unreachable), the button does not render — same graceful degradation as status badges
 - [ ] Tests verify: button hidden when movie exists in Radarr, button disabled when Radarr not configured, button absent when Radarr unreachable, clicking opens modal, button disappears after successful request, compact variant renders on cards, standard variant renders on detail page
 
 ## Notes


### PR DESCRIPTION
## Summary
- US-01 (Radarr API client): all 14 criteria verified in `radarr-client.ts` + `router.ts` → Done
- US-02 (Request modal): all 17 criteria verified in `RequestMovieModal.tsx` → Done
- US-03 (Request integration): 9/12 criteria done → Partial (modal opening and post-success disappearance not yet wired — `RequestMovieButton` has `onRequest` callback but `MovieDetailPage` doesn't pass it, falling back to "coming soon" toast)

## Test plan
- [ ] Docs-only change — no code modified, CI should pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)