### PR TITLE
docs: mark PRD-029 US-02 Done (image cache)

### DIFF
--- a/docs/themes/03-media/prds/029-tmdb-client/README.md
+++ b/docs/themes/03-media/prds/029-tmdb-client/README.md
@@ -87,7 +87,7 @@ No new tables — uses the `movies` table from PRD-028. Image paths written to `
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-tmdb-http-client](us-01-tmdb-http-client.md) | HTTP client with token bucket rate limiter, search endpoint, metadata fetch | Partial | Yes |
-| 02 | [us-02-image-cache](us-02-image-cache.md) | Poster/backdrop download, local storage, serving endpoint, fallback chain | Partial | Yes |
+| 02 | [us-02-image-cache](us-02-image-cache.md) | Poster/backdrop download, local storage, serving endpoint, fallback chain | Done | Yes |
 | 03 | [us-03-add-to-library](us-03-add-to-library.md) | addMovie flow (fetch + create + download), refreshMovie, idempotency | Partial | Blocked by us-01, us-02 |
 
 US-01 and US-02 can run in parallel. US-03 composes them into the add-to-library flow.


### PR DESCRIPTION
## Summary

- `us-02-image-cache.md` already has Status: Done with all 12 criteria checked
- PRD-029 README table was still showing US-02 as Partial
- Syncs the README table to reflect the actual US file state
- PRD-029 overall stays Partial (US-01 and US-03 still Partial)

## Test plan
- [ ] Verify `us-02-image-cache.md` Status is Done and all criteria are `[x]`
- [ ] Verify PRD-029 README US-02 row now shows Done
- [ ] Verify PRD-029 Status remains Partial (US-01 and US-03 not yet Done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)