### PR TITLE
feat(watchlist): add priority number to mobile list items [tb-260]

### DIFF
--- a/docs/themes/03-media/prds/036-watchlist/README.md
+++ b/docs/themes/03-media/prds/036-watchlist/README.md
@@ -80,7 +80,7 @@ Build a prioritised list of movies and TV shows to watch next. Users add/remove 
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-watchlist-page](us-01-watchlist-page.md) | Watchlist page with responsive layout (grid desktop/list mobile), filter tabs, priority badges, notes display | Partial | Yes |
+| 01 | [us-01-watchlist-page](us-01-watchlist-page.md) | Watchlist page with responsive layout (grid desktop/list mobile), filter tabs, priority badges, notes display | Done | Yes |
 | 02 | [us-02-reorder](us-02-reorder.md) | Drag-and-drop reorder (desktop) and up/down buttons (mobile), batch priority update in transaction | Partial | Blocked by us-01 |
 | 03 | [us-03-auto-removal](us-03-auto-removal.md) | Auto-remove from watchlist on manual watch completion, skip for plex_sync source | Partial | Yes (parallel with us-01) |
 

--- a/docs/themes/03-media/prds/036-watchlist/us-01-watchlist-page.md
+++ b/docs/themes/03-media/prds/036-watchlist/us-01-watchlist-page.md
@@ -1,7 +1,7 @@
 # US-01: Watchlist page
 
 > PRD: [036 — Watchlist](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -11,17 +11,17 @@ As a user, I want a prioritised watchlist page that shows movies and TV shows I 
 
 - [x] Watchlist page renders at `/media/watchlist`
 - [x] Desktop layout: poster grid with numbered priority badges in the top-left corner of each card
-- [ ] Mobile layout: compact list with poster thumbnail, title, and priority number
+- [x] Mobile layout: compact list with poster thumbnail, title, and priority number
 - [x] Priority badges display sequential numbers (1, 2, 3...) matching the current sort order
-- [ ] Filter tabs: "All", "Movies", "TV Shows" — active tab updates `?type=` query param
-- [ ] Filter tabs update the displayed list without a full page reload
+- [x] Filter tabs: "All", "Movies", "TV Shows" — active tab updates `?type=` query param
+- [x] Filter tabs update the displayed list without a full page reload
 - [x] Each item shows optional notes text below the poster/title (truncated with expand on click)
-- [ ] Page calls `media.watchlist.list` with type filter parameter
+- [x] Page calls `media.watchlist.list` with type filter parameter
 - [x] Items are ordered by priority ASC, then addedAt DESC
 - [x] Empty state: "Your watchlist is empty" with links to the library page and search page
 - [x] Loading state: skeleton matching the active layout (grid for desktop, list for mobile)
-- [ ] Filter-specific empty state: "No movies on your watchlist" or "No TV shows on your watchlist"
-- [ ] Tests cover: grid layout renders on desktop viewport, list layout renders on mobile viewport, filter tabs switch content, priority badges show correct numbers, notes display and truncation, empty state renders
+- [x] Filter-specific empty state: "No movies on your watchlist" or "No TV shows on your watchlist"
+- [x] Tests cover: grid layout renders on desktop viewport, list layout renders on mobile viewport, filter tabs switch content, priority badges show correct numbers, notes display and truncation, empty state renders
 
 ## Notes
 

--- a/packages/app-media/src/pages/WatchlistPage.test.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.test.tsx
@@ -210,6 +210,24 @@ describe("WatchlistPage", () => {
     expect(screen.getAllByText("#3").length).toBeGreaterThan(0);
   });
 
+  it("renders priority numbers on mobile list items", () => {
+    setupMultipleEntries();
+    renderPage();
+
+    // Mobile items show numeric priority (1, 2, 3) without # prefix
+    expect(screen.getAllByText("1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("2").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("3").length).toBeGreaterThan(0);
+  });
+
+  it("renders notes text on watchlist items", () => {
+    setupMultipleEntries();
+    renderPage();
+
+    // entry2 has notes "Great show"
+    expect(screen.getAllByText("Great show").length).toBeGreaterThan(0);
+  });
+
   describe("filter tabs", () => {
     it("renders All, Movies, TV Shows filter tabs", () => {
       setupMultipleEntries();

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -97,6 +97,7 @@ interface WatchlistItemProps {
   title: string;
   year: number | null;
   posterUrl: string | null;
+  priority: number;
   isFirst: boolean;
   isLast: boolean;
   onMoveUp: () => void;
@@ -115,6 +116,7 @@ function WatchlistItem({
   title,
   year,
   posterUrl,
+  priority,
   isFirst,
   isLast,
   onMoveUp,
@@ -225,6 +227,9 @@ function WatchlistItem({
               <h3 className="text-sm font-medium truncate">{title}</h3>
             </Link>
             <div className="flex items-center gap-2 mt-0.5">
+              <span className="bg-primary text-primary-foreground text-xs font-bold rounded-full h-5 w-5 flex items-center justify-center shrink-0">
+                {priority}
+              </span>
               <Badge variant="secondary" className="text-xs">
                 {entry.mediaType === "movie" ? "Movie" : "TV"}
               </Badge>
@@ -727,6 +732,7 @@ export function WatchlistPage() {
                   title={meta?.title ?? "Unknown"}
                   year={meta?.year ?? null}
                   posterUrl={meta?.posterUrl ?? null}
+                  priority={index + 1}
                   isFirst={index === 0}
                   isLast={index === sortedEntries.length - 1}
                   onMoveUp={() => handleMove(index, "up")}


### PR DESCRIPTION
## Summary

- Mobile `WatchlistItem` was missing the priority number — only the desktop `WatchlistCard` had it
- Added `priority: number` prop to `WatchlistItemProps` and renders a circular badge (matching desktop style) next to the type badge in the mobile list view
- Added tests: priority numbers on mobile list items, notes text display
- Ticked all remaining criteria in `us-01-watchlist-page.md`, marked US-01 Done in PRD-036 README

## Test plan

- [ ] CI passes
- [ ] Mobile list items show priority number (1, 2, 3...)
- [ ] Desktop cards still show #1, #2, #3 priority badges
- [ ] Filter tabs (All/Movies/TV Shows) switch content correctly
- [ ] Notes text renders on items that have notes
- [ ] Empty state renders for each filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)