### PR TITLE
fix(search): wire search registrations + PRD-058 docs sync [tb-272/tb-275]

### DIFF
--- a/docs/themes/01-foundation/README.md
+++ b/docs/themes/01-foundation/README.md
@@ -28,7 +28,7 @@ Build a multi-app platform from a shared foundation: one monorepo, one shell, on
 | 4 | [DB Schema Patterns](epics/04-db-schema-patterns.md) | SQLite, timestamp migrations, shared entities, cross-domain FKs, seed data, UUIDs | Partial |
 | 5 | [Responsive Foundation](epics/05-responsive-foundation.md) | Tailwind v4 breakpoints, mobile-first, 44x44px touch targets, component adaptations | Partial |
 | 6 | [Drizzle ORM](epics/06-drizzle-orm.md) | Type-safe queries and schema-as-code, replacing raw SQL | Done |
-| 7 | [Search](epics/07-search.md) | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | Not started |
+| 7 | [Search](epics/07-search.md) | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | In progress |
 
 Epic 0 is prerequisite to everything. Epics 1-5 can be built incrementally. Epic 6 is independent.
 

--- a/docs/themes/01-foundation/epics/07-search.md
+++ b/docs/themes/01-foundation/epics/07-search.md
@@ -12,7 +12,7 @@ Build a platform-wide search system accessible from the TopBar. Searches across 
 |---|-----|---------|--------|
 | 056 | [Search UI](../prds/056-search-ui/README.md) | TopBar search bar, results panel with context-aware sections (current app first), keyboard navigation, recent searches, result linking via URIs | In progress |
 | 057 | [Search Engine](../prds/057-search-engine/README.md) | Cross-domain query fan-out, domain adapter interface, relevance ranking, context-based ordering. Structured query syntax (`type:movie year:>2000 fight`) as progressive enhancement | Done |
-| 058 | [Contextual Intelligence](../prds/058-contextual-intelligence/README.md) | Shell tracks active app, page, entity being viewed. Exposes via context/store for Search, AI Overlay, and future consumers | Not started |
+| 058 | [Contextual Intelligence](../prds/058-contextual-intelligence/README.md) | Shell tracks active app, page, entity being viewed. Exposes via context/store for Search, AI Overlay, and future consumers | Partial |
 
 PRD-058 first (context system). PRD-057 consumes it (engine uses context for ranking). PRD-056 consumes both (UI displays context-aware results).
 

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/README.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/README.md
@@ -1,7 +1,7 @@
 # PRD-058: Contextual Intelligence
 
 > Epic: [07 — Search](../../epics/07-search.md)
-> Status: Not started
+> Status: Partial
 
 ## Overview
 
