### PR TITLE
feat(finance): implement Up Bank API batch import

### DIFF
--- a/docs/themes/02-finance/prds/022-deduplication-parsers/README.md
+++ b/docs/themes/02-finance/prds/022-deduplication-parsers/README.md
@@ -113,7 +113,7 @@ Fetched via Up Bank REST API, not CSV upload. Batch import by date range.
 | 02  | [us-02-amex-parser](us-02-amex-parser.md)       | Amex CSV parser: date, amount inversion, location extraction                | Done        | Yes                             |
 | 03  | [us-03-anz-parser](us-03-anz-parser.md)         | ANZ CSV parser                                                              | Done        | Yes                             |
 | 04  | [us-04-ing-parser](us-04-ing-parser.md)         | ING CSV parser                                                              | Done        | Yes                             |
-| 05  | [us-05-up-bank-import](us-05-up-bank-import.md) | Up Bank API batch import by date range                                      | Not started | Yes                             |
+| 05  | [us-05-up-bank-import](us-05-up-bank-import.md) | Up Bank API batch import by date range                                      | Done        | Yes                             |
 | 06  | [us-06-common-utils](us-06-common-utils.md)     | Shared utilities: normaliseDate, normaliseAmount, extractLocation, checksum | Done        | No (first, parallel with us-01) |
 | 07  | [us-07-anz-pdf-parser](us-07-anz-pdf-parser.md) | ANZ PDF credit card statement parser                                        | Not started | Yes                             |
 

