### PR TITLE
feat(rotation): leaving soon shelf + countdown badges (PRD-072 US-01) [tb-357]

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/shelf/local-shelves.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/local-shelves.ts
@@ -491,6 +491,59 @@ export const franchiseCompletionsShelf: ShelfDefinition = {
 };
 
 // ---------------------------------------------------------------------------
+// leaving-soon: movies scheduled for removal (rotation_status = 'leaving')
+// ---------------------------------------------------------------------------
+
+export const leavingSoonShelf: ShelfDefinition = {
+  id: 'leaving-soon',
+  template: false,
+  category: 'local',
+  generate(_profile: PreferenceProfile): ShelfInstance[] {
+    const db = getDrizzle();
+    // Only generate the shelf when there are leaving movies
+    const count = db
+      .select({ id: movies.id })
+      .from(movies)
+      .where(eq(movies.rotationStatus, 'leaving'))
+      .limit(1)
+      .all();
+
+    if (count.length === 0) return [];
+
+    return [
+      {
+        shelfId: 'leaving-soon',
+        title: 'Leaving Soon',
+        subtitle: 'Watch before they go',
+        emoji: '⏳',
+        score: 0.95, // pinned near top
+        query: ({ limit, offset }) => {
+          const db = getDrizzle();
+          const rows = db
+            .select({
+              ...movieCols,
+              rotationExpiresAt: movies.rotationExpiresAt,
+            })
+            .from(movies)
+            .where(eq(movies.rotationStatus, 'leaving'))
+            .orderBy(sql`${movies.rotationExpiresAt} ASC NULLS LAST`)
+            .limit(limit)
+            .offset(offset)
+            .all();
+          return Promise.resolve(
+            rows.map((r) => ({
+              ...toResult(r),
+              inLibrary: true,
+              rotationExpiresAt: r.rotationExpiresAt ?? undefined,
+            }))
+          );
+        },
+      },
+    ];
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Register all shelves on module load
 // ---------------------------------------------------------------------------
 
@@ -502,3 +555,4 @@ registerShelf(polarizingShelf);
 registerShelf(friendProofShelf);
 registerShelf(recentlyAddedShelf);
 registerShelf(franchiseCompletionsShelf);
+registerShelf(leavingSoonShelf);

--- a/apps/pops-api/src/modules/media/discovery/types.ts
+++ b/apps/pops-api/src/modules/media/discovery/types.ts
@@ -76,6 +76,8 @@ export interface DiscoverResult {
   isWatched: boolean;
   /** Whether this movie is on the user's watchlist. */
   onWatchlist: boolean;
+  /** ISO timestamp when the movie is scheduled to leave (rotation). */
+  rotationExpiresAt?: string;
 }
 
 /** A discover result enriched with preference-based match scoring. */

--- a/apps/pops-api/src/modules/media/rotation/router.ts
+++ b/apps/pops-api/src/modules/media/rotation/router.ts
@@ -4,7 +4,10 @@
  * PRD-070
  */
 import { z } from 'zod';
+import { eq, asc } from 'drizzle-orm';
+import { movies } from '@pops/db-types';
 import { router, protectedProcedure } from '../../../trpc.js';
+import { getDrizzle } from '../../../db.js';
 import { cancelLeaving } from './leaving-lifecycle.js';
 import {
   startRotationScheduler,
@@ -54,5 +57,23 @@ export const rotationRouter = router({
       return { success: false, message: 'A rotation cycle is already in progress' };
     }
     return { success: true, result };
+  }),
+
+  /** Get movies currently in the 'leaving' state, sorted by expiry. */
+  getLeavingMovies: protectedProcedure.query(() => {
+    const db = getDrizzle();
+    return db
+      .select({
+        id: movies.id,
+        tmdbId: movies.tmdbId,
+        title: movies.title,
+        posterPath: movies.posterPath,
+        rotationExpiresAt: movies.rotationExpiresAt,
+        rotationMarkedAt: movies.rotationMarkedAt,
+      })
+      .from(movies)
+      .where(eq(movies.rotationStatus, 'leaving'))
+      .orderBy(asc(movies.rotationExpiresAt))
+      .all();
   }),
 });

