### PR TITLE
feat(finance): ANZ and ING CSV transformers (#1871, #1873)

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/transformers/anz.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/transformers/anz.test.ts
@@ -16,17 +16,22 @@ describe('transformAnz', () => {
       Amount: '-5000.00',
       Description: 'ANZ M-BANKING FUNDS TFER TRANSFER 685361  TO 4564XXXXXXXX7373',
     };
+    const sortedRow = Object.fromEntries(
+      Object.keys(row)
+        .toSorted()
+        .map((k) => [k, row[k as keyof typeof row]])
+    );
 
     const result = transformAnz(row);
 
     expect(result.date).toBe('2026-04-07');
     expect(result.description).toBe('ANZ M-BANKING FUNDS TFER TRANSFER 685361 TO 4564XXXXXXXX7373');
     expect(result.amount).toBe(-5000);
-    expect(result.account).toBe('ANZ');
+    expect(result.account).toBe('ANZ Everyday');
     expect(result.location).toBeUndefined();
-    expect(result.rawRow).toBe(JSON.stringify(row));
+    expect(result.rawRow).toBe(JSON.stringify(sortedRow));
     expect(result.checksum).toBe(
-      crypto.createHash('sha256').update(JSON.stringify(row)).digest('hex')
+      crypto.createHash('sha256').update(JSON.stringify(sortedRow)).digest('hex')
     );
   });
 
@@ -105,15 +110,15 @@ describe('transformAnz', () => {
       Date: '07/04/2026',
       Amount: '-50.00',
       Description: 'TEST',
-      Account: 'ANZ Everyday',
+      Account: 'ANZ Savings',
     };
 
     const result = transformAnz(row);
 
-    expect(result.account).toBe('ANZ Everyday');
+    expect(result.account).toBe('ANZ Savings');
   });
 
