### PR TITLE
feat(import-review): edits to rule-matched txns trigger ChangeSet proposals (#1649)

### DIFF
--- a/docs/themes/02-finance/prds/020-import-wizard-ui/README.md
+++ b/docs/themes/02-finance/prds/020-import-wizard-ui/README.md
@@ -169,7 +169,7 @@ interface ImportStore {
 | 14 | [us-14-save-and-learn](us-14-save-and-learn.md) | "Save & Learn" uses bundled proposal + approval + reject-with-feedback, then re-evaluates remaining transactions | To Review | Blocked by us-10 |
 | 15 | [us-15-type-override](us-15-type-override.md) | Override type to transfer/income — makes entity optional, bypasses entity validation | Done | Blocked by us-09 |
 | 16 | [us-16-review-gate](us-16-review-gate.md) | Validation gate: all uncertain/failed must be resolved before advancing to Step 5 | Done | Blocked by us-10 |
-| 23 | [us-23-edit-rule-matched-transactions](us-23-edit-rule-matched-transactions.md) | Editing a rule-matched transaction triggers a bundled Correction Proposal ChangeSet (add/edit/remove rules) | Partial | Blocked by us-13 |
+| 23 | [us-23-edit-rule-matched-transactions](us-23-edit-rule-matched-transactions.md) | Editing a rule-matched transaction triggers a bundled Correction Proposal ChangeSet (add/edit/remove rules) | Done | Blocked by us-13 |
 
 ### Tag Review (Step 5)
 

--- a/docs/themes/02-finance/prds/020-import-wizard-ui/us-23-edit-rule-matched-transactions.md
+++ b/docs/themes/02-finance/prds/020-import-wizard-ui/us-23-edit-rule-matched-transactions.md
@@ -1,7 +1,7 @@
 # US-23: Edit rule-matched transactions (proposal-driven)
 
 > PRD: [020 — Import Wizard UI](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -10,14 +10,14 @@ As a user, I want to safely correct transactions that were matched by learned ru
 ## Acceptance Criteria
 
 - [x] Transactions that were matched by learned rules are clearly marked as such in the Matched tab, including the rule pattern and match type.
-- [ ] When the user edits a rule-matched transaction (entity, transaction type, location, or description), the UI does not immediately “just change the transaction”.
-- [ ] Instead, saving the edit opens a **bundled Correction Proposal ChangeSet** that may include rule operations such as:
+- [x] When the user edits a rule-matched transaction (entity, transaction type, location, or description), the UI does not immediately “just change the transaction”.
+- [x] Instead, saving the edit opens a **bundled Correction Proposal ChangeSet** that may include rule operations such as:
   - Create a new rule that fits the corrected transaction
   - Edit an existing rule to narrow or broaden it
   - Disable or remove a rule that is producing incorrect matches
-- [ ] The proposal includes an **impact preview** for the current import: which other transactions would change if approved.
-- [ ] The user can **Approve** (apply atomically, then re-evaluate remaining transactions) or **Reject** with a required feedback message.
-- [ ] If rejected, the system can generate a follow-up ChangeSet proposal incorporating the feedback.
+- [x] The proposal includes an **impact preview** for the current import: which other transactions would change if approved.
+- [x] The user can **Approve** (apply atomically, then re-evaluate remaining transactions) or **Reject** with a required feedback message.
+- [x] If rejected, the system can generate a follow-up ChangeSet proposal incorporating the feedback.
 
 ## Notes
 

--- a/packages/app-finance/src/components/imports/ReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.test.tsx
@@ -132,14 +132,25 @@ vi.mock("./TransactionCard", async () => {
     TransactionCard: ({
       transaction,
       onAcceptAiSuggestion,
+      onEdit,
     }: {
       transaction: { description: string; entity?: { entityName?: string } };
       onAcceptAiSuggestion?: (t: unknown) => void;
+      onEdit?: (t: unknown) => void;
     }) =>
       React.createElement(
         "div",
         { "data-testid": `tx-${transaction.description}` },
         transaction.description,
+        onEdit &&
+          React.createElement(
+            "button",
+            {
+              "aria-label": `Edit ${transaction.description}`,
+              onClick: () => onEdit(transaction),
+            },
+            "Edit"
+          ),
         onAcceptAiSuggestion &&
           React.createElement(
             "button",
@@ -192,9 +203,27 @@ vi.mock("./TransactionGroup", async () => {
   };
 });
 
-vi.mock("./EditableTransactionCard", () => ({
-  EditableTransactionCard: () => null,
-}));
+vi.mock("./EditableTransactionCard", async () => {
+  const React = await import("react");
+  return {
+    EditableTransactionCard: ({
+      transaction,
+      onSave,
+    }: {
+      transaction: { description: string };
+      onSave: (t: unknown, edited: unknown, shouldLearn?: boolean) => void;
+    }) =>
+      React.createElement(
+        "button",
+        {
+          "data-testid": `save-edit-${transaction.description}`,
+          onClick: () =>
+            onSave(transaction, { description: `${transaction.description} FIXED` }, false),
+        },
+        "Save Once"
+      ),
+  };
+});
 
 vi.mock("./BatchProposalsPanel", () => ({
   BatchProposalsPanel: () => null,
@@ -444,6 +473,42 @@ describe("ReviewStep — Save & Learn proposal flow", () => {
       (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("Applied to")
     );
     expect(appliedToCalls).toHaveLength(0);
+  });
+});
+
+describe("ReviewStep — rule-matched edit proposal flow", () => {
+  it("opens a ChangeSet proposal when saving edits to a rule-matched transaction", async () => {
+    mockAnalyzeCorrectionMutateAsync.mockResolvedValue({
+      data: { matchType: "prefix", pattern: "WOOLWORTHS", confidence: 0.9 },
+    });
+
+    const tx = makeTx("WOOLWORTHS 1234 SYDNEY", {
+      status: "matched",
+      ruleProvenance: { pattern: "WOOLWORTHS", matchType: "contains", confidence: 0.95 },
+      entity: {
+        entityId: "ent-1",
+        entityName: "Woolworths",
+        matchType: "learned",
+        confidence: 0.95,
+      },
+    });
+
+    mockProcessedTransactions = { matched: [tx], uncertain: [], failed: [], skipped: [] };
+    render(<ReviewStep />);
+
+    // Click edit and save (mocked EditableTransactionCard emits Save Once)
+    fireEvent.click(screen.getByLabelText(`Edit ${tx.description}`));
+    fireEvent.click(screen.getByTestId(`save-edit-${tx.description}`));
+
+    await vi.waitFor(() => {
+      const props = lastProposalDialogProps as { signal?: unknown };
+      expect(props.signal).toEqual(
+        expect.objectContaining({
+          entityId: "ent-1",
+          entityName: "Woolworths",
+        })
+      );
+    });
   });
 });
 

--- a/packages/app-finance/src/components/imports/ReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.tsx
@@ -453,6 +453,52 @@ export function ReviewStep() {
       editedFields: Partial<ProcessedTransaction>,
       shouldLearn: boolean = false
     ) => {
+      const isRuleMatched =
+        Boolean(transaction.ruleProvenance) || transaction.entity?.matchType === "learned";
+
+      // Detect what changed (include description/amount changes so Save & Learn works for any edit)
+      const hasChanges =
+        editedFields.description !== transaction.description ||
+        editedFields.amount !== transaction.amount ||
+        editedFields.entity?.entityId !== transaction.entity?.entityId ||
+        editedFields.location !== transaction.location ||
+        editedFields.online !== transaction.online ||
+        editedFields.transactionType !== transaction.transactionType;
+
+      if (isRuleMatched && hasChanges) {
+        setEditingTransaction(null);
+
+        const entityId = editedFields.entity?.entityId ?? transaction.entity?.entityId ?? null;
+        const entityName =
+          editedFields.entity?.entityName ?? transaction.entity?.entityName ?? null;
+        const updatedDescription = editedFields.description ?? transaction.description;
+        const updatedAmount = editedFields.amount ?? transaction.amount;
+        const updatedLocation = editedFields.location ?? transaction.location ?? null;
+        const updatedType =
+          editedFields.transactionType ?? transaction.transactionType ?? "purchase";
+
+        void generateProposal({
+          description: updatedDescription,
+          entityId,
+          entityName,
+          amount: updatedAmount,
+          location: updatedLocation,
+          transactionType: updatedType,
+        });
+
+        if (entityName) {
+          batchAnalysis.addCorrection({
+            description: updatedDescription,
+            entityName,
+            amount: updatedAmount,
+            account: transaction.account,
+            currentTags: (transaction.suggestedTags ?? []).map((s) => s.tag),
+          });
+        }
+
+        return;
+      }
+
       const updatedTx: ProcessedTransaction = {
         ...transaction,
         ...editedFields,
@@ -494,15 +540,6 @@ export function ReviewStep() {
         };
       });
       setEditingTransaction(null);
-
-      // Detect what changed (include description/amount changes so Save & Learn works for any edit)
-      const hasChanges =
-        editedFields.description !== transaction.description ||
-        editedFields.amount !== transaction.amount ||
-        editedFields.entity?.entityId !== transaction.entity?.entityId ||
-        editedFields.location !== transaction.location ||
-        editedFields.online !== transaction.online ||
-        editedFields.transactionType !== transaction.transactionType;
 
       if (shouldLearn && hasChanges) {
         const entityId = editedFields.entity?.entityId ?? transaction.entity?.entityId ?? null;


### PR DESCRIPTION
## Summary
- Route edits to rule-matched transactions into the bundled Correction Proposal flow (no silent overrides).
- Add coverage ensuring rule-matched edit saves open a proposal.
- Update PRD-020 US-23 status to Done.

## Test plan
- `mise lint`
- `mise typecheck`
- `pnpm -C packages/app-finance test`