### PR TITLE
feat(import): wire Tag Review to tag rule ChangeSet APIs (#1741)

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -20,6 +20,10 @@
       "types": "./src/modules/core/corrections/types.ts",
       "default": "./src/modules/core/corrections/types.ts"
     },
+    "./modules/core/tag-rules/types": {
+      "types": "./src/modules/core/tag-rules/types.ts",
+      "default": "./src/modules/core/tag-rules/types.ts"
+    },
     "./modules/core/entities/types": {
       "types": "./src/modules/core/entities/types.ts",
       "default": "./src/modules/core/entities/types.ts"

--- a/apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts
@@ -6,6 +6,8 @@ import { logger } from '../../../../lib/logger.js';
 import { ValidationError } from '../../../../shared/errors.js';
 import { findMatchingCorrectionFromRules } from '../../../core/corrections/service.js';
 import { applyChangeSet } from '../../../core/corrections/service.js';
+import { applyTagRuleChangeSet, upsertVocabularyTag } from '../../../core/tag-rules/service.js';
+import type { TagRuleChangeSet } from '../../../core/tag-rules/types.js';
 import type { TransactionRow } from '../../transactions/types.js';
 import type { CommitPayload, CommitResult, FailedTransactionDetail } from '../types.js';
 
@@ -94,6 +96,17 @@ function validateCommitPayload(payload: CommitPayload): void {
     }
   }
 
+  for (const cs of payload.tagRuleChangeSets) {
+    for (const op of cs.ops) {
+      if (op.op === 'add' && op.data.entityId?.startsWith(TEMP_ENTITY_PREFIX)) {
+        referencedTempIds.add(op.data.entityId);
+      }
+      if (op.op === 'edit' && op.data.entityId?.startsWith(TEMP_ENTITY_PREFIX)) {
+        referencedTempIds.add(op.data.entityId);
+      }
+    }
+  }
+
   for (const txn of payload.transactions) {
     if (txn.entityId?.startsWith(TEMP_ENTITY_PREFIX)) {
       referencedTempIds.add(txn.entityId);
@@ -129,6 +142,39 @@ function resolveChangeSetTempIds(
       return op;
     }),
   };
+}
+
+function resolveTagRuleChangeSetTempIds(
+  cs: TagRuleChangeSet,
+  tempIdMap: Map<string, string>
+): TagRuleChangeSet {
+  return {
+    ...cs,
+    ops: cs.ops.map((op) => {
+      if (op.op === 'add' && op.data.entityId?.startsWith(TEMP_ENTITY_PREFIX)) {
+        const realId = tempIdMap.get(op.data.entityId);
+        return { ...op, data: { ...op.data, entityId: realId ?? op.data.entityId } };
+      }
+      if (op.op === 'edit' && op.data.entityId?.startsWith(TEMP_ENTITY_PREFIX)) {
+        const realId = tempIdMap.get(op.data.entityId);
+        return { ...op, data: { ...op.data, entityId: realId ?? op.data.entityId } };
+      }
+      return op;
+    }),
+  };
+}
+
+function collectTagsFromTagRuleChangeSet(cs: TagRuleChangeSet): string[] {
+  const tags = new Set<string>();
+  for (const op of cs.ops) {
+    if (op.op === 'add' && op.data.tags) {
+      for (const t of op.data.tags) {
+        const s = t.trim();
+        if (s) tags.add(s);
+      }
+    }
+  }
+  return [...tags];
 }
 
 /**
@@ -187,6 +233,17 @@ export function commitImport(payload: CommitPayload): CommitResult {
       for (const op of resolved.ops) {
         rulesApplied[op.op]++;
       }
+    }
+
+    // Phase 2b: Apply pending tag-rule ChangeSets (PRD-029) with resolved temp IDs
+    let tagRulesApplied = 0;
+    for (const cs of payload.tagRuleChangeSets) {
+      const resolved = resolveTagRuleChangeSetTempIds(cs, tempIdMap);
+      for (const tag of collectTagsFromTagRuleChangeSet(resolved)) {
+        upsertVocabularyTag(tag, 'user');
+      }
+      applyTagRuleChangeSet(resolved);
+      tagRulesApplied += resolved.ops.length;
     }
 
     // Phase 3: Write transactions with resolved temp IDs
@@ -249,6 +306,7 @@ export function commitImport(payload: CommitPayload): CommitResult {
     return {
       entitiesCreated,
       rulesApplied,
+      tagRulesApplied,
       transactionsImported,
       transactionsFailed,
       failedDetails,

--- a/apps/pops-api/src/modules/finance/imports/router.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/router.test.ts
@@ -603,6 +603,7 @@ describe('imports.commitImport', () => {
     expect(result.data.transactionsFailed).toBe(0);
     expect(result.data.failedDetails).toEqual([]);
     expect(result.data.rulesApplied).toEqual({ add: 0, edit: 0, disable: 0, remove: 0 });
+    expect(result.data.tagRulesApplied).toBe(0);
     expect(result.data.retroactiveReclassifications).toBe(0);
     expect(result.message).toBe('Import committed');
 
@@ -686,6 +687,7 @@ describe('imports.commitImport', () => {
 
     expect(result.data.entitiesCreated).toBe(1);
     expect(result.data.rulesApplied).toEqual({ add: 1, edit: 0, disable: 0, remove: 0 });
+    expect(result.data.tagRulesApplied).toBe(0);
 
     // Verify the correction rule has the real entity ID
     const entity = db.prepare('SELECT id FROM entities WHERE name = ?').get('TestCorp') as {
@@ -706,6 +708,7 @@ describe('imports.commitImport', () => {
 
     expect(result.data.entitiesCreated).toBe(0);
     expect(result.data.rulesApplied).toEqual({ add: 0, edit: 0, disable: 0, remove: 0 });
+    expect(result.data.tagRulesApplied).toBe(0);
     expect(result.data.transactionsImported).toBe(1);
   });
 
@@ -809,6 +812,38 @@ describe('imports.commitImport', () => {
 
     expect(result.data.entitiesCreated).toBe(2);
     expect(result.data.transactionsImported).toBe(3);
+  });
+
+  it('applies pending tag rule change sets during commit', async () => {
+    const result = await caller.finance.imports.commitImport({
+      entities: [],
+      changeSets: [],
+      tagRuleChangeSets: [
+        {
+          source: 'unit-test',
+          ops: [
+            {
+              op: 'add' as const,
+              data: {
+                descriptionPattern: 'SAVE_A_TAG_RULE_TEST',
+                matchType: 'contains' as const,
+                tags: ['UnitTestTag'],
+              },
+            },
+          ],
+        },
+      ],
+      transactions: [makeTxn({ description: 'SAVE_A_TAG_RULE_TEST 1', tags: ['UnitTestTag'] })],
+    });
+
+    expect(result.data.tagRulesApplied).toBe(1);
+
+    const rule = db
+      .prepare(
+        'SELECT description_pattern FROM transaction_tag_rules WHERE description_pattern = ?'
+      )
+      .get('SAVE_A_TAG_RULE_TEST') as { description_pattern: string } | undefined;
+    expect(rule?.description_pattern).toBe('SAVE_A_TAG_RULE_TEST');
   });
 
   it('throws UNAUTHORIZED without auth', async () => {

--- a/apps/pops-api/src/modules/finance/imports/router.ts
+++ b/apps/pops-api/src/modules/finance/imports/router.ts
@@ -6,7 +6,7 @@
  * - executeImport: Write confirmed transactions to SQLite - returns session ID for polling
  * - getImportProgress: Poll for import progress by session ID
  * - createEntity: Create new entity in SQLite
- * - commitImport: Atomically create entities, apply changeSets, and write transactions
+ * - commitImport: Atomically create entities, apply changeSets + tag rule changeSets, and write transactions
  */
 import { TRPCError } from '@trpc/server';
 import crypto from 'crypto';

