### PR TITLE
feat(search): wire keyboard navigation into search UI [tb-273]

### DIFF
--- a/apps/pops-shell/src/app/layout/SearchInput.tsx
+++ b/apps/pops-shell/src/app/layout/SearchInput.tsx
@@ -10,6 +10,7 @@ import {
   type SearchResultHit,
   useCurrentApp,
   useSearchResultNavigation,
+  useSearchKeyboardNav,
 } from "@pops/navigation";
 
 const DEBOUNCE_MS = 300;
@@ -34,6 +35,7 @@ function domainToLabel(domain: string): string {
 
 export function SearchInput() {
   const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const query = useSearchStore((s) => s.query);
   const isOpen = useSearchStore((s) => s.isOpen);
@@ -110,7 +112,29 @@ export function SearchInput() {
 
   const handleClose = useCallback(() => {
     setOpen(false);
+    inputRef.current?.blur();
   }, [setOpen]);
+
+  // Mirror the sort order used by SearchResultsPanel (context-first, then by max score desc)
+  const orderedUris = useMemo<string[]>(() => {
+    const sorted = [...sections]
+      .filter((s) => s.hits.length > 0)
+      .sort((a, b) => {
+        if (a.isContext && !b.isContext) return -1;
+        if (!a.isContext && b.isContext) return 1;
+        const aMax = Math.max(...a.hits.map((h) => h.score));
+        const bMax = Math.max(...b.hits.map((h) => h.score));
+        return bMax - aMax;
+      });
+    return sorted.flatMap((s) => s.hits.map((h) => h.uri));
+  }, [sections]);
+
+  const { selectedIndex } = useSearchKeyboardNav({
+    containerRef,
+    resultCount: orderedUris.length,
+    onSelect: (i) => handleResultClick(orderedUris[i]),
+    onClose: handleClose,
+  });
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -153,7 +177,7 @@ export function SearchInput() {
   const showPanel = isOpen && query.length > 0;
 
   return (
-    <div className="hidden md:flex relative items-center max-w-sm w-full mx-4">
+    <div ref={containerRef} className="hidden md:flex relative items-center max-w-sm w-full mx-4">
       <Search className="absolute left-2.5 h-4 w-4 text-muted-foreground pointer-events-none" />
       <Input
         ref={inputRef}
@@ -186,6 +210,7 @@ export function SearchInput() {
           onClose={handleClose}
           onResultClick={handleResultClick}
           onShowMore={handleShowMore}
+          selectedIndex={selectedIndex}
         />
       )}
     </div>

--- a/docs/themes/01-foundation/epics/07-search.md
+++ b/docs/themes/01-foundation/epics/07-search.md
@@ -10,7 +10,7 @@ Build a platform-wide search system accessible from the TopBar. Searches across 
 
 | # | PRD | Summary | Status |
 |---|-----|---------|--------|
-| 056 | [Search UI](../prds/056-search-ui/README.md) | TopBar search bar, results panel with context-aware sections (current app first), keyboard navigation, recent searches, result linking via URIs | In progress |
+| 056 | [Search UI](../prds/056-search-ui/README.md) | TopBar search bar, results panel with context-aware sections (current app first), keyboard navigation, recent searches, result linking via URIs | Done |
 | 057 | [Search Engine](../prds/057-search-engine/README.md) | Cross-domain query fan-out, domain adapter interface, relevance ranking, context-based ordering. Structured query syntax (`type:movie year:>2000 fight`) as progressive enhancement | Done |
 | 058 | [Contextual Intelligence](../prds/058-contextual-intelligence/README.md) | Shell tracks active app, page, entity being viewed. Exposes via context/store for Search, AI Overlay, and future consumers | Partial |
 

--- a/docs/themes/01-foundation/prds/056-search-ui/README.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/README.md
@@ -1,7 +1,7 @@
 # PRD-056: Search UI
 
 > Epic: [07 — Search](../../epics/07-search.md)
-> Status: In progress
+> Status: Done
 
 ## Overview
 
@@ -30,7 +30,7 @@ Build the search UI — a TopBar search bar with a results panel that shows cont
 | 02b | [us-02b-result-component-registry](us-02b-result-component-registry.md) | Frontend ResultComponent registry, domain lookup, generic fallback, show more | Done | Blocked by us-02 |
 | 03 | [us-03-result-navigation](us-03-result-navigation.md) | Click/keyboard-navigate results, resolve URIs to routes | Done | Yes |
 | 04 | [us-04-recent-searches](us-04-recent-searches.md) | Recent search history in localStorage, shown when input is empty | Done | — |
-| 05 | [us-05-keyboard-nav](us-05-keyboard-nav.md) | Arrow keys navigate results across sections, Enter selects, Escape closes | In progress | — |
+| 05 | [us-05-keyboard-nav](us-05-keyboard-nav.md) | Arrow keys navigate results across sections, Enter selects, Escape closes | Done | — |
 
 ## Out of Scope
 

--- a/docs/themes/01-foundation/prds/056-search-ui/us-05-keyboard-nav.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/us-05-keyboard-nav.md
@@ -1,7 +1,7 @@
 # US-05: Keyboard navigation
 
 > PRD: [056 — Search UI](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a user, I want to navigate search results with keyboard so that I can search 
 
 ## Acceptance Criteria
 
-- [ ] Arrow Up/Down moves selection through results (across sections)
-- [ ] Enter selects the highlighted result (navigates to it)
-- [ ] Escape closes the results panel and blurs the input
-- [ ] Tab moves focus out of search entirely
-- [ ] Visual highlight on the currently selected result
-- [ ] Selected result scrolls into view if outside the panel viewport
+- [x] Arrow Up/Down moves selection through results (across sections)
+- [x] Enter selects the highlighted result (navigates to it)
+- [x] Escape closes the results panel and blurs the input
+- [x] Tab moves focus out of search entirely
+- [x] Visual highlight on the currently selected result
+- [x] Selected result scrolls into view if outside the panel viewport
 
 ## Notes
 

--- a/packages/navigation/src/SearchResultsPanel.test.tsx
+++ b/packages/navigation/src/SearchResultsPanel.test.tsx
@@ -218,4 +218,57 @@ describe("SearchResultsPanel", () => {
     render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
     expect(screen.queryByTestId("show-more-movies")).not.toBeInTheDocument();
   });
+
+  it("assigns sequential data-result-index attributes across all section hits", () => {
+    const sections = [
+      makeSection({
+        domain: "movies",
+        label: "Movies",
+        hits: [
+          { uri: "m/1", score: 0.9, matchField: "t", matchType: "exact", data: {} },
+          { uri: "m/2", score: 0.8, matchField: "t", matchType: "prefix", data: {} },
+        ],
+        totalCount: 2,
+      }),
+      makeSection({
+        domain: "transactions",
+        label: "Transactions",
+        hits: [
+          { uri: "t/1", score: 0.5, matchField: "d", matchType: "contains", data: {} },
+        ],
+        totalCount: 1,
+      }),
+    ];
+    render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]).toHaveAttribute("data-result-index", "0");
+    expect(buttons[1]).toHaveAttribute("data-result-index", "1");
+    expect(buttons[2]).toHaveAttribute("data-result-index", "2");
+  });
+
+  it("applies bg-accent highlight to the selected result button", () => {
+    const sections = [
+      makeSection({
+        hits: [
+          { uri: "m/1", score: 0.9, matchField: "t", matchType: "exact", data: {} },
+          { uri: "m/2", score: 0.8, matchField: "t", matchType: "prefix", data: {} },
+        ],
+        totalCount: 2,
+      }),
+    ];
+    render(
+      <SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} selectedIndex={1} />
+    );
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]!.className).not.toContain(" bg-accent");
+    expect(buttons[1]!.className).toContain(" bg-accent");
+  });
+
+  it("does not highlight any result when selectedIndex is -1 (default)", () => {
+    render(<SearchResultsPanel sections={[makeSection()]} query="test" onClose={vi.fn()} />);
+    const buttons = screen.getAllByRole("button");
+    buttons.forEach((btn) => {
+      expect(btn.className).not.toMatch(/ bg-accent(?!\/)/);
+    });
+  });
 });

