### PR TITLE
feat(rotation): external list source adapters — TMDB top rated + Letterboxd (PRD-071 US-04) [tb-353]

### DIFF
--- a/apps/pops-api/src/modules/media/rotation/letterboxd-source.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/letterboxd-source.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for Letterboxd list rotation source adapter.
+ *
+ * PRD-071 US-04
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { parseLetterboxdListPage } from './letterboxd-source.js';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock logger
+vi.mock('../../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn() },
+}));
+
+const { letterboxdSource } = await import('./letterboxd-source.js');
+
+// ---------------------------------------------------------------------------
+// Sample HTML fragments that mimic Letterboxd list page structure
+// ---------------------------------------------------------------------------
+
+const SAMPLE_LIST_PAGE = `
+<html>
+<body>
+<ul class="poster-list">
+  <li class="poster-container">
+    <div data-film-slug="the-shawshank-redemption-1994" data-tmdb-id="278" class="film-poster">
+      <img alt="The Shawshank Redemption" src="/poster.jpg" />
+    </div>
+  </li>
+  <li class="poster-container">
+    <div data-film-slug="the-godfather-1972" data-tmdb-id="238" class="film-poster">
+      <img alt="The Godfather" src="/poster2.jpg" />
+    </div>
+  </li>
+  <li class="poster-container">
+    <div data-film-slug="the-dark-knight-2008" data-tmdb-id="155" class="film-poster">
+      <img alt="The Dark Knight" src="/poster3.jpg" />
+    </div>
+  </li>
+</ul>
+</body>
+</html>
+`;
+
+const SAMPLE_PAGE_WITH_NEXT = `
+<html>
+<body>
+<ul class="poster-list">
+  <li class="poster-container">
+    <div data-film-slug="inception-2010" data-tmdb-id="27205" class="film-poster">
+      <img alt="Inception" src="/poster.jpg" />
+    </div>
+  </li>
+</ul>
+<a class="next" href="/page/2/">Next</a>
+</body>
+</html>
+`;
+
+const SAMPLE_PAGE_2 = `
+<html>
+<body>
+<ul class="poster-list">
+  <li class="poster-container">
+    <div data-film-slug="the-matrix-1999" data-tmdb-id="603" class="film-poster">
+      <img alt="The Matrix" src="/poster.jpg" />
+    </div>
+  </li>
+</ul>
+</body>
+</html>
+`;
+
+// ---------------------------------------------------------------------------
+// Tests: parseLetterboxdListPage (pure function)
+// ---------------------------------------------------------------------------
+
+describe('parseLetterboxdListPage', () => {
+  it('extracts movies with TMDB IDs from HTML', () => {
+    const movies = parseLetterboxdListPage(SAMPLE_LIST_PAGE);
+
+    expect(movies).toHaveLength(3);
+    expect(movies[0]).toMatchObject({ tmdbId: 278, title: 'The Shawshank Redemption' });
+    expect(movies[1]).toMatchObject({ tmdbId: 238, title: 'The Godfather' });
+    expect(movies[2]).toMatchObject({ tmdbId: 155, title: 'The Dark Knight' });
+  });
+
+  it('returns empty array for HTML with no films', () => {
+    const movies = parseLetterboxdListPage('<html><body>No movies here</body></html>');
+    expect(movies).toHaveLength(0);
+  });
+
+  it('derives title from slug', () => {
+    const movies = parseLetterboxdListPage(
+      '<div data-film-slug="pulp-fiction-1994" data-tmdb-id="680" class="film">'
+    );
+    expect(movies[0]!.title).toBe('Pulp Fiction');
+  });
+
+  it('sets rating and posterPath to null', () => {
+    const movies = parseLetterboxdListPage(SAMPLE_LIST_PAGE);
+    for (const movie of movies) {
+      expect(movie.rating).toBeNull();
+      expect(movie.posterPath).toBeNull();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: letterboxdSource adapter
+// ---------------------------------------------------------------------------
+
+describe('letterboxdSource', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('has correct type identifier', () => {
+    expect(letterboxdSource.type).toBe('letterboxd');
+  });
+
+  it('throws when listUrl is missing', async () => {
+    await expect(letterboxdSource.fetchCandidates({})).rejects.toThrow(
+      'letterboxd source requires a non-empty listUrl'
+    );
+  });
+
+  it('throws when listUrl is empty string', async () => {
+    await expect(letterboxdSource.fetchCandidates({ listUrl: '' })).rejects.toThrow(
+      'letterboxd source requires a non-empty listUrl'
+    );
+  });
+
+  it('fetches and parses a single-page list', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => SAMPLE_LIST_PAGE,
+    });
+
+    const candidates = await letterboxdSource.fetchCandidates({
+      listUrl: 'https://letterboxd.com/user/list/my-list',
+    });
+
+    expect(candidates).toHaveLength(3);
+    expect(candidates[0]!.tmdbId).toBe(278);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://letterboxd.com/user/list/my-list/',
+      expect.objectContaining({ headers: expect.any(Object) })
+    );
+  });
+
+  it('paginates across multiple pages', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => SAMPLE_PAGE_WITH_NEXT,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => SAMPLE_PAGE_2,
+      });
+
+    const candidates = await letterboxdSource.fetchCandidates({
+      listUrl: 'https://letterboxd.com/user/list/my-list',
+    });
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]!.tmdbId).toBe(27205);
+    expect(candidates[1]!.tmdbId).toBe(603);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns empty array on HTTP error for first page', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+
+    const candidates = await letterboxdSource.fetchCandidates({
+      listUrl: 'https://letterboxd.com/user/list/does-not-exist',
+    });
+
+    expect(candidates).toHaveLength(0);
+  });
+
+  it('returns partial results when later page fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => SAMPLE_PAGE_WITH_NEXT,
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+    const candidates = await letterboxdSource.fetchCandidates({
+      listUrl: 'https://letterboxd.com/user/list/my-list',
+    });
+
+    // Returns the first page results only
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]!.tmdbId).toBe(27205);
+  });
+
+  it('returns partial results on network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('DNS resolution failed'));
+
+    const candidates = await letterboxdSource.fetchCandidates({
+      listUrl: 'https://letterboxd.com/user/list/my-list',
+    });
+
+    expect(candidates).toHaveLength(0);
+  });
+
+  it('strips trailing slash from URL', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => SAMPLE_LIST_PAGE,
+    });
+
+    await letterboxdSource.fetchCandidates({
+      listUrl: 'https://letterboxd.com/user/list/my-list/',
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://letterboxd.com/user/list/my-list/',
+      expect.any(Object)
+    );
+  });
+});

