### PR TITLE
fix(finance): rename autoSaveRuleAndReEvaluate to openRuleProposalDialog

### DIFF
--- a/packages/app-finance/src/components/imports/ReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.tsx
@@ -57,7 +57,7 @@ export function ReviewStep() {
     browseOpen,
     setBrowseOpen,
     generateProposal,
-    autoSaveRuleAndReEvaluate,
+    openRuleProposalDialog,
   } = useProposalGeneration();
 
   const handleBulkEntitySelect = useCallback(
@@ -181,7 +181,7 @@ export function ReviewStep() {
   } = useBulkAssignment({
     setLocalTransactions,
     handleEntitySelect,
-    autoSaveRuleAndReEvaluate,
+    openRuleProposalDialog,
     generateProposal,
   });
 

--- a/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
+++ b/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
@@ -23,7 +23,7 @@ interface UseBulkAssignmentArgs {
     entityId: string,
     entityName: string
   ) => void;
-  autoSaveRuleAndReEvaluate: (
+  openRuleProposalDialog: (
     triggeringTransaction: ProcessedTransaction,
     entityId: string,
     entityName: string
@@ -44,7 +44,7 @@ interface UseBulkAssignmentArgs {
 export function useBulkAssignment({
   setLocalTransactions,
   handleEntitySelect,
-  autoSaveRuleAndReEvaluate,
+  openRuleProposalDialog,
   generateProposal,
 }: UseBulkAssignmentArgs) {
   const [showCreateDialog, setShowCreateDialog] = useState(false);
@@ -97,9 +97,9 @@ export function useBulkAssignment({
       // Always accept the transaction itself
       handleEntitySelect(transaction, entityId, entityName);
 
-      autoSaveRuleAndReEvaluate(transaction, entityId, entityName);
+      openRuleProposalDialog(transaction, entityId, entityName);
     },
-    [handleEntitySelect, entities, handleCreateEntity, autoSaveRuleAndReEvaluate]
+    [handleEntitySelect, entities, handleCreateEntity, openRuleProposalDialog]
   );
 
   /**
@@ -160,9 +160,9 @@ export function useBulkAssignment({
           `Accepted ${transactions.length} transaction${transactions.length !== 1 ? 's' : ''}`
         );
 
-        // Auto-save correction rule using the first transaction and re-evaluate
+        // Open the rule proposal dialog using the first transaction and re-evaluate
         if (firstTx) {
-          autoSaveRuleAndReEvaluate(firstTx, resolvedEntityId, entityName);
+          openRuleProposalDialog(firstTx, resolvedEntityId, entityName);
         }
       } catch (error) {
         toast.error(
@@ -174,7 +174,7 @@ export function useBulkAssignment({
       entities,
       addPendingEntity,
       dbEntitiesData?.data,
-      autoSaveRuleAndReEvaluate,
+      openRuleProposalDialog,
       setLocalTransactions,
     ]
   );

--- a/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
+++ b/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
@@ -160,7 +160,7 @@ export function useBulkAssignment({
           `Accepted ${transactions.length} transaction${transactions.length !== 1 ? 's' : ''}`
         );
 
-        // Open the rule proposal dialog using the first transaction and re-evaluate
+        // Open the rule proposal dialog for the first transaction (re-evaluation happens after approval)
         if (firstTx) {
           openRuleProposalDialog(firstTx, resolvedEntityId, entityName);
         }

--- a/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
+++ b/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
@@ -170,13 +170,7 @@ export function useBulkAssignment({
         );
       }
     },
-    [
-      entities,
-      addPendingEntity,
-      dbEntitiesData?.data,
-      openRuleProposalDialog,
-      setLocalTransactions,
-    ]
+    [entities, addPendingEntity, dbEntitiesData?.data, openRuleProposalDialog, setLocalTransactions]
   );
 
   /**

--- a/packages/app-finance/src/components/imports/hooks/useProposalGeneration.ts
+++ b/packages/app-finance/src/components/imports/hooks/useProposalGeneration.ts
@@ -113,10 +113,10 @@ export function useProposalGeneration() {
   );
 
   /**
-   * Generate a Correction Proposal (ChangeSet) from a correction signal.
+   * Open the Rule Proposal dialog for a correction signal.
    * Rule changes only happen after explicit approval in the proposal dialog.
    */
-  const autoSaveRuleAndReEvaluate = useCallback(
+  const openRuleProposalDialog = useCallback(
     (triggeringTransaction: ProcessedTransaction, entityId: string, entityName: string) => {
       void generateProposal({ triggeringTransaction, entityId, entityName });
     },
@@ -131,6 +131,6 @@ export function useProposalGeneration() {
     browseOpen,
     setBrowseOpen,
     generateProposal,
-    autoSaveRuleAndReEvaluate,
+    openRuleProposalDialog,
   };
 }


### PR DESCRIPTION
## Summary

- Renames `autoSaveRuleAndReEvaluate` → `openRuleProposalDialog` across `useProposalGeneration`, `useBulkAssignment`, and `ReviewStep`
- Updates the JSDoc on the function to reflect what it actually does: opens the Rule Proposal dialog for user review
- No behaviour change — purely a naming correction to remove the misleading "autoSave" framing

Closes #1884

## Test plan

- [x] `pnpm typecheck` passes for `app-finance` (pre-existing unrelated failure in media module excluded)
- [x] `pnpm test` in `app-finance`: 251 tests pass