### PR TITLE
docs: mark PRD-036 watchlist as Done

### DIFF
--- a/docs/themes/03-media/epics/03-tracking-watchlist.md
+++ b/docs/themes/03-media/epics/03-tracking-watchlist.md
@@ -11,7 +11,7 @@ Build watch history tracking and watchlist management. Track what's been watched
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
 | 035 | [Watch History](../prds/035-watch-history/README.md) | Episode/movie watch tracking, chronological history page, mark-as-watched actions, undo toast | Partial |
-| 036 | [Watchlist](../prds/036-watchlist/README.md) | Add/remove from watchlist, priority ordering, filters, auto-remove on watch (manual watches only, not Plex sync) | Partial |
+| 036 | [Watchlist](../prds/036-watchlist/README.md) | Add/remove from watchlist, priority ordering, filters, auto-remove on watch (manual watches only, not Plex sync) | Done |
 
 PRD-035 and PRD-036 can be built in parallel. PRD-036's auto-remove depends on PRD-035's watch tracking.
 

--- a/docs/themes/03-media/prds/036-watchlist/README.md
+++ b/docs/themes/03-media/prds/036-watchlist/README.md
@@ -1,7 +1,7 @@
 # PRD-036: Watchlist
 
 > Epic: [03 — Tracking & Watchlist](../../epics/03-tracking-watchlist.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -81,8 +81,8 @@ Build a prioritised list of movies and TV shows to watch next. Users add/remove 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-watchlist-page](us-01-watchlist-page.md) | Watchlist page with responsive layout (grid desktop/list mobile), filter tabs, priority badges, notes display | Done | Yes |
-| 02 | [us-02-reorder](us-02-reorder.md) | Drag-and-drop reorder (desktop) and up/down buttons (mobile), batch priority update in transaction | Partial | Blocked by us-01 |
-| 03 | [us-03-auto-removal](us-03-auto-removal.md) | Auto-remove from watchlist on manual watch completion, skip for plex_sync source | Partial | Yes (parallel with us-01) |
+| 02 | [us-02-reorder](us-02-reorder.md) | Drag-and-drop reorder (desktop) and up/down buttons (mobile), batch priority update in transaction | Done | Blocked by us-01 |
+| 03 | [us-03-auto-removal](us-03-auto-removal.md) | Auto-remove from watchlist on manual watch completion, skip for plex_sync source | Done | Yes (parallel with us-01) |
 
 US-02 depends on US-01 (needs the watchlist grid/list to add reorder interactions). US-03 is backend logic and can be built independently.
 


### PR DESCRIPTION
## Summary

- PRD-036 README: US-02 (reorder) and US-03 (auto-removal) Partial → Done; overall Status Partial → Done
- Epic 03 (Tracking & Watchlist) PRD table: PRD-036 Partial → Done

All three US files were already marked Done in prior PRs — this syncs the parent tables.

## Test plan

- [ ] PRD-036 README shows Status: Done with all 3 US rows showing Done
- [ ] Epic 03 table shows PRD-036 as Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)