### PR TITLE
fix(docker): add missing @pops/navigation to pops-shell Dockerfile

### DIFF
--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -14,6 +14,7 @@ COPY packages/app-media/package.json ./packages/app-media/
 COPY packages/app-inventory/package.json ./packages/app-inventory/
 COPY packages/app-ai/package.json ./packages/app-ai/
 COPY packages/api-client/package.json ./packages/api-client/
+COPY packages/navigation/package.json ./packages/navigation/
 
 # Install pnpm and dependencies (cached across builds)
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -33,6 +34,7 @@ COPY packages/app-media/ ./packages/app-media/
 COPY packages/app-inventory/ ./packages/app-inventory/
 COPY packages/app-ai/ ./packages/app-ai/
 COPY packages/api-client/ ./packages/api-client/
+COPY packages/navigation/ ./packages/navigation/
 COPY apps/pops-api/ ./apps/pops-api/
 COPY apps/pops-shell/ ./apps/pops-shell/
 


### PR DESCRIPTION
## Summary

- Docker build of `pops-shell` was failing with `Cannot find module '@pops/navigation'`
- The `packages/navigation` directory was not included in the Docker build context
- Added `COPY packages/navigation/package.json` (for `pnpm install`) and `COPY packages/navigation/` (for TypeScript compilation)
- Same pattern as all other workspace packages already in the Dockerfile

## Root cause

`@pops/navigation` is a `workspace:*` dependency of `pops-shell`, `app-finance`, and `app-media`. When the Dockerfile copies source files for the build, it was missing the navigation package, so TypeScript couldn't resolve the module.

## Test plan
- [ ] Docker build of pops-shell completes without TS2307 errors
- [ ] `RootLayout.tsx`, `EntitiesResultComponent.tsx`, `TransactionsResultComponent.tsx` resolve `@pops/navigation` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)