--- a/packages/navigation/src/SearchResultsPanel.tsx
+++ b/packages/navigation/src/SearchResultsPanel.tsx
@@ -28,6 +28,8 @@ export interface SearchResultsPanelProps {
   onClose: () => void;
   onResultClick?: (uri: string) => void;
   onShowMore?: (domain: string) => void;
+  /** Index of the currently keyboard-selected result (flat index across all sections). -1 = none. */
+  selectedIndex?: number;
 }
 
 const COLOR_CLASSES: Record<string, string> = {
@@ -72,6 +74,7 @@ export function SearchResultsPanel({
   onClose,
   onResultClick,
   onShowMore,
+  selectedIndex = -1,
 }: SearchResultsPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -128,6 +131,8 @@ export function SearchResultsPanel({
     );
   }
 
+  let globalIndex = 0;
+
   return (
     <div
       ref={panelRef}
@@ -150,25 +155,30 @@ export function SearchResultsPanel({
               color={section.color}
             />
             <ul className="px-1 pb-1">
-              {section.hits.map((hit) => (
-                <li key={hit.uri}>
-                  <button
-                    type="button"
-                    className="w-full cursor-pointer rounded-md px-2 py-1.5 text-left hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
-                    onClick={() => onResultClick?.(hit.uri)}
-                    data-uri={hit.uri}
-                  >
-                    <ResultComponent
-                      data={{
-                        ...hit.data,
-                        _query: query,
-                        _matchField: hit.matchField,
-                        _matchType: hit.matchType,
-                      }}
-                    />
-                  </button>
-                </li>
-              ))}
+              {section.hits.map((hit) => {
+                const hitIndex = globalIndex++;
+                const isSelected = hitIndex === selectedIndex;
+                return (
+                  <li key={hit.uri}>
+                    <button
+                      type="button"
+                      className={`w-full cursor-pointer rounded-md px-2 py-1.5 text-left hover:bg-accent focus-visible:bg-accent focus-visible:outline-none${isSelected ? " bg-accent" : ""}`}
+                      onClick={() => onResultClick?.(hit.uri)}
+                      data-uri={hit.uri}
+                      data-result-index={hitIndex}
+                    >
+                      <ResultComponent
+                        data={{
+                          ...hit.data,
+                          _query: query,
+                          _matchField: hit.matchField,
+                          _matchType: hit.matchType,
+                        }}
+                      />
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
             {section.totalCount > section.hits.length && (
               <button


### PR DESCRIPTION
## Summary

- **SearchResultsPanel**: adds `selectedIndex` prop — applies `bg-accent` highlight to the selected button, adds `data-result-index` attributes for scroll-into-view targeting
- **SearchInput**: wires `useSearchKeyboardNav` — adds `containerRef` on the outer div, computes `orderedUris` (same sort as panel: context-first then max score desc), passes `selectedIndex` to the panel; `handleClose` now also blurs the input so Escape fully exits search
- **Tests**: three new tests for sequential `data-result-index` assignment, selected-index highlight, and no-highlight when `selectedIndex=-1`
- **Docs**: US-05 all criteria checked → Done; PRD-056 → Done; Epic 07 PRD-056 row → Done

## Test plan

- [ ] `packages/navigation` lint + typecheck pass
- [ ] `apps/pops-shell` lint + typecheck pass
- [ ] Arrow Down/Up moves selection through results across sections
- [ ] Enter navigates to the highlighted result
- [ ] Escape closes the panel and blurs the search input
- [ ] Selected result is visually highlighted with `bg-accent`
- [ ] Selected result scrolls into view when outside the panel viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)