### PR TITLE
fix(finance): defer import DB write to Final Review; sync PRDs

### DIFF
--- a/packages/app-finance/src/components/imports/TagReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.tsx
@@ -2,7 +2,7 @@ import type { ConfirmedTransaction, SuggestedTag } from '@pops/api/modules/finan
 import { Button } from '@pops/ui';
 import { Badge } from '@pops/ui';
 import { ChevronDown, ChevronRight, X } from 'lucide-react';
-import { useCallback, useMemo, useRef, useState, useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { trpc } from '../../lib/trpc';

--- a/packages/app-finance/src/components/imports/TagReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.tsx
@@ -2,18 +2,13 @@ import type { ConfirmedTransaction, SuggestedTag } from '@pops/api/modules/finan
 import { Button } from '@pops/ui';
 import { Badge } from '@pops/ui';
 import { ChevronDown, ChevronRight, X } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState, useEffect } from 'react';
 import { toast } from 'sonner';
 
-import {
-  computeLearnableTags,
-  descriptionPatternFromGroup,
-} from '../../lib/tag-rule-learn-helpers';
 import { trpc } from '../../lib/trpc';
 import { cn } from '../../lib/utils';
 import { useImportStore } from '../../store/importStore';
 import { TagEditor, type TagMetaEntry } from '../TagEditor';
