### PR TITLE
fix(ci): restrict root-deploy to workflow_dispatch only

### DIFF
--- a/.github/workflows/root-deploy.yml
+++ b/.github/workflows/root-deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy to Production
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/docs/themes/00-infrastructure/prds/016-cicd-pipelines/README.md
+++ b/docs/themes/00-infrastructure/prds/016-cicd-pipelines/README.md
@@ -1,7 +1,7 @@
 # PRD-016: CI/CD Pipelines
 
 > Epic: [04 — CI/CD Pipelines](../../epics/04-cicd-pipelines.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -17,11 +17,11 @@ Set up GitHub Actions workflows for quality gates and deployment. Every PR runs 
 | `fe-test-e2e.yml`   | PR / push                        | Playwright e2e tests                           |
 | `infra-quality.yml` | PR / push (ansible changes)      | YAML lint, ansible-lint, syntax check          |
 | `tools-quality.yml` | PR / push (import tools changes) | Lint, test                                     |
-| `root-deploy.yml`   | Push to main + workflow_dispatch | Typecheck, lint, test, build, deploy to server |
+| `root-deploy.yml`   | workflow_dispatch (manual only)  | Typecheck, lint, test, build, deploy to server |
 
 ## Business Rules
 
-- Deployment runs on push to main and via manual `workflow_dispatch` — see issue #1818 for tracking the gap between this and the originally-specified manual-only trigger
+- Deployment runs only via manual `workflow_dispatch` — never auto-deploys on push to main (self-hosted runner security risk per ADR-015)
 - Self-hosted runner runs on the production server — used only for the deploy step
 - All quality gates (typecheck, lint, test, build) must pass before deploy step runs
 - Path filters on CI workflows — only trigger when relevant files change
@@ -32,14 +32,14 @@ Set up GitHub Actions workflows for quality gates and deployment. Every PR runs 
 | #   | Story                                             | Summary                                                         | Status  | Parallelisable   |
 | --- | ------------------------------------------------- | --------------------------------------------------------------- | ------- | ---------------- |
 | 01  | [us-01-pr-workflows](us-01-pr-workflows.md)       | CI workflows for PRs: API, shell, test, e2e, ansible, tools     | Done    | No (first)       |
-| 02  | [us-02-deploy-workflow](us-02-deploy-workflow.md) | Manual deploy workflow with quality gates and server deployment | Partial | Blocked by us-01 |
+| 02  | [us-02-deploy-workflow](us-02-deploy-workflow.md) | Manual deploy workflow with quality gates and server deployment | Done    | Blocked by us-01 |
 
 ## Verification
 
 - PR with API changes triggers `api-quality.yml`
 - PR with shell changes triggers `fe-quality.yml`
 - Failing tests block PR merge
-- `root-deploy.yml` triggers on push to main and via `workflow_dispatch` (see issue #1818 for the gap vs. manual-only spec)
+- `root-deploy.yml` triggers only via `workflow_dispatch` (manual only, fixed in #1818)
 - Deploy runs quality gates before deployment step
 - Deploy reaches the server and restarts services
 
@@ -51,4 +51,4 @@ Set up GitHub Actions workflows for quality gates and deployment. Every PR runs 
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-18

--- a/docs/themes/00-infrastructure/prds/016-cicd-pipelines/README.md
+++ b/docs/themes/00-infrastructure/prds/016-cicd-pipelines/README.md
@@ -29,10 +29,10 @@ Set up GitHub Actions workflows for quality gates and deployment. Every PR runs 
 
 ## User Stories
 
-| #   | Story                                             | Summary                                                         | Status  | Parallelisable   |
-| --- | ------------------------------------------------- | --------------------------------------------------------------- | ------- | ---------------- |
-| 01  | [us-01-pr-workflows](us-01-pr-workflows.md)       | CI workflows for PRs: API, shell, test, e2e, ansible, tools     | Done    | No (first)       |
-| 02  | [us-02-deploy-workflow](us-02-deploy-workflow.md) | Manual deploy workflow with quality gates and server deployment | Done    | Blocked by us-01 |
+| #   | Story                                             | Summary                                                         | Status | Parallelisable   |
+| --- | ------------------------------------------------- | --------------------------------------------------------------- | ------ | ---------------- |
+| 01  | [us-01-pr-workflows](us-01-pr-workflows.md)       | CI workflows for PRs: API, shell, test, e2e, ansible, tools     | Done   | No (first)       |
+| 02  | [us-02-deploy-workflow](us-02-deploy-workflow.md) | Manual deploy workflow with quality gates and server deployment | Done   | Blocked by us-01 |
 
 ## Verification
 

--- a/docs/themes/00-infrastructure/prds/016-cicd-pipelines/us-02-deploy-workflow.md
+++ b/docs/themes/00-infrastructure/prds/016-cicd-pipelines/us-02-deploy-workflow.md
@@ -1,7 +1,7 @@
 # US-02: Manual deploy workflow
 
 > PRD: [016 — CI/CD Pipelines](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -9,7 +9,7 @@ As an operator, I want a manual deploy workflow that runs quality gates then dep
 
 ## Acceptance Criteria
 
-- [ ] `root-deploy.yml` triggered only via `workflow_dispatch` (manual) — currently also triggers on push to main (see issue #1818)
+- [x] `root-deploy.yml` triggered only via `workflow_dispatch` (manual) — fixed in #1818
 - [x] Runs typecheck, lint, test, build as quality gates before deploy
 - [x] If any gate fails, deployment is skipped
 - [x] Deployment step SSHes to server and runs Ansible deploy playbook


### PR DESCRIPTION
## Summary

- Removes the `on.push: branches: [main]` trigger from `.github/workflows/root-deploy.yml`
- Deployment is now exclusively manual via `workflow_dispatch`, per PRD-016 US-02 and ADR-015
- The self-hosted runner (which runs on the production server) is no longer reachable from automatic push events, closing the security gap

## Docs

- PRD-016 US-02: ticked the manual-trigger acceptance criterion, status `Partial` → `Done`
- PRD-016 README: updated workflow table, business rules, and verification notes; status `Partial` → `Done`; bumped drift-check date to 2026-04-18

## Test plan

- [ ] Confirm `.github/workflows/root-deploy.yml` `on:` block contains only `workflow_dispatch` (no `push`)
- [ ] Trigger workflow manually from GitHub Actions UI — should run normally
- [ ] Push to `main` (after merge) — confirm `root-deploy.yml` does NOT trigger

Closes #1818