### PR TITLE
docs(search): mark PRD-057 Done — US-03b/06b/08b verified implemented [tb-271]

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,6 +53,7 @@ Live status of every theme and epic. Updated as work completes.
 | DB schema patterns & migrations | Done | 28 tables, timestamp migrations, entity types |
 | Responsive foundation | Done | Tailwind v4 breakpoints, mobile-first, touch targets |
 | Drizzle ORM migration | Done | All modules use Drizzle ORM; raw SQL eliminated |
+| Search (TopBar, results panel, cross-domain) | In progress | PRD-056 (UI) in progress, PRD-057 (engine) Done, PRD-058 (context) not started |
 
 ### Phase 2 — Core Apps
 

--- a/docs/themes/01-foundation/README.md
+++ b/docs/themes/01-foundation/README.md
@@ -28,7 +28,7 @@ Build a multi-app platform from a shared foundation: one monorepo, one shell, on
 | 4 | [DB Schema Patterns](epics/04-db-schema-patterns.md) | SQLite, timestamp migrations, shared entities, cross-domain FKs, seed data, UUIDs | Partial |
 | 5 | [Responsive Foundation](epics/05-responsive-foundation.md) | Tailwind v4 breakpoints, mobile-first, 44x44px touch targets, component adaptations | Partial |
 | 6 | [Drizzle ORM](epics/06-drizzle-orm.md) | Type-safe queries and schema-as-code, replacing raw SQL | Done |
-| 7 | [Search](epics/07-search.md) | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | Not started |
+| 7 | [Search](epics/07-search.md) | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | In progress |
 
 Epic 0 is prerequisite to everything. Epics 1-5 can be built incrementally. Epic 6 is independent.
 

--- a/docs/themes/01-foundation/epics/07-search.md
+++ b/docs/themes/01-foundation/epics/07-search.md
@@ -11,7 +11,7 @@ Build a platform-wide search system accessible from the TopBar. Searches across 
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
 | 056 | [Search UI](../prds/056-search-ui/README.md) | TopBar search bar, results panel with context-aware sections (current app first), keyboard navigation, recent searches, result linking via URIs | In progress |
-| 057 | [Search Engine](../prds/057-search-engine/README.md) | Cross-domain query fan-out, domain adapter interface, relevance ranking, context-based ordering. Structured query syntax (`type:movie year:>2000 fight`) as progressive enhancement | In progress |
+| 057 | [Search Engine](../prds/057-search-engine/README.md) | Cross-domain query fan-out, domain adapter interface, relevance ranking, context-based ordering. Structured query syntax (`type:movie year:>2000 fight`) as progressive enhancement | Done |
 | 058 | [Contextual Intelligence](../prds/058-contextual-intelligence/README.md) | Shell tracks active app, page, entity being viewed. Exposes via context/store for Search, AI Overlay, and future consumers | Not started |
 
 PRD-058 first (context system). PRD-057 consumes it (engine uses context for ranking). PRD-056 consumes both (UI displays context-aware results).

--- a/docs/themes/01-foundation/prds/057-search-engine/README.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/README.md
@@ -1,7 +1,7 @@
 # PRD-057: Search Engine
 
 > Epic: [07 — Search](../../epics/07-search.md)
-> Status: In progress
+> Status: Done
 
 ## Overview
 
@@ -72,17 +72,17 @@ v1 is plain text only. Structured syntax added as v2 USs.
 | 02 | [us-02-movies-adapter](us-02-movies-adapter.md) | Movies backend adapter: search by title | Done | — |
 | 02b | [us-02b-movies-result-component](us-02b-movies-result-component.md) | Movies ResultComponent: poster + title + year + rating | Done | — |
 | 03 | [us-03-tv-shows-adapter](us-03-tv-shows-adapter.md) | TV shows backend adapter: search by name | Done | — |
-| 03b | [us-03b-tv-shows-result-component](us-03b-tv-shows-result-component.md) | TV shows ResultComponent: poster + name + status + seasons | Not started | — |
+| 03b | [us-03b-tv-shows-result-component](us-03b-tv-shows-result-component.md) | TV shows ResultComponent: poster + name + status + seasons | Done | — |
 | 04 | [us-04-transactions-adapter](us-04-transactions-adapter.md) | Transactions backend adapter: search by description | Done | — |
 | 04b | [us-04b-transactions-result-component](us-04b-transactions-result-component.md) | Transactions ResultComponent: description + colored amount + date | Done | — |
 | 05 | [us-05-entities-adapter](us-05-entities-adapter.md) | Entities backend adapter: search by name | Done | — |
 | 05b | [us-05b-entities-result-component](us-05b-entities-result-component.md) | Entities ResultComponent: name + type badge + aliases | Done | — |
 | 06 | [us-06-budgets-adapter](us-06-budgets-adapter.md) | Budgets backend adapter: search by category | Done | — |
-| 06b | [us-06b-budgets-result-component](us-06b-budgets-result-component.md) | Budgets ResultComponent: category + period + amount | Not started | — |
+| 06b | [us-06b-budgets-result-component](us-06b-budgets-result-component.md) | Budgets ResultComponent: category + period + amount | Done | — |
 | 07 | [us-07-inventory-items-adapter](us-07-inventory-items-adapter.md) | Inventory items backend adapter: search by name and asset ID | Done | — |
 | 07b | [us-07b-inventory-items-result-component](us-07b-inventory-items-result-component.md) | Inventory ResultComponent: name + brand + location + value | Done | — |
 | 08 | [us-08-fan-out-ranking](us-08-fan-out-ranking.md) | Query fan-out to all adapters, section collection, context ordering | Done | — |