-  it('defaults account to "ANZ" when Account field is absent', () => {
+  it('defaults account to "ANZ Everyday" when Account field is absent', () => {
     const row = {
       Date: '07/04/2026',
       Amount: '-50.00',
@@ -122,7 +127,18 @@ describe('transformAnz', () => {
 
     const result = transformAnz(row);
 
-    expect(result.account).toBe('ANZ');
+    expect(result.account).toBe('ANZ Everyday');
+  });
+
+  it('rawRow contains key-sorted JSON regardless of input key order', () => {
+    const rowAbc = { Amount: '-50.00', Date: '07/04/2026', Description: 'TEST' };
+    const rowZyx = { Description: 'TEST', Date: '07/04/2026', Amount: '-50.00' };
+
+    const result1 = transformAnz(rowAbc);
+    const result2 = transformAnz(rowZyx);
+
+    expect(result1.rawRow).toBe(result2.rawRow);
+    expect(result1.checksum).toBe(result2.checksum);
   });
 
   it('throws for invalid date format', () => {
@@ -270,9 +286,9 @@ describe('transformAnz — cleanDescription', () => {
     expect(transformAnz(row).description).toBe('MERCHANT');
   });
 
-  it('handles empty string', () => {
+  it('throws for empty description', () => {
     const row = { Date: '07/04/2026', Amount: '-50.00', Description: '' };
-    expect(transformAnz(row).description).toBe('');
+    expect(() => transformAnz(row)).toThrow('empty Description');
   });
 
   it('preserves single spaces between words', () => {
@@ -280,8 +296,8 @@ describe('transformAnz — cleanDescription', () => {
     expect(transformAnz(row).description).toBe('ANZ M-BANKING FUNDS TFER');
   });
 
-  it('handles whitespace-only string', () => {
+  it('throws for whitespace-only description', () => {
     const row = { Date: '07/04/2026', Amount: '-50.00', Description: '   ' };
-    expect(transformAnz(row).description).toBe('');
+    expect(() => transformAnz(row)).toThrow('empty Description');
   });
 });

--- a/apps/pops-api/src/modules/finance/imports/transformers/anz.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/transformers/anz.test.ts
@@ -1,0 +1,287 @@
+import crypto from 'crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import { transformAnz } from './anz.js';
+
+/**
+ * Unit tests for ANZ CSV transformer.
+ * All functions are pure (no external dependencies) and tested in isolation.
+ */
+
+describe('transformAnz', () => {
+  it('transforms complete ANZ CSV row correctly', () => {
+    const row = {
+      Date: '07/04/2026',
+      Amount: '-5000.00',
+      Description: 'ANZ M-BANKING FUNDS TFER TRANSFER 685361  TO 4564XXXXXXXX7373',
+    };
+
+    const result = transformAnz(row);
+
+    expect(result.date).toBe('2026-04-07');
+    expect(result.description).toBe('ANZ M-BANKING FUNDS TFER TRANSFER 685361 TO 4564XXXXXXXX7373');
+    expect(result.amount).toBe(-5000);
+    expect(result.account).toBe('ANZ');
+    expect(result.location).toBeUndefined();
+    expect(result.rawRow).toBe(JSON.stringify(row));
+    expect(result.checksum).toBe(
+      crypto.createHash('sha256').update(JSON.stringify(row)).digest('hex')
+    );
+  });
+
+  it('preserves positive amount (income) without inversion', () => {
+    const row = {
+      Date: '07/04/2026',
+      Amount: '5000.00',
+      Description: 'PAYMENT FROM J SMITH',
+    };
+
+    const result = transformAnz(row);
+
+    expect(result.amount).toBe(5000);
+  });
+
+  it('preserves negative amount (expense) without inversion', () => {
+    const row = {
+      Date: '07/04/2026',
+      Amount: '-73.14',
+      Description: 'PAYPAL *GITHUB INC',
+    };
+
+    const result = transformAnz(row);
+
+    expect(result.amount).toBe(-73.14);
+  });
+
+  it('generates consistent checksum for same CSV row', () => {
+    const row = {
+      Date: '07/04/2026',
+      Amount: '-50.00',
+      Description: 'TEST',
+    };
+
+    const result1 = transformAnz(row);
+    const result2 = transformAnz(row);
+
+    expect(result1.checksum).toBe(result2.checksum);
+    expect(result1.checksum).toHaveLength(64); // SHA-256 hex digest
+  });
+
+  it('generates different checksums for different rows', () => {
+    const row1 = {
+      Date: '07/04/2026',
+      Amount: '-50.00',
+      Description: 'TEST',
+    };
+
+    const row2 = {
+      Date: '08/04/2026',
+      Amount: '-50.00',
+      Description: 'TEST',
+    };
+
+    const result1 = transformAnz(row1);
+    const result2 = transformAnz(row2);
+
+    expect(result1.checksum).not.toBe(result2.checksum);
+  });
+
+  it('checksum equals SHA-256 of rawRow', () => {
+    const row = {
+      Date: '07/04/2026',
+      Amount: '-50.00',
+      Description: 'TEST MERCHANT',
+    };
+
+    const result = transformAnz(row);
+
+    const expected = crypto.createHash('sha256').update(result.rawRow).digest('hex');
+    expect(result.checksum).toBe(expected);
+  });
+
+  it('uses Account field from row when present', () => {
+    const row = {
+      Date: '07/04/2026',
+      Amount: '-50.00',
+      Description: 'TEST',
+      Account: 'ANZ Everyday',
+    };
+
+    const result = transformAnz(row);
+
+    expect(result.account).toBe('ANZ Everyday');
+  });
+
+  it('defaults account to "ANZ" when Account field is absent', () => {
+    const row = {
+      Date: '07/04/2026',
+      Amount: '-50.00',
+      Description: 'TEST',
+    };
+
+    const result = transformAnz(row);
+
+    expect(result.account).toBe('ANZ');
+  });
+
+  it('throws for invalid date format', () => {
+    const row = {
+      Date: '2026-04-07',
+      Amount: '-50.00',
+      Description: 'TEST',
+    };
+
+    expect(() => transformAnz(row)).toThrow('Invalid date format');
+  });
+
+  it('throws for invalid amount', () => {
+    const row = {
+      Date: '07/04/2026',
+      Amount: 'not-a-number',
+      Description: 'TEST',
+    };
+
+    expect(() => transformAnz(row)).toThrow('Invalid amount');
+  });
+
+  it('throws for empty amount', () => {
+    const row = {
+      Date: '07/04/2026',
+      Amount: '',
+      Description: 'TEST',
+    };
+
+    expect(() => transformAnz(row)).toThrow('Invalid amount');
+  });
+});
+
+describe('transformAnz — normaliseDate', () => {
+  it('converts DD/MM/YYYY to YYYY-MM-DD', () => {
+    const row = { Date: '07/04/2026', Amount: '-50.00', Description: 'TEST' };
+    expect(transformAnz(row).date).toBe('2026-04-07');
+  });
+
+  it('pads single-digit day', () => {
+    const row = { Date: '1/04/2026', Amount: '-50.00', Description: 'TEST' };
+    expect(transformAnz(row).date).toBe('2026-04-01');
+  });
+
+  it('pads single-digit month', () => {
+    const row = { Date: '07/4/2026', Amount: '-50.00', Description: 'TEST' };
+    expect(transformAnz(row).date).toBe('2026-04-07');
+  });
+
+  it('pads single-digit day and month', () => {
+    const row = { Date: '1/2/2026', Amount: '-50.00', Description: 'TEST' };
+    expect(transformAnz(row).date).toBe('2026-02-01');
+  });
+
+  it('handles leap year', () => {
+    const row = { Date: '29/02/2024', Amount: '-50.00', Description: 'TEST' };
+    expect(transformAnz(row).date).toBe('2024-02-29');
+  });
+
+  it('throws for wrong separator', () => {
+    const row = { Date: '07-04-2026', Amount: '-50.00', Description: 'TEST' };
+    expect(() => transformAnz(row)).toThrow('Invalid date format');
+  });
+
+  it('throws for empty string', () => {
+    const row = { Date: '', Amount: '-50.00', Description: 'TEST' };
+    expect(() => transformAnz(row)).toThrow('Invalid date format');
+  });
+
+  it('throws for too many parts', () => {
+    const row = { Date: '07/04/2026/extra', Amount: '-50.00', Description: 'TEST' };
+    expect(() => transformAnz(row)).toThrow('Invalid date format');
+  });
+});
+
+describe('transformAnz — normaliseAmount', () => {
+  it('keeps negative amount as-is (expense)', () => {
+    const row = { Date: '07/04/2026', Amount: '-100.50', Description: 'TEST' };
+    expect(transformAnz(row).amount).toBe(-100.5);
+  });
+
+  it('keeps positive amount as-is (income)', () => {
+    const row = { Date: '07/04/2026', Amount: '2500.00', Description: 'SALARY' };
+    expect(transformAnz(row).amount).toBe(2500);
+  });
+
+  it('handles zero', () => {
+    const row = { Date: '07/04/2026', Amount: '0', Description: 'TEST' };
+    expect(transformAnz(row).amount).toBe(0);
+  });
+
+  it('handles integer string', () => {
+    const row = { Date: '07/04/2026', Amount: '-50', Description: 'TEST' };
+    expect(transformAnz(row).amount).toBe(-50);
+  });
+
+  it('handles large amount', () => {
+    const row = { Date: '07/04/2026', Amount: '-5000.00', Description: 'TEST' };
+    expect(transformAnz(row).amount).toBe(-5000);
+  });
+
+  it('handles leading whitespace in amount', () => {
+    const row = { Date: '07/04/2026', Amount: '  -50.00', Description: 'TEST' };
+    expect(transformAnz(row).amount).toBe(-50);
+  });
+
+  it('handles trailing whitespace in amount', () => {
+    const row = { Date: '07/04/2026', Amount: '-50.00  ', Description: 'TEST' };
+    expect(transformAnz(row).amount).toBe(-50);
+  });
+
+  it('throws for non-numeric string', () => {
+    const row = { Date: '07/04/2026', Amount: 'abc', Description: 'TEST' };
+    expect(() => transformAnz(row)).toThrow('Invalid amount');
+  });
+
+  it('throws for null-like undefined field', () => {
+    const row: Record<string, unknown> = {
+      Date: '07/04/2026',
+      Description: 'TEST',
+      Amount: undefined,
+    };
+    expect(() => transformAnz(row as Record<string, string>)).toThrow('Invalid amount');
+  });
+});
+
+describe('transformAnz — cleanDescription', () => {
+  it('removes double spaces', () => {
+    const row = { Date: '07/04/2026', Amount: '-50.00', Description: 'TRANSFER  685361' };
+    expect(transformAnz(row).description).toBe('TRANSFER 685361');
+  });
+
+  it('removes multiple spaces (3+)', () => {
+    const row = { Date: '07/04/2026', Amount: '-50.00', Description: 'A   B    C' };
+    expect(transformAnz(row).description).toBe('A B C');
+  });
+
+  it('trims leading whitespace', () => {
+    const row = { Date: '07/04/2026', Amount: '-50.00', Description: '  MERCHANT' };
+    expect(transformAnz(row).description).toBe('MERCHANT');
+  });
+
+  it('trims trailing whitespace', () => {
+    const row = { Date: '07/04/2026', Amount: '-50.00', Description: 'MERCHANT  ' };
+    expect(transformAnz(row).description).toBe('MERCHANT');
+  });
+
+  it('handles empty string', () => {
+    const row = { Date: '07/04/2026', Amount: '-50.00', Description: '' };
+    expect(transformAnz(row).description).toBe('');
+  });
+
+  it('preserves single spaces between words', () => {
+    const row = { Date: '07/04/2026', Amount: '-50.00', Description: 'ANZ M-BANKING FUNDS TFER' };
+    expect(transformAnz(row).description).toBe('ANZ M-BANKING FUNDS TFER');
+  });
+
+  it('handles whitespace-only string', () => {
+    const row = { Date: '07/04/2026', Amount: '-50.00', Description: '   ' };
+    expect(transformAnz(row).description).toBe('');
+  });
+});

--- a/apps/pops-api/src/modules/finance/imports/transformers/anz.ts
+++ b/apps/pops-api/src/modules/finance/imports/transformers/anz.ts
@@ -41,23 +41,36 @@ function cleanDescription(description: string): string {
  * - Amount:      Signed float — expenses already negative, income positive
  * - Description: Merchant / transfer description
  *
- * Account defaults to "ANZ" when not present in the row.
+ * Account defaults to "ANZ Everyday" when not present in the row.
  *
  * The checksum is a SHA-256 of the key-sorted JSON representation of the row
- * (rawRow), so checksum == SHA-256(rawRow) holds deterministically.
+ * (rawRow), so checksum == SHA-256(rawRow) holds deterministically regardless
+ * of the key insertion order in the input object.
  */
 export function transformAnz(row: Record<string, string>): ParsedTransaction {
+  const description = cleanDescription(row['Description'] ?? '');
+  if (!description) {
+    throw new Error('Row has an empty Description');
+  }
+
+  // Key-sort the row so rawRow and checksum are stable regardless of CSV column order
+  const sortedRow = Object.fromEntries(
+    Object.keys(row)
+      .toSorted()
+      .map((k) => [k, row[k] ?? ''])
+  );
+
   // Store full row as JSON for audit trail and AI context
-  const rawRow = JSON.stringify(row);
+  const rawRow = JSON.stringify(sortedRow);
 
   // Generate checksum for reliable deduplication
   const checksum = crypto.createHash('sha256').update(rawRow).digest('hex');
 
   return {
     date: normaliseDate(row['Date'] ?? ''),
-    description: cleanDescription(row['Description'] ?? ''),
+    description,
     amount: normaliseAmount(row['Amount'] ?? ''),
-    account: row['Account'] ?? 'ANZ',
+    account: row['Account'] ?? 'ANZ Everyday',
     rawRow,
     checksum,
   };

--- a/apps/pops-api/src/modules/finance/imports/transformers/anz.ts
+++ b/apps/pops-api/src/modules/finance/imports/transformers/anz.ts
@@ -1,0 +1,64 @@
+import crypto from 'crypto';
+
+import type { ParsedTransaction } from '../types.js';
+
+/**
+ * Normalize date from DD/MM/YYYY to YYYY-MM-DD
+ */
+function normaliseDate(dateStr: string): string {
+  const parts = dateStr.split('/');
+  if (parts.length !== 3) {
+    throw new Error(`Invalid date format: ${dateStr}`);
+  }
+  const [day, month, year] = parts;
+  return `${year}-${(month ?? '').padStart(2, '0')}-${(day ?? '').padStart(2, '0')}`;
+}
+
+/**
+ * Normalize amount — ANZ uses correct sign convention already.
+ * Expenses are negative, income is positive. No inversion needed.
+ */
+function normaliseAmount(amountStr: string): number {
+  const amount = parseFloat(amountStr);
+  if (isNaN(amount)) {
+    throw new TypeError(`Invalid amount: ${amountStr}`);
+  }
+  return amount;
+}
+
+/**
+ * Clean whitespace from description field
+ */
+function cleanDescription(description: string): string {
+  return description.replaceAll(/\s{2,}/g, ' ').trim();
+}
+
+/**
+ * Transform ANZ CSV row to ParsedTransaction.
+ *
+ * ANZ CSV columns (no header row — callers must assign these key names):
+ * - Date:        DD/MM/YYYY
+ * - Amount:      Signed float — expenses already negative, income positive
+ * - Description: Merchant / transfer description
+ *
+ * Account defaults to "ANZ" when not present in the row.
+ *
+ * The checksum is a SHA-256 of the key-sorted JSON representation of the row
+ * (rawRow), so checksum == SHA-256(rawRow) holds deterministically.
+ */
+export function transformAnz(row: Record<string, string>): ParsedTransaction {
+  // Store full row as JSON for audit trail and AI context
+  const rawRow = JSON.stringify(row);
+
+  // Generate checksum for reliable deduplication
+  const checksum = crypto.createHash('sha256').update(rawRow).digest('hex');
+
+  return {
+    date: normaliseDate(row['Date'] ?? ''),
+    description: cleanDescription(row['Description'] ?? ''),
+    amount: normaliseAmount(row['Amount'] ?? ''),
+    account: row['Account'] ?? 'ANZ',
+    rawRow,
+    checksum,
+  };
+}

--- a/apps/pops-api/src/modules/finance/imports/transformers/ing.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/transformers/ing.test.ts
@@ -18,6 +18,11 @@ describe('transformIng', () => {
       Debit: '8.00',
       Balance: '987.09',
     };
+    const sortedRow = Object.fromEntries(
+      Object.keys(row)
+        .toSorted()
+        .map((k) => [k, row[k as keyof typeof row]])
+    );
 
     const result = transformIng(row);
 
@@ -26,9 +31,9 @@ describe('transformIng', () => {
     expect(result.amount).toBe(-8);
     expect(result.account).toBe('ING Savings');
     expect(result.location).toBeUndefined();
-    expect(result.rawRow).toBe(JSON.stringify(row));
+    expect(result.rawRow).toBe(JSON.stringify(sortedRow));
     expect(result.checksum).toBe(
-      crypto.createHash('sha256').update(JSON.stringify(row)).digest('hex')
+      crypto.createHash('sha256').update(JSON.stringify(sortedRow)).digest('hex')
     );
   });
 
@@ -101,6 +106,29 @@ describe('transformIng', () => {
 
     const expected = crypto.createHash('sha256').update(result.rawRow).digest('hex');
     expect(result.checksum).toBe(expected);
+  });
+
+  it('rawRow contains key-sorted JSON regardless of input key order', () => {
+    const rowAbc = {
+      Balance: '100.00',
+      Credit: '50.00',
+      Date: '10/04/2026',
+      Debit: '',
+      Description: 'TEST',
+    };
+    const rowZyx = {
+      Description: 'TEST',
+      Debit: '',
+      Date: '10/04/2026',
+      Credit: '50.00',
+      Balance: '100.00',
+    };
+
+    const result1 = transformIng(rowAbc);
+    const result2 = transformIng(rowZyx);
+
+    expect(result1.rawRow).toBe(result2.rawRow);
+    expect(result1.checksum).toBe(result2.checksum);
   });
 
   it('account is always "ING Savings"', () => {
@@ -419,9 +447,9 @@ describe('transformIng — cleanDescription', () => {
     expect(transformIng(row).description).toBe('MERCHANT');
   });
 
-  it('handles empty string', () => {
+  it('throws for empty description', () => {
     const row = { Date: '10/04/2026', Description: '', Credit: '50.00', Debit: '', Balance: '' };
-    expect(transformIng(row).description).toBe('');
+    expect(() => transformIng(row)).toThrow('empty Description');
   });
 
   it('preserves single spaces between words', () => {
@@ -435,8 +463,8 @@ describe('transformIng — cleanDescription', () => {
     expect(transformIng(row).description).toBe('To my account Internal Transfer');
   });
 
-  it('handles whitespace-only string', () => {
+  it('throws for whitespace-only description', () => {
     const row = { Date: '10/04/2026', Description: '   ', Credit: '50.00', Debit: '', Balance: '' };
-    expect(transformIng(row).description).toBe('');
+    expect(() => transformIng(row)).toThrow('empty Description');
   });
 });

--- a/apps/pops-api/src/modules/finance/imports/transformers/ing.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/transformers/ing.test.ts
@@ -1,0 +1,442 @@
+import crypto from 'crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import { transformIng } from './ing.js';
+
+/**
+ * Unit tests for ING CSV transformer.
+ * All functions are pure (no external dependencies) and tested in isolation.
+ */
+
+describe('transformIng', () => {
+  it('transforms a debit row correctly', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'To my account - Internal Transfer',
+      Credit: '',
+      Debit: '8.00',
+      Balance: '987.09',
+    };
+
+    const result = transformIng(row);
+
+    expect(result.date).toBe('2026-04-10');
+    expect(result.description).toBe('To my account - Internal Transfer');
+    expect(result.amount).toBe(-8);
+    expect(result.account).toBe('ING Savings');
+    expect(result.location).toBeUndefined();
+    expect(result.rawRow).toBe(JSON.stringify(row));
+    expect(result.checksum).toBe(
+      crypto.createHash('sha256').update(JSON.stringify(row)).digest('hex')
+    );
+  });
+
+  it('transforms a credit row correctly', () => {
+    const row = {
+      Date: '02/04/2026',
+      Description: 'Loan repayment - Osko Payment',
+      Credit: '650.00',
+      Debit: '',
+      Balance: '995.09',
+    };
+
+    const result = transformIng(row);
+
+    expect(result.date).toBe('2026-04-02');
+    expect(result.description).toBe('Loan repayment - Osko Payment');
+    expect(result.amount).toBe(650);
+    expect(result.account).toBe('ING Savings');
+  });
+
+  it('generates consistent checksum for same CSV row', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '',
+      Debit: '50.00',
+      Balance: '100.00',
+    };
+
+    const result1 = transformIng(row);
+    const result2 = transformIng(row);
+
+    expect(result1.checksum).toBe(result2.checksum);
+    expect(result1.checksum).toHaveLength(64); // SHA-256 hex digest
+  });
+
+  it('generates different checksums for different rows', () => {
+    const row1 = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '',
+      Debit: '50.00',
+      Balance: '100.00',
+    };
+
+    const row2 = {
+      Date: '11/04/2026',
+      Description: 'TEST',
+      Credit: '',
+      Debit: '50.00',
+      Balance: '50.00',
+    };
+
+    const result1 = transformIng(row1);
+    const result2 = transformIng(row2);
+
+    expect(result1.checksum).not.toBe(result2.checksum);
+  });
+
+  it('checksum equals SHA-256 of rawRow', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST MERCHANT',
+      Credit: '100.00',
+      Debit: '',
+      Balance: '500.00',
+    };
+
+    const result = transformIng(row);
+
+    const expected = crypto.createHash('sha256').update(result.rawRow).digest('hex');
+    expect(result.checksum).toBe(expected);
+  });
+
+  it('account is always "ING Savings"', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '100.00',
+      Debit: '',
+      Balance: '500.00',
+    };
+
+    expect(transformIng(row).account).toBe('ING Savings');
+  });
+
+  it('throws for invalid date format', () => {
+    const row = {
+      Date: '2026-04-10',
+      Description: 'TEST',
+      Credit: '100.00',
+      Debit: '',
+      Balance: '500.00',
+    };
+
+    expect(() => transformIng(row)).toThrow('Invalid date format');
+  });
+
+  it('throws when both Credit and Debit are populated', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '100.00',
+      Debit: '50.00',
+      Balance: '500.00',
+    };
+
+    expect(() => transformIng(row)).toThrow('both Credit and Debit');
+  });
+
+  it('throws when both Credit and Debit are empty', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '',
+      Debit: '',
+      Balance: '500.00',
+    };
+
+    expect(() => transformIng(row)).toThrow('no Credit or Debit value');
+  });
+
+  it('throws for invalid credit amount', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: 'not-a-number',
+      Debit: '',
+      Balance: '500.00',
+    };
+
+    expect(() => transformIng(row)).toThrow('Invalid credit amount');
+  });
+
+  it('throws for invalid debit amount', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '',
+      Debit: 'not-a-number',
+      Balance: '500.00',
+    };
+
+    expect(() => transformIng(row)).toThrow('Invalid debit amount');
+  });
+});
+
+describe('transformIng — normaliseDate', () => {
+  it('converts DD/MM/YYYY to YYYY-MM-DD', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '50.00',
+      Debit: '',
+      Balance: '',
+    };
+    expect(transformIng(row).date).toBe('2026-04-10');
+  });
+
+  it('pads single-digit day', () => {
+    const row = { Date: '1/04/2026', Description: 'TEST', Credit: '50.00', Debit: '', Balance: '' };
+    expect(transformIng(row).date).toBe('2026-04-01');
+  });
+
+  it('pads single-digit month', () => {
+    const row = { Date: '10/4/2026', Description: 'TEST', Credit: '50.00', Debit: '', Balance: '' };
+    expect(transformIng(row).date).toBe('2026-04-10');
+  });
+
+  it('pads single-digit day and month', () => {
+    const row = { Date: '1/2/2026', Description: 'TEST', Credit: '50.00', Debit: '', Balance: '' };
+    expect(transformIng(row).date).toBe('2026-02-01');
+  });
+
+  it('handles leap year', () => {
+    const row = {
+      Date: '29/02/2024',
+      Description: 'TEST',
+      Credit: '50.00',
+      Debit: '',
+      Balance: '',
+    };
+    expect(transformIng(row).date).toBe('2024-02-29');
+  });
+
+  it('throws for wrong separator', () => {
+    const row = {
+      Date: '10-04-2026',
+      Description: 'TEST',
+      Credit: '50.00',
+      Debit: '',
+      Balance: '',
+    };
+    expect(() => transformIng(row)).toThrow('Invalid date format');
+  });
+
+  it('throws for empty string', () => {
+    const row = { Date: '', Description: 'TEST', Credit: '50.00', Debit: '', Balance: '' };
+    expect(() => transformIng(row)).toThrow('Invalid date format');
+  });
+
+  it('throws for too many parts', () => {
+    const row = {
+      Date: '10/04/2026/extra',
+      Description: 'TEST',
+      Credit: '50.00',
+      Debit: '',
+      Balance: '',
+    };
+    expect(() => transformIng(row)).toThrow('Invalid date format');
+  });
+});
+
+describe('transformIng — normaliseAmount (Credit/Debit)', () => {
+  it('returns positive amount for credit', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '650.00',
+      Debit: '',
+      Balance: '',
+    };
+    expect(transformIng(row).amount).toBe(650);
+  });
+
+  it('returns negative amount for debit', () => {
+    const row = { Date: '10/04/2026', Description: 'TEST', Credit: '', Debit: '8.00', Balance: '' };
+    expect(transformIng(row).amount).toBe(-8);
+  });
+
+  it('handles large debit', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '',
+      Debit: '8000.00',
+      Balance: '',
+    };
+    expect(transformIng(row).amount).toBe(-8000);
+  });
+
+  it('handles large credit', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '20000.00',
+      Debit: '',
+      Balance: '',
+    };
+    expect(transformIng(row).amount).toBe(20000);
+  });
+
+  it('handles credit with decimal places', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '85.50',
+      Debit: '',
+      Balance: '',
+    };
+    expect(transformIng(row).amount).toBe(85.5);
+  });
+
+  it('handles debit with decimal places', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '',
+      Debit: '497.78',
+      Balance: '',
+    };
+    expect(transformIng(row).amount).toBe(-497.78);
+  });
+
+  it('handles credit with whitespace padding', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '  650.00  ',
+      Debit: '',
+      Balance: '',
+    };
+    expect(transformIng(row).amount).toBe(650);
+  });
+
+  it('handles debit with whitespace padding', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '',
+      Debit: '  8.00  ',
+      Balance: '',
+    };
+    expect(transformIng(row).amount).toBe(-8);
+  });
+
+  it('treats whitespace-only credit as empty (uses debit)', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '   ',
+      Debit: '8.00',
+      Balance: '',
+    };
+    expect(transformIng(row).amount).toBe(-8);
+  });
+
+  it('treats whitespace-only debit as empty (uses credit)', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '650.00',
+      Debit: '   ',
+      Balance: '',
+    };
+    expect(transformIng(row).amount).toBe(650);
+  });
+
+  it('throws when both credit and debit are non-empty', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'TEST',
+      Credit: '100.00',
+      Debit: '50.00',
+      Balance: '',
+    };
+    expect(() => transformIng(row)).toThrow('both Credit and Debit');
+  });
+
+  it('throws when both are empty', () => {
+    const row = { Date: '10/04/2026', Description: 'TEST', Credit: '', Debit: '', Balance: '' };
+    expect(() => transformIng(row)).toThrow('no Credit or Debit value');
+  });
+
+  it('throws for non-numeric credit', () => {
+    const row = { Date: '10/04/2026', Description: 'TEST', Credit: 'abc', Debit: '', Balance: '' };
+    expect(() => transformIng(row)).toThrow('Invalid credit amount');
+  });
+
+  it('throws for non-numeric debit', () => {
+    const row = { Date: '10/04/2026', Description: 'TEST', Credit: '', Debit: 'xyz', Balance: '' };
+    expect(() => transformIng(row)).toThrow('Invalid debit amount');
+  });
+});
+
+describe('transformIng — cleanDescription', () => {
+  it('removes double spaces', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'LOAN  REPAYMENT',
+      Credit: '650.00',
+      Debit: '',
+      Balance: '',
+    };
+    expect(transformIng(row).description).toBe('LOAN REPAYMENT');
+  });
+
+  it('removes multiple spaces (3+)', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'A   B    C',
+      Credit: '50.00',
+      Debit: '',
+      Balance: '',
+    };
+    expect(transformIng(row).description).toBe('A B C');
+  });
+
+  it('trims leading whitespace', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: '  MERCHANT',
+      Credit: '50.00',
+      Debit: '',
+      Balance: '',
+    };
+    expect(transformIng(row).description).toBe('MERCHANT');
+  });
+
+  it('trims trailing whitespace', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'MERCHANT  ',
+      Credit: '50.00',
+      Debit: '',
+      Balance: '',
+    };
+    expect(transformIng(row).description).toBe('MERCHANT');
+  });
+
+  it('handles empty string', () => {
+    const row = { Date: '10/04/2026', Description: '', Credit: '50.00', Debit: '', Balance: '' };
+    expect(transformIng(row).description).toBe('');
+  });
+
+  it('preserves single spaces between words', () => {
+    const row = {
+      Date: '10/04/2026',
+      Description: 'To my account Internal Transfer',
+      Credit: '50.00',
+      Debit: '',
+      Balance: '',
+    };
+    expect(transformIng(row).description).toBe('To my account Internal Transfer');
+  });
+
+  it('handles whitespace-only string', () => {
+    const row = { Date: '10/04/2026', Description: '   ', Credit: '50.00', Debit: '', Balance: '' };
+    expect(transformIng(row).description).toBe('');
+  });
+});

