### PR TITLE
feat(media): queue + download buttons for rotation [tb-361]

### DIFF
--- a/apps/pops-api/src/modules/media/rotation/router.ts
+++ b/apps/pops-api/src/modules/media/rotation/router.ts
@@ -409,36 +409,52 @@ export const rotationRouter = router({
     .mutation(({ input }) => {
       const db = getDrizzle();
 
-      // Ensure a manual source exists (upsert)
-      let manualSource = db
-        .select()
-        .from(rotationSources)
-        .where(eq(rotationSources.type, 'manual'))
-        .get();
-
-      if (!manualSource) {
-        manualSource = db
-          .insert(rotationSources)
-          .values({ type: 'manual', name: 'Manual Queue', priority: 5, enabled: 1 })
-          .returning()
+      return db.transaction((tx) => {
+        // Reject if movie is excluded
+        const excluded = tx
+          .select({ id: rotationExclusions.id })
+          .from(rotationExclusions)
+          .where(eq(rotationExclusions.tmdbId, input.tmdbId))
           .get();
-      }
 
-      // Insert candidate (ignore if already exists)
-      db.insert(rotationCandidates)
-        .values({
-          sourceId: manualSource.id,
-          tmdbId: input.tmdbId,
-          title: input.title,
-          year: input.year ?? null,
-          rating: input.rating ?? null,
-          posterPath: input.posterPath ?? null,
-          status: 'pending',
-        })
-        .onConflictDoNothing()
-        .run();
+        if (excluded) {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'Movie is excluded from rotation',
+          });
+        }
 
-      return { success: true };
+        // Ensure a manual source exists (upsert inside transaction)
+        let manualSource = tx
+          .select()
+          .from(rotationSources)
+          .where(eq(rotationSources.type, 'manual'))
+          .get();
+
+        if (!manualSource) {
+          manualSource = tx
+            .insert(rotationSources)
+            .values({ type: 'manual', name: 'Manual Queue', priority: 5, enabled: 1 })
+            .returning()
+            .get();
+        }
+
+        // Insert candidate (ignore if already exists)
+        tx.insert(rotationCandidates)
+          .values({
+            sourceId: manualSource.id,
+            tmdbId: input.tmdbId,
+            title: input.title,
+            year: input.year ?? null,
+            rating: input.rating ?? null,
+            posterPath: input.posterPath ?? null,
+            status: 'pending',
+          })
+          .onConflictDoNothing()
+          .run();
+
+        return { success: true };
+      });
     }),
 
   /** Check candidate/exclusion status for a movie. PRD-072 US-05. */
@@ -467,14 +483,16 @@ export const rotationRouter = router({
       };
     }),
 
-  /** Remove a movie from the rotation queue. PRD-072 US-05. */
+  /** Remove a pending movie from the rotation queue. PRD-072 US-05. */
   removeFromQueue: protectedProcedure
     .input(z.object({ tmdbId: z.number().int().positive() }))
     .mutation(({ input }) => {
       const db = getDrizzle();
       const result = db
         .delete(rotationCandidates)
-        .where(eq(rotationCandidates.tmdbId, input.tmdbId))
+        .where(
+          sql`${rotationCandidates.tmdbId} = ${input.tmdbId} AND ${rotationCandidates.status} = 'pending'`
+        )
         .run();
       return { success: result.changes > 0 };
     }),

--- a/apps/pops-api/src/modules/media/rotation/router.ts
+++ b/apps/pops-api/src/modules/media/rotation/router.ts
@@ -394,4 +394,88 @@ export const rotationRouter = router({
 
       return { success: result.changes > 0 };
     }),
