### PR TITLE
feat(merged-state): computeMergedRules + computeMergedEntities (PRD-030 US-03+04) [tb-332]

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -11,6 +11,18 @@
     "./modules/finance/imports": {
       "types": "./src/modules/finance/imports/types.ts",
       "default": "./src/modules/finance/imports/types.ts"
+    },
+    "./modules/core/corrections/service": {
+      "types": "./src/modules/core/corrections/service.ts",
+      "default": "./src/modules/core/corrections/service.ts"
+    },
+    "./modules/core/corrections/types": {
+      "types": "./src/modules/core/corrections/types.ts",
+      "default": "./src/modules/core/corrections/types.ts"
+    },
+    "./modules/core/entities/types": {
+      "types": "./src/modules/core/entities/types.ts",
+      "default": "./src/modules/core/entities/types.ts"
     }
   },
   "scripts": {

--- a/docs/themes/02-finance/prds/030-local-first-import/README.md
+++ b/docs/themes/02-finance/prds/030-local-first-import/README.md
@@ -83,8 +83,8 @@ No new backend endpoints. All operations are zustand store actions and pure func
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-pending-entity-store](us-01-pending-entity-store.md) | Zustand slice buffering entity creations with temp IDs | Done | Yes |
 | 02 | [us-02-pending-changeset-store](us-02-pending-changeset-store.md) | Zustand slice buffering approved ChangeSets in order | Done | Yes |
-| 03 | [us-03-merged-rule-computation](us-03-merged-rule-computation.md) | Pure function computing merged rules from DB + pending ChangeSets | Not started | Blocked by US-02 |
-| 04 | [us-04-merged-entity-list](us-04-merged-entity-list.md) | Pure function computing merged entities from DB + pending | Not started | Blocked by US-01 |
+| 03 | [us-03-merged-rule-computation](us-03-merged-rule-computation.md) | Pure function computing merged rules from DB + pending ChangeSets | Done | Blocked by US-02 |
+| 04 | [us-04-merged-entity-list](us-04-merged-entity-list.md) | Pure function computing merged entities from DB + pending | Done | Blocked by US-01 |
 | 05 | [us-05-redirect-entity-creation](us-05-redirect-entity-creation.md) | EntityCreateDialog writes to local store instead of tRPC | Not started | Blocked by US-01, US-04 |
 | 06 | [us-06-redirect-changeset-approval](us-06-redirect-changeset-approval.md) | CorrectionProposalDialog stores ChangeSet locally instead of calling server | Not started | Blocked by US-02, US-03, US-07 |
 | 07 | [us-07-local-re-evaluation](us-07-local-re-evaluation.md) | Re-evaluate transactions against merged rule set after local approval | Not started | Blocked by US-03 |

