### PR TITLE
chore: add typecheck to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npx lint-staged
+pnpm typecheck


### PR DESCRIPTION
## Summary
- Adds `pnpm typecheck` to the husky pre-commit hook so type errors are caught before commit, not just in CI

## Test plan
- [x] `pnpm typecheck` passes across all 13 packages
- [x] Pre-commit hook runs both lint-staged and typecheck on commit