### PR TITLE
docs: mark PRD-035 Done and Epic 03 Tracking & Watchlist Done

### DIFF
--- a/docs/themes/03-media/README.md
+++ b/docs/themes/03-media/README.md
@@ -22,7 +22,7 @@ Build a personal media intelligence app — not just a tracker, but a system tha
 | 0 | [Data Model & API](epics/00-data-model-api.md) | Split tables (movies, shows, seasons, episodes), comparisons schema, tRPC routers | Done |
 | 1 | [Metadata Integration](epics/01-metadata-integration.md) | TMDB (movies) and TheTVDB (TV) — search, metadata fetch, poster cache, rate limiting | Partial |
 | 2 | [App Package & Core UI](epics/02-app-package-ui.md) | `@pops/app-media` — routes, pages, browse/search/detail views | Done |
-| 3 | [Tracking & Watchlist](epics/03-tracking-watchlist.md) | Watch history, watchlist management, episode-level progress | Partial |
+| 3 | [Tracking & Watchlist](epics/03-tracking-watchlist.md) | Watch history, watchlist management, episode-level progress | Done |
 | 4 | [Ratings & Comparisons](epics/04-ratings-comparisons.md) | 1v1 pairwise comparisons, ELO scoring, rankings, radar charts | Done |
 | 5 | [Discovery & Recommendations](epics/05-discovery-recommendations.md) | Trending, new releases, personalised suggestions | Partial |
 | 6 | [Plex Sync](epics/06-plex-sync.md) | Library import, watch history sync (local + Discover cloud), watchlist sync, auto-check on add | Done |

--- a/docs/themes/03-media/epics/03-tracking-watchlist.md
+++ b/docs/themes/03-media/epics/03-tracking-watchlist.md
@@ -10,7 +10,7 @@ Build watch history tracking and watchlist management. Track what's been watched
 
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
-| 035 | [Watch History](../prds/035-watch-history/README.md) | Episode/movie watch tracking, chronological history page, mark-as-watched actions, undo toast | Partial |
+| 035 | [Watch History](../prds/035-watch-history/README.md) | Episode/movie watch tracking, chronological history page, mark-as-watched actions, undo toast | Done |
 | 036 | [Watchlist](../prds/036-watchlist/README.md) | Add/remove from watchlist, priority ordering, filters, auto-remove on watch (manual watches only, not Plex sync) | Done |
 
 PRD-035 and PRD-036 can be built in parallel. PRD-036's auto-remove depends on PRD-035's watch tracking.

--- a/docs/themes/03-media/prds/035-watch-history/README.md
+++ b/docs/themes/03-media/prds/035-watch-history/README.md
@@ -1,7 +1,7 @@
 # PRD-035: Watch History
 
 > Epic: [03 — Tracking & Watchlist](../../epics/03-tracking-watchlist.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- PRD-035 Watch History: all 3 US are now Done (US-01 history page, US-02 episode enrichment #1437, US-03 delete watch event #1440) → update PRD-035 Status: Partial → Done
- Epic 03 Tracking & Watchlist: both PRDs now Done (035 + 036) → update Epic 03 Status: Partial → Done
- Theme README: Epic 03 row Partial → Done

## Test plan
- [x] Docs-only change — no code
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)