### PR TITLE
feat(finance): drag-to-reorder rule priority in Manage Rules (closes #1742)

### DIFF
--- a/apps/pops-api/src/modules/core/corrections/service.ts
+++ b/apps/pops-api/src/modules/core/corrections/service.ts
@@ -567,6 +567,7 @@ export function applyChangeSetToRules(
         isActive:
           op.data.isActive !== undefined ? Boolean(op.data.isActive) : Boolean(existing.isActive),
         confidence: op.data.confidence !== undefined ? op.data.confidence : existing.confidence,
+        priority: op.data.priority !== undefined ? op.data.priority : existing.priority,
       });
     } else if (op.op === 'disable') {
       replace({ ...existing, isActive: false });

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -64,7 +64,7 @@ Live status of every theme and epic. Updated as work completes.
 | Transaction ledger (CRUD, filtering, tagging) | Done   | 6 pages, inline editing                 |
 | Import pipeline (CSV wizard, entity matching) | Partial  | 7-step wizard; atomic `commitImport` path still blocked by Tag Review `executeImport` (knoxio/pops#1740) |
 | Entity registry                               | Done   | Aliases, default tags, AI fallback      |
-| Corrections (learned rules)                   | Partial  | Classification + proposals; tag-rule wizard UI open (knoxio/pops#1741); rule manager gaps #1742–#1744 |
+| Corrections (learned rules)                   | Partial  | Classification + proposals; tag-rule wizard UI open (knoxio/pops#1741); rule manager gaps #1743–#1744 |
 | Budgets                                       | Done   | Monthly/yearly, active/inactive         |
 | Wishlist                                      | Done   | Savings goals with progress             |
 | AI categorisation                             | Done   | Claude Haiku, disk-cached, cost-tracked |

--- a/docs/themes/02-finance/prds/032-rule-manager-priority/README.md
+++ b/docs/themes/02-finance/prds/032-rule-manager-priority/README.md
@@ -65,7 +65,7 @@ No new endpoints. Existing endpoints change:
 | 02  | [us-02-priority-aware-matching](us-02-priority-aware-matching.md)               | Update matching algorithm to sort by priority ASC         | Done        | Blocked by us-01         |
 | 03  | [us-03-browse-all-mode](us-03-browse-all-mode.md)                               | Browse-all mode for CorrectionProposalDialog              | Done        | Blocked by PRD-030 us-03 |
 | 04  | [us-04-manage-rules-button](us-04-manage-rules-button.md)                       | "Manage Rules" button in ReviewStep                       | Done        | Blocked by us-03         |
-| 05  | [us-05-drag-to-reorder](us-05-drag-to-reorder.md)                               | Drag-to-reorder priority in browse-mode sidebar           | Not started | Blocked by us-01, us-03; knoxio/pops#1742 |
+| 05  | [us-05-drag-to-reorder](us-05-drag-to-reorder.md)                               | Drag-to-reorder priority in browse-mode sidebar           | Done        | Blocked by us-01, us-03; knoxio/pops#1742 |
 | 06  | [us-06-impact-preview-db-transactions](us-06-impact-preview-db-transactions.md) | Impact preview includes existing DB transactions          | Not started | Blocked by us-03; knoxio/pops#1743        |
 | 07  | [us-07-override-indicators](us-07-override-indicators.md)                       | Override indicators when multiple rules match             | Done        | Blocked by us-02; knoxio/pops#1744        |
 | 08  | [us-08-orphaned-entity-indicators](us-08-orphaned-entity-indicators.md)         | Orphaned entity badges on /finance/entities               | Done        | Yes                      |

--- a/docs/themes/02-finance/prds/032-rule-manager-priority/us-05-drag-to-reorder.md
+++ b/docs/themes/02-finance/prds/032-rule-manager-priority/us-05-drag-to-reorder.md
@@ -1,7 +1,7 @@
 # US-05: Drag-to-reorder priority
 
 > PRD: [032 — Global Rule Manager & Priority Ordering](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user, I want to drag rules in the browse-mode sidebar to reorder them so th
 
 ## Acceptance Criteria
 
-- [ ] Each rule row in the browse-mode sidebar has a visible drag handle on the left.
-- [ ] Dragging a rule to a new position produces `edit` ChangeSet ops that update the `priority` field for all affected rules.
-- [ ] After a drop, priorities are renumbered using gaps of 10 (e.g. 10, 20, 30...) so that future insertions between rules don't require renumbering the entire list.
-- [ ] The sidebar list order reflects priority order (`priority ASC`, `id ASC` tie-break) at all times, including after a reorder.
-- [ ] Drag-and-drop works correctly when the list contains a mix of DB rules and pending rules.
-- [ ] A reorder followed by Cancel discards all priority changes from that dialog session.
-- [ ] The drag interaction provides visual feedback: a ghost element follows the cursor and a drop indicator marks the target position.
+- [x] Each rule row in the browse-mode sidebar has a visible drag handle on the left.
+- [x] Dragging a rule to a new position produces `edit` ChangeSet ops that update the `priority` field for all affected rules.
+- [x] After a drop, priorities are renumbered using gaps of 10 (e.g. 10, 20, 30...) so that future insertions between rules don't require renumbering the entire list.
+- [x] The sidebar list order reflects priority order (`priority ASC`, `id ASC` tie-break) at all times, including after a reorder.
+- [x] Drag-and-drop works correctly when the list contains a mix of DB rules and pending rules.
+- [x] A reorder followed by Cancel discards all priority changes from that dialog session.
+- [x] The drag interaction provides visual feedback: a ghost element follows the cursor and a drop indicator marks the target position.
 
 ## Notes
 

--- a/packages/app-finance/package.json
+++ b/packages/app-finance/package.json
@@ -14,6 +14,9 @@
     "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@pops/api": "workspace:*",
     "@pops/api-client": "workspace:*",
@@ -23,7 +26,7 @@
     "@tanstack/react-table": "^8.21.3",
     "crypto-js": "^4.2.0",
     "date-fns": "^4.1.0",
-    "lucide-react": "^1.7.0",
+    "lucide-react": "^1.8.0",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/app-finance/src/components/imports/BrowseRulesSidebar.tsx
+++ b/packages/app-finance/src/components/imports/BrowseRulesSidebar.tsx
@@ -1,0 +1,251 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  DragOverlay,
+  type DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Badge } from '@pops/ui';
+import { GripVertical } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+import type { LocalOp } from './correction-proposal-shared';
+import type { CorrectionRule } from './RulePicker';
+
+function BrowseRuleSidebarRowContent(props: { rule: CorrectionRule; hasLocalOp: boolean }) {
+  const { rule, hasLocalOp } = props;
+  const isPending = rule.id.startsWith('temp:');
+  return (
+    <div className="flex-1 min-w-0 space-y-1">
+      <div className="flex items-center gap-1.5 flex-wrap">
+        <code className="text-xs truncate max-w-[180px]">{rule.descriptionPattern}</code>
+        <Badge variant="outline" className="text-[10px] h-4 px-1.5">
+          {rule.matchType}
+        </Badge>
+        {isPending && (
+          <Badge variant="default" className="text-[10px] h-4 px-1.5 bg-amber-500">
+            pending
+          </Badge>
+        )}
+        {hasLocalOp && (
+          <Badge variant="secondary" className="text-[10px] h-4 px-1.5">
+            edited
+          </Badge>
+        )}
+        {!rule.isActive && (
+          <Badge variant="secondary" className="text-[10px] h-4 px-1.5">
+            disabled
+          </Badge>
+        )}
+      </div>
+      <div className="text-[11px] text-muted-foreground truncate">
+        {[rule.entityName, rule.location, rule.transactionType].filter(Boolean).join(' · ') ||
+          'no outcome set'}
+      </div>
+    </div>
+  );
+}
+
+function BrowseRuleSidebarRowStatic(props: {
+  rule: CorrectionRule;
+  selected: boolean;
+  hasLocalOp: boolean;
+  onSelect: () => void;
+}) {
+  const { rule, selected, hasLocalOp, onSelect } = props;
+  return (
+    <li
+      className={`px-3 py-2 cursor-pointer hover:bg-muted/50 ${selected ? 'bg-muted' : ''}`}
+      onClick={onSelect}
+    >
+      <div className="flex items-start gap-2">
+        <BrowseRuleSidebarRowContent rule={rule} hasLocalOp={hasLocalOp} />
+      </div>
+    </li>
+  );
+}
+
+function BrowseRuleSidebarRowSortable(props: {
+  rule: CorrectionRule;
+  selected: boolean;
+  hasLocalOp: boolean;
+  onSelect: () => void;
+}) {
+  const { rule, selected, hasLocalOp, onSelect } = props;
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: rule.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.45 : 1,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`px-3 py-2 hover:bg-muted/50 ${selected ? 'bg-muted' : ''}`}
+      {...attributes}
+    >
+      <div className="flex items-start gap-1">
+        <button
+          type="button"
+          className="mt-0.5 shrink-0 cursor-grab touch-none rounded p-1 text-muted-foreground hover:bg-muted active:cursor-grabbing"
+          aria-label={`Drag to reorder rule: ${rule.descriptionPattern}`}
+          onClick={(e) => e.stopPropagation()}
+          {...listeners}
+        >
+          <GripVertical className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          className="min-w-0 flex-1 cursor-pointer text-left"
+          onClick={onSelect}
+        >
+          <BrowseRuleSidebarRowContent rule={rule} hasLocalOp={hasLocalOp} />
+        </button>
+      </div>
+    </li>
+  );
+}
+
+export interface BrowseRulesSidebarProps {
+  canDragReorder: boolean;
+  orderedMerged: CorrectionRule[];
+  orderedFiltered: CorrectionRule[];
+  selectedRuleId: string | null;
+  localOps: LocalOp[];
+  onSelectRule: (id: string) => void;
+  onReorderFullList: (reordered: CorrectionRule[]) => void;
+}
+
+export function BrowseRulesSidebar(props: BrowseRulesSidebarProps) {
+  const {
+    canDragReorder,
+    orderedMerged,
+    orderedFiltered,
+    selectedRuleId,
+    localOps,
+    onSelectRule,
+    onReorderFullList,
+  } = props;
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor)
+  );
+  const [dragActiveId, setDragActiveId] = useState<string | null>(null);
+
+  const dragOverlayRule = useMemo(
+    () => orderedMerged.find((r) => r.id === dragActiveId) ?? null,
+    [orderedMerged, dragActiveId]
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setDragActiveId(String(event.active.id));
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setDragActiveId(null);
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const list = orderedMerged;
+      const oldIndex = list.findIndex((r) => r.id === active.id);
+      const newIndex = list.findIndex((r) => r.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+      const reordered = arrayMove(list, oldIndex, newIndex);
+      onReorderFullList(reordered);
+    },
+    [orderedMerged, onReorderFullList]
+  );
+
+  const handleDragCancel = useCallback(() => {
+    setDragActiveId(null);
+  }, []);
+
+  if (orderedFiltered.length === 0) {
+    return <div className="p-4 text-sm text-muted-foreground">No rules found.</div>;
+  }
+
+  if (canDragReorder) {
+    return (
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+      >
+        <SortableContext
+          items={orderedMerged.map((r) => r.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <ul className="divide-y" role="list" aria-label="Classification rules">
+            {orderedMerged.map((rule) => {
+              const selected = rule.id === selectedRuleId;
+              const hasLocalOp = localOps.some(
+                (o) => o.kind !== 'add' && o.targetRuleId === rule.id
+              );
+              return (
+                <BrowseRuleSidebarRowSortable
+                  key={rule.id}
+                  rule={rule}
+                  selected={selected}
+                  hasLocalOp={hasLocalOp}
+                  onSelect={() => onSelectRule(rule.id)}
+                />
+              );
+            })}
+          </ul>
+        </SortableContext>
+        <DragOverlay dropAnimation={null}>
+          {dragOverlayRule ? (
+            <div className="rounded-md border bg-background px-3 py-2 shadow-md">
+              <div className="flex items-start gap-2">
+                <GripVertical className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <BrowseRuleSidebarRowContent
+                  rule={dragOverlayRule}
+                  hasLocalOp={localOps.some(
+                    (o) => o.kind !== 'add' && o.targetRuleId === dragOverlayRule.id
+                  )}
+                />
+              </div>
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    );
+  }
+
+  return (
+    <ul className="divide-y" role="list" aria-label="Classification rules">
+      {orderedFiltered.map((rule) => {
+        const selected = rule.id === selectedRuleId;
+        const hasLocalOp = localOps.some((o) => o.kind !== 'add' && o.targetRuleId === rule.id);
+        return (
+          <BrowseRuleSidebarRowStatic
+            key={rule.id}
+            rule={rule}
+            selected={selected}
+            hasLocalOp={hasLocalOp}
+            onSelect={() => onSelectRule(rule.id)}
+          />
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
@@ -1,5 +1,4 @@
 import {
-  Badge,
   Button,
   Dialog,
   DialogContent,
@@ -10,9 +9,13 @@ import {
   Input,
 } from '@pops/ui';
 import { Plus, Search } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
+import {
+  applyBrowsePriorityReorder,
+  sortRulesForBrowseDisplay,
+} from '../../lib/correction-browse-reorder';
 import { computeMergedRules } from '../../lib/merged-state';
 import { trpc } from '../../lib/trpc';
 import { useImportStore } from '../../store/importStore';
@@ -36,6 +39,10 @@ import { useApplyRejectMutations } from './hooks/useApplyRejectMutations';
 import { localOpsToChangeSet, newClientId, useLocalOps } from './hooks/useLocalOps';
 import { usePreviewEffects } from './hooks/usePreviewEffects';
 import type { CorrectionRule } from './RulePicker';
+
+const BrowseRulesSidebar = lazy(() =>
+  import('./BrowseRulesSidebar').then((m) => ({ default: m.BrowseRulesSidebar }))
+);
 
 // Re-export shared symbols so existing consumers don't break
 export type {
@@ -85,6 +92,7 @@ export interface CorrectionProposalDialogProps {
 export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
   const minConfidence = props.minConfidence ?? 0.7;
   const isBrowseMode = props.mode === 'browse';
+  const { onOpenChange, onBrowseClose } = props;
 
   // ---- initial propose query ---------------------------------------------
 
@@ -212,26 +220,39 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
     { enabled: isBrowseMode && props.open, staleTime: 30_000 }
   );
 
-  const browseDbRules = browseListQuery.data?.data ?? [];
-
   const browseMergedRules: CorrectionRule[] = useMemo(() => {
     if (!isBrowseMode) return [];
+    const browseDbRules = browseListQuery.data?.data ?? [];
     if (pendingChangeSets.length === 0) return browseDbRules;
     return computeMergedRules(
       browseDbRules as unknown as Parameters<typeof computeMergedRules>[0],
       pendingChangeSets
     ) as unknown as CorrectionRule[];
-  }, [isBrowseMode, browseDbRules, pendingChangeSets]);
+  }, [isBrowseMode, browseListQuery.data?.data, pendingChangeSets]);
 
-  const browseFilteredRules = useMemo(() => {
+  const browseOrderedMerged = useMemo(
+    () => sortRulesForBrowseDisplay(browseMergedRules, localOps),
+    [browseMergedRules, localOps]
+  );
+
+  const browseOrderedFiltered = useMemo(() => {
     const needle = browseSearch.trim().toLowerCase();
-    if (!needle) return browseMergedRules;
-    return browseMergedRules.filter((r) => {
+    if (!needle) return browseOrderedMerged;
+    return browseOrderedMerged.filter((r) => {
       const haystack =
         `${r.descriptionPattern} ${r.entityName ?? ''} ${r.matchType} ${r.location ?? ''}`.toLowerCase();
       return haystack.includes(needle);
     });
-  }, [browseMergedRules, browseSearch]);
+  }, [browseOrderedMerged, browseSearch]);
+
+  const browseCanDragReorder = browseSearch.trim() === '' && browseOrderedMerged.length >= 2;
+
+  const handleBrowseReorderFullList = useCallback(
+    (reordered: CorrectionRule[]) => {
+      setLocalOps((prev) => applyBrowsePriorityReorder(reordered, prev));
+    },
+    [setLocalOps]
+  );
 
   const browseSelectedRule = useMemo(
     () => browseMergedRules.find((r) => r.id === browseSelectedRuleId) ?? null,
@@ -246,29 +267,42 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
 
   // ---- handlers -----------------------------------------------------------
 
-  function handleOpenChange(open: boolean) {
-    if (!open && isBrowseMode) {
-      const currentCount = useImportStore.getState().pendingChangeSets.length;
-      const hadChanges = currentCount !== browseInitialPendingCountRef.current;
-      setBrowseSearch('');
-      setBrowseSelectedRuleId(null);
-      setLocalOps([]);
-      setSelectedClientId(null);
-      props.onOpenChange(false);
-      props.onBrowseClose?.(hadChanges);
-      return;
-    }
-    props.onOpenChange(open);
-    if (!open) {
-      setLocalOps([]);
-      setSelectedClientId(null);
-      setPreviewView('selected');
-      resetPreviewState();
-      resetMutationState();
-      setRationale(null);
-      seededForSignalRef.current = null;
-    }
-  }
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && isBrowseMode) {
+        const currentCount = useImportStore.getState().pendingChangeSets.length;
+        const hadChanges = currentCount !== browseInitialPendingCountRef.current;
+        setBrowseSearch('');
+        setBrowseSelectedRuleId(null);
+        setLocalOps([]);
+        setSelectedClientId(null);
+        onOpenChange(false);
+        onBrowseClose?.(hadChanges);
+        return;
+      }
+      onOpenChange(open);
+      if (!open) {
+        setLocalOps([]);
+        setSelectedClientId(null);
+        setPreviewView('selected');
+        resetPreviewState();
+        resetMutationState();
+        setRationale(null);
+        seededForSignalRef.current = null;
+      }
+    },
+    [
+      isBrowseMode,
+      onOpenChange,
+      onBrowseClose,
+      resetPreviewState,
+      resetMutationState,
+      setLocalOps,
+      setSelectedClientId,
+      setRationale,
+      seededForSignalRef,
+    ]
+  );
 
   handleCloseRef.current = () => handleOpenChange(false);
 
@@ -352,31 +386,7 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
       toast.success(`${localOps.length} rule change${localOps.length === 1 ? '' : 's'} saved`);
     }
     handleOpenChange(false);
-  }, [localOps, addPendingChangeSet]);
-
-  // ---- browse mode keyboard nav -------------------------------------------
-  const browseListRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (!isBrowseMode || !props.open) return;
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
-        e.preventDefault();
-        const list = browseFilteredRules;
-        if (list.length === 0) return;
-        const currentIdx = list.findIndex((r) => r.id === browseSelectedRuleId);
-        let nextIdx: number;
-        if (e.key === 'ArrowDown') {
-          nextIdx = currentIdx < list.length - 1 ? currentIdx + 1 : 0;
-        } else {
-          nextIdx = currentIdx > 0 ? currentIdx - 1 : list.length - 1;
-        }
-        const nextRule = list[nextIdx];
-        if (nextRule) handleBrowseSelectRule(nextRule.id);
-      }
-    }
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [isBrowseMode, props.open, browseFilteredRules, browseSelectedRuleId]);
+  }, [localOps, addPendingChangeSet, handleOpenChange]);
 
   // ---- shared memos (must be above any early return) ----------------------
 
@@ -417,7 +427,7 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
           ) : (
             <div className="grid grid-cols-[300px_minmax(0,1fr)] gap-0 border-y flex-1 min-h-0">
               {/* Sidebar: rule list with search */}
-              <div className="flex flex-col min-h-0 border-r" ref={browseListRef}>
+              <div className="flex flex-col min-h-0 border-r">
                 <div className="px-3 py-2 border-b">
                   <div className="relative">
                     <Search className="absolute left-2 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
@@ -429,69 +439,32 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
                     />
                   </div>
                 </div>
-                <div className="px-3 py-1.5 text-[10px] text-muted-foreground border-b">
-                  {browseFilteredRules.length} rule{browseFilteredRules.length === 1 ? '' : 's'}
-                  {browseSearch && ` matching "${browseSearch}"`}
+                <div className="px-3 py-1.5 text-[10px] text-muted-foreground border-b space-y-0.5">
+                  <div>
+                    {browseOrderedFiltered.length} rule
+                    {browseOrderedFiltered.length === 1 ? '' : 's'}
+                    {browseSearch && ` matching "${browseSearch}"`}
+                  </div>
+                  {browseSearch.trim() !== '' && (
+                    <div className="text-[10px] text-muted-foreground/90">
+                      Clear search to drag rules into priority order.
+                    </div>
+                  )}
                 </div>
                 <div className="flex-1 overflow-auto">
-                  {browseFilteredRules.length === 0 ? (
-                    <div className="p-4 text-sm text-muted-foreground">No rules found.</div>
-                  ) : (
-                    <ul className="divide-y">
-                      {browseFilteredRules.map((rule) => {
-                        const selected = rule.id === browseSelectedRuleId;
-                        const isPending = rule.id.startsWith('temp:');
-                        const hasLocalOp = localOps.some(
-                          (o) => o.kind !== 'add' && o.targetRuleId === rule.id
-                        );
-                        return (
-                          <li
-                            key={rule.id}
-                            className={`px-3 py-2 cursor-pointer hover:bg-muted/50 ${
-                              selected ? 'bg-muted' : ''
-                            }`}
-                            onClick={() => handleBrowseSelectRule(rule.id)}
-                          >
-                            <div className="flex items-start gap-2">
-                              <div className="flex-1 min-w-0 space-y-1">
-                                <div className="flex items-center gap-1.5 flex-wrap">
-                                  <code className="text-xs truncate max-w-[180px]">
-                                    {rule.descriptionPattern}
-                                  </code>
-                                  <Badge variant="outline" className="text-[10px] h-4 px-1.5">
-                                    {rule.matchType}
-                                  </Badge>
-                                  {isPending && (
-                                    <Badge
-                                      variant="default"
-                                      className="text-[10px] h-4 px-1.5 bg-amber-500"
-                                    >
-                                      pending
-                                    </Badge>
-                                  )}
-                                  {hasLocalOp && (
-                                    <Badge variant="secondary" className="text-[10px] h-4 px-1.5">
-                                      edited
-                                    </Badge>
-                                  )}
-                                  {!rule.isActive && (
-                                    <Badge variant="secondary" className="text-[10px] h-4 px-1.5">
-                                      disabled
-                                    </Badge>
-                                  )}
-                                </div>
-                                <div className="text-[11px] text-muted-foreground truncate">
-                                  {[rule.entityName, rule.location, rule.transactionType]
-                                    .filter(Boolean)
-                                    .join(' · ') || 'no outcome set'}
-                                </div>
-                              </div>
-                            </div>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  )}
+                  <Suspense
+                    fallback={<div className="p-3 text-xs text-muted-foreground">Loading…</div>}
+                  >
+                    <BrowseRulesSidebar
+                      canDragReorder={browseCanDragReorder}
+                      orderedMerged={browseOrderedMerged}
+                      orderedFiltered={browseOrderedFiltered}
+                      selectedRuleId={browseSelectedRuleId}
+                      localOps={localOps}
+                      onSelectRule={handleBrowseSelectRule}
+                      onReorderFullList={handleBrowseReorderFullList}
+                    />
+                  </Suspense>
                 </div>
                 <div className="border-t p-2">
                   <Button

--- a/packages/app-finance/src/components/imports/ImportWizard.tsx
+++ b/packages/app-finance/src/components/imports/ImportWizard.tsx
@@ -1,13 +1,15 @@
 import { Progress } from '@pops/ui';
+import { lazy, Suspense } from 'react';
 
 import { useImportStore } from '../../store/importStore';
 import { ColumnMapStep } from './ColumnMapStep';
 import { FinalReviewStep } from './FinalReviewStep';
 import { ProcessingStep } from './ProcessingStep';
-import { ReviewStep } from './ReviewStep';
 import { SummaryStep } from './SummaryStep';
 import { TagReviewStep } from './TagReviewStep';
 import { UploadStep } from './UploadStep';
+
+const ReviewStep = lazy(() => import('./ReviewStep').then((m) => ({ default: m.ReviewStep })));
 
 /**
  * Import wizard orchestrator - manages 7-step flow
@@ -67,7 +69,15 @@ export function ImportWizard() {
 
       {/* Current step content */}
       <div className="bg-white dark:bg-gray-900 rounded-lg border shadow-sm p-6">
-        {CurrentStepComponent ? <CurrentStepComponent /> : <div>Unknown step</div>}
+        {currentStep === 4 ? (
+          <Suspense fallback={<div className="text-sm text-muted-foreground">Loading review…</div>}>
+            <ReviewStep />
+          </Suspense>
+        ) : CurrentStepComponent ? (
+          <CurrentStepComponent />
+        ) : (
+          <div>Unknown step</div>
+        )}
       </div>
     </div>
   );

--- a/packages/app-finance/src/lib/correction-browse-reorder.test.ts
+++ b/packages/app-finance/src/lib/correction-browse-reorder.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import type { LocalOp } from '../components/imports/correction-proposal-shared';
+import type { CorrectionRule } from '../components/imports/RulePicker';
+import {
+  applyBrowsePriorityReorder,
+  compareRulesForBrowse,
+  effectiveRulePriority,
+  sortRulesForBrowseDisplay,
+} from './correction-browse-reorder';
+
+function rule(
+  partial: Partial<CorrectionRule> & Pick<CorrectionRule, 'id' | 'descriptionPattern'>
+): CorrectionRule {
+  return {
+    matchType: 'exact',
+    entityId: null,
+    entityName: null,
+    location: null,
+    tags: [],
+    transactionType: null,
+    isActive: true,
+    priority: 0,
+    confidence: 0.9,
+    timesApplied: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastUsedAt: null,
+    ...partial,
+  };
+}
+
+describe('correction-browse-reorder', () => {
+  it('sorts by priority then id', () => {
+    const rules = [
+      rule({ id: 'b', descriptionPattern: 'B', priority: 20 }),
+      rule({ id: 'a', descriptionPattern: 'A', priority: 10 }),
+    ];
+    const sorted = sortRulesForBrowseDisplay(rules, []);
+    expect(sorted.map((r) => r.id)).toEqual(['a', 'b']);
+  });
+
+  it('respects priority from local edit ops', () => {
+    const rules = [
+      rule({ id: 'a', descriptionPattern: 'A', priority: 10 }),
+      rule({ id: 'b', descriptionPattern: 'B', priority: 20 }),
+    ];
+    const localOps: LocalOp[] = [
+      {
+        kind: 'edit',
+        clientId: 'e1',
+        targetRuleId: 'b',
+        targetRule: rules[1] ?? null,
+        data: { priority: 5 },
+        dirty: true,
+      },
+    ];
+    const sorted = sortRulesForBrowseDisplay(rules, localOps);
+    expect(sorted.map((r) => r.id)).toEqual(['b', 'a']);
+  });
+
+  it('applyBrowsePriorityReorder assigns gaps of 10', () => {
+    const r0 = rule({ id: 'x', descriptionPattern: 'X', priority: 10 });
+    const r1 = rule({ id: 'y', descriptionPattern: 'Y', priority: 20 });
+    const reordered = [r1, r0];
+    const next = applyBrowsePriorityReorder(reordered, []);
+    expect(next).toHaveLength(2);
+    expect(next[0]?.kind).toBe('edit');
+    expect(next[1]?.kind).toBe('edit');
+    if (next[0]?.kind === 'edit' && next[1]?.kind === 'edit') {
+      const byId = Object.fromEntries(
+        next.map((o) => (o.kind === 'edit' ? [o.targetRuleId, o.data.priority] : []))
+      );
+      expect(byId['y']).toBe(10);
+      expect(byId['x']).toBe(20);
+    }
+  });
+
+  it('compareRulesForBrowse tie-breaks by id', () => {
+    const a = rule({ id: 'a', descriptionPattern: 'A', priority: 0 });
+    const b = rule({ id: 'b', descriptionPattern: 'B', priority: 0 });
+    expect(compareRulesForBrowse(a, b)).toBeLessThan(0);
+  });
+
+  it('effectiveRulePriority reads last matching edit', () => {
+    const r = rule({ id: 'a', descriptionPattern: 'A', priority: 100 });
+    const ops: LocalOp[] = [
+      {
+        kind: 'edit',
+        clientId: '1',
+        targetRuleId: 'a',
+        targetRule: r,
+        data: { priority: 50 },
+        dirty: true,
+      },
+      {
+        kind: 'edit',
+        clientId: '2',
+        targetRuleId: 'a',
+        targetRule: r,
+        data: { priority: 30 },
+        dirty: true,
+      },
+    ];
+    expect(effectiveRulePriority(r, ops)).toBe(30);
+  });
+});

--- a/packages/app-finance/src/lib/correction-browse-reorder.ts
+++ b/packages/app-finance/src/lib/correction-browse-reorder.ts
@@ -1,0 +1,86 @@
+import type { LocalOp } from '../components/imports/correction-proposal-shared';
+import { newClientId } from '../components/imports/hooks/useLocalOps';
+import type { CorrectionRule } from '../components/imports/RulePicker';
+
+/** Priority order for browse sidebar (PRD-032 US-05). */
+export function compareRulesForBrowse(a: CorrectionRule, b: CorrectionRule): number {
+  const pa = a.priority - b.priority;
+  if (pa !== 0) return pa;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+export function effectiveRulePriority(rule: CorrectionRule, localOps: LocalOp[]): number {
+  for (let i = localOps.length - 1; i >= 0; i -= 1) {
+    const o = localOps[i];
+    if (!o || o.kind !== 'edit') continue;
+    if (o.targetRuleId === rule.id && o.data.priority !== undefined) {
+      return o.data.priority;
+    }
+  }
+  return rule.priority;
+}
+
+export function sortRulesForBrowseDisplay(
+  rules: CorrectionRule[],
+  localOps: LocalOp[]
+): CorrectionRule[] {
+  return [...rules].sort((a, b) => {
+    const pa = effectiveRulePriority(a, localOps) - effectiveRulePriority(b, localOps);
+    if (pa !== 0) return pa;
+    return compareRulesForBrowse(a, b);
+  });
+}
+
+function editDataFromRule(rule: CorrectionRule) {
+  return {
+    entityId: rule.entityId ?? undefined,
+    entityName: rule.entityName ?? undefined,
+    location: rule.location ?? undefined,
+    tags: rule.tags,
+    transactionType: rule.transactionType ?? undefined,
+    isActive: rule.isActive,
+    confidence: rule.confidence,
+    priority: rule.priority,
+  };
+}
+
+/**
+ * After a drag reorder of `orderedRules`, upsert `edit` ops so priorities become
+ * 10, 20, 30, … (gaps of 10).
+ */
+export function applyBrowsePriorityReorder(
+  orderedRules: CorrectionRule[],
+  localOps: LocalOp[]
+): LocalOp[] {
+  let next = [...localOps];
+
+  orderedRules.forEach((rule, index) => {
+    const newPriority = (index + 1) * 10;
+    const prevEffective = effectiveRulePriority(rule, next);
+    if (prevEffective === newPriority) return;
+
+    const existingIdx = next.findIndex((o) => o.kind === 'edit' && o.targetRuleId === rule.id);
+
+    if (existingIdx !== -1) {
+      const op = next[existingIdx];
+      if (!op || op.kind !== 'edit') return;
+      next = next.map((o, i) =>
+        i === existingIdx && o.kind === 'edit'
+          ? { ...o, data: { ...o.data, priority: newPriority }, dirty: true }
+          : o
+      );
+      return;
+    }
+
+    next.push({
+      kind: 'edit',
+      clientId: newClientId('edit'),
+      targetRuleId: rule.id,
+      targetRule: rule,
+      data: { ...editDataFromRule(rule), priority: newPriority },
+      dirty: true,
+    });
+  });
+
+  return next;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,7 +185,7 @@ importers:
         version: 5.96.2(react@19.2.4)
       lucide-react:
         specifier: ^1.7.0
-        version: 1.7.0(react@19.2.4)
+        version: 1.8.0(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -332,7 +332,7 @@ importers:
         version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       lucide-react:
         specifier: ^1.7.0
-        version: 1.7.0(react@19.2.4)
+        version: 1.8.0(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -379,6 +379,15 @@ importers:
 
   packages/app-finance:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.2.4))
@@ -407,8 +416,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       lucide-react:
-        specifier: ^1.7.0
-        version: 1.7.0(react@19.2.4)
+        specifier: ^1.8.0
+        version: 1.8.0(react@19.2.4)
       papaparse:
         specifier: ^5.5.3
         version: 5.5.3
@@ -511,7 +520,7 @@ importers:
         version: 0.0.4
       lucide-react:
         specifier: ^1.7.0
-        version: 1.7.0(react@19.2.4)
+        version: 1.8.0(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -596,7 +605,7 @@ importers:
         version: 5.96.2(react@19.2.4)
       lucide-react:
         specifier: ^1.7.0
-        version: 1.7.0(react@19.2.4)
+        version: 1.8.0(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -831,7 +840,7 @@ importers:
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       lucide-react:
         specifier: ^1.7.0
-        version: 1.7.0(react@19.2.4)
+        version: 1.8.0(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -5208,8 +5217,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@1.7.0:
-    resolution: {integrity: sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==}
+  lucide-react@1.8.0:
+    resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -10796,7 +10805,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@1.7.0(react@19.2.4):
+  lucide-react@1.8.0(react@19.2.4):
     dependencies:
       react: 19.2.4
 


### PR DESCRIPTION
## Summary
Implements [PRD-032 US-05](docs/themes/02-finance/prds/032-rule-manager-priority/us-05-drag-to-reorder.md) / **#1742**: drag-and-drop reorder in **Manage Rules** browse mode.

## Changes
- **Browse sidebar**: `@dnd-kit` vertical sortable list with left **grip** handle, **DragOverlay** ghost, **PointerSensor** + **KeyboardSensor** (accessible reorder).
- **Priority ops**: drop renumbers the **full** merged rule list with gaps of **10** via `edit` ops (`applyBrowsePriorityReorder`); merges into existing edit ops when present.
- **Display order**: `sortRulesForBrowseDisplay` — `priority ASC`, `id ASC`, overlaying `data.priority` from in-dialog edit ops.
- **Search**: drag disabled; hint to clear search (reordering only applies to the full ordered list).
- **Cancel**: unchanged — clears `localOps`, discarding priority edits for the session.
- **API**: `applyChangeSetToRules` now applies `priority` on `edit` (was missing; needed for merged preview correctness).

## Docs
- US-05 acceptance criteria marked complete; PRD-032 story table updated (US-05 **Done**).

## Notes
- Removed global **ArrowUp/ArrowDown** window listener for browse list (conflicted with keyboard sortable); selection is click-based; keyboard reorder uses dnd-kit sensors on the sortable list.

Closes #1742.