### PR TITLE
fix(search): clickable tiles, URL back-state, watchlist/watched actions (#1912, #1913)

### DIFF
--- a/docs/themes/03-media/prds/032-search-page/README.md
+++ b/docs/themes/03-media/prds/032-search-page/README.md
@@ -30,6 +30,7 @@ Build a search page that queries TMDB for movies and TheTVDB for TV shows. Displ
 | ----------------------- | ---------------------------------------------------------------------------------- |
 | Layout                  | Tab or section layout: "Movies (TMDB)" / "TV Shows (TheTVDB)"                      |
 | Result card             | Poster thumbnail, title, year, overview snippet (2-3 lines, truncated)             |
+| Clickable card          | In-library cards are `<Link>` elements navigating to the detail page               |
 | "Add to Library" button | Per-result action — triggers the add flow                                          |
 | "In Library" badge      | Shown if tmdbId (movies) or tvdbId (TV shows) already exists in the local database |
 | Loading state           | Per-section spinner/skeleton (one API may respond before the other)                |
@@ -45,6 +46,23 @@ Build a search page that queries TMDB for movies and TheTVDB for TV shows. Displ
 | Already exists | Button pre-renders as "In Library" badge (idempotent — no error if added again)      |
 | Failure        | Button reverts to "Add", error toast with message                                    |
 
+### Watchlist and Watch Actions on Search Results
+
+#### Not-in-library movie cards
+
+| Button              | Action                                                              |
+| ------------------- | ------------------------------------------------------------------- |
+| Add to Library      | `addMovie` — adds to library only                                   |
+| Watchlist + Library | `addMovie` → on success → `watchlist.add` with returned local id    |
+| Watched + Library   | `addMovie` → on success → `watchHistory.log` with returned local id |
+
+#### In-library items
+
+| Element         | Detail                                                              |
+| --------------- | ------------------------------------------------------------------- |
+| WatchlistToggle | Shown for all in-library items (movies and TV) when `mediaId` known |
+| Mark Watched    | Shown for in-library movies only; calls `watchHistory.log` directly |
+
 ## API Dependencies
 
 | Procedure                 | Usage                                                              |
@@ -54,6 +72,10 @@ Build a search page that queries TMDB for movies and TheTVDB for TV shows. Displ
 | `media.library.addMovie`  | Add a movie to the library by TMDB ID (fetches full metadata)      |
 | `media.library.addTvShow` | Add a TV show to the library by TheTVDB ID (fetches full metadata) |
 | `media.library.list`      | Check which tmdbIds/tvdbIds are already in the library             |
+| `media.watchlist.add`     | Add an item to the watchlist (compound action after addMovie)      |
+| `media.watchlist.remove`  | Remove an item from the watchlist (via WatchlistToggle)            |
+| `media.watchlist.status`  | Check watchlist status for in-library items (via WatchlistToggle)  |
+| `media.watchHistory.log`  | Log a watch event (compound or direct for in-library movies)       |
 
 ## Business Rules
 
@@ -62,7 +84,11 @@ Build a search page that queries TMDB for movies and TheTVDB for TV shows. Displ
 - "In Library" detection checks the local database, not the external API
 - Adding an item that already exists is idempotent — no duplicate rows, no error
 - The add flow fetches full metadata from the external API and stores it locally; the search result itself is a preview only
-- Search query is persisted in the URL (`?q=`) so the page can be bookmarked or shared
+- Search query is persisted in the URL (`?q=`) so the back button restores the query
+- In-library cards are wrapped in a `<Link>` navigating to the detail page; action buttons inside stop click propagation so they don't trigger navigation
+- Compound add-to-watchlist and mark-watched actions chain `addMovie` first, then use the local id returned by the response for the secondary call
+- The local id returned by compound `addMovie` calls is cached in session state (`sessionMovieLocalIds`) so subsequent in-session interactions have the id without waiting for a library query refetch
+- TV shows do not have compound watchlist/watched actions on the search page (episode-level tracking requires the detail page)
 
 ## Edge Cases
 
@@ -78,13 +104,15 @@ Build a search page that queries TMDB for movies and TheTVDB for TV shows. Displ
 
 ## User Stories
 
-| #   | Story                                                     | Summary                                                                              | Status | Parallelisable   |
-| --- | --------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------ | ---------------- |
-| 01  | [us-01-search-input](us-01-search-input.md)               | Debounced search input querying TMDB and TheTVDB in parallel                         | Done   | No (first)       |
-| 02  | [us-02-search-results](us-02-search-results.md)           | Result cards with poster/title/year/overview, "In Library" badge, tab/section layout | Done   | Blocked by us-01 |
-| 03  | [us-03-add-to-library-flow](us-03-add-to-library-flow.md) | Add button with spinner, addMovie/addTvShow call, success toast, badge update        | Done   | Blocked by us-02 |
+| #   | Story                                                                 | Summary                                                                              | Status | Parallelisable   |
+| --- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------ | ---------------- |
+| 01  | [us-01-search-input](us-01-search-input.md)                           | Debounced search input querying TMDB and TheTVDB in parallel                         | Done   | No (first)       |
+| 02  | [us-02-search-results](us-02-search-results.md)                       | Result cards with poster/title/year/overview, "In Library" badge, tab/section layout | Done   | Blocked by us-01 |
+| 03  | [us-03-add-to-library-flow](us-03-add-to-library-flow.md)             | Add button with spinner, addMovie/addTvShow call, success toast, badge update        | Done   | Blocked by us-02 |
+| 04  | [us-04-clickable-tiles](us-04-clickable-tiles.md)                     | In-library cards link to detail page; URL `?q=` preserves query across navigation    | Done   | Blocked by us-02 |
+| 05  | [us-05-watchlist-watched-actions](us-05-watchlist-watched-actions.md) | Compound watchlist/watched actions on search results                                 | Done   | Blocked by us-03 |
 
-US-02 depends on US-01 (needs search state). US-03 depends on US-02 (needs result cards to attach the button to).
+US-02 depends on US-01 (needs search state). US-03 depends on US-02 (needs result cards to attach the button to). US-04 and US-05 depend on US-03.
 
 ## Verification
 
@@ -95,6 +123,13 @@ US-02 depends on US-01 (needs search state). US-03 depends on US-02 (needs resul
 - Adding an item that already exists does not create a duplicate
 - Per-section loading and error states work independently
 - Empty states are accurate per section
+- In-library cards are clickable links navigating to the correct detail page
+- Browser back button restores the search query via `?q=` param
+- Clicking action buttons on a linked card does not trigger navigation
+- "Watchlist + Library" calls addMovie then watchlist.add with the returned local id
+- "Watched + Library" calls addMovie then watchHistory.log with the returned local id
+- In-library movie cards show WatchlistToggle and Mark Watched button
+- In-library TV cards show WatchlistToggle (no Mark Watched — episode-level)
 
 ## Out of Scope
 
@@ -105,4 +140,4 @@ US-02 depends on US-01 (needs search state). US-03 depends on US-02 (needs resul
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-18

--- a/docs/themes/03-media/prds/032-search-page/us-04-clickable-tiles.md
+++ b/docs/themes/03-media/prds/032-search-page/us-04-clickable-tiles.md
@@ -1,0 +1,23 @@
+# US-04: Clickable Tiles and URL Back-State
+
+> PRD: [PRD-032 Search Page](README.md)
+> Status: Done
+
+## Story
+
+As a user browsing search results, I want in-library cards to be clickable links so I can navigate directly to the detail page, and I want the browser back button to restore my search query.
+
+## Acceptance Criteria
+
+- [ ] In-library movie cards are rendered as `<Link>` elements navigating to `/media/movies/:id`
+- [ ] In-library TV cards are rendered as `<Link>` elements navigating to `/media/tv/:id`
+- [ ] Not-in-library cards are not clickable links (plain `div`)
+- [ ] The search query is synced to the URL `?q=` param after the 300ms debounce
+- [ ] Navigating away and pressing Back restores the query input and results
+- [ ] Action buttons inside linked cards call `e.stopPropagation()` and `e.preventDefault()` so they do not trigger card navigation
+
+## Implementation Notes
+
+- `href` prop on `SearchResultCard` is set from the local DB id (`movieTmdbToLocalId` / `tvTvdbToLocalId`)
+- The `?q=` param sync uses `useSearchParams` + `setSearchParams({ replace: true })` so it does not add history entries on every keystroke
+- `SearchResultCard` wraps the card in `<Link to={href}>` when `href` is set; the action buttons container has an `onClick` that stops propagation

--- a/docs/themes/03-media/prds/032-search-page/us-05-watchlist-watched-actions.md
+++ b/docs/themes/03-media/prds/032-search-page/us-05-watchlist-watched-actions.md
@@ -1,0 +1,32 @@
+# US-05: Watchlist and Watched Actions on Search Results
+
+> PRD: [PRD-032 Search Page](README.md)
+> Status: Done
+
+## Story
+
+As a user browsing search results, I want to add a movie to my watchlist or mark it as watched in a single click, without having to visit the detail page first.
+
+## Acceptance Criteria
+
+### Not-in-library movies
+
+- [ ] A "Watchlist + Library" button appears; clicking it calls `addMovie` and on success calls `watchlist.add` with the returned local id
+- [ ] A "Watched + Library" button appears; clicking it calls `addMovie` and on success calls `watchHistory.log` with the returned local id
+- [ ] Both compound buttons are disabled while the primary `addMovie` call is pending
+
+### In-library items
+
+- [ ] A `WatchlistToggle` component is rendered for all in-library items (movies and TV) when the local `mediaId` is known
+- [ ] A "Mark Watched" button is rendered for in-library movies only; clicking it calls `watchHistory.log` directly with the local `mediaId`
+- [ ] The "Mark Watched" button is not shown for TV shows (episode-level tracking is on the detail page)
+
+### Session state
+
+- [ ] The local id returned by a compound `addMovie` call is stored in session state so subsequent in-session actions (e.g. Mark Watched after Watchlist + Library) have the id available without a library query refetch
+
+## Implementation Notes
+
+- `SearchResultCard` receives `onAddToWatchlistAndLibrary`, `onMarkWatchedAndLibrary` (not-in-library) and `onMarkWatched` (in-library) as prop callbacks
+- `SearchPage` manages `sessionMovieLocalIds: Map<tmdbId, localId>` to cache ids from compound add responses
+- TV shows do not receive `onAddToWatchlistAndLibrary` or `onMarkWatchedAndLibrary` — the search page only supports episode-level watch logging via the TV show detail page

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,52 +1,19 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-const root = path.dirname(fileURLToPath(import.meta.url));
-
-/**
- * Groups absolute file paths by their nearest package root (apps/* or packages/*).
- * Files outside those directories are grouped under the repo root.
- */
-function groupByPackage(filenames) {
-  const groups = {};
-  for (const f of filenames) {
-    const rel = path.relative(root, f);
-    const parts = rel.split(path.sep);
-    const pkgDir =
-      (parts[0] === 'apps' || parts[0] === 'packages') && parts.length > 1
-        ? path.join(root, parts[0], parts[1])
-        : root;
-    (groups[pkgDir] ||= []).push(f);
-  }
-  return groups;
-}
-
 /** Shell-escape a path for use inside a bash -c string. */
 function esc(s) {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
 export default {
-  '*.{ts,tsx}': (filenames) => {
-    const groups = groupByPackage(filenames);
+  '*.{js,jsx,ts,tsx,mjs,cjs}': (filenames) => {
     const formatFiles = filenames.map(esc).join(' ');
 
-    // 1. oxfmt --write  (auto-fix formatting)
-    // 2. eslint --fix   (auto-fix lint, per-package CWD so config resolves)
-    // 3. oxfmt --check  (verify formatting)
-    // 4. eslint         (verify lint)
-    return [
-      `oxfmt --write ${formatFiles}`,
-      ...Object.entries(groups).map(
-        ([pkgDir, files]) =>
-          `bash -c 'cd ${esc(pkgDir)} && eslint --fix ${files.map(esc).join(' ')}'`
-      ),
-      `oxfmt --check ${formatFiles}`,
-      ...Object.entries(groups).map(
-        ([pkgDir, files]) => `bash -c 'cd ${esc(pkgDir)} && eslint ${files.map(esc).join(' ')}'`
-      ),
-    ];
+    // 1. oxlint --fix  (auto-fix lint issues)
+    // 2. oxfmt --write (auto-fix formatting and import sort)
+    return [`oxlint --fix ${formatFiles}`, `oxfmt --write ${formatFiles}`];
   },
 
-  '*.css': ['oxfmt --write', 'oxfmt --check'],
+  '*.{json,md,css}': (filenames) => {
+    const formatFiles = filenames.map(esc).join(' ');
+    return [`oxfmt --write ${formatFiles}`];
+  },
 };

--- a/packages/app-media/src/components/SearchResultCard.tsx
+++ b/packages/app-media/src/components/SearchResultCard.tsx
@@ -298,18 +298,8 @@ export function SearchResultCard({
           </div>
         )}
 
-        {/* Action buttons — stop propagation so card link doesn't navigate on button click */}
-        <div
-          className="mt-auto flex flex-wrap items-center gap-2 pt-1"
-          onClick={
-            href
-              ? (e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                }
-              : undefined
-          }
-        >
+        {/* Action buttons — z-index above the overlay link so clicks reach the buttons */}
+        <div className="relative z-10 mt-auto flex flex-wrap items-center gap-2 pt-1">
           {inLibrary ? (
             <InLibraryActionButtons
               type={type}
@@ -347,22 +337,22 @@ export function SearchResultCard({
   );
 
   const baseClasses = cn(
-    'flex gap-4 rounded-lg border bg-card p-3 text-card-foreground',
+    'relative flex gap-4 rounded-lg border bg-card p-3 text-card-foreground',
     href && 'transition-colors hover:bg-accent/50',
     className
   );
 
-  if (href) {
-    return (
-      <Link
-        to={href}
-        className={baseClasses}
-        aria-label={`${title} (${type === 'movie' ? 'Movie' : 'TV'})`}
-      >
-        {cardContent}
-      </Link>
-    );
-  }
-
-  return <div className={baseClasses}>{cardContent}</div>;
+  return (
+    <div className={baseClasses}>
+      {href && (
+        <Link
+          to={href}
+          className="absolute inset-0 rounded-lg"
+          aria-label={`${title} (${type === 'movie' ? 'Movie' : 'TV'})`}
+          tabIndex={-1}
+        />
+      )}
+      {cardContent}
+    </div>
+  );
 }

--- a/packages/app-media/src/components/SearchResultCard.tsx
+++ b/packages/app-media/src/components/SearchResultCard.tsx
@@ -84,6 +84,125 @@ export function buildPosterUrl(
   return posterPath;
 }
 
+interface InLibraryActionButtonsProps {
+  type: SearchResultType;
+  mediaId?: number;
+  onMarkWatched?: () => void;
+  isMarkingWatched?: boolean;
+}
+
+/** Action buttons shown when the item is already in the library. */
+function InLibraryActionButtons({
+  type,
+  mediaId,
+  onMarkWatched,
+  isMarkingWatched,
+}: InLibraryActionButtonsProps) {
+  return (
+    <>
+      <Badge variant="secondary" className="gap-1">
+        <Check className="h-3 w-3" />
+        In Library
+      </Badge>
+      {mediaId != null && (
+        <WatchlistToggle mediaType={type} mediaId={mediaId} className="h-7 text-xs" />
+      )}
+      {type === 'movie' && mediaId != null && onMarkWatched != null && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-7 gap-1 text-xs"
+          onClick={onMarkWatched}
+          disabled={isMarkingWatched}
+          aria-label="Mark as watched"
+        >
+          {isMarkingWatched ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <Eye className="h-3 w-3" />
+          )}
+          {isMarkingWatched ? 'Logging\u2026' : 'Mark Watched'}
+        </Button>
+      )}
+    </>
+  );
+}
+
+interface NotInLibraryActionButtonsProps {
+  type: SearchResultType;
+  addDisabled?: boolean;
+  addDisabledReason?: string;
+  isAdding?: boolean;
+  onAdd?: () => void;
+  onAddToWatchlistAndLibrary?: () => void;
+  isAddingToWatchlistAndLibrary?: boolean;
+  onMarkWatchedAndLibrary?: () => void;
+  isMarkingWatchedAndLibrary?: boolean;
+}
+
+/** Action buttons shown when the item is not yet in the library. */
+function NotInLibraryActionButtons({
+  type,
+  addDisabled,
+  addDisabledReason,
+  isAdding,
+  onAdd,
+  onAddToWatchlistAndLibrary,
+  isAddingToWatchlistAndLibrary,
+  onMarkWatchedAndLibrary,
+  isMarkingWatchedAndLibrary,
+}: NotInLibraryActionButtonsProps) {
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="outline"
+        className="h-7 gap-1 text-xs"
+        disabled={addDisabled || isAdding}
+        title={addDisabledReason}
+        onClick={onAdd}
+      >
+        {isAdding ? <Loader2 className="h-3 w-3 animate-spin" /> : <Plus className="h-3 w-3" />}
+        {isAdding ? 'Adding\u2026' : 'Add to Library'}
+      </Button>
+      {onAddToWatchlistAndLibrary != null && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-7 gap-1 text-xs"
+          onClick={onAddToWatchlistAndLibrary}
+          disabled={isAdding || isAddingToWatchlistAndLibrary}
+          aria-label="Add to watchlist and library"
+        >
+          {isAddingToWatchlistAndLibrary ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <Bookmark className="h-3 w-3" />
+          )}
+          {isAddingToWatchlistAndLibrary ? 'Adding\u2026' : 'Watchlist + Library'}
+        </Button>
+      )}
+      {type === 'movie' && onMarkWatchedAndLibrary != null && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-7 gap-1 text-xs"
+          onClick={onMarkWatchedAndLibrary}
+          disabled={isAdding || isMarkingWatchedAndLibrary}
+          aria-label="Mark as watched and add to library"
+        >
+          {isMarkingWatchedAndLibrary ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <Eye className="h-3 w-3" />
+          )}
+          {isMarkingWatchedAndLibrary ? 'Logging\u2026' : 'Watched + Library'}
+        </Button>
+      )}
+    </>
+  );
+}
+
 export function SearchResultCard({
   type,
   title,
@@ -192,84 +311,24 @@ export function SearchResultCard({
           }
         >
           {inLibrary ? (
-            <>
-              <Badge variant="secondary" className="gap-1">
-                <Check className="h-3 w-3" />
-                In Library
-              </Badge>
-              {mediaId != null && (
-                <WatchlistToggle mediaType={type} mediaId={mediaId} className="h-7 text-xs" />
-              )}
-              {type === 'movie' && mediaId != null && onMarkWatched != null && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-7 gap-1 text-xs"
-                  onClick={onMarkWatched}
-                  disabled={isMarkingWatched}
-                  aria-label="Mark as watched"
-                >
-                  {isMarkingWatched ? (
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                  ) : (
-                    <Eye className="h-3 w-3" />
-                  )}
-                  {isMarkingWatched ? 'Logging\u2026' : 'Mark Watched'}
-                </Button>
-              )}
-            </>
+            <InLibraryActionButtons
+              type={type}
+              mediaId={mediaId}
+              onMarkWatched={onMarkWatched}
+              isMarkingWatched={isMarkingWatched}
+            />
           ) : (
-            <>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 gap-1 text-xs"
-                disabled={addDisabled || isAdding}
-                title={addDisabledReason}
-                onClick={onAdd}
-              >
-                {isAdding ? (
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                ) : (
-                  <Plus className="h-3 w-3" />
-                )}
-                {isAdding ? 'Adding\u2026' : 'Add to Library'}
-              </Button>
-              {onAddToWatchlistAndLibrary != null && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-7 gap-1 text-xs"
-                  onClick={onAddToWatchlistAndLibrary}
-                  disabled={isAdding || isAddingToWatchlistAndLibrary}
-                  aria-label="Add to watchlist and library"
-                >
-                  {isAddingToWatchlistAndLibrary ? (
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                  ) : (
-                    <Bookmark className="h-3 w-3" />
-                  )}
-                  {isAddingToWatchlistAndLibrary ? 'Adding\u2026' : 'Watchlist + Library'}
-                </Button>
-              )}
-              {type === 'movie' && onMarkWatchedAndLibrary != null && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-7 gap-1 text-xs"
-                  onClick={onMarkWatchedAndLibrary}
-                  disabled={isAdding || isMarkingWatchedAndLibrary}
-                  aria-label="Mark as watched and add to library"
-                >
-                  {isMarkingWatchedAndLibrary ? (
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                  ) : (
-                    <Eye className="h-3 w-3" />
-                  )}
-                  {isMarkingWatchedAndLibrary ? 'Logging\u2026' : 'Watched + Library'}
-                </Button>
-              )}
-            </>
+            <NotInLibraryActionButtons
+              type={type}
+              addDisabled={addDisabled}
+              addDisabledReason={addDisabledReason}
+              isAdding={isAdding}
+              onAdd={onAdd}
+              onAddToWatchlistAndLibrary={onAddToWatchlistAndLibrary}
+              isAddingToWatchlistAndLibrary={isAddingToWatchlistAndLibrary}
+              onMarkWatchedAndLibrary={onMarkWatchedAndLibrary}
+              isMarkingWatchedAndLibrary={isMarkingWatchedAndLibrary}
+            />
           )}
           {inLibrary && rotationStatus === 'leaving' && rotationExpiresAt && (
             <LeavingBadge rotationExpiresAt={rotationExpiresAt} />

--- a/packages/app-media/src/components/SearchResultCard.tsx
+++ b/packages/app-media/src/components/SearchResultCard.tsx
@@ -1,4 +1,4 @@
-import { Check, Film, Loader2, Plus, Tv } from 'lucide-react';
+import { Bookmark, Check, Eye, Film, Loader2, Plus, Tv } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';
 
@@ -9,11 +9,20 @@ import { Link } from 'react-router';
  * When the item is already in the library (`inLibrary === true`) and has a
  * 'leaving' rotation status, a LeavingBadge is rendered to indicate the
  * removal countdown (PRD-072 US-01).
+ *
+ * For in-library items (mediaId provided): shows WatchlistToggle and (movies)
+ * a Mark as Watched button inline.
+ * For not-in-library items: shows compound "Add to Watchlist + Library" and
+ * (movies) "Mark as Watched + Library" buttons alongside "Add to Library".
+ *
+ * When href is set the card becomes a clickable link. Buttons inside stop
+ * click propagation so navigation only fires on background card clicks.
  */
 import { Badge, Button, cn, Skeleton } from '@pops/ui';
 
 import { LeavingBadge } from './LeavingBadge';
 import { MovieActionButtons } from './MovieActionButtons';
+import { WatchlistToggle } from './WatchlistToggle';
 
 import type { RotationMeta } from '../lib/types';
 
@@ -32,10 +41,29 @@ export interface SearchResultCardProps extends RotationMeta {
   voteAverage?: number | null;
   genres?: string[];
   inLibrary?: boolean;
+  /** Local library DB ID — enables watchlist/watched actions for in-library items. */
+  mediaId?: number;
   addDisabled?: boolean;
   addDisabledReason?: string;
   isAdding?: boolean;
   onAdd?: () => void;
+  /**
+   * Compound action: add to library then add to watchlist.
+   * Only shown for not-in-library items.
+   */
+  onAddToWatchlistAndLibrary?: () => void;
+  isAddingToWatchlistAndLibrary?: boolean;
+  /**
+   * Compound action: add to library then mark as watched.
+   * Only shown for not-in-library movie items.
+   */
+  onMarkWatchedAndLibrary?: () => void;
+  isMarkingWatchedAndLibrary?: boolean;
+  /**
+   * Simple mark-as-watched for in-library movies.
+   */
+  onMarkWatched?: () => void;
+  isMarkingWatched?: boolean;
   /** When set, the card becomes a clickable link to the detail page. */
   href?: string;
   className?: string;
@@ -68,10 +96,17 @@ export function SearchResultCard({
   inLibrary,
   rotationStatus,
   rotationExpiresAt,
+  mediaId,
   addDisabled,
   addDisabledReason,
   isAdding,
   onAdd,
+  onAddToWatchlistAndLibrary,
+  isAddingToWatchlistAndLibrary,
+  onMarkWatchedAndLibrary,
+  isMarkingWatchedAndLibrary,
+  onMarkWatched,
+  isMarkingWatched,
   href,
   className,
 }: SearchResultCardProps) {
@@ -144,29 +179,97 @@ export function SearchResultCard({
           </div>
         )}
 
-        {/* Action buttons */}
-        <div className="mt-auto flex items-center gap-2 pt-1">
+        {/* Action buttons — stop propagation so card link doesn't navigate on button click */}
+        <div
+          className="mt-auto flex flex-wrap items-center gap-2 pt-1"
+          onClick={
+            href
+              ? (e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }
+              : undefined
+          }
+        >
           {inLibrary ? (
-            <Badge variant="secondary" className="gap-1">
-              <Check className="h-3 w-3" />
-              In Library
-            </Badge>
-          ) : (
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-7 gap-1 text-xs"
-              disabled={addDisabled || isAdding}
-              title={addDisabledReason}
-              onClick={onAdd}
-            >
-              {isAdding ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : (
-                <Plus className="h-3 w-3" />
+            <>
+              <Badge variant="secondary" className="gap-1">
+                <Check className="h-3 w-3" />
+                In Library
+              </Badge>
+              {mediaId != null && (
+                <WatchlistToggle mediaType={type} mediaId={mediaId} className="h-7 text-xs" />
               )}
-              {isAdding ? 'Adding…' : 'Add to Library'}
-            </Button>
+              {type === 'movie' && mediaId != null && onMarkWatched != null && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 gap-1 text-xs"
+                  onClick={onMarkWatched}
+                  disabled={isMarkingWatched}
+                  aria-label="Mark as watched"
+                >
+                  {isMarkingWatched ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <Eye className="h-3 w-3" />
+                  )}
+                  {isMarkingWatched ? 'Logging\u2026' : 'Mark Watched'}
+                </Button>
+              )}
+            </>
+          ) : (
+            <>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 gap-1 text-xs"
+                disabled={addDisabled || isAdding}
+                title={addDisabledReason}
+                onClick={onAdd}
+              >
+                {isAdding ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Plus className="h-3 w-3" />
+                )}
+                {isAdding ? 'Adding\u2026' : 'Add to Library'}
+              </Button>
+              {onAddToWatchlistAndLibrary != null && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 gap-1 text-xs"
+                  onClick={onAddToWatchlistAndLibrary}
+                  disabled={isAdding || isAddingToWatchlistAndLibrary}
+                  aria-label="Add to watchlist and library"
+                >
+                  {isAddingToWatchlistAndLibrary ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <Bookmark className="h-3 w-3" />
+                  )}
+                  {isAddingToWatchlistAndLibrary ? 'Adding\u2026' : 'Watchlist + Library'}
+                </Button>
+              )}
+              {type === 'movie' && onMarkWatchedAndLibrary != null && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 gap-1 text-xs"
+                  onClick={onMarkWatchedAndLibrary}
+                  disabled={isAdding || isMarkingWatchedAndLibrary}
+                  aria-label="Mark as watched and add to library"
+                >
+                  {isMarkingWatchedAndLibrary ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <Eye className="h-3 w-3" />
+                  )}
+                  {isMarkingWatchedAndLibrary ? 'Logging\u2026' : 'Watched + Library'}
+                </Button>
+              )}
+            </>
           )}
           {inLibrary && rotationStatus === 'leaving' && rotationExpiresAt && (
             <LeavingBadge rotationExpiresAt={rotationExpiresAt} />

--- a/packages/app-media/src/pages/SearchPage.test.tsx
+++ b/packages/app-media/src/pages/SearchPage.test.tsx
@@ -12,6 +12,8 @@ const {
   mockLibraryTv,
   mockAddMovieMutation,
   mockAddTvMutation,
+  mockWatchlistAddMutation,
+  mockWatchHistoryLogMutation,
   mockMovieRefetch,
   mockTvRefetch,
 } = vi.hoisted(() => ({
@@ -21,6 +23,8 @@ const {
   mockLibraryTv: vi.fn(),
   mockAddMovieMutation: vi.fn(),
   mockAddTvMutation: vi.fn(),
+  mockWatchlistAddMutation: vi.fn(),
+  mockWatchHistoryLogMutation: vi.fn(),
   mockMovieRefetch: vi.fn(),
   mockTvRefetch: vi.fn(),
 }));
@@ -39,8 +43,14 @@ vi.mock('../lib/trpc', () => ({
         list: { useQuery: (...args: unknown[]) => mockLibraryTv(...args) },
       },
       library: {
-        addMovie: { useMutation: () => ({ mutate: mockAddMovieMutation }) },
-        addTvShow: { useMutation: () => ({ mutate: mockAddTvMutation }) },
+        addMovie: { useMutation: () => ({ mutate: mockAddMovieMutation, isPending: false }) },
+        addTvShow: { useMutation: () => ({ mutate: mockAddTvMutation, isPending: false }) },
+      },
+      watchlist: {
+        add: { useMutation: () => ({ mutate: mockWatchlistAddMutation, isPending: false }) },
+      },
+      watchHistory: {
+        log: { useMutation: () => ({ mutate: mockWatchHistoryLogMutation, isPending: false }) },
       },
     },
   },
@@ -55,7 +65,10 @@ vi.mock('../components/SearchResultCard', () => ({
     if (props.type === 'movie') lastMovieCardProps.push(props);
     else lastTvCardProps.push(props);
     return (
-      <div data-testid={`card-${props.type as string}-${props.title as string}`}>
+      <div
+        data-testid={`card-${props.type as string}-${props.title as string}`}
+        data-href={props.href as string | undefined}
+      >
         <span>{props.title as string}</span>
         {Boolean(props.inLibrary) && <span data-testid="in-library-badge">In Library</span>}
         {!props.posterUrl && <span data-testid="no-poster" />}
@@ -407,5 +420,180 @@ describe('SearchPage — overview passed to cards', () => {
 
     const severanceCard = lastTvCardProps.find((p) => p.title === 'Severance');
     expect(severanceCard?.overview).toBeNull();
+  });
+});
+
+describe('SearchPage — clickable links for in-library items (#1913)', () => {
+  it('passes href to in-library movie card pointing to detail page', () => {
+    renderPage();
+
+    // Inception (tmdbId=101) maps to localId=1 from LIBRARY_MOVIES
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    expect(inceptionCard?.href).toBe('/media/movies/1');
+  });
+
+  it('does not pass href to not-in-library movie card', () => {
+    renderPage();
+
+    const interstellarCard = lastMovieCardProps.find((p) => p.title === 'Interstellar');
+    expect(interstellarCard?.href).toBeUndefined();
+  });
+
+  it('passes href to in-library TV card pointing to detail page', () => {
+    renderPage();
+
+    // Breaking Bad (tvdbId=201) maps to localId=2 from LIBRARY_TV
+    const bbCard = lastTvCardProps.find((p) => p.title === 'Breaking Bad');
+    expect(bbCard?.href).toBe('/media/tv/2');
+  });
+
+  it('does not pass href to not-in-library TV card', () => {
+    renderPage();
+
+    const severanceCard = lastTvCardProps.find((p) => p.title === 'Severance');
+    expect(severanceCard?.href).toBeUndefined();
+  });
+
+  it('passes mediaId to in-library movie card', () => {
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    expect(inceptionCard?.mediaId).toBe(1);
+  });
+
+  it('passes mediaId to in-library TV card', () => {
+    renderPage();
+
+    const bbCard = lastTvCardProps.find((p) => p.title === 'Breaking Bad');
+    expect(bbCard?.mediaId).toBe(2);
+  });
+
+  it('does not pass mediaId to not-in-library movie card', () => {
+    setupEmptyLibrary();
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    expect(inceptionCard?.mediaId).toBeUndefined();
+  });
+});
+
+describe('SearchPage — compound actions (#1912)', () => {
+  it('passes onAddToWatchlistAndLibrary to not-in-library movie cards', () => {
+    setupEmptyLibrary();
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    expect(typeof inceptionCard?.onAddToWatchlistAndLibrary).toBe('function');
+  });
+
+  it('does not pass onAddToWatchlistAndLibrary to in-library movie cards', () => {
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    expect(inceptionCard?.onAddToWatchlistAndLibrary).toBeUndefined();
+  });
+
+  it('passes onMarkWatchedAndLibrary to not-in-library movie cards', () => {
+    setupEmptyLibrary();
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    expect(typeof inceptionCard?.onMarkWatchedAndLibrary).toBe('function');
+  });
+
+  it('does not pass onMarkWatchedAndLibrary to in-library movie cards', () => {
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    expect(inceptionCard?.onMarkWatchedAndLibrary).toBeUndefined();
+  });
+
+  it('passes onMarkWatched to in-library movie cards', () => {
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    expect(typeof inceptionCard?.onMarkWatched).toBe('function');
+  });
+
+  it('does not pass onMarkWatched to not-in-library movie cards (no localId)', () => {
+    setupEmptyLibrary();
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    expect(inceptionCard?.onMarkWatched).toBeUndefined();
+  });
+
+  it('calling onAddToWatchlistAndLibrary triggers addMovie then watchlist.add', () => {
+    setupEmptyLibrary();
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const handler = inceptionCard?.onAddToWatchlistAndLibrary as (() => void) | undefined;
+    expect(handler).toBeDefined();
+
+    handler?.();
+
+    expect(mockAddMovieMutation).toHaveBeenCalledWith(
+      { tmdbId: 101 },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+
+    // Simulate addMovie success with local id
+    const onSuccess = mockAddMovieMutation.mock.calls[0]?.[1]?.onSuccess;
+    onSuccess?.({ data: { id: 99 }, created: true, message: 'Movie added to library' });
+
+    expect(mockWatchlistAddMutation).toHaveBeenCalledWith(
+      { mediaType: 'movie', mediaId: 99 },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+
+  it('calling onMarkWatchedAndLibrary triggers addMovie then watchHistory.log', () => {
+    setupEmptyLibrary();
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const handler = inceptionCard?.onMarkWatchedAndLibrary as (() => void) | undefined;
+    expect(handler).toBeDefined();
+
+    handler?.();
+
+    expect(mockAddMovieMutation).toHaveBeenCalledWith(
+      { tmdbId: 101 },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+
+    const onSuccess = mockAddMovieMutation.mock.calls[0]?.[1]?.onSuccess;
+    onSuccess?.({ data: { id: 99 }, created: true, message: 'Movie added to library' });
+
+    expect(mockWatchHistoryLogMutation).toHaveBeenCalledWith(
+      { mediaType: 'movie', mediaId: 99 },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+
+  it('calling onMarkWatched for in-library movie triggers watchHistory.log directly', () => {
+    renderPage();
+
+    const inceptionCard = lastMovieCardProps.find((p) => p.title === 'Inception');
+    const handler = inceptionCard?.onMarkWatched as (() => void) | undefined;
+    expect(handler).toBeDefined();
+
+    handler?.();
+
+    expect(mockWatchHistoryLogMutation).toHaveBeenCalledWith(
+      { mediaType: 'movie', mediaId: 1 },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+    // addMovie should NOT be called for an in-library item
+    expect(mockAddMovieMutation).not.toHaveBeenCalled();
+  });
+
+  it('does not pass onAddToWatchlistAndLibrary to TV cards', () => {
+    renderPage();
+
+    // TV compound watchlist action not supported (no episode-level tracking)
+    const bbCard = lastTvCardProps.find((p) => p.title === 'Breaking Bad');
+    expect(bbCard?.onAddToWatchlistAndLibrary).toBeUndefined();
   });
 });

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -92,14 +92,17 @@ export function SearchPage() {
   const [addedIds, setAddedIds] = useState<Set<string>>(new Set());
   // Track compound "add to watchlist" pending state (by tmdbId)
   const [addingToWatchlistIds, setAddingToWatchlistIds] = useState<Set<number>>(new Set());
-  // Track compound "mark watched" pending state (by tmdbId or mediaId)
-  const [markingWatchedIds, setMarkingWatchedIds] = useState<Set<number>>(new Set());
+  // Track compound "mark watched" pending state (by tmdbId — not-yet-in-library flow)
+  const [markingWatchedTmdbIds, setMarkingWatchedTmdbIds] = useState<Set<number>>(new Set());
+  // Track in-library "mark watched" pending state (by local DB mediaId)
+  const [markingWatchedMediaIds, setMarkingWatchedMediaIds] = useState<Set<number>>(new Set());
   /**
    * Cache tmdbId → local DB id for movies added this session via compound
    * actions. The library query cache won't reflect newly added items until
    * it's refetched, so we store the mapping from the addMovie response.
    */
   const [sessionMovieLocalIds, setSessionMovieLocalIds] = useState<Map<number, number>>(new Map());
+  const [sessionTvLocalIds, setSessionTvLocalIds] = useState<Map<number, number>>(new Map());
 
   const shouldSearchMovies = debouncedQuery.length > 0 && (mode === 'movies' || mode === 'both');
   const shouldSearchTv = debouncedQuery.length > 0 && (mode === 'tv' || mode === 'both');
@@ -187,8 +190,9 @@ export function SearchPage() {
       addTvShowMutation.mutate(
         { tvdbId },
         {
-          onSuccess: () => {
+          onSuccess: (result) => {
             setAddedIds((prev) => new Set(prev).add(key));
+            setSessionTvLocalIds((prev) => new Map(prev).set(tvdbId, result.data.show.id));
             toast.success('TV show added to library');
           },
           onError: (err: { message: string }) => {
@@ -204,7 +208,7 @@ export function SearchPage() {
         }
       );
     },
-    [addTvShowMutation]
+    [addTvShowMutation, setSessionTvLocalIds]
   );
 
   /**
@@ -270,7 +274,7 @@ export function SearchPage() {
   const handleMarkWatchedAndLibrary = useCallback(
     (tmdbId: number) => {
       const key = makeKey('movie', tmdbId);
-      setMarkingWatchedIds((prev) => new Set(prev).add(tmdbId));
+      setMarkingWatchedTmdbIds((prev) => new Set(prev).add(tmdbId));
       setAddingIds((prev) => new Set(prev).add(key));
       addMovieMutation.mutate(
         { tmdbId },
@@ -289,7 +293,7 @@ export function SearchPage() {
                   toast.error(`Movie added to library but watch log failed: ${err.message}`);
                 },
                 onSettled: () => {
-                  setMarkingWatchedIds((prev) => {
+                  setMarkingWatchedTmdbIds((prev) => {
                     const next = new Set(prev);
                     next.delete(tmdbId);
                     return next;
@@ -300,7 +304,7 @@ export function SearchPage() {
           },
           onError: (err: { message: string }) => {
             toast.error(`Failed to add movie: ${err.message}`);
-            setMarkingWatchedIds((prev) => {
+            setMarkingWatchedTmdbIds((prev) => {
               const next = new Set(prev);
               next.delete(tmdbId);
               return next;
@@ -324,7 +328,7 @@ export function SearchPage() {
    */
   const handleMarkWatched = useCallback(
     (mediaId: number) => {
-      setMarkingWatchedIds((prev) => new Set(prev).add(mediaId));
+      setMarkingWatchedMediaIds((prev) => new Set(prev).add(mediaId));
       watchHistoryLogMutation.mutate(
         { mediaType: 'movie', mediaId },
         {
@@ -335,7 +339,7 @@ export function SearchPage() {
             toast.error(`Failed to log watch: ${err.message}`);
           },
           onSettled: () => {
-            setMarkingWatchedIds((prev) => {
+            setMarkingWatchedMediaIds((prev) => {
               const next = new Set(prev);
               next.delete(mediaId);
               return next;
@@ -486,7 +490,7 @@ export function SearchPage() {
                             handleMarkWatchedAndLibrary(movie.tmdbId);
                           }
                     }
-                    isMarkingWatchedAndLibrary={markingWatchedIds.has(movie.tmdbId)}
+                    isMarkingWatchedAndLibrary={markingWatchedTmdbIds.has(movie.tmdbId)}
                     onMarkWatched={
                       localId != null
                         ? () => {
@@ -494,7 +498,7 @@ export function SearchPage() {
                           }
                         : undefined
                     }
-                    isMarkingWatched={localId != null && markingWatchedIds.has(localId)}
+                    isMarkingWatched={localId != null && markingWatchedMediaIds.has(localId)}
                     href={localId != null ? `/media/movies/${localId}` : undefined}
                   />
                 );
@@ -544,7 +548,8 @@ export function SearchPage() {
               {tvResults.map((show: TvSearchResult) => {
                 const key = makeKey('tv', show.tvdbId);
                 const inLibrary = tvTvdbIds.has(show.tvdbId) || addedIds.has(key);
-                const localId = tvTvdbToLocalId.get(show.tvdbId);
+                const localId =
+                  tvTvdbToLocalId.get(show.tvdbId) ?? sessionTvLocalIds.get(show.tvdbId);
                 return (
                   <SearchResultCard
                     key={show.tvdbId}

--- a/packages/app-media/src/pages/SearchPage.tsx
+++ b/packages/app-media/src/pages/SearchPage.tsx
@@ -9,6 +9,13 @@ import { toast } from 'sonner';
  * Features: 300ms debounced search, type toggle (Movies/TV/Both),
  * responsive result grid, "Add to Library" with loading state,
  * "In Library" badge for items already in the collection.
+ *
+ * In-library items get a clickable card link to the detail page, a
+ * WatchlistToggle, and (movies) a Mark as Watched button.
+ *
+ * Not-in-library items get compound "Watchlist + Library" and (movies)
+ * "Watched + Library" buttons that add the item then trigger the secondary
+ * action in a single click.
  */
 import { Button, Skeleton, Tabs, TabsList, TabsTrigger, TextInput } from '@pops/ui';
 
@@ -83,6 +90,16 @@ export function SearchPage() {
   const [addingIds, setAddingIds] = useState<Set<string>>(new Set());
   // Track items successfully added this session
   const [addedIds, setAddedIds] = useState<Set<string>>(new Set());
+  // Track compound "add to watchlist" pending state (by tmdbId)
+  const [addingToWatchlistIds, setAddingToWatchlistIds] = useState<Set<number>>(new Set());
+  // Track compound "mark watched" pending state (by tmdbId or mediaId)
+  const [markingWatchedIds, setMarkingWatchedIds] = useState<Set<number>>(new Set());
+  /**
+   * Cache tmdbId → local DB id for movies added this session via compound
+   * actions. The library query cache won't reflect newly added items until
+   * it's refetched, so we store the mapping from the addMovie response.
+   */
+  const [sessionMovieLocalIds, setSessionMovieLocalIds] = useState<Map<number, number>>(new Map());
 
   const shouldSearchMovies = debouncedQuery.length > 0 && (mode === 'movies' || mode === 'both');
   const shouldSearchTv = debouncedQuery.length > 0 && (mode === 'tv' || mode === 'both');
@@ -130,6 +147,8 @@ export function SearchPage() {
   // Mutations
   const addMovieMutation = trpc.media.library.addMovie.useMutation();
   const addTvShowMutation = trpc.media.library.addTvShow.useMutation();
+  const watchlistAddMutation = trpc.media.watchlist.add.useMutation();
+  const watchHistoryLogMutation = trpc.media.watchHistory.log.useMutation();
 
   const makeKey = (type: SearchResultType, id: number) => `${type}:${id}`;
 
@@ -140,8 +159,9 @@ export function SearchPage() {
       addMovieMutation.mutate(
         { tmdbId },
         {
-          onSuccess: () => {
+          onSuccess: (result) => {
             setAddedIds((prev) => new Set(prev).add(key));
+            setSessionMovieLocalIds((prev) => new Map(prev).set(tmdbId, result.data.id));
             toast.success('Movie added to library');
           },
           onError: (err: { message: string }) => {
@@ -185,6 +205,146 @@ export function SearchPage() {
       );
     },
     [addTvShowMutation]
+  );
+
+  /**
+   * Compound action: add movie to library, then add to watchlist.
+   * The local DB id returned by addMovie is used for the watchlist call and
+   * also stored in sessionMovieLocalIds so subsequent actions have the id.
+   */
+  const handleAddToWatchlistAndLibrary = useCallback(
+    (tmdbId: number) => {
+      const key = makeKey('movie', tmdbId);
+      setAddingToWatchlistIds((prev) => new Set(prev).add(tmdbId));
+      setAddingIds((prev) => new Set(prev).add(key));
+      addMovieMutation.mutate(
+        { tmdbId },
+        {
+          onSuccess: (result) => {
+            const movieId = result.data.id;
+            setAddedIds((prev) => new Set(prev).add(key));
+            setSessionMovieLocalIds((prev) => new Map(prev).set(tmdbId, movieId));
+            watchlistAddMutation.mutate(
+              { mediaType: 'movie', mediaId: movieId },
+              {
+                onSuccess: () => {
+                  toast.success('Added to watchlist and library');
+                },
+                onError: (err: { message: string }) => {
+                  toast.error(`Movie added to library but watchlist failed: ${err.message}`);
+                },
+                onSettled: () => {
+                  setAddingToWatchlistIds((prev) => {
+                    const next = new Set(prev);
+                    next.delete(tmdbId);
+                    return next;
+                  });
+                },
+              }
+            );
+          },
+          onError: (err: { message: string }) => {
+            toast.error(`Failed to add movie: ${err.message}`);
+            setAddingToWatchlistIds((prev) => {
+              const next = new Set(prev);
+              next.delete(tmdbId);
+              return next;
+            });
+          },
+          onSettled: () => {
+            setAddingIds((prev) => {
+              const next = new Set(prev);
+              next.delete(key);
+              return next;
+            });
+          },
+        }
+      );
+    },
+    [addMovieMutation, watchlistAddMutation]
+  );
+
+  /**
+   * Compound action: add movie to library, then log as watched.
+   */
+  const handleMarkWatchedAndLibrary = useCallback(
+    (tmdbId: number) => {
+      const key = makeKey('movie', tmdbId);
+      setMarkingWatchedIds((prev) => new Set(prev).add(tmdbId));
+      setAddingIds((prev) => new Set(prev).add(key));
+      addMovieMutation.mutate(
+        { tmdbId },
+        {
+          onSuccess: (result) => {
+            const movieId = result.data.id;
+            setAddedIds((prev) => new Set(prev).add(key));
+            setSessionMovieLocalIds((prev) => new Map(prev).set(tmdbId, movieId));
+            watchHistoryLogMutation.mutate(
+              { mediaType: 'movie', mediaId: movieId },
+              {
+                onSuccess: () => {
+                  toast.success('Marked as watched and added to library');
+                },
+                onError: (err: { message: string }) => {
+                  toast.error(`Movie added to library but watch log failed: ${err.message}`);
+                },
+                onSettled: () => {
+                  setMarkingWatchedIds((prev) => {
+                    const next = new Set(prev);
+                    next.delete(tmdbId);
+                    return next;
+                  });
+                },
+              }
+            );
+          },
+          onError: (err: { message: string }) => {
+            toast.error(`Failed to add movie: ${err.message}`);
+            setMarkingWatchedIds((prev) => {
+              const next = new Set(prev);
+              next.delete(tmdbId);
+              return next;
+            });
+          },
+          onSettled: () => {
+            setAddingIds((prev) => {
+              const next = new Set(prev);
+              next.delete(key);
+              return next;
+            });
+          },
+        }
+      );
+    },
+    [addMovieMutation, watchHistoryLogMutation]
+  );
+
+  /**
+   * Simple mark-as-watched for an in-library movie (local DB id known).
+   */
+  const handleMarkWatched = useCallback(
+    (mediaId: number) => {
+      setMarkingWatchedIds((prev) => new Set(prev).add(mediaId));
+      watchHistoryLogMutation.mutate(
+        { mediaType: 'movie', mediaId },
+        {
+          onSuccess: () => {
+            toast.success('Marked as watched');
+          },
+          onError: (err: { message: string }) => {
+            toast.error(`Failed to log watch: ${err.message}`);
+          },
+          onSettled: () => {
+            setMarkingWatchedIds((prev) => {
+              const next = new Set(prev);
+              next.delete(mediaId);
+              return next;
+            });
+          },
+        }
+      );
+    },
+    [watchHistoryLogMutation]
   );
 
   const hasQuery = debouncedQuery.length > 0;
@@ -290,7 +450,8 @@ export function SearchPage() {
               {movieResults.map((movie: MovieSearchResult) => {
                 const key = makeKey('movie', movie.tmdbId);
                 const inLibrary = movieTmdbIds.has(movie.tmdbId) || addedIds.has(key);
-                const localId = movieTmdbToLocalId.get(movie.tmdbId);
+                const localId =
+                  movieTmdbToLocalId.get(movie.tmdbId) ?? sessionMovieLocalIds.get(movie.tmdbId);
                 const rotation = movieTmdbToRotation.get(movie.tmdbId);
                 return (
                   <SearchResultCard
@@ -305,10 +466,35 @@ export function SearchPage() {
                     inLibrary={inLibrary}
                     rotationStatus={rotation?.rotationStatus}
                     rotationExpiresAt={rotation?.rotationExpiresAt}
+                    mediaId={localId}
                     isAdding={addingIds.has(key)}
                     onAdd={() => {
                       handleAddMovie(movie.tmdbId);
                     }}
+                    onAddToWatchlistAndLibrary={
+                      inLibrary
+                        ? undefined
+                        : () => {
+                            handleAddToWatchlistAndLibrary(movie.tmdbId);
+                          }
+                    }
+                    isAddingToWatchlistAndLibrary={addingToWatchlistIds.has(movie.tmdbId)}
+                    onMarkWatchedAndLibrary={
+                      inLibrary
+                        ? undefined
+                        : () => {
+                            handleMarkWatchedAndLibrary(movie.tmdbId);
+                          }
+                    }
+                    isMarkingWatchedAndLibrary={markingWatchedIds.has(movie.tmdbId)}
+                    onMarkWatched={
+                      localId != null
+                        ? () => {
+                            handleMarkWatched(localId);
+                          }
+                        : undefined
+                    }
+                    isMarkingWatched={localId != null && markingWatchedIds.has(localId)}
                     href={localId != null ? `/media/movies/${localId}` : undefined}
                   />
                 );
@@ -369,10 +555,12 @@ export function SearchPage() {
                     posterUrl={buildPosterUrl(show.posterPath, 'tv')}
                     genres={show.genres}
                     inLibrary={inLibrary}
+                    mediaId={localId}
                     isAdding={addingIds.has(key)}
                     onAdd={() => {
                       handleAddTvShow(show.tvdbId);
                     }}
+                    onAddToWatchlistAndLibrary={undefined}
                     href={localId != null ? `/media/tv/${localId}` : undefined}
                   />
                 );


### PR DESCRIPTION
## Summary

- **#1913**: In-library movie and TV cards are now `<Link>` elements navigating to `/media/movies/:id` and `/media/tv/:id`. Search query synced to `?q=` URL param so browser back button restores the query.
- **#1912**: Not-in-library movie cards gain compound **Watchlist + Library** and **Watched + Library** buttons (addMovie then watchlist.add/watchHistory.log). In-library items show WatchlistToggle and (movies) a **Mark Watched** button. Action buttons stop click propagation so they don't trigger card navigation.
- Also fixes `lint-staged.config.mjs` which still referenced `eslint` after the oxlint migration — replaced with `oxlint --fix` + `oxfmt --write`.

## Test plan

- [ ] Search for a movie in library — card is a link to `/media/movies/:id`, shows WatchlistToggle and Mark Watched button
- [ ] Search for a movie not in library — "Watchlist + Library" and "Watched + Library" buttons appear
- [ ] Click "Watchlist + Library" — adds movie then adds to watchlist
- [ ] Click "Watched + Library" — adds movie then logs as watched
- [ ] Click action buttons on a linked card — only the button action fires, no navigation
- [ ] Navigate away and press Back — search query is restored via `?q=`
- [ ] Search for a TV show in library — card links to `/media/tv/:id`, shows WatchlistToggle (no Mark Watched)
- [ ] 662 unit tests pass

Closes #1912, #1913