### PR TITLE
fix(imports): type-safe computeMergedRules to prevent tags validation error

### DIFF
--- a/apps/pops-api/src/modules/core/corrections/types.ts
+++ b/apps/pops-api/src/modules/core/corrections/types.ts
@@ -67,6 +67,30 @@ export function toCorrection(row: CorrectionRow): Correction {
 }
 
 /**
+ * Inverse of `toCorrection`: map the API response shape back to the DB row
+ * shape. Used by frontend code that needs to feed API-shaped rules into pure
+ * helpers (e.g. `applyChangeSetToRules`) that operate on DB rows.
+ */
+export function correctionToRow(c: Correction): CorrectionRow {
+  return {
+    id: c.id,
+    descriptionPattern: c.descriptionPattern,
+    matchType: c.matchType,
+    entityId: c.entityId,
+    entityName: c.entityName,
+    location: c.location,
+    tags: JSON.stringify(c.tags),
+    transactionType: c.transactionType,
+    isActive: c.isActive,
+    confidence: c.confidence,
+    priority: c.priority,
+    timesApplied: c.timesApplied,
+    createdAt: c.createdAt,
+    lastUsedAt: c.lastUsedAt,
+  };
+}
+
+/**
  * Normalize description for pattern matching
  */
 export function normalizeDescription(description: string): string {

--- a/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
@@ -234,10 +234,7 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
     if (!isBrowseMode) return [];
     const browseDbRules = browseListQuery.data?.data ?? [];
     if (pendingChangeSets.length === 0) return browseDbRules;
-    return computeMergedRules(
-      browseDbRules as unknown as Parameters<typeof computeMergedRules>[0],
-      pendingChangeSets
-    ) as unknown as CorrectionRule[];
+    return computeMergedRules(browseDbRules, pendingChangeSets);
   }, [isBrowseMode, browseListQuery.data?.data, pendingChangeSets]);
 
   const browseOrderedMerged = useMemo(

--- a/packages/app-finance/src/components/imports/hooks/useTransactionReview.ts
+++ b/packages/app-finance/src/components/imports/hooks/useTransactionReview.ts
@@ -56,22 +56,14 @@ export function useTransactionReview() {
     prevChangeSetsRef.current = pendingChangeSets;
     if (!dbRulesData?.data) return;
 
-    // tags is string[] from tRPC but string in CorrectionRow (SQLite JSON) — cast through unknown
-    const freshRules = computeMergedRules(
-      dbRulesData.data as unknown as Parameters<typeof computeMergedRules>[0],
-      pendingChangeSets
-    );
+    const freshRules = computeMergedRules(dbRulesData.data, pendingChangeSets);
     const current = localTxRef.current;
     // Demote rule-promoted transactions back to uncertain for re-evaluation
     const rulePromoted = current.matched.filter((t) => t.ruleProvenance);
     const manuallyMatched = current.matched.filter((t) => !t.ruleProvenance);
     const candidateUncertain = [...current.uncertain, ...rulePromoted];
 
-    const reeval = reevaluateTransactions(
-      candidateUncertain,
-      current.failed,
-      freshRules as unknown as Parameters<typeof reevaluateTransactions>[2]
-    );
+    const reeval = reevaluateTransactions(candidateUncertain, current.failed, freshRules);
 
     const updated = {
       ...current,

--- a/packages/app-finance/src/lib/local-re-evaluation.test.ts
+++ b/packages/app-finance/src/lib/local-re-evaluation.test.ts
@@ -1,10 +1,10 @@
-import type { CorrectionRow } from '@pops/api/modules/core/corrections/types';
+import type { Correction } from '@pops/api/modules/core/corrections/types';
 import { describe, expect, it } from 'vitest';
 
 import type { ProcessedTransaction } from '../store/importStore';
 import { reevaluateTransactions } from './local-re-evaluation';
 
-function makeRule(overrides: Partial<CorrectionRow> = {}): CorrectionRow {
+function makeRule(overrides: Partial<Correction> = {}): Correction {
   return {
     id: overrides.id ?? 'rule-1',
     descriptionPattern: overrides.descriptionPattern ?? 'WOOLWORTHS',
@@ -12,7 +12,7 @@ function makeRule(overrides: Partial<CorrectionRow> = {}): CorrectionRow {
     entityId: overrides.entityId ?? 'entity-1',
     entityName: overrides.entityName ?? 'Woolworths',
     location: overrides.location ?? null,
-    tags: overrides.tags ?? '[]',
+    tags: overrides.tags ?? [],
     transactionType: overrides.transactionType ?? 'purchase',
     isActive: overrides.isActive ?? true,
     confidence: overrides.confidence ?? 0.95,
@@ -20,7 +20,7 @@ function makeRule(overrides: Partial<CorrectionRow> = {}): CorrectionRow {
     timesApplied: overrides.timesApplied ?? 5,
     createdAt: '2025-01-01T00:00:00.000Z',
     lastUsedAt: null,
-  } as CorrectionRow;
+  };
 }
 
 function makeTxn(overrides: Partial<ProcessedTransaction> = {}): ProcessedTransaction {

--- a/packages/app-finance/src/lib/local-re-evaluation.ts
+++ b/packages/app-finance/src/lib/local-re-evaluation.ts
@@ -49,9 +49,7 @@ function findAllMatchingRules(
   minConfidence: number = 0.7
 ): Correction[] {
   const normalized = normalizeDescription(description);
-  // isActive is stored as integer in SQLite but typed as boolean via Drizzle mode: "boolean".
-  // Use truthiness to handle both representations (1/true).
-  const eligible = rules.filter((r) => !!r.isActive && r.confidence >= minConfidence);
+  const eligible = rules.filter((r) => r.isActive && r.confidence >= minConfidence);
 
   const exactMatches = eligible
     .filter((r) => r.matchType === 'exact' && r.descriptionPattern === normalized)

--- a/packages/app-finance/src/lib/local-re-evaluation.ts
+++ b/packages/app-finance/src/lib/local-re-evaluation.ts
@@ -5,9 +5,9 @@
  * the same matching logic as the server-side findMatchingCorrectionFromRules.
  * Runs entirely client-side with no server round-trip.
  */
-import type { CorrectionRow } from '@pops/api/modules/core/corrections/types';
+import type { Correction } from '@pops/api/modules/core/corrections/types';
 import {
-  classifyCorrectionMatch,
+  HIGH_CONFIDENCE_THRESHOLD,
   normalizeDescription,
 } from '@pops/api/modules/core/corrections/types';
 import type { MatchedRule } from '@pops/api/modules/finance/imports';
@@ -21,6 +21,19 @@ export interface ReEvaluationResult {
   affectedCount: number;
 }
 
+interface LocalMatchResult {
+  correction: Correction;
+  status: 'matched' | 'uncertain';
+}
+
+/** Local classifier for `Correction` (the upstream helper is typed on CorrectionRow). */
+function classifyCorrection(correction: Correction): LocalMatchResult {
+  return {
+    correction,
+    status: correction.confidence >= HIGH_CONFIDENCE_THRESHOLD ? 'matched' : 'uncertain',
+  };
+}
+
 /**
  * Returns ALL rules that match `description`, sorted by the old type-priority
  * order (exact → contains → regex), with confidence/timesApplied tie-breaking
@@ -32,9 +45,9 @@ export interface ReEvaluationResult {
  */
 function findAllMatchingRules(
   description: string,
-  rules: CorrectionRow[],
+  rules: Correction[],
   minConfidence: number = 0.7
-): CorrectionRow[] {
+): Correction[] {
   const normalized = normalizeDescription(description);
   // isActive is stored as integer in SQLite but typed as boolean via Drizzle mode: "boolean".
   // Use truthiness to handle both representations (1/true).
@@ -84,7 +97,7 @@ function findAllMatchingRules(
 export function reevaluateTransactions(
   uncertain: ProcessedTransaction[],
   failed: ProcessedTransaction[],
-  mergedRules: CorrectionRow[],
+  mergedRules: Correction[],
   minConfidence: number = 0.7
 ): ReEvaluationResult {
   const newMatched: ProcessedTransaction[] = [];
@@ -94,7 +107,7 @@ export function reevaluateTransactions(
 
   for (const txn of uncertain) {
     const allMatches = findAllMatchingRules(txn.description, mergedRules, minConfidence);
-    const match = allMatches.length > 0 ? classifyCorrectionMatch(allMatches[0]!) : null;
+    const match = allMatches.length > 0 ? classifyCorrection(allMatches[0]!) : null;
     if (match && match.status === 'matched') {
       const matchedRules: MatchedRule[] = allMatches.map((rule) => ({
         ruleId: rule.id,
@@ -132,7 +145,7 @@ export function reevaluateTransactions(
 
   for (const txn of failed) {
     const allMatches = findAllMatchingRules(txn.description, mergedRules, minConfidence);
-    const match = allMatches.length > 0 ? classifyCorrectionMatch(allMatches[0]!) : null;
+    const match = allMatches.length > 0 ? classifyCorrection(allMatches[0]!) : null;
     if (match && match.status === 'matched') {
       const matchedRules: MatchedRule[] = allMatches.map((rule) => ({
         ruleId: rule.id,

--- a/packages/app-finance/src/lib/merged-state.test.ts
+++ b/packages/app-finance/src/lib/merged-state.test.ts
@@ -1,4 +1,4 @@
-import type { CorrectionRow } from '@pops/api/modules/core/corrections/types';
+import type { Correction } from '@pops/api/modules/core/corrections/types';
 import type { Entity } from '@pops/api/modules/core/entities/types';
 import { describe, expect, it } from 'vitest';
 
@@ -9,7 +9,7 @@ import { computeMergedEntities, computeMergedRules } from './merged-state';
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeRule(overrides: Partial<CorrectionRow> = {}): CorrectionRow {
+function makeRule(overrides: Partial<Correction> = {}): Correction {
   return {
     id: 'rule-1',
     descriptionPattern: 'WOOLWORTHS',
@@ -17,7 +17,7 @@ function makeRule(overrides: Partial<CorrectionRow> = {}): CorrectionRow {
     entityId: 'entity-1',
     entityName: 'Woolworths',
     location: null,
-    tags: '[]',
+    tags: [],
     transactionType: 'purchase',
     isActive: true,
     confidence: 0.95,
@@ -26,7 +26,7 @@ function makeRule(overrides: Partial<CorrectionRow> = {}): CorrectionRow {
     createdAt: '2026-01-01T00:00:00Z',
     lastUsedAt: '2026-03-01T00:00:00Z',
     ...overrides,
-  } as CorrectionRow;
+  };
 }
 
 function makePendingChangeSet(
@@ -112,7 +112,7 @@ describe('computeMergedRules', () => {
   });
 
   it('applies multiple sequential ChangeSets (add then edit same rule)', () => {
-    const dbRules: CorrectionRow[] = [];
+    const dbRules: Correction[] = [];
 
     const cs1 = makePendingChangeSet({
       ops: [

--- a/packages/app-finance/src/lib/merged-state.test.ts
+++ b/packages/app-finance/src/lib/merged-state.test.ts
@@ -224,6 +224,19 @@ describe('computeMergedRules', () => {
     expect(result1[0].confidence).toBe(0.8);
     expect(result2[0].confidence).toBe(0.9);
   });
+
+  it('preserves tags as string[] (not a JSON-encoded string) after applying ops', () => {
+    // Regression guard: the previous implementation leaked CorrectionRow (tags: string)
+    // out of the merge, which caused downstream edit ops to send `tags: "[\"grocery\"]"`
+    // and fail server-side Zod validation.
+    const dbRules = [makeRule({ id: 'r1', tags: ['grocery'] })];
+    const cs = makePendingChangeSet({
+      ops: [{ op: 'edit', id: 'r1', data: { confidence: 0.9 } }],
+    });
+    const [merged] = computeMergedRules(dbRules, [cs]);
+    expect(Array.isArray(merged?.tags)).toBe(true);
+    expect(merged?.tags).toEqual(['grocery']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/app-finance/src/lib/merged-state.ts
+++ b/packages/app-finance/src/lib/merged-state.ts
@@ -1,6 +1,6 @@
 import { applyChangeSetToRules } from '@pops/api/modules/core/corrections/pure-service';
 import type { Correction, CorrectionRow } from '@pops/api/modules/core/corrections/types';
-import { toCorrection } from '@pops/api/modules/core/corrections/types';
+import { correctionToRow, toCorrection } from '@pops/api/modules/core/corrections/types';
 import type { Entity } from '@pops/api/modules/core/entities/types';
 
 import type { PendingChangeSet, PendingEntity } from '../store/importStore';
@@ -11,30 +11,6 @@ import type { PendingChangeSet, PendingEntity } from '../store/importStore';
 
 let _cachedRulesInput: { dbRules: Correction[]; pending: PendingChangeSet[] } | null = null;
 let _cachedRulesOutput: Correction[] | null = null;
-
-/**
- * Convert an API-shaped `Correction` (tags: string[]) into the DB row shape
- * (`CorrectionRow`, tags: JSON string) so it can be fed into the pure-service
- * helpers that operate on DB rows.
- */
-function correctionToRow(c: Correction): CorrectionRow {
-  return {
-    id: c.id,
-    descriptionPattern: c.descriptionPattern,
-    matchType: c.matchType,
-    entityId: c.entityId,
-    entityName: c.entityName,
-    location: c.location,
-    tags: JSON.stringify(c.tags),
-    transactionType: c.transactionType,
-    isActive: c.isActive,
-    confidence: c.confidence,
-    priority: c.priority,
-    timesApplied: c.timesApplied,
-    createdAt: c.createdAt,
-    lastUsedAt: c.lastUsedAt,
-  };
-}
 
 /**
  * Fold `applyChangeSetToRules` over each pending ChangeSet in insertion order,

--- a/packages/app-finance/src/lib/merged-state.ts
+++ b/packages/app-finance/src/lib/merged-state.ts
@@ -1,5 +1,6 @@
 import { applyChangeSetToRules } from '@pops/api/modules/core/corrections/pure-service';
-import type { CorrectionRow } from '@pops/api/modules/core/corrections/types';
+import type { Correction, CorrectionRow } from '@pops/api/modules/core/corrections/types';
+import { toCorrection } from '@pops/api/modules/core/corrections/types';
 import type { Entity } from '@pops/api/modules/core/entities/types';
 
 import type { PendingChangeSet, PendingEntity } from '../store/importStore';
@@ -8,18 +9,45 @@ import type { PendingChangeSet, PendingEntity } from '../store/importStore';
 // computeMergedRules — PRD-030 US-03
 // ---------------------------------------------------------------------------
 
-let _cachedRulesInput: { dbRules: CorrectionRow[]; pending: PendingChangeSet[] } | null = null;
-let _cachedRulesOutput: CorrectionRow[] | null = null;
+let _cachedRulesInput: { dbRules: Correction[]; pending: PendingChangeSet[] } | null = null;
+let _cachedRulesOutput: Correction[] | null = null;
+
+/**
+ * Convert an API-shaped `Correction` (tags: string[]) into the DB row shape
+ * (`CorrectionRow`, tags: JSON string) so it can be fed into the pure-service
+ * helpers that operate on DB rows.
+ */
+function correctionToRow(c: Correction): CorrectionRow {
+  return {
+    id: c.id,
+    descriptionPattern: c.descriptionPattern,
+    matchType: c.matchType,
+    entityId: c.entityId,
+    entityName: c.entityName,
+    location: c.location,
+    tags: JSON.stringify(c.tags),
+    transactionType: c.transactionType,
+    isActive: c.isActive,
+    confidence: c.confidence,
+    priority: c.priority,
+    timesApplied: c.timesApplied,
+    createdAt: c.createdAt,
+    lastUsedAt: c.lastUsedAt,
+  };
+}
 
 /**
  * Fold `applyChangeSetToRules` over each pending ChangeSet in insertion order,
  * starting from the DB rules as the base. Memoized by reference equality on
  * both input arrays.
+ *
+ * Operates on the API `Correction` shape (tags: string[]) at the boundary so
+ * the frontend never has to juggle the DB's JSON-encoded tags string.
  */
 export function computeMergedRules(
-  dbRules: CorrectionRow[],
+  dbRules: Correction[],
   pendingChangeSets: PendingChangeSet[]
-): CorrectionRow[] {
+): Correction[] {
   // Memoization: same input refs → same output ref
   if (
     _cachedRulesInput &&
@@ -30,15 +58,17 @@ export function computeMergedRules(
     return _cachedRulesOutput;
   }
 
-  let result: CorrectionRow[];
+  let result: Correction[];
 
   if (pendingChangeSets.length === 0) {
     result = dbRules;
   } else {
-    result = pendingChangeSets.reduce<CorrectionRow[]>(
+    const baseRows = dbRules.map(correctionToRow);
+    const mergedRows = pendingChangeSets.reduce<CorrectionRow[]>(
       (acc, pcs) => applyChangeSetToRules(acc, pcs.changeSet),
-      dbRules
+      baseRows
     );
+    result = mergedRows.map(toCorrection);
   }
 
   _cachedRulesInput = { dbRules, pending: pendingChangeSets };


### PR DESCRIPTION
## Summary

- Editing a rule in the Manage Rules dialog while pending changesets touched that rule caused a Zod validation error on the impact preview request: `tags: expected array, received string`.
- Root cause: `computeMergedRules` was declared as `CorrectionRow[]` in and out, but every caller fed it `Correction[]` through `as unknown as` casts. Inside, `applyChangeSetToRules` runs `JSON.stringify(op.data.tags)` on touched rules — when the input was actually `Correction[]` (tags: `string[]`), that stringified tags value leaked back into downstream edit op payloads, which then failed Zod on the server.
- Fix: move the boundary to `Correction[]` (API shape). `computeMergedRules` now accepts and returns `Correction[]`; internally it maps to `CorrectionRow`, runs the pure-service fold, then maps back via `toCorrection`. `reevaluateTransactions` signature was adjusted likewise (it never reads tags). All `as unknown as` casts at both call sites are gone.

## Test plan

- [x] `pnpm --filter @pops/app-finance typecheck` — clean
- [x] `pnpm --filter @pops/app-finance test` — 250/250 passing
- [x] `pnpm --filter @pops/app-finance lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm --filter @pops/app-finance format:check` — clean
- [ ] Manual: open Manage Rules, stage a pending edit that touches a rule, then edit a transfer rule (no entity) → impact preview renders without Zod error