### PR TITLE
fix(rotation): write per-movie details to rotation_log

### DIFF
--- a/apps/pops-api/src/modules/media/rotation/addition-gating.ts
+++ b/apps/pops-api/src/modules/media/rotation/addition-gating.ts
@@ -73,8 +73,15 @@ export function getAdditionBudget(
 // Queue processing
 // ---------------------------------------------------------------------------
 
+/** A movie that was successfully added during the rotation cycle. */
+export interface AddedMovieRef {
+  tmdbId: number;
+  title: string;
+}
+
 export interface AdditionResult {
   added: number;
+  addedMovies: AddedMovieRef[];
   skippedReason: string | null;
 }
 
@@ -90,12 +97,20 @@ export interface AdditionResult {
  */
 export async function addMoviesFromQueue(budget: number): Promise<AdditionResult> {
   if (budget <= 0) {
-    return { added: 0, skippedReason: 'additions skipped — below target free space' };
+    return {
+      added: 0,
+      addedMovies: [],
+      skippedReason: 'additions skipped — below target free space',
+    };
   }
 
   const client = getRadarrClient();
   if (!client) {
-    return { added: 0, skippedReason: 'Radarr not configured — cannot add movies' };
+    return {
+      added: 0,
+      addedMovies: [],
+      skippedReason: 'Radarr not configured — cannot add movies',
+    };
   }
 
   const qualityProfileId = getSetting(SETTINGS_KEYS.qualityProfileId);
@@ -104,6 +119,7 @@ export async function addMoviesFromQueue(budget: number): Promise<AdditionResult
   if (!qualityProfileId || !rootFolderPath) {
     return {
       added: 0,
+      addedMovies: [],
       skippedReason: 'rotation_quality_profile_id or rotation_root_folder_path not configured',
     };
   }
@@ -114,10 +130,11 @@ export async function addMoviesFromQueue(budget: number): Promise<AdditionResult
   const selected = aggregateCandidates(budget);
 
   if (selected.length === 0) {
-    return { added: 0, skippedReason: 'no pending candidates in queue' };
+    return { added: 0, addedMovies: [], skippedReason: 'no pending candidates in queue' };
   }
 
   let added = 0;
+  const addedMovies: AddedMovieRef[] = [];
   for (const candidate of selected) {
     try {
       // Check if already in Radarr
@@ -157,6 +174,7 @@ export async function addMoviesFromQueue(budget: number): Promise<AdditionResult
         .where(eq(rotationCandidates.id, candidate.candidateId))
         .run();
       added++;
+      addedMovies.push({ tmdbId: candidate.tmdbId, title: candidate.title });
 
       console.warn(
         `[Rotation] Added: ${candidate.title} (tmdb=${candidate.tmdbId}, weight=${candidate.weight.toFixed(2)})`
@@ -174,5 +192,5 @@ export async function addMoviesFromQueue(budget: number): Promise<AdditionResult
     }
   }
 
-  return { added, skippedReason: null };
+  return { added, addedMovies, skippedReason: null };
 }

--- a/apps/pops-api/src/modules/media/rotation/rotation-log.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/rotation-log.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 /**
- * Tests for listRotationLog and getRotationLogStats endpoints.
+ * Tests for listRotationLog, getRotationLogStats, and writeRotationLog behaviour.
  *
  * PRD-072 US-06
  */
@@ -9,6 +9,7 @@ import { rotationLog } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
 import { createCaller, setupTestContext } from '../../../shared/test-utils.js';
+import { _writeRotationLogForTest } from './scheduler.js';
 
 const ctx = setupTestContext();
 
@@ -178,5 +179,83 @@ describe('rotation.getRotationLogStats', () => {
     const caller = createCaller();
     const stats = await caller.media.rotation.getRotationLogStats();
     expect(stats.totalRotated).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeRotationLog (via _writeRotationLogForTest)
+// ---------------------------------------------------------------------------
+
+describe('writeRotationLog', () => {
+  beforeEach(() => ctx.setup());
+  afterEach(() => {
+    ctx.teardown();
+  });
+
+  const baseResult = {
+    moviesMarkedLeaving: 0,
+    moviesRemoved: 0,
+    moviesAdded: 0,
+    removalsFailed: 0,
+    freeSpaceGb: 100,
+    targetFreeGb: 80,
+    skippedReason: null,
+    marked: [],
+    removed: [],
+    added: [],
+    failed: [],
+  };
+
+  it('writes null details when all per-movie arrays are empty', async () => {
+    _writeRotationLogForTest(baseResult);
+
+    const caller = createCaller();
+    const result = await caller.media.rotation.listRotationLog({});
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.details).toBeNull();
+  });
+
+  it('writes parseable JSON details when at least one array is non-empty', async () => {
+    _writeRotationLogForTest({
+      ...baseResult,
+      moviesAdded: 1,
+      added: [{ tmdbId: 42, title: 'Inception' }],
+    });
+
+    const caller = createCaller();
+    const result = await caller.media.rotation.listRotationLog({});
+    const details = result.items[0]!.details;
+    expect(details).not.toBeNull();
+    const parsed: unknown = JSON.parse(details!);
+    expect(parsed).toMatchObject({
+      marked: [],
+      removed: [],
+      added: [{ tmdbId: 42, title: 'Inception' }],
+      failed: [],
+    });
+  });
+
+  it('includes all four detail keys when multiple arrays are populated', async () => {
+    _writeRotationLogForTest({
+      ...baseResult,
+      moviesMarkedLeaving: 1,
+      moviesRemoved: 1,
+      moviesAdded: 1,
+      removalsFailed: 1,
+      marked: [{ tmdbId: 1, title: 'A' }],
+      removed: [{ tmdbId: 2, title: 'B' }],
+      added: [{ tmdbId: 3, title: 'C' }],
+      failed: [{ tmdbId: 4, title: 'D', reason: 'timeout' }],
+    });
+
+    const caller = createCaller();
+    const result = await caller.media.rotation.listRotationLog({});
+    const parsed: unknown = JSON.parse(result.items[0]!.details!);
+    expect(parsed).toMatchObject({
+      marked: [{ tmdbId: 1, title: 'A' }],
+      removed: [{ tmdbId: 2, title: 'B' }],
+      added: [{ tmdbId: 3, title: 'C' }],
+      failed: [{ tmdbId: 4, title: 'D' }],
+    });
   });
 });

--- a/apps/pops-api/src/modules/media/rotation/rotation-log.test.ts
+++ b/apps/pops-api/src/modules/media/rotation/rotation-log.test.ts
@@ -245,7 +245,7 @@ describe('writeRotationLog', () => {
       marked: [{ tmdbId: 1, title: 'A' }],
       removed: [{ tmdbId: 2, title: 'B' }],
       added: [{ tmdbId: 3, title: 'C' }],
-      failed: [{ tmdbId: 4, title: 'D', reason: 'timeout' }],
+      failed: [{ tmdbId: 4, title: 'D', error: 'timeout' }],
     });
 
     const caller = createCaller();

--- a/apps/pops-api/src/modules/media/rotation/scheduler.ts
+++ b/apps/pops-api/src/modules/media/rotation/scheduler.ts
@@ -374,12 +374,19 @@ export async function runRotationCycle(): Promise<RotationCycleResult> {
 
 function writeRotationLog(result: RotationCycleResult): void {
   const db = getDrizzle();
-  const details = JSON.stringify({
-    marked: result.marked,
-    removed: result.removed,
-    added: result.added,
-    failed: result.failed,
-  });
+  const hasDetails =
+    result.marked.length > 0 ||
+    result.removed.length > 0 ||
+    result.added.length > 0 ||
+    result.failed.length > 0;
+  const details = hasDetails
+    ? JSON.stringify({
+        marked: result.marked,
+        removed: result.removed,
+        added: result.added,
+        failed: result.failed,
+      })
+    : null;
   db.insert(rotationLog)
     .values({
       executedAt: new Date().toISOString(),
@@ -406,4 +413,9 @@ export function _resetRotationScheduler(): void {
   lastCycleError = null;
   isCycleRunning = false;
   cronExpression = DEFAULT_CRON;
+}
+
+/** Expose writeRotationLog for unit testing — for testing only. */
+export function _writeRotationLogForTest(result: RotationCycleResult): void {
+  writeRotationLog(result);
 }

--- a/apps/pops-api/src/modules/media/rotation/scheduler.ts
+++ b/apps/pops-api/src/modules/media/rotation/scheduler.ts
@@ -60,6 +60,17 @@ export interface RotationSchedulerStatus {
   nextRunAt: string | null;
 }
 
+/** Per-movie reference stored in the rotation log details. */
+export interface RotationMovieRef {
+  tmdbId: number;
+  title: string;
+}
+
+/** Per-movie reference for failed removals, which may carry an error message. */
+export interface RotationFailedMovieRef extends RotationMovieRef {
+  error?: string;
+}
+
 export interface RotationCycleResult {
   moviesMarkedLeaving: number;
   moviesRemoved: number;
@@ -68,6 +79,11 @@ export interface RotationCycleResult {
   freeSpaceGb: number;
   targetFreeGb: number;
   skippedReason: string | null;
+  /** Per-movie detail lists written to the rotation_log details column. */
+  marked: RotationMovieRef[];
+  removed: RotationMovieRef[];
+  added: RotationMovieRef[];
+  failed: RotationFailedMovieRef[];
 }
 
 // ---------------------------------------------------------------------------
@@ -206,6 +222,10 @@ export async function runRotationCycle(): Promise<RotationCycleResult> {
       freeSpaceGb: 0,
       targetFreeGb: getTargetFreeGb(),
       skippedReason: 'Concurrent cycle already running',
+      marked: [],
+      removed: [],
+      added: [],
+      failed: [],
     };
     writeRotationLog(result);
     return result;
@@ -223,6 +243,12 @@ export async function runRotationCycle(): Promise<RotationCycleResult> {
     const expiredResults = await processExpiredMovies();
     const moviesRemoved = expiredResults.filter((r) => r.success).length;
     const removalsFailed = expiredResults.filter((r) => !r.success).length;
+    const removedMovies: RotationMovieRef[] = expiredResults
+      .filter((r) => r.success)
+      .map((r) => ({ tmdbId: r.tmdbId, title: r.title }));
+    const failedMovies: RotationFailedMovieRef[] = expiredResults
+      .filter((r) => !r.success)
+      .map((r) => ({ tmdbId: r.tmdbId, title: r.title, error: r.error }));
 
     // Step 2: Measure free space
     let freeSpaceGb: number;
@@ -237,6 +263,10 @@ export async function runRotationCycle(): Promise<RotationCycleResult> {
         freeSpaceGb: 0,
         targetFreeGb,
         skippedReason: 'Radarr unavailable — cannot measure disk space',
+        marked: [],
+        removed: removedMovies,
+        added: [],
+        failed: failedMovies,
       };
       writeRotationLog(result);
       lastCycleAt = new Date().toISOString();
@@ -250,6 +280,7 @@ export async function runRotationCycle(): Promise<RotationCycleResult> {
     const deficit = calculateRemovalDeficit(targetFreeGb, freeSpaceGb, leavingSizeGb);
 
     let moviesMarkedLeaving = 0;
+    let markedMovies: RotationMovieRef[] = [];
     if (deficit > 0) {
       const downloadingIds = await getDownloadingTmdbIds();
       const eligible = getEligibleForRemoval(movieSizes, downloadingIds);
@@ -263,6 +294,7 @@ export async function runRotationCycle(): Promise<RotationCycleResult> {
           expiresAt.toISOString()
         );
         moviesMarkedLeaving = selection.moviesToMark.length;
+        markedMovies = selection.moviesToMark.map((m) => ({ tmdbId: m.tmdbId, title: m.title }));
       }
     }
 
@@ -295,6 +327,10 @@ export async function runRotationCycle(): Promise<RotationCycleResult> {
       freeSpaceGb,
       targetFreeGb,
       skippedReason: null,
+      marked: markedMovies,
+      removed: removedMovies,
+      added: additionResult.addedMovies,
+      failed: failedMovies,
     };
 
     writeRotationLog(result);
@@ -320,6 +356,10 @@ export async function runRotationCycle(): Promise<RotationCycleResult> {
       freeSpaceGb: 0,
       targetFreeGb,
       skippedReason: `Cycle error: ${message}`,
+      marked: [],
+      removed: [],
+      added: [],
+      failed: [],
     };
     writeRotationLog(result);
     return result;
@@ -334,6 +374,12 @@ export async function runRotationCycle(): Promise<RotationCycleResult> {
 
 function writeRotationLog(result: RotationCycleResult): void {
   const db = getDrizzle();
+  const details = JSON.stringify({
+    marked: result.marked,
+    removed: result.removed,
+    added: result.added,
+    failed: result.failed,
+  });
   db.insert(rotationLog)
     .values({
       executedAt: new Date().toISOString(),
@@ -344,7 +390,7 @@ function writeRotationLog(result: RotationCycleResult): void {
       freeSpaceGb: result.freeSpaceGb,
       targetFreeGb: result.targetFreeGb,
       skippedReason: result.skippedReason,
-      details: null,
+      details,
     })
     .run();
 }


### PR DESCRIPTION
## Summary

- `writeRotationLog` was always writing `details: null`; this fix serialises per-movie data as JSON
- `AdditionResult` gains an `addedMovies: AddedMovieRef[]` field so successfully-added movies are threaded through without re-querying
- `RotationCycleResult` gains `marked`, `removed`, `added`, and `failed` arrays; all call-sites populate them from the data already computed in the cycle
- The JSON shape — `{ marked, removed, added, failed }` with `{ tmdbId, title }[]` elements — matches exactly what `RotationLogPage.tsx` parses

## Test plan

- [x] `mise typecheck` — all 16 packages pass with no errors
- [x] `pnpm test` in `apps/pops-api` — 132 test files, 2366 tests, all pass
- [ ] Manual: trigger a rotation cycle and confirm the `rotation_log` row has a non-null `details` column with correct movie lists

Closes #1875