### PR TITLE
docs(prds): add drift check placeholder to every PRD

### DIFF
--- a/docs/themes/00-infrastructure/prds/012-hardware-os-provisioning/README.md
+++ b/docs/themes/00-infrastructure/prds/012-hardware-os-provisioning/README.md
@@ -62,3 +62,7 @@ All Ansible commands run from the `infra/ansible/` directory due to relative `ro
 - Docker Compose service definitions (PRD-013)
 - Cloudflare Tunnel setup (PRD-014)
 - Application deployment
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/013-docker-runtime/README.md
+++ b/docs/themes/00-infrastructure/prds/013-docker-runtime/README.md
@@ -66,3 +66,7 @@ Three networks isolate service groups:
 - Cloudflare Tunnel configuration (PRD-014)
 - Secret injection (PRD-015)
 - CI/CD (PRD-016)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/014-networking-access/README.md
+++ b/docs/themes/00-infrastructure/prds/014-networking-access/README.md
@@ -56,3 +56,7 @@ The `cloudflared` container maintains an outbound connection to Cloudflare. No i
 - VPN or Tailscale (decided against in ADR-015)
 - SSL certificate management (Cloudflare handles it)
 - Application-level auth
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/015-secrets-management/README.md
+++ b/docs/themes/00-infrastructure/prds/015-secrets-management/README.md
@@ -59,3 +59,7 @@ Ansible Vault (encrypted at rest)
 - Secret rotation automation
 - Key management services (KMS)
 - Secret scanning in CI
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/016-cicd-pipelines/README.md
+++ b/docs/themes/00-infrastructure/prds/016-cicd-pipelines/README.md
@@ -48,3 +48,7 @@ Set up GitHub Actions workflows for quality gates and deployment. Every PR runs 
 - Auto-deployment from PRs
 - Release versioning or changelogs
 - Multiple deployment environments
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/017-backups/README.md
+++ b/docs/themes/00-infrastructure/prds/017-backups/README.md
@@ -45,3 +45,7 @@ Set up encrypted offsite backups of the SQLite database, Paperless-ngx data, and
 - Point-in-time recovery
 - Multi-region replication
 - Backup monitoring dashboard
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/018-monitoring/README.md
+++ b/docs/themes/00-infrastructure/prds/018-monitoring/README.md
@@ -34,3 +34,7 @@ Set up monitoring so that service failures are detected without manual checking.
 - Metrics dashboards (Prometheus, Grafana)
 - External uptime monitoring
 - Alerting (email, Slack, Telegram) — future enhancement
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/060-database-operations/README.md
+++ b/docs/themes/00-infrastructure/prds/060-database-operations/README.md
@@ -92,3 +92,7 @@ US-02, US-03, and US-05 can all parallelise. US-04 depends on US-01 (needs the u
 - WAL archival or point-in-time recovery
 - Database replication or read replicas
 - Automated rollback of Drizzle migrations (Drizzle doesn't support down migrations — restore from backup instead)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/061-smart-deploy/README.md
+++ b/docs/themes/00-infrastructure/prds/061-smart-deploy/README.md
@@ -131,3 +131,7 @@ US-01 and US-05 can start in parallel. US-02 and US-03 depend on US-01. US-04 de
 - Multi-environment deployment (staging, production)
 - Container registry (images built locally on the server)
 - Deployment notifications (Slack, email)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/073-redis-container/README.md
+++ b/docs/themes/00-infrastructure/prds/073-redis-container/README.md
@@ -71,3 +71,7 @@ US-03 and US-04 can parallelise after US-01. US-02 depends on US-01 (needs a run
 - Redis Sentinel, clustering, or replication
 - Redis persistence (RDB/AOF) — ephemeral by design (ADR-016)
 - Redis AUTH password (single-user, backend-network-only, no external exposure)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/074-job-queue/README.md
+++ b/docs/themes/00-infrastructure/prds/074-job-queue/README.md
@@ -80,3 +80,7 @@ US-03 can run in parallel with US-02 (API reads from queues, worker writes — i
 - Cortex-specific job types (defined in the Cortex theme)
 - Rate limiting per queue (add when needed)
 - Multi-node worker deployment (single worker process is sufficient)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/075-openapi-contract/README.md
+++ b/docs/themes/00-infrastructure/prds/075-openapi-contract/README.md
@@ -86,3 +86,7 @@ US-02 and US-03 can parallelise after US-01. US-04 can start after US-01 (valida
 - API key authentication (Cloudflare Access handles auth)
 - GraphQL or gRPC alternatives
 - Versioning beyond `/api/v1/` (cross that bridge when breaking changes happen)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/00-infrastructure/prds/076-vector-storage/README.md
+++ b/docs/themes/00-infrastructure/prds/076-vector-storage/README.md
@@ -99,3 +99,7 @@ US-03 and US-04 can parallelise after US-02.
 - Hybrid search (combining vector + keyword) — future enhancement
 - Local embedding model inference — remote API only
 - Cross-database vector queries (e.g., querying vectors from a different SQLite file)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/001-project-bootstrap/README.md
+++ b/docs/themes/01-foundation/prds/001-project-bootstrap/README.md
@@ -63,3 +63,7 @@ Every US is only done when all of the following pass:
 - Application code
 - CI/CD pipelines (Infrastructure theme)
 - Docker configuration (Infrastructure theme)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/002-design-tokens-theming/README.md
+++ b/docs/themes/01-foundation/prds/002-design-tokens-theming/README.md
@@ -135,3 +135,7 @@ Every US is only done when:
 - Component implementation (PRD-003)
 - Storybook configuration (PRD-004)
 - Shell-side colour propagation mechanism (PRD-007)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/003-components/README.md
+++ b/docs/themes/01-foundation/prds/003-components/README.md
@@ -190,3 +190,7 @@ Every US is only done when:
 - Storybook configuration (PRD-004)
 - Responsive design audit (PRD-010)
 - Domain-specific components (stay in app packages)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/004-storybook/README.md
+++ b/docs/themes/01-foundation/prds/004-storybook/README.md
@@ -77,3 +77,7 @@ packages/ui/src/components/
 - Writing stories for every component (that's part of PRD-003 per-component USs)
 - Visual regression testing (Chromatic, Percy — future enhancement)
 - Storybook deployment or hosting
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/005-shell/README.md
+++ b/docs/themes/01-foundation/prds/005-shell/README.md
@@ -214,3 +214,7 @@ Every US is only done when:
 - App theme colour propagation (PRD-007)
 - Responsive design audit (PRD-010)
 - Individual app pages (each app theme owns its pages)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/006-app-switcher/README.md
+++ b/docs/themes/01-foundation/prds/006-app-switcher/README.md
@@ -111,3 +111,7 @@ With only one app registered, the switcher should not feel empty:
 - App theme colour propagation (PRD-007)
 - Search / command palette (PRD-056/057)
 - Favourites, pinning, or notifications
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/007-app-theme-colour-propagation/README.md
+++ b/docs/themes/01-foundation/prds/007-app-theme-colour-propagation/README.md
@@ -78,3 +78,7 @@ No database changes. The colour is declared in the app's `navConfig` (already pa
 ## Dependencies
 
 PRD-007 propagation is only effective when PRD-002 US-02 (define `--app-accent` CSS variable values) and PRD-002 US-04 (replace hardcoded colour classes with `bg-app-accent` tokens) are both complete. Without those, the shell sets variables that no component consumes.
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/008-api-server/README.md
+++ b/docs/themes/01-foundation/prds/008-api-server/README.md
@@ -164,3 +164,7 @@ US-02 and US-03 can parallelise after US-01. US-04 depends on US-02. US-05 can p
 - Domain-specific business logic (each theme owns its modules)
 - Database schema (PRD-009)
 - Deployment configuration (Infrastructure theme)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/009-db-schema-patterns/README.md
+++ b/docs/themes/01-foundation/prds/009-db-schema-patterns/README.md
@@ -161,3 +161,7 @@ US-02, US-03, US-04 can parallelise after US-01. US-05 depends on tables existin
 - ORM choice (PRD-011)
 - Automated rollback tooling
 - Multi-database setup
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/010-responsive-foundation/README.md
+++ b/docs/themes/01-foundation/prds/010-responsive-foundation/README.md
@@ -126,3 +126,7 @@ US-02, US-03, US-04 can parallelise after US-01.
 - App-specific page redesigns
 - Mobile-specific features (swipe, pull-to-refresh)
 - Performance optimisation for mobile networks
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/011-drizzle-orm/README.md
+++ b/docs/themes/01-foundation/prds/011-drizzle-orm/README.md
@@ -89,3 +89,7 @@ US-03, US-04, US-05 can parallelise after US-02. US-06 can parallelise with US-0
 - Changing the database engine (stays SQLite)
 - Async queries (synchronous mode preserved)
 - New domain schemas (those come from their respective themes)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/056-search-ui/README.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/README.md
@@ -38,3 +38,7 @@ Build the search UI — a TopBar search bar with a results panel that shows cont
 - Contextual intelligence system (PRD-058)
 - Structured query syntax UI hints (part of PRD-057 v2)
 - Context enrichment / semantic tagging (v2 idea — see ideas/app-ideas.md)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/057-search-engine/README.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/README.md
@@ -106,3 +106,7 @@ All 6 backend adapters (us-02 through us-07) can parallelise. All 6 frontend com
 - Contextual intelligence (PRD-058)
 - Full-text search indexing (SQLite FTS5 — future if LIKE queries are too slow)
 - Context enrichment / semantic tagging (v2 idea — see ideas/app-ideas.md)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/01-foundation/prds/058-contextual-intelligence/README.md
+++ b/docs/themes/01-foundation/prds/058-contextual-intelligence/README.md
@@ -53,3 +53,7 @@ interface AppContext {
 - What consumers do with the context (each PRD owns its own logic)
 - Persisting context across sessions
 - Analytics or tracking of user navigation patterns
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/019-transactions/README.md
+++ b/docs/themes/02-finance/prds/019-transactions/README.md
@@ -106,3 +106,7 @@ US-02 and US-03 can parallelise after US-01. US-04 can parallelise with US-02.
 - Import pipeline (PRD-020-022)
 - Entity management (PRD-023)
 - Budget aggregation (PRD-025)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/020-import-wizard-ui/README.md
+++ b/docs/themes/02-finance/prds/020-import-wizard-ui/README.md
@@ -240,3 +240,7 @@ US-03 and US-04 can parallelise. US-11, US-12, US-13, US-14, US-15 can paralleli
 - Entity matching engine internals (PRD-021)
 - Deduplication and parser internals (PRD-022)
 - The matching/dedup/AI algorithms — this PRD covers the UI wrapper
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/021-entity-matching-engine/README.md
+++ b/docs/themes/02-finance/prds/021-entity-matching-engine/README.md
@@ -118,3 +118,7 @@ US-02, US-03, US-04 can parallelise after US-01.
 - Import wizard UI (PRD-020)
 - Deduplication (PRD-022)
 - AI rule creation from corrections (PRD-027)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/022-deduplication-parsers/README.md
+++ b/docs/themes/02-finance/prds/022-deduplication-parsers/README.md
@@ -121,3 +121,7 @@ US-02 through US-05 can all parallelise (independent parsers). US-06 is shared u
 - Entity matching (PRD-021)
 - Import wizard UI (PRD-020)
 - New bank format support (add a new parser when needed)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/023-entities/README.md
+++ b/docs/themes/02-finance/prds/023-entities/README.md
@@ -80,3 +80,7 @@ Build the entity registry — the merchant/payee database that transactions and 
 
 - Entity matching logic (PRD-021)
 - Cross-domain entity usage beyond finance (future domains will reference the same entity table)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/024-corrections/README.md
+++ b/docs/themes/02-finance/prds/024-corrections/README.md
@@ -134,3 +134,7 @@ The system must distinguish between:
 
 - Tag rule learning (PRD-029)
 - A standalone rules management UI outside the import flow
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/025-budgets/README.md
+++ b/docs/themes/02-finance/prds/025-budgets/README.md
@@ -54,3 +54,7 @@ Build budget tracking — spending categories with monthly or yearly limits. Sho
 - Spend vs target calculation (requires transaction aggregation by tag/category — future enhancement)
 - Budget alerts or notifications
 - Forecasting
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/026-wishlist/README.md
+++ b/docs/themes/02-finance/prds/026-wishlist/README.md
@@ -54,3 +54,7 @@ Build the wishlist — savings goals with target amounts, progress tracking, and
 - Price tracking or alerts
 - Integration with inventory (linking purchased items)
 - Automatic "saved" updates from transactions
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/027-ai-rule-creation/README.md
+++ b/docs/themes/02-finance/prds/027-ai-rule-creation/README.md
@@ -120,3 +120,7 @@ Documentation alignment: knoxio/pops#1746.
 - AI usage tracking UI (AI theme, PRD-052)
 - Corrections management UI (future enhancement)
 - Regex pattern suggestions (AI could suggest regex, but start with prefix/contains/exact)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/028-correction-proposal-engine/README.md
+++ b/docs/themes/02-finance/prds/028-correction-proposal-engine/README.md
@@ -139,3 +139,7 @@ Rejection is reserved for the "this whole direction is wrong, start over" case �
 - A correction like “WOOLWORTHS 12837192” → “Woolworths” produces a proposal that generalises correctly and matches other Woolworths variants in the same import after approval.
 - A transfer correction (e.g. PayID) can produce a rule that classifies similar rows as transfer without an entity.
 - A wrong rule match can be corrected via edit, resulting in a ChangeSet proposal that fixes the rule system rather than silently overriding the one transaction.
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/029-tag-rule-proposals/README.md
+++ b/docs/themes/02-finance/prds/029-tag-rule-proposals/README.md
@@ -121,3 +121,7 @@ The UI must support accepting/rejecting suggestions at either scope:
 
 - Tag edits in the current import can produce a proposal that increases the quality of future tag suggestions. _(API ready; import wizard integration pending — knoxio/pops#1741.)_
 - Approving a tag rule proposal immediately improves suggested tags for remaining transactions in the current import without altering entity/type classification. _(Same — #1741.)_
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/030-local-first-import/README.md
+++ b/docs/themes/02-finance/prds/030-local-first-import/README.md
@@ -101,3 +101,7 @@ No new backend endpoints. All operations are zustand store actions and pure func
 - The global rule manager UI (PRD-032)
 - Tag rule changes (already local in current implementation, covered by PRD-029)
 - Undo/redo within the pending state (future enhancement)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/031-final-review-commit/README.md
+++ b/docs/themes/02-finance/prds/031-final-review-commit/README.md
@@ -80,3 +80,7 @@ CommitResult {
 - The local-first stores and merge layer (PRD-030)
 - The global rule manager UI (PRD-032)
 - Undo/rollback after commit is completed
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/032-rule-manager-priority/README.md
+++ b/docs/themes/02-finance/prds/032-rule-manager-priority/README.md
@@ -76,3 +76,7 @@ No new endpoints. Existing endpoints change:
 - The commit endpoint and retroactive reclassification (PRD-031)
 - Tag rule management (PRD-029)
 - Entity editing/creation from the rule manager (handled by existing EntityCreateDialog)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/02-finance/prds/069-drop-online-field/README.md
+++ b/docs/themes/02-finance/prds/069-drop-online-field/README.md
@@ -55,3 +55,7 @@ Tag-related procedures are untouched; they already handle the use case.
 - A "system tag" vs "user tag" distinction at runtime. The vocabulary table's `source: "seed"` field already exists if seed data ever wants to ship default tags; this PRD does not use it.
 - Any change to the persisted `transactions` schema or migrations.
 - Any change to `transaction_tag_rules` table or its CRUD endpoints.
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/028-media-data-model-api/README.md
+++ b/docs/themes/03-media/prds/028-media-data-model-api/README.md
@@ -275,3 +275,7 @@ US-01 and US-02 can run in parallel (independent tables). US-03 needs US-01. US-
 - UI pages and components (Epic 02)
 - Plex sync (Epic 06)
 - Recommendation engine (Epic 05)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/029-tmdb-client/README.md
+++ b/docs/themes/03-media/prds/029-tmdb-client/README.md
@@ -98,3 +98,7 @@ US-01 and US-02 can run in parallel. US-03 composes them into the add-to-library
 - UI for search/browse (Epic 02)
 - Bulk import from external lists
 - Person/cast/crew data
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/030-thetvdb-client/README.md
+++ b/docs/themes/03-media/prds/030-thetvdb-client/README.md
@@ -112,3 +112,7 @@ US-01 and US-02 can run in parallel. US-03 composes them into the add-to-library
 - UI for search/browse (Epic 02)
 - Plex metadata matching (Epic 06)
 - Episode still image caching (future enhancement — posters only for v1)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/031-library-page/README.md
+++ b/docs/themes/03-media/prds/031-library-page/README.md
@@ -91,3 +91,7 @@ US-02 depends on US-01 (needs MediaCard). US-03 can be built in parallel with US
 - Movie/show detail views (PRD-033, PRD-034)
 - Watch status indicators on cards (Epic 03: Tracking & Watchlist)
 - Comparison scores on cards (Epic 04: Ratings & Comparisons)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/032-search-page/README.md
+++ b/docs/themes/03-media/prds/032-search-page/README.md
@@ -102,3 +102,7 @@ US-02 depends on US-01 (needs search state). US-03 depends on US-02 (needs resul
 - Editing or removing library items
 - Advanced search filters (genre, year range, etc.)
 - Trending or recommended results (Epic 05: Discovery & Recommendations)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/033-movie-detail-page/README.md
+++ b/docs/themes/03-media/prds/033-movie-detail-page/README.md
@@ -129,3 +129,7 @@ US-01 builds the page shell. US-02, US-03, and US-04 are independent components 
 - Cast/crew information (future enhancement)
 - Similar movies recommendations (Epic 05)
 - External links (TMDB page, streaming availability)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/034-tv-show-detail-page/README.md
+++ b/docs/themes/03-media/prds/034-tv-show-detail-page/README.md
@@ -146,3 +146,7 @@ US-02 depends on US-01 (needs the page shell). US-03 and US-04 are independent c
 - Cast/crew information
 - Episode ratings or comparisons
 - Recommendations for similar shows (Epic 05)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/035-watch-history/README.md
+++ b/docs/themes/03-media/prds/035-watch-history/README.md
@@ -92,3 +92,7 @@ US-02 depends on US-01 (needs the history list to add episode-specific rendering
 - Undo toast for mark-as-watched (lives on the detail page, not the history page)
 - Plex watch history sync (PRD-039)
 - In-progress / "continue watching" tracking
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/036-watchlist/README.md
+++ b/docs/themes/03-media/prds/036-watchlist/README.md
@@ -105,3 +105,7 @@ US-02 depends on US-01 (needs the watchlist grid/list to add reorder interaction
 - Add/remove actions on detail pages (PRD-033, PRD-034 own the detail page actions)
 - Plex sync integration (PRD-039)
 - Watchlist sharing or export
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/037-ratings-comparisons/README.md
+++ b/docs/themes/03-media/prds/037-ratings-comparisons/README.md
@@ -142,3 +142,7 @@ US-01 depends on US-02 (arena needs Elo scoring to record comparisons). US-03 th
 - Smart pair selection based on score uncertainty
 - AI-driven comparison prompts
 - Radar charts on detail pages (detail pages own their own display)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/038-discovery-recommendations/README.md
+++ b/docs/themes/03-media/prds/038-discovery-recommendations/README.md
@@ -156,3 +156,7 @@ All three stories can be built in parallel — they are independent sections of 
 - Temporal pattern analysis (e.g., "you watch comedies on weekends")
 - TV show recommendations (movie-only for now)
 - Caching TMDB trending data locally
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/039-plex-sync/README.md
+++ b/docs/themes/03-media/prds/039-plex-sync/README.md
@@ -207,3 +207,7 @@ US-01 is the foundation (auth required for all Plex API calls). US-02 and US-03 
 - Plex user rating import
 - Bidirectional watchlist sync with Plex Discover (see [PRD-059](../059-plex-watchlist-sync/README.md))
 - Multi-user Plex support (single user only)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/040-arr-status-display/README.md
+++ b/docs/themes/03-media/prds/040-arr-status-display/README.md
@@ -102,3 +102,7 @@ US-01 is the foundation. US-02 and US-03 can be built in parallel once US-01 is 
 - Download queue management (start/stop/prioritise downloads)
 - Radarr/Sonarr webhook receivers for real-time status updates
 - Plex availability checks (Epic 06: Plex Sync)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/041-radarr-request-management/README.md
+++ b/docs/themes/03-media/prds/041-radarr-request-management/README.md
@@ -103,3 +103,7 @@ US-01 is the API layer. US-02 builds the modal component. US-03 integrates the b
 - Quality profile management (create/edit profiles within POPS)
 - Download queue management (pause/cancel/prioritise)
 - Radarr tag management
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/042-sonarr-request-management/README.md
+++ b/docs/themes/03-media/prds/042-sonarr-request-management/README.md
@@ -134,3 +134,7 @@ US-01 is the API layer. US-02, US-03, and US-04 can be built in parallel once US
 - Download queue management
 - Sonarr tag management
 - Episode renaming or file management
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/059-plex-watchlist-sync/README.md
+++ b/docs/themes/03-media/prds/059-plex-watchlist-sync/README.md
@@ -118,3 +118,7 @@ US-02 and US-03 can parallelise after US-01.
 - Real-time sync via Plex webhooks (polling is sufficient)
 - Watchlist priority sync (Plex has no priority concept)
 - Syncing watchlist notes or metadata beyond the item reference
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/060-discover-page/README.md
+++ b/docs/themes/03-media/prds/060-discover-page/README.md
@@ -201,3 +201,7 @@ Fully parallel: us-01, us-03, us-04, us-10, us-11, us-13
 - Collaborative filtering (would need multi-user data)
 - Social features (shared lists, reviews)
 - IMDB trending (no public API without scraping)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/062-comparison-intelligence/README.md
+++ b/docs/themes/03-media/prds/062-comparison-intelligence/README.md
@@ -185,3 +185,7 @@ US-01, US-02, US-04, US-06 can be built in parallel. US-03 shares recalc logic w
 - TV show comparisons
 - AI-suggested pairs
 - Score decay over time (soft decay in ELO math — deferred, staleness model handles the user-facing concern)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/063-post-watch-debrief/README.md
+++ b/docs/themes/03-media/prds/063-post-watch-debrief/README.md
@@ -104,3 +104,7 @@ US-01 and US-02 can parallelise. US-04 and US-05 can parallelise once US-03 is d
 - TV show debriefs (movie-only for now)
 - Auto-starting debrief on watch event (manual trigger, prompted by notification)
 - Debrief analytics or progress tracking beyond the badge/banner
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/064-batch-tier-list/README.md
+++ b/docs/themes/03-media/prds/064-batch-tier-list/README.md
@@ -118,3 +118,7 @@ US-01, US-02, US-03 can parallelise. US-05 and US-06 can parallelise once US-04 
 - TV show tier lists
 - Cross-dimension tier lists (one dimension per session)
 - Undo individual implied comparisons after submission (delete the batch via history if needed)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/065-shelf-discovery/README.md
+++ b/docs/themes/03-media/prds/065-shelf-discovery/README.md
@@ -158,3 +158,7 @@ US-01 and US-03 can parallelise. US-04 through US-09 (all shelf implementations)
 - AI-generated shelf titles or descriptions
 - Editorial/curated shelves (all algorithmic)
 - Streaming availability data (no API integration with Netflix/etc.)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/066-arena-redesign/README.md
+++ b/docs/themes/03-media/prds/066-arena-redesign/README.md
@@ -144,3 +144,7 @@ All existing — no new endpoints:
 - Redesign of Rankings, Tier List, or Debrief pages
 - Mobile-specific layout breakpoints
 - Animations or transitions between pairs
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/067-comparison-history-enhancements/README.md
+++ b/docs/themes/03-media/prds/067-comparison-history-enhancements/README.md
@@ -61,3 +61,7 @@ The Matrix  +12  beat  Inception  -12    CINEMATOGRAPHY  4/6/2026  [🗑]
 | #   | Story                                 | Summary                                                                      | Status |
 | --- | ------------------------------------- | ---------------------------------------------------------------------------- | ------ |
 | 01  | [us-01-elo-delta](us-01-elo-delta.md) | Store ELO deltas on comparison record; display as coloured badges in history | Done   |
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/068-comparison-history-search/README.md
+++ b/docs/themes/03-media/prds/068-comparison-history-search/README.md
@@ -40,3 +40,7 @@ Add `search?: string` to `ComparisonHistoryQuerySchema`. When provided, filter c
 | #   | Story                                         | Summary                                      | Status      | Parallelisable |
 | --- | --------------------------------------------- | -------------------------------------------- | ----------- | -------------- |
 | 01  | [us-01-search-filter](us-01-search-filter.md) | Backend search param + frontend search input | In progress | Yes            |
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/070-rotation-engine/README.md
+++ b/docs/themes/03-media/prds/070-rotation-engine/README.md
@@ -113,3 +113,7 @@ The rotation engine is a daily automated job that manages the movie library life
 - Smart removal selection based on ratings/comparisons (future enhancement)
 - Multi-instance Radarr support
 - Notification system (email/push when movies are leaving)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/071-source-lists/README.md
+++ b/docs/themes/03-media/prds/071-source-lists/README.md
@@ -131,3 +131,7 @@ interface CandidateMovie {
 - Source recommendations based on user taste profile
 - Social features (sharing lists between POPS users)
 - TV show sources
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/03-media/prds/072-rotation-ui/README.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/README.md
@@ -136,3 +136,7 @@ Paginated history of rotation cycles. Each entry shows:
 - Calendar view of rotation schedule
 - Drag-to-reorder candidate queue priority
 - Public sharing of rotation stats
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/04-inventory/prds/043-inventory-data-model-api/README.md
+++ b/docs/themes/04-inventory/prds/043-inventory-data-model-api/README.md
@@ -159,3 +159,7 @@ US-01 and US-02 can run in parallel (independent tables). US-03 needs US-01. US-
 - Connection graph visualisation (Epic 03)
 - Paperless-ngx integration (Epic 04)
 - Warranty and value reporting (Epic 05)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/04-inventory/prds/044-items-list-page/README.md
+++ b/docs/themes/04-inventory/prds/044-items-list-page/README.md
@@ -86,3 +86,7 @@ All three stories can be built in parallel. US-01 and US-02 are independent view
 - Location tree management (Epic 02)
 - Connection graph visualisation (Epic 03)
 - Warranty alerts in list view (Epic 05)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/04-inventory/prds/045-item-detail-page/README.md
+++ b/docs/themes/04-inventory/prds/045-item-detail-page/README.md
@@ -141,3 +141,7 @@ All four stories can be built in parallel — they render independent sections o
 - Document linking to Paperless-ngx (Epic 04)
 - Location tree browsing from this page (Epic 02)
 - Connection management (adding/removing connections — Epic 03)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/04-inventory/prds/046-item-form/README.md
+++ b/docs/themes/04-inventory/prds/046-item-form/README.md
@@ -128,3 +128,7 @@ All four stories can be built in parallel. US-01 provides the form shell; US-02,
 - Barcode/QR code scanning for asset IDs
 - Auto-populating item details from a product database
 - Connection management from the form (done on the detail page)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/04-inventory/prds/047-location-tree-management/README.md
+++ b/docs/themes/04-inventory/prds/047-location-tree-management/README.md
@@ -77,3 +77,7 @@ US-02, US-03, and US-04 can parallelise after US-01.
 - AI-assisted location path suggestions
 - Map or floor plan view
 - Bulk item reassignment between locations
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/04-inventory/prds/048-connections-graph/README.md
+++ b/docs/themes/04-inventory/prds/048-connections-graph/README.md
@@ -77,3 +77,7 @@ US-02 and US-03 can parallelise after US-01.
 - Connection types or labels (power, data, audio — item metadata carries this)
 - Automated connection discovery
 - Connection weight or bandwidth metadata
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/04-inventory/prds/049-paperless-integration/README.md
+++ b/docs/themes/04-inventory/prds/049-paperless-integration/README.md
@@ -86,3 +86,7 @@ US-02 and US-03 can parallelise after US-01.
 - OCR or text extraction within POPS
 - Full Paperless management UI
 - Automatic document matching based on item name or purchase date
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/04-inventory/prds/050-warranty-tracking/README.md
+++ b/docs/themes/04-inventory/prds/050-warranty-tracking/README.md
@@ -76,3 +76,7 @@ US-02 and US-03 can parallelise after US-01.
 - Automated warranty date extraction from receipts
 - Extended warranty purchase tracking
 - Depreciation calculations
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/04-inventory/prds/051-value-insurance-reporting/README.md
+++ b/docs/themes/04-inventory/prds/051-value-insurance-reporting/README.md
@@ -93,3 +93,7 @@ US-01 and US-02 can parallelise. US-03 blocked by us-01. US-04 blocked by us-03.
 - Depreciation calculations
 - Historical value tracking over time
 - Export to CSV or spreadsheet format
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/README.md
+++ b/docs/themes/05-ai/prds/052-ai-usage-cost-tracking/README.md
@@ -51,3 +51,7 @@ Uses the existing `ai_usage` table (created in PRD-009):
 
 - AI configuration and rules management (PRD-053)
 - Per-domain cost breakdown (future — needs domain tagging on ai_usage rows)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/05-ai/prds/053-ai-configuration-rules/README.md
+++ b/docs/themes/05-ai/prds/053-ai-configuration-rules/README.md
@@ -50,3 +50,7 @@ All USs can parallelise — independent pages.
 - AI overlay (PRD-054)
 - AI inference (PRD-055)
 - Custom prompt editing (prompts live in code)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/05-ai/prds/054-ai-overlay/README.md
+++ b/docs/themes/05-ai/prds/054-ai-overlay/README.md
@@ -217,3 +217,7 @@ US-01, US-04, US-10 can start in parallel. US-07, US-08, US-09 (domain verbs) ca
 - Persistent conversation history beyond 24h
 - AI-initiated messages (assistant always responds, never initiates)
 - Image/file upload in chat (future: receipt photos)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/05-ai/prds/055-ai-inference-monitoring/README.md
+++ b/docs/themes/05-ai/prds/055-ai-inference-monitoring/README.md
@@ -30,3 +30,7 @@ Build proactive AI capabilities — anomaly detection, smart automations, and sc
 - Interactive assistant (PRD-054)
 - Training custom models
 - Real-time streaming analysis
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/077-engram-file-format/README.md
+++ b/docs/themes/06-cerebrum/prds/077-engram-file-format/README.md
@@ -231,3 +231,7 @@ US-03 and US-04 can parallelise with each other and with US-02. US-05 depends on
 - Scope inference or auto-classification (PRD-078, PRD-081)
 - File watching and automatic index sync (PRD-079)
 - Content curation or consolidation (PRD-085)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/078-scope-model/README.md
+++ b/docs/themes/06-cerebrum/prds/078-scope-model/README.md
@@ -150,3 +150,7 @@ US-02 and US-03 can parallelise with each other after US-01 is complete. US-04 d
 - Scope-based consolidation boundaries (PRD-085 — Glia Curation)
 - UI for scope management (future — Cerebrum has no dedicated UI in this phase)
 - Scope permissions or multi-user access control — this is output filtering, not auth
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/079-engram-indexing/README.md
+++ b/docs/themes/06-cerebrum/prds/079-engram-indexing/README.md
@@ -94,3 +94,7 @@ US-02 depends on us-01 (needs file events to process). US-03 depends on us-02 (n
 - Content creation or ingestion (PRD-081, Epic 02)
 - Curation or consolidation of indexed data (PRD-085 — Glia Curation)
 - LLM-based content classification (PRD-081 — Cortex Classification)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/080-retrieval-engine/README.md
+++ b/docs/themes/06-cerebrum/prds/080-retrieval-engine/README.md
@@ -88,3 +88,7 @@ US-01 and US-02 can parallelise. US-03 merges their outputs and requires both. U
 - Full-text keyword search (BM25) — may be added later as an additional retrieval mode
 - Caching of search results (future optimisation if needed)
 - Streaming context assembly for long contexts
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
@@ -122,3 +122,7 @@ US-01, US-02, and US-03 define the three input channels and can parallelise. US-
 - Semantic embedding generation (PRD-079 — Thalamus handles embedding sync after the engram is written)
 - Content curation or consolidation (PRD-085 — Glia operates on stored engrams, not during ingestion)
 - Template creation or editing (PRD-077 — templates are managed outside the ingestion pipeline)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/082-query-engine/README.md
+++ b/docs/themes/06-cerebrum/prds/082-query-engine/README.md
@@ -103,3 +103,7 @@ US-02 can parallelise with US-01 (scope inference is a separable module). US-03 
 - Answer formatting for specific output media (PRD-083 handles document formatting)
 - User feedback on answer quality (future — could feed into retrieval tuning)
 - Streaming answer generation (future — initial implementation is request/response)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/083-document-generation/README.md
+++ b/docs/themes/06-cerebrum/prds/083-document-generation/README.md
@@ -103,3 +103,7 @@ US-01 establishes the core generation pipeline (retrieval, synthesis, formatting
 - Automated scheduled report generation (Epic 06 — Reflex triggers generation)
 - Template-based output formatting (future — initial output is Markdown only)
 - Collaborative document editing (single-user system)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/084-proactive-nudges/README.md
+++ b/docs/themes/06-cerebrum/prds/084-proactive-nudges/README.md
@@ -134,3 +134,7 @@ US-01 establishes the nudge data model, storage, and action framework. US-02 and
 - Custom nudge types defined by the user (future — initial system has four fixed types)
 - Nudge delivery via email or push notifications (future — initial channels are shell and Moltbot only)
 - Nudge aggregation dashboards (future — initial implementation is a flat list)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/085-curation-workers/README.md
+++ b/docs/themes/06-cerebrum/prds/085-curation-workers/README.md
@@ -117,3 +117,7 @@ All four workers are independent and can be built in parallel. Each worker depen
 - Curation during the ingest pipeline (Glia runs asynchronously)
 - Cross-scope operations (never — regardless of trust level)
 - Scheduling of worker runs (PRD-089 — Reflex System handles cron triggers)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/086-trust-graduation/README.md
+++ b/docs/themes/06-cerebrum/prds/086-trust-graduation/README.md
@@ -113,3 +113,7 @@ US-01 and US-02 can be built in parallel. US-03 and US-04 both depend on the `gl
 - Scheduling worker runs (PRD-089 — Reflex System)
 - Notification delivery infrastructure (existing shell/Moltbot patterns)
 - User preference for which action types should never graduate (future — manual override of graduation)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/087-ego-core/README.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/README.md
