### PR TITLE
feat(rotation): leaving lifecycle + cancel endpoint (PRD-070 US-03) [tb-347]

### DIFF
--- a/apps/pops-api/src/modules/media/index.ts
+++ b/apps/pops-api/src/modules/media/index.ts
@@ -16,6 +16,7 @@ import { searchRouter } from './search/index.js';
 import { discoveryRouter } from './discovery/index.js';
 import { arrRouter } from './arr/index.js';
 import { plexRouter } from './plex/index.js';
+import { rotationRouter } from './rotation/router.js';
 
 export const mediaRouter = router({
   movies: moviesRouter,
@@ -28,4 +29,5 @@ export const mediaRouter = router({
   discovery: discoveryRouter,
   arr: arrRouter,
   plex: plexRouter,
+  rotation: rotationRouter,
 });

--- a/apps/pops-api/src/modules/media/rotation/leaving-lifecycle.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/leaving-lifecycle.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock getDrizzle before importing the module under test
+const mockGet = vi.fn();
+const mockRun = vi.fn();
+const mockWhere = vi.fn(() => ({ get: mockGet, run: mockRun }));
+const mockSet = vi.fn(() => ({ where: mockWhere }));
+const mockFrom = vi.fn(() => ({ where: mockWhere }));
+const mockSelect = vi.fn(() => ({ from: mockFrom }));
+const mockUpdate = vi.fn(() => ({ set: mockSet }));
+
+vi.mock('../../../db.js', () => ({
+  getDrizzle: () => ({
+    select: mockSelect,
+    update: mockUpdate,
+  }),
+}));
+
+// Must import after mocking
+const { cancelLeaving, clearLeavingOnWatchlistAdd } = await import('./leaving-lifecycle.js');
+
+describe('cancelLeaving', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false if movie does not exist', () => {
+    mockGet.mockReturnValueOnce(undefined);
+    expect(cancelLeaving(999)).toBe(false);
+  });
+
+  it('returns false if movie is not in leaving state', () => {
+    mockGet.mockReturnValueOnce({ id: 1, rotationStatus: null });
+    expect(cancelLeaving(1)).toBe(false);
+  });
+
+  it('clears leaving status and returns true', () => {
+    mockGet.mockReturnValueOnce({ id: 1, rotationStatus: 'leaving' });
+    expect(cancelLeaving(1)).toBe(true);
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalledWith({
+      rotationStatus: null,
+      rotationExpiresAt: null,
+      rotationMarkedAt: null,
+    });
+  });
+});
+
+describe('clearLeavingOnWatchlistAdd', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false for non-movie media types', () => {
+    expect(clearLeavingOnWatchlistAdd('tv_show', 1)).toBe(false);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it('returns false if movie is not in leaving state', () => {
+    mockGet.mockReturnValueOnce({ id: 1, rotationStatus: null });
+    expect(clearLeavingOnWatchlistAdd('movie', 1)).toBe(false);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('clears leaving status for movies being added to watchlist', () => {
+    mockGet.mockReturnValueOnce({ id: 5, rotationStatus: 'leaving' });
+    expect(clearLeavingOnWatchlistAdd('movie', 5)).toBe(true);
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalledWith({
+      rotationStatus: null,
+      rotationExpiresAt: null,
+      rotationMarkedAt: null,
+    });
+  });
+});

--- a/apps/pops-api/src/modules/media/rotation/leaving-lifecycle.ts
+++ b/apps/pops-api/src/modules/media/rotation/leaving-lifecycle.ts
@@ -1,0 +1,66 @@
+/**
+ * Leaving lifecycle service — cancel leaving status on movies.
+ *
+ * PRD-070 US-03
+ */
+import { eq, and } from 'drizzle-orm';
+import { movies, mediaWatchlist } from '@pops/db-types';
+import { getDrizzle } from '../../../db.js';
+
+/**
+ * Clear leaving/protected rotation status for a specific movie.
+ * Returns true if the movie existed and was updated, false otherwise.
+ */
+export function cancelLeaving(movieId: number): boolean {
+  const db = getDrizzle();
+  const movie = db
+    .select({ id: movies.id, rotationStatus: movies.rotationStatus })
+    .from(movies)
+    .where(eq(movies.id, movieId))
+    .get();
+
+  if (!movie) return false;
+  if (movie.rotationStatus !== 'leaving') return false;
+
+  db.update(movies)
+    .set({
+      rotationStatus: null,
+      rotationExpiresAt: null,
+      rotationMarkedAt: null,
+    })
+    .where(eq(movies.id, movieId))
+    .run();
+
+  return true;
+}
+
+/**
+ * Side-effect for watchlist add: if the movie being added has
+ * rotation_status = 'leaving', clear it.
+ *
+ * Called from the watchlist router after a successful watchlist insert.
+ * Only operates on movies (not TV shows).
+ */
+export function clearLeavingOnWatchlistAdd(mediaType: string, mediaId: number): boolean {
+  if (mediaType !== 'movie') return false;
+
+  const db = getDrizzle();
+  const movie = db
+    .select({ id: movies.id, rotationStatus: movies.rotationStatus })
+    .from(movies)
+    .where(eq(movies.id, mediaId))
+    .get();
+
+  if (!movie || movie.rotationStatus !== 'leaving') return false;
+
+  db.update(movies)
+    .set({
+      rotationStatus: null,
+      rotationExpiresAt: null,
+      rotationMarkedAt: null,
+    })
+    .where(eq(movies.id, mediaId))
+    .run();
+
+  return true;
+}

--- a/apps/pops-api/src/modules/media/rotation/leaving-lifecycle.ts
+++ b/apps/pops-api/src/modules/media/rotation/leaving-lifecycle.ts
@@ -3,8 +3,8 @@
  *
  * PRD-070 US-03
  */
-import { eq, and } from 'drizzle-orm';
-import { movies, mediaWatchlist } from '@pops/db-types';
+import { eq } from 'drizzle-orm';
+import { movies } from '@pops/db-types';
 import { getDrizzle } from '../../../db.js';
 
 /**

--- a/apps/pops-api/src/modules/media/rotation/router.ts
+++ b/apps/pops-api/src/modules/media/rotation/router.ts
@@ -1,0 +1,21 @@
+/**
+ * Rotation tRPC router — endpoints for the library rotation system.
+ *
+ * PRD-070
+ */
+import { z } from 'zod';
+import { router, protectedProcedure } from '../../../trpc.js';
+import { cancelLeaving } from './leaving-lifecycle.js';
+
+export const rotationRouter = router({
+  /** Cancel leaving status for a specific movie. */
+  cancelLeaving: protectedProcedure
+    .input(z.object({ movieId: z.number().int().positive() }))
+    .mutation(({ input }) => {
+      const updated = cancelLeaving(input.movieId);
+      return {
+        success: updated,
+        message: updated ? 'Leaving status cancelled' : 'Movie not found or not leaving',
+      };
+    }),
+});

--- a/apps/pops-api/src/modules/media/watchlist/router.ts
+++ b/apps/pops-api/src/modules/media/watchlist/router.ts
@@ -16,6 +16,7 @@ import * as service from './service.js';
 import { NotFoundError, ConflictError } from '../../../shared/errors.js';
 import { getPlexClient } from '../plex/service.js';
 import { pushToPlexWatchlist } from './plex-push.js';
+import { clearLeavingOnWatchlistAdd } from '../rotation/leaving-lifecycle.js';
 
 const DEFAULT_LIMIT = 50;
 const DEFAULT_OFFSET = 0;
@@ -66,6 +67,11 @@ export const watchlistRouter = router({
   /** Add an item to the watchlist. Idempotent — returns existing entry if already present. */
   add: protectedProcedure.input(AddToWatchlistSchema).mutation(async ({ input }) => {
     const { row, created } = service.addToWatchlist(input);
+
+    // Clear leaving rotation status if the movie was in the leaving state
+    if (created) {
+      clearLeavingOnWatchlistAdd(input.mediaType, input.mediaId);
+    }
 
     // Best-effort push to Plex — failures do not block local operation
     if (created) {


### PR DESCRIPTION
## Summary
- `cancelLeaving(movieId)` clears leaving rotation status for a specific movie
- `clearLeavingOnWatchlistAdd()` side-effect in watchlist.add — auto-cancels leaving when movie is added to watchlist
- New `rotation.cancelLeaving` tRPC endpoint via rotation router registered in media module
- Stacks on #1702 (tb-346: removal selection service)

## Test plan
- [x] 6 unit tests for cancelLeaving and clearLeavingOnWatchlistAdd
- [x] 17 total rotation tests pass (11 removal-selection + 6 leaving-lifecycle)
- [x] All 14 packages typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)