### PR TITLE
docs(media): mark PRD-042 US-02 Done in README table

### DIFF
--- a/docs/themes/03-media/prds/042-sonarr-request-management/README.md
+++ b/docs/themes/03-media/prds/042-sonarr-request-management/README.md
@@ -115,7 +115,7 @@ Users override defaults in the request modal or later via per-season toggles on 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-sonarr-api-client](us-01-sonarr-api-client.md) | Sonarr v3 API client — profiles, root folders, add series, check existence, update monitoring, calendar, trigger search | Done | Yes |
-| 02 | [us-02-request-modal](us-02-request-modal.md) | Request modal with quality/language/root folder selectors, season monitoring defaults (future=on, past=off) | Not started | Blocked by us-01 |
+| 02 | [us-02-request-modal](us-02-request-modal.md) | Request modal with quality/language/root folder selectors, season monitoring defaults (future=on, past=off) | Done | Blocked by us-01 |
 | 03 | [us-03-season-monitoring](us-03-season-monitoring.md) | Per-season monitoring toggles on show detail, per-episode monitoring on season detail | Not started | Blocked by us-01 |
 | 04 | [us-04-calendar](us-04-calendar.md) | Calendar view of upcoming episodes (next 30 days), grouped by date, poster/series/episode display | Not started | Blocked by us-01 |
 


### PR DESCRIPTION
## Summary

- `RequestSeriesModal` was already implemented (US-02 spec already marked Done)
- US-01 was marked Done in #1438 (merged today)
- PRD-042 README table had US-02 showing `Not started` — update to `Done`

## Test plan
- [ ] CI passes (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)