### PR TITLE
fix(inventory): disconnect by item pair, photo upload with compression

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -64,6 +64,7 @@
     "node-cron": "^4.2.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
+    "sharp": "^0.34.5",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/apps/pops-api/src/modules/inventory/connections/connections.test.ts
+++ b/apps/pops-api/src/modules/inventory/connections/connections.test.ts
@@ -150,26 +150,69 @@ describe('inventory.connections.connect', () => {
 });
 
 describe('inventory.connections.disconnect', () => {
-  it('removes an existing connection', async () => {
+  it('removes an existing connection by itemAId and itemBId', async () => {
     const [idA, idB] = seedTwoItems();
-    const connId = seedItemConnection(db, idA, idB);
+    seedItemConnection(db, idA, idB);
 
-    const result = await caller.inventory.connections.disconnect({ id: connId });
+    const result = await caller.inventory.connections.disconnect({ itemAId: idA, itemBId: idB });
 
     expect(result.message).toBe('Items disconnected');
 
-    const row = db.prepare('SELECT * FROM item_connections WHERE id = ?').get(connId);
+    const row = db
+      .prepare('SELECT * FROM item_connections WHERE item_a_id = ? AND item_b_id = ?')
+      .get(idA, idB);
     expect(row).toBeUndefined();
   });
 
-  it('throws NOT_FOUND for nonexistent connection', async () => {
-    await expect(caller.inventory.connections.disconnect({ id: 999 })).rejects.toThrow(TRPCError);
+  it('normalises A<B ordering when inputs are reversed', async () => {
+    const [idA, idB] = seedTwoItems();
+    seedItemConnection(db, idA, idB);
+
+    // Pass reversed order — should still find and delete the connection
+    const result = await caller.inventory.connections.disconnect({ itemAId: idB, itemBId: idA });
+
+    expect(result.message).toBe('Items disconnected');
+
+    const row = db
+      .prepare('SELECT * FROM item_connections WHERE item_a_id = ? AND item_b_id = ?')
+      .get(idA, idB);
+    expect(row).toBeUndefined();
+  });
+
+  it('throws NOT_FOUND when no connection exists between the two items', async () => {
+    const [idA, idB] = seedTwoItems();
+
+    await expect(
+      caller.inventory.connections.disconnect({ itemAId: idA, itemBId: idB })
+    ).rejects.toThrow(TRPCError);
 
     try {
-      await caller.inventory.connections.disconnect({ id: 999 });
+      await caller.inventory.connections.disconnect({ itemAId: idA, itemBId: idB });
     } catch (err) {
       expect((err as TRPCError).code).toBe('NOT_FOUND');
     }
+  });
+
+  it('does not remove unrelated connections', async () => {
+    const idA = seedInventoryItem(db, { item_name: 'A' });
+    const idB = seedInventoryItem(db, { item_name: 'B' });
+    const idC = seedInventoryItem(db, { item_name: 'C' });
+
+    const pairAB = [idA, idB].toSorted() as [string, string];
+    const pairAC = [idA, idC].toSorted() as [string, string];
+    seedItemConnection(db, pairAB[0], pairAB[1]);
+    seedItemConnection(db, pairAC[0], pairAC[1]);
+
+    await caller.inventory.connections.disconnect({
+      itemAId: pairAB[0],
+      itemBId: pairAB[1],
+    });
+
+    // A-C connection should still exist
+    const surviving = db
+      .prepare('SELECT * FROM item_connections WHERE item_a_id = ? AND item_b_id = ?')
+      .get(pairAC[0], pairAC[1]);
+    expect(surviving).toBeDefined();
   });
 });
 
@@ -512,9 +555,9 @@ describe('inventory.connections auth', () => {
 
   it('throws UNAUTHORIZED without auth on disconnect', async () => {
     const unauthCaller = createCaller(false);
-    await expect(unauthCaller.inventory.connections.disconnect({ id: 1 })).rejects.toThrow(
-      TRPCError
-    );
+    await expect(
+      unauthCaller.inventory.connections.disconnect({ itemAId: 'a', itemBId: 'b' })
+    ).rejects.toThrow(TRPCError);
   });
 
   it('throws UNAUTHORIZED without auth on listForItem', async () => {

--- a/apps/pops-api/src/modules/inventory/connections/router.ts
+++ b/apps/pops-api/src/modules/inventory/connections/router.ts
@@ -2,7 +2,6 @@
  * Item connections tRPC router — connect/disconnect inventory items.
  */
 import { TRPCError } from '@trpc/server';
-import { z } from 'zod';
 
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta } from '../../../shared/pagination.js';
@@ -11,6 +10,7 @@ import * as service from './service.js';
 import {
   ConnectionQuerySchema,
   ConnectItemsSchema,
+  DisconnectItemsSchema,
   GraphQuerySchema,
   toConnection,
   TraceQuerySchema,
@@ -39,20 +39,18 @@ export const connectionsRouter = router({
     }
   }),
 
-  /** Disconnect two items by connection ID. */
-  disconnect: protectedProcedure
-    .input(z.object({ id: z.number().int().positive() }))
-    .mutation(({ input }) => {
-      try {
-        service.disconnectItems(input.id);
-        return { message: 'Items disconnected' };
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-        }
-        throw err;
+  /** Disconnect two items by their item IDs. Normalises A<B ordering automatically. */
+  disconnect: protectedProcedure.input(DisconnectItemsSchema).mutation(({ input }) => {
+    try {
+      service.disconnectItems(input.itemAId, input.itemBId);
+      return { message: 'Items disconnected' };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
       }
-    }),
+      throw err;
+    }
+  }),
 
   /** List all connections for an item (appears in either A or B column). */
   listForItem: protectedProcedure.input(ConnectionQuerySchema).query(({ input }) => {

--- a/apps/pops-api/src/modules/inventory/connections/service.ts
+++ b/apps/pops-api/src/modules/inventory/connections/service.ts
@@ -71,20 +71,26 @@ export function connectItems(inputA: string, inputB: string): ItemConnectionRow 
 }
 
 /**
- * Disconnect two items by connection ID. Throws NotFoundError if missing.
+ * Disconnect two items by their item IDs. Normalises A<B ordering before lookup.
+ * Throws NotFoundError if no connection exists between the two items.
  */
-export function disconnectItems(id: number): void {
+export function disconnectItems(inputA: string, inputB: string): void {
   const db = getDrizzle();
+
+  // Enforce A<B ordering (same normalisation as connectItems)
+  const [itemAId, itemBId] = inputA < inputB ? [inputA, inputB] : [inputB, inputA];
 
   const [row] = db
     .select({ id: itemConnections.id })
     .from(itemConnections)
-    .where(eq(itemConnections.id, id))
+    .where(and(eq(itemConnections.itemAId, itemAId), eq(itemConnections.itemBId, itemBId)))
     .all();
 
-  if (!row) throw new NotFoundError('Item connection', String(id));
+  if (!row) {
+    throw new NotFoundError('Item connection', `${itemAId}-${itemBId}`);
+  }
 
-  db.delete(itemConnections).where(eq(itemConnections.id, id)).run();
+  db.delete(itemConnections).where(eq(itemConnections.id, row.id)).run();
 }
 
 /**

--- a/apps/pops-api/src/modules/inventory/connections/types.ts
+++ b/apps/pops-api/src/modules/inventory/connections/types.ts
@@ -29,6 +29,13 @@ export const ConnectItemsSchema = z.object({
 });
 export type ConnectItemsInput = z.infer<typeof ConnectItemsSchema>;
 
+/** Zod schema for disconnecting two items by their item IDs. */
+export const DisconnectItemsSchema = z.object({
+  itemAId: z.string().min(1, 'Item A ID is required'),
+  itemBId: z.string().min(1, 'Item B ID is required'),
+});
+export type DisconnectItemsInput = z.infer<typeof DisconnectItemsSchema>;
+
 /** Zod schema for listing connections for an item. */
 export const ConnectionQuerySchema = z.object({
   itemId: z.string().min(1, 'Item ID is required'),

--- a/apps/pops-api/src/modules/inventory/photos/photos.test.ts
+++ b/apps/pops-api/src/modules/inventory/photos/photos.test.ts
@@ -29,6 +29,196 @@ afterEach(() => {
   ctx.teardown();
 });
 
+describe('inventory.photos.upload', () => {
+  it('compresses the image via sharp and writes to INVENTORY_IMAGES_DIR', async () => {
+    // A minimal valid JPEG buffer (1x1 pixel)
+    const { default: sharp } = await import('sharp');
+    const fakeJpegBuffer = await sharp({
+      create: { width: 2000, height: 1500, channels: 3, background: { r: 100, g: 150, b: 200 } },
+    })
+      .jpeg()
+      .toBuffer();
+
+    const tempDir = join(tmpdir(), `pops-upload-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    const originalEnv = process.env.INVENTORY_IMAGES_DIR;
+    process.env.INVENTORY_IMAGES_DIR = tempDir;
+
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'Camera' });
+
+      const result = await caller.inventory.photos.upload({
+        itemId,
+        fileBase64: fakeJpegBuffer.toString('base64'),
+      });
+
+      expect(result.message).toBe('Photo uploaded');
+      expect(result.data.itemId).toBe(itemId);
+      expect(result.data.filePath).toMatch(/^items\/.+\/photo_001\.jpg$/);
+
+      // File should exist on disk
+      const fullPath = join(tempDir, result.data.filePath);
+      expect(existsSync(fullPath)).toBe(true);
+
+      // Compressed image should be within 1920px on both sides
+      const metadata = await sharp(fullPath).metadata();
+      expect(metadata.width).toBeLessThanOrEqual(1920);
+      expect(metadata.height).toBeLessThanOrEqual(1920);
+    } finally {
+      process.env.INVENTORY_IMAGES_DIR = originalEnv;
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses sequential filenames (photo_001, photo_002, etc.)', async () => {
+    const { default: sharp } = await import('sharp');
+    const fakeJpegBuffer = await sharp({
+      create: { width: 100, height: 100, channels: 3, background: { r: 0, g: 0, b: 0 } },
+    })
+      .jpeg()
+      .toBuffer();
+    const base64 = fakeJpegBuffer.toString('base64');
+
+    const tempDir = join(tmpdir(), `pops-upload-seq-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    const originalEnv = process.env.INVENTORY_IMAGES_DIR;
+    process.env.INVENTORY_IMAGES_DIR = tempDir;
+
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'Camera' });
+
+      const result1 = await caller.inventory.photos.upload({ itemId, fileBase64: base64 });
+      const result2 = await caller.inventory.photos.upload({ itemId, fileBase64: base64 });
+      const result3 = await caller.inventory.photos.upload({ itemId, fileBase64: base64 });
+
+      expect(result1.data.filePath).toMatch(/photo_001\.jpg$/);
+      expect(result2.data.filePath).toMatch(/photo_002\.jpg$/);
+      expect(result3.data.filePath).toMatch(/photo_003\.jpg$/);
+    } finally {
+      process.env.INVENTORY_IMAGES_DIR = originalEnv;
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates the item directory if it does not exist', async () => {
+    const { default: sharp } = await import('sharp');
+    const fakeJpegBuffer = await sharp({
+      create: { width: 50, height: 50, channels: 3, background: { r: 0, g: 0, b: 0 } },
+    })
+      .jpeg()
+      .toBuffer();
+
+    const tempDir = join(tmpdir(), `pops-upload-mkdir-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    const originalEnv = process.env.INVENTORY_IMAGES_DIR;
+    process.env.INVENTORY_IMAGES_DIR = tempDir;
+
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'Camera' });
+      const itemDir = join(tempDir, 'items', itemId);
+      expect(existsSync(itemDir)).toBe(false);
+
+      await caller.inventory.photos.upload({
+        itemId,
+        fileBase64: fakeJpegBuffer.toString('base64'),
+      });
+
+      expect(existsSync(itemDir)).toBe(true);
+    } finally {
+      process.env.INVENTORY_IMAGES_DIR = originalEnv;
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates a DB record with the correct filePath', async () => {
+    const { default: sharp } = await import('sharp');
+    const fakeJpegBuffer = await sharp({
+      create: { width: 50, height: 50, channels: 3, background: { r: 0, g: 0, b: 0 } },
+    })
+      .jpeg()
+      .toBuffer();
+
+    const tempDir = join(tmpdir(), `pops-upload-db-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    const originalEnv = process.env.INVENTORY_IMAGES_DIR;
+    process.env.INVENTORY_IMAGES_DIR = tempDir;
+
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'Camera' });
+
+      const result = await caller.inventory.photos.upload({
+        itemId,
+        fileBase64: fakeJpegBuffer.toString('base64'),
+        caption: 'Front view',
+      });
+
+      const row = db.prepare('SELECT * FROM item_photos WHERE id = ?').get(result.data.id) as
+        | { file_path: string; caption: string | null; item_id: string }
+        | undefined;
+
+      expect(row).toBeDefined();
+      expect(row!.item_id).toBe(itemId);
+      expect(row!.file_path).toMatch(/^items\/.+\/photo_001\.jpg$/);
+      expect(row!.caption).toBe('Front view');
+    } finally {
+      process.env.INVENTORY_IMAGES_DIR = originalEnv;
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws NOT_FOUND when item does not exist', async () => {
+    const tempDir = join(tmpdir(), `pops-upload-notfound-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    const originalEnv = process.env.INVENTORY_IMAGES_DIR;
+    process.env.INVENTORY_IMAGES_DIR = tempDir;
+
+    try {
+      const fakeBase64 = Buffer.from('fake-data').toString('base64');
+      await expect(
+        caller.inventory.photos.upload({ itemId: 'nonexistent', fileBase64: fakeBase64 })
+      ).rejects.toThrow(TRPCError);
+
+      try {
+        await caller.inventory.photos.upload({ itemId: 'nonexistent', fileBase64: fakeBase64 });
+      } catch (err) {
+        expect((err as TRPCError).code).toBe('NOT_FOUND');
+      }
+    } finally {
+      process.env.INVENTORY_IMAGES_DIR = originalEnv;
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws BAD_REQUEST when INVENTORY_IMAGES_DIR is not set', async () => {
+    const originalEnv = process.env.INVENTORY_IMAGES_DIR;
+    delete process.env.INVENTORY_IMAGES_DIR;
+
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'Camera' });
+      const fakeBase64 = Buffer.from('fake-data').toString('base64');
+
+      await expect(
+        caller.inventory.photos.upload({ itemId, fileBase64: fakeBase64 })
+      ).rejects.toThrow(TRPCError);
+
+      try {
+        await caller.inventory.photos.upload({ itemId, fileBase64: fakeBase64 });
+      } catch (err) {
+        expect((err as TRPCError).code).toBe('BAD_REQUEST');
+      }
+    } finally {
+      process.env.INVENTORY_IMAGES_DIR = originalEnv;
+    }
+  });
+
+  it('throws UNAUTHORIZED without auth', async () => {
+    const unauthCaller = createCaller(false);
+    await expect(
+      unauthCaller.inventory.photos.upload({ itemId: 'a', fileBase64: 'dGVzdA==' })
+    ).rejects.toThrow(TRPCError);
+  });
+});
+
 describe('inventory.photos.attach', () => {
   it('attaches a photo to an item', async () => {
     const itemId = seedInventoryItem(db, { item_name: 'TV' });

--- a/apps/pops-api/src/modules/inventory/photos/router.ts
+++ b/apps/pops-api/src/modules/inventory/photos/router.ts
@@ -14,12 +14,42 @@ import {
   ReorderPhotosSchema,
   toPhoto,
   UpdatePhotoSchema,
+  UploadPhotoSchema,
 } from './types.js';
 
 const DEFAULT_LIMIT = 50;
 const DEFAULT_OFFSET = 0;
 
 export const photosRouter = router({
+  /**
+   * Upload a photo for an inventory item.
+   * Accepts base64-encoded file bytes, compresses (1920px max, HEIC→JPEG, strip EXIF),
+   * writes to `{INVENTORY_IMAGES_DIR}/items/{itemId}/photo_NNN.jpg`, and creates a DB record.
+   */
+  upload: protectedProcedure.input(UploadPhotoSchema).mutation(async ({ input }) => {
+    try {
+      const buffer = Buffer.from(input.fileBase64, 'base64');
+      const row = await service.uploadPhoto({
+        itemId: input.itemId,
+        buffer,
+        caption: input.caption,
+        sortOrder: input.sortOrder,
+      });
+      return {
+        data: toPhoto(row),
+        message: 'Photo uploaded',
+      };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+      }
+      if (err instanceof ValidationError) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: err.message });
+      }
+      throw err;
+    }
+  }),
+
   /** Attach a photo to an inventory item. */
   attach: protectedProcedure.input(AttachPhotoSchema).mutation(({ input }) => {
     try {

--- a/apps/pops-api/src/modules/inventory/photos/service.ts
+++ b/apps/pops-api/src/modules/inventory/photos/service.ts
@@ -1,17 +1,23 @@
 /**
  * Item photos service — attach/remove/reorder photos using Drizzle ORM.
  */
-import { existsSync, unlinkSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, mkdirSync, readdirSync, unlinkSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 
 import { asc, count, eq } from 'drizzle-orm';
+import sharp from 'sharp';
 
 import { homeInventory, itemPhotos } from '@pops/db-types';
 
 import { getDb, getDrizzle } from '../../../db.js';
 import { NotFoundError, ValidationError } from '../../../shared/errors.js';
 
-import type { AttachPhotoInput, ItemPhotoRow, UpdatePhotoInput } from './types.js';
+import type {
+  AttachPhotoInput,
+  ItemPhotoRow,
+  UpdatePhotoInput,
+  UploadPhotoInput,
+} from './types.js';
 
 /** Reject path traversal attempts in file paths. */
 function assertSafeFilePath(filePath: string): void {
@@ -43,6 +49,73 @@ function getPhoto(id: number): ItemPhotoRow {
   const [row] = db.select().from(itemPhotos).where(eq(itemPhotos.id, id)).all();
   if (!row) throw new NotFoundError('Item photo', String(id));
   return row;
+}
+
+/**
+ * Compress an image buffer: resize to max 1920px on longest side,
+ * convert HEIC/HEIF to JPEG, and strip all EXIF metadata.
+ */
+async function compressImage(inputBuffer: Buffer): Promise<Buffer> {
+  return sharp(inputBuffer)
+    .rotate() // Apply EXIF orientation before stripping metadata
+    .resize(1920, 1920, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality: 85 })
+    .toBuffer();
+}
+
+/**
+ * Determine the next sequential photo filename within an item's directory.
+ * Returns a path like `items/{itemId}/photo_001.jpg`.
+ */
+function nextPhotoFilename(baseDir: string, itemId: string): string {
+  const itemDir = join(baseDir, 'items', itemId);
+  mkdirSync(itemDir, { recursive: true });
+
+  const existing = existsSync(itemDir)
+    ? readdirSync(itemDir).filter((f) => /^photo_\d+\.jpg$/.test(f))
+    : [];
+
+  const nextNum = existing.length + 1;
+  const seq = String(nextNum).padStart(3, '0');
+  return join('items', itemId, `photo_${seq}.jpg`);
+}
+
+/** Upload, compress, and attach a photo to an inventory item. */
+export async function uploadPhoto(input: UploadPhotoInput): Promise<ItemPhotoRow> {
+  const db = getDrizzle();
+
+  assertItemExists(input.itemId);
+
+  const baseDir = process.env.INVENTORY_IMAGES_DIR;
+  if (!baseDir) {
+    throw new ValidationError('INVENTORY_IMAGES_DIR is not configured');
+  }
+
+  // Compress the image (resize, convert HEIC→JPEG, strip EXIF)
+  const compressed = await compressImage(input.buffer);
+
+  // Determine sequential filename and write to disk
+  const relPath = nextPhotoFilename(baseDir, input.itemId);
+  const fullPath = resolve(baseDir, relPath);
+  const { writeFileSync } = await import('node:fs');
+  writeFileSync(fullPath, compressed);
+
+  // Insert photo record into DB
+  const result = db
+    .insert(itemPhotos)
+    .values({
+      itemId: input.itemId,
+      filePath: relPath,
+      caption: input.caption ?? null,
+      sortOrder: input.sortOrder,
+    })
+    .run();
+
+  const id = Number(result.lastInsertRowid);
+  return getPhoto(id);
 }
 
 /** Attach a photo to an inventory item. */

--- a/apps/pops-api/src/modules/inventory/photos/types.ts
+++ b/apps/pops-api/src/modules/inventory/photos/types.ts
@@ -35,6 +35,27 @@ export const AttachPhotoSchema = z.object({
 });
 export type AttachPhotoInput = z.infer<typeof AttachPhotoSchema>;
 
+/**
+ * Input for uploading and compressing a photo (multipart upload).
+ * The buffer contains the raw file bytes (JPEG, PNG, HEIC, etc.).
+ */
+export interface UploadPhotoInput {
+  itemId: string;
+  buffer: Buffer;
+  caption?: string | null;
+  sortOrder: number;
+}
+
+/** Zod schema for the upload procedure (used by the tRPC router). */
+export const UploadPhotoSchema = z.object({
+  itemId: z.string().min(1, 'Item ID is required'),
+  /** Base64-encoded file bytes. The router decodes this to a Buffer. */
+  fileBase64: z.string().min(1, 'File content is required'),
+  caption: z.string().nullable().optional(),
+  sortOrder: z.number().int().nonnegative().optional().default(0),
+});
+export type UploadPhotoSchemaInput = z.infer<typeof UploadPhotoSchema>;
+
 /** Zod schema for updating a photo. */
 export const UpdatePhotoSchema = z.object({
   caption: z.string().nullable().optional(),

--- a/docs/themes/04-inventory/prds/043-inventory-data-model-api/README.md
+++ b/docs/themes/04-inventory/prds/043-inventory-data-model-api/README.md
@@ -148,7 +148,7 @@ Photo storage path: `{INVENTORY_IMAGES_DIR}/items/{itemId}/photo_NNN.jpg`
 | 01  | [us-01-items-locations-schema](us-01-items-locations-schema.md)       | Tables for items and locations with indexes, FK constraints, self-referential location tree | Partial | Yes                     |
 | 02  | [us-02-connections-photos-schema](us-02-connections-photos-schema.md) | Tables for item_connections (with A<B dedup) and item_photos with indexes and cascades      | Done    | Yes                     |
 | 03  | [us-03-items-locations-api](us-03-items-locations-api.md)             | CRUD procedures for items and locations                                                     | Done    | Blocked by us-01        |
-| 04  | [us-04-connections-photos-api](us-04-connections-photos-api.md)       | Procedures for connections and photos                                                       | Partial | Blocked by us-01, us-02 |
+| 04  | [us-04-connections-photos-api](us-04-connections-photos-api.md)       | Procedures for connections and photos                                                       | Done    | Blocked by us-01, us-02 |
 
 US-01 and US-02 can run in parallel (independent tables). US-03 needs US-01. US-04 needs both US-01 and US-02.
 

--- a/docs/themes/04-inventory/prds/043-inventory-data-model-api/us-04-connections-photos-api.md
+++ b/docs/themes/04-inventory/prds/043-inventory-data-model-api/us-04-connections-photos-api.md
@@ -1,7 +1,7 @@
 # US-04: Connections and photos API
 
 > PRD: [043 — Inventory Data Model & API](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -10,18 +10,18 @@ As a developer, I want tRPC procedures for item connections and photos so that i
 ## Acceptance Criteria
 
 - [x] `inventory.connections.connect` — accepts two item IDs, normalises ordering (enforces A<B), inserts connection; returns error if items are the same or connection already exists
-- [ ] `inventory.connections.disconnect` — accepts two item IDs, normalises ordering, deletes the connection row
+- [x] `inventory.connections.disconnect` — accepts two item IDs, normalises ordering, deletes the connection row
 - [x] `inventory.connections.listForItem` — accepts an item ID, returns all connected items by querying both itemAId and itemBId sides
 - [x] `inventory.connections.traceChain` — accepts an item ID and optional maxDepth (default 10), uses a recursive CTE to traverse the connection graph, returns the full chain of connected items with depth info
 - [x] `traceChain` stops recursion at maxDepth to prevent runaway queries
 - [x] `traceChain` handles cycles in the connection graph without infinite recursion
-- [ ] `inventory.photos.upload` — accepts itemId and file (multipart), compresses image (1920px max dimension, HEIC→JPEG conversion, strip EXIF metadata), stores file at `{INVENTORY_IMAGES_DIR}/items/{itemId}/photo_NNN.jpg`, creates database record
+- [x] `inventory.photos.upload` — accepts itemId and file (multipart), compresses image (1920px max dimension, HEIC→JPEG conversion, strip EXIF metadata), stores file at `{INVENTORY_IMAGES_DIR}/items/{itemId}/photo_NNN.jpg`, creates database record
 - [x] `inventory.photos.delete` — removes the database record and deletes the file from disk; 404 if not found
 - [x] `inventory.photos.reorder` — accepts itemId and ordered array of photoIds, sets sortOrder based on array position
 - [x] `inventory.photos.listForItem` — returns all photos for an item, sorted by sortOrder ASC
-- [ ] Photo upload creates the item's directory if it does not exist
-- [ ] Photo filenames are sequential within an item's directory (photo_001.jpg, photo_002.jpg, etc.)
-- [ ] Tests cover: connect/disconnect with A<B normalisation, duplicate connection rejection, self-connection rejection, listForItem queries both sides, traceChain recursive traversal, traceChain max depth limit, photo upload with compression, photo delete (record + file), photo reorder
+- [x] Photo upload creates the item's directory if it does not exist
+- [x] Photo filenames are sequential within an item's directory (photo_001.jpg, photo_002.jpg, etc.)
+- [x] Tests cover: connect/disconnect with A<B normalisation, duplicate connection rejection, self-connection rejection, listForItem queries both sides, traceChain recursive traversal, traceChain max depth limit, photo upload with compression, photo delete (record + file), photo reorder
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "onlyBuiltDependencies": [
       "better-sqlite3",
       "esbuild",
-      "msw"
+      "msw",
+      "sharp"
     ],
     "overrides": {
       "cssstyle": "6.0.2"

--- a/packages/app-inventory/src/pages/ItemDetailPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.test.tsx
@@ -455,7 +455,7 @@ describe('ItemDetailPage', () => {
       const confirmButton = screen.getByRole('button', { name: /^Disconnect$/i });
       fireEvent.click(confirmButton);
 
-      expect(mockDisconnectMutate).toHaveBeenCalledWith({ id: 'c1' });
+      expect(mockDisconnectMutate).toHaveBeenCalledWith({ itemAId: 'item-1', itemBId: 'item-2' });
     });
 
     it('disconnect dialog title includes the connected item name', () => {

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -330,7 +330,7 @@ export function ItemDetailPage() {
                 key={conn.id}
                 connectedItemId={conn.itemAId === id ? conn.itemBId : conn.itemAId}
                 onDisconnect={() => {
-                  disconnectMutation.mutate({ id: conn.id });
+                  disconnectMutation.mutate({ itemAId: conn.itemAId, itemBId: conn.itemBId });
                 }}
                 isDisconnecting={disconnectMutation.isPending}
               />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -1682,6 +1685,159 @@ packages:
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
       react-hook-form: ^7.55.0
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
@@ -5476,6 +5632,10 @@ packages:
     resolution: {integrity: sha512-7vhnBh2LVLyxOd1ZQWwXv7OATCnQcxdqc8FbZdNigZriNOwDsHklQmPpvPt1jcrFK5mzMI+cyuAYv8WzERx2Og==}
     hasBin: true
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -6776,6 +6936,102 @@ snapshots:
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.72.1(react@19.2.5)
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@inquirer/ansi@2.0.5': {}
 
@@ -10509,6 +10765,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - typescript
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- `inventory.connections.disconnect` now accepts `{ itemAId, itemBId }` instead of `{ id }`, matching the spec and the connect procedure's A<B normalisation behaviour
- `inventory.photos.upload` implemented: accepts base64-encoded file bytes, runs through `sharp` (1920px max dimension, HEIC→JPEG, EXIF stripped via `.rotate()`), writes sequential filenames (`photo_001.jpg`, ...) to `{INVENTORY_IMAGES_DIR}/items/{itemId}/`, inserts DB record
- `ItemDetailPage` updated to call disconnect with `{ itemAId, itemBId }`
- Expanded disconnect tests: A<B normalisation, no-connection 404, unrelated connections untouched
- New upload tests: compression sizing, sequential filenames, directory creation, DB record, NOT_FOUND, missing env var
- US-04 acceptance criteria marked complete in PRD 043

Closes #1841

## Test plan
- [ ] `pnpm --filter @pops/api test --run` — all pass
- [ ] `pnpm typecheck` — no errors
- [ ] Disconnect an item connection from ItemDetailPage — confirm it removes correctly without needing to know the connection's internal ID
- [ ] Upload a photo via the API — confirm file appears at correct path with JPEG extension and dimensions ≤ 1920px