### PR TITLE
feat(rotation): source plugin interface + Plex watchlist adapter (PRD-071 US-02)

### DIFF
--- a/apps/pops-api/src/modules/media/index.ts
+++ b/apps/pops-api/src/modules/media/index.ts
@@ -7,6 +7,8 @@ import { moviesRouter } from './movies/router.js';
 // Side-effect: register search adapters
 import './search/movies-adapter.js';
 import './search/tv-shows-adapter.js';
+// Side-effect: register rotation source adapters
+import './rotation/register-sources.js';
 import { tvShowsRouter } from './tv-shows/index.js';
 import { comparisonsRouter } from './comparisons/index.js';
 import { watchlistRouter } from './watchlist/router.js';

--- a/apps/pops-api/src/modules/media/rotation/plex-watchlist-source.ts
+++ b/apps/pops-api/src/modules/media/rotation/plex-watchlist-source.ts
@@ -1,0 +1,44 @@
+/**
+ * Plex watchlist rotation source adapter.
+ *
+ * PRD-071 US-02: fetches the user's Plex Discover watchlist and
+ * extracts TMDB IDs for rotation candidate discovery.
+ */
+import { extractExternalIdAsNumber } from '../plex/sync-helpers.js';
+import { getPlexClientId, getPlexToken } from '../plex/service.js';
+import { fetchPlexWatchlist } from '../plex/sync-watchlist.js';
+import type { CandidateMovie, RotationSourceAdapter } from './source-types.js';
+
+export const plexWatchlistSource: RotationSourceAdapter = {
+  type: 'plex_watchlist',
+
+  async fetchCandidates(_config: Record<string, unknown>): Promise<CandidateMovie[]> {
+    const token = getPlexToken();
+    if (!token) {
+      throw new Error('Plex token not configured — cannot fetch watchlist');
+    }
+
+    const clientId = getPlexClientId();
+    const watchlistItems = await fetchPlexWatchlist(token, clientId);
+
+    const candidates: CandidateMovie[] = [];
+
+    for (const item of watchlistItems) {
+      // Only include movies (skip TV shows)
+      if (item.type !== 'movie') continue;
+
+      const tmdbId = extractExternalIdAsNumber(item, 'tmdb');
+      if (!tmdbId) continue;
+
+      candidates.push({
+        tmdbId,
+        title: item.title,
+        year: item.year,
+        rating: item.audienceRating ?? item.rating ?? null,
+        posterPath: item.thumbUrl,
+      });
+    }
+
+    return candidates;
+  },
+};

--- a/apps/pops-api/src/modules/media/rotation/register-sources.ts
+++ b/apps/pops-api/src/modules/media/rotation/register-sources.ts
@@ -1,0 +1,9 @@
+/**
+ * Register all rotation source adapters.
+ *
+ * Imported as a side-effect in the media module index.
+ */
+import { registerSourceAdapter } from './source-registry.js';
+import { plexWatchlistSource } from './plex-watchlist-source.js';
+
+registerSourceAdapter(plexWatchlistSource);

--- a/apps/pops-api/src/modules/media/rotation/router.ts
+++ b/apps/pops-api/src/modules/media/rotation/router.ts
@@ -15,6 +15,8 @@ import {
   getRotationSchedulerStatus,
   runRotationCycleNow,
 } from './scheduler.js';
+import { getRegisteredTypes } from './source-registry.js';
+import { syncSource } from './sync-source.js';
 
 export const rotationRouter = router({
   /** Cancel leaving status for a specific movie. */
@@ -75,5 +77,17 @@ export const rotationRouter = router({
       .where(eq(movies.rotationStatus, 'leaving'))
       .orderBy(asc(movies.rotationExpiresAt))
       .all();
+  }),
+
+  /** Sync a specific rotation source (fetch candidates from adapter). */
+  syncSource: protectedProcedure
+    .input(z.object({ sourceId: z.number().int().positive() }))
+    .mutation(async ({ input }) => {
+      return syncSource(input.sourceId);
+    }),
+
+  /** List registered source adapter types. */
+  sourceTypes: protectedProcedure.query(() => {
+    return { types: getRegisteredTypes() };
   }),
 });

