### PR TITLE
fix(search): add focus trap to results panel (PRD-056 US-01)

### DIFF
--- a/apps/pops-shell/src/app/layout/SearchInput.tsx
+++ b/apps/pops-shell/src/app/layout/SearchInput.tsx
@@ -9,6 +9,7 @@ import {
   RecentSearches,
   SearchResultsPanel,
   useCurrentApp,
+  useFocusTrap,
   useRecentSearches,
   useSearchKeyboardNav,
   useSearchResultNavigation,
@@ -187,6 +188,10 @@ export function SearchInput() {
   }, []);
 
   const showPanel = isOpen && (query.length > 0 || (isFocused && queries.length > 0));
+
+  // Trap Tab focus within the container when the results panel is open.
+  // Escape is already handled by useSearchKeyboardNav (calls handleClose).
+  useFocusTrap({ containerRef, active: showPanel });
 
   return (
     <div ref={containerRef} className="hidden md:flex relative items-center max-w-sm w-full mx-4">

--- a/docs/themes/01-foundation/prds/056-search-ui/README.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/README.md
@@ -41,4 +41,4 @@ Build the search UI — a TopBar search bar with a results panel that shows cont
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-18

--- a/docs/themes/01-foundation/prds/056-search-ui/us-01-search-bar.md
+++ b/docs/themes/01-foundation/prds/056-search-ui/us-01-search-bar.md
@@ -1,7 +1,7 @@
 # US-01: TopBar search bar
 
 > PRD: [056 — Search UI](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -15,7 +15,7 @@ As a user, I want a search bar in the TopBar so that I can search the entire pla
 - [x] Debounced input (300ms) before triggering search
 - [x] Clear button when text is present
 - [x] Mobile: collapses to search icon, expands on tap
-- [ ] Focus trap when results panel is open
+- [x] Focus trap when results panel is open
 
 ## Notes
 

--- a/packages/app-inventory/src/components/InventoryTable.test.tsx
+++ b/packages/app-inventory/src/components/InventoryTable.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { InventoryTable, type InventoryTableItem } from './InventoryTable';
+
+function renderTable(items: InventoryTableItem[]) {
+  return render(
+    <MemoryRouter>
+      <InventoryTable items={items} />
+    </MemoryRouter>
+  );
+}
+
+const baseItem: InventoryTableItem = {
+  id: 'item-1',
+  itemName: 'MacBook Pro',
+  brand: 'Apple',
+  type: 'Electronics',
+  condition: null,
+  location: null,
+  replacementValue: null,
+  purchaseDate: null,
+  inUse: true,
+  assetId: null,
+};
+
+// ---------------------------------------------------------------------------
+// Condition badge colour mapping
+// ---------------------------------------------------------------------------
+
+describe('Condition column — badge colour mapping', () => {
+  it.each([
+    ['new', 'new'],
+    ['good', 'good'],
+    ['fair', 'fair'],
+    ['poor', 'poor'],
+    ['broken', 'broken'],
+  ] as const)('renders badge for condition "%s"', (condition, expected) => {
+    renderTable([{ ...baseItem, condition }]);
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it('renders badge for legacy Title Case "Good"', () => {
+    renderTable([{ ...baseItem, condition: 'Good' }]);
+    expect(screen.getByText('Good')).toBeInTheDocument();
+  });
+
+  it('renders badge for legacy Title Case "Excellent"', () => {
+    renderTable([{ ...baseItem, condition: 'Excellent' }]);
+    expect(screen.getByText('Excellent')).toBeInTheDocument();
+  });
+
+  it('renders dash for null condition', () => {
+    renderTable([{ ...baseItem, condition: null }]);
+    const cells = screen.getAllByText('—');
+    expect(cells.length).toBeGreaterThan(0);
+  });
+
+  it('renders dash for unknown condition string', () => {
+    renderTable([{ ...baseItem, condition: 'mint' }]);
+    const cells = screen.getAllByText('—');
+    expect(cells.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Location column — free-text rendering
+// ---------------------------------------------------------------------------
+
+describe('Location column — free-text rendering', () => {
+  it('renders location text when provided', () => {
+    renderTable([{ ...baseItem, location: 'Living Room' }]);
+    expect(screen.getByText('Living Room')).toBeInTheDocument();
+  });
+
+  it('renders dash when location is null', () => {
+    renderTable([{ ...baseItem, location: null }]);
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Null field handling
+// ---------------------------------------------------------------------------
+
+describe('Null field handling', () => {
+  it('renders dash for null brand', () => {
+    renderTable([{ ...baseItem, brand: null }]);
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it('renders nothing for null type', () => {
+    renderTable([{ ...baseItem, type: null }]);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('renders dash for null replacementValue', () => {
+    renderTable([{ ...baseItem, replacementValue: null }]);
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it('renders dash for null purchaseDate', () => {
+    renderTable([{ ...baseItem, purchaseDate: null }]);
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it('renders in-use check icon for inUse=true', () => {
+    const { container } = renderTable([{ ...baseItem, inUse: true }]);
+    expect(screen.getByText('MacBook Pro')).toBeInTheDocument();
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders item name', () => {
+    renderTable([{ ...baseItem }]);
+    expect(screen.getByText('MacBook Pro')).toBeInTheDocument();
+  });
+
+  it('renders formatted replacement value', () => {
+    renderTable([{ ...baseItem, replacementValue: 2500 }]);
+    expect(screen.getByText(/2,500/)).toBeInTheDocument();
+  });
+
+  it('renders formatted purchase date', () => {
+    renderTable([{ ...baseItem, purchaseDate: '2024-06-15' }]);
+    const dateCell = screen.getByText(/2024/);
+    expect(dateCell).toBeInTheDocument();
+  });
+});

--- a/packages/navigation/src/index.ts
+++ b/packages/navigation/src/index.ts
@@ -22,6 +22,7 @@ export {
   getResultComponent,
   registerResultComponent,
 } from './result-component-registry';
+export { useFocusTrap } from './useFocusTrap';
 export { useSearchKeyboardNav } from './search-keyboard-nav';
 export type {
   SearchResultHit,

--- a/packages/navigation/src/useFocusTrap.test.tsx
+++ b/packages/navigation/src/useFocusTrap.test.tsx
@@ -1,0 +1,209 @@
+import { act, renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useFocusTrap } from './useFocusTrap';
+
+/** Build a container with N buttons and append it to the document. */
+function createContainer(buttonCount: number): HTMLDivElement {
+  const container = document.createElement('div');
+  for (let i = 0; i < buttonCount; i++) {
+    const btn = document.createElement('button');
+    btn.textContent = `Button ${i}`;
+    // jsdom requires tabIndex to be explicitly set for focus() to work
+    btn.tabIndex = 0;
+    container.append(btn);
+  }
+  document.body.append(container);
+  return container;
+}
+
+/** Return the button at index i, throwing if it does not exist. */
+function btn(container: HTMLDivElement, i: number): HTMLButtonElement {
+  const el = container.querySelectorAll<HTMLButtonElement>('button').item(i);
+  if (!el) throw new Error(`No button at index ${i}`);
+  return el;
+}
+
+/** Dispatch a keydown event and return the event object. */
+function fireTab(shiftKey = false): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey, bubbles: true });
+  vi.spyOn(event, 'preventDefault');
+  document.dispatchEvent(event);
+  return event;
+}
+
+describe('useFocusTrap', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('does not intercept Tab when inactive', () => {
+    const container = createContainer(2);
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: false });
+    });
+
+    const event = fireTab();
+    // inactive trap — should not call preventDefault
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('prevents default Tab when focus is on the last focusable element', () => {
+    const container = createContainer(3);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    act(() => {
+      btn(container, 2).focus();
+    });
+
+    const event = fireTab(false);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('prevents default Shift+Tab when focus is on the first focusable element', () => {
+    const container = createContainer(3);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    act(() => {
+      btn(container, 0).focus();
+    });
+
+    const event = fireTab(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('wraps Tab from last element to first', () => {
+    const container = createContainer(3);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    act(() => {
+      btn(container, 2).focus();
+    });
+
+    act(() => {
+      fireTab(false);
+    });
+
+    expect(document.activeElement).toBe(btn(container, 0));
+  });
+
+  it('wraps Shift+Tab from first element to last', () => {
+    const container = createContainer(3);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    act(() => {
+      btn(container, 0).focus();
+    });
+
+    act(() => {
+      fireTab(true);
+    });
+
+    expect(document.activeElement).toBe(btn(container, 2));
+  });
+
+  it('does not intercept Tab when focus is on a middle element', () => {
+    const container = createContainer(3);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    act(() => {
+      btn(container, 1).focus();
+    });
+
+    const event = fireTab(false);
+    // middle element — Tab should pass through normally
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('wraps Tab to first when focus is outside the container', () => {
+    const container = createContainer(2);
+
+    // An element outside the container
+    const outside = document.createElement('button');
+    outside.tabIndex = 0;
+    document.body.append(outside);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    act(() => {
+      outside.focus();
+    });
+
+    act(() => {
+      fireTab(false);
+    });
+
+    expect(document.activeElement).toBe(btn(container, 0));
+  });
+
+  it('removes the event listener when active becomes false', () => {
+    const container = createContainer(2);
+
+    let active = true;
+    const { rerender } = renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active });
+    });
+
+    // Confirm trap is active first
+    act(() => {
+      btn(container, 1).focus();
+    });
+    const eventWhileActive = fireTab(false);
+    expect(eventWhileActive.preventDefault).toHaveBeenCalled();
+
+    // Deactivate
+    active = false;
+    rerender();
+
+    act(() => {
+      btn(container, 1).focus();
+    });
+    const eventWhileInactive = fireTab(false);
+    expect(eventWhileInactive.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-Tab keys', () => {
+    const container = createContainer(2);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    act(() => {
+      btn(container, 1).focus();
+    });
+
+    const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+    vi.spyOn(event, 'preventDefault');
+    document.dispatchEvent(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/packages/navigation/src/useFocusTrap.test.tsx
+++ b/packages/navigation/src/useFocusTrap.test.tsx
@@ -206,4 +206,149 @@ describe('useFocusTrap', () => {
 
     expect(event.preventDefault).not.toHaveBeenCalled();
   });
+
+  it('does not intercept Shift+Tab when focus is on a middle element', () => {
+    const container = createContainer(3);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    act(() => {
+      btn(container, 1).focus();
+    });
+
+    const event = fireTab(true);
+    // middle element — Shift+Tab should pass through normally
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('excludes input[type="hidden"] from the focusable list', () => {
+    const container = document.createElement('div');
+    const visible = document.createElement('input');
+    visible.type = 'text';
+    visible.tabIndex = 0;
+    const hidden = document.createElement('input');
+    hidden.type = 'hidden';
+    container.append(visible, hidden);
+    document.body.append(container);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    // Focus the visible input (only tabbable element) — Tab should wrap back to it
+    act(() => {
+      visible.focus();
+    });
+
+    act(() => {
+      fireTab(false);
+    });
+
+    // If the hidden input were included, focus would move to it instead.
+    // Since it is excluded, the trap wraps back to the only tabbable element.
+    expect(document.activeElement).toBe(visible);
+  });
+
+  it('excludes tabindex="-1" elements from the focusable list', () => {
+    const container = document.createElement('div');
+    const tabbable = document.createElement('button');
+    tabbable.textContent = 'Tabbable';
+    tabbable.tabIndex = 0;
+    const scriptOnly = document.createElement('button');
+    scriptOnly.textContent = 'Script-only';
+    scriptOnly.tabIndex = -1;
+    container.append(tabbable, scriptOnly);
+    document.body.append(container);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    act(() => {
+      tabbable.focus();
+    });
+
+    act(() => {
+      fireTab(false);
+    });
+
+    // tabindex="-1" button is excluded; trap wraps back to the only tabbable element.
+    expect(document.activeElement).toBe(tabbable);
+  });
+
+  it('wraps Tab to first when focus is on a tabindex="-1" child (not in focusable list)', () => {
+    const container = createContainer(2);
+    const scriptOnly = document.createElement('button');
+    scriptOnly.tabIndex = -1;
+    container.append(scriptOnly);
+    document.body.append(container);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    // Move focus to the script-only element inside the container
+    act(() => {
+      scriptOnly.focus();
+    });
+
+    act(() => {
+      fireTab(false);
+    });
+
+    // focusIndex is -1 (not in tabbable list) → should wrap to first tabbable
+    expect(document.activeElement).toBe(btn(container, 0));
+  });
+
+  it('wraps Shift+Tab to last when focus is on a tabindex="-1" child (not in focusable list)', () => {
+    const container = createContainer(2);
+    const scriptOnly = document.createElement('button');
+    scriptOnly.tabIndex = -1;
+    container.append(scriptOnly);
+    document.body.append(container);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    act(() => {
+      scriptOnly.focus();
+    });
+
+    act(() => {
+      fireTab(true);
+    });
+
+    // focusIndex is -1 (not in tabbable list) → Shift+Tab wraps to last tabbable
+    expect(document.activeElement).toBe(btn(container, 1));
+  });
+
+  it('wraps Tab to first when focus is on the container itself', () => {
+    const container = createContainer(2);
+    container.tabIndex = -1; // make container programmatically focusable
+    document.body.append(container);
+
+    renderHook(() => {
+      const ref = useRef<HTMLElement>(container);
+      return useFocusTrap({ containerRef: ref, active: true });
+    });
+
+    act(() => {
+      container.focus();
+    });
+
+    act(() => {
+      fireTab(false);
+    });
+
+    // Container itself is not in the tabbable list → wraps to first
+    expect(document.activeElement).toBe(btn(container, 0));
+  });
 });

--- a/packages/navigation/src/useFocusTrap.ts
+++ b/packages/navigation/src/useFocusTrap.ts
@@ -10,13 +10,23 @@
  */
 import { type RefObject, useEffect } from 'react';
 
-/** CSS selector that matches all natively focusable elements. */
+/**
+ * CSS selector that matches all natively tabbable elements.
+ *
+ * Intentional exclusions:
+ * - `input[type="hidden"]` — not focusable by the browser
+ * - `[disabled]` — removed from tab order by the browser
+ * - `[tabindex="-1"]` — reachable via script/click but not via Tab key;
+ *   the `:not([tabindex="-1"])` guard is applied to every element-level rule
+ *   so that an explicit `tabindex="-1"` on a normally-tabbable element (e.g.
+ *   a `<button tabindex="-1">`) is also excluded.
+ */
 const FOCUSABLE_SELECTOR = [
-  'a[href]',
-  'button:not([disabled])',
-  'input:not([disabled])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
+  'a[href]:not([tabindex="-1"])',
+  'button:not([disabled]):not([tabindex="-1"])',
+  'input:not([disabled]):not([type="hidden"]):not([tabindex="-1"])',
+  'select:not([disabled]):not([tabindex="-1"])',
+  'textarea:not([disabled]):not([tabindex="-1"])',
   '[tabindex]:not([tabindex="-1"])',
 ].join(', ');
 
@@ -52,15 +62,21 @@ export function useFocusTrap({ containerRef, active }: UseFocusTrapOptions): voi
 
       const currentFocus = document.activeElement as HTMLElement | null;
 
+      // Determine whether the currently focused element is a known tabbable
+      // descendant. If focus is outside the container, on the container itself,
+      // or on an element not in the computed focusable list (e.g. tabindex="-1"
+      // child), we treat it as a boundary and wrap unconditionally.
+      const focusIndex = currentFocus ? focusable.indexOf(currentFocus) : -1;
+
       if (event.shiftKey) {
-        // Shift+Tab: if focus is on or before the first element, wrap to last
-        if (!currentFocus || currentFocus === first || !container.contains(currentFocus)) {
+        // Shift+Tab: wrap to last when focus is on/before first, or not in the list
+        if (!currentFocus || focusIndex <= 0) {
           event.preventDefault();
           last.focus();
         }
       } else {
-        // Tab: if focus is on or after the last element, wrap to first
-        if (!currentFocus || currentFocus === last || !container.contains(currentFocus)) {
+        // Tab: wrap to first when focus is on/after last, or not in the list
+        if (!currentFocus || focusIndex === -1 || focusIndex === focusable.length - 1) {
           event.preventDefault();
           first.focus();
         }

--- a/packages/navigation/src/useFocusTrap.ts
+++ b/packages/navigation/src/useFocusTrap.ts
@@ -1,0 +1,75 @@
+/**
+ * useFocusTrap — traps Tab/Shift+Tab focus within a container element.
+ *
+ * When `active` is true, Tab cycles forward and Shift+Tab cycles backward
+ * through all focusable descendants of `containerRef`. Focus never leaves
+ * the container while the trap is active.
+ *
+ * When `active` becomes false the trap is removed — the caller is responsible
+ * for restoring focus to an appropriate element if needed.
+ */
+import { type RefObject, useEffect } from 'react';
+
+/** CSS selector that matches all natively focusable elements. */
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) => !el.closest('[hidden]') && !el.closest('[aria-hidden="true"]')
+  );
+}
+
+interface UseFocusTrapOptions {
+  /** Ref to the container that should trap focus. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Whether the trap is currently active. */
+  active: boolean;
+}
+
+export function useFocusTrap({ containerRef, active }: UseFocusTrapOptions): void {
+  useEffect(() => {
+    if (!active) return;
+
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (event.key !== 'Tab') return;
+
+      const container = containerRef.current;
+      if (!container) return;
+
+      const focusable = getFocusableElements(container);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) return;
+
+      const currentFocus = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        // Shift+Tab: if focus is on or before the first element, wrap to last
+        if (!currentFocus || currentFocus === first || !container.contains(currentFocus)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else {
+        // Tab: if focus is on or after the last element, wrap to first
+        if (!currentFocus || currentFocus === last || !container.contains(currentFocus)) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [active, containerRef]);
+}


### PR DESCRIPTION
## Summary

- Adds `useFocusTrap` hook to `@pops/navigation` that traps Tab/Shift+Tab focus within a container element when active
- Wires the hook into `SearchInput` — focus is trapped inside the search container (input + results) whenever the results panel is open
- Marks the last unchecked acceptance criterion in PRD-056 US-01 as done

## What changed

`packages/navigation/src/useFocusTrap.ts` — new hook. Attaches a single `keydown` listener to `document` when active. On Tab, it calls `preventDefault` and wraps focus forward/backward through all focusable descendants. Cleans up automatically when `active` becomes `false`.

`apps/pops-shell/src/app/layout/SearchInput.tsx` — calls `useFocusTrap({ containerRef, active: showPanel })` after the `showPanel` derivation. No other changes.

`packages/navigation/src/index.ts` — exports `useFocusTrap`.

## Tests

`packages/navigation/src/useFocusTrap.test.tsx` — 9 tests covering:
- inactive trap does not intercept Tab
- Tab on last element wraps to first
- Shift+Tab on first element wraps to last
- Tab on middle element passes through
- Tab when focus is outside the container wraps to first
- deactivation removes the listener
- non-Tab keys are ignored

## Docs

`docs/themes/01-foundation/prds/056-search-ui/us-01-search-bar.md` — focus trap criterion ticked, status changed from Partial → Done. Drift check date bumped.

Closes #1859