### PR TITLE
docs(prd-031): mark US-03 Done — empty/loading/error states verified [tb-258]

### DIFF
--- a/docs/themes/03-media/prds/031-library-page/README.md
+++ b/docs/themes/03-media/prds/031-library-page/README.md
@@ -70,7 +70,7 @@ Build the media library — a responsive grid of all owned movies and TV shows. 
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-media-card](us-01-media-card.md) | MediaCard component with poster fallback chain, title, year, type badge, click navigation | Partial | No (first) |
 | 02 | [us-02-library-grid](us-02-library-grid.md) | Library page with responsive grid, type filter tabs, sort select, search input, pagination | Partial | Blocked by us-01 |
-| 03 | [us-03-empty-loading-states](us-03-empty-loading-states.md) | Empty state with CTA, loading skeleton grid, error state with retry | Partial | Yes (parallel with us-02) |
+| 03 | [us-03-empty-loading-states](us-03-empty-loading-states.md) | Empty state with CTA, loading skeleton grid, error state with retry | Done | Yes (parallel with us-02) |
 
 US-02 depends on US-01 (needs MediaCard). US-03 can be built in parallel with US-02 (independent state components).
 

--- a/docs/themes/03-media/prds/031-library-page/us-03-empty-loading-states.md
+++ b/docs/themes/03-media/prds/031-library-page/us-03-empty-loading-states.md
@@ -1,7 +1,7 @@
 # US-03: Empty, loading, and error states
 
 > PRD: [031 — Library Page](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -10,14 +10,14 @@ As a user, I want clear feedback when the library is empty, loading, or has an e
 ## Acceptance Criteria
 
 - [x] Empty state renders when the library has zero items (no filters active): heading, descriptive text, and a CTA link/button navigating to `/media/search`
-- [ ] Empty search state renders when filters/search return zero results: "No results for [query]" message with a "Clear search" button that resets all filters — search not implemented; shows generic "No results match your filters" without clear button
+- [x] Empty search state renders when filters/search return zero results: "No results for [query]" message with a "Clear search" button that resets all filters
 - [x] Loading state renders a skeleton grid matching the poster card dimensions and the current column count
-- [ ] Skeleton cards animate with a shimmer/pulse effect — skeletons render but no shimmer/pulse animation
-- [ ] Skeleton grid renders the expected number of cards based on the current page size (24/48/96) — hardcoded to 12; pagination not implemented
-- [ ] Error state renders an error message with a "Retry" button that re-fetches the library data — no error state handling
-- [ ] Error state does not show a stack trace or technical details to the user — not implemented
+- [x] Skeleton cards animate with a shimmer/pulse effect
+- [x] Skeleton grid renders the expected number of cards based on the current page size (24/48/96)
+- [x] Error state renders an error message with a "Retry" button that re-fetches the library data
+- [x] Error state does not show a stack trace or technical details to the user
 - [x] States transition correctly: loading → content (or empty, or error)
-- [ ] Tests cover: empty state renders with CTA link, empty search state shows clear button, skeleton grid renders correct card count, error state renders retry button, retry triggers re-fetch
+- [x] Tests cover: empty state renders with CTA link, empty search state shows clear button, skeleton grid renders correct card count, error state renders retry button, retry triggers re-fetch
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Verified US-03 criteria against `LibraryPage.tsx` and `LibraryPage.test.tsx`
- All items already implemented — docs-only update

## What was verified

- Empty search state: `LibraryPage.tsx` lines 319-330 — "No results for [query]" + "Clear search" button
- Skeleton animation: `@pops/ui` `Skeleton` component has `animate-pulse` class
- Dynamic skeleton count: `<LibrarySkeleton count={pageSize} />` at line 299
- Error state: lines 300-307 — generic message + Retry button + no stack trace
- Tests: `LibraryPage.test.tsx` covers loading with pageSize param, error+retry, empty state, empty search clear button

🤖 Generated with [Claude Code](https://claude.com/claude-code)