--- a/packages/app-media/src/components/LeavingBadge.tsx
+++ b/packages/app-media/src/components/LeavingBadge.tsx
@@ -1,0 +1,52 @@
+/**
+ * LeavingBadge — countdown overlay showing when a movie is leaving the library.
+ *
+ * PRD-072 US-01
+ */
+import { cn } from '@pops/ui';
+
+export interface LeavingBadgeProps {
+  /** ISO timestamp of when the movie is scheduled to leave. */
+  rotationExpiresAt: string;
+  /** Additional CSS classes. */
+  className?: string;
+}
+
+function getDaysRemaining(expiresAt: string): number {
+  const now = new Date();
+  const expires = new Date(expiresAt);
+  const diffMs = expires.getTime() - now.getTime();
+  return Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+}
+
+function getBadgeText(days: number): string {
+  if (days <= 0) return 'Last day';
+  if (days === 1) return 'Leaving tomorrow';
+  return `Leaving in ${days} days`;
+}
+
+function getBadgeColor(days: number): string {
+  if (days <= 3) return 'bg-red-600 text-white';
+  if (days <= 7) return 'bg-amber-500 text-white';
+  return 'bg-muted text-muted-foreground';
+}
+
+export function LeavingBadge({ rotationExpiresAt, className }: LeavingBadgeProps) {
+  const days = getDaysRemaining(rotationExpiresAt);
+  const text = getBadgeText(days);
+  const color = getBadgeColor(days);
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold leading-tight',
+        color,
+        className
+      )}
+    >
+      {text}
+    </span>
+  );
+}
+
+LeavingBadge.displayName = 'LeavingBadge';