+
+  /** Add a movie to the rotation queue manually. PRD-072 US-05. */
+  addToQueue: protectedProcedure
+    .input(
+      z.object({
+        tmdbId: z.number().int().positive(),
+        title: z.string().min(1),
+        year: z.number().int().optional(),
+        rating: z.number().optional(),
+        posterPath: z.string().optional(),
+      })
+    )
+    .mutation(({ input }) => {
+      const db = getDrizzle();
+
+      // Ensure a manual source exists (upsert)
+      let manualSource = db
+        .select()
+        .from(rotationSources)
+        .where(eq(rotationSources.type, 'manual'))
+        .get();
+
+      if (!manualSource) {
+        manualSource = db
+          .insert(rotationSources)
+          .values({ type: 'manual', name: 'Manual Queue', priority: 5, enabled: 1 })
+          .returning()
+          .get();
+      }
+
+      // Insert candidate (ignore if already exists)
+      db.insert(rotationCandidates)
+        .values({
+          sourceId: manualSource.id,
+          tmdbId: input.tmdbId,
+          title: input.title,
+          year: input.year ?? null,
+          rating: input.rating ?? null,
+          posterPath: input.posterPath ?? null,
+          status: 'pending',
+        })
+        .onConflictDoNothing()
+        .run();
+
+      return { success: true };
+    }),
+
+  /** Check candidate/exclusion status for a movie. PRD-072 US-05. */
+  getCandidateStatus: protectedProcedure
+    .input(z.object({ tmdbId: z.number().int().positive() }))
+    .query(({ input }) => {
+      const db = getDrizzle();
+
+      const candidate = db
+        .select({ status: rotationCandidates.status, id: rotationCandidates.id })
+        .from(rotationCandidates)
+        .where(eq(rotationCandidates.tmdbId, input.tmdbId))
+        .get();
+
+      const excluded = db
+        .select({ id: rotationExclusions.id })
+        .from(rotationExclusions)
+        .where(eq(rotationExclusions.tmdbId, input.tmdbId))
+        .get();
+
+      return {
+        inQueue: candidate?.status === 'pending',
+        candidateId: candidate?.id ?? null,
+        candidateStatus: candidate?.status ?? null,
+        isExcluded: !!excluded,
+      };
+    }),
+
+  /** Remove a movie from the rotation queue. PRD-072 US-05. */
+  removeFromQueue: protectedProcedure
+    .input(z.object({ tmdbId: z.number().int().positive() }))
+    .mutation(({ input }) => {
+      const db = getDrizzle();
+      const result = db
+        .delete(rotationCandidates)
+        .where(eq(rotationCandidates.tmdbId, input.tmdbId))
+        .run();
+      return { success: result.changes > 0 };
+    }),
 });

--- a/packages/app-media/src/components/DiscoverCard.test.tsx
+++ b/packages/app-media/src/components/DiscoverCard.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { DiscoverCard } from './DiscoverCard';
 
