### PR TITLE
fix(ui): restore 44px touch targets on icon buttons with h-8 overrides

### DIFF
--- a/packages/app-finance/src/pages/BudgetsPage.tsx
+++ b/packages/app-finance/src/pages/BudgetsPage.tsx
@@ -236,7 +236,7 @@ export function BudgetsPage() {
         <div className="text-right">
           <DropdownMenu
             trigger={
-              <Button variant="ghost" size="icon-sm" className="p-0" aria-label="Actions">
+              <Button variant="ghost" size="icon" aria-label="Actions">
                 <MoreHorizontal className="h-4 w-4" />
               </Button>
             }

--- a/packages/app-finance/src/pages/BudgetsPage.tsx
+++ b/packages/app-finance/src/pages/BudgetsPage.tsx
@@ -236,7 +236,7 @@ export function BudgetsPage() {
         <div className="text-right">
           <DropdownMenu
             trigger={
-              <Button variant="ghost" size="icon" className="h-8 w-8 p-0" aria-label="Actions">
+              <Button variant="ghost" size="icon-sm" className="p-0" aria-label="Actions">
                 <MoreHorizontal className="h-4 w-4" />
               </Button>
             }

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -289,7 +289,7 @@ export function EntitiesPage() {
         <div className="text-right">
           <DropdownMenu
             trigger={
-              <Button variant="ghost" size="icon-sm" className="p-0" aria-label="Actions">
+              <Button variant="ghost" size="icon" aria-label="Actions">
                 <MoreHorizontal className="h-4 w-4" />
               </Button>
             }

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -289,7 +289,7 @@ export function EntitiesPage() {
         <div className="text-right">
           <DropdownMenu
             trigger={
-              <Button variant="ghost" size="icon" className="h-8 w-8 p-0" aria-label="Actions">
+              <Button variant="ghost" size="icon-sm" className="p-0" aria-label="Actions">
                 <MoreHorizontal className="h-4 w-4" />
               </Button>
             }

--- a/packages/app-finance/src/pages/WishlistPage.tsx
+++ b/packages/app-finance/src/pages/WishlistPage.tsx
@@ -252,7 +252,7 @@ export function WishlistPage() {
         <div className="text-right">
           <DropdownMenu
             trigger={
-              <Button variant="ghost" size="icon-sm" className="p-0" aria-label="Actions">
+              <Button variant="ghost" size="icon" aria-label="Actions">
                 <MoreHorizontal className="h-4 w-4" />
               </Button>
             }

--- a/packages/app-finance/src/pages/WishlistPage.tsx
+++ b/packages/app-finance/src/pages/WishlistPage.tsx
@@ -252,7 +252,7 @@ export function WishlistPage() {
         <div className="text-right">
           <DropdownMenu
             trigger={
-              <Button variant="ghost" size="icon" className="h-8 w-8 p-0" aria-label="Actions">
+              <Button variant="ghost" size="icon-sm" className="p-0" aria-label="Actions">
                 <MoreHorizontal className="h-4 w-4" />
               </Button>
             }

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -569,7 +569,7 @@ function DocumentsList({
                           href={`${paperlessBaseUrl}/documents/${doc.paperlessDocumentId}/details`}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent"
+                          className="relative inline-flex items-center justify-center size-9 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent before:absolute before:content-[''] before:-inset-1"
                           title="View in Paperless"
                           aria-label="View in Paperless"
                         >
@@ -578,8 +578,8 @@ function DocumentsList({
                       )}
                       <Button
                         variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 text-destructive hover:text-destructive shrink-0"
+                        size="icon-sm"
+                        className="text-destructive hover:text-destructive shrink-0"
                         onClick={() => {
                           unlinkMutation.mutate({ id: doc.id });
                         }}
@@ -725,8 +725,8 @@ function ConnectionRow({
         <AlertDialogTrigger asChild>
           <Button
             variant="ghost"
-            size="icon"
-            className="h-8 w-8 text-destructive hover:text-destructive shrink-0"
+            size="icon-sm"
+            className="text-destructive hover:text-destructive shrink-0"
             disabled={isDisconnecting}
             title="Disconnect"
             aria-label="Disconnect"

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -578,7 +578,7 @@ function DocumentsList({
                       )}
                       <Button
                         variant="ghost"
-                        size="icon-sm"
+                        size="icon"
                         className="text-destructive hover:text-destructive shrink-0"
                         onClick={() => {
                           unlinkMutation.mutate({ id: doc.id });
@@ -725,7 +725,7 @@ function ConnectionRow({
         <AlertDialogTrigger asChild>
           <Button
             variant="ghost"
-            size="icon-sm"
+            size="icon"
             className="text-destructive hover:text-destructive shrink-0"
             disabled={isDisconnecting}
             title="Disconnect"


### PR DESCRIPTION
## Summary

- `size="icon"` with `className="h-8 w-8"` leaves buttons at 32px with no pseudo-element touch expansion — below the 44px WCAG/Apple HIG minimum
- Switch 4 occurrences (ItemDetailPage ×2, BudgetsPage, WishlistPage, EntitiesPage) from `size="icon"` to `size="icon-sm"`, which provides `size-9` (36px) + `before:-inset-1` for 44px touch area
- Add pseudo-element to the Paperless `<a>` link in ItemDetailPage for the same reason
- All other button sizes (`xs`, `sm`, `icon-xs`, `icon-sm`, `default`, `icon-lg`) already meet 44px via pseudo-element or full size

## Test plan

- [ ] Unlink document button in ItemDetailPage is still functional and visually unchanged
- [ ] Disconnect button in ItemDetailPage is still functional
- [ ] Actions dropdown triggers in Budgets, Wishlist, Entities pages work correctly

Closes #1838