### PR TITLE
feat(search): wire search result component registrations at package load time [tb-272]

### DIFF
--- a/docs/themes/01-foundation/README.md
+++ b/docs/themes/01-foundation/README.md
@@ -28,7 +28,7 @@ Build a multi-app platform from a shared foundation: one monorepo, one shell, on
 | 4 | [DB Schema Patterns](epics/04-db-schema-patterns.md) | SQLite, timestamp migrations, shared entities, cross-domain FKs, seed data, UUIDs | Partial |
 | 5 | [Responsive Foundation](epics/05-responsive-foundation.md) | Tailwind v4 breakpoints, mobile-first, 44x44px touch targets, component adaptations | Partial |
 | 6 | [Drizzle ORM](epics/06-drizzle-orm.md) | Type-safe queries and schema-as-code, replacing raw SQL | Done |
-| 7 | [Search](epics/07-search.md) | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | Not started |
+| 7 | [Search](epics/07-search.md) | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | In progress |
 
 Epic 0 is prerequisite to everything. Epics 1-5 can be built incrementally. Epic 6 is independent.
 

--- a/packages/app-finance/src/index.ts
+++ b/packages/app-finance/src/index.ts
@@ -9,3 +9,4 @@ export { routes, navConfig } from "./routes";
 // Side-effect: register search result components
 import "./components/search/EntitiesResultComponent";
 import "./components/search/TransactionsResultComponent";
+import "./components/search/BudgetResult";

--- a/packages/app-inventory/src/index.ts
+++ b/packages/app-inventory/src/index.ts
@@ -5,3 +5,6 @@
  * to lazily load inventory pages under /inventory/*.
  */
 export { routes, navConfig } from "./routes";
+
+// Side-effect: register search result components
+import "./components/search/register";

--- a/packages/app-media/src/index.ts
+++ b/packages/app-media/src/index.ts
@@ -5,3 +5,6 @@
  * to lazily load media pages under /media/*.
  */
 export { routes, navConfig } from "./routes";
+
+// Side-effect: register search result components
+import "./components/search/register";


### PR DESCRIPTION
## Summary

- `packages/app-media/src/index.ts`: add `import "./components/search/register"` — registers movies + tv-shows domains
- `packages/app-inventory/src/index.ts`: add `import "./components/search/register"` — registers inventory-items domain
- `packages/app-finance/src/index.ts`: add `import "./components/search/BudgetResult"` — adds budgets alongside existing entities + transactions
- `docs/themes/01-foundation/README.md`: Epic 7 Not started → In progress

All 6 ResultComponents now register at app package load time, matching the same pattern as route registration.

## Test plan

- [ ] Verify app-media/index.ts imports search/register
- [ ] Verify app-inventory/index.ts imports search/register
- [ ] Verify app-finance/index.ts imports BudgetResult
- [ ] CI green (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)