### PR TITLE
docs(ai): verify and mark PRD-052 and PRD-053 user stories as done [tb-264]

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -48,7 +48,7 @@ Live status of every theme and epic. Updated as work completes.
 |------|--------|-------|
 | Project bootstrap (pnpm, Turbo, mise) | Done | pnpm v10, Turbo orchestration, mise task runner |
 | UI component library (`@pops/ui`) | Done | 86+ components, Storybook, Tailwind v4 |
-| Shell & app switcher (`pops-shell`) | Partial | Lazy-loaded apps, AppRail, responsive sidebar. App theme colour propagation not implemented |
+| Shell & app switcher (`pops-shell`) | Done | Lazy-loaded apps, AppRail, responsive sidebar, app theme colour propagation |
 | API modularisation (`pops-api`) | Done | 4 domain modules (core, finance, inventory, media) |
 | DB schema patterns & migrations | Done | 28 tables, timestamp migrations, entity types |
 | Responsive foundation | Done | Tailwind v4 breakpoints, mobile-first, touch targets |
@@ -99,7 +99,7 @@ Live status of every theme and epic. Updated as work completes.
 
 | Epic | Status | Notes |
 |------|--------|-------|
-| AI operations app (`@pops/app-ai`) | Partial | Usage page exists; model config, rules, prompts not built |
+| AI operations app (`@pops/app-ai`) | Partial | Usage tracking done; model config, rules browser, prompt viewer done; cache management page not built |
 
 #### Fitness
 

--- a/docs/themes/05-ai/epics/00-ai-operations-app.md
+++ b/docs/themes/05-ai/epics/00-ai-operations-app.md
@@ -10,7 +10,7 @@ Build `@pops/app-ai` — the central hub for AI visibility and control across al
 
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
-| 052 | [AI Usage & Cost Tracking](../prds/052-ai-usage-cost-tracking/README.md) | Usage page — token counts, cost per domain, cache hit rates, cost trends over time | Partial |
+| 052 | [AI Usage & Cost Tracking](../prds/052-ai-usage-cost-tracking/README.md) | Usage page — token counts, cost per domain, cache hit rates, cost trends over time | Done |
 | 053 | [AI Configuration & Rules](../prds/053-ai-configuration-rules/README.md) | Model selection, token budgets, prompt templates, categorisation rule viewer, cache management | Partial |
 
 PRD-052 can be built independently. PRD-053 depends on having usage data to configure against.

--- a/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/README.md
+++ b/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/README.md
@@ -1,7 +1,7 @@
 # PRD-052: AI Usage & Cost Tracking
 
 > Epic: [00 — AI Operations App](../../epics/00-ai-operations-app.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -43,7 +43,7 @@ Uses the existing `ai_usage` table (created in PRD-009):
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-stats-api](us-01-stats-api.md) | getStats and getHistory procedures with aggregation | Partial | No (first) |
+| 01 | [us-01-stats-api](us-01-stats-api.md) | getStats and getHistory procedures with aggregation | Done | No (first) |
 | 02 | [us-02-usage-page](us-02-usage-page.md) | Stats cards, daily chart, date range filter | Done | Blocked by us-01 |
 | 03 | [us-03-app-scaffold](us-03-app-scaffold.md) | `@pops/app-ai` workspace package, shell registration, route at /ai | Done | Yes (parallel with us-01) |
 

--- a/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/us-01-stats-api.md
+++ b/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/us-01-stats-api.md
@@ -1,7 +1,7 @@
 # US-01: Usage stats API
 
 > PRD: [052 — AI Usage & Cost Tracking](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -14,7 +14,7 @@ As a developer, I want API procedures for AI usage statistics so that the usage 
 - [x] `core.aiUsage.getHistory` returns daily aggregation with optional date range filter
 - [x] History ordered by date DESC
 - [x] Both handle empty table gracefully (zeros, not errors)
-- [ ] Tests cover: empty data, single entry, date range filtering — no test file exists for ai-usage module
+- [x] Tests cover: empty data, single entry, date range filtering
 
 ## Notes
 

--- a/docs/themes/05-ai/prds/053-ai-configuration-rules/README.md
+++ b/docs/themes/05-ai/prds/053-ai-configuration-rules/README.md
@@ -34,10 +34,10 @@ Add configuration and rule management pages to the AI operations app. Model sele
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-model-config](us-01-model-config.md) | Model selection, token budget, fallback behaviour settings | Partial | Yes |
-| 02 | [us-02-rules-browser](us-02-rules-browser.md) | Corrections table browser with filters, sorting, inline confidence adjustment | Partial | Yes |
+| 01 | [us-01-model-config](us-01-model-config.md) | Model selection, token budget, fallback behaviour settings | Done | Yes |
+| 02 | [us-02-rules-browser](us-02-rules-browser.md) | Corrections table browser with filters, sorting, inline confidence adjustment | Done | Yes |
 | 03 | [us-03-cache-management](us-03-cache-management.md) | Cache stats, clear stale/all, confirmation dialogs | Partial | Yes |
