### PR TITLE
fix(infra): park moltbot, fix @pops/types build

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -64,9 +64,11 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
         if: inputs.skip != 'true'
-      - name: Build db-types
+      - name: Build shared packages
         if: inputs.skip != 'true' && inputs.needs-db-build
-        run: pnpm --filter @pops/db-types build
+        run: |
+          pnpm --filter @pops/db-types build
+          pnpm --filter @pops/types build
       - run: cd ${{ inputs.package-path }} && pnpm typecheck
         if: inputs.skip != 'true'
 
@@ -89,9 +91,11 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
         if: inputs.skip != 'true'
-      - name: Build db-types
+      - name: Build shared packages
         if: inputs.skip != 'true' && inputs.needs-db-build
-        run: pnpm --filter @pops/db-types build
+        run: |
+          pnpm --filter @pops/db-types build
+          pnpm --filter @pops/types build
       - run: cd ${{ inputs.package-path }} && pnpm test
         if: inputs.skip != 'true'
 

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -60,7 +60,9 @@ jobs:
 
       - name: Build shared packages
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
-        run: cd packages/db-types && pnpm build
+        run: |
+          cd packages/db-types && pnpm build
+          cd ../types && pnpm build
 
       - name: Type check
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -57,7 +57,9 @@ jobs:
 
       - name: Build shared packages
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
-        run: cd packages/db-types && pnpm build
+        run: |
+          cd packages/db-types && pnpm build
+          cd ../types && pnpm build
 
       - name: Typecheck
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -66,7 +66,9 @@ jobs:
 
       - name: Build shared packages
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
-        run: cd packages/db-types && pnpm build
+        run: |
+          cd packages/db-types && pnpm build
+          cd ../types && pnpm build
 
       - name: Type check
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -57,7 +57,9 @@ jobs:
 
       - name: Build shared packages
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
-        run: cd packages/db-types && pnpm build
+        run: |
+          cd packages/db-types && pnpm build
+          cd ../types && pnpm build
 
       - name: Cache Playwright browsers
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -6,6 +6,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 
 # Copy all workspace packages
 COPY packages/db-types/package.json ./packages/db-types/
+COPY packages/types/package.json ./packages/types/
 COPY apps/pops-api/package.json ./apps/pops-api/
 
 # Install pnpm and dependencies (cached across builds)
@@ -15,11 +16,15 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # Copy source files
 COPY packages/db-types/src ./packages/db-types/src
 COPY packages/db-types/tsconfig.json ./packages/db-types/
+COPY packages/types/src ./packages/types/src
+COPY packages/types/tsconfig.json ./packages/types/
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
 
-# Build db-types first
+# Build shared packages first
 WORKDIR /app/packages/db-types
+RUN pnpm build
+WORKDIR /app/packages/types
 RUN pnpm build
 
 # Build pops-api
@@ -43,9 +48,11 @@ COPY --from=builder /app/apps/pops-api/dist ./dist
 COPY --from=builder /app/apps/pops-api/src/db/migrations ./dist/db/migrations
 COPY --from=builder /app/apps/pops-api/src/db/drizzle-migrations ./dist/db/drizzle-migrations
 
-# Copy db-types built output into node_modules
+# Copy shared package built output into node_modules
 COPY --from=builder /app/packages/db-types/dist ./node_modules/@pops/db-types/dist
 COPY --from=builder /app/packages/db-types/package.json ./node_modules/@pops/db-types/
+COPY --from=builder /app/packages/types/dist ./node_modules/@pops/types/dist
+COPY --from=builder /app/packages/types/package.json ./node_modules/@pops/types/
 
 ARG BUILD_VERSION=dev
 ENV BUILD_VERSION=$BUILD_VERSION

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -15,15 +15,20 @@ COPY packages/app-inventory/package.json ./packages/app-inventory/
 COPY packages/app-ai/package.json ./packages/app-ai/
 COPY packages/api-client/package.json ./packages/api-client/
 COPY packages/navigation/package.json ./packages/navigation/
+COPY packages/types/package.json ./packages/types/
 
 # Install pnpm and dependencies (cached across builds)
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     corepack enable && pnpm install --frozen-lockfile
 
-# Copy db-types source and build it first (same pattern as pops-api Dockerfile)
+# Build shared packages first (same pattern as pops-api Dockerfile)
 COPY packages/db-types/src ./packages/db-types/src
 COPY packages/db-types/tsconfig.json ./packages/db-types/
+COPY packages/types/src ./packages/types/src
+COPY packages/types/tsconfig.json ./packages/types/
 WORKDIR /app/packages/db-types
+RUN pnpm build
+WORKDIR /app/packages/types
 RUN pnpm build
 
 # Copy remaining source files

--- a/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
+++ b/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
@@ -105,6 +105,8 @@ services:
     image: moltbot/moltbot:latest
     container_name: pops-moltbot
     restart: unless-stopped
+    profiles:
+      - moltbot
     networks:
       - backend
     volumes:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -111,11 +111,13 @@ services:
     volumes:
       - paperless-redis:/data
 
-  # ── MOLTBOT ──────────────────────────────────────────────────────
+  # ── MOLTBOT (on-demand) ───────────────────────────────────────────
   moltbot:
     image: moltbot/moltbot:latest
     container_name: pops-moltbot
     restart: unless-stopped
+    profiles:
+      - moltbot
     networks:
       - backend
     volumes:

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,12 +3,17 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch --preserveWatchOutput",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "isolatedModules": true,
-    "noEmit": true
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- **Park moltbot**: Move moltbot service behind `profiles: [moltbot]` in both local and production docker-compose so it doesn't start during deploys. Upstream `moltbot:latest` now requires `CLAWDBOT_GATEWAY_TOKEN` which was never configured, causing health check failures.
- **Fix @pops/types build**: Add `tsc` build step and proper `dist/` exports (matching `@pops/db-types` pattern). The package was exporting raw `.ts` with bundler resolution, which Node16 consumers like pops-api couldn't resolve — breaking typecheck on main.

## Test plan
- [x] Full turbo typecheck passes (15/15 packages)
- [ ] Deploy succeeds with moltbot excluded
- [ ] When ready, `docker compose --profile moltbot up moltbot` brings it back