### PR TITLE
feat(discovery): add isWatched + onWatchlist flags to all discover endpoints [tb-273]

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/context-picks-service.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/context-picks-service.test.ts
@@ -13,6 +13,8 @@ vi.mock("./context-collections.js", async (importOriginal) => {
 
 vi.mock("./flags.js", () => ({
   getDismissedTmdbIds: vi.fn().mockReturnValue(new Set()),
+  getWatchedTmdbIds: vi.fn().mockReturnValue(new Set()),
+  getWatchlistTmdbIds: vi.fn().mockReturnValue(new Set()),
 }));
 
 // Mock database access
@@ -28,7 +30,7 @@ vi.mock("../../../db.js", () => ({
 
 import { getContextPicks } from "./context-picks-service.js";
 import { getActiveCollections } from "./context-collections.js";
-import { getDismissedTmdbIds } from "./flags.js";
+import { getDismissedTmdbIds, getWatchedTmdbIds, getWatchlistTmdbIds } from "./flags.js";
 
 /** Build a mock TMDB search response. */
 function makeTmdbResponse(tmdbIds: number[]): TmdbSearchResponse {
@@ -255,5 +257,49 @@ describe("getContextPicks", () => {
       "https://image.tmdb.org/t/p/w342/poster999.jpg"
     );
     expect(result.collections[0]!.results[0]!.inLibrary).toBe(false);
+  });
+
+  it("sets isWatched=true when tmdbId is in watch history", async () => {
+    vi.mocked(getWatchedTmdbIds).mockReturnValue(new Set([10]));
+
+    vi.mocked(getActiveCollections).mockReturnValue([
+      {
+        id: "test",
+        title: "Test",
+        emoji: "🧪",
+        genreIds: [18],
+        keywordIds: [],
+        trigger: () => true,
+      },
+    ]);
+
+    const client = makeMockClient([makeTmdbResponse([10, 20])]);
+    const result = await getContextPicks(client);
+
+    const results = result.collections[0]!.results;
+    expect(results.find((r) => r.tmdbId === 10)!.isWatched).toBe(true);
+    expect(results.find((r) => r.tmdbId === 20)!.isWatched).toBe(false);
+  });
+
+  it("sets onWatchlist=true when tmdbId is on watchlist", async () => {
+    vi.mocked(getWatchlistTmdbIds).mockReturnValue(new Set([20]));
+
+    vi.mocked(getActiveCollections).mockReturnValue([
+      {
+        id: "test",
+        title: "Test",
+        emoji: "🧪",
+        genreIds: [18],
+        keywordIds: [],
+        trigger: () => true,
+      },
+    ]);
+
+    const client = makeMockClient([makeTmdbResponse([10, 20])]);
+    const result = await getContextPicks(client);
+
+    const results = result.collections[0]!.results;
+    expect(results.find((r) => r.tmdbId === 20)!.onWatchlist).toBe(true);
+    expect(results.find((r) => r.tmdbId === 10)!.onWatchlist).toBe(false);
   });
 });

--- a/apps/pops-api/src/modules/media/discovery/context-picks-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/context-picks-service.ts
@@ -7,7 +7,7 @@ import { movies } from "@pops/db-types";
 import type { TmdbClient } from "../tmdb/client.js";
 import type { DiscoverResult } from "./types.js";
 import { getActiveCollections, type ContextCollection } from "./context-collections.js";
-import { getDismissedTmdbIds } from "./flags.js";
+import { getDismissedTmdbIds, getWatchedTmdbIds, getWatchlistTmdbIds } from "./flags.js";
 
 /** A context collection result set for the API response. */
 export interface ContextPicksCollection {
@@ -46,6 +46,8 @@ async function fetchCollectionResults(
   collection: ContextCollection,
   libraryIds: Set<number>,
   dismissedIds: Set<number>,
+  watchedIds: Set<number>,
+  watchlistIds: Set<number>,
   page: number
 ): Promise<DiscoverResult[]> {
   const response = await client.discoverMovies({
@@ -73,8 +75,8 @@ async function fetchCollectionResults(
         genreIds: r.genreIds,
         popularity: r.popularity,
         inLibrary,
-        isWatched: false,
-        onWatchlist: false,
+        isWatched: watchedIds.has(r.tmdbId),
+        onWatchlist: watchlistIds.has(r.tmdbId),
       };
     });
 }
@@ -95,13 +97,22 @@ export async function getContextPicks(
 
   const activeCollections = getActiveCollections(hour, month, dayOfWeek);
   const libraryIds = getLibraryTmdbIds();
-
   const dismissedIds = getDismissedTmdbIds();
+  const watchedIds = getWatchedTmdbIds();
+  const watchlistIds = getWatchlistTmdbIds();
 
   const collectionResults = await Promise.all(
     activeCollections.map(async (col) => {
       const page = pages?.[col.id] ?? 1;
-      const results = await fetchCollectionResults(client, col, libraryIds, dismissedIds, page);
+      const results = await fetchCollectionResults(
+        client,
+        col,
+        libraryIds,
+        dismissedIds,
+        watchedIds,
+        watchlistIds,
+        page
+      );
       return {
         id: col.id,
         title: col.title,

--- a/apps/pops-api/src/modules/media/discovery/genre-spotlight-service.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/genre-spotlight-service.test.ts
@@ -5,9 +5,11 @@ import type { PreferenceProfile } from "./types.js";
 
 vi.mock("./flags.js", () => ({
   getDismissedTmdbIds: vi.fn().mockReturnValue(new Set()),
+  getWatchedTmdbIds: vi.fn().mockReturnValue(new Set()),
+  getWatchlistTmdbIds: vi.fn().mockReturnValue(new Set()),
 }));
 
-import { getDismissedTmdbIds } from "./flags.js";
+import { getDismissedTmdbIds, getWatchedTmdbIds, getWatchlistTmdbIds } from "./flags.js";
 import {
   selectTopGenres,
   getGenreSpotlight,
@@ -257,5 +259,21 @@ describe("getGenreSpotlightPage — dismissed filtering", () => {
     expect(tmdbIds).not.toContain(10);
     expect(tmdbIds).toContain(20);
     expect(tmdbIds).toContain(30);
+  });
+
+  it("sets isWatched and onWatchlist flags on page results", async () => {
+    vi.mocked(getWatchedTmdbIds).mockReturnValue(new Set([20]));
+    vi.mocked(getWatchlistTmdbIds).mockReturnValue(new Set([30]));
+
+    const client = {
+      discoverMovies: vi.fn(async () => makeTmdbResponse([20, 30, 40])),
+    } as unknown as TmdbClient;
+
+    const result = await getGenreSpotlightPage(client, makeProfile(), new Set(), 35, 2);
+
+    expect(result.results.find((r) => r.tmdbId === 20)!.isWatched).toBe(true);
+    expect(result.results.find((r) => r.tmdbId === 30)!.onWatchlist).toBe(true);
+    expect(result.results.find((r) => r.tmdbId === 40)!.isWatched).toBe(false);
+    expect(result.results.find((r) => r.tmdbId === 40)!.onWatchlist).toBe(false);
   });
 });

--- a/apps/pops-api/src/modules/media/discovery/genre-spotlight-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/genre-spotlight-service.ts
@@ -12,7 +12,7 @@ import type {
 } from "./types.js";
 import { TMDB_GENRE_MAP } from "./types.js";
 import { scoreDiscoverResults } from "./service.js";
-import { getDismissedTmdbIds } from "./flags.js";
+import { getDismissedTmdbIds, getWatchedTmdbIds, getWatchlistTmdbIds } from "./flags.js";
 
 /** Genre name → TMDB genre ID reverse map. */
 const GENRE_NAME_TO_ID: Record<string, number> = {};
@@ -115,6 +115,8 @@ export async function getGenreSpotlight(
   }
 
   const dismissedIds = getDismissedTmdbIds();
+  const watchedIds = getWatchedTmdbIds();
+  const watchlistIds = getWatchlistTmdbIds();
 
   const entries = await Promise.all(
     genres.map(async (genreName) => {
@@ -145,8 +147,8 @@ export async function getGenreSpotlight(
             genreIds: r.genreIds,
             popularity: r.popularity,
             inLibrary,
-            isWatched: false,
-            onWatchlist: false,
+            isWatched: watchedIds.has(r.tmdbId),
+            onWatchlist: watchlistIds.has(r.tmdbId),
           };
         });
 
@@ -178,6 +180,8 @@ export async function getGenreSpotlightPage(
 ): Promise<GenreSpotlightPageResponse> {
   const genreName = TMDB_GENRE_MAP[genreId] ?? "Unknown";
   const dismissedIds = getDismissedTmdbIds();
+  const watchedIds = getWatchedTmdbIds();
+  const watchlistIds = getWatchlistTmdbIds();
 
   const response = await client.discoverMovies({
     genreIds: [genreId],
@@ -203,8 +207,8 @@ export async function getGenreSpotlightPage(
         genreIds: r.genreIds,
         popularity: r.popularity,
         inLibrary,
-        isWatched: false,
-        onWatchlist: false,
+        isWatched: watchedIds.has(r.tmdbId),
+        onWatchlist: watchlistIds.has(r.tmdbId),
       };
     });
 

--- a/apps/pops-api/src/modules/media/discovery/tmdb-service.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/tmdb-service.test.ts
@@ -19,7 +19,7 @@ vi.mock("./flags.js", () => ({
 }));
 
 import { getDrizzle } from "../../../db.js";
-import { getDismissedTmdbIds } from "./flags.js";
+import { getDismissedTmdbIds, getWatchedTmdbIds, getWatchlistTmdbIds } from "./flags.js";
 import { getRecommendations } from "./tmdb-service.js";
 
 const mockGetDrizzle = vi.mocked(getDrizzle);
@@ -198,5 +198,33 @@ describe("getRecommendations", () => {
     const client = makeTmdbClient([[makeTmdbResult({ tmdbId: 100 })]]);
     const result = await getRecommendations(client, 1);
     expect(result.results.every((r) => !r.inLibrary)).toBe(true);
+  });
+
+  it("sets isWatched=true when tmdbId is in watch history", async () => {
+    vi.mocked(getWatchedTmdbIds).mockReturnValue(new Set([100]));
+    const mockDb = createMockDb();
+    mockGetDrizzle.mockReturnValue(mockDb);
+
+    const client = makeTmdbClient([
+      [makeTmdbResult({ tmdbId: 100 }), makeTmdbResult({ tmdbId: 400 })],
+    ]);
+    const result = await getRecommendations(client, 1);
+
+    expect(result.results.find((r) => r.tmdbId === 100)!.isWatched).toBe(true);
+    expect(result.results.find((r) => r.tmdbId === 400)!.isWatched).toBe(false);
+  });
+
+  it("sets onWatchlist=true when tmdbId is on watchlist", async () => {
+    vi.mocked(getWatchlistTmdbIds).mockReturnValue(new Set([400]));
+    const mockDb = createMockDb();
+    mockGetDrizzle.mockReturnValue(mockDb);
+
+    const client = makeTmdbClient([
+      [makeTmdbResult({ tmdbId: 100 }), makeTmdbResult({ tmdbId: 400 })],
+    ]);
+    const result = await getRecommendations(client, 1);
+
+    expect(result.results.find((r) => r.tmdbId === 400)!.onWatchlist).toBe(true);
+    expect(result.results.find((r) => r.tmdbId === 100)!.onWatchlist).toBe(false);
   });
 });

--- a/apps/pops-api/src/modules/media/discovery/tmdb-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/tmdb-service.ts
@@ -104,6 +104,8 @@ export async function getRecommendations(
 
   const libraryIds = getLibraryTmdbIds();
   const dismissedIds = getDismissedTmdbIds();
+  const watchedIds = getWatchedTmdbIds();
+  const watchlistIds = getWatchlistTmdbIds();
 
   // Fetch recommendations for each top movie in parallel
   const recPromises = topMovies.map((m) => client.getMovieRecommendations(m.tmdbId, 1));
@@ -132,8 +134,8 @@ export async function getRecommendations(
         genreIds: result.genreIds,
         popularity: result.popularity,
         inLibrary: false,
-        isWatched: false,
-        onWatchlist: false,
+        isWatched: watchedIds.has(result.tmdbId),
+        onWatchlist: watchlistIds.has(result.tmdbId),
       });
     }
   }
@@ -174,6 +176,7 @@ export async function getWatchlistRecommendations(
   const libraryIds = getLibraryTmdbIds();
   const watchlistIds = getWatchlistTmdbIds();
   const dismissedIds = getDismissedTmdbIds();
+  const watchedIds = getWatchedTmdbIds();
 
   // Fetch similar movies for each watchlist item in parallel
   const simPromises = watchlistItems.map((m) => client.getMovieSimilar(m.tmdbId, 1));
@@ -207,8 +210,8 @@ export async function getWatchlistRecommendations(
         genreIds: result.genreIds,
         popularity: result.popularity,
         inLibrary: false,
-        isWatched: false,
-        onWatchlist: false,
+        isWatched: watchedIds.has(result.tmdbId),
+        onWatchlist: false, // watchlist items are excluded from results
       });
     }
   }


### PR DESCRIPTION
## Summary

- 4 discover endpoints were hardcoding `isWatched: false` and `onWatchlist: false`
- Wired up `getWatchedTmdbIds()` and `getWatchlistTmdbIds()` from `flags.ts` in:
  - `context-picks-service.ts` (`contextPicks` endpoint)
  - `tmdb-service.ts` — `getRecommendations` and `getWatchlistRecommendations`
  - `genre-spotlight-service.ts` — `getGenreSpotlight` and `getGenreSpotlightPage`
- Note: `getWatchlistRecommendations` keeps `onWatchlist: false` (watchlist items are excluded from results by design)
- Already-correct endpoints unchanged: `getTrending`, `getTrendingFromPlex`

Closes #1373

## Tests added
- `context-picks-service.test.ts`: 2 tests (isWatched, onWatchlist flags)
- `tmdb-service.test.ts`: 2 tests (isWatched, onWatchlist flags for recommendations)
- `genre-spotlight-service.test.ts`: 1 test (both flags on page results)

## Test plan
- [ ] CI green
- [ ] isWatched/onWatchlist flags verified in each service test

🤖 Generated with [Claude Code](https://claude.com/claude-code)