### PR TITLE
fix(finance-import): apply corrections in progress processing

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/service.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.test.ts
@@ -497,6 +497,121 @@ describe("processImportWithProgress", () => {
       expect.objectContaining({ tag: "Groceries", source: "rule", pattern: "woolworths" })
     );
   });
+
+  it("falls through to entity matching when correction matches without entityId", async () => {
+    seedEntity(db, { name: "Woolworths", id: "woolworths-id" });
+    orm()
+      .insert(transactionCorrections)
+      .values({
+        id: "corr-progress-no-entity",
+        descriptionPattern: "woolworths",
+        matchType: "contains",
+        entityId: null,
+        entityName: "Woolworths",
+        tags: '["Groceries"]',
+        confidence: 0.95,
+      })
+      .run();
+
+    const sessionId = "22222222-2222-2222-2222-222222222222";
+    setProgress(sessionId, {
+      sessionId,
+      status: "processing",
+      currentStep: "deduplicating",
+      totalTransactions: 1,
+      processedCount: 0,
+      currentBatch: [],
+      errors: [],
+      startedAt: new Date().toISOString(),
+    });
+
+    await processImportWithProgress(sessionId, [baseParsedTransaction], "Amex");
+
+    const progress = getProgress(sessionId);
+    const result = progress?.result as Awaited<ReturnType<typeof processImport>>;
+    expect(result.matched.length).toBe(1);
+    expect(result.matched[0]!.entity.matchType).toBe("prefix");
+  });
+
+  it("routes low-confidence corrections to uncertain", async () => {
+    seedEntity(db, { name: "Woolworths", id: "woolworths-id" });
+    orm()
+      .insert(transactionCorrections)
+      .values({
+        id: "corr-progress-low-confidence",
+        descriptionPattern: "woolworths",
+        matchType: "contains",
+        entityId: "woolworths-id",
+        entityName: "Woolworths",
+        tags: '["Groceries"]',
+        confidence: 0.8,
+      })
+      .run();
+
+    const sessionId = "33333333-3333-3333-3333-333333333333";
+    setProgress(sessionId, {
+      sessionId,
+      status: "processing",
+      currentStep: "deduplicating",
+      totalTransactions: 1,
+      processedCount: 0,
+      currentBatch: [],
+      errors: [],
+      startedAt: new Date().toISOString(),
+    });
+
+    await processImportWithProgress(sessionId, [baseParsedTransaction], "Amex");
+
+    const progress = getProgress(sessionId);
+    const result = progress?.result as Awaited<ReturnType<typeof processImport>>;
+    expect(result.uncertain.length).toBe(1);
+    expect(result.uncertain[0]!.entity.matchType).toBe("learned");
+    expect(result.matched.length).toBe(0);
+  });
+
+  it("handles mixed batch independently (one correction match, one normal match)", async () => {
+    seedEntity(db, { name: "Woolworths", id: "woolworths-id" });
+    seedEntity(db, { name: "Netflix", id: "netflix-id" });
+    orm()
+      .insert(transactionCorrections)
+      .values({
+        id: "corr-progress-mixed",
+        descriptionPattern: "woolworths",
+        matchType: "contains",
+        entityId: "woolworths-id",
+        entityName: "Woolworths",
+        tags: "[]",
+        confidence: 0.95,
+      })
+      .run();
+
+    const sessionId = "44444444-4444-4444-4444-444444444444";
+    setProgress(sessionId, {
+      sessionId,
+      status: "processing",
+      currentStep: "deduplicating",
+      totalTransactions: 2,
+      processedCount: 0,
+      currentBatch: [],
+      errors: [],
+      startedAt: new Date().toISOString(),
+    });
+
+    const t2: ParsedTransaction = {
+      ...baseParsedTransaction,
+      description: "NETFLIX.COM SUBSCRIPTION",
+      rawRow: '{"Date":"13/02/2026","Description":"NETFLIX.COM SUBSCRIPTION"}',
+      checksum: "netflix-123",
+    };
+
+    await processImportWithProgress(sessionId, [baseParsedTransaction, t2], "Amex");
+
+    const progress = getProgress(sessionId);
+    const result = progress?.result as Awaited<ReturnType<typeof processImport>>;
+    expect(result.matched.length).toBe(2);
+    expect(result.matched.some((t) => t.entity.matchType === "learned")).toBe(true);
+    expect(result.matched.some((t) => t.entity.matchType === "prefix")).toBe(true);
+  });
 });
 
 describe("executeImport", () => {

--- a/apps/pops-api/src/modules/finance/imports/service.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.ts
@@ -103,6 +103,71 @@ function buildSuggestedTags(
   });
 }
 
