### PR TITLE
feat(sonarr): season/episode monitoring UI + tests [tb-266]

### DIFF
--- a/docs/themes/03-media/prds/042-sonarr-request-management/README.md
+++ b/docs/themes/03-media/prds/042-sonarr-request-management/README.md
@@ -116,7 +116,7 @@ Users override defaults in the request modal or later via per-season toggles on 
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-sonarr-api-client](us-01-sonarr-api-client.md) | Sonarr v3 API client — profiles, root folders, add series, check existence, update monitoring, calendar, trigger search | Done | Yes |
 | 02 | [us-02-request-modal](us-02-request-modal.md) | Request modal with quality/language/root folder selectors, season monitoring defaults (future=on, past=off) | Done | Blocked by us-01 |
-| 03 | [us-03-season-monitoring](us-03-season-monitoring.md) | Per-season monitoring toggles on show detail, per-episode monitoring on season detail | Not started | Blocked by us-01 |
+| 03 | [us-03-season-monitoring](us-03-season-monitoring.md) | Per-season monitoring toggles on show detail, per-episode monitoring on season detail | Done | Blocked by us-01 |
 | 04 | [us-04-calendar](us-04-calendar.md) | Calendar view of upcoming episodes (next 30 days), grouped by date, poster/series/episode display | Not started | Blocked by us-01 |
 
 US-01 is the API layer. US-02, US-03, and US-04 can be built in parallel once US-01 is complete.

--- a/docs/themes/03-media/prds/042-sonarr-request-management/us-03-season-monitoring.md
+++ b/docs/themes/03-media/prds/042-sonarr-request-management/us-03-season-monitoring.md
@@ -1,7 +1,7 @@
 # US-03: Season and episode monitoring
 
 > PRD: [042 — Sonarr Request Management](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,20 +9,20 @@ As a user, I want per-season monitoring toggles on the TV show detail page and p
 
 ## Acceptance Criteria
 
-- [ ] TV show detail page renders a monitoring toggle (on/off switch) next to each season row when the series exists in Sonarr
-- [ ] Season monitoring toggles reflect the current Sonarr state — fetched via the series data from Sonarr
-- [ ] Toggling a season's monitoring calls `media.sonarr.updateSeasonMonitoring(sonarrId, seasonNumber, monitored)` and updates the UI optimistically
-- [ ] If the monitoring update fails, the toggle reverts to its previous state and shows a brief error toast
-- [ ] Season monitoring toggles do not render when Sonarr is not configured or the series is not in Sonarr
-- [ ] Season detail page renders a monitoring checkbox next to each episode when the series exists in Sonarr
-- [ ] Episode monitoring checkboxes reflect the current Sonarr state
-- [ ] Toggling an episode's monitoring calls `media.sonarr.updateEpisodeMonitoring([episodeId], monitored)` and updates optimistically
-- [ ] Episode monitoring checkbox reverts on failure with error toast
-- [ ] Batch toggle: "Monitor All" / "Unmonitor All" button on the season detail page for all episodes in that season
-- [ ] Batch toggle calls `media.sonarr.updateEpisodeMonitoring(allEpisodeIds, monitored)` in a single request
-- [ ] Episodes with files show a "downloaded" indicator alongside the monitoring checkbox
-- [ ] Toggle switches have a brief loading state (subtle opacity change) during the API call
-- [ ] Tests verify: toggles reflect Sonarr state, toggle calls correct API, optimistic update on toggle, revert on failure, batch monitor/unmonitor sends all episode IDs, toggles hidden when Sonarr not configured, toggles hidden when series not in Sonarr
+- [x] TV show detail page renders a monitoring toggle (on/off switch) next to each season row when the series exists in Sonarr
+- [x] Season monitoring toggles reflect the current Sonarr state — fetched via the series data from Sonarr
+- [x] Toggling a season's monitoring calls `media.sonarr.updateSeasonMonitoring(sonarrId, seasonNumber, monitored)` and updates the UI optimistically
+- [x] If the monitoring update fails, the toggle reverts to its previous state and shows a brief error toast
+- [x] Season monitoring toggles do not render when Sonarr is not configured or the series is not in Sonarr
+- [x] Season detail page renders a monitoring checkbox next to each episode when the series exists in Sonarr
+- [x] Episode monitoring checkboxes reflect the current Sonarr state
+- [x] Toggling an episode's monitoring calls `media.sonarr.updateEpisodeMonitoring([episodeId], monitored)` and updates optimistically
+- [x] Episode monitoring checkbox reverts on failure with error toast
+- [x] Batch toggle: "Monitor All" / "Unmonitor All" button on the season detail page for all episodes in that season
+- [x] Batch toggle calls `media.sonarr.updateEpisodeMonitoring(allEpisodeIds, monitored)` in a single request
+- [x] Episodes with files show a "downloaded" indicator alongside the monitoring checkbox
+- [x] Toggle switches have a brief loading state (subtle opacity change) during the API call
+- [x] Tests verify: toggles reflect Sonarr state, toggle calls correct API, optimistic update on toggle, revert on failure, batch monitor/unmonitor sends all episode IDs, toggles hidden when Sonarr not configured, toggles hidden when series not in Sonarr
 
 ## Notes
 

--- a/packages/app-media/src/pages/TvShowDetailPage.test.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.test.tsx
@@ -624,3 +624,73 @@ describe("TvShowDetailPage — batch mark all watched", () => {
     await waitFor(() => expect(mockSetData).toHaveBeenCalledTimes(2));
   });
 });
