### PR TITLE
docs: mark AI Operations app as Done in roadmap [tb-265]

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -99,7 +99,7 @@ Live status of every theme and epic. Updated as work completes.
 
 | Epic | Status | Notes |
 |------|--------|-------|
-| AI operations app (`@pops/app-ai`) | Partial | Usage tracking done; model config, rules browser, prompt viewer done; cache management page not built |
+| AI operations app (`@pops/app-ai`) | Done | Usage, model config, rules browser, prompt viewer, cache management — all pages built |
 
 #### Fitness
 


### PR DESCRIPTION
## Summary

- Roadmap AI Operations row: `Partial` → `Done`
- Updated note: "Usage, model config, rules browser, prompt viewer, cache management — all pages built"
- Shell & App Switcher row already shows Done (verified, from PR #1481)

All 4 PRD-053 user stories are now Done (PRs #1481, #1482). This is the missing roadmap update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)