### PR TITLE
fix(deps): downgrade jsdom ^29→^28 in packages/navigation [tb-312]

### DIFF
--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -27,7 +27,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "eslint": "^9.39.4",
-    "jsdom": "^29.0.1",
+    "jsdom": "^28.1.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.58.0",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,8 +695,8 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
       jsdom:
-        specifier: ^29.0.1
-        version: 29.0.1(@noble/hashes@1.8.0)
+        specifier: ^28.1.0
+        version: 28.1.0(@noble/hashes@1.8.0)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -705,7 +705,7 @@ importers:
         version: 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)
 
   packages/types:
     devDependencies:
@@ -6768,6 +6768,7 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
       lru-cache: 11.3.0
+    optional: true
 
   '@asamuzakjp/dom-selector@6.8.1':
     dependencies:
@@ -6784,6 +6785,7 @@ snapshots:
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.0
+    optional: true
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
@@ -10922,6 +10924,7 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   jsesc@3.1.0: {}
 


### PR DESCRIPTION
## Summary
- Downgrades `jsdom` from `^29.0.1` to `^28.1.0` in `packages/navigation`
- Same fix already applied to `app-inventory`, `app-media`, `app-ai` in PR #1603
- jsdom@29 depends on `@asamuzakjp/css-color@5` (async ESM) which causes `ERR_REQUIRE_ASYNC_MODULE` in vitest's CJS context

## Why this fixes production
Deploy #232 failed because the navigation package's test step hits the same jsdom@29 → css-color@5 async ESM crash that broke main earlier today.

## Test plan
- [ ] CI passes (navigation vitest now runs with jsdom@28.1.0)
- [ ] No other packages affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)