### PR TITLE
feat(search): wire search result component registrations at app load time [tb-272]

### DIFF
--- a/docs/themes/01-foundation/README.md
+++ b/docs/themes/01-foundation/README.md
@@ -28,7 +28,7 @@ Build a multi-app platform from a shared foundation: one monorepo, one shell, on
 | 4 | [DB Schema Patterns](epics/04-db-schema-patterns.md) | SQLite, timestamp migrations, shared entities, cross-domain FKs, seed data, UUIDs | Partial |
 | 5 | [Responsive Foundation](epics/05-responsive-foundation.md) | Tailwind v4 breakpoints, mobile-first, 44x44px touch targets, component adaptations | Partial |
 | 6 | [Drizzle ORM](epics/06-drizzle-orm.md) | Type-safe queries and schema-as-code, replacing raw SQL | Done |
-| 7 | [Search](epics/07-search.md) | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | Not started |
+| 7 | [Search](epics/07-search.md) | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | In progress |
 
 Epic 0 is prerequisite to everything. Epics 1-5 can be built incrementally. Epic 6 is independent.
 

--- a/packages/app-finance/src/index.ts
+++ b/packages/app-finance/src/index.ts
@@ -9,3 +9,4 @@ export { routes, navConfig } from "./routes";
 // Side-effect: register search result components
 import "./components/search/EntitiesResultComponent";
 import "./components/search/TransactionsResultComponent";
+import "./components/search/BudgetResult";

--- a/packages/app-inventory/src/index.ts
+++ b/packages/app-inventory/src/index.ts
@@ -5,3 +5,6 @@
  * to lazily load inventory pages under /inventory/*.
  */
 export { routes, navConfig } from "./routes";
+
+// Side-effect: register search result components
+import "./components/search/register";

--- a/packages/app-media/src/index.ts
+++ b/packages/app-media/src/index.ts
@@ -5,3 +5,6 @@
  * to lazily load media pages under /media/*.
  */
 export { routes, navConfig } from "./routes";
+
+// Side-effect: register search result components
+import "./components/search/register";


### PR DESCRIPTION
## Summary

- Add `import './components/search/register'` to `app-media/src/index.ts` — registers MovieSearchResult and TvShowSearchResult
- Add `import './components/search/register'` to `app-inventory/src/index.ts` — registers InventoryItemSearchResult
- Add `import './components/search/BudgetResult'` to `app-finance/src/index.ts` — registers BudgetResult alongside existing EntitiesResultComponent and TransactionsResultComponent
- Update Foundation README: Epic 7 Search → In progress

## Test plan

- [ ] Each app package's search result components are registered when the package loads
- [ ] Existing finance components (Entities, Transactions) still register correctly
- [ ] Foundation README correctly shows Epic 7 as In progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)