### PR TITLE
feat(context): wire useSetPageContext into app pages [tb-276]

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,7 +53,7 @@ Live status of every theme and epic. Updated as work completes.
 | DB schema patterns & migrations | Done | 28 tables, timestamp migrations, entity types |
 | Responsive foundation | Done | Tailwind v4 breakpoints, mobile-first, touch targets |
 | Drizzle ORM migration | Done | All modules use Drizzle ORM; raw SQL eliminated |
-| Platform search (Epic 07) | Partial | Search engine Done (PRD-057); UI in progress (PRD-056); contextual intelligence not started (PRD-058) |
+| Platform search (Epic 07) | Done | All 3 PRDs Done — search engine (PRD-057), UI (PRD-056), contextual intelligence (PRD-058) |
 
 ### Phase 2 — Core Apps
 

--- a/docs/themes/01-foundation/README.md
+++ b/docs/themes/01-foundation/README.md
@@ -28,7 +28,7 @@ Build a multi-app platform from a shared foundation: one monorepo, one shell, on
 | 4 | [DB Schema Patterns](epics/04-db-schema-patterns.md) | SQLite, timestamp migrations, shared entities, cross-domain FKs, seed data, UUIDs | Done |
 | 5 | [Responsive Foundation](epics/05-responsive-foundation.md) | Tailwind v4 breakpoints, mobile-first, 44x44px touch targets, component adaptations | Partial |
 | 6 | [Drizzle ORM](epics/06-drizzle-orm.md) | Type-safe queries and schema-as-code, replacing raw SQL | Done |
-| 7 | [Search](epics/07-search.md) | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | In progress |
+| 7 | [Search](epics/07-search.md) | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | Done |
 
 Epic 0 is prerequisite to everything. Epics 1-5 can be built incrementally. Epic 6 is independent.
 

--- a/docs/themes/01-foundation/epics/07-search.md
+++ b/docs/themes/01-foundation/epics/07-search.md
@@ -12,7 +12,7 @@ Build a platform-wide search system accessible from the TopBar. Searches across 
 |---|-----|---------|--------|
 | 056 | [Search UI](../prds/056-search-ui/README.md) | TopBar search bar, results panel with context-aware sections (current app first), keyboard navigation, recent searches, result linking via URIs | Done |
 | 057 | [Search Engine](../prds/057-search-engine/README.md) | Cross-domain query fan-out, domain adapter interface, relevance ranking, context-based ordering. Structured query syntax (`type:movie year:>2000 fight`) as progressive enhancement | Done |
