### PR TITLE
docs(media): Epic 08 Library Rotation specs

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -83,6 +83,7 @@ Live status of every theme and epic. Updated as work completes.
 | Discovery & recommendations | Done   | Discover page (PRDs 038, 060) and shelf-based discovery (PRD-065) all done                                                                |
 | Plex sync                   | Done   | Library import (paginated), watch history sync (local + Discover cloud), watchlist sync (bidirectional), auto-check on add, settings page |
 | Radarr & Sonarr             | Done   | Status badges, Radarr request management, Sonarr request management — all done                                                            |
+| Library rotation            | Not started | Automated movie lifecycle: source lists, daily add/remove cycle, disk space gating (PRDs 070-072)                                    |
 
 #### Inventory
 

--- a/docs/themes/03-media/README.md
+++ b/docs/themes/03-media/README.md
@@ -27,8 +27,9 @@ Build a personal media intelligence app — not just a tracker, but a system tha
 | 5 | [Discovery & Recommendations](epics/05-discovery-recommendations.md) | Trending, new releases, personalised suggestions | Done |
 | 6 | [Plex Sync](epics/06-plex-sync.md) | Library import, watch history sync (local + Discover cloud), watchlist sync, auto-check on add | Done |
 | 7 | [Radarr & Sonarr](epics/07-radarr-sonarr.md) | Status display, request management — evolves toward full Overseerr replacement | Done |
+| 8 | [Library Rotation](epics/08-library-rotation.md) | Automated movie lifecycle: source lists, daily add/remove cycle, disk space gating | Not started |
 
-Epic 0 is prerequisite to everything. Epic 1 prerequisite to 2. Epics 3-4 parallel after 2. Epic 5 depends on 4. Epics 6-7 parallel after 3.
+Epic 0 is prerequisite to everything. Epic 1 prerequisite to 2. Epics 3-4 parallel after 2. Epic 5 depends on 4. Epics 6-7 parallel after 3. Epic 8 depends on 3, 6, and 7.
 
 ## Key Decisions
 
@@ -44,6 +45,8 @@ Epic 0 is prerequisite to everything. Epic 1 prerequisite to 2. Epics 3-4 parall
 | Plex sync | Polling | Simpler than webhooks, no network config |
 | Radarr/Sonarr | Status + request management | Starts read-only, evolves to full request/management (replacing Overseerr) |
 | Library ownership | POPS-owned, multi-source | Library and watch history live in POPS — Plex, manual add, and future sources feed into it |
+| Library rotation | Automated daily cycle | Source-fed candidates, weighted random selection, disk-space-gated, 10-day leaving grace period |
+| Removal strategy | Radarr delete + file removal | Space > bandwidth; re-downloading is the feature, not a cost |
 
 ## Risks
 

--- a/docs/themes/03-media/epics/08-library-rotation.md
+++ b/docs/themes/03-media/epics/08-library-rotation.md
@@ -1,0 +1,33 @@
+# Epic 08: Library Rotation
+
+> Theme: [Media](../README.md)
+
+## Scope
+
+Automated movie lifecycle management. The system continuously rotates the on-disk movie library: sourcing new candidates from configurable lists, adding movies daily, and removing stale ones after a "leaving soon" grace period. The library stays fresh within a target disk space budget without manual intervention.
+
+Movies only. TV shows are out of scope.
+
+"Done" = the system runs daily unattended, movies cycle in and out, the UI shows what's coming and going, and disk usage stays within the configured target.
+
+## PRDs
+
+| # | PRD | Summary | Status |
+|---|-----|---------|--------|
+| 070 | [Rotation Engine](../prds/070-rotation-engine/README.md) | Daily cron, state machine, removal selection, addition execution, disk space gating | Not started |
+| 071 | [Source Lists](../prds/071-source-lists/README.md) | Source plugin system, candidate queue, exclusion list, weighted selection policy | Not started |
+| 072 | [Rotation UI](../prds/072-rotation-ui/README.md) | "Leaving Soon" shelf, rotation settings, source management, queue/exclusion views | Not started |
+
+PRD-070 is the foundation — the engine that runs the daily cycle. PRD-071 provides the candidate pipeline that feeds it. PRD-072 is the UI layer over both. Build order: 070 → 071 (blocked by 070's schema) → 072 (can start once 070's state machine exists, parallelisable with 071 for the settings/leaving-soon parts).
+
+## Dependencies
+
+- **Requires:** Epic 07 (Radarr integration — add, delete, search, disk space endpoints), Epic 06 (Plex sync — watchlist, friends data), Epic 03 (watchlist — protection logic)
+- **Unlocks:** Fully autonomous media library management. Future: TV show rotation, smart selection using comparison/rating data from Epic 04.
+
+## Out of Scope
+
+- TV show rotation (future epic)
+- Smart pair selection using ELO/comparison data (future enhancement to selection policy)
+- Multi-server Radarr support
+- Torrent/download management (Radarr handles that)