--- a/apps/pops-api/src/modules/media/rotation/source-registry.ts
+++ b/apps/pops-api/src/modules/media/rotation/source-registry.ts
@@ -1,0 +1,21 @@
+/**
+ * Rotation source adapter registry.
+ *
+ * Maps source type strings to adapter instances. New adapters are
+ * registered at startup; syncSource() looks them up at runtime.
+ */
+import type { RotationSourceAdapter } from './source-types.js';
+
+const adapters = new Map<string, RotationSourceAdapter>();
+
+export function registerSourceAdapter(adapter: RotationSourceAdapter): void {
+  adapters.set(adapter.type, adapter);
+}
+
+export function getSourceAdapter(type: string): RotationSourceAdapter | undefined {
+  return adapters.get(type);
+}
+
+export function getRegisteredTypes(): string[] {
+  return [...adapters.keys()];
+}

--- a/apps/pops-api/src/modules/media/rotation/source-types.ts
+++ b/apps/pops-api/src/modules/media/rotation/source-types.ts
@@ -1,0 +1,31 @@
+/**
+ * Rotation source plugin interface and types.
+ *
+ * PRD-071 US-02: defines the pluggable adapter pattern for fetching
+ * candidate movies from different sources (Plex watchlist, IMDB lists, etc.)
+ */
+
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+/** A candidate movie fetched from an external source. */
+export interface CandidateMovie {
+  tmdbId: number;
+  title: string;
+  year: number | null;
+  rating: number | null;
+  posterPath: string | null;
+}
+
+/** Plugin interface for a rotation source adapter. */
+export interface RotationSourceAdapter {
+  /** Unique source type identifier (matches rotation_sources.type). */
+  readonly type: string;
+
+  /**
+   * Fetch candidate movies from this source.
+   * @param config - JSON-parsed config from rotation_sources.config
+   */
+  fetchCandidates(config: Record<string, unknown>): Promise<CandidateMovie[]>;
+}

--- a/apps/pops-api/src/modules/media/rotation/sync-source.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/sync-source.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { eq } from 'drizzle-orm';
 import { rotationCandidates, rotationSources } from '@pops/db-types';
 import { getDrizzle } from '../../../db.js';
+import { setupTestContext } from '../../../shared/test-utils.js';
 import { registerSourceAdapter } from './source-registry.js';
 import { syncSource } from './sync-source.js';
 import type { CandidateMovie, RotationSourceAdapter } from './source-types.js';