--- a/apps/pops-api/src/modules/media/rotation/letterboxd-source.ts
+++ b/apps/pops-api/src/modules/media/rotation/letterboxd-source.ts
@@ -1,0 +1,128 @@
+/**
+ * Letterboxd list rotation source adapter.
+ *
+ * PRD-071 US-04: scrapes a Letterboxd list URL to extract movie entries,
+ * then resolves TMDB IDs via Letterboxd's built-in TMDB links.
+ *
+ * Letterboxd list pages include `data-tmdb-id` attributes on film poster
+ * elements, which we use directly instead of needing a separate API lookup.
+ *
+ * Config: { listUrl: string }
+ */
+import { logger } from '../../../lib/logger.js';
+import type { CandidateMovie, RotationSourceAdapter } from './source-types.js';
+
+const MAX_PAGES = 20;
+
+export const letterboxdSource: RotationSourceAdapter = {
+  type: 'letterboxd',
+
+  async fetchCandidates(config: Record<string, unknown>): Promise<CandidateMovie[]> {
+    const listUrl = config.listUrl;
+    if (typeof listUrl !== 'string' || !listUrl.trim()) {
+      throw new Error('letterboxd source requires a non-empty listUrl in config');
+    }
+
+    // Normalize URL — remove trailing slash, ensure it's a valid Letterboxd list URL
+    const baseUrl = listUrl.replace(/\/+$/, '');
+
+    const candidates: CandidateMovie[] = [];
+    let page = 1;
+
+    while (page <= MAX_PAGES) {
+      const pageUrl = page === 1 ? `${baseUrl}/` : `${baseUrl}/page/${page}/`;
+
+      let html: string;
+      try {
+        const response = await fetch(pageUrl, {
+          headers: {
+            Accept: 'text/html',
+            'User-Agent': 'POPS/1.0 (rotation source sync)',
+          },
+        });
+
+        if (!response.ok) {
+          if (page === 1) {
+            logger.warn(
+              `[letterboxd] Failed to fetch list: ${response.status} ${response.statusText}`
+            );
+            return [];
+          }
+          // Non-first page failing likely means we've exhausted the list
+          break;
+        }
+
+        html = await response.text();
+      } catch (err) {
+        logger.warn(
+          `[letterboxd] Network error fetching page ${page}: ${err instanceof Error ? err.message : String(err)}`
+        );
+        return candidates; // Return what we have so far
+      }
+
+      const pageMovies = parseLetterboxdListPage(html);
+      if (pageMovies.length === 0) break;
+
+      candidates.push(...pageMovies);
+
+      // Check if there's a next page link
+      if (!html.includes('class="next"')) break;
+
+      page++;
+    }
+
+    logger.info(`[letterboxd] Fetched ${candidates.length} candidates from ${baseUrl}`);
+    return candidates;
+  },
+};
+
+/**
+ * Parse a Letterboxd list page HTML and extract movie entries.
+ *
+ * Letterboxd film poster elements use `data-film-slug` and include
+ * TMDB IDs in `data-tmdb-id` attributes. Film titles are in the
+ * `alt` attribute of the poster img tag.
+ */
+export function parseLetterboxdListPage(html: string): CandidateMovie[] {
+  const candidates: CandidateMovie[] = [];
+
+  // Match film poster containers with TMDB IDs
+  // Pattern: data-film-slug="..." ... data-tmdb-id="NNN"
+  const filmPattern = /data-film-slug="([^"]*)"[^>]*data-tmdb-id="(\d+)"[^>]*>/g;
+
+  let match;
+  while ((match = filmPattern.exec(html)) !== null) {
+    const slug = match[1] ?? '';
+    const tmdbId = Number(match[2]);
+
+    if (!tmdbId) continue;
+
+    // Try to extract title from nearby alt text or slug
+    const title = slugToTitle(slug);
+
+    // Extract year from nearby context if available
+    const yearMatch = html
+      .slice(Math.max(0, match.index - 200), match.index + 500)
+      .match(/class="film-detail-content"[^>]*>.*?<small[^>]*>(\d{4})<\/small>/s);
+    const year = yearMatch ? Number(yearMatch[1]) : null;
+
+    candidates.push({
+      tmdbId,
+      title,
+      year,
+      rating: null,
+      posterPath: null,
+    });
+  }
+
+  return candidates;
+}
+
+/** Convert a Letterboxd slug to a readable title (best-effort). */
+function slugToTitle(slug: string): string {
+  return slug
+    .replace(/-\d{4}$/, '') // Remove trailing year
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}

