### PR TITLE
fix(inventory): wire SortablePhotoGrid into ItemFormPage for existing photos

### DIFF
--- a/packages/app-inventory/src/components/SortablePhotoGrid.test.tsx
+++ b/packages/app-inventory/src/components/SortablePhotoGrid.test.tsx
@@ -39,14 +39,30 @@ describe('SortablePhotoGrid', () => {
     expect(items[2]).toHaveAttribute('aria-label', 'Photo 3: Third');
   });
 
-  it('does not render when only one photo', () => {
-    const { container } = render(<SortablePhotoGrid photos={[photos[0]!]} onReorder={vi.fn()} />);
-    expect(container.innerHTML).toBe('');
+  it('renders a single photo without drag affordance', () => {
+    render(<SortablePhotoGrid photos={[photos[0]!]} onReorder={vi.fn()} />);
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveAttribute('draggable', 'false');
   });
 
   it('does not render when no photos', () => {
     const { container } = render(<SortablePhotoGrid photos={[]} onReorder={vi.fn()} />);
     expect(container.innerHTML).toBe('');
+  });
+
+  it('calls onDelete when delete button is clicked', () => {
+    const onDelete = vi.fn();
+    render(<SortablePhotoGrid photos={photos} onReorder={vi.fn()} onDelete={onDelete} />);
+    const deleteButtons = screen.getAllByRole('button', { name: /delete photo/i });
+    expect(deleteButtons).toHaveLength(3);
+    fireEvent.click(deleteButtons[0]!);
+    expect(onDelete).toHaveBeenCalledWith(1);
+  });
+
+  it('does not render delete buttons when onDelete is not provided', () => {
+    render(<SortablePhotoGrid photos={photos} onReorder={vi.fn()} />);
+    expect(screen.queryAllByRole('button', { name: /delete photo/i })).toHaveLength(0);
   });
 
   it('calls onReorder when an item is dropped on a new position', () => {

--- a/packages/app-inventory/src/components/SortablePhotoGrid.tsx
+++ b/packages/app-inventory/src/components/SortablePhotoGrid.tsx
@@ -2,9 +2,10 @@
  * SortablePhotoGrid — Drag-and-drop reorderable photo thumbnail grid.
  *
  * Uses native HTML5 drag-and-drop. On drop, calls onReorder with the
- * new ordered array of photo IDs.
+ * new ordered array of photo IDs. When onDelete is provided, each photo
+ * shows a delete button on hover.
  */
-import { GripVertical } from 'lucide-react';
+import { GripVertical, Trash2 } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
 
 import type { PhotoItem } from './PhotoGallery';
@@ -12,6 +13,7 @@ import type { PhotoItem } from './PhotoGallery';
 interface SortablePhotoGridProps {
   photos: PhotoItem[];
   onReorder: (orderedIds: number[]) => void;
+  onDelete?: (photoId: number) => void;
   baseUrl?: string;
   isReordering?: boolean;
 }
@@ -19,6 +21,7 @@ interface SortablePhotoGridProps {
 export function SortablePhotoGrid({
   photos,
   onReorder,
+  onDelete,
   baseUrl = '/api/inventory/photos',
   isReordering = false,
 }: SortablePhotoGridProps) {
@@ -74,7 +77,8 @@ export function SortablePhotoGrid({
     dragRef.current = null;
   }, []);
 
-  if (photos.length <= 1) return null;
+  if (photos.length === 0) return null;
+  const canReorder = photos.length > 1;
 
   return (
     <div
@@ -86,12 +90,12 @@ export function SortablePhotoGrid({
         <div
           key={photo.id}
           role="listitem"
-          draggable
-          onDragStart={() => handleDragStart(index)}
-          onDragOver={(e) => handleDragOver(e, index)}
-          onDrop={(e) => handleDrop(e, index)}
-          onDragEnd={handleDragEnd}
-          className={`relative group cursor-grab active:cursor-grabbing rounded-md overflow-hidden border transition-all ${
+          draggable={canReorder}
+          onDragStart={canReorder ? () => handleDragStart(index) : undefined}
+          onDragOver={canReorder ? (e) => handleDragOver(e, index) : undefined}
+          onDrop={canReorder ? (e) => handleDrop(e, index) : undefined}
+          onDragEnd={canReorder ? handleDragEnd : undefined}
+          className={`relative group rounded-md overflow-hidden border transition-all ${canReorder ? 'cursor-grab active:cursor-grabbing' : ''} ${
             dragIndex === index ? 'opacity-40 scale-95' : ''
           } ${overIndex === index && dragIndex !== index ? 'ring-2 ring-app-accent' : ''} ${
             isReordering ? 'pointer-events-none opacity-60' : ''
@@ -107,9 +111,21 @@ export function SortablePhotoGrid({
               draggable={false}
             />
           </div>
-          <div className="absolute top-1 left-1 p-0.5 rounded bg-background/70 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity">
-            <GripVertical className="h-3.5 w-3.5" />
-          </div>
+          {canReorder && (
+            <div className="absolute top-1 left-1 p-0.5 rounded bg-background/70 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity">
+              <GripVertical className="h-3.5 w-3.5" />
+            </div>
+          )}
+          {onDelete && (
+            <button
+              type="button"
+              onClick={() => onDelete(photo.id)}
+              className="absolute top-1 right-1 h-6 w-6 flex items-center justify-center rounded-full bg-background/80 text-destructive opacity-0 group-hover:opacity-100 transition-opacity hover:bg-background"
+              aria-label={`Delete photo ${photo.caption ?? photo.id}`}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          )}
           {index === 0 && (
             <span className="absolute bottom-1 left-1 text-2xs font-bold bg-app-accent text-white px-1.5 py-0.5 rounded">
               Primary

--- a/packages/app-inventory/src/pages/ItemFormPage.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.tsx
@@ -1,15 +1,4 @@
-import {
-  Eye,
-  ImageIcon,
-  Link2,
-  Loader2,
-  PenLine,
-  Save,
-  Search,
-  Trash2,
-  Wand2,
-  X,
-} from 'lucide-react';
+import { Eye, ImageIcon, Link2, Loader2, PenLine, Save, Search, Wand2, X } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import Markdown from 'react-markdown';
@@ -39,6 +28,7 @@ import {
 
 import { LocationPicker } from '../components/LocationPicker';
 import { PhotoUpload, type UploadedFile } from '../components/PhotoUpload';
+import { SortablePhotoGrid } from '../components/SortablePhotoGrid';
 import { useImageProcessor } from '../hooks/useImageProcessor';
 import { trpc } from '../lib/trpc';
 
@@ -225,7 +215,11 @@ export function ItemFormPage() {
     },
   });
 
-  const _reorderMutation = trpc.inventory.photos.reorder.useMutation();
+  const reorderMutation = trpc.inventory.photos.reorder.useMutation({
+    onSuccess: () => {
+      void refetchPhotos();
+    },
+  });
 
   const handleFilesSelected = useCallback(
     async (files: File[]) => {
@@ -699,33 +693,14 @@ export function ItemFormPage() {
 
           {/* Existing photos grid (edit mode) */}
           {isEditMode && existingPhotos.length > 0 && (
-            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
-              {existingPhotos
-                .toSorted((a, b) => a.sortOrder - b.sortOrder)
-                .map((photo) => (
-                  <div key={photo.id} className="group relative">
-                    <div className="w-full aspect-square rounded-md overflow-hidden border border-border bg-muted">
-                      <img
-                        src={`/api/inventory/photos/${encodeURIComponent(photo.filePath)}`}
-                        alt={photo.caption ?? `Photo ${photo.id}`}
-                        className="w-full h-full object-cover"
-                        loading="lazy"
-                      />
-                    </div>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        handleDeletePhoto(photo.id);
-                      }}
-                      className="absolute top-1 right-1 h-6 w-6 rounded-full bg-background/80 text-destructive opacity-0 group-hover:opacity-100 transition-opacity hover:bg-background"
-                      aria-label={`Delete photo ${photo.caption ?? photo.id}`}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
-                  </div>
-                ))}
-            </div>
+            <SortablePhotoGrid
+              photos={existingPhotos}
+              onReorder={(orderedIds) => {
+                reorderMutation.mutate({ itemId: id!, orderedIds });
+              }}
+              onDelete={handleDeletePhoto}
+              isReordering={reorderMutation.isPending}
+            />
           )}
 
           {/* Delete confirmation */}


### PR DESCRIPTION
## Summary
- Replace static existing-photo grid in `ItemFormPage` with `SortablePhotoGrid`
- Add `onDelete` prop to `SortablePhotoGrid` — renders per-photo delete button on hover
- Change single-photo guard from `photos.length <= 1` → `photos.length === 0` so a lone photo still shows without drag affordance
- Rename `_reorderMutation` → `reorderMutation` and wire it to `SortablePhotoGrid.onReorder`

Closes #1852

## Test plan
- [ ] `pnpm --filter @pops/app-inventory test --run` — 343 pass
- [ ] `pnpm typecheck` — no errors
- [ ] Edit an item with multiple photos — drag to reorder works, delete per photo works
- [ ] Edit an item with a single photo — photo shows without grip handle