### PR TITLE
docs(foundation): sync PRD-002 Design Tokens US statuses [tb-266]

### DIFF
--- a/docs/themes/01-foundation/prds/002-design-tokens-theming/README.md
+++ b/docs/themes/01-foundation/prds/002-design-tokens-theming/README.md
@@ -111,12 +111,12 @@ These patterns must be eliminated and replaced with token-based classes:
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-globals-css](us-01-globals-css.md) | Create globals.css with Tailwind imports, @theme block, CSS variables, light/dark tokens | Partial | No (first) |
-| 02 | [us-02-app-colour-variable](us-02-app-colour-variable.md) | Define the app colour CSS variable system (--app-accent, --app-accent-foreground) with per-colour definitions | Not started | Blocked by us-01 |
+| 01 | [us-01-globals-css](us-01-globals-css.md) | Create globals.css with Tailwind imports, @theme block, CSS variables, light/dark tokens | Done | No (first) |
+| 02 | [us-02-app-colour-variable](us-02-app-colour-variable.md) | Define the app colour CSS variable system (--app-accent, --app-accent-foreground) with per-colour definitions | Done | Blocked by us-01 |
 | 03 | [us-03-eliminate-arbitrary-values](us-03-eliminate-arbitrary-values.md) | Replace all arbitrary Tailwind values with token-based classes across all components | Partial | Blocked by us-01 |
 | 04 | [us-04-eliminate-hardcoded-colours](us-04-eliminate-hardcoded-colours.md) | Replace all hardcoded app colour classes (bg-indigo-600, text-emerald-400, etc.) with app-accent token references | Not started | Blocked by us-02 |
-| 05 | [us-05-semantic-status-tokens](us-05-semantic-status-tokens.md) | Define semantic status colour tokens (success, warning, info) and replace hardcoded red/green/yellow/blue | Not started | Blocked by us-01 |
-| 06 | [us-06-eliminate-inline-styles](us-06-eliminate-inline-styles.md) | Replace inline style={{}} hardcoded values and JS/TS colour constants with tokens | Not started | Yes |
+| 05 | [us-05-semantic-status-tokens](us-05-semantic-status-tokens.md) | Define semantic status colour tokens (success, warning, info) and replace hardcoded red/green/yellow/blue | Partial | Blocked by us-01 |
+| 06 | [us-06-eliminate-inline-styles](us-06-eliminate-inline-styles.md) | Replace inline style={{}} hardcoded values and JS/TS colour constants with tokens | Partial | Yes |
 
 ## Verification
 