--- a/docs/themes/02-finance/prds/022-deduplication-parsers/us-05-up-bank-import.md
+++ b/docs/themes/02-finance/prds/022-deduplication-parsers/us-05-up-bank-import.md
@@ -1,7 +1,7 @@
 # US-05: Up Bank API batch import
 
 > PRD: [022 — Deduplication & Parsers](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user, I want to batch import transactions from Up Bank via API so that my U
 
 ## Acceptance Criteria
 
-- [ ] Fetches transactions from Up Bank REST API by date range (`SINCE_DATE`)
-- [ ] Maps Up API response to ParsedTransaction format
-- [ ] Account from API response (Up Everyday, Up Savers)
-- [ ] Checksum generated from transaction data for deduplication
-- [ ] Up Bank API token read from secrets
-- [ ] Output: valid ParsedTransaction[] compatible with the same pipeline as CSV imports
-- [ ] Test with mock Up API responses
+- [x] Fetches transactions from Up Bank REST API by date range (`SINCE_DATE`)
+- [x] Maps Up API response to ParsedTransaction format
+- [x] Account from API response (Up Everyday, Up Savers)
+- [x] Checksum generated from transaction data for deduplication
+- [x] Up Bank API token read from secrets
+- [x] Output: valid ParsedTransaction[] compatible with the same pipeline as CSV imports
+- [x] Test with mock Up API responses
 
 ## Notes
 

--- a/packages/import-tools/src/import-up-batch.ts
+++ b/packages/import-tools/src/import-up-batch.ts
@@ -1,11 +1,15 @@
 /**
  * Up Bank API batch import script.
- * Fetches transactions from Up Bank API and imports to SQLite.
+ * Fetches transactions from Up Bank API and normalises to ParsedTransaction format.
  *
  * Usage: pnpm import:up [--since 2026-01-01] [--execute]
  */
 
+import { fetchUpAccounts, fetchUpTransactions, getUpApiToken } from './lib/up-client.js';
+import { transformUpTransaction } from './lib/up-transformer.js';
+
 import type { RunMode } from './lib/types.js';
+import type { ParsedTransaction } from './lib/types.js';
 
 function parseArgs(): { since?: string; mode: RunMode } {
   const args = process.argv.slice(2);
@@ -16,18 +20,65 @@ function parseArgs(): { since?: string; mode: RunMode } {
   return { since, mode };
 }
 
+/**
+ * Log a preview table of parsed transactions (first N rows).
+ */
+function logPreview(transactions: ParsedTransaction[], limit = 5): void {
+  const preview = transactions.slice(0, limit);
+  console.log('\n--- Preview (first %d of %d) ---', preview.length, transactions.length);
+  for (const tx of preview) {
+    console.log(
+      '  %s | %s | %s | %s',
+      tx.date,
+      String(tx.amount).padStart(10),
+      tx.account.padEnd(20),
+      tx.description
+    );
+  }
+  console.log('---\n');
+}
+
 async function main(): Promise<void> {
   const { since, mode } = parseArgs();
   console.log(`[import-up] Since: ${since ?? 'all'}, Mode: ${mode}`);
 
-  // TODO: Migrate from ~/Downloads/transactions/extract_personal_accounts.js
-  // 1. Fetch transactions from Up Bank API (with optional --since filter)
-  // 2. Normalise to ParsedTransaction format
-  // 3. Match entities via entity-matcher
-  // 4. Deduplicate against existing SQLite records
-  // 5. Write new transactions to SQLite (if --execute)
+  // 1. Resolve API token
+  const token = getUpApiToken();
 
-  console.log('[import-up] Not yet implemented — migrate from extract_personal_accounts.js');
+  // 2. Fetch accounts → build id→name map
+  console.log('[import-up] Fetching accounts...');
+  const accountMap = await fetchUpAccounts(token);
+  console.log(
+    `[import-up] Found ${accountMap.size} account(s):`,
+    [...accountMap.values()].join(', ')
+  );
+
+  // 3. Fetch transactions (with optional since filter)
+  console.log('[import-up] Fetching transactions...');
+  const rawTransactions = await fetchUpTransactions(token, since);
+  console.log(`[import-up] Fetched ${rawTransactions.length} transaction(s) from API`);
+
+  // 4. Map each transaction to ParsedTransaction
+  const parsed: ParsedTransaction[] = rawTransactions.map((tx) => {
+    const accountName = accountMap.get(tx.accountId) ?? 'Up (Unknown Account)';
+    return transformUpTransaction(tx, accountName);
+  });
+
+  // 5. Output
+  if (mode === 'dry-run') {
+    console.log(`[import-up] Dry-run complete — ${parsed.length} transaction(s) parsed`);
+    if (parsed.length > 0) {
+      logPreview(parsed);
+    }
+  } else {
+    // --execute: database write is future work; show what would be imported
+    console.log(
+      `[import-up] Execute mode — execution not yet wired to database. ${parsed.length} transaction(s) ready.`
+    );
+    if (parsed.length > 0) {
+      logPreview(parsed);
+    }
+  }
 }
 
 main().catch((err: unknown) => {

--- a/packages/import-tools/src/lib/types.ts
+++ b/packages/import-tools/src/lib/types.ts
@@ -9,6 +9,10 @@ export interface ParsedTransaction {
   location?: string;
   country?: string;
   online?: boolean;
+  /** Full source row as JSON string (for audit trail) */
+  rawRow?: string;
+  /** SHA-256 hash for deduplication */
+  checksum?: string;
 }
 
 /** Entity lookup entry: name -> entity ID */

--- a/packages/import-tools/src/lib/up-client.test.ts
+++ b/packages/import-tools/src/lib/up-client.test.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getUpApiToken } from './up-client.js';
+
+describe('getUpApiToken', () => {
+  // Snapshot original env before each test and restore after
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    delete process.env['UP_API_TOKEN'];
+    delete process.env['UP_API_TOKEN_FILE'];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('reads token from UP_API_TOKEN environment variable', () => {
+    process.env['UP_API_TOKEN'] = 'up:yeah:test-token-direct';
+    expect(getUpApiToken()).toBe('up:yeah:test-token-direct');
+  });
+
+  it('reads token from UP_API_TOKEN_FILE environment variable', () => {
+    const tokenContent = 'up:yeah:test-token-from-file\n';
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(tokenContent);
+
+    process.env['UP_API_TOKEN_FILE'] = '/run/secrets/up_api_token';
+    expect(getUpApiToken()).toBe('up:yeah:test-token-from-file');
+    expect(fs.readFileSync).toHaveBeenCalledWith('/run/secrets/up_api_token', 'utf-8');
+  });
+
+  it('prefers UP_API_TOKEN_FILE over UP_API_TOKEN when both are set', () => {
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('token-from-file');
+
+    process.env['UP_API_TOKEN_FILE'] = '/run/secrets/up_api_token';
+    process.env['UP_API_TOKEN'] = 'token-direct';
+    expect(getUpApiToken()).toBe('token-from-file');
+  });
+
+  it('throws when neither UP_API_TOKEN nor UP_API_TOKEN_FILE is set', () => {
+    expect(() => getUpApiToken()).toThrow(
+      'Up Bank API token not found. Set UP_API_TOKEN or UP_API_TOKEN_FILE environment variable.'
+    );
+  });
+
+  it('trims whitespace from token read from file', () => {
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('  up:yeah:padded-token  \n');
+    process.env['UP_API_TOKEN_FILE'] = '/run/secrets/up_api_token';
+    expect(getUpApiToken()).toBe('up:yeah:padded-token');
+  });
+});

--- a/packages/import-tools/src/lib/up-client.ts
+++ b/packages/import-tools/src/lib/up-client.ts
@@ -1,0 +1,139 @@
+import fs from 'fs';
+
+/**
+ * A single Up Bank transaction as normalised from the API response.
+ */
+export interface UpTransaction {
+  id: string;
+  description: string;
+  rawText: string | null;
+  /** Signed float parsed from the API `value` string, e.g. "-45.60" → -45.60 */
+  amount: number;
+  /** ISO 8601 datetime string */
+  settledAt: string;
+  /** UUID of the owning account */
+  accountId: string;
+}
+
+const BASE_URL = 'https://api.up.com.au/api/v1';
+
+/**
+ * Resolve the Up Bank API token.
+ *
+ * Resolution order:
+ * 1. `UP_API_TOKEN_FILE` env var — path to a file containing the token
+ * 2. `UP_API_TOKEN` env var — the token itself
+ *
+ * Throws if neither is set.
+ */
+export function getUpApiToken(): string {
+  const tokenFile = process.env['UP_API_TOKEN_FILE'];
+  if (tokenFile) {
+    return fs.readFileSync(tokenFile, 'utf-8').trim();
+  }
+
+  const token = process.env['UP_API_TOKEN'];
+  if (token) {
+    return token;
+  }
+
+  throw new Error(
+    'Up Bank API token not found. Set UP_API_TOKEN or UP_API_TOKEN_FILE environment variable.'
+  );
+}
+
+/**
+ * Fetch all Up Bank accounts and return a map of account ID → display name.
+ */
+export async function fetchUpAccounts(token: string): Promise<Map<string, string>> {
+  const response = await fetch(`${BASE_URL}/accounts`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Up Bank API error fetching accounts: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const body = (await response.json()) as {
+    data: Array<{
+      id: string;
+      attributes: { displayName: string; accountType: string };
+    }>;
+  };
+
+  const accounts = new Map<string, string>();
+  for (const account of body.data) {
+    accounts.set(account.id, account.attributes.displayName);
+  }
+
+  return accounts;
+}
+
+/**
+ * Fetch all transactions from the Up Bank API, handling pagination automatically.
+ *
+ * @param token - Up Bank API bearer token
+ * @param since - Optional ISO 8601 date string (e.g. "2026-01-01") to filter transactions
+ */
+export async function fetchUpTransactions(token: string, since?: string): Promise<UpTransaction[]> {
+  const params = new URLSearchParams({ 'page[size]': '100' });
+  if (since) {
+    // Up Bank API expects full ISO 8601 datetime
+    const sinceDate = since.includes('T') ? since : `${since}T00:00:00+10:00`;
+    params.set('filter[since]', sinceDate);
+  }
+
+  let url: string | null = `${BASE_URL}/transactions?${params.toString()}`;
+  const transactions: UpTransaction[] = [];
+
+  while (url !== null) {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Up Bank API error fetching transactions: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const body = (await response.json()) as {
+      data: Array<{
+        id: string;
+        attributes: {
+          description: string;
+          rawText: string | null;
+          amount: { value: string };
+          settledAt: string;
+        };
+        relationships: {
+          account: { data: { id: string } };
+        };
+      }>;
+      links: { next: string | null };
+    };
+
+    for (const item of body.data) {
+      transactions.push({
+        id: item.id,
+        description: item.attributes.description,
+        rawText: item.attributes.rawText,
+        amount: parseFloat(item.attributes.amount.value),
+        settledAt: item.attributes.settledAt,
+        accountId: item.relationships.account.data.id,
+      });
+    }
+
+    url = body.links.next;
+  }
+
+  return transactions;
+}

--- a/packages/import-tools/src/lib/up-transformer.test.ts
+++ b/packages/import-tools/src/lib/up-transformer.test.ts
@@ -1,0 +1,109 @@
+import crypto from 'crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import { transformUpTransaction } from './up-transformer.js';
+
+import type { UpTransaction } from './up-client.js';
+
+function makeUpTransaction(overrides: Partial<UpTransaction> = {}): UpTransaction {
+  return {
+    id: 'txn-uuid-abc123',
+    description: 'WOOLWORTHS',
+    rawText: 'WOOLWORTHS 1234',
+    amount: -45.6,
+    settledAt: '2026-01-15T12:00:00+10:00',
+    accountId: 'account-uuid-001',
+    ...overrides,
+  };
+}
+
+describe('transformUpTransaction', () => {
+  it('maps description correctly', () => {
+    const tx = makeUpTransaction({ description: 'COLES SUPERMARKET' });
+    const result = transformUpTransaction(tx, 'Up Everyday');
+    expect(result.description).toBe('COLES SUPERMARKET');
+  });
+
+  it('trims whitespace from description', () => {
+    const tx = makeUpTransaction({ description: '  UBER EATS  ' });
+    const result = transformUpTransaction(tx, 'Up Everyday');
+    expect(result.description).toBe('UBER EATS');
+  });
+
+  it('maps amount correctly for expenses (negative)', () => {
+    const tx = makeUpTransaction({ amount: -45.6 });
+    const result = transformUpTransaction(tx, 'Up Everyday');
+    expect(result.amount).toBe(-45.6);
+  });
+
+  it('maps amount correctly for income (positive)', () => {
+    const tx = makeUpTransaction({ amount: 1500.0 });
+    const result = transformUpTransaction(tx, 'Up Savings');
+    expect(result.amount).toBe(1500.0);
+  });
+
+  it('extracts date as YYYY-MM-DD from settledAt', () => {
+    const tx = makeUpTransaction({ settledAt: '2026-01-15T12:00:00+10:00' });
+    const result = transformUpTransaction(tx, 'Up Everyday');
+    expect(result.date).toBe('2026-01-15');
+  });
+
+  it('extracts date correctly when settledAt spans midnight boundaries', () => {
+    const tx = makeUpTransaction({ settledAt: '2025-12-31T23:59:59+10:00' });
+    const result = transformUpTransaction(tx, 'Up Everyday');
+    expect(result.date).toBe('2025-12-31');
+  });
+
+  it('maps account to the provided account name', () => {
+    const tx = makeUpTransaction();
+    const result = transformUpTransaction(tx, 'Up Savers');
+    expect(result.account).toBe('Up Savers');
+  });
+
+  it('checksum is stable for the same transaction ID', () => {
+    const tx = makeUpTransaction({ id: 'txn-stable-id' });
+    const r1 = transformUpTransaction(tx, 'Up Everyday');
+    const r2 = transformUpTransaction(tx, 'Up Everyday');
+    expect(r1.checksum).toBe(r2.checksum);
+  });
+
+  it('checksum differs for different transaction IDs', () => {
+    const r1 = transformUpTransaction(makeUpTransaction({ id: 'id-alpha' }), 'Up Everyday');
+    const r2 = transformUpTransaction(makeUpTransaction({ id: 'id-beta' }), 'Up Everyday');
+    expect(r1.checksum).not.toBe(r2.checksum);
+  });
+
+  it('checksum matches SHA-256 of the transaction ID', () => {
+    const tx = makeUpTransaction({ id: 'txn-verify-checksum' });
+    const result = transformUpTransaction(tx, 'Up Everyday');
+    const expected = crypto.createHash('sha256').update('txn-verify-checksum').digest('hex');
+    expect(result.checksum).toBe(expected);
+  });
+
+  it('rawRow is valid JSON', () => {
+    const tx = makeUpTransaction();
+    const result = transformUpTransaction(tx, 'Up Everyday');
+    expect(() => JSON.parse(result.rawRow ?? '')).not.toThrow();
+  });
+
+  it('rawRow contains the transaction ID', () => {
+    const tx = makeUpTransaction({ id: 'raw-row-id-check' });
+    const result = transformUpTransaction(tx, 'Up Everyday');
+    const parsed = JSON.parse(result.rawRow ?? '{}') as Record<string, unknown>;
+    expect(parsed['id']).toBe('raw-row-id-check');
+  });
+
+  it('rawRow contains description, amount, and settledAt', () => {
+    const tx = makeUpTransaction({
+      description: 'CALTEX PETROL',
+      amount: -80.0,
+      settledAt: '2026-03-01T09:00:00+10:00',
+    });
+    const result = transformUpTransaction(tx, 'Up Everyday');
+    const parsed = JSON.parse(result.rawRow ?? '{}') as Record<string, unknown>;
+    expect(parsed['description']).toBe('CALTEX PETROL');
+    expect(parsed['amount']).toBe(-80.0);
+    expect(parsed['settledAt']).toBe('2026-03-01T09:00:00+10:00');
+  });
+});

--- a/packages/import-tools/src/lib/up-transformer.ts
+++ b/packages/import-tools/src/lib/up-transformer.ts
@@ -1,0 +1,42 @@
+import crypto from 'crypto';
+
+import type { ParsedTransaction } from './types.js';
+import type { UpTransaction } from './up-client.js';
+
+/**
+ * Transform a single Up Bank API transaction into a ParsedTransaction.
+ *
+ * - `date`        : YYYY-MM-DD extracted from `settledAt`
+ * - `description` : `tx.description`, trimmed
+ * - `amount`      : already a signed number (negative = expense)
+ * - `account`     : display name resolved from the account map
+ * - `rawRow`      : JSON snapshot of key fields for audit trail
+ * - `checksum`    : SHA-256 of the Up transaction ID — stable per-transaction
+ *
+ * @param tx          - Normalised Up Bank transaction
+ * @param accountName - Display name for the owning account (e.g. "Up Everyday")
+ */
+export function transformUpTransaction(tx: UpTransaction, accountName: string): ParsedTransaction {
+  // settledAt is an ISO 8601 string; take just the date portion (YYYY-MM-DD)
+  const date = tx.settledAt.slice(0, 10);
+
+  const description = tx.description.trim();
+
+  const rawRow = JSON.stringify({
+    id: tx.id,
+    description: tx.description,
+    amount: tx.amount,
+    settledAt: tx.settledAt,
+  });
+
+  const checksum = crypto.createHash('sha256').update(tx.id).digest('hex');
+
+  return {
+    date,
+    description,
+    amount: tx.amount,
+    account: accountName,
+    rawRow,
+    checksum,
+  };
+}


### PR DESCRIPTION
## Summary
- `up-client.ts`: `getUpApiToken()` (env or file), `fetchUpAccounts()`, `fetchUpTransactions()` with full pagination via `links.next`
- `up-transformer.ts`: maps Up API transaction → `ParsedTransaction` (date from `settledAt`, checksum from SHA-256 of Up transaction ID for stable deduplication)
- `import-up-batch.ts` stub replaced: wires token → accounts → transactions → `ParsedTransaction[]`, dry-run preview table, `--execute` log
- Extend `ParsedTransaction` in `lib/types.ts` with optional `rawRow` and `checksum`
- 18 new tests: transformer (13) + `getUpApiToken` (5)
- Docs: US-05 marked Done

Closes #1874

## Test plan
- [ ] `pnpm --filter @pops/tools test --run` — 38 pass
- [ ] `pnpm typecheck` — no errors
- [ ] `UP_API_TOKEN=xxx pnpm import:up --since 2026-01-01` — dry-run lists transactions from Up API