### PR TITLE
docs(PRD22): add US-07 ANZ PDF statement parser spec

### DIFF
--- a/docs/themes/02-finance/prds/022-deduplication-parsers/README.md
+++ b/docs/themes/02-finance/prds/022-deduplication-parsers/README.md
@@ -54,11 +54,11 @@ Account: "ANZ Everyday" or "ANZ Savings" (from CSV or user selection)
 
 ### ANZ PDF (credit card statements)
 
-| PDF Column          | Mapping     | Transformation                                                |
-| ------------------- | ----------- | ------------------------------------------------------------- |
-| Date of Transaction | date        | DD/MM/YYYY → YYYY-MM-DD                                       |
-| Transaction Details | description | Clean whitespace                                              |
-| Amount ($A)         | amount      | Parse float; invert sign (purchases negative, CR → positive)  |
+| PDF Column          | Mapping     | Transformation                                               |
+| ------------------- | ----------- | ------------------------------------------------------------ |
+| Date of Transaction | date        | DD/MM/YYYY → YYYY-MM-DD                                      |
+| Transaction Details | description | Clean whitespace                                             |
+| Amount ($A)         | amount      | Parse float; invert sign (purchases negative, CR → positive) |
 
 Account: "ANZ Frequent Flyer Black" (hardcoded per statement type)
 

