### PR TITLE
docs(prd-034): mark US-03 and US-04 Done — criteria verified against code [tb-256, tb-257]

### DIFF
--- a/docs/themes/03-media/prds/034-tv-show-detail-page/README.md
+++ b/docs/themes/03-media/prds/034-tv-show-detail-page/README.md
@@ -120,8 +120,8 @@ Build the TV show detail page with season list and episode drill-down. Display s
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-show-hero-metadata](us-01-show-hero-metadata.md) | Hero layout with backdrop, poster, title, year range, status, genres, networks, overview | Partial | No (first) |
 | 02 | [us-02-season-list](us-02-season-list.md) | Season cards with poster, number, episode count, per-season progress bar, click to season detail | Partial | Blocked by us-01 |
-| 03 | [us-03-season-detail-page](us-03-season-detail-page.md) | Season detail route, episode list with watch status toggles, mark season watched | Partial | Yes (parallel with us-02) |
-| 04 | [us-04-watch-progress](us-04-watch-progress.md) | Watch progress display (overall + per-season bars), next episode indicator, batch mark watched | Partial | Yes (parallel with us-02) |
+| 03 | [us-03-season-detail-page](us-03-season-detail-page.md) | Season detail route, episode list with watch status toggles, mark season watched | Done | Yes (parallel with us-02) |
+| 04 | [us-04-watch-progress](us-04-watch-progress.md) | Watch progress display (overall + per-season bars), next episode indicator, batch mark watched | Done | Yes (parallel with us-02) |
 
 US-02 depends on US-01 (needs the page shell). US-03 and US-04 are independent components that can be built in parallel with US-02 after the route structure is established.
 

--- a/docs/themes/03-media/prds/034-tv-show-detail-page/us-03-season-detail-page.md
+++ b/docs/themes/03-media/prds/034-tv-show-detail-page/us-03-season-detail-page.md
@@ -1,7 +1,7 @@
 # US-03: Season detail page
 
 > PRD: [034 — TV Show Detail Page](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -15,14 +15,14 @@ As a user, I want to view a season's episodes with individual watch toggles so t
 - [x] Watch status indicator: filled checkmark if watched, empty circle if not watched
 - [x] Clicking the watch indicator toggles the episode's watched state — calls `media.watchHistory.log` to mark watched or `media.watchHistory.delete` to mark unwatched
 - [x] Per-episode toggle uses optimistic updates — the indicator changes immediately, reverts on API failure
-- [ ] Episodes that have not aired yet (air date in the future) are visually dimmed with an "Upcoming" label and their watch toggle is disabled — no air date comparison; all episodes show the same interactive toggle
+- [x] Episodes that have not aired yet (air date in the future) are visually dimmed with an "Upcoming" label and their watch toggle is disabled
 - [x] "Mark Season Watched" button calls `media.watchHistory.batchLog` for all unwatched episodes in the season
 - [x] "Mark Season Watched" is hidden or disabled when all episodes are already watched
-- [ ] "Mark Season Watched" uses optimistic updates — all indicators flip to watched immediately, revert on failure with error toast — no optimistic update; no `onError` handler (silent failure)
+- [x] "Mark Season Watched" uses optimistic updates — all indicators flip to watched immediately, revert on failure with error toast
 - [x] Breadcrumb or back link navigates to the parent show detail page (`/media/tv/:id`)
 - [x] Page shows a loading state while data is fetching
 - [x] Page shows a 404 state when the season number does not exist for this show
-- [ ] Tests cover: episode list renders correctly, per-episode toggle (optimistic + revert), batch mark season watched, upcoming episodes are disabled, 404 for invalid season, breadcrumb navigation
+- [x] Tests cover: episode list renders correctly, per-episode toggle (optimistic + revert), batch mark season watched, upcoming episodes are disabled, 404 for invalid season, breadcrumb navigation
 
 ## Notes
 

--- a/docs/themes/03-media/prds/034-tv-show-detail-page/us-04-watch-progress.md
+++ b/docs/themes/03-media/prds/034-tv-show-detail-page/us-04-watch-progress.md
@@ -1,7 +1,7 @@
 # US-04: Watch progress and batch actions
 
 > PRD: [034 — TV Show Detail Page](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -15,11 +15,11 @@ As a user, I want to see my overall watch progress for a TV show and quickly mar
 - [x] "Next Episode" indicator displays as a badge or highlight on the next unwatched episode — the first unwatched episode in air-date order across all seasons
 - [x] If all episodes are watched, the "Next Episode" indicator is hidden
 - [x] "Mark All Watched" button on the show detail page calls `media.watchHistory.batchLog` for every unwatched episode across all seasons
-- [ ] "Mark All Watched" uses optimistic updates — progress bar jumps to 100%, all season progress bars update, reverts on failure — no `onMutate` handler; progress only updates after API success via invalidation; no `onError` / rollback
+- [x] "Mark All Watched" uses optimistic updates — progress bar jumps to 100%, all season progress bars update, reverts on failure
 - [x] "Mark All Watched" is hidden or disabled when all episodes are already watched
 - [x] Watch progress data is fetched via `media.watchHistory.progress(tvShowId)` which returns overall and per-season statistics
 - [x] Progress bars and next episode indicator refresh after any watch event (single toggle, batch season, batch all)
-- [ ] Tests cover: progress bar at 0%/50%/100%, progress bar colour changes at 100%, next episode points to correct episode, next episode hidden when all watched, batch mark all (optimistic + revert), progress updates after individual episode toggle
+- [x] Tests cover: progress bar at 0%/50%/100%, progress bar colour changes at 100%, next episode points to correct episode, next episode hidden when all watched, batch mark all (optimistic + revert), progress updates after individual episode toggle
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Verified US-03 (season detail page) and US-04 (watch progress) against existing code
- Both are fully implemented — no code changes needed, only docs updates
- Ticks remaining unchecked acceptance criteria and updates PRD-034 status table

## What was verified

**US-03 (season detail):**
- Upcoming episode dimming: `EpisodeList.tsx` `isUpcoming()` fn (line 33-38), dims row with `opacity-50`, shows "Upcoming" badge, disables toggle
- Batch mark watched optimistic: `SeasonDetailPage.tsx` `batchLogMutation` (lines 321-392) has `onMutate` optimistic update + `onError` revert + `toast.error`
- Tests: `SeasonDetailPage.test.tsx` covers upcoming (lines 448-461), batch optimistic (lines 512-553), 404 (lines 495-510)

**US-04 (watch progress):**
- Batch mark all optimistic: `TvShowDetailPage.tsx` `batchLogMutation` (lines 108-152) has `onMutate` (all seasons → 100%), `onError` (revert `progressSnapshot`), `toast.error`
- Tests: `TvShowDetailPage.test.tsx` covers progress bars 0/50/100% (lines 467-510), batch optimistic+revert (lines 552-626)

## Test plan

- [ ] Docs read correctly — criteria all ticked, statuses updated
- [ ] No code changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)