### PR TITLE
feat(rotation): removal selection service (PRD-070 US-02) [tb-346]

### DIFF
--- a/apps/pops-api/src/modules/media/arr/base-client.ts
+++ b/apps/pops-api/src/modules/media/arr/base-client.ts
@@ -132,6 +132,29 @@ export class ArrBaseClient {
     return (await response.json()) as T;
   }
 
+  /** Make an authenticated DELETE request to the *arr API. */
+  protected async delete(path: string): Promise<void> {
+    const url = `${this.baseUrl}/api/v3${path}`;
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'DELETE',
+        headers: {
+          'X-Api-Key': this.apiKey,
+          Accept: 'application/json',
+        },
+        signal: AbortSignal.timeout(CONNECTION_TIMEOUT_MS),
+      });
+    } catch (err) {
+      throw toArrApiError(err, url);
+    }
+
+    if (!response.ok) {
+      throw new ArrApiError(`${response.status} ${response.statusText} — ${url}`, response.status);
+    }
+  }
+
   /** Test the connection by fetching system status. */
   async testConnection(): Promise<ArrSystemStatus> {
     return this.get<ArrSystemStatus>('/system/status');

--- a/apps/pops-api/src/modules/media/arr/radarr-client.ts
+++ b/apps/pops-api/src/modules/media/arr/radarr-client.ts
@@ -4,6 +4,7 @@
 import { ArrBaseClient } from './base-client.js';
 import type {
   RadarrMovie,
+  RadarrDiskSpace,
   RadarrQueueResponse,
   ArrStatusResult,
   RadarrQualityProfile,
@@ -74,6 +75,16 @@ export class RadarrClient extends ArrBaseClient {
       name: 'MoviesSearch',
       movieIds: [radarrId],
     });
+  }
+
+  /** Fetch disk space info from Radarr. */
+  async getDiskSpace(): Promise<RadarrDiskSpace[]> {
+    return this.get<RadarrDiskSpace[]>('/diskspace');
+  }
+
+  /** Delete a movie from Radarr by its Radarr ID. Set deleteFiles to also remove files. */
+  async deleteMovie(radarrId: number, deleteFiles = true): Promise<void> {
+    await this.delete(`/movie/${radarrId}?deleteFiles=${deleteFiles}`);
   }
 
   /**

--- a/apps/pops-api/src/modules/media/arr/types.ts
+++ b/apps/pops-api/src/modules/media/arr/types.ts
@@ -49,6 +49,16 @@ export interface RadarrMovie {
   tmdbId: number;
   monitored: boolean;
   hasFile: boolean;
+  /** Size of the movie file on disk in bytes (0 if no file). */
+  sizeOnDisk?: number;
+}
+
+/** Disk space info returned by Radarr /diskspace endpoint. */
+export interface RadarrDiskSpace {
+  path: string;
+  label: string;
+  freeSpace: number;
+  totalSpace: number;
 }
 
 export interface RadarrQualityProfile {

--- a/apps/pops-api/src/modules/media/rotation/removal-selection.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/removal-selection.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateRemovalDeficit,
+  selectMoviesForRemoval,
+  type EligibleMovie,
+  type MovieSizeMap,
+} from './removal-selection.js';
+
+// ---------------------------------------------------------------------------
+// calculateRemovalDeficit
+// ---------------------------------------------------------------------------
+
+describe('calculateRemovalDeficit', () => {
+  it('returns 0 when current free space exceeds target', () => {
+    expect(calculateRemovalDeficit(100, 150, 0)).toBe(0);
+  });
+
+  it('returns 0 when free space plus leaving size covers target', () => {
+    // target=100, current=80, leaving=30 → deficit = 100 - 80 - 30 = -10 → 0
+    expect(calculateRemovalDeficit(100, 80, 30)).toBe(0);
+  });
+
+  it('returns positive deficit when space is insufficient', () => {
+    // target=100, current=50, leaving=10 → deficit = 100 - 50 - 10 = 40
+    expect(calculateRemovalDeficit(100, 50, 10)).toBe(40);
+  });
+
+  it('accounts for zero leaving size', () => {
+    // target=100, current=60, leaving=0 → deficit = 40
+    expect(calculateRemovalDeficit(100, 60, 0)).toBe(40);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectMoviesForRemoval
+// ---------------------------------------------------------------------------
+
+function makeMovie(id: number, tmdbId: number, title: string, daysOld: number): EligibleMovie {
+  const d = new Date();
+  d.setDate(d.getDate() - daysOld);
+  return { id, tmdbId, title, createdAt: d.toISOString() };
+}
+
+describe('selectMoviesForRemoval', () => {
+  const eligible: EligibleMovie[] = [
+    makeMovie(1, 100, 'Old Movie', 90),
+    makeMovie(2, 200, 'Medium Movie', 60),
+    makeMovie(3, 300, 'Recent Movie', 30),
+    makeMovie(4, 400, 'Very Recent', 7),
+  ];
+
+  const sizes: MovieSizeMap = new Map([
+    [100, 10], // 10 GB
+    [200, 20], // 20 GB
+    [300, 15], // 15 GB
+    [400, 5], // 5 GB
+  ]);
+
+  it('returns empty when deficit is 0', () => {
+    const result = selectMoviesForRemoval(eligible, sizes, 0);
+    expect(result.moviesToMark).toHaveLength(0);
+    expect(result.totalSizeGb).toBe(0);
+  });
+
+  it('returns empty when deficit is negative', () => {
+    const result = selectMoviesForRemoval(eligible, sizes, -10);
+    expect(result.moviesToMark).toHaveLength(0);
+  });
+
+  it('selects oldest movie first when it covers the deficit', () => {
+    const result = selectMoviesForRemoval(eligible, sizes, 8);
+    expect(result.moviesToMark).toHaveLength(1);
+    expect(result.moviesToMark[0]!.tmdbId).toBe(100);
+    expect(result.totalSizeGb).toBe(10);
+  });
+
+  it('accumulates movies until deficit is covered', () => {
+    // Need 25 GB: movie 1 (10) + movie 2 (20) = 30 >= 25
+    const result = selectMoviesForRemoval(eligible, sizes, 25);
+    expect(result.moviesToMark).toHaveLength(2);
+    expect(result.moviesToMark.map((m) => m.tmdbId)).toEqual([100, 200]);
+    expect(result.totalSizeGb).toBe(30);
+  });
+
+  it('selects all movies if deficit exceeds total available', () => {
+    const result = selectMoviesForRemoval(eligible, sizes, 100);
+    expect(result.moviesToMark).toHaveLength(4);
+    expect(result.totalSizeGb).toBe(50);
+  });
+
+  it('skips movies with zero size', () => {
+    const sizesWithZero: MovieSizeMap = new Map([
+      [100, 0],
+      [200, 20],
+      [300, 15],
+      [400, 5],
+    ]);
+    const result = selectMoviesForRemoval(eligible, sizesWithZero, 10);
+    // Skips movie 100 (0 GB), takes movie 200 (20 GB)
+    expect(result.moviesToMark).toHaveLength(1);
+    expect(result.moviesToMark[0]!.tmdbId).toBe(200);
+    expect(result.totalSizeGb).toBe(20);
+  });
+
+  it('handles empty eligible list', () => {
+    const result = selectMoviesForRemoval([], sizes, 50);
+    expect(result.moviesToMark).toHaveLength(0);
+    expect(result.totalSizeGb).toBe(0);
+  });
+});

--- a/apps/pops-api/src/modules/media/rotation/removal-selection.ts
+++ b/apps/pops-api/src/modules/media/rotation/removal-selection.ts
@@ -23,9 +23,10 @@ export async function getRadarrDiskSpace(): Promise<number> {
   const client = getRadarrClient();
   if (!client) throw new Error('Radarr not configured');
   const disks = await client.getDiskSpace();
-  if (disks.length === 0) throw new Error('Radarr returned no disk space info');
+  const disk = disks[0];
+  if (!disk) throw new Error('Radarr returned no disk space info');
   // Use the first root folder disk (primary media disk)
-  return disks[0]!.freeSpace / BYTES_PER_GB;
+  return disk.freeSpace / BYTES_PER_GB;
 }
 
 /** Fetch sizeOnDisk for all movies from Radarr, returning a map of TMDB ID → size in GB. */
@@ -82,10 +83,10 @@ export interface EligibleMovie {
  * - Movies currently downloading in Radarr
  * - Movies with sizeOnDisk = 0 in Radarr
  */
-export async function getEligibleForRemoval(
+export function getEligibleForRemoval(
   movieSizes: MovieSizeMap,
   downloadingTmdbIds: Set<number>
-): Promise<EligibleMovie[]> {
+): EligibleMovie[] {
   const db = getDrizzle();
   const now = new Date().toISOString();
 
@@ -127,7 +128,8 @@ export async function getEligibleForRemoval(
     // Exclude movies currently downloading
     if (downloadingTmdbIds.has(m.tmdbId)) return false;
     // Exclude movies with no file (sizeOnDisk = 0 or not in Radarr)
-    if (!movieSizes.has(m.tmdbId) || movieSizes.get(m.tmdbId)! <= 0) return false;
+    const sizeGb = movieSizes.get(m.tmdbId);
+    if (sizeGb === undefined || sizeGb <= 0) return false;
     return true;
   });
 }

--- a/apps/pops-api/src/modules/media/rotation/removal-selection.ts
+++ b/apps/pops-api/src/modules/media/rotation/removal-selection.ts
@@ -1,0 +1,299 @@
+/**
+ * Removal selection service — selects movies for removal based on disk space
+ * deficit and processes expired leaving movies.
+ *
+ * PRD-070 US-02
+ */
+import { eq, and, asc, ne, inArray, sql } from 'drizzle-orm';
+import { movies, mediaWatchlist } from '@pops/db-types';
+import { getDrizzle } from '../../../db.js';
+import { getRadarrClient } from '../arr/service.js';
+
+const BYTES_PER_GB = 1_073_741_824;
+
+/** Map of TMDB ID → size in GB. */
+export type MovieSizeMap = Map<number, number>;
+
+// ---------------------------------------------------------------------------
+// Radarr helpers
+// ---------------------------------------------------------------------------
+
+/** Fetch free space in GB for the root folder's disk from Radarr /diskspace. */
+export async function getRadarrDiskSpace(): Promise<number> {
+  const client = getRadarrClient();
+  if (!client) throw new Error('Radarr not configured');
+  const disks = await client.getDiskSpace();
+  if (disks.length === 0) throw new Error('Radarr returned no disk space info');
+  // Use the first root folder disk (primary media disk)
+  return disks[0]!.freeSpace / BYTES_PER_GB;
+}
+
+/** Fetch sizeOnDisk for all movies from Radarr, returning a map of TMDB ID → size in GB. */
+export async function getRadarrMovieSizes(): Promise<MovieSizeMap> {
+  const client = getRadarrClient();
+  if (!client) throw new Error('Radarr not configured');
+  const radarrMovies = await client.getMovies();
+  const map = new Map<number, number>();
+  for (const m of radarrMovies) {
+    if (m.sizeOnDisk && m.sizeOnDisk > 0) {
+      map.set(m.tmdbId, m.sizeOnDisk / BYTES_PER_GB);
+    }
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Calculation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate how many GB of movies need to be removed.
+ *
+ * deficit = target_free_gb - current_free_gb - sum(sizeOnDisk of 'leaving' movies)
+ * Returns 0 if no removals are needed.
+ */
+export function calculateRemovalDeficit(
+  targetFreeGb: number,
+  currentFreeGb: number,
+  leavingSizeGb: number
+): number {
+  const deficit = targetFreeGb - currentFreeGb - leavingSizeGb;
+  return Math.max(0, deficit);
+}
+
+// ---------------------------------------------------------------------------
+// Eligible movie queries
+// ---------------------------------------------------------------------------
+
+export interface EligibleMovie {
+  id: number;
+  tmdbId: number;
+  title: string;
+  createdAt: string;
+}
+
+/**
+ * Get movies eligible for removal, ordered by created_at ASC (oldest first).
+ *
+ * Excludes:
+ * - Watchlist items
+ * - Movies with rotation_status = 'protected' (unexpired)
+ * - Movies with rotation_status = 'leaving'
+ * - Movies currently downloading in Radarr
+ * - Movies with sizeOnDisk = 0 in Radarr
+ */
+export async function getEligibleForRemoval(
+  movieSizes: MovieSizeMap,
+  downloadingTmdbIds: Set<number>
+): Promise<EligibleMovie[]> {
+  const db = getDrizzle();
+  const now = new Date().toISOString();
+
+  // Get watchlist movie IDs
+  const watchlistRows = db
+    .select({ mediaId: mediaWatchlist.mediaId })
+    .from(mediaWatchlist)
+    .where(eq(mediaWatchlist.mediaType, 'movie'))
+    .all();
+  const watchlistMovieIds = new Set(watchlistRows.map((r) => r.mediaId));
+
+  // Query movies that are NOT leaving and NOT protected (with unexpired protection)
+  const candidates = db
+    .select({
+      id: movies.id,
+      tmdbId: movies.tmdbId,
+      title: movies.title,
+      createdAt: movies.createdAt,
+      rotationStatus: movies.rotationStatus,
+      rotationExpiresAt: movies.rotationExpiresAt,
+    })
+    .from(movies)
+    .where(
+      and(
+        // Exclude movies already marked as leaving
+        ne(sql`coalesce(${movies.rotationStatus}, '')`, sql`'leaving'`)
+      )
+    )
+    .orderBy(asc(movies.createdAt))
+    .all();
+
+  return candidates.filter((m) => {
+    // Exclude watchlist items
+    if (watchlistMovieIds.has(m.id)) return false;
+    // Exclude protected movies with unexpired protection
+    if (m.rotationStatus === 'protected' && m.rotationExpiresAt && m.rotationExpiresAt > now) {
+      return false;
+    }
+    // Exclude movies currently downloading
+    if (downloadingTmdbIds.has(m.tmdbId)) return false;
+    // Exclude movies with no file (sizeOnDisk = 0 or not in Radarr)
+    if (!movieSizes.has(m.tmdbId) || movieSizes.get(m.tmdbId)! <= 0) return false;
+    return true;
+  });
+}
+
+/**
+ * Get the set of TMDB IDs that are currently downloading in Radarr.
+ */
+export async function getDownloadingTmdbIds(): Promise<Set<number>> {
+  const client = getRadarrClient();
+  if (!client) return new Set();
+  const queue = await client.getQueue();
+  // Build a map of Radarr movie ID → TMDB ID from the movie list
+  const radarrMovies = await client.getMovies();
+  const radarrIdToTmdb = new Map<number, number>();
+  for (const m of radarrMovies) {
+    radarrIdToTmdb.set(m.id, m.tmdbId);
+  }
+  const downloading = new Set<number>();
+  for (const record of queue.records) {
+    const tmdbId = radarrIdToTmdb.get(record.movieId);
+    if (tmdbId) downloading.add(tmdbId);
+  }
+  return downloading;
+}
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+export interface RemovalSelection {
+  moviesToMark: EligibleMovie[];
+  totalSizeGb: number;
+}
+
+/**
+ * Walk the eligible list oldest-first, accumulating sizeOnDisk, until
+ * cumulative size >= deficit. Returns the movies to be marked as leaving.
+ */
+export function selectMoviesForRemoval(
+  eligible: EligibleMovie[],
+  movieSizes: MovieSizeMap,
+  deficitGb: number
+): RemovalSelection {
+  if (deficitGb <= 0) return { moviesToMark: [], totalSizeGb: 0 };
+
+  const moviesToMark: EligibleMovie[] = [];
+  let totalSizeGb = 0;
+
+  for (const movie of eligible) {
+    const sizeGb = movieSizes.get(movie.tmdbId) ?? 0;
+    if (sizeGb <= 0) continue;
+    moviesToMark.push(movie);
+    totalSizeGb += sizeGb;
+    if (totalSizeGb >= deficitGb) break;
+  }
+
+  return { moviesToMark, totalSizeGb };
+}
+
+// ---------------------------------------------------------------------------
+// Expired movie processing
+// ---------------------------------------------------------------------------
+
+export interface ExpiredMovieResult {
+  tmdbId: number;
+  title: string;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Find 'leaving' movies past rotation_expires_at, delete them from Radarr
+ * (with files), and remove/update them in the POPS library.
+ *
+ * Continues on individual failures — never aborts the cycle.
+ */
+export async function processExpiredMovies(): Promise<ExpiredMovieResult[]> {
+  const db = getDrizzle();
+  const client = getRadarrClient();
+  if (!client) throw new Error('Radarr not configured');
+
+  const now = new Date().toISOString();
+
+  // Find all leaving movies past their expiry
+  const expired = db
+    .select({
+      id: movies.id,
+      tmdbId: movies.tmdbId,
+      title: movies.title,
+    })
+    .from(movies)
+    .where(and(eq(movies.rotationStatus, 'leaving'), sql`${movies.rotationExpiresAt} <= ${now}`))
+    .all();
+
+  const results: ExpiredMovieResult[] = [];
+
+  for (const movie of expired) {
+    try {
+      // Look up Radarr ID
+      const check = await client.checkMovie(movie.tmdbId);
+      if (check.exists && check.radarrId != null) {
+        await client.deleteMovie(check.radarrId, true);
+      }
+      // Movie deleted or not in Radarr — clear rotation status in POPS
+      db.update(movies)
+        .set({
+          rotationStatus: null,
+          rotationExpiresAt: null,
+          rotationMarkedAt: null,
+        })
+        .where(eq(movies.id, movie.id))
+        .run();
+      results.push({ tmdbId: movie.tmdbId, title: movie.title, success: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        `Failed to remove expired movie ${movie.title} (tmdb=${movie.tmdbId}):`,
+        message
+      );
+      results.push({
+        tmdbId: movie.tmdbId,
+        title: movie.title,
+        success: false,
+        error: message,
+      });
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Summing leaving movies' sizes
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the total size in GB of movies currently in the 'leaving' state.
+ */
+export function getLeavingMovieSizeGb(movieSizes: MovieSizeMap): number {
+  const db = getDrizzle();
+  const leavingMovies = db
+    .select({ tmdbId: movies.tmdbId })
+    .from(movies)
+    .where(eq(movies.rotationStatus, 'leaving'))
+    .all();
+
+  let total = 0;
+  for (const m of leavingMovies) {
+    total += movieSizes.get(m.tmdbId) ?? 0;
+  }
+  return total;
+}
+
+/**
+ * Mark selected movies as 'leaving' with the given expiry date.
+ */
+export function markMoviesAsLeaving(movieIds: number[], expiresAt: string): void {
+  if (movieIds.length === 0) return;
+  const db = getDrizzle();
+  const now = new Date().toISOString();
+  db.update(movies)
+    .set({
+      rotationStatus: 'leaving',
+      rotationExpiresAt: expiresAt,
+      rotationMarkedAt: now,
+    })
+    .where(inArray(movies.id, movieIds))
+    .run();
+}


### PR DESCRIPTION
## Summary
- Adds removal selection service for the rotation engine (`modules/media/rotation/removal-selection.ts`)
- Implements disk-space-driven movie removal: `getRadarrDiskSpace`, `getRadarrMovieSizes`, `calculateRemovalDeficit`, `getEligibleForRemoval`, `selectMoviesForRemoval`, `processExpiredMovies`, `markMoviesAsLeaving`, `getLeavingMovieSizeGb`
- Extends Radarr client: `DELETE` method on `ArrBaseClient`, `getDiskSpace()` and `deleteMovie()` on `RadarrClient`, `sizeOnDisk` on `RadarrMovie`, new `RadarrDiskSpace` type
- Eligible movies exclude: watchlist, protected (unexpired), leaving, downloading, zero-size
- Expired movie processing deletes via Radarr with files, continues on individual failures

## Test plan
- [x] 11 unit tests for `calculateRemovalDeficit` and `selectMoviesForRemoval` (pure functions)
- [x] All 14 packages typecheck clean
- [x] Lint + format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)