### PR TITLE
docs: mark PRD-031 Library Page as Done

### DIFF
--- a/docs/themes/03-media/epics/02-app-package-ui.md
+++ b/docs/themes/03-media/epics/02-app-package-ui.md
@@ -10,10 +10,10 @@ Build `@pops/app-media` — the workspace package with all media UI pages. Libra
 
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
-| 031 | [Library Page](../prds/031-library-page/README.md) | Grid view of owned media, filter by type (movie/TV), sorting, poster cards | Partial |
+| 031 | [Library Page](../prds/031-library-page/README.md) | Grid view of owned media, filter by type (movie/TV), sorting, poster cards | Done |
 | 032 | [Search Page](../prds/032-search-page/README.md) | Query TMDB/TheTVDB, display results, add-to-library flow with metadata fetch | Partial |
 | 033 | [Movie Detail Page](../prds/033-movie-detail-page/README.md) | Movie metadata display, poster/backdrop, cast, watch status, comparison scores, actions | Done |
-| 034 | [TV Show Detail Page](../prds/034-tv-show-detail-page/README.md) | Show metadata, season list, episode drill-down, per-episode watch tracking, season detail page | Partial |
+| 034 | [TV Show Detail Page](../prds/034-tv-show-detail-page/README.md) | Show metadata, season list, episode drill-down, per-episode watch tracking, season detail page | Done |
 
 PRD-031 and PRD-032 can be built in parallel. PRD-033 and PRD-034 can be built in parallel. All four depend on Epic 01 (metadata must be fetchable).
 

--- a/docs/themes/03-media/prds/031-library-page/README.md
+++ b/docs/themes/03-media/prds/031-library-page/README.md
@@ -1,7 +1,7 @@
 # PRD-031: Library Page
 
 > Epic: [02 — App Package & Core UI](../../epics/02-app-package-ui.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -68,8 +68,8 @@ Build the media library — a responsive grid of all owned movies and TV shows. 
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-media-card](us-01-media-card.md) | MediaCard component with poster fallback chain, title, year, type badge, click navigation | Partial | No (first) |
-| 02 | [us-02-library-grid](us-02-library-grid.md) | Library page with responsive grid, type filter tabs, sort select, search input, pagination | Partial | Blocked by us-01 |
+| 01 | [us-01-media-card](us-01-media-card.md) | MediaCard component with poster fallback chain, title, year, type badge, click navigation | Done | No (first) |
+| 02 | [us-02-library-grid](us-02-library-grid.md) | Library page with responsive grid, type filter tabs, sort select, search input, pagination | Done | Blocked by us-01 |
 | 03 | [us-03-empty-loading-states](us-03-empty-loading-states.md) | Empty state with CTA, loading skeleton grid, error state with retry | Done | Yes (parallel with us-02) |
 
 US-02 depends on US-01 (needs MediaCard). US-03 can be built in parallel with US-02 (independent state components).


### PR DESCRIPTION
All 3 US complete — US-01/US-02 were Done in their files but PRD README table was stale. Updated table and status. Also updates Epic 02 table (PRD-031 and PRD-034 → Done, PRD-034 was updated in previous PR but not yet reflected locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)