--- a/packages/app-media/src/components/LeavingSoonShelf.tsx
+++ b/packages/app-media/src/components/LeavingSoonShelf.tsx
@@ -48,7 +48,7 @@ export function LeavingSoonShelf() {
   return (
     <HorizontalScrollRow title="Leaving Soon" subtitle="Watch before they go">
       {movies.map((movie) => (
-        <div key={movie.id} className="relative w-36 shrink-0 sm:w-40">
+        <div key={movie.id} className="group relative w-36 shrink-0 sm:w-40">
           <MediaCard
             id={movie.id}
             type="movie"

--- a/packages/app-media/src/components/LeavingSoonShelf.tsx
+++ b/packages/app-media/src/components/LeavingSoonShelf.tsx
@@ -1,0 +1,88 @@
+/**
+ * LeavingSoonShelf — horizontal shelf showing movies scheduled for removal.
+ * Used on the Library page above the main grid.
+ *
+ * PRD-072 US-01
+ */
+import { toast } from 'sonner';
+import { X } from 'lucide-react';
+import { Button, Skeleton } from '@pops/ui';
+import { trpc } from '../lib/trpc';
+import { HorizontalScrollRow } from './HorizontalScrollRow';
+import { MediaCard } from './MediaCard';
+import { LeavingBadge } from './LeavingBadge';
+
+export function LeavingSoonShelf() {
+  const { data: movies, isLoading, refetch } = trpc.media.rotation.getLeavingMovies.useQuery();
+  const cancelMutation = trpc.media.rotation.cancelLeaving.useMutation({
+    onSuccess: (_data, variables) => {
+      const movie = movies?.find((m) => m.id === variables.movieId);
+      toast.success(`Kept "${movie?.title ?? 'movie'}" in library`);
+      void refetch();
+    },
+    onError: () => {
+      toast.error('Failed to cancel leaving status');
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <div className="px-1">
+          <Skeleton className="h-6 w-48" />
+        </div>
+        <div className="flex gap-4 overflow-hidden pb-2">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div key={i} className="w-36 shrink-0 space-y-2 sm:w-40">
+              <Skeleton className="aspect-[2/3] w-full rounded-md" />
+              <Skeleton className="h-4 w-3/4" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!movies || movies.length === 0) return null;
+
+  return (
+    <HorizontalScrollRow title="Leaving Soon" subtitle="Watch before they go">
+      {movies.map((movie) => (
+        <div key={movie.id} className="relative w-36 shrink-0 sm:w-40">
+          <MediaCard
+            id={movie.id}
+            type="movie"
+            title={movie.title}
+            posterUrl={movie.posterPath ? `/media/images/movie/${movie.tmdbId}/poster.jpg` : null}
+            showTypeBadge={false}
+          />
+
+          {/* Leaving countdown badge */}
+          {movie.rotationExpiresAt && (
+            <div className="absolute top-2 right-2 z-10">
+              <LeavingBadge rotationExpiresAt={movie.rotationExpiresAt} />
+            </div>
+          )}
+
+          {/* Keep button */}
+          <Button
+            variant="secondary"
+            size="icon"
+            className="absolute bottom-12 right-1 z-10 h-7 w-7 rounded-full opacity-0 transition-opacity group-hover:opacity-100 hover:opacity-100 focus:opacity-100"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              cancelMutation.mutate({ movieId: movie.id });
+            }}
+            disabled={cancelMutation.isPending}
+            title="Keep in library"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ))}
+    </HorizontalScrollRow>
+  );
+}
+
+LeavingSoonShelf.displayName = 'LeavingSoonShelf';

--- a/packages/app-media/src/components/ShelfSection.tsx
+++ b/packages/app-media/src/components/ShelfSection.tsx
@@ -12,6 +12,7 @@ import { Loader2 } from 'lucide-react';
 import { trpc } from '../lib/trpc';
 import { HorizontalScrollRow } from './HorizontalScrollRow';
 import { DiscoverCard } from './DiscoverCard';
+import { LeavingBadge } from './LeavingBadge';
 import type { DiscoverActionResult } from '../hooks/useDiscoverCardActions';
 
 interface ShelfItem {
@@ -26,6 +27,7 @@ interface ShelfItem {
   onWatchlist?: boolean;
   matchPercentage?: number;
   matchReason?: string;
+  rotationExpiresAt?: string;
 }
 
 export interface ShelfSectionProps {
@@ -190,32 +192,38 @@ export function ShelfSection({
     <div ref={sentinelRef} className="space-y-3">
       <HorizontalScrollRow title={title} subtitle={subtitle}>
         {visibleItems.map((item) => (
-          <DiscoverCard
-            key={item.tmdbId}
-            tmdbId={item.tmdbId}
-            title={item.title}
-            releaseDate={item.releaseDate}
-            posterPath={item.posterPath}
-            posterUrl={item.posterUrl}
-            voteAverage={item.voteAverage}
-            inLibrary={item.inLibrary}
-            isWatched={item.isWatched}
-            onWatchlist={item.onWatchlist}
-            matchPercentage={item.matchPercentage}
-            matchReason={item.matchReason}
-            isAddingToLibrary={addingToLibrary.has(item.tmdbId)}
-            isAddingToWatchlist={addingToWatchlist.has(item.tmdbId)}
-            isRemovingFromWatchlist={removingFromWatchlist.has(item.tmdbId)}
-            isMarkingWatched={markingWatched.has(item.tmdbId)}
-            isMarkingRewatched={markingRewatched.has(item.tmdbId)}
-            isDismissing={dismissing.has(item.tmdbId)}
-            onAddToLibrary={handleAddToLibrary}
-            onAddToWatchlist={handleAddToWatchlist}
-            onRemoveFromWatchlist={handleRemoveFromWatchlist}
-            onMarkWatched={handleMarkWatched}
-            onMarkRewatched={handleMarkRewatched}
-            onNotInterested={onNotInterested}
-          />
+          <div key={item.tmdbId} className="relative">
+            <DiscoverCard
+              tmdbId={item.tmdbId}
+              title={item.title}
+              releaseDate={item.releaseDate}
+              posterPath={item.posterPath}
+              posterUrl={item.posterUrl}
+              voteAverage={item.voteAverage}
+              inLibrary={item.inLibrary}
+              isWatched={item.isWatched}
+              onWatchlist={item.onWatchlist}
+              matchPercentage={item.matchPercentage}
+              matchReason={item.matchReason}
+              isAddingToLibrary={addingToLibrary.has(item.tmdbId)}
+              isAddingToWatchlist={addingToWatchlist.has(item.tmdbId)}
+              isRemovingFromWatchlist={removingFromWatchlist.has(item.tmdbId)}
+              isMarkingWatched={markingWatched.has(item.tmdbId)}
+              isMarkingRewatched={markingRewatched.has(item.tmdbId)}
+              isDismissing={dismissing.has(item.tmdbId)}
+              onAddToLibrary={handleAddToLibrary}
+              onAddToWatchlist={handleAddToWatchlist}
+              onRemoveFromWatchlist={handleRemoveFromWatchlist}
+              onMarkWatched={handleMarkWatched}
+              onMarkRewatched={handleMarkRewatched}
+              onNotInterested={onNotInterested}
+            />
+            {item.rotationExpiresAt && (
+              <div className="absolute top-2 right-2 z-10">
+                <LeavingBadge rotationExpiresAt={item.rotationExpiresAt} />
+              </div>
+            )}
+          </div>
         ))}
         {hasMore && (
           <div className="flex shrink-0 items-center px-2">

--- a/packages/app-media/src/pages/LibraryPage.test.tsx
+++ b/packages/app-media/src/pages/LibraryPage.test.tsx
@@ -8,6 +8,8 @@ const mockGenresQuery = vi.fn();
 const mockRefetch = vi.fn();
 const mockGetPendingDebriefs = vi.fn();
 
+const mockGetLeavingMovies = vi.fn();
+
 vi.mock('../lib/trpc', () => ({
   trpc: {
     media: {
@@ -17,6 +19,12 @@ vi.mock('../lib/trpc', () => ({
       },
       comparisons: {
         getPendingDebriefs: { useQuery: () => mockGetPendingDebriefs() },
+      },
+      rotation: {
+        getLeavingMovies: { useQuery: () => mockGetLeavingMovies() },
+        cancelLeaving: {
+          useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+        },
       },
     },
   },
@@ -34,6 +42,10 @@ vi.mock('../components/MediaCard', () => ({
 
 vi.mock('../components/DownloadQueue', () => ({
   DownloadQueue: () => <div data-testid="download-queue" />,
+}));
+
+vi.mock('../components/LeavingSoonShelf', () => ({
+  LeavingSoonShelf: () => <div data-testid="leaving-soon-shelf" />,
 }));
 
 vi.mock('../components/QuickPickDialog', () => ({
@@ -101,6 +113,7 @@ describe('LibraryPage', () => {
     vi.clearAllMocks();
     mockGenresQuery.mockReturnValue({ data: { data: ['Drama', 'Sci-Fi'] } });
     mockGetPendingDebriefs.mockReturnValue({ data: null });
+    mockGetLeavingMovies.mockReturnValue({ data: [], isLoading: false });
   });
 
   describe('Loading state', () => {

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -7,6 +7,7 @@ import { MediaGrid } from '../components/MediaGrid';
 import { MediaCard } from '../components/MediaCard';
 import { DebriefBanner } from '../components/DebriefBanner';
 import { DownloadQueue } from '../components/DownloadQueue';
+import { LeavingSoonShelf } from '../components/LeavingSoonShelf';
 import { QuickPickDialog } from '../components/QuickPickDialog';
 import { useMediaLibrary, type MediaType, type SortOption } from '../hooks/useMediaLibrary';
 
@@ -253,6 +254,9 @@ export function LibraryPage() {
 
       {/* Download queue */}
       <DownloadQueue />
+
+      {/* Leaving soon shelf — shows movies scheduled for removal */}
+      <LeavingSoonShelf />
 
       {/* Filter bar */}
       <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary
- Adds "Leaving Soon" shelf to Discover page via shelf registry (category: local, score: 0.95 for pinning)
- Adds `LeavingSoonShelf` component to Library page between DownloadQueue and filter bar
- New `LeavingBadge` component: countdown overlay with color coding (red <= 3d, amber <= 7d, neutral > 7d)
- Text: "Last day" (< 24h), "Leaving tomorrow" (< 48h), "Leaving in X days"
- "Keep" action button calls existing `rotation.cancelLeaving` endpoint
- New `rotation.getLeavingMovies` tRPC endpoint for Library page
- Extended `DiscoverResult` with optional `rotationExpiresAt` field
- LeavingBadge renders on DiscoverCards in ShelfSection when `rotationExpiresAt` is present
- Shelf auto-hides when no movies have leaving status

## Test plan
- [ ] Verify leaving-soon shelf appears on Discover page when leaving movies exist
- [ ] Verify leaving-soon shelf appears on Library page above filter bar
- [ ] Verify countdown badge shows correct text and color based on days remaining
- [ ] Verify "Keep" action clears leaving status and refreshes shelf
- [ ] Verify shelf is hidden when no movies are leaving
- [ ] Verify all 14 packages typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)