### PR TITLE
chore: add dependabot.yml for automated dependency updates [tb-283]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,210 @@
+version: 2
+
+updates:
+  # ── GitHub Actions ──────────────────────────────────────────────────────────
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── Docker (infra/docker-compose.yml) ───────────────────────────────────────
+  - package-ecosystem: docker
+    directory: /infra
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      docker-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — workspace root ────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+    open-pull-requests-limit: 5
+    groups:
+      root-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — apps/pops-api ─────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /apps/pops-api
+    schedule:
+      interval: weekly
+      day: tuesday
+    open-pull-requests-limit: 3
+    groups:
+      pops-api-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — apps/pops-shell ───────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /apps/pops-shell
+    schedule:
+      interval: weekly
+      day: tuesday
+    open-pull-requests-limit: 3
+    groups:
+      pops-shell-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — apps/moltbot ──────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /apps/moltbot
+    schedule:
+      interval: weekly
+      day: tuesday
+    open-pull-requests-limit: 3
+    groups:
+      moltbot-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — packages/ui ───────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /packages/ui
+    schedule:
+      interval: weekly
+      day: wednesday
+    open-pull-requests-limit: 3
+    groups:
+      ui-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — packages/db-types ────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /packages/db-types
+    schedule:
+      interval: weekly
+      day: wednesday
+    open-pull-requests-limit: 3
+    groups:
+      db-types-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — packages/api-client ──────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /packages/api-client
+    schedule:
+      interval: weekly
+      day: wednesday
+    open-pull-requests-limit: 3
+    groups:
+      api-client-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — packages/navigation ──────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /packages/navigation
+    schedule:
+      interval: weekly
+      day: wednesday
+    open-pull-requests-limit: 3
+    groups:
+      navigation-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — packages/app-finance ─────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /packages/app-finance
+    schedule:
+      interval: weekly
+      day: thursday
+    open-pull-requests-limit: 3
+    groups:
+      app-finance-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — packages/app-media ───────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /packages/app-media
+    schedule:
+      interval: weekly
+      day: thursday
+    open-pull-requests-limit: 3
+    groups:
+      app-media-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — packages/app-inventory ───────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /packages/app-inventory
+    schedule:
+      interval: weekly
+      day: thursday
+    open-pull-requests-limit: 3
+    groups:
+      app-inventory-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — packages/app-ai ──────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /packages/app-ai
+    schedule:
+      interval: weekly
+      day: thursday
+    open-pull-requests-limit: 3
+    groups:
+      app-ai-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — packages/types ────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /packages/types
+    schedule:
+      interval: weekly
+      day: thursday
+    open-pull-requests-limit: 3
+    groups:
+      types-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # ── npm/pnpm — packages/import-tools ────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /packages/import-tools
+    schedule:
+      interval: weekly
+      day: friday
+    open-pull-requests-limit: 3
+    groups:
+      import-tools-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` covering all dependency ecosystems in the monorepo
- **npm/pnpm**: One entry per workspace directory (root, `apps/pops-api`, `apps/pops-shell`, `apps/moltbot`, all `packages/*`)
- **GitHub Actions**: Weekly on Monday, groups minor+patch together
- **Docker**: Weekly on Monday for `infra/docker-compose.yml` images
- Minor and patch updates grouped per ecosystem to avoid PR flooding; major bumps open individually for explicit review
- Schedule spread across Mon–Fri to prevent batching all PRs on the same day
- `open-pull-requests-limit: 3–5` per ecosystem to keep the queue manageable

## Test plan

- [ ] Verify Dependabot picks up the config on the next scheduled run
- [ ] Confirm grouped PRs open for minor/patch; individual PRs for majors
- [ ] Check `open-pull-requests-limit` prevents PR flooding

🤖 Generated with [Claude Code](https://claude.com/claude-code)