### PR TITLE
feat(rotation): source management CRUD + UI (PRD-072 US-03) [tb-359]

### DIFF
--- a/apps/pops-api/src/modules/media/rotation/router.ts
+++ b/apps/pops-api/src/modules/media/rotation/router.ts
@@ -8,9 +8,10 @@ import {
   rotationCandidates,
   rotationExclusions,
   rotationLog,
+  rotationSources,
   settings,
 } from '@pops/db-types';
-import { asc, desc, eq } from 'drizzle-orm';
+import { asc, count, desc, eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { getDrizzle } from '../../../db.js';
@@ -202,6 +203,120 @@ export const rotationRouter = router({
       };
     }
   }),
+
+  /** List all configured sources with candidate counts. */
+  listSources: protectedProcedure.query(() => {
+    const db = getDrizzle();
+    const sources = db
+      .select({
+        id: rotationSources.id,
+        type: rotationSources.type,
+        name: rotationSources.name,
+        priority: rotationSources.priority,
+        enabled: rotationSources.enabled,
+        config: rotationSources.config,
+        lastSyncedAt: rotationSources.lastSyncedAt,
+        syncIntervalHours: rotationSources.syncIntervalHours,
+        createdAt: rotationSources.createdAt,
+        candidateCount: count(rotationCandidates.id),
+      })
+      .from(rotationSources)
+      .leftJoin(rotationCandidates, eq(rotationSources.id, rotationCandidates.sourceId))
+      .groupBy(rotationSources.id)
+      .orderBy(desc(rotationSources.priority))
+      .all();
+    return sources;
+  }),
+
+  /** Create a new rotation source. */
+  createSource: protectedProcedure
+    .input(
+      z.object({
+        type: z.string().min(1),
+        name: z.string().min(1),
+        priority: z.number().int().min(1).max(10).default(5),
+        enabled: z.boolean().default(true),
+        config: z.record(z.unknown()).default({}),
+        syncIntervalHours: z.number().int().min(1).default(24),
+      })
+    )
+    .mutation(({ input }) => {
+      const db = getDrizzle();
+      return db
+        .insert(rotationSources)
+        .values({
+          type: input.type,
+          name: input.name,
+          priority: input.priority,
+          enabled: input.enabled ? 1 : 0,
+          config: JSON.stringify(input.config),
+          syncIntervalHours: input.syncIntervalHours,
+        })
+        .returning()
+        .get();
+    }),
+
+  /** Update an existing rotation source. */
+  updateSource: protectedProcedure
+    .input(
+      z.object({
+        id: z.number().int().positive(),
+        name: z.string().min(1).optional(),
+        priority: z.number().int().min(1).max(10).optional(),
+        enabled: z.boolean().optional(),
+        config: z.record(z.unknown()).optional(),
+        syncIntervalHours: z.number().int().min(1).optional(),
+      })
+    )
+    .mutation(({ input }) => {
+      const db = getDrizzle();
+      const updates: Record<string, unknown> = {};
+      if (input.name !== undefined) updates.name = input.name;
+      if (input.priority !== undefined) updates.priority = input.priority;
+      if (input.enabled !== undefined) updates.enabled = input.enabled ? 1 : 0;
+      if (input.config !== undefined) updates.config = JSON.stringify(input.config);
+      if (input.syncIntervalHours !== undefined)
+        updates.syncIntervalHours = input.syncIntervalHours;
+
+      if (Object.keys(updates).length === 0) {
+        return { success: false, message: 'No fields to update' };
+      }
+
+      const result = db
+        .update(rotationSources)
+        .set(updates)
+        .where(eq(rotationSources.id, input.id))
+        .run();
+
+      return { success: result.changes > 0 };
+    }),
+
+  /** Delete a rotation source and its candidates. */
+  deleteSource: protectedProcedure
+    .input(z.object({ id: z.number().int().positive() }))
+    .mutation(({ input }) => {
+      const db = getDrizzle();
+
+      // Check if it's the manual source (cannot delete)
+      const source = db
+        .select({ type: rotationSources.type })
+        .from(rotationSources)
+        .where(eq(rotationSources.id, input.id))
+        .get();
+
+      if (!source) {
+        return { success: false, message: 'Source not found' };
+      }
+      if (source.type === 'manual') {
+        return { success: false, message: 'Cannot delete the manual source' };
+      }
+
+      // Delete candidates first, then the source
+      db.delete(rotationCandidates).where(eq(rotationCandidates.sourceId, input.id)).run();
+      db.delete(rotationSources).where(eq(rotationSources.id, input.id)).run();
+
+      return { success: true };
+    }),
 
   /** List exclusion entries, ordered by most recent first. */
   listExclusions: protectedProcedure

