### PR TITLE
docs: refresh README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ POPS (Personal Operations System) is a self-hosted personal operations platform 
 
 **Domains:** Finance (transactions, budgets, entities) | Media (movies, TV, watchlist, watch history, Plex/TMDB/TVDB integration) | Inventory (items, locations, warranties, insurance) | AI (usage tracking, model config, rules)
 
-Phase 0 (data import) is complete. Phase 1 (Foundation) is **in progress**.
+Phases 0 (infrastructure) and 1 (foundation) are complete. Phase 2 (core apps) is **in progress** — Finance, Media, Inventory, and AI Ops are largely shipped. See `docs/roadmap.md` for the full tracker.
 
 ## Commands
 
@@ -282,19 +282,22 @@ When a movie is added to the POPS library, automatically checks Plex Discover cl
 - **Chat:** Moltbot (Telegram)
 - **Backup:** Backblaze B2 via rclone (encrypted)
 
-## Import Tools
+## Import Pipeline
 
-Stubs in `tools/src/`. Original implementations in `~/Downloads/transactions/` need migration.
-Shared logic lives in `tools/src/lib/` — entity matcher, deduplicator, CSV parser, AI categorizer.
+Two interfaces: the **Import Wizard** (6-step UI in `app-finance`) and **CLI scripts** (`packages/import-tools/`).
 
-### Entity Matching Strategy (`tools/src/lib/entity-matcher.ts`)
-1. Manual aliases — hardcoded map of bank descriptions to entity names (per-bank)
-2. Exact match — case-insensitive against `entity_lookup.json`
-3. Prefix match — description starts with entity name (longest wins)
-4. Contains match — entity name found anywhere in description (min 4 chars, longest wins)
-5. Punctuation stripping — removes apostrophes for matching
+### Entity Matching Chain (`apps/pops-api/src/modules/finance/imports/`)
 
-Hit rate: ~95-100% with aliases. AI fallback handles the rest and caches results to `ai_entity_cache.json`.
+6-stage pipeline, highest priority first:
+1. **Learned corrections** — fuzzy match on normalized description against `v_active_corrections`
+2. **Manual aliases** — case-insensitive substring match from per-entity alias map
+3. **Exact match** — full description equals entity name
+4. **Prefix match** — description starts with entity name (longest wins)
+5. **Contains match** — entity name anywhere in description (min 4 chars, longest wins)
+6. **Punctuation stripping** — strip apostrophes, retry stages 2-5
+7. **AI fallback** — Claude Haiku API call, cached to disk + DB, rate-limited
+
+Hit rate: ~95-100% with aliases. AI fallback handles the rest. See `docs/themes/02-finance/prds/021-entity-matching-engine/` for the full PRD.
 
 ## Security Rules (Do Not Violate)
 
@@ -318,24 +321,17 @@ Hit rate: ~95-100% with aliases. AI fallback handles the rest and caches results
 
 ## Phases
 
-| Phase | Target | Status |
-|---|---|---|
-| 0 — Data Import | Feb 2026 | **Done** |
-| 1 — Foundation | Mar 2026 | **In Progress** |
-| 2 — Intelligence | Apr 2026 | Not Started |
-| 3 — Receipts & Inventory | May 2026 | Not Started |
-| 4 — Mobile | Jun 2026 | Not Started |
-| 5 — Polish | Jul+ 2026 | Not Started |
+| Phase | Status |
+|---|---|
+| 0 — Infrastructure | Done |
+| 1 — Foundation | Done |
+| 2 — Core Apps (Finance, Media, Inventory, AI Ops) | In progress |
+| 3 — AI Layer | Not started |
+| 4 — Expansion Apps | Not started |
+| 5 — Mobile & Hardware | Not started |
+| 6 — Long Tail | Not started |
 
-## Notion Project
-
-Full project documentation lives in Notion under **POPS - Personal Ops** (`30240f45-3d91-8017-b119-fe2ecd847f5f`). Key pages:
-- Architecture: `30240f45-3d91-81ba-aee5-e2cf0aa798c7`
-- Current State: `30240f45-3d91-81fa-9d75-e98050cc5e39`
-- Research & Decisions: `30240f45-3d91-8144-a9f8-cd9cb2f1ac0c`
-- Security Audit: `30240f45-3d91-81ea-a3ce-f38df117e7eb`
-- Phase 1 — Foundation: `30240f45-3d91-81e5-bfde-f14589113d62`
-- POPS Tracker (database): `a36c7a6b-be2f-4f94-8da5-c4c5ad9882b5`
+See `docs/roadmap.md` for the detailed implementation tracker.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -1,251 +1,165 @@
 # POPS — Personal Operations System
 