@@ -118,3 +118,7 @@ US-01 (conversation engine) is the foundation. US-02, US-03, and US-04 depend on
 - Voice input/output
 - Multi-user conversations or shared contexts
 - Custom system prompt editing by the user (future)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/088-ego-channels/README.md
+++ b/docs/themes/06-cerebrum/prds/088-ego-channels/README.md
@@ -73,3 +73,7 @@ All three channels are independent adapters and can be built in parallel. Each d
 - Voice input/output transcription
 - Third-party chat platform integrations beyond Telegram (future Plexus adapters)
 - Multi-turn conversations via MCP (MCP tools are stateless single-shot calls)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/089-reflex-system/README.md
+++ b/docs/themes/06-cerebrum/prds/089-reflex-system/README.md
@@ -125,3 +125,7 @@ US-01 defines the reflex format and parsing — all other stories depend on it. 
 - Complex conditional logic or branching (reflexes are simple trigger-action rules, not workflows)
 - External webhook receivers (future — Plexus adapters could emit events that trigger reflexes)
 - User-facing reflex creation UI (reflexes are configured via TOML file — a UI editor is future work)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/090-plugin-architecture/README.md
+++ b/docs/themes/06-cerebrum/prds/090-plugin-architecture/README.md
@@ -107,3 +107,7 @@ US-01 defines the interface that US-02 and US-03 depend on. US-04 (ingestion fil
 - Adapter marketplace or distribution (adapters are local TypeScript modules)
 - Real-time streaming from external sources (adapters use poll-based or webhook-based sync)
 - Adapter-specific UI configuration screens (configuration via plexus.toml)
+
+## Drift Check
+
+last checked: never

--- a/docs/themes/06-cerebrum/prds/091-core-adapters/README.md
+++ b/docs/themes/06-cerebrum/prds/091-core-adapters/README.md
@@ -93,3 +93,7 @@ All three adapters are independent implementations of the same interface and can
 - Real-time push notifications from external sources (adapters poll on configurable intervals)
 - Adapters beyond the three reference implementations (community or future work)
 - Two-way calendar sync (creating calendar events from engrams — emit direction is future)
+
+## Drift Check
+
+last checked: never


### PR DESCRIPTION
## Summary
- Append `## Drift Check` section with `last checked: never` to every PRD README under `docs/themes/*/prds/*/README.md` (97 files).
- Gives each PRD a dedicated slot to track when it was last reconciled against the code.

## Test plan
- [ ] Spot-check a few PRDs render with the new section at the end
- [ ] Confirm no other content was modified (`git diff` is purely additive)