### PR TITLE
fix(inventory): add TypeBadge/AssetIdBadge to connections, add disconnect confirmation (#1857)

### DIFF
--- a/packages/app-inventory/src/components/ConnectDialog.test.tsx
+++ b/packages/app-inventory/src/components/ConnectDialog.test.tsx
@@ -1,0 +1,275 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock tRPC hooks
+const mockItemsListQuery = vi.fn();
+const mockConnectMutate = vi.fn();
+const mockConnectMutation = vi.fn();
+
+vi.mock('../lib/trpc', () => ({
+  trpc: {
+    inventory: {
+      items: {
+        list: { useQuery: (...args: unknown[]) => mockItemsListQuery(...args) },
+      },
+      connections: {
+        connect: { useMutation: (...args: unknown[]) => mockConnectMutation(...args) },
+      },
+    },
+  },
+}));
+
+import { ConnectDialog } from './ConnectDialog';
+
+const defaultProps = {
+  currentItemId: 'item-1',
+  onConnected: vi.fn(),
+};
+
+function renderDialog() {
+  return render(<ConnectDialog {...defaultProps} />);
+}
+
+function openDialog() {
+  fireEvent.click(screen.getByRole('button', { name: /connect item/i }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockItemsListQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+  mockConnectMutation.mockReturnValue({
+    mutate: mockConnectMutate,
+    isPending: false,
+  });
+});
+
+describe('ConnectDialog', () => {
+  describe('trigger', () => {
+    it('renders the Connect Item trigger button', () => {
+      renderDialog();
+      expect(screen.getByRole('button', { name: /connect item/i })).toBeInTheDocument();
+    });
+
+    it('opens the dialog when trigger is clicked', () => {
+      renderDialog();
+      openDialog();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Connect Item' })).toBeInTheDocument();
+    });
+  });
+
+  describe('search prompt', () => {
+    it('shows prompt to type at least 2 characters before searching', () => {
+      renderDialog();
+      openDialog();
+      expect(screen.getByText('Type at least 2 characters to search')).toBeInTheDocument();
+    });
+
+    it('shows prompt when only 1 character typed', () => {
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), { target: { value: 'a' } });
+      expect(screen.getByText('Type at least 2 characters to search')).toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows skeleton rows while loading', () => {
+      mockItemsListQuery.mockReturnValue({ data: undefined, isLoading: true });
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), {
+        target: { value: 'mac' },
+      });
+      // Three skeleton divs should appear — detect via aria or count animated elements
+      // Skeletons don't have accessible roles, but the "No items found" and prompt should be absent
+      expect(screen.queryByText('No items found')).not.toBeInTheDocument();
+      expect(screen.queryByText('Type at least 2 characters to search')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty results', () => {
+    it('shows "No items found" when search returns empty list', () => {
+      mockItemsListQuery.mockReturnValue({ data: { data: [] }, isLoading: false });
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), {
+        target: { value: 'xyz' },
+      });
+      expect(screen.getByText('No items found')).toBeInTheDocument();
+    });
+  });
+
+  describe('search results', () => {
+    const searchResults = [
+      {
+        id: 'item-2',
+        itemName: 'USB-C Hub',
+        brand: 'CalDigit',
+        model: 'TS4',
+        assetId: 'HUB-022',
+        type: 'Electronics',
+      },
+      {
+        id: 'item-3',
+        itemName: 'Monitor',
+        brand: 'Dell',
+        model: null,
+        assetId: null,
+        type: null,
+      },
+    ];
+
+    function setupResults() {
+      mockItemsListQuery.mockReturnValue({
+        data: { data: searchResults },
+        isLoading: false,
+      });
+    }
+
+    it('renders item names', () => {
+      setupResults();
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), {
+        target: { value: 'us' },
+      });
+      expect(screen.getByText('USB-C Hub')).toBeInTheDocument();
+      expect(screen.getByText('Monitor')).toBeInTheDocument();
+    });
+
+    it('renders brand and model as plain text', () => {
+      setupResults();
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), {
+        target: { value: 'us' },
+      });
+      expect(screen.getByText('CalDigit · TS4')).toBeInTheDocument();
+    });
+
+    it('renders AssetIdBadge when assetId is present', () => {
+      setupResults();
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), {
+        target: { value: 'us' },
+      });
+      expect(screen.getByText('HUB-022')).toBeInTheDocument();
+    });
+
+    it('omits AssetIdBadge when assetId is null', () => {
+      setupResults();
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), {
+        target: { value: 'us' },
+      });
+      // Only one assetId badge — the Monitor has no assetId
+      expect(screen.queryAllByText(/MON-/)).toHaveLength(0);
+    });
+
+    it('renders TypeBadge when type is present', () => {
+      setupResults();
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), {
+        target: { value: 'us' },
+      });
+      expect(screen.getByText('Electronics')).toBeInTheDocument();
+    });
+
+    it('omits TypeBadge when type is null', () => {
+      setupResults();
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), {
+        target: { value: 'us' },
+      });
+      // Monitor has null type — only 1 TypeBadge (Electronics for USB-C Hub)
+      expect(screen.getAllByText('Electronics')).toHaveLength(1);
+    });
+
+    it('filters out the current item from results', () => {
+      mockItemsListQuery.mockReturnValue({
+        data: {
+          data: [
+            ...searchResults,
+            {
+              id: 'item-1',
+              itemName: 'Current Item',
+              brand: null,
+              model: null,
+              assetId: null,
+              type: null,
+            },
+          ],
+        },
+        isLoading: false,
+      });
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), {
+        target: { value: 'cu' },
+      });
+      expect(screen.queryByText('Current Item')).not.toBeInTheDocument();
+    });
+
+    it('calls connect mutation when result item is clicked', async () => {
+      setupResults();
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), {
+        target: { value: 'us' },
+      });
+      fireEvent.click(screen.getByText('USB-C Hub'));
+      expect(mockConnectMutate).toHaveBeenCalledWith({
+        itemAId: 'item-1',
+        itemBId: 'item-2',
+      });
+    });
+  });
+
+  describe('post-connect', () => {
+    it('resets search and closes on success', async () => {
+      let onSuccessCallback: (() => void) | undefined;
+      mockConnectMutation.mockImplementation((opts: { onSuccess?: () => void }) => {
+        onSuccessCallback = opts?.onSuccess;
+        return { mutate: mockConnectMutate, isPending: false };
+      });
+
+      mockItemsListQuery.mockReturnValue({
+        data: {
+          data: [
+            {
+              id: 'item-2',
+              itemName: 'USB-C Hub',
+              brand: null,
+              model: null,
+              assetId: null,
+              type: null,
+            },
+          ],
+        },
+        isLoading: false,
+      });
+
+      renderDialog();
+      openDialog();
+      fireEvent.change(screen.getByPlaceholderText('Search items...'), {
+        target: { value: 'us' },
+      });
+
+      expect(screen.getByText('USB-C Hub')).toBeInTheDocument();
+
+      // Simulate success
+      onSuccessCallback?.();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/packages/app-inventory/src/components/ConnectDialog.tsx
+++ b/packages/app-inventory/src/components/ConnectDialog.tsx
@@ -119,15 +119,19 @@ export function ConnectDialog({ currentItemId, onConnected }: ConnectDialogProps
               >
                 <div className="flex-1 min-w-0">
                   <div className="font-medium text-sm">{item.itemName}</div>
-                  <div className="flex flex-wrap items-center gap-1 mt-0.5">
-                    {(item.brand || item.model) && (
-                      <span className="text-xs text-muted-foreground">
-                        {[item.brand, item.model].filter(Boolean).join(' · ')}
-                      </span>
-                    )}
-                    {item.assetId && <AssetIdBadge assetId={item.assetId} />}
-                    {item.type && <TypeBadge type={item.type} />}
-                  </div>
+                  {item.brand || item.model || item.assetId || item.type ? (
+                    <div className="flex flex-wrap items-center gap-1 mt-0.5">
+                      {(item.brand || item.model) && (
+                        <span className="text-xs text-muted-foreground">
+                          {[item.brand, item.model].filter(Boolean).join(' · ')}
+                        </span>
+                      )}
+                      {item.assetId && <AssetIdBadge assetId={item.assetId} />}
+                      {item.type && <TypeBadge type={item.type} />}
+                    </div>
+                  ) : (
+                    <span className="text-xs text-muted-foreground mt-0.5">No details</span>
+                  )}
                 </div>
                 <Link2 className="h-4 w-4 text-muted-foreground shrink-0 ml-2" />
               </Button>

--- a/packages/app-inventory/src/components/ConnectDialog.tsx
+++ b/packages/app-inventory/src/components/ConnectDialog.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner';
  * displays results, and connects the selected item.
  */
 import {
+  AssetIdBadge,
   Button,
   Dialog,
   DialogContent,
@@ -17,6 +18,7 @@ import {
   DialogTrigger,
   Skeleton,
   TextInput,
+  TypeBadge,
 } from '@pops/ui';
 
 import { trpc } from '../lib/trpc';
@@ -115,11 +117,16 @@ export function ConnectDialog({ currentItemId, onConnected }: ConnectDialogProps
                 }}
                 disabled={connectMutation.isPending}
               >
-                <div>
+                <div className="flex-1 min-w-0">
                   <div className="font-medium text-sm">{item.itemName}</div>
-                  <div className="text-xs text-muted-foreground">
-                    {[item.brand, item.model, item.assetId].filter(Boolean).join(' · ') ||
-                      'No details'}
+                  <div className="flex flex-wrap items-center gap-1 mt-0.5">
+                    {(item.brand || item.model) && (
+                      <span className="text-xs text-muted-foreground">
+                        {[item.brand, item.model].filter(Boolean).join(' · ')}
+                      </span>
+                    )}
+                    {item.assetId && <AssetIdBadge assetId={item.assetId} />}
+                    {item.type && <TypeBadge type={item.type} />}
                   </div>
                 </div>
                 <Link2 className="h-4 w-4 text-muted-foreground shrink-0 ml-2" />

--- a/packages/app-inventory/src/pages/ItemDetailPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.test.tsx
@@ -458,6 +458,92 @@ describe('ItemDetailPage', () => {
       expect(mockDisconnectMutate).toHaveBeenCalledWith({ id: 'c1' });
     });
 
+    it('disconnect dialog title includes the connected item name', () => {
+      setupWithConnections();
+      renderAtRoute('/inventory/items/item-1');
+
+      const disconnectButtons = screen.getAllByRole('button', { name: /disconnect/i });
+      fireEvent.click(disconnectButtons[0]!);
+
+      expect(screen.getByText('Disconnect USB-C Hub?')).toBeInTheDocument();
+    });
+
+    it('disconnect dialog does not fire mutation without confirmation', () => {
+      const mockDisconnectMutate = vi.fn();
+      mockDisconnectMutation.mockReturnValue({
+        mutate: mockDisconnectMutate,
+        isPending: false,
+      });
+      setupWithConnections();
+      renderAtRoute('/inventory/items/item-1');
+
+      // Click the trigger only — no confirm
+      const disconnectButtons = screen.getAllByRole('button', { name: /disconnect/i });
+      fireEvent.click(disconnectButtons[0]!);
+
+      expect(mockDisconnectMutate).not.toHaveBeenCalled();
+    });
+
+    it('disconnect dialog cancel closes without firing mutation', () => {
+      const mockDisconnectMutate = vi.fn();
+      mockDisconnectMutation.mockReturnValue({
+        mutate: mockDisconnectMutate,
+        isPending: false,
+      });
+      setupWithConnections();
+      renderAtRoute('/inventory/items/item-1');
+
+      const disconnectButtons = screen.getAllByRole('button', { name: /disconnect/i });
+      fireEvent.click(disconnectButtons[0]!);
+
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(mockDisconnectMutate).not.toHaveBeenCalled();
+      expect(screen.queryByText('Disconnect USB-C Hub?')).not.toBeInTheDocument();
+    });
+
+    it('renders AssetIdBadge and TypeBadge for connected items with known values', () => {
+      mockItemQuery.mockImplementation(({ id }: { id: string }) => {
+        if (id === 'item-2') {
+          return {
+            data: {
+              data: { ...connectedItemA, assetId: 'HUB-022', type: 'Electronics' },
+            },
+            isLoading: false,
+            error: null,
+          };
+        }
+        if (id === 'item-3') {
+          return {
+            data: {
+              data: { ...connectedItemB, assetId: 'MON-010', type: 'Furniture' },
+            },
+            isLoading: false,
+            error: null,
+          };
+        }
+        return { data: { data: baseItem }, isLoading: false, error: null };
+      });
+
+      mockConnectionsQuery.mockReturnValue({
+        data: {
+          data: [
+            { id: 'c1', itemAId: 'item-1', itemBId: 'item-2' },
+            { id: 'c2', itemAId: 'item-3', itemBId: 'item-1' },
+          ],
+        },
+        isLoading: false,
+      });
+
+      renderAtRoute('/inventory/items/item-1');
+
+      expect(screen.getByText('HUB-022')).toBeInTheDocument();
+      expect(screen.getByText('MON-010')).toBeInTheDocument();
+      // TypeBadge renders type text — Electronics appears in multiple places (item detail + connection row)
+      expect(screen.getAllByText('Electronics').length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByText('Furniture')).toBeInTheDocument();
+    });
+
     it('renders Connected Items heading with icon', () => {
       renderAtRoute('/inventory/items/item-1');
       expect(screen.getByText('Connected Items')).toBeInTheDocument();

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -714,10 +714,12 @@ function ConnectionRow({
       <Link to={`/inventory/items/${connectedItemId}`} className="flex-1 min-w-0 hover:underline">
         <span className="font-medium">{itemName}</span>
         {item?.brand && <span className="text-muted-foreground text-sm ml-2">{item.brand}</span>}
-        <div className="flex flex-wrap items-center gap-1 mt-0.5">
-          {item?.assetId && <AssetIdBadge assetId={item.assetId} />}
-          {item?.type && <TypeBadge type={item.type} />}
-        </div>
+        {(item?.assetId || item?.type) && (
+          <div className="flex flex-wrap items-center gap-1 mt-0.5">
+            {item.assetId && <AssetIdBadge assetId={item.assetId} />}
+            {item.type && <TypeBadge type={item.type} />}
+          </div>
+        )}
       </Link>
       <AlertDialog>
         <AlertDialogTrigger asChild>

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -37,6 +37,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
   AlertTitle,
+  AssetIdBadge,
   Badge,
   Button,
   type Condition,
@@ -710,16 +711,20 @@ function ConnectionRow({
 
   return (
     <div className="flex items-center justify-between p-3 rounded-lg border">
-      <Link to={`/inventory/items/${connectedItemId}`} className="flex-1 hover:underline">
+      <Link to={`/inventory/items/${connectedItemId}`} className="flex-1 min-w-0 hover:underline">
         <span className="font-medium">{itemName}</span>
         {item?.brand && <span className="text-muted-foreground text-sm ml-2">{item.brand}</span>}
+        <div className="flex flex-wrap items-center gap-1 mt-0.5">
+          {item?.assetId && <AssetIdBadge assetId={item.assetId} />}
+          {item?.type && <TypeBadge type={item.type} />}
+        </div>
       </Link>
       <AlertDialog>
         <AlertDialogTrigger asChild>
           <Button
             variant="ghost"
             size="icon"
-            className="h-8 w-8 text-destructive hover:text-destructive"
+            className="h-8 w-8 text-destructive hover:text-destructive shrink-0"
             disabled={isDisconnecting}
             title="Disconnect"
             aria-label="Disconnect"
@@ -729,9 +734,9 @@ function ConnectionRow({
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Disconnect item?</AlertDialogTitle>
+            <AlertDialogTitle>Disconnect {itemName}?</AlertDialogTitle>
             <AlertDialogDescription>
-              This will remove the connection to {itemName}. You can reconnect later.
+              This will remove the connection between these items.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
## Summary

- `ConnectDialog` search results now show `AssetIdBadge` and `TypeBadge` alongside brand/model text instead of plain joined string
- `ConnectionRow` in `ItemDetailPage` now renders `AssetIdBadge` and `TypeBadge` for connected items (both null-guarded)
- Disconnect `AlertDialog` title now reads "Disconnect [item name]?" and description updated to "This will remove the connection between these items."

## Test plan

- [x] `ConnectDialog.test.tsx` added — covers trigger, search prompt, loading state, empty results, badge rendering (present/absent), current-item filtering, connect mutation, and post-success close
- [x] `ItemDetailPage.test.tsx` extended — covers disconnect dialog title with item name, cancel-without-mutation, and `AssetIdBadge`/`TypeBadge` rendering for connection rows
- [x] All 304 tests pass (`pnpm --filter @pops/app-inventory test`)
- [x] Full monorepo typecheck passes (16 turbo tasks)
- [x] lint-staged (oxfmt + eslint) clean on commit

Closes #1857