### PR TITLE
feat(ui): add EditableCell.stories.tsx co-located stories

### DIFF
--- a/docs/themes/01-foundation/prds/003-components/us-04-data-display.md
+++ b/docs/themes/01-foundation/prds/003-components/us-04-data-display.md
@@ -15,7 +15,9 @@ As a developer, I want data display components (DataTable, filters, view toggle)
 - [x] EditableCell — inline cell editing with save/cancel
 - [x] ViewToggleGroup — table/grid toggle, segmented button style, persists to localStorage
 - [ ] StatCard — metric display card with label, value, optional trend indicator (missing trend prop + arbitrary OKLCH values → #1795)
-- [ ] Each component has co-located `.stories.tsx` (DataTableFilters ✓, EditableCell → #1794, StatCard → #1795)
+- [x] DataTableFilters has co-located `.stories.tsx`
+- [x] EditableCell has co-located `.stories.tsx`
+- [ ] StatCard has co-located `.stories.tsx` (→ #1795)
 - [x] All exported from barrel `index.ts`
 - [ ] All use design tokens — no arbitrary values or hardcoded colours (StatCard uses arbitrary OKLCH → #1795)
 - [x] DataTable scrolls horizontally on viewports below 768px

--- a/packages/ui/src/components/EditableCell.stories.tsx
+++ b/packages/ui/src/components/EditableCell.stories.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+
+import { EditableCell } from './EditableCell';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof EditableCell> = {
+  title: 'Data Display/EditableCell',
+  component: EditableCell,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Wrapper to hold stateful value for interactive stories
+function EditableCellWrapper(props: React.ComponentProps<typeof EditableCell>) {
+  const [value, setValue] = useState(props.value);
+  return (
+    <div className="w-64">
+      <EditableCell
+        {...props}
+        value={value}
+        onSave={(v) => {
+          setValue(v as never);
+          return Promise.resolve();
+        }}
+      />
+    </div>
+  );
+}
+
+export const DisplayMode: Story = {
+  render: () => (
+    <div className="w-64">
+      <EditableCell value="Click to edit" onSave={() => {}} />
+    </div>
+  ),
+};
+
+export const TextEdit: Story = {
+  render: () => <EditableCellWrapper value="Editable text" type="text" onSave={() => {}} />,
+};
+
+export const NumberEdit: Story = {
+  render: () => <EditableCellWrapper value={42} type="number" onSave={() => {}} />,
+};
+
+export const DateEdit: Story = {
+  render: () => (
+    <EditableCellWrapper
+      value="2024-06-15"
+      type="date"
+      onSave={() => {}}
+      placeholder="YYYY-MM-DD"
+    />
+  ),
+};
+
+export const SelectEdit: Story = {
+  render: () => (
+    <EditableCellWrapper
+      value="active"
+      type="select"
+      options={[
+        { label: 'Active', value: 'active' },
+        { label: 'Inactive', value: 'inactive' },
+        { label: 'Pending', value: 'pending' },
+      ]}
+      onSave={() => {}}
+    />
+  ),
+};
+
+export const ValidationError: Story = {
+  render: () => (
+    <div className="w-64">
+      <EditableCell
+        value=""
+        type="text"
+        placeholder="Required field"
+        validate={(v) => (String(v).trim().length > 0 ? true : 'Value is required')}
+        onSave={() => {}}
+      />
+    </div>
+  ),
+};
+
+export const SavingState: Story = {
+  render: () => (
+    <div className="w-64">
+      <EditableCell
+        value="Slow save"
+        type="text"
+        onSave={() => new Promise((resolve) => setTimeout(resolve, 3000))}
+      />
+    </div>
+  ),
+};
+
+export const ReadOnly: Story = {
+  render: () => (
+    <div className="w-64">
+      <EditableCell value="Read-only value" editable={false} onSave={() => {}} />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/EditableCell.stories.tsx
+++ b/packages/ui/src/components/EditableCell.stories.tsx
@@ -16,8 +16,9 @@ const meta: Meta<typeof EditableCell> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// Wrapper to hold stateful value for interactive stories
-function EditableCellWrapper(props: React.ComponentProps<typeof EditableCell>) {
+type WrapperProps = Omit<React.ComponentProps<typeof EditableCell>, 'onSave'>;
+
+function EditableCellWrapper(props: WrapperProps) {
   const [value, setValue] = useState(props.value);
   return (
     <div className="w-64">
@@ -25,7 +26,7 @@ function EditableCellWrapper(props: React.ComponentProps<typeof EditableCell>) {
         {...props}
         value={value}
         onSave={(v) => {
-          setValue(v as never);
+          setValue(v);
           return Promise.resolve();
         }}
       />
@@ -42,22 +43,15 @@ export const DisplayMode: Story = {
 };
 
 export const TextEdit: Story = {
-  render: () => <EditableCellWrapper value="Editable text" type="text" onSave={() => {}} />,
+  render: () => <EditableCellWrapper value="Editable text" type="text" />,
 };
 
 export const NumberEdit: Story = {
-  render: () => <EditableCellWrapper value={42} type="number" onSave={() => {}} />,
+  render: () => <EditableCellWrapper value={42} type="number" />,
 };
 
 export const DateEdit: Story = {
-  render: () => (
-    <EditableCellWrapper
-      value="2024-06-15"
-      type="date"
-      onSave={() => {}}
-      placeholder="YYYY-MM-DD"
-    />
-  ),
+  render: () => <EditableCellWrapper value="2024-06-15" type="date" placeholder="YYYY-MM-DD" />,
 };
 
 export const SelectEdit: Story = {
@@ -70,7 +64,6 @@ export const SelectEdit: Story = {
         { label: 'Inactive', value: 'inactive' },
         { label: 'Pending', value: 'pending' },
       ]}
-      onSave={() => {}}
     />
   ),
 };


### PR DESCRIPTION
## Summary

- Adds `EditableCell.stories.tsx` co-located with the component (closes #1794)
- Stories cover all scenarios from US-04 acceptance criteria
- Updates `us-04-data-display.md` to split the co-located stories criterion and mark EditableCell done

## Stories added

| Story | Scenario |
|-------|----------|
| `DisplayMode` | Cell in display mode (hover shows pencil icon) |
| `TextEdit` | Text field type — interactive edit/save/cancel |
| `NumberEdit` | Number field type |
| `DateEdit` | Date field type |
| `SelectEdit` | Select dropdown with options |
| `ValidationError` | Required field validation with inline error message |
| `SavingState` | 3s async save — shows disabled inputs during save |
| `ReadOnly` | `editable={false}` — no pencil, no click-to-edit |

## Test plan

- [ ] `pnpm lint` passes (0 errors)
- [ ] `pnpm typecheck` passes across all packages
- [ ] Storybook renders all 8 stories under `Data Display/EditableCell`
- [ ] Clicking a cell in display mode enters edit mode
- [ ] Enter saves, Escape cancels
- [ ] Validation error story shows inline error on save attempt
- [ ] Read-only story shows no hover/pencil and is not clickable

https://claude.ai/code/session_01DsKaAWD7qPcJd48q3qomTa