-| 058 | [Contextual Intelligence](../prds/058-contextual-intelligence/README.md) | Shell tracks active app, page, entity being viewed. Exposes via context/store for Search, AI Overlay, and future consumers | Partial |
+| 058 | [Contextual Intelligence](../prds/058-contextual-intelligence/README.md) | Shell tracks active app, page, entity being viewed. Exposes via context/store for Search, AI Overlay, and future consumers | Done |
 
 PRD-058 first (context system). PRD-057 consumes it (engine uses context for ranking). PRD-056 consumes both (UI displays context-aware results).
 

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/README.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/README.md
@@ -1,7 +1,7 @@
 # PRD-058: Contextual Intelligence
 
 > Epic: [07 — Search](../../epics/07-search.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -44,7 +44,7 @@ interface AppContext {
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-context-provider](us-01-context-provider.md) | React context/store for app context, URL-based app detection | Done | No (first) |
-| 02 | [us-02-page-context-hooks](us-02-page-context-hooks.md) | Hooks for pages to set their page-level context (entity, filters) | Partial | Blocked by us-01 |
+| 02 | [us-02-page-context-hooks](us-02-page-context-hooks.md) | Hooks for pages to set their page-level context (entity, filters) | Done | Blocked by us-01 |
 | 03 | [us-03-context-consumer-api](us-03-context-consumer-api.md) | Consumer API for Search and AI to read current context | Done | Blocked by us-01 |
 
 ## Out of Scope

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/us-02-page-context-hooks.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/us-02-page-context-hooks.md
@@ -1,7 +1,7 @@
 # US-02: Page context hooks
 
 > PRD: [058 — Contextual Intelligence](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -11,8 +11,8 @@ As a developer, I want hooks that pages call to set their specific context so th
 
 - [x] `useSetPageContext({ page, pageType, entity?, filters? })` hook for pages to call on mount
 - [x] Context updates when page mounts — stale context from previous page cleared
-- [ ] Drill-down pages set entity context (e.g., movie detail sets the movie's URI and title)
-- [ ] List pages set filter context (e.g., transactions page sets active account/type/tag filters)
+- [x] Drill-down pages set entity context (e.g., movie detail sets the movie's URI and title)
+- [x] List pages set filter context (e.g., transactions page sets active account/type/tag filters)
 - [x] Context clears on unmount (navigation away)
 
 ## Notes

--- a/packages/app-finance/src/pages/BudgetsPage.tsx
+++ b/packages/app-finance/src/pages/BudgetsPage.tsx
@@ -3,6 +3,7 @@
  */
 import { useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
+import { useSetPageContext } from "@pops/navigation";
 import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -76,6 +77,7 @@ const DEFAULT_FORM_VALUES: BudgetFormValues = {
 };
 
 export function BudgetsPage() {
+  useSetPageContext({ page: "budgets" });
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingBudget, setEditingBudget] = useState<Budget | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);

--- a/packages/app-finance/src/pages/TransactionsPage.tsx
+++ b/packages/app-finance/src/pages/TransactionsPage.tsx
@@ -3,6 +3,7 @@
  */
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback } from "react";
+import { useSetPageContext } from "@pops/navigation";
 import { trpc } from "../lib/trpc";
 import { DataTable, SortableHeader } from "@pops/ui";
 import { Badge } from "@pops/ui";
@@ -25,6 +26,7 @@ interface Transaction {
 }
 
 export function TransactionsPage() {
+  useSetPageContext({ page: "transactions" });
   const utils = trpc.useUtils();
 
   // Fetch transactions using tRPC

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -4,6 +4,7 @@
  */
 import { useState } from "react";
 import { useParams, Link, useNavigate } from "react-router";
+import { useSetPageContext } from "@pops/navigation";
 import { toast } from "sonner";
 import Markdown from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
@@ -99,6 +100,14 @@ export function ItemDetailPage() {
     onError: (err) => {
       toast.error(`Failed to disconnect: ${err.message}`);
     },
+  });
+
+  useSetPageContext({
+    page: "item-detail",
+    pageType: "drill-down",
+    entity: itemData?.data
+      ? { uri: `pops:inventory/item/${id}`, type: "item", title: itemData.data.itemName }
+      : undefined,
   });
 
   if (isLoading) {

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -4,6 +4,7 @@
  */
 import { useState, useMemo, useCallback } from "react";
 import { useNavigate, useSearchParams } from "react-router";
+import { useSetPageContext } from "@pops/navigation";
 import {
   Package,
   LayoutGrid,
@@ -334,6 +335,17 @@ export function ItemsPage() {
   const handleViewChange = (mode: ViewMode) => setViewMode(mode);
 
   const hasActiveFilters = !!(typeFilter || conditionFilter || inUseFilter || locationFilter);
+
+  useSetPageContext({
+    page: "inventory",
+    filters: {
+      ...(search && { search }),
+      ...(typeFilter && { type: typeFilter }),
+      ...(conditionFilter && { condition: conditionFilter }),
+      ...(inUseFilter && { inUse: inUseFilter }),
+      ...(locationFilter && { locationId: locationFilter }),
+    },
+  });
 
   return (
     <div className="space-y-6">

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useSearchParams, Link } from "react-router";
+import { useSetPageContext } from "@pops/navigation";
 import { Button, Select, Skeleton, TextInput } from "@pops/ui";
 import { Sparkles, Settings, Search, ChevronLeft, ChevronRight, AlertCircle } from "lucide-react";
 import { MediaGrid } from "../components/MediaGrid";
@@ -188,6 +189,16 @@ export function LibraryPage() {
   const isLibraryEmpty = isEmpty && !debouncedSearch && typeFilter === "all" && !genreFilter;
 
   const showTypeBadge = typeFilter === "all";
+
+  useSetPageContext({
+    page: "library",
+    filters: {
+      ...(typeFilter !== "all" && { type: typeFilter }),
+      ...(sortBy !== "title" && { sort: sortBy }),
+      ...(debouncedSearch && { search: debouncedSearch }),
+      ...(genreFilter && { genre: genreFilter }),
+    },
+  });
 
   return (
     <div className="space-y-6">

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useParams, Link } from "react-router";
+import { useSetPageContext } from "@pops/navigation";
 import {
   Alert,
   AlertTitle,
@@ -72,6 +73,14 @@ export function MovieDetailPage() {
     undefined,
     { enabled: !Number.isNaN(movieId) }
   );
+
+  useSetPageContext({
+    page: "movie-detail",
+    pageType: "drill-down",
+    entity: data?.data
+      ? { uri: `pops:media/movie/${movieId}`, type: "movie", title: data.data.title }
+      : undefined,
+  });
 
   if (Number.isNaN(movieId)) {
     return (

--- a/packages/app-media/src/pages/SeasonDetailPage.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useParams, Link } from "react-router";
+import { useSetPageContext } from "@pops/navigation";
 import {
   Alert,
   AlertTitle,
@@ -394,6 +395,18 @@ export function SeasonDetailPage() {
   const isSeasonWatched = seasonProgress
     ? seasonProgress.watched >= seasonProgress.total && seasonProgress.total > 0
     : false;
+
+  useSetPageContext({
+    page: "season-detail",
+    pageType: "drill-down",
+    entity: showData?.data
+      ? {
+          uri: `pops:media/tv/${showId}/season/${seasonNum}`,
+          type: "season",
+          title: `${showData.data.name} — ${seasonNum === 0 ? "Specials" : `Season ${seasonNum}`}`,
+        }
+      : undefined,
+  });
 
   if (Number.isNaN(showId) || Number.isNaN(seasonNum)) {
     return (

--- a/packages/app-media/src/pages/TvShowDetailPage.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import { useParams, Link } from "react-router";
+import { useSetPageContext } from "@pops/navigation";
 import {
   Alert,
   AlertTitle,
@@ -162,6 +163,14 @@ export function TvShowDetailPage() {
       }),
     [rawSeasons]
   );
+
+  useSetPageContext({
+    page: "tv-show-detail",
+    pageType: "drill-down",
+    entity: data?.data
+      ? { uri: `pops:media/tv/${showId}`, type: "tvshow", title: data.data.name }
+      : undefined,
+  });
 
   if (Number.isNaN(showId)) {
     return (


### PR DESCRIPTION
## Summary

- **MovieDetailPage**, **TvShowDetailPage**, **SeasonDetailPage**, **ItemDetailPage**: call `useSetPageContext` with `pageType: "drill-down"` and entity context (uri, type, title) — entity is undefined while loading, updates once data arrives
- **LibraryPage**, **ItemsPage**: call `useSetPageContext` with active URL-based filter values (empty/default values omitted)
- **TransactionsPage**, **BudgetsPage**: call `useSetPageContext` with page name only (no URL-based filter state)
- Docs: US-02 → Done, PRD-058 → Done, Epic 07 all PRDs Done → Done, Foundation README Epic 7 → Done, roadmap Platform search → Done

This completes Epic 07 Search — all 3 PRDs (PRD-056, PRD-057, PRD-058) are now Done.

## Test plan

- [ ] CI green — typecheck passes for app-media, app-finance, app-inventory
- [ ] No new test file required — existing `useSetPageContext` tests in `packages/navigation` cover the hook lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)