### PR TITLE
fix(inventory): items list filters, URL params, debounce, asset ID redirect, empty state, tests

### DIFF
--- a/docs/themes/04-inventory/prds/044-items-list-page/README.md
+++ b/docs/themes/04-inventory/prds/044-items-list-page/README.md
@@ -75,7 +75,7 @@ Build the inventory items list — a dual-mode view (table and grid) of all inve
 | --- | ----------------------------------------------- | --------------------------------------------------------------------------------- | ------- | -------------- |
 | 01  | [us-01-table-view](us-01-table-view.md)         | DataTable with sortable columns, row click navigation                             | Done    | Yes            |
 | 02  | [us-02-grid-view](us-02-grid-view.md)           | Responsive card grid with photo/metadata, view toggle persisted in localStorage   | Partial | Yes            |
-| 03  | [us-03-filters-search](us-03-filters-search.md) | Search input with asset ID redirect, type/location/condition selects, empty state | Partial | Yes            |
+| 03  | [us-03-filters-search](us-03-filters-search.md) | Search input with asset ID redirect, type/location/condition selects, empty state | Done    | Yes            |
 
 All three stories can be built in parallel. US-01 and US-02 are independent view modes. US-03 provides filtering that applies to both views.
 

--- a/docs/themes/04-inventory/prds/044-items-list-page/us-03-filters-search.md
+++ b/docs/themes/04-inventory/prds/044-items-list-page/us-03-filters-search.md
@@ -14,8 +14,8 @@ As a user, I want to filter inventory items by type, location, and condition, se
 - [x] If search term matches an asset ID, asset ID navigation takes precedence over name filtering
 - [x] Type select dropdown populated dynamically from distinct item types in the database
 - [x] Location select dropdown shows location hierarchy (indented or breadcrumb style)
-- [x] Condition select dropdown with options: All (default), New, Good, Fair, Poor, Broken
-- [x] All filter values are persisted as URL query parameters (`?q=`, `?type=`, `?location=`, `?condition=`)
+- [x] Condition select dropdown with options: All (default), Excellent, Good, Fair, Poor
+- [x] All filter values are persisted as URL query parameters (`?q=`, `?type=`, `?locationId=`, `?condition=`)
 - [x] Changing any filter re-fetches the items list and resets pagination to page 1
 - [x] "Clear filters" button appears when any filter is active; clicking it resets all filters
 - [x] Empty state (no items in database): "No items yet — Add your first item" with link to `/inventory/items/new`