--- a/apps/pops-api/src/modules/media/rotation/register-sources.ts
+++ b/apps/pops-api/src/modules/media/rotation/register-sources.ts
@@ -6,6 +6,10 @@
 import { registerSourceAdapter } from './source-registry.js';
 import { plexWatchlistSource } from './plex-watchlist-source.js';
 import { plexFriendsSource } from './plex-friends-source.js';
+import { tmdbTopRatedSource } from './tmdb-top-rated-source.js';
+import { letterboxdSource } from './letterboxd-source.js';
 
 registerSourceAdapter(plexWatchlistSource);
 registerSourceAdapter(plexFriendsSource);
+registerSourceAdapter(tmdbTopRatedSource);
+registerSourceAdapter(letterboxdSource);

--- a/apps/pops-api/src/modules/media/rotation/tmdb-top-rated-source.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/tmdb-top-rated-source.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for TMDB top rated rotation source adapter.
+ *
+ * PRD-071 US-04
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CandidateMovie } from './source-types.js';
+
+// Mock TMDB client
+const mockDiscoverMovies = vi.fn();
+vi.mock('../tmdb/index.js', () => ({
+  getTmdbClient: () => ({
+    discoverMovies: mockDiscoverMovies,
+  }),
+}));
+
+// Mock logger
+vi.mock('../../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn() },
+}));
+
+// Import after mocks
+const { tmdbTopRatedSource } = await import('./tmdb-top-rated-source.js');
+
+describe('tmdbTopRatedSource', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('has correct type identifier', () => {
+    expect(tmdbTopRatedSource.type).toBe('tmdb_top_rated');
+  });
+
+  it('fetches candidates from TMDB discover endpoint', async () => {
+    mockDiscoverMovies.mockResolvedValueOnce({
+      page: 1,
+      totalPages: 1,
+      totalResults: 2,
+      results: [
+        {
+          tmdbId: 278,
+          title: 'The Shawshank Redemption',
+          releaseDate: '1994-09-23',
+          voteAverage: 8.7,
+          posterPath: '/9O7gLzmreU0nGkIB6K3BsJbzvNv.jpg',
+          originalTitle: 'The Shawshank Redemption',
+          overview: '',
+          backdropPath: null,
+          voteCount: 25000,
+          genreIds: [18, 80],
+          originalLanguage: 'en',
+          popularity: 100,
+        },
+        {
+          tmdbId: 238,
+          title: 'The Godfather',
+          releaseDate: '1972-03-14',
+          voteAverage: 8.7,
+          posterPath: '/3bhkrj58Vtu7enYsRolD1fZdja1.jpg',
+          originalTitle: 'The Godfather',
+          overview: '',
+          backdropPath: null,
+          voteCount: 19000,
+          genreIds: [18, 80],
+          originalLanguage: 'en',
+          popularity: 90,
+        },
+      ],
+    });
+
+    const candidates = await tmdbTopRatedSource.fetchCandidates({ pages: 1 });
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]).toEqual<CandidateMovie>({
+      tmdbId: 278,
+      title: 'The Shawshank Redemption',
+      year: 1994,
+      rating: 8.7,
+      posterPath: '/9O7gLzmreU0nGkIB6K3BsJbzvNv.jpg',
+    });
+    expect(candidates[1]).toEqual<CandidateMovie>({
+      tmdbId: 238,
+      title: 'The Godfather',
+      year: 1972,
+      rating: 8.7,
+      posterPath: '/3bhkrj58Vtu7enYsRolD1fZdja1.jpg',
+    });
+
+    expect(mockDiscoverMovies).toHaveBeenCalledWith({
+      sortBy: 'vote_average.desc',
+      voteCountGte: 500,
+      page: 1,
+    });
+  });
+
+  it('paginates across multiple pages', async () => {
+    mockDiscoverMovies
+      .mockResolvedValueOnce({
+        page: 1,
+        totalPages: 3,
+        totalResults: 60,
+        results: [
+          {
+            tmdbId: 278,
+            title: 'Movie 1',
+            releaseDate: '1994-01-01',
+            voteAverage: 9.0,
+            posterPath: null,
+            originalTitle: '',
+            overview: '',
+            backdropPath: null,
+            voteCount: 1000,
+            genreIds: [],
+            originalLanguage: 'en',
+            popularity: 50,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        page: 2,
+        totalPages: 3,
+        totalResults: 60,
+        results: [
+          {
+            tmdbId: 238,
+            title: 'Movie 2',
+            releaseDate: '1972-01-01',
+            voteAverage: 8.5,
+            posterPath: null,
+            originalTitle: '',
+            overview: '',
+            backdropPath: null,
+            voteCount: 900,
+            genreIds: [],
+            originalLanguage: 'en',
+            popularity: 40,
+          },
+        ],
+      });
+
+    const candidates = await tmdbTopRatedSource.fetchCandidates({ pages: 2 });
+
+    expect(candidates).toHaveLength(2);
+    expect(mockDiscoverMovies).toHaveBeenCalledTimes(2);
+  });
+
+  it('defaults to 5 pages when not specified', async () => {
+    // Return empty results for all pages
+    mockDiscoverMovies.mockResolvedValue({
+      page: 1,
+      totalPages: 1,
+      totalResults: 0,
+      results: [],
+    });
+
+    await tmdbTopRatedSource.fetchCandidates({});
+
+    // With totalPages=1, it stops after first page
+    expect(mockDiscoverMovies).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps pages at 25', async () => {
+    mockDiscoverMovies.mockResolvedValue({
+      page: 1,
+      totalPages: 100,
+      totalResults: 2000,
+      results: [
+        {
+          tmdbId: 1,
+          title: 'Movie',
+          releaseDate: '2020-01-01',
+          voteAverage: 7.0,
+          posterPath: null,
+          originalTitle: '',
+          overview: '',
+          backdropPath: null,
+          voteCount: 600,
+          genreIds: [],
+          originalLanguage: 'en',
+          popularity: 30,
+        },
+      ],
+    });
+
+    await tmdbTopRatedSource.fetchCandidates({ pages: 50 });
+
+    expect(mockDiscoverMovies).toHaveBeenCalledTimes(25);
+  });
+
+  it('handles null release date gracefully', async () => {
+    mockDiscoverMovies.mockResolvedValueOnce({
+      page: 1,
+      totalPages: 1,
+      totalResults: 1,
+      results: [
+        {
+          tmdbId: 999,
+          title: 'Unknown Year Movie',
+          releaseDate: '',
+          voteAverage: 7.5,
+          posterPath: null,
+          originalTitle: '',
+          overview: '',
+          backdropPath: null,
+          voteCount: 600,
+          genreIds: [],
+          originalLanguage: 'en',
+          popularity: 20,
+        },
+      ],
+    });
+
+    const candidates = await tmdbTopRatedSource.fetchCandidates({ pages: 1 });
+
+    expect(candidates[0]!.year).toBeNull();
+  });
+
+  it('returns empty array and logs warning on API error', async () => {
+    mockDiscoverMovies.mockRejectedValueOnce(new Error('API rate limited'));
+
+    const candidates = await tmdbTopRatedSource.fetchCandidates({ pages: 1 });
+
+    expect(candidates).toHaveLength(0);
+  });
+
+  it('stops early when totalPages exhausted', async () => {
+    mockDiscoverMovies.mockResolvedValueOnce({
+      page: 1,
+      totalPages: 1,
+      totalResults: 1,
+      results: [
+        {
+          tmdbId: 100,
+          title: 'Only Movie',
+          releaseDate: '2020-01-01',
+          voteAverage: 8.0,
+          posterPath: null,
+          originalTitle: '',
+          overview: '',
+          backdropPath: null,
+          voteCount: 700,
+          genreIds: [],
+          originalLanguage: 'en',
+          popularity: 25,
+        },
+      ],
+    });
+
+    const candidates = await tmdbTopRatedSource.fetchCandidates({ pages: 5 });
+
+    expect(candidates).toHaveLength(1);
+    expect(mockDiscoverMovies).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/pops-api/src/modules/media/rotation/tmdb-top-rated-source.ts
+++ b/apps/pops-api/src/modules/media/rotation/tmdb-top-rated-source.ts
@@ -1,0 +1,66 @@
+/**
+ * TMDB Top Rated rotation source adapter.
+ *
+ * PRD-071 US-04: fetches top-rated movies from TMDB as an alternative
+ * to scraping IMDB (which has no public API). Uses TMDB's discover
+ * endpoint sorted by vote average with a minimum vote count threshold.
+ */
+import { getTmdbClient } from '../tmdb/index.js';
+import { logger } from '../../../lib/logger.js';
+import type { CandidateMovie, RotationSourceAdapter } from './source-types.js';
+
+const DEFAULT_PAGES = 5;
+const MAX_PAGES = 25;
+const MIN_VOTE_COUNT = 500;
+
+export const tmdbTopRatedSource: RotationSourceAdapter = {
+  type: 'tmdb_top_rated',
+
+  async fetchCandidates(config: Record<string, unknown>): Promise<CandidateMovie[]> {
+    const pages = Math.min(
+      Math.max(1, typeof config.pages === 'number' ? config.pages : DEFAULT_PAGES),
+      MAX_PAGES
+    );
+
+    let client;
+    try {
+      client = getTmdbClient();
+    } catch {
+      logger.warn('[tmdb_top_rated] TMDB API key not configured — skipping');
+      return [];
+    }
+
+    const candidates: CandidateMovie[] = [];
+
+    for (let page = 1; page <= pages; page++) {
+      let result;
+      try {
+        result = await client.discoverMovies({
+          sortBy: 'vote_average.desc',
+          voteCountGte: MIN_VOTE_COUNT,
+          page,
+        });
+      } catch (err) {
+        logger.warn(
+          `[tmdb_top_rated] Failed fetching page ${page}: ${err instanceof Error ? err.message : String(err)}`
+        );
+        break;
+      }
+
+      for (const movie of result.results) {
+        candidates.push({
+          tmdbId: movie.tmdbId,
+          title: movie.title,
+          year: movie.releaseDate ? Number(movie.releaseDate.slice(0, 4)) || null : null,
+          rating: movie.voteAverage,
+          posterPath: movie.posterPath,
+        });
+      }
+
+      if (page >= result.totalPages) break;
+    }
+
+    logger.info(`[tmdb_top_rated] Fetched ${candidates.length} candidates from ${pages} page(s)`);
+    return candidates;
+  },
+};

--- a/docs/themes/03-media/prds/071-source-lists/README.md
+++ b/docs/themes/03-media/prds/071-source-lists/README.md
@@ -120,7 +120,7 @@ interface CandidateMovie {
 | 01  | [us-01-source-schema](us-01-source-schema.md)                     | Schema: `rotation_sources`, `rotation_candidates`, `rotation_exclusions` tables | Not started | Yes (parallel with PRD-070 US-01) |
 | 02  | [us-02-source-plugin-interface](us-02-source-plugin-interface.md) | Plugin interface + Plex watchlist adapter                                       | Not started | Blocked by US-01                  |
 | 03  | [us-03-plex-friends-source](us-03-plex-friends-source.md)         | Plex friends watchlist source adapter                                           | Done        | Blocked by US-02                  |
-| 04  | [us-04-external-list-source](us-04-external-list-source.md)       | IMDB/external list source adapter (web scraping or API)                         | Not started | Blocked by US-02                  |
+| 04  | [us-04-external-list-source](us-04-external-list-source.md)       | IMDB/external list source adapter (web scraping or API)                         | Done        | Blocked by US-02                  |
 | 05  | [us-05-selection-policy](us-05-selection-policy.md)               | Weighted random selection from candidate pool                                   | Not started | Blocked by US-01                  |
 | 06  | [us-06-exclusion-list](us-06-exclusion-list.md)                   | Exclusion list CRUD + filtering during selection                                | Not started | Blocked by US-01                  |
 | 07  | [us-07-source-sync-scheduler](us-07-source-sync-scheduler.md)     | Scheduled source syncing based on per-source intervals                          | Not started | Blocked by US-02                  |

--- a/docs/themes/03-media/prds/071-source-lists/us-04-external-list-source.md
+++ b/docs/themes/03-media/prds/071-source-lists/us-04-external-list-source.md
@@ -8,12 +8,12 @@ As a user, I want to add external movie lists (IMDB Top 100, Letterboxd lists) a
 
 ## Acceptance Criteria
 
-- [ ] `imdb_top_100` adapter fetches the IMDB Top 100 (or Top 250) list and extracts movie identifiers
-- [ ] IMDB IDs are resolved to TMDB IDs via the TMDB "find by external ID" endpoint
-- [ ] `letterboxd` adapter accepts a list URL in the source `config` and scrapes or fetches the list contents
-- [ ] Both adapters return `CandidateMovie[]` conforming to the plugin interface
-- [ ] Adapters handle pagination if the external list is large
-- [ ] Graceful degradation: if the external source is unreachable or the page structure changes, return empty array and log the error
+- [x] `tmdb_top_rated` adapter fetches top-rated movies via TMDB discover endpoint (used instead of IMDB scraping per notes — more maintainable)
+- [x] TMDB IDs come directly from the TMDB API response (no external ID resolution needed)
+- [x] `letterboxd` adapter accepts a list URL in the source `config` and scrapes the list contents
+- [x] Both adapters return `CandidateMovie[]` conforming to the plugin interface
+- [x] Adapters handle pagination if the external list is large
+- [x] Graceful degradation: if the external source is unreachable or the page structure changes, return empty array and log the error
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Adds `tmdb_top_rated` rotation source adapter — fetches top-rated movies via TMDB discover endpoint (sorted by vote average, min 500 votes). Configurable page count (default 5, max 25). More maintainable than scraping IMDB which has no public API.
- Adds `letterboxd` rotation source adapter — scrapes Letterboxd list URLs, extracts TMDB IDs from `data-tmdb-id` attributes on film poster elements. Handles multi-page pagination via "next" links.
- Both adapters conform to `RotationSourceAdapter` interface with graceful error handling (unreachable source → empty array + logged warning)
- Registered in source registry alongside existing `plex_watchlist` and `plex_friends` adapters

## Test plan

- [x] `tmdb-top-rated-source.test.ts` — 8 tests: pagination, page caps, error handling, null release dates
- [x] `letterboxd-source.test.ts` — 13 tests: HTML parsing, TMDB ID extraction, pagination, HTTP errors, network errors, config validation
- [x] Format, lint, typecheck all pass (full turbo typecheck across 14 packages)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)