### PR TITLE
drift-check(PRD28..PRD35) [media]

### DIFF
--- a/docs/themes/03-media/prds/028-media-data-model-api/README.md
+++ b/docs/themes/03-media/prds/028-media-data-model-api/README.md
@@ -278,4 +278,4 @@ US-01 and US-02 can run in parallel (independent tables). US-03 needs US-01. US-
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/03-media/prds/029-tmdb-client/README.md
+++ b/docs/themes/03-media/prds/029-tmdb-client/README.md
@@ -101,4 +101,4 @@ US-01 and US-02 can run in parallel. US-03 composes them into the add-to-library
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/03-media/prds/030-thetvdb-client/README.md
+++ b/docs/themes/03-media/prds/030-thetvdb-client/README.md
@@ -115,4 +115,4 @@ US-01 and US-02 can run in parallel. US-03 composes them into the add-to-library
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/03-media/prds/031-library-page/README.md
+++ b/docs/themes/03-media/prds/031-library-page/README.md
@@ -94,4 +94,4 @@ US-02 depends on US-01 (needs MediaCard). US-03 can be built in parallel with US
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/03-media/prds/032-search-page/README.md
+++ b/docs/themes/03-media/prds/032-search-page/README.md
@@ -105,4 +105,4 @@ US-02 depends on US-01 (needs search state). US-03 depends on US-02 (needs resul
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/03-media/prds/033-movie-detail-page/README.md
+++ b/docs/themes/03-media/prds/033-movie-detail-page/README.md
@@ -132,4 +132,4 @@ US-01 builds the page shell. US-02, US-03, and US-04 are independent components 
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/03-media/prds/033-movie-detail-page/us-03-mark-as-watched.md
+++ b/docs/themes/03-media/prds/033-movie-detail-page/us-03-mark-as-watched.md
@@ -15,10 +15,10 @@ As a user, I want to mark a movie as watched and have the option to undo so that
 - [x] On success: a toast notification appears with "Marked as watched" and an "Undo" action button
 - [x] The undo toast is visible for 5 seconds before auto-dismissing
 - [x] Clicking "Undo" within the toast window calls `media.watchHistory.delete` to remove the watch event
-- [ ] If the movie was on the watchlist before marking as watched, the server-side auto-removal takes effect; undo re-adds it to the watchlist — undo only deletes the watch event; does not re-add to watchlist. `logWatch` does not return whether watchlist removal occurred.
+- [x] If the movie was on the watchlist before marking as watched, the server-side auto-removal takes effect; undo re-adds it to the watchlist (`logWatch` returns `watchlistRemoved: boolean` so the client knows whether to re-add)
 - [x] After a successful watch log, the watch history section on the page refreshes to include the new entry
 - [x] The button remains usable after logging a watch (a movie can be watched multiple times — each click logs a new event)
-- [ ] Tests cover: API call with correct payload, success toast with undo action, undo deletes the watch event, button re-enabled after logging, watch history refresh after log
+- [x] Tests cover: API call with correct payload, success toast with undo action, undo deletes the watch event, undo re-adds to watchlist when `watchlistRemoved=true`, button re-enabled after logging, watch history refresh after log
 
 ## Notes
 

--- a/docs/themes/03-media/prds/033-movie-detail-page/us-03-mark-as-watched.md
+++ b/docs/themes/03-media/prds/033-movie-detail-page/us-03-mark-as-watched.md
@@ -15,7 +15,7 @@ As a user, I want to mark a movie as watched and have the option to undo so that
 - [x] On success: a toast notification appears with "Marked as watched" and an "Undo" action button
 - [x] The undo toast is visible for 5 seconds before auto-dismissing
 - [x] Clicking "Undo" within the toast window calls `media.watchHistory.delete` to remove the watch event
-- [x] If the movie was on the watchlist before marking as watched, the server-side auto-removal takes effect; undo re-adds it to the watchlist (`logWatch` returns `watchlistRemoved: boolean` so the client knows whether to re-add)
+- [x] If the movie was on the watchlist before marking as watched, the server-side auto-removal takes effect; undo re-adds it to the watchlist (`media.watchHistory.log` returns `watchlistRemoved: boolean` so the client knows whether to re-add)
 - [x] After a successful watch log, the watch history section on the page refreshes to include the new entry
 - [x] The button remains usable after logging a watch (a movie can be watched multiple times — each click logs a new event)
 - [x] Tests cover: API call with correct payload, success toast with undo action, undo deletes the watch event, undo re-adds to watchlist when `watchlistRemoved=true`, button re-enabled after logging, watch history refresh after log

--- a/docs/themes/03-media/prds/034-tv-show-detail-page/README.md
+++ b/docs/themes/03-media/prds/034-tv-show-detail-page/README.md
@@ -149,4 +149,4 @@ US-02 depends on US-01 (needs the page shell). US-03 and US-04 are independent c
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/03-media/prds/035-watch-history/README.md
+++ b/docs/themes/03-media/prds/035-watch-history/README.md
@@ -95,4 +95,4 @@ US-02 depends on US-01 (needs the history list to add episode-specific rendering
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17


### PR DESCRIPTION
## Summary

- Drift check for media PRDs 028-035 against codebase as of 2026-04-17
- All 8 PRDs verified Done; all user stories confirmed implemented
- PRD-033 US-03: two stale `[ ]` criteria corrected to `[x]` — the undo-watchlist-re-add feature and its tests were already in place; the criteria text incorrectly said the feature was missing

## PRD status after check

| PRD | Title | Status |
|-----|-------|--------|
| 028 | Media Data Model & API | Done — all 4 US verified |
| 029 | TMDB Client | Done — all 3 US verified |
| 030 | TheTVDB Client | Done — all 3 US verified |
| 031 | Library Page | Done — all 3 US verified |
| 032 | Search Page | Done — all 3 US verified |
| 033 | Movie Detail Page | Done — US-03 criteria corrected to [x] |
| 034 | TV Show Detail Page | Done — all 4 US verified |
| 035 | Watch History | Done — all 3 US verified |

## No new GH issues created

No gaps found — all implementation verified present in `packages/app-media` and `apps/pops-api/src/modules/media`.