### PR TITLE
feat(import-review): re-evaluate after ChangeSet approval

### DIFF
--- a/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
@@ -15,22 +15,25 @@ import {
   Badge,
   Separator,
 } from "@pops/ui";
-import type { inferRouterInputs } from "@trpc/server";
+import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import { toast } from "sonner";
 import type { AppRouter } from "@pops/api-client";
 import { trpc } from "../../lib/trpc";
 
 type CorrectionSignal =
   inferRouterInputs<AppRouter>["core"]["corrections"]["proposeChangeSet"]["signal"];
+type ApplyChangeSetAndReevaluateOutput =
+  inferRouterOutputs<AppRouter>["finance"]["imports"]["applyChangeSetAndReevaluate"];
 
 export interface CorrectionProposalDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  sessionId: string;
   signal: CorrectionSignal | null;
   /** Import-session descriptions used for deterministic previewChangeSet */
   previewTransactions: Array<{ checksum?: string; description: string }>;
   minConfidence?: number;
-  onApproved?: () => void;
+  onApproved?: (result: ApplyChangeSetAndReevaluateOutput["result"], affectedCount: number) => void;
 }
 
 function opLabel(op: { op: string }): string {
@@ -96,10 +99,10 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
     }
   );
 
-  const applyMutation = trpc.core.corrections.applyChangeSet.useMutation({
-    onSuccess: () => {
-      toast.success("Rules updated");
-      props.onApproved?.();
+  const applyMutation = trpc.finance.imports.applyChangeSetAndReevaluate.useMutation({
+    onSuccess: (res) => {
+      toast.success("Rules applied");
+      props.onApproved?.(res.result, res.affectedCount);
       props.onOpenChange(false);
       setFeedback("");
     },
@@ -129,7 +132,11 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
 
   const handleApprove = () => {
     if (!changeSet) return;
-    applyMutation.mutate({ changeSet });
+    if (!props.sessionId) {
+      toast.error("Missing import session id");
+      return;
+    }
+    applyMutation.mutate({ sessionId: props.sessionId, changeSet, minConfidence });
   };
 
   const handleReject = () => {
@@ -271,8 +278,8 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
           >
             Reject
           </Button>
-          <Button onClick={handleApprove} disabled={isBusy || !changeSet}>
-            Approve
+          <Button onClick={handleApprove} disabled={isBusy || !changeSet || !props.sessionId}>
+            {applyMutation.isPending ? "Applying & re-evaluating…" : "Approve"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/packages/app-finance/src/components/imports/ReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.test.tsx
@@ -116,12 +116,42 @@ vi.mock("./EntityCreateDialog", () => ({
 }));
 
 let lastProposalDialogProps: unknown = null;
+let proposalDialogApproveMode: "success" | "error" = "success";
+let proposalDialogApprovePayload: { result: unknown; affectedCount: number } | null = null;
 vi.mock("./CorrectionProposalDialog", async () => {
   const React = await import("react");
+  const { toast } = await import("sonner");
   return {
     CorrectionProposalDialog: (props: unknown) => {
       lastProposalDialogProps = props;
-      return React.createElement("div", { "data-testid": "proposal-dialog" });
+      const p = props as {
+        onApproved?: (result: unknown, affectedCount: number) => void;
+        sessionId?: string;
+      };
+      return React.createElement(
+        "div",
+        { "data-testid": "proposal-dialog" },
+        React.createElement(
+          "button",
+          {
+            "data-testid": "proposal-approve",
+            onClick: () => {
+              if (!p.sessionId) {
+                toast.error("Missing import session id");
+                return;
+              }
+              if (proposalDialogApproveMode === "error") {
+                toast.error("boom");
+                return;
+              }
+              const payload =
+                proposalDialogApprovePayload ?? ({ result: {}, affectedCount: 0 } as const);
+              p.onApproved?.(payload.result, payload.affectedCount);
+            },
+          },
+          "Approve"
+        )
+      );
     },
   };
 });
@@ -297,6 +327,8 @@ function makeTx(description: string, overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   lastProposalDialogProps = null;
+  proposalDialogApproveMode = "success";
+  proposalDialogApprovePayload = null;
   mockEntitiesQuery.mockReturnValue({
     data: {
       data: [
@@ -473,6 +505,54 @@ describe("ReviewStep — Save & Learn proposal flow", () => {
       (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("Applied to")
     );
     expect(appliedToCalls).toHaveLength(0);
+  });
+
+  it("approval updates localTransactions with re-evaluated result and shows affected-count toast", async () => {
+    mockProcessedTransactions = {
+      matched: [],
+      uncertain: [makeTx("WOOLWORTHS 1234 SYDNEY")],
+      failed: [],
+      skipped: [],
+    };
+    render(<ReviewStep />);
+
+    proposalDialogApprovePayload = {
+      result: {
+        matched: [makeTx("WOOLWORTHS 1234 SYDNEY", { status: "matched" })],
+        uncertain: [],
+        failed: [],
+        skipped: [],
+      },
+      affectedCount: 1,
+    };
+
+    fireEvent.click(screen.getByTestId("proposal-approve"));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Matched \(1\)/)).toBeInTheDocument();
+      expect(screen.getByText(/Uncertain \(0\)/)).toBeInTheDocument();
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      expect.stringContaining("Rules applied — 1 transaction re-evaluated")
+    );
+  });
+
+  it("approval failure shows error toast and local state remains unchanged", async () => {
+    mockProcessedTransactions = {
+      matched: [],
+      uncertain: [makeTx("WOOLWORTHS 1234 SYDNEY")],
+      failed: [],
+      skipped: [],
+    };
+    render(<ReviewStep />);
+
+    proposalDialogApproveMode = "error";
+    fireEvent.click(screen.getByTestId("proposal-approve"));
+
+    expect(mockToastError).toHaveBeenCalledWith("boom");
+    expect(screen.getByText(/Matched \(0\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Uncertain \(1\)/)).toBeInTheDocument();
   });
 });
 

--- a/packages/app-finance/src/components/imports/ReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.tsx
@@ -23,8 +23,14 @@ type ViewMode = "list" | "grouped";
  * Step 4: Review transactions and resolve uncertain/failed matches
  */
 export function ReviewStep() {
-  const { processedTransactions, setConfirmedTransactions, nextStep, prevStep, findSimilar } =
-    useImportStore();
+  const {
+    processedTransactions,
+    processSessionId,
+    setConfirmedTransactions,
+    nextStep,
+    prevStep,
+    findSimilar,
+  } = useImportStore();
 
   const [localTransactions, setLocalTransactions] = useState(processedTransactions);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
@@ -199,8 +205,6 @@ export function ReviewStep() {
   }, []);
 
   const analyzeCorrectionMutation = trpc.core.corrections.analyzeCorrection.useMutation();
-  // NOTE: The backend supports apply+re-evaluate, but for now this UI uses core.corrections.applyChangeSet
-  // and leaves import-session re-evaluation as a follow-up task.
 
   const computeFallbackPattern = useCallback((description: string) => {
     return description.toUpperCase().replace(/\d+/g, "").replace(/\s+/g, " ").trim();
@@ -635,6 +639,7 @@ export function ReviewStep() {
       <CorrectionProposalDialog
         open={proposalOpen}
         onOpenChange={setProposalOpen}
+        sessionId={processSessionId ?? ""}
         signal={proposalSignal}
         previewTransactions={[
           ...localTransactions.matched,
@@ -642,8 +647,11 @@ export function ReviewStep() {
           ...localTransactions.failed,
           ...localTransactions.skipped,
         ].map((t) => ({ checksum: t.checksum, description: t.description }))}
-        onApproved={() => {
-          // TODO(#1647): Re-evaluate remaining transactions after approval.
+        onApproved={(result, affectedCount) => {
+          setLocalTransactions(result);
+          toast.success(
+            `Rules applied — ${affectedCount} transaction${affectedCount === 1 ? "" : "s"} re-evaluated`
+          );
         }}
       />
       <div>


### PR DESCRIPTION
## Summary
- Wire `CorrectionProposalDialog` to call `finance.imports.applyChangeSetAndReevaluate`.
- Flow `processSessionId` from import store → ReviewStep → dialog and update ReviewStep `localTransactions` with the returned re-evaluated `ProcessImportOutput`.
- Show affected-count toast and remove the re-eval TODO.

## Test plan
- [x] `cd packages/app-finance && pnpm lint && pnpm typecheck && pnpm test`
- [x] `mise lint`
- [x] `mise typecheck`