### PR TITLE
fix(arena): show skeleton during pair refetch to prevent stale poster flash [tb-317]

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -331,6 +331,25 @@ describe("CompareArenaPage", () => {
     mockPairQuery.mockReturnValue({
       data: undefined,
       isLoading: true,
+      isFetching: true,
+      error: null,
+    });
+
+    renderPage();
+
+    expect(screen.queryByText("The Matrix")).toBeNull();
+    expect(screen.queryByText("Not enough watched movies")).toBeNull();
+  });
+
+  it("renders loading skeletons when pair is fetching (background refetch)", () => {
+    mockDimensionsQuery.mockReturnValue({
+      data: { data: [dim1] },
+      isLoading: false,
+    });
+    mockPairQuery.mockReturnValue({
+      data: { data: { movieA, movieB, dimensionId: 1 } },
+      isLoading: false,
+      isFetching: true,
       error: null,
     });
 

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -55,6 +55,7 @@ export function CompareArenaPage() {
   const {
     data: pairData,
     isLoading: pairLoading,
+    isFetching: pairFetching,
     error: pairError,
     refetch: refetchPair,
   } = trpc.media.comparisons.getSmartPair.useQuery(
@@ -360,7 +361,7 @@ export function CompareArenaPage() {
       )}
 
       {/* Arena */}
-      {pairLoading ? (
+      {pairLoading || pairFetching ? (
         <div className="grid grid-cols-2 gap-8">
           <MovieCardSkeleton />
           <MovieCardSkeleton />


### PR DESCRIPTION
## Summary

- **Root cause**: After recording a comparison, `pairData` refetches in the background. During this refetch, `isLoading` is `false` (only true on initial mount), so stale movie cards are rendered with old posters/titles while fresh data loads.
- **Fix**: Replace `isLoading` check with `isFetching`, which is `true` during both initial load and background refetches — showing skeletons throughout all transitions.
- **Test**: Added test asserting skeleton is shown during `isFetching` state.

## Test plan
- [x] Unit test added for skeleton during `isFetching`
- [x] Format/lint/typecheck passes
- [ ] CI green
- [ ] Manual: record a comparison, confirm no stale poster flash between rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)