### PR TITLE
feat(entities): orphaned entity indicators (PRD-032 US-08)

### DIFF
--- a/apps/pops-api/src/modules/core/entities/entities.test.ts
+++ b/apps/pops-api/src/modules/core/entities/entities.test.ts
@@ -351,3 +351,38 @@ describe("entities.delete", () => {
     expect(row.entity_name).toBe("Woolworths"); // denormalized name preserved
   });
 });
+
+describe("entities.list transactionCount", () => {
+  it("returns transactionCount=0 for entity with no transactions", async () => {
+    seedEntity(db, { name: "Orphaned Corp" });
+
+    const result = await caller.core.entities.list({});
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]!.transactionCount).toBe(0);
+  });
+
+  it("returns correct transactionCount for entity with transactions", async () => {
+    const entityId = seedEntity(db, { name: "Woolworths" });
+    seedTransaction(db, { entity_id: entityId, description: "WOOLWORTHS 1" });
+    seedTransaction(db, { entity_id: entityId, description: "WOOLWORTHS 2" });
+    seedTransaction(db, { entity_id: entityId, description: "WOOLWORTHS 3" });
+
+    const result = await caller.core.entities.list({});
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]!.transactionCount).toBe(3);
+  });
+
+  it("returns mixed counts for multiple entities", async () => {
+    const woolId = seedEntity(db, { name: "Woolworths" });
+    seedEntity(db, { name: "Orphaned Co" });
+    seedTransaction(db, { entity_id: woolId, description: "WOOLWORTHS" });
+
+    const result = await caller.core.entities.list({});
+    expect(result.data).toHaveLength(2);
+    // Sorted by name: Orphaned Co, Woolworths
+    expect(result.data[0]!.name).toBe("Orphaned Co");
+    expect(result.data[0]!.transactionCount).toBe(0);
+    expect(result.data[1]!.name).toBe("Woolworths");
+    expect(result.data[1]!.transactionCount).toBe(1);
+  });
+});

--- a/apps/pops-api/src/modules/core/entities/service.ts
+++ b/apps/pops-api/src/modules/core/entities/service.ts
@@ -3,19 +3,24 @@
  * SQLite is the source of truth. All operations are local.
  */
 import crypto from "crypto";
-import { eq, like, count, and, ne } from "drizzle-orm";
+import { eq, like, count, and, ne, sql } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
-import { entities } from "@pops/db-types";
+import { entities, transactions } from "@pops/db-types";
 import { NotFoundError, ConflictError } from "../../../shared/errors.js";
 import type { EntityRow, CreateEntityInput, UpdateEntityInput } from "./types.js";
 
+/** Entity row enriched with transaction count. */
+export interface EntityWithCount extends EntityRow {
+  transactionCount: number;
+}
+
 /** Count + rows for a paginated list. */
 export interface EntityListResult {
-  rows: EntityRow[];
+  rows: EntityWithCount[];
   total: number;
 }
 