--- a/apps/pops-api/src/modules/finance/imports/types.ts
+++ b/apps/pops-api/src/modules/finance/imports/types.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { ChangeSetSchema } from '../../core/corrections/types.js';
+import { TagRuleChangeSetSchema } from '../../core/tag-rules/types.js';
 
 /**
  * Transaction as parsed from CSV (client-side or transformer)
@@ -228,6 +229,7 @@ export type PendingChangeSet = z.infer<typeof pendingChangeSetSchema>;
 export const commitPayloadSchema = z.object({
   entities: z.array(pendingEntitySchema).default([]),
   changeSets: z.array(pendingChangeSetSchema).default([]),
+  tagRuleChangeSets: z.array(TagRuleChangeSetSchema).default([]),
   transactions: z.array(confirmedTransactionSchema),
 });
 
@@ -252,6 +254,8 @@ export type FailedTransactionDetail = z.infer<typeof failedTransactionDetailSche
 export const commitResultSchema = z.object({
   entitiesCreated: z.number().int().nonnegative(),
   rulesApplied: rulesAppliedSchema,
+  /** Count of tag-rule ChangeSet operations applied during commit (add/edit/disable/remove). */
+  tagRulesApplied: z.number().int().nonnegative(),
   transactionsImported: z.number().int().nonnegative(),
   transactionsFailed: z.number().int().nonnegative(),
   failedDetails: z.array(failedTransactionDetailSchema),

