### PR TITLE
feat(imports): retroactive reclassification after commit (PRD-031 US-04)

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/router.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/router.test.ts
@@ -4,7 +4,12 @@ import type { Database } from "better-sqlite3";
 import { eq } from "drizzle-orm";
 import { entities as entitiesTable } from "@pops/db-types";
 import { getDrizzle } from "../../../db.js";
-import { setupTestContext, seedEntity, createCaller } from "../../../shared/test-utils.js";
+import {
+  setupTestContext,
+  seedEntity,
+  seedTransaction,
+  createCaller,
+} from "../../../shared/test-utils.js";
 import { clearCache } from "./lib/ai-categorizer.js";
 import type {
   ProcessImportOutput,
@@ -812,5 +817,236 @@ describe("imports.commitImport", () => {
     await expect(
       unauthCaller.finance.imports.commitImport({ transactions: [makeTxn()] })
     ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// retroactive reclassification (US-04)
+// ---------------------------------------------------------------------------
+
+describe("imports.commitImport — retroactive reclassification", () => {
+  it("reclassifies existing transactions when new rules match", async () => {
+    // Seed an entity and a pre-existing transaction with no entity link
+    const entityId = seedEntity(db, { name: "Woolworths" });
+    seedTransaction(db, {
+      description: "WOOLWORTHS 9999",
+      entity_id: null,
+      entity_name: null,
+      checksum: "pre-existing-chk-1",
+    });
+
+    // Commit adds a rule matching "WOOLWORTHS" to the entity
+    const result = await caller.finance.imports.commitImport({
+      changeSets: [
+        {
+          ops: [
+            {
+              op: "add" as const,
+              data: {
+                descriptionPattern: "WOOLWORTHS",
+                matchType: "contains" as const,
+                entityId,
+                entityName: "Woolworths",
+                confidence: 0.95,
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [makeTxn({ description: "NEW IMPORT TXN" })],
+    });
+
+    expect(result.data.retroactiveReclassifications).toBe(1);
+
+    // Verify the existing transaction was updated
+    const txn = db
+      .prepare("SELECT entity_id, entity_name FROM transactions WHERE checksum = ?")
+      .get("pre-existing-chk-1") as { entity_id: string | null; entity_name: string | null };
+    expect(txn.entity_id).toBe(entityId);
+    expect(txn.entity_name).toBe("Woolworths");
+  });
+
+  it("excludes current import batch from reclassification", async () => {
+    const entityId = seedEntity(db, { name: "Coles" });
+    const importChecksum = "import-batch-chk-1";
+
+    // Commit with a rule that matches the imported transaction's description
+    const result = await caller.finance.imports.commitImport({
+      changeSets: [
+        {
+          ops: [
+            {
+              op: "add" as const,
+              data: {
+                descriptionPattern: "COLES",
+                matchType: "contains" as const,
+                entityId,
+                entityName: "Coles",
+                confidence: 0.95,
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [
+        makeTxn({
+          description: "COLES SUPERMARKET",
+          checksum: importChecksum,
+        }),
+      ],
+    });
+
+    // The imported transaction should NOT be reclassified (it was part of this batch)
+    expect(result.data.retroactiveReclassifications).toBe(0);
+  });
+
+  it("returns 0 when no existing transactions are affected", async () => {
+    // No pre-existing transactions in DB, just a new import
+    const result = await caller.finance.imports.commitImport({
+      changeSets: [
+        {
+          ops: [
+            {
+              op: "add" as const,
+              data: {
+                descriptionPattern: "NONEXISTENT",
+                matchType: "exact" as const,
+                confidence: 0.9,
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [makeTxn({ description: "SOME OTHER TXN" })],
+    });
+
+    expect(result.data.retroactiveReclassifications).toBe(0);
+  });
+
+  it("does not update transactions whose classification did not change", async () => {
+    const entityId = seedEntity(db, { name: "Netflix" });
+
+    // Pre-existing transaction already correctly linked
+    seedTransaction(db, {
+      description: "NETFLIX SUBSCRIPTION",
+      entity_id: entityId,
+      entity_name: "Netflix",
+      checksum: "already-correct-chk",
+    });
+
+    // Add a rule that matches but points to the same entity
+    const result = await caller.finance.imports.commitImport({
+      changeSets: [
+        {
+          ops: [
+            {
+              op: "add" as const,
+              data: {
+                descriptionPattern: "NETFLIX",
+                matchType: "contains" as const,
+                entityId,
+                entityName: "Netflix",
+                confidence: 0.95,
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [makeTxn({ description: "UNRELATED" })],
+    });
+
+    // Same entity — no reclassification
+    expect(result.data.retroactiveReclassifications).toBe(0);
+  });
+
+  it("reclassifies type and location when rule specifies them", async () => {
+    const entityId = seedEntity(db, { name: "Rent Corp" });
+
+    // Pre-existing transaction with different type and no location
+    seedTransaction(db, {
+      description: "RENT CORP PAYMENT",
+      entity_id: entityId,
+      entity_name: "Rent Corp",
+      type: "Expense",
+      location: null,
+      checksum: "type-location-chk",
+    });
+
+    // Add a rule that changes type to Transfer and sets location
+    const result = await caller.finance.imports.commitImport({
+      changeSets: [
+        {
+          ops: [
+            {
+              op: "add" as const,
+              data: {
+                descriptionPattern: "RENT CORP",
+                matchType: "contains" as const,
+                entityId,
+                entityName: "Rent Corp",
+                transactionType: "transfer" as const,
+                location: "Melbourne",
+                confidence: 0.95,
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [makeTxn({ description: "UNRELATED" })],
+    });
+
+    expect(result.data.retroactiveReclassifications).toBe(1);
+
+    // Verify type and location were updated
+    const txn = db
+      .prepare("SELECT type, location FROM transactions WHERE checksum = ?")
+      .get("type-location-chk") as { type: string; location: string | null };
+    expect(txn.type).toBe("Transfer");
+    expect(txn.location).toBe("Melbourne");
+  });
+
+  it("reclassification is part of the same transaction (rollback on error)", async () => {
+    const entitiesBefore = db.prepare("SELECT count(*) as c FROM entities").get() as { c: number };
+    const txnsBefore = db.prepare("SELECT count(*) as c FROM transactions").get() as { c: number };
+    const rulesBefore = db.prepare("SELECT count(*) as c FROM transaction_corrections").get() as {
+      c: number;
+    };
+
+    // Use a changeSet with an invalid edit op to trigger a rollback
+    const tempId = "temp:entity:00000000-0000-0000-0000-000000000099";
+    await expect(
+      caller.finance.imports.commitImport({
+        entities: [{ tempId, name: "RollbackReclassify" }],
+        changeSets: [
+          {
+            ops: [
+              {
+                op: "add" as const,
+                data: {
+                  descriptionPattern: "ROLLBACK",
+                  matchType: "exact" as const,
+                  entityId: tempId,
+                  entityName: "RollbackReclassify",
+                  confidence: 0.9,
+                },
+              },
+              // Invalid edit triggers rollback
+              { op: "edit" as const, id: "non-existent-id", data: { confidence: 0.5 } },
+            ],
+          },
+        ],
+        transactions: [makeTxn()],
+      })
+    ).rejects.toThrow();
+
+    // Everything rolled back
+    const entitiesAfter = db.prepare("SELECT count(*) as c FROM entities").get() as { c: number };
+    const txnsAfter = db.prepare("SELECT count(*) as c FROM transactions").get() as { c: number };
+    const rulesAfter = db.prepare("SELECT count(*) as c FROM transaction_corrections").get() as {
+      c: number;
+    };
+    expect(entitiesAfter.c).toBe(entitiesBefore.c);
+    expect(txnsAfter.c).toBe(txnsBefore.c);
+    expect(rulesAfter.c).toBe(rulesBefore.c);
   });
 });

--- a/apps/pops-api/src/modules/finance/imports/service.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.ts
@@ -7,16 +7,19 @@
  * - AI fallback with full row context
  * - Batch writes to SQLite
  */
-import { eq, and, isNotNull, ne, inArray } from "drizzle-orm";
+import { eq, and, isNotNull, ne, inArray, notInArray, asc } from "drizzle-orm";
 import { getDrizzle } from "../../../db.js";
-import { transactions, entities, tagVocabulary } from "@pops/db-types";
+import { transactions, entities, tagVocabulary, transactionCorrections } from "@pops/db-types";
 import { logger } from "../../../lib/logger.js";
 import { formatImportError } from "../../../lib/errors.js";
 import { matchEntity } from "./lib/entity-matcher.js";
 import { loadEntityMaps } from "./lib/entity-lookup.js";
 import { categorizeWithAi, AiCategorizationError } from "./lib/ai-categorizer.js";
 import { updateProgress } from "./progress-store.js";
-import { findMatchingCorrection } from "../../core/corrections/service.js";
+import {
+  findMatchingCorrection,
+  findMatchingCorrectionFromRules,
+} from "../../core/corrections/service.js";
 import { suggestTags } from "../../../shared/tag-suggester.js";
 import type { TransactionRow } from "../transactions/types.js";
 import { applyChangeSet } from "../../core/corrections/service.js";
@@ -1170,12 +1173,110 @@ export function commitImport(payload: CommitPayload): CommitResult {
       }
     }
 
+    // Phase 4: Retroactive reclassification — re-evaluate existing transactions
+    // against the updated rule set and update any whose classification changed.
+    const retroactiveReclassifications = reclassifyExistingTransactions(
+      db,
+      payload.transactions.map((t) => t.checksum).filter((c): c is string => c != null)
+    );
+
     return {
       entitiesCreated,
       rulesApplied,
       transactionsImported,
       transactionsFailed,
-      retroactiveReclassifications: 0,
+      retroactiveReclassifications,
     };
   });
+}
+
+const RECLASSIFY_BATCH_SIZE = 500;
+
+/**
+ * Re-evaluate all existing transactions against the current (updated) rule set.
+ * Excludes transactions from the current import batch (by checksum).
+ * Returns the count of transactions whose classification was updated.
+ */
+function reclassifyExistingTransactions(
+  db: ReturnType<typeof getDrizzle>,
+  importedChecksums: string[]
+): number {
+  // Fetch the full updated rule set
+  const allRules = db
+    .select()
+    .from(transactionCorrections)
+    .orderBy(asc(transactionCorrections.priority), asc(transactionCorrections.id))
+    .all();
+
+  if (allRules.length === 0) return 0;
+
+  let reclassified = 0;
+  let offset = 0;
+
+  while (true) {
+    // Fetch existing transactions in batches, excluding current import's checksums
+    let batchQuery = db
+      .select({
+        id: transactions.id,
+        description: transactions.description,
+        entityId: transactions.entityId,
+        type: transactions.type,
+        location: transactions.location,
+      })
+      .from(transactions)
+      .$dynamic();
+
+    if (importedChecksums.length > 0) {
+      batchQuery = batchQuery.where(notInArray(transactions.checksum, importedChecksums));
+    }
+
+    const batch = batchQuery
+      .orderBy(asc(transactions.id))
+      .limit(RECLASSIFY_BATCH_SIZE)
+      .offset(offset)
+      .all();
+
+    if (batch.length === 0) break;
+
+    for (const txn of batch) {
+      const match = findMatchingCorrectionFromRules(txn.description, allRules);
+
+      if (!match) continue;
+
+      const rule = match.correction;
+      const newEntityId = rule.entityId ?? null;
+      const newType = rule.transactionType
+        ? rule.transactionType === "transfer"
+          ? "Transfer"
+          : rule.transactionType === "income"
+            ? "Income"
+            : "Expense"
+        : null;
+      const newLocation = rule.location ?? null;
+
+      // Check if classification actually changed
+      const entityChanged = newEntityId !== (txn.entityId ?? null);
+      const typeChanged = newType !== null && newType !== txn.type;
+      const locationChanged = newLocation !== null && newLocation !== (txn.location ?? null);
+
+      if (!entityChanged && !typeChanged && !locationChanged) continue;
+
+      const updates: Record<string, unknown> = {};
+      if (entityChanged) {
+        updates.entityId = newEntityId;
+        updates.entityName = rule.entityName ?? null;
+      }
+      if (typeChanged) updates.type = newType;
+      if (locationChanged) updates.location = newLocation;
+      updates.lastEditedTime = new Date().toISOString();
+
+      db.update(transactions).set(updates).where(eq(transactions.id, txn.id)).run();
+
+      reclassified++;
+    }
+
+    offset += RECLASSIFY_BATCH_SIZE;
+  }
+
+  return reclassified;
 }

--- a/docs/themes/02-finance/prds/031-final-review-commit/README.md
+++ b/docs/themes/02-finance/prds/031-final-review-commit/README.md
@@ -69,7 +69,7 @@ CommitResult {
 | 01 | [us-01-step-scaffold](us-01-step-scaffold.md) | Add Step 6 to the wizard, shift Summary to Step 7, create FinalReviewStep shell | Not started | Yes |
 | 02 | [us-02-pending-changes-summary](us-02-pending-changes-summary.md) | Display all pending changes in FinalReviewStep with collapsible detail views | Not started | Blocked by us-01 + PRD-030 |
 | 03 | [us-03-commit-endpoint](us-03-commit-endpoint.md) | `commitImport` tRPC endpoint with single-transaction atomic writes | Done | Blocked by PRD-030 US-09 |
-| 04 | [us-04-retroactive-reclassification](us-04-retroactive-reclassification.md) | Reclassify existing DB transactions against new rule set within the commit transaction | Not started | Blocked by us-03 |
+| 04 | [us-04-retroactive-reclassification](us-04-retroactive-reclassification.md) | Reclassify existing DB transactions against new rule set within the commit transaction | Done | Blocked by us-03 |
 | 05 | [us-05-commit-progress-result](us-05-commit-progress-result.md) | "Approve & Commit All" button, progress indicator, and result display | Not started | Blocked by us-03, us-04 |
 | 06 | [us-06-summary-step-update](us-06-summary-step-update.md) | Update Summary step (now Step 7) with retroactive reclassification results | Not started | Blocked by us-05 |
 

--- a/docs/themes/02-finance/prds/031-final-review-commit/us-04-retroactive-reclassification.md
+++ b/docs/themes/02-finance/prds/031-final-review-commit/us-04-retroactive-reclassification.md
@@ -1,7 +1,7 @@
 # US-04: Retroactive reclassification
 
 > PRD: [031 — Import Final Review & Commit Step](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a user, I want newly committed rules to retroactively reclassify existing tra
 
 ## Acceptance Criteria
 
-- [ ] After rules are committed (inside the same DB transaction), the system queries all existing transactions and runs them through `findMatchingCorrectionFromRules` with the updated full rule set.
-- [ ] Any existing transaction whose matched rule changed (different entity, type, or location outcome) is updated in the database.
-- [ ] Processing is batched in groups of 500 rows to bound memory usage.
-- [ ] The count of reclassified transactions is returned in `CommitResult.retroactiveReclassifications`.
-- [ ] If no existing transactions are affected, the commit still succeeds and returns a reclassification count of 0.
-- [ ] Reclassification runs within the same DB transaction as entity/rule/transaction writes — a failure in reclassification rolls back the entire commit.
-- [ ] Transactions that were imported in the current commit are excluded from reclassification (they were already classified with the new rules).
-- [ ] Only transactions whose classification actually changed are updated — unchanged matches are not written.
+- [x] After rules are committed (inside the same DB transaction), the system queries all existing transactions and runs them through `findMatchingCorrectionFromRules` with the updated full rule set.
+- [x] Any existing transaction whose matched rule changed (different entity, type, or location outcome) is updated in the database.
+- [x] Processing is batched in groups of 500 rows to bound memory usage.
+- [x] The count of reclassified transactions is returned in `CommitResult.retroactiveReclassifications`.
+- [x] If no existing transactions are affected, the commit still succeeds and returns a reclassification count of 0.
+- [x] Reclassification runs within the same DB transaction as entity/rule/transaction writes — a failure in reclassification rolls back the entire commit.
+- [x] Transactions that were imported in the current commit are excluded from reclassification (they were already classified with the new rules).
+- [x] Only transactions whose classification actually changed are updated — unchanged matches are not written.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- After atomic commit writes entities, rules, and transactions, Phase 4 re-evaluates all existing DB transactions against the updated rule set using `findMatchingCorrectionFromRules`
- Transactions whose classification changed (entity, type, or location) are updated in-place within the same SQLite transaction
- Processing batched in groups of 500 rows; current import batch excluded by checksum
- Only changed classifications are written — unchanged matches are skipped
- Replaces hardcoded `retroactiveReclassifications: 0` with actual implementation

## Test plan
- [x] Reclassifies existing transactions when new rules match (entity updated)
- [x] Excludes current import batch from reclassification
- [x] Returns 0 when no existing transactions are affected
- [x] Does not update transactions whose classification did not change
- [x] Reclassification is part of the same transaction (rollback on error)
- [x] All 44 import router tests pass
- [x] Typecheck passes

Closes tb-339

🤖 Generated with [Claude Code](https://claude.com/claude-code)