### PR TITLE
fix(design-tokens): replace arbitrary Tailwind values with scale/token classes (US-03)

### DIFF
--- a/docs/themes/01-foundation/prds/002-design-tokens-theming/us-03-eliminate-arbitrary-values.md
+++ b/docs/themes/01-foundation/prds/002-design-tokens-theming/us-03-eliminate-arbitrary-values.md
@@ -9,7 +9,7 @@ As a developer, I want all arbitrary Tailwind values replaced with token-based c
 
 ## Acceptance Criteria
 
-- [x] All `w-[Npx]`, `h-[Npx]`, `min-w-[Npx]`, `max-h-[Npx]` replaced with Tailwind scale values — all files listed in issue #1783 are clean
+- [x] All `w-[Npx]`, `h-[Npx]`, `min-w-[Npx]`, `max-h-[Npx]` replaced with Tailwind scale values or theme tokens — all files listed in issue #1783 are clean
 - [ ] All centering hacks (`top-[50%]`, `translate-x-[-50%]`) replaced with built-in utilities
 - [ ] Arbitrary padding/margin (`p-[3px]`, `bottom-[-5px]`) replaced with closest token or custom token added to `@theme`
 - [x] Radix CSS variable bindings (`w-[var(--radix-*)]`) documented as permitted exception and left in place

--- a/docs/themes/01-foundation/prds/002-design-tokens-theming/us-03-eliminate-arbitrary-values.md
+++ b/docs/themes/01-foundation/prds/002-design-tokens-theming/us-03-eliminate-arbitrary-values.md
@@ -1,7 +1,7 @@
 # US-03: Eliminate arbitrary Tailwind values
 
 > PRD: [002 — Design Tokens & Theming](README.md)
-> Status: Partial
+> Status: Partial (further progress — all issue-listed files clean)
 
 ## Description
 
@@ -9,11 +9,11 @@ As a developer, I want all arbitrary Tailwind values replaced with token-based c
 
 ## Acceptance Criteria
 
-- [ ] All `w-[Npx]`, `h-[Npx]`, `min-w-[Npx]`, `max-h-[Npx]` replaced with Tailwind scale values
+- [x] All `w-[Npx]`, `h-[Npx]`, `min-w-[Npx]`, `max-h-[Npx]` replaced with Tailwind scale values — all files listed in issue #1783 are clean
 - [ ] All centering hacks (`top-[50%]`, `translate-x-[-50%]`) replaced with built-in utilities
 - [ ] Arbitrary padding/margin (`p-[3px]`, `bottom-[-5px]`) replaced with closest token or custom token added to `@theme`
 - [x] Radix CSS variable bindings (`w-[var(--radix-*)]`) documented as permitted exception and left in place
-- [ ] `grep` for arbitrary value patterns returns only permitted Radix exceptions
+- [ ] `grep` for arbitrary value patterns returns only permitted Radix exceptions — some files outside issue scope still have viewport-relative (`min-h-[60vh]`, `max-h-[90vh]`) and character-unit (`max-w-[18ch]`) values to resolve
 - [ ] No visual regressions — components render identically before and after
 
 ## Notes