-A unified platform for financial tracking, asset management, budgeting, AI-powered automation, and reporting. Self-hosted on an N95 mini PC with SQLite as the source of truth, AI-powered categorization, and Cloudflare Tunnel for secure access.
+Self-hosted personal operations platform. Finance, media tracking, home inventory, and AI operations — all in one monorepo, running on an N95 mini PC behind Cloudflare Tunnel.
 
-## Quick Deploy
-
-Deploy everything to production with one command:
-
-```bash
-./deploy.sh
-```
-
-The script will:
-- ✅ Run quality checks (typecheck + tests)
-- ✅ Deploy to N95 via Ansible
-- ✅ Rebuild Docker images
-- ✅ Restart services
-- ✅ Create git tag (v1, v2, v3, etc.)
-- ✅ Push tag to GitHub
-
-**Options:**
-```bash
-./deploy.sh --dry-run      # Preview changes
-./deploy.sh -v             # Verbose output
-./deploy.sh --skip-checks  # Skip tests (faster)
-```
-
-**Prerequisites:**
-- Ansible: `brew install ansible`
-- SSH key: `~/.ssh/pops_n95`
-- Vault password: `~/.ansible/pops-vault-password`
-
-See `docs/DEPLOYMENT_SETUP.md` for setup instructions.
+SQLite is the source of truth. Claude API handles categorization and entity matching. Everything deploys via Ansible + Docker Compose.
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                      INTERFACES                         │
-│  iPhone (PWA)  │  Telegram (Moltbot)  │  Web (Metabase) │
-└────────────────────────┬────────────────────────────────┘
-                         │
-                 Cloudflare Tunnel
-                         │
-┌────────────────────────┴────────────────────────────────┐
-│                 N95 MINI PC (Docker)                     │
-│                                                         │
-│  pops-api ─── Node.js REST over SQLite               │
-│  metabase ────── Dashboards & analytics                 │
-│  moltbot ─────── AI assistant (Telegram + finance)      │
-│  paperless-ngx ─ Receipt archive + OCR                  │
-│  pops-shell ──── React PWA (budget, wishlist, txns)     │
-└─────────────────────────────────────────────────────────┘
-                         │
-┌────────────────────────┴────────────────────────────────┐
-│                      DATA LAYER                         │
-│                                                         │
-│  SQLite (SoT)            │  Claude Haiku API             │
-│  ├─ Balance Sheet        │  (categorization, NL queries, │
-│  ├─ Entities             │   AI fallback) ~$1-5/month    │
-│  ├─ Home Inventory       │                               │
-│  ├─ Budget               │                               │
-│  └─ Wish List            │                               │
-└─────────────────────────────────────────────────────────┘
-                         │
-┌────────────────────────┴────────────────────────────────┐
-│                     BANK FEEDS                          │
-│  Up API (webhooks) │ ANZ CSV │ Amex CSV │ ING CSV       │
-│  Import scripts (Node.js) + Claude Haiku fallback       │
-│  Rule-based matching → AI fallback → cache new mappings │
-└─────────────────────────────────────────────────────────┘
+Interfaces
+  iPhone (PWA)  |  Telegram (Moltbot)  |  Metabase dashboards
+       │
+  Cloudflare Tunnel + Zero Trust
+       │
+N95 Mini PC (Docker Compose)
+  pops-shell ──── React PWA (Vite + nginx)
+  pops-api ────── tRPC API (Express + Drizzle ORM + SQLite)
+  metabase ────── Dashboards & analytics
+  moltbot ─────── Telegram AI assistant
+  paperless-ngx ─ Document archive + OCR
+       │
+Data Layer
+  SQLite ─── All domains (finance, media, inventory, AI)
+  Claude API ─ Categorization, entity matching, NL queries
+       │
+External APIs
+  Finance: Up Bank (webhooks) | ANZ/Amex/ING (CSV import)
+  Media:   Plex (local + Discover) | TMDB | TheTVDB | Radarr | Sonarr
 ```
 
-### Key Decisions
+### Docker Networks
 
-| Decision | Choice | Rationale |
+| Network | Services | Purpose |
 |---|---|---|
-| Source of truth | SQLite | Fast local queries, full control, no API rate limits |
-| AI provider | Claude Haiku API | Cents/month for this workload |
-| Chat interface | Telegram (Moltbot) | Cross-platform, pragmatic |
-| Dashboards | Metabase (self-hosted) | Open-source, Docker, SQLite-compatible |
-| Receipt storage | Paperless-ngx | Mature, self-hosted, OCR built-in |
-| Mobile app | PWA | No App Store, installs to home screen |
+| `pops-frontend` | cloudflared, pops-shell, pops-api, metabase | Public-facing |
+| `pops-backend` | pops-api, moltbot, tools | Internal + SQLite access |
+| `pops-documents` | cloudflared, paperless-ngx, paperless-redis | Isolated document processing |
 
-## Phases
+## Domains
 
-| Phase | Target | Description | Status |
-|---|---|---|---|
-| 0 — Data Import | Feb 2026 | All bank accounts imported to SQLite database | **Done** |
-| 1 — Foundation | Mar 2026 | Infrastructure, SQLite-only architecture, AI imports | **In Progress** |
-| 2 — Intelligence | Apr 2026 | Moltbot, dashboards, proactive alerts | Not Started |
-| 3 — Receipts & Inventory | May 2026 | Document management, receipt OCR, inventory linking | Not Started |
-| 4 — Mobile | Jun 2026 | PWA, quick-add, push notifications | Not Started |
-| 5 — Polish | Jul+ 2026 | Net worth, investments, super, reporting | Not Started |
-
-## Goals
-
-1. **Automated data pipeline** — Bank transactions flow into SQLite with minimal manual intervention. AI handles categorization, entity matching, and deduplication.
-2. **Proactive financial assistant** — Moltbot monitors spending, sends alerts via Telegram, answers natural language queries.
-3. **Budgeting system** — Envelope-style budgets with real-time tracking per category.
-4. **Wish list & planned purchases** — Tiered purchase planning with saving progress tracking.
-5. **Receipt & asset lifecycle** — Purchases get ID'd, labeled, receipt archived, linked to transaction and Home Inventory.
-6. **Accountant-ready reporting** — One-command FY tax reports with deductible items, categorized expenses, income summary.
-7. **Net worth visibility** — Dashboard combining account balances, asset values, super, and liabilities.
-8. **Mobile access** — PWA for on-the-go budget checks, quick expense entry, receipt capture.
-
-## Infrastructure
-
-### N95 Mini PC (POPS Server)
-- **OS:** Ubuntu 24.04 (Docker Compose, provisioned via Ansible)
-- **Services:** pops-api, metabase, moltbot, paperless-ngx, pops-shell
-- **Exposure:** Cloudflare Tunnel (free, zero port forwarding)
-- **URLs:** `pops.jmiranda.dev` (PWA), `pops-api.jmiranda.dev` (API), `pops-metabase.jmiranda.dev`, `pops-paperless.jmiranda.dev`
-
-### External Services
-- **Cloudflare Tunnel** — Secure exposure, free
-- **Claude Haiku API** — Transaction categorization, NL queries (~$1-5/month)
-- **Up Bank API** — Real-time transaction webhooks (free)
-- **Telegram** — Moltbot messaging interface (free)
+| Domain | Package | What it does |
+|---|---|---|
+| **Finance** | `app-finance` | Transactions, budgets, wishlists, entities, CSV import wizard with 6-stage entity matching + AI fallback, learned corrections |
+| **Media** | `app-media` | Movies & TV library, watchlist, watch history, ELO comparison arena, discovery, Plex/Radarr/Sonarr sync |
+| **Inventory** | `app-inventory` | Items, hierarchical locations, connections graph, warranties, insurance reports, Paperless-ngx document linking |
+| **AI Operations** | `app-ai` | Usage tracking, model config, rules browser, prompt viewer, cache management |
 
 ## Tech Stack
 
-- **Runtime:** Node.js
-- **Database:** SQLite (source of truth)
-- **Frontend:** React PWA
-- **Dashboards:** Metabase
-- **AI:** Claude Haiku API
-- **Infra:** Docker Compose, Cloudflare Tunnel
-- **OCR:** Paperless-ngx
-- **Chat:** Moltbot (Telegram)
+| Layer | Technology |
+|---|---|
+| Runtime | Node.js 24, pnpm 10 workspaces, Turborepo |
+| Database | SQLite via Drizzle ORM |
+| API | tRPC (type-safe end-to-end) |
+| Frontend | React, Vite, React Router, Tailwind v4, shadcn/ui (47 components) |
+| State | React Query (server), Zustand (client) |
+| Validation | Zod |
+| AI | Claude API (Haiku for categorization, entity matching) |
+| Testing | Vitest (unit), Playwright (E2E), Storybook |
+| Infra | Docker Compose, Ansible, Cloudflare Tunnel + Access |
+| CI | GitHub Actions (lint, typecheck, format, test, E2E, security) |
 
-## Active Bank Accounts
+## Status
 
-| Account | Type | Data Source | Automation |
-|---|---|---|---|
-| ANZ Everyday | Checking | CSV export | Manual download |
-| ANZ Frequent Flyer Black | Credit Card | CSV export | Manual download |
-| Amex | Credit Card | CSV export | Manual download |
-| Up Checking / Piggy | Checking + Savings | Up Bank API | Fully automatable (webhooks) |
-| ING Everyday / Loan | Checking + Personal Loan | CSV export | Manual download |
+See [`docs/roadmap.md`](docs/roadmap.md) for the full implementation tracker.
 
-## Development Workflow
+| Phase | Status |
+|---|---|
+| 0 — Infrastructure | Done |
+| 1 — Foundation | Done |
+| 2 — Core Apps (Finance, Media, Inventory, AI Ops) | In progress |
+| 3 — AI Layer | Not started |
+| 4 — Expansion Apps | Not started |
+| 5 — Mobile & Hardware | Not started |
+| 6 — Long Tail | Not started |
 
-### CI/CD Pipeline
-
-All code changes are validated automatically via GitHub Actions before merge:
-
-#### Ansible CI
-- **YAML Linting** - Validates YAML syntax and formatting (`yamllint`)
-- **Ansible Linting** - Enforces best practices (`ansible-lint` production profile)
-- **Syntax Checking** - Validates playbook syntax (all playbooks in matrix)
-- **Security Scanning** - Checks for hardcoded secrets and vault encryption
-- **Best Practices** - Validates FQCN usage, become patterns, minimal shell usage
-
-See [infra/ansible/README.md](infra/ansible/README.md) for detailed Ansible documentation.
-
-### Pre-commit Hooks
-
-Install pre-commit hooks to run quality checks locally before committing:
+## Quick Start
 
 ```bash
