### PR TITLE
fix(settings): address review gaps from #1763

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.85.0",
     "@pops/db-types": "workspace:*",
+    "@pops/types": "workspace:*",
     "@trpc/server": "^11.16.0",
     "better-sqlite3": "^12.8.0",
     "cron-parser": "^5.5.0",

--- a/apps/pops-api/src/modules/core/settings/index.ts
+++ b/apps/pops-api/src/modules/core/settings/index.ts
@@ -1,6 +1,6 @@
 /**
  * Settings module
  */
-export { SETTINGS_KEYS, type SettingsKey } from './keys.js';
+export { SETTINGS_KEY_VALUES, SETTINGS_KEYS, type SettingsKey } from './keys.js';
 export { settingsRouter } from './router.js';
 export type { SetSettingInput, Setting, SettingListInput } from './types.js';

--- a/apps/pops-api/src/modules/core/settings/keys.ts
+++ b/apps/pops-api/src/modules/core/settings/keys.ts
@@ -1,34 +1,4 @@
 /**
- * Typed settings key registry — single source of truth for all settings keys.
- *
- * Every key stored in the `settings` table must be listed here.
- * Import `SETTINGS_KEYS` and `SettingsKey` instead of using magic strings.
+ * Re-export settings keys from the canonical source in @pops/types.
  */
-export const SETTINGS_KEYS = {
-  // Plex
-  PLEX_URL: 'plex_url',
-  PLEX_TOKEN: 'plex_token',
-  PLEX_USERNAME: 'plex_username',
-  PLEX_ENCRYPTION_SEED: 'plex_encryption_seed',
-  PLEX_CLIENT_IDENTIFIER: 'plex_client_identifier',
-  PLEX_MOVIE_SECTION_ID: 'plex_movie_section_id',
-  PLEX_TV_SECTION_ID: 'plex_tv_section_id',
-  PLEX_SCHEDULER_ENABLED: 'plex_scheduler_enabled',
-  PLEX_SCHEDULER_INTERVAL_MS: 'plex_scheduler_interval_ms',
-
-  // Radarr / Sonarr
-  RADARR_URL: 'radarr_url',
-  RADARR_API_KEY: 'radarr_api_key',
-  SONARR_URL: 'sonarr_url',
-  SONARR_API_KEY: 'sonarr_api_key',
-
-  // AI
-  AI_MODEL: 'ai.model',
-  AI_MONTHLY_TOKEN_BUDGET: 'ai.monthlyTokenBudget',
-  AI_BUDGET_EXCEEDED_FALLBACK: 'ai.budgetExceededFallback',
-
-  // App
-  THEME: 'theme',
-} as const;
-
-export type SettingsKey = (typeof SETTINGS_KEYS)[keyof typeof SETTINGS_KEYS];
+export { SETTINGS_KEY_VALUES, SETTINGS_KEYS, type SettingsKey } from '@pops/types';

--- a/apps/pops-api/src/modules/core/settings/router.ts
+++ b/apps/pops-api/src/modules/core/settings/router.ts
@@ -7,9 +7,9 @@ import { z } from 'zod';
 import { NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta } from '../../../shared/pagination.js';
 import { protectedProcedure, router } from '../../../trpc.js';
-import type { SettingsKey } from './keys.js';
+import { SETTINGS_KEY_VALUES } from './keys.js';
 import * as service from './service.js';
-import { SetSettingSchema, SettingListSchema, toSetting } from './types.js';
+import { SettingListSchema, toSetting } from './types.js';
 
 const DEFAULT_LIMIT = 50;
 const DEFAULT_OFFSET = 0;
@@ -29,30 +29,36 @@ export const settingsRouter = router({
   }),
 
   /** Get a single setting by key (returns null when key does not exist) */
-  get: protectedProcedure.input(z.object({ key: z.string() })).query(({ input }) => {
-    const row = service.getSettingOrNull(input.key as SettingsKey);
-    return { data: row ? toSetting(row) : null };
-  }),
+  get: protectedProcedure
+    .input(z.object({ key: z.enum(SETTINGS_KEY_VALUES) }))
+    .query(({ input }) => {
+      const row = service.getSettingOrNull(input.key);
+      return { data: row ? toSetting(row) : null };
+    }),
 
   /** Set a setting value (upsert — creates or updates) */
-  set: protectedProcedure.input(SetSettingSchema).mutation(({ input }) => {
-    const row = service.setSetting(input);
-    return {
-      data: toSetting(row),
-      message: 'Setting saved',
-    };
-  }),
+  set: protectedProcedure
+    .input(z.object({ key: z.enum(SETTINGS_KEY_VALUES), value: z.string() }))
+    .mutation(({ input }) => {
+      const row = service.setSetting(input);
+      return {
+        data: toSetting(row),
+        message: 'Setting saved',
+      };
+    }),
 
   /** Delete a setting by key */
