### PR TITLE
feat(tier-list): wire TierListBoard (dnd-kit) into TierListPage [tb-287]

### DIFF
--- a/packages/app-media/src/components/TierListBoard.test.tsx
+++ b/packages/app-media/src/components/TierListBoard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { TierListBoard, type TierMovie } from "./TierListBoard";
 
 const sampleMovies: TierMovie[] = [
@@ -95,5 +95,67 @@ describe("TierListBoard", () => {
     expect(screen.getByText("All movies placed!")).toBeTruthy();
     const submitBtn = screen.getByRole("button", { name: /submit tier list/i });
     expect(submitBtn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("enables submit button when 2 or more movies are pre-placed via initialPlacements", () => {
+    render(
+      <TierListBoard
+        movies={sampleMovies}
+        onSubmit={vi.fn()}
+        initialPlacements={{ S: [1], A: [2] }}
+      />
+    );
+
+    const submitBtn = screen.getByRole("button", { name: /submit tier list \(2 placed\)/i });
+    expect(submitBtn.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("keeps submit disabled when only 1 movie is pre-placed", () => {
+    render(
+      <TierListBoard movies={sampleMovies} onSubmit={vi.fn()} initialPlacements={{ S: [1] }} />
+    );
+
+    const submitBtn = screen.getByRole("button", { name: /submit tier list/i });
+    expect(submitBtn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("calls onSubmit with correct {movieId, tier} placements when button clicked", () => {
+    const handleSubmit = vi.fn();
+    render(
+      <TierListBoard
+        movies={sampleMovies}
+        onSubmit={handleSubmit}
+        initialPlacements={{ S: [1, 3], B: [2] }}
+      />
+    );
+
+    const submitBtn = screen.getByRole("button", { name: /submit tier list \(3 placed\)/i });
+    fireEvent.click(submitBtn);
+
+    expect(handleSubmit).toHaveBeenCalledOnce();
+    const placements = handleSubmit.mock.calls[0]![0] as Array<{ movieId: number; tier: string }>;
+    expect(placements).toHaveLength(3);
+    expect(placements).toContainEqual({ movieId: 1, tier: "S" });
+    expect(placements).toContainEqual({ movieId: 3, tier: "S" });
+    expect(placements).toContainEqual({ movieId: 2, tier: "B" });
+  });
+
+  it("excludes placed movies from the unranked pool", () => {
+    render(
+      <TierListBoard movies={sampleMovies} onSubmit={vi.fn()} initialPlacements={{ A: [1, 2] }} />
+    );
+
+    // Placed movies should not appear in unranked count
+    expect(screen.getByText("Unranked (2)")).toBeTruthy();
+  });
+
+  it("does not call onSubmit when button is disabled", () => {
+    const handleSubmit = vi.fn();
+    render(<TierListBoard movies={sampleMovies} onSubmit={handleSubmit} />);
+
+    const submitBtn = screen.getByRole("button", { name: /submit tier list/i });
+    fireEvent.click(submitBtn);
+
+    expect(handleSubmit).not.toHaveBeenCalled();
   });
 });

--- a/packages/app-media/src/components/TierListBoard.tsx
+++ b/packages/app-media/src/components/TierListBoard.tsx
@@ -57,15 +57,22 @@ interface TierListBoardProps {
   movies: TierMovie[];
   onSubmit: (placements: Array<{ movieId: number; tier: Tier }>) => void;
   submitPending?: boolean;
+  /** Optional initial placements — useful for tests and pre-loading saved state. */
+  initialPlacements?: Partial<TierPlacements>;
 }
 
-export function TierListBoard({ movies, onSubmit, submitPending }: TierListBoardProps) {
+export function TierListBoard({
+  movies,
+  onSubmit,
+  submitPending,
+  initialPlacements,
+}: TierListBoardProps) {
   const [placements, setPlacements] = useState<TierPlacements>({
-    S: [],
-    A: [],
-    B: [],
-    C: [],
-    D: [],
+    S: initialPlacements?.S ?? [],
+    A: initialPlacements?.A ?? [],
+    B: initialPlacements?.B ?? [],
+    C: initialPlacements?.C ?? [],
+    D: initialPlacements?.D ?? [],
   });
   const [activeId, setActiveId] = useState<number | null>(null);
 

--- a/packages/app-media/src/pages/TierListPage.tsx
+++ b/packages/app-media/src/pages/TierListPage.tsx
@@ -1,299 +1,29 @@
 /**
- * TierListPage — dimension selector + unranked movie pool for tier placement.
+ * TierListPage — dimension selector + TierListBoard for drag-and-drop tier placement.
  *
- * Loads up to 8 movies from getTierListMovies and displays them as
- * draggable cards in an unranked pool. Dimension can be switched via chips.
- * After placing movies in tiers, submit to record pairwise comparisons.
+ * Loads up to 8 movies from getTierListMovies and passes them to TierListBoard.
+ * Dimension can be switched via chips. After placing movies in tiers, submit
+ * to record pairwise comparisons.
  */
 import { useState, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router";
-import { Alert, AlertTitle, AlertDescription, Button, Skeleton, cn } from "@pops/ui";
-import { LayoutGrid, RefreshCw, Send } from "lucide-react";
+import { Alert, AlertTitle, AlertDescription, Skeleton, cn } from "@pops/ui";
+import { LayoutGrid } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "../lib/trpc";
-import { useTierListSubmit, type Tier, type TierPlacement } from "../hooks/useTierListSubmit";
+import { useTierListSubmit, type TierPlacement } from "../hooks/useTierListSubmit";
+import { TierListBoard, type TierMovie } from "../components/TierListBoard";
 import { TierListSummary } from "../components/TierListSummary";
-
-function MovieCardSkeleton() {
-  return (
-    <div className="flex flex-col items-center gap-2 w-28">
-      <Skeleton className="w-28 aspect-[2/3] rounded-lg" />
-      <Skeleton className="h-3 w-20" />
-    </div>
-  );
-}
 
 function PoolSkeleton() {
   return (
     <div className="flex flex-wrap justify-center gap-4 py-8">
       {Array.from({ length: 8 }).map((_, i) => (
-        <MovieCardSkeleton key={i} />
+        <div key={i} className="flex flex-col items-center gap-2 w-28">
+          <Skeleton className="w-28 aspect-[2/3] rounded-lg" />
+          <Skeleton className="h-3 w-20" />
+        </div>
       ))}
-    </div>
-  );
-}
-
-interface TierListMovie {
-  id: number;
-  title: string;
-  posterUrl: string | null;
-  score: number;
-  comparisonCount: number;
-}
-
-interface MovieCardProps {
-  movie: TierListMovie;
-  onDragStart: (e: React.DragEvent, movie: TierListMovie) => void;
-}
-
-function MovieCard({ movie, onDragStart }: MovieCardProps) {
-  return (
-    <div
-      draggable
-      onDragStart={(e) => onDragStart(e, movie)}
-      className="flex flex-col items-center gap-1.5 w-28 cursor-grab active:cursor-grabbing select-none group"
-      role="listitem"
-      aria-label={movie.title}
-    >
-      <div className="relative w-28 aspect-[2/3] rounded-lg overflow-hidden border-2 border-transparent group-hover:border-primary/50 transition-colors bg-muted">
-        {movie.posterUrl ? (
-          <img
-            src={movie.posterUrl}
-            alt={`${movie.title} poster`}
-            className="w-full h-full object-cover"
-            loading="lazy"
-            draggable={false}
-          />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center text-muted-foreground">
-            <LayoutGrid className="h-8 w-8" />
-          </div>
-        )}
-      </div>
-      <span className="text-xs text-center leading-tight line-clamp-2 max-w-full">
-        {movie.title}
-      </span>
-    </div>
-  );
-}
-
-const TIERS: Tier[] = ["S", "A", "B", "C", "D"];
-
-const TIER_COLORS: Record<Tier, string> = {
-  S: "bg-red-500/20 border-red-500/40 text-red-700 dark:text-red-400",
-  A: "bg-orange-500/20 border-orange-500/40 text-orange-700 dark:text-orange-400",
-  B: "bg-yellow-500/20 border-yellow-500/40 text-yellow-700 dark:text-yellow-400",
-  C: "bg-green-500/20 border-green-500/40 text-green-700 dark:text-green-400",
-  D: "bg-blue-500/20 border-blue-500/40 text-blue-700 dark:text-blue-400",
-};
-
-function TierRow({
-  tier,
-  movies,
-  onDrop,
-  onDragStart,
-}: {
-  tier: Tier;
-  movies: TierListMovie[];
-  onDrop: (tier: Tier, movie: TierListMovie) => void;
-  onDragStart: (e: React.DragEvent, movie: TierListMovie) => void;
-}) {
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "move";
-  }, []);
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      try {
-        const movie = JSON.parse(e.dataTransfer.getData("application/json")) as TierListMovie;
-        onDrop(tier, movie);
-      } catch {
-        // ignore invalid drag data
-      }
-    },
-    [tier, onDrop]
-  );
-
-  return (
-    <div className="flex gap-2 min-h-[80px]">
-      <div
-        className={cn(
-          "flex items-center justify-center w-12 shrink-0 rounded-l-lg border-2 font-bold text-lg",
-          TIER_COLORS[tier]
-        )}
-      >
-        {tier}
-      </div>
-      <div
-        className="flex-1 flex flex-wrap items-center gap-2 p-2 rounded-r-lg border border-dashed border-border bg-muted/20 min-h-[80px]"
-        onDragOver={handleDragOver}
-        onDrop={handleDrop}
-        role="list"
-        aria-label={`Tier ${tier}`}
-      >
-        {movies.map((movie) => (
-          <MovieCard key={movie.id} movie={movie} onDragStart={onDragStart} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function UnrankedPool({
-  dimensionId,
-  onSubmit,
-  isPending,
-}: {
-  dimensionId: number;
-  onSubmit: (dimensionId: number, placements: TierPlacement[]) => void;
-  isPending: boolean;
-}) {
-  const { data, isLoading, error, refetch, isFetching } =
-    trpc.media.comparisons.getTierListMovies.useQuery({ dimensionId }, { staleTime: Infinity });
-
-  const [tierAssignments, setTierAssignments] = useState<Map<number, Tier>>(new Map());
-
-  const handleDragStart = useCallback((e: React.DragEvent, movie: TierListMovie) => {
-    e.dataTransfer.setData("application/json", JSON.stringify(movie));
-    e.dataTransfer.effectAllowed = "move";
-  }, []);
-
-  const handleDrop = useCallback((tier: Tier, movie: TierListMovie) => {
-    setTierAssignments((prev) => {
-      const next = new Map(prev);
-      next.set(movie.id, tier);
-      return next;
-    });
-  }, []);
-
-  const handlePoolDrop = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    try {
-      const movie = JSON.parse(e.dataTransfer.getData("application/json")) as TierListMovie;
-      setTierAssignments((prev) => {
-        const next = new Map(prev);
-        next.delete(movie.id);
-        return next;
-      });
-    } catch {
-      // ignore
-    }
-  }, []);
-
-  const handlePoolDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "move";
-  }, []);
-
-  const movies: TierListMovie[] = useMemo(() => data?.data ?? [], [data]);
-
-  const unrankedMovies = useMemo(
-    () => movies.filter((m) => !tierAssignments.has(m.id)),
-    [movies, tierAssignments]
-  );
-
-  const tierMovies = useMemo(() => {
-    const map: Record<Tier, TierListMovie[]> = { S: [], A: [], B: [], C: [], D: [] };
-    for (const movie of movies) {
-      const tier = tierAssignments.get(movie.id);
-      if (tier) map[tier].push(movie);
-    }
-    return map;
-  }, [movies, tierAssignments]);
-
-  const placedCount = tierAssignments.size;
-
-  const handleSubmit = useCallback(() => {
-    const placements: TierPlacement[] = [];
-    for (const [movieId, tier] of tierAssignments) {
-      placements.push({ movieId, tier });
-    }
-    onSubmit(dimensionId, placements);
-  }, [tierAssignments, dimensionId, onSubmit]);
-
-  if (error) {
-    return (
-      <Alert variant="destructive">
-        <AlertTitle>Error</AlertTitle>
-        <AlertDescription>Failed to load movies for tier list.</AlertDescription>
-      </Alert>
-    );
-  }
-
-  if (isLoading) return <PoolSkeleton />;
-
-  if (movies.length === 0) {
-    return (
-      <div className="text-center py-16">
-        <LayoutGrid className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
-        <p className="text-muted-foreground">
-          No eligible movies for this dimension. Compare more movies or check your exclusions.
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-4">
-      {/* Tier rows */}
-      <div className="space-y-2">
-        {TIERS.map((tier) => (
-          <TierRow
-            key={tier}
-            tier={tier}
-            movies={tierMovies[tier]}
-            onDrop={handleDrop}
-            onDragStart={handleDragStart}
-          />
-        ))}
-      </div>
-
-      {/* Unranked pool */}
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Unranked ({unrankedMovies.length})
-          </h2>
-          <button
-            type="button"
-            onClick={() => refetch()}
-            disabled={isFetching}
-            className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline disabled:text-muted-foreground disabled:no-underline"
-            aria-label="Refresh movie pool"
-          >
-            <RefreshCw className={cn("h-3.5 w-3.5", isFetching && "animate-spin")} />
-            Refresh
-          </button>
-        </div>
-
-        <div
-          className="flex flex-wrap justify-center gap-4 p-4 rounded-xl border border-dashed border-border bg-muted/30"
-          role="list"
-          aria-label="Unranked movies"
-          onDragOver={handlePoolDragOver}
-          onDrop={handlePoolDrop}
-        >
-          {unrankedMovies.length > 0 ? (
-            unrankedMovies.map((movie) => (
-              <MovieCard key={movie.id} movie={movie} onDragStart={handleDragStart} />
-            ))
-          ) : (
-            <p className="text-sm text-muted-foreground py-4">
-              All movies placed! Submit your tier list.
-            </p>
-          )}
-        </div>
-      </div>
-
-      {/* Submit button */}
-      <div className="flex justify-center">
-        <Button onClick={handleSubmit} disabled={placedCount < 2 || isPending} className="gap-2">
-          <Send className="h-4 w-4" />
-          {isPending ? "Submitting..." : `Submit Tier List (${placedCount} movies)`}
-        </Button>
-      </div>
     </div>
   );
 }
@@ -310,22 +40,45 @@ export function TierListPage() {
     [dimensionsData?.data]
   );
 
-  // Auto-select first dimension once loaded
   const effectiveDimension = selectedDimension ?? activeDimensions[0]?.id ?? null;
 
-  // Build movieId → title map from the tier list movies query
-  const { data: tierMoviesData } = trpc.media.comparisons.getTierListMovies.useQuery(
+  const {
+    data: tierMoviesData,
+    isLoading: moviesLoading,
+    error: moviesError,
+  } = trpc.media.comparisons.getTierListMovies.useQuery(
     { dimensionId: effectiveDimension! },
     { enabled: effectiveDimension != null, staleTime: Infinity }
   );
 
+  const movies: TierMovie[] = useMemo(
+    () =>
+      (tierMoviesData?.data ?? []).map(
+        (m: {
+          id: number;
+          title: string;
+          posterUrl: string | null;
+          score: number;
+          comparisonCount: number;
+        }) => ({
+          mediaType: "movie" as const,
+          mediaId: m.id,
+          title: m.title,
+          posterUrl: m.posterUrl,
+          score: m.score,
+          comparisonCount: m.comparisonCount,
+        })
+      ),
+    [tierMoviesData]
+  );
+
   const movieTitles = useMemo(() => {
     const map = new Map<number, string>();
-    for (const m of tierMoviesData?.data ?? []) {
-      map.set(m.id, m.title);
+    for (const m of movies) {
+      map.set(m.mediaId, m.title);
     }
     return map;
-  }, [tierMoviesData]);
+  }, [movies]);
 
   const {
     submit,
@@ -346,6 +99,14 @@ export function TierListPage() {
       reset();
     },
     [reset]
+  );
+
+  const handleSubmit = useCallback(
+    (placements: Array<{ movieId: number; tier: string }>) => {
+      if (effectiveDimension == null) return;
+      submit(effectiveDimension, placements as TierPlacement[]);
+    },
+    [effectiveDimension, submit]
   );
 
   const handleDoAnother = useCallback(() => {
@@ -408,15 +169,23 @@ export function TierListPage() {
               onDoAnother={handleDoAnother}
               onDone={handleDone}
             />
-          ) : (
-            effectiveDimension && (
-              <UnrankedPool
-                dimensionId={effectiveDimension}
-                onSubmit={submit}
-                isPending={isPending}
-              />
-            )
-          )}
+          ) : moviesLoading ? (
+            <PoolSkeleton />
+          ) : moviesError ? (
+            <Alert variant="destructive">
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>Failed to load movies for tier list.</AlertDescription>
+            </Alert>
+          ) : movies.length === 0 ? (
+            <div className="text-center py-16">
+              <LayoutGrid className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
+              <p className="text-muted-foreground">
+                No eligible movies for this dimension. Compare more movies or check your exclusions.
+              </p>
+            </div>
+          ) : effectiveDimension != null ? (
+            <TierListBoard movies={movies} onSubmit={handleSubmit} submitPending={isPending} />
+          ) : null}
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Replaces the HTML5 drag-and-drop implementation in TierListPage with the existing `TierListBoard` component (@dnd-kit), which was previously unused
- Adds `initialPlacements` prop to `TierListBoard` for pre-loading state and testing
- Adds 5 new behavioral tests for submit logic

**Why:** The HTML5 drag-and-drop API does not work on mobile/touch. TierListBoard already implemented the correct approach using @dnd-kit's `PointerSensor` which handles both mouse and touch events natively.

**Changes:**
- `TierListPage.tsx`: removes `UnrankedPool`/`MovieCard`/`TierRow` HTML5 components (-304 lines), moves `getTierListMovies` query to page level, maps `id→mediaId` for `TierMovie`, passes `onSubmit` callback bridging to `useTierListSubmit`
- `TierListBoard.tsx`: adds `initialPlacements?: Partial<TierPlacements>` prop
- `TierListBoard.test.tsx`: 5 new tests — submit enabled with ≥2 placements, correct `{movieId, tier}` payload on submit, unranked pool exclusion, disabled button not firing onSubmit

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `prettier --check` clean
- [x] 5 new tests verify submit behavior
- [ ] Navigate to `/media/tier-list` — drag movies between tiers (mouse and touch)
- [ ] Submit with ≥2 placed — comparisons recorded, score changes shown

Closes GH-1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)