-# Install pre-commit
-pip install pre-commit
-
-# Install hooks
-pre-commit install
-
-# Run manually on all files
-pre-commit run --all-files
+# Prerequisites: mise (https://mise.jdx.dev)
+mise setup             # Install dependencies + tools
+mise db:init           # Initialize SQLite database
+mise db:seed           # Seed with test data
+mise dev               # Start API + shell dev servers
 ```
 
-Hooks include:
-- `yamllint` - YAML syntax and formatting
-- `ansible-lint` - Ansible best practices
-- `detect-secrets` - Hardcoded credentials detection
-- `check-yaml` - YAML syntax validation
-- `trailing-whitespace` - Trailing whitespace removal
-- `end-of-file-fixer` - Ensure files end with newline
-- `check-added-large-files` - Prevent large file commits
+The shell runs at `localhost:5568`, the API at `localhost:3000`.
 
-### Task Runner (mise)
+## Development
 
-POPS uses [mise](https://mise.jdx.dev/) for task running and tool version management.
+See [`AGENTS.md`](AGENTS.md) for the full command reference, repo structure, data flows, and coding standards.
 
-**Installation:**
+### Key Commands
+
 ```bash
-curl https://mise.run | sh
-echo 'eval "$(/Users/helix/.local/bin/mise activate zsh)"' >> ~/.zshrc
-source ~/.zshrc
+mise dev               # All dev servers
+mise test              # All tests
+mise typecheck         # Type check all packages
+mise lint              # Lint all packages
+mise build             # Build all packages
 ```
 
-**Common Tasks:**
+### Database
+
 ```bash
