### PR TITLE
feat(entities): complete entity CRUD (PRD-023 US-01)

### DIFF
--- a/apps/pops-api/src/modules/core/entities/entities.test.ts
+++ b/apps/pops-api/src/modules/core/entities/entities.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { TRPCError } from "@trpc/server";
 import type { Database } from "better-sqlite3";
-import { setupTestContext, seedEntity, createCaller } from "../../../shared/test-utils.js";
+import {
+  setupTestContext,
+  seedEntity,
+  seedTransaction,
+  createCaller,
+} from "../../../shared/test-utils.js";
 
 const ctx = setupTestContext();
 let caller: ReturnType<typeof createCaller>;
@@ -283,6 +288,25 @@ describe("entities.update", () => {
       code: "BAD_REQUEST",
     });
   });
+
+  it("throws CONFLICT when renaming to an existing name", async () => {
+    seedEntity(db, { name: "Woolworths" });
+    const colesId = seedEntity(db, { name: "Coles" });
+
+    await expect(
+      caller.core.entities.update({ id: colesId, data: { name: "Woolworths" } })
+    ).rejects.toThrow(TRPCError);
+    await expect(
+      caller.core.entities.update({ id: colesId, data: { name: "Woolworths" } })
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+  });
+
+  it("allows renaming to the same name (no false conflict)", async () => {
+    const id = seedEntity(db, { name: "Woolworths" });
+
+    const result = await caller.core.entities.update({ id, data: { name: "Woolworths" } });
+    expect(result.data.name).toBe("Woolworths");
+  });
 });
 
 describe("entities.delete", () => {
@@ -312,5 +336,18 @@ describe("entities.delete", () => {
     await expect(caller.core.entities.delete({ id })).rejects.toMatchObject({
       code: "NOT_FOUND",
     });
+  });
+
+  it("sets entity_id to NULL on related transactions (FK cascade)", async () => {
+    const entityId = seedEntity(db, { name: "Woolworths" });
+    const txnId = seedTransaction(db, { entity_id: entityId, entity_name: "Woolworths" });
+
+    await caller.core.entities.delete({ id: entityId });
+
+    const row = db
+      .prepare("SELECT entity_id, entity_name FROM transactions WHERE id = ?")
+      .get(txnId) as { entity_id: string | null; entity_name: string | null };
+    expect(row.entity_id).toBeNull();
+    expect(row.entity_name).toBe("Woolworths"); // denormalized name preserved
   });
 });

--- a/apps/pops-api/src/modules/core/entities/router.ts
+++ b/apps/pops-api/src/modules/core/entities/router.ts
@@ -75,6 +75,9 @@ export const entitiesRouter = router({
         if (err instanceof NotFoundError) {
           throw new TRPCError({ code: "NOT_FOUND", message: err.message });
         }
+        if (err instanceof ConflictError) {
+          throw new TRPCError({ code: "CONFLICT", message: err.message });
+        }
         throw err;
       }
     }),

--- a/apps/pops-api/src/modules/core/entities/service.ts
+++ b/apps/pops-api/src/modules/core/entities/service.ts
@@ -3,7 +3,7 @@
  * SQLite is the source of truth. All operations are local.
  */
 import crypto from "crypto";
-import { eq, like, count, and } from "drizzle-orm";
+import { eq, like, count, and, ne } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
 import { entities } from "@pops/db-types";
 import { NotFoundError, ConflictError } from "../../../shared/errors.js";
@@ -103,6 +103,19 @@ export function updateEntity(id: string, input: UpdateEntityInput): EntityRow {
 
   // Verify it exists first
   getEntity(id);
+
+  // Check for duplicate name (excluding current entity)
+  if (input.name !== undefined) {
+    const [existing] = db
+      .select({ id: entities.id })
+      .from(entities)
+      .where(and(eq(entities.name, input.name), ne(entities.id, id)))
+      .all();
+
+    if (existing) {
+      throw new ConflictError(`Entity with name '${input.name}' already exists`);
+    }
+  }
 
   const updates: Partial<typeof entities.$inferInsert> = {};
   let hasUpdates = false;

--- a/docs/themes/02-finance/prds/023-entities/README.md
+++ b/docs/themes/02-finance/prds/023-entities/README.md
@@ -1,7 +1,7 @@
 # PRD-023: Entities
 
 > Epic: [02 — Entities](../../epics/02-entities.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -64,7 +64,7 @@ Build the entity registry — the merchant/payee database that transactions and 
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-schema-api](us-01-schema-api.md) | Entity table, CRUD procedures, alias/tag serialization | Partial | No (first) |
+| 01 | [us-01-schema-api](us-01-schema-api.md) | Entity table, CRUD procedures, alias/tag serialization | Done | No (first) |
 | 02 | [us-02-entities-page](us-02-entities-page.md) | DataTable with search, type filter, alias/tag display | Done | Blocked by us-01 |
 | 03 | [us-03-entity-crud-ui](us-03-entity-crud-ui.md) | Create/edit/delete dialogs on the entities page | Done | Blocked by us-02 |
 


### PR DESCRIPTION
## Summary
- Add duplicate-name validation to `updateEntity` (previously only enforced on create) — returns 409 CONFLICT when renaming to an existing name
- Add FK SET NULL cascade integration test: seed entity + transaction, delete entity, verify `transaction.entity_id` becomes null while `entity_name` is preserved
- Add update-name-conflict test (409 CONFLICT) and same-name-no-false-conflict test
- Mark PRD-023 US-01 acceptance criteria as Done; update PRD-023 README status

## Test plan
- [x] All 30 entity tests pass (`cd apps/pops-api && pnpm test -- --run entities`)
- [x] No entity-related TypeScript errors
- [x] FK cascade verified: `entity_id` nulled, `entity_name` preserved on delete

Closes tb-330

🤖 Generated with [Claude Code](https://claude.com/claude-code)