### PR TITLE
fix(debrief): correct navigate targets for done and do-another actions

### DIFF
--- a/packages/app-media/src/components/DebriefControls.test.tsx
+++ b/packages/app-media/src/components/DebriefControls.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Capture mutation options
@@ -45,6 +45,23 @@ import {
 
 function renderWithRouter(ui: React.ReactElement) {
   return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+/** Renders ui inside a MemoryRouter that also mounts a catch-all route
+ *  displaying the current pathname, so navigation can be asserted. */
+function renderWithRouterAndSpy(ui: React.ReactElement, initialPath = '/') {
+  function PathDisplay() {
+    const loc = useLocation();
+    return <div data-testid="current-path">{loc.pathname}</div>;
+  }
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path={initialPath} element={ui} />
+        <Route path="*" element={<PathDisplay />} />
+      </Routes>
+    </MemoryRouter>
+  );
 }
 
 describe('SkipDimensionButton', () => {
@@ -145,6 +162,13 @@ describe('CompletionSummary', () => {
   it('hides Do Another button when no callback', () => {
     renderWithRouter(<CompletionSummary data={summaryData} />);
     expect(screen.queryByText('Do another')).not.toBeInTheDocument();
+  });
+
+  it('Done button navigates to /media/rankings', async () => {
+    const user = userEvent.setup();
+    renderWithRouterAndSpy(<CompletionSummary data={summaryData} />, '/start');
+    await user.click(screen.getByTestId('done-btn'));
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/media/rankings');
   });
 });
 

--- a/packages/app-media/src/components/DebriefControls.tsx
+++ b/packages/app-media/src/components/DebriefControls.tsx
@@ -170,7 +170,7 @@ export function CompletionSummary({ data, onDoAnother }: CompletionSummaryProps)
           <Button
             variant="default"
             size="sm"
-            onClick={() => navigate('/media/compare/rankings')}
+            onClick={() => navigate('/media/rankings')}
             data-testid="done-btn"
           >
             Done

--- a/packages/app-media/src/pages/DebriefPage.test.tsx
+++ b/packages/app-media/src/pages/DebriefPage.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TooltipProvider } from '@pops/ui';
@@ -65,6 +66,25 @@ function renderWithMovie(movieId: string) {
       <TooltipProvider>
         <Routes>
           <Route path="/media/debrief/:movieId" element={<DebriefPage />} />
+        </Routes>
+      </TooltipProvider>
+    </MemoryRouter>
+  );
+}
+
+/** Renders the debrief page with a catch-all route that exposes the
+ *  current pathname so post-navigation assertions can be made. */
+function renderWithMovieAndSpy(movieId: string) {
+  function PathDisplay() {
+    const loc = useLocation();
+    return <div data-testid="current-path">{loc.pathname}</div>;
+  }
+  return render(
+    <MemoryRouter initialEntries={[`/media/debrief/${movieId}`]}>
+      <TooltipProvider>
+        <Routes>
+          <Route path="/media/debrief/:movieId" element={<DebriefPage />} />
+          <Route path="*" element={<PathDisplay />} />
         </Routes>
       </TooltipProvider>
     </MemoryRouter>
@@ -289,5 +309,20 @@ describe('DebriefPage', () => {
     renderWithMovie('abc');
 
     expect(screen.getByText('Invalid movie ID.')).toBeInTheDocument();
+  });
+
+  it('"Do another" button navigates to /media/compare', async () => {
+    const user = userEvent.setup();
+    mockDebriefQuery.mockReturnValue({
+      data: { data: completedDebrief },
+      isLoading: false,
+      error: null,
+    });
+    renderWithMovieAndSpy('42');
+
+    // The completion summary shows when all dimensions are done
+    expect(screen.getByTestId('completion-summary')).toBeInTheDocument();
+    await user.click(screen.getByText('Do another'));
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/media/compare');
   });
 });

--- a/packages/app-media/src/pages/DebriefPage.tsx
+++ b/packages/app-media/src/pages/DebriefPage.tsx
@@ -98,7 +98,7 @@ export function DebriefPage() {
   };
 
   const handleDoAnother = () => {
-    navigate('/media/history');
+    navigate('/media/compare');
   };
 
   // ── Loading / Error states ──


### PR DESCRIPTION
## Summary

- Fixes #1847: Done button in `CompletionSummary` navigated to `/media/compare/rankings` (404); corrected to `/media/rankings`
- Fixes #1845: `handleDoAnother` in `DebriefPage` navigated to `/media/history` instead of starting a new comparison; corrected to `/media/compare`

Both navigation paths are covered by new tests that assert the correct route is reached after the button click.

## Test plan

- [ ] Run `pnpm --filter @pops/app-media test -- --run` — 636 tests pass
- [ ] After debrief completes, clicking Done lands on `/media/rankings`
- [ ] After debrief completes, clicking Do another lands on `/media/compare` (the compare arena)