### PR TITLE
fix(arena): make dimension label prominent

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -391,7 +391,7 @@ export function CompareArenaPage() {
         </div>
       ) : pairData?.data ? (
         <>
-          <p className="text-center text-muted-foreground text-sm">
+          <p className="text-center text-base font-medium">
             Which movie has better{" "}
             {(() => {
               const dim = activeDimensions.find((d: { id: number }) => d.id === dimensionId);
@@ -400,17 +400,17 @@ export function CompareArenaPage() {
               return desc ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span className="font-medium text-foreground underline decoration-dotted cursor-help">
+                    <span className="text-primary underline decoration-dotted cursor-help">
                       {name}
                     </span>
                   </TooltipTrigger>
                   <TooltipContent>{desc}</TooltipContent>
                 </Tooltip>
               ) : (
-                <span className="font-medium text-foreground">{name}</span>
+                <span className="text-primary">{name}</span>
               );
             })()}
-            ? Click to pick.
+            ?
           </p>
           <div className="relative grid grid-cols-2 gap-6">
             <MovieCard


### PR DESCRIPTION
## Summary
- Changed dimension question from small muted text (`text-sm text-muted-foreground`) to prominent `text-base font-medium`
- Dimension name now uses `text-primary` color for clear visual emphasis
- Removed redundant "Click to pick." suffix — the UI is self-explanatory

## Test plan
- [ ] Open Compare Arena — verify "Which movie has better <Dimension>?" is clearly readable
- [ ] Verify dimension name is highlighted in primary color
- [ ] Verify tooltip still appears on hover when dimension has a description

Fixes tb-302

🤖 Generated with [Claude Code](https://claude.com/claude-code)