### PR TITLE
drift-check(PRD08..PRD11)

### DIFF
--- a/docs/themes/01-foundation/prds/008-api-server/README.md
+++ b/docs/themes/01-foundation/prds/008-api-server/README.md
@@ -167,4 +167,4 @@ US-02 and US-03 can parallelise after US-01. US-04 depends on US-02. US-05 can p
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/01-foundation/prds/009-db-schema-patterns/README.md
+++ b/docs/themes/01-foundation/prds/009-db-schema-patterns/README.md
@@ -164,4 +164,4 @@ US-02, US-03, US-04 can parallelise after US-01. US-05 depends on tables existin
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/01-foundation/prds/010-responsive-foundation/README.md
+++ b/docs/themes/01-foundation/prds/010-responsive-foundation/README.md
@@ -103,7 +103,7 @@ Per Apple HIG and WCAG:
 | #   | Story                                               | Summary                                                                                              | Status      | Parallelisable |
 | --- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------- | -------------- |
 | 01  | [us-01-mobile-shell](us-01-mobile-shell.md)         | Shell layout works on mobile: compact TopBar, mobile nav pattern, full-width content                 | Done        | No (first)     |
-| 02  | [us-02-component-audit](us-02-component-audit.md)   | All @pops/ui components render without overflow at 375px: DataTable, forms, dialogs, filters         | Partial     | Yes            |
+| 02  | [us-02-component-audit](us-02-component-audit.md)   | All @pops/ui components render without overflow at 375px: DataTable, forms, dialogs, filters         | Done        | Yes            |
 | 03  | [us-03-touch-targets](us-03-touch-targets.md)       | All interactive elements meet 44x44px minimum with 8px spacing                                       | Not started | Yes            |
 | 04  | [us-04-page-conventions](us-04-page-conventions.md) | Page width, padding, empty state, error state, and title icon conventions established and documented | Done        | Yes            |
 
@@ -129,4 +129,4 @@ US-02, US-03, US-04 can parallelise after US-01.
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17

--- a/docs/themes/01-foundation/prds/010-responsive-foundation/us-02-component-audit.md
+++ b/docs/themes/01-foundation/prds/010-responsive-foundation/us-02-component-audit.md
@@ -1,7 +1,7 @@
 # US-02: Responsive component audit
 
 > PRD: [010 — Responsive Foundation](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -10,12 +10,12 @@ As a user on a small screen, I want tables, forms, and dialogs to be usable so t
 ## Acceptance Criteria
 
 - [x] DataTable: horizontal scroll on mobile, no content clipped
-- [ ] DataTableFilters: collapsed behind "Filters" button on mobile, opens as sheet/drawer — toggle button exists but opens inline grid, not a sheet/drawer
-- [ ] Forms: labels stacked above inputs, inputs full-width, min height 44px — labels stacked ✅, full-width ✅, but default height is 40px (h-10), not 44px
+- [x] DataTableFilters: collapsed behind "Filters" button on mobile, opens as sheet/drawer — mobile "Filters" button opens a Dialog overlay with apply/clear actions
+- [x] Forms: labels stacked above inputs, inputs full-width, min height 44px — labels stacked ✅, full-width ✅, default height h-11 (44px) ✅
 - [x] Dialogs: full-screen on mobile (<768px), slide up from bottom if feasible
 - [x] Autocomplete/Combobox: dropdown positioned correctly, not viewport-clipped
-- [ ] ChipInput: chips wrap to multiple lines, remove buttons touch-friendly — wraps ✅, but remove buttons are 32px (below 44px touch target)
-- [ ] All components verified at 375px — no overflow, no clipping — filter selects have fixed widths (w-45, min-w-50) that may overflow 375px
+- [x] ChipInput: chips wrap to multiple lines, remove buttons touch-friendly — wraps ✅, remove buttons min-w-11 min-h-11 (44px) ✅
+- [x] All components verified at 375px — no overflow, no clipping — filter selects use w-full on mobile, sm: prefix scopes fixed widths to ≥640px
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/011-drizzle-orm/README.md
+++ b/docs/themes/01-foundation/prds/011-drizzle-orm/README.md
@@ -92,4 +92,4 @@ US-03, US-04, US-05 can parallelise after US-02. US-06 can parallelise with US-0
 
 ## Drift Check
 
-last checked: never
+last checked: 2026-04-17


### PR DESCRIPTION
## Summary

Drift check for foundation PRDs 008-011. Bumps last checked to 2026-04-17, marks gaps.

- **PRD-008 (API Server):** All USs verified Done. Code confirms Express+tRPC setup, module pattern, middleware stack, router composition, and webhook routes are all present and correct.
- **PRD-009 (DB Schema Patterns):** All USs verified Done. Migration runner, entity types, schema registry, settings table, and seeder all confirmed in code.
- **PRD-010 (Responsive Foundation):** Partial. US-02 marked Done — DataTableFilters now uses mobile dialog overlay, inputs are h-11 (44px), ChipInput remove buttons are min-w-11 min-h-11, filter selects are w-full on mobile. US-03 (touch targets) remains Not started — Button sm size is h-9 (36px) and table action buttons use h-8/h-9. Issue #1838 opened for US-03 gap.
- **PRD-011 (Drizzle ORM):** All USs verified Done. Drizzle ORM installed, schema files in packages/db-types/src/schema/, drizzle-kit migrations, mise tasks all present.

## Test plan

- [ ] Verify last checked dates bumped on all 4 PRD READMEs
- [ ] Verify US-02 in PRD-010 is marked Done with all criteria checked
- [ ] Verify US-03 in PRD-010 remains Not started (correct gap)
- [ ] Issue #1838 covers the touch target gap