-mise dev              # Run all dev servers
-mise dev:api          # Run pops-api only
-mise dev:shell        # Run pops-shell only
-
-mise test             # Run all tests
-mise typecheck        # Type check all packages
-mise build            # Build all packages
-
-mise setup            # Initial project setup
-mise tasks            # List all available tasks
+mise db:init           # Initialize empty database
+mise db:seed           # Seed with test data
+mise db:clear          # Clear all data (preserves schema)
 ```
 
-**Database Management:**
+### Quality Gate (pre-push)
+
 ```bash
-mise db:init          # Initialize empty database with schema
-mise db:clear         # Clear all data (preserves schema)
-mise db:seed          # Seed with comprehensive test data
+mise lint && mise typecheck    # Must pass before every push
 ```
 
-See `mise.toml` for all available tasks and [CLAUDE.md](CLAUDE.md) for detailed command reference.
+### E2E Tests
 
-### E2E Testing
-
-POPS uses Playwright for end-to-end tests with two modes:
-
-- **Mocked** — fast, no real API/DB, suitable for UI logic tests
-- **Integration** — real SQLite DB via the named env system, no external API calls
+Playwright with two modes: **mocked** (fast, no real DB) and **integration** (real SQLite via named env system). Named envs auto-skip external API calls — safe to run in CI without credentials.
 
 ```bash
