### PR TITLE
drift-check(PRD05)

### DIFF
--- a/docs/themes/01-foundation/prds/005-shell/README.md
+++ b/docs/themes/01-foundation/prds/005-shell/README.md
@@ -38,19 +38,19 @@ Each app package exports routes and a nav config. The shell imports and mounts t
 
 ```typescript
 // App package exports (e.g., @pops/app-finance/src/index.ts)
-export { routes } from "./routes";
-export { navConfig } from "./routes";
+export { routes } from './routes';
+export { navConfig } from './routes';
 
 // navConfig shape
 export const navConfig: AppNavConfig = {
-  id: "finance",
-  label: "Finance",
-  icon: "DollarSign", // Lucide icon name
-  color: "emerald", // App accent colour
-  basePath: "/finance",
+  id: 'finance',
+  label: 'Finance',
+  icon: 'DollarSign', // Lucide icon name
+  color: 'emerald', // App accent colour
+  basePath: '/finance',
   items: [
-    { path: "", label: "Dashboard", icon: "LayoutDashboard" },
-    { path: "/transactions", label: "Transactions", icon: "CreditCard" },
+    { path: '', label: 'Dashboard', icon: 'LayoutDashboard' },
+    { path: '/transactions', label: 'Transactions', icon: 'CreditCard' },
     // ...
   ],
 };
@@ -60,8 +60,8 @@ The shell lazily loads each app:
 
 ```typescript
 // apps/pops-shell/src/app/router.tsx
-const financeRoutes = lazy(() => import("@pops/app-finance"));
-const mediaRoutes = lazy(() => import("@pops/app-media"));
+const financeRoutes = lazy(() => import('@pops/app-finance'));
+const mediaRoutes = lazy(() => import('@pops/app-media'));
 ```
 
 Adding a new app means: create a workspace package, export routes + navConfig, register in the shell router. No shell code changes beyond the registration.

--- a/docs/themes/01-foundation/prds/005-shell/README.md
+++ b/docs/themes/01-foundation/prds/005-shell/README.md
@@ -38,19 +38,19 @@ Each app package exports routes and a nav config. The shell imports and mounts t
 
 ```typescript
 // App package exports (e.g., @pops/app-finance/src/index.ts)
-export { routes } from './routes';
-export { navConfig } from './routes';
+export { routes } from "./routes";
+export { navConfig } from "./routes";
 
 // navConfig shape
 export const navConfig: AppNavConfig = {
-  id: 'finance',
-  label: 'Finance',
-  icon: 'DollarSign', // Lucide icon name
-  color: 'emerald', // App accent colour
-  basePath: '/finance',
+  id: "finance",
+  label: "Finance",
+  icon: "DollarSign", // Lucide icon name
+  color: "emerald", // App accent colour
+  basePath: "/finance",
   items: [
-    { path: '', label: 'Dashboard', icon: 'LayoutDashboard' },
-    { path: '/transactions', label: 'Transactions', icon: 'CreditCard' },
+    { path: "", label: "Dashboard", icon: "LayoutDashboard" },
+    { path: "/transactions", label: "Transactions", icon: "CreditCard" },
     // ...
   ],
 };
@@ -60,8 +60,8 @@ The shell lazily loads each app:
 
 ```typescript
 // apps/pops-shell/src/app/router.tsx
-const financeRoutes = lazy(() => import('@pops/app-finance'));
-const mediaRoutes = lazy(() => import('@pops/app-media'));
+const financeRoutes = lazy(() => import("@pops/app-finance"));
+const mediaRoutes = lazy(() => import("@pops/app-media"));
 ```
 
 Adding a new app means: create a workspace package, export routes + navConfig, register in the shell router. No shell code changes beyond the registration.
@@ -186,13 +186,13 @@ The key rule: app packages depend on `@pops/ui` and shared packages, never on ot
 
 ## User Stories
 
