### PR TITLE
fix(tb-300): remove Compare History and Quick Pick from side nav

### DIFF
--- a/packages/app-media/src/routes.tsx
+++ b/packages/app-media/src/routes.tsx
@@ -124,9 +124,7 @@ export const navConfig: AppNavConfig = {
     { path: "/rankings", label: "Rankings", icon: "Trophy" },
     { path: "/search", label: "Search", icon: "Search" },
     { path: "/compare", label: "Compare", icon: "ArrowLeftRight" },
-    { path: "/compare/history", label: "Compare History", icon: "History" },
     { path: "/tier-list", label: "Tier List", icon: "Layers" },
-    { path: "/quick-pick", label: "Quick Pick", icon: "Shuffle" },
   ],
 };
 


### PR DESCRIPTION
## Summary
- Removes "Compare History" and "Quick Pick" from the media side nav (`navConfig.items`)
- Routes are preserved — both pages remain accessible via direct URL
- Fixes tb-300: these items were cluttering the subnav with infrequently-used secondary pages

## Test plan
- [ ] Navigate to /media — confirm Compare History and Quick Pick no longer appear in the side nav
- [ ] Navigate directly to /media/compare/history — confirm page still loads
- [ ] Navigate directly to /media/quick-pick — confirm page still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)