-  delete: protectedProcedure.input(z.object({ key: z.string() })).mutation(({ input }) => {
-    try {
-      service.deleteSetting(input.key as SettingsKey);
-      return { message: 'Setting deleted' };
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+  delete: protectedProcedure
+    .input(z.object({ key: z.enum(SETTINGS_KEY_VALUES) }))
+    .mutation(({ input }) => {
+      try {
+        service.deleteSetting(input.key);
+        return { message: 'Setting deleted' };
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+        }
+        throw err;
       }
-      throw err;
-    }
-  }),
+    }),
 });

--- a/apps/pops-api/src/modules/core/settings/service.ts
+++ b/apps/pops-api/src/modules/core/settings/service.ts
@@ -64,7 +64,7 @@ export function setSetting(input: SetSettingInput): SettingRow {
     })
     .run();
 
-  return getSetting(input.key as SettingsKey);
+  return getSetting(input.key);
 }
 
 /** Delete a setting by key */

--- a/apps/pops-api/src/modules/core/settings/settings.test.ts
+++ b/apps/pops-api/src/modules/core/settings/settings.test.ts
@@ -44,9 +44,9 @@ describe('settings.list', () => {
   });
 
   it('paginates results', async () => {
-    seedSetting(db, { key: 'a', value: '1' });
-    seedSetting(db, { key: 'b', value: '2' });
-    seedSetting(db, { key: 'c', value: '3' });
+    seedSetting(db, { key: SETTINGS_KEYS.PLEX_URL, value: 'http://plex:32400' });
+    seedSetting(db, { key: SETTINGS_KEYS.PLEX_TOKEN, value: 'abc' });
+    seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'dark' });
 
     const result = await caller.core.settings.list({ limit: 2, offset: 0 });
     expect(result.data).toHaveLength(2);
@@ -74,7 +74,7 @@ describe('settings.get', () => {
   });
 
   it('returns null for missing key', async () => {
-    const result = await caller.core.settings.get({ key: 'nonexistent' });
+    const result = await caller.core.settings.get({ key: SETTINGS_KEYS.RADARR_URL });
     expect(result.data).toBeNull();
   });
 });
@@ -99,17 +99,19 @@ describe('settings.set', () => {
   });
 
   it('persists to the database', async () => {
-    await caller.core.settings.set({ key: 'new_key', value: 'new_value' });
-    const row = db.prepare('SELECT * FROM settings WHERE key = ?').get('new_key') as {
+    await caller.core.settings.set({ key: SETTINGS_KEYS.RADARR_URL, value: 'http://radarr:7878' });
+    const row = db
+      .prepare('SELECT * FROM settings WHERE key = ?')
+      .get(SETTINGS_KEYS.RADARR_URL) as {
       key: string;
       value: string;
     };
     expect(row).toBeDefined();
-    expect(row.value).toBe('new_value');
+    expect(row.value).toBe('http://radarr:7878');
   });
 
   it('allows empty string value', async () => {
-    const result = await caller.core.settings.set({ key: 'empty', value: '' });
+    const result = await caller.core.settings.set({ key: SETTINGS_KEYS.SONARR_URL, value: '' });
     expect(result.data.value).toBe('');
   });
 });