--- a/docs/themes/03-media/prds/070-rotation-engine/README.md
+++ b/docs/themes/03-media/prds/070-rotation-engine/README.md
@@ -1,0 +1,115 @@
+# PRD-070: Rotation Engine
+
+> Epic: [Library Rotation](../../epics/08-library-rotation.md)
+
+## Overview
+
+The rotation engine is a daily automated job that manages the movie library lifecycle. Disk space is the primary driver: the system removes enough old movies to stay below a target free-space threshold, then adds new movies from the candidate queue if space permits. Removals go through a "leaving soon" grace period before files are actually deleted via Radarr. The number of movies removed or added on any given day is variable — entirely determined by disk usage.
+
+## Data Model
+
+### `rotation_config` (settings table keys)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `rotation_enabled` | boolean | `false` | Master switch |
+| `rotation_cron_expression` | string | `0 3 * * *` | When the daily job runs (cron syntax) |
+| `rotation_leaving_days` | integer | `10` | Days in "leaving" state before removal |
+| `rotation_target_free_gb` | integer | `200` | Target minimum free disk space in GB — the primary driver for removals |
+| `rotation_daily_additions` | integer | `2` | Max movies to add per cycle (gated by disk space) |
+| `rotation_avg_movie_gb` | real | `15` | Estimated average movie size in GB (used to calculate how many to mark leaving when Radarr `sizeOnDisk` unavailable) |
+| `rotation_protected_days` | integer | `30` | Days a manually-downloaded movie is protected from rotation |
+
+### `movies` table additions
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `rotation_status` | text (enum) | `null` | `null` = normal/eligible, `'leaving'` = marked for removal, `'protected'` = manually added, temporarily shielded |
+| `rotation_expires_at` | text (ISO datetime) | `null` | When `leaving` → eligible for removal, or when `protected` → enters rotation pool |
+| `rotation_marked_at` | text (ISO datetime) | `null` | When the movie was marked as leaving (for UI countdown) |
+
+### `rotation_log`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | integer PK | Auto-increment |
+| `executed_at` | text | ISO datetime of job execution |
+| `movies_marked_leaving` | integer | Count marked leaving this cycle |
+| `movies_removed` | integer | Count actually removed (expired + deleted) |
+| `movies_added` | integer | Count added from candidate queue |
+| `removals_failed` | integer | Count of failed Radarr deletions |
+| `free_space_gb` | real | Disk space at time of execution |
+| `target_free_gb` | real | Configured target at time of execution |
+| `skipped_reason` | text | `null` if ran, otherwise reason for skip (e.g., `'radarr_unreachable'`) |
+| `details` | text (JSON) | Movie titles/IDs for each action |
+
+## API Surface
+
+### Internal (used by the cron job, not exposed as tRPC)
+
+- `runRotationCycle()` — orchestrates the full daily cycle
+- `getRadarrDiskSpace()` → free space in GB via Radarr `/api/v3/diskspace`
+- `getRadarrMovieSizes()` → map of Radarr movie ID → `sizeOnDisk` in GB (from Radarr `/api/v3/movie`)
+- `calculateRemovalCount(freeSpaceGb, targetFreeGb, pendingLeavingGb)` → how many additional movies to mark leaving to reach the target, accounting for movies already in the leaving pipeline
+- `getEligibleForRemoval()` → all eligible movies ordered by `created_at` ASC, excluding watchlist items, `protected` movies, movies already `leaving`, and movies currently downloading in Radarr. Includes `sizeOnDisk` from Radarr for each.
+- `markAsLeaving(movieIds, expiryDate)` — sets `rotation_status = 'leaving'`
+- `processExpiredMovies()` — finds `leaving` movies past `rotation_expires_at`, calls Radarr delete with `deleteFiles=true`
+- `addFromQueue(count)` — picks from candidate queue (PRD-071), calls Radarr add with `searchForMovie: true`
+
+### tRPC (exposed to UI)
+
+- `rotation.getConfig` — current rotation settings
+- `rotation.updateConfig` — update settings (partial)
+- `rotation.getStatus` — current state: next run, last run summary, disk space, leaving count
+- `rotation.getLeavingSoon` — movies with `rotation_status = 'leaving'`, sorted by `rotation_expires_at`
+- `rotation.getLog` — paginated rotation execution history
+- `rotation.runNow` — manually trigger a rotation cycle
+- `rotation.cancelLeaving(movieId)` — clear leaving status, return to active pool
+
+## Business Rules
+
+- **Disk space drives removals:** The system calculates how much space needs to be freed: `deficit = rotation_target_free_gb - current_free_space_gb - pending_leaving_space_gb`. If `deficit > 0`, it marks the oldest eligible movies as leaving until the cumulative `sizeOnDisk` of newly marked movies covers the deficit. If `deficit ≤ 0`, no new movies are marked leaving this cycle. "Pending leaving space" accounts for movies already in the `leaving` state whose expiry hasn't hit yet — their space will be reclaimed soon, so they count toward the budget.
+- **Removal selection order:** Eligible movies are ordered by `created_at` ASC (oldest first). The system walks this list, accumulating `sizeOnDisk`, until the deficit is covered. This is deterministic, not random — the oldest movies go first.
+- **Eligibility exclusions:** Movies on the user's watchlist, movies with `rotation_status = 'protected'` (unexpired), movies already `leaving`, and movies currently downloading in Radarr are all excluded from removal selection.
+- **Leaving grace period:** Marked movies stay in the library for `rotation_leaving_days` (default 10). During this period they appear in the "Leaving Soon" shelf. After expiry, they are deleted from Radarr with `deleteFiles=true`.
+- **Expired movie processing:** Each cycle first processes all expired leaving movies (deletes from Radarr), then recalculates free space, then decides whether to mark more movies as leaving.
+- **Watchlist protection:** Any movie on the user's watchlist is permanently ineligible for rotation. If a movie is marked `leaving` and then added to the watchlist, the leaving status is immediately cleared.
+- **Manual download protection:** Movies added via the "Download" action (bypassing the queue) get `rotation_status = 'protected'` with `rotation_expires_at` set to `now + rotation_protected_days`. After expiry, status clears to `null` (eligible).
+- **Addition gating:** After removals, if free space ≥ `rotation_target_free_gb`, add up to `rotation_daily_additions` movies from the candidate queue. If free space is still below target (not enough expired movies freed space yet), skip additions entirely.
+- **Movie size data:** Each movie's `sizeOnDisk` comes from Radarr's `/api/v3/movie` response. If a movie isn't in Radarr (removed externally), fall back to `rotation_avg_movie_gb` as an estimate.
+- **No compounding on total failure:** If the entire cycle fails (Radarr unreachable), log the failure and skip. Do not carry over missed removals/additions to the next day.
+- **Cycle order:** Process expired deletions → measure free space → mark new leaving movies → measure free space again → add from queue.
+
+## Edge Cases
+
+| Case | Behaviour |
+|------|-----------|
+| Deficit requires more removals than eligible movies | Mark all eligible as leaving, log the shortfall. Remaining deficit carries naturally to next cycle (free space will still be below target) |
+| Deficit is 0 or negative (plenty of space) | Skip marking, no new leaving movies this cycle |
+| No candidates in queue for addition | Skip additions, log "queue empty" |
+| Radarr unreachable at cycle start | Log `skipped_reason = 'radarr_unreachable'`, skip entire cycle |
+| Movie deleted from Radarr externally | Removal succeeds (no-op on Radarr side), clear from POPS |
+| Movie marked leaving but re-added to watchlist | Clear leaving status immediately (watchlist router calls rotation service) |
+| Disk space endpoint returns multiple disks | Use the disk where the Radarr root folder lives |
+| Rotation disabled mid-cycle | Complete current cycle, don't schedule next |
+| All movies are watchlisted or protected | 0 eligible for removal, log and skip. Additions still proceed if space permits |
+| Single large movie (e.g., 80GB 4K) covers entire deficit | Mark just that one movie — removal count is driven by bytes, not count |
+| Radarr `sizeOnDisk` is 0 for a movie (not yet downloaded) | Skip it — no space to reclaim. It will be picked up once it has files |
+
+## User Stories
+
+| # | Story | Summary | Status | Parallelisable |
+|---|-------|---------|--------|----------------|
+| 01 | [us-01-rotation-schema](us-01-rotation-schema.md) | Schema migration: new columns on `movies`, `rotation_log` table | Not started | Yes |
+| 02 | [us-02-removal-selection](us-02-removal-selection.md) | Disk-space-driven removal: deficit calculation, oldest-first selection, Radarr delete | Not started | Blocked by US-01 |
+| 03 | [us-03-leaving-lifecycle](us-03-leaving-lifecycle.md) | Leaving state machine: mark, expire, watchlist interaction | Not started | Blocked by US-01 |
+| 04 | [us-04-addition-execution](us-04-addition-execution.md) | Add movies from queue to Radarr with search trigger | Not started | Blocked by US-01, PRD-071 US-01 |
+| 05 | [us-05-disk-space-gating](us-05-disk-space-gating.md) | Addition gating: only add movies when free space is above target | Not started | Blocked by US-02, US-04 |
+| 06 | [us-06-daily-cron](us-06-daily-cron.md) | Scheduler: cron-based job orchestrating the full cycle | Not started | Blocked by US-02, US-03, US-04 |
+
+## Out of Scope
+
+- TV show rotation
+- Smart removal selection based on ratings/comparisons (future enhancement)
+- Multi-instance Radarr support
+- Notification system (email/push when movies are leaving)

--- a/docs/themes/03-media/prds/070-rotation-engine/us-01-rotation-schema.md
+++ b/docs/themes/03-media/prds/070-rotation-engine/us-01-rotation-schema.md
@@ -1,0 +1,19 @@
+# US-01: Rotation Schema
+
+> PRD: [Rotation Engine](README.md)
+
+## Description
+
+As a system, I need the database schema for rotation state tracking so that movies can be marked as leaving, protected, or eligible, and rotation cycles can be logged.
+
+## Acceptance Criteria
+
+- [ ] `movies` table has new nullable columns: `rotation_status` (text), `rotation_expires_at` (text), `rotation_marked_at` (text)
+- [ ] `rotation_log` table exists with columns per PRD data model: `id`, `executed_at`, `movies_marked_leaving`, `movies_removed`, `movies_added`, `removals_failed`, `free_space_gb`, `target_free_gb`, `skipped_reason`, `details`
+- [ ] Rotation config keys are documented and retrievable from the settings table (no new table — reuse existing k-v settings pattern)
+- [ ] Migration is idempotent and does not affect existing movie data (all new columns default to `null`)
+- [ ] Drizzle schema types are exported from `@pops/db-types`
+
+## Notes
+
+Follow the existing migration pattern in `apps/pops-api/src/db/migrations/`. The settings keys (`rotation_enabled`, `rotation_cron_expression`, etc.) are inserted on first access, not via migration — consistent with how Plex/Radarr settings work.

