### PR TITLE
refactor(core): create typed settings key registry [tb-372]

### DIFF
--- a/apps/pops-api/src/modules/core/settings/index.ts
+++ b/apps/pops-api/src/modules/core/settings/index.ts
@@ -1,5 +1,7 @@
 /**
  * Settings module
  */
+export { SETTINGS_KEYS } from './keys.js';
+export type { SettingsKey } from './keys.js';
 export { settingsRouter } from './router.js';
 export type { SetSettingInput, Setting, SettingListInput } from './types.js';

--- a/apps/pops-api/src/modules/core/settings/index.ts
+++ b/apps/pops-api/src/modules/core/settings/index.ts
@@ -1,7 +1,6 @@
 /**
  * Settings module
  */
-export { SETTINGS_KEYS } from './keys.js';
-export type { SettingsKey } from './keys.js';
+export { SETTINGS_KEYS, type SettingsKey } from './keys.js';
 export { settingsRouter } from './router.js';
 export type { SetSettingInput, Setting, SettingListInput } from './types.js';

--- a/apps/pops-api/src/modules/core/settings/keys.ts
+++ b/apps/pops-api/src/modules/core/settings/keys.ts
@@ -1,0 +1,34 @@
+/**
+ * Typed settings key registry — single source of truth for all settings keys.
+ *
+ * Every key stored in the `settings` table must be listed here.
+ * Import `SETTINGS_KEYS` and `SettingsKey` instead of using magic strings.
+ */
+export const SETTINGS_KEYS = {
+  // Plex
+  PLEX_URL: 'plex_url',
+  PLEX_TOKEN: 'plex_token',
+  PLEX_USERNAME: 'plex_username',
+  PLEX_ENCRYPTION_SEED: 'plex_encryption_seed',
+  PLEX_CLIENT_IDENTIFIER: 'plex_client_identifier',
+  PLEX_MOVIE_SECTION_ID: 'plex_movie_section_id',
+  PLEX_TV_SECTION_ID: 'plex_tv_section_id',
+  PLEX_SCHEDULER_ENABLED: 'plex_scheduler_enabled',
+  PLEX_SCHEDULER_INTERVAL_MS: 'plex_scheduler_interval_ms',
+
+  // Radarr / Sonarr
+  RADARR_URL: 'radarr_url',
+  RADARR_API_KEY: 'radarr_api_key',
+  SONARR_URL: 'sonarr_url',
+  SONARR_API_KEY: 'sonarr_api_key',
+
+  // AI
+  AI_MODEL: 'ai.model',
+  AI_MONTHLY_TOKEN_BUDGET: 'ai.monthlyTokenBudget',
+  AI_BUDGET_EXCEEDED_FALLBACK: 'ai.budgetExceededFallback',
+
+  // App
+  THEME: 'theme',
+} as const;
+
+export type SettingsKey = (typeof SETTINGS_KEYS)[keyof typeof SETTINGS_KEYS];

--- a/apps/pops-api/src/modules/core/settings/router.ts
+++ b/apps/pops-api/src/modules/core/settings/router.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import { NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta } from '../../../shared/pagination.js';
 import { protectedProcedure, router } from '../../../trpc.js';
+import type { SettingsKey } from './keys.js';
 import * as service from './service.js';
 import { SetSettingSchema, SettingListSchema, toSetting } from './types.js';
 
