### PR TITLE
Fix overall confidence calculation and boost low-confidence in smart pairs

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -1273,7 +1273,6 @@ describe("tiered draws", () => {
 });
 
 describe("calculateConfidence", () => {
-  // Import the pure function directly for unit tests
   it("returns 0 at count=0", async () => {
     const { calculateConfidence } = await import("./types.js");
     expect(calculateConfidence(0)).toBe(0);
@@ -1292,6 +1291,49 @@ describe("calculateConfidence", () => {
   it("returns ~0.82 at count=30", async () => {
     const { calculateConfidence } = await import("./types.js");
     expect(calculateConfidence(30)).toBeCloseTo(0.8204, 2);
+  });
+});
+
+describe("calculateOverallConfidence", () => {
+  it("returns 0 when all dimensions have 0 comparisons", async () => {
+    const { calculateOverallConfidence } = await import("./types.js");
+    expect(calculateOverallConfidence([0, 0, 0], 3)).toBe(0);
+  });
+
+  it("returns 0 when totalActiveDimensions is 0", async () => {
+    const { calculateOverallConfidence } = await import("./types.js");
+    expect(calculateOverallConfidence([], 0)).toBe(0);
+  });
+
+  it("penalizes sparse coverage", async () => {
+    const { calculateOverallConfidence, calculateConfidence } = await import("./types.js");
+    // 7 comparisons in 1 of 10 dimensions → (1/10) × conf(7)
+    const expected = (1 / 10) * calculateConfidence(7);
+    expect(calculateOverallConfidence([7], 10)).toBeCloseTo(expected, 4);
+  });
+
+  it("rewards full coverage", async () => {
+    const { calculateOverallConfidence, calculateConfidence } = await import("./types.js");
+    // 3 comparisons in all 3 dimensions → (3/3) × conf(3)
+    const expected = (3 / 3) * calculateConfidence(3);
+    expect(calculateOverallConfidence([3, 3, 3], 3)).toBeCloseTo(expected, 4);
+  });
+
+  it("computes coverage × avgDepth for mixed counts", async () => {
+    const { calculateOverallConfidence, calculateConfidence } = await import("./types.js");
+    // 3 comparisons in dim1, 1 in dim2, 0 in dim3 (but only 2 dims have scores)
+    // coverage = 2/3, avgDepth = (conf(3) + conf(1)) / 2
+    const avgDepth = (calculateConfidence(3) + calculateConfidence(1)) / 2;
+    const expected = (2 / 3) * avgDepth;
+    expect(calculateOverallConfidence([3, 1], 3)).toBeCloseTo(expected, 4);
+  });
+
+  it("missing dimensions count against coverage but not depth", async () => {
+    const { calculateOverallConfidence, calculateConfidence } = await import("./types.js");
+    // Movie has scores in 2 of 5 dims, both with 10 comparisons
+    // coverage = 2/5, avgDepth = conf(10)
+    const expected = (2 / 5) * calculateConfidence(10);
+    expect(calculateOverallConfidence([10, 10], 5)).toBeCloseTo(expected, 4);
   });
 });
 
@@ -1348,7 +1390,7 @@ describe("confidence in API responses", () => {
     expect(movie1!.confidence).toBeCloseTo(1 - 1 / Math.sqrt(3), 3); // count=2 → sqrt(3)
   });
 
-  it("overall rankings confidence = min confidence across dimensions", async () => {
+  it("overall rankings confidence = coverage × average depth", async () => {
     const dim1 = seedDimension(db, { name: "Story", active: 1 });
     const dim2 = seedDimension(db, { name: "Visuals", active: 1 });
 
@@ -1394,8 +1436,12 @@ describe("confidence in API responses", () => {
     const movie1 = result.data.find((r) => r.mediaId === 1);
     expect(movie1).toBeDefined();
     // dim1: 3 comparisons → confidence ~0.5, dim2: 1 comparison → confidence ~0.29
-    // overall = min = ~0.29
-    expect(movie1!.confidence).toBeCloseTo(1 - 1 / Math.sqrt(2), 3); // count=1 → sqrt(2)
+    // coverage = 2/2 = 1.0, avgDepth = (0.5 + 0.29) / 2 ≈ 0.396
+    // overall = 1.0 × 0.396 ≈ 0.396
+    const conf1 = 1 - 1 / Math.sqrt(4); // count=3
+    const conf2 = 1 - 1 / Math.sqrt(2); // count=1
+    const expected = (2 / 2) * ((conf1 + conf2) / 2);
+    expect(movie1!.confidence).toBeCloseTo(expected, 3);
   });
 
   it("per-dimension rankings exclude excluded movies", async () => {

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -18,6 +18,7 @@ import {
 import { NotFoundError, ConflictError, ValidationError } from "../../../shared/errors.js";
 import {
   calculateConfidence,
+  calculateOverallConfidence,
   type ComparisonDimensionRow,
   type ComparisonRow,
   type MediaScoreRow,
@@ -902,9 +903,16 @@ export function getSmartPair(dimensionId?: number): SmartPairResult | null {
       const recB = recencyWeight(b.daysSinceLastWatch);
       const staleA = a.staleness;
       const staleB = b.staleness;
+      // Boost pairs where either movie has low confidence on this dimension.
+      // confidenceNeed is 1.0 at 0 comparisons, ~0.71 at 1, ~0.5 at 3, ~0.18 at 30.
+      // Use max so a single under-compared movie is enough to boost the pair.
+      const confNeed = Math.max(
+        1 - calculateConfidence(a.comparisonCount),
+        1 - calculateConfidence(b.comparisonCount)
+      );
       const jitter = 0.7 + Math.random() * 0.6; // [0.7, 1.3]
 
-      const priority = infoGain * recA * recB * staleA * staleB * jitter;
+      const priority = infoGain * recA * recB * staleA * staleB * confNeed * jitter;
       scoredPairs.push({ movieA: a, movieB: b, priority });
     }
   }
@@ -1136,6 +1144,8 @@ export function getRankings(
     )
     .get(...filterParams) as { total: number };
 
+  const totalActiveDimensions = activeDimensionIds.length;
+
   const rows = rawDb
     .prepare(
       `SELECT
@@ -1143,7 +1153,7 @@ export function getRankings(
         ms.media_id as mediaId,
         SUM(ms.score * cd.weight) / SUM(cd.weight) as score,
         SUM(ms.comparison_count) as comparisonCount,
-        MIN(ms.comparison_count) as minComparisonCount,
+        GROUP_CONCAT(ms.comparison_count) as perDimCounts,
         COALESCE(m.title, tv.name, 'Unknown') as title,
         CASE
           WHEN ms.media_type = 'movie' THEN CAST(SUBSTR(m.release_date, 1, 4) AS INTEGER)
@@ -1172,7 +1182,7 @@ export function getRankings(
     mediaId: number;
     score: number;
     comparisonCount: number;
-    minComparisonCount: number;
+    perDimCounts: string;
     title: string;
     year: number | null;
     moviePosterPath: string | null;
@@ -1184,17 +1194,20 @@ export function getRankings(
   }>;
 
   return {
-    rows: rows.map((row, i) => ({
-      rank: offset + i + 1,
-      mediaType: row.mediaType,
-      mediaId: row.mediaId,
-      title: row.title,
-      year: row.year,
-      posterUrl: resolvePosterUrl(row),
-      score: Math.round(row.score * 10) / 10,
-      comparisonCount: row.comparisonCount,
-      confidence: calculateConfidence(row.minComparisonCount),
-    })),
+    rows: rows.map((row, i) => {
+      const counts = row.perDimCounts.split(",").map(Number);
+      return {
+        rank: offset + i + 1,
+        mediaType: row.mediaType,
+        mediaId: row.mediaId,
+        title: row.title,
+        year: row.year,
+        posterUrl: resolvePosterUrl(row),
+        score: Math.round(row.score * 10) / 10,
+        comparisonCount: row.comparisonCount,
+        confidence: calculateOverallConfidence(counts, totalActiveDimensions),
+      };
+    }),
     total: countResult.total,
   };
 }

--- a/apps/pops-api/src/modules/media/comparisons/types.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types.ts
@@ -64,12 +64,35 @@ export function toComparison(row: ComparisonRow): Comparison {
 }
 
 /**
- * Derive confidence (0–1) from how many comparisons a media item has undergone.
+ * Derive per-dimension confidence (0–1) from how many comparisons a media item
+ * has undergone on a single dimension.
  * Formula: 1 - (1 / sqrt(comparisonCount + 1))
  * At 0 comparisons → 0, at 1 → ~0.29, at 3 → ~0.5, at 30 → ~0.82.
  */
 export function calculateConfidence(comparisonCount: number): number {
   return 1 - 1 / Math.sqrt(comparisonCount + 1);
+}
+
+/**
+ * Derive overall confidence (0–1) from dimension coverage and depth.
+ *
+ * Option C: coverageRatio × averageDepth
+ *  - coverageRatio = dimensionsWithComparisons / totalActiveDimensions
+ *  - averageDepth  = mean of per-dimension confidence across scored dimensions
+ *
+ * A movie with 7 comparisons in 3 of 10 dimensions → (3/10) × 0.65 ≈ 0.20
+ * A movie with 3 comparisons across all 10 dimensions → (10/10) × 0.50 = 0.50
+ */
+export function calculateOverallConfidence(
+  perDimensionCounts: number[],
+  totalActiveDimensions: number
+): number {
+  if (totalActiveDimensions === 0) return 0;
+  const scored = perDimensionCounts.filter((c) => c > 0);
+  if (scored.length === 0) return 0;
+  const coverageRatio = scored.length / totalActiveDimensions;
+  const avgDepth = scored.reduce((sum, c) => sum + calculateConfidence(c), 0) / scored.length;
+  return coverageRatio * avgDepth;
 }
 
 /** API response shape for a media score. */


### PR DESCRIPTION
## Summary
- **Overall confidence** now uses coverage×depth instead of MIN across dimensions. A movie with 7 comparisons in 3/10 dimensions gets ~20% instead of 65% (penalizes sparse coverage), while a movie with 3 comparisons across all 10 gets 50% instead of 50% (rewards breadth).
- **Smart pair selection** now includes a `confidenceNeed` boost factor — movies with low per-dimension confidence are prioritized in the arena, improving ranking quality over time.

## Test plan
- [x] All 2095 tests pass
- [x] Typecheck clean
- [x] Lint clean (0 errors)
- [x] 5 new unit tests for `calculateOverallConfidence`
- [x] Updated integration test for overall rankings confidence
- [ ] Verify confidence values look reasonable on production after deploy