### PR TITLE
chore(ci): standardise ci:fix across workspaces and enforce in CI

### DIFF
--- a/.github/workflows/package-scripts-check.yml
+++ b/.github/workflows/package-scripts-check.yml
@@ -1,0 +1,28 @@
+name: Package Scripts Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/package.json"
+      - "pnpm-workspace.yaml"
+      - "scripts/check-package-scripts.mjs"
+      - ".github/workflows/package-scripts-check.yml"
+  pull_request:
+    paths:
+      - "**/package.json"
+      - "pnpm-workspace.yaml"
+      - "scripts/check-package-scripts.mjs"
+      - ".github/workflows/package-scripts-check.yml"
+
+jobs:
+  check:
+    name: Verify workspace package scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Ensure every workspace package exposes ci:fix / test / quality scripts
+        run: node scripts/check-package-scripts.mjs

--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -51,7 +51,8 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:all": "vitest run && vitest run --config vitest.integration.config.ts",
     "test:watch": "vitest",
-    "ci": "pnpm typecheck && pnpm lint && pnpm format:check && pnpm test && pnpm build"
+    "ci": "pnpm typecheck && pnpm lint && pnpm format:check && pnpm test && pnpm build",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",

--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -17,7 +17,8 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
-    "test:e2e:debug": "playwright test --debug"
+    "test:e2e:debug": "playwright test --debug",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "dependencies": {
     "@pops/api-client": "workspace:*",

--- a/apps/pops-storybook/.storybook/main.ts
+++ b/apps/pops-storybook/.storybook/main.ts
@@ -1,8 +1,8 @@
 import type { StorybookConfig } from '@storybook/react-vite';
-import { mergeConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { mergeConfig } from 'vite';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -13,7 +13,7 @@ const config: StorybookConfig = {
     '../../../packages/ui/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../../../packages/*/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
   ],
-  addons: ['@storybook/addon-essentials', '@storybook/addon-a11y', '@chromatic-com/storybook'],
+  addons: ['@storybook/addon-a11y', '@chromatic-com/storybook'],
   framework: {
     name: '@storybook/react-vite',
     options: {},

--- a/apps/pops-storybook/.storybook/preview.tsx
+++ b/apps/pops-storybook/.storybook/preview.tsx
@@ -1,5 +1,6 @@
+import '@pops/ui/theme';
+
 import type { Preview } from '@storybook/react-vite';
-import '@pops/ui/theme/globals.css';
 
 const APP_COLOURS = [
   { value: 'app-emerald', title: 'Emerald', left: '🟢' },

--- a/apps/pops-storybook/eslint.config.js
+++ b/apps/pops-storybook/eslint.config.js
@@ -1,0 +1,8 @@
+import storybook from "eslint-plugin-storybook";
+
+import { createBaseConfig } from "../../eslint.config.base.mjs";
+
+export default [
+  ...createBaseConfig({ react: true }),
+  ...storybook.configs["flat/recommended"],
+];

--- a/apps/pops-storybook/package.json
+++ b/apps/pops-storybook/package.json
@@ -5,7 +5,14 @@
   "type": "module",
   "scripts": {
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .storybook",
+    "lint:fix": "eslint .storybook --fix",
+    "format:check": "oxfmt -c ../../.oxfmtrc.json --check \".storybook/**/*.{ts,tsx}\"",
+    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \".storybook/**/*.{ts,tsx}\"",
+    "test": "echo \"(no tests in @pops/storybook)\"",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "dependencies": {
     "@pops/app-finance": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint:fix": "turbo lint:fix",
     "format:check": "turbo format:check",
     "format:fix": "turbo format:fix",
-    "ci:fix": "turbo run lint:fix && turbo run format:fix && turbo run typecheck lint format:check",
+    "ci:fix": "turbo run format:fix && turbo run lint:fix && turbo run typecheck format:check lint",
+    "check:package-scripts": "node scripts/check-package-scripts.mjs",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format:check": "oxfmt -c ../../.oxfmtrc.json --check \"src/**/*.ts\"",
-    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.ts\""
+    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.ts\"",
+    "test": "echo \"(no tests in @pops/api-client)\"",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "dependencies": {
     "@pops/api": "workspace:*",

--- a/packages/app-ai/package.json
+++ b/packages/app-ai/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "format:check": "oxfmt -c ../../.oxfmtrc.json --check \"src/**/*.{ts,tsx}\"",
-    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx}\""
+    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx}\"",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "dependencies": {
     "@pops/api-client": "workspace:*",

--- a/packages/app-finance/package.json
+++ b/packages/app-finance/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "format:check": "oxfmt -c ../../.oxfmtrc.json --check \"src/**/*.{ts,tsx}\"",
-    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx}\""
+    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx}\"",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/packages/app-inventory/package.json
+++ b/packages/app-inventory/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format:check": "oxfmt -c ../../.oxfmtrc.json --check \"src/**/*.{ts,tsx}\"",
-    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx}\""
+    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx}\"",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/packages/app-media/package.json
+++ b/packages/app-media/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format:check": "oxfmt -c ../../.oxfmtrc.json --check \"src/**/*.{ts,tsx}\"",
-    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx}\""
+    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx}\"",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/packages/db-types/package.json
+++ b/packages/db-types/package.json
@@ -22,7 +22,9 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format:check": "oxfmt -c ../../.oxfmtrc.json --check \"src/**/*.ts\"",
-    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.ts\""
+    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.ts\"",
+    "test": "echo \"(no tests in @pops/db-types)\"",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2"

