### PR TITLE
feat(search): wire search API to SearchInput — show results panel [gh-1260]

### DIFF
--- a/apps/pops-shell/src/app/layout/SearchInput.test.ts
+++ b/apps/pops-shell/src/app/layout/SearchInput.test.ts
@@ -1,0 +1,45 @@
+/**
+ * SearchInput section-mapping logic tests.
+ *
+ * The SearchResultsPanel component is tested comprehensively in the navigation
+ * package. These tests cover the mapping helpers used to transform tRPC API
+ * sections into panel-ready sections.
+ */
+import { describe, it, expect } from "vitest";
+
+/** Replicated from SearchInput — must stay in sync. */
+function domainToLabel(domain: string): string {
+  return domain
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+describe("domainToLabel", () => {
+  it("capitalises a single-word domain", () => {
+    expect(domainToLabel("movies")).toBe("Movies");
+    expect(domainToLabel("budgets")).toBe("Budgets");
+    expect(domainToLabel("entities")).toBe("Entities");
+    expect(domainToLabel("transactions")).toBe("Transactions");
+  });
+
+  it("splits hyphenated domains into title-cased words", () => {
+    expect(domainToLabel("tv-shows")).toBe("Tv Shows");
+    expect(domainToLabel("inventory-items")).toBe("Inventory Items");
+  });
+});
+
+describe("showPanel condition", () => {
+  it("is true only when open and query is non-empty", () => {
+    const cases: [boolean, string, boolean][] = [
+      [true, "lamp", true],
+      [true, "", false],
+      [false, "lamp", false],
+      [false, "", false],
+    ];
+
+    for (const [isOpen, query, expected] of cases) {
+      expect(isOpen && query.length > 0).toBe(expected);
+    }
+  });
+});

--- a/apps/pops-shell/src/app/layout/SearchInput.tsx
+++ b/apps/pops-shell/src/app/layout/SearchInput.tsx
@@ -1,29 +1,88 @@
-import { useCallback, useEffect, useRef } from "react";
-import { Search, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import type { ReactNode } from "react";
+import { Search, X, Film, Tv, Box, ArrowRightLeft, PiggyBank, Building2 } from "lucide-react";
 import { Input, Button } from "@pops/ui";
 import { useSearchStore } from "@/store/searchStore";
+import { trpc } from "@/lib/trpc";
+import {
+  SearchResultsPanel,
+  type SearchResultSection,
+  useCurrentApp,
+  useSearchResultNavigation,
+} from "@pops/navigation";
 
 const DEBOUNCE_MS = 300;
+
+/** Map Lucide icon name string → icon ReactNode (14px). */
+const ICON_MAP: Record<string, ReactNode> = {
+  Film: <Film className="h-3.5 w-3.5" />,
+  Tv: <Tv className="h-3.5 w-3.5" />,
+  Box: <Box className="h-3.5 w-3.5" />,
+  ArrowRightLeft: <ArrowRightLeft className="h-3.5 w-3.5" />,
+  PiggyBank: <PiggyBank className="h-3.5 w-3.5" />,
+  Building2: <Building2 className="h-3.5 w-3.5" />,
+};
+
+/** Derive a human-readable section label from a domain slug. */
+function domainToLabel(domain: string): string {
+  return domain
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
 
 export function SearchInput() {
   const inputRef = useRef<HTMLInputElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const query = useSearchStore((s) => s.query);
+  const isOpen = useSearchStore((s) => s.isOpen);
   const setQuery = useSearchStore((s) => s.setQuery);
+  const setOpen = useSearchStore((s) => s.setOpen);
   const clear = useSearchStore((s) => s.clear);
+
+  const currentApp = useCurrentApp();
+  const { navigateTo } = useSearchResultNavigation();
+
+  const { data: searchData } = trpc.core.search.query.useQuery(
+    { text: query, context: { app: currentApp ?? null, page: null } },
+    { enabled: isOpen && query.length > 0 }
+  );
+
+  const sections = useMemo<SearchResultSection[]>(() => {
+    if (!searchData?.sections) return [];
+    return searchData.sections.map((section) => ({
+      domain: section.domain,
+      label: domainToLabel(section.domain),
+      icon: ICON_MAP[section.icon] ?? <Search className="h-3.5 w-3.5" />,
+      color: section.color,
+      isContext: section.isContextSection,
+      hits: section.hits.map((h) => ({
+        ...h,
+        data: (h.data ?? {}) as Record<string, unknown>,
+      })),
+      totalCount: section.totalCount,
+    }));
+  }, [searchData]);
+
+  const handleResultClick = useCallback(
+    (uri: string) => {
+      navigateTo(uri);
+      clear();
+    },
+    [navigateTo, clear]
+  );
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+  }, [setOpen]);
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
-
       if (timerRef.current) clearTimeout(timerRef.current);
-
       timerRef.current = setTimeout(() => {
         setQuery(value);
       }, DEBOUNCE_MS);
-
-      // Update the input immediately for responsiveness
-      // but debounce the store update
     },
     [setQuery]
   );
@@ -44,7 +103,6 @@ export function SearchInput() {
         inputRef.current?.focus();
       }
     }
-
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
@@ -55,6 +113,8 @@ export function SearchInput() {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, []);
+
+  const showPanel = isOpen && query.length > 0;
 
   return (
     <div className="hidden md:flex relative items-center max-w-sm w-full mx-4">
@@ -82,6 +142,14 @@ export function SearchInput() {
         <kbd className="absolute right-2.5 hidden lg:inline-flex h-5 items-center gap-0.5 rounded border bg-muted px-1.5 text-[10px] font-medium text-muted-foreground pointer-events-none">
           ⌘K
         </kbd>
+      )}
+      {showPanel && (
+        <SearchResultsPanel
+          sections={sections}
+          query={query}
+          onClose={handleClose}
+          onResultClick={handleResultClick}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- `SearchInput.tsx` previously rendered only the text input with no results panel
- Now calls `trpc.core.search.query` when `isOpen && query.length > 0`
- Maps API `SearchSection[]` → `SearchResultSection[]` (domainToLabel, icon lookup via `ICON_MAP`, data cast)
- Renders `SearchResultsPanel` below the input when results are available
- Section ordering, context highlighting, empty-section hiding, outside-click/Escape close all handled by `SearchResultsPanel` (already tested in navigation package)
- Navigates via `useSearchResultNavigation` and clears search on result click

## Test plan

- [x] `SearchInput.test.ts` — `domainToLabel` conversions + `showPanel` condition
- [x] `SearchResultsPanel.test.tsx` (navigation pkg) already covers all layout/ordering/close criteria
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)