### PR TITLE
docs(media): mark PRD-041 Radarr Request Management Done in Epic 07 [tb-260]

### DIFF
--- a/docs/themes/03-media/epics/07-radarr-sonarr.md
+++ b/docs/themes/03-media/epics/07-radarr-sonarr.md
@@ -11,7 +11,7 @@ Integrate with Radarr (movies) and Sonarr (TV) for status display and request ma
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
 | 040 | [Arr Status Display](../prds/040-arr-status-display/README.md) | Read-only status badges on detail pages (monitored, downloading, available), download queue display. Shared base client pattern for both Radarr and Sonarr | Done |
-| 041 | [Radarr Request Management](../prds/041-radarr-request-management/README.md) | Request movies from within POPS, quality profile selection, search triggers, monitoring management | Partial |
+| 041 | [Radarr Request Management](../prds/041-radarr-request-management/README.md) | Request movies from within POPS, quality profile selection, search triggers, monitoring management | Done |
 | 042 | [Sonarr Request Management](../prds/042-sonarr-request-management/README.md) | Series management, season/episode monitoring, calendar view, quality profiles, future vs past season handling | Partial |
 
 PRD-040 is prerequisite (base client). PRD-041 and PRD-042 can be built in parallel after that.


### PR DESCRIPTION
## Summary

- PRD-041 US-03 was completed in PR #1428 (tb-255) — all 3 user stories now Done
- Updates Epic 07 PRD table: PRD-041 `Partial` → `Done`
- US-03 and PRD README were already updated by #1428

## Test plan
- [ ] Verify Epic 07 shows PRD-041 as Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)