### PR TITLE
fix(arena): show skeleton during pair refetch to prevent stale poster flash [tb-317]

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -331,6 +331,25 @@ describe("CompareArenaPage", () => {
     mockPairQuery.mockReturnValue({
       data: undefined,
       isLoading: true,
+      isFetching: true,
+      error: null,
+    });
+
+    renderPage();
+
+    expect(screen.queryByText("The Matrix")).toBeNull();
+    expect(screen.queryByText("Not enough watched movies")).toBeNull();
+  });
+
+  it("renders loading skeletons when pair is fetching (background refetch)", () => {
+    mockDimensionsQuery.mockReturnValue({
+      data: { data: [dim1] },
+      isLoading: false,
+    });
+    mockPairQuery.mockReturnValue({
+      data: { data: { movieA, movieB, dimensionId: 1 } },
+      isLoading: false,
+      isFetching: true,
       error: null,
     });
 

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -55,6 +55,7 @@ export function CompareArenaPage() {
   const {
     data: pairData,
     isLoading: pairLoading,
+    isFetching: pairFetching,
     error: pairError,
     refetch: refetchPair,
   } = trpc.media.comparisons.getSmartPair.useQuery(
@@ -360,7 +361,7 @@ export function CompareArenaPage() {
       )}
 
       {/* Arena */}
-      {pairLoading ? (
+      {pairLoading || pairFetching ? (
         <div className="grid grid-cols-2 gap-8">
           <MovieCardSkeleton />
           <MovieCardSkeleton />


### PR DESCRIPTION
## Summary
- Adds `isFetching` to the pair query destructuring alongside existing `isLoading`
- Shows `MovieCardSkeleton` during both initial load AND background refetch (after pick/draw/skip)
- Previously, `isLoading` was only `true` during first fetch — on refetch the stale movie cards were shown with old posters and new titles

## Test plan
- [ ] Record a comparison — old movie cards should disappear immediately and show skeletons while new pair loads
- [ ] No stale poster/title mismatch during pair transitions
- [ ] New test added: "renders loading skeletons when pair is fetching (background refetch)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)