### PR TITLE
feat(rotation): daily cron scheduler (PRD-070 US-06) [tb-350]

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -56,6 +56,7 @@
     "express-rate-limit": "^8.3.2",
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.3",
+    "node-cron": "^4.2.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "zod": "^3.24.0"
@@ -65,6 +66,7 @@
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^22.12.0",
+    "@types/node-cron": "^3.0.11",
     "@types/papaparse": "^5.5.2",
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.58.0",

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -10,6 +10,10 @@ import { closeDb } from './db.js';
 import { startTtlWatcher } from './modules/core/envs/ttl-watcher.js';
 import { startupCleanup } from './modules/core/envs/registry.js';
 import { resumeSchedulerIfEnabled, stopScheduler } from './modules/media/plex/scheduler.js';
+import {
+  resumeRotationSchedulerIfEnabled,
+  stopRotationScheduler,
+} from './modules/media/rotation/scheduler.js';
 
 const port = Number(process.env['PORT'] ?? 3000);
 const app = createApp();
@@ -31,12 +35,19 @@ if (resumedScheduler) {
   console.log(`[pops-api] Plex scheduler resumed (interval: ${resumedScheduler.intervalMs}ms)`);
 }
 
+// Auto-resume rotation scheduler if it was previously running
+const resumedRotation = resumeRotationSchedulerIfEnabled();
+if (resumedRotation) {
+  console.log(`[pops-api] Rotation scheduler resumed (cron: ${resumedRotation.cronExpression})`);
+}
+
 // Periodically purge expired named environments
 const ttlWatcher = startTtlWatcher();
 
 function shutdown(): void {
   console.log('[pops-api] Shutting down...');
   stopScheduler();
+  stopRotationScheduler();
   clearInterval(ttlWatcher);
   server.close(() => {
     closeDb();

--- a/apps/pops-api/src/modules/media/rotation/router.ts
+++ b/apps/pops-api/src/modules/media/rotation/router.ts
@@ -6,6 +6,12 @@
 import { z } from 'zod';
 import { router, protectedProcedure } from '../../../trpc.js';
 import { cancelLeaving } from './leaving-lifecycle.js';
+import {
+  startRotationScheduler,
+  stopRotationScheduler,
+  getRotationSchedulerStatus,
+  runRotationCycleNow,
+} from './scheduler.js';
 
 export const rotationRouter = router({
   /** Cancel leaving status for a specific movie. */
@@ -18,4 +24,35 @@ export const rotationRouter = router({
         message: updated ? 'Leaving status cancelled' : 'Movie not found or not leaving',
       };
     }),
+
+  /** Get rotation scheduler status. */
+  status: protectedProcedure.query(() => {
+    return getRotationSchedulerStatus();
+  }),
+
+  /** Toggle the rotation scheduler on/off. */
+  toggle: protectedProcedure
+    .input(
+      z.object({
+        enabled: z.boolean(),
+        cronExpression: z.string().optional(),
+      })
+    )
+    .mutation(({ input }) => {
+      if (input.enabled) {
+        return startRotationScheduler({
+          cronExpression: input.cronExpression,
+        });
+      }
+      return stopRotationScheduler();
+    }),
+
+  /** Trigger an immediate rotation cycle. */
+  runNow: protectedProcedure.mutation(async () => {
+    const result = await runRotationCycleNow();
+    if (!result) {
+      return { success: false, message: 'A rotation cycle is already in progress' };
+    }
+    return { success: true, result };
+  }),
 });

--- a/apps/pops-api/src/modules/media/rotation/scheduler.ts
+++ b/apps/pops-api/src/modules/media/rotation/scheduler.ts
@@ -129,7 +129,7 @@ export function startRotationScheduler(options?: {
 /** Stop the rotation scheduler. No-op if not running. */
 export function stopRotationScheduler(): RotationSchedulerStatus {
   if (task) {
-    task.stop();
+    void task.stop();
     task = null;
   }
 

--- a/apps/pops-api/src/modules/media/rotation/scheduler.ts
+++ b/apps/pops-api/src/modules/media/rotation/scheduler.ts
@@ -1,0 +1,320 @@
+/**
+ * Rotation scheduler — daily cron job orchestrating the full rotation cycle.
+ *
+ * Follows the Plex scheduler singleton pattern: module-level state,
+ * settings-driven, auto-resume on startup.
+ *
+ * PRD-070 US-06
+ */
+import cron, { type ScheduledTask } from 'node-cron';
+import { eq } from 'drizzle-orm';
+import { settings, rotationLog } from '@pops/db-types';
+import { getDrizzle } from '../../../db.js';
+import {
+  getRadarrDiskSpace,
+  getRadarrMovieSizes,
+  calculateRemovalDeficit,
+  getEligibleForRemoval,
+  getDownloadingTmdbIds,
+  selectMoviesForRemoval,
+  markMoviesAsLeaving,
+  getLeavingMovieSizeGb,
+  processExpiredMovies,
+} from './removal-selection.js';
+
+// ---------------------------------------------------------------------------
+// Settings keys
+// ---------------------------------------------------------------------------
+
+const SETTINGS_KEYS = {
+  enabled: 'rotation_enabled',
+  cronExpression: 'rotation_cron_expression',
+  targetFreeGb: 'rotation_target_free_gb',
+  leavingDays: 'rotation_leaving_days',
+} as const;
+
+const DEFAULT_CRON = '0 3 * * *'; // 3 AM daily
+const DEFAULT_TARGET_FREE_GB = 100;
+const DEFAULT_LEAVING_DAYS = 7;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RotationSchedulerStatus {
+  isRunning: boolean;
+  isCycleRunning: boolean;
+  cronExpression: string;
+  lastCycleAt: string | null;
+  lastCycleError: string | null;
+}
+
+export interface RotationCycleResult {
+  moviesMarkedLeaving: number;
+  moviesRemoved: number;
+  moviesAdded: number;
+  removalsFailed: number;
+  freeSpaceGb: number;
+  targetFreeGb: number;
+  skippedReason: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Module singleton state
+// ---------------------------------------------------------------------------
+
+let task: ScheduledTask | null = null;
+let cronExpression = DEFAULT_CRON;
+let isCycleRunning = false;
+let lastCycleAt: string | null = null;
+let lastCycleError: string | null = null;
+
+// ---------------------------------------------------------------------------
+// Settings helpers
+// ---------------------------------------------------------------------------
+
+function getSetting(key: string): string | null {
+  const db = getDrizzle();
+  const record = db.select().from(settings).where(eq(settings.key, key)).get();
+  return record?.value ?? null;
+}
+
+function saveSetting(key: string, value: string): void {
+  const db = getDrizzle();
+  db.insert(settings)
+    .values({ key, value })
+    .onConflictDoUpdate({ target: settings.key, set: { value } })
+    .run();
+}
+
+function deleteSetting(key: string): void {
+  const db = getDrizzle();
+  db.delete(settings).where(eq(settings.key, key)).run();
+}
+
+function getTargetFreeGb(): number {
+  const val = getSetting(SETTINGS_KEYS.targetFreeGb);
+  return val ? Number(val) : DEFAULT_TARGET_FREE_GB;
+}
+
+function getLeavingDays(): number {
+  const val = getSetting(SETTINGS_KEYS.leavingDays);
+  return val ? Number(val) : DEFAULT_LEAVING_DAYS;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Start the rotation scheduler. No-op if already running. */
+export function startRotationScheduler(options?: {
+  cronExpression?: string;
+}): RotationSchedulerStatus {
+  if (task) return getRotationSchedulerStatus();
+
+  cronExpression =
+    options?.cronExpression ?? getSetting(SETTINGS_KEYS.cronExpression) ?? DEFAULT_CRON;
+
+  task = cron.schedule(cronExpression, () => {
+    void runRotationCycle();
+  });
+
+  saveSetting(SETTINGS_KEYS.enabled, 'true');
+  saveSetting(SETTINGS_KEYS.cronExpression, cronExpression);
+
+  console.log(`[Rotation] Scheduler started (cron: ${cronExpression})`);
+  return getRotationSchedulerStatus();
+}
+
+/** Stop the rotation scheduler. No-op if not running. */
+export function stopRotationScheduler(): RotationSchedulerStatus {
+  if (task) {
+    task.stop();
+    task = null;
+  }
+
+  deleteSetting(SETTINGS_KEYS.enabled);
+  deleteSetting(SETTINGS_KEYS.cronExpression);
+
+  console.log('[Rotation] Scheduler stopped');
+  return getRotationSchedulerStatus();
+}
+
+/** Get current scheduler status. */
+export function getRotationSchedulerStatus(): RotationSchedulerStatus {
+  return {
+    isRunning: task !== null,
+    isCycleRunning,
+    cronExpression,
+    lastCycleAt,
+    lastCycleError,
+  };
+}
+
+/** Auto-resume the scheduler on server startup if previously enabled. */
+export function resumeRotationSchedulerIfEnabled(): RotationSchedulerStatus | null {
+  const enabled = getSetting(SETTINGS_KEYS.enabled);
+  if (enabled !== 'true') return null;
+
+  const savedCron = getSetting(SETTINGS_KEYS.cronExpression) ?? DEFAULT_CRON;
+  console.log(`[Rotation] Auto-resuming scheduler (cron: ${savedCron})`);
+  return startRotationScheduler({ cronExpression: savedCron });
+}
+
+/** Trigger an immediate rotation cycle. Returns null if a cycle is already running. */
+export async function runRotationCycleNow(): Promise<RotationCycleResult | null> {
+  if (isCycleRunning) {
+    console.log('[Rotation] Cycle already in progress — skipping');
+    return null;
+  }
+  return runRotationCycle();
+}
+
+// ---------------------------------------------------------------------------
+// Core rotation cycle
+// ---------------------------------------------------------------------------
+
+export async function runRotationCycle(): Promise<RotationCycleResult> {
+  if (isCycleRunning) {
+    const result: RotationCycleResult = {
+      moviesMarkedLeaving: 0,
+      moviesRemoved: 0,
+      moviesAdded: 0,
+      removalsFailed: 0,
+      freeSpaceGb: 0,
+      targetFreeGb: getTargetFreeGb(),
+      skippedReason: 'Concurrent cycle already running',
+    };
+    writeRotationLog(result);
+    return result;
+  }
+
+  isCycleRunning = true;
+  const targetFreeGb = getTargetFreeGb();
+  const leavingDays = getLeavingDays();
+
+  try {
+    // Step 1: Process expired leaving movies (Radarr delete)
+    const expiredResults = await processExpiredMovies();
+    const moviesRemoved = expiredResults.filter((r) => r.success).length;
+    const removalsFailed = expiredResults.filter((r) => !r.success).length;
+
+    // Step 2: Measure free space
+    let freeSpaceGb: number;
+    try {
+      freeSpaceGb = await getRadarrDiskSpace();
+    } catch {
+      const result: RotationCycleResult = {
+        moviesMarkedLeaving: 0,
+        moviesRemoved,
+        moviesAdded: 0,
+        removalsFailed,
+        freeSpaceGb: 0,
+        targetFreeGb,
+        skippedReason: 'Radarr unavailable — cannot measure disk space',
+      };
+      writeRotationLog(result);
+      lastCycleAt = new Date().toISOString();
+      lastCycleError = result.skippedReason;
+      return result;
+    }
+
+    // Step 3: Calculate deficit and select movies for removal
+    const movieSizes = await getRadarrMovieSizes();
+    const leavingSizeGb = getLeavingMovieSizeGb(movieSizes);
+    const deficit = calculateRemovalDeficit(targetFreeGb, freeSpaceGb, leavingSizeGb);
+
+    let moviesMarkedLeaving = 0;
+    if (deficit > 0) {
+      const downloadingIds = await getDownloadingTmdbIds();
+      const eligible = getEligibleForRemoval(movieSizes, downloadingIds);
+      const selection = selectMoviesForRemoval(eligible, movieSizes, deficit);
+
+      if (selection.moviesToMark.length > 0) {
+        const expiresAt = new Date();
+        expiresAt.setDate(expiresAt.getDate() + leavingDays);
+        markMoviesAsLeaving(
+          selection.moviesToMark.map((m) => m.id),
+          expiresAt.toISOString()
+        );
+        moviesMarkedLeaving = selection.moviesToMark.length;
+      }
+    }
+
+    // Step 4: Add movies from candidate queue (stub — implemented by tb-348)
+    const moviesAdded = 0;
+
+    const result: RotationCycleResult = {
+      moviesMarkedLeaving,
+      moviesRemoved,
+      moviesAdded,
+      removalsFailed,
+      freeSpaceGb,
+      targetFreeGb,
+      skippedReason: null,
+    };
+
+    writeRotationLog(result);
+    lastCycleAt = new Date().toISOString();
+    lastCycleError = null;
+
+    console.log(
+      `[Rotation] Cycle complete: ${moviesRemoved} removed, ${moviesMarkedLeaving} marked leaving, ${moviesAdded} added, ${freeSpaceGb.toFixed(1)} GB free`
+    );
+
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    lastCycleAt = new Date().toISOString();
+    lastCycleError = message;
+    console.error('[Rotation] Cycle failed:', message);
+
+    const result: RotationCycleResult = {
+      moviesMarkedLeaving: 0,
+      moviesRemoved: 0,
+      moviesAdded: 0,
+      removalsFailed: 0,
+      freeSpaceGb: 0,
+      targetFreeGb,
+      skippedReason: `Cycle error: ${message}`,
+    };
+    writeRotationLog(result);
+    return result;
+  } finally {
+    isCycleRunning = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rotation log
+// ---------------------------------------------------------------------------
+
+function writeRotationLog(result: RotationCycleResult): void {
+  const db = getDrizzle();
+  db.insert(rotationLog)
+    .values({
+      executedAt: new Date().toISOString(),
+      moviesMarkedLeaving: result.moviesMarkedLeaving,
+      moviesRemoved: result.moviesRemoved,
+      moviesAdded: result.moviesAdded,
+      removalsFailed: result.removalsFailed,
+      freeSpaceGb: result.freeSpaceGb,
+      targetFreeGb: result.targetFreeGb,
+      skippedReason: result.skippedReason,
+      details: null,
+    })
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Reset all scheduler state — for testing only. */
+export function _resetRotationScheduler(): void {
+  stopRotationScheduler();
+  lastCycleAt = null;
+  lastCycleError = null;
+  isCycleRunning = false;
+  cronExpression = DEFAULT_CRON;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
+      node-cron:
+        specifier: ^4.2.1
+        version: 4.2.1
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -81,6 +84,9 @@ importers:
       '@types/node':
         specifier: ^22.12.0
         version: 22.19.15
+      '@types/node-cron':
+        specifier: ^3.0.11
+        version: 3.0.11
       '@types/papaparse':
         specifier: ^5.5.2
         version: 5.5.2
@@ -3260,6 +3266,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node-cron@3.0.11':
+    resolution: {integrity: sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
@@ -5361,6 +5370,10 @@ packages:
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
+
+  node-cron@4.2.1:
+    resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
+    engines: {node: '>=6.0.0'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -8673,6 +8686,8 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node-cron@3.0.11': {}
+
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
@@ -11027,6 +11042,8 @@ snapshots:
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
+
+  node-cron@4.2.1: {}
 
   node-domexception@1.0.0: {}
 


### PR DESCRIPTION
## Summary
- Adds `rotation/scheduler.ts` with node-cron based daily rotation scheduler (default 3 AM)
- Scheduler endpoints: `rotation.status`, `rotation.toggle`, `rotation.runNow` in tRPC router
- Auto-resume on server startup, graceful shutdown integration in `index.ts`
- Full rotation cycle: process expired → measure disk → calculate deficit → select removals → mark leaving → log results
- Settings-driven configuration (cron expression, target free GB, leaving days) with sensible defaults

## Test plan
- [ ] Verify typecheck passes across all 14 packages
- [ ] Verify `rotation.toggle` starts/stops the scheduler and persists settings
- [ ] Verify `rotation.runNow` triggers an immediate cycle with concurrency guard
- [ ] Verify `rotation.status` returns correct scheduler state
- [ ] Verify auto-resume on startup when previously enabled
- [ ] Verify rotation log entries are written for each cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)