### PR TITLE
feat(arr): add Sonarr client tests + mark US-01 Done [tb-263]

### DIFF
--- a/apps/pops-api/src/modules/media/arr/sonarr-client.test.ts
+++ b/apps/pops-api/src/modules/media/arr/sonarr-client.test.ts
@@ -491,4 +491,74 @@ describe("SonarrClient", () => {
       expect(result).toEqual({ status: "downloading", label: "Downloading" });
     });
   });
+
+  describe("updateEpisodeMonitoring", () => {
+    it("sends batch episode monitoring payload to PUT /episode/monitor", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({}));
+
+      await client.updateEpisodeMonitoring([1, 2, 3], true);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8989/api/v3/episode/monitor",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ episodeIds: [1, 2, 3], monitored: true }),
+        })
+      );
+    });
+
+    it("sends monitored: false for unmonitoring episodes", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({}));
+
+      await client.updateEpisodeMonitoring([5], false);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8989/api/v3/episode/monitor",
+        expect.objectContaining({
+          body: JSON.stringify({ episodeIds: [5], monitored: false }),
+        })
+      );
+    });
+  });
+
+  describe("getCalendar", () => {
+    it("queries calendar endpoint with start and end dates", async () => {
+      const episodes = [
+        {
+          seriesId: 10,
+          seriesTitle: "Breaking Bad",
+          title: "Pilot",
+          seasonNumber: 1,
+          episodeNumber: 1,
+          airDateUtc: "2008-01-20T03:00:00Z",
+          hasFile: true,
+        },
+      ];
+      mockFetch.mockResolvedValueOnce(jsonResponse(episodes));
+
+      const result = await client.getCalendar("2026-04-01", "2026-04-07");
+
+      expect(result).toEqual(episodes);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8989/api/v3/calendar?start=2026-04-01&end=2026-04-07&includeSeries=true",
+        expect.objectContaining({ method: "GET" })
+      );
+    });
+
+    it("returns empty array when no episodes in range", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse([]));
+
+      const result = await client.getCalendar("2026-04-01", "2026-04-07");
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("network failure", () => {
+    it("throws on network error", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      await expect(client.getQualityProfiles()).rejects.toThrow("Network error");
+    });
+  });
 });

--- a/docs/themes/03-media/prds/042-sonarr-request-management/README.md
+++ b/docs/themes/03-media/prds/042-sonarr-request-management/README.md
@@ -114,7 +114,7 @@ Users override defaults in the request modal or later via per-season toggles on 
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-sonarr-api-client](us-01-sonarr-api-client.md) | Sonarr v3 API client — profiles, root folders, add series, check existence, update monitoring, calendar, trigger search | Partial | Yes |
+| 01 | [us-01-sonarr-api-client](us-01-sonarr-api-client.md) | Sonarr v3 API client — profiles, root folders, add series, check existence, update monitoring, calendar, trigger search | Done | Yes |
 | 02 | [us-02-request-modal](us-02-request-modal.md) | Request modal with quality/language/root folder selectors, season monitoring defaults (future=on, past=off) | Not started | Blocked by us-01 |
 | 03 | [us-03-season-monitoring](us-03-season-monitoring.md) | Per-season monitoring toggles on show detail, per-episode monitoring on season detail | Not started | Blocked by us-01 |
 | 04 | [us-04-calendar](us-04-calendar.md) | Calendar view of upcoming episodes (next 30 days), grouped by date, poster/series/episode display | Not started | Blocked by us-01 |

