### PR TITLE
fix(comparisons): fix delete button stuck — track deletingId per-row [tb-322]

### DIFF
--- a/packages/app-media/src/pages/ComparisonHistoryPage.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.tsx
@@ -14,6 +14,7 @@ const PAGE_SIZE = 20;
 export function ComparisonHistoryPage() {
   const [page, setPage] = useState(0);
   const [dimensionFilter, setDimensionFilter] = useState<string>("");
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   const { data: dimensionsData } = trpc.media.comparisons.listDimensions.useQuery();
   const dimensions = dimensionsData?.data ?? [];
@@ -30,10 +31,14 @@ export function ComparisonHistoryPage() {
 
   const deleteMutation = trpc.media.comparisons.delete.useMutation({
     onSuccess: () => {
+      setDeletingId(null);
       utils.media.comparisons.listAll.invalidate();
       utils.media.comparisons.scores.invalidate();
       utils.media.comparisons.rankings.invalidate();
       refetch();
+    },
+    onError: () => {
+      setDeletingId(null);
     },
   });
 
@@ -51,6 +56,7 @@ export function ComparisonHistoryPage() {
   const dimensionMap = new Map(dimensions.map((d: { id: number; name: string }) => [d.id, d.name]));
 
   function handleDelete(id: number) {
+    setDeletingId(id);
     let cancelled = false;
     const toastId = toast("Comparison deleted", {
       duration: 5000,
@@ -58,6 +64,7 @@ export function ComparisonHistoryPage() {
         label: "Undo",
         onClick: () => {
           cancelled = true;
+          setDeletingId(null);
           toast.dismiss(toastId);
         },
       },
@@ -133,7 +140,7 @@ export function ComparisonHistoryPage() {
                 comparison={comp}
                 dimensionName={dimensionMap.get(comp.dimensionId) ?? "Unknown"}
                 onDelete={handleDelete}
-                isDeleting={deleteMutation.isPending}
+                isDeleting={deletingId === comp.id}
               />
             )
           )}


### PR DESCRIPTION
## Summary
- `isDeleting` was based on `deleteMutation.isPending` (global) — disabled ALL row delete buttons during any deletion
- Button was also not disabled during the 5-second toast window (before `mutate()` fires), allowing accidental double-clicks
- Fix: add `deletingId: number | null` state, set immediately on click, cleared on undo/mutation complete/error
- Each row now gets `isDeleting={deletingId === comp.id}` — only the specific row being deleted is disabled

## Test plan
- [ ] Click delete on one row — only that row's button disables immediately (others stay enabled)
- [ ] Wait 5s without undo — deletion fires, button clears
- [ ] Click undo within 5s — button re-enables, no deletion
- [ ] If mutation errors — button re-enables (onError handler)
- CI: existing ComparisonHistoryPage tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)