### PR TITLE
fix(comparisons): handle draw state in ComparisonHistoryPage [tb-321]

### DIFF
--- a/packages/app-media/src/pages/ComparisonHistoryPage.test.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.test.tsx
@@ -68,6 +68,23 @@ const COMPARISON = {
   mediaBId: 200,
   winnerType: "movie",
   winnerId: 100,
+  deltaA: 12,
+  deltaB: -12,
+  drawTier: null as string | null,
+  comparedAt: "2026-01-15T12:00:00Z",
+};
+const DRAW_COMPARISON = {
+  id: 11,
+  dimensionId: 1,
+  mediaAType: "movie",
+  mediaAId: 100,
+  mediaBType: "movie",
+  mediaBId: 200,
+  winnerType: "movie",
+  winnerId: 0,
+  deltaA: 0,
+  deltaB: 0,
+  drawTier: "high",
   comparedAt: "2026-01-15T12:00:00Z",
 };
 
@@ -124,6 +141,16 @@ describe("ComparisonHistoryPage", () => {
     expect(screen.getByText("beat")).toBeInTheDocument();
     expect(screen.getByText("Movie 200")).toBeInTheDocument();
     expect(screen.getAllByText("Overall").length).toBeGreaterThan(0);
+  });
+
+  it("shows tied display for draw comparisons (winnerId=0)", () => {
+    setupLoaded([DRAW_COMPARISON]);
+    renderPage();
+
+    expect(screen.getByText("tied")).toBeInTheDocument();
+    expect(screen.queryByText("beat")).not.toBeInTheDocument();
+    expect(screen.queryByText("Movie #0")).not.toBeInTheDocument();
+    expect(screen.getByText("high draw")).toBeInTheDocument();
   });
 
   it("shows empty state when no comparisons", () => {

--- a/packages/app-media/src/pages/ComparisonHistoryPage.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.tsx
@@ -158,6 +158,7 @@ export function ComparisonHistoryPage() {
               winnerId: number;
               deltaA: number | null;
               deltaB: number | null;
+              drawTier: string | null;
               comparedAt: string;
             }) => (
               <ComparisonRow
@@ -231,12 +232,14 @@ function ComparisonRow({
     winnerId: number;
     deltaA: number | null;
     deltaB: number | null;
+    drawTier: string | null;
     comparedAt: string;
   };
   dimensionName: string;
   onDelete: (id: number) => void;
   isDeleting: boolean;
 }) {
+  const isDraw = comparison.winnerId === 0;
   const winnerId = comparison.winnerId;
   const loserId = comparison.mediaAId === winnerId ? comparison.mediaBId : comparison.mediaAId;
   const winnerDelta = comparison.mediaAId === winnerId ? comparison.deltaA : comparison.deltaB;
@@ -248,16 +251,36 @@ function ComparisonRow({
         <div className="flex items-center gap-4 min-w-0">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 text-sm">
-              <MovieTitle mediaId={winnerId} className="font-semibold text-foreground" />
-              <EloDelta delta={winnerDelta} />
-              <span className="text-muted-foreground">beat</span>
-              <MovieTitle mediaId={loserId} className="text-muted-foreground" />
-              <EloDelta delta={loserDelta} />
+              {isDraw ? (
+                <>
+                  <MovieTitle
+                    mediaId={comparison.mediaAId}
+                    className="font-semibold text-foreground"
+                  />
+                  <EloDelta delta={comparison.deltaA} />
+                  <span className="text-muted-foreground">tied</span>
+                  <MovieTitle mediaId={comparison.mediaBId} className="text-muted-foreground" />
+                  <EloDelta delta={comparison.deltaB} />
+                </>
+              ) : (
+                <>
+                  <MovieTitle mediaId={winnerId} className="font-semibold text-foreground" />
+                  <EloDelta delta={winnerDelta} />
+                  <span className="text-muted-foreground">beat</span>
+                  <MovieTitle mediaId={loserId} className="text-muted-foreground" />
+                  <EloDelta delta={loserDelta} />
+                </>
+              )}
             </div>
             <div className="flex items-center gap-2 mt-0.5">
               <span className="text-2xs text-muted-foreground uppercase tracking-wider">
                 {dimensionName}
               </span>
+              {isDraw && comparison.drawTier && (
+                <span className="text-2xs text-muted-foreground capitalize">
+                  {comparison.drawTier} draw
+                </span>
+              )}
               <span className="text-2xs text-muted-foreground">
                 {new Date(comparison.comparedAt).toLocaleDateString()}
               </span>


### PR DESCRIPTION
## Summary

- Fix: `winnerId=0` (draw) was passed to `MovieTitle` as id 0, falling back to "Movie #0 beat X"
- Detect `isDraw = winnerId === 0` in `ComparisonRow` and render "[MovieA] tied [MovieB]" instead
- Add `drawTier` field to comp type — shows "high draw" / "mid draw" / "low draw" label
- For draws, correctly shows ELO deltas for both movies (not winner/loser assignments)
- Add draw test case (`DRAW_COMPARISON` fixture with `winnerId=0`)

## Test plan

- [ ] CI green
- [ ] "Movie #0 beat Spy" no longer appears for draws  
- [ ] Draws show "MovieA tied MovieB" with correct draw tier label
- [ ] Regular win comparisons unaffected — still "winner beat loser" with ELO deltas
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)