### PR TITLE
fix(media): show leaving badge on search results, detail page, and watchlist (#1879)

### DIFF
--- a/apps/pops-api/src/modules/media/movies/types.ts
+++ b/apps/pops-api/src/modules/media/movies/types.ts
@@ -31,6 +31,8 @@ export interface Movie {
   genres: string[];
   createdAt: string;
   updatedAt: string;
+  rotationStatus: 'leaving' | 'protected' | null;
+  rotationExpiresAt: string | null;
 }
 
 /** Map a SQLite row to the API response shape. */
@@ -97,6 +99,8 @@ export function toMovie(row: MovieRow): Movie {
       : [],
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    rotationStatus: row.rotationStatus ?? null,
+    rotationExpiresAt: row.rotationExpiresAt ?? null,
   };
 }
 

--- a/packages/app-media/src/components/SearchResultCard.tsx
+++ b/packages/app-media/src/components/SearchResultCard.tsx
@@ -6,9 +6,12 @@ import { Link } from 'react-router';
  * SearchResultCard — displays a search result from TMDB or TheTVDB.
  * Shows poster from external CDN, title, year, overview, genres, rating,
  * and an "Add to Library" / "In Library" action.
+ * When the item is already in the library and has a 'leaving' rotation status,
+ * a LeavingBadge is rendered to indicate the removal countdown (PRD-072 US-01).
  */
 import { Badge, Button, cn, Skeleton } from '@pops/ui';
 
+import { LeavingBadge } from './LeavingBadge';
 import { MovieActionButtons } from './MovieActionButtons';
 
 const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w342';