--- a/packages/app-finance/src/components/imports/FinalReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/FinalReviewStep.test.tsx
@@ -43,9 +43,17 @@ vi.mock('../../lib/trpc', () => ({
 
 vi.mock('../../lib/commit-payload', () => ({
   buildCommitPayload: vi.fn(
-    (entities: unknown[], changeSets: unknown[], transactions: unknown[]) => ({
+    (
+      entities: unknown[],
+      changeSets: unknown[],
+      tagRuleChangeSets: unknown[],
+      transactions: unknown[]
+    ) => ({
       entities,
       changeSets: (changeSets as Array<{ changeSet: unknown }>).map((pcs) => pcs.changeSet),
+      tagRuleChangeSets: (tagRuleChangeSets as Array<{ changeSet: unknown }>).map(
+        (pcs) => pcs.changeSet
+      ),
       transactions,
     })
   ),
@@ -59,6 +67,7 @@ function makeStoreState(overrides: Partial<typeof storeState> = {}) {
   return {
     pendingEntities: [],
     pendingChangeSets: [],
+    pendingTagRuleChangeSets: [],
     confirmedTransactions: [],
     processedTransactions: {
       matched: [],
@@ -91,7 +100,7 @@ describe('FinalReviewStep', () => {
   it('hides sections with zero items', () => {
     render(<FinalReviewStep />);
     expect(screen.queryByText('New Entities')).toBeNull();
-    expect(screen.queryByText('Rule Changes')).toBeNull();
+    expect(screen.queryByText('Classification Rule Changes')).toBeNull();
     expect(screen.queryByText('Transactions to Import')).toBeNull();
     expect(screen.queryByText('Tag Assignments')).toBeNull();
   });
@@ -215,6 +224,7 @@ describe('FinalReviewStep', () => {
       data: {
         entitiesCreated: 2,
         rulesApplied: { add: 1, edit: 0, disable: 0, remove: 0 },
+        tagRulesApplied: 0,
         transactionsImported: 5,
         transactionsFailed: 0,
         failedDetails: [],
@@ -226,6 +236,7 @@ describe('FinalReviewStep', () => {
       expect(mockSetCommitResult).toHaveBeenCalledWith({
         entitiesCreated: 2,
         rulesApplied: { add: 1, edit: 0, disable: 0, remove: 0 },
+        tagRulesApplied: 0,
         transactionsImported: 5,
         transactionsFailed: 0,
         failedDetails: [],
@@ -239,6 +250,7 @@ describe('FinalReviewStep', () => {
     const resultData = {
       entitiesCreated: 2,
       rulesApplied: { add: 1, edit: 0, disable: 0, remove: 0 },
+      tagRulesApplied: 0,
       transactionsImported: 5,
       transactionsFailed: 0,
       failedDetails: [],
@@ -254,7 +266,8 @@ describe('FinalReviewStep', () => {
       expect(screen.getByText('Commit Successful')).toBeDefined();
       expect(screen.getByText('Entities created:')).toBeDefined();
       expect(screen.getByText('Transactions imported:')).toBeDefined();
-      expect(screen.getByText('Rules applied:')).toBeDefined();
+      expect(screen.getByText('Classification rules applied:')).toBeDefined();
+      expect(screen.getByText('Tag rules applied:')).toBeDefined();
       expect(screen.getByText('Reclassifications:')).toBeDefined();
     });
   });

--- a/packages/app-finance/src/components/imports/FinalReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/FinalReviewStep.tsx
@@ -22,6 +22,12 @@ type ChangeSetOp =
   | { op: 'disable'; id: string }
   | { op: 'remove'; id: string };
 
+type TagRuleChangeSetOp =
+  | { op: 'add'; data: { descriptionPattern: string; tags?: string[]; [k: string]: unknown } }
+  | { op: 'edit'; id: string; data: Record<string, unknown> }
+  | { op: 'disable'; id: string }
+  | { op: 'remove'; id: string };
+
 // ---------------------------------------------------------------------------
 // Collapsible section wrapper
 // ---------------------------------------------------------------------------
@@ -99,9 +105,24 @@ function opDisplayLabel(op: ChangeSetOp): string {
   }
 }
 
+function tagRuleOpDisplayLabel(op: TagRuleChangeSetOp): string {
+  switch (op.op) {
+    case 'add': {
+      const tags = op.data.tags?.length ? ` → ${op.data.tags.join(', ')}` : '';
+      return `${op.data.descriptionPattern}${tags}`;
+    }
+    case 'edit':
+      return `Rule ${op.id.slice(0, 8)}`;
+    case 'disable':
+    case 'remove':
+      return `Rule ${op.id.slice(0, 8)}`;
+  }
+}
+
 export function FinalReviewStep() {
   const pendingEntities = useImportStore((s) => s.pendingEntities);
   const pendingChangeSets = useImportStore((s) => s.pendingChangeSets);
+  const pendingTagRuleChangeSets = useImportStore((s) => s.pendingTagRuleChangeSets);
   const confirmedTransactions = useImportStore((s) => s.confirmedTransactions);
   const processedTransactions = useImportStore((s) => s.processedTransactions);
   const prevStep = useImportStore((s) => s.prevStep);
@@ -125,7 +146,12 @@ export function FinalReviewStep() {
 
   const handleCommit = () => {
     setCommitError(null);
-    const payload = buildCommitPayload(pendingEntities, pendingChangeSets, confirmedTransactions);
+    const payload = buildCommitPayload(
+      pendingEntities,
+      pendingChangeSets,
+      pendingTagRuleChangeSets,
+      confirmedTransactions
+    );
     commitMutation.mutate(payload);
   };
 
@@ -155,8 +181,14 @@ export function FinalReviewStep() {
     [pendingChangeSets]
   );
 
+  const totalTagRuleOps = useMemo(
+    () => pendingTagRuleChangeSets.reduce((sum, pcs) => sum + pcs.changeSet.ops.length, 0),
+    [pendingTagRuleChangeSets]
+  );
+
   const hasEntities = pendingEntities.length > 0;
   const hasRuleChanges = totalOps > 0;
+  const hasTagRuleChanges = totalTagRuleOps > 0;
   const hasTransactions = txnBreakdown.total > 0;
   const hasTags = tagAssignmentCount > 0;
   const isCommitting = commitMutation.isPending;
@@ -187,7 +219,7 @@ export function FinalReviewStep() {
 
         {/* Rule changes */}
         {hasRuleChanges && (
-          <Section title="Rule Changes" count={totalOps}>
+          <Section title="Classification Rule Changes" count={totalOps}>
             <div className="space-y-3">
               {pendingChangeSets.map((pcs) => (
                 <div key={pcs.tempId} className="space-y-1">
@@ -195,11 +227,52 @@ export function FinalReviewStep() {
                     <p className="text-xs text-muted-foreground">Source: {pcs.changeSet.source}</p>
                   )}
                   <ul className="space-y-1">
-                    {pcs.changeSet.ops.map((op, idx) => {
+                    {pcs.changeSet.ops.map((op) => {
                       const badge = OP_BADGE[op.op];
                       const label = opDisplayLabel(op as ChangeSetOp);
+                      const rowKey =
+                        op.op === 'add'
+                          ? `${pcs.tempId}-cor-add-${op.data.descriptionPattern}`
+                          : `${pcs.tempId}-cor-${op.op}-${op.id}`;
                       return (
-                        <li key={idx} className="flex items-center gap-2 text-sm py-0.5">
+                        <li key={rowKey} className="flex items-center gap-2 text-sm py-0.5">
+                          {badge && (
+                            <span
+                              className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${badge.className}`}
+                            >
+                              {badge.icon}
+                              {badge.label}
+                            </span>
+                          )}
+                          <span className="font-mono text-xs truncate">{label}</span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </Section>
+        )}
+
+        {hasTagRuleChanges && (
+          <Section title="Tag Rule Changes" count={totalTagRuleOps}>
+            <div className="space-y-3">
+              {pendingTagRuleChangeSets.map((pcs) => (
+                <div key={pcs.tempId} className="space-y-1">
+                  {pcs.changeSet.source && (
+                    <p className="text-xs text-muted-foreground">Source: {pcs.changeSet.source}</p>
+                  )}
+                  <ul className="space-y-1">
+                    {pcs.changeSet.ops.map((op) => {
+                      const badge = OP_BADGE[op.op];
+                      const label = tagRuleOpDisplayLabel(op as TagRuleChangeSetOp);
+                      const rowKey =
+                        op.op === 'add'
+                          ? `${pcs.tempId}-add-${op.data.descriptionPattern}`
+                          : `${pcs.tempId}-${op.op}-${op.id}`;
+                      return (
+                        <li key={rowKey} className="flex items-center gap-2 text-sm py-0.5">
                           {badge && (
                             <span
                               className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${badge.className}`}
@@ -260,7 +333,7 @@ export function FinalReviewStep() {
         )}
 
         {/* Empty state */}
-        {!hasEntities && !hasRuleChanges && !hasTransactions && !hasTags && (
+        {!hasEntities && !hasRuleChanges && !hasTagRuleChanges && !hasTransactions && !hasTags && (
           <p className="text-sm text-muted-foreground text-center py-8">
             No pending changes to review.
           </p>
@@ -295,13 +368,17 @@ export function FinalReviewStep() {
               <span className="font-medium">{commitResult.transactionsImported}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-muted-foreground">Rules applied:</span>
+              <span className="text-muted-foreground">Classification rules applied:</span>
               <span className="font-medium">
                 {commitResult.rulesApplied.add +
                   commitResult.rulesApplied.edit +
                   commitResult.rulesApplied.disable +
                   commitResult.rulesApplied.remove}
               </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Tag rules applied:</span>
+              <span className="font-medium">{commitResult.tagRulesApplied ?? 0}</span>
             </div>
             {commitResult.transactionsFailed > 0 && (
               <div className="flex justify-between">
@@ -344,8 +421,11 @@ export function FinalReviewStep() {
                 Failed transactions:
               </p>
               <ul className="space-y-1">
-                {commitResult.failedDetails.map((detail, idx) => (
-                  <li key={idx} className="text-xs text-red-700 dark:text-red-300 flex gap-2">
+                {commitResult.failedDetails.map((detail) => (
+                  <li
+                    key={`${detail.checksum ?? 'no-chk'}-${detail.error}`}
+                    className="text-xs text-red-700 dark:text-red-300 flex gap-2"
+                  >
                     {detail.checksum && (
                       <span className="font-mono shrink-0">{detail.checksum.slice(0, 12)}</span>
                     )}

--- a/packages/app-finance/src/components/imports/SummaryStep.test.tsx
+++ b/packages/app-finance/src/components/imports/SummaryStep.test.tsx
@@ -25,6 +25,7 @@ function makeCommitResult(overrides: Record<string, unknown> = {}) {
   return {
     entitiesCreated: 3,
     rulesApplied: { add: 2, edit: 1, disable: 0, remove: 0 },
+    tagRulesApplied: 0,
     transactionsImported: 10,
     transactionsFailed: 1,
     failedDetails: [{ checksum: 'abc123def456', error: 'Duplicate checksum' }],

--- a/packages/app-finance/src/components/imports/SummaryStep.tsx
+++ b/packages/app-finance/src/components/imports/SummaryStep.tsx
@@ -28,7 +28,8 @@ export function SummaryStep() {
     commitResult.rulesApplied.add +
     commitResult.rulesApplied.edit +
     commitResult.rulesApplied.disable +
-    commitResult.rulesApplied.remove;
+    commitResult.rulesApplied.remove +
+    (commitResult.tagRulesApplied ?? 0);
 
   return (
     <div className="space-y-6">

--- a/packages/app-finance/src/components/imports/TagReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.tsx
@@ -5,10 +5,15 @@ import { ChevronDown, ChevronRight, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
+import {
+  computeLearnableTags,
+  descriptionPatternFromGroup,
+} from '../../lib/tag-rule-learn-helpers';
 import { trpc } from '../../lib/trpc';
 import { cn } from '../../lib/utils';
 import { useImportStore } from '../../store/importStore';
 import { TagEditor, type TagMetaEntry } from '../TagEditor';
+import { type TagRuleLearnSignal, TagRuleProposalDialog } from './TagRuleProposalDialog';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -102,6 +107,48 @@ export function TagReviewStep() {
     );
   }
 
+  const [learnOpen, setLearnOpen] = useState(false);
+  const [learnSignal, setLearnSignal] = useState<TagRuleLearnSignal | null>(null);
+
+  const previewTransactionsForRules = useMemo(
+    () =>
+      confirmedTransactions.map((t) => ({
+        transactionId: t.checksum,
+        description: t.description,
+        entityId: t.entityId ?? null,
+      })),
+    [confirmedTransactions]
+  );
+
+  const openLearnForGroup = useCallback(
+    (group: ConfirmedGroup) => {
+      const snap = initialTagsRef.current;
+      if (!snap || group.transactions.length === 0) return;
+      const learnable = computeLearnableTags(group.transactions, localTags, snap);
+      const fallback = unionTags(group.transactions.map((t) => localTags[t.checksum] ?? []));
+      const tags = learnable.length > 0 ? learnable : fallback;
+      if (tags.length === 0) {
+        toast.error('Add at least one tag to this group before saving a rule.');
+        return;
+      }
+      const pattern = descriptionPatternFromGroup(group.transactions.map((t) => t.description));
+      const eids = [
+        ...new Set(group.transactions.map((t) => t.entityId).filter(Boolean)),
+      ] as string[];
+      const entityId = eids.length === 1 ? eids[0]! : null;
+      const firstDesc = group.transactions[0]!.description;
+      setLearnSignal({
+        descriptionPattern:
+          pattern || firstDesc.slice(0, 16).toUpperCase().replace(/\s+/g, ' ').trim() || 'IMPORT',
+        matchType: 'contains',
+        entityId,
+        tags,
+      });
+      setLearnOpen(true);
+    },
+    [localTags]
+  );
+
   const groups = useMemo(() => groupByEntity(confirmedTransactions), [confirmedTransactions]);
 
   const { data: serverTags } = trpc.finance.transactions.availableTags.useQuery();
@@ -157,6 +204,13 @@ export function TagReviewStep() {
 
   return (
     <div className="space-y-6">
+      <TagRuleProposalDialog
+        open={learnOpen}
+        onOpenChange={setLearnOpen}
+        signal={learnSignal}
+        previewTransactions={previewTransactionsForRules}
+      />
+
       <div>
         <h2 className="text-2xl font-semibold mb-2">Tag Review</h2>
         <p className="text-sm text-muted-foreground">
@@ -184,6 +238,7 @@ export function TagReviewStep() {
             availableTags={availableTags ?? []}
             onUpdateTag={updateTag}
             onApplyGroupTags={handleApplyGroupTags}
+            onOpenTagRule={openLearnForGroup}
           />
         ))}
 
@@ -220,6 +275,7 @@ interface EntityGroupProps {
   availableTags: string[];
   onUpdateTag: (checksum: string, tags: string[]) => void;
   onApplyGroupTags: (group: ConfirmedGroup, tags: string[]) => void;
+  onOpenTagRule: (group: ConfirmedGroup) => void;
 }
 
 /**
@@ -234,6 +290,7 @@ function EntityGroup({
   availableTags,
   onUpdateTag,
   onApplyGroupTags,
+  onOpenTagRule,
 }: EntityGroupProps) {
   const [expanded, setExpanded] = useState(true);
 
@@ -329,6 +386,16 @@ function EntityGroup({
               Apply suggestions
             </Button>
           )}
+
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => onOpenTagRule(group)}
+            className="text-xs px-2 py-1 h-auto whitespace-nowrap"
+            title="Preview and save a reusable tag rule for this merchant group"
+          >
+            Save tag rule…
+          </Button>
         </div>
       </div>
 

--- a/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
@@ -44,14 +44,13 @@ function firstAddOpFingerprint(cs: TagRuleChangeSet): string | null {
     return `non-add|${cs.ops.length}|${cs.ops.map((o) => o.op).join(',')}`;
   }
   const d = first.data;
-  const tags = [...(d.tags ?? [])].map((t) => t.trim()).filter(Boolean).sort();
-  return [
-    cs.ops.length,
-    d.descriptionPattern,
-    d.matchType,
-    d.entityId ?? '',
-    tags.join('\0'),
-  ].join('|');
+  const tags = [...(d.tags ?? [])]
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .sort();
+  return [cs.ops.length, d.descriptionPattern, d.matchType, d.entityId ?? '', tags.join('\0')].join(
+    '|'
+  );
 }
 
 function patchFirstAddOp(

--- a/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
@@ -1,0 +1,401 @@
+import type { TagRuleChangeSet } from '@pops/api/modules/core/tag-rules/types';
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from '@pops/ui';
+import { Loader2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+import { trpc } from '../../lib/trpc';
+import { useImportStore } from '../../store/importStore';
+
+export interface TagRuleLearnSignal {
+  descriptionPattern: string;
+  matchType: 'exact' | 'contains' | 'regex';
+  entityId: string | null;
+  tags: string[];
+}
+
+export interface TagRuleProposalDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  signal: TagRuleLearnSignal | null;
+  previewTransactions: Array<{
+    transactionId: string;
+    description: string;
+    entityId?: string | null;
+  }>;
+}
+
+/** Stable comparison for v1 single-`add` proposals (avoids JSON key-order drift). */
+function firstAddOpFingerprint(cs: TagRuleChangeSet): string | null {
+  if (cs.ops.length === 0) return null;
+  const first = cs.ops[0];
+  if (!first || first.op !== 'add') {
+    return `non-add|${cs.ops.length}|${cs.ops.map((o) => o.op).join(',')}`;
+  }
+  const d = first.data;
+  const tags = [...(d.tags ?? [])].map((t) => t.trim()).filter(Boolean).sort();
+  return [
+    cs.ops.length,
+    d.descriptionPattern,
+    d.matchType,
+    d.entityId ?? '',
+    tags.join('\0'),
+  ].join('|');
+}
+
+function patchFirstAddOp(
+  changeSet: TagRuleChangeSet,
+  patch: Partial<{
+    descriptionPattern: string;
+    matchType: 'exact' | 'contains' | 'regex';
+    entityId: string | null;
+    tags: string[];
+  }>
+): TagRuleChangeSet {
+  const first = changeSet.ops[0];
+  if (!first || first.op !== 'add') return changeSet;
+  return {
+    ...changeSet,
+    ops: [{ ...first, data: { ...first.data, ...patch } }, ...changeSet.ops.slice(1)],
+  };
+}
+
+export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
+  const addPendingTagRuleChangeSet = useImportStore((s) => s.addPendingTagRuleChangeSet);
+
+  const disabledSignal = useMemo(
+    () => ({
+      descriptionPattern: '_',
+      matchType: 'contains' as const,
+      entityId: null as string | null,
+      tags: ['_'],
+    }),
+    []
+  );
+
+  const proposeInput = useMemo(() => {
+    if (!props.signal) return null;
+    return {
+      signal: {
+        descriptionPattern: props.signal.descriptionPattern,
+        matchType: props.signal.matchType,
+        entityId: props.signal.entityId,
+        tags: props.signal.tags,
+      },
+      transactions: props.previewTransactions.map((t) => ({
+        transactionId: t.transactionId,
+        description: t.description,
+        entityId: t.entityId ?? null,
+      })),
+      maxPreviewItems: 200,
+    };
+  }, [props.signal, props.previewTransactions]);
+
+  const proposeQuery = trpc.core.tagRules.proposeTagRuleChangeSet.useQuery(
+    proposeInput ?? {
+      signal: disabledSignal,
+      transactions: [],
+      maxPreviewItems: 200,
+    },
+    {
+      enabled: Boolean(props.open && proposeInput),
+      staleTime: 0,
+      retry: false,
+    }
+  );
+
+  const [draft, setDraft] = useState<TagRuleChangeSet | null>(null);
+  const [tagsText, setTagsText] = useState('');
+  const [rejectMode, setRejectMode] = useState(false);
+  const [rejectFeedback, setRejectFeedback] = useState('');
+
+  useEffect(() => {
+    if (!props.open) {
+      setDraft(null);
+      setTagsText('');
+      setRejectMode(false);
+      setRejectFeedback('');
+      return;
+    }
+    const data = proposeQuery.data;
+    if (!data) return;
+    setDraft(data.changeSet);
+    const first = data.changeSet.ops[0];
+    if (first && first.op === 'add') {
+      setTagsText(first.data.tags.join(', '));
+    }
+  }, [props.open, proposeQuery.data]);
+
+  const previewInput = useMemo(() => {
+    if (!props.open || !draft) return null;
+    return {
+      changeSet: draft,
+      transactions: props.previewTransactions.map((t) => ({
+        transactionId: t.transactionId,
+        description: t.description,
+        entityId: t.entityId ?? null,
+      })),
+      maxPreviewItems: 200,
+    };
+  }, [props.open, draft, props.previewTransactions]);
+
+  const previewQuery = trpc.core.tagRules.previewTagRuleChangeSet.useQuery(
+    previewInput ?? {
+      changeSet: { ops: [{ op: 'add' as const, data: { descriptionPattern: '_', tags: ['_'] } }] },
+      transactions: [],
+      maxPreviewItems: 200,
+    },
+    {
+      enabled: Boolean(previewInput),
+      staleTime: 0,
+      retry: false,
+    }
+  );
+
+  const rejectMutation = trpc.core.tagRules.rejectTagRuleChangeSet.useMutation({
+    onSuccess: () => {
+      toast.success('Proposal rejected — feedback recorded');
+      props.onOpenChange(false);
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const baseline = proposeQuery.data?.changeSet;
+  const hasStructuralEdits = useMemo(() => {
+    if (!draft || !baseline) return false;
+    const a = firstAddOpFingerprint(draft);
+    const b = firstAddOpFingerprint(baseline);
+    if (!a || !b) return true;
+    return a !== b;
+  }, [draft, baseline]);
+
+  const isBusy = proposeQuery.isFetching || previewQuery.isFetching || rejectMutation.isPending;
+
+  const canApply =
+    !isBusy &&
+    Boolean(draft) &&
+    !proposeQuery.isError &&
+    !previewQuery.isError &&
+    !previewQuery.isFetching &&
+    draft !== null;
+
+  const handlePatternChange = useCallback((value: string) => {
+    setDraft((prev) => (prev ? patchFirstAddOp(prev, { descriptionPattern: value }) : prev));
+  }, []);
+
+  const handleMatchTypeChange = useCallback((value: 'exact' | 'contains' | 'regex') => {
+    setDraft((prev) => (prev ? patchFirstAddOp(prev, { matchType: value }) : prev));
+  }, []);
+
+  const handleTagsBlur = useCallback(() => {
+    const tags = tagsText
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+    if (tags.length === 0) return;
+    setDraft((prev) => (prev ? patchFirstAddOp(prev, { tags }) : prev));
+  }, [tagsText]);
+
+  const handleApprove = useCallback(() => {
+    if (!draft) return;
+    const tags = tagsText
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+    if (tags.length === 0) {
+      toast.error('Add at least one tag before saving this rule.');
+      return;
+    }
+    const finalDraft = patchFirstAddOp(draft, { tags });
+    try {
+      addPendingTagRuleChangeSet({ changeSet: finalDraft, source: 'tag-rule-proposal' });
+      toast.success('Tag rule saved locally — it will apply when you commit the import');
+      props.onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save tag rule');
+    }
+  }, [addPendingTagRuleChangeSet, draft, props, tagsText]);
+
+  const handleConfirmReject = useCallback(() => {
+    if (!draft) return;
+    const trimmed = rejectFeedback.trim();
+    if (!trimmed) return;
+    rejectMutation.mutate({ changeSet: draft, feedback: trimmed });
+  }, [draft, rejectFeedback, rejectMutation]);
+
+  const firstAdd = draft?.ops[0]?.op === 'add' ? draft.ops[0].data : null;
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Save tag rule</DialogTitle>
+          <DialogDescription>
+            Preview how a new tag rule would affect this import batch, then approve it into your
+            pending changes (same flow as classification rules).
+          </DialogDescription>
+        </DialogHeader>
+
+        {proposeQuery.isLoading && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground py-6">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Building proposal…
+          </div>
+        )}
+
+        {proposeQuery.isError && (
+          <p className="text-sm text-destructive">{proposeQuery.error.message}</p>
+        )}
+
+        {draft && firstAdd && !proposeQuery.isLoading && (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="tag-rule-pattern">Description pattern</Label>
+              <Input
+                id="tag-rule-pattern"
+                value={firstAdd.descriptionPattern}
+                onChange={(e) => handlePatternChange(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="tag-rule-match">Match type</Label>
+              <select
+                id="tag-rule-match"
+                className="w-full h-10 rounded-md border border-input bg-background px-3 text-sm"
+                value={firstAdd.matchType}
+                onChange={(e) =>
+                  handleMatchTypeChange(e.target.value as 'exact' | 'contains' | 'regex')
+                }
+              >
+                <option value="contains">Contains</option>
+                <option value="exact">Exact</option>
+                <option value="regex">Regex</option>
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="tag-rule-tags">Tags (comma-separated)</Label>
+              <Input
+                id="tag-rule-tags"
+                value={tagsText}
+                onChange={(e) => setTagsText(e.target.value)}
+                onBlur={handleTagsBlur}
+              />
+            </div>
+
+            {proposeQuery.data?.rationale && (
+              <p className="text-xs text-muted-foreground">{proposeQuery.data.rationale}</p>
+            )}
+
+            <div className="rounded-md border p-3 space-y-2">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">Impact preview</p>
+                {previewQuery.isFetching && <Loader2 className="h-4 w-4 animate-spin" />}
+              </div>
+              {previewQuery.isError && (
+                <p className="text-xs text-destructive">{previewQuery.error.message}</p>
+              )}
+              {previewQuery.data && (
+                <>
+                  <p className="text-xs text-muted-foreground">
+                    {previewQuery.data.counts.affected} transaction
+                    {previewQuery.data.counts.affected === 1 ? '' : 's'} would receive new tag
+                    suggestions from this rule in this batch.
+                  </p>
+                  {previewQuery.data.counts.newTagProposals > 0 && (
+                    <p className="text-xs text-amber-700 dark:text-amber-300">
+                      Includes {previewQuery.data.counts.newTagProposals} new vocabulary tag
+                      proposal{previewQuery.data.counts.newTagProposals === 1 ? '' : 's'}.
+                    </p>
+                  )}
+                  <ul className="max-h-40 overflow-y-auto space-y-1 text-xs">
+                    {previewQuery.data.affected.slice(0, 50).map((row) => (
+                      <li key={row.transactionId} className="truncate">
+                        <span className="font-mono text-muted-foreground">
+                          {row.transactionId.slice(0, 10)}…
+                        </span>{' '}
+                        <span className="text-foreground">{row.description}</span>
+                        <div className="flex flex-wrap gap-1 mt-0.5">
+                          {row.after.suggestedTags.map((s) => (
+                            <Badge key={`${row.transactionId}-${s.tag}`} variant="secondary">
+                              {s.tag}
+                              {s.isNew ? ' (new)' : ''}
+                            </Badge>
+                          ))}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+
+            {hasStructuralEdits && (
+              <p className="text-xs text-muted-foreground">
+                You edited the proposed rule. Review the impact preview above, then reset to the
+                server proposal or keep your edits in sync (preview updates automatically).
+              </p>
+            )}
+          </div>
+        )}
+
+        {rejectMode && draft && (
+          <div className="space-y-2">
+            <Label htmlFor="tag-rule-reject-feedback">Feedback</Label>
+            <textarea
+              id="tag-rule-reject-feedback"
+              className="w-full min-h-[88px] rounded-md border border-input bg-background px-3 py-2 text-sm"
+              value={rejectFeedback}
+              onChange={(e) => setRejectFeedback(e.target.value)}
+              placeholder="Why should this rule not be learned?"
+            />
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          {!rejectMode ? (
+            <>
+              <Button type="button" variant="outline" onClick={() => props.onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="button" variant="ghost" onClick={() => setRejectMode(true)}>
+                Reject…
+              </Button>
+              <Button type="button" onClick={handleApprove} disabled={!canApply}>
+                Approve (save locally)
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button type="button" variant="outline" onClick={() => setRejectMode(false)}>
+                Back
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={handleConfirmReject}
+                disabled={!rejectFeedback.trim() || !draft}
+              >
+                Confirm reject
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app-finance/src/lib/commit-payload.test.ts
+++ b/packages/app-finance/src/lib/commit-payload.test.ts
@@ -1,8 +1,13 @@
 import type { ChangeSet } from '@pops/api/modules/core/corrections/types';
+import type { TagRuleChangeSet } from '@pops/api/modules/core/tag-rules/types';
 import type { ConfirmedTransaction } from '@pops/api/modules/finance/imports';
 import { describe, expect, it } from 'vitest';
 
-import type { PendingChangeSet, PendingEntity } from '../store/importStore';
+import type {
+  PendingChangeSet,
+  PendingEntity,
+  PendingTagRuleChangeSet,
+} from '../store/importStore';
 import { buildCommitPayload, type DanglingEntityRefError } from './commit-payload';
 
 // ---------------------------------------------------------------------------
@@ -24,6 +29,19 @@ function makePendingChangeSet(
 ): PendingChangeSet {
   return {
     tempId: `temp:changeset:${crypto.randomUUID()}`,
+    changeSet,
+    appliedAt: '2026-04-12T00:00:00Z',
+    source: 'test',
+    ...overrides,
+  };
+}
+
+function makePendingTagRuleChangeSet(
+  changeSet: TagRuleChangeSet,
+  overrides: Partial<PendingTagRuleChangeSet> = {}
+): PendingTagRuleChangeSet {
+  return {
+    tempId: `temp:tagrules:${crypto.randomUUID()}`,
     changeSet,
     appliedAt: '2026-04-12T00:00:00Z',
     source: 'test',
@@ -55,33 +73,61 @@ const sampleChangeSet: ChangeSet = {
   ops: [{ op: 'add', data: { descriptionPattern: 'TEST', matchType: 'exact' } }],
 };
 
+const sampleTagRuleChangeSet: TagRuleChangeSet = {
+  source: 'test',
+  reason: 'unit test',
+  ops: [
+    {
+      op: 'add',
+      data: {
+        descriptionPattern: 'WOOLWORTHS',
+        matchType: 'contains',
+        tags: ['Groceries'],
+      },
+    },
+  ],
+};
+
 // ---------------------------------------------------------------------------
 // Tests — PRD-030 US-09
 // ---------------------------------------------------------------------------
 
 describe('buildCommitPayload', () => {
   it('returns empty payload when no pending data', () => {
-    const payload = buildCommitPayload([], [], []);
+    const payload = buildCommitPayload([], [], [], []);
     expect(payload.entities).toEqual([]);
     expect(payload.changeSets).toEqual([]);
+    expect(payload.tagRuleChangeSets).toEqual([]);
     expect(payload.transactions).toEqual([]);
   });
 
   it('returns entities only when no changeSets or transactions', () => {
     const entity = makePendingEntity({ name: 'Coles' });
-    const payload = buildCommitPayload([entity], [], []);
+    const payload = buildCommitPayload([entity], [], [], []);
     expect(payload.entities).toHaveLength(1);
     expect(payload.entities[0].name).toBe('Coles');
     expect(payload.changeSets).toEqual([]);
+    expect(payload.tagRuleChangeSets).toEqual([]);
     expect(payload.transactions).toEqual([]);
   });
 
   it('returns changeSets only when no entities or transactions', () => {
     const pcs = makePendingChangeSet(sampleChangeSet);
-    const payload = buildCommitPayload([], [pcs], []);
+    const payload = buildCommitPayload([], [pcs], [], []);
     expect(payload.entities).toEqual([]);
     expect(payload.changeSets).toHaveLength(1);
     expect(payload.changeSets[0]).toEqual(sampleChangeSet);
+    expect(payload.tagRuleChangeSets).toEqual([]);
+    expect(payload.transactions).toEqual([]);
+  });
+
+  it('returns tagRuleChangeSets only when no entities or transactions', () => {
+    const pcs = makePendingTagRuleChangeSet(sampleTagRuleChangeSet);
+    const payload = buildCommitPayload([], [], [pcs], []);
+    expect(payload.entities).toEqual([]);
+    expect(payload.changeSets).toEqual([]);
+    expect(payload.tagRuleChangeSets).toHaveLength(1);
+    expect(payload.tagRuleChangeSets[0]).toEqual(sampleTagRuleChangeSet);
     expect(payload.transactions).toEqual([]);
   });
 
@@ -104,7 +150,7 @@ describe('buildCommitPayload', () => {
     const pcs = makePendingChangeSet(cs);
     const txn = makeConfirmedTransaction({ entityId: entity.tempId, entityName: 'New Corp' });
 
-    const payload = buildCommitPayload([entity], [pcs], [txn]);
+    const payload = buildCommitPayload([entity], [pcs], [], [txn]);
     expect(payload.entities).toHaveLength(1);
     expect(payload.changeSets).toHaveLength(1);
     expect(payload.transactions).toHaveLength(1);
@@ -128,10 +174,10 @@ describe('buildCommitPayload', () => {
     };
     const pcs = makePendingChangeSet(cs);
 
-    expect(() => buildCommitPayload([], [pcs], [])).toThrow(/Dangling entity reference/);
+    expect(() => buildCommitPayload([], [pcs], [], [])).toThrow(/Dangling entity reference/);
 
     try {
-      buildCommitPayload([], [pcs], []);
+      buildCommitPayload([], [pcs], [], []);
     } catch (err) {
       const e = err as Error & DanglingEntityRefError;
       expect(e.type).toBe('dangling-entity-ref');
@@ -148,7 +194,28 @@ describe('buildCommitPayload', () => {
     };
     const pcs = makePendingChangeSet(cs);
 
-    expect(() => buildCommitPayload([], [pcs], [])).toThrow(/Dangling entity reference/);
+    expect(() => buildCommitPayload([], [pcs], [], [])).toThrow(/Dangling entity reference/);
+  });
+
+  it('throws descriptive error for dangling entity reference in tag rule add op', () => {
+    const danglingId = 'temp:entity:does-not-exist';
+    const cs: TagRuleChangeSet = {
+      source: 'test',
+      ops: [
+        {
+          op: 'add',
+          data: {
+            descriptionPattern: 'BAD',
+            matchType: 'exact',
+            entityId: danglingId,
+            tags: ['Groceries'],
+          },
+        },
+      ],
+    };
+    const pcs = makePendingTagRuleChangeSet(cs);
+
+    expect(() => buildCommitPayload([], [], [pcs], [])).toThrow(/Dangling entity reference/);
   });
 
   it('does not throw for non-temp entity IDs in changeSets', () => {
@@ -166,7 +233,7 @@ describe('buildCommitPayload', () => {
       ],
     };
     const pcs = makePendingChangeSet(cs);
-    expect(() => buildCommitPayload([], [pcs], [])).not.toThrow();
+    expect(() => buildCommitPayload([], [pcs], [], [])).not.toThrow();
   });
 
   it('preserves ChangeSet insertion order', () => {
@@ -192,7 +259,7 @@ describe('buildCommitPayload', () => {
       { appliedAt: '2026-04-12T03:00:00Z' }
     );
 
-    const payload = buildCommitPayload([], [pcs1, pcs2, pcs3], []);
+    const payload = buildCommitPayload([], [pcs1, pcs2, pcs3], [], []);
     expect(payload.changeSets.map((cs) => cs.source)).toEqual(['first', 'second', 'third']);
   });
 
@@ -201,7 +268,7 @@ describe('buildCommitPayload', () => {
     const txn1 = makeConfirmedTransaction({ entityId: entity.tempId, entityName: 'Temp Corp' });
     const txn2 = makeConfirmedTransaction({ entityId: 'real-id', entityName: 'Real Corp' });
 
-    const payload = buildCommitPayload([entity], [], [txn1, txn2]);
+    const payload = buildCommitPayload([entity], [], [], [txn1, txn2]);
     expect(payload.transactions).toHaveLength(2);
     expect(payload.transactions[0].entityId).toBe(entity.tempId);
     expect(payload.transactions[1].entityId).toBe('real-id');
@@ -216,7 +283,7 @@ describe('buildCommitPayload', () => {
 
     // Transactions are NOT validated — only ChangeSet ops are.
     // Temp entity ID resolution in transactions is the commit endpoint's job.
-    const payload = buildCommitPayload([], [], [txn]);
+    const payload = buildCommitPayload([], [], [], [txn]);
     expect(payload.transactions).toHaveLength(1);
     expect(payload.transactions[0].entityId).toBe(danglingTempId);
   });
@@ -224,17 +291,20 @@ describe('buildCommitPayload', () => {
   it('returns a snapshot, not a live reference', () => {
     const entities = [makePendingEntity()];
     const changeSets = [makePendingChangeSet(sampleChangeSet)];
+    const tagRuleChangeSets = [makePendingTagRuleChangeSet(sampleTagRuleChangeSet)];
     const transactions = [makeConfirmedTransaction()];
 
-    const payload = buildCommitPayload(entities, changeSets, transactions);
+    const payload = buildCommitPayload(entities, changeSets, tagRuleChangeSets, transactions);
 
     // Mutating the input arrays should not affect the payload
     entities.push(makePendingEntity({ name: 'Extra' }));
     changeSets.push(makePendingChangeSet(sampleChangeSet));
+    tagRuleChangeSets.push(makePendingTagRuleChangeSet(sampleTagRuleChangeSet));
     transactions.push(makeConfirmedTransaction());
 
     expect(payload.entities).toHaveLength(1);
     expect(payload.changeSets).toHaveLength(1);
+    expect(payload.tagRuleChangeSets).toHaveLength(1);
     expect(payload.transactions).toHaveLength(1);
   });
 });

--- a/packages/app-finance/src/lib/commit-payload.ts
+++ b/packages/app-finance/src/lib/commit-payload.ts
@@ -1,7 +1,12 @@
 import type { ChangeSet } from '@pops/api/modules/core/corrections/types';
+import type { TagRuleChangeSet } from '@pops/api/modules/core/tag-rules/types';
 import type { ConfirmedTransaction } from '@pops/api/modules/finance/imports';
 
-import type { PendingChangeSet, PendingEntity } from '../store/importStore';
+import type {
+  PendingChangeSet,
+  PendingEntity,
+  PendingTagRuleChangeSet,
+} from '../store/importStore';
 
 // ---------------------------------------------------------------------------
 // CommitPayload — PRD-030 US-09
@@ -12,6 +17,7 @@ import type { PendingChangeSet, PendingEntity } from '../store/importStore';
 export interface CommitPayload {
   entities: PendingEntity[];
   changeSets: ChangeSet[];
+  tagRuleChangeSets: TagRuleChangeSet[];
   transactions: ConfirmedTransaction[];
 }
 
@@ -34,6 +40,7 @@ export interface DanglingEntityRefError {
 export function buildCommitPayload(
   pendingEntities: PendingEntity[],
   pendingChangeSets: PendingChangeSet[],
+  pendingTagRuleChangeSets: PendingTagRuleChangeSet[],
   confirmedTransactions: ConfirmedTransaction[]
 ): CommitPayload {
   // Build lookup of valid temp entity IDs
@@ -61,9 +68,31 @@ export function buildCommitPayload(
     }
   }
 
+  for (const pcs of pendingTagRuleChangeSets) {
+    for (const op of pcs.changeSet.ops) {
+      const entityId =
+        (op.op === 'add' || op.op === 'edit') && op.data.entityId ? op.data.entityId : null;
+
+      if (entityId?.startsWith('temp:entity:') && !validTempEntityIds.has(entityId)) {
+        const err: DanglingEntityRefError = {
+          type: 'dangling-entity-ref',
+          tempId: entityId,
+          changeSetTempId: pcs.tempId,
+        };
+        throw Object.assign(
+          new Error(
+            `Dangling entity reference: Tag rule ChangeSet ${pcs.tempId} references temp entity ${entityId} which does not exist in the pending entity list`
+          ),
+          err
+        );
+      }
+    }
+  }
+
   return {
     entities: [...pendingEntities],
     changeSets: pendingChangeSets.map((pcs) => pcs.changeSet),
+    tagRuleChangeSets: pendingTagRuleChangeSets.map((pcs) => pcs.changeSet),
     transactions: [...confirmedTransactions],
   };
 }

--- a/packages/app-finance/src/lib/tag-rule-learn-helpers.test.ts
+++ b/packages/app-finance/src/lib/tag-rule-learn-helpers.test.ts
@@ -1,0 +1,63 @@
+import type { ConfirmedTransaction } from '@pops/api/modules/finance/imports';
+import { describe, expect, it } from 'vitest';
+
+import { computeLearnableTags, descriptionPatternFromGroup } from './tag-rule-learn-helpers';
+
+function txn(overrides: Partial<ConfirmedTransaction> & { checksum: string }): ConfirmedTransaction {
+  return {
+    date: '2026-01-01',
+    description: 'X',
+    amount: -1,
+    account: 'Amex',
+    rawRow: '{}',
+    ...overrides,
+  };
+}
+
+describe('descriptionPatternFromGroup', () => {
+  it('returns empty string for no descriptions', () => {
+    expect(descriptionPatternFromGroup([])).toBe('');
+  });
+
+  it('truncates a single description to 48 chars', () => {
+    const long = 'A'.repeat(60);
+    expect(descriptionPatternFromGroup([long])).toBe('A'.repeat(48));
+  });
+
+  it('finds longest common substring (min length 4)', () => {
+    expect(
+      descriptionPatternFromGroup(['WOOLWORTHS METRO 1', 'WOOLWORTHS ONLINE', 'WOOLWORTHS 123'])
+    ).toBe('WOOLWORTHS');
+  });
+
+  it('falls back to a 16-char prefix when no common substring of length 4 exists', () => {
+    expect(descriptionPatternFromGroup(['AB', 'CD'])).toBe('AB');
+    expect(descriptionPatternFromGroup(['ABCDEFGH_ijkl', 'mnopqrstuvwxyz'])).toBe('ABCDEFGH_IJKL');
+  });
+});
+
+describe('computeLearnableTags', () => {
+  it('returns tags present locally but not in the initial snapshot', () => {
+    const transactions = [
+      txn({ checksum: 'a', description: 't1' }),
+      txn({ checksum: 'b', description: 't2' }),
+    ];
+    const initialTags = { a: ['Groceries'], b: ['Groceries'] };
+    const localTags = { a: ['Groceries', 'Online'], b: ['Groceries'] };
+    expect(computeLearnableTags(transactions, localTags, initialTags)).toEqual(['Online']);
+  });
+
+  it('returns sorted union when multiple transactions contribute new tags', () => {
+    const transactions = [txn({ checksum: 'a' }), txn({ checksum: 'b' })];
+    const initialTags = { a: [], b: [] };
+    const localTags = { a: ['Zebra'], b: ['Apple'] };
+    expect(computeLearnableTags(transactions, localTags, initialTags)).toEqual(['Apple', 'Zebra']);
+  });
+
+  it('returns empty when nothing new was added', () => {
+    const transactions = [txn({ checksum: 'a' })];
+    const initialTags = { a: ['Groceries'] };
+    const localTags = { a: ['Groceries'] };
+    expect(computeLearnableTags(transactions, localTags, initialTags)).toEqual([]);
+  });
+});

--- a/packages/app-finance/src/lib/tag-rule-learn-helpers.test.ts
+++ b/packages/app-finance/src/lib/tag-rule-learn-helpers.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 
 import { computeLearnableTags, descriptionPatternFromGroup } from './tag-rule-learn-helpers';
 
-function txn(overrides: Partial<ConfirmedTransaction> & { checksum: string }): ConfirmedTransaction {
+function txn(
+  overrides: Partial<ConfirmedTransaction> & { checksum: string }
+): ConfirmedTransaction {
   return {
     date: '2026-01-01',
     description: 'X',

--- a/packages/app-finance/src/lib/tag-rule-learn-helpers.ts
+++ b/packages/app-finance/src/lib/tag-rule-learn-helpers.ts
@@ -1,0 +1,43 @@
+import type { ConfirmedTransaction } from '@pops/api/modules/finance/imports';
+
+/**
+ * Tags the user added in this session (present in `localTags` but not in the
+ * immutable snapshot from when Tag Review first rendered).
+ */
+export function computeLearnableTags(
+  transactions: ConfirmedTransaction[],
+  localTags: Record<string, string[]>,
+  initialTags: Record<string, string[]>
+): string[] {
+  const learned = new Set<string>();
+  for (const t of transactions) {
+    const cur = new Set(localTags[t.checksum] ?? []);
+    const init = new Set(initialTags[t.checksum] ?? []);
+    for (const tag of cur) {
+      if (!init.has(tag)) learned.add(tag);
+    }
+  }
+  return [...learned].sort();
+}
+
+/**
+ * Derive a conservative `contains` pattern from a set of descriptions by
+ * searching for the longest common substring (min length 4).
+ */
+export function descriptionPatternFromGroup(descriptions: string[]): string {
+  const normalized = descriptions.map((d) => d.trim().toUpperCase()).filter(Boolean);
+  if (normalized.length === 0) return '';
+  if (normalized.length === 1) return normalized[0]!.slice(0, 48).trim();
+
+  const first = normalized[0]!;
+  const maxLen = Math.min(first.length, 48);
+  for (let len = maxLen; len >= 4; len--) {
+    for (let i = 0; i + len <= first.length; i++) {
+      const sub = first.slice(i, i + len);
+      if (normalized.every((d) => d.includes(sub))) return sub.trim();
+    }
+  }
+
+  // Last resort: short prefix (may be a weak `contains` anchor); user can edit in the dialog.
+  return first.slice(0, 16).trim();
+}

--- a/packages/app-finance/src/store/importStore.ts
+++ b/packages/app-finance/src/store/importStore.ts
@@ -1,4 +1,5 @@
 import type { ChangeSet } from '@pops/api/modules/core/corrections/types';
+import type { TagRuleChangeSet } from '@pops/api/modules/core/tag-rules/types';
 import type {
   ConfirmedTransaction,
   ImportWarning,
@@ -45,6 +46,22 @@ export interface PendingChangeSet {
 /** Input for creating a pending changeset (tempId and appliedAt are generated internally). */
 export interface AddPendingChangeSetInput {
   changeSet: ChangeSet;
+  source: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pending tag-rule ChangeSet — PRD-029 (bundled with import commit)
+// ---------------------------------------------------------------------------
+
+export interface PendingTagRuleChangeSet {
+  tempId: string; // Format: temp:tagrules:{uuid}
+  changeSet: TagRuleChangeSet;
+  appliedAt: string; // ISO-8601
+  source: string;
+}
+
+export interface AddPendingTagRuleChangeSetInput {
+  changeSet: TagRuleChangeSet;
   source: string;
 }
 
@@ -112,6 +129,7 @@ interface ImportStore {
   // Local-first pending state (PRD-030)
   pendingEntities: PendingEntity[];
   pendingChangeSets: PendingChangeSet[];
+  pendingTagRuleChangeSets: PendingTagRuleChangeSet[];
 
   // Actions
   setFile: (file: File | null) => void;
@@ -142,6 +160,11 @@ interface ImportStore {
   addPendingChangeSet: (input: AddPendingChangeSetInput) => PendingChangeSet;
   listPendingChangeSets: () => PendingChangeSet[];
   removePendingChangeSet: (tempId: string) => void;
+
+  // Pending tag-rule ChangeSets (PRD-029)
+  addPendingTagRuleChangeSet: (input: AddPendingTagRuleChangeSetInput) => PendingTagRuleChangeSet;
+  listPendingTagRuleChangeSets: () => PendingTagRuleChangeSet[];
+  removePendingTagRuleChangeSet: (tempId: string) => void;
 
   // Transaction management
   updateTransaction: (
@@ -180,6 +203,7 @@ const initialState = {
   commitResult: null,
   pendingEntities: [],
   pendingChangeSets: [],
+  pendingTagRuleChangeSets: [],
 };
 
 /**
@@ -213,6 +237,7 @@ const downstreamReset: Pick<
   | 'commitResult'
   | 'pendingEntities'
   | 'pendingChangeSets'
+  | 'pendingTagRuleChangeSets'
 > = {
   headers: initialState.headers,
   rows: initialState.rows,
@@ -225,6 +250,7 @@ const downstreamReset: Pick<
   commitResult: initialState.commitResult,
   pendingEntities: initialState.pendingEntities,
   pendingChangeSets: initialState.pendingChangeSets,
+  pendingTagRuleChangeSets: initialState.pendingTagRuleChangeSets,
 };
 
 function isSameFile(a: File | null, b: File | null): boolean {
@@ -338,6 +364,26 @@ export const useImportStore = create<ImportStore>((set) => ({
     set((state) => ({
       pendingChangeSets: state.pendingChangeSets.filter(
         (c: PendingChangeSet) => c.tempId !== tempId
+      ),
+    })),
+
+  addPendingTagRuleChangeSet: (input: AddPendingTagRuleChangeSetInput): PendingTagRuleChangeSet => {
+    const entry: PendingTagRuleChangeSet = {
+      tempId: `temp:tagrules:${crypto.randomUUID()}`,
+      changeSet: input.changeSet,
+      appliedAt: new Date().toISOString(),
+      source: input.source,
+    };
+
+    set((prev) => ({ pendingTagRuleChangeSets: [...prev.pendingTagRuleChangeSets, entry] }));
+    return entry;
+  },
+  listPendingTagRuleChangeSets: (): PendingTagRuleChangeSet[] =>
+    useImportStore.getState().pendingTagRuleChangeSets,
+  removePendingTagRuleChangeSet: (tempId: string) =>
+    set((state) => ({
+      pendingTagRuleChangeSets: state.pendingTagRuleChangeSets.filter(
+        (c: PendingTagRuleChangeSet) => c.tempId !== tempId
       ),
     })),
 


### PR DESCRIPTION
Closes #1741.

- Tag Review: **Save tag rule…** opens a proposal dialog using `core.tagRules.proposeTagRuleChangeSet` / `previewTagRuleChangeSet`, with reject via `rejectTagRuleChangeSet`.
- Approved rules are buffered as `pendingTagRuleChangeSets` (same local-first pattern as classification corrections) and shown on Final Review.
- `commitImport` accepts `tagRuleChangeSets`, applies them atomically (temp entity ID resolution + vocabulary upserts), and returns `tagRulesApplied`.