-| 08b | [us-08b-show-more-pagination](us-08b-show-more-pagination.md) | Show more pagination within a single domain section | Not started | — |
+| 08b | [us-08b-show-more-pagination](us-08b-show-more-pagination.md) | Show more pagination within a single domain section | Done | — |
 | 09 | [us-09-structured-syntax](us-09-structured-syntax.md) | Parse structured query syntax (type:, domain:, year:, value:) and apply filters | Not started | — |
 
 All 6 backend adapters (us-02 through us-07) can parallelise. All 6 frontend components (us-02b through us-07b) can parallelise once their backend counterpart is done.

--- a/docs/themes/01-foundation/prds/057-search-engine/us-03b-tv-shows-result-component.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-03b-tv-shows-result-component.md
@@ -1,7 +1,7 @@
 # US-03b: TV shows result component (frontend)
 
 > PRD: [057 — Search Engine](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a user, I want TV show search results to show poster, name, year, status, and
 
 ## Acceptance Criteria
 
-- [ ] `TvShowsResultComponent` registered in frontend registry for domain `"tv-shows"`
-- [ ] Renders: poster thumbnail (small, left-aligned) + name + year + status badge + season count
-- [ ] Highlights matched portion of name using `query` prop + `matchField`/`matchType`
-- [ ] Poster loads from local cache URL; falls back to Tv icon on error
-- [ ] Status badge styled by status value (Continuing = blue, Ended = muted, etc.)
-- [ ] Tests: renders correctly with all fields, poster fallback, status badge, highlighting
+- [x] `TvShowsResultComponent` registered in frontend registry for domain `"tv-shows"`
+- [x] Renders: poster thumbnail (small, left-aligned) + name + year + status badge + season count
+- [x] Highlights matched portion of name using `query` prop + `matchField`/`matchType`
+- [x] Poster loads from local cache URL; falls back to Tv icon on error
+- [x] Status badge styled by status value (Continuing = blue, Ended = muted, etc.)
+- [x] Tests: renders correctly with all fields, poster fallback, status badge, highlighting
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/057-search-engine/us-06b-budgets-result-component.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-06b-budgets-result-component.md
@@ -1,7 +1,7 @@
 # US-06b: Budgets result component (frontend)
 
 > PRD: [057 — Search Engine](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,10 +9,10 @@ As a user, I want budget search results to show category, period, and amount so 
 
 ## Acceptance Criteria
 
-- [ ] `BudgetsResultComponent` registered in frontend registry for domain `"budgets"`
-- [ ] Renders: category + period (monthly/yearly) + formatted amount
-- [ ] Highlights matched portion of category using `query` prop + `matchField`/`matchType`
-- [ ] Tests: renders correctly, highlighting works
+- [x] `BudgetsResultComponent` registered in frontend registry for domain `"budgets"`
+- [x] Renders: category + period (monthly/yearly) + formatted amount
+- [x] Highlights matched portion of category using `query` prop + `matchField`/`matchType`
+- [x] Tests: renders correctly, highlighting works
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/057-search-engine/us-08b-show-more-pagination.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-08b-show-more-pagination.md
@@ -1,7 +1,7 @@
 # US-08b: Show more pagination
 
 > PRD: [057 — Search Engine](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,11 +9,11 @@ As a user, I want to load more results within a section so I can find items beyo
 
 ## Acceptance Criteria
 
-- [ ] `showMore(domain, query, context, offset, limit)` returns next page of results for a single adapter
-- [ ] Calls only the adapter for the specified domain — not a full fan-out
-- [ ] Returns hits + updated totalCount
-- [ ] Offset-based pagination (offset 0 = first 5, offset 5 = next 5, etc.)
-- [ ] Tests: show more returns correct offset, respects limit, single adapter called
+- [x] `showMore(domain, query, context, offset, limit)` returns next page of results for a single adapter
+- [x] Calls only the adapter for the specified domain — not a full fan-out
+- [x] Returns hits + updated totalCount
+- [x] Offset-based pagination (offset 0 = first 5, offset 5 = next 5, etc.)
+- [x] Tests: show more returns correct offset, respects limit, single adapter called
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- **US-03b** (TvShowSearchResult): all 6 criteria verified in code → Done
- **US-06b** (BudgetResult): all 4 criteria verified in code → Done
- **US-08b** (showMore pagination): engine + router + UI + tests all verified → Done
- **PRD-057 README**: rows 03b/06b/08b → Done, status → Done (US-09 is explicitly deferred v2 in its own Notes)
- **Epic 07**: PRD-057 row → Done
- **Foundation README**: Epic 7 Not started → In progress (PRD-056 still in progress)
- **Roadmap**: added Search row (In progress)

US-09 (structured syntax) is marked "Not started" and its Notes already say "v2 feature". No change needed there.

## Test plan

- [ ] Verify TvShowSearchResult.tsx renders poster + name + year + status badge + season count
- [ ] Verify TvShowSearchResult is registered in register.ts for domain "tv-shows"
- [ ] Verify BudgetResult.tsx renders category + period + amount, calls registerResultComponent inline
- [ ] Verify engine.ts showMore function + router.ts showMore procedure + SearchInput.tsx handler
- [ ] Confirm PRD-057 README table all rows correct
- [ ] Confirm Epic 07 table updated
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)