### PR TITLE
ops: force full redeploy (ansible + all dockers)

### DIFF
--- a/infra/.redeploy-trigger
+++ b/infra/.redeploy-trigger
@@ -1,0 +1,10 @@
+# Deploy Trigger
+
+This file exists only to force the deployment pipeline to take the full-infra
+path, which runs the Ansible playbook and rebuilds every Docker service.
+
+Bumping the timestamp below produces a no-op change under `infra/`, which the
+`Detect Changes` job in `.github/workflows/root-deploy.yml` treats as an infra
+change and therefore triggers `type=full` (Ansible + all containers).
+
+Last triggered: 2026-04-18


### PR DESCRIPTION
## Summary
- No-op change adding `infra/.redeploy-trigger` to flip the `infra` detector in `.github/workflows/root-deploy.yml` to `true`.
- When `infra=true`, the deploy job sets `type=full`, which runs the Ansible playbook and rebuilds every Docker service (pops-shell, pops-api, etc.).
- Intentional: no functional code changes, no runtime behavior change.

## Test plan
- [ ] Merge to main and confirm `Detect Changes` reports `infra=true` / `deploy_needed=true`
- [ ] Confirm the `Deploy` job picks `type=full` and executes `ansible-playbook playbooks/deploy.yml`
- [ ] Confirm all containers come up healthy (`pops-api`, `pops-shell`)