### PR TITLE
fix(pages): memoize entity/filters passed to useSetPageContext [tb-319]

### DIFF
--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -2,7 +2,7 @@
  * Item detail page — shows item info and connected items.
  * Route: /inventory/items/:id
  */
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useParams, Link, useNavigate } from "react-router";
 import { useSetPageContext } from "@pops/navigation";
 import { toast } from "sonner";
@@ -102,15 +102,15 @@ export function ItemDetailPage() {
     },
   });
 
-  useSetPageContext({
-    page: "item-detail",
-    pageType: "drill-down",
-    entity: {
+  const itemEntity = useMemo(
+    () => ({
       uri: `pops:inventory/item/${id ?? ""}`,
-      type: "item",
+      type: "item" as const,
       title: itemData?.data?.itemName ?? "",
-    },
-  });
+    }),
+    [id, itemData?.data?.itemName]
+  );
+  useSetPageContext({ page: "item-detail", pageType: "drill-down", entity: itemEntity });
 
   if (isLoading) {
     return (

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -238,15 +238,16 @@ export function ItemsPage() {
   const inUseFilter = searchParams.get("inUse") ?? "";
   const locationFilter = searchParams.get("locationId") ?? "";
 
-  useSetPageContext({
-    page: "items",
-    filters: {
+  const itemsFilters = useMemo(
+    () => ({
       ...(search && { search }),
       ...(typeFilter && { type: typeFilter }),
       ...(conditionFilter && { condition: conditionFilter }),
       ...(locationFilter && { locationId: locationFilter }),
-    },
-  });
+    }),
+    [search, typeFilter, conditionFilter, locationFilter]
+  );
+  useSetPageContext({ page: "items", filters: itemsFilters });
 
   const setParam = useCallback(
     (key: string, value: string) => {

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useParams, Link } from "react-router";
 import { useSetPageContext } from "@pops/navigation";
 import {
@@ -74,15 +75,15 @@ export function MovieDetailPage() {
     { enabled: !Number.isNaN(movieId) }
   );
 
-  useSetPageContext({
-    page: "movie-detail",
-    pageType: "drill-down",
-    entity: {
+  const movieEntity = useMemo(
+    () => ({
       uri: `pops:media/movie/${movieId}`,
-      type: "movie",
+      type: "movie" as const,
       title: data?.data?.title ?? "",
-    },
-  });
+    }),
+    [movieId, data?.data?.title]
+  );
+  useSetPageContext({ page: "movie-detail", pageType: "drill-down", entity: movieEntity });
 
   if (Number.isNaN(movieId)) {
     return (

--- a/packages/app-media/src/pages/SeasonDetailPage.tsx
+++ b/packages/app-media/src/pages/SeasonDetailPage.tsx
@@ -396,15 +396,15 @@ export function SeasonDetailPage() {
     ? seasonProgress.watched >= seasonProgress.total && seasonProgress.total > 0
     : false;
 
-  useSetPageContext({
-    page: "season-detail",
-    pageType: "drill-down",
-    entity: {
+  const seasonEntity = useMemo(
+    () => ({
       uri: `pops:media/tv/${showId}/season/${seasonNum}`,
-      type: "season",
+      type: "season" as const,
       title: showData?.data?.name ?? "",
-    },
-  });
+    }),
+    [showId, seasonNum, showData?.data?.name]
+  );
+  useSetPageContext({ page: "season-detail", pageType: "drill-down", entity: seasonEntity });
 
   if (Number.isNaN(showId) || Number.isNaN(seasonNum)) {
     return (

--- a/packages/app-media/src/pages/TvShowDetailPage.tsx
+++ b/packages/app-media/src/pages/TvShowDetailPage.tsx
@@ -164,15 +164,15 @@ export function TvShowDetailPage() {
     [rawSeasons]
   );
 
-  useSetPageContext({
-    page: "tvshow-detail",
-    pageType: "drill-down",
-    entity: {
+  const tvShowEntity = useMemo(
+    () => ({
       uri: `pops:media/tv/${showId}`,
-      type: "tvshow",
+      type: "tvshow" as const,
       title: data?.data?.name ?? "",
-    },
-  });
+    }),
+    [showId, data?.data?.name]
+  );
+  useSetPageContext({ page: "tvshow-detail", pageType: "drill-down", entity: tvShowEntity });
 
   if (Number.isNaN(showId)) {
     return (


### PR DESCRIPTION
## Summary
- **Root cause**: `useSetPageContext` uses `useLayoutEffect` with `options.entity` and `options.filters` in its dependency array. Passing inline object literals causes a new reference on every render → effect fires → `setPageContext` updates state → re-render → new object → infinite loop → React error #185.
- **Fix**: Wrap entity/filters in `useMemo` keyed on actual primitive values in all affected pages

## Pages fixed
- `packages/app-media/src/pages/MovieDetailPage.tsx`
- `packages/app-media/src/pages/TvShowDetailPage.tsx`
- `packages/app-media/src/pages/SeasonDetailPage.tsx`
- `packages/app-inventory/src/pages/ItemDetailPage.tsx`
- `packages/app-inventory/src/pages/ItemsPage.tsx` (filters object)

## Test plan
- [ ] Navigate to any movie detail page — should no longer crash
- [ ] Navigate to a TV show detail page — should not crash
- [ ] Navigate to a season detail page — should not crash
- [ ] Navigate to an inventory item detail page — should not crash
- [ ] Verify all pages still show correct context (entity title in nav, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)