### PR TITLE
feat(rotation): exclusion list CRUD + sync filtering (PRD-071 US-06) [tb-355]

### DIFF
--- a/apps/pops-api/src/modules/media/rotation/exclusion-list.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/exclusion-list.test.ts
@@ -1,0 +1,244 @@
+import { rotationCandidates, rotationExclusions, rotationSources } from '@pops/db-types';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getDrizzle } from '../../../db.js';
+import { createCaller, setupTestContext } from '../../../shared/test-utils.js';
+import { registerSourceAdapter } from './source-registry.js';
+import type { RotationSourceAdapter } from './source-types.js';
+import { syncSource } from './sync-source.js';
+
+const ctx = setupTestContext();
+
+function insertSource(overrides: Partial<typeof rotationSources.$inferInsert> = {}) {
+  const db = getDrizzle();
+  return db
+    .insert(rotationSources)
+    .values({ type: 'test', name: 'Test', priority: 5, enabled: 1, ...overrides })
+    .returning()
+    .get();
+}
+
+function insertCandidate(
+  sourceId: number,
+  tmdbId: number,
+  overrides: Partial<typeof rotationCandidates.$inferInsert> = {}
+) {
+  const db = getDrizzle();
+  return db
+    .insert(rotationCandidates)
+    .values({
+      sourceId,
+      tmdbId,
+      title: `Movie ${tmdbId}`,
+      status: 'pending',
+      ...overrides,
+    })
+    .returning()
+    .get();
+}
+
+// ---------------------------------------------------------------------------
+// tRPC exclusion endpoint tests
+// ---------------------------------------------------------------------------
+
+describe('rotation.listExclusions', () => {
+  beforeEach(() => ctx.setup());
+  afterEach(() => ctx.teardown());
+
+  it('returns empty list when no exclusions', async () => {
+    const caller = createCaller();
+    const result = await caller.media.rotation.listExclusions({});
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it('returns exclusions ordered by excludedAt desc', async () => {
+    const db = getDrizzle();
+    db.insert(rotationExclusions).values({ tmdbId: 100, title: 'Movie A' }).run();
+    db.insert(rotationExclusions).values({ tmdbId: 200, title: 'Movie B' }).run();
+
+    const caller = createCaller();
+    const result = await caller.media.rotation.listExclusions({});
+    expect(result.items).toHaveLength(2);
+    expect(result.total).toBe(2);
+  });
+
+  it('supports pagination with limit and offset', async () => {
+    const db = getDrizzle();
+    for (let i = 1; i <= 5; i++) {
+      db.insert(rotationExclusions)
+        .values({ tmdbId: i * 100, title: `Movie ${i}` })
+        .run();
+    }
+
+    const caller = createCaller();
+    const page1 = await caller.media.rotation.listExclusions({ limit: 2, offset: 0 });
+    expect(page1.items).toHaveLength(2);
+    expect(page1.total).toBe(5);
+
+    const page2 = await caller.media.rotation.listExclusions({ limit: 2, offset: 2 });
+    expect(page2.items).toHaveLength(2);
+  });
+});
+
+describe('rotation.excludeCandidate', () => {
+  beforeEach(() => ctx.setup());
+  afterEach(() => ctx.teardown());
+
+  it('adds movie to exclusion list', async () => {
+    const caller = createCaller();
+    const result = await caller.media.rotation.excludeCandidate({
+      tmdbId: 550,
+      title: 'Fight Club',
+      reason: 'Not interested',
+    });
+
+    expect(result.success).toBe(true);
+
+    const db = getDrizzle();
+    const exclusion = db
+      .select()
+      .from(rotationExclusions)
+      .where(eq(rotationExclusions.tmdbId, 550))
+      .get();
+    expect(exclusion).toBeTruthy();
+    expect(exclusion!.title).toBe('Fight Club');
+    expect(exclusion!.reason).toBe('Not interested');
+  });
+
+  it('marks matching candidate as excluded', async () => {
+    const source = insertSource();
+    insertCandidate(source.id, 550);
+
+    const caller = createCaller();
+    await caller.media.rotation.excludeCandidate({ tmdbId: 550, title: 'Fight Club' });
+
+    const db = getDrizzle();
+    const candidate = db
+      .select()
+      .from(rotationCandidates)
+      .where(eq(rotationCandidates.tmdbId, 550))
+      .get();
+    expect(candidate!.status).toBe('excluded');
+  });
+
+  it('does not error if no matching candidate exists', async () => {
+    const caller = createCaller();
+    const result = await caller.media.rotation.excludeCandidate({
+      tmdbId: 999,
+      title: 'No Candidate',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('is idempotent for duplicate tmdbId', async () => {
+    const caller = createCaller();
+    await caller.media.rotation.excludeCandidate({ tmdbId: 550, title: 'Fight Club' });
+    await caller.media.rotation.excludeCandidate({ tmdbId: 550, title: 'Fight Club' });
+
+    const db = getDrizzle();
+    const exclusions = db
+      .select()
+      .from(rotationExclusions)
+      .where(eq(rotationExclusions.tmdbId, 550))
+      .all();
+    expect(exclusions).toHaveLength(1);
+  });
+});
+
+describe('rotation.removeExclusion', () => {
+  beforeEach(() => ctx.setup());
+  afterEach(() => ctx.teardown());
+
+  it('removes exclusion and resets candidate to pending', async () => {
+    const source = insertSource();
+    insertCandidate(source.id, 550, { status: 'excluded' });
+
+    const db = getDrizzle();
+    db.insert(rotationExclusions).values({ tmdbId: 550, title: 'Fight Club' }).run();
+
+    const caller = createCaller();
+    const result = await caller.media.rotation.removeExclusion({ tmdbId: 550 });
+
+    expect(result.success).toBe(true);
+
+    const exclusion = db
+      .select()
+      .from(rotationExclusions)
+      .where(eq(rotationExclusions.tmdbId, 550))
+      .get();
+    expect(exclusion).toBeUndefined();
+
+    const candidate = db
+      .select()
+      .from(rotationCandidates)
+      .where(eq(rotationCandidates.tmdbId, 550))
+      .get();
+    expect(candidate!.status).toBe('pending');
+  });
+
+  it('returns success:false for non-existent exclusion', async () => {
+    const caller = createCaller();
+    const result = await caller.media.rotation.removeExclusion({ tmdbId: 999 });
+    expect(result.success).toBe(false);
+  });
+
+  it('does not reset candidate if exclusion did not exist', async () => {
+    const source = insertSource();
+    insertCandidate(source.id, 550, { status: 'added' });
+
+    const caller = createCaller();
+    await caller.media.rotation.removeExclusion({ tmdbId: 550 });
+
+    const db = getDrizzle();
+    const candidate = db
+      .select()
+      .from(rotationCandidates)
+      .where(eq(rotationCandidates.tmdbId, 550))
+      .get();
+    expect(candidate!.status).toBe('added');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sync source exclusion filtering
+// ---------------------------------------------------------------------------
+
+describe('syncSource exclusion filtering', () => {
+  beforeEach(() => {
+    ctx.setup();
+    const adapter: RotationSourceAdapter = {
+      type: 'test_excl',
+      fetchCandidates: vi.fn().mockResolvedValue([
+        { tmdbId: 100, title: 'Allowed Movie', year: 2020, rating: 7.0, posterPath: null },
+        { tmdbId: 200, title: 'Excluded Movie', year: 2021, rating: 8.0, posterPath: null },
+      ]),
+    };
+    registerSourceAdapter(adapter);
+  });
+
+  afterEach(() => ctx.teardown());
+
+  it('inserts excluded candidates with status excluded', async () => {
+    const db = getDrizzle();
+    db.insert(rotationExclusions).values({ tmdbId: 200, title: 'Excluded Movie' }).run();
+
+    const source = insertSource({ type: 'test_excl' });
+    await syncSource(source.id);
+
+    const allowed = db
+      .select()
+      .from(rotationCandidates)
+      .where(eq(rotationCandidates.tmdbId, 100))
+      .get();
+    const excluded = db
+      .select()
+      .from(rotationCandidates)
+      .where(eq(rotationCandidates.tmdbId, 200))
+      .get();
+
+    expect(allowed!.status).toBe('pending');
+    expect(excluded!.status).toBe('excluded');
+  });
+});

--- a/apps/pops-api/src/modules/media/rotation/router.ts
+++ b/apps/pops-api/src/modules/media/rotation/router.ts
@@ -3,7 +3,13 @@
  *
  * PRD-070 + PRD-071
  */
-import { movies, rotationLog, settings } from '@pops/db-types';
+import {
+  movies,
+  rotationCandidates,
+  rotationExclusions,
+  rotationLog,
+  settings,
+} from '@pops/db-types';
 import { asc, desc, eq } from 'drizzle-orm';
 import { z } from 'zod';
 
@@ -196,4 +202,78 @@ export const rotationRouter = router({
       };
     }
   }),
+
+  /** List exclusion entries, ordered by most recent first. */
+  listExclusions: protectedProcedure
+    .input(
+      z
+        .object({
+          limit: z.number().int().min(1).max(100).default(50),
+          offset: z.number().int().min(0).default(0),
+        })
+        .default({})
+    )
+    .query(({ input }) => {
+      const db = getDrizzle();
+      const items = db
+        .select()
+        .from(rotationExclusions)
+        .orderBy(desc(rotationExclusions.excludedAt))
+        .limit(input.limit)
+        .offset(input.offset)
+        .all();
+      const total = db
+        .select({ count: rotationExclusions.id })
+        .from(rotationExclusions)
+        .all().length;
+      return { items, total };
+    }),
+
+  /** Exclude a candidate — add to exclusion list and mark candidate as excluded. */
+  excludeCandidate: protectedProcedure
+    .input(
+      z.object({
+        tmdbId: z.number().int().positive(),
+        title: z.string().min(1),
+        reason: z.string().optional(),
+      })
+    )
+    .mutation(({ input }) => {
+      const db = getDrizzle();
+      db.insert(rotationExclusions)
+        .values({
+          tmdbId: input.tmdbId,
+          title: input.title,
+          reason: input.reason ?? null,
+        })
+        .onConflictDoNothing()
+        .run();
+
+      db.update(rotationCandidates)
+        .set({ status: 'excluded' })
+        .where(eq(rotationCandidates.tmdbId, input.tmdbId))
+        .run();
+
+      return { success: true };
+    }),
+
+  /** Remove a movie from the exclusion list. Resets matching candidate to pending. */
+  removeExclusion: protectedProcedure
+    .input(z.object({ tmdbId: z.number().int().positive() }))
+    .mutation(({ input }) => {
+      const db = getDrizzle();
+      const result = db
+        .delete(rotationExclusions)
+        .where(eq(rotationExclusions.tmdbId, input.tmdbId))
+        .run();
+
+      if (result.changes > 0) {
+        db.update(rotationCandidates)
+          .set({ status: 'pending' })
+          .where(eq(rotationCandidates.tmdbId, input.tmdbId))
+          .run();
+      }
+
+      return { success: result.changes > 0 };
+    }),
 });

--- a/apps/pops-api/src/modules/media/rotation/sync-source.ts
+++ b/apps/pops-api/src/modules/media/rotation/sync-source.ts
@@ -4,7 +4,7 @@
  *
  * PRD-071 US-02: syncSource(sourceId) implementation.
  */
-import { rotationCandidates, rotationSources } from '@pops/db-types';
+import { rotationCandidates, rotationExclusions, rotationSources } from '@pops/db-types';
 import { eq, sql } from 'drizzle-orm';
 
 import { getDrizzle } from '../../../db.js';
@@ -49,10 +49,20 @@ export async function syncSource(sourceId: number): Promise<SyncSourceResult> {
 
   const candidates = await adapter.fetchCandidates(config);
 
+  // Build set of excluded tmdb_ids for status assignment during upsert
+  const excludedTmdbIds = new Set(
+    db
+      .select({ tmdbId: rotationExclusions.tmdbId })
+      .from(rotationExclusions)
+      .all()
+      .map((r) => r.tmdbId)
+  );
+
   let inserted = 0;
   let skipped = 0;
 
   for (const candidate of candidates) {
+    const status = excludedTmdbIds.has(candidate.tmdbId) ? 'excluded' : 'pending';
     const result = db
       .insert(rotationCandidates)
       .values({
@@ -62,6 +72,7 @@ export async function syncSource(sourceId: number): Promise<SyncSourceResult> {
         year: candidate.year,
         rating: candidate.rating,
         posterPath: candidate.posterPath,
+        status,
       })
       .onConflictDoNothing()
       .run();

--- a/docs/themes/03-media/prds/071-source-lists/README.md
+++ b/docs/themes/03-media/prds/071-source-lists/README.md
@@ -122,7 +122,7 @@ interface CandidateMovie {
 | 03  | [us-03-plex-friends-source](us-03-plex-friends-source.md)         | Plex friends watchlist source adapter                                           | Done        | Blocked by US-02                  |
 | 04  | [us-04-external-list-source](us-04-external-list-source.md)       | IMDB/external list source adapter (web scraping or API)                         | Done        | Blocked by US-02                  |
 | 05  | [us-05-selection-policy](us-05-selection-policy.md)               | Weighted random selection from candidate pool                                   | Done        | Blocked by US-01                  |
-| 06  | [us-06-exclusion-list](us-06-exclusion-list.md)                   | Exclusion list CRUD + filtering during selection                                | Not started | Blocked by US-01                  |
+| 06  | [us-06-exclusion-list](us-06-exclusion-list.md)                   | Exclusion list CRUD + filtering during selection                                | Done        | Blocked by US-01                  |
 | 07  | [us-07-source-sync-scheduler](us-07-source-sync-scheduler.md)     | Scheduled source syncing based on per-source intervals                          | Not started | Blocked by US-02                  |
 
 ## Out of Scope

--- a/docs/themes/03-media/prds/071-source-lists/us-06-exclusion-list.md
+++ b/docs/themes/03-media/prds/071-source-lists/us-06-exclusion-list.md
@@ -8,12 +8,12 @@ As a user, I want to exclude specific movies from ever being added by the rotati
 
 ## Acceptance Criteria
 
-- [ ] `rotation.exclusions.list` returns paginated exclusion entries (title, tmdb_id, reason, excluded_at)
-- [ ] `rotation.candidates.exclude(tmdbId)` moves a candidate to the exclusion list: inserts into `rotation_exclusions`, updates candidate status to `'excluded'`
-- [ ] `rotation.exclusions.remove(tmdbId)` deletes from `rotation_exclusions`. If a matching candidate exists, resets its status to `'pending'`
-- [ ] Exclusion is checked during candidate selection (US-05) — excluded `tmdb_id`s are filtered out
-- [ ] Exclusion is checked during source sync — if a synced movie is in the exclusion list, it's inserted with `status = 'excluded'` rather than `'pending'`
-- [ ] Exclusion entries persist across source syncs (not deleted when sources are re-synced)
+- [x] `rotation.exclusions.list` returns paginated exclusion entries (title, tmdb_id, reason, excluded_at)
+- [x] `rotation.candidates.exclude(tmdbId)` moves a candidate to the exclusion list: inserts into `rotation_exclusions`, updates candidate status to `'excluded'`
+- [x] `rotation.exclusions.remove(tmdbId)` deletes from `rotation_exclusions`. If a matching candidate exists, resets its status to `'pending'`
+- [x] Exclusion is checked during candidate selection (US-05) — excluded `tmdb_id`s are filtered out
+- [x] Exclusion is checked during source sync — if a synced movie is in the exclusion list, it's inserted with `status = 'excluded'` rather than `'pending'`
+- [x] Exclusion entries persist across source syncs (not deleted when sources are re-synced)
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Add 3 tRPC endpoints: `listExclusions` (paginated), `excludeCandidate` (blocklist + mark candidate), `removeExclusion` (un-exclude + reset candidate to pending)
- Modify `syncSource` to check exclusion list during upsert — excluded movies get `status='excluded'` instead of `'pending'`
- Update PRD-071 docs: US-06 acceptance criteria checked, status → Done
- 11 tests covering all endpoints + sync exclusion filtering

## Test plan
- [x] All 11 tests pass (`pnpm vitest exclusion-list`)
- [x] Existing sync-source tests still pass (8/8)
- [x] `pnpm typecheck` green across all 14 packages
- [x] `pnpm lint` + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)