### PR TITLE
fix(library): wrap useSetPageContext filters in useMemo [tb-284]

### DIFF
--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useSearchParams, Link } from "react-router";
 import { useSetPageContext } from "@pops/navigation";
 import { Button, Select, Skeleton, TextInput } from "@pops/ui";
@@ -194,14 +194,16 @@ export function LibraryPage() {
     pageSize,
   });
 
-  useSetPageContext({
-    page: "library",
-    filters: {
+  const pageContextFilters = useMemo(
+    () => ({
       ...(typeFilter !== "all" && { type: typeFilter }),
       ...(sortBy !== "title" && { sort: sortBy }),
       ...(searchQuery && { search: searchQuery }),
-    },
-  });
+    }),
+    [typeFilter, sortBy, searchQuery]
+  );
+
+  useSetPageContext({ page: "library", filters: pageContextFilters });
 
   const totalItems = pagination.total;
   const totalPages = pagination.totalPages;


### PR DESCRIPTION
## Summary

- Wraps the inline filters object in `useSetPageContext` with `useMemo` in LibraryPage.tsx
- Fixes second source of React #185 infinite render loop (first was fixed in #1509)

**Root cause:** `useSetPageContext` places `options.filters` in a `useLayoutEffect` dep array. An inline object literal (`{ type, sort, search }`) creates a new reference every render → effect fires → `setPageContext` triggers AppContextProvider state update (via spread `{ ...prev }`) → re-renders all context consumers including LibraryPage → new filters object → loop.

**Fix:** `useMemo` with `[typeFilter, sortBy, searchQuery]` deps so the reference only changes when the values actually change.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `prettier --check` clean
- [ ] Navigate to `/media` — library loads without crash
- [ ] Change type filter / sort — context filters update correctly

Closes GH-1515 (follow-up to #1509)

🤖 Generated with [Claude Code](https://claude.com/claude-code)