### PR TITLE
fix(docker): add @pops/navigation to pops-shell Dockerfile

### DIFF
--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -14,6 +14,7 @@ COPY packages/app-media/package.json ./packages/app-media/
 COPY packages/app-inventory/package.json ./packages/app-inventory/
 COPY packages/app-ai/package.json ./packages/app-ai/
 COPY packages/api-client/package.json ./packages/api-client/
+COPY packages/navigation/package.json ./packages/navigation/
 
 # Install pnpm and dependencies (cached across builds)
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -33,6 +34,7 @@ COPY packages/app-media/ ./packages/app-media/
 COPY packages/app-inventory/ ./packages/app-inventory/
 COPY packages/app-ai/ ./packages/app-ai/
 COPY packages/api-client/ ./packages/api-client/
+COPY packages/navigation/ ./packages/navigation/
 COPY apps/pops-api/ ./apps/pops-api/
 COPY apps/pops-shell/ ./apps/pops-shell/
 


### PR DESCRIPTION
## Summary

- Adds `packages/navigation/package.json` to the workspace package.json COPY section
- Adds `packages/navigation/` to the source file COPY section

The `@pops/navigation` package was added to the workspace (PR #1396) but was never included in the pops-shell Docker build context. This caused the production Docker build to fail with:

```
src/app/layout/RootLayout.tsx(15,36): error TS2307: Cannot find module '@pops/navigation' or its corresponding type declarations.
```

## Test plan

- [ ] Docker build succeeds (`mise docker:build`)
- [ ] pops-shell container starts and serves the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)