### PR TITLE
fix(paperless): wire PAPERLESS_BASE_URL/PAPERLESS_API_TOKEN into compose configs (#1858)

### DIFF
--- a/apps/pops-api/.env.example
+++ b/apps/pops-api/.env.example
@@ -24,3 +24,9 @@ THETVDB_API_KEY=your_thetvdb_api_key_here
 # In production this is mounted as a Docker secret at /run/secrets/claude_api_key;
 # in local dev, set it here or export CLAUDE_API_KEY in your shell.
 CLAUDE_API_KEY=your_claude_api_key_here
+
+# Paperless-ngx (optional — document management integration)
+# PAPERLESS_BASE_URL: the base URL of your Paperless-ngx instance (e.g. http://localhost:8000)
+# PAPERLESS_API_TOKEN: the API token from Paperless-ngx Settings → API
+PAPERLESS_BASE_URL=
+PAPERLESS_API_TOKEN=

--- a/docs/themes/04-inventory/prds/049-paperless-integration/us-01-paperless-client.md
+++ b/docs/themes/04-inventory/prds/049-paperless-integration/us-01-paperless-client.md
@@ -10,13 +10,13 @@ As a developer, I want a Paperless-ngx API client service so that POPS can searc
 ## Acceptance Criteria
 
 - [x] `PaperlessClient` service created with methods: `search(query)`, `getThumbnail(docId)`, `getDocument(docId)`, `healthCheck()`
-- [ ] Base URL and API token read from env vars (`PAPERLESS_BASE_URL`, `PAPERLESS_API_TOKEN`) — **env vars are `PAPERLESS_URL` and `PAPERLESS_TOKEN`, not the names specified**
+- [x] Base URL and API token read from env vars (`PAPERLESS_BASE_URL`, `PAPERLESS_API_TOKEN`)
 - [x] `search(query)` calls `GET /api/documents/?query=X` — returns array of `{ id, title, created, correspondent, thumbnailUrl }`
 - [x] `getThumbnail(docId)` calls `GET /api/documents/:id/thumb/` — returns binary image data
 - [x] `getDocument(docId)` calls `GET /api/documents/:id/` — returns full document metadata
 - [x] `healthCheck()` calls `GET /api/documents/?page_size=1` — returns `{ available: true }` on 200, `{ available: false }` on any error
 - [x] All requests include `Authorization: Token XXX` header
-- [ ] Request timeout: 5 seconds — slow Paperless responses do not block POPS — **no explicit timeout set; uses default Node.js fetch (indefinite)**
+- [x] Request timeout: 5 seconds — slow Paperless responses do not block POPS
 - [x] Connection errors caught and returned as `{ available: false }` — never thrown to callers
 - [x] `item_documents` table created with columns per the data model
 - [x] CRUD procedures created: `inventory.documents.link`, `inventory.documents.unlink`, `inventory.documents.listForItem`

--- a/docs/themes/04-inventory/prds/049-paperless-integration/us-01-paperless-client.md
+++ b/docs/themes/04-inventory/prds/049-paperless-integration/us-01-paperless-client.md
@@ -16,7 +16,7 @@ As a developer, I want a Paperless-ngx API client service so that POPS can searc
 - [x] `getDocument(docId)` calls `GET /api/documents/:id/` — returns full document metadata
 - [x] `healthCheck()` calls `GET /api/documents/?page_size=1` — returns `{ available: true }` on 200, `{ available: false }` on any error
 - [x] All requests include `Authorization: Token XXX` header
-- [x] Request timeout: 5 seconds — slow Paperless responses do not block POPS
+- [x] Request timeout: 5s for metadata/search requests, 10s for thumbnail fetches — slow Paperless responses do not block POPS
 - [x] Connection errors caught and returned as `{ available: false }` — never thrown to callers
 - [x] `item_documents` table created with columns per the data model
 - [x] CRUD procedures created: `inventory.documents.link`, `inventory.documents.unlink`, `inventory.documents.listForItem`

--- a/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
+++ b/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
@@ -28,8 +28,10 @@ services:
       SQLITE_PATH: /data/sqlite/pops.db
       PORT: "3000"
       # Paperless-ngx integration (optional — leave unset to disable)
-      PAPERLESS_BASE_URL: "{{ vault_paperless_base_url | default('') }}"
-      PAPERLESS_API_TOKEN: "{{ vault_paperless_api_token | default('') }}"
+      PAPERLESS_BASE_URL: >-
+        {{ vault_paperless_base_url | default('') }}
+      PAPERLESS_API_TOKEN: >-
+        {{ vault_paperless_api_token | default('') }}
     expose:
       - "3000"
     healthcheck:

--- a/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
+++ b/infra/ansible/roles/pops-deploy/templates/docker-compose.yml.j2
@@ -27,6 +27,9 @@ services:
       NODE_ENV: production
       SQLITE_PATH: /data/sqlite/pops.db
       PORT: "3000"
+      # Paperless-ngx integration (optional — leave unset to disable)
+      PAPERLESS_BASE_URL: "{{ vault_paperless_base_url | default('') }}"
+      PAPERLESS_API_TOKEN: "{{ vault_paperless_api_token | default('') }}"
     expose:
       - "3000"
     healthcheck:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -26,6 +26,9 @@ services:
       NODE_ENV: production
       SQLITE_PATH: /data/sqlite/pops.db
       PORT: '3000'
+      # Paperless-ngx integration (optional — leave unset to disable)
+      PAPERLESS_BASE_URL: ${PAPERLESS_BASE_URL:-}
+      PAPERLESS_API_TOKEN: ${PAPERLESS_API_TOKEN:-}
     expose:
       - '3000'
     healthcheck:

--- a/packages/app-finance/src/components/imports/ReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.tsx
@@ -57,7 +57,7 @@ export function ReviewStep() {
     browseOpen,
     setBrowseOpen,
     generateProposal,
-    autoSaveRuleAndReEvaluate,
+    openRuleProposalDialog,
   } = useProposalGeneration();
 
   const handleBulkEntitySelect = useCallback(
@@ -181,7 +181,7 @@ export function ReviewStep() {
   } = useBulkAssignment({
     setLocalTransactions,
     handleEntitySelect,
-    autoSaveRuleAndReEvaluate,
+    openRuleProposalDialog,
     generateProposal,
   });
 

--- a/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
+++ b/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
@@ -23,7 +23,7 @@ interface UseBulkAssignmentArgs {
     entityId: string,
     entityName: string
   ) => void;
-  autoSaveRuleAndReEvaluate: (
+  openRuleProposalDialog: (
     triggeringTransaction: ProcessedTransaction,
     entityId: string,
     entityName: string
@@ -44,7 +44,7 @@ interface UseBulkAssignmentArgs {
 export function useBulkAssignment({
   setLocalTransactions,
   handleEntitySelect,
-  autoSaveRuleAndReEvaluate,
+  openRuleProposalDialog,
   generateProposal,
 }: UseBulkAssignmentArgs) {
   const [showCreateDialog, setShowCreateDialog] = useState(false);
@@ -97,9 +97,9 @@ export function useBulkAssignment({
       // Always accept the transaction itself
       handleEntitySelect(transaction, entityId, entityName);
 
-      autoSaveRuleAndReEvaluate(transaction, entityId, entityName);
+      openRuleProposalDialog(transaction, entityId, entityName);
     },
-    [handleEntitySelect, entities, handleCreateEntity, autoSaveRuleAndReEvaluate]
+    [handleEntitySelect, entities, handleCreateEntity, openRuleProposalDialog]
   );
 
   /**
@@ -160,9 +160,9 @@ export function useBulkAssignment({
           `Accepted ${transactions.length} transaction${transactions.length !== 1 ? 's' : ''}`
         );
 
-        // Auto-save correction rule using the first transaction and re-evaluate
+        // Open the rule proposal dialog using the first transaction and re-evaluate
         if (firstTx) {
-          autoSaveRuleAndReEvaluate(firstTx, resolvedEntityId, entityName);
+          openRuleProposalDialog(firstTx, resolvedEntityId, entityName);
         }
       } catch (error) {
         toast.error(
@@ -174,7 +174,7 @@ export function useBulkAssignment({
       entities,
       addPendingEntity,
       dbEntitiesData?.data,
-      autoSaveRuleAndReEvaluate,
+      openRuleProposalDialog,
       setLocalTransactions,
     ]
   );

--- a/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
+++ b/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
@@ -160,7 +160,7 @@ export function useBulkAssignment({
           `Accepted ${transactions.length} transaction${transactions.length !== 1 ? 's' : ''}`
         );
 
-        // Open the rule proposal dialog using the first transaction and re-evaluate
+        // Open the rule proposal dialog for the first transaction (re-evaluation happens after approval)
         if (firstTx) {
           openRuleProposalDialog(firstTx, resolvedEntityId, entityName);
         }

--- a/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
+++ b/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
@@ -170,13 +170,7 @@ export function useBulkAssignment({
         );
       }
     },
-    [
-      entities,
-      addPendingEntity,
-      dbEntitiesData?.data,
-      openRuleProposalDialog,
-      setLocalTransactions,
-    ]
+    [entities, addPendingEntity, dbEntitiesData?.data, openRuleProposalDialog, setLocalTransactions]
   );
 
   /**

--- a/packages/app-finance/src/components/imports/hooks/useProposalGeneration.ts
+++ b/packages/app-finance/src/components/imports/hooks/useProposalGeneration.ts
@@ -113,10 +113,10 @@ export function useProposalGeneration() {
   );
 
   /**
-   * Generate a Correction Proposal (ChangeSet) from a correction signal.
+   * Open the Rule Proposal dialog for a correction signal.
    * Rule changes only happen after explicit approval in the proposal dialog.
    */
-  const autoSaveRuleAndReEvaluate = useCallback(
+  const openRuleProposalDialog = useCallback(
     (triggeringTransaction: ProcessedTransaction, entityId: string, entityName: string) => {
       void generateProposal({ triggeringTransaction, entityId, entityName });
     },
@@ -131,6 +131,6 @@ export function useProposalGeneration() {
     browseOpen,
     setBrowseOpen,
     generateProposal,
-    autoSaveRuleAndReEvaluate,
+    openRuleProposalDialog,
   };
 }


### PR DESCRIPTION
## Summary

- Wire `PAPERLESS_BASE_URL` and `PAPERLESS_API_TOKEN` into the pops-api service environment in `infra/docker-compose.yml` and the Ansible production template — without this the integration was silently disabled in all deployed environments regardless of whether the vars were set on the host
- Add the two vars to `apps/pops-api/.env.example` so local dev setup is self-documenting
- Mark two previously-failing acceptance criteria as done in the US doc: the code in `index.ts` already read the correct env var names, and `client.ts` already used `AbortSignal.timeout(5_000)` in `get()` — the doc notes were stale

Note: `PAPERLESS_URL` in the paperless-ngx service blocks is untouched — that is a Paperless-ngx application config var (its own public URL), not a pops-api client setting.

Closes #1858

## Test plan

- [ ] `pnpm test` in `apps/pops-api` passes (2366 tests)
- [ ] No format issues in changed files
- [ ] Deploy with `PAPERLESS_BASE_URL` and `PAPERLESS_API_TOKEN` set — `inventory.paperless.status` returns `{ configured: true }`
- [ ] Deploy without those vars set — `inventory.paperless.status` returns `{ configured: false }`