### PR TITLE
fix(deps): downgrade jsdom ^29 → ^28 in app-inventory, app-media, app-ai [tb-309]

### DIFF
--- a/packages/app-ai/package.json
+++ b/packages/app-ai/package.json
@@ -31,7 +31,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "eslint": "^10.0.3",
-    "jsdom": "^29.0.1",
+    "jsdom": "^28.1.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.58.0",
     "vitest": "^3.2.4"

--- a/packages/app-inventory/package.json
+++ b/packages/app-inventory/package.json
@@ -43,7 +43,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "eslint": "^9.39.4",
-    "jsdom": "^29.0.1",
+    "jsdom": "^28.1.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.58.0",
     "vitest": "^3.2.4"

--- a/packages/app-media/package.json
+++ b/packages/app-media/package.json
@@ -35,7 +35,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "eslint": "^9.39.4",
-    "jsdom": "^29.0.1",
+    "jsdom": "^28.1.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.58.0",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,8 +326,8 @@ importers:
         specifier: ^10.0.3
         version: 10.0.3(jiti@2.6.1)
       jsdom:
-        specifier: ^29.0.1
-        version: 29.0.1(@noble/hashes@1.8.0)
+        specifier: ^28.1.0
+        version: 28.1.0(@noble/hashes@1.8.0)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -336,7 +336,7 @@ importers:
         version: 8.58.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
 
   packages/app-finance:
     dependencies:
@@ -517,8 +517,8 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
       jsdom:
-        specifier: ^29.0.1
-        version: 29.0.1(@noble/hashes@1.8.0)
+        specifier: ^28.1.0
+        version: 28.1.0(@noble/hashes@1.8.0)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -527,7 +527,7 @@ importers:
         version: 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
 
   packages/app-media:
     dependencies:
@@ -590,8 +590,8 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
       jsdom:
-        specifier: ^29.0.1
-        version: 29.0.1(@noble/hashes@1.8.0)
+        specifier: ^28.1.0
+        version: 28.1.0(@noble/hashes@1.8.0)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -600,7 +600,7 @@ importers:
         version: 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
 
   packages/db-types:
     dependencies:


### PR DESCRIPTION
## Summary
- Downgrades jsdom from `^29.0.1` to `^28.1.0` in `packages/app-inventory`, `packages/app-media`, `packages/app-ai`
- Regenerates `pnpm-lock.yaml` so these packages resolve to `jsdom@28.x`

## Root cause
jsdom@29.0.1 depends on `@asamuzakjp/css-color@5.0.1` which ships as **async ESM** (top-level await in `dist/esm/index.js`). Node.js 22 throws `ERR_REQUIRE_ASYNC_MODULE` when jsdom's CJS code at `jsdom/living/css/helpers/css-values.js` tries to `require()` it. This crashes vitest before any tests run.

jsdom@28.x depends on `@asamuzakjp/css-color@4.x` (CJS, no top-level await) — works correctly.

`app-finance` was already downgraded to `^28.1.0` in PR #1595. This PR completes the fix for the remaining three packages.

Verified: PR #1601 (eslint/js revert) still showed the same error, confirming eslint/js was not the root cause.

## Test plan
- [ ] Inventory Quality CI passes
- [ ] AI Quality CI passes
- [ ] Media Quality CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)