--- a/packages/import-tools/package.json
+++ b/packages/import-tools/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "ci": "pnpm typecheck && pnpm lint && pnpm format:check && pnpm test",
-    "ci:fix": "pnpm lint:fix && pnpm format:fix && pnpm typecheck && pnpm lint && pnpm format:check",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint",
     "import:anz": "tsx src/import-anz.ts",
     "import:amex": "tsx src/import-amex.ts",
     "import:ing": "tsx src/import-ing.ts",

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -15,7 +15,8 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format:check": "oxfmt -c ../../.oxfmtrc.json --check \"src/**/*.{ts,tsx}\"",
-    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx}\""
+    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx}\"",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "dependencies": {
     "react": "^19.2.5",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,7 +18,9 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format:check": "oxfmt -c ../../.oxfmtrc.json --check \"src/**/*.ts\"",
-    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.ts\""
+    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.ts\"",
+    "test": "echo \"(no tests in @pops/types)\"",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "devDependencies": {
     "eslint": "^10.2.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,8 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format:check": "oxfmt -c ../../.oxfmtrc.json --check \"src/**/*.{ts,tsx,css}\"",
-    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx,css}\""
+    "format:fix": "oxfmt -c ../../.oxfmtrc.json --write \"src/**/*.{ts,tsx,css}\"",
+    "ci:fix": "pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm format:check && pnpm lint"
   },
   "dependencies": {
     "@fontsource-variable/plus-jakarta-sans": "^5.2.8",

--- a/scripts/check-package-scripts.mjs
+++ b/scripts/check-package-scripts.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * check-package-scripts.mjs
+ *
+ * Enforces that every workspace package exposes a consistent set of scripts
+ * so the monorepo's CI/quality tooling can rely on them uniformly.
+ *
+ * For each workspace package listed in `pnpm-workspace.yaml`, this script
+ * verifies the `package.json` declares:
+ *
+ *   - `typecheck`
+ *   - `lint` / `lint:fix`
+ *   - `format:check` / `format:fix`
+ *   - `test`
+ *   - `ci:fix`
+ *
+ * The `ci:fix` script must run — in order — format:fix, lint:fix, typecheck,
+ * format:check, lint. A package that legitimately has no tests can opt out by
+ * declaring a `test` that simply echoes a message (so `pnpm -r test` still
+ * succeeds). Fails the process with a non-zero exit code on any violation.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const REQUIRED_SCRIPTS = [
+  "typecheck",
+  "lint",
+  "lint:fix",
+  "format:check",
+  "format:fix",
+  "test",
+  "ci:fix",
+];
+
+/**
+ * ci:fix must execute the full quality sequence in this order:
+ *   format:fix → lint:fix → typecheck → format:check → lint
+ */
+const CI_FIX_REQUIRED_TOKENS = [
+  "format:fix",
+  "lint:fix",
+  "typecheck",
+  "format:check",
+  "lint",
+];
+
+/** Read `pnpm-workspace.yaml` and return the list of glob entries. */
+function readWorkspaceGlobs() {
+  const raw = readFileSync(join(REPO_ROOT, "pnpm-workspace.yaml"), "utf8");
+  const globs = [];
+  let inPackages = false;
+  for (const rawLine of raw.split("\n")) {
+    const line = rawLine.trimEnd();
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (inPackages) {
+      const match = line.match(/^\s*-\s*(?:"([^"]+)"|'([^']+)'|(\S+))\s*$/);
+      if (match) {
+        globs.push(match[1] ?? match[2] ?? match[3]);
+      } else if (/^\S/.test(line)) {
+        // Top-level key — end of `packages:` block
+        break;
+      }
+    }
+  }
+  return globs;
+}
+
+/** Expand a simple `apps/*`-style glob into concrete package directories. */
+async function expandGlob(glob) {
+  if (!glob.includes("*")) {
+    return [join(REPO_ROOT, glob)];
+  }
+  const starIdx = glob.indexOf("*");
+  const parent = glob.slice(0, starIdx).replace(/\/$/, "");
+  const parentAbs = join(REPO_ROOT, parent);
+  const entries = await readdir(parentAbs, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(parentAbs, entry.name));
+}
+
+/**
+ * Validate a single `package.json`. Returns an array of human-readable errors;
+ * an empty array means the package is compliant.
+ */
+function validatePackage(pkgJsonPath, pkg) {
+  const errors = [];
+  const scripts = pkg.scripts ?? {};
+
+  for (const name of REQUIRED_SCRIPTS) {
+    if (!scripts[name] || !scripts[name].trim()) {
+      errors.push(`missing script "${name}"`);
+    }
+  }
+
+  const ciFix = scripts["ci:fix"];
+  if (ciFix) {
+    // Match each required token with a word boundary so "lint" does not match
+    // the "lint" inside "lint:fix". Track the *first* occurrence of each
+    // token as its position for ordering checks.
+    const occurrences = CI_FIX_REQUIRED_TOKENS.map((token) => {
+      const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const re = new RegExp(`(?<![\\w:])${escaped}(?![\\w:])`);
+      const match = ciFix.match(re);
+      return { token, idx: match?.index ?? -1 };
+    });
+    for (const { token, idx } of occurrences) {
+      if (idx === -1) {
+        errors.push(`"ci:fix" is missing step "${token}" (got: ${ciFix})`);
+      }
+    }
+    const present = occurrences.filter((entry) => entry.idx !== -1);
+    for (let i = 1; i < present.length; i += 1) {
+      if (present[i].idx < present[i - 1].idx) {
+        errors.push(
+          `"ci:fix" runs "${present[i].token}" before "${present[i - 1].token}"; expected order: ${CI_FIX_REQUIRED_TOKENS.join(" → ")}`,
+        );
+        break;
+      }
+    }
+  }
+
+  return errors;
+}
+
+async function main() {
+  const globs = readWorkspaceGlobs();
+  if (globs.length === 0) {
+    console.error("No workspace entries found in pnpm-workspace.yaml");
+    process.exit(1);
+  }
+
+  const seen = new Set();
+  const packages = [];
+  for (const glob of globs) {
+    for (const dir of await expandGlob(glob)) {
+      if (seen.has(dir)) continue;
+      seen.add(dir);
+      // Only include directories that actually ship a package.json. A
+      // workspace glob like `apps/*` will match ancillary folders such as
+      // `apps/moltbot` (a Python-adjacent service with no Node manifest).
+      if (!existsSync(join(dir, "package.json"))) continue;
+      packages.push(dir);
+    }
+  }
+
+  const failures = [];
+  for (const dir of packages.sort()) {
+    const pkgJsonPath = join(dir, "package.json");
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+    } catch (err) {
+      failures.push({ dir, errors: [`cannot read package.json: ${err.message}`] });
+      continue;
+    }
+    const errors = validatePackage(pkgJsonPath, pkg);
+    if (errors.length > 0) {
+      failures.push({ dir, name: pkg.name, errors });
+    }
+  }
+
+  if (failures.length === 0) {
+    console.log(`All ${packages.length} workspace packages expose the required scripts.`);
+    return;
+  }
+
+  console.error(
+    `\nPackage-script check failed for ${failures.length} package(s):\n`,
+  );
+  for (const failure of failures) {
+    const label = failure.name ?? failure.dir;
+    console.error(`  ✖ ${label} (${failure.dir})`);
+    for (const err of failure.errors) {
+      console.error(`      - ${err}`);
+    }
+  }
+  console.error(
+    "\nEvery workspace package must declare: " +
+      REQUIRED_SCRIPTS.map((s) => `"${s}"`).join(", ") +
+      ".\n`ci:fix` must run: " +
+      CI_FIX_REQUIRED_TOKENS.join(" → ") +
+      ".\n",
+  );
+  process.exit(1);
+}
+
+await main();

