### PR TITLE
drift-check(PRD03)

### DIFF
--- a/docs/themes/01-foundation/prds/003-components/README.md
+++ b/docs/themes/01-foundation/prds/003-components/README.md
@@ -193,4 +193,4 @@ Every US is only done when:
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/01-foundation/prds/003-components/us-04-data-display.md
+++ b/docs/themes/01-foundation/prds/003-components/us-04-data-display.md
@@ -9,16 +9,16 @@ As a developer, I want data display components (DataTable, filters, view toggle)
 
 ## Acceptance Criteria
 
-- [ ] DataTable — sortable columns, pagination, row selection, horizontal scroll on mobile
-- [ ] DataTableFilters — filter bar with column-specific filter inputs
-- [ ] InfiniteScrollTable — DataTable variant with scroll-based pagination
-- [ ] EditableCell — inline cell editing with save/cancel
+- [x] DataTable — sortable columns, pagination, row selection, horizontal scroll on mobile
+- [x] DataTableFilters — filter bar with column-specific filter inputs
+- [x] InfiniteScrollTable — DataTable variant with scroll-based pagination
+- [x] EditableCell — inline cell editing with save/cancel
 - [x] ViewToggleGroup — table/grid toggle, segmented button style, persists to localStorage
-- [ ] StatCard — metric display card with label, value, optional trend indicator
-- [ ] Each component has co-located `.stories.tsx`
-- [ ] All exported from barrel `index.ts`
-- [ ] All use design tokens — no arbitrary values or hardcoded colours
-- [ ] DataTable scrolls horizontally on viewports below 768px
+- [ ] StatCard — metric display card with label, value, optional trend indicator (missing trend indicator — #1791)
+- [ ] Each component has co-located `.stories.tsx` (EditableCell and StatCard missing stories — #1791)
+- [x] All exported from barrel `index.ts`
+- [ ] All use design tokens — no arbitrary values or hardcoded colours (StatCard uses arbitrary oklch values — #1792)
+- [x] DataTable scrolls horizontally on viewports below 768px
 - [ ] ViewToggleGroup rendered directly above the content it controls, not in page header
 
 ## Notes

--- a/docs/themes/01-foundation/prds/003-components/us-06-icon-standards.md
+++ b/docs/themes/01-foundation/prds/003-components/us-06-icon-standards.md
@@ -13,9 +13,9 @@ As a developer, I want all interactive actions across the platform to use the st
 - [x] All "edit" actions use `Pencil` icon (not `Edit2`, not `PenLine`)
 - [x] All "delete/remove" actions use `Trash2` icon (not `Trash`)
 - [x] All "close/dismiss" actions use `X` icon
-- [ ] No text-only action labels exist — every action has an icon (icon-only with `aria-label`, or icon + text)
+- [ ] No text-only action labels exist — every action has an icon (icon-only with `aria-label`, or icon + text) (gaps in ProcessingStep, SummaryStep, WarrantiesPage, QuickPickPage, TierListSummary — #1793)
 - [x] All icon-only buttons have `aria-label` for accessibility
-- [ ] All destructive actions use `variant="ghost"` with `text-destructive` styling
+- [ ] All destructive actions use `variant="ghost"` with `text-destructive` styling (9 buttons still use `variant="destructive"` — #1793)
 - [ ] Compact actions (table rows, list items) use icon-only buttons
 - [ ] Prominent actions (page CTAs, form buttons) use icon + text
 - [x] `grep` for banned icon names (`Edit2`, `Trash`, `PenLine`) returns zero hits


### PR DESCRIPTION
## Drift check: PRD-003 — Components

**Last checked:** 2026-04-17 (was: never)

### Summary

PRD-003 is **Partial**. 4 of 6 user stories are Done; 2 are Partial.

| US | Story | Status | Verified |
|----|-------|--------|---------|
| US-01 | @pops/ui package scaffold | Done | ✅ Package config, tsconfig, barrel export all present |
| US-02 | Primitive components (28) | Done | ✅ All shadcn/Radix primitives present with co-located stories |
| US-03 | Composite form inputs | Done | ✅ TextInput, NumberInput, DateTimeInput, CheckboxInput, RadioInput, ChipInput, Autocomplete, ComboboxSelect all present with stories |
| US-04 | Data display composites | Partial | ⚠️ DataTable, DataTableFilters, InfiniteScrollTable, EditableCell, ViewToggleGroup all implemented. Gaps: StatCard missing trend indicator, EditableCell/StatCard missing stories, StatCard uses arbitrary oklch values |
| US-05 | Utility composites | Done | ✅ Button wrapper, Chip, DropdownMenu wrapper, Select wrapper, ErrorBoundary, StatCard all present |
| US-06 | Icon standards | Partial | ⚠️ Icon vocabulary + aria-labels done. Remaining: text-only action buttons and `variant="destructive"` misuse |

### Gap issues opened

- #1791 — US-04: StatCard missing trend indicator and co-located stories (EditableCell, StatCard)
- #1792 — US-04: StatCard uses arbitrary oklch values instead of design tokens
- #1793 — US-06: Text-only action buttons and destructive variant misuse (9 files)

### Changes in this PR

- Checked off implemented criteria in `us-04-data-display.md` (DataTable, DataTableFilters, InfiniteScrollTable, EditableCell, exported barrel, horizontal scroll)
- Annotated remaining gaps in `us-04-data-display.md` and `us-06-icon-standards.md` with issue refs
- Bumped `last checked: never` → `last checked: 2026-04-17` in README

https://claude.ai/code/session_01LyLs2R1PGnXiHy9NdtDaC4