--- a/apps/pops-api/src/modules/media/rotation/source-crud.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/source-crud.test.ts
@@ -1,0 +1,222 @@
+import { rotationCandidates, rotationSources } from '@pops/db-types';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getDrizzle } from '../../../db.js';
+import { createCaller, setupTestContext } from '../../../shared/test-utils.js';
+
+const ctx = setupTestContext();
+
+function insertSource(overrides: Partial<typeof rotationSources.$inferInsert> = {}) {
+  const db = getDrizzle();
+  return db
+    .insert(rotationSources)
+    .values({ type: 'test', name: 'Test', priority: 5, enabled: 1, ...overrides })
+    .returning()
+    .get();
+}
+
+function insertCandidate(
+  sourceId: number,
+  tmdbId: number,
+  overrides: Partial<typeof rotationCandidates.$inferInsert> = {}
+) {
+  const db = getDrizzle();
+  return db
+    .insert(rotationCandidates)
+    .values({
+      sourceId,
+      tmdbId,
+      title: `Movie ${tmdbId}`,
+      status: 'pending',
+      ...overrides,
+    })
+    .returning()
+    .get();
+}
+
+// ---------------------------------------------------------------------------
+// listSources
+// ---------------------------------------------------------------------------
+
+describe('rotation.listSources', () => {
+  beforeEach(() => ctx.setup());
+  afterEach(() => ctx.teardown());
+
+  it('returns empty list when no sources', async () => {
+    const caller = createCaller();
+    const result = await caller.media.rotation.listSources();
+    expect(result).toEqual([]);
+  });
+
+  it('returns sources ordered by priority descending', async () => {
+    insertSource({ name: 'Low', priority: 2 });
+    insertSource({ name: 'High', priority: 9 });
+    insertSource({ name: 'Mid', priority: 5 });
+
+    const caller = createCaller();
+    const result = await caller.media.rotation.listSources();
+
+    expect(result).toHaveLength(3);
+    expect(result[0]!.name).toBe('High');
+    expect(result[1]!.name).toBe('Mid');
+    expect(result[2]!.name).toBe('Low');
+  });
+
+  it('includes candidate count per source', async () => {
+    const src = insertSource({ name: 'WithCandidates' });
+    insertCandidate(src.id, 100);
+    insertCandidate(src.id, 200);
+    insertSource({ name: 'Empty' });
+
+    const caller = createCaller();
+    const result = await caller.media.rotation.listSources();
+
+    const withCandidates = result.find((s) => s.name === 'WithCandidates');
+    const empty = result.find((s) => s.name === 'Empty');
+    expect(withCandidates?.candidateCount).toBe(2);
+    expect(empty?.candidateCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSource
+// ---------------------------------------------------------------------------
+
+describe('rotation.createSource', () => {
+  beforeEach(() => ctx.setup());
+  afterEach(() => ctx.teardown());
+
+  it('creates a source with defaults', async () => {
+    const caller = createCaller();
+    const result = await caller.media.rotation.createSource({
+      type: 'plex_watchlist',
+      name: 'My Watchlist',
+    });
+
+    expect(result.type).toBe('plex_watchlist');
+    expect(result.name).toBe('My Watchlist');
+    expect(result.priority).toBe(5);
+    expect(result.enabled).toBe(1);
+    expect(result.syncIntervalHours).toBe(24);
+  });
+
+  it('creates a source with custom values', async () => {
+    const caller = createCaller();
+    const result = await caller.media.rotation.createSource({
+      type: 'plex_friends',
+      name: 'Friend List',
+      priority: 8,
+      enabled: false,
+      config: { friendUuid: 'abc123' },
+      syncIntervalHours: 12,
+    });
+
+    expect(result.name).toBe('Friend List');
+    expect(result.priority).toBe(8);
+    expect(result.enabled).toBe(0);
+    expect(result.syncIntervalHours).toBe(12);
+    expect(JSON.parse(result.config!)).toEqual({ friendUuid: 'abc123' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateSource
+// ---------------------------------------------------------------------------
+
+describe('rotation.updateSource', () => {
+  beforeEach(() => ctx.setup());
+  afterEach(() => ctx.teardown());
+
+  it('updates name and priority', async () => {
+    const src = insertSource({ name: 'Old Name', priority: 3 });
+
+    const caller = createCaller();
+    const result = await caller.media.rotation.updateSource({
+      id: src.id,
+      name: 'New Name',
+      priority: 9,
+    });
+
+    expect(result).toEqual({ success: true });
+
+    const db = getDrizzle();
+    const updated = db.select().from(rotationSources).where(eq(rotationSources.id, src.id)).get();
+    expect(updated?.name).toBe('New Name');
+    expect(updated?.priority).toBe(9);
+  });
+
+  it('toggles enabled status', async () => {
+    const src = insertSource({ enabled: 1 });
+
+    const caller = createCaller();
+    await caller.media.rotation.updateSource({ id: src.id, enabled: false });
+
+    const db = getDrizzle();
+    const updated = db.select().from(rotationSources).where(eq(rotationSources.id, src.id)).get();
+    expect(updated?.enabled).toBe(0);
+  });
+
+  it('returns failure when no fields provided', async () => {
+    const src = insertSource();
+
+    const caller = createCaller();
+    const result = await caller.media.rotation.updateSource({ id: src.id });
+
+    expect(result).toEqual({ success: false, message: 'No fields to update' });
+  });
+
+  it('returns failure for nonexistent source', async () => {
+    const caller = createCaller();
+    const result = await caller.media.rotation.updateSource({ id: 99999, name: 'X' });
+
+    expect(result).toEqual({ success: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteSource
+// ---------------------------------------------------------------------------
+
+describe('rotation.deleteSource', () => {
+  beforeEach(() => ctx.setup());
+  afterEach(() => ctx.teardown());
+
+  it('deletes source and its candidates', async () => {
+    const src = insertSource({ type: 'plex_watchlist', name: 'Deletable' });
+    insertCandidate(src.id, 100);
+    insertCandidate(src.id, 200);
+
+    const caller = createCaller();
+    const result = await caller.media.rotation.deleteSource({ id: src.id });
+
+    expect(result).toEqual({ success: true });
+
+    const db = getDrizzle();
+    const sources = db.select().from(rotationSources).all();
+    expect(sources).toHaveLength(0);
+
+    const candidates = db.select().from(rotationCandidates).all();
+    expect(candidates).toHaveLength(0);
+  });
+
+  it('prevents deleting manual source', async () => {
+    const src = insertSource({ type: 'manual', name: 'Manual Queue' });
+
+    const caller = createCaller();
+    const result = await caller.media.rotation.deleteSource({ id: src.id });
+
+    expect(result).toEqual({ success: false, message: 'Cannot delete the manual source' });
+
+    const db = getDrizzle();
+    const sources = db.select().from(rotationSources).all();
+    expect(sources).toHaveLength(1);
+  });
+
+  it('returns failure for nonexistent source', async () => {
+    const caller = createCaller();
+    const result = await caller.media.rotation.deleteSource({ id: 99999 });
+
+    expect(result).toEqual({ success: false, message: 'Source not found' });
+  });
+});

--- a/docs/themes/03-media/prds/072-rotation-ui/README.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/README.md
@@ -125,7 +125,7 @@ Paginated history of rotation cycles. Each entry shows:
 | --- | --------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------- | --------------------------------------- |
 | 01  | [us-01-leaving-soon-shelf](us-01-leaving-soon-shelf.md)         | Leaving Soon shelf on Library + Discover pages, countdown badges on cards | Done        | Blocked by PRD-070 US-03                |
 | 02  | [us-02-rotation-settings](us-02-rotation-settings.md)           | Rotation settings page with all configuration controls                    | Done        | Blocked by PRD-070 US-01                |
-| 03  | [us-03-source-management](us-03-source-management.md)           | Source list CRUD page with type-specific config                           | Not started | Blocked by PRD-071 US-01                |
+| 03  | [us-03-source-management](us-03-source-management.md)           | Source list CRUD page with type-specific config                           | Done        | Blocked by PRD-071 US-01                |
 | 04  | [us-04-candidate-queue](us-04-candidate-queue.md)               | Candidate queue page with tabs (pending, added, excluded)                 | Not started | Blocked by PRD-071 US-01                |
 | 05  | [us-05-queue-download-buttons](us-05-queue-download-buttons.md) | "Add to Queue" and "Download" buttons on discovery pages                  | Not started | Blocked by PRD-071 US-01, PRD-070 US-01 |
 | 06  | [us-06-rotation-log](us-06-rotation-log.md)                     | Rotation execution history page                                           | Not started | Blocked by PRD-070 US-06                |

--- a/docs/themes/03-media/prds/072-rotation-ui/us-03-source-management.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/us-03-source-management.md
@@ -8,14 +8,14 @@ As a user, I want to add, edit, and remove rotation sources so that I control wh
 
 ## Acceptance Criteria
 
-- [ ] Source list page shows all configured sources: name, type icon, priority (visual bar or number), enabled toggle, last synced timestamp, candidate count
-- [ ] "Add Source" button opens a create modal with: type selector (dropdown), name input, priority slider (1-10), type-specific config fields, sync interval input
-- [ ] Type-specific config fields render dynamically based on selected type (see PRD-072 table)
-- [ ] Edit modal pre-fills existing values; allows changing name, priority, config, enabled, interval
-- [ ] Delete source shows confirmation dialog warning that its candidates will also be removed
-- [ ] "Sync Now" button per source triggers immediate sync with loading indicator
-- [ ] The `manual` source appears in the list but cannot be deleted or have its type changed
-- [ ] Sources can be reordered by dragging (updates priority values) or priority can be set numerically
+- [x] Source list page shows all configured sources: name, type icon, priority (visual bar or number), enabled toggle, last synced timestamp, candidate count
+- [x] "Add Source" button opens a create modal with: type selector (dropdown), name input, priority slider (1-10), type-specific config fields, sync interval input
+- [x] Type-specific config fields render dynamically based on selected type (see PRD-072 table)
+- [x] Edit modal pre-fills existing values; allows changing name, priority, config, enabled, interval
+- [x] Delete source shows confirmation dialog warning that its candidates will also be removed
+- [x] "Sync Now" button per source triggers immediate sync with loading indicator
+- [x] The `manual` source appears in the list but cannot be deleted or have its type changed
+- [x] Sources can be reordered by dragging (updates priority values) or priority can be set numerically
 
 ## Notes
 

--- a/packages/app-media/src/components/SourceManagementSection.tsx
+++ b/packages/app-media/src/components/SourceManagementSection.tsx
@@ -1,0 +1,451 @@
+/**
+ * SourceManagementSection — CRUD UI for rotation source management.
+ *
+ * PRD-072 US-03
+ */
+import { Button, Label, NumberInput, Select, Switch } from '@pops/ui';
+import { Clock, Database, Plus, RefreshCw, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { trpc } from '../lib/trpc';
+
+// ---------------------------------------------------------------------------
+// Type icons for source types
+// ---------------------------------------------------------------------------
+
+const SOURCE_TYPE_LABELS: Record<string, string> = {
+  plex_watchlist: 'Plex Watchlist',
+  plex_friends: 'Plex Friends',
+  tmdb_top_rated: 'TMDB Top Rated',
+  letterboxd: 'Letterboxd',
+  manual: 'Manual Queue',
+};
+
+function sourceTypeLabel(type: string): string {
+  return SOURCE_TYPE_LABELS[type] ?? type;
+}
+
+function formatSyncDate(iso: string | null): string {
+  if (!iso) return 'Never';
+  return new Date(iso).toLocaleString();
+}
+
+// ---------------------------------------------------------------------------
+// Source card
+// ---------------------------------------------------------------------------
+
+interface SourceCardProps {
+  source: {
+    id: number;
+    type: string;
+    name: string;
+    priority: number;
+    enabled: number;
+    config: string | null;
+    lastSyncedAt: string | null;
+    syncIntervalHours: number;
+    candidateCount: number;
+  };
+  onEdit: () => void;
+}
+
+function SourceCard({ source, onEdit }: SourceCardProps) {
+  const utils = trpc.useUtils();
+
+  const syncMutation = trpc.media.rotation.syncSource.useMutation({
+    onSuccess: (data) => {
+      toast.success(`Synced "${source.name}": ${data.candidatesInserted} new candidates`);
+      void utils.media.rotation.listSources.invalidate();
+    },
+    onError: () => toast.error(`Failed to sync "${source.name}"`),
+  });
+
+  const toggleMutation = trpc.media.rotation.updateSource.useMutation({
+    onSuccess: () => {
+      void utils.media.rotation.listSources.invalidate();
+    },
+    onError: () => toast.error('Failed to update source'),
+  });
+
+  const deleteMutation = trpc.media.rotation.deleteSource.useMutation({
+    onSuccess: (data) => {
+      if (data.success) {
+        toast.success(`Deleted "${source.name}"`);
+        void utils.media.rotation.listSources.invalidate();
+      } else {
+        toast.error('message' in data ? data.message : 'Failed to delete source');
+      }
+    },
+    onError: () => toast.error('Failed to delete source'),
+  });
+
+  const isManual = source.type === 'manual';
+
+  return (
+    <div className="flex items-center gap-4 rounded-md border p-4">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-medium truncate">{source.name}</span>
+          <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+            {sourceTypeLabel(source.type)}
+          </span>
+        </div>
+        <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
+          <span>Priority: {source.priority}/10</span>
+          <span className="flex items-center gap-1">
+            <Database className="h-3 w-3" />
+            {source.candidateCount} candidates
+          </span>
+          <span className="flex items-center gap-1">
+            <Clock className="h-3 w-3" />
+            {formatSyncDate(source.lastSyncedAt)}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 shrink-0">
+        <Switch
+          checked={source.enabled === 1}
+          onCheckedChange={(checked) => toggleMutation.mutate({ id: source.id, enabled: checked })}
+          disabled={toggleMutation.isPending}
+          aria-label={`Toggle ${source.name}`}
+        />
+
+        {!isManual && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => syncMutation.mutate({ sourceId: source.id })}
+            disabled={syncMutation.isPending || source.enabled !== 1}
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${syncMutation.isPending ? 'animate-spin' : ''}`} />
+          </Button>
+        )}
+
+        <Button variant="outline" size="sm" onClick={onEdit}>
+          Edit
+        </Button>
+
+        {!isManual && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              if (window.confirm(`Delete "${source.name}" and all its candidates?`)) {
+                deleteMutation.mutate({ id: source.id });
+              }
+            }}
+            disabled={deleteMutation.isPending}
+          >
+            <Trash2 className="h-3.5 w-3.5 text-destructive" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Source form (shared between create and edit)
+// ---------------------------------------------------------------------------
+
+interface SourceFormProps {
+  mode: 'create' | 'edit';
+  initialValues?: {
+    id?: number;
+    type: string;
+    name: string;
+    priority: number;
+    enabled: boolean;
+    config: Record<string, unknown>;
+    syncIntervalHours: number;
+  };
+  sourceTypes: string[];
+  onClose: () => void;
+}
+
+function SourceForm({ mode, initialValues, sourceTypes, onClose }: SourceFormProps) {
+  const [type, setType] = useState(initialValues?.type ?? sourceTypes[0] ?? 'plex_watchlist');
+  const [name, setName] = useState(initialValues?.name ?? '');
+  const [priority, setPriority] = useState(initialValues?.priority ?? 5);
+  const [enabled, setEnabled] = useState(initialValues?.enabled ?? true);
+  const [syncIntervalHours, setSyncIntervalHours] = useState(
+    initialValues?.syncIntervalHours ?? 24
+  );
+  // Type-specific config
+  const [configValues, setConfigValues] = useState<Record<string, unknown>>(
+    initialValues?.config ?? {}
+  );
+
+  const utils = trpc.useUtils();
+
+  const createMutation = trpc.media.rotation.createSource.useMutation({
+    onSuccess: () => {
+      toast.success('Source created');
+      void utils.media.rotation.listSources.invalidate();
+      onClose();
+    },
+    onError: () => toast.error('Failed to create source'),
+  });
+
+  const updateMutation = trpc.media.rotation.updateSource.useMutation({
+    onSuccess: () => {
+      toast.success('Source updated');
+      void utils.media.rotation.listSources.invalidate();
+      onClose();
+    },
+    onError: () => toast.error('Failed to update source'),
+  });
+
+  const plexFriendsQuery = trpc.media.rotation.listPlexFriends.useQuery(undefined, {
+    enabled: type === 'plex_friends',
+  });
+
+  const handleSubmit = () => {
+    if (!name.trim()) {
+      toast.error('Name is required');
+      return;
+    }
+
+    if (mode === 'create') {
+      createMutation.mutate({
+        type,
+        name: name.trim(),
+        priority,
+        enabled,
+        config: configValues,
+        syncIntervalHours,
+      });
+    } else if (initialValues?.id) {
+      updateMutation.mutate({
+        id: initialValues.id,
+        name: name.trim(),
+        priority,
+        enabled,
+        config: configValues,
+        syncIntervalHours,
+      });
+    }
+  };
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <div className="rounded-lg border bg-card p-6 space-y-4">
+      <h3 className="text-lg font-semibold">{mode === 'create' ? 'Add Source' : 'Edit Source'}</h3>
+
+      {mode === 'create' && (
+        <div className="space-y-1.5">
+          <Label className="text-muted-foreground">Source Type</Label>
+          <Select
+            value={type}
+            onChange={(e) => {
+              setType(e.target.value);
+              setConfigValues({});
+            }}
+            options={sourceTypes.map((t) => ({ value: t, label: sourceTypeLabel(t) }))}
+            size="sm"
+          />
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <Label className="text-muted-foreground">Name</Label>
+        <input
+          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Source name"
+        />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label className="text-muted-foreground">Priority (1-10)</Label>
+          <NumberInput
+            value={priority}
+            onChange={(e) => setPriority(Math.min(10, Math.max(1, Number(e.target.value) || 1)))}
+            min={1}
+            max={10}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label className="text-muted-foreground">Sync interval (hours)</Label>
+          <NumberInput
+            value={syncIntervalHours}
+            onChange={(e) => setSyncIntervalHours(Math.max(1, Number(e.target.value) || 1))}
+            min={1}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Switch checked={enabled} onCheckedChange={setEnabled} />
+        <Label className="text-muted-foreground">Enabled</Label>
+      </div>
+
+      {/* Type-specific config fields */}
+      {type === 'plex_friends' && (
+        <div className="space-y-1.5">
+          <Label className="text-muted-foreground">Plex Friend</Label>
+          {plexFriendsQuery.isLoading ? (
+            <p className="text-xs text-muted-foreground">Loading friends...</p>
+          ) : plexFriendsQuery.data?.error ? (
+            <p className="text-xs text-red-400">{plexFriendsQuery.data.error}</p>
+          ) : (
+            <Select
+              value={(configValues.friendUuid as string) ?? ''}
+              onChange={(e) => {
+                const friend = plexFriendsQuery.data?.friends.find(
+                  (f) => f.uuid === e.target.value
+                );
+                setConfigValues({
+                  friendUuid: e.target.value,
+                  friendUsername: friend?.username ?? '',
+                });
+              }}
+              options={[
+                { value: '', label: 'Select a friend...' },
+                ...(plexFriendsQuery.data?.friends.map((f) => ({
+                  value: f.uuid,
+                  label: f.username,
+                })) ?? []),
+              ]}
+              size="sm"
+            />
+          )}
+        </div>
+      )}
+
+      {type === 'letterboxd' && (
+        <div className="space-y-1.5">
+          <Label className="text-muted-foreground">List URL</Label>
+          <input
+            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            value={(configValues.listUrl as string) ?? ''}
+            onChange={(e) => setConfigValues({ ...configValues, listUrl: e.target.value })}
+            placeholder="https://letterboxd.com/user/list/name/"
+          />
+        </div>
+      )}
+
+      {type === 'tmdb_top_rated' && (
+        <div className="space-y-1.5">
+          <Label className="text-muted-foreground">Pages to fetch (1-25)</Label>
+          <NumberInput
+            value={(configValues.pages as number) ?? 5}
+            onChange={(e) =>
+              setConfigValues({
+                ...configValues,
+                pages: Math.min(25, Math.max(1, Number(e.target.value) || 5)),
+              })
+            }
+            min={1}
+            max={25}
+          />
+          <p className="text-xs text-muted-foreground">~20 movies per page</p>
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <Button onClick={handleSubmit} disabled={isPending} size="sm">
+          {isPending ? <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" /> : null}
+          {mode === 'create' ? 'Add Source' : 'Save Changes'}
+        </Button>
+        <Button variant="outline" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main section
+// ---------------------------------------------------------------------------
+
+export function SourceManagementSection() {
+  const sourcesQuery = trpc.media.rotation.listSources.useQuery();
+  const sourceTypesQuery = trpc.media.rotation.sourceTypes.useQuery();
+
+  const [showForm, setShowForm] = useState<'create' | 'edit' | null>(null);
+  const [editingSource, setEditingSource] = useState<{
+    id: number;
+    type: string;
+    name: string;
+    priority: number;
+    enabled: boolean;
+    config: Record<string, unknown>;
+    syncIntervalHours: number;
+  } | null>(null);
+
+  const handleEdit = (source: NonNullable<typeof sourcesQuery.data>[number]) => {
+    let config: Record<string, unknown> = {};
+    try {
+      if (source.config) config = JSON.parse(source.config) as Record<string, unknown>;
+    } catch {
+      /* empty */
+    }
+    setEditingSource({
+      id: source.id,
+      type: source.type,
+      name: source.name,
+      priority: source.priority,
+      enabled: source.enabled === 1,
+      config,
+      syncIntervalHours: source.syncIntervalHours,
+    });
+    setShowForm('edit');
+  };
+
+  const sourceTypes = sourceTypesQuery.data?.types ?? [];
+
+  return (
+    <div className="rounded-lg border bg-card p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Sources</h2>
+          <p className="text-sm text-muted-foreground">
+            Configure where candidate movies come from
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            setEditingSource(null);
+            setShowForm('create');
+          }}
+        >
+          <Plus className="h-3.5 w-3.5 mr-1.5" />
+          Add Source
+        </Button>
+      </div>
+
+      {showForm && (
+        <SourceForm
+          mode={showForm}
+          initialValues={showForm === 'edit' && editingSource ? editingSource : undefined}
+          sourceTypes={sourceTypes}
+          onClose={() => {
+            setShowForm(null);
+            setEditingSource(null);
+          }}
+        />
+      )}
+
+      <div className="space-y-2">
+        {sourcesQuery.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading sources...</p>
+        ) : !sourcesQuery.data?.length ? (
+          <p className="text-sm text-muted-foreground">No sources configured</p>
+        ) : (
+          sourcesQuery.data.map((source) => (
+            <SourceCard key={source.id} source={source} onEdit={() => handleEdit(source)} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/app-media/src/pages/RotationSettingsPage.tsx
+++ b/packages/app-media/src/pages/RotationSettingsPage.tsx
@@ -22,6 +22,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import { toast } from 'sonner';
 
+import { SourceManagementSection } from '../components/SourceManagementSection';
 import { trpc } from '../lib/trpc';
 
 const SCHEDULE_PRESETS = [
@@ -321,6 +322,9 @@ export function RotationSettingsPage() {
           Save Settings
         </Button>
       </fieldset>
+
+      {/* Sources */}
+      <SourceManagementSection />
 
       {/* Disk space */}
       <div className="rounded-lg border bg-card p-6 space-y-4">


### PR DESCRIPTION
## Summary
- Add 4 tRPC endpoints for source CRUD: `listSources` (with candidate counts via LEFT JOIN), `createSource`, `updateSource`, `deleteSource` (with manual source protection + cascade delete)
- New `SourceManagementSection` component with `SourceCard` (toggle/sync/edit/delete actions) and `SourceForm` (dynamic type-specific config: Plex friends dropdown, Letterboxd URL, TMDB pages)
- Integrated into `RotationSettingsPage` between Parameters and Disk Space sections
- 12 backend integration tests covering all CRUD endpoints and edge cases

## Test plan
- [x] `pnpm turbo typecheck` passes across all 14 packages
- [x] 12 source CRUD tests pass (`source-crud.test.ts`)
- [x] Pre-commit hooks pass (oxfmt, eslint, typecheck)
- [ ] Manual verification: source list renders, add/edit/delete/toggle/sync work end-to-end
- [ ] Verify Plex friends picker populates from API when creating `plex_friends` source

🤖 Generated with [Claude Code](https://claude.com/claude-code)