### PR TITLE
feat(comparisons): optimistic delete with undo progress bar

### DIFF
--- a/packages/app-media/src/pages/ComparisonHistoryPage.test.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.test.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
@@ -5,10 +6,14 @@ import { ComparisonHistoryPage } from "./ComparisonHistoryPage";
 
 // Mock sonner
 const mockToast = vi.fn().mockReturnValue("toast-id-1");
+const mockToastCustom = vi.fn().mockReturnValue("toast-custom-1");
 const mockToastDismiss = vi.fn();
+const mockToastError = vi.fn();
 vi.mock("sonner", () => ({
   toast: Object.assign((...args: unknown[]) => mockToast(...args), {
+    custom: (...args: unknown[]) => mockToastCustom(...args),
     dismiss: (...args: unknown[]) => mockToastDismiss(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
   }),
 }));
 
@@ -169,21 +174,24 @@ describe("ComparisonHistoryPage", () => {
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it("shows undo toast on delete without immediately deleting", () => {
+  it("optimistically hides row and shows undo toast on delete", () => {
     setupLoaded();
     renderPage();
+
+    expect(screen.getByText("Movie 100")).toBeInTheDocument();
 
     const deleteBtn = screen.getByRole("button", { name: "" });
     fireEvent.click(deleteBtn);
 
-    expect(mockToast).toHaveBeenCalledWith(
-      "Comparison deleted",
-      expect.objectContaining({ duration: 5000 })
-    );
+    // Row removed optimistically
+    expect(screen.queryByText("Movie 100")).not.toBeInTheDocument();
+    // Custom toast shown with undo
+    expect(mockToastCustom).toHaveBeenCalled();
+    // Mutation not fired yet
     expect(mockDeleteMutate).not.toHaveBeenCalled();
   });
 
-  it("executes delete after 5-second window", () => {
+  it("executes delete after 5-second undo window", () => {
     setupLoaded();
     renderPage();
 
@@ -191,25 +199,38 @@ describe("ComparisonHistoryPage", () => {
     fireEvent.click(deleteBtn);
 
     expect(mockDeleteMutate).not.toHaveBeenCalled();
-    vi.advanceTimersByTime(5000);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
     expect(mockDeleteMutate).toHaveBeenCalledWith({ id: COMPARISON.id });
   });
 
-  it("cancels delete when undo is clicked", () => {
+  it("cancels delete and restores row when undo is clicked", () => {
     setupLoaded();
     renderPage();
 
     const deleteBtn = screen.getByRole("button", { name: "" });
     fireEvent.click(deleteBtn);
 
-    // Simulate clicking undo via the action callback
-    const toastCall = mockToast.mock.calls[0];
-    const opts = toastCall?.[1] as { action?: { onClick: () => void } };
-    opts?.action?.onClick();
+    // Row gone
+    expect(screen.queryByText("Movie 100")).not.toBeInTheDocument();
 
-    vi.advanceTimersByTime(5000);
+    // Extract the render function passed to toast.custom and render it to get the Undo button
+    const renderFn = mockToastCustom.mock.calls[0]![0] as (
+      id: string | number
+    ) => React.ReactElement;
+    const toastElement = renderFn("toast-custom-1");
+    const { getByText: getToastByText } = render(toastElement);
+    fireEvent.click(getToastByText("Undo"));
+
+    // Row restored
+    expect(screen.getByText("Movie 100")).toBeInTheDocument();
+    // Timer should not fire delete
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
     expect(mockDeleteMutate).not.toHaveBeenCalled();
-    expect(mockToastDismiss).toHaveBeenCalledWith("toast-id-1");
+    expect(mockToastDismiss).toHaveBeenCalledWith("toast-custom-1");
   });
 
   it("invalidates queries on successful delete", () => {
@@ -217,12 +238,13 @@ describe("ComparisonHistoryPage", () => {
     renderPage();
 
     // Trigger the onSuccess callback directly
-    deleteMutationOpts.onSuccess?.();
+    act(() => {
+      deleteMutationOpts.onSuccess?.(undefined, { id: COMPARISON.id });
+    });
 
     expect(mockInvalidateListAll).toHaveBeenCalled();
     expect(mockInvalidateScores).toHaveBeenCalled();
     expect(mockInvalidateRankings).toHaveBeenCalled();
-    expect(mockRefetch).toHaveBeenCalled();
   });
 
   it("filters by dimension", () => {

--- a/packages/app-media/src/pages/ComparisonHistoryPage.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.tsx
@@ -2,14 +2,15 @@
  * ComparisonHistoryPage — paginated list of all comparisons with delete capability.
  * Allows users to review past comparisons and undo mistakes.
  */
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Link } from "react-router";
 import { toast } from "sonner";
 import { Button, Card, CardContent, Skeleton, Select, Input } from "@pops/ui";
-import { Trash2, ChevronLeft, ChevronRight, History } from "lucide-react";
+import { Trash2, ChevronLeft, ChevronRight, History, Undo2 } from "lucide-react";
 import { trpc } from "../lib/trpc";
 
 const PAGE_SIZE = 20;
+const UNDO_DELAY_MS = 5000;
 
 function useDebouncedValue(value: string, delay: number): string {
   const [debounced, setDebounced] = useState(value);
@@ -24,7 +25,8 @@ export function ComparisonHistoryPage() {
   const [page, setPage] = useState(0);
   const [dimensionFilter, setDimensionFilter] = useState<string>("");
   const [searchInput, setSearchInput] = useState<string>("");
-  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [pendingDeletes, setPendingDeletes] = useState<Set<number>>(new Set());
+  const pendingTimers = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
 
   const debouncedSearch = useDebouncedValue(searchInput, 300);
 
@@ -34,7 +36,7 @@ export function ComparisonHistoryPage() {
   const parsedDimensionId = dimensionFilter ? Number(dimensionFilter) : undefined;
   const searchParam = debouncedSearch.trim() || undefined;
 
-  const { data, isLoading, refetch } = trpc.media.comparisons.listAll.useQuery({
+  const { data, isLoading } = trpc.media.comparisons.listAll.useQuery({
     dimensionId: parsedDimensionId,
     search: searchParam,
     limit: PAGE_SIZE,
@@ -44,19 +46,40 @@ export function ComparisonHistoryPage() {
   const utils = trpc.useUtils();
 
   const deleteMutation = trpc.media.comparisons.delete.useMutation({
-    onSuccess: () => {
-      setDeletingId(null);
-      utils.media.comparisons.listAll.invalidate();
-      utils.media.comparisons.scores.invalidate();
-      utils.media.comparisons.rankings.invalidate();
-      refetch();
+    onSuccess: (_data, variables) => {
+      setPendingDeletes((prev) => {
+        const next = new Set(prev);
+        next.delete(variables.id);
+        return next;
+      });
+      void utils.media.comparisons.listAll.invalidate();
+      void utils.media.comparisons.scores.invalidate();
+      void utils.media.comparisons.rankings.invalidate();
     },
-    onError: () => {
-      setDeletingId(null);
+    onError: (_error, variables) => {
+      setPendingDeletes((prev) => {
+        const next = new Set(prev);
+        next.delete(variables.id);
+        return next;
+      });
+      toast.error("Failed to delete comparison");
     },
   });
 
-  const comparisons = data?.data ?? [];
+  const handleUndo = useCallback((id: number, toastId: string | number) => {
+    const timer = pendingTimers.current.get(id);
+    if (timer) clearTimeout(timer);
+    pendingTimers.current.delete(id);
+    setPendingDeletes((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+    toast.dismiss(toastId);
+  }, []);
+
+  const allComparisons = data?.data ?? [];
+  const comparisons = allComparisons.filter((c: { id: number }) => !pendingDeletes.has(c.id));
   const totalPages = data?.pagination ? Math.ceil(data.pagination.total / PAGE_SIZE) : 0;
 
   const dimensionOptions = [
@@ -70,22 +93,20 @@ export function ComparisonHistoryPage() {
   const dimensionMap = new Map(dimensions.map((d: { id: number; name: string }) => [d.id, d.name]));
 
   function handleDelete(id: number) {
-    setDeletingId(id);
-    let cancelled = false;
-    const toastId = toast("Comparison deleted", {
-      duration: 5000,
-      action: {
-        label: "Undo",
-        onClick: () => {
-          cancelled = true;
-          setDeletingId(null);
-          toast.dismiss(toastId);
-        },
-      },
-    });
-    setTimeout(() => {
-      if (!cancelled) deleteMutation.mutate({ id });
-    }, 5000);
+    setPendingDeletes((prev) => new Set(prev).add(id));
+
+    const toastId = toast.custom(
+      (tId) => <UndoToast toastId={tId} onUndo={() => handleUndo(id, tId)} />,
+      { duration: UNDO_DELAY_MS + 500 }
+    );
+
+    const timer = setTimeout(() => {
+      pendingTimers.current.delete(id);
+      toast.dismiss(toastId);
+      deleteMutation.mutate({ id });
+    }, UNDO_DELAY_MS);
+
+    pendingTimers.current.set(id, timer);
   }
 
   return (
@@ -166,7 +187,6 @@ export function ComparisonHistoryPage() {
                 comparison={comp}
                 dimensionName={dimensionMap.get(comp.dimensionId) ?? "Unknown"}
                 onDelete={handleDelete}
-                isDeleting={deletingId === comp.id}
               />
             )
           )}
@@ -223,7 +243,6 @@ function ComparisonRow({
   comparison,
   dimensionName,
   onDelete,
-  isDeleting,
 }: {
   comparison: {
     id: number;
@@ -237,7 +256,6 @@ function ComparisonRow({
   };
   dimensionName: string;
   onDelete: (id: number) => void;
-  isDeleting: boolean;
 }) {
   const isDraw = comparison.winnerId === 0;
   const winnerId = comparison.winnerId;
@@ -291,13 +309,41 @@ function ComparisonRow({
           variant="ghost"
           size="sm"
           onClick={() => onDelete(comparison.id)}
-          disabled={isDeleting}
           className="opacity-0 group-hover:opacity-100 transition-opacity text-destructive hover:text-destructive"
         >
           <Trash2 className="h-4 w-4" />
         </Button>
       </CardContent>
     </Card>
+  );
+}
+
+/** Toast with a shrinking progress bar and undo button. */
+function UndoToast({ toastId, onUndo }: { toastId: string | number; onUndo: () => void }) {
+  void toastId;
+  return (
+    <div className="bg-card border border-border rounded-lg shadow-lg px-4 py-3 w-72">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm text-foreground">Comparison deleted</span>
+        <button
+          onClick={onUndo}
+          className="flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+        >
+          <Undo2 className="h-3.5 w-3.5" />
+          Undo
+        </button>
+      </div>
+      <div className="mt-2 h-1 w-full rounded-full bg-muted overflow-hidden">
+        <div
+          className="h-full rounded-full bg-primary animate-shrink-bar"
+          style={
+            {
+              "--shrink-duration": `${UNDO_DELAY_MS}ms`,
+            } as React.CSSProperties
+          }
+        />
+      </div>
+    </div>
   );
 }
 

--- a/packages/ui/src/theme/globals.css
+++ b/packages/ui/src/theme/globals.css
@@ -111,6 +111,17 @@
       height: 0;
     }
   }
+
+  @keyframes shrink-bar {
+    from {
+      width: 100%;
+    }
+    to {
+      width: 0%;
+    }
+  }
+
+  --animate-shrink-bar: shrink-bar var(--shrink-duration, 5000ms) linear forwards;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Delete now hides the comparison row immediately (optimistic removal)
- Shows a custom toast with a shrinking progress bar indicating time until the delete is applied
- Clicking Undo restores the row and cancels the mutation
- Previous behavior: row stayed visible for 5s with no feedback, then disappeared

## Test plan
- [x] All 13 ComparisonHistoryPage tests pass (updated for new behavior)
- [x] 473 app-media tests pass
- [ ] Delete a comparison, verify row disappears immediately
- [ ] Verify progress bar shrinks over 5 seconds
- [ ] Click Undo before bar empties, verify row reappears
- [ ] Let timer expire, verify comparison is actually deleted