### PR TITLE
feat(rotation): addition gating (PRD-070 US-05) [tb-349]

### DIFF
--- a/apps/pops-api/src/modules/media/rotation/addition-gating.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/addition-gating.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { getAdditionBudget } from './addition-gating.js';
+
+describe('getAdditionBudget', () => {
+  it('returns 0 when free space is below target', () => {
+    expect(getAdditionBudget(90, 100, 15, 2)).toBe(0);
+  });
+
+  it('returns 0 when free space equals target exactly', () => {
+    expect(getAdditionBudget(100, 100, 15, 2)).toBe(0);
+  });
+
+  it('returns daily max when there is plenty of headroom', () => {
+    // 300 free, 100 target → 200 headroom, 200/15 = 13 possible, capped at 2
+    expect(getAdditionBudget(300, 100, 15, 2)).toBe(2);
+  });
+
+  it('reduces count when headroom is tight', () => {
+    // 210 free, 200 target → 10 headroom, 10/15 = 0 (floor)
+    expect(getAdditionBudget(210, 200, 15, 2)).toBe(0);
+  });
+
+  it('allows partial additions when space is limited', () => {
+    // 230 free, 200 target → 30 headroom, 30/15 = 2, but daily max is 5
+    expect(getAdditionBudget(230, 200, 15, 5)).toBe(2);
+  });
+
+  it('returns 0 when avgMovieGb is 0', () => {
+    expect(getAdditionBudget(300, 100, 0, 2)).toBe(0);
+  });
+
+  it('returns 0 when avgMovieGb is negative', () => {
+    expect(getAdditionBudget(300, 100, -5, 2)).toBe(0);
+  });
+
+  it('handles large headroom correctly', () => {
+    // 1000 free, 100 target → 900 headroom, 900/15 = 60, capped at 10
+    expect(getAdditionBudget(1000, 100, 15, 10)).toBe(10);
+  });
+});

