### PR TITLE
fix(navigation): add types + exports fields to fix TS2307 module resolution

### DIFF
--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Problem
`Deploy to Production` has been failing on every push to main since the `@pops/navigation` package was created. The Docker build step fails with:

```
TS2307: Cannot find module '@pops/navigation' or its corresponding type declarations
```

Affects: `pops-shell/RootLayout.tsx`, `app-finance/search`, `app-media/search`, `app-inventory/search`.

## Root Cause
`packages/navigation/package.json` was missing `"types"` and `"exports"` fields. With `moduleResolution: "bundler"`, TypeScript needs these to resolve a workspace package's source files.

## Fix
Add the same fields used by `@pops/ui` (the working reference):
```json
"types": "src/index.ts",
"exports": { ".": "./src/index.ts" }
```

## Verification
- `pnpm typecheck` → 14/14 successful (all navigation errors gone)
- All quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)