### PR TITLE
fix(finance): add transaction-scope Save rule button in Tag Review

### DIFF
--- a/docs/themes/02-finance/prds/029-tag-rule-proposals/us-02-generate-tag-proposal.md
+++ b/docs/themes/02-finance/prds/029-tag-rule-proposals/us-02-generate-tag-proposal.md
@@ -1,7 +1,7 @@
 # US-02: Generate tag rule proposal from tag edits
 
 > PRD: [029 — Tag Rule Proposals](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -15,4 +15,4 @@ As a user, I want the system to propose tag rules based on my tag edits during i
 - [x] Each operation includes rationale and an impact preview for the current import session **in the import UI flow**.
 - [x] Proposal scope is bounded to relevant rules and the current import context **in the import UI flow** — all confirmed transactions are passed as preview scope.
 - [ ] In an empty database (no existing tag vocabulary), tag suggestions are still generated using the seed taxonomy (v1) as the starting vocabulary **through the wizard**.
-- [ ] Proposals can be generated from transaction scope signals (single-transaction tag edit) — only group scope is wired; transaction-level signal is not yet connected.
+- [x] Proposals can be generated from transaction scope signals (single-transaction tag edit) — "Save rule…" button appears per transaction row in Tag Review (knoxio/pops#1928).

--- a/packages/app-finance/src/components/imports/TagReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.test.tsx
@@ -288,13 +288,44 @@ describe('TagReviewStep — Save tag rule wiring (PRD-029 US-02 / US-03)', () =>
     expect(screen.queryByTestId('dialog')).not.toBeInTheDocument();
   });
 
-  it('renders one "Save tag rule…" button per group even with multiple groups', () => {
+  it('renders one "Save tag rule…" button per group and one "Save rule…" per transaction', () => {
     seedTransactions([woolworthsTx1, netflixTx, noTagTx]);
     renderTagReviewStep();
 
-    // Three entity groups: Woolworths, Netflix, Unknown
+    // 3 group-level buttons + 3 transaction-level buttons = 6 total
     const saveButtons = screen.getAllByRole('button', { name: /Save tag rule/i });
-    expect(saveButtons).toHaveLength(3);
+    expect(saveButtons).toHaveLength(6);
+    // Group-level buttons use the entity name
+    expect(screen.getByLabelText('Save tag rule for Woolworths')).toBeInTheDocument();
+    expect(screen.getByLabelText('Save tag rule for Netflix')).toBeInTheDocument();
+    // Transaction-level buttons use the raw description
+    expect(screen.getByLabelText('Save tag rule for WOOLWORTHS METRO')).toBeInTheDocument();
+    expect(screen.getByLabelText('Save tag rule for NETFLIX.COM')).toBeInTheDocument();
+  });
+
+  it('opens TagRuleProposalDialog when "Save rule…" is clicked on a transaction row with tags', async () => {
+    seedTransactions([woolworthsTx1]);
+    renderTagReviewStep();
+
+    const saveBtn = screen.getByLabelText('Save tag rule for WOOLWORTHS METRO');
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dialog')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a toast and does not open dialog when transaction row has no tags', async () => {
+    seedTransactions([noTagTx]);
+    renderTagReviewStep();
+
+    const saveBtn = screen.getByLabelText('Save tag rule for UNKNOWN VENDOR');
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockToastInfo).toHaveBeenCalledWith(expect.stringContaining('Add at least one tag'));
+    });
+    expect(screen.queryByTestId('dialog')).not.toBeInTheDocument();
   });
 
   it('shows empty state when there are no confirmed transactions', () => {

--- a/packages/app-finance/src/components/imports/TagReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.tsx
@@ -200,6 +200,27 @@ export function TagReviewStep() {
   );
 
   /**
+   * Called when the user clicks "Save rule…" on a single transaction row.
+   * Builds a signal from that transaction's description and current tags.
+   */
+  const handleOpenTagRuleDialogForTransaction = useCallback(
+    (transaction: ConfirmedTransaction, tags: string[]) => {
+      if (tags.length === 0) {
+        toast.info('Add at least one tag to this transaction before saving a rule.');
+        return;
+      }
+      const signal: TagRuleLearnSignal = {
+        descriptionPattern: transaction.description,
+        matchType: 'contains',
+        entityId: transaction.entityId ?? null,
+        tags,
+      };
+      setTagRuleDialog({ signal, groupEntityName: transaction.description });
+    },
+    []
+  );
+
+  /**
    * Capture the entity name at dialog-open time in a ref so it is stable
    * inside handleTagRuleApplied even when tagRuleDialog state has been cleared.
    */
@@ -265,6 +286,7 @@ export function TagReviewStep() {
             onUpdateTag={updateTag}
             onApplyGroupTags={handleApplyGroupTags}
             onSaveTagRule={handleOpenTagRuleDialog}
+            onSaveTagRuleForTransaction={handleOpenTagRuleDialogForTransaction}
           />
         ))}
 
@@ -318,6 +340,8 @@ interface EntityGroupProps {
   onApplyGroupTags: (group: ConfirmedGroup, tags: string[]) => void;
   /** Opens the TagRuleProposalDialog pre-populated with this group's signal. */
   onSaveTagRule: (group: ConfirmedGroup) => void;
+  /** Opens the TagRuleProposalDialog pre-populated from a single transaction's description + tags. */
+  onSaveTagRuleForTransaction: (transaction: ConfirmedTransaction, tags: string[]) => void;
 }
 
 /**
@@ -334,6 +358,7 @@ function EntityGroup({
   onUpdateTag,
   onApplyGroupTags,
   onSaveTagRule,
+  onSaveTagRuleForTransaction,
 }: EntityGroupProps) {
   const [expanded, setExpanded] = useState(true);
 
@@ -473,6 +498,7 @@ function EntityGroup({
                 onSave={(tags) => {
                   onUpdateTag(t.checksum, tags);
                 }}
+                onSaveTagRule={onSaveTagRuleForTransaction}
               />
             ))}
           </div>
@@ -661,6 +687,7 @@ interface TransactionTagRowProps {
   originalSuggestedTags: SuggestedTag[];
   availableTags: string[];
   onSave: (tags: string[]) => void;
+  onSaveTagRule?: (transaction: ConfirmedTransaction, tags: string[]) => void;
 }
 
 /**
@@ -674,6 +701,7 @@ function TransactionTagRow({
   originalSuggestedTags,
   availableTags,
   onSave,
+  onSaveTagRule,
 }: TransactionTagRowProps) {
   const amount = transaction.amount;
   const isNegative = amount < 0;
@@ -682,7 +710,7 @@ function TransactionTagRow({
   const tagMeta = useMemo(() => buildTagMetaMap(originalSuggestedTags), [originalSuggestedTags]);
 
   return (
-    <div className="flex items-center gap-3 px-4 py-2 hover:bg-muted/20 transition-colors">
+    <div className="flex items-center gap-3 px-4 py-2 hover:bg-muted/20 transition-colors group/txrow">
       {/* Transaction metadata */}
       <div className="flex-1 min-w-0">
         <p className="text-sm truncate">{transaction.description}</p>