-# Run all E2E tests
 cd apps/pops-shell && pnpm test:e2e
-
-# Run in UI mode (interactive)
-cd apps/pops-shell && pnpm test:e2e --ui
 ```
 
-The `globalSetup` creates an isolated `e2e` named environment (seeded SQLite DB) before the run. Tests route through `?env=e2e` so they hit real data without touching production. `globalTeardown` deletes the env after the run.
-
-Named envs auto-skip external API calls (Claude) — safe to run in CI without real credentials.
-
-### Local Development Setup
+## Deploy
 
 ```bash
-# Install Ansible tools
-pip install -r infra/ansible/requirements.txt
+./deploy.sh                    # Full deploy to N95 via Ansible
+./deploy.sh --dry-run          # Preview changes
+./deploy.sh --skip-checks      # Skip quality gates (faster)
+```
 
-# Install Ansible Galaxy collections
-ansible-galaxy collection install community.general
-ansible-galaxy collection install community.docker
+Requires: Ansible (`brew install ansible`), SSH key (`~/.ssh/pops_n95`), vault password (`~/.ansible/pops-vault-password`). See [`docs/DEPLOYMENT_SETUP.md`](docs/DEPLOYMENT_SETUP.md) for setup.
 
-# Run Ansible linting locally
-yamllint infra/ansible/
-ansible-lint infra/ansible/
+## Repo Structure
 
-# Syntax check playbooks
-cd infra/ansible
-ansible-playbook --syntax-check playbooks/site.yml
+```
+apps/
+├── pops-api/              # tRPC API (Express + Drizzle ORM + SQLite)
+├── pops-shell/            # React shell (Vite + nginx)
+└── moltbot/               # Telegram bot config + finance skill
+
+packages/
+├── app-finance/           # Finance domain UI
+├── app-media/             # Media domain UI
+├── app-inventory/         # Inventory domain UI
+├── app-ai/                # AI operations UI
+├── ui/                    # Shared component library (shadcn-based)
+├── db-types/              # Drizzle schema + TypeScript types
+├── api-client/            # tRPC client setup
+├── auth/                  # Authentication utilities
+├── navigation/            # App navigation config
+├── widgets/               # Dashboard widgets
+├── types/                 # Cross-package type definitions
+├── test-utils/            # Test helpers
+└── import-tools/          # Bank import scripts (standalone)
+
+infra/
+├── ansible/               # Provisioning + deployment playbooks
+└── docker-compose.yml     # Production service definitions
+
+docs/
+├── roadmap.md             # Implementation tracker
+└── themes/                # PRDs, epics, user stories
 ```


### PR DESCRIPTION
## Summary
- Rewrote README to reflect the actual platform: multi-domain (finance, media, inventory, AI ops), correct tech stack (tRPC, Drizzle, Tailwind v4, shadcn/ui), accurate architecture diagram, real phase statuses
- Removed personal bank account data and dead Notion page references
- Updated AGENTS.md: phase status (0+1 done, 2 in progress), replaced stale import tools section with current 7-stage entity matching chain, removed Notion IDs

## Test plan
- [ ] Docs-only change — verify markdown renders correctly on GitHub