--- a/apps/pops-api/src/modules/finance/imports/transformers/ing.ts
+++ b/apps/pops-api/src/modules/finance/imports/transformers/ing.ts
@@ -79,15 +79,27 @@ function cleanDescription(description: string): string {
  * (rawRow), so checksum == SHA-256(rawRow) holds deterministically.
  */
 export function transformIng(row: Record<string, string>): ParsedTransaction {
+  const description = cleanDescription(row['Description'] ?? '');
+  if (!description) {
+    throw new Error('Row has an empty Description');
+  }
+
+  // Key-sort the row so rawRow and checksum are stable regardless of CSV column order
+  const sortedRow = Object.fromEntries(
+    Object.keys(row)
+      .toSorted()
+      .map((k) => [k, row[k] ?? ''])
+  );
+
   // Store full row as JSON for audit trail and AI context
-  const rawRow = JSON.stringify(row);
+  const rawRow = JSON.stringify(sortedRow);
 
   // Generate checksum for reliable deduplication
   const checksum = crypto.createHash('sha256').update(rawRow).digest('hex');
 
   return {
     date: normaliseDate(row['Date'] ?? ''),
-    description: cleanDescription(row['Description'] ?? ''),
+    description,
     amount: normaliseAmount(row['Credit'] ?? '', row['Debit'] ?? ''),
     account: 'ING Savings',
     rawRow,

--- a/apps/pops-api/src/modules/finance/imports/transformers/ing.ts
+++ b/apps/pops-api/src/modules/finance/imports/transformers/ing.ts
@@ -1,0 +1,96 @@
+import crypto from 'crypto';
+
+import type { ParsedTransaction } from '../types.js';
+
+/**
+ * Normalize date from DD/MM/YYYY to YYYY-MM-DD
+ */
+function normaliseDate(dateStr: string): string {
+  const parts = dateStr.split('/');
+  if (parts.length !== 3) {
+    throw new Error(`Invalid date format: ${dateStr}`);
+  }
+  const [day, month, year] = parts;
+  return `${year}-${(month ?? '').padStart(2, '0')}-${(day ?? '').padStart(2, '0')}`;
+}
+
+/**
+ * Combine ING Credit and Debit columns into a single signed amount.
+ *
+ * ING CSV has two amount columns:
+ * - Credit: positive value when money arrives (income/refund), empty otherwise
+ * - Debit:  positive value when money leaves (expense), empty otherwise
+ *
+ * Returns a signed float: credits positive, debits negative.
+ * Throws if neither or both columns have a parseable value.
+ */
+function normaliseAmount(creditStr: string, debitStr: string): number {
+  const creditTrimmed = creditStr.trim();
+  const debitTrimmed = debitStr.trim();
+
+  const hasCredit = creditTrimmed !== '';
+  const hasDebit = debitTrimmed !== '';
+
+  if (hasCredit && hasDebit) {
+    throw new Error(
+      `Row has both Credit and Debit values: Credit="${creditStr}" Debit="${debitStr}"`
+    );
+  }
+
+  if (hasCredit) {
+    const amount = parseFloat(creditTrimmed);
+    if (isNaN(amount)) {
+      throw new TypeError(`Invalid credit amount: ${creditStr}`);
+    }
+    return amount;
+  }
+
+  if (hasDebit) {
+    const amount = parseFloat(debitTrimmed);
+    if (isNaN(amount)) {
+      throw new TypeError(`Invalid debit amount: ${debitStr}`);
+    }
+    return -amount;
+  }
+
+  throw new Error(`Row has no Credit or Debit value`);
+}
+
+/**
+ * Clean whitespace from description field
+ */
+function cleanDescription(description: string): string {
+  return description.replaceAll(/\s{2,}/g, ' ').trim();
+}
+
+/**
+ * Transform ING CSV row to ParsedTransaction.
+ *
+ * ING CSV columns:
+ * - Date:        DD/MM/YYYY
+ * - Description: Merchant / transfer description
+ * - Credit:      Positive float when money received; empty otherwise
+ * - Debit:       Positive float when money spent; empty otherwise
+ * - Balance:     Running balance (ignored)
+ *
+ * Account is hardcoded to "ING Savings".
+ *
+ * The checksum is a SHA-256 of the key-sorted JSON representation of the row
+ * (rawRow), so checksum == SHA-256(rawRow) holds deterministically.
+ */
+export function transformIng(row: Record<string, string>): ParsedTransaction {
+  // Store full row as JSON for audit trail and AI context
+  const rawRow = JSON.stringify(row);
+
+  // Generate checksum for reliable deduplication
+  const checksum = crypto.createHash('sha256').update(rawRow).digest('hex');
+
+  return {
+    date: normaliseDate(row['Date'] ?? ''),
+    description: cleanDescription(row['Description'] ?? ''),
+    amount: normaliseAmount(row['Credit'] ?? '', row['Debit'] ?? ''),
+    account: 'ING Savings',
+    rawRow,
+    checksum,
+  };
+}

--- a/docs/themes/02-finance/prds/022-deduplication-parsers/README.md
+++ b/docs/themes/02-finance/prds/022-deduplication-parsers/README.md
@@ -112,8 +112,8 @@ Fetched via Up Bank REST API, not CSV upload. Batch import by date range.
 | --- | ----------------------------------------------- | ----------------------------------------------------------------------------------- | ----------- | ------------------------------- |
 | 01  | [us-01-checksum-dedup](us-01-checksum-dedup.md) | Checksum-based deduplication with batch SQLite queries                              | Done        | No (first)                      |
 | 02  | [us-02-amex-parser](us-02-amex-parser.md)       | Amex CSV parser: date, amount inversion, location extraction                        | Done        | Yes                             |
-| 03  | [us-03-anz-parser](us-03-anz-parser.md)         | ANZ CSV parser                                                                      | Not started | Yes                             |
-| 04  | [us-04-ing-parser](us-04-ing-parser.md)         | ING CSV parser                                                                      | Not started | Yes                             |
+| 03  | [us-03-anz-parser](us-03-anz-parser.md)         | ANZ CSV parser                                                                      | Done        | Yes                             |
+| 04  | [us-04-ing-parser](us-04-ing-parser.md)         | ING CSV parser                                                                      | Done        | Yes                             |
 | 05  | [us-05-up-bank-import](us-05-up-bank-import.md) | Up Bank API batch import by date range                                              | Not started | Yes                             |
 | 06  | [us-06-common-utils](us-06-common-utils.md)     | Shared utilities: normaliseDate, normaliseAmount, extractLocation, online detection | Partial     | No (first, parallel with us-01) |
 | 07  | [us-07-anz-pdf-parser](us-07-anz-pdf-parser.md) | ANZ PDF credit card statement parser                                                | Not started | Yes                             |
@@ -137,4 +137,4 @@ US-02 through US-05 and US-07 can all parallelise (independent parsers). US-06 i
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-18

--- a/docs/themes/02-finance/prds/022-deduplication-parsers/us-03-anz-parser.md
+++ b/docs/themes/02-finance/prds/022-deduplication-parsers/us-03-anz-parser.md
@@ -1,7 +1,7 @@
 # US-03: ANZ CSV parser
 
 > PRD: [022 — Deduplication & Parsers](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user, I want to import ANZ CSV exports so that my everyday/savings transact
 
 ## Acceptance Criteria
 
-- [ ] Parses ANZ CSV format
-- [ ] Date: DD/MM/YYYY → YYYY-MM-DD
-- [ ] Amount: parse float (ANZ uses correct sign — expenses negative, income positive)
-- [ ] Description: clean whitespace
-- [ ] Account: "ANZ Everyday" or "ANZ Savings" (from CSV or user selection)
-- [ ] Output: valid ParsedTransaction[] with checksums
-- [ ] Test with sample ANZ CSV data
+- [x] Parses ANZ CSV format
+- [x] Date: DD/MM/YYYY → YYYY-MM-DD
+- [x] Amount: parse float (ANZ uses correct sign — expenses negative, income positive)
+- [x] Description: clean whitespace
+- [x] Account: "ANZ Everyday" or "ANZ Savings" (from CSV or user selection)
+- [x] Output: valid ParsedTransaction[] with checksums
+- [x] Test with sample ANZ CSV data
 
 ## Notes
 

--- a/docs/themes/02-finance/prds/022-deduplication-parsers/us-04-ing-parser.md
+++ b/docs/themes/02-finance/prds/022-deduplication-parsers/us-04-ing-parser.md
@@ -1,7 +1,7 @@
 # US-04: ING CSV parser
 
 > PRD: [022 — Deduplication & Parsers](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user, I want to import ING CSV exports so that my savings transactions are 
 
 ## Acceptance Criteria
 
-- [ ] Parses ING CSV format with Credit/Debit columns
-- [ ] Date: DD/MM/YYYY → YYYY-MM-DD
-- [ ] Amount: parse Credit/Debit, negate debits
-- [ ] Description: clean whitespace
-- [ ] Account: "ING Savings"
-- [ ] Output: valid ParsedTransaction[] with checksums
-- [ ] Test with sample ING CSV data
+- [x] Parses ING CSV format with Credit/Debit columns
+- [x] Date: DD/MM/YYYY → YYYY-MM-DD
+- [x] Amount: parse Credit/Debit, negate debits
+- [x] Description: clean whitespace
+- [x] Account: "ING Savings"
+- [x] Output: valid ParsedTransaction[] with checksums
+- [x] Test with sample ING CSV data
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Implements `transformAnz` in `apps/pops-api/src/modules/finance/imports/transformers/anz.ts` — ANZ CSV parser following the `amex.ts` pattern. Date DD/MM/YYYY → YYYY-MM-DD, amount passed through as-is (ANZ already uses correct sign convention), description whitespace cleaned, account defaults to `"ANZ"` or uses an optional `Account` column from the row.
- Implements `transformIng` in `apps/pops-api/src/modules/finance/imports/transformers/ing.ts` — ING CSV parser. Combines separate `Credit` and `Debit` columns into a single signed amount (credits positive, debits negated). Account is hardcoded to `"ING Savings"`.
- 75 unit tests covering date parsing, amount sign, description cleaning, checksum determinism, and all error paths.
- Marks PRD-022 US-03 and US-04 as Done.

Closes #1871
Closes #1873

## Test plan

- [x] `pnpm --filter @pops/api test -- --run` — 2504 tests pass (135 files)
- [x] `pnpm --filter @pops/api typecheck` — clean
- [x] Pre-commit hooks (lint-staged + oxfmt + eslint + turbo typecheck) — all passed