--- a/packages/app-ai/src/pages/RulesBrowserPage.tsx
+++ b/packages/app-ai/src/pages/RulesBrowserPage.tsx
@@ -121,7 +121,7 @@ function ConfidenceSlider({
   }, []);
 
   return (
-    <div className="flex items-center gap-2 min-w-[140px]">
+    <div className="flex items-center gap-2 min-w-35">
       <Slider
         min={0}
         max={1}

--- a/packages/app-finance/src/components/imports/BrowseRulesSidebar.tsx
+++ b/packages/app-finance/src/components/imports/BrowseRulesSidebar.tsx
@@ -29,7 +29,7 @@ function BrowseRuleSidebarRowContent(props: { rule: CorrectionRule; hasLocalOp: 
   return (
     <div className="flex-1 min-w-0 space-y-1">
       <div className="flex items-center gap-1.5 flex-wrap">
-        <code className="text-xs truncate max-w-[180px]">{rule.descriptionPattern}</code>
+        <code className="text-xs truncate max-w-45">{rule.descriptionPattern}</code>
         <Badge variant="outline" className="text-[10px] h-4 px-1.5">
           {rule.matchType}
         </Badge>

--- a/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
@@ -412,8 +412,8 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
       <Dialog open={props.open} onOpenChange={handleOpenChange}>
         <DialogContent
           className="
-            max-w-[92vw] max-h-[88vh] w-[1180px]
-            md:max-w-[92vw] md:w-[1180px]
+            max-w-(--size-dialog-max-vw) max-h-(--size-dialog-max-vh) w-(--size-dialog-xl)
+            md:max-w-(--size-dialog-max-vw) md:w-(--size-dialog-xl)
             flex flex-col gap-0 overflow-hidden p-0
           "
         >

--- a/packages/app-finance/src/pages/BudgetsPage.tsx
+++ b/packages/app-finance/src/pages/BudgetsPage.tsx
@@ -328,7 +328,7 @@ export function BudgetsPage() {
 
       {/* Add/Edit Dialog */}
       <Dialog open={isDialogOpen} onOpenChange={(open) => !isSubmitting && setIsDialogOpen(open)}>
-        <DialogContent className="sm:max-w-[425px]">
+        <DialogContent className="sm:max-w-(--size-dialog-sm)">
           <form onSubmit={form.handleSubmit(onSubmit)}>
             <DialogHeader>
               <DialogTitle>{editingBudget ? 'Edit Budget' : 'New Budget'}</DialogTitle>

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -387,7 +387,7 @@ export function EntitiesPage() {
 
       {/* Add/Edit Dialog */}
       <Dialog open={isDialogOpen} onOpenChange={(open) => !isSubmitting && setIsDialogOpen(open)}>
-        <DialogContent className="sm:max-w-[500px]">
+        <DialogContent className="sm:max-w-125">
           <form onSubmit={form.handleSubmit(onSubmit)}>
             <DialogHeader>
               <DialogTitle>{editingEntity ? 'Edit Entity' : 'New Entity'}</DialogTitle>

--- a/packages/app-finance/src/pages/WishlistPage.tsx
+++ b/packages/app-finance/src/pages/WishlistPage.tsx
@@ -236,7 +236,7 @@ export function WishlistPage() {
         }
         const percentage = Math.min(100, Math.round((saved / targetAmount) * 100));
         return (
-          <div className="flex items-center gap-2 min-w-[120px]">
+          <div className="flex items-center gap-2 min-w-30">
             <Progress value={percentage} className="h-2 flex-1" />
             <span className="text-xs font-medium tabular-nums w-10 text-right">{percentage}%</span>
           </div>
@@ -337,7 +337,7 @@ export function WishlistPage() {
 
       {/* Add/Edit Dialog */}
       <Dialog open={isDialogOpen} onOpenChange={(open) => !isSubmitting && setIsDialogOpen(open)}>
-        <DialogContent className="sm:max-w-[425px]">
+        <DialogContent className="sm:max-w-(--size-dialog-sm)">
           <form onSubmit={form.handleSubmit(onSubmit)}>
             <DialogHeader>
               <DialogTitle>{editingItem ? 'Edit Item' : 'New Wishlist Item'}</DialogTitle>

--- a/packages/app-inventory/src/components/ConnectionGraph.tsx
+++ b/packages/app-inventory/src/components/ConnectionGraph.tsx
@@ -385,7 +385,7 @@ export function ConnectionGraph({ itemId }: ConnectionGraphProps): React.ReactEl
   }, [draw, findNodeAt, itemId, navigate]);
 
   if (isLoading) {
-    return <Skeleton className="h-[400px] w-full rounded-lg" />;
+    return <Skeleton className="h-100 w-full rounded-lg" />;
   }
 
   if (error) {
@@ -401,7 +401,7 @@ export function ConnectionGraph({ itemId }: ConnectionGraphProps): React.ReactEl
   return (
     <div
       ref={containerRef}
-      className="relative h-[400px] w-full border rounded-lg bg-muted/20 overflow-hidden"
+      className="relative h-100 w-full border rounded-lg bg-muted/20 overflow-hidden"
     >
       <canvas ref={canvasRef} className="w-full h-full cursor-grab active:cursor-grabbing" />
       <div className="absolute bottom-2 right-2 text-xs text-muted-foreground">

--- a/packages/app-inventory/src/components/ConnectionTracePanel.tsx
+++ b/packages/app-inventory/src/components/ConnectionTracePanel.tsx
@@ -71,7 +71,7 @@ function TraceNodeRow({ node, depth, currentItemId }: TraceNodeRowProps) {
             </button>
           </CollapsibleTrigger>
         ) : (
-          <span className="w-[18px]" />
+          <span className="w-4.5" />
         )}
 
         <span className={`text-sm truncate ${isCurrent ? 'font-semibold' : 'font-medium'}`}>

--- a/packages/app-inventory/src/components/LocationPicker.tsx
+++ b/packages/app-inventory/src/components/LocationPicker.tsx
@@ -119,7 +119,7 @@ function TreeNode({
             )}
           </span>
         ) : (
-          <span className="w-[18px] shrink-0" />
+          <span className="w-4.5 shrink-0" />
         )}
         <span className="truncate">{node.name}</span>
       </button>
@@ -230,7 +230,7 @@ export function LocationPicker({
         </Button>
       </PopoverTrigger>
 
-      <PopoverContent className="w-[280px] p-0" align="start">
+      <PopoverContent className="w-70 p-0" align="start">
         {/* Search */}
         <div className="border-b px-3 py-2">
           <input
@@ -243,7 +243,7 @@ export function LocationPicker({
         </div>
 
         {/* Tree */}
-        <div className="max-h-[240px] overflow-y-auto p-1">
+        <div className="max-h-60 overflow-y-auto p-1">
           {locations.length === 0 ? (
             <p className="py-4 text-center text-sm text-muted-foreground">No locations found</p>
           ) : (

--- a/packages/app-inventory/src/pages/InsuranceReportPage.test.tsx
+++ b/packages/app-inventory/src/pages/InsuranceReportPage.test.tsx
@@ -224,7 +224,7 @@ describe('InsuranceReportPage', () => {
     renderPage();
     const img = screen.getByAltText('Photo of Television');
     expect(img).toBeInTheDocument();
-    expect(img.className).toContain('print:max-w-[200px]');
+    expect(img.className).toContain('print:max-w-50');
   });
 
   it('renders photo thumbnails with break-inside-avoid for print', () => {

--- a/packages/app-inventory/src/pages/InsuranceReportPage.tsx
+++ b/packages/app-inventory/src/pages/InsuranceReportPage.tsx
@@ -341,7 +341,7 @@ export function InsuranceReportPage(): React.ReactElement {
                           <img
                             src={`/inventory/photos/${item.photoPath}`}
                             alt={`Photo of ${item.itemName}`}
-                            className="w-8 h-8 rounded object-cover print:w-auto print:h-auto print:max-w-[200px] print:break-inside-avoid"
+                            className="w-8 h-8 rounded object-cover print:w-auto print:h-auto print:max-w-50 print:break-inside-avoid"
                           />
                         ) : (
                           <div

--- a/packages/app-inventory/src/pages/LocationTreePage.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.tsx
@@ -177,7 +177,7 @@ function InlineInput({
       onKeyDown={handleKeyDown}
       onBlur={onCancel}
       placeholder={placeholder}
-      className="text-sm font-medium bg-transparent border-b border-app-accent outline-none px-0.5 py-0 w-full max-w-[200px]"
+      className="text-sm font-medium bg-transparent border-b border-app-accent outline-none px-0.5 py-0 w-full max-w-50"
     />
   );
 }
@@ -393,7 +393,7 @@ function LocationNode({
               </button>
             </CollapsibleTrigger>
           ) : (
-            <span className="w-[22px]" />
+            <span className="w-5.5" />
           )}
 
           {hasChildren && open ? (
@@ -532,7 +532,7 @@ function LocationNode({
                       paddingLeft: `calc(${depth + 1} * var(--tree-indent-step) + var(--tree-indent-base))`,
                     }}
                   >
-                    <span className="w-[22px]" />
+                    <span className="w-5.5" />
                     <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
                     <InlineInput
                       onSave={onNewChildSave}
@@ -873,7 +873,7 @@ export function LocationTreePage() {
                   className="flex items-center gap-1.5 py-1.5 px-2"
                   style={{ paddingLeft: 'var(--tree-indent-base)' }}
                 >
-                  <span className="w-[22px]" />
+                  <span className="w-5.5" />
                   <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
                   <InlineInput
                     onSave={handleNewRootSave}

--- a/packages/app-media/src/components/TierListBoard.tsx
+++ b/packages/app-media/src/components/TierListBoard.tsx
@@ -302,7 +302,7 @@ function TierRow({
     <div
       ref={setNodeRef}
       aria-label={`Tier ${tier}`}
-      className={`flex items-stretch min-h-[80px] rounded-lg border transition-colors ${
+      className={`flex items-stretch min-h-20 rounded-lg border transition-colors ${
         TIER_COLORS[tier]
       } ${isOver ? 'ring-2 ring-primary' : ''}`}
     >
@@ -312,7 +312,7 @@ function TierRow({
         {tier}
       </div>
       <SortableContext items={movieIds.map(String)} strategy={horizontalListSortingStrategy}>
-        <div className="flex-1 flex items-center gap-2 p-2 min-h-[80px]">
+        <div className="flex-1 flex items-center gap-2 p-2 min-h-20">
           {movies.length === 0 && (
             <span className="text-muted-foreground text-sm px-2">Drop movies here</span>
           )}
@@ -405,7 +405,7 @@ function DraggableMovieCard({ movie }: { movie: TierMovie }) {
           <ImageOff className="h-3 w-3 text-muted-foreground" />
         </div>
       )}
-      <span className="text-xs font-medium truncate max-w-[100px]">{movie.title}</span>
+      <span className="text-xs font-medium truncate max-w-25">{movie.title}</span>
     </div>
   );
 }
@@ -425,7 +425,7 @@ function MovieCardOverlay({ movie }: { movie: TierMovie }) {
           <ImageOff className="h-3 w-3 text-muted-foreground" />
         </div>
       )}
-      <span className="text-xs font-medium truncate max-w-[100px]">{movie.title}</span>
+      <span className="text-xs font-medium truncate max-w-25">{movie.title}</span>
     </div>
   );
 }

--- a/packages/app-media/src/pages/CandidateQueuePage.tsx
+++ b/packages/app-media/src/pages/CandidateQueuePage.tsx
@@ -90,7 +90,7 @@ function CandidateCard({ candidate, actions = 'none' }: CandidateCardProps) {
 
   return (
     <div className="flex items-center gap-3 rounded-md border p-3">
-      <div className="h-[72px] w-[48px] shrink-0 overflow-hidden rounded bg-muted">
+      <div className="h-18 w-12 shrink-0 overflow-hidden rounded bg-muted">
         {candidate.posterPath ? (
           <img
             src={`${TMDB_IMG}${candidate.posterPath}`}
@@ -233,7 +233,7 @@ function CandidateList({ status, actions }: CandidateListProps) {
       {query.isLoading ? (
         <div className="space-y-2">
           {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton key={i} className="h-[88px] w-full rounded-md" />
+            <Skeleton key={i} className="h-22 w-full rounded-md" />
           ))}
         </div>
       ) : !query.data?.items.length ? (

--- a/packages/app-media/src/pages/plex-settings/PlexSyncHistory.tsx
+++ b/packages/app-media/src/pages/plex-settings/PlexSyncHistory.tsx
@@ -29,7 +29,7 @@ export function PlexSyncHistory({ syncLogs }: PlexSyncHistoryProps) {
             key={log.id}
             className="flex items-center gap-3 flex-wrap rounded-md border bg-muted/30 px-3 py-2 text-sm"
           >
-            <span className="text-muted-foreground min-w-[140px]">
+            <span className="text-muted-foreground min-w-35">
               {new Date(log.syncedAt).toLocaleString()}
             </span>
             <span className="text-emerald-400">{log.moviesSynced} movies</span>

--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -42,7 +42,7 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-xs" />
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-(--tooltip-arrow-offset) rotate-45 rounded-xs" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/packages/ui/src/theme/globals.css
+++ b/packages/ui/src/theme/globals.css
@@ -85,6 +85,7 @@
   --font-size-2xs--line-height: 0.75rem;
 
   /* Radius */
+  --radius-xs: 2px;
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -143,6 +144,15 @@
   --tree-indent-step: 1.25rem; /* 20px — main tree row indent per depth */
   --tree-indent-base: 0.5rem; /* 8px — base left padding at depth 0 */
   --tree-picker-step: 1rem; /* 16px — compact picker indent per depth */
+
+  /* Dialog sizing tokens — values without clean Tailwind scale equivalents */
+  --size-dialog-sm: 425px;
+  --size-dialog-xl: 1180px;
+  --size-dialog-max-vw: 92vw;
+  --size-dialog-max-vh: 88vh;
+
+  /* Tooltip arrow positioning */
+  --tooltip-arrow-offset: calc(-50% - 2px);
 
   /* Light mode - Clean, Warm, Efficient with subtle indigo tint */
   --background: oklch(


### PR DESCRIPTION
## Summary

Closes #1783. Implements the remaining work for PRD-002 US-03 — eliminates arbitrary Tailwind values across 15 component files.

- Replaces all px-based `w-[Npx]`, `h-[Npx]`, `min-w-[Npx]`, `max-w-[Npx]`, `max-h-[Npx]` with Tailwind numeric scale equivalents (e.g. `w-[280px]` → `w-70`, `h-[400px]` → `h-100`)
- Adds dialog sizing tokens to `globals.css` `:root` for values with no clean scale equivalent: `--size-dialog-sm` (425px), `--size-dialog-xl` (1180px), `--size-dialog-max-vw` (92vw), `--size-dialog-max-vh` (88vh)
- Adds `--tooltip-arrow-offset` token and replaces `translate-y-[calc(-50%_-_2px)]` in `tooltip.tsx`
- Adds `--radius-xs: 2px` to `@theme` for consistency with existing `rounded-xs` usage

**Files changed:**
- `packages/ui/src/theme/globals.css` — new size/radius tokens
- `packages/ui/src/primitives/tooltip.tsx` — `translate-y-[calc(-50%_-_2px)]` → token reference
- `packages/app-inventory/` — ConnectionGraph, ConnectionTracePanel, LocationPicker, LocationTreePage, InsuranceReportPage
- `packages/app-finance/` — WishlistPage, BudgetsPage, EntitiesPage, CorrectionProposalDialog, BrowseRulesSidebar
- `packages/app-media/` — CandidateQueuePage, TierListBoard, PlexSyncHistory
- `packages/app-ai/` — RulesBrowserPage

## Test plan

- [ ] All 15 turbo typecheck tasks pass (verified in pre-commit hook)
- [ ] Lint passes on all modified packages (verified)
- [ ] No visual regressions — all replaced values are pixel-exact equivalents on the Tailwind 4px spacing scale, or reference the new CSS custom property tokens

https://claude.ai/code/session_01QTbZi8m59xgjAd8Uj93JPB