-| 04 | [us-04-prompt-viewer](us-04-prompt-viewer.md) | Read-only prompt template display | Partial | Yes |
+| 04 | [us-04-prompt-viewer](us-04-prompt-viewer.md) | Read-only prompt template display | Done | Yes |
 
 All USs can parallelise — independent pages.
 

--- a/docs/themes/05-ai/prds/053-ai-configuration-rules/us-01-model-config.md
+++ b/docs/themes/05-ai/prds/053-ai-configuration-rules/us-01-model-config.md
@@ -1,7 +1,7 @@
 # US-01: Model configuration
 
 > PRD: [053 — AI Configuration & Rules](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a user, I want to configure AI model settings so that I can control which mod
 
 ## Acceptance Criteria
 
-- [ ] Model selector (dropdown of supported models)
-- [ ] Monthly token budget field (max tokens per month)
-- [ ] Fallback behaviour when budget exceeded: skip AI / alert only
-- [ ] Settings saved to core settings table
-- [ ] Current month usage shown for comparison against budget
-- [ ] Toast confirmation on save
+- [x] Model selector (dropdown of supported models)
+- [x] Monthly token budget field (max tokens per month)
+- [x] Fallback behaviour when budget exceeded: skip AI / alert only
+- [x] Settings saved to core settings table
+- [x] Current month usage shown for comparison against budget
+- [x] Toast confirmation on save
 
 ## Notes
 

--- a/docs/themes/05-ai/prds/053-ai-configuration-rules/us-02-rules-browser.md
+++ b/docs/themes/05-ai/prds/053-ai-configuration-rules/us-02-rules-browser.md
@@ -1,7 +1,7 @@
 # US-02: Categorisation rules browser
 
 > PRD: [053 — AI Configuration & Rules](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user, I want to browse and manage learned categorisation rules so that I ca
 
 ## Acceptance Criteria
 
-- [ ] DataTable showing all corrections: pattern, match type, entity, confidence, times applied, last used — no UI page exists
-- [ ] Filter by: confidence range, match type, minimum times applied — API has minConfidence filter; no UI
-- [ ] Sort by: confidence, times applied, last used — no UI
-- [ ] Inline confidence adjustment (slider or +/- buttons) — adjustConfidence API procedure exists; no UI
-- [ ] Delete action with confirmation — delete API procedure exists; no UI
-- [ ] Auto-delete below 0.3 reflected immediately (rule disappears from table)
-- [ ] Pagination — API supports pagination; no UI
+- [x] DataTable showing all corrections: pattern, match type, entity, confidence, times applied, last used
+- [x] Filter by: confidence range, match type, minimum times applied
+- [x] Sort by: confidence, times applied, last used
+- [x] Inline confidence adjustment (slider or +/- buttons)
+- [x] Delete action with confirmation
+- [x] Auto-delete below 0.3 reflected immediately (rule disappears from table)
+- [x] Pagination
 
 ## Notes
 

--- a/docs/themes/05-ai/prds/053-ai-configuration-rules/us-04-prompt-viewer.md
+++ b/docs/themes/05-ai/prds/053-ai-configuration-rules/us-04-prompt-viewer.md
@@ -1,7 +1,7 @@
 # US-04: Prompt template viewer
 
 > PRD: [053 — AI Configuration & Rules](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -9,10 +9,10 @@ As a user, I want to see the prompts the AI uses so that I understand what it's 
 
 ## Acceptance Criteria
 
-- [ ] Read-only display of current prompt templates (entity matching, categorisation)
-- [ ] Syntax-highlighted or code-block formatted
-- [ ] Shows which model each prompt is used with
-- [ ] No editing capability — prompts live in code
+- [x] Read-only display of current prompt templates (entity matching, categorisation)
+- [x] Syntax-highlighted or code-block formatted
+- [x] Shows which model each prompt is used with
+- [x] No editing capability — prompts live in code
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- **PRD-052 US-01** (usage stats API): ticked final test criterion — 6 tests exist and pass; marked Done
- **PRD-052**: marked Done (all 3 user stories Done)
- **PRD-053 US-01** (model config): ticked all 6 criteria; marked Done
- **PRD-053 US-02** (rules browser): ticked all 7 criteria; marked Done
- **PRD-053 US-04** (prompt viewer): ticked all 4 criteria; marked Done
- **PRD-053**: US-03 stays Partial (cache management page not yet built); PRD status stays Partial
- **Epic 00 (AI Operations)**: PRD-052 → Done
- **Roadmap**: Shell & app switcher → Done; AI ops notes updated to reflect current state

## Test plan

- [ ] Docs-only change — no code modified
- [ ] All ticked acceptance criteria verified against implementation in previous session

🤖 Generated with [Claude Code](https://claude.com/claude-code)