### PR TITLE
feat(search): wire keyboard navigation into search UI [tb-273]

### DIFF
--- a/apps/pops-shell/src/app/layout/SearchInput.tsx
+++ b/apps/pops-shell/src/app/layout/SearchInput.tsx
@@ -10,6 +10,7 @@ import {
   type SearchResultHit,
   useCurrentApp,
   useSearchResultNavigation,
+  useSearchKeyboardNav,
 } from "@pops/navigation";
 
 const DEBOUNCE_MS = 300;
@@ -34,6 +35,7 @@ function domainToLabel(domain: string): string {
 
 export function SearchInput() {
   const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const query = useSearchStore((s) => s.query);
   const isOpen = useSearchStore((s) => s.isOpen);
@@ -78,6 +80,21 @@ export function SearchInput() {
     });
   }, [searchData, extraHits]);
 
+  // Flat ordered URI list matching the sort order SearchResultsPanel uses
+  // (context section first, then by highest score descending)
+  const orderedUris = useMemo(() => {
+    const sorted = [...sections]
+      .filter((s) => s.hits.length > 0)
+      .sort((a, b) => {
+        if (a.isContext && !b.isContext) return -1;
+        if (!a.isContext && b.isContext) return 1;
+        const aMax = Math.max(...a.hits.map((h) => h.score));
+        const bMax = Math.max(...b.hits.map((h) => h.score));
+        return bMax - aMax;
+      });
+    return sorted.flatMap((s) => s.hits.map((h) => h.uri));
+  }, [sections]);
+
   const handleShowMore = useCallback(
     async (domain: string) => {
       const section = sections.find((s) => s.domain === domain);
@@ -111,6 +128,13 @@ export function SearchInput() {
   const handleClose = useCallback(() => {
     setOpen(false);
   }, [setOpen]);
+
+  const { selectedIndex } = useSearchKeyboardNav({
+    containerRef,
+    resultCount: orderedUris.length,
+    onSelect: (index) => handleResultClick(orderedUris[index] ?? ""),
+    onClose: handleClose,
+  });
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -153,7 +177,7 @@ export function SearchInput() {
   const showPanel = isOpen && query.length > 0;
 
   return (
-    <div className="hidden md:flex relative items-center max-w-sm w-full mx-4">
+    <div ref={containerRef} className="hidden md:flex relative items-center max-w-sm w-full mx-4">
       <Search className="absolute left-2.5 h-4 w-4 text-muted-foreground pointer-events-none" />
       <Input
         ref={inputRef}
@@ -186,6 +210,7 @@ export function SearchInput() {
           onClose={handleClose}
           onResultClick={handleResultClick}
           onShowMore={handleShowMore}
+          selectedIndex={selectedIndex}
         />
       )}
     </div>

--- a/docs/themes/01-foundation/epics/07-search.md
+++ b/docs/themes/01-foundation/epics/07-search.md
@@ -10,7 +10,7 @@ Build a platform-wide search system accessible from the TopBar. Searches across 
 
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
-| 056 | [Search UI](../prds/056-search-ui/README.md) | TopBar search bar, results panel with context-aware sections (current app first), keyboard navigation, recent searches, result linking via URIs | In progress |
+| 056 | [Search UI](../prds/056-search-ui/README.md) | TopBar search bar, results panel with context-aware sections (current app first), keyboard navigation, recent searches, result linking via URIs | Done |
 | 057 | [Search Engine](../prds/057-search-engine/README.md) | Cross-domain query fan-out, domain adapter interface, relevance ranking, context-based ordering. Structured query syntax (`type:movie year:>2000 fight`) as progressive enhancement | Done |
 | 058 | [Contextual Intelligence](../prds/058-contextual-intelligence/README.md) | Shell tracks active app, page, entity being viewed. Exposes via context/store for Search, AI Overlay, and future consumers | Not started |
 

--- a/docs/themes/01-foundation/prds/056-search-ui/README.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/README.md
@@ -1,7 +1,7 @@
 # PRD-056: Search UI
 
 > Epic: [07 — Search](../../epics/07-search.md)
-> Status: In progress
+> Status: Done
 
 ## Overview
 
@@ -30,7 +30,7 @@ Build the search UI — a TopBar search bar with a results panel that shows cont
 | 02b | [us-02b-result-component-registry](us-02b-result-component-registry.md) | Frontend ResultComponent registry, domain lookup, generic fallback, show more | Done | Blocked by us-02 |
 | 03 | [us-03-result-navigation](us-03-result-navigation.md) | Click/keyboard-navigate results, resolve URIs to routes | Done | Yes |
 | 04 | [us-04-recent-searches](us-04-recent-searches.md) | Recent search history in localStorage, shown when input is empty | Done | — |
-| 05 | [us-05-keyboard-nav](us-05-keyboard-nav.md) | Arrow keys navigate results across sections, Enter selects, Escape closes | In progress | — |
+| 05 | [us-05-keyboard-nav](us-05-keyboard-nav.md) | Arrow keys navigate results across sections, Enter selects, Escape closes | Done | — |
 
 ## Out of Scope
 

--- a/docs/themes/01-foundation/prds/056-search-ui/us-05-keyboard-nav.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/us-05-keyboard-nav.md
@@ -1,7 +1,7 @@
 # US-05: Keyboard navigation
 
 > PRD: [056 — Search UI](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a user, I want to navigate search results with keyboard so that I can search 
 
 ## Acceptance Criteria
 
-- [ ] Arrow Up/Down moves selection through results (across sections)
-- [ ] Enter selects the highlighted result (navigates to it)
-- [ ] Escape closes the results panel and blurs the input
-- [ ] Tab moves focus out of search entirely
-- [ ] Visual highlight on the currently selected result
-- [ ] Selected result scrolls into view if outside the panel viewport
+- [x] Arrow Up/Down moves selection through results (across sections)
+- [x] Enter selects the highlighted result (navigates to it)
+- [x] Escape closes the results panel and blurs the input
+- [x] Tab moves focus out of search entirely
+- [x] Visual highlight on the currently selected result
+- [x] Selected result scrolls into view if outside the panel viewport
 
 ## Notes
 

--- a/packages/navigation/src/SearchResultsPanel.test.tsx
+++ b/packages/navigation/src/SearchResultsPanel.test.tsx
@@ -218,4 +218,81 @@ describe("SearchResultsPanel", () => {
     render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
     expect(screen.queryByTestId("show-more-movies")).not.toBeInTheDocument();
   });
+
+  it("assigns sequential data-result-index to hit buttons", () => {
+    const sections = [
+      makeSection({
+        domain: "movies",
+        hits: [
+          { uri: "m/1", score: 1.0, matchField: "title", matchType: "exact", data: {} },
+          { uri: "m/2", score: 0.8, matchField: "title", matchType: "prefix", data: {} },
+        ],
+        totalCount: 2,
+      }),
+    ];
+    render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]).toHaveAttribute("data-result-index", "0");
+    expect(buttons[1]).toHaveAttribute("data-result-index", "1");
+  });
+
+  it("assigns sequential data-result-index across multiple sections", () => {
+    const sections = [
+      makeSection({
+        domain: "movies",
+        hits: [{ uri: "m/1", score: 1.0, matchField: "title", matchType: "exact", data: {} }],
+        totalCount: 1,
+      }),
+      makeSection({
+        domain: "transactions",
+        label: "Transactions",
+        hits: [{ uri: "t/1", score: 0.8, matchField: "desc", matchType: "prefix", data: {} }],
+        totalCount: 1,
+      }),
+    ];
+    render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]).toHaveAttribute("data-result-index", "0");
+    expect(buttons[1]).toHaveAttribute("data-result-index", "1");
+  });
+
+  it("highlights the selected result by selectedIndex", () => {
+    const sections = [
+      makeSection({
+        domain: "movies",
+        hits: [
+          { uri: "m/1", score: 1.0, matchField: "title", matchType: "exact", data: {} },
+          { uri: "m/2", score: 0.8, matchField: "title", matchType: "prefix", data: {} },
+        ],
+        totalCount: 2,
+      }),
+    ];
+    render(
+      <SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} selectedIndex={1} />
+    );
+    const [first, second] = screen.getAllByRole("button");
+    // first is not selected — no standalone bg-accent (hover:bg-accent is always present)
+    expect(first!.className).not.toContain(" bg-accent");
+    // second is selected — standalone bg-accent is appended
+    expect(second!.className).toContain(" bg-accent");
+  });
+
+  it("highlights first result when selectedIndex is 0", () => {
+    const sections = [
+      makeSection({
+        domain: "movies",
+        hits: [
+          { uri: "m/1", score: 1.0, matchField: "title", matchType: "exact", data: {} },
+          { uri: "m/2", score: 0.8, matchField: "title", matchType: "prefix", data: {} },
+        ],
+        totalCount: 2,
+      }),
+    ];
+    render(
+      <SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} selectedIndex={0} />
+    );
+    const [first, second] = screen.getAllByRole("button");
+    expect(first!.className).toContain(" bg-accent");
+    expect(second!.className).not.toContain(" bg-accent");
+  });
 });

