### PR TITLE
drift-check(PRD06)

### DIFF
--- a/docs/themes/01-foundation/prds/006-app-switcher/README.md
+++ b/docs/themes/01-foundation/prds/006-app-switcher/README.md
@@ -114,4 +114,4 @@ With only one app registered, the switcher should not feel empty:
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17


### PR DESCRIPTION
## Summary

Drift check of **PRD-006 (App Switcher)** against the current implementation.

- PRD and US statuses were already correctly marked **Partial** in docs — no status changes needed
- Bumped `last checked: never` → `last checked: 2026-04-17`
- Created 3 GitHub issues for confirmed gaps

## What's done (verified ✓)

| US | Story | Status |
|----|-------|--------|
| US-02 | App rail | Done — all criteria confirmed in `AppRail.tsx` |
| US-04 | Layout integration | Done — `RootLayout.tsx` wires everything correctly |

## Gaps found

| Issue | US | Gap |
|-------|----|-----|
| #1813 | US-01 | Icon names in navConfig typed as `string` — missing entries fail silently (no TS error, no runtime warning; AppRail shows first letter, PageNav renders nothing) |
| #1814 | US-03 | Tablet PageNav overlay has a navigation-effect race condition — `setPageNavOpen(true)` in AppRail is immediately overridden by `setPageNavOpen(false)` in RootLayout's `useEffect` on `location.pathname` |
| #1815 | US-03 | `PageNav.tsx` uses `text-[10px]` and `tracking-[0.15em]` — arbitrary values instead of design tokens |

## Files changed

- `docs/themes/01-foundation/prds/006-app-switcher/README.md` — bump `last checked`

https://claude.ai/code/session_01SeQLgPFMd2FuPDQzgdBwSx