### PR TITLE
fix(arena): correct Not Watched tooltip label [tb-304]

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -419,7 +419,6 @@ export function CompareArenaPage() {
             stalePending={markStaleMutation.isPending}
             onBlacklist={() => handleBlacklist(pairData.data.movieA)}
             blacklistPending={blacklistMutation.isPending}
-            dimensionName={activeDimName}
           />
 
           {/* Center column — actions for both movies */}
@@ -522,7 +521,6 @@ export function CompareArenaPage() {
             stalePending={markStaleMutation.isPending}
             onBlacklist={() => handleBlacklist(pairData.data.movieB)}
             blacklistPending={blacklistMutation.isPending}
-            dimensionName={activeDimName}
           />
         </div>
       ) : null}
@@ -584,7 +582,6 @@ function MovieCard({
   stalePending,
   onBlacklist,
   blacklistPending,
-  dimensionName,
 }: {
   movie: { id: number; title: string; posterPath: string | null; posterUrl: string | null };
   onPick: () => void;
@@ -598,7 +595,6 @@ function MovieCard({
   stalePending?: boolean;
   onBlacklist?: () => void;
   blacklistPending?: boolean;
-  dimensionName?: string;
 }) {
   const posterSrc = movie.posterUrl ?? undefined;
   const [imgError, setImgError] = useState(false);
@@ -706,7 +702,7 @@ function MovieCard({
                 </button>
               </TooltipTrigger>
               <TooltipContent>
-                Not watched — remove from {dimensionName ?? "rankings"}
+                Not watched — exclude globally from all rankings
               </TooltipContent>
             </Tooltip>
           )}


### PR DESCRIPTION
## Summary

- The "Not watched" MovieCard button tooltip said _"remove from \<dimension\>"_, implying a per-dimension action
- The underlying `blacklistMovie` mutation is **global** — it removes the movie from all comparisons across all dimensions
- Fixed tooltip to say _"Not watched — exclude globally from all rankings"_
- Removed now-unused `dimensionName` prop from `MovieCard` (was only used by this tooltip)

## Files changed

- `packages/app-media/src/pages/CompareArenaPage.tsx`

## Test plan

- [ ] Hover "Not watched" icon on a movie card in the Arena — tooltip should read "Not watched — exclude globally from all rankings"
- [ ] Click "Not watched" button, confirm — movie should be removed from all rankings (not just current dimension)
- [ ] Verify no TypeScript or lint errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)