### PR TITLE
ci: revert blacksmith runners to GitHub-hosted ubuntu-latest

### DIFF
--- a/.github/workflows/_pkg-check.yml
+++ b/.github/workflows/_pkg-check.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: "Skip — no relevant changes"
         if: inputs.skip == 'true'
@@ -48,7 +48,7 @@ jobs:
 
   typecheck:
     name: Typecheck
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: "Skip — no relevant changes"
         if: inputs.skip == 'true'
@@ -75,7 +75,7 @@ jobs:
   test:
     name: Test
     if: ${{ inputs.has-test }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: "Skip — no relevant changes"
         if: inputs.skip == 'true'
@@ -102,7 +102,7 @@ jobs:
   format:
     name: Format
     if: ${{ inputs.has-format }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: "Skip — no relevant changes"
         if: inputs.skip == 'true'

--- a/.github/workflows/ai-quality.yml
+++ b/.github/workflows/ai-quality.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/api-client-quality.yml
+++ b/.github/workflows/api-client-quality.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.api }}
@@ -32,7 +32,7 @@ jobs:
 
   quality-checks:
     name: quality
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes]
     if: always()
 

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.backend }}
@@ -27,7 +27,7 @@ jobs:
 
   test-backend:
     name: Backend Tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes]
     if: always()
 
@@ -86,7 +86,7 @@ jobs:
 
   lint-frozen-migrations:
     name: Frozen Migrations Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
 
     steps:

--- a/.github/workflows/db-types-quality.yml
+++ b/.github/workflows/db-types-quality.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.docker }}
@@ -35,7 +35,7 @@ jobs:
 
   docker-build:
     name: Validate Docker builds
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes]
     if: always()
     steps:

--- a/.github/workflows/fe-quality.yml
+++ b/.github/workflows/fe-quality.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.shell }}
@@ -41,7 +41,7 @@ jobs:
 
   quality:
     name: Quality Checks
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes]
     if: always()
     steps:

--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.e2e }}
@@ -26,7 +26,7 @@ jobs:
 
   e2e-tests:
     name: Playwright E2E Tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes]
     if: always()
     timeout-minutes: 30

--- a/.github/workflows/finance-quality.yml
+++ b/.github/workflows/finance-quality.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/infra-quality.yml
+++ b/.github/workflows/infra-quality.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -32,7 +32,7 @@ jobs:
 
   lint-yaml:
     name: YAML Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes]
     if: always()
     steps:
@@ -53,7 +53,7 @@ jobs:
 
   ansible-lint:
     name: Ansible Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes]
     if: always()
     steps:
@@ -82,7 +82,7 @@ jobs:
 
   syntax-check:
     name: Ansible Syntax Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes]
     if: always()
     strategy:
@@ -123,7 +123,7 @@ jobs:
 
   security-check:
     name: Security Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes]
     if: always()
     steps:
@@ -162,7 +162,7 @@ jobs:
 
   best-practices:
     name: Best Practices Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes]
     if: always()
     steps:
@@ -212,7 +212,7 @@ jobs:
 
   summary:
     name: CI Summary
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [lint-yaml, ansible-lint, syntax-check, security-check, best-practices]
     if: always()
     steps:

--- a/.github/workflows/inventory-quality.yml
+++ b/.github/workflows/inventory-quality.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/media-quality.yml
+++ b/.github/workflows/media-quality.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/navigation-quality.yml
+++ b/.github/workflows/navigation-quality.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/root-deploy.yml
+++ b/.github/workflows/root-deploy.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       frontend: ${{ steps.diff.outputs.frontend }}
       backend: ${{ steps.diff.outputs.backend }}
@@ -90,7 +90,7 @@ jobs:
   # Quality checks run in parallel for faster feedback
   lint:
     name: Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: changes
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy_needed == 'true'
     steps:
@@ -105,7 +105,7 @@ jobs:
 
   typecheck:
     name: Typecheck
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: changes
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy_needed == 'true'
     steps:
@@ -120,7 +120,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: changes
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy_needed == 'true'
     steps:
@@ -135,7 +135,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: changes
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy_needed == 'true'
     steps:

--- a/.github/workflows/tools-quality.yml
+++ b/.github/workflows/tools-quality.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/ui-quality.yml
+++ b/.github/workflows/ui-quality.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}

--- a/.github/workflows/workflows-quality.yml
+++ b/.github/workflows/workflows-quality.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -25,7 +25,7 @@ jobs:
 
   yaml-lint:
     name: YAML Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes]
     if: always()
     steps:


### PR DESCRIPTION
## Summary
- Reverts the runner label change from #1775 — all workflow jobs go back to `ubuntu-latest`.

## Test plan
- [ ] CI runs on this PR succeed on GitHub-hosted runners