@@ -40,10 +41,13 @@ function createTestSource(overrides: Partial<typeof rotationSources.$inferInsert
 // Tests
 // ---------------------------------------------------------------------------
 
+const ctx = setupTestContext();
+
 describe('syncSource', () => {
   let adapter: RotationSourceAdapter;
 
   beforeEach(() => {
+    ctx.setup();
     adapter = createMockAdapter([
       { tmdbId: 550, title: 'Fight Club', year: 1999, rating: 8.4, posterPath: '/poster1.jpg' },
       { tmdbId: 680, title: 'Pulp Fiction', year: 1994, rating: 8.9, posterPath: '/poster2.jpg' },
@@ -52,9 +56,7 @@ describe('syncSource', () => {
   });
 
   afterEach(() => {
-    const db = getDrizzle();
-    db.delete(rotationCandidates).run();
-    db.delete(rotationSources).run();
+    ctx.teardown();
   });
 
   it('inserts candidates from the adapter', async () => {

--- a/apps/pops-api/src/modules/media/rotation/sync-source.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/sync-source.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { rotationCandidates, rotationSources } from '@pops/db-types';
+import { getDrizzle } from '../../../db.js';
+import { registerSourceAdapter } from './source-registry.js';
+import { syncSource } from './sync-source.js';
+import type { CandidateMovie, RotationSourceAdapter } from './source-types.js';
+
+// ---------------------------------------------------------------------------
+// Test adapter
+// ---------------------------------------------------------------------------
+
+function createMockAdapter(candidates: CandidateMovie[]): RotationSourceAdapter {
+  return {
+    type: 'test_source',
+    fetchCandidates: vi.fn().mockResolvedValue(candidates),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTestSource(overrides: Partial<typeof rotationSources.$inferInsert> = {}) {
+  const db = getDrizzle();
+  return db
+    .insert(rotationSources)
+    .values({
+      type: 'test_source',
+      name: 'Test Source',
+      priority: 5,
+      enabled: 1,
+      ...overrides,
+    })
+    .returning()
+    .get();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('syncSource', () => {
+  let adapter: RotationSourceAdapter;
+
+  beforeEach(() => {
+    adapter = createMockAdapter([
+      { tmdbId: 550, title: 'Fight Club', year: 1999, rating: 8.4, posterPath: '/poster1.jpg' },
+      { tmdbId: 680, title: 'Pulp Fiction', year: 1994, rating: 8.9, posterPath: '/poster2.jpg' },
+    ]);
+    registerSourceAdapter(adapter);
+  });
+
+  afterEach(() => {
+    const db = getDrizzle();
+    db.delete(rotationCandidates).run();
+    db.delete(rotationSources).run();
+  });
+
+  it('inserts candidates from the adapter', async () => {
+    const source = createTestSource();
+    const result = await syncSource(source.id);
+
+    expect(result.candidatesFetched).toBe(2);
+    expect(result.candidatesInserted).toBe(2);
+    expect(result.candidatesSkipped).toBe(0);
+
+    const db = getDrizzle();
+    const rows = db.select().from(rotationCandidates).all();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.tmdbId).toBe(550);
+    expect(rows[0]!.title).toBe('Fight Club');
+    expect(rows[1]!.tmdbId).toBe(680);
+  });
+
+  it('skips duplicate tmdbIds on re-sync', async () => {
+    const source = createTestSource();
+
+    await syncSource(source.id);
+    const result2 = await syncSource(source.id);
+
+    expect(result2.candidatesFetched).toBe(2);
+    expect(result2.candidatesInserted).toBe(0);
+    expect(result2.candidatesSkipped).toBe(2);
+
+    const db = getDrizzle();
+    const rows = db.select().from(rotationCandidates).all();
+    expect(rows).toHaveLength(2);
+  });
+
+  it('updates lastSyncedAt on the source', async () => {
+    const source = createTestSource();
+    expect(source.lastSyncedAt).toBeNull();
+
+    await syncSource(source.id);
+
+    const db = getDrizzle();
+    const updated = db
+      .select()
+      .from(rotationSources)
+      .where(eq(rotationSources.id, source.id))
+      .get();
+    expect(updated!.lastSyncedAt).toBeTruthy();
+  });
+
+  it('throws for non-existent source', async () => {
+    await expect(syncSource(9999)).rejects.toThrow('not found');
+  });
+
+  it('throws for disabled source', async () => {
+    const source = createTestSource({ enabled: 0 });
+    await expect(syncSource(source.id)).rejects.toThrow('disabled');
+  });
+
+  it('throws for unknown source type', async () => {
+    const source = createTestSource({ type: 'unknown_type' });
+    await expect(syncSource(source.id)).rejects.toThrow('No adapter registered');
+  });
+
+  it('handles empty candidates', async () => {
+    const emptyAdapter = createMockAdapter([]);
+    registerSourceAdapter({ ...emptyAdapter, type: 'empty_source' });
+    const source = createTestSource({ type: 'empty_source' });
+
+    const result = await syncSource(source.id);
+
+    expect(result.candidatesFetched).toBe(0);
+    expect(result.candidatesInserted).toBe(0);
+    expect(result.candidatesSkipped).toBe(0);
+  });
+
+  it('parses config JSON and passes to adapter', async () => {
+    const source = createTestSource({ config: '{"key":"value"}' });
+
+    await syncSource(source.id);
+
+    expect(adapter.fetchCandidates).toHaveBeenCalledWith({ key: 'value' });
+  });
+});

--- a/apps/pops-api/src/modules/media/rotation/sync-source.ts
+++ b/apps/pops-api/src/modules/media/rotation/sync-source.ts
@@ -1,0 +1,86 @@
+/**
+ * Rotation source sync — fetches candidates from an adapter and
+ * upserts them into the rotation_candidates table.
+ *
+ * PRD-071 US-02: syncSource(sourceId) implementation.
+ */
+import { eq, sql } from 'drizzle-orm';
+import { rotationCandidates, rotationSources } from '@pops/db-types';
+import { getDrizzle } from '../../../db.js';
+import { getRegisteredTypes, getSourceAdapter } from './source-registry.js';
+
+export interface SyncSourceResult {
+  sourceId: number;
+  sourceType: string;
+  candidatesFetched: number;
+  candidatesInserted: number;
+  candidatesSkipped: number;
+}
+
+/**
+ * Sync a rotation source: fetch candidates via its adapter and upsert
+ * into the rotation_candidates table.
+ */
+export async function syncSource(sourceId: number): Promise<SyncSourceResult> {
+  const db = getDrizzle();
+
+  const source = db.select().from(rotationSources).where(eq(rotationSources.id, sourceId)).get();
+
+  if (!source) {
+    throw new Error(`Rotation source ${sourceId} not found`);
+  }
+
+  if (!source.enabled) {
+    throw new Error(`Rotation source ${sourceId} (${source.name}) is disabled`);
+  }
+
+  const adapter = getSourceAdapter(source.type);
+  if (!adapter) {
+    throw new Error(
+      `No adapter registered for source type "${source.type}". ` +
+        `Registered types: ${JSON.stringify(getRegisteredTypes())}`
+    );
+  }
+
+  const config: Record<string, unknown> = source.config ? JSON.parse(source.config) : {};
+
+  const candidates = await adapter.fetchCandidates(config);
+
+  let inserted = 0;
+  let skipped = 0;
+
+  for (const candidate of candidates) {
+    const result = db
+      .insert(rotationCandidates)
+      .values({
+        sourceId,
+        tmdbId: candidate.tmdbId,
+        title: candidate.title,
+        year: candidate.year,
+        rating: candidate.rating,
+        posterPath: candidate.posterPath,
+      })
+      .onConflictDoNothing()
+      .run();
+
+    if (result.changes > 0) {
+      inserted++;
+    } else {
+      skipped++;
+    }
+  }
+
+  // Update lastSyncedAt on the source
+  db.update(rotationSources)
+    .set({ lastSyncedAt: sql`datetime('now')` })
+    .where(eq(rotationSources.id, sourceId))
+    .run();
+
+  return {
+    sourceId,
+    sourceType: source.type,
+    candidatesFetched: candidates.length,
+    candidatesInserted: inserted,
+    candidatesSkipped: skipped,
+  };
+}

--- a/apps/pops-api/src/modules/media/rotation/sync-source.ts
+++ b/apps/pops-api/src/modules/media/rotation/sync-source.ts
@@ -42,7 +42,9 @@ export async function syncSource(sourceId: number): Promise<SyncSourceResult> {
     );
   }
 
-  const config: Record<string, unknown> = source.config ? JSON.parse(source.config) : {};
+  const config: Record<string, unknown> = source.config
+    ? (JSON.parse(source.config) as Record<string, unknown>)
+    : {};
 
   const candidates = await adapter.fetchCandidates(config);
 

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -493,6 +493,48 @@ export function createTestDb(): Database {
     );
     CREATE INDEX IF NOT EXISTS idx_shelf_impressions_shelf_id
       ON shelf_impressions(shelf_id);
+
+    CREATE TABLE IF NOT EXISTS rotation_sources (
+      id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+      type                TEXT    NOT NULL,
+      name                TEXT    NOT NULL,
+      priority            INTEGER NOT NULL DEFAULT 5,
+      enabled             INTEGER NOT NULL DEFAULT 1,
+      config              TEXT,
+      last_synced_at      TEXT,
+      sync_interval_hours INTEGER NOT NULL DEFAULT 24,
+      created_at          TEXT    NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_rotation_sources_type
+      ON rotation_sources(type);
+
+    CREATE TABLE IF NOT EXISTS rotation_candidates (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_id     INTEGER NOT NULL REFERENCES rotation_sources(id) ON DELETE CASCADE,
+      tmdb_id       INTEGER NOT NULL,
+      title         TEXT    NOT NULL,
+      year          INTEGER,
+      rating        REAL,
+      poster_path   TEXT,
+      status        TEXT    NOT NULL DEFAULT 'pending',
+      discovered_at TEXT    NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_rotation_candidates_tmdb_id
+      ON rotation_candidates(tmdb_id);
+    CREATE INDEX IF NOT EXISTS idx_rotation_candidates_source_id
+      ON rotation_candidates(source_id);
+    CREATE INDEX IF NOT EXISTS idx_rotation_candidates_status
+      ON rotation_candidates(status);
+
+    CREATE TABLE IF NOT EXISTS rotation_exclusions (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      tmdb_id     INTEGER NOT NULL,
+      title       TEXT    NOT NULL,
+      reason      TEXT,
+      excluded_at TEXT    NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_rotation_exclusions_tmdb_id
+      ON rotation_exclusions(tmdb_id);
   `);
 
   // Seed tag vocabulary (v1) for tests to match dev/prod init behavior.


### PR DESCRIPTION
## Summary
- Introduces `RotationSourceAdapter` plugin interface and in-memory registry for extensible rotation source types
- Implements Plex watchlist adapter wrapping existing `fetchPlexWatchlist` infra
- Adds `syncSource(sourceId)` function: fetches candidates via adapter → upserts into `rotation_candidates` table with dedup
- Exposes `syncSource` mutation and `sourceTypes` query on the rotation tRPC router
- 8 integration tests covering insert, dedup, config parsing, error cases

## Test plan
- [x] 8 vitest integration tests pass (insert, dedup, lastSyncedAt update, error cases, empty candidates, config parsing)
- [x] Full monorepo typecheck clean (14 packages)
- [x] Lint clean
- [ ] CI green

Closes tb-351

🤖 Generated with [Claude Code](https://claude.com/claude-code)