@@ -26,6 +29,10 @@ export interface SearchResultCardProps {
   voteAverage?: number | null;
   genres?: string[];
   inLibrary?: boolean;
+  /** Rotation status — shows LeavingBadge when 'leaving' (PRD-072 US-01). */
+  rotationStatus?: 'leaving' | 'protected' | null;
+  /** ISO date string for when the item leaves rotation. Required when rotationStatus is 'leaving'. */
+  rotationExpiresAt?: string | null;
   addDisabled?: boolean;
   addDisabledReason?: string;
   isAdding?: boolean;
@@ -60,6 +67,8 @@ export function SearchResultCard({
   voteAverage,
   genres,
   inLibrary,
+  rotationStatus,
+  rotationExpiresAt,
   addDisabled,
   addDisabledReason,
   isAdding,
@@ -159,6 +168,9 @@ export function SearchResultCard({
               )}
               {isAdding ? 'Adding…' : 'Add to Library'}
             </Button>
+          )}
+          {rotationStatus === 'leaving' && rotationExpiresAt && (
+            <LeavingBadge rotationExpiresAt={rotationExpiresAt} />
           )}
           {type === 'movie' && tmdbId != null && (
             <MovieActionButtons

--- a/packages/app-media/src/components/SearchResultCard.tsx
+++ b/packages/app-media/src/components/SearchResultCard.tsx
@@ -6,19 +6,22 @@ import { Link } from 'react-router';
  * SearchResultCard — displays a search result from TMDB or TheTVDB.
  * Shows poster from external CDN, title, year, overview, genres, rating,
  * and an "Add to Library" / "In Library" action.
- * When the item is already in the library and has a 'leaving' rotation status,
- * a LeavingBadge is rendered to indicate the removal countdown (PRD-072 US-01).
+ * When the item is already in the library (`inLibrary === true`) and has a
+ * 'leaving' rotation status, a LeavingBadge is rendered to indicate the
+ * removal countdown (PRD-072 US-01).
  */
 import { Badge, Button, cn, Skeleton } from '@pops/ui';
 
 import { LeavingBadge } from './LeavingBadge';
 import { MovieActionButtons } from './MovieActionButtons';
 
+import type { RotationMeta } from '../lib/types';
+
 const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w342';
 
 export type SearchResultType = 'movie' | 'tv';
 
-export interface SearchResultCardProps {
+export interface SearchResultCardProps extends RotationMeta {
   type: SearchResultType;
   title: string;
   /** TMDB ID — required for movie request button. */
@@ -29,10 +32,6 @@ export interface SearchResultCardProps {
   voteAverage?: number | null;
   genres?: string[];
   inLibrary?: boolean;
-  /** Rotation status — shows LeavingBadge when 'leaving' (PRD-072 US-01). */
-  rotationStatus?: 'leaving' | 'protected' | null;
-  /** ISO date string for when the item leaves rotation. Required when rotationStatus is 'leaving'. */
-  rotationExpiresAt?: string | null;
   addDisabled?: boolean;
   addDisabledReason?: string;
   isAdding?: boolean;
@@ -169,7 +168,7 @@ export function SearchResultCard({
               {isAdding ? 'Adding…' : 'Add to Library'}
             </Button>
           )}
-          {rotationStatus === 'leaving' && rotationExpiresAt && (
+          {inLibrary && rotationStatus === 'leaving' && rotationExpiresAt && (
             <LeavingBadge rotationExpiresAt={rotationExpiresAt} />
           )}
           {type === 'movie' && tmdbId != null && (

--- a/packages/app-media/src/lib/types.ts
+++ b/packages/app-media/src/lib/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared media rotation types used across components and pages.
+ */
+
+/** Rotation metadata for a media item that may be leaving the library. */
+export interface RotationMeta {
+  /** Current rotation status. 'leaving' means the item is scheduled for removal. */
+  rotationStatus?: 'leaving' | 'protected' | null;
+  /** ISO date string for when the item leaves rotation. Required when rotationStatus is 'leaving'. */
+  rotationExpiresAt?: string | null;
+}

--- a/packages/app-media/src/pages/CompareArenaPage.tsx
+++ b/packages/app-media/src/pages/CompareArenaPage.tsx
@@ -159,7 +159,7 @@ export function CompareArenaPage() {
   );
 
   const addToWatchlistMutation = trpc.media.watchlist.add.useMutation({
-    onSuccess: (_data: unknown, variables: { mediaType: string; mediaId: number }) => {
+    onSuccess: (_data, variables) => {
       utils.media.watchlist.list.invalidate();
       const movie =
         variables.mediaId === movieAId ? pairData?.data?.movieA : pairData?.data?.movieB;

--- a/packages/app-media/src/pages/MovieDetailPage.test.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.test.tsx
@@ -49,6 +49,11 @@ vi.mock('../components/FreshnessBadge', () => ({
 vi.mock('../components/ExcludedDimensions', () => ({
   ExcludedDimensions: () => null,
 }));
+vi.mock('../components/LeavingBadge', () => ({
+  LeavingBadge: ({ rotationExpiresAt }: { rotationExpiresAt: string }) => (
+    <span data-testid="leaving-badge">{rotationExpiresAt}</span>
+  ),
+}));
 
 import { MovieDetailPage } from './MovieDetailPage';
 
@@ -347,6 +352,53 @@ describe('MovieDetailPage', () => {
       expect(
         container.querySelectorAll("[class*='animate-pulse'], [data-slot='skeleton']").length
       ).toBeGreaterThan(0);
+    });
+  });
+
+  describe('leaving badge in hero row', () => {
+    it('renders LeavingBadge when rotationStatus is leaving and rotationExpiresAt is set', () => {
+      mockMovieQuery.mockReturnValue({
+        data: {
+          data: {
+            ...baseMovie,
+            rotationStatus: 'leaving',
+            rotationExpiresAt: '2026-05-01T00:00:00Z',
+          },
+        },
+        isLoading: false,
+        error: null,
+      });
+      renderAtRoute('/media/movies/1');
+      expect(screen.getByTestId('leaving-badge')).toBeInTheDocument();
+    });
+
+    it('does not render LeavingBadge when rotationStatus is not leaving', () => {
+      mockMovieQuery.mockReturnValue({
+        data: {
+          data: { ...baseMovie, rotationStatus: 'protected', rotationExpiresAt: null },
+        },
+        isLoading: false,
+        error: null,
+      });
+      renderAtRoute('/media/movies/1');
+      expect(screen.queryByTestId('leaving-badge')).not.toBeInTheDocument();
+    });
+
+    it('does not render LeavingBadge when rotationStatus is leaving but rotationExpiresAt is null', () => {
+      mockMovieQuery.mockReturnValue({
+        data: {
+          data: { ...baseMovie, rotationStatus: 'leaving', rotationExpiresAt: null },
+        },
+        isLoading: false,
+        error: null,
+      });
+      renderAtRoute('/media/movies/1');
+      expect(screen.queryByTestId('leaving-badge')).not.toBeInTheDocument();
+    });
+
+    it('does not render LeavingBadge when rotationStatus is absent', () => {
+      renderAtRoute('/media/movies/1');
+      expect(screen.queryByTestId('leaving-badge')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/app-media/src/pages/MovieDetailPage.tsx
+++ b/packages/app-media/src/pages/MovieDetailPage.tsx
@@ -21,6 +21,7 @@ import { ArrStatusBadge } from '../components/ArrStatusBadge';
 import { ComparisonScores } from '../components/ComparisonScores';
 import { ExcludedDimensions } from '../components/ExcludedDimensions';
 import { FreshnessBadge } from '../components/FreshnessBadge';
+import { LeavingBadge } from '../components/LeavingBadge';
 import { MarkAsWatchedButton } from '../components/MarkAsWatchedButton';
 import { MovieActionButtons } from '../components/MovieActionButtons';
 import { WatchlistToggle } from '../components/WatchlistToggle';
@@ -248,6 +249,9 @@ export function MovieDetailPage() {
                 posterPath={movie.posterPath ?? undefined}
               />
               <FreshnessBadge daysSinceWatch={daysSinceWatch} staleness={staleness} />
+              {movie.rotationStatus === 'leaving' && movie.rotationExpiresAt && (
+                <LeavingBadge rotationExpiresAt={movie.rotationExpiresAt} />
+              )}
               {pendingDebrief && (
                 <Link to={`/media/debrief/${movie.id}`}>
                   <Button variant="outline" size="sm">

--- a/packages/app-media/src/pages/SearchPage.test.tsx
+++ b/packages/app-media/src/pages/SearchPage.test.tsx
@@ -122,7 +122,14 @@ const TV_RESULTS = [
   },
 ];
 
-const LIBRARY_MOVIES = [{ id: 1, tmdbId: 101 }]; // Inception is in library
+const LIBRARY_MOVIES = [
+  {
+    id: 1,
+    tmdbId: 101,
+    rotationStatus: 'leaving' as const,
+    rotationExpiresAt: '2026-05-01T00:00:00Z',
+  },
+]; // Inception is in library with leaving rotation
 const LIBRARY_TV = [{ id: 2, tvdbId: 201 }]; // Breaking Bad is in library
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -358,6 +365,32 @@ describe('SearchPage — poster fallback (via card props)', () => {
 
     const bbCard = lastTvCardProps.find((p) => p.title === 'Breaking Bad');
     expect(bbCard?.posterUrl).toBe('https://cdn.tvdb.com/bb.jpg');
+  });
+});
+
+describe('SearchPage — rotation fields passed to in-library movie cards', () => {
+  it('passes rotationStatus and rotationExpiresAt for in-library movies', () => {
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    expect(inceptionCard?.rotationStatus).toBe('leaving');
+    expect(inceptionCard?.rotationExpiresAt).toBe('2026-05-01T00:00:00Z');
+  });
+
+  it('passes undefined rotationStatus and rotationExpiresAt for movies not in library', () => {
+    renderPage();
+
+    const interstellarCard = lastMovieCardProps.find((p) => p.title === 'Interstellar');
+    expect(interstellarCard?.rotationStatus).toBeUndefined();
+    expect(interstellarCard?.rotationExpiresAt).toBeUndefined();
+  });
+
+  it('passes no rotation fields when library is empty', () => {
+    setupEmptyLibrary();
+    renderPage();
+
+    expect(lastMovieCardProps.every((p) => p.rotationStatus === undefined)).toBe(true);
+    expect(lastMovieCardProps.every((p) => p.rotationExpiresAt === undefined)).toBe(true);
   });
 });
 

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -120,6 +120,12 @@ export function SearchPage() {
   const tvTvdbToLocalId = new Map(
     (libraryTvShows.data?.data ?? []).map((s: { id: number; tvdbId: number }) => [s.tvdbId, s.id])
   );
+  const movieTmdbToRotation = new Map(
+    (libraryMovies.data?.data ?? []).map((m) => [
+      m.tmdbId,
+      { rotationStatus: m.rotationStatus, rotationExpiresAt: m.rotationExpiresAt },
+    ])
+  );
 
   // Mutations
   const addMovieMutation = trpc.media.library.addMovie.useMutation();
@@ -285,6 +291,7 @@ export function SearchPage() {
                 const key = makeKey('movie', movie.tmdbId);
                 const inLibrary = movieTmdbIds.has(movie.tmdbId) || addedIds.has(key);
                 const localId = movieTmdbToLocalId.get(movie.tmdbId);
+                const rotation = movieTmdbToRotation.get(movie.tmdbId);
                 return (
                   <SearchResultCard
                     key={movie.tmdbId}
@@ -296,6 +303,8 @@ export function SearchPage() {
                     posterUrl={buildPosterUrl(movie.posterPath, 'movie')}
                     voteAverage={movie.voteAverage}
                     inLibrary={inLibrary}
+                    rotationStatus={rotation?.rotationStatus}
+                    rotationExpiresAt={rotation?.rotationExpiresAt}
                     isAdding={addingIds.has(key)}
                     onAdd={() => {
                       handleAddMovie(movie.tmdbId);

--- a/packages/app-media/src/pages/WatchlistPage.test.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.test.tsx
@@ -55,6 +55,12 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock('../components/LeavingBadge', () => ({
+  LeavingBadge: ({ rotationExpiresAt }: { rotationExpiresAt: string }) => (
+    <span data-testid="leaving-badge">{rotationExpiresAt}</span>
+  ),
+}));
+
 import { WatchlistPage } from './WatchlistPage';
 
 function renderPage() {
@@ -311,6 +317,70 @@ describe('WatchlistPage', () => {
       await user.click(screen.getByRole('tab', { name: 'TV Shows' }));
 
       expect(screen.getByText('No TV shows on your watchlist.')).toBeInTheDocument();
+    });
+  });
+
+  describe('leaving badge', () => {
+    it('shows LeavingBadge for a movie with rotationStatus leaving', () => {
+      mockWatchlistQuery.mockReturnValue({
+        data: { data: [entry1] },
+        isLoading: false,
+        error: null,
+      });
+      mockMoviesQuery.mockReturnValue({
+        data: {
+          data: [
+            {
+              id: 10,
+              title: 'The Matrix',
+              releaseDate: '1999-03-31',
+              posterUrl: null,
+              rotationStatus: 'leaving' as const,
+              rotationExpiresAt: '2026-05-01T00:00:00Z',
+            },
+          ],
+        },
+        isLoading: false,
+      });
+      mockTvShowsQuery.mockReturnValue({
+        data: { data: [] },
+        isLoading: false,
+      });
+
+      renderPage();
+
+      expect(screen.getAllByTestId('leaving-badge').length).toBeGreaterThan(0);
+    });
+
+    it('does not show LeavingBadge when rotationStatus is not leaving', () => {
+      mockWatchlistQuery.mockReturnValue({
+        data: { data: [entry1] },
+        isLoading: false,
+        error: null,
+      });
+      mockMoviesQuery.mockReturnValue({
+        data: {
+          data: [
+            {
+              id: 10,
+              title: 'The Matrix',
+              releaseDate: '1999-03-31',
+              posterUrl: null,
+              rotationStatus: null,
+              rotationExpiresAt: null,
+            },
+          ],
+        },
+        isLoading: false,
+      });
+      mockTvShowsQuery.mockReturnValue({
+        data: { data: [] },
+        isLoading: false,
+      });
+
+      renderPage();
+
+      expect(screen.queryByTestId('leaving-badge')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -32,6 +32,7 @@ import { toast } from 'sonner';
 import { Alert, AlertDescription, AlertTitle, Badge, Skeleton, Textarea } from '@pops/ui';
 import { Button } from '@pops/ui';
 
+import { LeavingBadge } from '../components/LeavingBadge';
 import { trpc } from '../lib/trpc';
 
 type WatchlistFilter = 'all' | 'movie' | 'tv_show';
@@ -62,6 +63,8 @@ interface MediaMeta {
   title: string;
   year: number | null;
   posterUrl: string | null;
+  rotationStatus?: 'leaving' | 'protected' | null;
+  rotationExpiresAt?: string | null;
 }
 
 function WatchlistSkeleton() {
@@ -111,6 +114,8 @@ interface WatchlistItemProps {
   onUpdateNotes: (id: number, notes: string | null) => void;
   isUpdating: boolean;
   updateError: string | null;
+  rotationStatus?: 'leaving' | 'protected' | null;
+  rotationExpiresAt?: string | null;
 }
 
 function WatchlistItem({
@@ -130,6 +135,8 @@ function WatchlistItem({
   onUpdateNotes,
   isUpdating,
   updateError,
+  rotationStatus,
+  rotationExpiresAt,
 }: WatchlistItemProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(entry.notes ?? '');
@@ -236,6 +243,9 @@ function WatchlistItem({
                 {entry.mediaType === 'movie' ? 'Movie' : 'TV'}
               </Badge>
               {year && <span className="text-xs text-muted-foreground">{year}</span>}
+              {rotationStatus === 'leaving' && rotationExpiresAt && (
+                <LeavingBadge rotationExpiresAt={rotationExpiresAt} />
+              )}
             </div>
           </div>
 
@@ -333,6 +343,8 @@ interface WatchlistCardProps {
   isRemoving: boolean;
   dragAttributes?: DraggableAttributes;
   dragListeners?: Record<string, unknown>;
+  rotationStatus?: 'leaving' | 'protected' | null;
+  rotationExpiresAt?: string | null;
 }
 
 function WatchlistCard({
@@ -345,6 +357,8 @@ function WatchlistCard({
   isRemoving,
   dragAttributes,
   dragListeners,
+  rotationStatus,
+  rotationExpiresAt,
 }: WatchlistCardProps) {
   const navigate = useNavigate();
   const [imageError, setImageError] = useState(false);
@@ -436,6 +450,9 @@ function WatchlistCard({
           <h3 className="text-sm font-medium leading-tight line-clamp-2">{title}</h3>
         </Link>
         {year && <p className="text-xs text-muted-foreground">{year}</p>}
+        {rotationStatus === 'leaving' && rotationExpiresAt && (
+          <LeavingBadge rotationExpiresAt={rotationExpiresAt} />
+        )}
         {entry.notes && <p className="text-xs text-muted-foreground line-clamp-1">{entry.notes}</p>}
       </div>
     </div>
@@ -542,21 +559,16 @@ export function WatchlistPage() {
   const movieMap = useMemo(
     () =>
       new Map<number, MediaMeta>(
-        (moviesData?.data ?? []).map(
-          (m: {
-            id: number;
-            title: string;
-            releaseDate: string | null;
-            posterUrl: string | null;
-          }) => [
-            m.id,
-            {
-              title: m.title,
-              year: m.releaseDate ? new Date(m.releaseDate).getFullYear() : null,
-              posterUrl: m.posterUrl,
-            },
-          ]
-        )
+        (moviesData?.data ?? []).map((m) => [
+          m.id,
+          {
+            title: m.title,
+            year: m.releaseDate ? new Date(m.releaseDate).getFullYear() : null,
+            posterUrl: m.posterUrl,
+            rotationStatus: m.rotationStatus,
+            rotationExpiresAt: m.rotationExpiresAt,
+          },
+        ])
       ),
     [moviesData?.data]
   );
@@ -771,6 +783,10 @@ export function WatchlistPage() {
                   }}
                   isUpdating={updateMutation.isPending && updateMutation.variables?.id === entry.id}
                   updateError={updateErrorId === entry.id ? updateErrorMsg : null}
+                  rotationStatus={entry.mediaType === 'movie' ? meta?.rotationStatus : undefined}
+                  rotationExpiresAt={
+                    entry.mediaType === 'movie' ? meta?.rotationExpiresAt : undefined
+                  }
                 />
               );
             })}
@@ -805,6 +821,12 @@ export function WatchlistPage() {
                         removeMutation.mutate({ id });
                       }}
                       isRemoving={removingId === entry.id}
+                      rotationStatus={
+                        entry.mediaType === 'movie' ? meta?.rotationStatus : undefined
+                      }
+                      rotationExpiresAt={
+                        entry.mediaType === 'movie' ? meta?.rotationExpiresAt : undefined
+                      }
                     />
                   ) : (
                     <WatchlistCard
@@ -819,6 +841,12 @@ export function WatchlistPage() {
                         removeMutation.mutate({ id });
                       }}
                       isRemoving={removingId === entry.id}
+                      rotationStatus={
+                        entry.mediaType === 'movie' ? meta?.rotationStatus : undefined
+                      }
+                      rotationExpiresAt={
+                        entry.mediaType === 'movie' ? meta?.rotationExpiresAt : undefined
+                      }
                     />
                   );
                 })}
@@ -842,6 +870,12 @@ export function WatchlistPage() {
                           priority={idx + 1}
                           onRemove={() => {}}
                           isRemoving={false}
+                          rotationStatus={
+                            entry.mediaType === 'movie' ? meta?.rotationStatus : undefined
+                          }
+                          rotationExpiresAt={
+                            entry.mediaType === 'movie' ? meta?.rotationExpiresAt : undefined
+                          }
                         />
                       </div>
                     );

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -35,6 +35,8 @@ import { Button } from '@pops/ui';
 import { LeavingBadge } from '../components/LeavingBadge';
 import { trpc } from '../lib/trpc';
 
+import type { RotationMeta } from '../lib/types';
+
 type WatchlistFilter = 'all' | 'movie' | 'tv_show';
 
 const FILTER_OPTIONS: { value: WatchlistFilter; label: string }[] = [
@@ -59,12 +61,10 @@ interface WatchlistEntry {
   posterUrl?: string | null;
 }
 
-interface MediaMeta {
+interface MediaMeta extends RotationMeta {
   title: string;
   year: number | null;
   posterUrl: string | null;
-  rotationStatus?: 'leaving' | 'protected' | null;
-  rotationExpiresAt?: string | null;
 }
 
 function WatchlistSkeleton() {
@@ -97,7 +97,7 @@ function WatchlistSkeleton() {
   );
 }
 
-interface WatchlistItemProps {
+interface WatchlistItemProps extends RotationMeta {
   entry: WatchlistEntry;
   title: string;
   year: number | null;
@@ -114,8 +114,6 @@ interface WatchlistItemProps {
   onUpdateNotes: (id: number, notes: string | null) => void;
   isUpdating: boolean;
   updateError: string | null;
-  rotationStatus?: 'leaving' | 'protected' | null;
-  rotationExpiresAt?: string | null;
 }
 
 function WatchlistItem({
@@ -333,7 +331,7 @@ function WatchlistItem({
   );
 }
 
-interface WatchlistCardProps {
+interface WatchlistCardProps extends RotationMeta {
   entry: WatchlistEntry;
   title: string;
   year: number | null;
@@ -343,8 +341,6 @@ interface WatchlistCardProps {
   isRemoving: boolean;
   dragAttributes?: DraggableAttributes;
   dragListeners?: Record<string, unknown>;
-  rotationStatus?: 'leaving' | 'protected' | null;
-  rotationExpiresAt?: string | null;
 }
 
 function WatchlistCard({


### PR DESCRIPTION
## Summary

- Adds `rotationStatus` and `rotationExpiresAt` to the `Movie` API interface and `toMovie()` mapper so rotation data flows to the frontend
- Renders `LeavingBadge` on `SearchResultCard` when an in-library movie has `rotationStatus === 'leaving'`
- Renders `LeavingBadge` on `MovieDetailPage` in the hero action-button row
- Renders `LeavingBadge` on `WatchlistPage` in both the mobile list view and desktop card grid (movies only; TV shows have no rotation fields)

## Test plan

- [ ] Typecheck passes for all packages (`pnpm typecheck` — turbo, 16 tasks)
- [ ] All 634 `@pops/app-media` tests pass
- [ ] Manually verify: search for a movie that's in the library and has `rotation_status = 'leaving'` — LeavingBadge appears in the search result card
- [ ] Manually verify: open that movie's detail page — LeavingBadge appears in the hero row
- [ ] Manually verify: add that movie to the watchlist — LeavingBadge appears in both mobile list and desktop card views