### PR TITLE
feat(import-store): pending entity + changeset stores (PRD-030 US-01+02) [tb-329]

### DIFF
--- a/docs/themes/02-finance/prds/030-local-first-import/README.md
+++ b/docs/themes/02-finance/prds/030-local-first-import/README.md
@@ -81,8 +81,8 @@ No new backend endpoints. All operations are zustand store actions and pure func
 
 | # | Story | Summary | Status | Parallelisable |
 |---|-------|---------|--------|----------------|
-| 01 | [us-01-pending-entity-store](us-01-pending-entity-store.md) | Zustand slice buffering entity creations with temp IDs | Not started | Yes |
-| 02 | [us-02-pending-changeset-store](us-02-pending-changeset-store.md) | Zustand slice buffering approved ChangeSets in order | Not started | Yes |
+| 01 | [us-01-pending-entity-store](us-01-pending-entity-store.md) | Zustand slice buffering entity creations with temp IDs | Done | Yes |
+| 02 | [us-02-pending-changeset-store](us-02-pending-changeset-store.md) | Zustand slice buffering approved ChangeSets in order | Done | Yes |
 | 03 | [us-03-merged-rule-computation](us-03-merged-rule-computation.md) | Pure function computing merged rules from DB + pending ChangeSets | Not started | Blocked by US-02 |
 | 04 | [us-04-merged-entity-list](us-04-merged-entity-list.md) | Pure function computing merged entities from DB + pending | Not started | Blocked by US-01 |
 | 05 | [us-05-redirect-entity-creation](us-05-redirect-entity-creation.md) | EntityCreateDialog writes to local store instead of tRPC | Not started | Blocked by US-01, US-04 |

