### PR TITLE
fix(media): use movie.id in debrief link on MovieDetailPage [tb-262]

### DIFF
--- a/packages/app-media/src/pages/MovieDetailPage.test.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.test.tsx
@@ -370,7 +370,7 @@ describe("MovieDetailPage", () => {
       renderAtRoute("/media/movies/1");
       const button = screen.getByText("Debrief this movie");
       expect(button).toBeInTheDocument();
-      expect(button.closest("a")).toHaveAttribute("href", "/media/debrief/42");
+      expect(button.closest("a")).toHaveAttribute("href", "/media/debrief/1");
     });
 
     it("hides debrief button when no pending debrief for this movie", () => {

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -233,7 +233,7 @@ export function MovieDetailPage() {
               />
               <FreshnessBadge daysSinceWatch={daysSinceWatch} staleness={staleness} />
               {pendingDebrief && (
-                <Link to={`/media/debrief/${pendingDebrief.sessionId}`}>
+                <Link to={`/media/debrief/${movie.id}`}>
                   <Button variant="outline" size="sm">
                     Debrief this movie
                   </Button>


### PR DESCRIPTION
## Summary

- The debrief button link in `MovieDetailPage.tsx` was using `pendingDebrief.sessionId` but the route is `/media/debrief/:movieId`
- `DebriefPage` calls `getDebrief({ mediaType: "movie", mediaId: movieId })` using the URL param — so it must be the movie ID, not session ID
- Fix: change `pendingDebrief.sessionId` → `movie.id` (equivalent to `pendingDebrief.movieId`)
- Update test: expected href was `/media/debrief/42` (sessionId), corrected to `/media/debrief/1` (movieId)

## Test plan
- [ ] CI passes (MovieDetailPage tests cover debrief link)
- [ ] Debrief button navigates to correct route

🤖 Generated with [Claude Code](https://claude.com/claude-code)