### PR TITLE
fix: source CRUD error handling + delete transaction [tb-359]

### DIFF
--- a/apps/pops-api/src/modules/media/rotation/router.ts
+++ b/apps/pops-api/src/modules/media/rotation/router.ts
@@ -11,6 +11,7 @@ import {
   rotationSources,
   settings,
 } from '@pops/db-types';
+import { TRPCError } from '@trpc/server';
 import { asc, count, desc, eq } from 'drizzle-orm';
 import { z } from 'zod';
 
@@ -279,7 +280,7 @@ export const rotationRouter = router({
         updates.syncIntervalHours = input.syncIntervalHours;
 
       if (Object.keys(updates).length === 0) {
-        return { success: false, message: 'No fields to update' };
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No fields to update' });
       }
 
       const result = db
@@ -305,15 +306,17 @@ export const rotationRouter = router({
         .get();
 
       if (!source) {
-        return { success: false, message: 'Source not found' };
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Source not found' });
       }
       if (source.type === 'manual') {
-        return { success: false, message: 'Cannot delete the manual source' };
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot delete the manual source' });
       }
 
-      // Delete candidates first, then the source
-      db.delete(rotationCandidates).where(eq(rotationCandidates.sourceId, input.id)).run();
-      db.delete(rotationSources).where(eq(rotationSources.id, input.id)).run();
+      // Delete candidates first, then the source — in a transaction
+      db.transaction(() => {
+        db.delete(rotationCandidates).where(eq(rotationCandidates.sourceId, input.id)).run();
+        db.delete(rotationSources).where(eq(rotationSources.id, input.id)).run();
+      });
 
       return { success: true };
     }),

--- a/apps/pops-api/src/modules/media/rotation/source-crud.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/source-crud.test.ts
@@ -157,16 +157,16 @@ describe('rotation.updateSource', () => {
     expect(updated?.enabled).toBe(0);
   });
 
-  it('returns failure when no fields provided', async () => {
+  it('throws when no fields provided', async () => {
     const src = insertSource();
 
     const caller = createCaller();
-    const result = await caller.media.rotation.updateSource({ id: src.id });
-
-    expect(result).toEqual({ success: false, message: 'No fields to update' });
+    await expect(caller.media.rotation.updateSource({ id: src.id })).rejects.toThrow(
+      'No fields to update'
+    );
   });
 
-  it('returns failure for nonexistent source', async () => {
+  it('returns no changes for nonexistent source', async () => {
     const caller = createCaller();
     const result = await caller.media.rotation.updateSource({ id: 99999, name: 'X' });
 
@@ -204,19 +204,19 @@ describe('rotation.deleteSource', () => {
     const src = insertSource({ type: 'manual', name: 'Manual Queue' });
 
     const caller = createCaller();
-    const result = await caller.media.rotation.deleteSource({ id: src.id });
-
-    expect(result).toEqual({ success: false, message: 'Cannot delete the manual source' });
+    await expect(caller.media.rotation.deleteSource({ id: src.id })).rejects.toThrow(
+      'Cannot delete the manual source'
+    );
 
     const db = getDrizzle();
     const sources = db.select().from(rotationSources).all();
     expect(sources).toHaveLength(1);
   });
 
-  it('returns failure for nonexistent source', async () => {
+  it('throws for nonexistent source', async () => {
     const caller = createCaller();
-    const result = await caller.media.rotation.deleteSource({ id: 99999 });
-
-    expect(result).toEqual({ success: false, message: 'Source not found' });
+    await expect(caller.media.rotation.deleteSource({ id: 99999 })).rejects.toThrow(
+      'Source not found'
+    );
   });
 });

--- a/packages/app-media/src/components/SourceManagementSection.tsx
+++ b/packages/app-media/src/components/SourceManagementSection.tsx
@@ -69,15 +69,11 @@ function SourceCard({ source, onEdit }: SourceCardProps) {
   });
 
   const deleteMutation = trpc.media.rotation.deleteSource.useMutation({
-    onSuccess: (data) => {
-      if (data.success) {
-        toast.success(`Deleted "${source.name}"`);
-        void utils.media.rotation.listSources.invalidate();
-      } else {
-        toast.error('message' in data ? data.message : 'Failed to delete source');
-      }
+    onSuccess: () => {
+      toast.success(`Deleted "${source.name}"`);
+      void utils.media.rotation.listSources.invalidate();
     },
-    onError: () => toast.error('Failed to delete source'),
+    onError: (err) => toast.error(err.message || 'Failed to delete source'),
   });
 
   const isManual = source.type === 'manual';


### PR DESCRIPTION
## Summary
- **updateSource**: throw `TRPCError(BAD_REQUEST)` for no-fields case instead of returning `{ success: false }` — fixes inconsistent return type that UI wasn't checking
- **deleteSource**: throw `TRPCError` for not-found/manual cases instead of returning data; wrap cascade delete (candidates + source) in a transaction for atomicity
- Frontend `SourceCard` updated to handle errors via `onError` callback
- Tests updated to expect thrown errors

Addresses QA feedback on PR #1738.

## Test plan
- [x] 12 source-crud tests pass (including updated error-case tests)
- [x] Lint + typecheck clean
- [ ] QA: verify delete source removes candidates atomically
- [ ] QA: verify "no fields" update shows error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)