--- a/docs/themes/02-finance/prds/030-local-first-import/us-01-pending-entity-store.md
+++ b/docs/themes/02-finance/prds/030-local-first-import/us-01-pending-entity-store.md
@@ -1,7 +1,7 @@
 # US-01: Pending entity store
 
 > PRD: [030 — Local-First Import State Layer](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -11,14 +11,14 @@ The slice manages a list of `PendingEntity` objects, each with a deterministic t
 
 ## Acceptance Criteria
 
-- [ ] A `pendingEntities` slice exists in the import store (or a companion store) with state `PendingEntity[]` and actions `addPendingEntity`, `listPendingEntities`, `removePendingEntity`.
-- [ ] `addPendingEntity` generates a temp ID in the format `temp:entity:{uuid}` and appends the entity to the pending list.
-- [ ] `addPendingEntity` rejects (throws or returns an error) if an entity with the same name (case-insensitive) already exists in the pending list.
-- [ ] `addPendingEntity` rejects if an entity with the same name (case-insensitive) already exists in a provided DB entity list (passed as parameter or available via the store).
-- [ ] `removePendingEntity(tempId)` removes the entity with the given temp ID. No-op if not found.
-- [ ] `listPendingEntities()` returns all pending entities in insertion order.
-- [ ] The `reset` action (or equivalent) clears all pending entities.
-- [ ] Unit tests cover: add, add-duplicate-pending, add-duplicate-db, remove, remove-nonexistent, list-ordering, reset.
+- [x] A `pendingEntities` slice exists in the import store (or a companion store) with state `PendingEntity[]` and actions `addPendingEntity`, `listPendingEntities`, `removePendingEntity`.
+- [x] `addPendingEntity` generates a temp ID in the format `temp:entity:{uuid}` and appends the entity to the pending list.
+- [x] `addPendingEntity` rejects (throws or returns an error) if an entity with the same name (case-insensitive) already exists in the pending list.
+- [x] `addPendingEntity` rejects if an entity with the same name (case-insensitive) already exists in a provided DB entity list (passed as parameter or available via the store).
+- [x] `removePendingEntity(tempId)` removes the entity with the given temp ID. No-op if not found.
+- [x] `listPendingEntities()` returns all pending entities in insertion order.
+- [x] The `reset` action (or equivalent) clears all pending entities.
+- [x] Unit tests cover: add, add-duplicate-pending, add-duplicate-db, remove, remove-nonexistent, list-ordering, reset.
 
 ## Notes
 

--- a/docs/themes/02-finance/prds/030-local-first-import/us-02-pending-changeset-store.md
+++ b/docs/themes/02-finance/prds/030-local-first-import/us-02-pending-changeset-store.md
@@ -1,7 +1,7 @@
 # US-02: Pending changeset store
 
 > PRD: [030 — Local-First Import State Layer](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -11,13 +11,13 @@ The slice manages an ordered list of `PendingChangeSet` objects. Insertion order
 
 ## Acceptance Criteria
 
-- [ ] A `pendingChangeSets` slice exists in the import store (or a companion store) with state `PendingChangeSet[]` and actions `addPendingChangeSet`, `listPendingChangeSets`, `removePendingChangeSet`.
-- [ ] `addPendingChangeSet` appends a new entry to the end of the ordered list with a temp ID in the format `temp:changeset:{uuid}`, the provided `ChangeSet`, an ISO `appliedAt` timestamp, and a `source` string.
-- [ ] `listPendingChangeSets()` returns all pending ChangeSets in insertion order.
-- [ ] `removePendingChangeSet(tempId)` removes the entry with the given temp ID. No-op if not found.
-- [ ] Removing a ChangeSet from the middle of the list preserves the relative order of remaining entries.
-- [ ] The `reset` action clears all pending ChangeSets.
-- [ ] Unit tests cover: add single, add multiple (order preserved), remove from middle, remove nonexistent, list ordering, reset.
+- [x] A `pendingChangeSets` slice exists in the import store (or a companion store) with state `PendingChangeSet[]` and actions `addPendingChangeSet`, `listPendingChangeSets`, `removePendingChangeSet`.
+- [x] `addPendingChangeSet` appends a new entry to the end of the ordered list with a temp ID in the format `temp:changeset:{uuid}`, the provided `ChangeSet`, an ISO `appliedAt` timestamp, and a `source` string.
+- [x] `listPendingChangeSets()` returns all pending ChangeSets in insertion order.
+- [x] `removePendingChangeSet(tempId)` removes the entry with the given temp ID. No-op if not found.
+- [x] Removing a ChangeSet from the middle of the list preserves the relative order of remaining entries.
+- [x] The `reset` action clears all pending ChangeSets.
+- [x] Unit tests cover: add single, add multiple (order preserved), remove from middle, remove nonexistent, list ordering, reset.
 
 ## Notes
 

--- a/packages/app-finance/src/store/importStore.test.ts
+++ b/packages/app-finance/src/store/importStore.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type { ParsedTransaction } from "@pops/api/modules/finance/imports";
-import {
-  useImportStore,
-  type ProcessedTransaction,
-  type ChangeSetData,
-} from "./importStore";
+import { useImportStore, type ProcessedTransaction, type ChangeSetData } from "./importStore";
 
 // ---------------------------------------------------------------------------
 // importStore — parsedTransactionsFingerprint / processedForFingerprint tests
@@ -200,18 +196,14 @@ describe("importStore — pendingEntities (PRD-030 US-01)", () => {
     const dbEntities = [{ name: "Coles" }, { name: "Woolworths" }];
 
     expect(() =>
-      useImportStore
-        .getState()
-        .addPendingEntity({ name: "coles", type: "merchant" }, dbEntities)
+      useImportStore.getState().addPendingEntity({ name: "coles", type: "merchant" }, dbEntities)
     ).toThrow(/already exists in the database/);
 
     expect(useImportStore.getState().pendingEntities).toHaveLength(0);
   });
 
   it("removePendingEntity removes by tempId", () => {
-    const e1 = useImportStore
-      .getState()
-      .addPendingEntity({ name: "First", type: "merchant" });
+    const e1 = useImportStore.getState().addPendingEntity({ name: "First", type: "merchant" });
     useImportStore.getState().addPendingEntity({ name: "Second", type: "merchant" });
 
     useImportStore.getState().removePendingEntity(e1.tempId);

--- a/packages/app-finance/src/store/importStore.test.ts
+++ b/packages/app-finance/src/store/importStore.test.ts
@@ -3,24 +3,11 @@ import type { ParsedTransaction } from "@pops/api/modules/finance/imports";
 import {
   useImportStore,
   type ProcessedTransaction,
-  type PendingEntity,
-  type PendingChangeset,
+  type ChangeSetData,
 } from "./importStore";
 
 // ---------------------------------------------------------------------------
 // importStore — parsedTransactionsFingerprint / processedForFingerprint tests
-//
-// The Step 3 "already processed" short-circuit is gated on
-// `processedForFingerprint === parsedTransactionsFingerprint`. These tests
-// exercise the store-level invariants that make that gate safe:
-//
-//   1. `setParsedTransactions` computes a content fingerprint from checksums.
-//   2. Passing an identical list is a no-op for downstream state (Back→
-//      Continue bounce without mutation).
-//   3. Passing a *different* list wipes downstream processed/confirmed state
-//      *and* clears `processedForFingerprint` so Step 3 cannot short-circuit
-//      with stale results.
-//   4. `setProcessedTransactions` pins results to the live fingerprint.
 // ---------------------------------------------------------------------------
 
 function makeTxn(checksum: string, description = "WOOLWORTHS"): ParsedTransaction {
@@ -59,8 +46,6 @@ describe("importStore — parsed/processed fingerprint", () => {
   it("computes a fingerprint from the concatenated checksums", () => {
     const txns = [makeTxn("a"), makeTxn("b"), makeTxn("c")];
     useImportStore.getState().setParsedTransactions(txns);
-    // Implementation detail: checksums joined by '|'. Deliberately asserted
-    // so a future refactor can't silently change the invalidation surface.
     expect(useImportStore.getState().parsedTransactionsFingerprint).toBe("a|b|c");
   });
 
@@ -74,7 +59,6 @@ describe("importStore — parsed/processed fingerprint", () => {
   it("re-setting an identical parsed list is a no-op for downstream processed state", () => {
     const txns = [makeTxn("a"), makeTxn("b")];
     useImportStore.getState().setParsedTransactions(txns);
-    // Pretend processing finished.
     useImportStore.getState().setProcessedTransactions({
       ...sampleProcessed(),
       warnings: undefined,
@@ -82,10 +66,8 @@ describe("importStore — parsed/processed fingerprint", () => {
     const fp = useImportStore.getState().parsedTransactionsFingerprint;
     expect(useImportStore.getState().processedForFingerprint).toBe(fp);
 
-    // Back→Continue bounce: re-set the same parsed list (same checksums).
     useImportStore.getState().setParsedTransactions([makeTxn("a"), makeTxn("b")]);
 
-    // Processed state must survive so Step 3 can short-circuit.
     expect(useImportStore.getState().processedTransactions.matched).toHaveLength(1);
     expect(useImportStore.getState().processedForFingerprint).toBe(fp);
     expect(useImportStore.getState().parsedTransactionsFingerprint).toBe(fp);
@@ -99,7 +81,6 @@ describe("importStore — parsed/processed fingerprint", () => {
     });
     expect(useImportStore.getState().processedForFingerprint).not.toBeNull();
 
-    // User went Back→Step 2, re-mapped columns, Continue — different checksums.
     useImportStore.getState().setParsedTransactions([makeTxn("x"), makeTxn("y")]);
 
     const state = useImportStore.getState();
@@ -127,7 +108,6 @@ describe("importStore — parsed/processed fingerprint", () => {
       warnings: undefined,
     });
 
-    // Simulate picking a new file — uses the File shape the setFile comparator expects.
     const fakeFile = { name: "new.csv", size: 10, lastModified: 1 } as unknown as File;
     useImportStore.getState().setFile(fakeFile);
 
@@ -171,20 +151,13 @@ describe("importStore — step range", () => {
 // Pending entities (PRD-030 US-01)
 // ---------------------------------------------------------------------------
 
-function makePendingEntity(overrides: Partial<PendingEntity> = {}): PendingEntity {
-  return {
-    tempId: "temp-1",
-    name: "Test Entity",
-    type: "merchant",
-    aliases: ["alias-1"],
-    defaultTransactionType: "expense",
-    defaultTags: ["food"],
-    createdAt: "2026-04-12T00:00:00Z",
-    ...overrides,
-  };
-}
+const sampleChangeSet: ChangeSetData = {
+  source: "ai",
+  reason: "test",
+  ops: [{ op: "add", data: {} }],
+};
 
-describe("importStore — pendingEntities", () => {
+describe("importStore — pendingEntities (PRD-030 US-01)", () => {
   beforeEach(() => {
     useImportStore.getState().reset();
   });
@@ -193,46 +166,84 @@ describe("importStore — pendingEntities", () => {
     expect(useImportStore.getState().pendingEntities).toEqual([]);
   });
 
-  it("addPendingEntity appends to the list", () => {
-    const e1 = makePendingEntity({ tempId: "t1" });
-    const e2 = makePendingEntity({ tempId: "t2", name: "Second" });
-    useImportStore.getState().addPendingEntity(e1);
-    useImportStore.getState().addPendingEntity(e2);
-    expect(useImportStore.getState().pendingEntities).toHaveLength(2);
-    expect(useImportStore.getState().pendingEntities[0].tempId).toBe("t1");
-    expect(useImportStore.getState().pendingEntities[1].tempId).toBe("t2");
+  it("addPendingEntity generates a temp ID in the format temp:entity:{uuid}", () => {
+    const entity = useImportStore.getState().addPendingEntity({
+      name: "Test Merchant",
+      type: "merchant",
+    });
+    expect(entity.tempId).toMatch(/^temp:entity:[0-9a-f-]{36}$/);
+    expect(entity.name).toBe("Test Merchant");
+    expect(entity.type).toBe("merchant");
+  });
+
+  it("addPendingEntity appends to the pending list in insertion order", () => {
+    useImportStore.getState().addPendingEntity({ name: "First", type: "merchant" });
+    useImportStore.getState().addPendingEntity({ name: "Second", type: "employer" });
+
+    const entities = useImportStore.getState().pendingEntities;
+    expect(entities).toHaveLength(2);
+    expect(entities[0].name).toBe("First");
+    expect(entities[1].name).toBe("Second");
+  });
+
+  it("addPendingEntity rejects duplicate name in pending list (case-insensitive)", () => {
+    useImportStore.getState().addPendingEntity({ name: "Woolworths", type: "merchant" });
+
+    expect(() =>
+      useImportStore.getState().addPendingEntity({ name: "woolworths", type: "merchant" })
+    ).toThrow(/already exists in pending list/);
+
+    expect(useImportStore.getState().pendingEntities).toHaveLength(1);
+  });
+
+  it("addPendingEntity rejects duplicate name in DB entity list (case-insensitive)", () => {
+    const dbEntities = [{ name: "Coles" }, { name: "Woolworths" }];
+
+    expect(() =>
+      useImportStore
+        .getState()
+        .addPendingEntity({ name: "coles", type: "merchant" }, dbEntities)
+    ).toThrow(/already exists in the database/);
+
+    expect(useImportStore.getState().pendingEntities).toHaveLength(0);
   });
 
   it("removePendingEntity removes by tempId", () => {
-    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t1" }));
-    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t2" }));
-    useImportStore.getState().removePendingEntity("t1");
+    const e1 = useImportStore
+      .getState()
+      .addPendingEntity({ name: "First", type: "merchant" });
+    useImportStore.getState().addPendingEntity({ name: "Second", type: "merchant" });
+
+    useImportStore.getState().removePendingEntity(e1.tempId);
+
     const entities = useImportStore.getState().pendingEntities;
     expect(entities).toHaveLength(1);
-    expect(entities[0].tempId).toBe("t2");
+    expect(entities[0].name).toBe("Second");
   });
 
   it("removePendingEntity with unknown id is a no-op", () => {
-    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t1" }));
+    useImportStore.getState().addPendingEntity({ name: "First", type: "merchant" });
     useImportStore.getState().removePendingEntity("nonexistent");
     expect(useImportStore.getState().pendingEntities).toHaveLength(1);
   });
 
-  it("clearPendingEntities empties the list", () => {
-    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t1" }));
-    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t2" }));
-    useImportStore.getState().clearPendingEntities();
-    expect(useImportStore.getState().pendingEntities).toEqual([]);
+  it("listPendingEntities returns all pending entities in insertion order", () => {
+    useImportStore.getState().addPendingEntity({ name: "A", type: "merchant" });
+    useImportStore.getState().addPendingEntity({ name: "B", type: "employer" });
+    useImportStore.getState().addPendingEntity({ name: "C", type: "merchant" });
+
+    const list = useImportStore.getState().listPendingEntities();
+    expect(list.map((e) => e.name)).toEqual(["A", "B", "C"]);
   });
 
-  it("reset clears pending entities", () => {
-    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t1" }));
+  it("reset clears all pending entities", () => {
+    useImportStore.getState().addPendingEntity({ name: "Test", type: "merchant" });
     useImportStore.getState().reset();
     expect(useImportStore.getState().pendingEntities).toEqual([]);
   });
 
   it("setFile with a different file clears pending entities", () => {
-    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t1" }));
+    useImportStore.getState().addPendingEntity({ name: "Test", type: "merchant" });
     const fakeFile = { name: "new.csv", size: 10, lastModified: 1 } as unknown as File;
     useImportStore.getState().setFile(fakeFile);
     expect(useImportStore.getState().pendingEntities).toEqual([]);
@@ -240,70 +251,110 @@ describe("importStore — pendingEntities", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Pending changesets (PRD-030 US-02)
+// Pending changeSets (PRD-030 US-02)
 // ---------------------------------------------------------------------------
 
-function makePendingChangeset(overrides: Partial<PendingChangeset> = {}): PendingChangeset {
-  return {
-    id: "cs-1",
-    changeSet: { source: "ai", reason: "test", ops: [{ op: "add", data: {} }] },
-    approvedAt: "2026-04-12T01:00:00Z",
-    description: "Fix entity mapping",
-    ...overrides,
-  };
-}
-
-describe("importStore — pendingChangesets", () => {
+describe("importStore — pendingChangeSets (PRD-030 US-02)", () => {
   beforeEach(() => {
     useImportStore.getState().reset();
   });
 
   it("starts with an empty array", () => {
-    expect(useImportStore.getState().pendingChangesets).toEqual([]);
+    expect(useImportStore.getState().pendingChangeSets).toEqual([]);
   });
 
-  it("addPendingChangeset appends to the list", () => {
-    const cs1 = makePendingChangeset({ id: "cs-1" });
-    const cs2 = makePendingChangeset({ id: "cs-2", description: "Second" });
-    useImportStore.getState().addPendingChangeset(cs1);
-    useImportStore.getState().addPendingChangeset(cs2);
-    expect(useImportStore.getState().pendingChangesets).toHaveLength(2);
-    expect(useImportStore.getState().pendingChangesets[0].id).toBe("cs-1");
-    expect(useImportStore.getState().pendingChangesets[1].id).toBe("cs-2");
+  it("addPendingChangeSet generates a temp ID in the format temp:changeset:{uuid}", () => {
+    const entry = useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "correction-proposal",
+    });
+    expect(entry.tempId).toMatch(/^temp:changeset:[0-9a-f-]{36}$/);
+    expect(entry.changeSet).toEqual(sampleChangeSet);
+    expect(entry.source).toBe("correction-proposal");
+    expect(entry.appliedAt).toBeTruthy();
   });
 
-  it("removePendingChangeset removes by id", () => {
-    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-1" }));
-    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-2" }));
-    useImportStore.getState().removePendingChangeset("cs-1");
-    const changesets = useImportStore.getState().pendingChangesets;
-    expect(changesets).toHaveLength(1);
-    expect(changesets[0].id).toBe("cs-2");
+  it("addPendingChangeSet appends in insertion order", () => {
+    useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "first",
+    });
+    useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "second",
+    });
+
+    const list = useImportStore.getState().pendingChangeSets;
+    expect(list).toHaveLength(2);
+    expect(list[0].source).toBe("first");
+    expect(list[1].source).toBe("second");
   });
 
-  it("removePendingChangeset with unknown id is a no-op", () => {
-    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-1" }));
-    useImportStore.getState().removePendingChangeset("nonexistent");
-    expect(useImportStore.getState().pendingChangesets).toHaveLength(1);
+  it("listPendingChangeSets returns all in insertion order", () => {
+    useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "a",
+    });
+    useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "b",
+    });
+    useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "c",
+    });
+
+    const list = useImportStore.getState().listPendingChangeSets();
+    expect(list.map((cs) => cs.source)).toEqual(["a", "b", "c"]);
   });
 
-  it("clearPendingChangesets empties the list", () => {
-    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-1" }));
-    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-2" }));
-    useImportStore.getState().clearPendingChangesets();
-    expect(useImportStore.getState().pendingChangesets).toEqual([]);
+  it("removePendingChangeSet removes from the middle preserving order", () => {
+    const cs1 = useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "first",
+    });
+    const cs2 = useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "second",
+    });
+    const cs3 = useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "third",
+    });
+
+    useImportStore.getState().removePendingChangeSet(cs2.tempId);
+
+    const list = useImportStore.getState().pendingChangeSets;
+    expect(list).toHaveLength(2);
+    expect(list[0].tempId).toBe(cs1.tempId);
+    expect(list[1].tempId).toBe(cs3.tempId);
   });
 
-  it("reset clears pending changesets", () => {
-    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-1" }));
+  it("removePendingChangeSet with unknown id is a no-op", () => {
+    useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "test",
+    });
+    useImportStore.getState().removePendingChangeSet("nonexistent");
+    expect(useImportStore.getState().pendingChangeSets).toHaveLength(1);
+  });
+
+  it("reset clears all pending changeSets", () => {
+    useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "test",
+    });
     useImportStore.getState().reset();
-    expect(useImportStore.getState().pendingChangesets).toEqual([]);
+    expect(useImportStore.getState().pendingChangeSets).toEqual([]);
   });
 
-  it("setFile with a different file clears pending changesets", () => {
-    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-1" }));
+  it("setFile with a different file clears pending changeSets", () => {
+    useImportStore.getState().addPendingChangeSet({
+      changeSet: sampleChangeSet,
+      source: "test",
+    });
     const fakeFile = { name: "new.csv", size: 10, lastModified: 1 } as unknown as File;
     useImportStore.getState().setFile(fakeFile);
-    expect(useImportStore.getState().pendingChangesets).toEqual([]);
+    expect(useImportStore.getState().pendingChangeSets).toEqual([]);
   });
 });

--- a/packages/app-finance/src/store/importStore.test.ts
+++ b/packages/app-finance/src/store/importStore.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type { ParsedTransaction } from "@pops/api/modules/finance/imports";
-import { useImportStore, type ProcessedTransaction } from "./importStore";
+import {
+  useImportStore,
+  type ProcessedTransaction,
+  type PendingEntity,
+  type PendingChangeset,
+} from "./importStore";
 
 // ---------------------------------------------------------------------------
 // importStore — parsedTransactionsFingerprint / processedForFingerprint tests
@@ -130,5 +135,175 @@ describe("importStore — parsed/processed fingerprint", () => {
     expect(state.parsedTransactionsFingerprint).toBe("");
     expect(state.processedForFingerprint).toBeNull();
     expect(state.processedTransactions.matched).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step range — currentStep supports 1..7 (PRD-031 adds step 7)
+// ---------------------------------------------------------------------------
+
+describe("importStore — step range", () => {
+  beforeEach(() => {
+    useImportStore.getState().reset();
+  });
+
+  it("nextStep caps at 7", () => {
+    useImportStore.getState().goToStep(6);
+    useImportStore.getState().nextStep();
+    expect(useImportStore.getState().currentStep).toBe(7);
+    useImportStore.getState().nextStep();
+    expect(useImportStore.getState().currentStep).toBe(7);
+  });
+
+  it("prevStep floors at 1", () => {
+    useImportStore.getState().goToStep(1);
+    useImportStore.getState().prevStep();
+    expect(useImportStore.getState().currentStep).toBe(1);
+  });
+
+  it("goToStep sets arbitrary step", () => {
+    useImportStore.getState().goToStep(5);
+    expect(useImportStore.getState().currentStep).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pending entities (PRD-030 US-01)
+// ---------------------------------------------------------------------------
+
+function makePendingEntity(overrides: Partial<PendingEntity> = {}): PendingEntity {
+  return {
+    tempId: "temp-1",
+    name: "Test Entity",
+    type: "merchant",
+    aliases: ["alias-1"],
+    defaultTransactionType: "expense",
+    defaultTags: ["food"],
+    createdAt: "2026-04-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("importStore — pendingEntities", () => {
+  beforeEach(() => {
+    useImportStore.getState().reset();
+  });
+
+  it("starts with an empty array", () => {
+    expect(useImportStore.getState().pendingEntities).toEqual([]);
+  });
+
+  it("addPendingEntity appends to the list", () => {
+    const e1 = makePendingEntity({ tempId: "t1" });
+    const e2 = makePendingEntity({ tempId: "t2", name: "Second" });
+    useImportStore.getState().addPendingEntity(e1);
+    useImportStore.getState().addPendingEntity(e2);
+    expect(useImportStore.getState().pendingEntities).toHaveLength(2);
+    expect(useImportStore.getState().pendingEntities[0].tempId).toBe("t1");
+    expect(useImportStore.getState().pendingEntities[1].tempId).toBe("t2");
+  });
+
+  it("removePendingEntity removes by tempId", () => {
+    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t1" }));
+    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t2" }));
+    useImportStore.getState().removePendingEntity("t1");
+    const entities = useImportStore.getState().pendingEntities;
+    expect(entities).toHaveLength(1);
+    expect(entities[0].tempId).toBe("t2");
+  });
+
+  it("removePendingEntity with unknown id is a no-op", () => {
+    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t1" }));
+    useImportStore.getState().removePendingEntity("nonexistent");
+    expect(useImportStore.getState().pendingEntities).toHaveLength(1);
+  });
+
+  it("clearPendingEntities empties the list", () => {
+    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t1" }));
+    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t2" }));
+    useImportStore.getState().clearPendingEntities();
+    expect(useImportStore.getState().pendingEntities).toEqual([]);
+  });
+
+  it("reset clears pending entities", () => {
+    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t1" }));
+    useImportStore.getState().reset();
+    expect(useImportStore.getState().pendingEntities).toEqual([]);
+  });
+
+  it("setFile with a different file clears pending entities", () => {
+    useImportStore.getState().addPendingEntity(makePendingEntity({ tempId: "t1" }));
+    const fakeFile = { name: "new.csv", size: 10, lastModified: 1 } as unknown as File;
+    useImportStore.getState().setFile(fakeFile);
+    expect(useImportStore.getState().pendingEntities).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pending changesets (PRD-030 US-02)
+// ---------------------------------------------------------------------------
+
+function makePendingChangeset(overrides: Partial<PendingChangeset> = {}): PendingChangeset {
+  return {
+    id: "cs-1",
+    changeSet: { source: "ai", reason: "test", ops: [{ op: "add", data: {} }] },
+    approvedAt: "2026-04-12T01:00:00Z",
+    description: "Fix entity mapping",
+    ...overrides,
+  };
+}
+
+describe("importStore — pendingChangesets", () => {
+  beforeEach(() => {
+    useImportStore.getState().reset();
+  });
+
+  it("starts with an empty array", () => {
+    expect(useImportStore.getState().pendingChangesets).toEqual([]);
+  });
+
+  it("addPendingChangeset appends to the list", () => {
+    const cs1 = makePendingChangeset({ id: "cs-1" });
+    const cs2 = makePendingChangeset({ id: "cs-2", description: "Second" });
+    useImportStore.getState().addPendingChangeset(cs1);
+    useImportStore.getState().addPendingChangeset(cs2);
+    expect(useImportStore.getState().pendingChangesets).toHaveLength(2);
+    expect(useImportStore.getState().pendingChangesets[0].id).toBe("cs-1");
+    expect(useImportStore.getState().pendingChangesets[1].id).toBe("cs-2");
+  });
+
+  it("removePendingChangeset removes by id", () => {
+    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-1" }));
+    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-2" }));
+    useImportStore.getState().removePendingChangeset("cs-1");
+    const changesets = useImportStore.getState().pendingChangesets;
+    expect(changesets).toHaveLength(1);
+    expect(changesets[0].id).toBe("cs-2");
+  });
+
+  it("removePendingChangeset with unknown id is a no-op", () => {
+    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-1" }));
+    useImportStore.getState().removePendingChangeset("nonexistent");
+    expect(useImportStore.getState().pendingChangesets).toHaveLength(1);
+  });
+
+  it("clearPendingChangesets empties the list", () => {
+    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-1" }));
+    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-2" }));
+    useImportStore.getState().clearPendingChangesets();
+    expect(useImportStore.getState().pendingChangesets).toEqual([]);
+  });
+
+  it("reset clears pending changesets", () => {
+    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-1" }));
+    useImportStore.getState().reset();
+    expect(useImportStore.getState().pendingChangesets).toEqual([]);
+  });
+
+  it("setFile with a different file clears pending changesets", () => {
+    useImportStore.getState().addPendingChangeset(makePendingChangeset({ id: "cs-1" }));
+    const fakeFile = { name: "new.csv", size: 10, lastModified: 1 } as unknown as File;
+    useImportStore.getState().setFile(fakeFile);
+    expect(useImportStore.getState().pendingChangesets).toEqual([]);
   });
 });

--- a/packages/app-finance/src/store/importStore.ts
+++ b/packages/app-finance/src/store/importStore.ts
@@ -309,21 +309,13 @@ export const useImportStore = create<ImportStore>((set) => ({
 
     // Check uniqueness against pending list
     const state = useImportStore.getState();
-    if (
-      state.pendingEntities.some(
-        (e: PendingEntity) => e.name.toLowerCase() === nameLower
-      )
-    ) {
-      throw new Error(
-        `Entity with name "${input.name}" already exists in pending list`
-      );
+    if (state.pendingEntities.some((e: PendingEntity) => e.name.toLowerCase() === nameLower)) {
+      throw new Error(`Entity with name "${input.name}" already exists in pending list`);
     }
 
     // Check uniqueness against DB entity list
     if (dbEntities.some((e) => e.name.toLowerCase() === nameLower)) {
-      throw new Error(
-        `Entity with name "${input.name}" already exists in the database`
-      );
+      throw new Error(`Entity with name "${input.name}" already exists in the database`);
     }
 
     const entity: PendingEntity = {
@@ -335,13 +327,10 @@ export const useImportStore = create<ImportStore>((set) => ({
     set((prev) => ({ pendingEntities: [...prev.pendingEntities, entity] }));
     return entity;
   },
-  listPendingEntities: (): PendingEntity[] =>
-    useImportStore.getState().pendingEntities,
+  listPendingEntities: (): PendingEntity[] => useImportStore.getState().pendingEntities,
   removePendingEntity: (tempId: string) =>
     set((state) => ({
-      pendingEntities: state.pendingEntities.filter(
-        (e: PendingEntity) => e.tempId !== tempId
-      ),
+      pendingEntities: state.pendingEntities.filter((e: PendingEntity) => e.tempId !== tempId),
     })),
 
   // Pending changeset management (PRD-030 US-02)
@@ -356,8 +345,7 @@ export const useImportStore = create<ImportStore>((set) => ({
     set((prev) => ({ pendingChangeSets: [...prev.pendingChangeSets, entry] }));
     return entry;
   },
-  listPendingChangeSets: (): PendingChangeSet[] =>
-    useImportStore.getState().pendingChangeSets,
+  listPendingChangeSets: (): PendingChangeSet[] => useImportStore.getState().pendingChangeSets,
   removePendingChangeSet: (tempId: string) =>
     set((state) => ({
       pendingChangeSets: state.pendingChangeSets.filter(

--- a/packages/app-finance/src/store/importStore.ts
+++ b/packages/app-finance/src/store/importStore.ts
@@ -301,12 +301,19 @@ export const useImportStore = create<ImportStore>((set) => ({
   reset: () => set(initialState),
 
   // Pending entity management (PRD-030 US-01)
-  addPendingEntity: (input, dbEntities = []) => {
+  addPendingEntity: (
+    input: AddPendingEntityInput,
+    dbEntities: Array<{ name: string }> = []
+  ): PendingEntity => {
     const nameLower = input.name.toLowerCase();
 
     // Check uniqueness against pending list
     const state = useImportStore.getState();
-    if (state.pendingEntities.some((e) => e.name.toLowerCase() === nameLower)) {
+    if (
+      state.pendingEntities.some(
+        (e: PendingEntity) => e.name.toLowerCase() === nameLower
+      )
+    ) {
       throw new Error(
         `Entity with name "${input.name}" already exists in pending list`
       );
@@ -328,14 +335,17 @@ export const useImportStore = create<ImportStore>((set) => ({
     set((prev) => ({ pendingEntities: [...prev.pendingEntities, entity] }));
     return entity;
   },
-  listPendingEntities: () => useImportStore.getState().pendingEntities,
-  removePendingEntity: (tempId) =>
+  listPendingEntities: (): PendingEntity[] =>
+    useImportStore.getState().pendingEntities,
+  removePendingEntity: (tempId: string) =>
     set((state) => ({
-      pendingEntities: state.pendingEntities.filter((e) => e.tempId !== tempId),
+      pendingEntities: state.pendingEntities.filter(
+        (e: PendingEntity) => e.tempId !== tempId
+      ),
     })),
 
   // Pending changeset management (PRD-030 US-02)
-  addPendingChangeSet: (input) => {
+  addPendingChangeSet: (input: AddPendingChangeSetInput): PendingChangeSet => {
     const entry: PendingChangeSet = {
       tempId: `temp:changeset:${crypto.randomUUID()}`,
       changeSet: input.changeSet,
@@ -346,11 +356,12 @@ export const useImportStore = create<ImportStore>((set) => ({
     set((prev) => ({ pendingChangeSets: [...prev.pendingChangeSets, entry] }));
     return entry;
   },
-  listPendingChangeSets: () => useImportStore.getState().pendingChangeSets,
-  removePendingChangeSet: (tempId) =>
+  listPendingChangeSets: (): PendingChangeSet[] =>
+    useImportStore.getState().pendingChangeSets,
+  removePendingChangeSet: (tempId: string) =>
     set((state) => ({
       pendingChangeSets: state.pendingChangeSets.filter(
-        (c) => c.tempId !== tempId
+        (c: PendingChangeSet) => c.tempId !== tempId
       ),
     })),
 

--- a/packages/app-finance/src/store/importStore.ts
+++ b/packages/app-finance/src/store/importStore.ts
@@ -15,26 +15,39 @@ export type BankType = "Amex";
 // ---------------------------------------------------------------------------
 
 export interface PendingEntity {
-  tempId: string;
+  tempId: string; // Format: temp:entity:{uuid}
   name: string;
   type: string;
-  aliases: string[];
-  defaultTransactionType: string;
-  defaultTags: string[];
-  createdAt: string; // ISO-8601
+}
+
+/** Input for creating a pending entity (tempId is generated internally). */
+export interface AddPendingEntityInput {
+  name: string;
+  type: string;
 }
 
 // ---------------------------------------------------------------------------
 // Pending changeset — rule ChangeSet approved during import, not yet committed.
-// The `changeSet` field mirrors the server ChangeSet shape (source, reason, ops)
-// but is stored as an opaque record so the store stays decoupled from zod schemas.
 // ---------------------------------------------------------------------------
 
-export interface PendingChangeset {
-  id: string;
-  changeSet: Record<string, unknown>;
-  approvedAt: string; // ISO-8601
-  description: string;
+/** Mirrors the server ChangeSet shape (source, reason, ops). */
+export interface ChangeSetData {
+  source?: string;
+  reason?: string;
+  ops: Record<string, unknown>[];
+}
+
+export interface PendingChangeSet {
+  tempId: string; // Format: temp:changeset:{uuid}
+  changeSet: ChangeSetData;
+  appliedAt: string; // ISO-8601
+  source: string;
+}
+
+/** Input for creating a pending changeset (tempId and appliedAt are generated internally). */
+export interface AddPendingChangeSetInput {
+  changeSet: ChangeSetData;
+  source: string;
 }
 
 /**
@@ -105,7 +118,7 @@ interface ImportStore {
 
   // Local-first pending state (PRD-030)
   pendingEntities: PendingEntity[];
-  pendingChangesets: PendingChangeset[];
+  pendingChangeSets: PendingChangeSet[];
 
   // Actions
   setFile: (file: File | null) => void;
@@ -126,14 +139,17 @@ interface ImportStore {
   reset: () => void;
 
   // Pending entity management (PRD-030 US-01)
-  addPendingEntity: (entity: PendingEntity) => void;
+  addPendingEntity: (
+    input: AddPendingEntityInput,
+    dbEntities?: Array<{ name: string }>
+  ) => PendingEntity;
+  listPendingEntities: () => PendingEntity[];
   removePendingEntity: (tempId: string) => void;
-  clearPendingEntities: () => void;
 
   // Pending changeset management (PRD-030 US-02)
-  addPendingChangeset: (cs: PendingChangeset) => void;
-  removePendingChangeset: (id: string) => void;
-  clearPendingChangesets: () => void;
+  addPendingChangeSet: (input: AddPendingChangeSetInput) => PendingChangeSet;
+  listPendingChangeSets: () => PendingChangeSet[];
+  removePendingChangeSet: (tempId: string) => void;
 
   // Transaction management
   updateTransaction: (
@@ -172,7 +188,7 @@ const initialState = {
   executeSessionId: null,
   importResult: null,
   pendingEntities: [],
-  pendingChangesets: [],
+  pendingChangeSets: [],
 };
 
 /**
@@ -206,7 +222,7 @@ const downstreamReset: Pick<
   | "executeSessionId"
   | "importResult"
   | "pendingEntities"
-  | "pendingChangesets"
+  | "pendingChangeSets"
 > = {
   headers: initialState.headers,
   rows: initialState.rows,
@@ -219,7 +235,7 @@ const downstreamReset: Pick<
   executeSessionId: initialState.executeSessionId,
   importResult: initialState.importResult,
   pendingEntities: initialState.pendingEntities,
-  pendingChangesets: initialState.pendingChangesets,
+  pendingChangeSets: initialState.pendingChangeSets,
 };
 
 function isSameFile(a: File | null, b: File | null): boolean {
@@ -285,22 +301,58 @@ export const useImportStore = create<ImportStore>((set) => ({
   reset: () => set(initialState),
 
   // Pending entity management (PRD-030 US-01)
-  addPendingEntity: (entity) =>
-    set((state) => ({ pendingEntities: [...state.pendingEntities, entity] })),
+  addPendingEntity: (input, dbEntities = []) => {
+    const nameLower = input.name.toLowerCase();
+
+    // Check uniqueness against pending list
+    const state = useImportStore.getState();
+    if (state.pendingEntities.some((e) => e.name.toLowerCase() === nameLower)) {
+      throw new Error(
+        `Entity with name "${input.name}" already exists in pending list`
+      );
+    }
+
+    // Check uniqueness against DB entity list
+    if (dbEntities.some((e) => e.name.toLowerCase() === nameLower)) {
+      throw new Error(
+        `Entity with name "${input.name}" already exists in the database`
+      );
+    }
+
+    const entity: PendingEntity = {
+      tempId: `temp:entity:${crypto.randomUUID()}`,
+      name: input.name,
+      type: input.type,
+    };
+
+    set((prev) => ({ pendingEntities: [...prev.pendingEntities, entity] }));
+    return entity;
+  },
+  listPendingEntities: () => useImportStore.getState().pendingEntities,
   removePendingEntity: (tempId) =>
     set((state) => ({
       pendingEntities: state.pendingEntities.filter((e) => e.tempId !== tempId),
     })),
-  clearPendingEntities: () => set({ pendingEntities: [] }),
 
   // Pending changeset management (PRD-030 US-02)
-  addPendingChangeset: (cs) =>
-    set((state) => ({ pendingChangesets: [...state.pendingChangesets, cs] })),
-  removePendingChangeset: (id) =>
+  addPendingChangeSet: (input) => {
+    const entry: PendingChangeSet = {
+      tempId: `temp:changeset:${crypto.randomUUID()}`,
+      changeSet: input.changeSet,
+      appliedAt: new Date().toISOString(),
+      source: input.source,
+    };
+
+    set((prev) => ({ pendingChangeSets: [...prev.pendingChangeSets, entry] }));
+    return entry;
+  },
+  listPendingChangeSets: () => useImportStore.getState().pendingChangeSets,
+  removePendingChangeSet: (tempId) =>
     set((state) => ({
-      pendingChangesets: state.pendingChangesets.filter((c) => c.id !== id),
+      pendingChangeSets: state.pendingChangeSets.filter(
+        (c) => c.tempId !== tempId
+      ),
     })),
-  clearPendingChangesets: () => set({ pendingChangesets: [] }),
 
   updateTransaction: (transaction, updates) =>
     set((state) => {

--- a/packages/app-finance/src/store/importStore.ts
+++ b/packages/app-finance/src/store/importStore.ts
@@ -10,6 +10,33 @@ import { findSimilarTransactions } from "../lib/transaction-utils";
 
 export type BankType = "Amex";
 
+// ---------------------------------------------------------------------------
+// Pending entity — created during import, stored locally until step 7 commit.
+// ---------------------------------------------------------------------------
+
+export interface PendingEntity {
+  tempId: string;
+  name: string;
+  type: string;
+  aliases: string[];
+  defaultTransactionType: string;
+  defaultTags: string[];
+  createdAt: string; // ISO-8601
+}
+
+// ---------------------------------------------------------------------------
+// Pending changeset — rule ChangeSet approved during import, not yet committed.
+// The `changeSet` field mirrors the server ChangeSet shape (source, reason, ops)
+// but is stored as an opaque record so the store stays decoupled from zod schemas.
+// ---------------------------------------------------------------------------
+
+export interface PendingChangeset {
+  id: string;
+  changeSet: Record<string, unknown>;
+  approvedAt: string; // ISO-8601
+  description: string;
+}
+
 /**
  * Extended ProcessedTransaction with frontend-only fields
  */
@@ -18,7 +45,7 @@ export interface ProcessedTransaction extends BaseProcessedTransaction {
 }
 
 interface ImportStore {
-  // Current wizard step (1-6)
+  // Current wizard step (1-7)
   currentStep: number;
 
   // Step 1: Upload
@@ -76,6 +103,10 @@ interface ImportStore {
     skipped: number;
   } | null;
 
+  // Local-first pending state (PRD-030)
+  pendingEntities: PendingEntity[];
+  pendingChangesets: PendingChangeset[];
+
   // Actions
   setFile: (file: File | null) => void;
   setBankType: (bankType: BankType) => void;
@@ -93,6 +124,16 @@ interface ImportStore {
   prevStep: () => void;
   goToStep: (step: number) => void;
   reset: () => void;
+
+  // Pending entity management (PRD-030 US-01)
+  addPendingEntity: (entity: PendingEntity) => void;
+  removePendingEntity: (tempId: string) => void;
+  clearPendingEntities: () => void;
+
+  // Pending changeset management (PRD-030 US-02)
+  addPendingChangeset: (cs: PendingChangeset) => void;
+  removePendingChangeset: (id: string) => void;
+  clearPendingChangesets: () => void;
 
   // Transaction management
   updateTransaction: (
@@ -130,6 +171,8 @@ const initialState = {
   confirmedTransactions: [],
   executeSessionId: null,
   importResult: null,
+  pendingEntities: [],
+  pendingChangesets: [],
 };
 
 /**
@@ -162,6 +205,8 @@ const downstreamReset: Pick<
   | "confirmedTransactions"
   | "executeSessionId"
   | "importResult"
+  | "pendingEntities"
+  | "pendingChangesets"
 > = {
   headers: initialState.headers,
   rows: initialState.rows,
@@ -173,6 +218,8 @@ const downstreamReset: Pick<
   confirmedTransactions: initialState.confirmedTransactions,
   executeSessionId: initialState.executeSessionId,
   importResult: initialState.importResult,
+  pendingEntities: initialState.pendingEntities,
+  pendingChangesets: initialState.pendingChangesets,
 };
 
 function isSameFile(a: File | null, b: File | null): boolean {
@@ -232,10 +279,28 @@ export const useImportStore = create<ImportStore>((set) => ({
   setExecuteSessionId: (executeSessionId) => set({ executeSessionId }),
   setImportResult: (importResult) => set({ importResult }),
 
-  nextStep: () => set((state) => ({ currentStep: Math.min(state.currentStep + 1, 6) })),
+  nextStep: () => set((state) => ({ currentStep: Math.min(state.currentStep + 1, 7) })),
   prevStep: () => set((state) => ({ currentStep: Math.max(state.currentStep - 1, 1) })),
   goToStep: (step) => set({ currentStep: step }),
   reset: () => set(initialState),
+
+  // Pending entity management (PRD-030 US-01)
+  addPendingEntity: (entity) =>
+    set((state) => ({ pendingEntities: [...state.pendingEntities, entity] })),
+  removePendingEntity: (tempId) =>
+    set((state) => ({
+      pendingEntities: state.pendingEntities.filter((e) => e.tempId !== tempId),
+    })),
+  clearPendingEntities: () => set({ pendingEntities: [] }),
+
+  // Pending changeset management (PRD-030 US-02)
+  addPendingChangeset: (cs) =>
+    set((state) => ({ pendingChangesets: [...state.pendingChangesets, cs] })),
+  removePendingChangeset: (id) =>
+    set((state) => ({
+      pendingChangesets: state.pendingChangesets.filter((c) => c.id !== id),
+    })),
+  clearPendingChangesets: () => set({ pendingChangesets: [] }),
 
   updateTransaction: (transaction, updates) =>
     set((state) => {


### PR DESCRIPTION
## Summary
- Aligns `PendingEntity` and `PendingChangeSet` zustand slices with PRD-030 acceptance criteria
- `addPendingEntity` generates `temp:entity:{uuid}` IDs and enforces case-insensitive name uniqueness against both pending list and DB entities
- `addPendingChangeSet` generates `temp:changeset:{uuid}` IDs with auto-timestamped `appliedAt`
- 28 unit tests covering all acceptance criteria: add, duplicate-pending, duplicate-db, remove, remove-nonexistent, list-ordering, reset

## Test plan
- [x] All 28 vitest tests pass
- [x] ESLint clean on both files
- [ ] Manual review: verify temp ID format matches `temp:entity:{uuid}` / `temp:changeset:{uuid}`
- [ ] Verify name uniqueness throws on case-insensitive duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)