### PR TITLE
fix(discovery): populate isWatched/onWatchlist flags in all discover endpoints [gh-1373]

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/context-picks-service.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/context-picks-service.test.ts
@@ -12,6 +12,8 @@ vi.mock("./context-collections.js", async (importOriginal) => {
 });
 
 vi.mock("./flags.js", () => ({
+  getWatchedTmdbIds: vi.fn().mockReturnValue(new Set()),
+  getWatchlistTmdbIds: vi.fn().mockReturnValue(new Set()),
   getDismissedTmdbIds: vi.fn().mockReturnValue(new Set()),
 }));
 
@@ -28,7 +30,7 @@ vi.mock("../../../db.js", () => ({
 
 import { getContextPicks } from "./context-picks-service.js";
 import { getActiveCollections } from "./context-collections.js";
-import { getDismissedTmdbIds } from "./flags.js";
+import { getDismissedTmdbIds, getWatchedTmdbIds, getWatchlistTmdbIds } from "./flags.js";
 
 /** Build a mock TMDB search response. */
 function makeTmdbResponse(tmdbIds: number[]): TmdbSearchResponse {
@@ -255,5 +257,33 @@ describe("getContextPicks", () => {
       "https://image.tmdb.org/t/p/w342/poster999.jpg"
     );
     expect(result.collections[0]!.results[0]!.inLibrary).toBe(false);
+  });
+
+  it("sets isWatched and onWatchlist flags from flag helpers", async () => {
+    vi.mocked(getDismissedTmdbIds).mockReturnValue(new Set());
+    vi.mocked(getWatchedTmdbIds).mockReturnValue(new Set([300]));
+    vi.mocked(getWatchlistTmdbIds).mockReturnValue(new Set([400]));
+
+    const mockedGetActive = vi.mocked(getActiveCollections);
+    mockedGetActive.mockReturnValue([
+      {
+        id: "test",
+        title: "Test",
+        emoji: "🧪",
+        genreIds: [18],
+        keywordIds: [],
+        trigger: () => true,
+      },
+    ]);
+
+    const client = makeMockClient([makeTmdbResponse([300, 400, 500])]);
+
+    const result = await getContextPicks(client);
+    const results = result.collections[0]!.results;
+
+    expect(results.find((r) => r.tmdbId === 300)?.isWatched).toBe(true);
+    expect(results.find((r) => r.tmdbId === 400)?.onWatchlist).toBe(true);
+    expect(results.find((r) => r.tmdbId === 500)?.isWatched).toBe(false);
+    expect(results.find((r) => r.tmdbId === 500)?.onWatchlist).toBe(false);
   });
 });

--- a/apps/pops-api/src/modules/media/discovery/context-picks-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/context-picks-service.ts
@@ -7,7 +7,7 @@ import { movies } from "@pops/db-types";
 import type { TmdbClient } from "../tmdb/client.js";
 import type { DiscoverResult } from "./types.js";
 import { getActiveCollections, type ContextCollection } from "./context-collections.js";
-import { getDismissedTmdbIds } from "./flags.js";
+import { getWatchedTmdbIds, getWatchlistTmdbIds, getDismissedTmdbIds } from "./flags.js";
 
 /** A context collection result set for the API response. */
 export interface ContextPicksCollection {
@@ -46,6 +46,8 @@ async function fetchCollectionResults(
   collection: ContextCollection,
   libraryIds: Set<number>,
   dismissedIds: Set<number>,
+  watchedIds: Set<number>,
+  watchlistIds: Set<number>,
   page: number
 ): Promise<DiscoverResult[]> {
   const response = await client.discoverMovies({
@@ -73,8 +75,8 @@ async function fetchCollectionResults(
         genreIds: r.genreIds,
         popularity: r.popularity,
         inLibrary,
-        isWatched: false,
-        onWatchlist: false,
+        isWatched: watchedIds.has(r.tmdbId),
+        onWatchlist: watchlistIds.has(r.tmdbId),
       };
     });
 }
@@ -95,13 +97,22 @@ export async function getContextPicks(
 
   const activeCollections = getActiveCollections(hour, month, dayOfWeek);
   const libraryIds = getLibraryTmdbIds();
-
+  const watchedIds = getWatchedTmdbIds();
+  const watchlistIds = getWatchlistTmdbIds();
   const dismissedIds = getDismissedTmdbIds();
 
   const collectionResults = await Promise.all(
     activeCollections.map(async (col) => {
       const page = pages?.[col.id] ?? 1;
-      const results = await fetchCollectionResults(client, col, libraryIds, dismissedIds, page);
+      const results = await fetchCollectionResults(
+        client,
+        col,
+        libraryIds,
+        dismissedIds,
+        watchedIds,
+        watchlistIds,
+        page
+      );
       return {
         id: col.id,
         title: col.title,

--- a/apps/pops-api/src/modules/media/discovery/genre-spotlight-service.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/genre-spotlight-service.test.ts
@@ -4,10 +4,12 @@ import type { TmdbSearchResponse } from "../tmdb/types.js";
 import type { PreferenceProfile } from "./types.js";
 
 vi.mock("./flags.js", () => ({
+  getWatchedTmdbIds: vi.fn().mockReturnValue(new Set()),
+  getWatchlistTmdbIds: vi.fn().mockReturnValue(new Set()),
   getDismissedTmdbIds: vi.fn().mockReturnValue(new Set()),
 }));
 
-import { getDismissedTmdbIds } from "./flags.js";
+import { getDismissedTmdbIds, getWatchedTmdbIds, getWatchlistTmdbIds } from "./flags.js";
 import {
   selectTopGenres,
   getGenreSpotlight,
@@ -221,6 +223,27 @@ describe("getGenreSpotlight", () => {
       page: 1,
     });
   });
+
+  it("sets isWatched and onWatchlist flags on spotlight results", async () => {
+    vi.mocked(getDismissedTmdbIds).mockReturnValue(new Set());
+    vi.mocked(getWatchedTmdbIds).mockReturnValue(new Set([100]));
+    vi.mocked(getWatchlistTmdbIds).mockReturnValue(new Set([200]));
+
+    const client = {
+      discoverMovies: vi.fn(async () => makeTmdbResponse([100, 200, 300])),
+    } as unknown as TmdbClient;
+    const profile = makeProfile({
+      genreAffinities: [{ genre: "Comedy", avgScore: 7.5, movieCount: 8, totalComparisons: 15 }],
+    });
+
+    const result = await getGenreSpotlight(client, profile, new Set());
+    const results = result.genres[0]!.results;
+
+    expect(results.find((r) => r.tmdbId === 100)?.isWatched).toBe(true);
+    expect(results.find((r) => r.tmdbId === 200)?.onWatchlist).toBe(true);
+    expect(results.find((r) => r.tmdbId === 300)?.isWatched).toBe(false);
+    expect(results.find((r) => r.tmdbId === 300)?.onWatchlist).toBe(false);
+  });
 });
 
 describe("getGenreSpotlightPage — dismissed filtering", () => {
@@ -257,5 +280,23 @@ describe("getGenreSpotlightPage — dismissed filtering", () => {
     expect(tmdbIds).not.toContain(10);
     expect(tmdbIds).toContain(20);
     expect(tmdbIds).toContain(30);
+  });
+
+  it("sets isWatched and onWatchlist flags on page results", async () => {
+    vi.mocked(getDismissedTmdbIds).mockReturnValue(new Set());
+    vi.mocked(getWatchedTmdbIds).mockReturnValue(new Set([10]));
+    vi.mocked(getWatchlistTmdbIds).mockReturnValue(new Set([20]));
+
+    const client = {
+      discoverMovies: vi.fn(async () => makeTmdbResponse([10, 20, 30])),
+    } as unknown as TmdbClient;
+    const profile = makeProfile();
+
+    const result = await getGenreSpotlightPage(client, profile, new Set(), 35, 1);
+
+    expect(result.results.find((r) => r.tmdbId === 10)?.isWatched).toBe(true);
+    expect(result.results.find((r) => r.tmdbId === 20)?.onWatchlist).toBe(true);
+    expect(result.results.find((r) => r.tmdbId === 30)?.isWatched).toBe(false);
+    expect(result.results.find((r) => r.tmdbId === 30)?.onWatchlist).toBe(false);
   });
 });

--- a/apps/pops-api/src/modules/media/discovery/genre-spotlight-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/genre-spotlight-service.ts
@@ -12,7 +12,7 @@ import type {
 } from "./types.js";
 import { TMDB_GENRE_MAP } from "./types.js";
 import { scoreDiscoverResults } from "./service.js";
-import { getDismissedTmdbIds } from "./flags.js";
+import { getWatchedTmdbIds, getWatchlistTmdbIds, getDismissedTmdbIds } from "./flags.js";
 
 /** Genre name → TMDB genre ID reverse map. */
 const GENRE_NAME_TO_ID: Record<string, number> = {};
@@ -114,6 +114,8 @@ export async function getGenreSpotlight(
     return { genres: [] };
   }
 
+  const watchedIds = getWatchedTmdbIds();
+  const watchlistIds = getWatchlistTmdbIds();
   const dismissedIds = getDismissedTmdbIds();
 
   const entries = await Promise.all(
@@ -145,8 +147,8 @@ export async function getGenreSpotlight(
             genreIds: r.genreIds,
             popularity: r.popularity,
             inLibrary,
-            isWatched: false,
-            onWatchlist: false,
+            isWatched: watchedIds.has(r.tmdbId),
+            onWatchlist: watchlistIds.has(r.tmdbId),
           };
         });
 
@@ -177,6 +179,8 @@ export async function getGenreSpotlightPage(
   page: number
 ): Promise<GenreSpotlightPageResponse> {
   const genreName = TMDB_GENRE_MAP[genreId] ?? "Unknown";
+  const watchedIds = getWatchedTmdbIds();
+  const watchlistIds = getWatchlistTmdbIds();
   const dismissedIds = getDismissedTmdbIds();
 
   const response = await client.discoverMovies({
@@ -203,8 +207,8 @@ export async function getGenreSpotlightPage(
         genreIds: r.genreIds,
         popularity: r.popularity,
         inLibrary,
-        isWatched: false,
-        onWatchlist: false,
+        isWatched: watchedIds.has(r.tmdbId),
+        onWatchlist: watchlistIds.has(r.tmdbId),
       };
     });
 

--- a/apps/pops-api/src/modules/media/discovery/tmdb-service.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/tmdb-service.test.ts
@@ -19,11 +19,13 @@ vi.mock("./flags.js", () => ({
 }));
 
 import { getDrizzle } from "../../../db.js";
-import { getDismissedTmdbIds } from "./flags.js";
+import { getDismissedTmdbIds, getWatchedTmdbIds, getWatchlistTmdbIds } from "./flags.js";
 import { getRecommendations } from "./tmdb-service.js";
 
 const mockGetDrizzle = vi.mocked(getDrizzle);
 const mockGetDismissedTmdbIds = vi.mocked(getDismissedTmdbIds);
+const mockGetWatchedTmdbIds = vi.mocked(getWatchedTmdbIds);
+const mockGetWatchlistTmdbIds = vi.mocked(getWatchlistTmdbIds);
 
 /** Build a minimal TmdbSearchResult. */
 function makeTmdbResult(overrides: Partial<TmdbSearchResult> = {}): TmdbSearchResult {
@@ -93,6 +95,8 @@ describe("getRecommendations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetDismissedTmdbIds.mockReturnValue(new Set());
+    mockGetWatchedTmdbIds.mockReturnValue(new Set());
+    mockGetWatchlistTmdbIds.mockReturnValue(new Set());
   });
 
   it("returns empty when no top movies exist", async () => {
@@ -198,5 +202,31 @@ describe("getRecommendations", () => {
     const client = makeTmdbClient([[makeTmdbResult({ tmdbId: 100 })]]);
     const result = await getRecommendations(client, 1);
     expect(result.results.every((r) => !r.inLibrary)).toBe(true);
+  });
+
+  it("sets isWatched=true for watched tmdbIds", async () => {
+    const mockDb = createMockDb();
+    mockGetDrizzle.mockReturnValue(mockDb);
+    mockGetWatchedTmdbIds.mockReturnValue(new Set([100]));
+
+    const client = makeTmdbClient([
+      [makeTmdbResult({ tmdbId: 100 }), makeTmdbResult({ tmdbId: 101 })],
+    ]);
+    const result = await getRecommendations(client, 1);
+    expect(result.results.find((r) => r.tmdbId === 100)?.isWatched).toBe(true);
+    expect(result.results.find((r) => r.tmdbId === 101)?.isWatched).toBe(false);
+  });
+
+  it("sets onWatchlist=true for watchlisted tmdbIds", async () => {
+    const mockDb = createMockDb();
+    mockGetDrizzle.mockReturnValue(mockDb);
+    mockGetWatchlistTmdbIds.mockReturnValue(new Set([100]));
+
+    const client = makeTmdbClient([
+      [makeTmdbResult({ tmdbId: 100 }), makeTmdbResult({ tmdbId: 101 })],
+    ]);
+    const result = await getRecommendations(client, 1);
+    expect(result.results.find((r) => r.tmdbId === 100)?.onWatchlist).toBe(true);
+    expect(result.results.find((r) => r.tmdbId === 101)?.onWatchlist).toBe(false);
   });
 });

--- a/apps/pops-api/src/modules/media/discovery/tmdb-service.ts
+++ b/apps/pops-api/src/modules/media/discovery/tmdb-service.ts
@@ -103,6 +103,8 @@ export async function getRecommendations(
   }
 
   const libraryIds = getLibraryTmdbIds();
+  const watchedIds = getWatchedTmdbIds();
+  const watchlistIds = getWatchlistTmdbIds();
   const dismissedIds = getDismissedTmdbIds();
 
   // Fetch recommendations for each top movie in parallel
@@ -132,8 +134,8 @@ export async function getRecommendations(
         genreIds: result.genreIds,
         popularity: result.popularity,
         inLibrary: false,
-        isWatched: false,
-        onWatchlist: false,
+        isWatched: watchedIds.has(result.tmdbId),
+        onWatchlist: watchlistIds.has(result.tmdbId),
       });
     }
   }
@@ -172,6 +174,7 @@ export async function getWatchlistRecommendations(
   }
 
   const libraryIds = getLibraryTmdbIds();
+  const watchedIds = getWatchedTmdbIds();
   const watchlistIds = getWatchlistTmdbIds();
   const dismissedIds = getDismissedTmdbIds();
 
@@ -207,8 +210,8 @@ export async function getWatchlistRecommendations(
         genreIds: result.genreIds,
         popularity: result.popularity,
         inLibrary: false,
-        isWatched: false,
-        onWatchlist: false,
+        isWatched: watchedIds.has(result.tmdbId),
+        onWatchlist: watchlistIds.has(result.tmdbId),
       });
     }
   }


### PR DESCRIPTION
## Summary

- `getRecommendations`, `getWatchlistRecommendations` (tmdb-service.ts), `getContextPicks` (context-picks-service.ts), `getGenreSpotlight`, and `getGenreSpotlightPage` (genre-spotlight-service.ts) all hardcoded `isWatched: false` and `onWatchlist: false`
- All five functions now call `getWatchedTmdbIds()` and `getWatchlistTmdbIds()` from `flags.ts` and populate flags correctly
- `plex-service.ts` already set these flags correctly — no change needed there

## Test plan

- [x] New tests in `tmdb-service.test.ts` verify `isWatched`/`onWatchlist` are set on `getRecommendations` results
- [x] New test in `context-picks-service.test.ts` verifies flags are set per flag helpers
- [x] New tests in `genre-spotlight-service.test.ts` verify flags on both `getGenreSpotlight` and `getGenreSpotlightPage` results
- [x] All 8 + 8 + 15 existing tests still pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)