### PR TITLE
docs(search): sync PRD-058 contextual intelligence status [tb-275]

### DIFF
--- a/docs/themes/01-foundation/epics/07-search.md
+++ b/docs/themes/01-foundation/epics/07-search.md
@@ -12,7 +12,7 @@ Build a platform-wide search system accessible from the TopBar. Searches across 
 |---|-----|---------|--------|
 | 056 | [Search UI](../prds/056-search-ui/README.md) | TopBar search bar, results panel with context-aware sections (current app first), keyboard navigation, recent searches, result linking via URIs | In progress |
 | 057 | [Search Engine](../prds/057-search-engine/README.md) | Cross-domain query fan-out, domain adapter interface, relevance ranking, context-based ordering. Structured query syntax (`type:movie year:>2000 fight`) as progressive enhancement | Done |
-| 058 | [Contextual Intelligence](../prds/058-contextual-intelligence/README.md) | Shell tracks active app, page, entity being viewed. Exposes via context/store for Search, AI Overlay, and future consumers | Not started |
+| 058 | [Contextual Intelligence](../prds/058-contextual-intelligence/README.md) | Shell tracks active app, page, entity being viewed. Exposes via context/store for Search, AI Overlay, and future consumers | Partial |
 
 PRD-058 first (context system). PRD-057 consumes it (engine uses context for ranking). PRD-056 consumes both (UI displays context-aware results).
 

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/README.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/README.md
@@ -1,7 +1,7 @@
 # PRD-058: Contextual Intelligence
 
 > Epic: [07 — Search](../../epics/07-search.md)
-> Status: Not started
+> Status: Partial
 
 ## Overview
 
@@ -43,9 +43,9 @@ interface AppContext {
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-context-provider](us-01-context-provider.md) | React context/store for app context, URL-based app detection | Not started | No (first) |
-| 02 | [us-02-page-context-hooks](us-02-page-context-hooks.md) | Hooks for pages to set their page-level context (entity, filters) | Not started | Blocked by us-01 |
-| 03 | [us-03-context-consumer-api](us-03-context-consumer-api.md) | Consumer API for Search and AI to read current context | Not started | Blocked by us-01 |
+| 01 | [us-01-context-provider](us-01-context-provider.md) | React context/store for app context, URL-based app detection | Done | No (first) |
+| 02 | [us-02-page-context-hooks](us-02-page-context-hooks.md) | Hooks for pages to set their page-level context (entity, filters) | Partial | Blocked by us-01 |
+| 03 | [us-03-context-consumer-api](us-03-context-consumer-api.md) | Consumer API for Search and AI to read current context | Done | Blocked by us-01 |
 
 ## Out of Scope
 

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/us-01-context-provider.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/us-01-context-provider.md
@@ -1,7 +1,7 @@
 # US-01: Context provider
 
 > PRD: [058 — Contextual Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a developer, I want a context provider that tracks the active app and exposes
 
 ## Acceptance Criteria
 
-- [ ] Context provider wraps the app (in shell's provider stack)
-- [ ] Active app detected from URL path (`/media/*` → "media", `/finance/*` → "finance")
-- [ ] Updates automatically on navigation
-- [ ] `useAppContext()` hook returns current context
-- [ ] Default context when no app matched (e.g. root `/`): `{ app: null, page: null, pageType: "top-level" }` — entity and filters are undefined
-- [ ] No re-renders in components that don't consume context
+- [x] Context provider wraps the app (in shell's provider stack)
+- [x] Active app detected from URL path (`/media/*` → "media", `/finance/*` → "finance")
+- [x] Updates automatically on navigation
+- [x] `useAppContext()` hook returns current context
+- [x] Default context when no app matched (e.g. root `/`): `{ app: null, page: null, pageType: "top-level" }` — entity and filters are undefined
+- [x] No re-renders in components that don't consume context
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/us-02-page-context-hooks.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/us-02-page-context-hooks.md
@@ -1,7 +1,7 @@
 # US-02: Page context hooks
 
 > PRD: [058 — Contextual Intelligence](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -9,12 +9,14 @@ As a developer, I want hooks that pages call to set their specific context so th
 
 ## Acceptance Criteria
 
-- [ ] `useSetPageContext({ page, pageType, entity?, filters? })` hook for pages to call on mount
-- [ ] Context updates when page mounts — stale context from previous page cleared
+- [x] `useSetPageContext({ page, pageType, entity?, filters? })` hook for pages to call on mount
+- [x] Context updates when page mounts — stale context from previous page cleared
 - [ ] Drill-down pages set entity context (e.g., movie detail sets the movie's URI and title)
 - [ ] List pages set filter context (e.g., transactions page sets active account/type/tag filters)
-- [ ] Context clears on unmount (navigation away)
+- [x] Context clears on unmount (navigation away)
 
 ## Notes
 
 Each page calls this hook once in its component body. The hook handles mount/unmount/update lifecycle. Pages don't need to know who consumes the context.
+
+Hook is implemented in `packages/navigation/src/hooks.ts` and exported from `@pops/navigation`, but no app pages call it yet.

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/us-03-context-consumer-api.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/us-03-context-consumer-api.md
@@ -1,7 +1,7 @@
 # US-03: Context consumer API
 
 > PRD: [058 — Contextual Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a developer, I want a clean API for consumers (Search, AI) to read the curren
 
 ## Acceptance Criteria
 
-- [ ] `useAppContext()` returns full `AppContext` object
-- [ ] `useCurrentApp()` convenience hook returns just the app string
-- [ ] `useCurrentEntity()` convenience hook returns the entity if on a drill-down page, null otherwise
-- [ ] Context is always up-to-date (reflects current navigation state)
-- [ ] TypeScript types exported for consumer use
-- [ ] Works from any component in the tree (shell, app packages, @pops/ui)
+- [x] `useAppContext()` returns full `AppContext` object
+- [x] `useCurrentApp()` convenience hook returns just the app string
+- [x] `useCurrentEntity()` convenience hook returns the entity if on a drill-down page, null otherwise
+- [x] Context is always up-to-date (reflects current navigation state)
+- [x] TypeScript types exported for consumer use
+- [x] Works from any component in the tree (shell, app packages, @pops/ui)
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- US-01 (context provider) → Done: AppContextProvider wraps shell in RootLayout.tsx, URL-based app detection, updates on nav, default context `{ app: null, page: null, pageType: 'top-level' }`, memoized to avoid spurious re-renders
- US-02 (page context hooks) → Partial: `useSetPageContext` hook implemented and exported from `@pops/navigation`, but no app pages call it yet
- US-03 (consumer API) → Done: `useAppContext`, `useCurrentApp`, `useCurrentEntity` all implemented and exported; TypeScript types exported
- PRD-058 → Partial
- Epic 07 PRD-058 row → Partial

## Test plan

- [ ] No code changes — docs only
- [ ] US-01 criteria verified against packages/navigation/src/AppContextProvider.tsx and apps/pops-shell/src/app/layout/RootLayout.tsx
- [ ] US-03 criteria verified against packages/navigation/src/hooks.ts and src/index.ts exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)