--- a/scripts/check-package-scripts.mjs
+++ b/scripts/check-package-scripts.mjs
@@ -48,25 +48,39 @@ const CI_FIX_REQUIRED_TOKENS = [
   "lint",
 ];
 
-/** Read `pnpm-workspace.yaml` and return the list of glob entries. */
+/**
+ * Strip an unquoted `# comment` tail from a YAML line. Does not attempt to
+ * handle `#` characters that appear inside quoted strings, which is fine for
+ * our usage (workspace globs never contain `#`).
+ */
+function stripYamlComment(line) {
+  const hashIdx = line.indexOf("#");
+  return hashIdx === -1 ? line : line.slice(0, hashIdx);
+}
+
+/**
+ * Read `pnpm-workspace.yaml` and return the list of glob entries under the
+ * top-level `packages:` key. Intentionally avoids a YAML dependency — the file
+ * shape is simple and stable — but handles comments and blank lines robustly.
+ */
 function readWorkspaceGlobs() {
   const raw = readFileSync(join(REPO_ROOT, "pnpm-workspace.yaml"), "utf8");
   const globs = [];
   let inPackages = false;
   for (const rawLine of raw.split("\n")) {
-    const line = rawLine.trimEnd();
+    const line = stripYamlComment(rawLine).trimEnd();
+    if (line.trim() === "") continue;
     if (/^packages:\s*$/.test(line)) {
       inPackages = true;
       continue;
     }
-    if (inPackages) {
-      const match = line.match(/^\s*-\s*(?:"([^"]+)"|'([^']+)'|(\S+))\s*$/);
-      if (match) {
-        globs.push(match[1] ?? match[2] ?? match[3]);
-      } else if (/^\S/.test(line)) {
-        // Top-level key — end of `packages:` block
-        break;
-      }
+    if (!inPackages) continue;
+    const match = line.match(/^\s*-\s*(?:"([^"]+)"|'([^']+)'|(\S+))\s*$/);
+    if (match) {
+      globs.push(match[1] ?? match[2] ?? match[3]);
+    } else if (/^\S/.test(line)) {
+      // Top-level key — end of `packages:` block.
+      break;
     }
   }
   return globs;
@@ -80,7 +94,20 @@ async function expandGlob(glob) {
   const starIdx = glob.indexOf("*");
   const parent = glob.slice(0, starIdx).replace(/\/$/, "");
   const parentAbs = join(REPO_ROOT, parent);
-  const entries = await readdir(parentAbs, { withFileTypes: true });
+  let entries;
+  try {
+    entries = await readdir(parentAbs, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      throw new Error(
+        `Workspace glob "${glob}" points at missing directory "${parent}" — ` +
+          `update pnpm-workspace.yaml or create the directory.`,
+      );
+    }
+    throw new Error(
+      `Failed to read workspace glob "${glob}" at "${parent}": ${err.message}`,
+    );
+  }
   return entries
     .filter((entry) => entry.isDirectory())
     .map((entry) => join(parentAbs, entry.name));


### PR DESCRIPTION
## Summary

- Adds a consistent **`ci:fix`** script to every workspace package — runs `format:fix` → `lint:fix` → `typecheck` → `format:check` → `lint`.
- Ensures every workspace package exposes `typecheck`, `lint`, `lint:fix`, `format:check`, `format:fix`, `test`, and `ci:fix`. Packages without real tests (`api-client`, `db-types`, `types`, `storybook`) get a no-op `test` so `pnpm -r test` succeeds everywhere.
- New **`scripts/check-package-scripts.mjs`** guard + **`.github/workflows/package-scripts-check.yml`** enforce the above on every PR, so future packages can't be merged without the full quality surface.
- Fixes two pre-existing issues surfaced while making ci:fix green in `pops-storybook`: drops the missing `@storybook/addon-essentials` entry (not installed in this workspace) and switches the preview CSS side-effect import to the declared `@pops/ui/theme` export so typecheck passes.
- Normalises the existing `@pops/tools` (`import-tools`) `ci:fix` to the same step order.

## Test plan

- [x] `pnpm run check:package-scripts` — all 13 workspace packages pass
- [x] `pnpm run ci:fix` — 42/42 turbo tasks succeed (0 errors)
- [x] `pnpm test` — all 17 test tasks succeed (9 real suites pass, 4 no-op stubs acknowledge absence)
- [ ] CI: `Package Scripts Check` workflow runs green on this PR
- [ ] CI: existing quality workflows stay green