--- a/docs/themes/03-media/prds/070-rotation-engine/us-02-removal-selection.md
+++ b/docs/themes/03-media/prds/070-rotation-engine/us-02-removal-selection.md
@@ -1,0 +1,24 @@
+# US-02: Removal Selection
+
+> PRD: [Rotation Engine](README.md)
+
+## Description
+
+As a system, I need to select movies for removal based on disk space deficit so that the library stays within the configured free-space target.
+
+## Acceptance Criteria
+
+- [ ] `getRadarrDiskSpace()` calls Radarr `/api/v3/diskspace`, returns free space in GB for the root folder's disk
+- [ ] `getRadarrMovieSizes()` fetches `sizeOnDisk` for all movies from Radarr `/api/v3/movie`, returns a map of TMDB ID → size in GB
+- [ ] `calculateRemovalCount()` computes: `deficit = target_free_gb - current_free_gb - sum(sizeOnDisk of movies already in 'leaving' state)`. If `deficit ≤ 0`, returns 0 (no removals needed)
+- [ ] `getEligibleForRemoval()` returns movies ordered by `created_at` ASC, excluding: watchlist items, `rotation_status = 'protected'` (unexpired), `rotation_status = 'leaving'`, movies currently downloading in Radarr, movies with `sizeOnDisk = 0`
+- [ ] The system walks the eligible list oldest-first, accumulating `sizeOnDisk`, until cumulative size ≥ deficit. These movies are marked as leaving
+- [ ] `processExpiredMovies()` finds `leaving` movies past `rotation_expires_at`, calls Radarr `DELETE /movie/{id}?deleteFiles=true` for each
+- [ ] On successful Radarr deletion, the movie is removed from the POPS library (or marked accordingly)
+- [ ] If a deletion fails, log the error and continue with the next expired movie — don't abort the cycle
+- [ ] Movies not found in Radarr (deleted externally) are cleaned up from POPS without error
+- [ ] All operations are logged with movie IDs, titles, and sizes for audit
+
+## Notes
+
+Radarr's movie endpoint includes `sizeOnDisk` in bytes — convert to GB. The Radarr client already has `checkMovie(tmdbId)` for resolving Radarr IDs. For bulk operations, prefer fetching all movies once (`getMovies()`) rather than N individual lookups.

--- a/docs/themes/03-media/prds/070-rotation-engine/us-03-leaving-lifecycle.md
+++ b/docs/themes/03-media/prds/070-rotation-engine/us-03-leaving-lifecycle.md
@@ -1,0 +1,19 @@
+# US-03: Leaving Lifecycle
+
+> PRD: [Rotation Engine](README.md)
+
+## Description
+
+As a user, I want movies marked as "leaving" to be recoverable by adding them to my watchlist or clicking "Keep," so that the rotation system respects my intent.
+
+## Acceptance Criteria
+
+- [ ] When a movie is added to the watchlist (via `watchlist.add`), if it has `rotation_status = 'leaving'`, the status is cleared to `null` and `rotation_expires_at` / `rotation_marked_at` are set to `null`
+- [ ] `rotation.cancelLeaving(movieId)` endpoint clears leaving status for a specific movie
+- [ ] Cancelling leaving status returns the movie to the normal eligible pool (no special protection)
+- [ ] The watchlist service integration is a side-effect in the existing watchlist add flow — not a separate endpoint
+- [ ] Movies with `rotation_status = 'protected'` whose `rotation_expires_at` has passed are automatically cleared to `null` (checked during removal selection, not a separate job)
+
+## Notes
+
+The watchlist router (`watchlist.add`) needs to call into the rotation service to clear leaving status. Keep the coupling minimal — a single function call after successful watchlist insertion.

--- a/docs/themes/03-media/prds/070-rotation-engine/us-04-addition-execution.md
+++ b/docs/themes/03-media/prds/070-rotation-engine/us-04-addition-execution.md
@@ -1,0 +1,21 @@
+# US-04: Addition Execution
+
+> PRD: [Rotation Engine](README.md)
+
+## Description
+
+As a system, I need to add movies from the candidate queue to Radarr so that new content enters the library daily.
+
+## Acceptance Criteria
+
+- [ ] `addFromQueue(count)` calls the selection policy from PRD-071 to pick `count` candidates
+- [ ] For each selected candidate, calls Radarr `addMovie` with `searchForMovie: true`
+- [ ] On successful Radarr add, creates a POPS library entry (or updates if the movie already exists in POPS but not in Radarr)
+- [ ] Updates the candidate's status to `'added'` in `rotation_candidates`
+- [ ] If Radarr add fails for a candidate (already exists, unavailable), picks the next candidate — always tries to fill the requested count
+- [ ] Movies added via rotation have `rotation_status = null` (immediately eligible for future rotation)
+- [ ] All additions are logged with movie IDs/titles
+
+## Notes
+
+The existing `arrService.addMovie` and TMDB metadata fetch patterns should be reused. The candidate already has a `tmdb_id`, so TMDB lookup provides the full metadata needed for the POPS library entry.

--- a/docs/themes/03-media/prds/070-rotation-engine/us-05-disk-space-gating.md
+++ b/docs/themes/03-media/prds/070-rotation-engine/us-05-disk-space-gating.md
@@ -1,0 +1,20 @@
+# US-05: Addition Gating
+
+> PRD: [Rotation Engine](README.md)
+
+## Description
+
+As a system, I need to gate movie additions on available disk space so that new movies are only added when the library is within its storage budget.
+
+## Acceptance Criteria
+
+- [ ] After expired movie deletions and new leaving marks, the cycle re-checks free space via Radarr
+- [ ] If free space ≥ `rotation_target_free_gb`: proceed to add up to `rotation_daily_additions` movies from the candidate queue
+- [ ] If free space < `rotation_target_free_gb`: skip additions entirely, log "additions skipped — below target free space"
+- [ ] The addition count (`rotation_daily_additions`, default 2) is configurable via settings
+- [ ] Each addition is estimated at `rotation_avg_movie_gb` for space budgeting — if adding N movies would project free space below target, reduce the count
+- [ ] Actual add/remove counts and free space are recorded in the `rotation_log` entry
+
+## Notes
+
+This is a gate, not a driver. Removals are driven by disk space deficit (US-02). Additions are a fixed daily count that only runs when there's room. The `rotation_avg_movie_gb` estimate prevents over-adding — if target free space is 200GB, current is 210GB, and avg movie is 15GB, only add 0 movies (210 - 2×15 = 180 < 200).

