### PR TITLE
fix(security): resolve CodeQL path-injection in images route (tb-363)

### DIFF
--- a/apps/pops-api/src/routes/media/images.ts
+++ b/apps/pops-api/src/routes/media/images.ts
@@ -12,7 +12,7 @@
  */
 import { type Router as ExpressRouter, Router } from 'express';
 import { open, stat, unlink } from 'node:fs/promises';
-import { join, resolve, extname } from 'node:path';
+import { join, resolve, extname, basename } from 'node:path';
 import { createHash } from 'node:crypto';
 import { MEDIA_DIR_NAMES } from '../../modules/media/tmdb/image-cache.js';
 import { getImageCache } from '../../modules/media/tmdb/index.js';
@@ -44,6 +44,19 @@ const TMDB_CDN_SIZES: Record<string, string> = {
 function getImagesDir(): string {
   const dir = process.env.MEDIA_IMAGES_DIR ?? './data/media/images';
   return resolve(dir); // Return absolute path
+}
+
+/**
+ * Join `filename` to `dir` safely. Uses `basename` to strip any directory
+ * components from `filename` (path traversal sanitizer), then verifies the
+ * result stays within `dir`. Returns the resolved absolute path, or null on
+ * failure.
+ */
+function safeJoin(dir: string, filename: string): string | null {
+  const safe = basename(filename); // strip any path separators — CodeQL sanitizer
+  if (!safe || safe === '.' || safe === '..') return null;
+  const resolved = resolve(dir, safe);
+  return resolved.startsWith(dir + '/') || resolved === dir ? resolved : null;
 }
 
 /**
@@ -142,13 +155,19 @@ router.get('/media/images/:mediaType/:id/:filename', async (req, res): Promise<v
 
   // Override resolution: if requesting poster.jpg, check for override.jpg first
   if (filename === 'poster.jpg') {
-    const overridePath = join(mediaDir, 'override.jpg');
-    const served = await tryServeFile(overridePath, res);
-    if (served) return;
+    const overridePath = safeJoin(resolvedDir, 'override.jpg');
+    if (overridePath) {
+      const served = await tryServeFile(overridePath, res);
+      if (served) return;
+    }
   }
 
   // Remove corrupted SVG placeholders so they don't block downloads or get served
-  const filePath = join(mediaDir, filename);
+  const filePath = safeJoin(resolvedDir, filename);
+  if (!filePath) {
+    res.status(400).json({ error: 'Invalid path' });
+    return;
+  }
   const wasCorrupted = await removeCorruptedPlaceholder(filePath);
   if (!wasCorrupted) {
     const served = await tryServeFile(filePath, res);


### PR DESCRIPTION
## Summary
- Introduces `safeJoin()` helper that applies `path.basename()` (a CodeQL-recognized path sanitizer) to strip any directory components from user-supplied filenames before joining them to the allowed base directory
- Verifies the resolved path stays within the allowed directory as a secondary defense
- Replaces direct `join(mediaDir, filename)` calls with `safeJoin(resolvedDir, filename)` for all file operations in the images route

## CodeQL alerts resolved
- #59: `open(filePath)` in `removeCorruptedPlaceholder`
- #46: `unlink(filePath)` in `removeCorruptedPlaceholder`
- #47: `stat(filePath)` in `tryServeFile`
- #48: `res.sendFile(resolve(filePath))` in `tryServeFile`

## Test plan
- [ ] Existing behavior unchanged: valid image requests still served correctly
- [ ] CodeQL scan passes without path-injection alerts on this file
- [ ] Path traversal attempts (e.g. `../../../etc/passwd` as filename) return 400 (already blocked by VALID_FILENAMES check, now also by safeJoin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)