--- a/docs/themes/02-finance/prds/022-deduplication-parsers/README.md
+++ b/docs/themes/02-finance/prds/022-deduplication-parsers/README.md
@@ -42,7 +42,7 @@ Each bank has a different CSV format. A parser (transformer) normalizes to `Pars
 
 Account: "Amex" (hardcoded)
 
-### ANZ
+### ANZ CSV
 
 | CSV Column  | Mapping     | Transformation                         |
 | ----------- | ----------- | -------------------------------------- |
@@ -51,6 +51,18 @@ Account: "Amex" (hardcoded)
 | Description | description | Clean whitespace                       |
 
 Account: "ANZ Everyday" or "ANZ Savings" (from CSV or user selection)
+
+### ANZ PDF (credit card statements)
+
+| PDF Column          | Mapping     | Transformation                                                |
+| ------------------- | ----------- | ------------------------------------------------------------- |
+| Date of Transaction | date        | DD/MM/YYYY → YYYY-MM-DD                                       |
+| Transaction Details | description | Clean whitespace                                              |
+| Amount ($A)         | amount      | Parse float; invert sign (purchases negative, CR → positive)  |
+
+Account: "ANZ Frequent Flyer Black" (hardcoded per statement type)
+
+Supplementary rows (foreign currency lines, overseas fee lines) have no Card Used value and must be skipped. Sign convention differs from the CSV format — all amounts are positive in the PDF, with `CR` marking credits.
 
 ### ING
 
@@ -104,8 +116,9 @@ Fetched via Up Bank REST API, not CSV upload. Batch import by date range.
 | 04  | [us-04-ing-parser](us-04-ing-parser.md)         | ING CSV parser                                                                      | Not started | Yes                             |
 | 05  | [us-05-up-bank-import](us-05-up-bank-import.md) | Up Bank API batch import by date range                                              | Not started | Yes                             |
 | 06  | [us-06-common-utils](us-06-common-utils.md)     | Shared utilities: normaliseDate, normaliseAmount, extractLocation, online detection | Partial     | No (first, parallel with us-01) |
+| 07  | [us-07-anz-pdf-parser](us-07-anz-pdf-parser.md) | ANZ PDF credit card statement parser                                                | Not started | Yes                             |
 
-US-02 through US-05 can all parallelise (independent parsers). US-06 is shared utilities used by all parsers.
+US-02 through US-05 and US-07 can all parallelise (independent parsers). US-06 is shared utilities used by all parsers.
 
 ## Verification
 

--- a/docs/themes/02-finance/prds/022-deduplication-parsers/us-07-anz-pdf-parser.md
+++ b/docs/themes/02-finance/prds/022-deduplication-parsers/us-07-anz-pdf-parser.md
@@ -11,16 +11,17 @@ As a user, I want to import ANZ PDF credit card statements so that transactions 
 
 ANZ Frequent Flyer Black (and other ANZ credit card) PDF statements. Transaction table columns:
 
-| Column               | Notes                                                                  |
-| -------------------- | ---------------------------------------------------------------------- |
-| Date Processed       | DD/MM/YYYY — when ANZ posted it; ignored in favour of transaction date |
-| Date of Transaction  | DD/MM/YYYY — actual merchant date; use this as `date`                  |
-| Card Used            | Last 4 digits; absent on supplementary rows                            |
-| Transaction Details  | Merchant name + location string                                        |
-| Amount ($A)          | Positive float; `CR` suffix denotes credits (payments, refunds)        |
-| Balance              | Running balance after row; ignored                                     |
+| Column              | Notes                                                                  |
+| ------------------- | ---------------------------------------------------------------------- |
+| Date Processed      | DD/MM/YYYY — when ANZ posted it; ignored in favour of transaction date |
+| Date of Transaction | DD/MM/YYYY — actual merchant date; use this as `date`                  |
+| Card Used           | Last 4 digits; absent on supplementary rows                            |
+| Transaction Details | Merchant name + location string                                        |
+| Amount ($A)         | Positive float; `CR` suffix denotes credits (payments, refunds)        |
+| Balance             | Running balance after row; ignored                                     |
 
 **Supplementary rows** (skip entirely — no card number, no amount):
+
 - Foreign currency equivalent lines (e.g. `3.99 USD`, `182.00 EUR`)
 - Overseas transaction fee lines (e.g. `INCL OVERSEAS TXN FEE 1.20 AUD`)
 

--- a/docs/themes/02-finance/prds/022-deduplication-parsers/us-07-anz-pdf-parser.md
+++ b/docs/themes/02-finance/prds/022-deduplication-parsers/us-07-anz-pdf-parser.md
@@ -1,0 +1,42 @@
+# US-07: ANZ PDF statement parser
+
+> PRD: [022 — Deduplication & Parsers](README.md)
+> Status: Not started
+
+## Description
+
+As a user, I want to import ANZ PDF credit card statements so that transactions not available via CSV export are in POPS.
+
+## Format
+
+ANZ Frequent Flyer Black (and other ANZ credit card) PDF statements. Transaction table columns:
+
+| Column               | Notes                                                                  |
+| -------------------- | ---------------------------------------------------------------------- |
+| Date Processed       | DD/MM/YYYY — when ANZ posted it; ignored in favour of transaction date |
+| Date of Transaction  | DD/MM/YYYY — actual merchant date; use this as `date`                  |
+| Card Used            | Last 4 digits; absent on supplementary rows                            |
+| Transaction Details  | Merchant name + location string                                        |
+| Amount ($A)          | Positive float; `CR` suffix denotes credits (payments, refunds)        |
+| Balance              | Running balance after row; ignored                                     |
+
+**Supplementary rows** (skip entirely — no card number, no amount):
+- Foreign currency equivalent lines (e.g. `3.99 USD`, `182.00 EUR`)
+- Overseas transaction fee lines (e.g. `INCL OVERSEAS TXN FEE 1.20 AUD`)
+
+## Acceptance Criteria
+
+- [ ] Extracts text from ANZ PDF using a PDF parsing library (e.g. `pdf-parse`)
+- [ ] Identifies and skips supplementary rows (no card last-4, no amount)
+- [ ] Date: `Date of Transaction` column, DD/MM/YYYY → YYYY-MM-DD
+- [ ] Amount: parse float; amounts with `CR` suffix are positive (credits); all other amounts are negative (expenses)
+- [ ] Description: clean whitespace from Transaction Details field
+- [ ] Account: `"ANZ Frequent Flyer Black"` (hardcoded; extend when other ANZ PDF variants appear)
+- [ ] Output: valid `ParsedTransaction[]` with checksums
+- [ ] Test with sample ANZ PDF statement data
+
+## Notes
+
+Sign convention differs from the ANZ CSV parser: the PDF shows all amounts as positive, using `CR` to mark credits. Purchases must be negated; credits stay positive.
+
+The last-4 card digits in the Card Used column can vary within a single statement (supplementary cards). This field is not used in `ParsedTransaction` — presence/absence is only used to identify supplementary rows.


### PR DESCRIPTION
## Summary

- Adds US-07 (`us-07-anz-pdf-parser.md`) to PRD-022 specifying ANZ credit card PDF statement parsing
- Updates PRD-022 README with the ANZ PDF format section alongside the existing ANZ CSV section

## Format details captured

ANZ Frequent Flyer Black PDF has two date columns (processed vs transaction), all-positive amounts with a `CR` suffix for credits, and supplementary rows (foreign currency lines, overseas fee lines) that must be skipped. Sign convention is inverted vs the ANZ CSV parser.