--- a/docs/themes/03-media/prds/070-rotation-engine/us-06-daily-cron.md
+++ b/docs/themes/03-media/prds/070-rotation-engine/us-06-daily-cron.md
@@ -1,0 +1,22 @@
+# US-06: Daily Cron
+
+> PRD: [Rotation Engine](README.md)
+
+## Description
+
+As a system, I need a scheduled job that orchestrates the full rotation cycle daily so that the library rotates without manual intervention.
+
+## Acceptance Criteria
+
+- [ ] A cron-based scheduler runs `runRotationCycle()` at the configured `rotation_cron_expression`
+- [ ] `runRotationCycle()` executes in order: sync sources → process expired leaving movies (Radarr delete) → measure free space → calculate deficit → mark new leaving movies (oldest first, by size) → measure free space again → add movies from queue (if space permits)
+- [ ] The scheduler auto-resumes on server startup if `rotation_enabled = true` (same pattern as Plex sync scheduler)
+- [ ] `rotation.runNow` tRPC endpoint triggers an immediate cycle outside the cron schedule
+- [ ] Concurrent cycles are prevented — if a cycle is already running, skip the new invocation and log it
+- [ ] The scheduler respects `rotation_enabled` — toggling off stops future runs, toggling on schedules the next
+- [ ] Each cycle creates a `rotation_log` entry with all counts, disk space, and skip reasons
+- [ ] Graceful shutdown: in-progress cycle completes before the server exits (SIGTERM handling)
+
+## Notes
+
+Follow the existing Plex scheduler pattern (`plex/scheduler.ts`): module-level singleton, `setInterval` or node-cron, settings-driven, resume on boot. Consider using `node-cron` for proper cron expression support instead of `setInterval` with fixed intervals.