-vi.mock('./RequestMovieButton', () => ({
-  RequestMovieButton: ({ tmdbId }: { tmdbId: number; title: string; variant?: string }) => (
+vi.mock('./MovieActionButtons', () => ({
+  MovieActionButtons: ({ tmdbId }: { tmdbId: number; title: string; variant?: string }) => (
     <button data-testid={`request-${tmdbId}`}>Request</button>
   ),
 }));

--- a/packages/app-media/src/components/DiscoverCard.tsx
+++ b/packages/app-media/src/components/DiscoverCard.tsx
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 
-import { RequestMovieButton } from './RequestMovieButton';
+import { MovieActionButtons } from './MovieActionButtons';
 
 export interface DiscoverCardProps {
   tmdbId: number;
@@ -204,10 +204,11 @@ export function DiscoverCard({
             </Button>
           )}
           {!inLibrary && (
-            <RequestMovieButton
+            <MovieActionButtons
               tmdbId={tmdbId}
               title={title}
               year={year ? parseInt(year, 10) : new Date().getFullYear()}
+              rating={voteAverage}
               variant="compact"
             />
           )}

--- a/packages/app-media/src/components/MovieActionButtons.tsx
+++ b/packages/app-media/src/components/MovieActionButtons.tsx
@@ -174,7 +174,7 @@ function RotationButtons({
       <Button
         variant="outline"
         size="sm"
-        className="text-emerald-500 border-emerald-500/50 hover:text-red-400 hover:border-red-400/50"
+        className="group text-emerald-500 border-emerald-500/50 hover:text-red-400 hover:border-red-400/50"
         onClick={() => removeFromQueueMutation.mutate({ tmdbId })}
         disabled={removeFromQueueMutation.isPending}
       >

--- a/packages/app-media/src/components/MovieActionButtons.tsx
+++ b/packages/app-media/src/components/MovieActionButtons.tsx
@@ -1,0 +1,274 @@
+/**
+ * MovieActionButtons — conditional action buttons for non-library movies.
+ *
+ * When rotation is enabled: shows "Add to Queue" and "Download" buttons
+ * with status badges (In Queue, Excluded).
+ * When rotation is disabled: delegates to the existing RequestMovieButton.
+ *
+ * PRD-072 US-05
+ */
+import { Button } from '@pops/ui';
+import { Ban, Check, Download, ListPlus, Loader2, X } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { trpc } from '../lib/trpc';
+import { RequestMovieButton } from './RequestMovieButton';
+import { RequestMovieModal } from './RequestMovieModal';
+
+type ButtonVariant = 'standard' | 'compact';
+
+export interface MovieActionButtonsProps {
+  tmdbId: number;
+  title: string;
+  year: number;
+  posterPath?: string;
+  rating?: number;
+  variant?: ButtonVariant;
+}
+
+export function MovieActionButtons({
+  tmdbId,
+  title,
+  year,
+  posterPath,
+  rating,
+  variant = 'standard',
+}: MovieActionButtonsProps) {
+  const { data: statusData } = trpc.media.rotation.status.useQuery();
+  const rotationEnabled = statusData?.isRunning ?? false;
+
+  if (!rotationEnabled) {
+    return <RequestMovieButton tmdbId={tmdbId} title={title} year={year} variant={variant} />;
+  }
+
+  return (
+    <RotationButtons
+      tmdbId={tmdbId}
+      title={title}
+      year={year}
+      posterPath={posterPath}
+      rating={rating}
+      variant={variant}
+    />
+  );
+}
+
+function RotationButtons({
+  tmdbId,
+  title,
+  year,
+  posterPath,
+  rating,
+  variant,
+}: MovieActionButtonsProps & { variant: ButtonVariant }) {
+  const [downloadModalOpen, setDownloadModalOpen] = useState(false);
+  const utils = trpc.useUtils();
+
+  const { data: configData } = trpc.media.arr.getConfig.useQuery();
+  const radarrConfigured = configData?.data?.radarrConfigured === true;
+
+  const movieStatus = trpc.media.arr.getMovieStatus.useQuery(
+    { tmdbId },
+    { enabled: radarrConfigured }
+  );
+
+  const { data: candidateData, isLoading: candidateLoading } =
+    trpc.media.rotation.getCandidateStatus.useQuery({ tmdbId });
+
+  const addToQueueMutation = trpc.media.rotation.addToQueue.useMutation({
+    onSuccess: () => {
+      toast.success('Added to rotation queue');
+      void utils.media.rotation.getCandidateStatus.invalidate({ tmdbId });
+    },
+    onError: () => toast.error('Failed to add to queue'),
+  });
+
+  const removeFromQueueMutation = trpc.media.rotation.removeFromQueue.useMutation({
+    onSuccess: () => {
+      toast.success('Removed from queue');
+      void utils.media.rotation.getCandidateStatus.invalidate({ tmdbId });
+    },
+    onError: () => toast.error('Failed to remove from queue'),
+  });
+
+  const removeExclusionMutation = trpc.media.rotation.removeExclusion.useMutation({
+    onSuccess: () => {
+      toast.success('Exclusion removed');
+      void utils.media.rotation.getCandidateStatus.invalidate({ tmdbId });
+    },
+    onError: () => toast.error('Failed to remove exclusion'),
+  });
+
+  // Movie already in Radarr — hide buttons
+  const radarrStatus = movieStatus.data?.data?.status;
+  if (radarrStatus && radarrStatus !== 'not_found') return null;
+
+  // Loading state
+  if (candidateLoading || movieStatus.isLoading) return null;
+
+  const inQueue = candidateData?.inQueue ?? false;
+  const isExcluded = candidateData?.isExcluded ?? false;
+
+  // Excluded badge
+  if (isExcluded) {
+    if (variant === 'compact') {
+      return (
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7 text-amber-500 hover:bg-amber-500/20"
+          onClick={() => removeExclusionMutation.mutate({ tmdbId })}
+          disabled={removeExclusionMutation.isPending}
+          title="Excluded — click to un-exclude"
+          aria-label="Un-exclude movie"
+        >
+          {removeExclusionMutation.isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Ban className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      );
+    }
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        className="text-amber-500 border-amber-500/50"
+        onClick={() => removeExclusionMutation.mutate({ tmdbId })}
+        disabled={removeExclusionMutation.isPending}
+      >
+        {removeExclusionMutation.isPending ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Ban className="h-4 w-4" />
+        )}
+        Excluded
+      </Button>
+    );
+  }
+
+  // In Queue badge
+  if (inQueue) {
+    if (variant === 'compact') {
+      return (
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7 text-emerald-500 hover:bg-red-500/20 hover:text-red-400"
+          onClick={() => removeFromQueueMutation.mutate({ tmdbId })}
+          disabled={removeFromQueueMutation.isPending}
+          title="In Queue — click to remove"
+          aria-label="Remove from queue"
+        >
+          {removeFromQueueMutation.isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Check className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      );
+    }
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        className="text-emerald-500 border-emerald-500/50 hover:text-red-400 hover:border-red-400/50"
+        onClick={() => removeFromQueueMutation.mutate({ tmdbId })}
+        disabled={removeFromQueueMutation.isPending}
+      >
+        {removeFromQueueMutation.isPending ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <>
+            <Check className="h-4 w-4 group-hover:hidden" />
+            <X className="h-4 w-4 hidden group-hover:inline" />
+          </>
+        )}
+        In Queue
+      </Button>
+    );
+  }
+
+  // Action buttons: Add to Queue + Download
+  const handleAddToQueue = () => {
+    addToQueueMutation.mutate({ tmdbId, title, year, posterPath, rating });
+  };
+
+  if (variant === 'compact') {
+    return (
+      <>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7 text-white hover:bg-white/20"
+          onClick={handleAddToQueue}
+          disabled={addToQueueMutation.isPending}
+          title="Add to Rotation Queue"
+          aria-label="Add to Rotation Queue"
+        >
+          {addToQueueMutation.isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <ListPlus className="h-3.5 w-3.5" />
+          )}
+        </Button>
+        {radarrConfigured && (
+          <>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-7 w-7 text-white hover:bg-white/20"
+              onClick={() => setDownloadModalOpen(true)}
+              title="Download Now"
+              aria-label="Download Now"
+            >
+              <Download className="h-3.5 w-3.5" />
+            </Button>
+            <RequestMovieModal
+              open={downloadModalOpen}
+              onClose={() => setDownloadModalOpen(false)}
+              tmdbId={tmdbId}
+              title={title}
+              year={year}
+            />
+          </>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleAddToQueue}
+        disabled={addToQueueMutation.isPending}
+      >
+        {addToQueueMutation.isPending ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <ListPlus className="h-4 w-4" />
+        )}
+        Add to Queue
+      </Button>
+      {radarrConfigured && (
+        <>
+          <Button variant="outline" size="sm" onClick={() => setDownloadModalOpen(true)}>
+            <Download className="h-4 w-4" />
+            Download
+          </Button>
+          <RequestMovieModal
+            open={downloadModalOpen}
+            onClose={() => setDownloadModalOpen(false)}
+            tmdbId={tmdbId}
+            title={title}
+            year={year}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/packages/app-media/src/components/SearchResultCard.tsx
+++ b/packages/app-media/src/components/SearchResultCard.tsx
@@ -8,7 +8,7 @@ import { Check, Film, Loader2, Plus, Tv } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';
 
-import { RequestMovieButton } from './RequestMovieButton';
+import { MovieActionButtons } from './MovieActionButtons';
 
 const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w342';
 
@@ -156,10 +156,11 @@ export function SearchResultCard({
             </Button>
           )}
           {type === 'movie' && tmdbId != null && (
-            <RequestMovieButton
+            <MovieActionButtons
               tmdbId={tmdbId}
               title={title}
               year={year ? parseInt(year, 10) : new Date().getFullYear()}
+              rating={voteAverage ?? undefined}
             />
           )}
         </div>

--- a/packages/app-media/src/pages/MovieDetailPage.test.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.test.tsx
@@ -40,8 +40,8 @@ vi.mock('../components/ComparisonScores', () => ({
 vi.mock('../components/ArrStatusBadge', () => ({
   ArrStatusBadge: () => <span>Arr Status</span>,
 }));
-vi.mock('../components/RequestMovieButton', () => ({
-  RequestMovieButton: () => null,
+vi.mock('../components/MovieActionButtons', () => ({
+  MovieActionButtons: () => null,
 }));
 vi.mock('../components/FreshnessBadge', () => ({
   FreshnessBadge: () => null,

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -243,6 +243,8 @@ export function MovieDetailPage() {
                 tmdbId={movie.tmdbId}
                 title={movie.title}
                 year={year ?? new Date().getFullYear()}
+                rating={movie.voteAverage ?? undefined}
+                posterPath={movie.posterPath ?? undefined}
               />
               <FreshnessBadge daysSinceWatch={daysSinceWatch} staleness={staleness} />
               {pendingDebrief && (

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -21,7 +21,7 @@ import { ComparisonScores } from '../components/ComparisonScores';
 import { ExcludedDimensions } from '../components/ExcludedDimensions';
 import { FreshnessBadge } from '../components/FreshnessBadge';
 import { MarkAsWatchedButton } from '../components/MarkAsWatchedButton';
-import { RequestMovieButton } from '../components/RequestMovieButton';
+import { MovieActionButtons } from '../components/MovieActionButtons';
 import { WatchlistToggle } from '../components/WatchlistToggle';
 import { formatCurrency, formatLanguage, formatRuntime } from '../lib/format';
 import { trpc } from '../lib/trpc';
@@ -239,7 +239,7 @@ export function MovieDetailPage() {
               <WatchlistToggle mediaType="movie" mediaId={movie.id} />
               <MarkAsWatchedButton mediaId={movie.id} />
               <ArrStatusBadge kind="movie" externalId={movie.tmdbId} />
-              <RequestMovieButton
+              <MovieActionButtons
                 tmdbId={movie.tmdbId}
                 title={movie.title}
                 year={year ?? new Date().getFullYear()}

--- a/packages/app-media/src/pages/SearchPage.test.tsx
+++ b/packages/app-media/src/pages/SearchPage.test.tsx
@@ -70,8 +70,8 @@ vi.mock('../components/SearchResultCard', () => ({
   },
 }));
 
-vi.mock('../components/RequestMovieButton', () => ({
-  RequestMovieButton: () => null,
+vi.mock('../components/MovieActionButtons', () => ({
+  MovieActionButtons: () => null,
 }));
 
 vi.mock('sonner', () => ({


### PR DESCRIPTION
## Summary
- Add `addToQueue`, `getCandidateStatus`, and `removeFromQueue` backend endpoints to the rotation router (PRD-072 US-05)
- Create `MovieActionButtons` component that conditionally shows rotation queue/download buttons when rotation is enabled, falling back to the existing `RequestMovieButton` when disabled
- Replace `RequestMovieButton` with `MovieActionButtons` in `DiscoverCard`, `SearchResultCard`, and `MovieDetailPage`

## Changes
- **Backend** (`rotation/router.ts`): 3 new endpoints — `addToQueue` (upserts manual source + inserts candidate), `getCandidateStatus` (checks queue/exclusion status), `removeFromQueue` (deletes candidate by tmdbId)
- **Frontend** (`MovieActionButtons.tsx`): New wrapper component with two variants (`standard`/`compact`). Shows "Add to Queue" + download button when not queued, "In Queue" badge (clickable to remove) when queued, "Excluded" badge (clickable to un-exclude) when excluded
- **Integration**: Swapped `RequestMovieButton` → `MovieActionButtons` in 3 consumer components + updated test mocks

## Test plan
- [ ] Verify `MovieActionButtons` shows rotation controls when `rotation.status` returns `isRunning: true`
- [ ] Verify fallback to `RequestMovieButton` when rotation is disabled
- [ ] Verify "Add to Queue" creates candidate via `addToQueue` mutation
- [ ] Verify "In Queue" badge appears after adding, click removes via `removeFromQueue`
- [ ] Verify "Excluded" badge shows for excluded movies, click un-excludes
- [ ] Verify compact variant renders correctly in `DiscoverCard` hover overlay
- [ ] Verify existing tests pass (`DiscoverCard.test.tsx`, `MovieDetailPage.test.tsx`, `SearchPage.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)