### PR TITLE
feat(discover): add context:morning/evening/weekend/seasonal shelves [gh-1473]

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/context-collections.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/context-collections.test.ts
@@ -7,8 +7,8 @@ function findCollection(id: string) {
 }
 
 describe("CONTEXT_COLLECTIONS", () => {
-  it("defines 7 collections", () => {
-    expect(CONTEXT_COLLECTIONS).toHaveLength(7);
+  it("defines 11 collections", () => {
+    expect(CONTEXT_COLLECTIONS).toHaveLength(11);
   });
 
   it("each collection has required fields", () => {
@@ -132,6 +132,98 @@ describe("trigger — oscar-season", () => {
   });
 });
 
+describe("trigger — morning", () => {
+  const col = findCollection("morning");
+
+  it("matches 6am", () => {
+    expect(col.trigger(6, 6, 3)).toBe(true);
+  });
+
+  it("matches 10am (boundary)", () => {
+    expect(col.trigger(10, 6, 3)).toBe(true);
+  });
+
+  it("rejects 11am (after window)", () => {
+    expect(col.trigger(11, 6, 3)).toBe(false);
+  });
+
+  it("rejects 5am (before window)", () => {
+    expect(col.trigger(5, 6, 3)).toBe(false);
+  });
+
+  it("rejects 3pm", () => {
+    expect(col.trigger(15, 6, 3)).toBe(false);
+  });
+});
+
+describe("trigger — evening", () => {
+  const col = findCollection("evening");
+
+  it("matches 6pm", () => {
+    expect(col.trigger(18, 6, 3)).toBe(true);
+  });
+
+  it("matches 10pm (boundary)", () => {
+    expect(col.trigger(22, 6, 3)).toBe(true);
+  });
+
+  it("rejects 11pm (after window)", () => {
+    expect(col.trigger(23, 6, 3)).toBe(false);
+  });
+
+  it("rejects 5pm (before window)", () => {
+    expect(col.trigger(17, 6, 3)).toBe(false);
+  });
+
+  it("rejects noon", () => {
+    expect(col.trigger(12, 6, 3)).toBe(false);
+  });
+});
+
+describe("trigger — weekend", () => {
+  const col = findCollection("weekend");
+
+  it("matches Saturday", () => {
+    expect(col.trigger(14, 6, 6)).toBe(true);
+  });
+
+  it("matches Sunday", () => {
+    expect(col.trigger(14, 6, 0)).toBe(true);
+  });
+
+  it("rejects Monday", () => {
+    expect(col.trigger(14, 6, 1)).toBe(false);
+  });
+
+  it("rejects Friday", () => {
+    expect(col.trigger(14, 6, 5)).toBe(false);
+  });
+});
+
+describe("trigger — seasonal", () => {
+  const col = findCollection("seasonal");
+
+  it("matches June", () => {
+    expect(col.trigger(12, 6, 3)).toBe(true);
+  });
+
+  it("matches July", () => {
+    expect(col.trigger(12, 7, 3)).toBe(true);
+  });
+
+  it("matches August", () => {
+    expect(col.trigger(12, 8, 3)).toBe(true);
+  });
+
+  it("rejects May (before summer)", () => {
+    expect(col.trigger(12, 5, 3)).toBe(false);
+  });
+
+  it("rejects September (after summer)", () => {
+    expect(col.trigger(12, 9, 3)).toBe(false);
+  });
+});
+
 describe("trigger — rainy-day", () => {
   const col = findCollection("rainy-day");
 
@@ -148,17 +240,17 @@ describe("getActiveCollections", () => {
   });
 
   it("fills with rainy-day fallback when no triggers match", () => {
-    // Wednesday 3pm in June — nothing matches except rainy-day
-    const result = getActiveCollections(15, 6, 3);
+    // Wednesday 3pm in November — nothing matches except rainy-day
+    const result = getActiveCollections(15, 11, 3);
     expect(result[0]!.id).toBe("rainy-day");
     expect(result[1]!.id).toBe("rainy-day");
   });
 
   it("includes rainy-day when only 1 non-fallback matches", () => {
-    // Sunday 3pm in June — only sunday-flicks matches
-    const result = getActiveCollections(15, 6, 0);
+    // Wednesday 3pm in February — only oscar-season matches
+    const result = getActiveCollections(15, 2, 3);
     const ids = result.map((c) => c.id);
-    expect(ids).toContain("sunday-flicks");
+    expect(ids).toContain("oscar-season");
     expect(ids).toContain("rainy-day");
   });
 

--- a/apps/pops-api/src/modules/media/discovery/context-collections.ts
+++ b/apps/pops-api/src/modules/media/discovery/context-collections.ts
@@ -74,6 +74,38 @@ export const CONTEXT_COLLECTIONS: ContextCollection[] = [
     trigger: (_hour, month) => month === 2 || month === 3,
   },
   {
+    id: "morning",
+    title: "Morning Watch",
+    emoji: "🌅",
+    genreIds: [35, 16, 10751], // Comedy + Animation + Family
+    keywordIds: [],
+    trigger: (hour) => hour >= 6 && hour <= 10,
+  },
+  {
+    id: "evening",
+    title: "Evening Picks",
+    emoji: "🌆",
+    genreIds: [18, 53, 28], // Drama + Thriller + Action
+    keywordIds: [],
+    trigger: (hour) => hour >= 18 && hour <= 22,
+  },
+  {
+    id: "weekend",
+    title: "Weekend Watch",
+    emoji: "🎉",
+    genreIds: [28, 12, 35], // Action + Adventure + Comedy
+    keywordIds: [],
+    trigger: (_hour, _month, dayOfWeek) => dayOfWeek === SATURDAY || dayOfWeek === SUNDAY,
+  },
+  {
+    id: "seasonal",
+    title: "Summer Blockbusters",
+    emoji: "☀️",
+    genreIds: [28, 12, 878], // Action + Adventure + Science Fiction
+    keywordIds: [],
+    trigger: (_hour, month) => month >= 6 && month <= 8,
+  },
+  {
     id: FALLBACK_ID,
     title: "Rainy Day",
     emoji: "🌧️",

--- a/apps/pops-api/src/modules/media/discovery/shelf/context-shelves.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/context-shelves.test.ts
@@ -284,6 +284,129 @@ describe("oscar-season instance", () => {
 });
 
 // ---------------------------------------------------------------------------
+// morning: active 6am–10am
+// ---------------------------------------------------------------------------
+
+describe("morning instance", () => {
+  it("generates instance at 8am", () => {
+    vi.setSystemTime(new Date("2024-06-12T08:00:00")); // Wednesday 8am
+    const instances = contextShelfDefinition.generate(stubProfile);
+    const instance = instances.find((i) => i.shelfId === "context:morning");
+    expect(instance).toBeDefined();
+    expect(instance!.shelfId).toBe("context:morning");
+    vi.useRealTimers();
+  });
+
+  it("generates instance at 6am (boundary)", () => {
+    vi.setSystemTime(new Date("2024-06-12T06:00:00"));
+    const instances = contextShelfDefinition.generate(stubProfile);
+    expect(instances.find((i) => i.shelfId === "context:morning")).toBeDefined();
+    vi.useRealTimers();
+  });
+
+  it("does not generate instance at 11am", () => {
+    vi.setSystemTime(new Date("2024-06-12T11:00:00"));
+    const instances = contextShelfDefinition.generate(stubProfile);
+    expect(instances.find((i) => i.shelfId === "context:morning")).toBeUndefined();
+    vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evening: active 6pm–10pm
+// ---------------------------------------------------------------------------
+
+describe("evening instance", () => {
+  it("generates instance at 8pm", () => {
+    vi.setSystemTime(new Date("2024-06-12T20:00:00")); // Wednesday 8pm
+    const instances = contextShelfDefinition.generate(stubProfile);
+    const instance = instances.find((i) => i.shelfId === "context:evening");
+    expect(instance).toBeDefined();
+    expect(instance!.shelfId).toBe("context:evening");
+    vi.useRealTimers();
+  });
+
+  it("does not generate instance at 11pm", () => {
+    vi.setSystemTime(new Date("2024-06-12T23:00:00"));
+    const instances = contextShelfDefinition.generate(stubProfile);
+    expect(instances.find((i) => i.shelfId === "context:evening")).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it("does not generate instance at noon", () => {
+    vi.setSystemTime(new Date("2024-06-12T12:00:00"));
+    const instances = contextShelfDefinition.generate(stubProfile);
+    expect(instances.find((i) => i.shelfId === "context:evening")).toBeUndefined();
+    vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// weekend: active on Saturday and Sunday
+// ---------------------------------------------------------------------------
+
+describe("weekend instance", () => {
+  it("generates instance on Saturday", () => {
+    vi.setSystemTime(new Date("2024-06-15T14:00:00")); // Saturday
+    const instances = contextShelfDefinition.generate(stubProfile);
+    const instance = instances.find((i) => i.shelfId === "context:weekend");
+    expect(instance).toBeDefined();
+    expect(instance!.shelfId).toBe("context:weekend");
+    vi.useRealTimers();
+  });
+
+  it("generates instance on Sunday", () => {
+    vi.setSystemTime(new Date("2024-06-16T14:00:00")); // Sunday
+    const instances = contextShelfDefinition.generate(stubProfile);
+    expect(instances.find((i) => i.shelfId === "context:weekend")).toBeDefined();
+    vi.useRealTimers();
+  });
+
+  it("does not generate instance on Friday", () => {
+    vi.setSystemTime(new Date("2024-06-14T14:00:00")); // Friday
+    const instances = contextShelfDefinition.generate(stubProfile);
+    expect(instances.find((i) => i.shelfId === "context:weekend")).toBeUndefined();
+    vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seasonal: active June–August (summer blockbusters)
+// ---------------------------------------------------------------------------
+
+describe("seasonal instance", () => {
+  it("generates instance in July", () => {
+    vi.setSystemTime(new Date("2024-07-10T12:00:00")); // July
+    const instances = contextShelfDefinition.generate(stubProfile);
+    const instance = instances.find((i) => i.shelfId === "context:seasonal");
+    expect(instance).toBeDefined();
+    expect(instance!.shelfId).toBe("context:seasonal");
+    vi.useRealTimers();
+  });
+
+  it("generates instance in June", () => {
+    vi.setSystemTime(new Date("2024-06-01T12:00:00")); // June
+    const instances = contextShelfDefinition.generate(stubProfile);
+    expect(instances.find((i) => i.shelfId === "context:seasonal")).toBeDefined();
+    vi.useRealTimers();
+  });
+
+  it("does not generate instance in May", () => {
+    vi.setSystemTime(new Date("2024-05-15T12:00:00")); // May
+    const instances = contextShelfDefinition.generate(stubProfile);
+    expect(instances.find((i) => i.shelfId === "context:seasonal")).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it("does not generate instance in September", () => {
+    vi.setSystemTime(new Date("2024-09-01T12:00:00")); // September
+    const instances = contextShelfDefinition.generate(stubProfile);
+    expect(instances.find((i) => i.shelfId === "context:seasonal")).toBeUndefined();
+    vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // rainy-day: always active (fallback)
 // ---------------------------------------------------------------------------
 

--- a/apps/pops-api/src/modules/media/discovery/shelf/session.service.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/session.service.test.ts
@@ -218,6 +218,25 @@ describe("assembleSession", () => {
     expect(mockGetShelfFreshness).toHaveBeenCalledWith(0);
   });
 
+  it("applies +0.3 context boost — context shelves outscore equal tmdb shelves", () => {
+    // Context shelf with base score 0.5, tmdb shelf also 0.5 — context should win
+    const contextDef = makeDefinition("context", "context", [makeInstance("context:morning", 0.5)]);
+    // Register enough tmdb shelves to fill a session
+    const tmdbDefs = Array.from({ length: 15 }, (_, i) =>
+      makeDefinition(`tmdb-${i}`, "tmdb", [makeInstance(`tmdb-${i}`, 0.5)])
+    );
+    mockGetRegisteredShelves.mockReturnValue([contextDef, ...tmdbDefs]);
+
+    // Run many times — context shelf should consistently appear in results
+    let contextCount = 0;
+    for (let i = 0; i < 20; i++) {
+      const result = assembleSession(profile, new Map());
+      if (result.some((s) => s.shelfId === "context:morning")) contextCount++;
+    }
+    // With +0.3 boost over equal-scored competitors, context shelf appears far more often
+    expect(contextCount).toBeGreaterThanOrEqual(15);
+  });
+
   it("does not include duplicate shelf IDs in result", () => {
     const definitions = Array.from({ length: 15 }, (_, i) =>
       makeDefinition(`shelf-${i}`, "tmdb", [makeInstance(`shelf-${i}`, 0.8)])

--- a/apps/pops-api/src/modules/media/discovery/shelf/session.service.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/session.service.ts
@@ -10,8 +10,9 @@
  *   - at least 1 personal shelf (shelfId starts with 'recommendations' or 'because-you-watched')
  *
  * Scoring:
- *   score = instance.score × freshness × (1 + varietyBonus)
+ *   score = instance.score × freshness × (1 + varietyBonus + contextBonus)
  *   varietyBonus = 0.2 if category !== previous selected category, else 0
+ *   contextBonus = 0.3 if category === 'context' (time-triggered shelves), else 0
  */
 import type { PreferenceProfile, ShelfInstance, ShelfCategory } from "./types.js";
 import { getRegisteredShelves } from "./registry.js";
@@ -24,6 +25,7 @@ const MAX_GENRE_SHELVES = 2;
 const MAX_LOCAL_PER_WINDOW = 1;
 const LOCAL_WINDOW_SIZE = 3;
 const VARIETY_BONUS = 0.2;
+const CONTEXT_BOOST = 0.3;
 
 function isGenreShelf(shelfId: string): boolean {
   return shelfId.startsWith("best-in-genre") || shelfId.startsWith("genre-crossover");
@@ -39,11 +41,12 @@ interface ScoredCandidate {
   baseScore: number;
 }
 
-/** Compute scores for all candidates, applying variety bonus based on last category. */
+/** Compute scores for all candidates, applying variety bonus and context boost. */
 function computeScore(candidate: ScoredCandidate, lastCategory: ShelfCategory | null): number {
   const varietyBonus =
     lastCategory !== null && candidate.category !== lastCategory ? VARIETY_BONUS : 0;
-  return candidate.baseScore * (1 + varietyBonus);
+  const contextBonus = candidate.category === "context" ? CONTEXT_BOOST : 0;
+  return candidate.baseScore * (1 + varietyBonus + contextBonus);
 }
 
 /** Weighted random sample from candidates proportional to their scores. */


### PR DESCRIPTION
## Summary

- Adds 4 new time-triggered context shelf collections to `context-collections.ts`:
  - `context:morning` (6–10am) — Comedy, Animation, Family genres
  - `context:evening` (6–10pm) — Drama, Thriller, Action genres
  - `context:weekend` (Sat/Sun) — Action, Adventure, Comedy genres
  - `context:seasonal` (Jun–Aug) — Action, Adventure, Science Fiction (summer blockbusters)
- Implements the PRD-065 `+0.3` context boost in `assembleSession` (`session.service.ts`) so active context shelves score higher than equally-rated non-context shelves
- Updates tests: `context-collections.test.ts` (7→11 collections, 4 new trigger describe blocks), `context-shelves.test.ts` (4 new instance describe blocks), `session.service.test.ts` (context boost coverage)
- Fixes 2 `getActiveCollections` tests that used June as a "no trigger" month (seasonal now covers Jun–Aug); updated to use November

## Test plan

- [x] 100 tests pass across 3 test files (`context-collections`, `context-shelves`, `session.service`)
- [x] `pnpm typecheck` clean
- [x] `pnpm format --check` clean
- [x] `pnpm lint` clean

Closes #1473

🤖 Generated with [Claude Code](https://claude.com/claude-code)