### PR TITLE
feat(media): add compare history, tier list, quick pick to nav [tb-285]

### DIFF
--- a/packages/app-media/src/routes.tsx
+++ b/packages/app-media/src/routes.tsx
@@ -124,6 +124,9 @@ export const navConfig: AppNavConfig = {
     { path: "/rankings", label: "Rankings", icon: "Trophy" },
     { path: "/search", label: "Search", icon: "Search" },
     { path: "/compare", label: "Compare", icon: "ArrowLeftRight" },
+    { path: "/compare/history", label: "Compare History", icon: "History" },
+    { path: "/tier-list", label: "Tier List", icon: "Layers" },
+    { path: "/quick-pick", label: "Quick Pick", icon: "Shuffle" },
   ],
 };
 


### PR DESCRIPTION
## Summary

- `/media/compare` and `/media/rankings` were already in the nav
- Adds the three missing comparison routes so all features are reachable without knowing the URL:
  - `/media/compare/history` — Compare History (History icon)
  - `/media/tier-list` — Tier List (Layers icon)
  - `/media/quick-pick` — Quick Pick (Shuffle icon)
- Single-file change to `navConfig.items` in `packages/app-media/src/routes.tsx`

## Test plan

- [ ] Verify all three new items appear in the media sidebar nav
- [ ] Confirm each nav item navigates to the correct page
- [ ] Check icons render correctly (History, Layers, Shuffle from lucide-react)

🤖 Generated with [Claude Code](https://claude.com/claude-code)