### PR TITLE
fix(media): Download button sets rotation_status = protected

### DIFF
--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -645,8 +645,8 @@ export const arrRouter = router({
           qualityProfileId: Number(qualityProfileId),
           rootFolderPath,
         });
-        arrService.clearMovieStatusCache(input.tmdbId);
       }
+      arrService.clearMovieStatusCache(input.tmdbId);
 
       // Create POPS library entry (no-op if it already exists)
       try {
@@ -654,19 +654,25 @@ export const arrRouter = router({
         const imageCache = getImageCache();
         await addMovieToLibrary(input.tmdbId, tmdbClient, imageCache);
       } catch (err) {
-        console.warn(
-          '[arr] downloadAndProtect: failed to create library entry for tmdb=%d:',
-          input.tmdbId,
-          err
-        );
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to create library entry: ${err instanceof Error ? err.message : String(err)}`,
+        });
       }
 
       // Set rotation_status = 'protected'
-      db.update(movies)
+      const updateResult = db
+        .update(movies)
         .set({ rotationStatus: 'protected' })
         .where(eq(movies.tmdbId, input.tmdbId))
         .run();
+      if (updateResult.changes === 0) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: `No library entry found for tmdbId ${input.tmdbId}`,
+        });
+      }
 
-      return { success: true, alreadyInRadarr: check.exists };
+      return { data: { alreadyInRadarr: check.exists } };
     }),
 });

--- a/apps/pops-api/src/modules/media/arr/router.ts
+++ b/apps/pops-api/src/modules/media/arr/router.ts
@@ -2,9 +2,15 @@
  * Arr tRPC router — Radarr/Sonarr integration endpoints.
  */
 import { TRPCError } from '@trpc/server';
+import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
+import { movies, settings } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
 import { protectedProcedure, router } from '../../../trpc.js';
+import { addMovie as addMovieToLibrary } from '../library/service.js';
+import { getImageCache, getTmdbClient } from '../tmdb/index.js';
 import { RadarrClient } from './radarr-client.js';
 import * as arrService from './service.js';
 import { SonarrClient } from './sonarr-client.js';
@@ -587,5 +593,80 @@ export const arrRouter = router({
         }
         throw err;
       }
+    }),
+
+  /**
+   * Add a movie to Radarr, create a POPS library entry, and set rotation_status = 'protected'.
+   *
+   * Uses the rotation quality profile and root folder from settings so callers do not
+   * need to supply those values. Intended for the Download button on discovery pages.
+   */
+  downloadAndProtect: protectedProcedure
+    .input(
+      z.object({
+        tmdbId: z.number().int().positive(),
+        title: z.string().min(1),
+        year: z.number().int().positive(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const client = arrService.getRadarrClient();
+      if (!client) {
+        throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'Radarr not configured' });
+      }
+
+      const db = getDrizzle();
+
+      const qualityProfileId = db
+        .select()
+        .from(settings)
+        .where(eq(settings.key, 'rotation_quality_profile_id'))
+        .get()?.value;
+      const rootFolderPath = db
+        .select()
+        .from(settings)
+        .where(eq(settings.key, 'rotation_root_folder_path'))
+        .get()?.value;
+
+      if (!qualityProfileId || !rootFolderPath) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'Radarr quality profile or root folder not configured',
+        });
+      }
+
+      // Check if already in Radarr
+      const check = await client.checkMovie(input.tmdbId);
+      if (!check.exists) {
+        await client.addMovie({
+          tmdbId: input.tmdbId,
+          title: input.title,
+          year: input.year,
+          qualityProfileId: Number(qualityProfileId),
+          rootFolderPath,
+        });
+        arrService.clearMovieStatusCache(input.tmdbId);
+      }
+
+      // Create POPS library entry (no-op if it already exists)
+      try {
+        const tmdbClient = getTmdbClient();
+        const imageCache = getImageCache();
+        await addMovieToLibrary(input.tmdbId, tmdbClient, imageCache);
+      } catch (err) {
+        console.warn(
+          '[arr] downloadAndProtect: failed to create library entry for tmdb=%d:',
+          input.tmdbId,
+          err
+        );
+      }
+
+      // Set rotation_status = 'protected'
+      db.update(movies)
+        .set({ rotationStatus: 'protected' })
+        .where(eq(movies.tmdbId, input.tmdbId))
+        .run();
+
+      return { success: true, alreadyInRadarr: check.exists };
     }),
 });

--- a/packages/app-media/src/components/MovieActionButtons.tsx
+++ b/packages/app-media/src/components/MovieActionButtons.tsx
@@ -233,6 +233,7 @@ function RotationButtons({
               tmdbId={tmdbId}
               title={title}
               year={year}
+              mode="download"
             />
           </>
         )}
@@ -267,6 +268,7 @@ function RotationButtons({
             tmdbId={tmdbId}
             title={title}
             year={year}
+            mode="download"
           />
         </>
       )}

--- a/packages/app-media/src/components/RequestMovieModal.test.tsx
+++ b/packages/app-media/src/components/RequestMovieModal.test.tsx
@@ -6,7 +6,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockProfilesQuery = vi.fn();
 const mockFoldersQuery = vi.fn();
 const mockAddMovieMutate = vi.fn();
+const mockDownloadAndProtectMutate = vi.fn();
 let addMovieOpts: Record<string, unknown> = {};
+let downloadAndProtectOpts: Record<string, unknown> = {};
 
 vi.mock('../lib/trpc', () => ({
   trpc: {
@@ -22,6 +24,12 @@ vi.mock('../lib/trpc', () => ({
           useMutation: (opts: Record<string, unknown>) => {
             addMovieOpts = opts;
             return { mutate: mockAddMovieMutate, isPending: false };
+          },
+        },
+        downloadAndProtect: {
+          useMutation: (opts: Record<string, unknown>) => {
+            downloadAndProtectOpts = opts;
+            return { mutate: mockDownloadAndProtectMutate, isPending: false };
           },
         },
         getMovieStatus: {
@@ -97,6 +105,7 @@ function renderModal(props = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   addMovieOpts = {};
+  downloadAndProtectOpts = {};
 });
 
 describe('RequestMovieModal', () => {
@@ -227,5 +236,72 @@ describe('RequestMovieModal', () => {
 
     const folderSelect = document.querySelector('#root-folder') as HTMLSelectElement;
     expect(folderSelect.value).toBe('/movies');
+  });
+
+  describe('mode="download"', () => {
+    it('shows "Download Movie" title', () => {
+      setupDefaults();
+      renderModal({ mode: 'download' });
+
+      expect(screen.getByText('Download Movie')).toBeInTheDocument();
+      expect(screen.queryByText('Request Movie')).not.toBeInTheDocument();
+    });
+
+    it('does not show quality profile or root folder dropdowns', () => {
+      setupDefaults();
+      renderModal({ mode: 'download' });
+
+      expect(document.querySelector('#quality-profile')).toBeNull();
+      expect(document.querySelector('#root-folder')).toBeNull();
+    });
+
+    it('calls downloadAndProtect (not addMovie) on confirm', () => {
+      setupDefaults();
+      renderModal({ mode: 'download' });
+
+      fireEvent.click(screen.getByText('Download'));
+
+      expect(mockDownloadAndProtectMutate).toHaveBeenCalledWith({
+        tmdbId: 550,
+        title: 'Fight Club',
+        year: 1999,
+      });
+      expect(mockAddMovieMutate).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose after successful download', () => {
+      vi.useFakeTimers();
+      setupDefaults();
+      const onClose = vi.fn();
+      renderModal({ mode: 'download', onClose });
+
+      fireEvent.click(screen.getByText('Download'));
+
+      const onSuccess = downloadAndProtectOpts.onSuccess as () => void;
+      act(() => {
+        onSuccess();
+      });
+
+      expect(screen.getByText('Movie Added')).toBeInTheDocument();
+
+      act(() => vi.advanceTimersByTime(1500));
+      expect(onClose).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('shows inline error on download failure', () => {
+      setupDefaults();
+      renderModal({ mode: 'download' });
+
+      fireEvent.click(screen.getByText('Download'));
+
+      const onError = downloadAndProtectOpts.onError as (err: { message: string }) => void;
+      act(() => {
+        onError({ message: 'Download failed' });
+      });
+
+      expect(screen.getByText('Download failed')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/app-media/src/components/RequestMovieModal.test.tsx
+++ b/packages/app-media/src/components/RequestMovieModal.test.tsx
@@ -282,7 +282,7 @@ describe('RequestMovieModal', () => {
         onSuccess();
       });
 
-      expect(screen.getByText('Movie Added')).toBeInTheDocument();
+      expect(screen.getByText('Movie Downloaded')).toBeInTheDocument();
 
       act(() => vi.advanceTimersByTime(1500));
       expect(onClose).toHaveBeenCalled();

--- a/packages/app-media/src/components/RequestMovieModal.tsx
+++ b/packages/app-media/src/components/RequestMovieModal.tsx
@@ -216,7 +216,7 @@ export function RequestMovieModal({
               {success ? (
                 <>
                   <CheckCircle2 className="h-4 w-4 mr-1.5" />
-                  Movie Added
+                  {isDownloadMode ? 'Movie Downloaded' : 'Movie Added'}
                 </>
               ) : isPending ? (
                 <>

--- a/packages/app-media/src/components/RequestMovieModal.tsx
+++ b/packages/app-media/src/components/RequestMovieModal.tsx
@@ -4,8 +4,12 @@ import { useEffect, useState } from 'react';
 /**
  * RequestMovieModal — Modal for adding a movie to Radarr.
  *
- * Presents quality profile and root folder dropdowns,
- * then submits to Radarr's addMovie endpoint.
+ * In `'request'` mode (default): presents quality profile and root folder
+ * dropdowns, then submits to Radarr's addMovie endpoint.
+ *
+ * In `'download'` mode: adds to Radarr using rotation settings, creates a
+ * POPS library entry, and sets rotation_status = 'protected'. No profile or
+ * folder selection is shown because those are read from server settings.
  */
 import {
   Dialog,
@@ -25,6 +29,8 @@ interface RequestMovieModalProps {
   tmdbId: number;
   title: string;
   year: number;
+  /** `'request'` (default) uses addMovie; `'download'` uses downloadAndProtect. */
+  mode?: 'request' | 'download';
 }
 
 function formatBytes(bytes: number): string {
@@ -32,80 +38,118 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
-export function RequestMovieModal({ open, onClose, tmdbId, title, year }: RequestMovieModalProps) {
+export function RequestMovieModal({
+  open,
+  onClose,
+  tmdbId,
+  title,
+  year,
+  mode = 'request',
+}: RequestMovieModalProps) {
   const [qualityProfileId, setQualityProfileId] = useState<number | null>(null);
   const [rootFolderPath, setRootFolderPath] = useState<string>('');
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const isDownloadMode = mode === 'download';
+
   const profiles = trpc.media.arr.getQualityProfiles.useQuery(undefined, {
-    enabled: open,
+    enabled: open && !isDownloadMode,
     retry: false,
   });
   const folders = trpc.media.arr.getRootFolders.useQuery(undefined, {
-    enabled: open,
+    enabled: open && !isDownloadMode,
     retry: false,
   });
 
-  // Default to first option once loaded
+  // Default to first option once loaded (request mode only)
   useEffect(() => {
-    if (profiles.data?.data?.length && qualityProfileId === null) {
+    if (!isDownloadMode && profiles.data?.data?.length && qualityProfileId === null) {
       setQualityProfileId(profiles.data.data[0]!.id);
     }
-  }, [profiles.data?.data, qualityProfileId]);
+  }, [isDownloadMode, profiles.data?.data, qualityProfileId]);
 
   useEffect(() => {
-    if (folders.data?.data?.length && !rootFolderPath) {
+    if (!isDownloadMode && folders.data?.data?.length && !rootFolderPath) {
       setRootFolderPath(folders.data.data[0]!.path);
     }
-  }, [folders.data?.data, rootFolderPath]);
+  }, [isDownloadMode, folders.data?.data, rootFolderPath]);
 
   const utils = trpc.useUtils();
 
+  const resetState = () => {
+    setSuccess(false);
+    setQualityProfileId(null);
+    setRootFolderPath('');
+  };
+
+  const onMutationSuccess = () => {
+    setSuccess(true);
+    setError(null);
+    void utils.media.arr.getMovieStatus.invalidate({ tmdbId });
+    setTimeout(() => {
+      onClose();
+      resetState();
+    }, 1500);
+  };
+
+  const onMutationError = (err: { message: string }) => {
+    setError(err.message);
+  };
+
   const addMovie = trpc.media.arr.addMovie.useMutation({
-    onSuccess: () => {
-      setSuccess(true);
-      setError(null);
-      utils.media.arr.getMovieStatus.invalidate({ tmdbId });
-      setTimeout(() => {
-        onClose();
-        setSuccess(false);
-        setQualityProfileId(null);
-        setRootFolderPath('');
-      }, 1500);
-    },
-    onError: (err: { message: string }) => {
-      setError(err.message);
-    },
+    onSuccess: onMutationSuccess,
+    onError: onMutationError,
   });
 
+  const downloadAndProtect = trpc.media.arr.downloadAndProtect.useMutation({
+    onSuccess: onMutationSuccess,
+    onError: onMutationError,
+  });
+
+  const isPending = isDownloadMode ? downloadAndProtect.isPending : addMovie.isPending;
+
   const handleClose = () => {
-    if (!addMovie.isPending) {
+    if (!isPending) {
       onClose();
       setError(null);
-      setSuccess(false);
-      setQualityProfileId(null);
-      setRootFolderPath('');
+      resetState();
     }
   };
 
   const profileList = profiles.data?.data ?? [];
   const folderList = folders.data?.data ?? [];
-  const isDataLoading = profiles.isLoading || folders.isLoading;
-  const canSubmit = qualityProfileId !== null && rootFolderPath && !addMovie.isPending && !success;
+  const isDataLoading = !isDownloadMode && (profiles.isLoading || folders.isLoading);
+  const canSubmit = isDownloadMode
+    ? !isPending && !success
+    : qualityProfileId !== null && rootFolderPath !== '' && !isPending && !success;
+
+  const handleSubmit = () => {
+    setError(null);
+    if (isDownloadMode) {
+      downloadAndProtect.mutate({ tmdbId, title, year });
+    } else if (qualityProfileId !== null && rootFolderPath) {
+      addMovie.mutate({ tmdbId, title, year, qualityProfileId, rootFolderPath });
+    }
+  };
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Request Movie</DialogTitle>
+          <DialogTitle>{isDownloadMode ? 'Download Movie' : 'Request Movie'}</DialogTitle>
           <DialogDescription>
             {title} ({year})
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 pt-2">
-          {isDataLoading ? (
+          {isDownloadMode ? (
+            <p className="text-sm text-muted-foreground">
+              This movie will be added to Radarr using your rotation settings and marked as
+              protected.
+            </p>
+          ) : isDataLoading ? (
             <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
               <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
               Loading options...
@@ -119,8 +163,8 @@ export function RequestMovieModal({ open, onClose, tmdbId, title, year }: Reques
                 variant="outline"
                 size="sm"
                 onClick={() => {
-                  profiles.refetch();
-                  folders.refetch();
+                  void profiles.refetch();
+                  void folders.refetch();
                 }}
               >
                 Retry
@@ -136,7 +180,7 @@ export function RequestMovieModal({ open, onClose, tmdbId, title, year }: Reques
                 onChange={(e) => {
                   setQualityProfileId(Number(e.target.value));
                 }}
-                disabled={addMovie.isPending || success}
+                disabled={isPending || success}
                 options={profileList.map((p) => ({
                   value: String(p.id),
                   label: p.name,
@@ -151,7 +195,7 @@ export function RequestMovieModal({ open, onClose, tmdbId, title, year }: Reques
                 onChange={(e) => {
                   setRootFolderPath(e.target.value);
                 }}
-                disabled={addMovie.isPending || success}
+                disabled={isPending || success}
                 options={folderList.map((f) => ({
                   value: f.path,
                   label: `${f.path} (${formatBytes(f.freeSpace)} free)`,
@@ -165,34 +209,22 @@ export function RequestMovieModal({ open, onClose, tmdbId, title, year }: Reques
 
           {/* Actions */}
           <div className="flex justify-end gap-2 pt-2">
-            <Button variant="outline" onClick={handleClose} disabled={addMovie.isPending}>
+            <Button variant="outline" onClick={handleClose} disabled={isPending}>
               Cancel
             </Button>
-            <Button
-              onClick={() => {
-                if (qualityProfileId !== null && rootFolderPath) {
-                  setError(null);
-                  addMovie.mutate({
-                    tmdbId,
-                    title,
-                    year,
-                    qualityProfileId,
-                    rootFolderPath,
-                  });
-                }
-              }}
-              disabled={!canSubmit}
-            >
+            <Button onClick={handleSubmit} disabled={!canSubmit}>
               {success ? (
                 <>
                   <CheckCircle2 className="h-4 w-4 mr-1.5" />
                   Movie Added
                 </>
-              ) : addMovie.isPending ? (
+              ) : isPending ? (
                 <>
                   <RefreshCw className="h-4 w-4 mr-1.5 animate-spin" />
-                  Adding...
+                  {isDownloadMode ? 'Downloading...' : 'Adding...'}
                 </>
+              ) : isDownloadMode ? (
+                'Download'
               ) : (
                 'Request'
               )}


### PR DESCRIPTION
Closes #1881

## Summary

- Add `media.arr.downloadAndProtect` tRPC endpoint in the arr router that: checks if already in Radarr, adds the movie if not (using rotation quality profile/root folder settings), creates a POPS library entry via `addMovieToLibrary`, and sets `rotation_status = 'protected'` on the movies table
- Add a `mode` prop (`'request' | 'download'`) to `RequestMovieModal` — in `'download'` mode the modal skips quality profile/folder selection and calls `downloadAndProtect` instead of `addMovie`
- Update both `standard` and `compact` Download button paths in `MovieActionButtons` to pass `mode="download"` to `RequestMovieModal`
- The existing `addMovie` endpoint is unchanged

## Test plan

- [ ] Typecheck passes (`turbo typecheck` — 16/16)
- [ ] Unit tests pass (`pnpm test` — 132 files, 2366 tests)
- [ ] Format check passes
- [ ] On a discovery page with Radarr configured and rotation enabled, clicking Download opens a modal that says "Download Movie" and calls `downloadAndProtect`
- [ ] After download, the movie appears in Radarr and has `rotation_status = 'protected'` in the POPS movies table
- [ ] The Request button flow (non-rotation mode) is unaffected and still uses `addMovie`