--- a/packages/navigation/src/SearchResultsPanel.tsx
+++ b/packages/navigation/src/SearchResultsPanel.tsx
@@ -28,6 +28,8 @@ export interface SearchResultsPanelProps {
   onClose: () => void;
   onResultClick?: (uri: string) => void;
   onShowMore?: (domain: string) => void;
+  /** Index of the currently keyboard-selected result (flat, across all sections). -1 = none. */
+  selectedIndex?: number;
 }
 
 const COLOR_CLASSES: Record<string, string> = {
@@ -72,6 +74,7 @@ export function SearchResultsPanel({
   onClose,
   onResultClick,
   onShowMore,
+  selectedIndex = -1,
 }: SearchResultsPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -128,6 +131,8 @@ export function SearchResultsPanel({
     );
   }
 
+  let globalIndex = 0;
+
   return (
     <div
       ref={panelRef}
@@ -150,25 +155,30 @@ export function SearchResultsPanel({
               color={section.color}
             />
             <ul className="px-1 pb-1">
-              {section.hits.map((hit) => (
-                <li key={hit.uri}>
-                  <button
-                    type="button"
-                    className="w-full cursor-pointer rounded-md px-2 py-1.5 text-left hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
-                    onClick={() => onResultClick?.(hit.uri)}
-                    data-uri={hit.uri}
-                  >
-                    <ResultComponent
-                      data={{
-                        ...hit.data,
-                        _query: query,
-                        _matchField: hit.matchField,
-                        _matchType: hit.matchType,
-                      }}
-                    />
-                  </button>
-                </li>
-              ))}
+              {section.hits.map((hit) => {
+                const itemIndex = globalIndex++;
+                const isSelected = itemIndex === selectedIndex;
+                return (
+                  <li key={hit.uri}>
+                    <button
+                      type="button"
+                      className={`w-full cursor-pointer rounded-md px-2 py-1.5 text-left hover:bg-accent focus-visible:bg-accent focus-visible:outline-none${isSelected ? " bg-accent" : ""}`}
+                      onClick={() => onResultClick?.(hit.uri)}
+                      data-uri={hit.uri}
+                      data-result-index={itemIndex}
+                    >
+                      <ResultComponent
+                        data={{
+                          ...hit.data,
+                          _query: query,
+                          _matchField: hit.matchField,
+                          _matchType: hit.matchType,
+                        }}
+                      />
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
             {section.totalCount > section.hits.length && (
               <button


### PR DESCRIPTION
## Summary

- Wire `useSearchKeyboardNav` in `SearchInput.tsx`: add `containerRef` to the outer div, compute `orderedUris` (sorted same as the panel: context-section first, then by max score), hook handles ArrowDown/Up/Enter/Escape
- Add `selectedIndex` prop to `SearchResultsPanel`: assigns `data-result-index` to each hit button and appends `bg-accent` class on the selected item
- Tests added to `SearchResultsPanel.test.tsx` for index attributes and highlight behavior
- US-05 all criteria Done → PRD-056 all stories Done → PRD-056 status → Done
- Epic 07 PRD-056 row → Done

## Test plan

- [ ] ArrowDown/Up moves selection through results across sections
- [ ] Enter navigates to selected result and closes panel
- [ ] Escape closes the panel
- [ ] Selected result scrolls into view (handled by useSearchKeyboardNav)
- [ ] Visual highlight (bg-accent) on selected result
- [ ] Tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)