+function applyLearnedCorrection(args: {
+  transaction: ParsedTransaction;
+  minConfidence: number;
+  knownTags: string[];
+  index: number;
+  total: number;
+}): { processed: ProcessedTransaction; bucket: "matched" | "uncertain" } | null {
+  const { transaction, minConfidence, knownTags, index, total } = args;
+
+  const correctionResult = findMatchingCorrection(transaction.description, minConfidence);
+  if (!correctionResult) return null;
+
+  const { correction, status } = correctionResult;
+  const entityId = correction.entityId;
+
+  if (!entityId) {
+    logger.debug(
+      {
+        index,
+        total,
+        description: transaction.description.substring(0, 50),
+        confidence: correction.confidence,
+        status,
+      },
+      "[Import] Learned correction matched but has no entityId; falling through"
+    );
+    return null;
+  }
+
+  logger.debug(
+    {
+      index,
+      total,
+      description: transaction.description.substring(0, 50),
+      entityName: correction.entityName,
+      confidence: correction.confidence,
+      status,
+    },
+    "[Import] Applied learned correction"
+  );
+
+  return {
+    processed: {
+      ...transaction,
+      location: correction.location ?? transaction.location,
+      entity: {
+        entityId,
+        entityName: correction.entityName ?? "Unknown",
+        matchType: "learned",
+        confidence: correction.confidence,
+      },
+      status,
+      suggestedTags: buildSuggestedTags(
+        transaction.description,
+        entityId,
+        parseCorrectionTags(correction.tags),
+        null,
+        knownTags,
+        correction.descriptionPattern
+      ),
+    },
+    bucket: status === "matched" ? "matched" : "uncertain",
+  };
+}
+
 // Entity lookup and alias loading moved to lib/entity-lookup.ts
 
 /**
@@ -239,45 +304,18 @@ export async function processImport(
     try {
       // Step 1: Apply learned corrections (highest priority)
       // When a correction matches, skip all subsequent matching stages.
-      const correctionResult = findMatchingCorrection(transaction.description, 0.7);
+      const correctionApplied = applyLearnedCorrection({
+        transaction,
+        minConfidence: 0.7,
+        knownTags,
+        index: i + 1,
+        total: newTransactions.length,
+      });
 
-      if (correctionResult) {
-        const { correction, status } = correctionResult;
-        const entityId = correction.entityId;
-        if (entityId) {
-          logger.debug(
-            {
-              index: i + 1,
-              total: newTransactions.length,
-              description: transaction.description.substring(0, 50),
-              entityName: correction.entityName,
-              confidence: correction.confidence,
-              status,
-            },
-            "[Import] Applied learned correction"
-          );
-
-          matched.push({
-            ...transaction,
-            location: correction.location ?? transaction.location,
-            entity: {
-              entityId,
-              entityName: correction.entityName ?? "Unknown",
-              matchType: "learned" as never, // UI-only matchType
-              confidence: correction.confidence,
-            },
-            status,
-            suggestedTags: buildSuggestedTags(
-              transaction.description,
-              entityId,
-              parseCorrectionTags(correction.tags),
-              null,
-              knownTags,
-              correction.descriptionPattern
-            ),
-          });
-          continue; // Skip all subsequent matching stages
-        }
+      if (correctionApplied) {
+        if (correctionApplied.bucket === "matched") matched.push(correctionApplied.processed);
+        else uncertain.push(correctionApplied.processed);
+        continue;
       }
 
       // Step 2: Try universal entity matching
@@ -644,47 +682,20 @@ export async function processImportWithProgress(
       try {
         // Step 1: Apply learned corrections (highest priority)
         // When a correction matches, skip all subsequent matching stages.
-        const correctionResult = findMatchingCorrection(transaction.description, 0.7);
+        const correctionApplied = applyLearnedCorrection({
+          transaction,
+          minConfidence: 0.7,
+          knownTags,
+          index: i + 1,
+          total: newTransactions.length,
+        });
 
-        if (correctionResult) {
-          const { correction, status } = correctionResult;
-          const entityId = correction.entityId;
-          if (entityId) {
-            logger.debug(
-              {
-                index: i + 1,
-                total: newTransactions.length,
-                description: transaction.description.substring(0, 50),
-                entityName: correction.entityName,
-                confidence: correction.confidence,
-                status,
-              },
-              "[Import] Applied learned correction"
-            );
+        if (correctionApplied) {
+          if (correctionApplied.bucket === "matched") matched.push(correctionApplied.processed);
+          else uncertain.push(correctionApplied.processed);
 
-            matched.push({
-              ...transaction,
-              location: correction.location ?? transaction.location,
-              entity: {
-                entityId,
-                entityName: correction.entityName ?? "Unknown",
-                matchType: "learned" as never, // UI-only matchType
-                confidence: correction.confidence,
-              },
-              status,
-              suggestedTags: buildSuggestedTags(
-                transaction.description,
-                entityId,
-                parseCorrectionTags(correction.tags),
-                null,
-                knownTags,
-                correction.descriptionPattern
-              ),
-            });
-
-            batchItem.status = "success";
-            continue; // Skip all subsequent matching stages
-          }
+          batchItem.status = "success";
+          continue;
         }
 
         const match = matchEntity(transaction.description, entityLookup, aliases);

--- a/apps/pops-api/src/modules/finance/imports/types.ts
+++ b/apps/pops-api/src/modules/finance/imports/types.ts
@@ -23,7 +23,7 @@ export type ParsedTransaction = z.infer<typeof parsedTransactionSchema>;
 export const entityMatchSchema = z.object({
   entityId: z.string().optional(),
   entityName: z.string().optional(),
-  matchType: z.enum(["alias", "exact", "prefix", "contains", "ai", "none"]),
+  matchType: z.enum(["alias", "exact", "prefix", "contains", "ai", "learned", "none"]),
   confidence: z.number().min(0).max(1).optional(),
 });
 


### PR DESCRIPTION
## Summary
- Apply learned correction rules first in `processImportWithProgress()` (matches `processImport`) and skip subsequent matching stages.
- Keep suggested tag attribution consistent (rule tags include the matched pattern).
- Add unit coverage for the progress path.

Closes #1641.

## Test plan
- [x] `mise lint`
- [x] `mise typecheck`
- [x] `pnpm test --filter @pops/api`