### PR TITLE
drift-check(PRD03)

### DIFF
--- a/docs/themes/01-foundation/prds/003-components/README.md
+++ b/docs/themes/01-foundation/prds/003-components/README.md
@@ -193,4 +193,4 @@ Every US is only done when:
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/01-foundation/prds/003-components/us-04-data-display.md
+++ b/docs/themes/01-foundation/prds/003-components/us-04-data-display.md
@@ -14,10 +14,10 @@ As a developer, I want data display components (DataTable, filters, view toggle)
 - [ ] InfiniteScrollTable — DataTable variant with scroll-based pagination
 - [ ] EditableCell — inline cell editing with save/cancel
 - [x] ViewToggleGroup — table/grid toggle, segmented button style, persists to localStorage
-- [ ] StatCard — metric display card with label, value, optional trend indicator
-- [ ] Each component has co-located `.stories.tsx`
+- [ ] StatCard — metric display card with label, value, optional trend indicator (trend prop missing — see #1791)
+- [ ] Each component has co-located `.stories.tsx` (missing: StatCard, EditableCell, DataTableFilters — see #1791, #1796)
 - [ ] All exported from barrel `index.ts`
-- [ ] All use design tokens — no arbitrary values or hardcoded colours
+- [ ] All use design tokens — no arbitrary values or hardcoded colours (StatCard uses hardcoded OKLCH — see #1792)
 - [ ] DataTable scrolls horizontally on viewports below 768px
 - [ ] ViewToggleGroup rendered directly above the content it controls, not in page header
 

--- a/docs/themes/01-foundation/prds/003-components/us-06-icon-standards.md
+++ b/docs/themes/01-foundation/prds/003-components/us-06-icon-standards.md
@@ -13,9 +13,9 @@ As a developer, I want all interactive actions across the platform to use the st
 - [x] All "edit" actions use `Pencil` icon (not `Edit2`, not `PenLine`)
 - [x] All "delete/remove" actions use `Trash2` icon (not `Trash`)
 - [x] All "close/dismiss" actions use `X` icon
-- [ ] No text-only action labels exist — every action has an icon (icon-only with `aria-label`, or icon + text)
+- [ ] No text-only action labels exist — every action has an icon (icon-only with `aria-label`, or icon + text) (see #1793)
 - [x] All icon-only buttons have `aria-label` for accessibility
-- [ ] All destructive actions use `variant="ghost"` with `text-destructive` styling
+- [ ] All destructive actions use `variant="ghost"` with `text-destructive` styling (see #1793)
 - [ ] Compact actions (table rows, list items) use icon-only buttons
 - [ ] Prominent actions (page CTAs, form buttons) use icon + text
 - [x] `grep` for banned icon names (`Edit2`, `Trash`, `PenLine`) returns zero hits


### PR DESCRIPTION
## Summary

Drift check for PRD-003 (Components). Status and last-checked field updated.

**PRD status: Partial** — confirmed, no change needed.

## What was checked

- US-01 package scaffold → **Done** ✅
- US-02 primitives → **Done** ✅
- US-03 form inputs → **Done** ✅
- US-04 data display → **Partial** — gaps confirmed, issue refs added
- US-05 utility components → **Done** ✅
- US-06 icon standards → **Partial** — gaps confirmed, issue refs added

## Gaps found (open issues linked)

| Gap | Issue |
|-----|-------|
| StatCard missing `trend` prop | #1791 |
| StatCard/EditableCell missing `.stories.tsx` | #1791 |
| StatCard uses hardcoded OKLCH values (not design tokens) | #1792 |
| DataTableFilters missing co-located `.stories.tsx` | #1796 (new) |
| Text-only action buttons without icons | #1793 |
| `variant="destructive"` misuse on inline actions | #1793 |

## Changes

- `docs/themes/01-foundation/prds/003-components/README.md` — bumped `last checked` to 2026-04-17
- `us-04-data-display.md` — annotated unchecked criteria with issue refs
- `us-06-icon-standards.md` — annotated unchecked criteria with issue refs

https://claude.ai/code/session_0121Bjfd9izYV5dF3Qwbf6g6