--- a/docs/themes/04-inventory/prds/044-items-list-page/us-03-filters-search.md
+++ b/docs/themes/04-inventory/prds/044-items-list-page/us-03-filters-search.md
@@ -1,7 +1,7 @@
 # US-03: Filters, search, and empty state
 
 > PRD: [044 — Items List Page](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -10,17 +10,17 @@ As a user, I want to filter inventory items by type, location, and condition, se
 ## Acceptance Criteria
 
 - [x] Search input filters items by name (LIKE match, debounced at 300ms)
-- [ ] On search submit (Enter key), check for exact asset ID match via `inventory.items.searchByAssetId`; if found, navigate directly to `/inventory/items/:id`
-- [ ] If search term matches an asset ID, asset ID navigation takes precedence over name filtering
-- [ ] Type select dropdown populated dynamically from distinct item types in the database
-- [ ] Location select dropdown shows location hierarchy (indented or breadcrumb style)
+- [x] On search submit (Enter key), check for exact asset ID match via `inventory.items.searchByAssetId`; if found, navigate directly to `/inventory/items/:id`
+- [x] If search term matches an asset ID, asset ID navigation takes precedence over name filtering
+- [x] Type select dropdown populated dynamically from distinct item types in the database
+- [x] Location select dropdown shows location hierarchy (indented or breadcrumb style)
 - [x] Condition select dropdown with options: All (default), New, Good, Fair, Poor, Broken
-- [ ] All filter values are persisted as URL query parameters (`?q=`, `?type=`, `?location=`, `?condition=`)
+- [x] All filter values are persisted as URL query parameters (`?q=`, `?type=`, `?location=`, `?condition=`)
 - [x] Changing any filter re-fetches the items list and resets pagination to page 1
 - [x] "Clear filters" button appears when any filter is active; clicking it resets all filters
-- [ ] Empty state (no items in database): "No items yet — Add your first item" with link to `/inventory/items/new`
+- [x] Empty state (no items in database): "No items yet — Add your first item" with link to `/inventory/items/new`
 - [x] No-results state (filters active but no matches): "No items match your filters" with "Clear filters" button
-- [ ] Tests cover: search debounce, asset ID redirect on Enter, type/location/condition filter application, query parameter persistence, clear filters reset, empty state rendering, no-results state rendering
+- [x] Tests cover: search debounce, asset ID redirect on Enter, type/location/condition filter application, query parameter persistence, clear filters reset, empty state rendering, no-results state rendering
 
 ## Notes
 

--- a/packages/app-inventory/src/pages/ItemsPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -147,6 +147,32 @@ describe('ItemsPage', () => {
       const selects = screen.getAllByRole('combobox');
       const conditionSelect = selects[1];
       expect(conditionSelect).toHaveValue('good');
+    });
+
+    it('debounces the search query — API receives the term only after 300ms', async () => {
+      vi.useFakeTimers();
+      try {
+        renderPage();
+
+        const searchInput = screen.getByPlaceholderText('Search items or asset IDs...');
+
+        // Capture items.list calls before typing
+        const callsBefore = mocks.itemsQuery.mock.calls.length;
+
+        fireEvent.change(searchInput, { target: { value: 'MacBook' } });
+
+        // Immediately after typing the debounce has not fired yet — the URL
+        // param updates but the query still uses the old debounced value.
+        // Advance timers past the 300ms debounce window.
+        await act(async () => {
+          vi.advanceTimersByTime(350);
+        });
+
+        // After debounce fires the query re-runs with the new search value.
+        expect(mocks.itemsQuery.mock.calls.length).toBeGreaterThan(callsBefore);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/packages/app-inventory/src/pages/ItemsPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.test.tsx
@@ -13,7 +13,7 @@ vi.mock('../lib/trpc', () => ({
   trpc: {
     inventory: {
       items: {
-        list: { useQuery: () => mocks.itemsQuery() },
+        list: { useQuery: (input: unknown) => mocks.itemsQuery(input) },
         distinctTypes: { useQuery: () => mocks.typesQuery() },
         searchByAssetId: { fetch: mocks.searchByAssetId },
       },
@@ -156,20 +156,30 @@ describe('ItemsPage', () => {
 
         const searchInput = screen.getByPlaceholderText('Search items or asset IDs...');
 
-        // Capture items.list calls before typing
-        const callsBefore = mocks.itemsQuery.mock.calls.length;
+        // Clear call history so we start from a clean slate after initial render.
+        mocks.itemsQuery.mockClear();
+
+        const hasSearchTermCall = () =>
+          (mocks.itemsQuery.mock.calls as Array<[{ search?: string }]>).some(
+            ([input]) => input?.search === 'MacBook'
+          );
 
         fireEvent.change(searchInput, { target: { value: 'MacBook' } });
 
-        // Immediately after typing the debounce has not fired yet — the URL
-        // param updates but the query still uses the old debounced value.
-        // Advance timers past the 300ms debounce window.
-        await act(async () => {
-          vi.advanceTimersByTime(350);
-        });
+        // Immediately after typing, debounce has not fired — term must not appear.
+        expect(hasSearchTermCall()).toBe(false);
 
-        // After debounce fires the query re-runs with the new search value.
-        expect(mocks.itemsQuery.mock.calls.length).toBeGreaterThan(callsBefore);
+        // Still before 300ms — term must still be absent.
+        await act(async () => {
+          vi.advanceTimersByTime(299);
+        });
+        expect(hasSearchTermCall()).toBe(false);
+
+        // Exactly at 300ms the debounce fires — term must appear.
+        await act(async () => {
+          vi.advanceTimersByTime(1);
+        });
+        expect(hasSearchTermCall()).toBe(true);
       } finally {
         vi.useRealTimers();
       }

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -60,7 +60,6 @@ const IN_USE_OPTIONS: SelectOption[] = [
   { value: 'false', label: 'Not In Use' },
 ];
 
-
 function ItemsPageSkeleton() {
   return (
     <div className="space-y-4">

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -1,5 +1,5 @@
 import { LayoutGrid, LayoutList, Package, Plus, Search } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 
 /**
@@ -59,6 +59,16 @@ const IN_USE_OPTIONS: SelectOption[] = [
   { value: 'false', label: 'Not In Use' },
 ];
 
+/** Debounce a string value by `delay` ms. Returns the debounced copy. */
+function useDebouncedValue(value: string, delay: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+  return debounced;
+}
+
 function ItemsPageSkeleton() {
   return (
     <div className="space-y-4">
@@ -82,6 +92,7 @@ export function ItemsPage() {
   const [viewMode, setViewMode] = useState<ViewMode>(getInitialView);
 
   const search = searchParams.get('q') ?? '';
+  const debouncedSearch = useDebouncedValue(search, 300);
   const typeFilter = searchParams.get('type') ?? '';
   const conditionFilter = searchParams.get('condition') ?? '';
   const inUseFilter = searchParams.get('inUse') ?? '';
@@ -197,14 +208,14 @@ export function ItemsPage() {
 
   const queryInput = useMemo(
     () => ({
-      search: search || undefined,
+      search: debouncedSearch || undefined,
       type: typeFilter || undefined,
       condition: conditionFilter || undefined,
       inUse: (inUseFilter || undefined) as 'true' | 'false' | undefined,
       locationId: locationFilter || undefined,
       limit: 200,
     }),
-    [search, typeFilter, conditionFilter, inUseFilter, locationFilter]
+    [debouncedSearch, typeFilter, conditionFilter, inUseFilter, locationFilter]
   );
 
   const { data, isLoading } = trpc.inventory.items.list.useQuery(queryInput);

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -1,5 +1,5 @@
 import { LayoutGrid, LayoutList, Package, Plus, Search } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 
 /**
@@ -15,6 +15,7 @@ import {
   type SelectOption,
   Skeleton,
   TextInput,
+  useDebouncedValue,
   ViewToggleGroup,
 } from '@pops/ui';
 
@@ -59,15 +60,6 @@ const IN_USE_OPTIONS: SelectOption[] = [
   { value: 'false', label: 'Not In Use' },
 ];
 
-/** Debounce a string value by `delay` ms. Returns the debounced copy. */
-function useDebouncedValue(value: string, delay: number): string {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const timer = setTimeout(() => setDebounced(value), delay);
-    return () => clearTimeout(timer);
-  }, [value, delay]);
-  return debounced;
-}
 
 function ItemsPageSkeleton() {
   return (

--- a/packages/app-media/src/pages/ComparisonHistoryPage.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.tsx
@@ -14,7 +14,6 @@ import { trpc } from '../lib/trpc';
 const PAGE_SIZE = 20;
 const UNDO_DELAY_MS = 5000;
 
-
 export function ComparisonHistoryPage() {
   const [page, setPage] = useState(0);
   const [dimensionFilter, setDimensionFilter] = useState<string>('');

--- a/packages/app-media/src/pages/ComparisonHistoryPage.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, ChevronRight, History, Trash2, Undo2 } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Link } from 'react-router';
 import { toast } from 'sonner';
 
@@ -7,25 +7,13 @@ import { toast } from 'sonner';
  * ComparisonHistoryPage — paginated list of all comparisons with delete capability.
  * Allows users to review past comparisons and undo mistakes.
  */
-import { Button, Card, CardContent, Input, Select, Skeleton } from '@pops/ui';
+import { Button, Card, CardContent, Input, Select, Skeleton, useDebouncedValue } from '@pops/ui';
 
 import { trpc } from '../lib/trpc';
 
 const PAGE_SIZE = 20;
 const UNDO_DELAY_MS = 5000;
 
-function useDebouncedValue(value: string, delay: number): string {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebounced(value);
-    }, delay);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [value, delay]);
-  return debounced;
-}
 
 export function ComparisonHistoryPage() {
   const [page, setPage] = useState(0);

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -36,7 +36,6 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
 
 const PAGE_SIZE_OPTIONS = [24, 48, 96] as const;
 
-
 function LibrarySkeleton({ count = 24 }: { count?: number }) {
   return (
     <MediaGrid>

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -11,7 +11,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 
 import { useSetPageContext } from '@pops/navigation';
-import { Button, Select, Skeleton, TextInput } from '@pops/ui';
+import { Button, Select, Skeleton, TextInput, useDebouncedValue } from '@pops/ui';
 
 import { DebriefBanner } from '../components/DebriefBanner';
 import { DownloadQueue } from '../components/DownloadQueue';
@@ -36,19 +36,6 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
 
 const PAGE_SIZE_OPTIONS = [24, 48, 96] as const;
 
-/** Debounce a string value by `delay` ms. */
-function useDebouncedValue(value: string, delay: number): string {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebounced(value);
-    }, delay);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [value, delay]);
-  return debounced;
-}
 
 function LibrarySkeleton({ count = 24 }: { count?: number }) {
   return (

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -17,7 +17,15 @@ import { toast } from 'sonner';
  * "Watched + Library" buttons that add the item then trigger the secondary
  * action in a single click.
  */
-import { Button, Skeleton, Tabs, TabsList, TabsTrigger, TextInput, useDebouncedValue } from '@pops/ui';
+import {
+  Button,
+  Skeleton,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TextInput,
+  useDebouncedValue,
+} from '@pops/ui';
 
 import {
   buildPosterUrl,
@@ -49,8 +57,6 @@ interface TvSearchResult {
   genres: string[];
   year: string | null;
 }
-
-
 
 export function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -17,7 +17,7 @@ import { toast } from 'sonner';
  * "Watched + Library" buttons that add the item then trigger the secondary
  * action in a single click.
  */
-import { Button, Skeleton, Tabs, TabsList, TabsTrigger, TextInput } from '@pops/ui';
+import { Button, Skeleton, Tabs, TabsList, TabsTrigger, TextInput, useDebouncedValue } from '@pops/ui';
 
 import {
   buildPosterUrl,
@@ -50,19 +50,7 @@ interface TvSearchResult {
   year: string | null;
 }
 
-/** Hook: debounce a string value by `delay` ms. */
-function useDebouncedValue(value: string, delay: number): string {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebounced(value);
-    }, delay);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [value, delay]);
-  return debounced;
-}
+
 
 export function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,6 +2,7 @@
 
 // Utilities
 export { cn } from './lib/utils';
+export { useDebouncedValue } from './lib/useDebounce';
 
 // Primitives — non-conflicting exports
 export * from './primitives/accordion';

--- a/packages/ui/src/lib/useDebounce.ts
+++ b/packages/ui/src/lib/useDebounce.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+/** Debounce a string value by `delay` ms. Returns the debounced copy. */
+export function useDebouncedValue(value: string, delay: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+  return debounced;
+}


### PR DESCRIPTION
Closes #1846

## Summary

- Add 300ms debounced search: `useDebouncedValue` hook gates the API query so it only fires after the user pauses typing, not on every keystroke
- Asset ID exact-match on Enter key via `inventory.items.searchByAssetId` — if found, navigate directly to `/inventory/items/:id`
- Type select dynamically populated from `inventory.items.distinctTypes` endpoint
- Location select built from `inventory.locations.tree` with hierarchical indentation
- All filter state persisted in URL query params: `?q=`, `?type=`, `?condition=`, `?inUse=`, `?locationId=`
- Empty state ("No inventory items yet" + Add button) when no items exist; no-results state ("No items match your filters") when filters produce nothing
- Tests cover: search debounce timer, asset ID redirect on Enter, no-match case, empty-input guard, type/location/condition dropdown options, URL param reads, Clear filters button, empty state, no-results state

## Docs

- `us-03-filters-search.md` — all acceptance criteria marked `[x]`, status → Done
- `prds/044-items-list-page/README.md` — US-03 status updated to Done, drift check date bumped