--- a/docs/themes/02-finance/prds/030-local-first-import/us-03-merged-rule-computation.md
+++ b/docs/themes/02-finance/prds/030-local-first-import/us-03-merged-rule-computation.md
@@ -1,7 +1,7 @@
 # US-03: Merged rule set computation
 
 > PRD: [030 — Local-First Import State Layer](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -11,13 +11,13 @@ The function folds `applyChangeSetToRules` (from `corrections/service.ts`) over 
 
 ## Acceptance Criteria
 
-- [ ] A pure function `computeMergedRules(dbRules: CorrectionRow[], pendingChangeSets: PendingChangeSet[]) => CorrectionRow[]` exists and is exported.
-- [ ] The function applies each pending ChangeSet's `.changeSet` to the accumulator in insertion order using `applyChangeSetToRules`.
-- [ ] With zero pending ChangeSets, the function returns the DB rules array unchanged (referential equality).
-- [ ] With one pending ChangeSet containing an `add` operation, the result includes the new rule with a temp ID.
-- [ ] With multiple pending ChangeSets, later ChangeSets see the cumulative effect of earlier ones (e.g. a ChangeSet that edits a rule added by a prior ChangeSet works correctly).
-- [ ] The function is memoized so that identical inputs (by reference) return the same output reference.
-- [ ] Unit tests cover: zero pending, single add, single edit, multiple sequential (add then edit same rule), remove then reference (error case), mixed operations.
+- [x] A pure function `computeMergedRules(dbRules: CorrectionRow[], pendingChangeSets: PendingChangeSet[]) => CorrectionRow[]` exists and is exported.
+- [x] The function applies each pending ChangeSet's `.changeSet` to the accumulator in insertion order using `applyChangeSetToRules`.
+- [x] With zero pending ChangeSets, the function returns the DB rules array unchanged (referential equality).
+- [x] With one pending ChangeSet containing an `add` operation, the result includes the new rule with a temp ID.
+- [x] With multiple pending ChangeSets, later ChangeSets see the cumulative effect of earlier ones (e.g. a ChangeSet that edits a rule added by a prior ChangeSet works correctly).
+- [x] The function is memoized so that identical inputs (by reference) return the same output reference.
+- [x] Unit tests cover: zero pending, single add, single edit, multiple sequential (add then edit same rule), remove then reference (error case), mixed operations.
 
 ## Notes
 

--- a/docs/themes/02-finance/prds/030-local-first-import/us-04-merged-entity-list.md
+++ b/docs/themes/02-finance/prds/030-local-first-import/us-04-merged-entity-list.md
@@ -1,7 +1,7 @@
 # US-04: Merged entity list
 
 > PRD: [030 — Local-First Import State Layer](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -11,13 +11,13 @@ Pending entities are adapted to the `Entity` interface. When a pending entity ha
 
 ## Acceptance Criteria
 
-- [ ] A pure function `computeMergedEntities(dbEntities: Entity[], pendingEntities: PendingEntity[]) => Entity[]` exists and is exported.
-- [ ] Pending entities are mapped to the `Entity` interface, using their `tempId` as `id`, their `name`, and their `type`. Other `Entity` fields use sensible defaults (e.g. empty aliases, null optional fields).
-- [ ] When a pending entity's name matches a DB entity's name (case-insensitive comparison), the pending entity replaces the DB entity in the output.
-- [ ] When there is no name collision, both DB and pending entities appear in the output.
-- [ ] DB entities appear first in the output, followed by non-colliding pending entities (or a single sorted list — consistent ordering is the requirement).
-- [ ] The function is memoized so that identical inputs (by reference) return the same output reference.
-- [ ] Unit tests cover: zero pending, pending with no collision, pending replacing DB entity, multiple collisions, case-insensitive collision (e.g. "woolworths" vs "Woolworths"), empty DB list with pending entities.
+- [x] A pure function `computeMergedEntities(dbEntities: Entity[], pendingEntities: PendingEntity[]) => Entity[]` exists and is exported.
+- [x] Pending entities are mapped to the `Entity` interface, using their `tempId` as `id`, their `name`, and their `type`. Other `Entity` fields use sensible defaults (e.g. empty aliases, null optional fields).
+- [x] When a pending entity's name matches a DB entity's name (case-insensitive comparison), the pending entity replaces the DB entity in the output.
+- [x] When there is no name collision, both DB and pending entities appear in the output.
+- [x] DB entities appear first in the output, followed by non-colliding pending entities (or a single sorted list — consistent ordering is the requirement).
+- [x] The function is memoized so that identical inputs (by reference) return the same output reference.
+- [x] Unit tests cover: zero pending, pending with no collision, pending replacing DB entity, multiple collisions, case-insensitive collision (e.g. "woolworths" vs "Woolworths"), empty DB list with pending entities.
 
 ## Notes
 

--- a/packages/app-finance/src/lib/merged-state.test.ts
+++ b/packages/app-finance/src/lib/merged-state.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect } from "vitest";
+import type { CorrectionRow } from "@pops/api/modules/core/corrections/types";
+import type { Entity } from "@pops/api/modules/core/entities/types";
+import type { PendingChangeSet, PendingEntity, ChangeSetData } from "../store/importStore";
+import { computeMergedRules, computeMergedEntities } from "./merged-state";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRule(overrides: Partial<CorrectionRow> = {}): CorrectionRow {
+  return {
+    id: "rule-1",
+    descriptionPattern: "WOOLWORTHS",
+    matchType: "exact",
+    entityId: "entity-1",
+    entityName: "Woolworths",
+    location: null,
+    tags: "[]",
+    transactionType: "purchase",
+    isActive: true,
+    confidence: 0.95,
+    timesApplied: 10,
+    createdAt: "2026-01-01T00:00:00Z",
+    lastUsedAt: "2026-03-01T00:00:00Z",
+    ...overrides,
+  } as CorrectionRow;
+}
+
+function makePendingChangeSet(
+  changeSet: ChangeSetData,
+  overrides: Partial<PendingChangeSet> = {}
+): PendingChangeSet {
+  return {
+    tempId: `temp:changeset:${crypto.randomUUID()}`,
+    changeSet,
+    appliedAt: "2026-04-12T00:00:00Z",
+    source: "test",
+    ...overrides,
+  };
+}
+
+function makeEntity(overrides: Partial<Entity> = {}): Entity {
+  return {
+    id: "entity-1",
+    name: "Woolworths",
+    type: "merchant",
+    abn: null,
+    aliases: [],
+    defaultTransactionType: null,
+    defaultTags: [],
+    notes: null,
+    lastEditedTime: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makePendingEntity(overrides: Partial<PendingEntity> = {}): PendingEntity {
+  return {
+    tempId: `temp:entity:${crypto.randomUUID()}`,
+    name: "New Merchant",
+    type: "merchant",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeMergedRules — PRD-030 US-03
+// ---------------------------------------------------------------------------
+
+describe("computeMergedRules", () => {
+  it("returns dbRules unchanged (referential equality) when no pending ChangeSets", () => {
+    const dbRules = [makeRule()];
+    const result = computeMergedRules(dbRules, []);
+    expect(result).toBe(dbRules);
+  });
+
+  it("applies a single add operation", () => {
+    const dbRules = [makeRule()];
+    const cs = makePendingChangeSet({
+      ops: [
+        {
+          op: "add",
+          data: {
+            descriptionPattern: "coles",
+            matchType: "exact",
+            entityId: "entity-2",
+            entityName: "Coles",
+            confidence: 0.9,
+          },
+        },
+      ],
+    });
+
+    const result = computeMergedRules(dbRules, [cs]);
+    expect(result).toHaveLength(2);
+    expect(result[1].descriptionPattern).toBe("COLES");
+    expect(result[1].id).toMatch(/^temp:/);
+  });
+
+  it("applies a single edit operation", () => {
+    const dbRules = [makeRule({ id: "rule-1", confidence: 0.5 })];
+    const cs = makePendingChangeSet({
+      ops: [{ op: "edit", id: "rule-1", data: { confidence: 0.99 } }],
+    });
+
+    const result = computeMergedRules(dbRules, [cs]);
+    expect(result).toHaveLength(1);
+    expect(result[0].confidence).toBe(0.99);
+  });
+
+  it("applies multiple sequential ChangeSets (add then edit same rule)", () => {
+    const dbRules: CorrectionRow[] = [];
+
+    const cs1 = makePendingChangeSet({
+      ops: [
+        {
+          op: "add",
+          data: {
+            descriptionPattern: "aldi",
+            matchType: "exact",
+            entityId: "entity-3",
+            entityName: "Aldi",
+            confidence: 0.8,
+          },
+        },
+      ],
+    });
+
+    // After cs1, the added rule gets a temp ID like "temp:1"
+    const intermediateResult = computeMergedRules(dbRules, [cs1]);
+    const addedRuleId = intermediateResult[0].id;
+
+    const cs2 = makePendingChangeSet({
+      ops: [{ op: "edit", id: addedRuleId, data: { confidence: 0.95 } }],
+    });
+
+    const result = computeMergedRules(dbRules, [cs1, cs2]);
+    expect(result).toHaveLength(1);
+    expect(result[0].confidence).toBe(0.95);
+  });
+
+  it("throws when a ChangeSet references a removed rule", () => {
+    const dbRules = [makeRule({ id: "rule-1" })];
+
+    const cs1 = makePendingChangeSet({
+      ops: [{ op: "remove", id: "rule-1" }],
+    });
+
+    const cs2 = makePendingChangeSet({
+      ops: [{ op: "edit", id: "rule-1", data: { confidence: 0.5 } }],
+    });
+
+    expect(() => computeMergedRules(dbRules, [cs1, cs2])).toThrow();
+  });
+
+  it("handles mixed operations across ChangeSets", () => {
+    const dbRules = [
+      makeRule({ id: "rule-1", descriptionPattern: "WOOLWORTHS" }),
+      makeRule({ id: "rule-2", descriptionPattern: "COLES" }),
+    ];
+
+    const cs = makePendingChangeSet({
+      ops: [
+        {
+          op: "add",
+          data: {
+            descriptionPattern: "aldi",
+            matchType: "exact",
+            entityId: "entity-3",
+            entityName: "Aldi",
+            confidence: 0.8,
+          },
+        },
+        { op: "disable", id: "rule-2" },
+        { op: "edit", id: "rule-1", data: { confidence: 0.99 } },
+      ],
+    });
+
+    const result = computeMergedRules(dbRules, [cs]);
+    expect(result).toHaveLength(3);
+
+    const rule1 = result.find((r) => r.id === "rule-1");
+    expect(rule1?.confidence).toBe(0.99);
+
+    const rule2 = result.find((r) => r.id === "rule-2");
+    expect(rule2?.isActive).toBe(false);
+
+    const addedRule = result.find((r) => r.id.startsWith("temp:"));
+    expect(addedRule?.descriptionPattern).toBe("ALDI");
+  });
+
+  it("is memoized — same input refs return same output ref", () => {
+    const dbRules = [makeRule()];
+    const pending = [
+      makePendingChangeSet({
+        ops: [{ op: "edit", id: "rule-1", data: { confidence: 0.8 } }],
+      }),
+    ];
+
+    const result1 = computeMergedRules(dbRules, pending);
+    const result2 = computeMergedRules(dbRules, pending);
+    expect(result1).toBe(result2);
+  });
+
+  it("recomputes when input refs change", () => {
+    const dbRules = [makeRule()];
+    const pending1 = [
+      makePendingChangeSet({
+        ops: [{ op: "edit", id: "rule-1", data: { confidence: 0.8 } }],
+      }),
+    ];
+    const pending2 = [
+      makePendingChangeSet({
+        ops: [{ op: "edit", id: "rule-1", data: { confidence: 0.9 } }],
+      }),
+    ];
+
+    const result1 = computeMergedRules(dbRules, pending1);
+    const result2 = computeMergedRules(dbRules, pending2);
+    expect(result1).not.toBe(result2);
+    expect(result1[0].confidence).toBe(0.8);
+    expect(result2[0].confidence).toBe(0.9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeMergedEntities — PRD-030 US-04
+// ---------------------------------------------------------------------------
+
+describe("computeMergedEntities", () => {
+  it("returns dbEntities unchanged when no pending entities", () => {
+    const dbEntities = [makeEntity()];
+    const result = computeMergedEntities(dbEntities, []);
+    expect(result).toBe(dbEntities);
+  });
+
+  it("adds pending entities after DB entities when no collision", () => {
+    const dbEntities = [makeEntity({ id: "e1", name: "Woolworths" })];
+    const pending = [makePendingEntity({ name: "Coles" })];
+
+    const result = computeMergedEntities(dbEntities, pending);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Woolworths");
+    expect(result[1].name).toBe("Coles");
+    expect(result[1].id).toMatch(/^temp:entity:/);
+  });
+
+  it("replaces DB entity when pending entity has same name", () => {
+    const dbEntities = [makeEntity({ id: "e1", name: "Woolworths", type: "merchant" })];
+    const pending = [makePendingEntity({ name: "Woolworths", type: "supermarket" })];
+
+    const result = computeMergedEntities(dbEntities, pending);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toMatch(/^temp:entity:/);
+    expect(result[0].type).toBe("supermarket");
+  });
+
+  it("handles multiple collisions", () => {
+    const dbEntities = [
+      makeEntity({ id: "e1", name: "Woolworths" }),
+      makeEntity({ id: "e2", name: "Coles" }),
+      makeEntity({ id: "e3", name: "Aldi" }),
+    ];
+    const pending = [
+      makePendingEntity({ name: "Woolworths", type: "updated" }),
+      makePendingEntity({ name: "Coles", type: "updated" }),
+    ];
+
+    const result = computeMergedEntities(dbEntities, pending);
+    expect(result).toHaveLength(3);
+    // Aldi (non-colliding DB) comes first
+    expect(result[0].name).toBe("Aldi");
+    expect(result[0].id).toBe("e3");
+    // Then pending entities
+    expect(result[1].type).toBe("updated");
+    expect(result[2].type).toBe("updated");
+  });
+
+  it("handles case-insensitive collision", () => {
+    const dbEntities = [makeEntity({ id: "e1", name: "Woolworths" })];
+    const pending = [makePendingEntity({ name: "woolworths", type: "updated" })];
+
+    const result = computeMergedEntities(dbEntities, pending);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("woolworths");
+    expect(result[0].id).toMatch(/^temp:entity:/);
+  });
+
+  it("handles empty DB list with pending entities", () => {
+    const pending = [
+      makePendingEntity({ name: "New Corp" }),
+      makePendingEntity({ name: "Another Corp" }),
+    ];
+
+    const result = computeMergedEntities([], pending);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("New Corp");
+    expect(result[1].name).toBe("Another Corp");
+    expect(result[0].aliases).toEqual([]);
+    expect(result[0].abn).toBeNull();
+    expect(result[0].defaultTransactionType).toBeNull();
+    expect(result[0].defaultTags).toEqual([]);
+    expect(result[0].notes).toBeNull();
+  });
+
+  it("is memoized — same input refs return same output ref", () => {
+    const dbEntities = [makeEntity()];
+    const pending = [makePendingEntity()];
+
+    const result1 = computeMergedEntities(dbEntities, pending);
+    const result2 = computeMergedEntities(dbEntities, pending);
+    expect(result1).toBe(result2);
+  });
+
+  it("recomputes when input refs change", () => {
+    const dbEntities = [makeEntity()];
+    const pending1 = [makePendingEntity({ name: "A" })];
+    const pending2 = [makePendingEntity({ name: "B" })];
+
+    const result1 = computeMergedEntities(dbEntities, pending1);
+    const result2 = computeMergedEntities(dbEntities, pending2);
+    expect(result1).not.toBe(result2);
+  });
+});

--- a/packages/app-finance/src/lib/merged-state.test.ts
+++ b/packages/app-finance/src/lib/merged-state.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { CorrectionRow } from "@pops/api/modules/core/corrections/types";
 import type { Entity } from "@pops/api/modules/core/entities/types";
-import type { PendingChangeSet, PendingEntity, ChangeSetData } from "../store/importStore";
+import type { PendingChangeSet, PendingEntity, ChangeSet } from "../store/importStore";
 import { computeMergedRules, computeMergedEntities } from "./merged-state";
 
 // ---------------------------------------------------------------------------
@@ -28,7 +28,7 @@ function makeRule(overrides: Partial<CorrectionRow> = {}): CorrectionRow {
 }
 
 function makePendingChangeSet(
-  changeSet: ChangeSetData,
+  changeSet: ChangeSet,
   overrides: Partial<PendingChangeSet> = {}
 ): PendingChangeSet {
   return {

--- a/packages/app-finance/src/lib/merged-state.test.ts
+++ b/packages/app-finance/src/lib/merged-state.test.ts
@@ -21,6 +21,7 @@ function makeRule(overrides: Partial<CorrectionRow> = {}): CorrectionRow {
     isActive: true,
     confidence: 0.95,
     timesApplied: 10,
+    priority: 0,
     createdAt: "2026-01-01T00:00:00Z",
     lastUsedAt: "2026-03-01T00:00:00Z",
     ...overrides,

--- a/packages/app-finance/src/lib/merged-state.ts
+++ b/packages/app-finance/src/lib/merged-state.ts
@@ -1,0 +1,108 @@
+import { applyChangeSetToRules } from "@pops/api/modules/core/corrections/service";
+import type { CorrectionRow } from "@pops/api/modules/core/corrections/types";
+import type { Entity } from "@pops/api/modules/core/entities/types";
+import type { PendingChangeSet, PendingEntity } from "../store/importStore";
+
+// ---------------------------------------------------------------------------
+// computeMergedRules — PRD-030 US-03
+// ---------------------------------------------------------------------------
+
+let _cachedRulesInput: { dbRules: CorrectionRow[]; pending: PendingChangeSet[] } | null = null;
+let _cachedRulesOutput: CorrectionRow[] | null = null;
+
+/**
+ * Fold `applyChangeSetToRules` over each pending ChangeSet in insertion order,
+ * starting from the DB rules as the base. Memoized by reference equality on
+ * both input arrays.
+ */
+export function computeMergedRules(
+  dbRules: CorrectionRow[],
+  pendingChangeSets: PendingChangeSet[]
+): CorrectionRow[] {
+  // Memoization: same input refs → same output ref
+  if (
+    _cachedRulesInput &&
+    _cachedRulesInput.dbRules === dbRules &&
+    _cachedRulesInput.pending === pendingChangeSets &&
+    _cachedRulesOutput
+  ) {
+    return _cachedRulesOutput;
+  }
+
+  let result: CorrectionRow[];
+
+  if (pendingChangeSets.length === 0) {
+    result = dbRules;
+  } else {
+    result = pendingChangeSets.reduce<CorrectionRow[]>(
+      (acc, pcs) => applyChangeSetToRules(acc, pcs.changeSet),
+      dbRules
+    );
+  }
+
+  _cachedRulesInput = { dbRules, pending: pendingChangeSets };
+  _cachedRulesOutput = result;
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// computeMergedEntities — PRD-030 US-04
+// ---------------------------------------------------------------------------
+
+let _cachedEntitiesInput: { dbEntities: Entity[]; pending: PendingEntity[] } | null = null;
+let _cachedEntitiesOutput: Entity[] | null = null;
+
+/**
+ * Adapt pending entities to the `Entity` interface and merge them with DB
+ * entities. When a pending entity's name matches a DB entity's name
+ * (case-insensitive), the pending version replaces the DB entry.
+ * DB entities appear first, followed by non-colliding pending entities.
+ * Memoized by reference equality on both input arrays.
+ */
+export function computeMergedEntities(
+  dbEntities: Entity[],
+  pendingEntities: PendingEntity[]
+): Entity[] {
+  // Memoization: same input refs → same output ref
+  if (
+    _cachedEntitiesInput &&
+    _cachedEntitiesInput.dbEntities === dbEntities &&
+    _cachedEntitiesInput.pending === pendingEntities &&
+    _cachedEntitiesOutput
+  ) {
+    return _cachedEntitiesOutput;
+  }
+
+  if (pendingEntities.length === 0) {
+    _cachedEntitiesInput = { dbEntities, pending: pendingEntities };
+    _cachedEntitiesOutput = dbEntities;
+    return dbEntities;
+  }
+
+  // Build a set of pending entity names (lowercased) for collision detection
+  const pendingNameSet = new Set(pendingEntities.map((pe) => pe.name.toLowerCase()));
+
+  // Map pending entities to the Entity interface
+  const adaptedPending: Entity[] = pendingEntities.map((pe) => ({
+    id: pe.tempId,
+    name: pe.name,
+    type: pe.type,
+    abn: null,
+    aliases: [],
+    defaultTransactionType: null,
+    defaultTags: [],
+    notes: null,
+    lastEditedTime: new Date().toISOString(),
+  }));
+
+  // Filter out DB entities that collide with pending entities
+  const filteredDb = dbEntities.filter((e) => !pendingNameSet.has(e.name.toLowerCase()));
+
+  // DB entities first, then non-colliding pending (all pending are non-colliding
+  // with each other since addPendingEntity enforces uniqueness)
+  const result = [...filteredDb, ...adaptedPending];
+
+  _cachedEntitiesInput = { dbEntities, pending: pendingEntities };
+  _cachedEntitiesOutput = result;
+  return result;
+}

--- a/packages/app-finance/src/store/importStore.test.ts
+++ b/packages/app-finance/src/store/importStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type { ParsedTransaction } from "@pops/api/modules/finance/imports";
-import { useImportStore, type ProcessedTransaction, type ChangeSetData } from "./importStore";
+import { useImportStore, type ProcessedTransaction, type ChangeSet } from "./importStore";
 
 // ---------------------------------------------------------------------------
 // importStore — parsedTransactionsFingerprint / processedForFingerprint tests
@@ -147,10 +147,10 @@ describe("importStore — step range", () => {
 // Pending entities (PRD-030 US-01)
 // ---------------------------------------------------------------------------
 
-const sampleChangeSet: ChangeSetData = {
+const sampleChangeSet: ChangeSet = {
   source: "ai",
   reason: "test",
-  ops: [{ op: "add", data: {} }],
+  ops: [{ op: "add", data: { descriptionPattern: "TEST", matchType: "exact" } }],
 };
 
 describe("importStore — pendingEntities (PRD-030 US-01)", () => {

--- a/packages/app-finance/src/store/importStore.ts
+++ b/packages/app-finance/src/store/importStore.ts
@@ -6,9 +6,11 @@ import type {
   ImportResult,
   ImportWarning,
 } from "@pops/api/modules/finance/imports";
+import type { ChangeSet } from "@pops/api/modules/core/corrections/types";
 import { findSimilarTransactions } from "../lib/transaction-utils";
 
 export type BankType = "Amex";
+export type { ChangeSet };
 
 // ---------------------------------------------------------------------------
 // Pending entity — created during import, stored locally until step 7 commit.
@@ -30,23 +32,16 @@ export interface AddPendingEntityInput {
 // Pending changeset — rule ChangeSet approved during import, not yet committed.
 // ---------------------------------------------------------------------------
 
-/** Mirrors the server ChangeSet shape (source, reason, ops). */
-export interface ChangeSetData {
-  source?: string;
-  reason?: string;
-  ops: Record<string, unknown>[];
-}
-
 export interface PendingChangeSet {
   tempId: string; // Format: temp:changeset:{uuid}
-  changeSet: ChangeSetData;
+  changeSet: ChangeSet;
   appliedAt: string; // ISO-8601
   source: string;
 }
 
 /** Input for creating a pending changeset (tempId and appliedAt are generated internally). */
 export interface AddPendingChangeSetInput {
-  changeSet: ChangeSetData;
+  changeSet: ChangeSet;
   source: string;
 }
 


### PR DESCRIPTION
## Summary
- `computeMergedRules`: folds `applyChangeSetToRules` over pending ChangeSets in order, memoized by reference equality
- `computeMergedEntities`: merges DB + pending entities with case-insensitive collision handling, memoized
- Added `@pops/api` exports for corrections and entities types/service so frontend can import pure functions
- 16 unit tests covering all acceptance criteria from US-03 and US-04

## Test plan
- [x] All 16 vitest tests pass
- [x] ESLint + Prettier clean
- [ ] Verify memoization: same refs return same output ref
- [ ] Verify collision: pending entity replaces DB entity on case-insensitive match

🤖 Generated with [Claude Code](https://claude.com/claude-code)