### PR TITLE
feat(discover): hide Request button when inLibrary, add watchlist remove toggle [GH-1374]

### DIFF
--- a/packages/app-media/src/components/DiscoverCard.test.tsx
+++ b/packages/app-media/src/components/DiscoverCard.test.tsx
@@ -105,7 +105,7 @@ describe("DiscoverCard — watched", () => {
 describe("DiscoverCard — watchlist states", () => {
   it("shows filled bookmark icon when onWatchlist=true", () => {
     render(<DiscoverCard {...baseProps} onWatchlist={true} />);
-    expect(screen.getByLabelText("On Watchlist")).toBeTruthy();
+    expect(screen.getByLabelText("Remove from Watchlist")).toBeTruthy();
   });
 
   it("shows unfilled bookmark icon when onWatchlist=false", () => {
@@ -113,11 +113,30 @@ describe("DiscoverCard — watchlist states", () => {
     expect(screen.getByLabelText("Add to Watchlist")).toBeTruthy();
   });
 
-  it("calls onAddToWatchlist with tmdbId when bookmark clicked", () => {
-    const onWatchlist = vi.fn();
-    render(<DiscoverCard {...baseProps} onWatchlist={false} onAddToWatchlist={onWatchlist} />);
+  it("calls onAddToWatchlist with tmdbId when bookmark clicked (not on watchlist)", () => {
+    const onAdd = vi.fn();
+    render(<DiscoverCard {...baseProps} onWatchlist={false} onAddToWatchlist={onAdd} />);
     fireEvent.click(screen.getByLabelText("Add to Watchlist"));
-    expect(onWatchlist).toHaveBeenCalledWith(42);
+    expect(onAdd).toHaveBeenCalledWith(42);
+  });
+
+  it("calls onRemoveFromWatchlist with tmdbId when bookmark clicked (already on watchlist)", () => {
+    const onRemove = vi.fn();
+    render(<DiscoverCard {...baseProps} onWatchlist={true} onRemoveFromWatchlist={onRemove} />);
+    fireEvent.click(screen.getByLabelText("Remove from Watchlist"));
+    expect(onRemove).toHaveBeenCalledWith(42);
+  });
+});
+
+describe("DiscoverCard — request button visibility", () => {
+  it("shows Request button when not in library", () => {
+    render(<DiscoverCard {...baseProps} inLibrary={false} />);
+    expect(screen.getByTestId("request-42")).toBeTruthy();
+  });
+
+  it("hides Request button when in library", () => {
+    render(<DiscoverCard {...baseProps} inLibrary={true} />);
+    expect(screen.queryByTestId("request-42")).toBeNull();
   });
 });
 

--- a/packages/app-media/src/components/DiscoverCard.tsx
+++ b/packages/app-media/src/components/DiscoverCard.tsx
@@ -33,6 +33,8 @@ export interface DiscoverCardProps {
   isMarkingRewatched?: boolean;
   onAddToLibrary?: (tmdbId: number) => void;
   onAddToWatchlist?: (tmdbId: number) => void;
+  onRemoveFromWatchlist?: (tmdbId: number) => void;
+  isRemovingFromWatchlist?: boolean;
   onMarkWatched?: (tmdbId: number) => void;
   onMarkRewatched?: (tmdbId: number) => void;
   onNotInterested?: (tmdbId: number) => void;
@@ -58,6 +60,8 @@ export function DiscoverCard({
   isAddingToWatchlist,
   onAddToLibrary,
   onAddToWatchlist,
+  onRemoveFromWatchlist,
+  isRemovingFromWatchlist,
   onMarkWatched,
   isMarkingWatched,
   isMarkingRewatched,
@@ -150,12 +154,14 @@ export function DiscoverCard({
             size="icon"
             variant="ghost"
             className="h-7 w-7 text-white hover:bg-white/20"
-            onClick={() => onAddToWatchlist?.(tmdbId)}
-            disabled={isAddingToWatchlist}
-            title={onWatchlist ? "On Watchlist" : "Add to Watchlist"}
-            aria-label={onWatchlist ? "On Watchlist" : "Add to Watchlist"}
+            onClick={() =>
+              onWatchlist ? onRemoveFromWatchlist?.(tmdbId) : onAddToWatchlist?.(tmdbId)
+            }
+            disabled={isAddingToWatchlist || isRemovingFromWatchlist}
+            title={onWatchlist ? "Remove from Watchlist" : "Add to Watchlist"}
+            aria-label={onWatchlist ? "Remove from Watchlist" : "Add to Watchlist"}
           >
-            {isAddingToWatchlist ? (
+            {isAddingToWatchlist || isRemovingFromWatchlist ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
             ) : onWatchlist ? (
               <BookmarkCheck className="h-3.5 w-3.5" />
@@ -196,12 +202,14 @@ export function DiscoverCard({
               )}
             </Button>
           )}
-          <RequestMovieButton
-            tmdbId={tmdbId}
-            title={title}
-            year={year ? parseInt(year, 10) : new Date().getFullYear()}
-            variant="compact"
-          />
+          {!inLibrary && (
+            <RequestMovieButton
+              tmdbId={tmdbId}
+              title={title}
+              year={year ? parseInt(year, 10) : new Date().getFullYear()}
+              variant="compact"
+            />
+          )}
           <Button
             size="icon"
             variant="ghost"


### PR DESCRIPTION
## Summary

Closes #1374.

- Hide `RequestMovieButton` when `inLibrary=true` (wrapped in `{!inLibrary && ...}`)
- Add `onRemoveFromWatchlist` and `isRemovingFromWatchlist` props; watchlist button now toggles: when `onWatchlist=true` it calls `onRemoveFromWatchlist`, otherwise `onAddToWatchlist`
- Update aria-label from `"On Watchlist"` → `"Remove from Watchlist"` (reflects the action)
- Add tests: Request button hidden/shown by inLibrary state; onRemoveFromWatchlist called when toggling off watchlist

Most other ACs were already implemented (add-to-lib hidden, filled bookmark, RotateCw for watched).

## Test plan

- [ ] `Request` button not rendered when `inLibrary=true`
- [ ] `Request` button rendered when `inLibrary=false`
- [ ] Bookmark click when `onWatchlist=false` calls `onAddToWatchlist`
- [ ] Bookmark click when `onWatchlist=true` calls `onRemoveFromWatchlist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)