### PR TITLE
chore: add pre-push conflict check against origin/main

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,9 @@
+branch=$(git branch --show-current)
+
+[ "$branch" = "main" ] && exit 0
+
+git fetch origin main --quiet
+if ! git merge-tree --write-tree origin/main HEAD > /dev/null 2>&1; then
+  echo "pre-push: branch '$branch' conflicts with origin/main — rebase before pushing."
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds a husky pre-push hook that runs `git merge-tree --write-tree` to detect textual conflicts with `origin/main` before pushing
- Skips the check when pushing main itself
- Prevents wasted CI runs on branches that would fail to merge

## Test plan
- [x] Hook exits 0 on a clean branch (no conflicts)
- [x] Hook skips when on main
- [x] Pre-commit hooks (lint-staged + typecheck) pass