### PR TITLE
fix(imports): prevent infinite render loop in ReviewStep

### DIFF
--- a/packages/app-finance/src/components/imports/hooks/useTransactionReview.ts
+++ b/packages/app-finance/src/components/imports/hooks/useTransactionReview.ts
@@ -13,10 +13,11 @@ export type ViewMode = 'list' | 'grouped';
  * unresolved count, and entity grouping for the ReviewStep.
  */
 export function useTransactionReview() {
-  const { processedTransactions, pendingChangeSets } = useImportStore((s) => ({
-    processedTransactions: s.processedTransactions,
-    pendingChangeSets: s.pendingChangeSets,
-  }));
+  // Select individually — returning a fresh object from the selector breaks
+  // Zustand v5 (useSyncExternalStore-based) and produces an infinite render
+  // loop (React #185). Use `useShallow` if you ever need object grouping here.
+  const processedTransactions = useImportStore((s) => s.processedTransactions);
+  const pendingChangeSets = useImportStore((s) => s.pendingChangeSets);
 
   const [localTransactions, setLocalTransactions] = useState(processedTransactions);
   const [viewMode, setViewMode] = useState<ViewMode>('grouped');


### PR DESCRIPTION
## Summary

- Step 4 (ReviewStep) crashed on mount with React error #185 ("Maximum update depth exceeded"), surfacing as soon as ProcessingStep auto-advanced from step 3.
- Root cause: a Zustand selector in \`useTransactionReview\` returned a fresh object on every call. Zustand v5 uses \`React.useSyncExternalStore\` directly (no selector memoization), so \`Object.is\` reported "changed" every render → infinite re-render.
- Fix: split into two single-value selectors. (\`useShallow\` would also work; nothing here needs atomic grouping.)

\`\`\`ts
// before
const { processedTransactions, pendingChangeSets } = useImportStore((s) => ({
  processedTransactions: s.processedTransactions,
  pendingChangeSets: s.pendingChangeSets,
}));

// after
const processedTransactions = useImportStore((s) => s.processedTransactions);
const pendingChangeSets = useImportStore((s) => s.pendingChangeSets);
\`\`\`

## Test plan

- [x] \`pnpm --filter @pops/app-finance test\` — 253 passed
- [x] \`pnpm --filter @pops/app-finance lint\` — 0 errors (pre-existing warnings unchanged)
- [x] \`pnpm --filter @pops/app-finance typecheck\` — clean
- [x] \`pnpm --filter @pops/app-finance format:check\` — clean
- [ ] Manual: run import flow through steps 3→4, confirm Review page renders without the error boundary tripping