### PR TITLE
feat(arena): watchlist toggle on movie cards [tb-318]

### DIFF
--- a/packages/app-media/src/pages/CompareArenaPage.test.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.test.tsx
@@ -88,6 +88,9 @@ vi.mock("../lib/trpc", () => ({
             return { mutate: mockWatchlistAddMutate, isPending: false };
           },
         },
+        remove: {
+          useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+        },
       },
     },
     useUtils: () => ({

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -149,10 +149,11 @@ export function CompareArenaPage() {
     { enabled: !!pairData?.data }
   );
 
-  const watchlistedMovieIds = new Set(
+  // Map from mediaId → watchlist entry id for toggle support
+  const watchlistedMovies = new Map(
     (watchlistData?.data ?? [])
       .filter((e: { mediaType: string }) => e.mediaType === "movie")
-      .map((e: { mediaId: number }) => e.mediaId)
+      .map((e: { mediaId: number; id: number }) => [e.mediaId, e.id])
   );
 
   const addToWatchlistMutation = trpc.media.watchlist.add.useMutation({
@@ -161,6 +162,17 @@ export function CompareArenaPage() {
       const movie =
         variables.mediaId === movieAId ? pairData?.data?.movieA : pairData?.data?.movieB;
       toast.success(`${movie?.title ?? "Movie"} added to watchlist`);
+    },
+  });
+
+  const removeFromWatchlistMutation = trpc.media.watchlist.remove.useMutation({
+    onSuccess: (_data: unknown, variables: { id: number }) => {
+      utils.media.watchlist.list.invalidate();
+      const mediaId = [...watchlistedMovies.entries()].find(
+        ([, entryId]) => entryId === variables.id
+      )?.[0];
+      const movie = mediaId === movieAId ? pairData?.data?.movieA : pairData?.data?.movieB;
+      toast.success(`${movie?.title ?? "Movie"} removed from watchlist`);
     },
   });
 
@@ -242,14 +254,16 @@ export function CompareArenaPage() {
     blacklistMutation.mutate({ mediaType: "movie", mediaId: blacklistTarget.id });
   }, [blacklistTarget, blacklistMutation]);
 
-  const handleAddToWatchlist = useCallback(
+  const handleToggleWatchlist = useCallback(
     (movieId: number) => {
-      addToWatchlistMutation.mutate({
-        mediaType: "movie",
-        mediaId: movieId,
-      });
+      const entryId = watchlistedMovies.get(movieId);
+      if (entryId !== undefined) {
+        removeFromWatchlistMutation.mutate({ id: entryId });
+      } else {
+        addToWatchlistMutation.mutate({ mediaType: "movie", mediaId: movieId });
+      }
     },
-    [addToWatchlistMutation]
+    [watchlistedMovies, addToWatchlistMutation, removeFromWatchlistMutation]
   );
 
   const handlePick = useCallback(
@@ -388,7 +402,7 @@ export function CompareArenaPage() {
         </div>
       ) : pairData?.data === null ? (
         <div className="text-center py-12 text-muted-foreground">
-          {watchlistedMovieIds.size > 0 ? (
+          {watchlistedMovies.size > 0 ? (
             <>
               <p className="text-lg mb-2">Not enough movies</p>
               <p className="text-sm">
@@ -444,9 +458,11 @@ export function CompareArenaPage() {
               isWinner={
                 scoreDelta?.isDraw ? undefined : scoreDelta?.winnerId === pairData.data.movieA.id
               }
-              onAddToWatchlist={() => handleAddToWatchlist(pairData.data.movieA.id)}
-              isOnWatchlist={watchlistedMovieIds.has(pairData.data.movieA.id)}
-              watchlistPending={addToWatchlistMutation.isPending}
+              onToggleWatchlist={() => handleToggleWatchlist(pairData.data.movieA.id)}
+              isOnWatchlist={watchlistedMovies.has(pairData.data.movieA.id)}
+              watchlistPending={
+                addToWatchlistMutation.isPending || removeFromWatchlistMutation.isPending
+              }
               onMarkStale={() => handleMarkStale(pairData.data.movieA.id)}
               stalePending={markStaleMutation.isPending}
               onNA={() => handleNA(pairData.data.movieA.id)}
@@ -533,9 +549,11 @@ export function CompareArenaPage() {
               isWinner={
                 scoreDelta?.isDraw ? undefined : scoreDelta?.winnerId === pairData.data.movieB.id
               }
-              onAddToWatchlist={() => handleAddToWatchlist(pairData.data.movieB.id)}
-              isOnWatchlist={watchlistedMovieIds.has(pairData.data.movieB.id)}
-              watchlistPending={addToWatchlistMutation.isPending}
+              onToggleWatchlist={() => handleToggleWatchlist(pairData.data.movieB.id)}
+              isOnWatchlist={watchlistedMovies.has(pairData.data.movieB.id)}
+              watchlistPending={
+                addToWatchlistMutation.isPending || removeFromWatchlistMutation.isPending
+              }
               onMarkStale={() => handleMarkStale(pairData.data.movieB.id)}
               stalePending={markStaleMutation.isPending}
               onNA={() => handleNA(pairData.data.movieB.id)}
@@ -597,7 +615,7 @@ function MovieCard({
   disabled,
   scoreDelta,
   isWinner,
-  onAddToWatchlist,
+  onToggleWatchlist,
   isOnWatchlist,
   watchlistPending,
   onMarkStale,
@@ -612,7 +630,7 @@ function MovieCard({
   disabled?: boolean;
   scoreDelta?: number | null;
   isWinner?: boolean;
-  onAddToWatchlist?: () => void;
+  onToggleWatchlist?: () => void;
   isOnWatchlist?: boolean;
   watchlistPending?: boolean;
   onMarkStale?: () => void;
@@ -657,26 +675,32 @@ function MovieCard({
         </button>
 
         {/* TOP ZONE — non-dismissing actions */}
-        {onAddToWatchlist && (
+        {onToggleWatchlist && (
           <Tooltip>
             <TooltipTrigger asChild>
               <button
                 onClick={(e) => {
                   e.stopPropagation();
-                  onAddToWatchlist();
+                  onToggleWatchlist();
                 }}
-                disabled={isOnWatchlist || watchlistPending}
+                disabled={watchlistPending}
                 className={`absolute top-2 left-2 p-1.5 rounded-full backdrop-blur-sm transition-colors ${
                   isOnWatchlist
-                    ? "bg-app-accent/90 text-app-accent-foreground"
+                    ? "bg-app-accent/90 text-app-accent-foreground hover:bg-red-500/90 hover:text-white"
                     : "bg-black/50 text-white/80 hover:text-white hover:bg-black/70"
                 }`}
-                aria-label={isOnWatchlist ? "On watchlist" : `Add ${movie.title} to watchlist`}
+                aria-label={
+                  isOnWatchlist
+                    ? `Remove ${movie.title} from watchlist`
+                    : `Add ${movie.title} to watchlist`
+                }
               >
                 <Bookmark className={`h-4 w-4 ${isOnWatchlist ? "fill-current" : ""}`} />
               </button>
             </TooltipTrigger>
-            <TooltipContent>{isOnWatchlist ? "On watchlist" : "Add to watchlist"}</TooltipContent>
+            <TooltipContent>
+              {isOnWatchlist ? "Remove from watchlist" : "Add to watchlist"}
+            </TooltipContent>
           </Tooltip>
         )}
 


### PR DESCRIPTION
## Summary

- Replaces the add-only bookmark button with a full toggle: clicking when already bookmarked removes from watchlist
- Uses `Map<mediaId, entryId>` instead of `Set<mediaId>` so the remove mutation can be called with the correct entry ID
- Button shows accent color when on watchlist; hovering turns red to signal remove action
- Tooltip and aria-label update contextually ("Add to watchlist" / "Remove from watchlist")
- Both `addToWatchlistMutation.isPending` and `removeFromWatchlistMutation.isPending` disable the button during mutation

## Test plan

- [ ] Add a movie pair where both movies are on watchlist — verify both bookmarks show filled/accent
- [ ] Hover a filled bookmark — verify it turns red
- [ ] Click a filled bookmark — verify toast "removed from watchlist" and bookmark unfills
- [ ] Click an empty bookmark — verify toast "added to watchlist" and bookmark fills
- [ ] CI green

Supersedes #1619 (closed) — rebased cleanly on main after tb-314 and tb-322 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)