### PR TITLE
fix(app-media): remove unused @/* path alias causing TS6 baseUrl deprecation

### DIFF
--- a/packages/app-media/tsconfig.json
+++ b/packages/app-media/tsconfig.json
@@ -8,9 +8,6 @@
     "rootDir": "src",
     "isolatedModules": true,
     "noEmit": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "types": []
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary
- Removes the unused `@/*` path alias from `packages/app-media/tsconfig.json`
- The alias implicitly required `baseUrl` which is deprecated in TypeScript 6 (TS5101 error) and will break in TS7
- No code in app-media actually uses `@/*` imports — confirmed by grep

## Test plan
- [ ] CI typecheck passes for app-media
- [ ] No `@/*` import aliases used anywhere in `packages/app-media/src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)