### PR TITLE
fix(media): wrap LibraryPage filters in useMemo to prevent context loop [tb-284]

### DIFF
--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useSearchParams, Link } from "react-router";
 import { useSetPageContext } from "@pops/navigation";
 import { Button, Select, Skeleton, TextInput } from "@pops/ui";
@@ -194,14 +194,16 @@ export function LibraryPage() {
     pageSize,
   });
 
-  useSetPageContext({
-    page: "library",
-    filters: {
-      ...(typeFilter !== "all" && { type: typeFilter }),
-      ...(sortBy !== "title" && { sort: sortBy }),
-      ...(searchQuery && { search: searchQuery }),
-    },
-  });
+  const libraryFilters = useMemo(() => {
+    const f: Record<string, string> = {};
+    if (typeFilter !== "all") f.type = typeFilter;
+    if (sortBy !== "title") f.sort = sortBy;
+    if (searchQuery) f.search = searchQuery;
+    if (genreFilter) f.genre = genreFilter;
+    return f;
+  }, [typeFilter, sortBy, searchQuery, genreFilter]);
+
+  useSetPageContext({ page: "library", pageType: "top-level", filters: libraryFilters });
 
   const totalItems = pagination.total;
   const totalPages = pagination.totalPages;


### PR DESCRIPTION
## Summary

- Wraps the inline filters object in `LibraryPage.tsx` in `useMemo` with stable deps
- Prevents the `useSetPageContext` → `AppContextProvider.setPageContext` → re-render → new filters reference → `useLayoutEffect` re-fires infinite loop (React error #185)
- Also adds `genreFilter` to the filters map (was missing from the inline spread version)

## Root cause

`useSetPageContext` has `options.filters` in its `useLayoutEffect` dependency array. The previous inline object literal `{ ...(typeFilter !== "all" && { type: typeFilter }), ... }` created a new object reference on every render, causing the loop.

## Test plan

- [x] `pnpm format --check` clean (app-media)
- [x] Pre-existing `@pops/navigation` resolution errors in isolated packages are unchanged

Closes #1473 (follow-up fix after tb-281/#1509)

🤖 Generated with [Claude Code](https://claude.com/claude-code)