--- a/docs/themes/03-media/prds/071-source-lists/README.md
+++ b/docs/themes/03-media/prds/071-source-lists/README.md
@@ -1,0 +1,133 @@
+# PRD-071: Source Lists
+
+> Epic: [Library Rotation](../../epics/08-library-rotation.md)
+
+## Overview
+
+Source lists define where candidate movies come from. Each source is a plugin that fetches movies from an external list (Plex watchlist, friends' watchlists, IMDB top 100, etc.) and feeds them into a unified candidate queue. A selection policy picks from this queue using weighted randomisation based on source priority and movie rating. An exclusion list prevents specific movies from ever being added.
+
+## Data Model
+
+### `rotation_sources`
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | integer PK | Auto-increment | |
+| `type` | text (enum) | — | `'plex_watchlist'`, `'plex_friends'`, `'imdb_top_100'`, `'manual'`, `'letterboxd'` (extensible) |
+| `name` | text | — | Display name (e.g., "João's Plex Watchlist", "IMDB Top 250") |
+| `priority` | integer | `1` | Higher = more likely to be selected. Scale: 1-10 |
+| `enabled` | boolean | `true` | |
+| `config` | text (JSON) | `'{}'` | Source-specific config (e.g., friend username, list URL) |
+| `last_synced_at` | text | `null` | ISO datetime of last successful sync |
+| `sync_interval_hours` | integer | `24` | How often to re-fetch candidates from this source |
+| `created_at` | text | `datetime('now')` | |
+
+### `rotation_candidates`
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | integer PK | Auto-increment | |
+| `source_id` | integer FK | — | References `rotation_sources.id` |
+| `tmdb_id` | integer | — | TMDB movie ID |
+| `title` | text | — | For display without TMDB lookup |
+| `year` | integer | `null` | Release year |
+| `rating` | real | `null` | TMDB/IMDB rating (0-10 scale) |
+| `poster_path` | text | `null` | TMDB poster path |
+| `status` | text (enum) | `'pending'` | `'pending'`, `'added'`, `'skipped'`, `'excluded'` |
+| `discovered_at` | text | `datetime('now')` | When the source first returned this movie |
+
+Unique constraint: `(tmdb_id)` — a movie appears once in the queue regardless of how many sources return it. If multiple sources return the same movie, it inherits the highest source priority.
+
+### `rotation_exclusions`
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | integer PK | Auto-increment | |
+| `tmdb_id` | integer | — | TMDB movie ID (unique) |
+| `title` | text | — | For display |
+| `reason` | text | `null` | Optional user note |
+| `excluded_at` | text | `datetime('now')` | |
+
+## API Surface
+
+### Source Sync (internal)
+
+- `syncSource(sourceId)` — fetch candidates from a single source, upsert into `rotation_candidates`
+- `syncAllSources()` — sync all enabled sources whose `last_synced_at + sync_interval_hours` has passed
+- `aggregateCandidates(count)` → weighted random selection from pending candidates
+
+### Source Plugin Interface
+
+Each source type implements:
+
+```
+interface RotationSource {
+  type: string
+  fetchCandidates(config: Record<string, unknown>): Promise<CandidateMovie[]>
+}
+
+interface CandidateMovie {
+  tmdbId: number
+  title: string
+  year: number | null
+  rating: number | null
+  posterPath: string | null
+}
+```
+
+### tRPC
+
+- `rotation.sources.list` — all configured sources with sync status
+- `rotation.sources.create` — add a new source
+- `rotation.sources.update` — edit source (name, priority, config, enabled, interval)
+- `rotation.sources.delete` — remove source + its candidates
+- `rotation.sources.syncNow(sourceId)` — manually trigger sync for one source
+- `rotation.candidates.list` — paginated queue with source info, filterable by status
+- `rotation.candidates.exclude(tmdbId)` — move to exclusion list
+- `rotation.candidates.addToQueue(tmdbId)` — manually add a movie to the candidate queue (source = `manual`)
+- `rotation.exclusions.list` — paginated exclusion list
+- `rotation.exclusions.remove(tmdbId)` — un-exclude a movie
+
+## Business Rules
+
+- **Source priority weighting:** When selecting candidates for addition, each candidate's selection weight = `source_priority × (rating / 10)`. A priority-10 source with a 7.5-rated movie has weight `10 × 0.75 = 7.5`. A priority-3 source with a 9.0 movie has weight `3 × 0.9 = 2.7`. The user's watchlist at priority 10 dominates.
+- **Default source priorities:** User's Plex watchlist = 10, friends' watchlists = 6, curated external lists (IMDB, Letterboxd) = 3, manual queue = 8.
+- **Deduplication:** If multiple sources return the same `tmdb_id`, keep one candidate row. The effective priority is the max priority across all sources that include it. Track contributing sources in a junction table or JSON array.
+- **Exclusion filtering:** Before selection, remove any candidate whose `tmdb_id` appears in `rotation_exclusions` or already exists in the `movies` library table.
+- **Library filtering:** Candidates already in the POPS library (matched by `tmdb_id`) are skipped during selection. They remain in the candidate table with `status = 'skipped'` so they can re-enter the pool if the movie is later removed.
+- **Candidate staleness:** If a source no longer returns a candidate (e.g., movie removed from a friend's watchlist), keep it in the queue for 30 days before marking as `stale`. Stale candidates are deprioritised but not deleted — the source may re-add them.
+- **Manual queue:** The "Add to Queue" button creates a candidate with `source_id` pointing to a system-created `manual` source. These have high priority (8) by default.
+- **Direct download bypass:** The "Download" button skips the candidate queue entirely. It calls Radarr `addMovie` with `searchForMovie: true` and sets `rotation_status = 'protected'` on the POPS movie record (per PRD-070).
+- **Source sync errors:** If a source sync fails (API down, auth expired), log the error, keep existing candidates, retry next interval. Don't purge candidates on sync failure.
+- **Rating fallback:** If a candidate has no rating (rare for movies), assign a default weight of `source_priority × 0.5`.
+
+## Edge Cases
+
+| Case | Behaviour |
+|------|-----------|
+| Source returns 0 candidates | Log, mark `last_synced_at`, no candidates added |
+| All candidates already in library | Selection returns empty, no additions this cycle |
+| Source deleted while candidates pending | Cascade delete candidates from that source |
+| Same movie excluded then un-excluded | Remove from exclusions, candidate re-enters pool if still present |
+| Candidate added to library, then movie removed from library | Candidate status resets to `pending` on next source sync |
+| TMDB ID changes for a movie | Extremely rare; handled by re-sync matching by title+year as fallback |
+| Friend removes movie from their watchlist | Candidate stays for 30 days (staleness rule), then deprioritised |
+
+## User Stories
+
+| # | Story | Summary | Status | Parallelisable |
+|---|-------|---------|--------|----------------|
+| 01 | [us-01-source-schema](us-01-source-schema.md) | Schema: `rotation_sources`, `rotation_candidates`, `rotation_exclusions` tables | Not started | Yes (parallel with PRD-070 US-01) |
+| 02 | [us-02-source-plugin-interface](us-02-source-plugin-interface.md) | Plugin interface + Plex watchlist adapter | Not started | Blocked by US-01 |
+| 03 | [us-03-plex-friends-source](us-03-plex-friends-source.md) | Plex friends watchlist source adapter | Not started | Blocked by US-02 |
+| 04 | [us-04-external-list-source](us-04-external-list-source.md) | IMDB/external list source adapter (web scraping or API) | Not started | Blocked by US-02 |
+| 05 | [us-05-selection-policy](us-05-selection-policy.md) | Weighted random selection from candidate pool | Not started | Blocked by US-01 |
+| 06 | [us-06-exclusion-list](us-06-exclusion-list.md) | Exclusion list CRUD + filtering during selection | Not started | Blocked by US-01 |
+| 07 | [us-07-source-sync-scheduler](us-07-source-sync-scheduler.md) | Scheduled source syncing based on per-source intervals | Not started | Blocked by US-02 |
+
+## Out of Scope
+
+- Streaming availability checking (which platform has the movie)
+- Source recommendations based on user taste profile
+- Social features (sharing lists between POPS users)
+- TV show sources

--- a/docs/themes/03-media/prds/071-source-lists/us-01-source-schema.md
+++ b/docs/themes/03-media/prds/071-source-lists/us-01-source-schema.md
@@ -1,0 +1,22 @@
+# US-01: Source Schema
+
+> PRD: [Source Lists](README.md)
+
+## Description
+
+As a system, I need the database tables for rotation sources, candidates, and exclusions so that the candidate pipeline has persistent storage.
+
+## Acceptance Criteria
+
+- [ ] `rotation_sources` table exists with columns per PRD data model: `id`, `type`, `name`, `priority`, `enabled`, `config`, `last_synced_at`, `sync_interval_hours`, `created_at`
+- [ ] `rotation_candidates` table exists with columns: `id`, `source_id`, `tmdb_id`, `title`, `year`, `rating`, `poster_path`, `status`, `discovered_at`
+- [ ] `rotation_candidates` has a unique constraint on `tmdb_id`
+- [ ] `rotation_exclusions` table exists with columns: `id`, `tmdb_id`, `title`, `reason`, `excluded_at`
+- [ ] `rotation_exclusions` has a unique constraint on `tmdb_id`
+- [ ] Foreign key: `rotation_candidates.source_id` → `rotation_sources.id` with cascade delete
+- [ ] A system `manual` source is seeded on first server boot (type = `'manual'`, name = `'Manual Queue'`, priority = 8)
+- [ ] Drizzle schema types are exported from `@pops/db-types`
+
+## Notes
+
+Follow existing Drizzle schema patterns in `packages/db-types/src/schema/`. The `config` column on `rotation_sources` stores JSON — use text with application-level parsing (consistent with how settings work elsewhere).

--- a/docs/themes/03-media/prds/071-source-lists/us-02-source-plugin-interface.md
+++ b/docs/themes/03-media/prds/071-source-lists/us-02-source-plugin-interface.md
@@ -1,0 +1,21 @@
+# US-02: Source Plugin Interface + Plex Watchlist Adapter
+
+> PRD: [Source Lists](README.md)
+
+## Description
+
+As a system, I need a plugin interface for rotation sources and a Plex watchlist adapter so that the user's own Plex watchlist can feed candidates into the rotation queue.
+
+## Acceptance Criteria
+
+- [ ] `RotationSource` interface defined: `type: string`, `fetchCandidates(config): Promise<CandidateMovie[]>`
+- [ ] `CandidateMovie` type defined: `tmdbId: number`, `title: string`, `year: number | null`, `rating: number | null`, `posterPath: string | null`
+- [ ] Source registry maps source types to their adapter implementations
+- [ ] `plex_watchlist` adapter fetches the user's Plex Discover watchlist (reuse existing `PlexClient.getWatchlist` patterns from sync-watchlist)
+- [ ] Adapter extracts TMDB ID from Plex metadata `Guid` array, resolves title/year/rating from TMDB
+- [ ] `syncSource(sourceId)` fetches candidates via the adapter and upserts into `rotation_candidates` (insert new, skip existing by `tmdb_id`)
+- [ ] `last_synced_at` is updated on the source record after successful sync
+
+## Notes
+
+The Plex watchlist sync already exists in `plex/sync-watchlist.ts` — reuse the TMDB ID extraction and Plex API call patterns. The adapter wraps these into the `RotationSource` interface.

--- a/docs/themes/03-media/prds/071-source-lists/us-03-plex-friends-source.md
+++ b/docs/themes/03-media/prds/071-source-lists/us-03-plex-friends-source.md
@@ -1,0 +1,21 @@
+# US-03: Plex Friends Watchlist Source
+
+> PRD: [Source Lists](README.md)
+
+## Description
+
+As a user, I want to use my Plex friends' watchlists as a source of movie candidates so that movies my friends are interested in can enter my rotation pool.
+
+## Acceptance Criteria
+
+- [ ] `plex_friends` adapter accepts a friend username (or Plex user ID) in the source `config`
+- [ ] Adapter fetches the friend's public watchlist via Plex Discover API
+- [ ] Extracts TMDB IDs from Plex metadata, resolves movie details from TMDB
+- [ ] Only returns movies (filters out TV shows)
+- [ ] If the friend's watchlist is private or inaccessible, returns empty array and logs a warning
+- [ ] Multiple `plex_friends` sources can exist (one per friend), each with independent priority and sync interval
+- [ ] tRPC endpoint or helper to list available Plex friends (for the source config UI picker)
+
+## Notes
+
+Plex Discover API access to friends' watchlists may require the friend to have their watchlist set to public/friends. If the API doesn't expose this directly, explore `https://community.plex.tv` endpoints or the friends sharing API. Document any limitations found.

--- a/docs/themes/03-media/prds/071-source-lists/us-04-external-list-source.md
+++ b/docs/themes/03-media/prds/071-source-lists/us-04-external-list-source.md
@@ -1,0 +1,20 @@
+# US-04: External List Source
+
+> PRD: [Source Lists](README.md)
+
+## Description
+
+As a user, I want to add external movie lists (IMDB Top 100, Letterboxd lists) as rotation sources so that curated lists feed into my candidate pool.
+
+## Acceptance Criteria
+
+- [ ] `imdb_top_100` adapter fetches the IMDB Top 100 (or Top 250) list and extracts movie identifiers
+- [ ] IMDB IDs are resolved to TMDB IDs via the TMDB "find by external ID" endpoint
+- [ ] `letterboxd` adapter accepts a list URL in the source `config` and scrapes or fetches the list contents
+- [ ] Both adapters return `CandidateMovie[]` conforming to the plugin interface
+- [ ] Adapters handle pagination if the external list is large
+- [ ] Graceful degradation: if the external source is unreachable or the page structure changes, return empty array and log the error
+
+## Notes
+
+IMDB doesn't have a public API — scraping or using an intermediary (TMDB's curated lists, or a maintained IMDB dataset) may be more reliable. TMDB itself has a "Top Rated" endpoint (`/movie/top_rated`) that could serve as an alternative. Evaluate the most maintainable approach.

--- a/docs/themes/03-media/prds/071-source-lists/us-05-selection-policy.md
+++ b/docs/themes/03-media/prds/071-source-lists/us-05-selection-policy.md
@@ -1,0 +1,21 @@
+# US-05: Selection Policy
+
+> PRD: [Source Lists](README.md)
+
+## Description
+
+As a system, I need a weighted random selection policy so that higher-priority sources and higher-rated movies are more likely to be picked from the candidate queue.
+
+## Acceptance Criteria
+
+- [ ] `aggregateCandidates(count)` selects `count` movies from `rotation_candidates` where `status = 'pending'`
+- [ ] Selection weight per candidate = `source_priority × (rating / 10)`. If rating is null, use `source_priority × 0.5`
+- [ ] If multiple sources contributed the same `tmdb_id`, the effective priority is the maximum across those sources
+- [ ] Candidates whose `tmdb_id` exists in the `movies` library table are excluded (already in library)
+- [ ] Candidates whose `tmdb_id` exists in `rotation_exclusions` are excluded
+- [ ] Selection uses weighted random sampling without replacement (once a movie is picked, it can't be picked again in the same cycle)
+- [ ] The function returns the selected candidates with their computed weights for logging
+
+## Notes
+
+Weighted random sampling: compute cumulative weights, generate a random number, binary search for the selected index. Remove the selected item and repeat for the remaining count. Standard reservoir sampling also works.

--- a/docs/themes/03-media/prds/071-source-lists/us-06-exclusion-list.md
+++ b/docs/themes/03-media/prds/071-source-lists/us-06-exclusion-list.md
@@ -1,0 +1,20 @@
+# US-06: Exclusion List
+
+> PRD: [Source Lists](README.md)
+
+## Description
+
+As a user, I want to exclude specific movies from ever being added by the rotation system so that unwanted movies don't keep appearing in the queue.
+
+## Acceptance Criteria
+
+- [ ] `rotation.exclusions.list` returns paginated exclusion entries (title, tmdb_id, reason, excluded_at)
+- [ ] `rotation.candidates.exclude(tmdbId)` moves a candidate to the exclusion list: inserts into `rotation_exclusions`, updates candidate status to `'excluded'`
+- [ ] `rotation.exclusions.remove(tmdbId)` deletes from `rotation_exclusions`. If a matching candidate exists, resets its status to `'pending'`
+- [ ] Exclusion is checked during candidate selection (US-05) — excluded `tmdb_id`s are filtered out
+- [ ] Exclusion is checked during source sync — if a synced movie is in the exclusion list, it's inserted with `status = 'excluded'` rather than `'pending'`
+- [ ] Exclusion entries persist across source syncs (not deleted when sources are re-synced)
+
+## Notes
+
+The exclusion list is a user-managed blocklist. It's separate from the watchlist — the watchlist protects movies already in the library, the exclusion list prevents movies from entering the library.

--- a/docs/themes/03-media/prds/071-source-lists/us-07-source-sync-scheduler.md
+++ b/docs/themes/03-media/prds/071-source-lists/us-07-source-sync-scheduler.md
@@ -1,0 +1,21 @@
+# US-07: Source Sync Scheduler
+
+> PRD: [Source Lists](README.md)
+
+## Description
+
+As a system, I need to periodically sync rotation sources so that the candidate queue stays populated with fresh movies from all configured sources.
+
+## Acceptance Criteria
+
+- [ ] `syncAllSources()` iterates enabled sources where `last_synced_at + sync_interval_hours` has elapsed (or `last_synced_at` is null)
+- [ ] Each source is synced independently — one source failing does not block others
+- [ ] Source sync runs before the rotation cycle's addition step (called from `runRotationCycle` in PRD-070 US-06)
+- [ ] `rotation.sources.syncNow(sourceId)` tRPC endpoint triggers an immediate sync for a single source
+- [ ] Sync results are logged: source name, candidates found, new candidates added, errors
+- [ ] Concurrent sync calls for the same source are prevented (skip if already syncing)
+- [ ] Stale candidates (source no longer returns them for 30 days) are marked with lower priority, not deleted
+
+## Notes
+
+Source sync is triggered as part of the rotation cycle, not as an independent scheduler. This keeps the timing simple: sync sources → select candidates → add movies. The per-source `sync_interval_hours` prevents unnecessary API calls when sources update infrequently.

--- a/docs/themes/03-media/prds/072-rotation-ui/README.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/README.md
@@ -1,0 +1,137 @@
+# PRD-072: Rotation UI
+
+> Epic: [Library Rotation](../../epics/08-library-rotation.md)
+
+## Overview
+
+The UI layer for the library rotation system. Surfaces the "Leaving Soon" countdown on movie cards and in a dedicated shelf, provides a settings page for rotation configuration, and offers management views for source lists, the candidate queue, and the exclusion list. Two distinct action buttons — "Add to Queue" and "Download" — give users control over how movies enter the library.
+
+## Pages & Components
+
+### Leaving Soon Shelf (Library page + Discover page)
+
+A shelf showing movies with `rotation_status = 'leaving'`, sorted by `rotation_expires_at` ascending (soonest first). Appears in two places:
+
+1. **Library page** — as a pinned shelf near the top, above the general library grid
+2. **Discover page** — registered as a shelf in the shelf registry (PRD-065). Category: `local`. Always included when there are leaving movies (not subject to the random shelf assembly — it's pinned at the top of the Discover page alongside any other pinned shelves).
+
+Shelf behaviour:
+
+- Each card shows a countdown badge: "Leaving in X days" (or "Last day" when < 24h remain)
+- Clicking a card opens the movie detail page (existing)
+- A "Keep" action on each card clears the leaving status (calls `rotation.cancelLeaving`)
+- Adding a leaving movie to the watchlist also clears leaving status (handled by PRD-070 business rule)
+
+### Leaving Soon Badge (Movie Cards)
+
+On any movie card across the app (library, search results, detail page), if the movie has `rotation_status = 'leaving'`:
+
+- Show a countdown badge overlaid on the poster (bottom-left or top-right corner)
+- Badge style: urgent red when ≤ 3 days, warning amber when ≤ 7 days, neutral when > 7 days
+
+### Rotation Settings Page
+
+Located under Media settings. Controls:
+
+| Setting | Input | Description |
+|---------|-------|-------------|
+| Enabled | Toggle | Master on/off switch |
+| Schedule | Cron input or preset picker (daily at 3am, 6am, midnight) | When the job runs |
+| Leaving window | Number input (days) | How long movies stay in "leaving" state before deletion |
+| Daily additions | Number input | Max movies to add per cycle (gated by disk space) |
+| Target free space | Number input (GB) | Minimum free disk space — drives how many movies get marked for removal |
+| Average movie size | Number input (GB) | Fallback estimate when Radarr `sizeOnDisk` unavailable |
+| Protected days | Number input | How long manually-downloaded movies are shielded from rotation |
+
+Also displays:
+- Current disk space (live from Radarr)
+- Last rotation run summary (timestamp, counts, errors)
+- Next scheduled run time
+- A "Run Now" button to trigger a manual cycle
+
+### Source List Management Page
+
+CRUD interface for rotation sources.
+
+- List view: source name, type icon, priority (visual indicator), enabled toggle, last synced, candidate count
+- Create/edit modal: type selector, name, priority slider (1-10), type-specific config fields, sync interval
+- Delete with confirmation (warns about candidate deletion)
+- "Sync Now" button per source
+- Drag-to-reorder for priority (visual, updates priority values)
+
+Type-specific config fields:
+
+| Source Type | Config Fields |
+|-------------|---------------|
+| `plex_watchlist` | None (uses connected Plex account) |
+| `plex_friends` | Friend username picker (from Plex friends list) |
+| `imdb_top_100` | None (hardcoded URL) |
+| `letterboxd` | List URL |
+| `manual` | None (system-managed, one per install) |
+
+### Candidate Queue Page
+
+Tabbed view showing the candidate pipeline:
+
+- **Pending** tab: movies waiting to be added. Shows title, year, rating, source name, priority badge, discovered date. Actions: "Download" (bypass queue), "Exclude"
+- **Added** tab: movies that were added by the rotation engine. Shows added date
+- **Excluded** tab: the exclusion list. Shows title, excluded date, reason. Action: "Un-exclude"
+
+Each tab is paginated and searchable by title.
+
+### Add to Queue / Download Buttons
+
+On movie discovery pages (search results, Discover page, external recommendations):
+
+- **"Add to Queue"** — adds the movie to `rotation_candidates` with source = `manual`. Does NOT trigger a Radarr download. Toast confirmation: "Added to rotation queue"
+- **"Download"** — adds to Radarr immediately with `searchForMovie: true`, creates POPS library entry with `rotation_status = 'protected'`. Toast confirmation: "Downloading — protected for 30 days"
+
+Button placement: side by side where the current "Request" button lives. If the movie is already in the library, show status instead. If already in the queue, show "In Queue" badge.
+
+### Rotation Log Page
+
+Paginated history of rotation cycles. Each entry shows:
+
+- Execution timestamp
+- Movies marked leaving (count + expand to see titles)
+- Movies removed (count + titles)
+- Movies added (count + titles)
+- Failed removals (count + details)
+- Disk space at time of run
+- Skip reason if applicable
+
+## Business Rules
+
+- **Badge urgency thresholds:** ≤ 3 days = red, ≤ 7 days = amber, > 7 days = neutral. These are hardcoded — no config needed.
+- **"Keep" action:** Calls `rotation.cancelLeaving(movieId)`. Resets `rotation_status` to `null`, clears `rotation_expires_at` and `rotation_marked_at`. The movie re-enters the eligible pool and may be selected again in a future cycle.
+- **Settings validation:** Daily additions ≥ 1, leaving window ≥ 1 day, target free space ≥ 0, avg movie size > 0, protected days ≥ 0.
+- **Source creation:** The `manual` source is auto-created on first use and cannot be deleted. All other sources are user-managed.
+- **Queue/Download mutual exclusivity per movie:** If a movie is in the queue and the user clicks "Download", remove it from the queue and add directly. If a movie was already downloaded (in library), don't show "Add to Queue."
+
+## Edge Cases
+
+| Case | Behaviour |
+|------|-----------|
+| Rotation disabled | Settings page shows all controls greyed out except the toggle. Leaving Soon shelf hidden on both Library and Discover pages |
+| No sources configured | Source page shows empty state with setup prompt. Rotation can run but will have no candidates to add |
+| Radarr disconnected | Settings page shows warning. "Run Now" disabled. Disk space shows "unavailable" |
+| Movie in queue and in library simultaneously | Show "In Library" badge, hide queue actions. Candidate status = `skipped` |
+| User cancels leaving on a movie daily | No limit on "Keep" actions. The movie re-enters the eligible pool. Since removal is oldest-first and deterministic, it will be re-selected if it's still among the oldest. Add to watchlist for permanent protection |
+
+## User Stories
+
+| # | Story | Summary | Status | Parallelisable |
+|---|-------|---------|--------|----------------|
+| 01 | [us-01-leaving-soon-shelf](us-01-leaving-soon-shelf.md) | Leaving Soon shelf on Library + Discover pages, countdown badges on cards | Not started | Blocked by PRD-070 US-03 |
+| 02 | [us-02-rotation-settings](us-02-rotation-settings.md) | Rotation settings page with all configuration controls | Not started | Blocked by PRD-070 US-01 |
+| 03 | [us-03-source-management](us-03-source-management.md) | Source list CRUD page with type-specific config | Not started | Blocked by PRD-071 US-01 |
+| 04 | [us-04-candidate-queue](us-04-candidate-queue.md) | Candidate queue page with tabs (pending, added, excluded) | Not started | Blocked by PRD-071 US-01 |
+| 05 | [us-05-queue-download-buttons](us-05-queue-download-buttons.md) | "Add to Queue" and "Download" buttons on discovery pages | Not started | Blocked by PRD-071 US-01, PRD-070 US-01 |
+| 06 | [us-06-rotation-log](us-06-rotation-log.md) | Rotation execution history page | Not started | Blocked by PRD-070 US-06 |
+
+## Out of Scope
+
+- Push notifications (email, mobile) for leaving movies
+- Calendar view of rotation schedule
+- Drag-to-reorder candidate queue priority
+- Public sharing of rotation stats

--- a/docs/themes/03-media/prds/072-rotation-ui/us-01-leaving-soon-shelf.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/us-01-leaving-soon-shelf.md
@@ -1,0 +1,23 @@
+# US-01: Leaving Soon Shelf
+
+> PRD: [Rotation UI](README.md)
+
+## Description
+
+As a user, I want to see which movies are about to leave my library — on both the Library page and the Discover page — so that I can watch them before they're removed or choose to keep them.
+
+## Acceptance Criteria
+
+- [ ] A "Leaving Soon" shelf appears on the movie library page when there are movies with `rotation_status = 'leaving'`
+- [ ] The same "Leaving Soon" shelf appears on the Discover page, registered in the shelf registry (PRD-065 pattern). Category: `local`. It is pinned (always shown when leaving movies exist, not subject to random shelf assembly)
+- [ ] On both pages, movies are sorted by `rotation_expires_at` ASC (soonest departures first)
+- [ ] Each card shows a countdown badge: "Leaving in X days", "Last day" (< 24h), or "Leaving tomorrow" (< 48h)
+- [ ] Badge colour: red when ≤ 3 days, amber when ≤ 7 days, neutral when > 7 days
+- [ ] The countdown badge also appears on movie cards elsewhere in the app (search, detail page, watchlist) when that movie is leaving
+- [ ] Each card has a "Keep" action that clears the leaving status (calls `rotation.cancelLeaving`)
+- [ ] Both shelves are hidden when rotation is disabled or no movies are leaving
+- [ ] Shelf uses the existing `MediaCard` component — badge is an overlay, not a new card type
+
+## Notes
+
+On the Library page, the shelf sits near the top — above the general library grid, below any pinned/featured section. On the Discover page, it's a pinned shelf at the top of the page (above the randomly assembled shelves). The shelf definition follows the `ShelfDefinition` interface from PRD-065 and registers via `registerShelf()`. The "Keep" action should be a quick-action (icon button on hover or swipe) — not a full modal flow.

--- a/docs/themes/03-media/prds/072-rotation-ui/us-02-rotation-settings.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/us-02-rotation-settings.md
@@ -1,0 +1,24 @@
+# US-02: Rotation Settings Page
+
+> PRD: [Rotation UI](README.md)
+
+## Description
+
+As a user, I want to configure the rotation system's behaviour so that I can control the pace, timing, and disk space targets for library rotation.
+
+## Acceptance Criteria
+
+- [ ] Settings page accessible under Media settings (new section or tab)
+- [ ] Toggle for `rotation_enabled` with clear on/off state
+- [ ] Schedule picker: preset options (daily at 3am, 6am, midnight) or custom cron input with validation
+- [ ] Number inputs for: leaving window (days), daily additions (max movies to add per cycle), target free space (GB), average movie size (GB, for space estimation), protected days
+- [ ] Input validation per PRD rules: daily additions ≥ 1, leaving window ≥ 1, target free space ≥ 0, avg movie size > 0, protected days ≥ 0
+- [ ] Displays current Radarr disk space (live query, with "unavailable" state if Radarr is disconnected)
+- [ ] Displays last rotation run summary: timestamp, movies added/removed/marked, errors
+- [ ] Displays next scheduled run time
+- [ ] "Run Now" button to trigger an immediate rotation cycle (disabled if Radarr is disconnected or rotation is disabled)
+- [ ] All controls disabled (greyed out) except the master toggle when rotation is off
+
+## Notes
+
+Follow the existing Plex settings page pattern for layout. The "Run Now" button should show a loading/progress indicator while the cycle runs.

--- a/docs/themes/03-media/prds/072-rotation-ui/us-03-source-management.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/us-03-source-management.md
@@ -1,0 +1,22 @@
+# US-03: Source Management UI
+
+> PRD: [Rotation UI](README.md)
+
+## Description
+
+As a user, I want to add, edit, and remove rotation sources so that I control where candidate movies come from and their relative priority.
+
+## Acceptance Criteria
+
+- [ ] Source list page shows all configured sources: name, type icon, priority (visual bar or number), enabled toggle, last synced timestamp, candidate count
+- [ ] "Add Source" button opens a create modal with: type selector (dropdown), name input, priority slider (1-10), type-specific config fields, sync interval input
+- [ ] Type-specific config fields render dynamically based on selected type (see PRD-072 table)
+- [ ] Edit modal pre-fills existing values; allows changing name, priority, config, enabled, interval
+- [ ] Delete source shows confirmation dialog warning that its candidates will also be removed
+- [ ] "Sync Now" button per source triggers immediate sync with loading indicator
+- [ ] The `manual` source appears in the list but cannot be deleted or have its type changed
+- [ ] Sources can be reordered by dragging (updates priority values) or priority can be set numerically
+
+## Notes
+
+The Plex friends picker (for `plex_friends` type) should query available friends from the Plex API and present them in a dropdown rather than requiring manual username entry.

--- a/docs/themes/03-media/prds/072-rotation-ui/us-04-candidate-queue.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/us-04-candidate-queue.md
@@ -1,0 +1,22 @@
+# US-04: Candidate Queue Page
+
+> PRD: [Rotation UI](README.md)
+
+## Description
+
+As a user, I want to browse the candidate queue and exclusion list so that I can see what movies are coming, exclude unwanted ones, and manage the pipeline.
+
+## Acceptance Criteria
+
+- [ ] Tabbed view with three tabs: Pending, Added, Excluded
+- [ ] **Pending tab:** shows candidates with `status = 'pending'`. Columns/cards: poster, title, year, rating, source name, priority badge, discovered date. Actions per item: "Download" (bypass queue → Radarr), "Exclude"
+- [ ] **Added tab:** shows candidates with `status = 'added'`. Columns/cards: poster, title, year, source, date added. Read-only
+- [ ] **Excluded tab:** shows `rotation_exclusions` entries. Columns/cards: poster, title, excluded date, reason. Action: "Un-exclude"
+- [ ] All tabs are paginated (default 20 per page) and searchable by title
+- [ ] Pending tab shows total count badge on the tab label
+- [ ] "Download" action on a pending candidate: removes from queue, adds to Radarr with search, creates POPS library entry with `rotation_status = 'protected'`
+- [ ] "Exclude" action: moves candidate to exclusion list, optionally with a reason (text input in a small popover)
+
+## Notes
+
+Use the existing DataTable or card grid components. The poster can use the `poster_path` from the candidate record with the TMDB image base URL.

--- a/docs/themes/03-media/prds/072-rotation-ui/us-05-queue-download-buttons.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/us-05-queue-download-buttons.md
@@ -1,0 +1,22 @@
+# US-05: Queue & Download Buttons
+
+> PRD: [Rotation UI](README.md)
+
+## Description
+
+As a user, I want "Add to Queue" and "Download" buttons on movie discovery pages so that I can control how new movies enter my library.
+
+## Acceptance Criteria
+
+- [ ] On search results, Discover page, and anywhere a non-library movie card appears: show two action buttons
+- [ ] **"Add to Queue"** — creates a `rotation_candidates` entry with source = `manual`. Toast: "Added to rotation queue". Button changes to "In Queue" badge after click
+- [ ] **"Download"** — adds to Radarr with `searchForMovie: true`, creates POPS library entry with `rotation_status = 'protected'`. Toast: "Downloading — protected for 30 days". Button changes to status indicator (downloading/available)
+- [ ] If the movie is already in the library: show library status instead of action buttons (existing behaviour)
+- [ ] If the movie is already in the candidate queue: show "In Queue" badge with option to remove
+- [ ] If the movie is in the exclusion list: show "Excluded" badge with option to un-exclude
+- [ ] Buttons replace or sit alongside the existing "Request" button — no duplicate functionality
+- [ ] Both buttons are available only when rotation is enabled. When disabled, the existing request flow is used
+
+## Notes
+
+This changes the movie request flow. When rotation is enabled, the two-button pattern replaces the single "Request" button. When rotation is disabled, the original request flow (direct to Radarr) remains. The transition should be seamless — no config migration needed, just conditional rendering.

--- a/docs/themes/03-media/prds/072-rotation-ui/us-06-rotation-log.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/us-06-rotation-log.md
@@ -1,0 +1,20 @@
+# US-06: Rotation Log Page
+
+> PRD: [Rotation UI](README.md)
+
+## Description
+
+As a user, I want to see a history of rotation cycles so that I can verify the system is working correctly and review what was added or removed.
+
+## Acceptance Criteria
+
+- [ ] Rotation log page shows paginated history of `rotation_log` entries, newest first
+- [ ] Each entry displays: execution timestamp, movies marked leaving (count), movies removed (count), movies added (count), failed removals (count), disk space at time of run, skip reason (if any)
+- [ ] Each entry is expandable to show details: list of movie titles/IDs for each action category (marked, removed, added, failed)
+- [ ] Entries with errors or skip reasons are visually distinguished (warning/error styling)
+- [ ] Page shows summary stats at top: total movies rotated (all time), average per day, current streak (days since last skip)
+- [ ] Empty state when no rotation cycles have run yet
+
+## Notes
+
+The `details` JSON column in `rotation_log` contains the per-movie information. Parse and display it in the expanded view. Keep the collapsed view scannable — just the numbers.


### PR DESCRIPTION
## Summary

- Adds **Epic 08: Library Rotation** under the Media theme — automated movie lifecycle management
- **PRD-070: Rotation Engine** (6 user stories) — disk-space-driven removal of oldest movies, leaving grace period, Radarr delete with file cleanup, addition gating
- **PRD-071: Source Lists** (7 user stories) — plugin-based source system (Plex watchlist, friends, IMDB, Letterboxd, manual queue), weighted random selection policy, exclusion list
- **PRD-072: Rotation UI** (6 user stories) — Leaving Soon shelf on Library + Discover pages, countdown badges, rotation settings, source management, candidate queue, rotation log
- Updates theme README (new epic row + key decisions) and roadmap tracker

## Test plan

- [ ] All internal markdown links resolve correctly (verified via script)
- [ ] All user story back-links point to parent PRD README
- [ ] Status tables are consistent across all levels (theme → epic → PRD → US)
- [ ] PRD numbers are globally unique and sequential (070, 071, 072 — after existing 069)
- [ ] No implementation details in docs — specs only