### PR TITLE
ci: always run package-scripts-check on PRs

### DIFF
--- a/.github/workflows/package-scripts-check.yml
+++ b/.github/workflows/package-scripts-check.yml
@@ -3,17 +3,7 @@ name: Package Scripts Check
 on:
   push:
     branches: [main]
-    paths:
-      - "**/package.json"
-      - "pnpm-workspace.yaml"
-      - "scripts/check-package-scripts.mjs"
-      - ".github/workflows/package-scripts-check.yml"
   pull_request:
-    paths:
-      - "**/package.json"
-      - "pnpm-workspace.yaml"
-      - "scripts/check-package-scripts.mjs"
-      - ".github/workflows/package-scripts-check.yml"
 
 jobs:
   check:


### PR DESCRIPTION
## Summary
- Remove `paths` filter from `package-scripts-check.yml` so the workflow always runs on PRs
- The check is a required status check in the branch ruleset, but the paths filter prevented it from reporting a status on PRs that don't touch `package.json` files, causing PRs to show as BLOCKED

## Test plan
- [ ] Verify "Verify workspace package scripts" check appears and passes on this PR
- [ ] Verify existing PRs (#1800, #1802) pick up the check after this merges