### PR TITLE
docs: mark PRD-032 Search Page Done and Epic 02 Complete

### DIFF
--- a/docs/themes/03-media/README.md
+++ b/docs/themes/03-media/README.md
@@ -21,7 +21,7 @@ Build a personal media intelligence app — not just a tracker, but a system tha
 |---|------|---------|--------|
 | 0 | [Data Model & API](epics/00-data-model-api.md) | Split tables (movies, shows, seasons, episodes), comparisons schema, tRPC routers | Done |
 | 1 | [Metadata Integration](epics/01-metadata-integration.md) | TMDB (movies) and TheTVDB (TV) — search, metadata fetch, poster cache, rate limiting | Partial |
-| 2 | [App Package & Core UI](epics/02-app-package-ui.md) | `@pops/app-media` — routes, pages, browse/search/detail views | Partial |
+| 2 | [App Package & Core UI](epics/02-app-package-ui.md) | `@pops/app-media` — routes, pages, browse/search/detail views | Done |
 | 3 | [Tracking & Watchlist](epics/03-tracking-watchlist.md) | Watch history, watchlist management, episode-level progress | Partial |
 | 4 | [Ratings & Comparisons](epics/04-ratings-comparisons.md) | 1v1 pairwise comparisons, ELO scoring, rankings, radar charts | Done |
 | 5 | [Discovery & Recommendations](epics/05-discovery-recommendations.md) | Trending, new releases, personalised suggestions | Partial |

--- a/docs/themes/03-media/epics/02-app-package-ui.md
+++ b/docs/themes/03-media/epics/02-app-package-ui.md
@@ -11,7 +11,7 @@ Build `@pops/app-media` — the workspace package with all media UI pages. Libra
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
 | 031 | [Library Page](../prds/031-library-page/README.md) | Grid view of owned media, filter by type (movie/TV), sorting, poster cards | Done |
-| 032 | [Search Page](../prds/032-search-page/README.md) | Query TMDB/TheTVDB, display results, add-to-library flow with metadata fetch | Partial |
+| 032 | [Search Page](../prds/032-search-page/README.md) | Query TMDB/TheTVDB, display results, add-to-library flow with metadata fetch | Done |
 | 033 | [Movie Detail Page](../prds/033-movie-detail-page/README.md) | Movie metadata display, poster/backdrop, cast, watch status, comparison scores, actions | Done |
 | 034 | [TV Show Detail Page](../prds/034-tv-show-detail-page/README.md) | Show metadata, season list, episode drill-down, per-episode watch tracking, season detail page | Done |
 

--- a/docs/themes/03-media/prds/032-search-page/README.md
+++ b/docs/themes/03-media/prds/032-search-page/README.md
@@ -1,7 +1,7 @@
 # PRD-032: Search Page
 
 > Epic: [02 — App Package & Core UI](../../epics/02-app-package-ui.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -80,9 +80,9 @@ Build a search page that queries TMDB for movies and TheTVDB for TV shows. Displ
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-search-input](us-01-search-input.md) | Debounced search input querying TMDB and TheTVDB in parallel | Partial | No (first) |
+| 01 | [us-01-search-input](us-01-search-input.md) | Debounced search input querying TMDB and TheTVDB in parallel | Done | No (first) |
 | 02 | [us-02-search-results](us-02-search-results.md) | Result cards with poster/title/year/overview, "In Library" badge, tab/section layout | Done | Blocked by us-01 |
-| 03 | [us-03-add-to-library-flow](us-03-add-to-library-flow.md) | Add button with spinner, addMovie/addTvShow call, success toast, badge update | Partial | Blocked by us-02 |
+| 03 | [us-03-add-to-library-flow](us-03-add-to-library-flow.md) | Add button with spinner, addMovie/addTvShow call, success toast, badge update | Done | Blocked by us-02 |
 
 US-02 depends on US-01 (needs search state). US-03 depends on US-02 (needs result cards to attach the button to).
 


### PR DESCRIPTION
PRD-032 (Search Page): all 3 US now Done. US-02 tests were merged in PR #1432, but README table was still stale. Updated all 3 US statuses and PRD status to Done.

Since all 4 PRDs in Epic 02 are now Done (031 ✓, 032 ✓, 033 ✓, 034 ✓), Epic 02 (App Package & Core UI) is marked Done in the theme README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)