@@ -698,6 +726,21 @@ function TransactionTagRow({
       >
         {isNegative ? '-' : '+'}${Math.abs(amount).toFixed(2)}
       </span>
+
+      {/* Save tag rule button — visible on hover */}
+      {onSaveTagRule && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onSaveTagRule(transaction, tags)}
+          className="text-xs px-2 py-1 h-auto whitespace-nowrap text-muted-foreground hover:text-foreground opacity-0 group-hover/txrow:opacity-100 transition-opacity flex-shrink-0"
+          title="Save a reusable tag rule for this transaction"
+          aria-label={`Save tag rule for ${transaction.description}`}
+        >
+          <BookmarkPlus className="w-3.5 h-3.5 mr-1" />
+          Save rule…
+        </Button>
+      )}
 
       {/* Inline tag editor — with source badge display in trigger */}
       <div className="flex-shrink-0 w-44">


### PR DESCRIPTION
## Summary

- Adds a per-transaction "Save rule…" button in `TransactionTagRow` that appears on hover (opacity-0 → opacity-100 via Tailwind group-hover)
- Clicking it opens `TagRuleProposalDialog` pre-filled with the transaction's raw description as `descriptionPattern` (rather than the entity group name), enabling more granular rule learning
- Toast shown if the transaction has no tags (mirrors existing group-level guard)
- `EntityGroupProps` gets a new `onSaveTagRuleForTransaction` prop threaded from `TagReviewStep` → `EntityGroup` → `TransactionTagRow`

Closes #1928

## Test plan

- [x] All existing tests pass (268 tests)
- [x] New tests added: `opens TagRuleProposalDialog when "Save rule…" is clicked on a transaction row with tags`, `shows a toast and does not open dialog when transaction row has no tags`
- [x] Updated count assertion now expects 6 buttons (3 group-level + 3 transaction-level) for 3-group fixture
- [x] Full turbo typecheck passes (16/16)