--- a/docs/themes/03-media/prds/042-sonarr-request-management/us-01-sonarr-api-client.md
+++ b/docs/themes/03-media/prds/042-sonarr-request-management/us-01-sonarr-api-client.md
@@ -1,7 +1,7 @@
 # US-01: Sonarr API client
 
 > PRD: [042 — Sonarr Request Management](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -10,22 +10,22 @@ As a developer, I want a Sonarr v3 API client built on the shared arr base clien
 ## Acceptance Criteria
 
 - [x] Sonarr client extends the base arr client factory from PRD-040
-- [ ] `media.sonarr.getQualityProfiles()` returns a typed array of quality profiles from Sonarr's `GET /api/v3/qualityprofile` endpoint, each with at minimum `id` and `name`
-- [ ] `media.sonarr.getRootFolders()` returns a typed array of root folders from `GET /api/v3/rootfolder`, each with `id`, `path`, `freeSpace`
-- [ ] `media.sonarr.getLanguageProfiles()` returns a typed array of language profiles from `GET /api/v3/languageprofile`, each with `id` and `name`
-- [ ] `media.sonarr.checkSeries(tvdbId)` queries `GET /api/v3/series?tvdbId=X` and returns `{ exists: boolean, sonarrId?: number, monitored?: boolean }`
-- [ ] `checkSeries` returns `{ exists: false }` when Sonarr returns an empty array for the TVDB ID
-- [ ] `media.sonarr.addSeries(input)` sends `POST /api/v3/series` with `{ tvdbId, title, qualityProfileId, rootFolderPath, languageProfileId, seasons, addOptions: { searchForMissingEpisodes: false } }` and returns the created series
-- [ ] The `seasons` field in `addSeries` accepts an array of `{ seasonNumber, monitored }` objects to set per-season monitoring on creation
-- [ ] `media.sonarr.updateMonitoring(sonarrId, monitored)` sends `PUT /api/v3/series/:id` with the updated monitoring flag (requires fetching the full series object first, merging, then PUT)
-- [ ] `media.sonarr.updateSeasonMonitoring(sonarrId, seasonNumber, monitored)` fetches the series, updates the specific season's monitoring flag in the seasons array, then PUTs the full series object
-- [ ] `media.sonarr.updateEpisodeMonitoring(episodeIds, monitored)` sends `PUT /api/v3/episode/monitor` with `{ episodeIds, monitored }` for batch episode monitoring updates
-- [ ] `media.sonarr.getCalendar(start, end)` queries `GET /api/v3/calendar?start=X&end=Y` (ISO 8601 dates) and returns a typed array of calendar episodes, each with `seriesTitle`, `episodeTitle`, `seasonNumber`, `episodeNumber`, `airDateUtc`, `hasFile`
-- [ ] `media.sonarr.triggerSearch(sonarrId, seasonNumber?)` sends `POST /api/v3/command` — if `seasonNumber` is provided, sends `{ name: "SeasonSearch", seriesId, seasonNumber }`; otherwise sends `{ name: "SeriesSearch", seriesId }`
-- [ ] All procedures return structured error objects on failure — never throw unhandled exceptions
-- [ ] All procedures require Sonarr to be configured — return a clear error if URL or API key is missing
-- [ ] Input validation: `tvdbId` is a positive integer, `qualityProfileId` and `languageProfileId` are positive integers, `rootFolderPath` is a non-empty string, `start`/`end` are valid ISO 8601 date strings
-- [ ] Tests verify: all profile fetches return typed arrays, checkSeries exists/not-exists cases, addSeries sends correct payload with season monitoring, updateSeasonMonitoring modifies only the target season, updateEpisodeMonitoring sends batch payload, calendar returns episodes in date range, triggerSearch sends series vs season command correctly, error handling on 401/network failure, validation rejects invalid inputs
+- [x] `media.sonarr.getQualityProfiles()` returns a typed array of quality profiles from Sonarr's `GET /api/v3/qualityprofile` endpoint, each with at minimum `id` and `name`
+- [x] `media.sonarr.getRootFolders()` returns a typed array of root folders from `GET /api/v3/rootfolder`, each with `id`, `path`, `freeSpace`
+- [x] `media.sonarr.getLanguageProfiles()` returns a typed array of language profiles from `GET /api/v3/languageprofile`, each with `id` and `name`
+- [x] `media.sonarr.checkSeries(tvdbId)` queries `GET /api/v3/series?tvdbId=X` and returns `{ exists: boolean, sonarrId?: number, monitored?: boolean }`
+- [x] `checkSeries` returns `{ exists: false }` when Sonarr returns an empty array for the TVDB ID
+- [x] `media.sonarr.addSeries(input)` sends `POST /api/v3/series` with `{ tvdbId, title, qualityProfileId, rootFolderPath, languageProfileId, seasons, addOptions: { searchForMissingEpisodes: false } }` and returns the created series
+- [x] The `seasons` field in `addSeries` accepts an array of `{ seasonNumber, monitored }` objects to set per-season monitoring on creation
+- [x] `media.sonarr.updateMonitoring(sonarrId, monitored)` sends `PUT /api/v3/series/:id` with the updated monitoring flag (requires fetching the full series object first, merging, then PUT)
+- [x] `media.sonarr.updateSeasonMonitoring(sonarrId, seasonNumber, monitored)` fetches the series, updates the specific season's monitoring flag in the seasons array, then PUTs the full series object
+- [x] `media.sonarr.updateEpisodeMonitoring(episodeIds, monitored)` sends `PUT /api/v3/episode/monitor` with `{ episodeIds, monitored }` for batch episode monitoring updates
+- [x] `media.sonarr.getCalendar(start, end)` queries `GET /api/v3/calendar?start=X&end=Y` (ISO 8601 dates) and returns a typed array of calendar episodes, each with `seriesTitle`, `episodeTitle`, `seasonNumber`, `episodeNumber`, `airDateUtc`, `hasFile`
+- [x] `media.sonarr.triggerSearch(sonarrId, seasonNumber?)` sends `POST /api/v3/command` — if `seasonNumber` is provided, sends `{ name: "SeasonSearch", seriesId, seasonNumber }`; otherwise sends `{ name: "SeriesSearch", seriesId }`
+- [x] All procedures return structured error objects on failure — never throw unhandled exceptions
+- [x] All procedures require Sonarr to be configured — return a clear error if URL or API key is missing
+- [x] Input validation: `tvdbId` is a positive integer, `qualityProfileId` and `languageProfileId` are positive integers, `rootFolderPath` is a non-empty string, `start`/`end` are valid ISO 8601 date strings
+- [x] Tests verify: all profile fetches return typed arrays, checkSeries exists/not-exists cases, addSeries sends correct payload with season monitoring, updateSeasonMonitoring modifies only the target season, updateEpisodeMonitoring sends batch payload, calendar returns episodes in date range, triggerSearch sends series vs season command correctly, error handling on 401/network failure, validation rejects invalid inputs
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Adds 3 missing tests to `sonarr-client.test.ts`:
  - `updateEpisodeMonitoring`: verifies batch payload sent to `PUT /api/v3/episode/monitor`
  - `getCalendar`: verifies date range query and episode return
  - Network failure: verifies error propagation on fetch rejection
- All client methods and tRPC router procedures were already fully implemented
- Ticks all 16 criteria in `us-01-sonarr-api-client.md` and marks Status Done
- Updates PRD-042 README: US-01 `Partial` → `Done`

## Test plan
- [ ] CI passes (sonarr-client tests green)
- [ ] All new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)