--- a/docs/themes/01-foundation/prds/002-design-tokens-theming/us-01-globals-css.md
+++ b/docs/themes/01-foundation/prds/002-design-tokens-theming/us-01-globals-css.md
@@ -1,7 +1,7 @@
 # US-01: Create globals.css with design tokens
 
 > PRD: [002 — Design Tokens & Theming](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -17,7 +17,7 @@ As a developer, I want a single `globals.css` file in `@pops/ui/theme` that defi
 - [x] Shell entry point imports `@pops/ui/theme`
 - [x] Light mode and dark mode both render correctly
 - [x] No theme-related CSS exists outside this file
-- [ ] All custom Tailwind utility classes used across the codebase (e.g., `text-2xs`) are defined in the `@theme` block — no undefined utility classes
+- [x] All custom Tailwind utility classes used across the codebase (e.g., `text-2xs`) are defined in the `@theme` block — no undefined utility classes
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/002-design-tokens-theming/us-02-app-colour-variable.md
+++ b/docs/themes/01-foundation/prds/002-design-tokens-theming/us-02-app-colour-variable.md
@@ -1,7 +1,7 @@
 # US-02: Define app colour variable system
 
 > PRD: [002 — Design Tokens & Theming](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a developer, I want CSS variable definitions for app-specific accent colours 
 
 ## Acceptance Criteria
 
-- [ ] `--app-accent` and `--app-accent-foreground` CSS variables defined in globals.css
-- [ ] Per-colour class definitions for each supported colour (emerald, indigo, amber, rose, sky, violet)
-- [ ] Default falls back to `--primary` when no app colour is set
-- [ ] Dark mode variants work for all app colours
-- [ ] Tailwind utility classes `bg-app-accent`, `text-app-accent`, `border-app-accent` etc. are usable
-- [ ] Opacity modifiers work (`bg-app-accent/10`, `text-app-accent/80`)
+- [x] `--app-accent` and `--app-accent-foreground` CSS variables defined in globals.css
+- [x] Per-colour class definitions for each supported colour (emerald, indigo, amber, rose, sky, violet)
+- [x] Default falls back to `--primary` when no app colour is set
+- [x] Dark mode variants work for all app colours
+- [x] Tailwind utility classes `bg-app-accent`, `text-app-accent`, `border-app-accent` etc. are usable
+- [x] Opacity modifiers work (`bg-app-accent/10`, `text-app-accent/80`)
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/002-design-tokens-theming/us-05-semantic-status-tokens.md
+++ b/docs/themes/01-foundation/prds/002-design-tokens-theming/us-05-semantic-status-tokens.md
@@ -1,7 +1,7 @@
 # US-05: Semantic status colour tokens
 
 > PRD: [002 — Design Tokens & Theming](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -9,9 +9,9 @@ As a developer, I want semantic colour tokens for status states (success, warnin
 
 ## Acceptance Criteria
 
-- [ ] CSS variables defined in globals.css: `--color-success`, `--color-success-foreground`, `--color-warning`, `--color-warning-foreground`, `--color-info`, `--color-info-foreground`
-- [ ] Light and dark mode values for all status tokens
-- [ ] Tailwind utility classes available: `text-success`, `bg-success`, `border-success`, etc.
+- [x] CSS variables defined in globals.css: `--color-success`, `--color-success-foreground`, `--color-warning`, `--color-warning-foreground`, `--color-info`, `--color-info-foreground`
+- [x] Light and dark mode values for all status tokens
+- [x] Tailwind utility classes available: `text-success`, `bg-success`, `border-success`, etc.
 - [ ] All `text-red-500/600/700` and `bg-red-50` error/destructive patterns replaced with `text-destructive` or `text-error` tokens
 - [ ] All `text-green-500/600` and `bg-green-50` success patterns replaced with `text-success` or `bg-success` tokens
 - [ ] All `text-yellow-500` and `bg-yellow-50` warning patterns replaced with `text-warning` or `bg-warning` tokens

--- a/docs/themes/01-foundation/prds/002-design-tokens-theming/us-06-eliminate-inline-styles.md
+++ b/docs/themes/01-foundation/prds/002-design-tokens-theming/us-06-eliminate-inline-styles.md
@@ -1,7 +1,7 @@
 # US-06: Eliminate inline styles and JS/TS colour constants
 
 > PRD: [002 — Design Tokens & Theming](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -9,10 +9,10 @@ As a developer, I want all inline `style={{}}` hardcoded values and JS/TS colour
 
 ## Acceptance Criteria
 
-- [ ] UI primitive focus borders (`rgb(55, 65, 81)` in TextInput, DateTimeInput, NumberInput, Select, ChipInput) replaced with `border-border` or a CSS variable — no inline `style={{ boxShadow: "..." }}` with hardcoded RGB
+- [x] UI primitive focus borders (`rgb(55, 65, 81)` in TextInput, DateTimeInput, NumberInput, Select, ChipInput) replaced with `border-border` or a CSS variable — no inline `style={{ boxShadow: "..." }}` with hardcoded RGB
 - [ ] Inline `style={{ outline: "none", boxShadow: "none" }}` replaced with Tailwind `outline-none shadow-none`
-- [ ] Hardcoded `paddingLeft` for tree indentation replaced with a CSS custom property (`--tree-indent`) or Tailwind `pl-` class where possible
-- [ ] `style={{ paddingLeft: "8px" }}` replaced with `pl-2`
+- [x] Hardcoded `paddingLeft` for tree indentation replaced with a CSS custom property (`--tree-indent`) or Tailwind `pl-` class where possible
+- [x] `style={{ paddingLeft: "8px" }}` replaced with `pl-2`
 - [ ] ConnectionGraph hex colour constants (`#6366f1`, `#f59e0b`, `#10b981`, etc.) extracted to a `GRAPH_COLORS` design token object exported from `@pops/ui/theme`
 - [ ] Canvas rendering code references the token object, not hardcoded hex strings
 - [ ] Dynamic progress bar widths (`style={{ width: \`${percent}%\` }}`) are acceptable — document as permitted pattern


### PR DESCRIPTION
## Summary

Audit of PRD-002 Design Tokens & Theming — verified each US criterion against actual code, updated statuses accordingly.

- **US-01** Partial → Done: final criterion (`text-2xs` @utility) confirmed defined in globals.css
- **US-02** Not started → Done: all 6 app-accent criteria confirmed (`--app-accent` vars, 6 per-colour classes with light/dark, primary fallback, Tailwind utilities, opacity modifiers)
- **US-03** Partial: unchanged — Radix exception criterion already ticked; many arbitrary px values still in app packages and `tooltip.tsx`
- **US-04** Not started: unchanged — hardcoded colour classes (`text-emerald-400`, `text-indigo-500`, etc.) remain in app packages
- **US-05** Not started → Partial: CSS variables, light/dark, Tailwind utilities confirmed in globals.css; component migration not done
- **US-06** Not started → Partial: `rgb(55,65,81)` focus border removed, tree `paddingLeft` uses CSS vars, `paddingLeft: "8px"` gone; `style={{outline/boxShadow:none}}` and `GRAPH_COLORS` hex strings remain

## Test plan

- [ ] No code changes — docs only, no typecheck/lint required

🤖 Generated with [Claude Code](https://claude.com/claude-code)