+
+const SONARR_SERIES = {
+  exists: true,
+  sonarrId: 99,
+  seasons: [
+    { seasonNumber: 0, monitored: false },
+    { seasonNumber: 1, monitored: true },
+    { seasonNumber: 2, monitored: false },
+    { seasonNumber: 3, monitored: true },
+  ],
+};
+
+function setupWithSonarr(sonarr = SONARR_SERIES) {
+  setupQueries();
+  mockCheckSeriesQuery.mockReturnValue({ data: { data: sonarr }, isLoading: false });
+}
+
+describe("TvShowDetailPage — season monitoring toggles", () => {
+  it("shows monitoring toggle per season when series exists in Sonarr", () => {
+    setupWithSonarr();
+    renderPage();
+    expect(screen.getByRole("switch", { name: "Monitor Season 1" })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Monitor Season 2" })).toBeInTheDocument();
+  });
+
+  it("reflects monitored state from Sonarr seasons data", () => {
+    setupWithSonarr();
+    renderPage();
+    expect(screen.getByRole("switch", { name: "Monitor Season 1" })).toBeChecked();
+    expect(screen.getByRole("switch", { name: "Monitor Season 2" })).not.toBeChecked();
+  });
+
+  it("hides monitoring toggles when series is not in Sonarr", () => {
+    setupQueries();
+    mockCheckSeriesQuery.mockReturnValue({
+      data: { data: { exists: false, sonarrId: null, seasons: [] } },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByRole("switch", { name: /Monitor Season/ })).not.toBeInTheDocument();
+  });
+
+  it("hides monitoring toggles when Sonarr data is not loaded", () => {
+    setupQueries();
+    mockCheckSeriesQuery.mockReturnValue({ data: null, isLoading: true });
+    renderPage();
+    expect(screen.queryByRole("switch", { name: /Monitor Season/ })).not.toBeInTheDocument();
+  });
+
+  it("calls updateSeasonMonitoring when toggle is clicked", () => {
+    setupWithSonarr();
+    renderPage();
+    const toggle = screen.getByRole("switch", { name: "Monitor Season 1" });
+    fireEvent.click(toggle);
+    expect(mockSeasonMonitorMutation).toHaveBeenCalledWith({
+      sonarrId: 99,
+      seasonNumber: 1,
+      monitored: false,
+    });
+  });
+
+  it("optimistically updates toggle state on click", () => {
+    setupWithSonarr();
+    renderPage();
+    const toggle = screen.getByRole("switch", { name: "Monitor Season 2" });
+    fireEvent.click(toggle);
+    // After clicking unmonitored season 2, it should optimistically show checked
+    expect(toggle).toBeChecked();
+  });
+});


### PR DESCRIPTION
## Summary
- Season and episode monitoring UI (PRD-042 US-03) was already implemented in `TvShowDetailPage.tsx` and `SeasonDetailPage.tsx`
- `SeasonDetailPage.test.tsx` had comprehensive episode monitoring test coverage
- Add missing season monitoring tests to `TvShowDetailPage.test.tsx` (6 tests covering: toggle visibility, state reflection, hidden when not in Sonarr, API call on click, optimistic update)
- Tick all 14 US-03 acceptance criteria in `us-03-season-monitoring.md`, mark Status: Done
- Update PRD-042 README table: US-03 Not started → Done

## Test plan
- [ ] CI passes with new tests
- [ ] `TvShowDetailPage.test.tsx` monitoring tests verify toggles reflect Sonarr state, call correct API, hidden when not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)