@@ -127,8 +129,12 @@ describe('settings.delete', () => {
   });
 
   it('throws NOT_FOUND for missing key', async () => {
-    await expect(caller.core.settings.delete({ key: 'nonexistent' })).rejects.toThrow(TRPCError);
-    await expect(caller.core.settings.delete({ key: 'nonexistent' })).rejects.toMatchObject({
+    await expect(
+      caller.core.settings.delete({ key: SETTINGS_KEYS.SONARR_API_KEY })
+    ).rejects.toThrow(TRPCError);
+    await expect(
+      caller.core.settings.delete({ key: SETTINGS_KEYS.SONARR_API_KEY })
+    ).rejects.toMatchObject({
       code: 'NOT_FOUND',
     });
   });

--- a/apps/pops-api/src/modules/core/settings/types.ts
+++ b/apps/pops-api/src/modules/core/settings/types.ts
@@ -1,4 +1,5 @@
 import type { SettingRow } from '@pops/db-types';
+import type { SettingsKey } from '@pops/types';
 import { z } from 'zod';
 
 export type { SettingRow };
@@ -17,12 +18,11 @@ export function toSetting(row: SettingRow): Setting {
   };
 }
 
-/** Schema for setting a value (upsert) */
-export const SetSettingSchema = z.object({
-  key: z.string().min(1, 'Key is required'),
-  value: z.string(),
-});
-export type SetSettingInput = z.infer<typeof SetSettingSchema>;
+/** Input for setting a value (upsert) — used internally by the service */
+export interface SetSettingInput {
+  key: SettingsKey;
+  value: string;
+}
 
 /** Schema for list query */
 export const SettingListSchema = z.object({

--- a/apps/pops-api/src/modules/media/arr/service.ts
+++ b/apps/pops-api/src/modules/media/arr/service.ts
@@ -6,7 +6,7 @@ import { eq } from 'drizzle-orm';
 
 import { getDrizzle } from '../../../db.js';
 import { getEnv } from '../../../env.js';
-import { SETTINGS_KEYS } from '../../core/settings/keys.js';
+import { type SettingsKey, SETTINGS_KEYS } from '../../core/settings/keys.js';
 import { RadarrClient } from './radarr-client.js';
 import { SonarrClient } from './sonarr-client.js';
 import type {
@@ -38,18 +38,18 @@ const showStatusCache = new Map<number, CacheEntry>();
 // Settings helpers (settings table with env var fallback, like Plex)
 // ---------------------------------------------------------------------------
 
-function getSetting(key: string): string | null {
+function getSetting(key: SettingsKey): string | null {
   const db = getDrizzle();
   const record = db.select().from(settings).where(eq(settings.key, key)).get();
   if (record?.value) return record.value;
   return null;
 }
 
-function getArrSetting(key: string, envName: string): string | null {
+function getArrSetting(key: SettingsKey, envName: string): string | null {
   return getSetting(key) || getEnv(envName) || null;
 }
 
-function saveSetting(key: string, value: string): void {
+function saveSetting(key: SettingsKey, value: string): void {
   const db = getDrizzle();
   db.insert(settings)
     .values({ key, value })
@@ -57,7 +57,7 @@ function saveSetting(key: string, value: string): void {
     .run();
 }
 
-function deleteSetting(key: string): void {
+function deleteSetting(key: SettingsKey): void {
   const db = getDrizzle();
   db.delete(settings).where(eq(settings.key, key)).run();
 }

--- a/apps/pops-api/src/modules/media/arr/service.ts
+++ b/apps/pops-api/src/modules/media/arr/service.ts
@@ -6,7 +6,7 @@ import { eq } from 'drizzle-orm';
 
 import { getDrizzle } from '../../../db.js';
 import { getEnv } from '../../../env.js';
-import { type SettingsKey, SETTINGS_KEYS } from '../../core/settings/keys.js';
+import { SETTINGS_KEYS, type SettingsKey } from '../../core/settings/keys.js';
 import { RadarrClient } from './radarr-client.js';
 import { SonarrClient } from './sonarr-client.js';
 import type {

--- a/packages/app-ai/src/pages/ModelConfigPage.test.tsx
+++ b/packages/app-ai/src/pages/ModelConfigPage.test.tsx
@@ -1,3 +1,4 @@
+import { SETTINGS_KEYS } from '@pops/types';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
@@ -104,9 +105,9 @@ describe('ModelConfigPage', () => {
   it('populates form with existing settings', () => {
     setupDefaults({
       settings: {
-        'ai.model': 'claude-haiku-4-5-20251001',
-        'ai.monthlyTokenBudget': '500000',
-        'ai.budgetExceededFallback': 'alert',
+        [SETTINGS_KEYS.AI_MODEL]: 'claude-haiku-4-5-20251001',
+        [SETTINGS_KEYS.AI_MONTHLY_TOKEN_BUDGET]: '500000',
+        [SETTINGS_KEYS.AI_BUDGET_EXCEEDED_FALLBACK]: 'alert',
       },
     });
     renderPage();
@@ -128,15 +129,15 @@ describe('ModelConfigPage', () => {
     });
 
     expect(mockMutateAsync).toHaveBeenCalledWith({
-      key: 'ai.model',
+      key: SETTINGS_KEYS.AI_MODEL,
       value: 'claude-haiku-4-5-20251001',
     });
     expect(mockMutateAsync).toHaveBeenCalledWith({
-      key: 'ai.monthlyTokenBudget',
+      key: SETTINGS_KEYS.AI_MONTHLY_TOKEN_BUDGET,
       value: '',
     });
     expect(mockMutateAsync).toHaveBeenCalledWith({
-      key: 'ai.budgetExceededFallback',
+      key: SETTINGS_KEYS.AI_BUDGET_EXCEEDED_FALLBACK,
       value: 'skip',
     });
     expect(mockToastSuccess).toHaveBeenCalledWith('AI configuration saved');
@@ -157,7 +158,7 @@ describe('ModelConfigPage', () => {
 
   it('displays current usage stats', () => {
     setupDefaults({
-      settings: { 'ai.monthlyTokenBudget': '200000' },
+      settings: { [SETTINGS_KEYS.AI_MONTHLY_TOKEN_BUDGET]: '200000' },
     });
     renderPage();
     expect(screen.getByText('Current Month Tokens')).toBeInTheDocument();
@@ -169,8 +170,8 @@ describe('ModelConfigPage', () => {
   it('shows budget exceeded alert when over limit', () => {
     setupDefaults({
       settings: {
-        'ai.monthlyTokenBudget': '1000',
-        'ai.budgetExceededFallback': 'skip',
+        [SETTINGS_KEYS.AI_MONTHLY_TOKEN_BUDGET]: '1000',
+        [SETTINGS_KEYS.AI_BUDGET_EXCEEDED_FALLBACK]: 'skip',
       },
       stats: {
         last30Days: {
@@ -196,7 +197,7 @@ describe('ModelConfigPage', () => {
 
   it('shows progress bar when budget is set', () => {
     setupDefaults({
-      settings: { 'ai.monthlyTokenBudget': '200000' },
+      settings: { [SETTINGS_KEYS.AI_MONTHLY_TOKEN_BUDGET]: '200000' },
     });
     renderPage();
     expect(screen.getByRole('progressbar')).toBeInTheDocument();

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,4 +10,4 @@ export type {
   SearchHit,
   StructuredFilter,
 } from './search.js';
-export { SETTINGS_KEYS, type SettingsKey } from './settings-keys.js';
+export { SETTINGS_KEY_VALUES, SETTINGS_KEYS, type SettingsKey } from './settings-keys.js';

--- a/packages/types/src/settings-keys.ts
+++ b/packages/types/src/settings-keys.ts
@@ -1,10 +1,27 @@
 /**
- * Typed settings key registry — shared between backend and frontend.
+ * Typed settings key registry — single source of truth for all settings keys.
  *
- * This is a subset of settings keys needed by frontend packages.
- * The canonical source is apps/pops-api/src/modules/core/settings/keys.ts.
+ * Every key stored in the `settings` table must be listed here.
+ * Import `SETTINGS_KEYS` and `SettingsKey` instead of using magic strings.
  */
 export const SETTINGS_KEYS = {
+  // Plex
+  PLEX_URL: 'plex_url',
+  PLEX_TOKEN: 'plex_token',
+  PLEX_USERNAME: 'plex_username',
+  PLEX_ENCRYPTION_SEED: 'plex_encryption_seed',
+  PLEX_CLIENT_IDENTIFIER: 'plex_client_identifier',
+  PLEX_MOVIE_SECTION_ID: 'plex_movie_section_id',
+  PLEX_TV_SECTION_ID: 'plex_tv_section_id',
+  PLEX_SCHEDULER_ENABLED: 'plex_scheduler_enabled',
+  PLEX_SCHEDULER_INTERVAL_MS: 'plex_scheduler_interval_ms',
+
+  // Radarr / Sonarr
+  RADARR_URL: 'radarr_url',
+  RADARR_API_KEY: 'radarr_api_key',
+  SONARR_URL: 'sonarr_url',
+  SONARR_API_KEY: 'sonarr_api_key',
+
   // AI
   AI_MODEL: 'ai.model',
   AI_MONTHLY_TOKEN_BUDGET: 'ai.monthlyTokenBudget',
@@ -15,3 +32,6 @@ export const SETTINGS_KEYS = {
 } as const;
 
 export type SettingsKey = (typeof SETTINGS_KEYS)[keyof typeof SETTINGS_KEYS];
+
+/** All valid settings key values as an array — used for z.enum() validation. */
+export const SETTINGS_KEY_VALUES = Object.values(SETTINGS_KEYS) as [SettingsKey, ...SettingsKey[]];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@pops/db-types':
         specifier: workspace:*
         version: link:../../packages/db-types
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       '@trpc/server':
         specifier: ^11.16.0
         version: 11.16.0(typescript@6.0.2)


### PR DESCRIPTION
## Summary

Follow-up fixes for the typed settings key registry (PR #1760, tb-372), addressing all 4 gaps from #1763:

- **Single source of truth**: Moved canonical `SETTINGS_KEYS` (all 17 keys) to `@pops/types`. API's `keys.ts` now re-exports from `@pops/types` — no duplicate to fall out of sync.
- **z.enum() validation**: Replaced `as SettingsKey` casts in router with `z.enum(SETTINGS_KEY_VALUES)` for runtime + compile-time safety on `get`, `set`, and `delete` endpoints.
- **Typed arr/service helpers**: `getSetting`, `getArrSetting`, `saveSetting`, `deleteSetting` now accept `SettingsKey` instead of `string`.
- **Test constants**: `ModelConfigPage.test.tsx` and `settings.test.ts` replaced all magic strings with `SETTINGS_KEYS.*` constants.

Closes #1763

## Test plan

- [x] `mise typecheck` — all 14 packages pass
- [x] Settings tests pass (13/13)
- [x] Pre-commit hooks pass (lint, format, typecheck)
- [ ] CI quality + backend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)