### PR TITLE
feat(entities): orphaned entity indicators (PRD-032 US-08)

### DIFF
--- a/apps/pops-api/src/modules/core/entities/entities.test.ts
+++ b/apps/pops-api/src/modules/core/entities/entities.test.ts
@@ -385,4 +385,35 @@ describe("entities.list transactionCount", () => {
     expect(result.data[1]!.name).toBe("Woolworths");
     expect(result.data[1]!.transactionCount).toBe(1);
   });
+
+  it("counts transactions regardless of type (status-agnostic)", async () => {
+    const entityId = seedEntity(db, { name: "Multi-Type Corp" });
+    seedTransaction(db, { entity_id: entityId, type: "purchase" });
+    seedTransaction(db, { entity_id: entityId, type: "transfer" });
+    seedTransaction(db, { entity_id: entityId, type: "income" });
+
+    const result = await caller.core.entities.list({});
+    expect(result.data[0]!.transactionCount).toBe(3);
+  });
+
+  it("orphanedOnly filter returns only zero-count entities", async () => {
+    const woolId = seedEntity(db, { name: "Woolworths" });
+    seedEntity(db, { name: "Orphaned Co" });
+    seedEntity(db, { name: "Also Orphaned" });
+    seedTransaction(db, { entity_id: woolId, description: "WOOLWORTHS" });
+
+    const result = await caller.core.entities.list({ orphanedOnly: true });
+    expect(result.data).toHaveLength(2);
+    expect(result.pagination.total).toBe(2);
+    expect(result.data.every((e) => e.transactionCount === 0)).toBe(true);
+  });
+
+  it("orphanedOnly filter excludes entities with transactions", async () => {
+    const woolId = seedEntity(db, { name: "Woolworths" });
+    seedTransaction(db, { entity_id: woolId, description: "WOOLWORTHS" });
+
+    const result = await caller.core.entities.list({ orphanedOnly: true });
+    expect(result.data).toHaveLength(0);
+    expect(result.pagination.total).toBe(0);
+  });
 });