-/** List entities with optional search and type filters. */
+/** List entities with optional search and type filters, including transaction count. */
 export function listEntities(
   search: string | undefined,
   type: string | undefined,
@@ -23,9 +28,6 @@ export function listEntities(
   offset: number
 ): EntityListResult {
   const db = getDrizzle();
-
-  let query = db.select().from(entities).$dynamic();
-  let countQuery = db.select({ total: count() }).from(entities).$dynamic();
 
   const conditions = [];
   if (search) {
@@ -35,17 +37,39 @@ export function listEntities(
     conditions.push(eq(entities.type, type));
   }
 
-  if (conditions.length > 0) {
-    const where = and(...conditions);
-    query = query.where(where);
-    countQuery = countQuery.where(where);
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  // LEFT JOIN to get transaction count per entity
+  const rows = db
+    .select({
+      id: entities.id,
+      notionId: entities.notionId,
+      name: entities.name,
+      type: entities.type,
+      abn: entities.abn,
+      aliases: entities.aliases,
+      defaultTransactionType: entities.defaultTransactionType,
+      defaultTags: entities.defaultTags,
+      notes: entities.notes,
+      lastEditedTime: entities.lastEditedTime,
+      transactionCount: sql<number>`CAST(COUNT(${transactions.id}) AS INTEGER)`,
+    })
+    .from(entities)
+    .leftJoin(transactions, eq(entities.id, transactions.entityId))
+    .where(whereClause)
+    .groupBy(entities.id)
+    .orderBy(entities.name)
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  let countQuery = db.select({ total: count() }).from(entities).$dynamic();
+  if (whereClause) {
+    countQuery = countQuery.where(whereClause);
   }
-
-  const rows = query.orderBy(entities.name).limit(limit).offset(offset).all();
-
   const [countResult] = countQuery.all();
 
-  return { rows: rows, total: countResult?.total ?? 0 };
+  return { rows, total: countResult?.total ?? 0 };
 }
 
 /** Get a single entity by id. Throws NotFoundError if missing. */

--- a/apps/pops-api/src/modules/core/entities/types.ts
+++ b/apps/pops-api/src/modules/core/entities/types.ts
@@ -16,10 +16,11 @@ export interface Entity {
   defaultTags: string[];
   notes: string | null;
   lastEditedTime: string;
+  transactionCount?: number;
 }
 
 /** Map a SQLite row to the API response shape. */
-export function toEntity(row: EntityRow): Entity {
+export function toEntity(row: EntityRow & { transactionCount?: number }): Entity {
   return {
     id: row.id,
     name: row.name,
@@ -47,6 +48,7 @@ export function toEntity(row: EntityRow): Entity {
       : [],
     notes: row.notes,
     lastEditedTime: row.lastEditedTime,
+    transactionCount: row.transactionCount,
   };
 }
 

--- a/docs/themes/02-finance/prds/032-rule-manager-priority/README.md
+++ b/docs/themes/02-finance/prds/032-rule-manager-priority/README.md
@@ -68,7 +68,7 @@ No new endpoints. Existing endpoints change:
 | 05 | [us-05-drag-to-reorder](us-05-drag-to-reorder.md) | Drag-to-reorder priority in browse-mode sidebar | Not started | Blocked by us-01, us-03 |
 | 06 | [us-06-impact-preview-db-transactions](us-06-impact-preview-db-transactions.md) | Impact preview includes existing DB transactions | Not started | Blocked by us-03 |
 | 07 | [us-07-override-indicators](us-07-override-indicators.md) | Override indicators when multiple rules match | Not started | Blocked by us-02 |
-| 08 | [us-08-orphaned-entity-indicators](us-08-orphaned-entity-indicators.md) | Orphaned entity badges on /finance/entities | Not started | Yes |
+| 08 | [us-08-orphaned-entity-indicators](us-08-orphaned-entity-indicators.md) | Orphaned entity badges on /finance/entities | Done | Yes |
 
 ## Out of Scope
 

--- a/docs/themes/02-finance/prds/032-rule-manager-priority/us-08-orphaned-entity-indicators.md
+++ b/docs/themes/02-finance/prds/032-rule-manager-priority/us-08-orphaned-entity-indicators.md
@@ -1,7 +1,7 @@
 # US-08: Orphaned entity indicators
 
 > PRD: [032 — Global Rule Manager & Priority Ordering](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,12 +9,12 @@ As a user, I want to see which entities have zero transactions on the `/finance/
 
 ## Acceptance Criteria
 
-- [ ] The entities query performs a LEFT JOIN from entities to transactions and includes a `transactionCount` (or equivalent) in the response.
-- [ ] Entities with `transactionCount = 0` display an "Orphaned" badge in the entity list.
-- [ ] An entity with only "skipped" transactions is NOT considered orphaned — any transaction association (regardless of status) counts.
-- [ ] A "Show orphaned only" filter toggle is available on the entities page. When active, only entities with zero transactions are displayed.
-- [ ] The filter toggle state does not persist across page navigations (resets to "show all" on mount).
-- [ ] The "Orphaned" badge is visually distinct (e.g. muted colour, warning style) and does not interfere with existing entity badges or status indicators.
+- [x] The entities query performs a LEFT JOIN from entities to transactions and includes a `transactionCount` (or equivalent) in the response.
+- [x] Entities with `transactionCount = 0` display an "Orphaned" badge in the entity list.
+- [x] An entity with only "skipped" transactions is NOT considered orphaned — any transaction association (regardless of status) counts.
+- [x] A "Show orphaned only" filter toggle is available on the entities page. When active, only entities with zero transactions are displayed.
+- [x] The filter toggle state does not persist across page navigations (resets to "show all" on mount).
+- [x] The "Orphaned" badge is visually distinct (e.g. muted colour, warning style) and does not interfere with existing entity badges or status indicators.
 
 ## Notes
 

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -51,6 +51,7 @@ interface Entity {
   defaultTags: string[];
   notes: string | null;
   lastEditedTime: string;
+  transactionCount?: number;
 }
 
 const ENTITY_TYPES = ["company", "person", "place", "brand", "organisation"] as const;
@@ -88,6 +89,7 @@ export function EntitiesPage() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingEntity, setEditingEntity] = useState<Entity | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [showOrphanedOnly, setShowOrphanedOnly] = useState(false);
 
   const utils = trpc.useUtils();
   const { data, isLoading, error, refetch } = trpc.core.entities.list.useQuery({
@@ -169,7 +171,19 @@ export function EntitiesPage() {
     {
       accessorKey: "name",
       header: ({ column }) => <SortableHeader column={column}>Name</SortableHeader>,
-      cell: ({ row }) => <div className="font-medium">{row.original.name}</div>,
+      cell: ({ row }) => (
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{row.original.name}</span>
+          {row.original.transactionCount === 0 && (
+            <Badge
+              variant="outline"
+              className="text-xs text-muted-foreground border-muted-foreground/30"
+            >
+              Orphaned
+            </Badge>
+          )}
+        </div>
+      ),
     },
     {
       accessorKey: "type",
@@ -341,17 +355,28 @@ export function EntitiesPage() {
           <Skeleton className="h-64 w-full" />
         </div>
       ) : (
-        <DataTable
-          columns={columns}
-          data={data?.data ?? []}
-          searchable
-          searchColumn="name"
-          searchPlaceholder="Search entities..."
-          paginated
-          defaultPageSize={50}
-          pageSizeOptions={[25, 50, 100]}
-          filters={tableFilters}
-        />
+        <>
+          <div className="flex items-center gap-2">
+            <Button
+              variant={showOrphanedOnly ? "default" : "outline"}
+              size="sm"
+              onClick={() => setShowOrphanedOnly((prev) => !prev)}
+            >
+              {showOrphanedOnly ? "Showing orphaned only" : "Show orphaned only"}
+            </Button>
+          </div>
+          <DataTable
+            columns={columns}
+            data={(data?.data ?? []).filter((e) => !showOrphanedOnly || e.transactionCount === 0)}
+            searchable
+            searchColumn="name"
+            searchPlaceholder="Search entities..."
+            paginated
+            defaultPageSize={50}
+            pageSizeOptions={[25, 50, 100]}
+            filters={tableFilters}
+          />
+        </>
       )}
 
       {/* Add/Edit Dialog */}


### PR DESCRIPTION
## Summary
- Add `transactionCount` to entity list via LEFT JOIN from entities → transactions
- Display "Orphaned" badge on entities with zero transactions in the name column
- Add "Show orphaned only" toggle filter (resets on mount, no persistence)
- 3 new tests covering transactionCount=0, correct counts, and mixed counts

## Test plan
- [x] `npx vitest run entities.test.ts` — 33/33 pass (including 3 new transactionCount tests)
- [ ] Manual: verify "Orphaned" badge appears for entities with no transactions
- [ ] Manual: verify toggle filters to only orphaned entities and resets on navigation

Closes tb-337

🤖 Generated with [Claude Code](https://claude.com/claude-code)