### PR TITLE
feat(search): wire recent searches into SearchInput

### DIFF
--- a/apps/pops-shell/src/app/layout/SearchInput.tsx
+++ b/apps/pops-shell/src/app/layout/SearchInput.tsx
@@ -223,8 +223,8 @@ export function SearchInput() {
           ⌘K
         </kbd>
       )}
-      {showPanel && (
-        query.length > 0 ? (
+      {showPanel &&
+        (query.length > 0 ? (
           <SearchResultsPanel
             sections={sections}
             query={query}
@@ -244,8 +244,7 @@ export function SearchInput() {
               onClear={clearAll}
             />
           </div>
-        )
-      )}
+        ))}
     </div>
   );
 }

--- a/apps/pops-shell/src/app/layout/SearchInput.tsx
+++ b/apps/pops-shell/src/app/layout/SearchInput.tsx
@@ -159,7 +159,6 @@ export function SearchInput() {
 
   const handleClear = useCallback(() => {
     clear();
-    setIsFocused(true);
     if (inputRef.current) {
       inputRef.current.value = '';
       inputRef.current.focus();
@@ -202,8 +201,10 @@ export function SearchInput() {
           setIsFocused(true);
           setOpen(true);
         }}
-        onBlur={() => {
-          setIsFocused(false);
+        onBlur={(e) => {
+          if (!containerRef.current?.contains(e.relatedTarget as Node)) {
+            setIsFocused(false);
+          }
         }}
         className="pl-9 pr-9 h-9 bg-muted/50 border-transparent focus:border-border focus:bg-background transition-colors"
         aria-label="Search POPS"

--- a/apps/pops-shell/src/app/layout/SearchInput.tsx
+++ b/apps/pops-shell/src/app/layout/SearchInput.tsx
@@ -6,8 +6,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   type SearchResultHit,
   type SearchResultSection,
+  RecentSearches,
   SearchResultsPanel,
   useCurrentApp,
+  useRecentSearches,
   useSearchKeyboardNav,
   useSearchResultNavigation,
 } from '@pops/navigation';
@@ -45,8 +47,11 @@ export function SearchInput() {
   const setOpen = useSearchStore((s) => s.setOpen);
   const clear = useSearchStore((s) => s.clear);
 
+  const [isFocused, setIsFocused] = useState(false);
+
   const currentApp = useCurrentApp();
   const { navigateTo } = useSearchResultNavigation();
+  const { queries, addQuery, clearAll } = useRecentSearches();
   const utils = trpc.useUtils();
 
   /** Extra hits appended by "Show more" per domain. */
@@ -121,10 +126,11 @@ export function SearchInput() {
 
   const handleResultClick = useCallback(
     (uri: string) => {
+      if (query) addQuery(query);
       navigateTo(uri);
       clear();
     },
-    [navigateTo, clear]
+    [query, addQuery, navigateTo, clear]
   );
 
   const handleClose = useCallback(() => {
@@ -153,6 +159,7 @@ export function SearchInput() {
 
   const handleClear = useCallback(() => {
     clear();
+    setIsFocused(true);
     if (inputRef.current) {
       inputRef.current.value = '';
       inputRef.current.focus();
@@ -180,7 +187,7 @@ export function SearchInput() {
     };
   }, []);
 
-  const showPanel = isOpen && query.length > 0;
+  const showPanel = isOpen && (query.length > 0 || (isFocused && queries.length > 0));
 
   return (
     <div ref={containerRef} className="hidden md:flex relative items-center max-w-sm w-full mx-4">
@@ -191,6 +198,13 @@ export function SearchInput() {
         placeholder="Search POPS..."
         defaultValue={query}
         onChange={handleChange}
+        onFocus={() => {
+          setIsFocused(true);
+          setOpen(true);
+        }}
+        onBlur={() => {
+          setIsFocused(false);
+        }}
         className="pl-9 pr-9 h-9 bg-muted/50 border-transparent focus:border-border focus:bg-background transition-colors"
         aria-label="Search POPS"
       />
@@ -210,14 +224,27 @@ export function SearchInput() {
         </kbd>
       )}
       {showPanel && (
-        <SearchResultsPanel
-          sections={sections}
-          query={query}
-          onClose={handleClose}
-          onResultClick={handleResultClick}
-          onShowMore={handleShowMore}
-          selectedIndex={selectedIndex}
-        />
+        query.length > 0 ? (
+          <SearchResultsPanel
+            sections={sections}
+            query={query}
+            onClose={handleClose}
+            onResultClick={handleResultClick}
+            onShowMore={handleShowMore}
+            selectedIndex={selectedIndex}
+          />
+        ) : (
+          <div className="absolute left-0 right-0 top-full z-50 mt-1 rounded-lg border bg-popover shadow-lg">
+            <RecentSearches
+              queries={queries}
+              onSelect={(q) => {
+                if (inputRef.current) inputRef.current.value = q;
+                setQuery(q);
+              }}
+              onClear={clearAll}
+            />
+          </div>
+        )
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- Imports `useRecentSearches` and `RecentSearches` from `@pops/navigation`
- Tracks input focus state via `onFocus`/`onBlur` on the Input element
- Calls `addQuery(query)` when a result is clicked, persisting non-empty queries to localStorage
- Shows `RecentSearches` panel when the input is focused and query is empty
- Wraps `RecentSearches` in the same `absolute left-0 right-0 top-full z-50` container used by `SearchResultsPanel` for consistent positioning
- Resets `isFocused` to `true` after clearing so the recent searches panel can reappear on re-focus

## Test plan

- [ ] Focus the search input with no text — recent searches panel appears if history exists
- [ ] Type a query, click a result — query is saved to recent history
- [ ] Clear the input — panel disappears, re-focusing shows recent searches
- [ ] Click "Clear recent" in the panel — history is wiped, panel closes
- [ ] Click a recent query — input is populated with the query and search triggers
- [ ] `pnpm test` in `apps/pops-shell` passes (94 tests)

Closes #1864