--- a/apps/pops-api/src/modules/media/rotation/addition-gating.ts
+++ b/apps/pops-api/src/modules/media/rotation/addition-gating.ts
@@ -1,0 +1,152 @@
+/**
+ * Addition gating service — gates movie additions on available disk space.
+ *
+ * After removals and leaving marks, the cycle re-checks free space. Additions
+ * from the candidate queue only proceed when there is enough room.
+ *
+ * PRD-070 US-05
+ */
+import { eq, asc } from 'drizzle-orm';
+import { settings, rotationCandidates } from '@pops/db-types';
+import { getDrizzle } from '../../../db.js';
+import { getRadarrClient } from '../arr/service.js';
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+const SETTINGS_KEYS = {
+  dailyAdditions: 'rotation_daily_additions',
+  avgMovieGb: 'rotation_avg_movie_gb',
+  qualityProfileId: 'rotation_quality_profile_id',
+  rootFolderPath: 'rotation_root_folder_path',
+} as const;
+
+const DEFAULT_DAILY_ADDITIONS = 2;
+const DEFAULT_AVG_MOVIE_GB = 15;
+
+function getSetting(key: string): string | null {
+  const db = getDrizzle();
+  const record = db.select().from(settings).where(eq(settings.key, key)).get();
+  return record?.value ?? null;
+}
+
+export function getDailyAdditions(): number {
+  const val = getSetting(SETTINGS_KEYS.dailyAdditions);
+  return val ? Number(val) : DEFAULT_DAILY_ADDITIONS;
+}
+
+export function getAvgMovieGb(): number {
+  const val = getSetting(SETTINGS_KEYS.avgMovieGb);
+  return val ? Number(val) : DEFAULT_AVG_MOVIE_GB;
+}
+
+// ---------------------------------------------------------------------------
+// Budget calculation (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate how many movies can be added without dropping below the target.
+ *
+ * Returns 0 if free space is already below target.
+ * Otherwise returns min(dailyAdditions, floor((freeSpace - target) / avgMovieGb)).
+ */
+export function getAdditionBudget(
+  freeSpaceGb: number,
+  targetFreeGb: number,
+  avgMovieGb: number,
+  dailyAdditions: number
+): number {
+  if (freeSpaceGb < targetFreeGb) return 0;
+  if (avgMovieGb <= 0) return 0;
+  const headroom = freeSpaceGb - targetFreeGb;
+  const maxBySpace = Math.floor(headroom / avgMovieGb);
+  return Math.min(dailyAdditions, maxBySpace);
+}
+
+// ---------------------------------------------------------------------------
+// Queue processing
+// ---------------------------------------------------------------------------
+
+export interface AdditionResult {
+  added: number;
+  skippedReason: string | null;
+}
+
+/**
+ * Pull up to `budget` pending candidates from the queue and add them to
+ * Radarr. Updates candidate status to 'added' on success or 'skipped' on
+ * failure.
+ *
+ * Returns the number of movies successfully added.
+ */
+export async function addMoviesFromQueue(budget: number): Promise<AdditionResult> {
+  if (budget <= 0) {
+    return { added: 0, skippedReason: 'additions skipped — below target free space' };
+  }
+
+  const client = getRadarrClient();
+  if (!client) {
+    return { added: 0, skippedReason: 'Radarr not configured — cannot add movies' };
+  }
+
+  const qualityProfileId = getSetting(SETTINGS_KEYS.qualityProfileId);
+  const rootFolderPath = getSetting(SETTINGS_KEYS.rootFolderPath);
+
+  if (!qualityProfileId || !rootFolderPath) {
+    return {
+      added: 0,
+      skippedReason: 'rotation_quality_profile_id or rotation_root_folder_path not configured',
+    };
+  }
+
+  const db = getDrizzle();
+  const candidates = db
+    .select()
+    .from(rotationCandidates)
+    .where(eq(rotationCandidates.status, 'pending'))
+    .orderBy(asc(rotationCandidates.discoveredAt))
+    .limit(budget)
+    .all();
+
+  let added = 0;
+  for (const candidate of candidates) {
+    try {
+      // Check if already in Radarr
+      const check = await client.checkMovie(candidate.tmdbId);
+      if (check.exists) {
+        db.update(rotationCandidates)
+          .set({ status: 'skipped' })
+          .where(eq(rotationCandidates.id, candidate.id))
+          .run();
+        continue;
+      }
+
+      await client.addMovie({
+        tmdbId: candidate.tmdbId,
+        title: candidate.title,
+        year: candidate.year ?? new Date().getFullYear(),
+        qualityProfileId: Number(qualityProfileId),
+        rootFolderPath,
+      });
+
+      db.update(rotationCandidates)
+        .set({ status: 'added' })
+        .where(eq(rotationCandidates.id, candidate.id))
+        .run();
+      added++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[Rotation] Failed to add candidate ${candidate.title} (tmdb=${candidate.tmdbId}):`,
+        message
+      );
+      db.update(rotationCandidates)
+        .set({ status: 'skipped' })
+        .where(eq(rotationCandidates.id, candidate.id))
+        .run();
+    }
+  }
+
+  return { added, skippedReason: null };
+}

--- a/apps/pops-api/src/modules/media/rotation/scheduler.ts
+++ b/apps/pops-api/src/modules/media/rotation/scheduler.ts
@@ -21,6 +21,12 @@ import {
   getLeavingMovieSizeGb,
   processExpiredMovies,
 } from './removal-selection.js';
+import {
+  getAdditionBudget,
+  addMoviesFromQueue,
+  getDailyAdditions,
+  getAvgMovieGb,
+} from './addition-gating.js';
 
 // ---------------------------------------------------------------------------
 // Settings keys
@@ -241,8 +247,26 @@ export async function runRotationCycle(): Promise<RotationCycleResult> {
       }
     }
 
-    // Step 4: Add movies from candidate queue (stub — implemented by tb-348)
-    const moviesAdded = 0;
+    // Step 4: Re-check free space and add movies from candidate queue
+    let postFreeSpaceGb: number;
+    try {
+      postFreeSpaceGb = await getRadarrDiskSpace();
+    } catch {
+      postFreeSpaceGb = freeSpaceGb; // fall back to earlier measurement
+    }
+
+    const budget = getAdditionBudget(
+      postFreeSpaceGb,
+      targetFreeGb,
+      getAvgMovieGb(),
+      getDailyAdditions()
+    );
+    const additionResult = await addMoviesFromQueue(budget);
+    const moviesAdded = additionResult.added;
+
+    if (budget === 0) {
+      console.log('[Rotation] Additions skipped — below target free space');
+    }
 
     const result: RotationCycleResult = {
       moviesMarkedLeaving,


### PR DESCRIPTION
## Summary
- Adds `addition-gating.ts` with `getAdditionBudget()` pure function that calculates how many movies can be added without dropping below target free space
- `addMoviesFromQueue()` pulls pending candidates from `rotation_candidates` table and adds via Radarr, respecting configurable `rotation_daily_additions` (default 2) and `rotation_avg_movie_gb` (default 15)
- Updates scheduler Step 4 to re-check free space post-removals, compute budget, and gate additions accordingly
- Logs "additions skipped — below target free space" when budget is 0
- 8 unit tests for `getAdditionBudget()` covering edge cases

## Test plan
- [ ] Verify `getAdditionBudget()` returns 0 when free space < target
- [ ] Verify additions are capped by daily limit and projected space
- [ ] Verify candidates are pulled in `discoveredAt` order and status updated to 'added'/'skipped'
- [ ] Verify missing `rotation_quality_profile_id` or `rotation_root_folder_path` gracefully skips additions
- [ ] Verify scheduler integrates addition gating after removal step

🤖 Generated with [Claude Code](https://claude.com/claude-code)