### PR TITLE
docs(foundation): fix PRD-009 status inconsistencies [tb-268]

### DIFF
--- a/docs/themes/01-foundation/epics/04-db-schema-patterns.md
+++ b/docs/themes/01-foundation/epics/04-db-schema-patterns.md
@@ -10,7 +10,7 @@ Establish the database conventions that all domains follow: SQLite as source of 
 
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
-| 009 | [DB Schema Patterns](../prds/009-db-schema-patterns/README.md) | Migration conventions, entity type system, cross-domain FKs, seed data, UUID PKs, standard columns | Partial |
+| 009 | [DB Schema Patterns](../prds/009-db-schema-patterns/README.md) | Migration conventions, entity type system, cross-domain FKs, seed data, UUID PKs, standard columns | Done |
 
 ## Dependencies
 

--- a/docs/themes/01-foundation/prds/009-db-schema-patterns/README.md
+++ b/docs/themes/01-foundation/prds/009-db-schema-patterns/README.md
@@ -1,7 +1,7 @@
 # PRD-009: DB Schema Patterns
 
 > Epic: [04 — DB Schema Patterns](../../epics/04-db-schema-patterns.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -138,8 +138,8 @@ Comprehensive test dataset for local development and e2e testing. Includes repre
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-migration-conventions](us-01-migration-conventions.md) | Establish migration naming, template file, runner, fresh DB path | Done | No (first) |
 | 02 | [us-02-entity-types](us-02-entity-types.md) | Add entity type system (type column, supported values) | Done | Blocked by us-01 |
-| 03 | [us-03-cross-domain-fks](us-03-cross-domain-fks.md) | Document FK patterns, formalise existing cross-domain links, create schema registry | Not started | Blocked by us-01 |
-| 04 | [us-04-settings-table](us-04-settings-table.md) | Create core settings table for dynamic application configuration | Partial | Blocked by us-01 |
+| 03 | [us-03-cross-domain-fks](us-03-cross-domain-fks.md) | Document FK patterns, formalise existing cross-domain links, create schema registry | Done | Blocked by us-01 |
+| 04 | [us-04-settings-table](us-04-settings-table.md) | Create core settings table for dynamic application configuration | Done | Blocked by us-01 |
 | 05 | [us-05-seed-data](us-05-seed-data.md) | Create comprehensive seed dataset for dev and e2e testing | Done | Blocked by us-01 |
 
 US-02, US-03, US-04 can parallelise after US-01. US-05 depends on tables existing.

--- a/docs/themes/01-foundation/prds/009-db-schema-patterns/us-04-settings-table.md
+++ b/docs/themes/01-foundation/prds/009-db-schema-patterns/us-04-settings-table.md
@@ -1,7 +1,7 @@
 # US-04: Create settings table
 
 > PRD: [009 — DB Schema Patterns](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -10,8 +10,8 @@ As a developer, I want a core settings table for dynamic application configurati
 ## Acceptance Criteria
 
 - [x] `settings` table created with `key TEXT PRIMARY KEY, value TEXT NOT NULL`
-- [ ] Core settings service with get/set/delete operations — **no settings service; settings read via direct DB queries**
-- [ ] Settings router with tRPC procedures — **no settings tRPC router**
+- [x] Core settings service with get/set/delete operations
+- [x] Settings router with tRPC procedures
 - [x] `initializeSchema()` includes the settings table
 - [x] Clear distinction documented: secrets (ENV) vs settings (DB)
 


### PR DESCRIPTION
## Summary

- **US-03**: README table showed `Not started` but the US doc has all 5 criteria ticked and `Status: Done` — fix the table entry
- **US-04**: Verified `apps/pops-api/src/modules/core/settings/` — `service.ts` has get/set/delete/list operations, `router.ts` has full tRPC CRUD. Tick criteria 2 and 3, remove stale "no service/router" annotations, mark Done
- **PRD-009**: All 5 USs now Done — mark PRD Status Done
- **Epic 04**: Only PRD-009, now Done — mark Epic Done

## Test plan

- [ ] Docs-only — no code changes, no typecheck/lint required

🤖 Generated with [Claude Code](https://claude.com/claude-code)