### PR TITLE
fix(media): fix library page infinite render loop [tb-281]

### DIFF
--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useSearchParams, Link } from "react-router";
 import { Button, Select, Skeleton, TextInput } from "@pops/ui";
 import { Sparkles, Settings, Search, ChevronLeft, ChevronRight, AlertCircle } from "lucide-react";
@@ -135,8 +135,16 @@ export function LibraryPage() {
   const [localSearch, setLocalSearch] = useState(searchQuery);
   const debouncedSearch = useDebouncedValue(localSearch, 300);
 
-  // Sync debounced search to URL
+  // Skip syncing on initial mount — localSearch is already initialised from the
+  // URL, so there is nothing to sync. Only sync after the user changes the search.
+  const hasMountedRef = useRef(false);
+
+  // Sync debounced search to URL (only after initial mount)
   useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
@@ -150,7 +158,12 @@ export function LibraryPage() {
       },
       { replace: true }
     );
-  }, [debouncedSearch, setSearchParams]);
+    // setSearchParams is intentionally omitted from deps — in React Router v7 it
+    // is not referentially stable (it changes whenever searchParams changes), so
+    // including it caused an infinite loop: effect → URL update → new setSearchParams
+    // reference → effect again. The functional-update form (prev => next) means we
+    // do not need the latest closure over searchParams.
+  }, [debouncedSearch]);
 
   const setParam = (key: string, value: string) => {
     setSearchParams(


### PR DESCRIPTION
## Summary

- `LibraryPage` had a `useEffect` that synced `debouncedSearch` to the URL. It included `setSearchParams` in its dependency array.
- In React Router v7, `setSearchParams` is **not** referentially stable — it gets a new function reference whenever `searchParams` changes.
- This created an infinite loop: effect runs → `setSearchParams` called → URL updates → `searchParams` changes → new `setSearchParams` ref → effect re-runs.
- React threw error #185 (Maximum update depth exceeded), crashing the library page permanently.

**Fix:**
1. Add a `hasMountedRef` — skip the effect body on initial mount. On mount, `localSearch` is already initialised from the URL (nothing to sync). Page should only reset to 1 when the user actively changes the search term.
2. Remove `setSearchParams` from the deps array. The functional-update form `(prev => next)` means the callback always reads the latest params without needing `setSearchParams` as a reactive dependency.

## Test plan

- [ ] Navigate to `/media` — library loads without crash
- [ ] Type in search box — URL updates with `?q=...&page=1` after debounce
- [ ] Clear search — URL reverts `q`, page resets to 1
- [ ] Navigate back to library from another page — URL state is preserved (not reset to page 1 on mount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)