### PR TITLE
refactor(infra): genericize server refs, .env-configurable deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,12 @@ PAPERLESS_API_TOKEN=
 
 # Paths
 SQLITE_PATH=./data/pops.db
+
+# Server deployment (used by deploy.sh and Ansible)
+POPS_SSH_KEY=~/.ssh/pops
+POPS_HOST=pops.local
+POPS_SSH_PORT=2222
+POPS_SSH_USER=pops
+POPS_DOMAIN=example.com
+POPS_RUNNER_NAME=pops-runner
+POPS_RUNNER_LABELS=self-hosted,linux,x64

--- a/.github/workflows/root-deploy.yml
+++ b/.github/workflows/root-deploy.yml
@@ -150,15 +150,14 @@ jobs:
         env:
           BUILD_VERSION: ${{ github.run_number }}
 
-  # Deploy to N95 server
+  # Deploy to server
   deploy:
-    name: Deploy to N95
+    name: Deploy
     runs-on: self-hosted
     needs: [changes, lint, typecheck, test, build]
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy_needed == 'true'
     environment:
       name: production
-      url: https://pops.jmiranda.dev
     env:
       BUILD_VERSION: ${{ github.run_number }}
 

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -81,5 +81,5 @@ Neutral, direct, efficient. Labels and microcopy should be concise and precise. 
 - shadcn/ui primitives + Radix UI
 - CVA (class-variance-authority) for component variants
 - PWA: standalone mode, `apple-mobile-web-app-capable`
-- Self-hosted on N95 mini PC — performance matters, no CDN dependencies
+- Self-hosted on a home server — performance matters, no CDN dependencies
 - Theme color: `#1a1a2e` (dark indigo)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ If another agent-specific file exists (e.g. `CLAUDE.md`), it should **only** poi
 
 ## Project Overview
 
-POPS (Personal Operations System) is a self-hosted personal operations platform covering finance, media, inventory, and AI. SQLite is the **primary data store**. Self-hosted services on an N95 mini PC provide analytics, dashboards, and AI-powered automation. Cloudflare Tunnel exposes services with zero port forwarding.
+POPS (Personal Operations System) is a self-hosted personal operations platform covering finance, media, inventory, and AI. SQLite is the **primary data store**. Self-hosted services on a home server provide analytics, dashboards, and AI-powered automation. Cloudflare Tunnel exposes services with zero port forwarding.
 
 **Domains:** Finance (transactions, budgets, entities) | Media (movies, TV, watchlist, watch history, Plex/TMDB/TVDB integration) | Inventory (items, locations, warranties, insurance) | AI (usage tracking, model config, rules)
 
@@ -60,7 +60,7 @@ mise docker:logs      # Show logs
 
 **Ansible:**
 ```bash
-mise ansible:provision    # Full N95 provision
+mise ansible:provision    # Full server provision
 mise ansible:deploy       # Deploy services only
 mise ansible:check        # Syntax check
 mise ansible:view         # View vault contents (read-only)
@@ -139,7 +139,7 @@ docker compose -f infra/docker-compose.yml config          # Validate compose fi
 # All ansible commands must run from the infra/ansible/ directory due to relative roles_path
 cd infra/ansible
 
-# Provision fresh N95 (full run)
+# Provision fresh server (full run)
 ansible-playbook playbooks/site.yml
 
 # Deploy/update services only (skip OS hardening)
@@ -186,7 +186,7 @@ infra/
 - `packages/app-*` — Domain-specific frontend packages (pages, components, hooks)
 - `packages/db-types/` — Drizzle schema definitions and inferred TypeScript types
 - `packages/import-tools/` — Bank import scripts (standalone, not in pnpm workspace)
-- `infra/ansible/` — Ansible playbooks + roles for provisioning the N95 mini PC
+- `infra/ansible/` — Ansible playbooks + roles for provisioning the home server
 
 ### Docker Networks
 - `pops-frontend` — cloudflared, pops-shell, metabase, pops-api
@@ -206,7 +206,7 @@ Interfaces: iPhone (PWA) | Telegram (Moltbot) | Web (Metabase)
     │
     Cloudflare Tunnel + Cloudflare Access (Zero Trust)
     │
-N95 Mini PC (Docker Compose):
+Server (Docker Compose):
     pops-api ── Node.js tRPC API over SQLite (Drizzle ORM)
     metabase ───── Dashboards & analytics
     moltbot ────── AI assistant (Telegram + finance plugin)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POPS — Personal Operations System
 
-Self-hosted personal operations platform. Finance, media tracking, home inventory, and AI operations — all in one monorepo, running on an N95 mini PC behind Cloudflare Tunnel.
+Self-hosted personal operations platform. Finance, media tracking, home inventory, and AI operations — all in one monorepo, deployed to a home server behind Cloudflare Tunnel.
 
 SQLite is the source of truth. Claude API handles categorization and entity matching. Everything deploys via Ansible + Docker Compose.
 
@@ -12,7 +12,7 @@ Interfaces
        │
   Cloudflare Tunnel + Zero Trust
        │
-N95 Mini PC (Docker Compose)
+Server (Docker Compose)
   pops-shell ──── React PWA (Vite + nginx)
   pops-api ────── tRPC API (Express + Drizzle ORM + SQLite)
   metabase ────── Dashboards & analytics
@@ -125,12 +125,12 @@ cd apps/pops-shell && pnpm test:e2e
 ## Deploy
 
 ```bash
