### PR TITLE
fix(media): fall back to TMDB API when poster_path is null

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/lib/debrief.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/debrief.ts
@@ -144,9 +144,7 @@ export function getDebriefOpponent(
 
   const posterUrl = movieRow.posterOverridePath
     ? movieRow.posterOverridePath
-    : movieRow.posterPath
-      ? `/media/images/movie/${movieRow.tmdbId}/poster.jpg`
-      : null;
+    : `/media/images/movie/${movieRow.tmdbId}/poster.jpg`;
 
   return {
     id: movieRow.id,
@@ -231,9 +229,7 @@ export function getPendingDebriefs(): PendingDebrief[] {
 
     const posterUrl = movieRow.posterOverridePath
       ? movieRow.posterOverridePath
-      : movieRow.posterPath
-        ? `/media/images/movie/${movieRow.tmdbId}/poster.jpg`
-        : null;
+      : `/media/images/movie/${movieRow.tmdbId}/poster.jpg`;
 
     results.push({
       sessionId: session.sessionId,

--- a/apps/pops-api/src/modules/media/comparisons/lib/tier-list.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/tier-list.ts
@@ -164,9 +164,11 @@ function toTierListMovie(row: {
   return {
     id: row.mediaId,
     title: row.title,
+    // Always generate the URL when tmdbId is available — the images endpoint
+    // handles the case where poster_path is null by fetching from TMDB on demand.
     posterUrl: row.moviePosterOverride
       ? row.moviePosterOverride
-      : row.moviePosterPath && row.movieTmdbId
+      : row.movieTmdbId
         ? `/media/images/movie/${row.movieTmdbId}/poster.jpg`
         : null,
     score: Math.round(row.score * 10) / 10,

--- a/apps/pops-api/src/modules/media/comparisons/rankings.service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/rankings.service.ts
@@ -22,8 +22,9 @@ export function resolvePosterUrl(row: {
 }): string | null {
   if (row.mediaType === 'movie') {
     if (row.moviePosterOverride) return row.moviePosterOverride;
-    if (row.moviePosterPath && row.movieTmdbId)
-      return `/media/images/movie/${row.movieTmdbId}/poster.jpg`;
+    // Always generate the URL when tmdbId is available — the images endpoint
+    // handles the case where poster_path is null by fetching from TMDB on demand.
+    if (row.movieTmdbId) return `/media/images/movie/${row.movieTmdbId}/poster.jpg`;
     return null;
   }
   if (row.tvPosterOverride) return row.tvPosterOverride;

--- a/apps/pops-api/src/modules/media/debrief/service.ts
+++ b/apps/pops-api/src/modules/media/debrief/service.ts
@@ -134,9 +134,7 @@ export function getDebrief(sessionId: number): DebriefResponse {
 
   const posterUrl = movieRow.posterOverridePath
     ? movieRow.posterOverridePath
-    : movieRow.posterPath
-      ? `/media/images/movie/${movieRow.tmdbId}/poster.jpg`
-      : null;
+    : `/media/images/movie/${movieRow.tmdbId}/poster.jpg`;
 
   // Get active dimensions
   const dims = db

--- a/apps/pops-api/src/routes/media/images.test.ts
+++ b/apps/pops-api/src/routes/media/images.test.ts
@@ -23,13 +23,21 @@ vi.mock('../../db.js', () => ({
   })),
 }));
 
-// Mock image cache
+// Mock image cache and TMDB client
 const mockDownloadMovieImages = vi.fn(async () => {});
 const mockDownloadTvShowImages = vi.fn(async () => {});
+const mockGetMovie = vi.fn(
+  async (): Promise<{ posterPath: string | null }> => ({
+    posterPath: null,
+  })
+);
 vi.mock('../../modules/media/tmdb/index.js', () => ({
   getImageCache: vi.fn(() => ({
     downloadMovieImages: mockDownloadMovieImages,
     downloadTvShowImages: mockDownloadTvShowImages,
+  })),
+  getTmdbClient: vi.fn(() => ({
+    getMovie: mockGetMovie,
   })),
 }));
 
@@ -92,6 +100,7 @@ beforeEach(() => {
   mockGet.mockReturnValue(undefined);
   mockDownloadMovieImages.mockResolvedValue(undefined);
   mockDownloadTvShowImages.mockResolvedValue(undefined);
+  mockGetMovie.mockResolvedValue({ posterPath: null });
 });
 
 afterEach(() => {
@@ -327,13 +336,69 @@ describe('GET /media/images/:mediaType/:id/:filename', () => {
       expect(res.status).toBe(404);
     });
 
-    it('returns 404 when DB has no poster_path', async () => {
+    it('returns 404 when DB has no poster_path and TMDB returns null', async () => {
       const app = createTestApp();
       mockGet.mockReturnValue({ path: null });
+      mockGetMovie.mockResolvedValue({ posterPath: null });
 
       const res = await request(app).get('/media/images/movie/550/poster.jpg');
 
+      expect(mockGetMovie).toHaveBeenCalledWith(550);
       expect(mockDownloadMovieImages).not.toHaveBeenCalled();
+      expect(res.status).toBe(404);
+    });
+
+    it('fetches poster from TMDB and redirects when DB has no poster_path but TMDB has one', async () => {
+      const app = createTestApp();
+      mockGet.mockReturnValue({ path: null });
+      mockGetMovie.mockResolvedValue({ posterPath: '/tmdb-fetched.jpg' });
+      // Download resolves but no file written — should fall through to CDN redirect
+      mockDownloadMovieImages.mockResolvedValue(undefined);
+
+      const res = await request(app).get('/media/images/movie/550/poster.jpg');
+
+      expect(mockGetMovie).toHaveBeenCalledWith(550);
+      expect(mockDownloadMovieImages).toHaveBeenCalledWith(550, '/tmdb-fetched.jpg', null, null);
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe('https://image.tmdb.org/t/p/w780/tmdb-fetched.jpg');
+    });
+
+    it('does not call TMDB when DB record does not exist at all', async () => {
+      const app = createTestApp();
+      mockGet.mockReturnValue(undefined);
+
+      const res = await request(app).get('/media/images/movie/9999/poster.jpg');
+
+      expect(mockGetMovie).not.toHaveBeenCalled();
+      expect(mockDownloadMovieImages).not.toHaveBeenCalled();
+      expect(res.status).toBe(404);
+    });
+
+    it('does not call TMDB for null path on non-poster image types', async () => {
+      const app = createTestApp();
+      mockGet.mockReturnValue({ path: null });
+
+      await request(app).get('/media/images/movie/550/backdrop.jpg');
+
+      expect(mockGetMovie).not.toHaveBeenCalled();
+    });
+
+    it('does not call TMDB for null path on TV shows', async () => {
+      const app = createTestApp();
+      mockGet.mockReturnValue({ path: null });
+
+      await request(app).get('/media/images/tv/81189/poster.jpg');
+
+      expect(mockGetMovie).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when TMDB lookup throws', async () => {
+      const app = createTestApp();
+      mockGet.mockReturnValue({ path: null });
+      mockGetMovie.mockRejectedValue(new Error('TMDB API unavailable'));
+
+      const res = await request(app).get('/media/images/movie/550/poster.jpg');
+
       expect(res.status).toBe(404);
     });
   });

--- a/apps/pops-api/src/routes/media/images.ts
+++ b/apps/pops-api/src/routes/media/images.ts
@@ -18,7 +18,7 @@ import { type Router as ExpressRouter, Router } from 'express';
 
 import { getDb } from '../../db.js';
 import { MEDIA_DIR_NAMES } from '../../modules/media/tmdb/image-cache.js';
-import { getImageCache } from '../../modules/media/tmdb/index.js';
+import { getImageCache, getTmdbClient } from '../../modules/media/tmdb/index.js';
 
 const VALID_MEDIA_TYPES = ['movie', 'tv'] as const;
 const VALID_FILENAMES = ['poster.jpg', 'backdrop.jpg', 'logo.png', 'override.jpg'] as const;
@@ -195,12 +195,21 @@ router.get('/media/images/:mediaType/:id/:filename', async (req, res): Promise<v
       .prepare(`SELECT ${pathColumn} AS path FROM ${table} WHERE ${idColumn} = ?`)
       .get(id) as { path: string | null } | undefined;
 
-    if (record?.path) {
+    // For movies with null poster_path, fetch from TMDB API to get the current path
+    let resolvedPath = record?.path ?? null;
+    if (!resolvedPath && mediaType === 'movie' && imageType === 'poster' && record !== undefined) {
+      const tmdbPath = await fetchPosterPathFromTmdb(Number(id));
+      if (tmdbPath) {
+        resolvedPath = tmdbPath;
+      }
+    }
+
+    if (resolvedPath) {
       // Tier 2: Download from CDN → cache → serve
       const downloaded = await downloadAndServe(
         mediaType,
         Number(id),
-        record.path,
+        resolvedPath,
         imageType,
         filePath,
         res
@@ -208,7 +217,7 @@ router.get('/media/images/:mediaType/:id/:filename', async (req, res): Promise<v
       if (downloaded) return;
 
       // Tier 3: Redirect browser to CDN URL directly
-      const cdnUrl = buildCdnFallbackUrl(mediaType, record.path, imageType);
+      const cdnUrl = buildCdnFallbackUrl(mediaType, resolvedPath, imageType);
       if (cdnUrl) {
         res.set('Cache-Control', 'private, max-age=300');
         res.redirect(302, cdnUrl);
@@ -222,6 +231,21 @@ router.get('/media/images/:mediaType/:id/:filename', async (req, res): Promise<v
   // No image source at all
   res.status(404).json({ error: 'Image not found' });
 });
+
+/**
+ * Fetch the poster_path for a movie from the TMDB API when the DB has no stored path.
+ * Returns the TMDB-relative path (e.g. "/abc123.jpg"), or null on failure/no result.
+ */
+async function fetchPosterPathFromTmdb(tmdbId: number): Promise<string | null> {
+  try {
+    const client = getTmdbClient();
+    const detail = await client.getMovie(tmdbId);
+    return detail.posterPath ?? null;
+  } catch (err) {
+    console.warn(`[Images] TMDB lookup for ${tmdbId} failed:`, err);
+    return null;
+  }
+}
 
 /**
  * Download an image from its original source (TMDB or TheTVDB) to the local cache,


### PR DESCRIPTION
## Summary

- `images.ts`: When `poster_path` is null in the DB for a movie poster request, the endpoint now calls the TMDB API to retrieve the current `poster_path`, then proceeds through the standard download+serve/CDN-redirect tiers. Without this, the three-tier fallback chain had nothing to work with.
- `debrief/service.ts`, `comparisons/lib/debrief.ts`, `comparisons/rankings.service.ts`, `comparisons/lib/tier-list.ts`: Always generate the `/media/images/movie/{tmdbId}/poster.jpg` URL when `tmdbId` is set, regardless of whether `poster_path` is populated. Previously these returned `null` when `poster_path` was null, causing the frontend to skip the image request entirely.

Closes #1844

## Test plan

- [ ] `images.test.ts` — new tests: TMDB fallback fires when DB has null path, redirects to CDN with TMDB-fetched path, does not call TMDB when DB record is absent, does not call TMDB for non-poster image types or TV shows, 404s gracefully when TMDB also returns null or throws
- [ ] All 31 existing image endpoint tests pass
- [ ] `pnpm typecheck` passes (no TS errors)
- [ ] `oxlint` and `oxfmt` clean on all changed files