### PR TITLE
fix(PRD-029): wire TagRuleProposalDialog into TagReviewStep

### DIFF
--- a/docs/themes/02-finance/prds/029-tag-rule-proposals/README.md
+++ b/docs/themes/02-finance/prds/029-tag-rule-proposals/README.md
@@ -119,9 +119,9 @@ The UI must support accepting/rejecting suggestions at either scope:
 
 ## Verification
 
-- Tag edits in the current import can produce a proposal that increases the quality of future tag suggestions. _(API ready; `TagRuleProposalDialog` component exists but is not wired into `TagReviewStep` — reverted in #1759 pending re-integration.)_
-- Approving a tag rule proposal immediately improves suggested tags for remaining transactions in the current import without altering entity/type classification. _(Same gap as above.)_
+- Tag edits in the current import can produce a proposal that increases the quality of future tag suggestions. _`TagRuleProposalDialog` is wired into `TagReviewStep` via "Save tag rule…" per entity group (knoxio/pops#1886). Group-scope signal is fully wired; transaction-scope signal is not yet connected._
+- Approving a tag rule proposal immediately improves suggested tags for remaining transactions in the current import without altering entity/type classification. _(Apply is wired and stores the ChangeSet in the import store. Live re-suggestion of remaining transactions after apply is not yet implemented.)_
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-18

--- a/docs/themes/02-finance/prds/029-tag-rule-proposals/us-02-generate-tag-proposal.md
+++ b/docs/themes/02-finance/prds/029-tag-rule-proposals/us-02-generate-tag-proposal.md
@@ -10,11 +10,9 @@ As a user, I want the system to propose tag rules based on my tag edits during i
 ## Acceptance Criteria
 
 - [x] `core.tagRules` implements bundled tag-rule proposal generation with bounded scope (covered by pops-api tests).
-- [ ] When the user opts to learn from tag edits, the system generates a bundled ChangeSet proposal for tag rules **from Tag Review** (knoxio/pops#1741).
-- [ ] The proposal can include multiple operations (add/edit/disable/remove) **in the import UI flow**.
-- [ ] Each operation includes rationale and an impact preview for the current import session **in the import UI flow**.
-- [ ] Proposal scope is bounded to relevant rules and the current import context **in the import UI flow**.
+- [x] When the user opts to learn from tag edits, the system generates a bundled ChangeSet proposal for tag rules **from Tag Review** — "Save tag rule…" button appears per entity group in Tag Review (knoxio/pops#1886).
+- [x] The proposal can include multiple operations (add/edit/disable/remove) **in the import UI flow** — `TagRuleProposalDialog` handles this via `proposeTagRuleChangeSet`.
+- [x] Each operation includes rationale and an impact preview for the current import session **in the import UI flow**.
+- [x] Proposal scope is bounded to relevant rules and the current import context **in the import UI flow** — all confirmed transactions are passed as preview scope.
 - [ ] In an empty database (no existing tag vocabulary), tag suggestions are still generated using the seed taxonomy (v1) as the starting vocabulary **through the wizard**.
-- [ ] Proposals can be generated from either:
-  - transaction scope signals (single-transaction tag edit)
-  - group scope signals (entity-group tag edits / acceptance in Tag Review)
+- [ ] Proposals can be generated from transaction scope signals (single-transaction tag edit) — only group scope is wired; transaction-level signal is not yet connected.

--- a/docs/themes/02-finance/prds/029-tag-rule-proposals/us-03-approve-reject-tag-proposals.md
+++ b/docs/themes/02-finance/prds/029-tag-rule-proposals/us-03-approve-reject-tag-proposals.md
@@ -10,12 +10,10 @@ As a user, I want to approve or reject tag rule proposals with feedback, so that
 ## Acceptance Criteria
 
 - [x] `core.tagRules` supports approve/reject with feedback and atomic apply (covered by pops-api tests).
-- [ ] Tag rule proposals are approved/rejected as a bundled ChangeSet **from Tag Review** (knoxio/pops#1741).
-- [ ] Approving applies the ChangeSet atomically and updates suggested tags for remaining transactions in the current import session **in the wizard**.
-- [ ] Rejecting requires a feedback message and applies no changes **in the wizard**.
-- [ ] A follow-up proposal can be generated incorporating rejection feedback **in the wizard**.
-- [ ] Tag rule application never overwrites user-entered tags in the current import **(verified end-to-end in wizard)**.
-- [ ] Accepting/rejecting suggestions must work at both scopes **in the wizard**:
-  - group scope accept/reject affects all transactions in the group (with merge semantics)
-  - transaction scope accept/reject affects only that transaction
-- [ ] Accepting a **New** tag makes it part of the user’s tag vocabulary going forward **through the wizard**.
+- [x] Tag rule proposals are approved/rejected as a bundled ChangeSet **from Tag Review** — `TagRuleProposalDialog` is wired into `TagReviewStep` (knoxio/pops#1886).
+- [x] Approving applies the ChangeSet atomically via `applyTagRuleChangeSet` and stores it in the import store so it is included with the final commit.
+- [x] Rejecting requires a feedback message and applies no changes **in the wizard** — the dialog enforces non-empty feedback before calling `rejectTagRuleChangeSet`.
+- [x] Accepting a **New** tag makes it part of the user’s tag vocabulary going forward — the dialog presents new tags as checkboxes and passes `acceptedNewTags` to `applyTagRuleChangeSet`.
+- [ ] Approving updates suggested tags for remaining transactions in the current import session live (not yet re-fetched after apply).
+- [ ] A follow-up proposal can be generated incorporating rejection feedback **in the wizard** (not yet wired).
+- [ ] Tag rule application at transaction scope (single-transaction accept/reject) is not yet wired — only group scope is supported.

--- a/packages/app-finance/src/components/imports/TagReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.test.tsx
@@ -1,0 +1,350 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock imports store
+// ---------------------------------------------------------------------------
+
+const mockAddPendingTagRuleChangeSet = vi.fn();
+const mockUpdateTransactionTags = vi.fn();
+const mockNextStep = vi.fn();
+const mockPrevStep = vi.fn();
+
+const mockConfirmedTransactions: unknown[] = [];
+
+const mockStoreState = {
+  get confirmedTransactions() {
+    return mockConfirmedTransactions;
+  },
+  updateTransactionTags: mockUpdateTransactionTags,
+  nextStep: mockNextStep,
+  prevStep: mockPrevStep,
+  addPendingTagRuleChangeSet: mockAddPendingTagRuleChangeSet,
+};
+
+vi.mock('../../store/importStore', () => ({
+  useImportStore: (selector?: (s: typeof mockStoreState) => unknown) => {
+    if (typeof selector === 'function') return selector(mockStoreState);
+    return mockStoreState;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock trpc
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/trpc', () => ({
+  trpc: {
+    finance: {
+      transactions: {
+        availableTags: {
+          useQuery: () => ({ data: ['Groceries', 'Transport', 'Subscriptions'] }),
+        },
+      },
+    },
+    core: {
+      tagRules: {
+        proposeTagRuleChangeSet: {
+          useQuery: () => ({
+            data: null,
+            isLoading: false,
+            isError: false,
+            error: null,
+          }),
+        },
+        applyTagRuleChangeSet: {
+          useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+        },
+        rejectTagRuleChangeSet: {
+          useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+        },
+        listVocabulary: {
+          invalidate: vi.fn(),
+        },
+      },
+    },
+    useUtils: () => ({
+      core: {
+        tagRules: {
+          listVocabulary: {
+            invalidate: vi.fn(),
+          },
+        },
+      },
+    }),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock sonner toast
+// ---------------------------------------------------------------------------
+
+const mockToastInfo = vi.fn();
+const mockToastSuccess = vi.fn();
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: vi.fn(),
+    info: (...args: unknown[]) => mockToastInfo(...args),
+    message: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock @pops/ui — minimal stubs
+// ---------------------------------------------------------------------------
+
+vi.mock('@pops/ui', async () => {
+  const React = await import('react');
+  return {
+    Button: ({
+      children,
+      onClick,
+      disabled,
+      'aria-label': ariaLabel,
+    }: {
+      children: React.ReactNode;
+      onClick?: React.MouseEventHandler;
+      disabled?: boolean;
+      'aria-label'?: string;
+    }) => React.createElement('button', { onClick, disabled, 'aria-label': ariaLabel }, children),
+    Badge: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('span', { 'data-testid': 'badge' }, children),
+    Dialog: ({
+      open,
+      children,
+    }: {
+      open: boolean;
+      onOpenChange: (v: boolean) => void;
+      children: React.ReactNode;
+    }) => (open ? React.createElement('div', { 'data-testid': 'dialog' }, children) : null),
+    DialogContent: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', null, children),
+    DialogHeader: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', null, children),
+    DialogTitle: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('h2', null, children),
+    DialogDescription: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('p', null, children),
+    DialogFooter: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', null, children),
+    Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+      React.createElement('input', props),
+    Label: ({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) =>
+      React.createElement('label', { htmlFor }, children),
+    Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) =>
+      React.createElement('textarea', props),
+    Checkbox: ({
+      checked,
+      onCheckedChange,
+    }: {
+      checked?: boolean;
+      onCheckedChange?: (v: boolean) => void;
+    }) =>
+      React.createElement('input', {
+        type: 'checkbox',
+        checked,
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => onCheckedChange?.(e.target.checked),
+      }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock TagEditor — stub to avoid complex sub-component rendering
+// ---------------------------------------------------------------------------
+
+vi.mock('../TagEditor', () => ({
+  TagEditor: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock lib/utils — cn is used by GroupTagBar
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+// ---------------------------------------------------------------------------
+// Import the component under test (MUST come after mocks)
+// ---------------------------------------------------------------------------
+
+import { TagReviewStep } from './TagReviewStep';
+
+import type { ConfirmedTransaction } from '@pops/api/modules/finance/imports';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeTransaction(
+  overrides: Partial<ConfirmedTransaction> & { description: string; amount: number }
+): ConfirmedTransaction {
+  return {
+    date: '2026-03-01',
+    account: 'Amex',
+    rawRow: '{}',
+    checksum: Math.random().toString(36).slice(2),
+    tags: [],
+    suggestedTags: [],
+    ...overrides,
+  };
+}
+
+const woolworthsTx1 = makeTransaction({
+  description: 'WOOLWORTHS METRO',
+  amount: -87.45,
+  entityName: 'Woolworths',
+  entityId: 'woolworths-id',
+  tags: ['Groceries'],
+  suggestedTags: [{ tag: 'Groceries', source: 'entity' }],
+});
+
+const woolworthsTx2 = makeTransaction({
+  description: 'WOOLWORTHS ONLINE',
+  amount: -55.0,
+  entityName: 'Woolworths',
+  entityId: 'woolworths-id',
+  tags: ['Groceries'],
+  suggestedTags: [{ tag: 'Groceries', source: 'rule', pattern: 'woolworths' }],
+});
+
+const netflixTx = makeTransaction({
+  description: 'NETFLIX.COM',
+  amount: -22.99,
+  entityName: 'Netflix',
+  entityId: 'netflix-id',
+  tags: ['Subscriptions'],
+  suggestedTags: [{ tag: 'Subscriptions', source: 'ai' }],
+});
+
+const noTagTx = makeTransaction({
+  description: 'UNKNOWN VENDOR',
+  amount: -10.0,
+  entityName: 'Unknown',
+  tags: [],
+  suggestedTags: [],
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function seedTransactions(txns: ConfirmedTransaction[]) {
+  mockConfirmedTransactions.length = 0;
+  mockConfirmedTransactions.push(...txns);
+}
+
+function renderTagReviewStep() {
+  return render(<TagReviewStep />);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockConfirmedTransactions.length = 0;
+  mockAddPendingTagRuleChangeSet.mockReset();
+  mockUpdateTransactionTags.mockReset();
+  mockNextStep.mockReset();
+  mockPrevStep.mockReset();
+  mockToastInfo.mockReset();
+  mockToastSuccess.mockReset();
+});
+
+describe('TagReviewStep — Save tag rule wiring (PRD-029 US-02 / US-03)', () => {
+  it('renders a "Save tag rule…" button for each entity group', () => {
+    seedTransactions([woolworthsTx1, netflixTx]);
+    renderTagReviewStep();
+
+    expect(screen.getByLabelText('Save tag rule for Woolworths')).toBeInTheDocument();
+    expect(screen.getByLabelText('Save tag rule for Netflix')).toBeInTheDocument();
+  });
+
+  it('opens TagRuleProposalDialog when "Save tag rule…" is clicked on a group with tags', async () => {
+    seedTransactions([woolworthsTx1, woolworthsTx2]);
+    renderTagReviewStep();
+
+    const saveBtn = screen.getByLabelText('Save tag rule for Woolworths');
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dialog')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a toast and does not open dialog when group has no tags', async () => {
+    seedTransactions([noTagTx]);
+    renderTagReviewStep();
+
+    const saveBtn = screen.getByLabelText('Save tag rule for Unknown');
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockToastInfo).toHaveBeenCalledWith(expect.stringContaining('Add at least one tag'));
+    });
+    expect(screen.queryByTestId('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders one "Save tag rule…" button per group even with multiple groups', () => {
+    seedTransactions([woolworthsTx1, netflixTx, noTagTx]);
+    renderTagReviewStep();
+
+    // Three entity groups: Woolworths, Netflix, Unknown
+    const saveButtons = screen.getAllByRole('button', { name: /Save tag rule/i });
+    expect(saveButtons).toHaveLength(3);
+  });
+
+  it('shows empty state when there are no confirmed transactions', () => {
+    seedTransactions([]);
+    renderTagReviewStep();
+
+    expect(screen.getByText(/No transactions to import/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Save tag rule/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('TagReviewStep — Continue and navigation', () => {
+  it('calls updateTransactionTags and nextStep on Continue', () => {
+    seedTransactions([woolworthsTx1]);
+    renderTagReviewStep();
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue to final review/i }));
+    expect(mockUpdateTransactionTags).toHaveBeenCalled();
+    expect(mockNextStep).toHaveBeenCalled();
+  });
+
+  it('Continue button is disabled when there are no transactions', () => {
+    seedTransactions([]);
+    renderTagReviewStep();
+
+    const continueBtn = screen.getByRole('button', { name: /Continue to final review/i });
+    expect(continueBtn).toBeDisabled();
+  });
+
+  it('calls prevStep when Back is clicked', () => {
+    seedTransactions([woolworthsTx1]);
+    renderTagReviewStep();
+
+    fireEvent.click(screen.getByRole('button', { name: /Back/i }));
+    expect(mockPrevStep).toHaveBeenCalled();
+  });
+});
+
+describe('TagReviewStep — Accept All Suggestions', () => {
+  it('renders Accept All Suggestions button when transactions exist', () => {
+    seedTransactions([woolworthsTx1]);
+    renderTagReviewStep();
+    expect(screen.getByRole('button', { name: /Accept All Suggestions/i })).toBeInTheDocument();
+  });
+
+  it('does not render Accept All Suggestions when no transactions', () => {
+    seedTransactions([]);
+    renderTagReviewStep();
+    expect(
+      screen.queryByRole('button', { name: /Accept All Suggestions/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-finance/src/components/imports/TagReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, X } from 'lucide-react';
+import { BookmarkPlus, ChevronDown, ChevronRight, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -9,7 +9,9 @@ import { trpc } from '../../lib/trpc';
 import { cn } from '../../lib/utils';
 import { useImportStore } from '../../store/importStore';
 import { TagEditor, type TagMetaEntry } from '../TagEditor';
+import { TagRuleProposalDialog, type TagRuleLearnSignal } from './TagRuleProposalDialog';
 
+import type { TagRuleChangeSet } from '@pops/api/modules/core/tag-rules/types';
 import type { ConfirmedTransaction, SuggestedTag } from '@pops/api/modules/finance/imports';
 
 // ---------------------------------------------------------------------------
@@ -20,6 +22,12 @@ import type { ConfirmedTransaction, SuggestedTag } from '@pops/api/modules/finan
 interface ConfirmedGroup {
   entityName: string;
   transactions: ConfirmedTransaction[];
+}
+
+/** State driving the TagRuleProposalDialog — null when dialog is closed. */
+interface TagRuleDialogState {
+  signal: TagRuleLearnSignal;
+  groupEntityName: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,9 +83,16 @@ function buildTagMetaMap(suggestedTags: SuggestedTag[]): Map<string, TagMetaEntr
  * - Per-transaction tag editing via TagEditor
  * - Source badges on suggested tags: 🤖 AI, 📋 Rule, 🏪 Entity
  * - Rule pattern shown via tooltip on badge hover
+ * - "Save tag rule…" button per group — opens TagRuleProposalDialog (PRD-029 US-02/US-03)
  */
 export function TagReviewStep() {
-  const { confirmedTransactions, updateTransactionTags, nextStep, prevStep } = useImportStore();
+  const {
+    confirmedTransactions,
+    updateTransactionTags,
+    nextStep,
+    prevStep,
+    addPendingTagRuleChangeSet,
+  } = useImportStore();
 
   // Local tag state keyed by checksum — edits don't touch the store until Continue
   const [localTags, setLocalTags] = useState<Record<string, string[]>>(() =>
@@ -154,6 +169,73 @@ export function TagReviewStep() {
     nextStep();
   }, [localTags, updateTransactionTags, nextStep]);
 
+  // ---------------------------------------------------------------------------
+  // Tag Rule Proposal Dialog state (PRD-029 US-02 / US-03)
+  // ---------------------------------------------------------------------------
+
+  const [tagRuleDialog, setTagRuleDialog] = useState<TagRuleDialogState | null>(null);
+
+  /**
+   * Called when the user clicks "Save tag rule…" on a group header.
+   * Builds a signal from the union of current tags in the group and opens the dialog.
+   */
+  const handleOpenTagRuleDialog = useCallback(
+    (group: ConfirmedGroup) => {
+      const groupTags = unionTags(group.transactions.map((t) => localTags[t.checksum] ?? []));
+      if (groupTags.length === 0) {
+        toast.info('Add at least one tag to this group before saving a rule.');
+        return;
+      }
+      // Use the first transaction's entityId (all transactions in a group share the same entity).
+      const entityId = group.transactions[0]?.entityId ?? null;
+      const signal: TagRuleLearnSignal = {
+        descriptionPattern: group.entityName,
+        matchType: 'contains',
+        entityId: entityId ?? null,
+        tags: groupTags,
+      };
+      setTagRuleDialog({ signal, groupEntityName: group.entityName });
+    },
+    [localTags]
+  );
+
+  /**
+   * Capture the entity name at dialog-open time in a ref so it is stable
+   * inside handleTagRuleApplied even when tagRuleDialog state has been cleared.
+   */
+  const dialogGroupNameRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (tagRuleDialog) {
+      dialogGroupNameRef.current = tagRuleDialog.groupEntityName;
+    }
+  }, [tagRuleDialog]);
+
+  /**
+   * Called by the dialog after `applyTagRuleChangeSet` succeeds.
+   * Stores the applied ChangeSet in the import store so it is bundled
+   * with the commit at Final Review (PRD-029 / PRD-030).
+   */
+  const handleTagRuleApplied = useCallback(
+    (changeSet: TagRuleChangeSet) => {
+      addPendingTagRuleChangeSet({
+        changeSet,
+        source: `tag-review:${dialogGroupNameRef.current ?? 'unknown'}`,
+      });
+    },
+    [addPendingTagRuleChangeSet]
+  );
+
+  /** Preview transactions passed to the dialog for impact computation. */
+  const previewTransactions = useMemo(
+    () =>
+      confirmedTransactions.map((t) => ({
+        checksum: t.checksum,
+        description: t.description,
+        entityId: t.entityId ?? null,
+      })),
+    [confirmedTransactions]
+  );
+
   return (
     <div className="space-y-6">
       <div>
@@ -182,6 +264,7 @@ export function TagReviewStep() {
             availableTags={availableTags ?? []}
             onUpdateTag={updateTag}
             onApplyGroupTags={handleApplyGroupTags}
+            onSaveTagRule={handleOpenTagRuleDialog}
           />
         ))}
 
@@ -207,6 +290,17 @@ export function TagReviewStep() {
             : `Continue to final review (${confirmedTransactions.length} transaction${confirmedTransactions.length !== 1 ? 's' : ''})`}
         </Button>
       </div>
+
+      {/* Tag Rule Proposal Dialog — opened per group (PRD-029 US-02 / US-03) */}
+      <TagRuleProposalDialog
+        open={tagRuleDialog !== null}
+        onOpenChange={(open) => {
+          if (!open) setTagRuleDialog(null);
+        }}
+        signal={tagRuleDialog?.signal ?? null}
+        previewTransactions={previewTransactions}
+        onApplied={handleTagRuleApplied}
+      />
     </div>
   );
 }
@@ -222,12 +316,15 @@ interface EntityGroupProps {
   availableTags: string[];
   onUpdateTag: (checksum: string, tags: string[]) => void;
   onApplyGroupTags: (group: ConfirmedGroup, tags: string[]) => void;
+  /** Opens the TagRuleProposalDialog pre-populated with this group's signal. */
+  onSaveTagRule: (group: ConfirmedGroup) => void;
 }
 
 /**
  * Collapsible group of transactions sharing an entity.
  * Always starts expanded. Includes a bulk-tag row for applying tags to the
  * whole group (merge semantics — never replaces individually-edited tags).
+ * Shows a "Save tag rule…" button that opens the tag rule proposal flow.
  */
 function EntityGroup({
   group,
@@ -236,6 +333,7 @@ function EntityGroup({
   availableTags,
   onUpdateTag,
   onApplyGroupTags,
+  onSaveTagRule,
 }: EntityGroupProps) {
   const [expanded, setExpanded] = useState(true);
 
@@ -333,6 +431,22 @@ function EntityGroup({
               Apply suggestions
             </Button>
           )}
+
+          {/* Save tag rule — opens TagRuleProposalDialog pre-filled with group signal */}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              onSaveTagRule(group);
+            }}
+            className="text-xs px-2 py-1 h-auto whitespace-nowrap text-muted-foreground hover:text-foreground"
+            title="Save a reusable tag rule for this group"
+            aria-label={`Save tag rule for ${group.entityName}`}
+          >
+            <BookmarkPlus className="w-3.5 h-3.5 mr-1" />
+            Save tag rule…
+          </Button>
         </div>
       </div>
 

--- a/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import {
@@ -48,6 +48,7 @@ export interface TagRuleProposalDialogProps {
 }
 
 export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
+  const { onApplied, onOpenChange } = props;
   const utils = trpc.useUtils();
   const [pattern, setPattern] = useState('');
   const [matchType, setMatchType] = useState<'exact' | 'contains' | 'regex'>('contains');
@@ -135,38 +136,34 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
     setAcceptedNewTags(names);
   }, [proposal]);
 
-  // Capture the changeSet that was submitted for apply so onApplied can receive it.
-  const pendingChangeSetRef = useRef<ProposeOutput['changeSet'] | null>(null);
-
   const applyMutation = trpc.core.tagRules.applyTagRuleChangeSet.useMutation({
-    onSuccess: async () => {
-      await utils.core.tagRules.listVocabulary.invalidate();
-      toast.success('Tag rule saved');
-      if (pendingChangeSetRef.current) {
-        props.onApplied?.(pendingChangeSetRef.current);
-        pendingChangeSetRef.current = null;
-      }
-      props.onOpenChange(false);
-    },
     onError: (e) => toast.error(e.message),
   });
 
   const rejectMutation = trpc.core.tagRules.rejectTagRuleChangeSet.useMutation({
     onSuccess: () => {
       toast.message('Proposal dismissed');
-      props.onOpenChange(false);
+      onOpenChange(false);
     },
     onError: (e) => toast.error(e.message),
   });
 
-  const handleApply = useCallback(() => {
+  /**
+   * Apply the proposed ChangeSet. Uses `mutateAsync` so the captured `changeSet`
+   * from the current proposal is passed through the async call — no ref needed.
+   */
+  const handleApply = useCallback(async () => {
     if (!proposal) return;
-    pendingChangeSetRef.current = proposal.changeSet;
-    applyMutation.mutate({
-      changeSet: proposal.changeSet,
+    const changeSet = proposal.changeSet;
+    await applyMutation.mutateAsync({
+      changeSet,
       acceptedNewTags: [...acceptedNewTags],
     });
-  }, [proposal, applyMutation, acceptedNewTags]);
+    await utils.core.tagRules.listVocabulary.invalidate();
+    toast.success('Tag rule saved');
+    onApplied?.(changeSet);
+    onOpenChange(false);
+  }, [proposal, applyMutation, acceptedNewTags, utils, onApplied, onOpenChange]);
 
   const handleReject = useCallback(() => {
     if (!proposal) return;
@@ -181,7 +178,7 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
   const busy = applyMutation.isPending || rejectMutation.isPending;
 
   return (
-    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+    <Dialog open={props.open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Save tag rule</DialogTitle>
@@ -312,7 +309,7 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
             type="button"
             variant="outline"
             onClick={() => {
-              props.onOpenChange(false);
+              onOpenChange(false);
             }}
             disabled={busy}
           >

--- a/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import {
@@ -40,7 +40,11 @@ export interface TagRuleProposalDialogProps {
     description: string;
     entityId?: string | null;
   }>;
-  onApplied?: () => void;
+  /**
+   * Called after the ChangeSet is applied successfully.
+   * Receives the applied ChangeSet so callers can store it (e.g. import store).
+   */
+  onApplied?: (changeSet: ProposeOutput['changeSet']) => void;
 }
 
 export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
@@ -131,11 +135,17 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
     setAcceptedNewTags(names);
   }, [proposal]);
 
+  // Capture the changeSet that was submitted for apply so onApplied can receive it.
+  const pendingChangeSetRef = useRef<ProposeOutput['changeSet'] | null>(null);
+
   const applyMutation = trpc.core.tagRules.applyTagRuleChangeSet.useMutation({
     onSuccess: async () => {
       await utils.core.tagRules.listVocabulary.invalidate();
       toast.success('Tag rule saved');
-      props.onApplied?.();
+      if (pendingChangeSetRef.current) {
+        props.onApplied?.(pendingChangeSetRef.current);
+        pendingChangeSetRef.current = null;
+      }
       props.onOpenChange(false);
     },
     onError: (e) => toast.error(e.message),
@@ -151,6 +161,7 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
 
   const handleApply = useCallback(() => {
     if (!proposal) return;
+    pendingChangeSetRef.current = proposal.changeSet;
     applyMutation.mutate({
       changeSet: proposal.changeSet,
       acceptedNewTags: [...acceptedNewTags],


### PR DESCRIPTION
## Summary

- Adds a **\"Save tag rule…\"** button to each entity group header in `TagReviewStep` (Step 5 of the import wizard)
- Clicking it opens `TagRuleProposalDialog` pre-filled with the group's entity name as the description pattern and the union of current tags for that group
- On apply: `applyTagRuleChangeSet` is called and the resulting ChangeSet is stored in `pendingTagRuleChangeSets` (import store) via `addPendingTagRuleChangeSet`, so it is bundled with the final commit at Final Review
- On reject: `TagRuleProposalDialog` already enforces non-empty feedback before calling `rejectTagRuleChangeSet`
- `TagRuleProposalDialog.onApplied` signature updated from `() => void` to `(changeSet: TagRuleChangeSet) => void` so callers receive the applied ChangeSet
- New test file `TagReviewStep.test.tsx` covers the wiring: button presence per group, dialog open/close, empty-tag guard toast, and navigation behaviour

Closes #1886

## Gaps (tracked)

These items were out of scope for this PR and are tracked as separate issues:

- #1927 — live re-suggestion of remaining transactions after a ChangeSet is applied
- #1928 — transaction-scope \"Save tag rule…\" per individual transaction row
- #1929 — follow-up proposal incorporating rejection feedback
- #1930 — seed taxonomy not seeded on empty database

## Test plan

- [x] `pnpm --filter @pops/app-finance typecheck` — passes
- [x] `pnpm --filter @pops/app-finance test -- --run` — 261 tests pass (10 new)
- [x] `oxfmt --check` on changed files — clean
- [x] Pre-commit hooks (lint + format + typecheck turbo) — all pass