### PR TITLE
docs: mark PRD-034 TV Show Detail and PRD-041 Radarr Request Done

### DIFF
--- a/docs/themes/03-media/epics/02-app-package-ui.md
+++ b/docs/themes/03-media/epics/02-app-package-ui.md
@@ -13,7 +13,7 @@ Build `@pops/app-media` — the workspace package with all media UI pages. Libra
 | 031 | [Library Page](../prds/031-library-page/README.md) | Grid view of owned media, filter by type (movie/TV), sorting, poster cards | Partial |
 | 032 | [Search Page](../prds/032-search-page/README.md) | Query TMDB/TheTVDB, display results, add-to-library flow with metadata fetch | Partial |
 | 033 | [Movie Detail Page](../prds/033-movie-detail-page/README.md) | Movie metadata display, poster/backdrop, cast, watch status, comparison scores, actions | Done |
-| 034 | [TV Show Detail Page](../prds/034-tv-show-detail-page/README.md) | Show metadata, season list, episode drill-down, per-episode watch tracking, season detail page | Partial |
+| 034 | [TV Show Detail Page](../prds/034-tv-show-detail-page/README.md) | Show metadata, season list, episode drill-down, per-episode watch tracking, season detail page | Done |
 
 PRD-031 and PRD-032 can be built in parallel. PRD-033 and PRD-034 can be built in parallel. All four depend on Epic 01 (metadata must be fetchable).
 

--- a/docs/themes/03-media/epics/07-radarr-sonarr.md
+++ b/docs/themes/03-media/epics/07-radarr-sonarr.md
@@ -11,7 +11,7 @@ Integrate with Radarr (movies) and Sonarr (TV) for status display and request ma
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
 | 040 | [Arr Status Display](../prds/040-arr-status-display/README.md) | Read-only status badges on detail pages (monitored, downloading, available), download queue display. Shared base client pattern for both Radarr and Sonarr | Done |
-| 041 | [Radarr Request Management](../prds/041-radarr-request-management/README.md) | Request movies from within POPS, quality profile selection, search triggers, monitoring management | Partial |
+| 041 | [Radarr Request Management](../prds/041-radarr-request-management/README.md) | Request movies from within POPS, quality profile selection, search triggers, monitoring management | Done |
 | 042 | [Sonarr Request Management](../prds/042-sonarr-request-management/README.md) | Series management, season/episode monitoring, calendar view, quality profiles, future vs past season handling | Partial |
 
 PRD-040 is prerequisite (base client). PRD-041 and PRD-042 can be built in parallel after that.

--- a/docs/themes/03-media/prds/034-tv-show-detail-page/README.md
+++ b/docs/themes/03-media/prds/034-tv-show-detail-page/README.md
@@ -1,7 +1,7 @@
 # PRD-034: TV Show Detail Page
 
 > Epic: [02 — App Package & Core UI](../../epics/02-app-package-ui.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -118,8 +118,8 @@ Build the TV show detail page with season list and episode drill-down. Display s
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-show-hero-metadata](us-01-show-hero-metadata.md) | Hero layout with backdrop, poster, title, year range, status, genres, networks, overview | Partial | No (first) |
-| 02 | [us-02-season-list](us-02-season-list.md) | Season cards with poster, number, episode count, per-season progress bar, click to season detail | Partial | Blocked by us-01 |
+| 01 | [us-01-show-hero-metadata](us-01-show-hero-metadata.md) | Hero layout with backdrop, poster, title, year range, status, genres, networks, overview | Done | No (first) |
+| 02 | [us-02-season-list](us-02-season-list.md) | Season cards with poster, number, episode count, per-season progress bar, click to season detail | Done | Blocked by us-01 |
 | 03 | [us-03-season-detail-page](us-03-season-detail-page.md) | Season detail route, episode list with watch status toggles, mark season watched | Done | Yes (parallel with us-02) |
 | 04 | [us-04-watch-progress](us-04-watch-progress.md) | Watch progress display (overall + per-season bars), next episode indicator, batch mark watched | Done | Yes (parallel with us-02) |
 


### PR DESCRIPTION
Updates stale status tables after recent merges:

- PRD-034 (TV Show Detail Page): all 4 US are Done, README table was showing US-01/US-02 as Partial. Status → Done.
- PRD-041 (Radarr Request Management): all 3 US merged (US-03 via PR #1428). Epic 07 table updated.
- Epic 02 table: PRD-034 → Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)