--- a/apps/pops-api/src/modules/core/entities/router.ts
+++ b/apps/pops-api/src/modules/core/entities/router.ts
@@ -19,7 +19,13 @@ export const entitiesRouter = router({
     const limit = input.limit ?? DEFAULT_LIMIT;
     const offset = input.offset ?? DEFAULT_OFFSET;
 
-    const { rows, total } = service.listEntities(input.search, input.type, limit, offset, input.orphanedOnly);
+    const { rows, total } = service.listEntities(
+      input.search,
+      input.type,
+      limit,
+      offset,
+      input.orphanedOnly
+    );
 
     return {
       data: rows.map(toEntity),

--- a/apps/pops-api/src/modules/core/entities/router.ts
+++ b/apps/pops-api/src/modules/core/entities/router.ts
@@ -19,7 +19,7 @@ export const entitiesRouter = router({
     const limit = input.limit ?? DEFAULT_LIMIT;
     const offset = input.offset ?? DEFAULT_OFFSET;
 
-    const { rows, total } = service.listEntities(input.search, input.type, limit, offset);
+    const { rows, total } = service.listEntities(input.search, input.type, limit, offset, input.orphanedOnly);
 
     return {
       data: rows.map(toEntity),

--- a/apps/pops-api/src/modules/core/entities/service.ts
+++ b/apps/pops-api/src/modules/core/entities/service.ts
@@ -72,7 +72,10 @@ export function listEntities(
   // Count query must match the same filter conditions
   if (orphanedOnly) {
     const countRows = db
-      .select({ id: entities.id, txnCount: sql<number>`CAST(COUNT(${transactions.id}) AS INTEGER)` })
+      .select({
+        id: entities.id,
+        txnCount: sql<number>`CAST(COUNT(${transactions.id}) AS INTEGER)`,
+      })
       .from(entities)
       .leftJoin(transactions, eq(entities.id, transactions.entityId))
       .where(whereClause)

--- a/apps/pops-api/src/modules/core/entities/service.ts
+++ b/apps/pops-api/src/modules/core/entities/service.ts
@@ -20,12 +20,13 @@ export interface EntityListResult {
   total: number;
 }
 
-/** List entities with optional search and type filters, including transaction count. */
+/** List entities with optional search, type, and orphaned filters, including transaction count. */
 export function listEntities(
   search: string | undefined,
   type: string | undefined,
   limit: number,
-  offset: number
+  offset: number,
+  orphanedOnly?: boolean
 ): EntityListResult {
   const db = getDrizzle();
 
@@ -40,7 +41,7 @@ export function listEntities(
   const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
   // LEFT JOIN to get transaction count per entity
-  const rows = db
+  let query = db
     .select({
       id: entities.id,
       notionId: entities.notionId,
@@ -59,9 +60,27 @@ export function listEntities(
     .where(whereClause)
     .groupBy(entities.id)
     .orderBy(entities.name)
-    .limit(limit)
-    .offset(offset)
-    .all();
+    .$dynamic();
+
+  // Server-side orphaned filter: only entities with zero transactions
+  if (orphanedOnly) {
+    query = query.having(sql`COUNT(${transactions.id}) = 0`);
+  }
+
+  const rows = query.limit(limit).offset(offset).all();
+
+  // Count query must match the same filter conditions
+  if (orphanedOnly) {
+    const countRows = db
+      .select({ id: entities.id, txnCount: sql<number>`CAST(COUNT(${transactions.id}) AS INTEGER)` })
+      .from(entities)
+      .leftJoin(transactions, eq(entities.id, transactions.entityId))
+      .where(whereClause)
+      .groupBy(entities.id)
+      .having(sql`COUNT(${transactions.id}) = 0`)
+      .all();
+    return { rows, total: countRows.length };
+  }
 
   let countQuery = db.select({ total: count() }).from(entities).$dynamic();
   if (whereClause) {

--- a/apps/pops-api/src/modules/core/entities/types.ts
+++ b/apps/pops-api/src/modules/core/entities/types.ts
@@ -5,7 +5,14 @@ import { ENTITY_TYPES } from "@pops/db-types";
 export type { EntityRow };
 export { ENTITY_TYPES };
 
-/** API response shape (camelCase). */
+/**
+ * API response shape (camelCase).
+ *
+ * `transactionCount` is only populated by the list endpoint (via LEFT JOIN).
+ * Non-list endpoints (get/create/update) return `undefined`. Use strict
+ * equality (`=== 0`) to identify orphaned entities — never a truthiness check,
+ * since `undefined` would be falsely treated as orphaned.
+ */
 export interface Entity {
   id: string;
   name: string;
@@ -80,6 +87,7 @@ export type UpdateEntityInput = z.infer<typeof UpdateEntitySchema>;
 export const EntityQuerySchema = z.object({
   search: z.string().optional(),
   type: z.enum(ENTITY_TYPES).optional(),
+  orphanedOnly: z.boolean().optional(),
   limit: z.coerce.number().positive().optional(),
   offset: z.coerce.number().nonnegative().optional(),
 });

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -94,6 +94,7 @@ export function EntitiesPage() {
   const utils = trpc.useUtils();
   const { data, isLoading, error, refetch } = trpc.core.entities.list.useQuery({
     limit: 100,
+    orphanedOnly: showOrphanedOnly || undefined,
   });
 
   const createMutation = trpc.core.entities.create.useMutation({
@@ -340,7 +341,11 @@ export function EntitiesPage() {
       <PageHeader
         title="Entities"
         description={
-          data ? `${data.pagination.total} total entities` : "Manage merchants and payees"
+          data
+            ? showOrphanedOnly
+              ? `${data.pagination.total} orphaned entities`
+              : `${data.pagination.total} total entities`
+            : "Manage merchants and payees"
         }
         actions={
           <Button onClick={handleAdd}>
@@ -367,7 +372,7 @@ export function EntitiesPage() {
           </div>
           <DataTable
             columns={columns}
-            data={(data?.data ?? []).filter((e) => !showOrphanedOnly || e.transactionCount === 0)}
+            data={data?.data ?? []}
             searchable
             searchColumn="name"
             searchPlaceholder="Search entities..."


### PR DESCRIPTION
## Summary
- Add `transactionCount` to entities list query via LEFT JOIN + COUNT, enabling identification of orphaned entities (count=0)
- Add "Orphaned" badge (muted warning style) for entities with zero transactions in EntitiesPage
- Add "Show orphaned only" filter toggle that resets on mount (not persisted)
- Add unit tests for transactionCount in entity service (count=0 and count>0 cases)

## Test plan
- [x] Entity with 0 transactions returns `transactionCount: 0`
- [x] Entity with transactions returns correct count
- [x] All 33 entity tests pass
- [x] Typecheck passes (pre-existing errors in unrelated files only)

Closes tb-337

🤖 Generated with [Claude Code](https://claude.com/claude-code)