-./deploy.sh                    # Full deploy to N95 via Ansible
+./deploy.sh                    # Full deploy via Ansible
 ./deploy.sh --dry-run          # Preview changes
 ./deploy.sh --skip-checks      # Skip quality gates (faster)
 ```
 
-Requires: Ansible (`brew install ansible`), SSH key (`~/.ssh/pops_n95`), vault password (`~/.ansible/pops-vault-password`). See [`docs/DEPLOYMENT_SETUP.md`](docs/DEPLOYMENT_SETUP.md) for setup.
+Requires: Ansible (`brew install ansible`), SSH key (configured via `POPS_SSH_KEY` in `.env`), vault password (`~/.ansible/pops-vault-password`). See [`docs/DEPLOYMENT_SETUP.md`](docs/DEPLOYMENT_SETUP.md) for setup.
 
 ## Repo Structure
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,11 +4,26 @@ set -e
 # POPS Deployment Script
 # Usage: ./deploy.sh [options]
 #
-# Simple one-command deployment to N95 server.
-# Runs Ansible playbook to deploy latest code.
+# One-command deployment to the POPS server.
+# Reads server config from .env (POPS_HOST, POPS_SSH_KEY, etc.)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+
+# Load .env if it exists (for POPS_HOST, POPS_SSH_KEY, etc.)
+if [ -f .env ]; then
+    set -a
+    # shellcheck disable=SC1091
+    source .env
+    set +a
+fi
+
+# Server configuration (from .env or defaults)
+POPS_SSH_KEY="${POPS_SSH_KEY:-~/.ssh/pops}"
+POPS_HOST="${POPS_HOST:-pops.local}"
+POPS_SSH_PORT="${POPS_SSH_PORT:-2222}"
+POPS_SSH_USER="${POPS_SSH_USER:-pops}"
+POPS_DOMAIN="${POPS_DOMAIN:-}"
 
 # Colors
 RED='\033[0;31m'
@@ -56,6 +71,13 @@ while [[ $# -gt 0 ]]; do
             echo "  ./deploy.sh                 # Deploy to production"
             echo "  ./deploy.sh --dry-run       # Preview changes"
             echo "  ./deploy.sh -v              # Deploy with verbose output"
+            echo ""
+            echo "Server config (from .env):"
+            echo "  POPS_HOST=$POPS_HOST"
+            echo "  POPS_SSH_KEY=$POPS_SSH_KEY"
+            echo "  POPS_SSH_PORT=$POPS_SSH_PORT"
+            echo "  POPS_SSH_USER=$POPS_SSH_USER"
+            echo "  POPS_DOMAIN=$POPS_DOMAIN"
             exit 0
             ;;
         *)
@@ -69,6 +91,9 @@ echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━�
 echo -e "${BLUE}POPS Deployment${NC}"
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo ""
+
+# Expand tilde in SSH key path
+POPS_SSH_KEY="${POPS_SSH_KEY/#\~/$HOME}"
 
 # Check prerequisites
 echo -e "${YELLOW}Checking prerequisites...${NC}"
@@ -87,20 +112,20 @@ if [ ! -f ~/.ansible/pops-vault-password ]; then
 fi
 echo -e "${GREEN}✓ Vault password configured${NC}"
 
-if [ ! -f ~/.ssh/pops_n95 ]; then
+if [ ! -f "$POPS_SSH_KEY" ]; then
     echo -e "${RED}✗ SSH key not found${NC}"
-    echo "Expected: ~/.ssh/pops_n95"
+    echo "Expected: $POPS_SSH_KEY (set POPS_SSH_KEY in .env)"
     exit 1
 fi
 echo -e "${GREEN}✓ SSH key found${NC}"
 
 # Test SSH connection
 echo -e "${YELLOW}Testing SSH connection...${NC}"
-if ssh -p 2222 -i ~/.ssh/pops_n95 -o ConnectTimeout=5 pops@pops.local "echo 'SSH OK'" > /dev/null 2>&1; then
+if ssh -p "$POPS_SSH_PORT" -i "$POPS_SSH_KEY" -o ConnectTimeout=5 "${POPS_SSH_USER}@${POPS_HOST}" "echo 'SSH OK'" > /dev/null 2>&1; then
     echo -e "${GREEN}✓ SSH connection successful${NC}"
 else
-    echo -e "${RED}✗ Cannot connect to N95${NC}"
-    echo "Check that N95 is reachable at pops.local:2222"
+    echo -e "${RED}✗ Cannot connect to server${NC}"
+    echo "Check that ${POPS_HOST}:${POPS_SSH_PORT} is reachable"
     exit 1
 fi
 
@@ -180,7 +205,7 @@ echo ""
 
 # Show deployment info
 echo -e "${BLUE}Deployment details:${NC}"
-echo "  Target: pops.local (N95 server)"
+echo "  Target: ${POPS_HOST}"
 echo "  Branch: $(git branch --show-current)"
 echo "  Commit: $(git rev-parse --short HEAD)"
 echo "  Version: $NEXT_VERSION"
@@ -203,6 +228,14 @@ echo -e "${YELLOW}Running Ansible deployment...${NC}"
 echo ""
 
 ANSIBLE_ARGS="-i inventory/hosts.yml --vault-password-file ~/.ansible/pops-vault-password"
+ANSIBLE_ARGS="$ANSIBLE_ARGS -e ansible_ssh_private_key_file=$POPS_SSH_KEY"
+ANSIBLE_ARGS="$ANSIBLE_ARGS -e ansible_host=$POPS_HOST"
+ANSIBLE_ARGS="$ANSIBLE_ARGS -e ansible_port=$POPS_SSH_PORT"
+ANSIBLE_ARGS="$ANSIBLE_ARGS -e ansible_user=$POPS_SSH_USER"
+
+if [ -n "$POPS_DOMAIN" ]; then
+    ANSIBLE_ARGS="$ANSIBLE_ARGS -e domain=$POPS_DOMAIN"
+fi
 
 if [ "$DRY_RUN" = true ]; then
     ANSIBLE_ARGS="$ANSIBLE_ARGS --check"
@@ -230,7 +263,7 @@ Deployed services:
 - pops-shell: $(cd apps/pops-shell && git log -1 --pretty=format:'%h %s')
 
 Deployed at: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-Deployed to: pops.local (N95)"
+Deployed to: ${POPS_HOST}"
 
         git tag -a "$NEXT_VERSION" -m "$COMMIT_MSG"
         echo -e "${GREEN}✓ Created tag $NEXT_VERSION${NC}"
@@ -244,17 +277,18 @@ Deployed to: pops.local (N95)"
 
         echo ""
         echo "Services deployed:"
-        echo "  • Finance API:    http://localhost:3000"
-        echo "  • Shell:          https://pops.jmiranda.dev"
-        echo "  • Metabase:       http://localhost:3001"
+        echo "  • API:       http://localhost:3000"
+        if [ -n "$POPS_DOMAIN" ]; then
+            echo "  • Shell:     https://pops.${POPS_DOMAIN}"
+        fi
         echo ""
         echo "Version: $NEXT_VERSION"
         echo ""
         echo "Check status:"
-        echo "  ssh -p 2222 pops@pops.local 'cd /opt/pops && docker compose ps'"
+        echo "  ssh -p ${POPS_SSH_PORT} ${POPS_SSH_USER}@${POPS_HOST} 'cd /opt/pops && docker compose ps'"
         echo ""
         echo "View logs:"
-        echo "  ssh -p 2222 pops@pops.local 'cd /opt/pops && docker compose logs -f'"
+        echo "  ssh -p ${POPS_SSH_PORT} ${POPS_SSH_USER}@${POPS_HOST} 'cd /opt/pops && docker compose logs -f'"
     fi
 else
     echo ""
@@ -265,6 +299,6 @@ else
     echo "Check Ansible output above for errors"
     echo ""
     echo "View server logs:"
-    echo "  ssh -p 2222 pops@pops.local 'cd /opt/pops && docker compose logs --tail=50'"
+    echo "  ssh -p ${POPS_SSH_PORT} ${POPS_SSH_USER}@${POPS_HOST} 'cd /opt/pops && docker compose logs --tail=50'"
     exit 1
 fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ## What is POPS?
 
-POPS (Personal Operations System) is a self-hosted platform that manages finances, home inventory, media tracking, and more — from a single shell, one database, one API. It runs on an N95 mini PC behind Cloudflare Tunnel with zero port forwarding.
+POPS (Personal Operations System) is a self-hosted platform that manages finances, home inventory, media tracking, and more — from a single shell, one database, one API. It runs on a home server behind Cloudflare Tunnel with zero port forwarding.
 
 See [vision.md](vision.md) for the full design philosophy.
 
@@ -52,4 +52,4 @@ See [CLAUDE.md](CLAUDE.md) for templates and standards.
 
 ## Current State
 
-POPS has a working platform with 4 apps (Finance, Media, Inventory, AI), deployed on an N95 mini PC with Docker, Cloudflare Tunnel, and CI/CD. See the [roadmap implementation tracker](roadmap.md#implementation-tracker) for detailed status.
+POPS has a working platform with 4 apps (Finance, Media, Inventory, AI), deployed on a home server with Docker, Cloudflare Tunnel, and CI/CD. See the [roadmap implementation tracker](roadmap.md#implementation-tracker) for detailed status.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,7 @@ Live status of every theme and epic. Updated as work completes.
 
 | Epic                            | Status | Notes                               |
 | ------------------------------- | ------ | ----------------------------------- |
-| N95 provisioning & OS hardening | Done   | Ansible playbook, SSH, firewall     |
+| Server provisioning & OS hardening | Done   | Ansible playbook, SSH, firewall     |
 | Docker Compose & networking     | Done   | 3 networks, 7+ services             |
 | Cloudflare Tunnel + Access      | Done   | Zero-trust, no port forwarding      |
 | CI/CD workflows                 | Done   | 8 GitHub Actions workflows          |
@@ -152,7 +152,7 @@ Live status of every theme and epic. Updated as work completes.
 
 > Provision the hardware and deployment pipeline that runs everything.
 
-- **N95 Mini PC** — Provision, harden, Docker runtime
+- **Server** — Provision, harden, Docker runtime
 - **Networking** — Cloudflare Tunnel, zero-trust access, Docker networks
 - **CI/CD** — GitHub Actions, automated quality gates, deployment workflows
 - **Secrets** — Ansible Vault, Docker secrets, environment management

--- a/docs/runbooks/go-live.md
+++ b/docs/runbooks/go-live.md
@@ -1,6 +1,6 @@
 # Go-Live Runbook
 
-Step-by-step procedure for transitioning from a dev database to production data on the N95 mini PC.
+Step-by-step procedure for transitioning from a dev database to production data on the server.
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@ Before starting, verify all of the following:
 - [ ] Production guards are active (`db:init`, `db:seed`, `db:clear` refuse to run when `NODE_ENV=production` — PRD-060 US-02)
 - [ ] Pre-migration backup is working (VACUUM INTO before migrations — PRD-060 US-03)
 - [ ] All pending migrations apply cleanly to a seeded test database
-- [ ] `.env` on the N95 has correct values (Up API token, TMDB key, Plex URL/token, Claude API key)
+- [ ] `.env` on the server has correct values (Up API token, TMDB key, Plex URL/token, Claude API key)
 - [ ] Ansible vault is up to date (`mise ansible:view` to confirm)
 
 ## Step 1: Deploy Fresh
@@ -167,7 +167,7 @@ mise audit
 | `mise entities:lookup` | Safe | Rebuild entity cache |
 | `mise docker:up` | Safe | Start/restart services |
 | `mise docker:down` | Safe | Stop services |
-| `mise ansible:deploy` | Careful | Deploy to N95 |
+| `mise ansible:deploy` | Careful | Deploy to server |
 | `drizzle-kit generate` | Careful | Generate schema migration |
 | `drizzle-kit migrate` | Careful | Apply pending migrations (prefer auto-apply on startup) |
 | `mise import:*` | Careful | Import bank data (idempotent, but verify first) |

--- a/docs/themes/00-infrastructure/README.md
+++ b/docs/themes/00-infrastructure/README.md
@@ -20,7 +20,7 @@ Set up a self-hosted production environment on dedicated hardware with zero-trus
 
 | # | Epic | Summary | Status |
 |---|------|---------|--------|
-| 0 | [Hardware & OS](epics/00-hardware-os.md) | N95 provisioning, OS hardening, SSH, firewall | Done |
+| 0 | [Hardware & OS](epics/00-hardware-os.md) | Server provisioning, OS hardening, SSH, firewall | Done |
 | 1 | [Docker Runtime](epics/01-docker-runtime.md) | Docker Compose, multi-network architecture, health checks, volumes | Done |
 | 2 | [Networking & Access](epics/02-networking-access.md) | Cloudflare Tunnel ingress, Cloudflare Access zero-trust auth | Done |
 | 3 | [Secrets Management](epics/03-secrets-management.md) | Ansible Vault for provisioning, Docker secrets for runtime | Done |

--- a/docs/themes/00-infrastructure/epics/04-cicd-pipelines.md
+++ b/docs/themes/00-infrastructure/epics/04-cicd-pipelines.md
@@ -4,7 +4,7 @@
 
 ## Scope
 
-GitHub Actions workflows for quality gates (typecheck, lint, test, build) and automated deployment. Merges to main auto-deploy to the N95 via a self-hosted runner. Smart deploy detects what changed and only rebuilds/restarts affected services.
+GitHub Actions workflows for quality gates (typecheck, lint, test, build) and automated deployment. Merges to main auto-deploy to the server via a self-hosted runner. Smart deploy detects what changed and only rebuilds/restarts affected services.
 
 ## PRDs
 

--- a/docs/themes/00-infrastructure/prds/061-smart-deploy/README.md
+++ b/docs/themes/00-infrastructure/prds/061-smart-deploy/README.md
@@ -10,7 +10,7 @@ Build a deploy pipeline that detects which services changed and only rebuilds/re
 ## Current State
 
 Every merge to main triggers a full Ansible deploy that:
-1. Git pulls the entire repo on the N95
+1. Git pulls the entire repo on the server
 2. Templates the docker-compose.yml
 3. Builds ALL custom Docker images (pops-api, pops-shell)
 4. Pulls ALL third-party images (metabase, paperless, moltbot, cloudflared)
@@ -120,12 +120,12 @@ US-01 and US-05 can start in parallel. US-02 and US-03 depend on US-01. US-04 de
 - Infra PR merges → full Ansible deploy
 - Health check catches a broken container and triggers full deploy recovery
 - Manual workflow_dispatch always does full deploy
-- Runner provisioning via Ansible works on a fresh N95
+- Runner provisioning via Ansible works on a fresh server
 
 ## Out of Scope
 
 - Blue/green or canary deployments
 - Rollback mechanism (revert the PR instead)
 - Multi-environment deployment (staging, production)
-- Container registry (images built locally on the N95)
+- Container registry (images built locally on the server)
 - Deployment notifications (Slack, email)

--- a/docs/themes/00-infrastructure/prds/061-smart-deploy/us-02-selective-build.md
+++ b/docs/themes/00-infrastructure/prds/061-smart-deploy/us-02-selective-build.md
@@ -14,7 +14,7 @@ As a developer, I want the deploy to only rebuild and restart services that chan
 - [x] If `backend` is true and `infra` is false: run `docker compose build pops-api && docker compose up -d pops-api`
 - [x] If both `frontend` and `backend` are true: build and restart both (but not third-party images)
 - [x] If `infra` is true: run full Ansible deploy (current behaviour)
-- [x] Docker commands run in the compose directory on the N95 (`/opt/pops`)
+- [x] Docker commands run in the compose directory on the server (`/opt/pops`)
 - [x] Git pull runs before any build to get latest code
 - [x] Docker layer caching reduces rebuild time for incremental changes
 - [x] Manual `workflow_dispatch` always triggers full deploy regardless of path detection

--- a/docs/themes/00-infrastructure/prds/061-smart-deploy/us-03-skip-deploy.md
+++ b/docs/themes/00-infrastructure/prds/061-smart-deploy/us-03-skip-deploy.md
@@ -11,7 +11,7 @@ As a developer, I want merges that only change documentation or CI workflows to 
 
 - [x] If path detection (us-01) sets `skip_deploy` to true, the deploy job exits early with success
 - [x] Deploy job logs: "No application changes — skipping deploy"
-- [x] No Docker commands, no Ansible, no git pull on the N95
+- [x] No Docker commands, no Ansible, no git pull on the server
 - [x] The deploy workflow still reports as "success" in GitHub (not skipped) so it doesn't block future required checks
 - [x] Applies to changes in: `docs/**`, `.github/workflows/**`, `*.md` at root, `packages/test-utils/**`
 - [x] Does NOT skip if any application code also changed in the same merge

--- a/docs/themes/00-infrastructure/prds/061-smart-deploy/us-05-ansible-runner-provisioning.md
+++ b/docs/themes/00-infrastructure/prds/061-smart-deploy/us-05-ansible-runner-provisioning.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-As a developer, I want the GitHub Actions self-hosted runner to be set up automatically by Ansible provisioning so that a fresh N95 server gets the runner without manual steps.
+As a developer, I want the GitHub Actions self-hosted runner to be set up automatically by Ansible provisioning so that a fresh server gets the runner without manual steps.
 
 ## Acceptance Criteria
 
@@ -16,8 +16,8 @@ As a developer, I want the GitHub Actions self-hosted runner to be set up automa
 - [x] Role ensures the service is enabled and started
 - [x] Role is idempotent — running it again on an already-configured runner is a no-op
 - [x] Registration token is fetched via the GitHub API (requires a PAT or app token stored in Ansible Vault)
-- [x] Runner labels: `self-hosted`, `linux`, `x64`, `n95`
-- [x] Runner name: `pops-n95`
+- [x] Runner labels: configured via `POPS_RUNNER_LABELS` env var
+- [x] Runner name: configured via `POPS_RUNNER_NAME` env var
 - [x] Role included in `playbooks/site.yml` (full provision) but NOT in `playbooks/deploy.yml` (service deploy only)
 - [x] Ansible vault password file is created at `~/.ansible/pops-vault-password` with correct permissions (600)
 - [x] Ansible itself is installed (via apt) as a dependency

--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -1,6 +1,6 @@
 # Ansible Infrastructure
 
-Infrastructure-as-code for POPS (Personal Operations System) deployment on N95 mini PC running Ubuntu 24.04.
+Infrastructure-as-code for POPS (Personal Operations System) deployment on Ubuntu 24.04.
 
 ## Directory Structure
 
@@ -94,7 +94,7 @@ ansible-playbook ansible/playbooks/site.yml --check
 ansible-playbook ansible/playbooks/site.yml
 
 # Limit to specific host
-ansible-playbook ansible/playbooks/site.yml --limit pops-n95
+ansible-playbook ansible/playbooks/site.yml --limit server
 
 # Run specific tags
 ansible-playbook ansible/playbooks/site.yml --tags docker,deploy

--- a/infra/ansible/inventory/group_vars/pops_servers/vars.yml
+++ b/infra/ansible/inventory/group_vars/pops_servers/vars.yml
@@ -1,13 +1,13 @@
 ---
 # Non-secret configuration for POPS servers
 
-domain: jmiranda.dev
+domain: example.com  # Override via POPS_DOMAIN in .env
 timezone: Australia/Melbourne
 
 # Service user (created by bootstrap playbook)
 pops_user: pops
 
-# Paths on the N95
+# Paths on the server
 docker_compose_dir: /opt/pops
 sqlite_data_dir: /opt/pops/data/sqlite
 paperless_data_dir: /opt/pops/data/paperless

--- a/infra/ansible/inventory/hosts.yml
+++ b/infra/ansible/inventory/hosts.yml
@@ -3,9 +3,9 @@ all:
   children:
     pops_servers:
       hosts:
-        n95:
+        server:
           ansible_host: pops.local
           ansible_port: 2222
           ansible_user: pops
-          ansible_ssh_private_key_file: ~/.ssh/pops_n95
+          ansible_ssh_private_key_file: ~/.ssh/pops
           ansible_python_interpreter: /usr/bin/python3

--- a/infra/ansible/playbooks/bootstrap.yml
+++ b/infra/ansible/playbooks/bootstrap.yml
@@ -32,7 +32,7 @@
     - name: Deploy SSH public key for pops
       ansible.posix.authorized_key:
         user: "{{ pops_user }}"
-        key: "{{ lookup('file', '~/.ssh/pops_n95.pub') }}"
+        key: "{{ lookup('file', ansible_ssh_private_key_file + '.pub') }}"
         state: present
 
     - name: Allow pops passwordless sudo
@@ -46,7 +46,7 @@
 
     - name: Verify SSH key login works
       ansible.builtin.command:
-        cmd: "ssh -i ~/.ssh/pops_n95 -o StrictHostKeyChecking=no -o BatchMode=yes {{ pops_user }}@{{ ansible_host }} whoami"
+        cmd: "ssh -i {{ ansible_ssh_private_key_file }} -o StrictHostKeyChecking=no -o BatchMode=yes {{ pops_user }}@{{ ansible_host }} whoami"
       delegate_to: localhost
       become: false
       changed_when: false

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     environment:
       PAPERLESS_SECRET_KEY_FILE: /run/secrets/paperless_secret_key
       PAPERLESS_REDIS: redis://paperless-redis:6379
-      PAPERLESS_URL: https://pops-paperless.jmiranda.dev
+      PAPERLESS_URL: https://pops-paperless.${POPS_DOMAIN:-localhost}
       PAPERLESS_TIME_ZONE: Australia/Melbourne
       PAPERLESS_OCR_LANGUAGE: eng
       PAPERLESS_ADMIN_USER: admin

--- a/infra/recovery.md
+++ b/infra/recovery.md
@@ -7,7 +7,7 @@
 
 | Requirement            | Details                                                                                                                                   |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| SSH access             | Port 2222 on the N95 (or physical access)                                                                                                 |
+| SSH access             | Port 2222 on the server (or physical access)                                                                                              |
 | rclone                 | Installed and configured with the `pops-b2` remote                                                                                        |
 | age                    | Installed (`apt install age`)                                                                                                             |
 | Backup passphrase      | From Ansible Vault (`vault_backup_encryption_passphrase`) — also stored in `/opt/pops/secrets/backup_encryption_passphrase` on the server |
@@ -155,7 +155,7 @@ If the server is completely new (fresh OS install):
 5. **Start services** — `docker compose up -d`
 6. **Verify** — follow Step 8
 7. **Re-enable backup timer** — `sudo systemctl enable --now pops-backup.timer`
-8. **Verify Cloudflare Tunnel** — check `https://pops.jmiranda.dev` is accessible
+8. **Verify Cloudflare Tunnel** — check the public URL is accessible (domain configured via `POPS_DOMAIN` in `.env`)
 
 ## Troubleshooting
 

--- a/mise.toml
+++ b/mise.toml
@@ -226,7 +226,7 @@ run = "docker compose -f infra/docker-compose.yml --profile tools run --rm tools
 # ============================================================================
 
 [tasks."ansible:provision"]
-description = "Provision fresh N95 (full run)"
+description = "Provision fresh server (full run)"
 dir = "infra/ansible"
 run = "ansible-playbook playbooks/site.yml"
 

--- a/scripts/setup-github-runner.sh
+++ b/scripts/setup-github-runner.sh
@@ -1,23 +1,40 @@
 #!/bin/bash
 set -e
 
-# Setup GitHub Actions self-hosted runner on N95 server
+# Setup GitHub Actions self-hosted runner on the POPS server
 # Usage: ./scripts/setup-github-runner.sh <GITHUB_TOKEN>
+#
+# Configure runner name/labels via .env:
+#   POPS_RUNNER_NAME=pops-runner
+#   POPS_RUNNER_LABELS=self-hosted,linux,x64
 
 if [ -z "$1" ]; then
     echo "Usage: $0 <GITHUB_TOKEN>"
     echo ""
-    echo "Get token from: https://github.com/joaopcmiranda/pops/settings/actions/runners/new"
+    echo "Get token from: Settings > Actions > Runners > New self-hosted runner"
     exit 1
+fi
+
+# Load .env if it exists
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/.env"
+    set +a
 fi
 
 RUNNER_TOKEN="$1"
 RUNNER_VERSION="2.313.0"
 WORK_DIR="/opt/pops/actions-runner"
+RUNNER_NAME="${POPS_RUNNER_NAME:-pops-runner}"
+RUNNER_LABELS="${POPS_RUNNER_LABELS:-self-hosted,linux,x64}"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "GitHub Actions Runner Setup"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Name:   $RUNNER_NAME"
+echo "  Labels: $RUNNER_LABELS"
 
 # Create runner directory
 echo "Creating runner directory..."
@@ -36,11 +53,12 @@ tar xzf "./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
 
 # Configure runner
 echo "Configuring runner..."
+REPO_URL=$(cd "$SCRIPT_DIR" && git remote get-url origin | sed 's/git@github.com:/https:\/\/github.com\//' | sed 's/\.git$//')
 ./config.sh \
-    --url https://github.com/joaopcmiranda/pops \
+    --url "$REPO_URL" \
     --token "$RUNNER_TOKEN" \
-    --name "n95-pops-runner" \
-    --labels "self-hosted,linux,x64,n95" \
+    --name "$RUNNER_NAME" \
+    --labels "$RUNNER_LABELS" \
     --work _work \
     --replace
 
@@ -59,12 +77,12 @@ sudo ./svc.sh start
 # Check status
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "✅ Runner setup complete!"
+echo "Runner setup complete!"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 sudo ./svc.sh status
 
 echo ""
 echo "Next steps:"
-echo "1. Verify runner appears in GitHub: https://github.com/joaopcmiranda/pops/settings/actions/runners"
+echo "1. Verify runner appears in GitHub repo Settings > Actions > Runners"
 echo "2. Push a commit to main to trigger deployment"
 echo "3. Monitor logs: sudo journalctl -u actions.runner.* -f"


### PR DESCRIPTION
## Summary
- Replace all N95 hardware-specific and personal (`jmiranda.dev`) references with generic terms across 23 files
- `deploy.sh` now reads `POPS_HOST`, `POPS_SSH_KEY`, `POPS_SSH_PORT`, `POPS_SSH_USER`, `POPS_DOMAIN` from `.env`
- Ansible inventory uses generic host alias (`server`) and SSH key path (`~/.ssh/pops`)
- `docker-compose.yml` uses `${POPS_DOMAIN:-localhost}` for Paperless URL
- GitHub runner setup script derives repo URL from git remote, uses `.env` for name/labels
- `.env.example` updated with all new deployment vars using non-identifying defaults

## Test plan
- [ ] Verify `deploy.sh --help` shows .env config values
- [ ] Verify `deploy.sh --dry-run` connects with correct SSH params from .env
- [ ] Confirm Ansible `hosts.yml` loads correctly with new host alias
- [ ] Confirm CI workflow runs without the hardcoded environment URL