### PR TITLE
fix(finance): Tag Review advances without executeImport (#1740)

### DIFF
--- a/apps/pops-shell/e2e/import-wizard.spec.ts
+++ b/apps/pops-shell/e2e/import-wizard.spec.ts
@@ -13,16 +13,16 @@ import {
 } from './fixtures/csv-samples';
 
 /**
- * E2E tests for Import Wizard (6-step flow)
+ * E2E tests for Import Wizard (7-step flow)
  *
  * Comprehensive test coverage:
  * 1. Upload CSV file
  * 2. Map columns
  * 3. Process transactions (with progress polling)
  * 4. Review and resolve uncertain matches
- * 5. Tag Review — confirm/adjust tags before import
- * 6. Execute import (with write overlay)
- * 7. View summary
+ * 5. Tag Review — confirm/adjust tags (session only; no DB write)
+ * 6. Final Review — `commitImport` (single DB write)
+ * 7. Summary — reads `commitResult` from the store
  *
  * Features tested:
  * - Transaction editing (Save Once vs Save & Learn)
@@ -30,7 +30,7 @@ import {
  * - Bulk operations (accept all, create for all, auto-match similar)
  * - Grouped vs List view modes
  * - Entity creation during review
- * - Progress polling for both process and execute phases
+ * - Progress polling for the process phase
  * - Warnings and errors handling
  * - Review tab navigation
  * - Real-world scenarios
@@ -223,6 +223,46 @@ const setupMockAPIs = async (page: Page, options: SetupMockAPIsOptions = {}) => 
     const isBatch = url.searchParams.has('batch');
     const responseData = { result: { data: { sessionId: 'execute-session-456' } } };
 
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(isBatch ? [responseData] : responseData),
+    });
+  });
+
+  await page.route(/\/trpc\/imports\.commitImport/, async (route) => {
+    if (executeError) {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            error: {
+              json: {
+                message: 'Commit failed',
+                code: -32603,
+                data: { code: 'INTERNAL_SERVER_ERROR', httpStatus: 500 },
+              },
+            },
+          },
+        ]),
+      });
+      return;
+    }
+
+    const url = new URL(route.request().url());
+    const isBatch = url.searchParams.has('batch');
+    const commitPayload = {
+      entitiesCreated: 0,
+      rulesApplied: { add: 0, edit: 0, disable: 0, remove: 0 },
+      transactionsImported: 2,
+      transactionsFailed: 0,
+      failedDetails: [] as Array<{ checksum?: string; error: string }>,
+      retroactiveReclassifications: 0,
+    };
+    const responseData = {
+      result: { data: { data: commitPayload, message: 'Import committed' } },
+    };
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -481,16 +521,23 @@ test.describe.skip('Import Wizard - Complete Flow', () => {
         timeout: 5000,
       });
 
-      // Import button should be visible
-      const importButton = page.getByRole('button', { name: /import.*transaction/i });
-      await expect(importButton).toBeEnabled();
-      await importButton.click();
+      const continueToFinal = page.getByRole('button', { name: /continue to final review/i });
+      await expect(continueToFinal).toBeEnabled();
+      await continueToFinal.click();
     });
 
-    // Step 6: Summary
-    await test.step('View summary', async () => {
+    // Step 6–7: Final Review (commit) → Summary
+    await test.step('Final review and summary', async () => {
+      await expect(page.getByRole('heading', { name: 'Final Review' })).toBeVisible({
+        timeout: 5000,
+      });
+      await page.getByRole('button', { name: /approve & commit all/i }).click();
+      await expect(page.getByRole('button', { name: /^continue$/i })).toBeVisible({
+        timeout: 10000,
+      });
+      await page.getByRole('button', { name: /^continue$/i }).click();
       await expect(page.getByText('Import Complete')).toBeVisible({ timeout: 10000 });
-      await expect(page.getByText('1 imported, 0 failed, 0 skipped')).toBeVisible();
+      await expect(page.getByText('Transactions Imported')).toBeVisible();
       await expect(page.getByRole('button', { name: /new import/i })).toBeVisible();
     });
   });
@@ -741,28 +788,40 @@ test.describe.skip('Import Wizard - Transfer and Income Transactions', () => {
     });
   });
 
-  test('should include transfer in import payload without entityId', async ({ page }) => {
+  test('should include transfer in commit payload without entityId', async ({ page }) => {
     let capturedTransactions: Array<Record<string, unknown>> = [];
 
     // Simple scenario: 1 matched + 1 uncertain, no failed
     await setupMockAPIs(page);
 
-    // Override executeImport AFTER setupMockAPIs so this handler runs first (last-registered wins)
-    await page.route(/\/trpc\/imports\.executeImport/, async (route) => {
+    // Override commitImport AFTER setupMockAPIs (last-registered wins) to capture payload
+    await page.route(/\/trpc\/imports\.commitImport/, async (route) => {
       const body = JSON.parse(route.request().postData() || '{}') as Record<string, unknown>;
-      // tRPC batch body format: {"0": {"transactions": [...]}} (no .json wrapper in this client version)
-      const item = body['0'] as
-        | { json?: { transactions?: unknown[] }; transactions?: unknown[] }
-        | undefined;
-      const txns = item?.json?.transactions ?? item?.transactions ?? [];
+      const item = body['0'] as { json?: { transactions?: unknown[] } } | undefined;
+      const txns = item?.json?.transactions ?? [];
       capturedTransactions = txns as Array<Record<string, unknown>>;
 
       const url = new URL(route.request().url());
-      const responseData = { result: { data: { sessionId: 'execute-session-456' } } };
+      const isBatch = url.searchParams.has('batch');
+      const responseData = {
+        result: {
+          data: {
+            data: {
+              entitiesCreated: 0,
+              rulesApplied: { add: 0, edit: 0, disable: 0, remove: 0 },
+              transactionsImported: 2,
+              transactionsFailed: 0,
+              failedDetails: [],
+              retroactiveReclassifications: 0,
+            },
+            message: 'Import committed',
+          },
+        },
+      };
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(url.searchParams.has('batch') ? [responseData] : responseData),
+        body: JSON.stringify(isBatch ? [responseData] : responseData),
       });
     });
 
@@ -775,14 +834,16 @@ test.describe.skip('Import Wizard - Transfer and Income Transactions', () => {
     await page.locator('select[name="type"]').selectOption('transfer');
     await page.getByRole('button', { name: /save once/i }).click();
 
-    // Continue to Tag Review then click Import
     await page.getByRole('button', { name: /continue to tag review/i }).click();
     await expect(page.getByRole('heading', { name: 'Tag Review' })).toBeVisible({ timeout: 5000 });
-    await page.getByRole('button', { name: /import.*transaction/i }).click();
+    await page.getByRole('button', { name: /continue to final review/i }).click();
+    await expect(page.getByRole('heading', { name: 'Final Review' })).toBeVisible({
+      timeout: 5000,
+    });
+    await page.getByRole('button', { name: /approve & commit all/i }).click();
 
     await page.waitForTimeout(1000);
 
-    // The transfer should appear in the payload without an entityId
     const transfer = capturedTransactions.find((t) => t['transactionType'] === 'transfer');
     expect(transfer).toBeDefined();
     expect(transfer?.['entityId']).toBeFalsy();
@@ -992,72 +1053,18 @@ test.describe.skip('Import Wizard - Progress Polling', () => {
     // The mock returns 4 stages: deduplicating → matching → writing → completed
   });
 
-  test('should poll for execute progress with write overlay', async ({ page }) => {
+  test('should advance from Tag Review to Final Review without execute overlay', async ({
+    page,
+  }) => {
     await setupMockAPIs(page, { scenario: 'simple', progressStages: 'instant' });
 
     await navigateToTagReviewStep(page);
 
-    // Override the progress mock for the execute session to return processing first
-    let executeProgressCalls = 0;
-    const mockData = createMockData('simple');
-    await page.route(/\/trpc\/imports\.getImportProgress/, async (route) => {
-      const url = new URL(route.request().url());
-      let sessionId = '';
-      try {
-        const raw = url.searchParams.get('input') ?? '{}';
-        sessionId = JSON.parse(decodeURIComponent(raw))['0']?.sessionId ?? '';
-      } catch {
-        /* ignore */
-      }
-
-      if (sessionId === 'execute-session-456') {
-        executeProgressCalls++;
-        if (executeProgressCalls < 2) {
-          await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify({
-              result: {
-                data: {
-                  status: 'processing',
-                  currentStep: 'writing',
-                  processedCount: 0,
-                  totalTransactions: 1,
-                  currentBatch: [],
-                },
-              },
-            }),
-          });
-        } else {
-          await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify({
-              result: {
-                data: { status: 'completed', result: { imported: 1, failed: [], skipped: 0 } },
-              },
-            }),
-          });
-        }
-      } else {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({
-            result: { data: { status: 'completed', result: mockData } },
-          }),
-        });
-      }
+    await page.getByRole('button', { name: /continue to final review/i }).click();
+    await expect(page.getByRole('heading', { name: 'Final Review' })).toBeVisible({
+      timeout: 5000,
     });
