### PR TITLE
ci: add Docker build validation to prevent deploy failures

### DIFF
--- a/.github/workflows/ai-quality.yml
+++ b/.github/workflows/ai-quality.yml
@@ -8,6 +8,7 @@ on:
       - "packages/ui/**"
       - "packages/db-types/**"
       - "packages/api-client/**"
+      - "packages/types/**"
       - ".github/workflows/ai-quality.yml"
       - ".github/workflows/_pkg-check.yml"
   pull_request:
@@ -30,6 +31,7 @@ jobs:
               - 'packages/ui/**'
               - 'packages/db-types/**'
               - 'packages/api-client/**'
+              - 'packages/types/**'
               - '.github/workflows/ai-quality.yml'
               - '.github/workflows/_pkg-check.yml'
 

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "apps/pops-api/**"
       - "packages/db-types/**"
+      - "packages/types/**"
       - ".github/workflows/api-quality.yml"
 
 jobs:
@@ -26,6 +27,7 @@ jobs:
             api:
               - 'apps/pops-api/**'
               - 'packages/db-types/**'
+              - 'packages/types/**'
               - '.github/workflows/api-quality.yml'
 
   quality-checks:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,55 @@
+name: Docker Build
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+    paths:
+      - "apps/pops-api/**"
+      - "apps/pops-shell/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/docker-build.yml"
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            docker:
+              - 'apps/pops-api/**'
+              - 'apps/pops-shell/**'
+              - 'packages/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.github/workflows/docker-build.yml'
+
+  docker-build:
+    name: Validate Docker builds
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: always()
+    steps:
+      - name: Skip — no relevant changes
+        if: github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true'
+        run: echo "No Docker-relevant changes detected — skipping"
+
+      - uses: actions/checkout@v6
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+
+      - name: Build pops-shell (builder stage)
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+        run: docker build --target builder -f apps/pops-shell/Dockerfile .
+
+      - name: Build pops-api (builder stage)
+        if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
+        run: docker build --target builder -f apps/pops-api/Dockerfile .

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -11,6 +11,7 @@ on:
       - "packages/api-client/**"
       - "packages/widgets/**"
       - "packages/navigation/**"
+      - "packages/types/**"
       - ".github/workflows/fe-quality.yml"
   pull_request:
 
@@ -35,6 +36,7 @@ jobs:
               - 'packages/api-client/**'
               - 'packages/widgets/**'
               - 'packages/navigation/**'
+              - 'packages/types/**'
               - '.github/workflows/fe-quality.yml'
 
   quality:


### PR DESCRIPTION
## Summary
- **Root cause**: CI runs typecheck/build on the full workspace checkout where all packages resolve fine. Docker builds only happen during deploy on the self-hosted runner, so missing `COPY` directives in Dockerfiles are never caught pre-merge.
- Adds a new `docker-build.yml` workflow that validates both Dockerfiles' builder stages on PRs and pushes to main
- Adds `packages/types/**` to the paths filters for `fe-quality`, `api-quality`, and `ai-quality` workflows so changes to `@pops/types` trigger dependent quality checks

## Investigation findings
The recent settings-keys refactor (cedf8287) moved types into `@pops/types`, but neither Dockerfile included that package. CI passed because:
1. `turbo typecheck` runs per-package with full workspace available
2. `pnpm build` in CI also has the full workspace
3. Docker builds use a curated subset of the workspace — the only place the missing package surfaces

## Test plan
- [x] All workflow YAML files are syntactically valid
- [x] `mise typecheck` passes (14/14 packages)
- [ ] New `docker-build.yml` workflow triggers and passes on this PR
- [ ] Verify a PR that breaks a Dockerfile COPY would be caught

Closes tb-381

🤖 Generated with [Claude Code](https://claude.com/claude-code)