### PR TITLE
fix(db): use content hashes for Drizzle migration tracking

### DIFF
--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -2,6 +2,7 @@ import BetterSqlite3 from "better-sqlite3";
 import { drizzle, type BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { createHash } from "node:crypto";
 import { readdirSync, readFileSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -162,7 +163,10 @@ function markDrizzleMigrationsFromJournal(
 
     const entries = filter ? journal.entries.filter(filter) : journal.entries;
     for (const entry of entries) {
-      insert.run(entry.tag, Date.now());
+      const sqlPath = join(DRIZZLE_MIGRATIONS_DIR, `${entry.tag}.sql`);
+      const sql = readFileSync(sqlPath, "utf8");
+      const hash = createHash("sha256").update(sql).digest("hex");
+      insert.run(hash, Date.now());
     }
   } catch {
     // Non-fatal — Drizzle migrate will handle it on next startup


### PR DESCRIPTION
## Summary
- `markDrizzleMigrationsFromJournal` was inserting the migration tag name (e.g. `0000_initial`) as the hash in `__drizzle_migrations`, but Drizzle's migrator computes SHA-256 of the SQL file content
- This mismatch caused all baseline migrations to appear unapplied on existing databases, and new migrations (like 0022_elo_deltas) were never executed
- Root cause of the production issue where `delta_a`/`delta_b` columns were missing from the comparisons table

## Test plan
- [x] All 2089 pops-api tests pass
- [x] Live database already patched with correct hashes and confirmed healthy
- [ ] Verify next deploy auto-applies any pending migrations without manual intervention