### PR TITLE
fix(docker): add @pops/types to both Dockerfiles

### DIFF
--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -6,6 +6,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 
 # Copy all workspace packages
 COPY packages/db-types/package.json ./packages/db-types/
+COPY packages/types/package.json ./packages/types/
 COPY apps/pops-api/package.json ./apps/pops-api/
 
 # Install pnpm and dependencies (cached across builds)
@@ -15,6 +16,8 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # Copy source files
 COPY packages/db-types/src ./packages/db-types/src
 COPY packages/db-types/tsconfig.json ./packages/db-types/
+COPY packages/types/src ./packages/types/src
+COPY packages/types/tsconfig.json ./packages/types/
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
 
@@ -46,6 +49,10 @@ COPY --from=builder /app/apps/pops-api/src/db/drizzle-migrations ./dist/db/drizz
 # Copy db-types built output into node_modules
 COPY --from=builder /app/packages/db-types/dist ./node_modules/@pops/db-types/dist
 COPY --from=builder /app/packages/db-types/package.json ./node_modules/@pops/db-types/
+
+# Copy types source into node_modules (source-only package, no build step)
+COPY --from=builder /app/packages/types/src ./node_modules/@pops/types/src
+COPY --from=builder /app/packages/types/package.json ./node_modules/@pops/types/
 
 ARG BUILD_VERSION=dev
 ENV BUILD_VERSION=$BUILD_VERSION

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -15,6 +15,7 @@ COPY packages/app-inventory/package.json ./packages/app-inventory/
 COPY packages/app-ai/package.json ./packages/app-ai/
 COPY packages/api-client/package.json ./packages/api-client/
 COPY packages/navigation/package.json ./packages/navigation/
+COPY packages/types/package.json ./packages/types/
 
 # Install pnpm and dependencies (cached across builds)
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -35,6 +36,7 @@ COPY packages/app-inventory/ ./packages/app-inventory/
 COPY packages/app-ai/ ./packages/app-ai/
 COPY packages/api-client/ ./packages/api-client/
 COPY packages/navigation/ ./packages/navigation/
+COPY packages/types/ ./packages/types/
 COPY apps/pops-api/ ./apps/pops-api/
 COPY apps/pops-shell/ ./apps/pops-shell/
 


### PR DESCRIPTION
## Summary
- Both Dockerfiles (`pops-shell`, `pops-api`) were written before `packages/types` existed
- The settings-keys refactor (cedf8287) moved `SettingsKey`/`SETTINGS_KEYS` into `@pops/types`, but neither Dockerfile copied that package into the Docker build context
- This caused TS2307 ("Cannot find module '@pops/types'") errors on every deploy since that merge

## Changes
- **pops-shell/Dockerfile**: Add `packages/types/package.json` to the lockfile layer and `packages/types/` to the source copy layer
- **pops-api/Dockerfile**: Add `packages/types/package.json` to the lockfile layer, source to build layer, and `src`+`package.json` to the production image (runtime values exported)

## Test plan
- [x] `mise typecheck` passes (14/14 packages)
- [ ] Docker build succeeds (`mise docker:build`)
- [ ] Deploy pipeline completes without TS errors

Closes tb-380

🤖 Generated with [Claude Code](https://claude.com/claude-code)