### PR TITLE
feat: adopt shared PageHeader in 7 drill-down pages (PRD-005 US-04)

### DIFF
--- a/docs/themes/01-foundation/prds/005-shell/README.md
+++ b/docs/themes/01-foundation/prds/005-shell/README.md
@@ -1,7 +1,7 @@
 # PRD-005: Shell
 
 > Epic: [02 — Shell & App Switcher](../../epics/02-shell-app-switcher.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -191,7 +191,7 @@ The key rule: app packages depend on `@pops/ui` and shared packages, never on ot
 | 01  | [us-01-shell-scaffold](us-01-shell-scaffold.md) | Create pops-shell with entry point, Vite config, provider stack                                        | Done                                             | No (first)       |
 | 02  | [us-02-layout](us-02-layout.md)                 | Build RootLayout, TopBar with fixed positioning, content area with independent scroll                  | Done                                             | Blocked by us-01 |
 | 03  | [us-03-routing](us-03-routing.md)               | Build router with lazy-loaded app registration, namespaced routes, error handling, NotFoundPage        | Done                                             | Blocked by us-01 |
-| 04  | [us-04-breadcrumbs](us-04-breadcrumbs.md)       | Build page-level navigation pattern: back button + breadcrumbs for drill-down pages, mobile truncation | Partial — PageHeader adoption incomplete (#1810) | Blocked by us-02 |
+| 04  | [us-04-breadcrumbs](us-04-breadcrumbs.md)       | Build page-level navigation pattern: back button + breadcrumbs for drill-down pages, mobile truncation | Done                                             | Blocked by us-02 |
 | 05  | [us-05-trpc-access](us-05-trpc-access.md)       | Set up tRPC client in shell and establish the import pattern for app packages                          | Done                                             | Blocked by us-01 |
 
 US-02 and US-03 can parallelise after US-01. US-04 depends on layout. US-05 can parallelise with US-02/US-03.

--- a/docs/themes/01-foundation/prds/005-shell/README.md
+++ b/docs/themes/01-foundation/prds/005-shell/README.md
@@ -186,13 +186,13 @@ The key rule: app packages depend on `@pops/ui` and shared packages, never on ot
 
 ## User Stories
 
-| #   | Story                                           | Summary                                                                                                | Status                                           | Parallelisable   |
-| --- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ---------------- |
-| 01  | [us-01-shell-scaffold](us-01-shell-scaffold.md) | Create pops-shell with entry point, Vite config, provider stack                                        | Done                                             | No (first)       |
-| 02  | [us-02-layout](us-02-layout.md)                 | Build RootLayout, TopBar with fixed positioning, content area with independent scroll                  | Done                                             | Blocked by us-01 |
-| 03  | [us-03-routing](us-03-routing.md)               | Build router with lazy-loaded app registration, namespaced routes, error handling, NotFoundPage        | Done                                             | Blocked by us-01 |
-| 04  | [us-04-breadcrumbs](us-04-breadcrumbs.md)       | Build page-level navigation pattern: back button + breadcrumbs for drill-down pages, mobile truncation | Done                                             | Blocked by us-02 |
-| 05  | [us-05-trpc-access](us-05-trpc-access.md)       | Set up tRPC client in shell and establish the import pattern for app packages                          | Done                                             | Blocked by us-01 |
+| #   | Story                                           | Summary                                                                                                | Status | Parallelisable   |
+| --- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------ | ---------------- |
+| 01  | [us-01-shell-scaffold](us-01-shell-scaffold.md) | Create pops-shell with entry point, Vite config, provider stack                                        | Done   | No (first)       |
+| 02  | [us-02-layout](us-02-layout.md)                 | Build RootLayout, TopBar with fixed positioning, content area with independent scroll                  | Done   | Blocked by us-01 |
+| 03  | [us-03-routing](us-03-routing.md)               | Build router with lazy-loaded app registration, namespaced routes, error handling, NotFoundPage        | Done   | Blocked by us-01 |
+| 04  | [us-04-breadcrumbs](us-04-breadcrumbs.md)       | Build page-level navigation pattern: back button + breadcrumbs for drill-down pages, mobile truncation | Done   | Blocked by us-02 |
+| 05  | [us-05-trpc-access](us-05-trpc-access.md)       | Set up tRPC client in shell and establish the import pattern for app packages                          | Done   | Blocked by us-01 |
 
 US-02 and US-03 can parallelise after US-01. US-04 depends on layout. US-05 can parallelise with US-02/US-03.
 

--- a/docs/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
+++ b/docs/themes/01-foundation/prds/005-shell/us-04-breadcrumbs.md
@@ -1,7 +1,7 @@
 # US-04: Build page-level navigation (back button + breadcrumbs)
 
 > PRD: [005 — Shell](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -19,7 +19,7 @@ As a developer, I want a standard page header pattern with back button and bread
 - [x] On mobile, middle breadcrumb segments collapse to `…` — first and last always visible
 - [x] Top-level pages (sidebar-accessible) show neither back button nor breadcrumbs
 - [x] Back navigation is never placed at the bottom of the page
-- [ ] All drill-down pages across all apps use the shared PageHeader pattern — no inline h1 styling (#1810)
+- [x] All drill-down pages across all apps use the shared PageHeader pattern — no inline h1 styling (#1810)
 
 ## Notes
 

--- a/packages/app-ai/src/pages/ModelConfigPage.test.tsx
+++ b/packages/app-ai/src/pages/ModelConfigPage.test.tsx
@@ -88,7 +88,7 @@ describe('ModelConfigPage', () => {
   it('renders the page heading and form fields', () => {
     setupDefaults();
     renderPage();
-    expect(screen.getByText('Model Configuration')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Model Configuration' })).toBeInTheDocument();
     expect(screen.getByText('AI Model')).toBeInTheDocument();
     expect(screen.getByText('Monthly Token Budget')).toBeInTheDocument();
     expect(screen.getByText('When Budget Exceeded')).toBeInTheDocument();
@@ -98,7 +98,7 @@ describe('ModelConfigPage', () => {
   it('shows loading skeleton while settings load', () => {
     setupDefaults({ loading: true });
     renderPage();
-    expect(screen.getByText('Model Configuration')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Model Configuration' })).toBeInTheDocument();
     // Form fields should not be rendered during loading
     expect(screen.queryByText('AI Model')).not.toBeInTheDocument();
   });

--- a/packages/app-ai/src/pages/ModelConfigPage.tsx
+++ b/packages/app-ai/src/pages/ModelConfigPage.tsx
@@ -1,4 +1,3 @@
-import { ArrowLeft } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import { toast } from 'sonner';
@@ -10,21 +9,7 @@ import { toast } from 'sonner';
  * and fallback behaviour when budget is exceeded. PRD-053/US-01.
  */
 import { SETTINGS_KEYS } from '@pops/types';
-import {
-  Alert,
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-  Button,
-  Input,
-  Label,
-  Select,
-  Skeleton,
-  StatCard,
-} from '@pops/ui';
+import { Alert, Button, Input, Label, PageHeader, Select, Skeleton, StatCard } from '@pops/ui';
 
 import { trpc } from '../lib/trpc';
 
@@ -115,34 +100,13 @@ export function ModelConfigPage() {
   const budgetUsedPct = budgetNum > 0 ? Math.min((currentMonthTokens / budgetNum) * 100, 100) : 0;
 
   const navigation = (
-    <>
-      <Breadcrumb>
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/ai">AI</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>Model Config</BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
-
-      <div className="flex items-center gap-3">
-        <Link
-          to="/ai"
-          className="inline-flex items-center justify-center h-8 w-8 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
-          aria-label="Back to AI"
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </Link>
-        <h1 className="text-2xl font-bold tracking-tight">Model Configuration</h1>
-      </div>
-
-      <p className="text-sm text-muted-foreground">Configure AI model and spending limits</p>
-    </>
+    <PageHeader
+      title="Model Configuration"
+      description="Configure AI model and spending limits"
+      backHref="/ai"
+      breadcrumbs={[{ label: 'AI', href: '/ai' }, { label: 'Model Configuration' }]}
+      renderLink={Link}
+    />
   );
 
   if (isLoading) {

--- a/packages/app-media/src/pages/ArrSettingsPage.tsx
+++ b/packages/app-media/src/pages/ArrSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Film, RefreshCw, Save, Tv } from 'lucide-react';
+import { Film, RefreshCw, Save, Tv } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import { toast } from 'sonner';
@@ -9,18 +9,7 @@ import { toast } from 'sonner';
  * Allows users to configure Radarr and Sonarr URLs and API keys
  * via the settings table (replacing env-var-only configuration).
  */
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-  Button,
-  Input,
-  Label,
-  Skeleton,
-} from '@pops/ui';
+import { Button, Input, Label, PageHeader, Skeleton } from '@pops/ui';
 
 import { ConnectionBadge } from '../components/ConnectionBadge';
 import { trpc } from '../lib/trpc';
@@ -185,32 +174,12 @@ export function ArrSettingsPage() {
 
   return (
     <div className="space-y-6 max-w-4xl mx-auto p-6">
-      {/* Breadcrumb */}
-      <Breadcrumb>
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/media">Media</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>Arr Settings</BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
-
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <Link
-          to="/media"
-          className="inline-flex items-center justify-center h-8 w-8 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
-          aria-label="Back to Media"
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </Link>
-        <h1 className="text-2xl font-bold tracking-tight">Radarr & Sonarr Settings</h1>
-      </div>
+      <PageHeader
+        title="Radarr & Sonarr Settings"
+        backHref="/media"
+        breadcrumbs={[{ label: 'Media', href: '/media' }, { label: 'Arr Settings' }]}
+        renderLink={Link}
+      />
 
       <p className="text-sm text-muted-foreground">
         Configure your Radarr and Sonarr connections to see download status badges on movie and TV

--- a/packages/app-media/src/pages/CandidateQueuePage.tsx
+++ b/packages/app-media/src/pages/CandidateQueuePage.tsx
@@ -1,12 +1,4 @@
-import {
-  ArrowLeft,
-  Ban,
-  ChevronLeft,
-  ChevronRight,
-  Download,
-  RotateCcw,
-  Search,
-} from 'lucide-react';
+import { Ban, ChevronLeft, ChevronRight, Download, RotateCcw, Search } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
@@ -19,6 +11,7 @@ import { toast } from 'sonner';
 import {
   Badge,
   Button,
+  PageHeader,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -398,17 +391,17 @@ export function CandidateQueuePage() {
 
   return (
     <div className="space-y-6 p-6">
-      <div className="flex items-center gap-3">
-        <Link to="/media/rotation">
-          <Button variant="ghost" size="sm">
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-        </Link>
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Candidate Queue</h1>
-          <p className="text-sm text-muted-foreground">Browse and manage rotation candidates</p>
-        </div>
-      </div>
+      <PageHeader
+        title="Candidate Queue"
+        description="Browse and manage rotation candidates"
+        backHref="/media/rotation"
+        breadcrumbs={[
+          { label: 'Media', href: '/media' },
+          { label: 'Rotation', href: '/media/rotation' },
+          { label: 'Candidate Queue' },
+        ]}
+        renderLink={Link}
+      />
 
       <Tabs
         value={tab}

--- a/packages/app-media/src/pages/DebriefPage.test.tsx
+++ b/packages/app-media/src/pages/DebriefPage.test.tsx
@@ -151,9 +151,9 @@ describe('DebriefPage', () => {
     });
     renderWithMovie('42');
 
+    expect(screen.getByRole('heading', { name: 'Inception', level: 1 })).toBeInTheDocument();
     const header = screen.getByTestId('debrief-header');
     expect(header).toBeInTheDocument();
-    expect(header.querySelector('h1')).toHaveTextContent('Inception');
     expect(header.querySelector('img')).toHaveAttribute('alt', 'Inception poster');
   });
 

--- a/packages/app-media/src/pages/DebriefPage.tsx
+++ b/packages/app-media/src/pages/DebriefPage.tsx
@@ -1,12 +1,4 @@
-import {
-  ArrowLeft,
-  CheckCircle,
-  ChevronDown,
-  ChevronUp,
-  Circle,
-  ImageOff,
-  Minus,
-} from 'lucide-react';
+import { CheckCircle, ChevronDown, ChevronUp, Circle, ImageOff, Minus } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';
 import { toast } from 'sonner';
@@ -21,7 +13,15 @@ import { toast } from 'sonner';
  * and recordDebriefComparison mutation. Advances through pending
  * dimensions; shows CompletionSummary when all are done.
  */
-import { Badge, Button, Skeleton, Tooltip, TooltipContent, TooltipTrigger } from '@pops/ui';
+import {
+  Badge,
+  Button,
+  PageHeader,
+  Skeleton,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@pops/ui';
 
 import { DebriefActionBar } from '../components/DebriefControls';
 import { trpc } from '../lib/trpc';
@@ -168,14 +168,16 @@ export function DebriefPage() {
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6">
-      {/* Back link */}
-      <Link
-        to="/media/history"
-        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm"
-      >
-        <ArrowLeft className="h-4 w-4" />
-        Back to history
-      </Link>
+      <PageHeader
+        title={debrief.movie.title}
+        backHref="/media/history"
+        breadcrumbs={[
+          { label: 'Media', href: '/media' },
+          { label: 'History', href: '/media/history' },
+          { label: debrief.movie.title },
+        ]}
+        renderLink={Link}
+      />
 
       {/* ── Poster header ── */}
       <div className="flex items-center gap-4" data-testid="debrief-header">
@@ -185,7 +187,6 @@ export function DebriefPage() {
           className="h-36 w-24 shrink-0 rounded-md object-cover"
         />
         <div>
-          <h1 className="text-2xl font-bold">{debrief.movie.title}</h1>
           <p className="text-muted-foreground text-sm">
             Debrief —{' '}
             {allComplete

--- a/packages/app-media/src/pages/PlexSettingsPage.tsx
+++ b/packages/app-media/src/pages/PlexSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, RefreshCw, Save, Server } from 'lucide-react';
+import { RefreshCw, Save, Server } from 'lucide-react';
 import { Link } from 'react-router';
 
 /**
@@ -7,18 +7,7 @@ import { Link } from 'react-router';
  * Shows connection health, available libraries, and sync buttons
  * for importing movies and TV shows from Plex into the local library.
  */
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-  Button,
-  Input,
-  Label,
-  Skeleton,
-} from '@pops/ui';
+import { Button, Input, Label, PageHeader, Skeleton } from '@pops/ui';
 
 import { ConnectionBadge } from '../components/ConnectionBadge';
 import { DiscoverSyncResultDisplay } from './plex-settings/components/DiscoverSyncResultDisplay';
@@ -58,47 +47,29 @@ export function PlexSettingsPage() {
 
   return (
     <div className="space-y-6 max-w-4xl mx-auto p-6">
-      {/* Breadcrumb */}
-      <Breadcrumb>
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/media">Media</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>Plex Settings</BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
-
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <Link
-          to="/media"
-          className="inline-flex items-center justify-center h-8 w-8 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
-          aria-label="Back to Media"
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </Link>
-        <h1 className="text-2xl font-bold tracking-tight">Plex Settings</h1>
-        {settings.status?.configured && <ConnectionBadge connected={settings.connected} />}
-
-        <div className="flex-1" />
-        {settings.status?.hasToken && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              mutations.disconnect.mutate();
-            }}
-            disabled={mutations.disconnect.isPending}
-          >
-            Disconnect
-          </Button>
-        )}
-      </div>
+      <PageHeader
+        title="Plex Settings"
+        backHref="/media"
+        breadcrumbs={[{ label: 'Media', href: '/media' }, { label: 'Plex Settings' }]}
+        renderLink={Link}
+        actions={
+          <>
+            {settings.status?.configured && <ConnectionBadge connected={settings.connected} />}
+            {settings.status?.hasToken && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  mutations.disconnect.mutate();
+                }}
+                disabled={mutations.disconnect.isPending}
+              >
+                Disconnect
+              </Button>
+            )}
+          </>
+        }
+      />
 
       <p className="text-sm text-muted-foreground">
         Connect your Plex Media Server to sync your movie and TV libraries, track watch history, and

--- a/packages/app-media/src/pages/RotationLogPage.tsx
+++ b/packages/app-media/src/pages/RotationLogPage.tsx
@@ -1,6 +1,5 @@
 import {
   AlertTriangle,
-  ArrowLeft,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
@@ -18,18 +17,13 @@ import { Link } from 'react-router';
  * PRD-072 US-06
  */
 import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
   Button,
   Card,
   CardContent,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  PageHeader,
   Skeleton,
 } from '@pops/ui';
 
@@ -73,39 +67,17 @@ export function RotationLogPage() {
 
   return (
     <div className="space-y-6 max-w-4xl mx-auto p-6">
-      {/* Breadcrumb */}
-      <Breadcrumb>
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/media">Media</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/media/rotation">Rotation</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>Log</BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
-
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <Link
-          to="/media/rotation"
-          className="inline-flex items-center justify-center h-8 w-8 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
-          aria-label="Back to Rotation Settings"
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </Link>
-        <ScrollText className="h-6 w-6 text-muted-foreground" />
-        <h1 className="text-2xl font-bold tracking-tight">Rotation Log</h1>
-      </div>
+      <PageHeader
+        title="Rotation Log"
+        icon={<ScrollText className="h-6 w-6 text-muted-foreground" />}
+        backHref="/media/rotation"
+        breadcrumbs={[
+          { label: 'Media', href: '/media' },
+          { label: 'Rotation', href: '/media/rotation' },
+          { label: 'Log' },
+        ]}
+        renderLink={Link}
+      />
 
       {/* Summary stats */}
       {statsLoading ? (

--- a/packages/app-media/src/pages/RotationSettingsPage.tsx
+++ b/packages/app-media/src/pages/RotationSettingsPage.tsx
@@ -139,7 +139,7 @@ export function RotationSettingsPage() {
       <PageHeader
         title="Rotation Settings"
         backHref="/media"
-        breadcrumbs={[{ label: 'Media', href: '/media' }, { label: 'Rotation Settings' }]}
+        breadcrumbs={[{ label: 'Media', href: '/media' }, { label: 'Rotation' }]}
         renderLink={Link}
       />
 

--- a/packages/app-media/src/pages/RotationSettingsPage.tsx
+++ b/packages/app-media/src/pages/RotationSettingsPage.tsx
@@ -1,13 +1,4 @@
-import {
-  AlertTriangle,
-  ArrowLeft,
-  Clock,
-  HardDrive,
-  Play,
-  RefreshCw,
-  Save,
-  ScrollText,
-} from 'lucide-react';
+import { AlertTriangle, Clock, HardDrive, Play, RefreshCw, Save, ScrollText } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import { toast } from 'sonner';
@@ -17,20 +8,7 @@ import { toast } from 'sonner';
  *
  * PRD-072 US-02
  */
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-  Button,
-  Label,
-  NumberInput,
-  Select,
-  Skeleton,
-  Switch,
-} from '@pops/ui';
+import { Button, Label, NumberInput, PageHeader, Select, Skeleton, Switch } from '@pops/ui';
 
 import { SourceManagementSection } from '../components/SourceManagementSection';
 import { trpc } from '../lib/trpc';
@@ -158,32 +136,12 @@ export function RotationSettingsPage() {
 
   return (
     <div className="space-y-6 max-w-4xl mx-auto p-6">
-      {/* Breadcrumb */}
-      <Breadcrumb>
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/media">Media</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>Rotation Settings</BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
-
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <Link
-          to="/media"
-          className="inline-flex items-center justify-center h-8 w-8 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
-          aria-label="Back to Media"
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </Link>
-        <h1 className="text-2xl font-bold tracking-tight">Rotation Settings</h1>
-      </div>
+      <PageHeader
+        title="Rotation Settings"
+        backHref="/media"
+        breadcrumbs={[{ label: 'Media', href: '/media' }, { label: 'Rotation Settings' }]}
+        renderLink={Link}
+      />
 
       <p className="text-sm text-muted-foreground">
         Configure how the library rotation system manages disk space by automatically cycling movies


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #1810 — completes PRD-005 US-04 (all drill-down pages use the shared `PageHeader` pattern).

- Replace inline `ArrowLeft` + `<h1>` header pattern with `<PageHeader>` in 7 pages:
  - `PlexSettingsPage` — actions (ConnectionBadge + Disconnect) moved to `actions` prop
  - `RotationSettingsPage`
  - `ArrSettingsPage`
  - `DebriefPage` — back link replaced; redundant poster-area `<h1>` removed
  - `CandidateQueuePage` — description moved to `description` prop
  - `RotationLogPage` — `ScrollText` icon moved to `icon` prop
  - `ModelConfigPage` — `navigation` fragment replaced with single `<PageHeader>`
- Remove per-page `Breadcrumb*` primitive imports (now encapsulated in PageHeader)
- Mark US-04 and PRD-005 as Done in docs

## Test plan

- [ ] `ci:fix` passes (lint, format, typecheck all green — verified locally, 16/16 tasks)
- [ ] Each page shows back button + breadcrumb trail using the shared PageHeader style
- [ ] PlexSettingsPage actions (ConnectionBadge, Disconnect button) still visible in header actions area
- [ ] DebriefPage still shows poster + debrief status text (h1 removed, p tag remains)
- [ ] CandidateQueuePage shows description text via PageHeader description prop

https://claude.ai/code/session_01X3v8BrByzPYFEv8vTEHHin
EOF
)