### PR TITLE
fix(navigation): add ! assertions for noUncheckedIndexedAccess in test

### DIFF
--- a/packages/navigation/src/SearchResultsPanel.test.tsx
+++ b/packages/navigation/src/SearchResultsPanel.test.tsx
@@ -232,8 +232,8 @@ describe("SearchResultsPanel", () => {
     ];
     render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
     const buttons = screen.getAllByRole("button");
-    expect(buttons[0]).toHaveAttribute("data-result-index", "0");
-    expect(buttons[1]).toHaveAttribute("data-result-index", "1");
+    expect(buttons[0]!).toHaveAttribute("data-result-index", "0");
+    expect(buttons[1]!).toHaveAttribute("data-result-index", "1");
   });
 
   it("assigns sequential data-result-index across multiple sections", () => {
@@ -252,8 +252,8 @@ describe("SearchResultsPanel", () => {
     ];
     render(<SearchResultsPanel sections={sections} query="test" onClose={vi.fn()} />);
     const buttons = screen.getAllByRole("button");
-    expect(buttons[0]).toHaveAttribute("data-result-index", "0");
-    expect(buttons[1]).toHaveAttribute("data-result-index", "1");
+    expect(buttons[0]!).toHaveAttribute("data-result-index", "0");
+    expect(buttons[1]!).toHaveAttribute("data-result-index", "1");
   });
 
   it("highlights the selected result by selectedIndex", () => {


### PR DESCRIPTION
## Summary
- `buttons[0]` and `buttons[1]` in `SearchResultsPanel.test.tsx` return `HTMLElement | undefined` under `noUncheckedIndexedAccess`
- Added `!` non-null assertions to two test cases (`data-result-index` assertions) to satisfy TypeScript

## Test plan
- [ ] `pnpm typecheck` passes in `packages/navigation`
- [ ] Tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)