@@ -43,9 +43,9 @@ interface AppContext {
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-context-provider](us-01-context-provider.md) | React context/store for app context, URL-based app detection | Not started | No (first) |
-| 02 | [us-02-page-context-hooks](us-02-page-context-hooks.md) | Hooks for pages to set their page-level context (entity, filters) | Not started | Blocked by us-01 |
-| 03 | [us-03-context-consumer-api](us-03-context-consumer-api.md) | Consumer API for Search and AI to read current context | Not started | Blocked by us-01 |
+| 01 | [us-01-context-provider](us-01-context-provider.md) | React context/store for app context, URL-based app detection | Done | No (first) |
+| 02 | [us-02-page-context-hooks](us-02-page-context-hooks.md) | Hooks for pages to set their page-level context (entity, filters) | Partial | Blocked by us-01 |
+| 03 | [us-03-context-consumer-api](us-03-context-consumer-api.md) | Consumer API for Search and AI to read current context | Done | Blocked by us-01 |
 
 ## Out of Scope
 

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/us-01-context-provider.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/us-01-context-provider.md
@@ -1,7 +1,7 @@
 # US-01: Context provider
 
 > PRD: [058 — Contextual Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a developer, I want a context provider that tracks the active app and exposes
 
 ## Acceptance Criteria
 
-- [ ] Context provider wraps the app (in shell's provider stack)
-- [ ] Active app detected from URL path (`/media/*` → "media", `/finance/*` → "finance")
-- [ ] Updates automatically on navigation
-- [ ] `useAppContext()` hook returns current context
-- [ ] Default context when no app matched (e.g. root `/`): `{ app: null, page: null, pageType: "top-level" }` — entity and filters are undefined
-- [ ] No re-renders in components that don't consume context
+- [x] Context provider wraps the app (in shell's provider stack)
+- [x] Active app detected from URL path (`/media/*` → "media", `/finance/*` → "finance")
+- [x] Updates automatically on navigation
+- [x] `useAppContext()` hook returns current context
+- [x] Default context when no app matched (e.g. root `/`): `{ app: null, page: null, pageType: "top-level" }` — entity and filters are undefined
+- [x] No re-renders in components that don't consume context
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/us-02-page-context-hooks.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/us-02-page-context-hooks.md
@@ -1,7 +1,7 @@
 # US-02: Page context hooks
 
 > PRD: [058 — Contextual Intelligence](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -9,11 +9,15 @@ As a developer, I want hooks that pages call to set their specific context so th
 
 ## Acceptance Criteria
 
-- [ ] `useSetPageContext({ page, pageType, entity?, filters? })` hook for pages to call on mount
-- [ ] Context updates when page mounts — stale context from previous page cleared
+- [x] `useSetPageContext({ page, pageType, entity?, filters? })` hook for pages to call on mount
+- [x] Context updates when page mounts — stale context from previous page cleared
 - [ ] Drill-down pages set entity context (e.g., movie detail sets the movie's URI and title)
 - [ ] List pages set filter context (e.g., transactions page sets active account/type/tag filters)
-- [ ] Context clears on unmount (navigation away)
+- [x] Context clears on unmount (navigation away)
+
+## Notes
+
+Hook is implemented in `packages/navigation/` and exported from `@pops/navigation`. Pages do not yet call `useSetPageContext` — the drill-down entity context and list filter context criteria are not yet wired.
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/us-03-context-consumer-api.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/us-03-context-consumer-api.md
@@ -1,7 +1,7 @@
 # US-03: Context consumer API
 
 > PRD: [058 — Contextual Intelligence](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a developer, I want a clean API for consumers (Search, AI) to read the curren
 
 ## Acceptance Criteria
 
-- [ ] `useAppContext()` returns full `AppContext` object
-- [ ] `useCurrentApp()` convenience hook returns just the app string
-- [ ] `useCurrentEntity()` convenience hook returns the entity if on a drill-down page, null otherwise
-- [ ] Context is always up-to-date (reflects current navigation state)
-- [ ] TypeScript types exported for consumer use
-- [ ] Works from any component in the tree (shell, app packages, @pops/ui)
+- [x] `useAppContext()` returns full `AppContext` object
+- [x] `useCurrentApp()` convenience hook returns just the app string
+- [x] `useCurrentEntity()` convenience hook returns the entity if on a drill-down page, null otherwise
+- [x] Context is always up-to-date (reflects current navigation state)
+- [x] TypeScript types exported for consumer use
+- [x] Works from any component in the tree (shell, app packages, @pops/ui)
 
 ## Notes
 

--- a/packages/app-finance/src/index.ts
+++ b/packages/app-finance/src/index.ts
@@ -9,3 +9,4 @@ export { routes, navConfig } from "./routes";
 // Side-effect: register search result components
 import "./components/search/EntitiesResultComponent";
 import "./components/search/TransactionsResultComponent";
+import "./components/search/BudgetResult";

--- a/packages/app-inventory/src/index.ts
+++ b/packages/app-inventory/src/index.ts
@@ -5,3 +5,6 @@
  * to lazily load inventory pages under /inventory/*.
  */
 export { routes, navConfig } from "./routes";
+
+// Side-effect: register search result components
+import "./components/search/register";

--- a/packages/app-media/src/index.ts
+++ b/packages/app-media/src/index.ts
@@ -5,3 +5,6 @@
  * to lazily load media pages under /media/*.
  */
 export { routes, navConfig } from "./routes";
+
+// Side-effect: register search result components
+import "./components/search/register";


### PR DESCRIPTION
## Summary

- **tb-272**: Add side-effect search registration imports to all 3 app packages so components are registered at load time
  - `@pops/app-media`: imports `./components/search/register` (registers movies + tv-shows)
  - `@pops/app-inventory`: imports `./components/search/register` (registers inventory-items)
  - `@pops/app-finance`: adds `./components/search/BudgetResult` (entities + transactions were already registered)
- **tb-275**: PRD-058 Contextual Intelligence docs sync — US-01 and US-03 were fully implemented but marked Not started
  - US-01 (AppContextProvider) → Done
  - US-02 (page context hooks) → Partial (hook exists, pages not wired)
  - US-03 (consumer API: useAppContext/useCurrentApp/useCurrentEntity) → Done
  - PRD-058 README → Partial
  - Epic 07 PRD-058 row → Partial
  - Foundation README Epic 7 → In progress

## Test plan

- [x] `pnpm typecheck` passes in app-media, app-inventory, app-finance
- [x] All 3 register.ts/BudgetResult files exist and export valid components
- [x] PRD-058 US-01 criteria verified against AppContextProvider.tsx and RootLayout.tsx
- [x] PRD-058 US-03 criteria verified against packages/navigation/src/hooks.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)