### PR TITLE
fix(deps): downgrade jsdom ^29→^28 in packages/navigation [tb-310]

### DIFF
--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -27,7 +27,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "eslint": "^9.39.4",
-    "jsdom": "^29.0.1",
+    "jsdom": "^28.1.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.58.0",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,8 +695,8 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
       jsdom:
-        specifier: ^29.0.1
-        version: 29.0.1(@noble/hashes@1.8.0)
+        specifier: ^28.1.0
+        version: 28.1.0(@noble/hashes@1.8.0)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -705,7 +705,7 @@ importers:
         version: 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
 
   packages/types:
     devDependencies:
@@ -9090,7 +9090,7 @@ snapshots:
       magic-string: 0.30.21
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
       ws: 8.20.0
     optionalDependencies:
       playwright: 1.59.1


### PR DESCRIPTION
## Summary

- Downgrades `jsdom` from `^29.0.1` to `^28.1.0` in `packages/navigation`
- Same fix as PR #1603 (applied to `app-inventory`, `app-media`, `app-ai`)
- jsdom@29 pulls `@asamuzakjp/css-color@5` and `@asamuzakjp/dom-selector@7` which are pure ESM with top-level await, causing `ERR_REQUIRE_ASYNC_MODULE` in vitest

## Unblocks

- tb-306: vitest 4 upgrade (PR #1585) — was failing due to this same ESM issue in packages/navigation tests

## Test plan

- [ ] CI: packages/navigation Quality / Test passes
- [ ] tb-306 vitest 4 upgrade can proceed after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)