### PR TITLE
docs(PRD-001): correct import-tools workspace status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ packages/
 ├── types/                 # Shared: Cross-package type definitions
 ├── test-utils/            # Shared: Test helpers
 ├── api-client/            # Shared: tRPC client setup
-└── import-tools/          # Standalone: Bank import scripts (not in pnpm workspace)
+└── import-tools/          # Bank import scripts
 
 infra/
 ├── ansible/               # Infrastructure as code (Ansible playbooks + roles)

--- a/docs/themes/01-foundation/prds/001-project-bootstrap/us-01-monorepo-init.md
+++ b/docs/themes/01-foundation/prds/001-project-bootstrap/us-01-monorepo-init.md
@@ -17,4 +17,4 @@ As a developer, I want a pnpm monorepo configured with workspace packages so tha
 
 ## Notes
 
-Import-tools is a standalone package (not in the workspace) — it has its own install and dependency tree. All other packages are part of the pnpm workspace.
+All packages under `apps/*` and `packages/*` (including import-tools) are part of the pnpm workspace and share a single dependency tree.


### PR DESCRIPTION
## Summary

- Removes stale "not in pnpm workspace" claim from US-01 notes in `docs/themes/01-foundation/prds/001-project-bootstrap/us-01-monorepo-init.md`
- Removes `(not in pnpm workspace)` annotation from `import-tools` entry in `AGENTS.md`

`packages/import-tools` has been listed in `pnpm-workspace.yaml` but the docs described it as standalone. This aligns docs with reality.

Closes #1779

## Test plan

- [ ] Verify `pnpm-workspace.yaml` includes `packages/import-tools` (it does, line 12)
- [ ] No code changes — docs-only fix

https://claude.ai/code/session_0163F6ZmAq4bGCEGPhYTZB1Z