### PR TITLE
feat(imports): commitImport atomic endpoint (PRD-031 US-03)

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/router.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/router.test.ts
@@ -569,3 +569,235 @@ describe("imports.applyChangeSetAndReevaluate", () => {
     expect(after.uncertain.some((t) => t.checksum === "zzz999")).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// commitImport
+// ---------------------------------------------------------------------------
+
+function makeTxn(overrides: Partial<ConfirmedTransaction> = {}): ConfirmedTransaction {
+  return {
+    date: "2025-01-15",
+    description: overrides.description ?? "WOOLWORTHS 1234",
+    amount: overrides.amount ?? -42.5,
+    account: overrides.account ?? "Amex",
+    rawRow: overrides.rawRow ?? '{"line":"test"}',
+    checksum: overrides.checksum ?? `chk-${Math.random().toString(36).slice(2, 10)}`,
+    ...overrides,
+  };
+}
+
+describe("imports.commitImport", () => {
+  it("commits transactions only (no entities or changeSets)", async () => {
+    const result = await caller.finance.imports.commitImport({
+      transactions: [makeTxn({ description: "COLES SUPERMARKET" })],
+    });
+
+    expect(result.data.entitiesCreated).toBe(0);
+    expect(result.data.transactionsImported).toBe(1);
+    expect(result.data.transactionsFailed).toBe(0);
+    expect(result.data.rulesApplied).toEqual({ add: 0, edit: 0, disable: 0, remove: 0 });
+    expect(result.data.retroactiveReclassifications).toBe(0);
+    expect(result.message).toBe("Import committed");
+
+    // Verify transaction written to DB
+    const rows = db.prepare("SELECT * FROM transactions WHERE description = ?").all("COLES SUPERMARKET");
+    expect(rows).toHaveLength(1);
+  });
+
+  it("creates pending entities and resolves temp IDs in transactions", async () => {
+    const tempId = "temp:entity:00000000-0000-0000-0000-000000000001";
+
+    const result = await caller.finance.imports.commitImport({
+      entities: [{ tempId, name: "Woolworths", type: "company" }],
+      changeSets: [],
+      transactions: [
+        makeTxn({
+          description: "WOOLWORTHS 1234",
+          entityId: tempId,
+          entityName: "Woolworths",
+        }),
+      ],
+    });
+
+    expect(result.data.entitiesCreated).toBe(1);
+    expect(result.data.transactionsImported).toBe(1);
+
+    // Verify entity was created
+    const entity = db.prepare("SELECT * FROM entities WHERE name = ?").get("Woolworths") as { id: string; type: string };
+    expect(entity).toBeDefined();
+    expect(entity.type).toBe("company");
+
+    // Verify transaction has the real entity ID (not temp ID)
+    const txn = db.prepare("SELECT entity_id FROM transactions WHERE description = ?").get("WOOLWORTHS 1234") as { entity_id: string };
+    expect(txn.entity_id).toBe(entity.id);
+    expect(txn.entity_id).not.toBe(tempId);
+  });
+
+  it("creates entities with non-default type", async () => {
+    const tempId = "temp:entity:00000000-0000-0000-0000-000000000002";
+
+    await caller.finance.imports.commitImport({
+      entities: [{ tempId, name: "ATO", type: "government" }],
+      transactions: [makeTxn()],
+    });
+
+    const entity = db.prepare("SELECT type FROM entities WHERE name = ?").get("ATO") as { type: string };
+    expect(entity.type).toBe("government");
+  });
+
+  it("resolves temp IDs in changeSet add ops", async () => {
+    const tempId = "temp:entity:00000000-0000-0000-0000-000000000003";
+
+    const result = await caller.finance.imports.commitImport({
+      entities: [{ tempId, name: "TestCorp" }],
+      changeSets: [
+        {
+          ops: [
+            {
+              op: "add" as const,
+              data: {
+                descriptionPattern: "TESTCORP",
+                matchType: "exact" as const,
+                entityId: tempId,
+                entityName: "TestCorp",
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [makeTxn()],
+    });
+
+    expect(result.data.entitiesCreated).toBe(1);
+    expect(result.data.rulesApplied).toEqual({ add: 1, edit: 0, disable: 0, remove: 0 });
+
+    // Verify the correction rule has the real entity ID
+    const entity = db.prepare("SELECT id FROM entities WHERE name = ?").get("TestCorp") as { id: string };
+    const rule = db.prepare("SELECT entity_id FROM transaction_corrections WHERE description_pattern = ?").get("TESTCORP") as { entity_id: string };
+    expect(rule.entity_id).toBe(entity.id);
+  });
+
+  it("skips empty entities and changeSets without error", async () => {
+    const result = await caller.finance.imports.commitImport({
+      entities: [],
+      changeSets: [],
+      transactions: [makeTxn()],
+    });
+
+    expect(result.data.entitiesCreated).toBe(0);
+    expect(result.data.rulesApplied).toEqual({ add: 0, edit: 0, disable: 0, remove: 0 });
+    expect(result.data.transactionsImported).toBe(1);
+  });
+
+  it("rejects unknown temp IDs with BAD_REQUEST", async () => {
+    const unknownTempId = "temp:entity:00000000-0000-0000-0000-999999999999";
+
+    await expect(
+      caller.finance.imports.commitImport({
+        transactions: [makeTxn({ entityId: unknownTempId })],
+      })
+    ).rejects.toThrow(TRPCError);
+
+    await expect(
+      caller.finance.imports.commitImport({
+        transactions: [makeTxn({ entityId: unknownTempId })],
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("rejects duplicate temp IDs", async () => {
+    const tempId = "temp:entity:00000000-0000-0000-0000-000000000004";
+
+    await expect(
+      caller.finance.imports.commitImport({
+        entities: [
+          { tempId, name: "Entity A" },
+          { tempId, name: "Entity B" },
+        ],
+        transactions: [makeTxn()],
+      })
+    ).rejects.toThrow(TRPCError);
+  });
+
+  it("rejects duplicate entity names", async () => {
+    const tempId1 = "temp:entity:00000000-0000-0000-0000-000000000005";
+    const tempId2 = "temp:entity:00000000-0000-0000-0000-000000000006";
+
+    await expect(
+      caller.finance.imports.commitImport({
+        entities: [
+          { tempId: tempId1, name: "Woolworths" },
+          { tempId: tempId2, name: "woolworths" },
+        ],
+        transactions: [makeTxn()],
+      })
+    ).rejects.toThrow(TRPCError);
+  });
+
+  it("rejects malformed temp ID format", async () => {
+    await expect(
+      caller.finance.imports.commitImport({
+        entities: [{ tempId: "bad-format", name: "Test" }],
+        transactions: [makeTxn()],
+      })
+    ).rejects.toThrow();
+  });
+
+  it("rolls back all writes if changeSet application fails", async () => {
+    const tempId = "temp:entity:00000000-0000-0000-0000-000000000007";
+    const entitiesBefore = db.prepare("SELECT count(*) as c FROM entities").get() as { c: number };
+    const txnsBefore = db.prepare("SELECT count(*) as c FROM transactions").get() as { c: number };
+
+    // This should fail because the edit op references a non-existent rule ID
+    await expect(
+      caller.finance.imports.commitImport({
+        entities: [{ tempId, name: "RollbackTest" }],
+        changeSets: [
+          {
+            ops: [{ op: "edit" as const, id: "non-existent-rule-id", data: { confidence: 0.9 } }],
+          },
+        ],
+        transactions: [makeTxn({ entityId: tempId, entityName: "RollbackTest" })],
+      })
+    ).rejects.toThrow();
+
+    // Verify entity was NOT created (rolled back)
+    const entitiesAfter = db.prepare("SELECT count(*) as c FROM entities").get() as { c: number };
+    expect(entitiesAfter.c).toBe(entitiesBefore.c);
+
+    // Verify no transactions were written (rolled back)
+    const txnsAfter = db.prepare("SELECT count(*) as c FROM transactions").get() as { c: number };
+    expect(txnsAfter.c).toBe(txnsBefore.c);
+  });
+
+  it("handles multiple entities and multiple transactions", async () => {
+    const tempId1 = "temp:entity:00000000-0000-0000-0000-000000000008";
+    const tempId2 = "temp:entity:00000000-0000-0000-0000-000000000009";
+
+    const result = await caller.finance.imports.commitImport({
+      entities: [
+        { tempId: tempId1, name: "Woolworths" },
+        { tempId: tempId2, name: "Coles", type: "company" },
+      ],
+      changeSets: [],
+      transactions: [
+        makeTxn({ description: "WOOLWORTHS 1", entityId: tempId1, entityName: "Woolworths" }),
+        makeTxn({ description: "COLES 1", entityId: tempId2, entityName: "Coles" }),
+        makeTxn({ description: "TRANSFER", transactionType: "transfer" }),
+      ],
+    });
+
+    expect(result.data.entitiesCreated).toBe(2);
+    expect(result.data.transactionsImported).toBe(3);
+  });
+
+  it("throws UNAUTHORIZED without auth", async () => {
+    const unauthCaller = createCaller(false);
+    await expect(
+      unauthCaller.finance.imports.commitImport({ transactions: [makeTxn()] })
+    ).rejects.toThrow(TRPCError);
+    await expect(
+      unauthCaller.finance.imports.commitImport({ transactions: [makeTxn()] })
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});

--- a/apps/pops-api/src/modules/finance/imports/router.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/router.test.ts
@@ -600,7 +600,9 @@ describe("imports.commitImport", () => {
     expect(result.message).toBe("Import committed");
 
     // Verify transaction written to DB
-    const rows = db.prepare("SELECT * FROM transactions WHERE description = ?").all("COLES SUPERMARKET");
+    const rows = db
+      .prepare("SELECT * FROM transactions WHERE description = ?")
+      .all("COLES SUPERMARKET");
     expect(rows).toHaveLength(1);
   });
 
@@ -623,12 +625,17 @@ describe("imports.commitImport", () => {
     expect(result.data.transactionsImported).toBe(1);
 
     // Verify entity was created
-    const entity = db.prepare("SELECT * FROM entities WHERE name = ?").get("Woolworths") as { id: string; type: string };
+    const entity = db.prepare("SELECT * FROM entities WHERE name = ?").get("Woolworths") as {
+      id: string;
+      type: string;
+    };
     expect(entity).toBeDefined();
     expect(entity.type).toBe("company");
 
     // Verify transaction has the real entity ID (not temp ID)
-    const txn = db.prepare("SELECT entity_id FROM transactions WHERE description = ?").get("WOOLWORTHS 1234") as { entity_id: string };
+    const txn = db
+      .prepare("SELECT entity_id FROM transactions WHERE description = ?")
+      .get("WOOLWORTHS 1234") as { entity_id: string };
     expect(txn.entity_id).toBe(entity.id);
     expect(txn.entity_id).not.toBe(tempId);
   });
@@ -641,7 +648,9 @@ describe("imports.commitImport", () => {
       transactions: [makeTxn()],
     });
 
-    const entity = db.prepare("SELECT type FROM entities WHERE name = ?").get("ATO") as { type: string };
+    const entity = db.prepare("SELECT type FROM entities WHERE name = ?").get("ATO") as {
+      type: string;
+    };
     expect(entity.type).toBe("government");
   });
 
@@ -672,8 +681,12 @@ describe("imports.commitImport", () => {
     expect(result.data.rulesApplied).toEqual({ add: 1, edit: 0, disable: 0, remove: 0 });
 
     // Verify the correction rule has the real entity ID
-    const entity = db.prepare("SELECT id FROM entities WHERE name = ?").get("TestCorp") as { id: string };
-    const rule = db.prepare("SELECT entity_id FROM transaction_corrections WHERE description_pattern = ?").get("TESTCORP") as { entity_id: string };
+    const entity = db.prepare("SELECT id FROM entities WHERE name = ?").get("TestCorp") as {
+      id: string;
+    };
+    const rule = db
+      .prepare("SELECT entity_id FROM transaction_corrections WHERE description_pattern = ?")
+      .get("TESTCORP") as { entity_id: string };
     expect(rule.entity_id).toBe(entity.id);
   });
 

--- a/apps/pops-api/src/modules/finance/imports/router.ts
+++ b/apps/pops-api/src/modules/finance/imports/router.ts
@@ -6,6 +6,7 @@
  * - executeImport: Write confirmed transactions to SQLite - returns session ID for polling
  * - getImportProgress: Poll for import progress by session ID
  * - createEntity: Create new entity in SQLite
+ * - commitImport: Atomically create entities, apply changeSets, and write transactions
  */
 import { z } from "zod";
 import crypto from "crypto";
@@ -16,6 +17,7 @@ import {
   executeImportInputSchema,
   createEntityInputSchema,
   applyChangeSetAndReevaluateInputSchema,
+  commitPayloadSchema,
   type ProcessImportOutput,
 } from "./types.js";
 import {
@@ -23,10 +25,11 @@ import {
   executeImportWithProgress,
   createEntity,
   reevaluateImportSessionResult,
+  commitImport,
 } from "./service.js";
 import { setProgress, getProgress, updateProgress } from "./progress-store.js";
 import { applyChangeSet } from "../../core/corrections/service.js";
-import { NotFoundError } from "../../../shared/errors.js";
+import { NotFoundError, ValidationError } from "../../../shared/errors.js";
 
 function isProcessImportOutput(result: unknown): result is ProcessImportOutput {
   return (
@@ -165,4 +168,20 @@ export const importsRouter = router({
 
       return { result: nextResult, affectedCount };
     }),
+
+  /**
+   * Commit an import atomically: create entities, apply rule changeSets,
+   * and write transactions in a single SQLite transaction.
+   */
+  commitImport: protectedProcedure.input(commitPayloadSchema).mutation(({ input }) => {
+    try {
+      const result = commitImport(input);
+      return { data: result, message: "Import committed" };
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: err.message });
+      }
+      throw err;
+    }
+  }),
 });

--- a/apps/pops-api/src/modules/finance/imports/service.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.ts
@@ -19,6 +19,8 @@ import { updateProgress } from "./progress-store.js";
 import { findMatchingCorrection } from "../../core/corrections/service.js";
 import { suggestTags } from "../../../shared/tag-suggester.js";
 import type { TransactionRow } from "../transactions/types.js";
+import { applyChangeSet } from "../../core/corrections/service.js";
+import { ValidationError } from "../../../shared/errors.js";
 import type {
   ParsedTransaction,
   ProcessedTransaction,
@@ -30,6 +32,9 @@ import type {
   ImportWarning,
   AiUsageStats,
   SuggestedTag,
+  CommitPayload,
+  CommitResult,
+  PendingEntity,
 } from "./types.js";
 
 export function reevaluateImportSessionResult(args: {
@@ -1001,4 +1006,180 @@ export function executeImportWithProgress(
       ],
     });
   }
+}
+
+// ---------------------------------------------------------------------------
+// Commit import (PRD-031 US-03) — atomic write of entities + rules + transactions
+// ---------------------------------------------------------------------------
+
+const TEMP_ENTITY_PREFIX = "temp:entity:";
+
+/**
+ * Validate a commit payload before executing the transaction.
+ * Checks that all temp ID references in changeSets and transactions
+ * can be resolved against the provided pending entities.
+ */
+function validateCommitPayload(payload: CommitPayload): void {
+  const tempIds = new Set(payload.entities.map((e) => e.tempId));
+
+  // Check for duplicate temp IDs
+  if (tempIds.size !== payload.entities.length) {
+    throw new ValidationError("Duplicate temp IDs in entities array");
+  }
+
+  // Check for duplicate entity names (case-insensitive)
+  const names = new Set<string>();
+  for (const entity of payload.entities) {
+    const lower = entity.name.toLowerCase();
+    if (names.has(lower)) {
+      throw new ValidationError(`Duplicate entity name: '${entity.name}'`);
+    }
+    names.add(lower);
+  }
+
+  // Collect all temp entity ID references in changeSets and transactions
+  const referencedTempIds = new Set<string>();
+
+  for (const cs of payload.changeSets) {
+    for (const op of cs.ops) {
+      if (op.op === "add" && op.data.entityId?.startsWith(TEMP_ENTITY_PREFIX)) {
+        referencedTempIds.add(op.data.entityId);
+      }
+      if (op.op === "edit" && op.data.entityId?.startsWith(TEMP_ENTITY_PREFIX)) {
+        referencedTempIds.add(op.data.entityId);
+      }
+    }
+  }
+
+  for (const txn of payload.transactions) {
+    if (txn.entityId?.startsWith(TEMP_ENTITY_PREFIX)) {
+      referencedTempIds.add(txn.entityId);
+    }
+  }
+
+  // Verify all referenced temp IDs exist in the entities array
+  for (const ref of referencedTempIds) {
+    if (!tempIds.has(ref)) {
+      throw new ValidationError(`Unknown temp ID referenced: '${ref}'`);
+    }
+  }
+}
+
+/**
+ * Replace temp entity IDs with real DB IDs in a ChangeSet's ops (returns a new ChangeSet).
+ */
+function resolveChangeSetTempIds(
+  cs: CommitPayload["changeSets"][number],
+  tempIdMap: Map<string, string>
+): CommitPayload["changeSets"][number] {
+  return {
+    ...cs,
+    ops: cs.ops.map((op) => {
+      if (op.op === "add" && op.data.entityId?.startsWith(TEMP_ENTITY_PREFIX)) {
+        const realId = tempIdMap.get(op.data.entityId);
+        return { ...op, data: { ...op.data, entityId: realId ?? op.data.entityId } };
+      }
+      if (op.op === "edit" && op.data.entityId?.startsWith(TEMP_ENTITY_PREFIX)) {
+        const realId = tempIdMap.get(op.data.entityId);
+        return { ...op, data: { ...op.data, entityId: realId ?? op.data.entityId } };
+      }
+      return op;
+    }),
+  };
+}
+
+/**
+ * Atomically commit an import: create entities, apply rule changeSets,
+ * and write transactions inside a single SQLite transaction.
+ */
+export function commitImport(payload: CommitPayload): CommitResult {
+  // Validate before starting the transaction
+  validateCommitPayload(payload);
+
+  const db = getDrizzle();
+
+  return db.transaction(() => {
+    // Phase 1: Create entities, build tempId -> realId map
+    const tempIdMap = new Map<string, string>();
+    let entitiesCreated = 0;
+
+    for (const pending of payload.entities) {
+      const { entityId } = createEntity(pending.name);
+      tempIdMap.set(pending.tempId, entityId);
+      entitiesCreated++;
+
+      // Update entity type if not default
+      if (pending.type !== "company") {
+        db.update(entities)
+          .set({ type: pending.type })
+          .where(eq(entities.id, entityId))
+          .run();
+      }
+    }
+
+    // Phase 2: Apply changeSets with resolved temp IDs
+    const rulesApplied = { add: 0, edit: 0, disable: 0, remove: 0 };
+
+    for (const cs of payload.changeSets) {
+      const resolved = resolveChangeSetTempIds(cs, tempIdMap);
+      applyChangeSet(resolved);
+
+      // Count ops by type
+      for (const op of resolved.ops) {
+        rulesApplied[op.op]++;
+      }
+    }
+
+    // Phase 3: Write transactions with resolved temp IDs
+    let transactionsImported = 0;
+    let transactionsFailed = 0;
+
+    for (const txn of payload.transactions) {
+      const entityId = txn.entityId?.startsWith(TEMP_ENTITY_PREFIX)
+        ? tempIdMap.get(txn.entityId) ?? txn.entityId
+        : txn.entityId;
+
+      try {
+        const type =
+          txn.transactionType === "transfer"
+            ? "Transfer"
+            : txn.transactionType === "income"
+              ? "Income"
+              : "Expense";
+
+        insertTransaction({
+          description: txn.description,
+          account: txn.account,
+          amount: txn.amount,
+          date: txn.date,
+          type,
+          tags: txn.tags ?? [],
+          entityId: entityId ?? null,
+          entityName: txn.entityName ?? null,
+          location: txn.location ?? null,
+          rawRow: txn.rawRow,
+          checksum: txn.checksum,
+        });
+
+        transactionsImported++;
+      } catch (error) {
+        logger.error(
+          {
+            description: txn.description.substring(0, 50),
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "[CommitImport] Transaction write failed"
+        );
+        transactionsFailed++;
+      }
+    }
+
+    return {
+      entitiesCreated,
+      rulesApplied,
+      transactionsImported,
+      transactionsFailed,
+      retroactiveReclassifications: 0,
+    };
+  });
 }

--- a/apps/pops-api/src/modules/finance/imports/service.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.ts
@@ -34,7 +34,6 @@ import type {
   SuggestedTag,
   CommitPayload,
   CommitResult,
-  PendingEntity,
 } from "./types.js";
 
 export function reevaluateImportSessionResult(args: {

--- a/apps/pops-api/src/modules/finance/imports/service.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.ts
@@ -1109,10 +1109,7 @@ export function commitImport(payload: CommitPayload): CommitResult {
 
       // Update entity type if not default
       if (pending.type !== "company") {
-        db.update(entities)
-          .set({ type: pending.type })
-          .where(eq(entities.id, entityId))
-          .run();
+        db.update(entities).set({ type: pending.type }).where(eq(entities.id, entityId)).run();
       }
     }
 
@@ -1135,7 +1132,7 @@ export function commitImport(payload: CommitPayload): CommitResult {
 
     for (const txn of payload.transactions) {
       const entityId = txn.entityId?.startsWith(TEMP_ENTITY_PREFIX)
-        ? tempIdMap.get(txn.entityId) ?? txn.entityId
+        ? (tempIdMap.get(txn.entityId) ?? txn.entityId)
         : txn.entityId;
 
       try {

--- a/apps/pops-api/src/modules/finance/imports/types.ts
+++ b/apps/pops-api/src/modules/finance/imports/types.ts
@@ -208,3 +208,45 @@ export const applyChangeSetAndReevaluateOutputSchema = z.object({
 export type ApplyChangeSetAndReevaluateOutput = z.infer<
   typeof applyChangeSetAndReevaluateOutputSchema
 >;
+
+// ---------------------------------------------------------------------------
+// Commit import (PRD-031 US-03)
+// ---------------------------------------------------------------------------
+
+export const pendingEntitySchema = z.object({
+  tempId: z.string().regex(/^temp:entity:[0-9a-f-]{36}$/, "Temp ID must match temp:entity:{uuid}"),
+  name: z.string().min(1),
+  type: z.enum(["company", "person", "government", "bank"]).default("company"),
+});
+
+export type PendingEntity = z.infer<typeof pendingEntitySchema>;
+
+export const pendingChangeSetSchema = ChangeSetSchema;
+export type PendingChangeSet = z.infer<typeof pendingChangeSetSchema>;
+
+export const commitPayloadSchema = z.object({
+  entities: z.array(pendingEntitySchema).default([]),
+  changeSets: z.array(pendingChangeSetSchema).default([]),
+  transactions: z.array(confirmedTransactionSchema),
+});
+
+export type CommitPayload = z.infer<typeof commitPayloadSchema>;
+
+export const rulesAppliedSchema = z.object({
+  add: z.number().int().nonnegative(),
+  edit: z.number().int().nonnegative(),
+  disable: z.number().int().nonnegative(),
+  remove: z.number().int().nonnegative(),
+});
+
+export type RulesApplied = z.infer<typeof rulesAppliedSchema>;
+
+export const commitResultSchema = z.object({
+  entitiesCreated: z.number().int().nonnegative(),
+  rulesApplied: rulesAppliedSchema,
+  transactionsImported: z.number().int().nonnegative(),
+  transactionsFailed: z.number().int().nonnegative(),
+  retroactiveReclassifications: z.number().int().nonnegative(),
+});
+
+export type CommitResult = z.infer<typeof commitResultSchema>;

--- a/docs/themes/02-finance/prds/031-final-review-commit/README.md
+++ b/docs/themes/02-finance/prds/031-final-review-commit/README.md
@@ -68,7 +68,7 @@ CommitResult {
 |---|-------|---------|--------|----------------|
 | 01 | [us-01-step-scaffold](us-01-step-scaffold.md) | Add Step 6 to the wizard, shift Summary to Step 7, create FinalReviewStep shell | Not started | Yes |
 | 02 | [us-02-pending-changes-summary](us-02-pending-changes-summary.md) | Display all pending changes in FinalReviewStep with collapsible detail views | Not started | Blocked by us-01 + PRD-030 |
-| 03 | [us-03-commit-endpoint](us-03-commit-endpoint.md) | `commitImport` tRPC endpoint with single-transaction atomic writes | Not started | Blocked by PRD-030 US-09 |
+| 03 | [us-03-commit-endpoint](us-03-commit-endpoint.md) | `commitImport` tRPC endpoint with single-transaction atomic writes | Done | Blocked by PRD-030 US-09 |
 | 04 | [us-04-retroactive-reclassification](us-04-retroactive-reclassification.md) | Reclassify existing DB transactions against new rule set within the commit transaction | Not started | Blocked by us-03 |
 | 05 | [us-05-commit-progress-result](us-05-commit-progress-result.md) | "Approve & Commit All" button, progress indicator, and result display | Not started | Blocked by us-03, us-04 |
 | 06 | [us-06-summary-step-update](us-06-summary-step-update.md) | Update Summary step (now Step 7) with retroactive reclassification results | Not started | Blocked by us-05 |

--- a/docs/themes/02-finance/prds/031-final-review-commit/us-03-commit-endpoint.md
+++ b/docs/themes/02-finance/prds/031-final-review-commit/us-03-commit-endpoint.md
@@ -1,7 +1,7 @@
 # US-03: Commit endpoint
 
 > PRD: [031 — Import Final Review & Commit Step](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a system, I want a single tRPC endpoint that accepts the full commit payload 
 
 ## Acceptance Criteria
 
-- [ ] A new `finance.imports.commitImport` tRPC mutation exists and accepts the `CommitPayload` shape (entities, changeSets, transactions).
-- [ ] All writes execute inside a single SQLite transaction — if any operation fails, the entire transaction rolls back.
-- [ ] Entities are created first; the returned real DB IDs replace all temp ID references in subsequent changeSets and transactions.
-- [ ] ChangeSets are applied via the existing `applyChangeSet` service, receiving resolved entity IDs.
-- [ ] Transactions are written using the existing execute import logic, receiving resolved entity IDs.
-- [ ] The endpoint returns a `CommitResult` with `entitiesCreated`, `rulesApplied` (broken down by add/edit/disable/remove), `transactionsImported`, `transactionsFailed`, and `retroactiveReclassifications` (initially 0 until US-04).
-- [ ] If `CommitPayload` contains zero entities or zero changeSets, those phases are skipped without error.
-- [ ] Input validation rejects malformed payloads (missing required fields, unknown temp IDs) with descriptive error messages before the transaction begins.
+- [x] A new `finance.imports.commitImport` tRPC mutation exists and accepts the `CommitPayload` shape (entities, changeSets, transactions).
+- [x] All writes execute inside a single SQLite transaction — if any operation fails, the entire transaction rolls back.
+- [x] Entities are created first; the returned real DB IDs replace all temp ID references in subsequent changeSets and transactions.
+- [x] ChangeSets are applied via the existing `applyChangeSet` service, receiving resolved entity IDs.
+- [x] Transactions are written using the existing execute import logic, receiving resolved entity IDs.
+- [x] The endpoint returns a `CommitResult` with `entitiesCreated`, `rulesApplied` (broken down by add/edit/disable/remove), `transactionsImported`, `transactionsFailed`, and `retroactiveReclassifications` (initially 0 until US-04).
+- [x] If `CommitPayload` contains zero entities or zero changeSets, those phases are skipped without error.
+- [x] Input validation rejects malformed payloads (missing required fields, unknown temp IDs) with descriptive error messages before the transaction begins.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Add `finance.imports.commitImport` tRPC mutation that atomically creates entities, applies rule changeSets, and writes transactions in a single SQLite transaction
- Temp ID resolution: `temp:entity:{uuid}` references in changeSets and transactions are replaced with real DB IDs after entity creation
- Input validation rejects duplicate temp IDs, duplicate entity names, unknown temp ID references, and malformed temp ID format before the transaction begins
- If any phase fails (entity creation, changeSet application), the entire transaction rolls back
- Returns `CommitResult` with `entitiesCreated`, `rulesApplied` (add/edit/disable/remove), `transactionsImported`, `transactionsFailed`, `retroactiveReclassifications` (0 until US-04)
- Marks PRD-031 US-03 as Done

## Test plan
- [x] 12 new commitImport tests all pass
- [x] Happy path: transactions only, entities + transactions, entities + changeSets + transactions
- [x] Temp ID resolution verified in transactions and changeSet add ops
- [x] Empty entities/changeSets arrays skip without error
- [x] Validation: unknown temp IDs, duplicate temp IDs, duplicate names, malformed format
- [x] Rollback: entity creation + changeSet failure rolls back all writes
- [x] Auth: UNAUTHORIZED without credentials
- [x] No new TypeScript errors in changed files

Closes tb-331

🤖 Generated with [Claude Code](https://claude.com/claude-code)