-| #   | Story                                           | Summary                                                                                                | Status  | Parallelisable   |
-| --- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------- | ---------------- |
-| 01  | [us-01-shell-scaffold](us-01-shell-scaffold.md) | Create pops-shell with entry point, Vite config, provider stack                                        | Done    | No (first)       |
-| 02  | [us-02-layout](us-02-layout.md)                 | Build RootLayout, TopBar with fixed positioning, content area with independent scroll                  | Done    | Blocked by us-01 |
-| 03  | [us-03-routing](us-03-routing.md)               | Build router with lazy-loaded app registration, namespaced routes, error handling, NotFoundPage        | Done    | Blocked by us-01 |
+| #   | Story                                           | Summary                                                                                                | Status                                           | Parallelisable   |
+| --- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ---------------- |
+| 01  | [us-01-shell-scaffold](us-01-shell-scaffold.md) | Create pops-shell with entry point, Vite config, provider stack                                        | Done                                             | No (first)       |
+| 02  | [us-02-layout](us-02-layout.md)                 | Build RootLayout, TopBar with fixed positioning, content area with independent scroll                  | Done                                             | Blocked by us-01 |
+| 03  | [us-03-routing](us-03-routing.md)               | Build router with lazy-loaded app registration, namespaced routes, error handling, NotFoundPage        | Done                                             | Blocked by us-01 |
 | 04  | [us-04-breadcrumbs](us-04-breadcrumbs.md)       | Build page-level navigation pattern: back button + breadcrumbs for drill-down pages, mobile truncation | Partial — PageHeader adoption incomplete (#1810) | Blocked by us-02 |
-| 05  | [us-05-trpc-access](us-05-trpc-access.md)       | Set up tRPC client in shell and establish the import pattern for app packages                          | Done    | Blocked by us-01 |
+| 05  | [us-05-trpc-access](us-05-trpc-access.md)       | Set up tRPC client in shell and establish the import pattern for app packages                          | Done                                             | Blocked by us-01 |
 
 US-02 and US-03 can parallelise after US-01. US-04 depends on layout. US-05 can parallelise with US-02/US-03.
 

--- a/docs/themes/01-foundation/prds/005-shell/README.md
+++ b/docs/themes/01-foundation/prds/005-shell/README.md
@@ -191,7 +191,7 @@ The key rule: app packages depend on `@pops/ui` and shared packages, never on ot
 | 01  | [us-01-shell-scaffold](us-01-shell-scaffold.md) | Create pops-shell with entry point, Vite config, provider stack                                        | Done    | No (first)       |
 | 02  | [us-02-layout](us-02-layout.md)                 | Build RootLayout, TopBar with fixed positioning, content area with independent scroll                  | Done    | Blocked by us-01 |
 | 03  | [us-03-routing](us-03-routing.md)               | Build router with lazy-loaded app registration, namespaced routes, error handling, NotFoundPage        | Done    | Blocked by us-01 |
-| 04  | [us-04-breadcrumbs](us-04-breadcrumbs.md)       | Build page-level navigation pattern: back button + breadcrumbs for drill-down pages, mobile truncation | Partial | Blocked by us-02 |
+| 04  | [us-04-breadcrumbs](us-04-breadcrumbs.md)       | Build page-level navigation pattern: back button + breadcrumbs for drill-down pages, mobile truncation | Partial — PageHeader adoption incomplete (#1810) | Blocked by us-02 |
 | 05  | [us-05-trpc-access](us-05-trpc-access.md)       | Set up tRPC client in shell and establish the import pattern for app packages                          | Done    | Blocked by us-01 |
 
 US-02 and US-03 can parallelise after US-01. US-04 depends on layout. US-05 can parallelise with US-02/US-03.
@@ -217,4 +217,4 @@ Every US is only done when:
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
+++ b/docs/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
@@ -30,9 +30,7 @@ Standard page header pattern:
   <Link to={parentPath}>
     <ArrowLeft className="h-5 w-5" />
   </Link>
-  <Breadcrumb
-    items={[{ label: "Library", href: "/media" }, { label: movie.title }]}
-  />
+  <Breadcrumb items={[{ label: 'Library', href: '/media' }, { label: movie.title }]} />
 </div>
 ```
 

--- a/docs/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
+++ b/docs/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
@@ -19,7 +19,7 @@ As a developer, I want a standard page header pattern with back button and bread
 - [x] On mobile, middle breadcrumb segments collapse to `…` — first and last always visible
 - [x] Top-level pages (sidebar-accessible) show neither back button nor breadcrumbs
 - [x] Back navigation is never placed at the bottom of the page
-- [ ] All drill-down pages across all apps use the shared PageHeader pattern — no inline h1 styling
+- [ ] All drill-down pages across all apps use the shared PageHeader pattern — no inline h1 styling (#1810)
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
+++ b/docs/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
@@ -30,7 +30,9 @@ Standard page header pattern:
   <Link to={parentPath}>
     <ArrowLeft className="h-5 w-5" />
   </Link>
-  <Breadcrumb items={[{ label: 'Library', href: '/media' }, { label: movie.title }]} />
+  <Breadcrumb
+    items={[{ label: "Library", href: "/media" }, { label: movie.title }]}
+  />
 </div>
 ```
 


### PR DESCRIPTION
## Drift check: PRD-005 — Shell

**Last checked:** 2026-04-17 (was: never)

### Summary

PRD-005 is **Partial**. 4 of 5 user stories are Done; 1 is Partial.

| US | Story | Status | Verified |
|----|-------|--------|---------|
| US-01 | Shell scaffold | Done | ✅ `package.json`, `vite.config.ts`, `index.html`, `main.tsx`, `App.tsx` all present; provider stack (tRPC, React Query, Toaster, TooltipProvider) confirmed |
| US-02 | Shell layout | Done | ✅ `RootLayout.tsx`, `TopBar.tsx` exist; TopBar fixed with `fixed top-0 w-full z-40`; content area scrolls independently |
| US-03 | Router / lazy-loaded app registration | Done | ✅ `createBrowserRouter`, namespaced routes (`/finance/*`, `/media/*`, `/inventory/*`, `/ai/*`), Suspense wrappers, `NotFoundPage`, `errorElement` all present |
| US-04 | Page-level navigation (back button + breadcrumbs) | Partial | ⚠️ `PageHeader` component exists in `@pops/ui` and is used by several pages — but 7 drill-down pages still render inline `ArrowLeft + <h1>` instead |
| US-05 | tRPC client + app package access pattern | Done | ✅ `lib/trpc.ts` re-exports from `@pops/api-client`; provider in `App.tsx`; ReactQueryDevtools present; no circular deps |

### Gap issue opened

- #1810 — US-04: PageHeader adoption incomplete — 7 drill-down pages still use inline ArrowLeft + h1 (`PlexSettingsPage`, `RotationSettingsPage`, `ArrSettingsPage`, `DebriefPage`, `CandidateQueuePage`, `RotationLogPage`, `ModelConfigPage`)

### Changes in this PR

- Bumped `last checked: never` → `last checked: 2026-04-17` in `docs/themes/01-foundation/prds/005-shell/README.md`
- Annotated US-04 status in PRD table with gap description and issue ref (#1810)
- Annotated unchecked criterion in `us-04-breadcrumbs.md` with issue ref (#1810)

https://claude.ai/code/session_01KhcQhCncEPrt15SUzcK7ZW