@@ -29,7 +30,7 @@ export const settingsRouter = router({
 
   /** Get a single setting by key (returns null when key does not exist) */
   get: protectedProcedure.input(z.object({ key: z.string() })).query(({ input }) => {
-    const row = service.getSettingOrNull(input.key);
+    const row = service.getSettingOrNull(input.key as SettingsKey);
     return { data: row ? toSetting(row) : null };
   }),
 
@@ -45,7 +46,7 @@ export const settingsRouter = router({
   /** Delete a setting by key */
   delete: protectedProcedure.input(z.object({ key: z.string() })).mutation(({ input }) => {
     try {
-      service.deleteSetting(input.key);
+      service.deleteSetting(input.key as SettingsKey);
       return { message: 'Setting deleted' };
     } catch (err) {
       if (err instanceof NotFoundError) {

--- a/apps/pops-api/src/modules/core/settings/service.ts
+++ b/apps/pops-api/src/modules/core/settings/service.ts
@@ -6,10 +6,11 @@ import { count, eq, like } from 'drizzle-orm';
 
 import { getDrizzle } from '../../../db.js';
 import { NotFoundError } from '../../../shared/errors.js';
+import type { SettingsKey } from './keys.js';
 import type { SetSettingInput, SettingRow } from './types.js';
 
 /** Get a single setting by key */
-export function getSetting(key: string): SettingRow {
+export function getSetting(key: SettingsKey): SettingRow {
   const db = getDrizzle();
   const [row] = db.select().from(settings).where(eq(settings.key, key)).all();
 
@@ -21,7 +22,7 @@ export function getSetting(key: string): SettingRow {
 }
 
 /** Get a single setting by key, returning null if not found */
-export function getSettingOrNull(key: string): SettingRow | null {
+export function getSettingOrNull(key: SettingsKey): SettingRow | null {
   const db = getDrizzle();
   const [row] = db.select().from(settings).where(eq(settings.key, key)).all();
   return row ?? null;
@@ -63,11 +64,11 @@ export function setSetting(input: SetSettingInput): SettingRow {
     })
     .run();
 
-  return getSetting(input.key);
+  return getSetting(input.key as SettingsKey);
 }
 
 /** Delete a setting by key */
-export function deleteSetting(key: string): void {
+export function deleteSetting(key: SettingsKey): void {
   const db = getDrizzle();
   const result = db.delete(settings).where(eq(settings.key, key)).run();
 

--- a/apps/pops-api/src/modules/core/settings/settings.test.ts
+++ b/apps/pops-api/src/modules/core/settings/settings.test.ts
@@ -3,6 +3,7 @@ import type { Database } from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createCaller, seedSetting, setupTestContext } from '../../../shared/test-utils.js';
+import { SETTINGS_KEYS } from './keys.js';
 
 const ctx = setupTestContext();
 let caller: ReturnType<typeof createCaller>;
@@ -24,8 +25,8 @@ describe('settings.list', () => {
   });
 
   it('returns all settings', async () => {
-    seedSetting(db, { key: 'plex_url', value: 'http://plex:32400' });
-    seedSetting(db, { key: 'theme', value: 'dark' });
+    seedSetting(db, { key: SETTINGS_KEYS.PLEX_URL, value: 'http://plex:32400' });
+    seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'dark' });
 
     const result = await caller.core.settings.list({});
     expect(result.data).toHaveLength(2);
@@ -33,9 +34,9 @@ describe('settings.list', () => {
   });
 
   it('filters by search term', async () => {
-    seedSetting(db, { key: 'plex_url', value: 'http://plex:32400' });
-    seedSetting(db, { key: 'plex_token', value: 'abc123' });
-    seedSetting(db, { key: 'theme', value: 'dark' });
+    seedSetting(db, { key: SETTINGS_KEYS.PLEX_URL, value: 'http://plex:32400' });
+    seedSetting(db, { key: SETTINGS_KEYS.PLEX_TOKEN, value: 'abc123' });
+    seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'dark' });
 
     const result = await caller.core.settings.list({ search: 'plex' });
     expect(result.data).toHaveLength(2);
@@ -64,11 +65,11 @@ describe('settings.list', () => {
 
 describe('settings.get', () => {
   it('returns a setting by key', async () => {
-    seedSetting(db, { key: 'theme', value: 'dark' });
+    seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'dark' });
 
-    const result = await caller.core.settings.get({ key: 'theme' });
+    const result = await caller.core.settings.get({ key: SETTINGS_KEYS.THEME });
     expect(result.data).not.toBeNull();
-    expect(result.data!.key).toBe('theme');
+    expect(result.data!.key).toBe(SETTINGS_KEYS.THEME);
     expect(result.data!.value).toBe('dark');
   });
 
@@ -80,20 +81,20 @@ describe('settings.get', () => {
 
 describe('settings.set', () => {
   it('creates a new setting', async () => {
-    const result = await caller.core.settings.set({ key: 'theme', value: 'dark' });
+    const result = await caller.core.settings.set({ key: SETTINGS_KEYS.THEME, value: 'dark' });
     expect(result.message).toBe('Setting saved');
-    expect(result.data.key).toBe('theme');
+    expect(result.data.key).toBe(SETTINGS_KEYS.THEME);
     expect(result.data.value).toBe('dark');
   });
 
   it('updates an existing setting (upsert)', async () => {
-    seedSetting(db, { key: 'theme', value: 'light' });
+    seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'light' });
 
-    const result = await caller.core.settings.set({ key: 'theme', value: 'dark' });
+    const result = await caller.core.settings.set({ key: SETTINGS_KEYS.THEME, value: 'dark' });
     expect(result.data.value).toBe('dark');
 
     // Verify only one row exists
-    const listResult = await caller.core.settings.list({ search: 'theme' });
+    const listResult = await caller.core.settings.list({ search: SETTINGS_KEYS.THEME });
     expect(listResult.data).toHaveLength(1);
   });
 
@@ -115,13 +116,13 @@ describe('settings.set', () => {
 
 describe('settings.delete', () => {
   it('deletes an existing setting', async () => {
-    seedSetting(db, { key: 'theme', value: 'dark' });
+    seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'dark' });
 
-    const result = await caller.core.settings.delete({ key: 'theme' });
+    const result = await caller.core.settings.delete({ key: SETTINGS_KEYS.THEME });
     expect(result.message).toBe('Setting deleted');
 
     // Verify it's gone
-    const check = await caller.core.settings.get({ key: 'theme' });
+    const check = await caller.core.settings.get({ key: SETTINGS_KEYS.THEME });
     expect(check.data).toBeNull();
   });
 

--- a/apps/pops-api/src/modules/media/arr/service.ts
+++ b/apps/pops-api/src/modules/media/arr/service.ts
@@ -6,6 +6,7 @@ import { eq } from 'drizzle-orm';
 
 import { getDrizzle } from '../../../db.js';
 import { getEnv } from '../../../env.js';
+import { SETTINGS_KEYS } from '../../core/settings/keys.js';
 import { RadarrClient } from './radarr-client.js';
 import { SonarrClient } from './sonarr-client.js';
 import type {
@@ -69,10 +70,10 @@ export function getArrSettings(): {
   sonarrApiKey: string | null;
 } {
   return {
-    radarrUrl: getArrSetting('radarr_url', 'RADARR_URL'),
-    radarrApiKey: getArrSetting('radarr_api_key', 'RADARR_API_KEY'),
-    sonarrUrl: getArrSetting('sonarr_url', 'SONARR_URL'),
-    sonarrApiKey: getArrSetting('sonarr_api_key', 'SONARR_API_KEY'),
+    radarrUrl: getArrSetting(SETTINGS_KEYS.RADARR_URL, 'RADARR_URL'),
+    radarrApiKey: getArrSetting(SETTINGS_KEYS.RADARR_API_KEY, 'RADARR_API_KEY'),
+    sonarrUrl: getArrSetting(SETTINGS_KEYS.SONARR_URL, 'SONARR_URL'),
+    sonarrApiKey: getArrSetting(SETTINGS_KEYS.SONARR_API_KEY, 'SONARR_API_KEY'),
   };
 }
 
@@ -84,35 +85,35 @@ export function saveArrSettings(config: {
   sonarrApiKey?: string;
 }): void {
   if (config.radarrUrl !== undefined) {
-    if (config.radarrUrl) saveSetting('radarr_url', config.radarrUrl);
-    else deleteSetting('radarr_url');
+    if (config.radarrUrl) saveSetting(SETTINGS_KEYS.RADARR_URL, config.radarrUrl);
+    else deleteSetting(SETTINGS_KEYS.RADARR_URL);
   }
   if (config.radarrApiKey !== undefined) {
-    if (config.radarrApiKey) saveSetting('radarr_api_key', config.radarrApiKey);
-    else deleteSetting('radarr_api_key');
+    if (config.radarrApiKey) saveSetting(SETTINGS_KEYS.RADARR_API_KEY, config.radarrApiKey);
+    else deleteSetting(SETTINGS_KEYS.RADARR_API_KEY);
   }
   if (config.sonarrUrl !== undefined) {
-    if (config.sonarrUrl) saveSetting('sonarr_url', config.sonarrUrl);
-    else deleteSetting('sonarr_url');
+    if (config.sonarrUrl) saveSetting(SETTINGS_KEYS.SONARR_URL, config.sonarrUrl);
+    else deleteSetting(SETTINGS_KEYS.SONARR_URL);
   }
   if (config.sonarrApiKey !== undefined) {
-    if (config.sonarrApiKey) saveSetting('sonarr_api_key', config.sonarrApiKey);
-    else deleteSetting('sonarr_api_key');
+    if (config.sonarrApiKey) saveSetting(SETTINGS_KEYS.SONARR_API_KEY, config.sonarrApiKey);
+    else deleteSetting(SETTINGS_KEYS.SONARR_API_KEY);
   }
 }
 
 /** Create a Radarr client if configured (settings table or env vars). */
 export function getRadarrClient(): RadarrClient | null {
-  const url = getArrSetting('radarr_url', 'RADARR_URL');
-  const key = getArrSetting('radarr_api_key', 'RADARR_API_KEY');
+  const url = getArrSetting(SETTINGS_KEYS.RADARR_URL, 'RADARR_URL');
+  const key = getArrSetting(SETTINGS_KEYS.RADARR_API_KEY, 'RADARR_API_KEY');
   if (!url || !key) return null;
   return new RadarrClient(url, key);
 }
 
 /** Create a Sonarr client if configured (settings table or env vars). */
 export function getSonarrClient(): SonarrClient | null {
-  const url = getArrSetting('sonarr_url', 'SONARR_URL');
-  const key = getArrSetting('sonarr_api_key', 'SONARR_API_KEY');
+  const url = getArrSetting(SETTINGS_KEYS.SONARR_URL, 'SONARR_URL');
+  const key = getArrSetting(SETTINGS_KEYS.SONARR_API_KEY, 'SONARR_API_KEY');
   if (!url || !key) return null;
   return new SonarrClient(url, key);
 }

--- a/apps/pops-api/src/modules/media/plex/plex-auth.test.ts
+++ b/apps/pops-api/src/modules/media/plex/plex-auth.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDrizzle } from '../../../db.js';
 import type { createCaller } from '../../../shared/test-utils.js';
 import { setupTestContext } from '../../../shared/test-utils.js';
+import { SETTINGS_KEYS } from '../../core/settings/keys.js';
 
 const ctx = setupTestContext();
 let caller: ReturnType<typeof createCaller>;
@@ -97,7 +98,11 @@ describe('checkAuthPin', () => {
 
     // Verify token is stored encrypted (not plaintext)
     const drizzle = getDrizzle();
-    const tokenRecord = drizzle.select().from(settings).where(eq(settings.key, 'plex_token')).get();
+    const tokenRecord = drizzle
+      .select()
+      .from(settings)
+      .where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN))
+      .get();
     expect(tokenRecord).toBeTruthy();
     expect(tokenRecord!.value).not.toBe('my-plex-token');
 
@@ -105,7 +110,7 @@ describe('checkAuthPin', () => {
     const usernameRecord = drizzle
       .select()
       .from(settings)
-      .where(eq(settings.key, 'plex_username'))
+      .where(eq(settings.key, SETTINGS_KEYS.PLEX_USERNAME))
       .get();
     expect(usernameRecord?.value).toBe('plexuser');
   });
@@ -162,24 +167,28 @@ describe('disconnect', () => {
     // Seed token and username
     drizzle
       .insert(settings)
-      .values({ key: 'plex_token', value: 'encrypted-token' })
+      .values({ key: SETTINGS_KEYS.PLEX_TOKEN, value: 'encrypted-token' })
       .onConflictDoUpdate({ target: settings.key, set: { value: 'encrypted-token' } })
       .run();
     drizzle
       .insert(settings)
-      .values({ key: 'plex_username', value: 'plexuser' })
+      .values({ key: SETTINGS_KEYS.PLEX_USERNAME, value: 'plexuser' })
       .onConflictDoUpdate({ target: settings.key, set: { value: 'plexuser' } })
       .run();
 
     const result = await caller.media.plex.disconnect();
     expect(result.message).toBe('Disconnected from Plex');
 
-    const tokenRecord = drizzle.select().from(settings).where(eq(settings.key, 'plex_token')).get();
+    const tokenRecord = drizzle
+      .select()
+      .from(settings)
+      .where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN))
+      .get();
     expect(tokenRecord).toBeUndefined();
     const usernameRecord = drizzle
       .select()
       .from(settings)
-      .where(eq(settings.key, 'plex_username'))
+      .where(eq(settings.key, SETTINGS_KEYS.PLEX_USERNAME))
       .get();
     expect(usernameRecord).toBeUndefined();
   });
@@ -191,7 +200,7 @@ describe('disconnect', () => {
 describe('getPlexUsername', () => {
   it('returns stored username', async () => {
     const drizzle = getDrizzle();
-    drizzle.insert(settings).values({ key: 'plex_username', value: 'plexuser' }).run();
+    drizzle.insert(settings).values({ key: SETTINGS_KEYS.PLEX_USERNAME, value: 'plexuser' }).run();
 
     const result = await caller.media.plex.getPlexUsername();
     expect(result.data).toBe('plexuser');

--- a/apps/pops-api/src/modules/media/plex/router.ts
+++ b/apps/pops-api/src/modules/media/plex/router.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 
 import { getDrizzle } from '../../../db.js';
 import { protectedProcedure, router } from '../../../trpc.js';
+import { SETTINGS_KEYS } from '../../core/settings/keys.js';
 import { PlexClient } from './client.js';
 import * as scheduler from './scheduler.js';
 import * as plexService from './service.js';
@@ -141,7 +142,11 @@ export const plexRouter = router({
       }
 
       const db = getDrizzle();
-      const tokenRecord = db.select().from(settings).where(eq(settings.key, 'plex_token')).get();
+      const tokenRecord = db
+        .select()
+        .from(settings)
+        .where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN))
+        .get();
       const token = tokenRecord?.value;
 
       try {
@@ -176,7 +181,7 @@ export const plexRouter = router({
 
       console.warn(`[Plex] Updating server URL to: ${finalUrl}`);
       db.insert(settings)
-        .values({ key: 'plex_url', value: finalUrl })
+        .values({ key: SETTINGS_KEYS.PLEX_URL, value: finalUrl })
         .onConflictDoUpdate({ target: settings.key, set: { value: finalUrl } })
         .run();
 
@@ -302,13 +307,13 @@ export const plexRouter = router({
         console.warn(`[Plex] Encrypting and saving token to database...`);
         const encryptedToken = plexService.encryptToken(data.authToken);
         db.insert(settings)
-          .values({ key: 'plex_token', value: encryptedToken })
+          .values({ key: SETTINGS_KEYS.PLEX_TOKEN, value: encryptedToken })
           .onConflictDoUpdate({ target: settings.key, set: { value: encryptedToken } })
           .run();
 
         if (data.username) {
           db.insert(settings)
-            .values({ key: 'plex_username', value: data.username })
+            .values({ key: SETTINGS_KEYS.PLEX_USERNAME, value: data.username })
             .onConflictDoUpdate({ target: settings.key, set: { value: data.username } })
             .run();
         }
@@ -325,7 +330,7 @@ export const plexRouter = router({
   disconnect: protectedProcedure.mutation(() => {
     const db = getDrizzle();
     db.delete(settings)
-      .where(inArray(settings.key, ['plex_token', 'plex_username']))
+      .where(inArray(settings.key, [SETTINGS_KEYS.PLEX_TOKEN, SETTINGS_KEYS.PLEX_USERNAME]))
       .run();
     return { message: 'Disconnected from Plex' };
   }),

--- a/apps/pops-api/src/modules/media/plex/scheduler.test.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler.test.ts
@@ -3,6 +3,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { SETTINGS_KEYS } from '../../core/settings/keys.js';
+
 // Mock dependencies
 const settingsStore = new Map<string, string>();
 const mockInsertSyncLog = vi.fn();
@@ -151,8 +153,8 @@ describe('startScheduler', () => {
   it('persists scheduler config to settings', () => {
     startScheduler({ intervalMs: 30000 });
 
-    expect(settingsStore.get('plex_scheduler_enabled')).toBe('true');
-    expect(settingsStore.get('plex_scheduler_interval_ms')).toBe('30000');
+    expect(settingsStore.get(SETTINGS_KEYS.PLEX_SCHEDULER_ENABLED)).toBe('true');
+    expect(settingsStore.get(SETTINGS_KEYS.PLEX_SCHEDULER_INTERVAL_MS)).toBe('30000');
   });
 });
 
@@ -172,12 +174,12 @@ describe('stopScheduler', () => {
 
   it('clears persisted scheduler config', () => {
     startScheduler({ intervalMs: 5000 });
-    expect(settingsStore.get('plex_scheduler_enabled')).toBe('true');
+    expect(settingsStore.get(SETTINGS_KEYS.PLEX_SCHEDULER_ENABLED)).toBe('true');
 
     stopScheduler();
 
-    expect(settingsStore.has('plex_scheduler_enabled')).toBe(false);
-    expect(settingsStore.has('plex_scheduler_interval_ms')).toBe(false);
+    expect(settingsStore.has(SETTINGS_KEYS.PLEX_SCHEDULER_ENABLED)).toBe(false);
+    expect(settingsStore.has(SETTINGS_KEYS.PLEX_SCHEDULER_INTERVAL_MS)).toBe(false);
   });
 });
 
@@ -460,16 +462,16 @@ describe('persistence', () => {
   });
 
   it('getPersistedSchedulerState returns config when enabled', () => {
-    settingsStore.set('plex_scheduler_enabled', 'true');
-    settingsStore.set('plex_scheduler_interval_ms', '45000');
+    settingsStore.set(SETTINGS_KEYS.PLEX_SCHEDULER_ENABLED, 'true');
+    settingsStore.set(SETTINGS_KEYS.PLEX_SCHEDULER_INTERVAL_MS, '45000');
 
     const state = getPersistedSchedulerState();
     expect(state).toEqual({ enabled: true, intervalMs: 45000 });
   });
 
   it('resumeSchedulerIfEnabled starts scheduler with persisted config', () => {
-    settingsStore.set('plex_scheduler_enabled', 'true');
-    settingsStore.set('plex_scheduler_interval_ms', '60000');
+    settingsStore.set(SETTINGS_KEYS.PLEX_SCHEDULER_ENABLED, 'true');
+    settingsStore.set(SETTINGS_KEYS.PLEX_SCHEDULER_INTERVAL_MS, '60000');
 
     const status = resumeSchedulerIfEnabled();
     expect(status).not.toBeNull();

--- a/apps/pops-api/src/modules/media/plex/scheduler.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler.ts
@@ -9,6 +9,7 @@ import { settings, syncLogs } from '@pops/db-types';
 import { desc, eq } from 'drizzle-orm';
 
 import { getDrizzle } from '../../../db.js';
+import { SETTINGS_KEYS } from '../../core/settings/keys.js';
 import type { PlexClient } from './client.js';
 import { getPlexClient, getPlexSectionIds, getPlexToken } from './service.js';
 import { isJobRunning } from './sync-job-manager.js';
@@ -50,12 +51,12 @@ export interface SyncLogEntry {
 
 const DEFAULT_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 
-// Settings keys for scheduler persistence
-const SETTINGS_KEYS = {
-  enabled: 'plex_scheduler_enabled',
-  intervalMs: 'plex_scheduler_interval_ms',
-  movieSectionId: 'plex_movie_section_id',
-  tvSectionId: 'plex_tv_section_id',
+// Local aliases for scheduler-specific settings keys
+const SCHEDULER_KEYS = {
+  enabled: SETTINGS_KEYS.PLEX_SCHEDULER_ENABLED,
+  intervalMs: SETTINGS_KEYS.PLEX_SCHEDULER_INTERVAL_MS,
+  movieSectionId: SETTINGS_KEYS.PLEX_MOVIE_SECTION_ID,
+  tvSectionId: SETTINGS_KEYS.PLEX_TV_SECTION_ID,
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -96,13 +97,13 @@ function deleteSetting(key: string): void {
 }
 
 function persistSchedulerConfig(): void {
-  saveSetting(SETTINGS_KEYS.enabled, 'true');
-  saveSetting(SETTINGS_KEYS.intervalMs, String(intervalMs));
+  saveSetting(SCHEDULER_KEYS.enabled, 'true');
+  saveSetting(SCHEDULER_KEYS.intervalMs, String(intervalMs));
 }
 
 function clearSchedulerConfig(): void {
-  deleteSetting(SETTINGS_KEYS.enabled);
-  deleteSetting(SETTINGS_KEYS.intervalMs);
+  deleteSetting(SCHEDULER_KEYS.enabled);
+  deleteSetting(SCHEDULER_KEYS.intervalMs);
 }
 
 function writeSyncLog(
@@ -188,9 +189,9 @@ export function getPersistedSchedulerState(): {
   enabled: boolean;
   intervalMs: number;
 } | null {
-  const enabled = getSetting(SETTINGS_KEYS.enabled);
+  const enabled = getSetting(SCHEDULER_KEYS.enabled);
   if (enabled !== 'true') return null;
-  const interval = getSetting(SETTINGS_KEYS.intervalMs);
+  const interval = getSetting(SCHEDULER_KEYS.intervalMs);
   return {
     enabled: true,
     intervalMs: interval ? Number(interval) : DEFAULT_INTERVAL_MS,

--- a/apps/pops-api/src/modules/media/plex/service.ts
+++ b/apps/pops-api/src/modules/media/plex/service.ts
@@ -9,6 +9,7 @@ import { eq } from 'drizzle-orm';
 
 import { getDrizzle } from '../../../db.js';
 import { getEnv } from '../../../env.js';
+import { SETTINGS_KEYS } from '../../core/settings/keys.js';
 import { PlexClient } from './client.js';
 
 // ---------------------------------------------------------------------------
@@ -36,19 +37,23 @@ function getEncryptionKey(): Buffer {
     return scryptSync(envKey, 'pops-plex-token', 32);
   }
   const db = getDrizzle();
-  const record = db.select().from(settings).where(eq(settings.key, 'plex_encryption_seed')).get();
+  const record = db
+    .select()
+    .from(settings)
+    .where(eq(settings.key, SETTINGS_KEYS.PLEX_ENCRYPTION_SEED))
+    .get();
   if (record) {
     return scryptSync(record.value, 'pops-plex-token', 32);
   }
   const seed = randomBytes(32).toString('hex');
   db.insert(settings)
-    .values({ key: 'plex_encryption_seed', value: seed })
+    .values({ key: SETTINGS_KEYS.PLEX_ENCRYPTION_SEED, value: seed })
     .onConflictDoNothing()
     .run();
   const finalRecord = db
     .select()
     .from(settings)
-    .where(eq(settings.key, 'plex_encryption_seed'))
+    .where(eq(settings.key, SETTINGS_KEYS.PLEX_ENCRYPTION_SEED))
     .get();
   return scryptSync(finalRecord?.value ?? seed, 'pops-plex-token', 32);
 }
@@ -79,18 +84,22 @@ export function decryptToken(ciphertext: string): string {
 
 export function getPlexClientId(): string {
   const db = getDrizzle();
-  const record = db.select().from(settings).where(eq(settings.key, 'plex_client_identifier')).get();
+  const record = db
+    .select()
+    .from(settings)
+    .where(eq(settings.key, SETTINGS_KEYS.PLEX_CLIENT_IDENTIFIER))
+    .get();
   if (!record) {
     const newId = randomUUID();
     console.warn(`[Plex] Generating new client identifier: ${newId}`);
     db.insert(settings)
-      .values({ key: 'plex_client_identifier', value: newId })
+      .values({ key: SETTINGS_KEYS.PLEX_CLIENT_IDENTIFIER, value: newId })
       .onConflictDoNothing()
       .run();
     const finalRecord = db
       .select()
       .from(settings)
-      .where(eq(settings.key, 'plex_client_identifier'))
+      .where(eq(settings.key, SETTINGS_KEYS.PLEX_CLIENT_IDENTIFIER))
       .get();
     return finalRecord?.value ?? newId;
   }
@@ -99,7 +108,7 @@ export function getPlexClientId(): string {
 
 export function getPlexUrl(): string | null {
   const db = getDrizzle();
-  const record = db.select().from(settings).where(eq(settings.key, 'plex_url')).get();
+  const record = db.select().from(settings).where(eq(settings.key, SETTINGS_KEYS.PLEX_URL)).get();
   if (record?.value) return record.value;
   return getEnv('PLEX_URL') || null;
 }
@@ -112,7 +121,11 @@ export function getPlexClient(): PlexClient | null {
   }
 
   const db = getDrizzle();
-  const tokenRecord = db.select().from(settings).where(eq(settings.key, 'plex_token')).get();
+  const tokenRecord = db
+    .select()
+    .from(settings)
+    .where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN))
+    .get();
   const encryptedToken = tokenRecord?.value;
 
   if (!encryptedToken) {
@@ -132,7 +145,11 @@ export function getPlexClient(): PlexClient | null {
 /** Get the decrypted Plex token (for cloud API calls that don't use PlexClient). */
 export function getPlexToken(): string | null {
   const db = getDrizzle();
-  const tokenRecord = db.select().from(settings).where(eq(settings.key, 'plex_token')).get();
+  const tokenRecord = db
+    .select()
+    .from(settings)
+    .where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN))
+    .get();
   const encryptedToken = tokenRecord?.value;
   if (!encryptedToken) return null;
 
@@ -145,7 +162,11 @@ export function getPlexToken(): string | null {
 
 export function getPlexUsername(): string | null {
   const db = getDrizzle();
-  const record = db.select().from(settings).where(eq(settings.key, 'plex_username')).get();
+  const record = db
+    .select()
+    .from(settings)
+    .where(eq(settings.key, SETTINGS_KEYS.PLEX_USERNAME))
+    .get();
   return record?.value ?? null;
 }
 
@@ -163,9 +184,13 @@ export function getPlexSectionIds(): PlexSectionIds {
   const movieRecord = db
     .select()
     .from(settings)
-    .where(eq(settings.key, 'plex_movie_section_id'))
+    .where(eq(settings.key, SETTINGS_KEYS.PLEX_MOVIE_SECTION_ID))
     .get();
-  const tvRecord = db.select().from(settings).where(eq(settings.key, 'plex_tv_section_id')).get();
+  const tvRecord = db
+    .select()
+    .from(settings)
+    .where(eq(settings.key, SETTINGS_KEYS.PLEX_TV_SECTION_ID))
+    .get();
   return {
     movieSectionId: movieRecord?.value ?? null,
     tvSectionId: tvRecord?.value ?? null,
@@ -176,13 +201,13 @@ export function savePlexSectionIds(movieSectionId?: string, tvSectionId?: string
   const db = getDrizzle();
   if (movieSectionId) {
     db.insert(settings)
-      .values({ key: 'plex_movie_section_id', value: movieSectionId })
+      .values({ key: SETTINGS_KEYS.PLEX_MOVIE_SECTION_ID, value: movieSectionId })
       .onConflictDoUpdate({ target: settings.key, set: { value: movieSectionId } })
       .run();
   }
   if (tvSectionId) {
     db.insert(settings)
-      .values({ key: 'plex_tv_section_id', value: tvSectionId })
+      .values({ key: SETTINGS_KEYS.PLEX_TV_SECTION_ID, value: tvSectionId })
       .onConflictDoUpdate({ target: settings.key, set: { value: tvSectionId } })
       .run();
   }
@@ -203,7 +228,7 @@ export async function testConnection(client: PlexClient): Promise<boolean> {
 
 export function getSyncStatus(client: PlexClient | null): PlexSyncStatus {
   const db = getDrizzle();
-  const token = db.select().from(settings).where(eq(settings.key, 'plex_token')).get();
+  const token = db.select().from(settings).where(eq(settings.key, SETTINGS_KEYS.PLEX_TOKEN)).get();
   const url = getPlexUrl();
 
   return {

--- a/packages/app-ai/package.json
+++ b/packages/app-ai/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@pops/api-client": "workspace:*",
+    "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.96.2",
     "@tanstack/react-table": "8.21.3",

--- a/packages/app-ai/src/pages/ModelConfigPage.tsx
+++ b/packages/app-ai/src/pages/ModelConfigPage.tsx
@@ -4,6 +4,7 @@
  * Allows configuring which AI model to use, monthly token budget,
  * and fallback behaviour when budget is exceeded. PRD-053/US-01.
  */
+import { SETTINGS_KEYS } from '@pops/types';
 import {
   Alert,
   Breadcrumb,
@@ -27,9 +28,9 @@ import { toast } from 'sonner';
 import { trpc } from '../lib/trpc';
 
 const SETTING_KEYS = {
-  model: 'ai.model',
-  budget: 'ai.monthlyTokenBudget',
-  fallback: 'ai.budgetExceededFallback',
+  model: SETTINGS_KEYS.AI_MODEL,
+  budget: SETTINGS_KEYS.AI_MONTHLY_TOKEN_BUDGET,
+  fallback: SETTINGS_KEYS.AI_BUDGET_EXCEEDED_FALLBACK,
 } as const;
 
 const SUPPORTED_MODELS = [

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,3 +10,4 @@ export type {
   SearchHit,
   StructuredFilter,
 } from './search.js';
+export { SETTINGS_KEYS, type SettingsKey } from './settings-keys.js';

--- a/packages/types/src/settings-keys.ts
+++ b/packages/types/src/settings-keys.ts
@@ -1,0 +1,17 @@
+/**
+ * Typed settings key registry — shared between backend and frontend.
+ *
+ * This is a subset of settings keys needed by frontend packages.
+ * The canonical source is apps/pops-api/src/modules/core/settings/keys.ts.
+ */
+export const SETTINGS_KEYS = {
+  // AI
+  AI_MODEL: 'ai.model',
+  AI_MONTHLY_TOKEN_BUDGET: 'ai.monthlyTokenBudget',
+  AI_BUDGET_EXCEEDED_FALLBACK: 'ai.budgetExceededFallback',
+
+  // App
+  THEME: 'theme',
+} as const;
+
+export type SettingsKey = (typeof SETTINGS_KEYS)[keyof typeof SETTINGS_KEYS];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,9 @@ importers:
       '@pops/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../types
       '@pops/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
## Summary
- Create central `SETTINGS_KEYS` constant object and `SettingsKey` type in `core/settings/keys.ts` with all 17 known settings keys
- Replace magic string settings keys across 7 source files (plex/service, plex/router, plex/scheduler, arr/service, settings service/router, ModelConfigPage)
- Type the settings service `get`/`getOrNull`/`delete` operations to accept `SettingsKey` instead of `string`
- Export frontend-relevant keys via `@pops/types` for cross-package consumption
- Update 4 test files to use typed constants

Closes #1719

## Test plan
- [x] `mise typecheck` passes (14/14 packages)
- [x] `mise lint` passes (no new errors)
- [x] Settings tests pass (52 tests across 3 files)
- [x] ModelConfigPage tests pass (9 tests)
- [x] Full API test suite passes (2296/2307 — 11 failures are pre-existing env test flakiness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)