### PR TITLE
docs: expand design context with principles and references

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,33 +1,85 @@
 # POPS Design Context
 
-## Target Audience
-Single user (owner) — but displayed on a wall-mounted iPad where others may see it. Must look impressive at a glance while being efficient for daily use.
+## Users
+Single owner-operator using POPS as a personal command center across finance, media, inventory, and AI. Primary display is a wall-mounted iPad (viewed from arm's length and 1-2 meters), with secondary use on desktop browsers. The interface is visible to guests — it should look intentional and impressive without explanation.
 
 ## Use Cases
-- Financial tracking: transactions, budgets, entity management
-- Media library: movies, TV shows, inventory
-- Dashboard: at-a-glance financial health, recent activity
-- Data import and management workflows
+- Financial tracking: transactions, budgets, entity management, import workflows
+- Media library: movies, TV shows, watchlist, compare arena, discovery
+- Inventory: items, locations, warranties, wish list
+- AI: usage tracking, model config, rules
+- Dashboard: at-a-glance health across all domains
 
-## Brand Personality & Tone
-- **Clean**: uncluttered, well-structured layouts
-- **Warm**: approachable, not cold/corporate
-- **Exciting**: distinctive enough to look impressive on a wall display
-- **Efficient**: data-dense where needed, quick to scan
+## Brand Personality
+**Precise, Warm, Confident.**
+
+POPS should feel like a well-engineered personal instrument — the calm authority of Linear's interface married with the warmth and personality of Up Bank and Flightly. It's a tool that earns trust through clarity, not flash. Data is presented with conviction, not apology.
+
+### Emotional Goals
+- **Confidence** — "Everything is under control." Clarity, order, trust in the data.
+- **Calm focus** — "No noise, just signal." Zen-like clarity, nothing screams for attention.
+
+### Voice
+Neutral, direct, efficient. Labels and microcopy should be concise and precise. No marketing language, no unnecessary friendliness — but not cold either. Think pilot's instrument panel: every label earns its place.
+
+## Aesthetic Direction
+
+### References
+- **Linear / Raycast** — Minimal, fast, monochrome foundations with deliberate accent pops. Keyboard-driven feel even on touch.
+- **Arc Browser / Amie** — Warm palette choices, subtle personality in transitions and spacing, feels alive without being noisy.
+- **Flightly** — Beautiful dark-mode data visualization, aviation-grade precision in card layouts, satisfying information density.
+- **Up Bank** — Bold domain colors used with restraint, friendly data presentation, financial data that feels approachable without being childish.
+
+### Anti-References
+- **Generic SaaS** — No cookie-cutter blue/white dashboards. If it looks like it could be any B2B tool, it's wrong.
+- **Brutalist / raw** — No developer-tool aesthetic. The system should feel polished and intentional, not thrown together.
+
+### Visual Tone
+- Dark mode is the primary experience (wall-mounted display in living spaces)
+- OKLCH color space for perceptually uniform, rich colors
+- Monochrome foundations with domain-specific accent colors (emerald for finance, indigo for media, amber for inventory, violet for AI)
+- Cards and surfaces use subtle depth, not harsh borders
+- Generous but not wasteful whitespace — data-dense where needed, breathing room where not
+- Typography carries hierarchy; color supports it, never replaces it
 
 ## Typography
-- **Primary font**: Plus Jakarta Sans Variable (warm geometric sans-serif)
-- **Fallback**: system-ui stack
-- **Scale**: Major third (1.25 ratio), fixed rem-based (app UI, not marketing)
-- **Financial data**: tabular-nums, monospace for amounts
+- **Primary font**: Plus Jakarta Sans Variable — warm geometric sans-serif
+- **Scale**: Fluid clamp-based headings for responsive sizing
+- **Financial data**: `tabular-nums` for aligned columns
+- **OpenType features**: `cv02`, `cv03`, `cv04`, `ss01` enabled
+- **Micro text**: Custom `text-2xs` (10px) for badges, stat labels, table headers
 
 ## Color System
-- OKLCH color space for dark mode (perceptually uniform)
-- HSL for light mode
-- Semantic tokens: foreground, muted-foreground, primary, destructive, success, warning, info
+- **Space**: OKLCH (perceptually uniform)
+- **Semantic tokens**: background, foreground, primary, muted, accent, destructive, success, warning, info
+- **Domain accents**: emerald (finance), indigo (media), amber (inventory), violet (AI), rose, sky (supporting)
+- **Charts**: 5-color OKLCH palette for data visualization
+- **Principle**: Color communicates meaning, not decoration. Every colored element should answer "why is this colored?"
+
+## Design Principles
+
+1. **Earned density** — Show more data, not more chrome. Every pixel of UI that isn't content must justify its existence. Prefer information-rich cards over decorative layouts, but never at the cost of scanability.
+
+2. **Quiet confidence** — The interface should feel calm and authoritative. No pulsing alerts, no aggressive CTAs, no visual shouting. Important information is prominent through hierarchy, not through loudness.
+
+3. **Warmth through craft** — Avoid clinical coldness not by adding decoration, but through considered typography, generous spacing, smooth transitions, and a palette that feels human. The warmth is in the details, not in illustrations or mascots.
+
+4. **Domain identity** — Each module (finance, media, inventory, AI) has its own accent color and subtle personality, but they all feel like rooms in the same house. Consistency in structure, variation in color.
+
+5. **Glanceability** — On a wall-mounted iPad, information must be scannable from 1-2 meters. Key metrics should be legible at distance; detail is available on approach. Design for two viewing distances.
+
+## Accessibility
+- iPad-optimized: 44px+ touch targets, no hover-dependent interactions
+- Wall-mount consideration: larger base text and key metrics for distance viewing
+- Respect `prefers-reduced-motion` for users who need it
+- WCAG AA contrast ratios minimum
+- Radix UI primitives ensure semantic HTML and ARIA patterns
+- Focus-visible rings for keyboard navigation (secondary input method)
 
 ## Technical Constraints
-- React + Tailwind CSS v4 (CSS-based @theme, no config file)
-- shadcn/ui component primitives
-- PWA on iPad (wall-mounted) + desktop browser
-- Self-hosted, performance matters (no CDN dependencies)
+- React 19 + Tailwind CSS v4 (CSS-based @theme, no config file)
+- shadcn/ui primitives + Radix UI
+- CVA (class-variance-authority) for component variants
+- PWA: standalone mode, `apple-mobile-web-app-capable`
+- Self-hosted on N95 mini PC — performance matters, no CDN dependencies
+- Theme color: `#1a1a2e` (dark indigo)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,3 +425,21 @@ See [CONVENTIONS.md](CONVENTIONS.md) for coding conventions (styling, API patter
 - Keep files small, modular and reusable.
 - Aim for small, well named and well structured code.
 - REuse reuse reuse. DRY principles!
+
+## Design Context
+
+Full design context lives in [`.impeccable.md`](.impeccable.md). Key principles for all UI work:
+
+**Personality:** Precise, Warm, Confident. Linear's clarity + Up Bank's approachability.
+**Emotions:** Confidence ("everything is under control") and calm focus ("no noise, just signal").
+
+**Anti-patterns:** Generic SaaS dashboards, brutalist/raw developer aesthetics.
+
+**5 Design Principles:**
+1. **Earned density** — More data, less chrome. Every non-content pixel justifies itself.
+2. **Quiet confidence** — Prominent through hierarchy, not loudness. No visual shouting.
+3. **Warmth through craft** — Warmth from typography, spacing, and transitions — not decoration.
+4. **Domain identity** — Each module has its accent color but all feel like rooms in the same house.
+5. **Glanceability** — Key metrics legible from 1-2m on wall-mounted iPad. Design for two viewing distances.
+
+**Technical:** Dark mode primary, OKLCH colors, Plus Jakarta Sans, 44px+ touch targets, `prefers-reduced-motion` respected.


### PR DESCRIPTION
## Summary
- Rewrites `.impeccable.md` with comprehensive design context: brand personality (Precise, Warm, Confident), aesthetic references (Linear, Arc, Flightly, Up Bank), anti-references, 5 design principles, and iPad accessibility requirements
- Adds condensed Design Context section to `CLAUDE.md` pointing to `.impeccable.md` for full details

## Test plan
- [ ] Verify `.impeccable.md` renders correctly on GitHub
- [ ] Verify `CLAUDE.md` Design Context section links correctly