-
-    // Click Import on Tag Review step
-    await page.getByRole('button', { name: /import.*transaction/i }).click();
-
-    // Verify overlay modal shown during write phase
-    await expect(page.getByTestId('import-progress-overlay')).toBeVisible({ timeout: 5000 });
-
-    // Wait for completion
-    await expect(page.getByText('Import Complete')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('import-progress-overlay')).not.toBeVisible();
   });
 
   test('should handle process failure with error display', async ({ page }) => {
@@ -1191,16 +1198,18 @@ test.describe.skip('Import Wizard - Warnings and Errors', () => {
     await expect(page.getByRole('heading', { name: 'Review' })).not.toBeVisible();
   });
 
-  test('should handle write failures in execute phase', async ({ page }) => {
+  test('should handle commit failure on Final Review', async ({ page }) => {
     await setupMockAPIs(page, { executeError: true });
 
     await navigateToTagReviewStep(page);
 
-    // Try to import from Tag Review step
-    await page.getByRole('button', { name: /import.*transaction/i }).click();
+    await page.getByRole('button', { name: /continue to final review/i }).click();
+    await expect(page.getByRole('heading', { name: 'Final Review' })).toBeVisible({
+      timeout: 5000,
+    });
+    await page.getByRole('button', { name: /approve & commit all/i }).click();
 
-    // Should show error - the component displays "Import failed" heading
-    await expect(page.getByText('Import failed')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Commit failed')).toBeVisible({ timeout: 10000 });
   });
 });
 
@@ -1351,18 +1360,25 @@ test.describe.skip('Import Wizard - Complete Import Flows', () => {
       .click();
     await page.waitForTimeout(500);
 
-    // Continue to Tag Review then import
+    // Continue to Tag Review → Final Review → commit → Summary
     await page.getByRole('tab', { name: /matched/i }).click();
     const continueButton = page.getByRole('button', { name: /continue to tag review/i });
     await expect(continueButton).toBeEnabled();
     await continueButton.click();
 
     await expect(page.getByRole('heading', { name: 'Tag Review' })).toBeVisible({ timeout: 5000 });
-    await page.getByRole('button', { name: /import.*transaction/i }).click();
+    await page.getByRole('button', { name: /continue to final review/i }).click();
+    await expect(page.getByRole('heading', { name: 'Final Review' })).toBeVisible({
+      timeout: 5000,
+    });
+    await page.getByRole('button', { name: /approve & commit all/i }).click();
+    await expect(page.getByRole('button', { name: /^continue$/i })).toBeVisible({
+      timeout: 10000,
+    });
+    await page.getByRole('button', { name: /^continue$/i }).click();
 
-    // Verify Summary (mock returns base matched count, not the resolved total)
     await expect(page.getByText('Import Complete')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText(/\d+ imported/i)).toBeVisible();
+    await expect(page.getByText('Transactions Imported')).toBeVisible();
   });
 
   test('should handle duplicate detection workflow', async ({ page }) => {
@@ -1557,19 +1573,19 @@ test.describe.skip('Import Wizard - Error Recovery', () => {
     await expect(page.getByRole('dialog')).not.toBeVisible();
   });
 
-  test('should handle network timeout during import', async ({ page }) => {
+  test('should surface commit errors on Final Review', async ({ page }) => {
     await setupMockAPIs(page, { executeError: true });
 
     await navigateToTagReviewStep(page);
 
-    // Try to import from Tag Review step
-    await page.getByRole('button', { name: /import.*transaction/i }).click();
+    await page.getByRole('button', { name: /continue to final review/i }).click();
+    await expect(page.getByRole('heading', { name: 'Final Review' })).toBeVisible({
+      timeout: 5000,
+    });
+    await page.getByRole('button', { name: /approve & commit all/i }).click();
 
-    // Component shows "Import failed" heading in the error state
-    await expect(page.getByText('Import failed')).toBeVisible({ timeout: 10000 });
-
-    // Should have retry button (from TagReviewStep error state)
-    await expect(page.getByRole('button', { name: /retry/i })).toBeVisible();
+    await expect(page.getByText('Commit failed')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: /approve & commit all/i })).toBeVisible();
   });
 
   test('should preserve state when navigating back', async ({ page }) => {

--- a/docs/themes/02-finance/prds/020-import-wizard-ui/README.md
+++ b/docs/themes/02-finance/prds/020-import-wizard-ui/README.md
@@ -137,10 +137,9 @@ interface ImportStore {
   pendingChangeSets: PendingChangeSet[]
   // Step 5
   confirmedTransactions: ConfirmedTransaction[]
-  // Step 6 — commit
+  // Step 6 — commit (single DB write)
   commitResult: CommitResult | null
-  // Step 7
-  importResult: { imported, failed, skipped, reclassified } | null
+  // Step 7 — summary reads commitResult
   // Actions
   nextStep(), prevStep(), goToStep(n), reset()
   updateTransaction(t, updates)
@@ -211,7 +210,7 @@ interface ImportStore {
 | 18  | [us-18-tag-source-badges](us-18-tag-source-badges.md)       | Source badges on suggested tags: rule (with pattern tooltip), AI, entity            | Done   | Blocked by us-17 |
 | 19  | [us-19-per-transaction-tags](us-19-per-transaction-tags.md) | Per-transaction TagEditor with autocomplete (server + session tags)                 | Done   | Blocked by us-17 |
 | 20  | [us-20-bulk-tag-apply](us-20-bulk-tag-apply.md)             | Group-level bulk tag application (merge semantics, never replaces individual edits) | Done   | Blocked by us-19 |
-| 21  | [us-21-execute-import](us-21-execute-import.md)             | Call executeImport, poll progress every 1.5s, show write status                     | Done   | Blocked by us-19 |
+| 21  | [us-21-execute-import](us-21-execute-import.md)             | Advance to Final Review; persist tags to session only — no DB write until Step 6      | Done   | Blocked by us-19 |
 
 ### Final Review & Commit (Step 6)
 
@@ -221,13 +220,13 @@ See PRD-031 for the full spec and user stories for this step.
 
 | #   | Story                             | Summary                                                                                                            | Status | Parallelisable   |
 | --- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------ | ---------------- |
-| 22  | [us-22-summary](us-22-summary.md) | Display import results (imported/failed/skipped/reclassified counts), "New Import" and "View Transactions" buttons | Done   | Blocked by us-21 |
+| 22  | [us-22-summary](us-22-summary.md) | Display commit results from Step 6, "New Import" and "View Transactions" buttons                                     | Done   | Blocked by PRD-031 / Step 6 commit |
 
 US-03 and US-04 can parallelise. US-11, US-12, US-13, US-14, US-15 can parallelise after US-10. US-18 and US-19 can parallelise after US-17.
 
 ## Verification
 
-- Full import flow works end-to-end: CSV → review → tags → database
+- Full import flow works end-to-end: CSV → review → tags → Final Review → `commitImport` → database
 - Duplicate CSVs are detected and skipped
 - Entity matching results categorise correctly (matched vs uncertain)
 - Tags from corrections, AI, and entity defaults all appear with correct source badges

--- a/docs/themes/02-finance/prds/020-import-wizard-ui/us-13-edit-transaction.md
+++ b/docs/themes/02-finance/prds/020-import-wizard-ui/us-13-edit-transaction.md
@@ -18,4 +18,4 @@ As a user, I want to edit a transaction's details during review so that I can fi
 
 ## Notes
 
-Edits are local (Zustand) until the final executeImport in Step 5. This dialog modifies the in-memory transaction, not the database.
+Edits are local (Zustand) until `commitImport` on Step 6. This dialog modifies the in-memory transaction, not the database.

--- a/docs/themes/02-finance/prds/020-import-wizard-ui/us-21-execute-import.md
+++ b/docs/themes/02-finance/prds/020-import-wizard-ui/us-21-execute-import.md
@@ -1,23 +1,24 @@
-# US-21: Execute import
+# US-21: Advance from Tag Review (no database write)
 
 > PRD: [020 — Import Wizard UI](README.md)
 > Status: Done
 
 ## Description
 
-As a user, I want to finalize the import and write transactions to the database so that the import is complete.
+As a user, I want to finish tagging and move to Final Review so that I can confirm the full payload before anything is written to the database.
 
 ## Acceptance Criteria
 
-- [x] "Import" button calls `finance.imports.executeImport` with confirmed transactions
-- [x] Returns session ID for progress tracking
-- [x] Polls `getImportProgress` every 1.5 seconds
-- [x] Shows write progress: count / total
-- [x] On completion: stores import result (imported/failed/skipped counts) in Zustand
-- [x] Advances to Step 6 (Summary) on completion
-- [x] Button disabled while executing (no double-submit)
-- [x] Error handling: if execution fails, show error with retry option
+- [x] Primary action on Tag Review (Step 5) advances to Final Review (Step 6) without calling `executeImport` or any other import write procedure
+- [x] Per-transaction tag edits from Step 5 are persisted to the in-memory import session via `updateTransactionTags` (checksum-keyed) before advancing
+- [x] Copy on Step 5 states that the database is not updated until Final Review / commit (aligned with PRD-031 single write path)
+- [x] No progress polling or import-result state on Step 5 for a write operation — those belong to `commitImport` on Step 6 and the summary step
 
 ## Notes
 
-The execute step writes to SQLite synchronously (no async queue). Tags are JSON stringified. Each transaction gets a generated UUID.
+The single SQLite write path for the wizard is **`commitImport` on Step 6** (PRD-031). Step 5 only updates local/session state; `executeImport` is not part of the Tag Review flow.
+
+## Dependencies
+
+- Blocked by: US-19 (per-transaction tags)
+- Blocks: US-22 (summary shows `commitResult` after Step 6)

--- a/docs/themes/02-finance/prds/030-local-first-import/README.md
+++ b/docs/themes/02-finance/prds/030-local-first-import/README.md
@@ -60,7 +60,7 @@ No new backend endpoints. All operations are zustand store actions and pure func
 
 ## Business Rules
 
-- No DB writes occur during Steps 1-6 of the import wizard. Entity creation, rule changes, and ChangeSet approvals are all buffered locally.
+- No DB writes occur during Steps 1–5 of the import wizard. Entity creation, rule changes, and ChangeSet approvals are all buffered locally. Step 6 performs the single write via `commitImport` (PRD-031).
 - Pending entities receive temp IDs (`temp:entity:{uuid}`) that must be resolved to real DB IDs at commit time.
 - The merged rule set is the single source of truth for all matching, preview, and re-evaluation during the import session.
 - When a pending entity is referenced by a pending rule, the rule stores the temp entity ID. The commit step resolves both in the correct dependency order (entities first, then rules).

--- a/packages/app-finance/src/components/imports/TagReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.tsx
@@ -1,7 +1,7 @@
 import type { ConfirmedTransaction, SuggestedTag } from '@pops/api/modules/finance/imports';
 import { Button } from '@pops/ui';
 import { Badge } from '@pops/ui';
-import { ChevronDown, ChevronRight, Loader2, X } from 'lucide-react';
+import { ChevronDown, ChevronRight, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -60,7 +60,7 @@ function buildTagMetaMap(suggestedTags: SuggestedTag[]): Map<string, TagMetaEntr
 // ---------------------------------------------------------------------------
 
 /**
- * Step 5: Tag Review — review and adjust tags before writing to Notion.
+ * Step 5: Tag Review — review and adjust tags before Final Review (no DB write here).
  *
  * Confirmed transactions arrive with tags pre-populated from AI/rule/entity
  * suggestions. This step lets the user accept, modify, or clear tags before
@@ -74,20 +74,20 @@ function buildTagMetaMap(suggestedTags: SuggestedTag[]): Map<string, TagMetaEntr
  * - Rule pattern shown via tooltip on badge hover
  */
 export function TagReviewStep() {
-  const {
-    confirmedTransactions,
-    updateTransactionTags,
-    nextStep,
-    prevStep,
-    setImportResult,
-    setExecuteSessionId,
-    executeSessionId,
-  } = useImportStore();
+  const { confirmedTransactions, updateTransactionTags, nextStep, prevStep } = useImportStore();
 
-  // Local tag state keyed by checksum — edits don't touch the store until Import
+  // Local tag state keyed by checksum — persisted to the store on Continue (still no DB write).
   const [localTags, setLocalTags] = useState<Record<string, string[]>>(() =>
     Object.fromEntries(confirmedTransactions.map((t) => [t.checksum, t.tags ?? []]))
   );
+
+  useEffect(() => {
+    setLocalTags((prev) =>
+      Object.fromEntries(
+        confirmedTransactions.map((t) => [t.checksum, prev[t.checksum] ?? t.tags ?? []])
+      )
+    );
+  }, [confirmedTransactions]);
 
   // Immutable snapshot of original suggested tags per checksum — for source badges
   const originalSuggestedTags = useMemo<Record<string, SuggestedTag[]>>(
@@ -95,8 +95,12 @@ export function TagReviewStep() {
     [confirmedTransactions]
   );
 
-  const [pollingEnabled, setPollingEnabled] = useState(false);
-  const [importError, setImportError] = useState<string | null>(null);
+  const initialTagsRef = useRef<Record<string, string[]> | null>(null);
+  if (initialTagsRef.current === null && confirmedTransactions.length > 0) {
+    initialTagsRef.current = Object.fromEntries(
+      confirmedTransactions.map((t) => [t.checksum, [...(t.tags ?? [])]])
+    );
+  }
 
   const groups = useMemo(() => groupByEntity(confirmedTransactions), [confirmedTransactions]);
 
@@ -108,42 +112,6 @@ export function TagReviewStep() {
     const local = Object.values(localTags).flat();
     return [...new Set([...(serverTags ?? []), ...local])].sort();
   }, [serverTags, localTags]);
-
-  const executeImportMutation = trpc.finance.imports.executeImport.useMutation({
-    onSuccess: (data) => {
-      setExecuteSessionId(data.sessionId);
-      setPollingEnabled(true);
-    },
-    onError: (err) => {
-      setImportError(err.message);
-    },
-  });
-
-  const progressQuery = trpc.finance.imports.getImportProgress.useQuery(
-    { sessionId: executeSessionId ?? '' },
-    { enabled: pollingEnabled && !!executeSessionId, refetchInterval: 1500 }
-  );
-
-  useEffect(() => {
-    if (!progressQuery.data) return;
-    const { status } = progressQuery.data;
-    if (status === 'completed') {
-      setPollingEnabled(false);
-      const result = progressQuery.data.result;
-      // Narrow to ExecuteImportOutput (has `imported` count) vs ProcessImportOutput
-      if (result && 'imported' in result) {
-        setImportResult({
-          imported: result.imported,
-          failed: result.failed,
-          skipped: result.skipped,
-        });
-        nextStep();
-      }
-    } else if (status === 'failed') {
-      setPollingEnabled(false);
-      setImportError('Import failed. Please try again.');
-    }
-  }, [progressQuery.data, nextStep, setImportResult]);
 
   const updateTag = useCallback((checksum: string, tags: string[]) => {
     setLocalTags((prev) => ({ ...prev, [checksum]: tags }));
@@ -175,85 +143,26 @@ export function TagReviewStep() {
     });
   }, []);
 
-  const handleImport = useCallback(() => {
-    setImportError(null);
-    // Sync local tags back into the store first
+  const handleContinue = useCallback(() => {
     for (const [checksum, tags] of Object.entries(localTags)) {
       updateTransactionTags(checksum, tags);
     }
-    // Build the final payload with updated tags (omit suggestedTags — metadata only)
-    const withTags: ConfirmedTransaction[] = confirmedTransactions.map((t) => ({
-      date: t.date,
-      description: t.description,
-      amount: t.amount,
-      account: t.account,
-      rawRow: t.rawRow,
-      checksum: t.checksum,
-      transactionType: t.transactionType,
-      entityId: t.entityId,
-      entityName: t.entityName,
-      location: t.location,
-      tags: localTags[t.checksum] ?? t.tags ?? [],
-    }));
-    executeImportMutation.mutate({ transactions: withTags });
-  }, [localTags, confirmedTransactions, updateTransactionTags, executeImportMutation]);
+    nextStep();
+  }, [localTags, updateTransactionTags, nextStep]);
 
-  const isImporting = pollingEnabled || executeImportMutation.isPending;
-
-  // ── Error state ──────────────────────────────────────────────────────────
-  if (importError) {
-    return (
-      <div className="space-y-6">
-        <div>
-          <h2 className="text-2xl font-semibold mb-2">Import failed</h2>
-          <p className="text-sm text-destructive">{importError}</p>
-        </div>
-        <div className="flex justify-between">
-          <Button variant="outline" onClick={prevStep}>
-            Back
-          </Button>
-          <Button
-            onClick={() => {
-              setImportError(null);
-              handleImport();
-            }}
-          >
-            Retry
-          </Button>
-        </div>
-      </div>
-    );
-  }
+  const continueLabel =
+    confirmedTransactions.length === 1
+      ? 'Continue to final review (1 transaction)'
+      : `Continue to final review (${confirmedTransactions.length} transactions)`;
 
   return (
     <div className="space-y-6">
-      {/* Progress overlay during import */}
-      {isImporting && (
-        <div
-          data-testid="import-progress-overlay"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
-        >
-          <div className="bg-card border rounded-xl p-8 shadow-xl flex flex-col items-center gap-4 max-w-sm w-full mx-4">
-            <Loader2 className="w-8 h-8 animate-spin text-primary" />
-            <div className="text-center space-y-1">
-              <p className="font-semibold">Importing transactions…</p>
-              {progressQuery.data?.status === 'processing' && (
-                <p className="text-sm text-muted-foreground">
-                  {progressQuery.data.currentStep === 'writing'
-                    ? `Writing ${progressQuery.data.processedCount ?? 0} / ${progressQuery.data.totalTransactions ?? confirmedTransactions.length}`
-                    : (progressQuery.data.currentStep ?? 'Processing…')}
-                </p>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-
       <div>
         <h2 className="text-2xl font-semibold mb-2">Tag Review</h2>
         <p className="text-sm text-muted-foreground">
-          Review and adjust tags before importing. Tags are pre-filled from AI suggestions, learned
-          rules, and entity defaults.
+          Review and adjust tags before the final step. Nothing is written to the database until you
+          commit on Final Review. Tags are pre-filled from AI suggestions, learned rules, and entity
+          defaults.
         </p>
       </div>
 
@@ -279,19 +188,21 @@ export function TagReviewStep() {
         ))}
 
         {confirmedTransactions.length === 0 && (
-          <p className="text-center py-8 text-muted-foreground text-sm">
-            No transactions to import.
-          </p>
+          <p className="text-center py-8 text-muted-foreground text-sm">No transactions to tag.</p>
         )}
       </div>
 
       {/* Footer navigation */}
       <div className="flex justify-between items-center pt-2">
-        <Button variant="outline" onClick={prevStep} disabled={isImporting}>
+        <Button variant="outline" onClick={prevStep}>
           Back
         </Button>
-        <Button onClick={handleImport} disabled={isImporting || confirmedTransactions.length === 0}>
-          {`Import ${confirmedTransactions.length} transaction${confirmedTransactions.length !== 1 ? 's' : ''} →`}
+        <Button
+          onClick={handleContinue}
+          disabled={confirmedTransactions.length === 0}
+          aria-label="Continue to final review"
+        >
+          {continueLabel}
         </Button>
       </div>
     </div>

--- a/packages/app-finance/src/store/importStore.ts
+++ b/packages/app-finance/src/store/importStore.ts
@@ -1,7 +1,6 @@
 import type { ChangeSet } from '@pops/api/modules/core/corrections/types';
 import type {
   ConfirmedTransaction,
-  ImportResult,
   ImportWarning,
   ParsedTransaction,
   ProcessedTransaction as BaseProcessedTransaction,
@@ -17,7 +16,7 @@ export type { ChangeSet };
 export type EntityType = 'company' | 'person' | 'government' | 'bank';
 
 // ---------------------------------------------------------------------------
-// Pending entity — created during import, stored locally until step 7 commit.
+// Pending entity — created during import, stored locally until Step 6 commit.
 // ---------------------------------------------------------------------------
 
 export interface PendingEntity {
@@ -98,7 +97,6 @@ interface ImportStore {
   // Step 4: Review (entity confirmation, no execute here)
 
   // Step 5: Tag Review
-  executeSessionId: string | null;
   processedTransactions: {
     matched: ProcessedTransaction[]; // Uses extended type
     uncertain: ProcessedTransaction[];
@@ -108,12 +106,7 @@ interface ImportStore {
   };
   confirmedTransactions: ConfirmedTransaction[];
 
-  // Step 7: Summary
-  importResult: {
-    imported: number;
-    failed: ImportResult[];
-    skipped: number;
-  } | null;
+  // Step 6 commit / Step 7 summary
   commitResult: CommitResult | null;
 
   // Local-first pending state (PRD-030)
@@ -130,8 +123,6 @@ interface ImportStore {
   setProcessSessionId: (sessionId: string | null) => void;
   setProcessedTransactions: (processed: ImportStore['processedTransactions']) => void;
   setConfirmedTransactions: (confirmed: ConfirmedTransaction[]) => void;
-  setExecuteSessionId: (sessionId: string | null) => void;
-  setImportResult: (result: ImportStore['importResult']) => void;
   setCommitResult: (result: CommitResult | null) => void;
 
   nextStep: () => void;
@@ -186,8 +177,6 @@ const initialState = {
     warnings: undefined,
   },
   confirmedTransactions: [],
-  executeSessionId: null,
-  importResult: null,
   commitResult: null,
   pendingEntities: [],
   pendingChangeSets: [],
@@ -221,8 +210,6 @@ const downstreamReset: Pick<
   | 'processedForFingerprint'
   | 'processedTransactions'
   | 'confirmedTransactions'
-  | 'executeSessionId'
-  | 'importResult'
   | 'commitResult'
   | 'pendingEntities'
   | 'pendingChangeSets'
@@ -235,8 +222,6 @@ const downstreamReset: Pick<
   processedForFingerprint: initialState.processedForFingerprint,
   processedTransactions: initialState.processedTransactions,
   confirmedTransactions: initialState.confirmedTransactions,
-  executeSessionId: initialState.executeSessionId,
-  importResult: initialState.importResult,
   commitResult: initialState.commitResult,
   pendingEntities: initialState.pendingEntities,
   pendingChangeSets: initialState.pendingChangeSets,
@@ -296,8 +281,6 @@ export const useImportStore = create<ImportStore>((set) => ({
       processedForFingerprint: state.parsedTransactionsFingerprint,
     })),
   setConfirmedTransactions: (confirmedTransactions) => set({ confirmedTransactions }),
-  setExecuteSessionId: (executeSessionId) => set({ executeSessionId }),
-  setImportResult: (importResult) => set({ importResult }),
   setCommitResult: (commitResult) => set({ commitResult }),
 
   nextStep: () => set((state) => ({ currentStep: Math.min(state.currentStep + 1, 7) })),


### PR DESCRIPTION
## Summary
Aligns the import wizard with PRD-031: **Tag Review (Step 5) no longer calls `executeImport`**. Tags are written to the Zustand session via `updateTransactionTags`, then the user continues to **Final Review** where **`commitImport`** is the only SQLite write.

## Changes
- `TagReviewStep`: remove execute mutation, progress polling, overlay, and Tag-step import error UI; primary CTA is **Continue to final review** (`aria-label` included); `useEffect` keeps `localTags` in sync when `confirmedTransactions` changes.
- `importStore`: remove `executeSessionId`, `importResult`, and related setters (summary already uses `commitResult`).
- Docs: PRD-020 (README, US-13, US-21), PRD-030 business rule for step boundaries.
- E2E: `setupMockAPIs` mocks `commitImport`; full flow and skipped tests updated for the 7-step wizard; transfer payload test captures `commitImport` body.

## Verification
- `mise lint` — pass
- `mise typecheck` — pass

Closes https://github.com/knoxio/pops/issues/1740