### PR TITLE
fix(media): add watchlist fallback in compare pair selection [tb-286]

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -782,10 +782,16 @@ export function getSmartPair(dimensionId?: number): SmartPairResult | null {
     cooloffPairs.add(`${r.media_b_id}-${r.media_a_id}`);
   }
 
-  // Filter eligible movies
-  const eligible = watchedMovies.filter(
+  // Filter eligible movies (exclude watchlisted and dimension-excluded)
+  let eligible = watchedMovies.filter(
     (m) => !watchlistedIds.has(m.mediaId) && !excludedIds.has(m.mediaId)
   );
+
+  // Fallback: if fewer than 2 non-watchlisted movies remain, include watchlisted movies
+  // so the arena stays usable when most of the library is on the watchlist
+  if (eligible.length < 2) {
+    eligible = watchedMovies.filter((m) => !excludedIds.has(m.mediaId));
+  }
 
   if (eligible.length < 2) return null;
 

--- a/apps/pops-api/src/modules/media/comparisons/smart-pair.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/smart-pair.test.ts
@@ -5,6 +5,7 @@ import {
   seedDimension,
   seedMovie,
   seedWatchHistoryEntry,
+  seedWatchlistEntry,
 } from "../../../shared/test-utils.js";
 import { getSmartPair } from "./service.js";
 
@@ -290,6 +291,42 @@ describe("getSmartPair", () => {
 
     // With 10 movies (45 possible pairs) and jitter, we should see variety
     expect(uniquePairs.size).toBeGreaterThan(5);
+  });
+
+  it("excludes watchlisted movies when enough non-watchlisted movies remain", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const m1 = seedMovie(db, { tmdb_id: 550, title: "Fight Club" });
+    const m2 = seedMovie(db, { tmdb_id: 551, title: "The Matrix" });
+    const m3 = seedMovie(db, { tmdb_id: 552, title: "Inception" });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m1 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m2 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m3 });
+    seedWatchlistEntry(db, { media_type: "movie", media_id: m3 });
+
+    // m3 is watchlisted — should never appear since m1+m2 form a valid pair
+    for (let i = 0; i < 20; i++) {
+      const result = getSmartPair(dimId);
+      expect(result).not.toBeNull();
+      const ids = [result!.movieA.id, result!.movieB.id];
+      expect(ids).not.toContain(m3);
+    }
+  });
+
+  it("falls back to include watchlisted movies when fewer than 2 non-watchlisted remain", () => {
+    const dimId = seedDimension(db, { name: "Overall" });
+    const m1 = seedMovie(db, { tmdb_id: 550, title: "Fight Club" });
+    const m2 = seedMovie(db, { tmdb_id: 551, title: "The Matrix" });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m1 });
+    seedWatchHistoryEntry(db, { media_type: "movie", media_id: m2 });
+    // Both movies are on the watchlist — without fallback, would return null
+    seedWatchlistEntry(db, { media_type: "movie", media_id: m1 });
+    seedWatchlistEntry(db, { media_type: "movie", media_id: m2 });
+
+    // Should still return a pair using the watchlisted movies
+    const result = getSmartPair(dimId);
+    expect(result).not.toBeNull();
+    const ids = new Set([result!.movieA.id, result!.movieB.id]);
+    expect(ids.size).toBe(2);
   });
 
   it("falls back to any eligible pair when all scored pairs are on cooloff", () => {


### PR DESCRIPTION
## Summary
- `getSmartPair` now falls back to including watchlisted movies when fewer than 2 non-watchlisted watched movies are eligible
- Without this fallback, the compare arena returned `null` (no pair) whenever most/all of the library was on the watchlist
- Watchlist exclusion still applies preferentially — watchlisted movies only appear in the arena when there's no other choice

## Changes
- `apps/pops-api/src/modules/media/comparisons/service.ts`: Changed `const eligible` → `let eligible`, added fallback re-filter block
- `apps/pops-api/src/modules/media/comparisons/smart-pair.test.ts`: Added two new tests — watchlist exclusion (normal path) and fallback inclusion (edge case)

## Test plan
- [ ] `excludes watchlisted movies when enough non-watchlisted movies remain` — watchlisted movie never appears when 2+ non-watchlisted are available
- [ ] `falls back to include watchlisted movies when fewer than 2 non-watchlisted remain` — pair returned even when all movies are watchlisted

Closes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)