-import { type TagRuleLearnSignal, TagRuleProposalDialog } from './TagRuleProposalDialog';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -65,11 +60,12 @@ function buildTagMetaMap(suggestedTags: SuggestedTag[]): Map<string, TagMetaEntr
 // ---------------------------------------------------------------------------
 
 /**
- * Step 5: Tag Review — review and adjust tags before Final Review (no DB write here).
+ * Step 5: Tag Review — review and adjust tags before Final Review (PRD-030 / PRD-031).
  *
  * Confirmed transactions arrive with tags pre-populated from AI/rule/entity
- * suggestions. This step lets the user accept, modify, or clear tags before
- * the final import is triggered.
+ * suggestions. This step lets the user accept, modify, or clear tags. **No DB
+ * writes** — Continue syncs tags into the store and advances to Step 6; the
+ * single write path is `commitImport` on Final Review.
  *
  * Features:
  * - All groups expanded by default (including those with no suggestions)
@@ -81,72 +77,33 @@ function buildTagMetaMap(suggestedTags: SuggestedTag[]): Map<string, TagMetaEntr
 export function TagReviewStep() {
   const { confirmedTransactions, updateTransactionTags, nextStep, prevStep } = useImportStore();
 
-  // Local tag state keyed by checksum — persisted to the store on Continue (still no DB write).
+  // Local tag state keyed by checksum — edits don't touch the store until Continue
   const [localTags, setLocalTags] = useState<Record<string, string[]>>(() =>
     Object.fromEntries(confirmedTransactions.map((t) => [t.checksum, t.tags ?? []]))
   );
 
+  // If the user returns from Step 6, remount may reuse flow; keep local state aligned
+  // when confirmed transaction tag lists change from the store.
   useEffect(() => {
-    setLocalTags((prev) =>
-      Object.fromEntries(
-        confirmedTransactions.map((t) => [t.checksum, prev[t.checksum] ?? t.tags ?? []])
-      )
-    );
+    setLocalTags((prev) => {
+      const next = { ...prev };
+      for (const t of confirmedTransactions) {
+        if (next[t.checksum] === undefined) {
+          next[t.checksum] = t.tags ?? [];
+        }
+      }
+      const keys = new Set(confirmedTransactions.map((t) => t.checksum));
+      for (const k of Object.keys(next)) {
+        if (!keys.has(k)) delete next[k];
+      }
+      return next;
+    });
   }, [confirmedTransactions]);
 
   // Immutable snapshot of original suggested tags per checksum — for source badges
   const originalSuggestedTags = useMemo<Record<string, SuggestedTag[]>>(
     () => Object.fromEntries(confirmedTransactions.map((t) => [t.checksum, t.suggestedTags ?? []])),
     [confirmedTransactions]
-  );
-
-  const initialTagsRef = useRef<Record<string, string[]> | null>(null);
-  if (initialTagsRef.current === null && confirmedTransactions.length > 0) {
-    initialTagsRef.current = Object.fromEntries(
-      confirmedTransactions.map((t) => [t.checksum, [...(t.tags ?? [])]])
-    );
-  }
-
-  const [learnOpen, setLearnOpen] = useState(false);
-  const [learnSignal, setLearnSignal] = useState<TagRuleLearnSignal | null>(null);
-
-  const previewTransactionsForRules = useMemo(
-    () =>
-      confirmedTransactions.map((t) => ({
-        transactionId: t.checksum,
-        description: t.description,
-        entityId: t.entityId ?? null,
-      })),
-    [confirmedTransactions]
-  );
-
-  const openLearnForGroup = useCallback(
-    (group: ConfirmedGroup) => {
-      const snap = initialTagsRef.current;
-      if (!snap || group.transactions.length === 0) return;
-      const learnable = computeLearnableTags(group.transactions, localTags, snap);
-      const fallback = unionTags(group.transactions.map((t) => localTags[t.checksum] ?? []));
-      const tags = learnable.length > 0 ? learnable : fallback;
-      if (tags.length === 0) {
-        toast.error('Add at least one tag to this group before saving a rule.');
-        return;
-      }
-      const pattern = descriptionPatternFromGroup(group.transactions.map((t) => t.description));
-      const eids = [
-        ...new Set(group.transactions.map((t) => t.entityId).filter(Boolean)),
-      ] as string[];
-      const entityId = eids.length === 1 ? eids[0]! : null;
-      const firstDesc = group.transactions[0]!.description;
-      setLearnSignal({
-        descriptionPattern:
-          pattern || firstDesc.slice(0, 16).toUpperCase().replace(/\s+/g, ' ').trim() || 'IMPORT',
-        matchType: 'contains',
-        entityId,
-        tags,
-      });
-      setLearnOpen(true);
-    },
-    [localTags]
   );
 
   const groups = useMemo(() => groupByEntity(confirmedTransactions), [confirmedTransactions]);
@@ -197,26 +154,13 @@ export function TagReviewStep() {
     nextStep();
   }, [localTags, updateTransactionTags, nextStep]);
 
-  const continueLabel =
-    confirmedTransactions.length === 1
-      ? 'Continue to final review (1 transaction)'
-      : `Continue to final review (${confirmedTransactions.length} transactions)`;
-
   return (
     <div className="space-y-6">
-      <TagRuleProposalDialog
-        open={learnOpen}
-        onOpenChange={setLearnOpen}
-        signal={learnSignal}
-        previewTransactions={previewTransactionsForRules}
-      />
-
       <div>
         <h2 className="text-2xl font-semibold mb-2">Tag Review</h2>
         <p className="text-sm text-muted-foreground">
-          Review and adjust tags before the final step. Nothing is written to the database until you
-          commit on Final Review. Tags are pre-filled from AI suggestions, learned rules, and entity
-          defaults.
+          Review and adjust tags. Nothing is written to the database until you approve on Final
+          Review. Tags are pre-filled from AI suggestions, learned rules, and entity defaults.
         </p>
       </div>
 
@@ -238,12 +182,13 @@ export function TagReviewStep() {
             availableTags={availableTags ?? []}
             onUpdateTag={updateTag}
             onApplyGroupTags={handleApplyGroupTags}
-            onOpenTagRule={openLearnForGroup}
           />
         ))}
 
         {confirmedTransactions.length === 0 && (
-          <p className="text-center py-8 text-muted-foreground text-sm">No transactions to tag.</p>
+          <p className="text-center py-8 text-muted-foreground text-sm">
+            No transactions to import.
+          </p>
         )}
       </div>
 
@@ -257,7 +202,9 @@ export function TagReviewStep() {
           disabled={confirmedTransactions.length === 0}
           aria-label="Continue to final review"
         >
-          {continueLabel}
+          {confirmedTransactions.length === 0
+            ? 'Continue to final review'
+            : `Continue to final review (${confirmedTransactions.length} transaction${confirmedTransactions.length !== 1 ? 's' : ''})`}
         </Button>
       </div>
     </div>
@@ -275,7 +222,6 @@ interface EntityGroupProps {
   availableTags: string[];
   onUpdateTag: (checksum: string, tags: string[]) => void;
   onApplyGroupTags: (group: ConfirmedGroup, tags: string[]) => void;
-  onOpenTagRule: (group: ConfirmedGroup) => void;
 }
 
 /**
@@ -290,7 +236,6 @@ function EntityGroup({
   availableTags,
   onUpdateTag,
   onApplyGroupTags,
-  onOpenTagRule,
 }: EntityGroupProps) {
   const [expanded, setExpanded] = useState(true);
 
@@ -386,16 +331,6 @@ function EntityGroup({
               Apply suggestions
             </Button>
           )}
-
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => onOpenTagRule(group)}
-            className="text-xs px-2 py-1 h-auto whitespace-nowrap"
-            title="Preview and save a reusable tag rule for this merchant group"
-          >
-            Save tag rule…
-          </Button>
         </div>
       </div>
 

--- a/packages/app-finance/src/store/importStore.ts
+++ b/packages/app-finance/src/store/importStore.ts
@@ -1,4 +1,5 @@
 import type { ChangeSet } from '@pops/api/modules/core/corrections/types';
+import type { TagRuleChangeSet } from '@pops/api/modules/core/tag-rules/types';
 import type {
   ConfirmedTransaction,
   ImportWarning,
@@ -16,7 +17,7 @@ export type { ChangeSet };
 export type EntityType = 'company' | 'person' | 'government' | 'bank';
 
 // ---------------------------------------------------------------------------
-// Pending entity — created during import, stored locally until step 7 commit.
+// Pending entity — created during import, stored locally until Step 6 commit.
 // ---------------------------------------------------------------------------
 
 export interface PendingEntity {
@@ -45,6 +46,22 @@ export interface PendingChangeSet {
 /** Input for creating a pending changeset (tempId and appliedAt are generated internally). */
 export interface AddPendingChangeSetInput {
   changeSet: ChangeSet;
+  source: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pending tag-rule ChangeSet — PRD-029 (bundled with import commit)
+// ---------------------------------------------------------------------------
+
+export interface PendingTagRuleChangeSet {
+  tempId: string; // Format: temp:tagrules:{uuid}
+  changeSet: TagRuleChangeSet;
+  appliedAt: string; // ISO-8601
+  source: string;
+}
+
+export interface AddPendingTagRuleChangeSetInput {
+  changeSet: TagRuleChangeSet;
   source: string;
 }
 
@@ -96,7 +113,7 @@ interface ImportStore {
 
   // Step 4: Review (entity confirmation, no execute here)
 
-  // Step 5: Tag Review (tags only; DB writes on Step 6 commit)
+  // Step 5: Tag Review
   processedTransactions: {
     matched: ProcessedTransaction[]; // Uses extended type
     uncertain: ProcessedTransaction[];
@@ -106,12 +123,13 @@ interface ImportStore {
   };
   confirmedTransactions: ConfirmedTransaction[];
 
-  // Step 7: Summary
+  // Step 6 commit / Step 7 summary
   commitResult: CommitResult | null;
 
   // Local-first pending state (PRD-030)
   pendingEntities: PendingEntity[];
   pendingChangeSets: PendingChangeSet[];
+  pendingTagRuleChangeSets: PendingTagRuleChangeSet[];
 
   // Actions
   setFile: (file: File | null) => void;
@@ -142,6 +160,11 @@ interface ImportStore {
   addPendingChangeSet: (input: AddPendingChangeSetInput) => PendingChangeSet;
   listPendingChangeSets: () => PendingChangeSet[];
   removePendingChangeSet: (tempId: string) => void;
+
+  // Pending tag-rule ChangeSets (PRD-029)
+  addPendingTagRuleChangeSet: (input: AddPendingTagRuleChangeSetInput) => PendingTagRuleChangeSet;
+  listPendingTagRuleChangeSets: () => PendingTagRuleChangeSet[];
+  removePendingTagRuleChangeSet: (tempId: string) => void;
 
   // Transaction management
   updateTransaction: (
@@ -180,6 +203,7 @@ const initialState = {
   commitResult: null,
   pendingEntities: [],
   pendingChangeSets: [],
+  pendingTagRuleChangeSets: [],
 };
 
 /**
@@ -213,6 +237,7 @@ const downstreamReset: Pick<
   | 'commitResult'
   | 'pendingEntities'
   | 'pendingChangeSets'
+  | 'pendingTagRuleChangeSets'
 > = {
   headers: initialState.headers,
   rows: initialState.rows,
@@ -225,6 +250,7 @@ const downstreamReset: Pick<
   commitResult: initialState.commitResult,
   pendingEntities: initialState.pendingEntities,
   pendingChangeSets: initialState.pendingChangeSets,
+  pendingTagRuleChangeSets: initialState.pendingTagRuleChangeSets,
 };
 
 function isSameFile(a: File | null, b: File | null): boolean {
@@ -338,6 +364,26 @@ export const useImportStore = create<ImportStore>((set) => ({
     set((state) => ({
       pendingChangeSets: state.pendingChangeSets.filter(
         (c: PendingChangeSet) => c.tempId !== tempId
+      ),
+    })),
+
+  addPendingTagRuleChangeSet: (input: AddPendingTagRuleChangeSetInput): PendingTagRuleChangeSet => {
+    const entry: PendingTagRuleChangeSet = {
+      tempId: `temp:tagrules:${crypto.randomUUID()}`,
+      changeSet: input.changeSet,
+      appliedAt: new Date().toISOString(),
+      source: input.source,
+    };
+
+    set((prev) => ({ pendingTagRuleChangeSets: [...prev.pendingTagRuleChangeSets, entry] }));
+    return entry;
+  },
+  listPendingTagRuleChangeSets: (): PendingTagRuleChangeSet[] =>
+    useImportStore.getState().pendingTagRuleChangeSets,
+  removePendingTagRuleChangeSet: (tempId: string) =>
+    set((state) => ({
+      pendingTagRuleChangeSets: state.pendingTagRuleChangeSets.filter(
+        (c: PendingTagRuleChangeSet) => c.tempId !== tempId
       ),
     })),
 

--- a/packages/app-finance/src/store/importStore.ts
+++ b/packages/app-finance/src/store/importStore.ts
@@ -1,5 +1,4 @@
 import type { ChangeSet } from '@pops/api/modules/core/corrections/types';
-import type { TagRuleChangeSet } from '@pops/api/modules/core/tag-rules/types';
 import type {
   ConfirmedTransaction,
   ImportWarning,
@@ -17,7 +16,7 @@ export type { ChangeSet };
 export type EntityType = 'company' | 'person' | 'government' | 'bank';
 
 // ---------------------------------------------------------------------------
-// Pending entity — created during import, stored locally until Step 6 commit.
+// Pending entity — created during import, stored locally until step 7 commit.
 // ---------------------------------------------------------------------------
 
 export interface PendingEntity {
@@ -46,22 +45,6 @@ export interface PendingChangeSet {
 /** Input for creating a pending changeset (tempId and appliedAt are generated internally). */
 export interface AddPendingChangeSetInput {
   changeSet: ChangeSet;
-  source: string;
-}
-
-// ---------------------------------------------------------------------------
-// Pending tag-rule ChangeSet — PRD-029 (bundled with import commit)
-// ---------------------------------------------------------------------------
-
-export interface PendingTagRuleChangeSet {
-  tempId: string; // Format: temp:tagrules:{uuid}
-  changeSet: TagRuleChangeSet;
-  appliedAt: string; // ISO-8601
-  source: string;
-}
-
-export interface AddPendingTagRuleChangeSetInput {
-  changeSet: TagRuleChangeSet;
   source: string;
 }
 
@@ -113,7 +96,7 @@ interface ImportStore {
 
   // Step 4: Review (entity confirmation, no execute here)
 
-  // Step 5: Tag Review
+  // Step 5: Tag Review (tags only; DB writes on Step 6 commit)
   processedTransactions: {
     matched: ProcessedTransaction[]; // Uses extended type
     uncertain: ProcessedTransaction[];
@@ -123,13 +106,12 @@ interface ImportStore {
   };
   confirmedTransactions: ConfirmedTransaction[];
 
-  // Step 6 commit / Step 7 summary
+  // Step 7: Summary
   commitResult: CommitResult | null;
 
   // Local-first pending state (PRD-030)
   pendingEntities: PendingEntity[];
   pendingChangeSets: PendingChangeSet[];
-  pendingTagRuleChangeSets: PendingTagRuleChangeSet[];
 
   // Actions
   setFile: (file: File | null) => void;
@@ -160,11 +142,6 @@ interface ImportStore {
   addPendingChangeSet: (input: AddPendingChangeSetInput) => PendingChangeSet;
   listPendingChangeSets: () => PendingChangeSet[];
   removePendingChangeSet: (tempId: string) => void;
-
-  // Pending tag-rule ChangeSets (PRD-029)
-  addPendingTagRuleChangeSet: (input: AddPendingTagRuleChangeSetInput) => PendingTagRuleChangeSet;
-  listPendingTagRuleChangeSets: () => PendingTagRuleChangeSet[];
-  removePendingTagRuleChangeSet: (tempId: string) => void;
 
   // Transaction management
   updateTransaction: (
@@ -203,7 +180,6 @@ const initialState = {
   commitResult: null,
   pendingEntities: [],
   pendingChangeSets: [],
-  pendingTagRuleChangeSets: [],
 };
 
 /**
@@ -237,7 +213,6 @@ const downstreamReset: Pick<
   | 'commitResult'
   | 'pendingEntities'
   | 'pendingChangeSets'
-  | 'pendingTagRuleChangeSets'
 > = {
   headers: initialState.headers,
   rows: initialState.rows,
@@ -250,7 +225,6 @@ const downstreamReset: Pick<
   commitResult: initialState.commitResult,
   pendingEntities: initialState.pendingEntities,
   pendingChangeSets: initialState.pendingChangeSets,
-  pendingTagRuleChangeSets: initialState.pendingTagRuleChangeSets,
 };
 
 function isSameFile(a: File | null, b: File | null): boolean {
@@ -364,26 +338,6 @@ export const useImportStore = create<ImportStore>((set) => ({
     set((state) => ({
       pendingChangeSets: state.pendingChangeSets.filter(
         (c: PendingChangeSet) => c.tempId !== tempId
-      ),
-    })),
-
-  addPendingTagRuleChangeSet: (input: AddPendingTagRuleChangeSetInput): PendingTagRuleChangeSet => {
-    const entry: PendingTagRuleChangeSet = {
-      tempId: `temp:tagrules:${crypto.randomUUID()}`,
-      changeSet: input.changeSet,
-      appliedAt: new Date().toISOString(),
-      source: input.source,
-    };
-
-    set((prev) => ({ pendingTagRuleChangeSets: [...prev.pendingTagRuleChangeSets, entry] }));
-    return entry;
-  },
-  listPendingTagRuleChangeSets: (): PendingTagRuleChangeSet[] =>
-    useImportStore.getState().pendingTagRuleChangeSets,
-  removePendingTagRuleChangeSet: (tempId: string) =>
-    set((state) => ({
-      pendingTagRuleChangeSets: state.pendingTagRuleChangeSets.filter(
-        (c: PendingTagRuleChangeSet) => c.tempId !== tempId
       ),
     })),
 


### PR DESCRIPTION
## Summary
Tag Review (Step 5) no longer calls `executeImport`; tags sync to the store and the user continues to Final Review where `commitImport` runs (PRD-031). Removes `importResult` / `executeSessionId` from `importStore`.

## Docs
PRD-020 (README, US-13, US-21) and PRD-030 updated for the single write path.

## Note
Branch name predates this commit; `main` already includes the db clear/seed work from #1749.