### PR TITLE
feat(cerebrum): PRD-077 engram file format, templates, index, CRUD, tRPC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,8 @@ PAPERLESS_API_TOKEN=
 
 # Paths
 SQLITE_PATH=./data/pops.db
+# Cerebrum engram root (Markdown files on disk). Absolute path recommended.
+ENGRAM_ROOT=./data/engrams
 
 # Server deployment (used by deploy.sh and Ansible)
 POPS_SSH_KEY=~/.ssh/pops

--- a/apps/pops-api/.env.example
+++ b/apps/pops-api/.env.example
@@ -13,6 +13,10 @@ DB_PATH=./data/pops.db
 # Directory for locally cached posters and backdrops
 MEDIA_IMAGES_DIR=./data/media/images
 
+# Cerebrum engram root — Markdown files on disk are the source of truth.
+# Defaults to ./data/engrams if unset. In production this is /opt/pops/engrams.
+ENGRAM_ROOT=./data/engrams
+
 # Media Metadata Providers
 # TMDB: Get a Read-Access Token (v4 auth) from https://www.themoviedb.org/settings/api
 TMDB_API_KEY=your_tmdb_v4_token_here

--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -59,7 +59,9 @@
     "drizzle-orm": "^0.45.2",
     "express": "^5.0.1",
     "express-rate-limit": "^8.3.2",
+    "gray-matter": "^4.0.3",
     "helmet": "^8.0.0",
+    "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.3",
     "node-cron": "^4.2.1",
     "pino": "^10.3.1",
@@ -70,6 +72,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
     "@types/express": "^5.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.6.0",
     "@types/node-cron": "^3.0.11",

--- a/apps/pops-api/src/db/drizzle-migrations/0031_romantic_hannibal_king.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0031_romantic_hannibal_king.sql
@@ -1,0 +1,45 @@
+CREATE TABLE `engram_index` (
+	`id` text PRIMARY KEY NOT NULL,
+	`file_path` text NOT NULL,
+	`type` text NOT NULL,
+	`source` text NOT NULL,
+	`status` text NOT NULL,
+	`template` text,
+	`created_at` text NOT NULL,
+	`modified_at` text NOT NULL,
+	`title` text NOT NULL,
+	`content_hash` text NOT NULL,
+	`word_count` integer NOT NULL,
+	`custom_fields` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `engram_index_file_path_unique` ON `engram_index` (`file_path`);--> statement-breakpoint
+CREATE INDEX `idx_engram_index_type` ON `engram_index` (`type`);--> statement-breakpoint
+CREATE INDEX `idx_engram_index_source` ON `engram_index` (`source`);--> statement-breakpoint
+CREATE INDEX `idx_engram_index_status` ON `engram_index` (`status`);--> statement-breakpoint
+CREATE INDEX `idx_engram_index_created_at` ON `engram_index` (`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_engram_index_content_hash` ON `engram_index` (`content_hash`);--> statement-breakpoint
+CREATE TABLE `engram_links` (
+	`source_id` text NOT NULL,
+	`target_id` text NOT NULL,
+	FOREIGN KEY (`source_id`) REFERENCES `engram_index`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_engram_links_target` ON `engram_links` (`target_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_engram_links_pair` ON `engram_links` (`source_id`,`target_id`);--> statement-breakpoint
+CREATE TABLE `engram_scopes` (
+	`engram_id` text NOT NULL,
+	`scope` text NOT NULL,
+	FOREIGN KEY (`engram_id`) REFERENCES `engram_index`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_engram_scopes_scope` ON `engram_scopes` (`scope`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_engram_scopes_pair` ON `engram_scopes` (`engram_id`,`scope`);--> statement-breakpoint
+CREATE TABLE `engram_tags` (
+	`engram_id` text NOT NULL,
+	`tag` text NOT NULL,
+	FOREIGN KEY (`engram_id`) REFERENCES `engram_index`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_engram_tags_tag` ON `engram_tags` (`tag`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_engram_tags_pair` ON `engram_tags` (`engram_id`,`tag`);

--- a/apps/pops-api/src/db/drizzle-migrations/meta/0031_snapshot.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/0031_snapshot.json
@@ -1,0 +1,3748 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3cfbadd3-7bad-454f-b6eb-0111e4ffc49a",
+  "prevId": "62d02fd1-62a6-4145-8674-e6334d759397",
+  "tables": {
+    "ai_usage": {
+      "name": "ai_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_created_at": {
+          "name": "idx_ai_usage_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_ai_usage_batch": {
+          "name": "idx_ai_usage_batch",
+          "columns": ["import_batch_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "budgets": {
+      "name": "budgets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "budgets_notion_id_unique": {
+          "name": "budgets_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        },
+        "idx_budgets_category_period": {
+          "name": "idx_budgets_category_period",
+          "columns": ["category", "COALESCE(\"period\", char(0))"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparison_dimensions": {
+      "name": "comparison_dimensions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparison_dimensions_name": {
+          "name": "idx_comparison_dimensions_name",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparison_skip_cooloffs": {
+      "name": "comparison_skip_cooloffs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_type": {
+          "name": "media_a_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_id": {
+          "name": "media_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_type": {
+          "name": "media_b_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_id": {
+          "name": "media_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skip_until": {
+          "name": "skip_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparison_skip_cooloffs_pair": {
+          "name": "idx_comparison_skip_cooloffs_pair",
+          "columns": ["dimension_id", "media_a_type", "media_a_id", "media_b_type", "media_b_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "comparison_skip_cooloffs_dimension_id_comparison_dimensions_id_fk": {
+          "name": "comparison_skip_cooloffs_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "comparison_skip_cooloffs",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparison_staleness": {
+      "name": "comparison_staleness",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staleness": {
+          "name": "staleness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparison_staleness_unique": {
+          "name": "idx_comparison_staleness_unique",
+          "columns": ["media_type", "media_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparisons": {
+      "name": "comparisons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_type": {
+          "name": "media_a_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_id": {
+          "name": "media_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_type": {
+          "name": "media_b_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_id": {
+          "name": "media_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winner_type": {
+          "name": "winner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "draw_tier": {
+          "name": "draw_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delta_a": {
+          "name": "delta_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delta_b": {
+          "name": "delta_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compared_at": {
+          "name": "compared_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparisons_dimension_id": {
+          "name": "idx_comparisons_dimension_id",
+          "columns": ["dimension_id"],
+          "isUnique": false
+        },
+        "idx_comparisons_media_a": {
+          "name": "idx_comparisons_media_a",
+          "columns": ["media_a_type", "media_a_id"],
+          "isUnique": false
+        },
+        "idx_comparisons_media_b": {
+          "name": "idx_comparisons_media_b",
+          "columns": ["media_b_type", "media_b_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comparisons_dimension_id_comparison_dimensions_id_fk": {
+          "name": "comparisons_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "comparisons",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_corrections": {
+      "name": "transaction_corrections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_pattern": {
+          "name": "description_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'exact'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "times_applied": {
+          "name": "times_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_corrections_pattern": {
+          "name": "idx_corrections_pattern",
+          "columns": ["description_pattern"],
+          "isUnique": false
+        },
+        "idx_corrections_priority": {
+          "name": "idx_corrections_priority",
+          "columns": ["priority"],
+          "isUnique": false
+        },
+        "idx_corrections_confidence": {
+          "name": "idx_corrections_confidence",
+          "columns": ["confidence"],
+          "isUnique": false
+        },
+        "idx_corrections_times_applied": {
+          "name": "idx_corrections_times_applied",
+          "columns": ["times_applied"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_corrections_entity_id_entities_id_fk": {
+          "name": "transaction_corrections_entity_id_entities_id_fk",
+          "tableFrom": "transaction_corrections",
+          "tableTo": "entities",
+          "columnsFrom": ["entity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debrief_results": {
+      "name": "debrief_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comparison_id": {
+          "name": "comparison_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debrief_results_session_id_debrief_sessions_id_fk": {
+          "name": "debrief_results_session_id_debrief_sessions_id_fk",
+          "tableFrom": "debrief_results",
+          "tableTo": "debrief_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "debrief_results_dimension_id_comparison_dimensions_id_fk": {
+          "name": "debrief_results_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "debrief_results",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "debrief_results_comparison_id_comparisons_id_fk": {
+          "name": "debrief_results_comparison_id_comparisons_id_fk",
+          "tableFrom": "debrief_results",
+          "tableTo": "comparisons",
+          "columnsFrom": ["comparison_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debrief_sessions": {
+      "name": "debrief_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "watch_history_id": {
+          "name": "watch_history_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debrief_sessions_watch_history_id_watch_history_id_fk": {
+          "name": "debrief_sessions_watch_history_id_watch_history_id_fk",
+          "tableFrom": "debrief_sessions",
+          "tableTo": "watch_history",
+          "columnsFrom": ["watch_history_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debrief_status": {
+      "name": "debrief_status",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "debriefed": {
+          "name": "debriefed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "debrief_status_media_dimension_idx": {
+          "name": "debrief_status_media_dimension_idx",
+          "columns": ["media_type", "media_id", "dimension_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "debrief_status_dimension_id_comparison_dimensions_id_fk": {
+          "name": "debrief_status_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "debrief_status",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dismissed_discover": {
+      "name": "dismissed_discover",
+      "columns": {
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_index": {
+      "name": "engram_index",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_fields": {
+          "name": "custom_fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "engram_index_file_path_unique": {
+          "name": "engram_index_file_path_unique",
+          "columns": ["file_path"],
+          "isUnique": true
+        },
+        "idx_engram_index_type": {
+          "name": "idx_engram_index_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_engram_index_source": {
+          "name": "idx_engram_index_source",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "idx_engram_index_status": {
+          "name": "idx_engram_index_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_engram_index_created_at": {
+          "name": "idx_engram_index_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_engram_index_content_hash": {
+          "name": "idx_engram_index_content_hash",
+          "columns": ["content_hash"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_links": {
+      "name": "engram_links",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_engram_links_target": {
+          "name": "idx_engram_links_target",
+          "columns": ["target_id"],
+          "isUnique": false
+        },
+        "uq_engram_links_pair": {
+          "name": "uq_engram_links_pair",
+          "columns": ["source_id", "target_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "engram_links_source_id_engram_index_id_fk": {
+          "name": "engram_links_source_id_engram_index_id_fk",
+          "tableFrom": "engram_links",
+          "tableTo": "engram_index",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_scopes": {
+      "name": "engram_scopes",
+      "columns": {
+        "engram_id": {
+          "name": "engram_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_engram_scopes_scope": {
+          "name": "idx_engram_scopes_scope",
+          "columns": ["scope"],
+          "isUnique": false
+        },
+        "uq_engram_scopes_pair": {
+          "name": "uq_engram_scopes_pair",
+          "columns": ["engram_id", "scope"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "engram_scopes_engram_id_engram_index_id_fk": {
+          "name": "engram_scopes_engram_id_engram_index_id_fk",
+          "tableFrom": "engram_scopes",
+          "tableTo": "engram_index",
+          "columnsFrom": ["engram_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_tags": {
+      "name": "engram_tags",
+      "columns": {
+        "engram_id": {
+          "name": "engram_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_engram_tags_tag": {
+          "name": "idx_engram_tags_tag",
+          "columns": ["tag"],
+          "isUnique": false
+        },
+        "uq_engram_tags_pair": {
+          "name": "uq_engram_tags_pair",
+          "columns": ["engram_id", "tag"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "engram_tags_engram_id_engram_index_id_fk": {
+          "name": "engram_tags_engram_id_engram_index_id_fk",
+          "tableFrom": "engram_tags",
+          "tableTo": "engram_index",
+          "columnsFrom": ["engram_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entities": {
+      "name": "entities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'company'"
+        },
+        "abn": {
+          "name": "abn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_transaction_type": {
+          "name": "default_transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_tags": {
+          "name": "default_tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entities_notion_id_unique": {
+          "name": "entities_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "db_path": {
+          "name": "db_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed_type": {
+          "name": "seed_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_environments_expires_at": {
+          "name": "idx_environments_expires_at",
+          "columns": ["expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "episodes": {
+      "name": "episodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "still_path": {
+          "name": "still_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_episodes_tvdb_id": {
+          "name": "idx_episodes_tvdb_id",
+          "columns": ["tvdb_id"],
+          "isUnique": true
+        },
+        "idx_episodes_season_number": {
+          "name": "idx_episodes_season_number",
+          "columns": ["season_id", "episode_number"],
+          "isUnique": true
+        },
+        "idx_episodes_season_id": {
+          "name": "idx_episodes_season_id",
+          "columns": ["season_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "episodes_season_id_seasons_id_fk": {
+          "name": "episodes_season_id_seasons_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "seasons",
+          "columnsFrom": ["season_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_inventory": {
+      "name": "home_inventory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room": {
+          "name": "room",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'good'"
+        },
+        "in_use": {
+          "name": "in_use",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warranty_expires": {
+          "name": "warranty_expires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "replacement_value": {
+          "name": "replacement_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resale_value": {
+          "name": "resale_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_transaction_id": {
+          "name": "purchase_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchased_from_id": {
+          "name": "purchased_from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchased_from_name": {
+          "name": "purchased_from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_inventory_notion_id_unique": {
+          "name": "home_inventory_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        },
+        "home_inventory_asset_id_unique": {
+          "name": "home_inventory_asset_id_unique",
+          "columns": ["asset_id"],
+          "isUnique": true
+        },
+        "idx_inventory_asset_id": {
+          "name": "idx_inventory_asset_id",
+          "columns": ["asset_id"],
+          "isUnique": true
+        },
+        "idx_inventory_name": {
+          "name": "idx_inventory_name",
+          "columns": ["item_name"],
+          "isUnique": false
+        },
+        "idx_inventory_location": {
+          "name": "idx_inventory_location",
+          "columns": ["location_id"],
+          "isUnique": false
+        },
+        "idx_inventory_type": {
+          "name": "idx_inventory_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_inventory_warranty": {
+          "name": "idx_inventory_warranty",
+          "columns": ["warranty_expires"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_inventory_purchase_transaction_id_transactions_id_fk": {
+          "name": "home_inventory_purchase_transaction_id_transactions_id_fk",
+          "tableFrom": "home_inventory",
+          "tableTo": "transactions",
+          "columnsFrom": ["purchase_transaction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_inventory_purchased_from_id_entities_id_fk": {
+          "name": "home_inventory_purchased_from_id_entities_id_fk",
+          "tableFrom": "home_inventory",
+          "tableTo": "entities",
+          "columnsFrom": ["purchased_from_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_inventory_location_id_locations_id_fk": {
+          "name": "home_inventory_location_id_locations_id_fk",
+          "tableFrom": "home_inventory",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_connections": {
+      "name": "item_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_a_id": {
+          "name": "item_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_b_id": {
+          "name": "item_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_connections_a": {
+          "name": "idx_item_connections_a",
+          "columns": ["item_a_id"],
+          "isUnique": false
+        },
+        "idx_item_connections_b": {
+          "name": "idx_item_connections_b",
+          "columns": ["item_b_id"],
+          "isUnique": false
+        },
+        "uq_item_connections_pair": {
+          "name": "uq_item_connections_pair",
+          "columns": ["item_a_id", "item_b_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "item_connections_item_a_id_home_inventory_id_fk": {
+          "name": "item_connections_item_a_id_home_inventory_id_fk",
+          "tableFrom": "item_connections",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_a_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_connections_item_b_id_home_inventory_id_fk": {
+          "name": "item_connections_item_b_id_home_inventory_id_fk",
+          "tableFrom": "item_connections",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_b_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_connections_order": {
+          "name": "chk_item_connections_order",
+          "value": "\"item_connections\".\"item_a_id\" < \"item_connections\".\"item_b_id\""
+        }
+      }
+    },
+    "item_documents": {
+      "name": "item_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paperless_document_id": {
+          "name": "paperless_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_documents_item": {
+          "name": "idx_item_documents_item",
+          "columns": ["item_id"],
+          "isUnique": false
+        },
+        "idx_item_documents_doc": {
+          "name": "idx_item_documents_doc",
+          "columns": ["paperless_document_id"],
+          "isUnique": false
+        },
+        "uq_item_documents_pair": {
+          "name": "uq_item_documents_pair",
+          "columns": ["item_id", "paperless_document_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "item_documents_item_id_home_inventory_id_fk": {
+          "name": "item_documents_item_id_home_inventory_id_fk",
+          "tableFrom": "item_documents",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_photos": {
+      "name": "item_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_photos_item": {
+          "name": "idx_item_photos_item",
+          "columns": ["item_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_photos_item_id_home_inventory_id_fk": {
+          "name": "item_photos_item_id_home_inventory_id_fk",
+          "tableFrom": "item_photos",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_locations_parent": {
+          "name": "idx_locations_parent",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "idx_locations_name": {
+          "name": "idx_locations_name",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "idx_locations_parent_sort": {
+          "name": "idx_locations_parent_sort",
+          "columns": ["parent_id", "sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_scores": {
+      "name": "media_scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1500
+        },
+        "comparison_count": {
+          "name": "comparison_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_media_scores_unique": {
+          "name": "idx_media_scores_unique",
+          "columns": ["media_type", "media_id", "dimension_id"],
+          "isUnique": true
+        },
+        "idx_media_scores_dimension": {
+          "name": "idx_media_scores_dimension",
+          "columns": ["dimension_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_scores_dimension_id_comparison_dimensions_id_fk": {
+          "name": "media_scores_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "media_scores",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watchlist": {
+      "name": "watchlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "plex_rating_key": {
+          "name": "plex_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_watchlist_media": {
+          "name": "idx_watchlist_media",
+          "columns": ["media_type", "media_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies": {
+      "name": "movies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_language": {
+          "name": "original_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget": {
+          "name": "budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_path": {
+          "name": "logo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_override_path": {
+          "name": "poster_override_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discover_rating_key": {
+          "name": "discover_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "rotation_status": {
+          "name": "rotation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_expires_at": {
+          "name": "rotation_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_marked_at": {
+          "name": "rotation_marked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_movies_rotation_status": {
+          "name": "idx_movies_rotation_status",
+          "columns": ["rotation_status"],
+          "isUnique": false
+        },
+        "idx_movies_tmdb_id": {
+          "name": "idx_movies_tmdb_id",
+          "columns": ["tmdb_id"],
+          "isUnique": true
+        },
+        "idx_movies_title": {
+          "name": "idx_movies_title",
+          "columns": ["title"],
+          "isUnique": false
+        },
+        "idx_movies_release_date": {
+          "name": "idx_movies_release_date",
+          "columns": ["release_date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_candidates": {
+      "name": "rotation_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_rotation_candidates_tmdb_id": {
+          "name": "idx_rotation_candidates_tmdb_id",
+          "columns": ["tmdb_id"],
+          "isUnique": true
+        },
+        "idx_rotation_candidates_source_id": {
+          "name": "idx_rotation_candidates_source_id",
+          "columns": ["source_id"],
+          "isUnique": false
+        },
+        "idx_rotation_candidates_status": {
+          "name": "idx_rotation_candidates_status",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rotation_candidates_source_id_rotation_sources_id_fk": {
+          "name": "rotation_candidates_source_id_rotation_sources_id_fk",
+          "tableFrom": "rotation_candidates",
+          "tableTo": "rotation_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_exclusions": {
+      "name": "rotation_exclusions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_rotation_exclusions_tmdb_id": {
+          "name": "idx_rotation_exclusions_tmdb_id",
+          "columns": ["tmdb_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_log": {
+      "name": "rotation_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_marked_leaving": {
+          "name": "movies_marked_leaving",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_removed": {
+          "name": "movies_removed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_added": {
+          "name": "movies_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removals_failed": {
+          "name": "removals_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "free_space_gb": {
+          "name": "free_space_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_free_gb": {
+          "name": "target_free_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skipped_reason": {
+          "name": "skipped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_sources": {
+      "name": "rotation_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_interval_hours": {
+          "name": "sync_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_rotation_sources_type": {
+          "name": "idx_rotation_sources_type",
+          "columns": ["type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "seasons": {
+      "name": "seasons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tv_show_id": {
+          "name": "tv_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_seasons_tvdb_id": {
+          "name": "idx_seasons_tvdb_id",
+          "columns": ["tvdb_id"],
+          "isUnique": true
+        },
+        "idx_seasons_show_number": {
+          "name": "idx_seasons_show_number",
+          "columns": ["tv_show_id", "season_number"],
+          "isUnique": true
+        },
+        "idx_seasons_tv_show_id": {
+          "name": "idx_seasons_tv_show_id",
+          "columns": ["tv_show_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "seasons_tv_show_id_tv_shows_id_fk": {
+          "name": "seasons_tv_show_id_tv_shows_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "tv_shows",
+          "columnsFrom": ["tv_show_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shelf_impressions": {
+      "name": "shelf_impressions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "shelf_id": {
+          "name": "shelf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_shelf_impressions_shelf_id": {
+          "name": "idx_shelf_impressions_shelf_id",
+          "columns": ["shelf_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_job_results": {
+      "name": "sync_job_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_sync_job_results_type_completed": {
+          "name": "idx_sync_job_results_type_completed",
+          "columns": ["job_type", "completed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_logs": {
+      "name": "sync_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_synced": {
+          "name": "movies_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tv_shows_synced": {
+          "name": "tv_shows_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag_vocabulary": {
+      "name": "tag_vocabulary",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'seed'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_tag_vocabulary_active": {
+          "name": "idx_tag_vocabulary_active",
+          "columns": ["is_active"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tier_overrides": {
+      "name": "tier_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_tier_overrides_unique": {
+          "name": "idx_tier_overrides_unique",
+          "columns": ["media_type", "media_id", "dimension_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tier_overrides_dimension_id_comparison_dimensions_id_fk": {
+          "name": "tier_overrides_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "tier_overrides",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_tag_rules": {
+      "name": "transaction_tag_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_pattern": {
+          "name": "description_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'exact'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "times_applied": {
+          "name": "times_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tag_rules_pattern": {
+          "name": "idx_tag_rules_pattern",
+          "columns": ["description_pattern"],
+          "isUnique": false
+        },
+        "idx_tag_rules_entity_id": {
+          "name": "idx_tag_rules_entity_id",
+          "columns": ["entity_id"],
+          "isUnique": false
+        },
+        "idx_tag_rules_priority": {
+          "name": "idx_tag_rules_priority",
+          "columns": ["priority"],
+          "isUnique": false
+        },
+        "idx_tag_rules_confidence": {
+          "name": "idx_tag_rules_confidence",
+          "columns": ["confidence"],
+          "isUnique": false
+        },
+        "idx_tag_rules_times_applied": {
+          "name": "idx_tag_rules_times_applied",
+          "columns": ["times_applied"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_tag_rules_entity_id_entities_id_fk": {
+          "name": "transaction_tag_rules_entity_id_entities_id_fk",
+          "tableFrom": "transaction_tag_rules",
+          "tableTo": "entities",
+          "columnsFrom": ["entity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account": {
+          "name": "account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_transaction_id": {
+          "name": "related_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_row": {
+          "name": "raw_row",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactions_notion_id_unique": {
+          "name": "transactions_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        },
+        "idx_transactions_date": {
+          "name": "idx_transactions_date",
+          "columns": ["date"],
+          "isUnique": false
+        },
+        "idx_transactions_account": {
+          "name": "idx_transactions_account",
+          "columns": ["account"],
+          "isUnique": false
+        },
+        "idx_transactions_entity": {
+          "name": "idx_transactions_entity",
+          "columns": ["entity_id"],
+          "isUnique": false
+        },
+        "idx_transactions_last_edited": {
+          "name": "idx_transactions_last_edited",
+          "columns": ["last_edited_time"],
+          "isUnique": false
+        },
+        "idx_transactions_notion_id": {
+          "name": "idx_transactions_notion_id",
+          "columns": ["notion_id"],
+          "isUnique": false
+        },
+        "idx_transactions_checksum": {
+          "name": "idx_transactions_checksum",
+          "columns": ["checksum"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "transactions_entity_id_entities_id_fk": {
+          "name": "transactions_entity_id_entities_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "entities",
+          "columnsFrom": ["entity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tv_shows": {
+      "name": "tv_shows",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_air_date": {
+          "name": "first_air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_air_date": {
+          "name": "last_air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_language": {
+          "name": "original_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "number_of_seasons": {
+          "name": "number_of_seasons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "number_of_episodes": {
+          "name": "number_of_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_run_time": {
+          "name": "episode_run_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_path": {
+          "name": "logo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_override_path": {
+          "name": "poster_override_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discover_rating_key": {
+          "name": "discover_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "networks": {
+          "name": "networks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_tv_shows_tvdb_id": {
+          "name": "idx_tv_shows_tvdb_id",
+          "columns": ["tvdb_id"],
+          "isUnique": true
+        },
+        "idx_tv_shows_name": {
+          "name": "idx_tv_shows_name",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "idx_tv_shows_first_air_date": {
+          "name": "idx_tv_shows_first_air_date",
+          "columns": ["first_air_date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watch_history": {
+      "name": "watch_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "blacklisted": {
+          "name": "blacklisted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_watch_history_media": {
+          "name": "idx_watch_history_media",
+          "columns": ["media_type", "media_id"],
+          "isUnique": false
+        },
+        "idx_watch_history_watched_at": {
+          "name": "idx_watch_history_watched_at",
+          "columns": ["watched_at"],
+          "isUnique": false
+        },
+        "idx_watch_history_unique": {
+          "name": "idx_watch_history_unique",
+          "columns": ["media_type", "media_id", "watched_at"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wish_list": {
+      "name": "wish_list",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_amount": {
+          "name": "target_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saved": {
+          "name": "saved",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "wish_list_notion_id_unique": {
+          "name": "wish_list_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_budgets_category_period": {
+        "columns": {
+          "COALESCE(\"period\", char(0))": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1776439486689,
       "tag": "0030_budgets_unique_category_period",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1776487561100,
+      "tag": "0031_romantic_hannibal_king",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -601,6 +601,51 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
       excluded_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
     CREATE UNIQUE INDEX IF NOT EXISTS idx_rotation_exclusions_tmdb_id ON rotation_exclusions(tmdb_id);
+
+    -- Cerebrum engram index (Markdown files on disk are the source of truth; this
+    -- mirrors frontmatter into SQLite for fast queries). Regenerable from files.
+    CREATE TABLE IF NOT EXISTS engram_index (
+      id            TEXT PRIMARY KEY,
+      file_path     TEXT NOT NULL UNIQUE,
+      type          TEXT NOT NULL,
+      source        TEXT NOT NULL,
+      status        TEXT NOT NULL,
+      template      TEXT,
+      created_at    TEXT NOT NULL,
+      modified_at   TEXT NOT NULL,
+      title         TEXT NOT NULL,
+      content_hash  TEXT NOT NULL,
+      word_count    INTEGER NOT NULL,
+      custom_fields TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_engram_index_type ON engram_index(type);
+    CREATE INDEX IF NOT EXISTS idx_engram_index_source ON engram_index(source);
+    CREATE INDEX IF NOT EXISTS idx_engram_index_status ON engram_index(status);
+    CREATE INDEX IF NOT EXISTS idx_engram_index_created_at ON engram_index(created_at);
+    CREATE INDEX IF NOT EXISTS idx_engram_index_content_hash ON engram_index(content_hash);
+
+    CREATE TABLE IF NOT EXISTS engram_scopes (
+      engram_id TEXT NOT NULL REFERENCES engram_index(id) ON DELETE CASCADE,
+      scope     TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_engram_scopes_pair ON engram_scopes(engram_id, scope);
+    CREATE INDEX IF NOT EXISTS idx_engram_scopes_scope ON engram_scopes(scope);
+
+    CREATE TABLE IF NOT EXISTS engram_tags (
+      engram_id TEXT NOT NULL REFERENCES engram_index(id) ON DELETE CASCADE,
+      tag       TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_engram_tags_pair ON engram_tags(engram_id, tag);
+    CREATE INDEX IF NOT EXISTS idx_engram_tags_tag ON engram_tags(tag);
+
+    -- target_id intentionally has no FK — frontmatter may reference engrams that
+    -- have not yet been indexed (created before target file is processed).
+    CREATE TABLE IF NOT EXISTS engram_links (
+      source_id TEXT NOT NULL REFERENCES engram_index(id) ON DELETE CASCADE,
+      target_id TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_engram_links_pair ON engram_links(source_id, target_id);
+    CREATE INDEX IF NOT EXISTS idx_engram_links_target ON engram_links(target_id);
   `);
 
   // Seed the system "Manual Queue" rotation source (PRD-071 US-01).

--- a/apps/pops-api/src/modules/cerebrum/engrams/file.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/file.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  countWords,
+  deriveTitle,
+  EngramParseError,
+  parseEngramFile,
+  serializeEngram,
+} from './file.js';
+import { canTransitionStatus, type EngramFrontmatter } from './schema.js';
+
+const BASE_FRONTMATTER: EngramFrontmatter = {
+  id: 'eng_20260418_0900_hello-world',
+  type: 'note',
+  scopes: ['personal.notes'],
+  created: '2026-04-18T09:00:00+10:00',
+  modified: '2026-04-18T09:00:00+10:00',
+  source: 'manual',
+  status: 'active',
+};
+
+describe('parseEngramFile', () => {
+  it('validates a well-formed engram', () => {
+    const file = [
+      '---',
+      `id: ${BASE_FRONTMATTER.id}`,
+      `type: ${BASE_FRONTMATTER.type}`,
+      'scopes:',
+      '  - personal.notes',
+      `created: ${BASE_FRONTMATTER.created}`,
+      `modified: ${BASE_FRONTMATTER.modified}`,
+      `source: ${BASE_FRONTMATTER.source}`,
+      `status: ${BASE_FRONTMATTER.status}`,
+      '---',
+      '',
+      '# Hello World',
+      '',
+      'Body text.',
+      '',
+    ].join('\n');
+
+    const { frontmatter, body } = parseEngramFile(file);
+    expect(frontmatter.id).toBe(BASE_FRONTMATTER.id);
+    expect(frontmatter.scopes).toEqual(['personal.notes']);
+    expect(body).toContain('# Hello World');
+  });
+
+  it('rejects frontmatter missing required fields', () => {
+    const file = '---\ntype: note\n---\n\nbody';
+    expect(() => parseEngramFile(file)).toThrow(EngramParseError);
+  });
+
+  it('accepts plexus: prefixed sources', () => {
+    const file = serializeEngram({ ...BASE_FRONTMATTER, source: 'plexus:github' }, '# hi');
+    const { frontmatter } = parseEngramFile(file);
+    expect(frontmatter.source).toBe('plexus:github');
+  });
+
+  it('rejects unknown source channels', () => {
+    const bad = `---\n${[
+      `id: ${BASE_FRONTMATTER.id}`,
+      'type: note',
+      'scopes:',
+      '  - personal.notes',
+      `created: ${BASE_FRONTMATTER.created}`,
+      `modified: ${BASE_FRONTMATTER.modified}`,
+      'source: smoke-signal',
+      'status: active',
+    ].join('\n')}\n---\n\nbody\n`;
+    expect(() => parseEngramFile(bad)).toThrow(EngramParseError);
+  });
+
+  it('preserves template-defined custom fields', () => {
+    const fm = { ...BASE_FRONTMATTER, template: 'decision', outcome: 'pending' };
+    const file = serializeEngram(fm as EngramFrontmatter, '# Decision');
+    const { frontmatter } = parseEngramFile(file);
+    expect((frontmatter as Record<string, unknown>)['outcome']).toBe('pending');
+  });
+});
+
+describe('serializeEngram', () => {
+  it('round-trips', () => {
+    const serialized = serializeEngram(BASE_FRONTMATTER, '# Hi\n\nBody.');
+    const { frontmatter, body } = parseEngramFile(serialized);
+    expect(frontmatter).toMatchObject(BASE_FRONTMATTER);
+    expect(body.trim()).toBe('# Hi\n\nBody.');
+  });
+
+  it('throws on invalid frontmatter at serialize time', () => {
+    expect(() =>
+      serializeEngram({ ...BASE_FRONTMATTER, scopes: [] } as EngramFrontmatter, 'body')
+    ).toThrow();
+  });
+});
+
+describe('deriveTitle', () => {
+  it('returns the first H1', () => {
+    expect(deriveTitle('\n# The Title\n\nbody')).toBe('The Title');
+  });
+
+  it('falls back to the first non-empty line when no H1', () => {
+    expect(deriveTitle('\n\nA plain line\nlater line')).toBe('A plain line');
+  });
+
+  it('returns Untitled for empty body', () => {
+    expect(deriveTitle('   \n\n')).toBe('Untitled');
+  });
+});
+
+describe('countWords', () => {
+  it('counts whitespace-delimited tokens', () => {
+    expect(countWords('one two  three\nfour')).toBe(4);
+  });
+
+  it('returns 0 for empty body', () => {
+    expect(countWords('   \n\n')).toBe(0);
+  });
+});
+
+describe('canTransitionStatus', () => {
+  it('permits active to archived', () => {
+    expect(canTransitionStatus('active', 'archived')).toBe(true);
+  });
+
+  it('treats consolidated and stale as terminal', () => {
+    expect(canTransitionStatus('consolidated', 'active')).toBe(false);
+    expect(canTransitionStatus('stale', 'active')).toBe(false);
+  });
+
+  it('allows restoring archived to active', () => {
+    expect(canTransitionStatus('archived', 'active')).toBe(true);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/file.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/file.ts
@@ -1,0 +1,125 @@
+/**
+ * Parse and serialize engram files on disk.
+ *
+ * The file is the source of truth. These helpers bridge the on-disk Markdown
+ * format and the validated in-memory shape; every read goes through
+ * `parseEngramFile`, every write through `serializeEngram`.
+ */
+import matter from 'gray-matter';
+import { dump as yamlDump, JSON_SCHEMA as yamlJsonSchema, load as yamlLoad } from 'js-yaml';
+import { ZodError } from 'zod';
+
+import { engramFrontmatterSchema, type EngramFrontmatter } from './schema.js';
+
+/**
+ * Use js-yaml's JSON_SCHEMA (not DEFAULT_SCHEMA) so ISO timestamps stay as
+ * strings rather than being parsed into `Date` objects. Preserving the
+ * original string preserves the timezone offset the user wrote.
+ */
+const yamlEngine = {
+  parse: (input: string): object => {
+    const out = yamlLoad(input, { schema: yamlJsonSchema });
+    return out && typeof out === 'object' ? (out as object) : {};
+  },
+  stringify: (input: object): string =>
+    yamlDump(input, { schema: yamlJsonSchema, lineWidth: -1, noRefs: true }),
+};
+
+const MATTER_OPTIONS = { engines: { yaml: yamlEngine }, language: 'yaml' } as const;
+
+export class EngramParseError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'EngramParseError';
+  }
+}
+
+export interface ParsedEngram {
+  frontmatter: EngramFrontmatter;
+  body: string;
+}
+
+/** Parse a raw file string into validated frontmatter and a Markdown body. */
+export function parseEngramFile(content: string): ParsedEngram {
+  let parsed: matter.GrayMatterFile<string>;
+  try {
+    parsed = matter(content, MATTER_OPTIONS);
+  } catch (err) {
+    throw new EngramParseError('Failed to parse YAML frontmatter', err);
+  }
+
+  try {
+    const frontmatter = engramFrontmatterSchema.parse(parsed.data);
+    return { frontmatter, body: parsed.content };
+  } catch (err) {
+    if (err instanceof ZodError) {
+      throw new EngramParseError(`Invalid engram frontmatter: ${err.message}`, err);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Produce a valid engram file string. Frontmatter keys are ordered for
+ * readable diffs; the body is trimmed and re-terminated with a single newline.
+ */
+export function serializeEngram(frontmatter: EngramFrontmatter, body: string): string {
+  // Validate so callers can't write malformed files by accident.
+  const valid = engramFrontmatterSchema.parse(frontmatter);
+  const ordered = orderFrontmatter(valid);
+  const trimmedBody = `${body.trimEnd()}\n`;
+  return matter.stringify(trimmedBody, ordered, MATTER_OPTIONS);
+}
+
+const FRONTMATTER_KEY_ORDER: readonly string[] = [
+  'id',
+  'type',
+  'scopes',
+  'created',
+  'modified',
+  'source',
+  'tags',
+  'links',
+  'status',
+  'template',
+];
+
+function orderFrontmatter(fm: EngramFrontmatter): Record<string, unknown> {
+  const source = fm as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of FRONTMATTER_KEY_ORDER) {
+    const value = source[key];
+    if (value !== undefined) out[key] = value;
+  }
+  // Preserve template-supplied custom fields at the bottom, sorted for diff stability.
+  const knownKeys = new Set<string>(FRONTMATTER_KEY_ORDER);
+  const customKeys = Object.keys(source)
+    .filter((k) => !knownKeys.has(k))
+    .toSorted();
+  for (const key of customKeys) {
+    out[key] = source[key];
+  }
+  return out;
+}
+
+/** Extract the first H1 heading from a body, or fall back to the first non-empty line. */
+export function deriveTitle(body: string): string {
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const h1 = /^#\s+(.+)$/.exec(line);
+    if (h1?.[1]) return h1[1].trim();
+    return line;
+  }
+  return 'Untitled';
+}
+
+/** Count words in the body (not frontmatter). Whitespace-delimited tokens. */
+export function countWords(body: string): number {
+  const trimmed = body.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}

--- a/apps/pops-api/src/modules/cerebrum/engrams/id.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/id.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatIdTimestamp, generateEngramId, slugify } from './id.js';
+
+describe('slugify', () => {
+  it('lowercases and hyphenates', () => {
+    expect(slugify('Agent Coordination Landscape')).toBe('agent-coordination-landscape');
+  });
+
+  it('strips diacritics', () => {
+    expect(slugify('Café déjà vu')).toBe('cafe-deja-vu');
+  });
+
+  it('collapses runs of non-alphanumerics', () => {
+    expect(slugify('foo   bar--baz_qux')).toBe('foo-bar-baz-qux');
+  });
+
+  it('truncates to 40 characters without leaving a trailing hyphen', () => {
+    const out = slugify('the quick brown fox jumps over the lazy dog really fast');
+    expect(out.length).toBeLessThanOrEqual(40);
+    expect(out.endsWith('-')).toBe(false);
+  });
+
+  it('returns "untitled" when no alphanumerics survive', () => {
+    expect(slugify('???!!!')).toBe('untitled');
+  });
+});
+
+describe('formatIdTimestamp', () => {
+  it('formats local date and time', () => {
+    const d = new Date(2026, 3, 18, 9, 5); // April 18, 09:05 local
+    expect(formatIdTimestamp(d)).toBe('20260418_0905');
+  });
+});
+
+describe('generateEngramId', () => {
+  const now = new Date(2026, 3, 18, 9, 42);
+
+  it('produces eng_{YYYYMMDD}_{HHmm}_{slug}', () => {
+    expect(generateEngramId({ title: 'Hello World', now })).toBe('eng_20260418_0942_hello-world');
+  });
+
+  it('appends a counter on collision', () => {
+    const taken = new Set(['eng_20260418_0942_hello', 'eng_20260418_0942_hello_2']);
+    const id = generateEngramId({
+      title: 'hello',
+      now,
+      isTaken: (c) => taken.has(c),
+    });
+    expect(id).toBe('eng_20260418_0942_hello_3');
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/id.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/id.ts
@@ -1,0 +1,62 @@
+/**
+ * Deterministic engram IDs.
+ *
+ * An engram's ID is a human-readable stamp: `eng_{YYYYMMDD}_{HHmm}_{slug}`.
+ * It also doubles as the filename, so the format must be filesystem-safe and
+ * stable across machines. Collisions are extremely unlikely inside a single
+ * minute on a single-user system, but we still append a counter suffix when
+ * two engrams share a title and minute.
+ */
+
+const MAX_SLUG_LENGTH = 40;
+
+/**
+ * Normalize a title into a filesystem-safe slug. Strips diacritics, lowercases,
+ * replaces non-alphanumerics with hyphens, collapses runs, and trims.
+ */
+export function slugify(title: string): string {
+  const normalized = title
+    .normalize('NFKD')
+    .replaceAll(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '');
+
+  if (normalized.length === 0) return 'untitled';
+  return normalized.slice(0, MAX_SLUG_LENGTH).replaceAll(/-+$/g, '') || 'untitled';
+}
+
+/** Format a Date as the `YYYYMMDD_HHmm` timestamp used in engram IDs. */
+export function formatIdTimestamp(date: Date): string {
+  const pad = (n: number, width = 2): string => String(n).padStart(width, '0');
+  const yyyy = pad(date.getFullYear(), 4);
+  const mm = pad(date.getMonth() + 1);
+  const dd = pad(date.getDate());
+  const hh = pad(date.getHours());
+  const min = pad(date.getMinutes());
+  return `${yyyy}${mm}${dd}_${hh}${min}`;
+}
+
+export interface GenerateIdInput {
+  title: string;
+  now?: Date;
+  /**
+   * Collision probe — should return true if the candidate ID is already taken.
+   * The caller owns the lookup (disk, index, or both).
+   */
+  isTaken?: (candidate: string) => boolean;
+}
+
+/**
+ * Generate a unique engram ID from a title. Appends `_2`, `_3`, … when the
+ * caller reports a collision.
+ */
+export function generateEngramId(input: GenerateIdInput): string {
+  const { title, now = new Date(), isTaken } = input;
+  const base = `eng_${formatIdTimestamp(now)}_${slugify(title)}`;
+  if (!isTaken || !isTaken(base)) return base;
+
+  let suffix = 2;
+  while (isTaken(`${base}_${suffix}`)) suffix += 1;
+  return `${base}_${suffix}`;
+}

--- a/apps/pops-api/src/modules/cerebrum/engrams/router.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/router.test.ts
@@ -79,6 +79,18 @@ describe('cerebrum tRPC router', () => {
     await expect(caller.cerebrum.templates.get({ name: 'missing' })).rejects.toThrow(/not found/i);
   });
 
+  it('surfaces the specific reason from a ValidationError (not generic "Validation failed")', async () => {
+    const caller = createCaller();
+    await expect(
+      caller.cerebrum.engrams.create({
+        type: 'decision',
+        title: 'Missing fields',
+        scopes: ['work'],
+        template: 'decision',
+      })
+    ).rejects.toThrow(/decision/i);
+  });
+
   it('delete archives instead of physically deleting', async () => {
     const caller = createCaller();
     const { engram } = await caller.cerebrum.engrams.create({

--- a/apps/pops-api/src/modules/cerebrum/engrams/router.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/router.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, setDb } from '../../../db.js';
+import { appRouter } from '../../../router.js';
+import { createTestDb } from '../../../shared/test-utils.js';
+import { resetCerebrumCache } from '../instance.js';
+
+import type { Database } from 'better-sqlite3';
+
+function createCaller() {
+  return appRouter.createCaller({ user: { email: 'test@example.com' } });
+}
+
+describe('cerebrum tRPC router', () => {
+  let db: Database;
+  let root: string;
+  let previousRoot: string | undefined;
+
+  beforeEach(() => {
+    db = createTestDb();
+    setDb(db);
+    root = mkdtempSync(join(tmpdir(), 'cerebrum-router-'));
+    previousRoot = process.env['ENGRAM_ROOT'];
+    process.env['ENGRAM_ROOT'] = root;
+    resetCerebrumCache();
+  });
+
+  afterEach(() => {
+    closeDb();
+    rmSync(root, { recursive: true, force: true });
+    if (previousRoot === undefined) delete process.env['ENGRAM_ROOT'];
+    else process.env['ENGRAM_ROOT'] = previousRoot;
+    resetCerebrumCache();
+  });
+
+  it('cerebrum.engrams.create + get + list round-trip', async () => {
+    const caller = createCaller();
+    const { engram } = await caller.cerebrum.engrams.create({
+      type: 'note',
+      title: 'Router Hello',
+      body: '# Router Hello\n\nHi.',
+      scopes: ['personal.notes'],
+    });
+    expect(engram.title).toBe('Router Hello');
+
+    const fetched = await caller.cerebrum.engrams.get({ id: engram.id });
+    expect(fetched.engram.id).toBe(engram.id);
+    expect(fetched.body).toContain('Hi.');
+
+    const listed = await caller.cerebrum.engrams.list({ type: 'note' });
+    expect(listed.total).toBe(1);
+    expect(listed.engrams[0]?.id).toBe(engram.id);
+  });
+
+  it('templates.list returns the bundled defaults', async () => {
+    const caller = createCaller();
+    const { templates } = await caller.cerebrum.templates.list();
+    const names = templates.map((t) => t.name).toSorted();
+    expect(names).toEqual([
+      'capture',
+      'decision',
+      'idea',
+      'journal',
+      'meeting',
+      'note',
+      'research',
+    ]);
+  });
+
+  it('templates.get returns a single template or NOT_FOUND', async () => {
+    const caller = createCaller();
+    const { template } = await caller.cerebrum.templates.get({ name: 'decision' });
+    expect(template.required_fields).toEqual(['decision', 'alternatives']);
+
+    await expect(caller.cerebrum.templates.get({ name: 'missing' })).rejects.toThrow(/not found/i);
+  });
+
+  it('delete archives instead of physically deleting', async () => {
+    const caller = createCaller();
+    const { engram } = await caller.cerebrum.engrams.create({
+      type: 'note',
+      title: 'To delete',
+      body: '# x',
+      scopes: ['x'],
+    });
+    await caller.cerebrum.engrams.delete({ id: engram.id });
+
+    const fetched = await caller.cerebrum.engrams.get({ id: engram.id });
+    expect(fetched.engram.status).toBe('archived');
+    expect(fetched.engram.filePath.startsWith('.archive/')).toBe(true);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/router.ts
@@ -1,0 +1,135 @@
+/**
+ * tRPC router for cerebrum.engrams.
+ *
+ * The router is a thin adapter over the EngramService — no file or database
+ * work lives here. All business logic belongs to the service layer.
+ */
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { HttpError, NotFoundError, ValidationError } from '../../../shared/errors.js';
+import { protectedProcedure, router } from '../../../trpc.js';
+import { getEngramService } from '../instance.js';
+import { ENGRAM_STATUSES, engramIdSchema, engramSourceSchema } from './schema.js';
+
+const customFieldsSchema = z.record(z.string(), z.unknown());
+
+const sortSchema = z.object({
+  field: z.enum(['created_at', 'modified_at', 'title']),
+  direction: z.enum(['asc', 'desc']),
+});
+
+const createSchema = z.object({
+  type: z.string().min(1),
+  title: z.string().min(1),
+  body: z.string().optional(),
+  scopes: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+  template: z.string().min(1).optional(),
+  customFields: customFieldsSchema.optional(),
+  source: engramSourceSchema.optional(),
+  links: z.array(engramIdSchema).optional(),
+});
+
+const updateSchema = z.object({
+  id: engramIdSchema,
+  title: z.string().min(1).optional(),
+  body: z.string().optional(),
+  scopes: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+  customFields: customFieldsSchema.optional(),
+  status: z.enum(ENGRAM_STATUSES).optional(),
+});
+
+const listSchema = z
+  .object({
+    type: z.string().optional(),
+    scopes: z.array(z.string().min(1)).optional(),
+    tags: z.array(z.string().min(1)).optional(),
+    status: z.enum(ENGRAM_STATUSES).optional(),
+    search: z.string().optional(),
+    limit: z.number().int().positive().max(500).optional(),
+    offset: z.number().int().nonnegative().optional(),
+    sort: sortSchema.optional(),
+  })
+  .optional();
+
+const linkSchema = z.object({
+  sourceId: engramIdSchema,
+  targetId: engramIdSchema,
+});
+
+function toTrpcError(err: unknown): never {
+  if (err instanceof NotFoundError) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+  }
+  if (err instanceof ValidationError) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: err.message, cause: err });
+  }
+  if (err instanceof HttpError) {
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: err.message });
+  }
+  throw err;
+}
+
+export const engramsRouter = router({
+  create: protectedProcedure.input(createSchema).mutation(({ input }) => {
+    try {
+      const engram = getEngramService().create(input);
+      return { engram };
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+
+  get: protectedProcedure.input(z.object({ id: engramIdSchema })).query(({ input }) => {
+    try {
+      const { engram, body } = getEngramService().read(input.id);
+      return { engram, body };
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+
+  update: protectedProcedure.input(updateSchema).mutation(({ input }) => {
+    try {
+      const { id, ...changes } = input;
+      const engram = getEngramService().update(id, changes);
+      return { engram };
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+
+  delete: protectedProcedure.input(z.object({ id: engramIdSchema })).mutation(({ input }) => {
+    try {
+      getEngramService().archive(input.id);
+      return { success: true };
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+
+  list: protectedProcedure.input(listSchema).query(({ input }) => {
+    const { engrams, total } = getEngramService().list(input ?? {});
+    return { engrams, total };
+  }),
+
+  link: protectedProcedure.input(linkSchema).mutation(({ input }) => {
+    try {
+      getEngramService().link(input.sourceId, input.targetId);
+      return { success: true };
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+
+  unlink: protectedProcedure.input(linkSchema).mutation(({ input }) => {
+    try {
+      getEngramService().unlink(input.sourceId, input.targetId);
+      return { success: true };
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/router.ts
@@ -23,7 +23,10 @@ const createSchema = z.object({
   type: z.string().min(1),
   title: z.string().min(1),
   body: z.string().optional(),
-  scopes: z.array(z.string().min(1)).optional(),
+  // `.min(1)` matches the engram frontmatter contract (at least one scope
+  // required). A template may inject `default_scopes`, so we allow `scopes`
+  // itself to be omitted — but never an empty array.
+  scopes: z.array(z.string().min(1)).min(1).optional(),
   tags: z.array(z.string().min(1)).optional(),
   template: z.string().min(1).optional(),
   customFields: customFieldsSchema.optional(),
@@ -35,7 +38,9 @@ const updateSchema = z.object({
   id: engramIdSchema,
   title: z.string().min(1).optional(),
   body: z.string().optional(),
-  scopes: z.array(z.string().min(1)).optional(),
+  // If `scopes` is present it must be non-empty; the frontmatter validator
+  // would otherwise reject the resulting file mid-write.
+  scopes: z.array(z.string().min(1)).min(1).optional(),
   tags: z.array(z.string().min(1)).optional(),
   customFields: customFieldsSchema.optional(),
   status: z.enum(ENGRAM_STATUSES).optional(),
@@ -64,7 +69,19 @@ function toTrpcError(err: unknown): never {
     throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
   }
   if (err instanceof ValidationError) {
-    throw new TRPCError({ code: 'BAD_REQUEST', message: err.message, cause: err });
+    // ValidationError.message is the generic "Validation failed" — the actual
+    // reason is stashed in `details`. Surface it so clients can show
+    // actionable feedback (e.g. "decision, alternatives are required").
+    const details = err.details;
+    const message =
+      typeof details === 'string'
+        ? details
+        : typeof details === 'object' &&
+            details !== null &&
+            typeof (details as { message?: unknown }).message === 'string'
+          ? (details as { message: string }).message
+          : err.message;
+    throw new TRPCError({ code: 'BAD_REQUEST', message, cause: err });
   }
   if (err instanceof HttpError) {
     throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: err.message });

--- a/apps/pops-api/src/modules/cerebrum/engrams/schema.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/schema.ts
@@ -1,0 +1,76 @@
+/**
+ * Engram Zod schemas.
+ *
+ * A single source of truth for both the file-format validator (used when
+ * parsing Markdown files on disk) and the API input validators (used at the
+ * tRPC layer). Shared so that a well-formed API call always round-trips to a
+ * well-formed engram file.
+ */
+import { z } from 'zod';
+
+export const ENGRAM_STATUSES = ['active', 'archived', 'consolidated', 'stale'] as const;
+export type EngramStatus = (typeof ENGRAM_STATUSES)[number];
+
+export const ENGRAM_SOURCES = ['manual', 'agent', 'moltbot', 'cli'] as const;
+/**
+ * Source of an engram. Plain values are the fixed channels; `plexus:{name}`
+ * is a namespaced prefix for plugin-driven ingestion.
+ */
+export const engramSourceSchema = z
+  .string()
+  .refine(
+    (value): value is EngramSource =>
+      (ENGRAM_SOURCES as readonly string[]).includes(value) || value.startsWith('plexus:'),
+    { message: "source must be one of 'manual|agent|moltbot|cli' or 'plexus:{name}'" }
+  );
+export type EngramSource = (typeof ENGRAM_SOURCES)[number] | `plexus:${string}`;
+
+/**
+ * A minimal ISO-8601 validator. Accepts an offset or 'Z'. We don't enforce
+ * milliseconds so `Date#toISOString` and editor-written values both pass.
+ */
+export const iso8601Schema = z
+  .string()
+  .regex(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$/,
+    'must be an ISO 8601 timestamp with timezone'
+  );
+
+export const ENGRAM_ID_PATTERN = /^eng_\d{8}_\d{4}_[a-z0-9-]+$/;
+export const engramIdSchema = z
+  .string()
+  .regex(ENGRAM_ID_PATTERN, 'must match eng_{YYYYMMDD}_{HHmm}_{slug}');
+
+/** Engram frontmatter — canonical shape of the YAML block in any `.md` file. */
+export const engramFrontmatterSchema = z
+  .object({
+    id: engramIdSchema,
+    type: z.string().min(1),
+    scopes: z.array(z.string().min(1)).min(1, 'at least one scope is required'),
+    created: iso8601Schema,
+    modified: iso8601Schema,
+    source: engramSourceSchema,
+    tags: z.array(z.string().min(1)).optional(),
+    links: z.array(engramIdSchema).optional(),
+    status: z.enum(ENGRAM_STATUSES),
+    template: z.string().min(1).optional(),
+  })
+  .passthrough();
+// `.passthrough()` preserves template-defined custom fields on the frontmatter
+// object so the CRUD service can store them in `custom_fields` without losing
+// unknown keys.
+
+export type EngramFrontmatter = z.infer<typeof engramFrontmatterSchema>;
+
+/** Status transitions enforced at the service layer. */
+const STATUS_TRANSITIONS: Record<EngramStatus, readonly EngramStatus[]> = {
+  active: ['archived', 'consolidated', 'stale'],
+  archived: ['active'],
+  consolidated: [],
+  stale: [],
+};
+
+export function canTransitionStatus(from: EngramStatus, to: EngramStatus): boolean {
+  if (from === to) return true;
+  return STATUS_TRANSITIONS[from].includes(to);
+}

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.test.ts
@@ -89,7 +89,7 @@ describe('EngramService', () => {
     expect(fileContent).toContain('Node');
   });
 
-  it('falls back to capture-style when the template does not exist', () => {
+  it('falls back to capture-style when the template does not exist (PRD-077 US-02)', () => {
     const engram = service.create({
       type: 'note',
       title: 'Falls back',
@@ -97,7 +97,32 @@ describe('EngramService', () => {
       template: 'nonexistent',
     });
     expect(engram.template).toBeNull();
-    expect(engram.type).toBe('note');
+    expect(engram.type).toBe('capture');
+    expect(engram.filePath.startsWith('capture/')).toBe(true);
+  });
+
+  it('rejects unsafe type values that could escape the engram root', () => {
+    expect(() =>
+      service.create({ type: '../etc', title: 'bad', body: '# x', scopes: ['x'] })
+    ).toThrow(ValidationError);
+    expect(() =>
+      service.create({ type: '.archive', title: 'bad', body: '# x', scopes: ['x'] })
+    ).toThrow(ValidationError);
+  });
+
+  it('dedupes duplicate scopes/tags/links from input', () => {
+    const engram = service.create({
+      type: 'note',
+      title: 'Dedupe',
+      body: '# Dedupe',
+      scopes: ['work', 'work', 'personal'],
+      tags: ['a', 'a', 'b'],
+    });
+    // The hydrator reads junction rows without ordering so compare as sets.
+    expect(new Set(engram.scopes)).toEqual(new Set(['work', 'personal']));
+    expect(engram.scopes).toHaveLength(2);
+    expect(new Set(engram.tags)).toEqual(new Set(['a', 'b']));
+    expect(engram.tags).toHaveLength(2);
   });
 
   it('updates title, body, and scopes and bumps modified', () => {

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.test.ts
@@ -1,0 +1,196 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { NotFoundError, ValidationError } from '../../../shared/errors.js';
+import { createTestDb } from '../../../shared/test-utils.js';
+import { TemplateRegistry } from '../templates/registry.js';
+import { seedDefaultTemplates } from '../templates/seed.js';
+import { parseEngramFile } from './file.js';
+import { EngramService } from './service.js';
+
+import type { Database } from 'better-sqlite3';
+
+/** A fixed clock that advances one minute per call. */
+function makeClock(start = new Date('2026-04-18T09:00:00Z')): () => Date {
+  let t = start.getTime();
+  return () => {
+    const d = new Date(t);
+    t += 60_000;
+    return d;
+  };
+}
+
+describe('EngramService', () => {
+  let db: Database;
+  let service: EngramService;
+  let root: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    root = mkdtempSync(join(tmpdir(), 'cerebrum-engrams-'));
+    const templatesDir = join(root, '.templates');
+    seedDefaultTemplates(templatesDir);
+    service = new EngramService({
+      root,
+      db: drizzle(db),
+      templates: new TemplateRegistry(templatesDir),
+      now: makeClock(),
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    db.close();
+  });
+
+  it('creates an engram file and index row', () => {
+    const engram = service.create({
+      type: 'note',
+      title: 'Hello World',
+      body: '# Hello World\n\nThe body.',
+      scopes: ['personal.notes'],
+    });
+
+    expect(engram.id).toMatch(/^eng_\d{8}_\d{4}_hello-world$/);
+    expect(engram.filePath).toBe(`note/${engram.id}.md`);
+    expect(engram.wordCount).toBeGreaterThan(0);
+    expect(existsSync(join(root, engram.filePath))).toBe(true);
+
+    const content = readFileSync(join(root, engram.filePath), 'utf8');
+    const { frontmatter, body } = parseEngramFile(content);
+    expect(frontmatter.id).toBe(engram.id);
+    expect(frontmatter.scopes).toEqual(['personal.notes']);
+    expect(body.trim()).toContain('The body.');
+  });
+
+  it('rejects create without scopes when no template is applied', () => {
+    expect(() => service.create({ type: 'note', title: 'No scope', body: 'x' })).toThrow(
+      ValidationError
+    );
+  });
+
+  it('uses a template to scaffold, merge scopes, and validate required fields', () => {
+    const engram = service.create({
+      type: 'decision',
+      title: 'Pick runtime',
+      scopes: ['work'],
+      template: 'decision',
+      customFields: { decision: 'Node', alternatives: ['Bun', 'Deno'] },
+    });
+    expect(engram.template).toBe('decision');
+    expect(engram.scopes).toEqual(['work']);
+    expect(engram.customFields['decision']).toBe('Node');
+    const fileContent = readFileSync(join(root, engram.filePath), 'utf8');
+    expect(fileContent).toContain('## Decision');
+    expect(fileContent).toContain('Node');
+  });
+
+  it('falls back to capture-style when the template does not exist', () => {
+    const engram = service.create({
+      type: 'note',
+      title: 'Falls back',
+      scopes: ['personal'],
+      template: 'nonexistent',
+    });
+    expect(engram.template).toBeNull();
+    expect(engram.type).toBe('note');
+  });
+
+  it('updates title, body, and scopes and bumps modified', () => {
+    const engram = service.create({
+      type: 'note',
+      title: 'First',
+      body: '# First\n\nbody',
+      scopes: ['personal'],
+    });
+    const updated = service.update(engram.id, {
+      title: 'Second',
+      scopes: ['personal', 'work'],
+    });
+    expect(updated.title).toBe('Second');
+    expect(updated.scopes).toEqual(['personal', 'work']);
+    expect(updated.modified).not.toBe(engram.modified);
+  });
+
+  it('archives an engram — file moves to .archive/ and status flips', () => {
+    const engram = service.create({
+      type: 'note',
+      title: 'To archive',
+      body: '# body',
+      scopes: ['personal'],
+    });
+    const archived = service.archive(engram.id);
+    expect(archived.status).toBe('archived');
+    expect(archived.filePath.startsWith('.archive/')).toBe(true);
+    expect(existsSync(join(root, engram.filePath))).toBe(false);
+    expect(existsSync(join(root, archived.filePath))).toBe(true);
+  });
+
+  it('links two engrams bidirectionally in both files and the index', () => {
+    const a = service.create({ type: 'note', title: 'A', body: '# a', scopes: ['x'] });
+    const b = service.create({ type: 'note', title: 'B', body: '# b', scopes: ['x'] });
+
+    service.link(a.id, b.id);
+
+    const reloadA = service.read(a.id).engram;
+    const reloadB = service.read(b.id).engram;
+    expect(reloadA.links).toContain(b.id);
+    expect(reloadB.links).toContain(a.id);
+  });
+
+  it('unlink removes links in both directions', () => {
+    const a = service.create({ type: 'note', title: 'A', body: '# a', scopes: ['x'] });
+    const b = service.create({ type: 'note', title: 'B', body: '# b', scopes: ['x'] });
+    service.link(a.id, b.id);
+    service.unlink(a.id, b.id);
+    expect(service.read(a.id).engram.links).not.toContain(b.id);
+    expect(service.read(b.id).engram.links).not.toContain(a.id);
+  });
+
+  it('list filters by type, scope, and tag', () => {
+    service.create({ type: 'note', title: 'One', body: '# o', scopes: ['work'], tags: ['t1'] });
+    service.create({ type: 'note', title: 'Two', body: '# t', scopes: ['personal'], tags: ['t2'] });
+    service.create({
+      type: 'decision',
+      title: 'Three',
+      body: '# th',
+      scopes: ['work'],
+      template: 'decision',
+      customFields: { decision: 'ok', alternatives: ['a'] },
+    });
+
+    expect(service.list({ type: 'note' }).total).toBe(2);
+    expect(service.list({ scopes: ['work'] }).total).toBe(2);
+    expect(service.list({ tags: ['t1'] }).total).toBe(1);
+    expect(service.list({ type: 'note', tags: ['t2'] }).total).toBe(1);
+  });
+
+  it('reindex rebuilds the index from files', () => {
+    const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+    service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });
+
+    // Directly nuke the index to simulate drift.
+    db.exec('DELETE FROM engram_index');
+    expect(service.list({}).total).toBe(0);
+
+    const result = service.reindex();
+    expect(result.indexed).toBe(2);
+    expect(service.list({}).total).toBe(2);
+    expect(service.read(a.id).engram.title).toBe('A');
+  });
+
+  it('read throws NotFound for unknown id', () => {
+    expect(() => service.read('eng_20260101_0000_nope')).toThrow(NotFoundError);
+  });
+
+  it('link accepts a missing target (creates index row but does not write a target file)', () => {
+    const a = service.create({ type: 'note', title: 'A', body: '# a', scopes: ['x'] });
+    const ghostId = 'eng_20260101_0000_ghost';
+    service.link(a.id, ghostId);
+    expect(service.read(a.id).engram.links).toContain(ghostId);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.ts
@@ -1,0 +1,713 @@
+/**
+ * Engram CRUD service — the only code that writes to the filesystem and the
+ * engram index. The file is always the source of truth; the index is a
+ * rebuildable cache of the frontmatter.
+ *
+ * Invariants:
+ *  - Every write writes the file atomically (temp + rename) before touching
+ *    the index, so a crash mid-write never leaves a ghost index row.
+ *  - `modified` frontmatter is set on every write, including link-only edits.
+ *  - Links are bidirectional — linking A→B writes both files.
+ *  - Deletes move to `.archive/` with the original type subdirectory preserved.
+ */
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative, sep } from 'node:path';
+
+import { and, count, eq, inArray, like, sql } from 'drizzle-orm';
+
+import { engramIndex, engramLinks, engramScopes, engramTags } from '@pops/db-types';
+
+import { NotFoundError, ValidationError } from '../../../shared/errors.js';
+import { applyTemplate } from '../templates/apply.js';
+import { countWords, deriveTitle, parseEngramFile, serializeEngram } from './file.js';
+import { generateEngramId } from './id.js';
+import {
+  canTransitionStatus,
+  ENGRAM_ID_PATTERN,
+  type EngramFrontmatter,
+  type EngramSource,
+  type EngramStatus,
+} from './schema.js';
+import { buildEngram, type Engram } from './types.js';
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+import type { TemplateRegistry } from '../templates/registry.js';
+
+const ARCHIVE_DIR = '.archive';
+const TEMPLATES_DIR = '.templates';
+const CONFIG_DIR = '.config';
+const INDEX_DIR = '.index';
+const WELL_KNOWN_DIRS = new Set([ARCHIVE_DIR, TEMPLATES_DIR, CONFIG_DIR, INDEX_DIR]);
+
+export interface CreateEngramInput {
+  type: string;
+  title: string;
+  body?: string;
+  scopes?: string[];
+  tags?: string[];
+  template?: string;
+  customFields?: Record<string, unknown>;
+  source?: EngramSource;
+  links?: string[];
+}
+
+export interface UpdateEngramInput {
+  title?: string;
+  body?: string;
+  scopes?: string[];
+  tags?: string[];
+  customFields?: Record<string, unknown>;
+  status?: EngramStatus;
+}
+
+export interface ListEngramsOptions {
+  type?: string;
+  scopes?: string[];
+  tags?: string[];
+  status?: EngramStatus;
+  search?: string;
+  limit?: number;
+  offset?: number;
+  sort?: {
+    field: 'created_at' | 'modified_at' | 'title';
+    direction: 'asc' | 'desc';
+  };
+}
+
+export interface ListEngramsResult {
+  engrams: Engram[];
+  total: number;
+}
+
+export interface EngramServiceOptions {
+  /** Root of the engram directory, e.g. `/opt/pops/engrams`. */
+  root: string;
+  db: BetterSQLite3Database;
+  templates: TemplateRegistry;
+  /** Override for deterministic tests. Defaults to `new Date()`. */
+  now?: () => Date;
+}
+
+export class EngramService {
+  private readonly root: string;
+  private readonly db: BetterSQLite3Database;
+  private readonly templates: TemplateRegistry;
+  private readonly now: () => Date;
+
+  constructor(options: EngramServiceOptions) {
+    this.root = options.root;
+    this.db = options.db;
+    this.templates = options.templates;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  create(input: CreateEngramInput): Engram {
+    const scopes = input.scopes ?? [];
+    const tags = input.tags ?? [];
+    const source = input.source ?? 'manual';
+
+    if (scopes.length === 0) {
+      // A template may supply default_scopes — defer the min-1 check until after applyTemplate.
+      if (!input.template) {
+        throw new ValidationError({ message: 'at least one scope is required' });
+      }
+    }
+
+    let body = input.body ?? '';
+    let customFields: Record<string, unknown> = input.customFields ?? {};
+    let templateName: string | undefined = input.template;
+    let mergedScopes = scopes;
+
+    if (templateName) {
+      const template = this.templates.get(templateName);
+      if (!template) {
+        console.warn(
+          `[cerebrum] Template '${templateName}' not found — creating a 'capture' engram instead.`
+        );
+        templateName = undefined;
+      } else {
+        const applied = applyTemplate({
+          template,
+          title: input.title,
+          body: input.body,
+          scopes,
+          customFields,
+        });
+        body = applied.body;
+        mergedScopes = applied.scopes;
+        customFields = applied.customFields;
+      }
+    }
+
+    if (mergedScopes.length === 0) {
+      throw new ValidationError({ message: 'at least one scope is required' });
+    }
+
+    const type = templateName ? input.type : input.type || 'capture';
+    const id = generateEngramId({
+      title: input.title,
+      now: this.now(),
+      isTaken: (candidate) => this.isIdTaken(candidate, type),
+    });
+
+    const nowIso = this.now().toISOString();
+    const frontmatter: EngramFrontmatter = {
+      id,
+      type,
+      scopes: mergedScopes,
+      created: nowIso,
+      modified: nowIso,
+      source,
+      status: 'active',
+      ...(tags.length > 0 ? { tags } : {}),
+      ...(input.links && input.links.length > 0 ? { links: input.links } : {}),
+      ...(templateName ? { template: templateName } : {}),
+      ...customFields,
+    };
+
+    const fileContent = serializeEngram(frontmatter, body);
+    const relPath = join(type, `${id}.md`);
+    this.writeFileAtomic(relPath, fileContent);
+
+    this.upsertIndex({
+      id,
+      filePath: relPath,
+      frontmatter,
+      body,
+      customFields,
+    });
+
+    return this.loadEngram(id);
+  }
+
+  read(id: string): { engram: Engram; body: string } {
+    const row = this.getIndexRow(id);
+    const content = readFileSync(this.absolutePath(row.file_path), 'utf8');
+    const { frontmatter, body } = parseEngramFile(content);
+    return {
+      engram: buildEngram(frontmatter, {
+        filePath: row.file_path,
+        title: row.title,
+        contentHash: row.content_hash,
+        wordCount: row.word_count,
+        customFields: parseCustomFields(row.custom_fields),
+      }),
+      body,
+    };
+  }
+
+  update(id: string, changes: UpdateEngramInput): Engram {
+    const row = this.getIndexRow(id);
+    const existingContent = readFileSync(this.absolutePath(row.file_path), 'utf8');
+    const { frontmatter, body } = parseEngramFile(existingContent);
+
+    if (changes.status && !canTransitionStatus(frontmatter.status, changes.status)) {
+      throw new ValidationError({
+        message: `cannot transition status from '${frontmatter.status}' to '${changes.status}'`,
+      });
+    }
+
+    const nextBody = applyTitleChange(changes.body ?? body, changes.title);
+    const customFields: Record<string, unknown> = {
+      ...(row.custom_fields ? parseCustomFields(row.custom_fields) : {}),
+      ...changes.customFields,
+    };
+
+    const nextFrontmatter: EngramFrontmatter = {
+      ...frontmatter,
+      ...customFields,
+      modified: this.now().toISOString(),
+      ...(changes.scopes ? { scopes: changes.scopes } : {}),
+      ...(changes.tags ? { tags: changes.tags } : {}),
+      ...(changes.status ? { status: changes.status } : {}),
+    };
+
+    if (!changes.tags && frontmatter.tags) nextFrontmatter.tags = frontmatter.tags;
+    if (nextFrontmatter.tags && nextFrontmatter.tags.length === 0) delete nextFrontmatter.tags;
+
+    const file = serializeEngram(nextFrontmatter, nextBody);
+    this.writeFileAtomic(row.file_path, file);
+    this.upsertIndex({
+      id,
+      filePath: row.file_path,
+      frontmatter: nextFrontmatter,
+      body: nextBody,
+      customFields,
+    });
+
+    return this.loadEngram(id);
+  }
+
+  archive(id: string): Engram {
+    const row = this.getIndexRow(id);
+    const existingContent = readFileSync(this.absolutePath(row.file_path), 'utf8');
+    const { frontmatter, body } = parseEngramFile(existingContent);
+
+    if (frontmatter.status === 'archived') return this.loadEngram(id);
+
+    const nextFrontmatter: EngramFrontmatter = {
+      ...frontmatter,
+      status: 'archived',
+      modified: this.now().toISOString(),
+    };
+    const archivedPath = join(ARCHIVE_DIR, row.file_path);
+    const archivedAbs = this.absolutePath(archivedPath);
+    mkdirSync(dirname(archivedAbs), { recursive: true });
+
+    const file = serializeEngram(nextFrontmatter, body);
+    writeFileAtomic(archivedAbs, file);
+    const sourceAbs = this.absolutePath(row.file_path);
+    if (existsSync(sourceAbs)) unlinkSync(sourceAbs);
+
+    const customFields = row.custom_fields ? parseCustomFields(row.custom_fields) : {};
+    this.upsertIndex({
+      id,
+      filePath: archivedPath,
+      frontmatter: nextFrontmatter,
+      body,
+      customFields,
+    });
+
+    return this.loadEngram(id);
+  }
+
+  link(sourceId: string, targetId: string): void {
+    if (sourceId === targetId) {
+      throw new ValidationError({ message: 'cannot link an engram to itself' });
+    }
+    const sourceRow = this.getIndexRow(sourceId);
+    const targetRow = this.findIndexRow(targetId);
+
+    this.mutateFrontmatter(sourceRow.id, (fm) => {
+      const links = new Set(fm.links ?? []);
+      links.add(targetId);
+      return { ...fm, links: [...links], modified: this.now().toISOString() };
+    });
+
+    if (targetRow) {
+      this.mutateFrontmatter(targetId, (fm) => {
+        const links = new Set(fm.links ?? []);
+        links.add(sourceId);
+        return { ...fm, links: [...links], modified: this.now().toISOString() };
+      });
+    }
+
+    this.db
+      .insert(engramLinks)
+      .values([
+        { sourceId, targetId },
+        ...(targetRow ? [{ sourceId: targetId, targetId: sourceId }] : []),
+      ])
+      .onConflictDoNothing()
+      .run();
+  }
+
+  unlink(sourceId: string, targetId: string): void {
+    const sourceRow = this.getIndexRow(sourceId);
+    const targetRow = this.findIndexRow(targetId);
+
+    this.mutateFrontmatter(sourceRow.id, (fm) => ({
+      ...fm,
+      links: (fm.links ?? []).filter((l) => l !== targetId),
+      modified: this.now().toISOString(),
+    }));
+
+    if (targetRow) {
+      this.mutateFrontmatter(targetId, (fm) => ({
+        ...fm,
+        links: (fm.links ?? []).filter((l) => l !== sourceId),
+        modified: this.now().toISOString(),
+      }));
+    }
+
+    this.db
+      .delete(engramLinks)
+      .where(
+        sql`(${engramLinks.sourceId} = ${sourceId} AND ${engramLinks.targetId} = ${targetId}) OR (${engramLinks.sourceId} = ${targetId} AND ${engramLinks.targetId} = ${sourceId})`
+      )
+      .run();
+  }
+
+  list(opts: ListEngramsOptions = {}): ListEngramsResult {
+    const conditions = [];
+    if (opts.type) conditions.push(eq(engramIndex.type, opts.type));
+    if (opts.status) conditions.push(eq(engramIndex.status, opts.status));
+    if (opts.search) conditions.push(like(engramIndex.title, `%${opts.search}%`));
+    if (opts.scopes && opts.scopes.length > 0) {
+      const scopeIds = this.db
+        .selectDistinct({ engramId: engramScopes.engramId })
+        .from(engramScopes)
+        .where(inArray(engramScopes.scope, opts.scopes))
+        .all()
+        .map((r) => r.engramId);
+      conditions.push(scopeIds.length > 0 ? inArray(engramIndex.id, scopeIds) : sql`0 = 1`);
+    }
+    if (opts.tags && opts.tags.length > 0) {
+      const tagIds = this.db
+        .selectDistinct({ engramId: engramTags.engramId })
+        .from(engramTags)
+        .where(inArray(engramTags.tag, opts.tags))
+        .all()
+        .map((r) => r.engramId);
+      conditions.push(tagIds.length > 0 ? inArray(engramIndex.id, tagIds) : sql`0 = 1`);
+    }
+
+    const where = conditions.length === 0 ? undefined : and(...conditions);
+    const sortField = opts.sort?.field ?? 'modified_at';
+    const sortDir = opts.sort?.direction ?? 'desc';
+    const orderColumn =
+      sortField === 'title'
+        ? engramIndex.title
+        : sortField === 'created_at'
+          ? engramIndex.createdAt
+          : engramIndex.modifiedAt;
+
+    const limit = opts.limit ?? 50;
+    const offset = opts.offset ?? 0;
+
+    const rowsQuery = this.db.select().from(engramIndex).$dynamic();
+    const rows = (where ? rowsQuery.where(where) : rowsQuery)
+      .orderBy(sortDir === 'asc' ? orderColumn : sql`${orderColumn} desc`)
+      .limit(limit)
+      .offset(offset)
+      .all();
+
+    const totalQuery = this.db.select({ total: count() }).from(engramIndex).$dynamic();
+    const [totalRow] = (where ? totalQuery.where(where) : totalQuery).all();
+
+    return {
+      engrams: rows.map((row) => this.loadEngramFromRow(indexRowFromDrizzle(row))),
+      total: totalRow?.total ?? 0,
+    };
+  }
+
+  reindex(): { indexed: number } {
+    const files = this.listEngramFiles();
+    const rowsToInsert: {
+      row: typeof engramIndex.$inferInsert;
+      scopes: string[];
+      tags: string[];
+      links: string[];
+    }[] = [];
+    for (const relPath of files) {
+      const absPath = this.absolutePath(relPath);
+      const content = readFileSync(absPath, 'utf8');
+      let parsed;
+      try {
+        parsed = parseEngramFile(content);
+      } catch (err) {
+        console.warn(`[cerebrum] Skipping ${relPath}: ${(err as Error).message}`);
+        continue;
+      }
+      const { frontmatter, body } = parsed;
+      const title = deriveTitle(body);
+      const contentHash = sha256(content);
+      const wordCount = countWords(body);
+      const { customFields } = splitCustomFields(frontmatter);
+
+      rowsToInsert.push({
+        row: {
+          id: frontmatter.id,
+          filePath: relPath,
+          type: frontmatter.type,
+          source: frontmatter.source,
+          status: frontmatter.status,
+          template: frontmatter.template ?? null,
+          createdAt: frontmatter.created,
+          modifiedAt: frontmatter.modified,
+          title,
+          contentHash,
+          wordCount,
+          customFields: Object.keys(customFields).length > 0 ? JSON.stringify(customFields) : null,
+        },
+        scopes: frontmatter.scopes,
+        tags: frontmatter.tags ?? [],
+        links: frontmatter.links ?? [],
+      });
+    }
+
+    this.db.transaction((tx) => {
+      tx.delete(engramLinks).run();
+      tx.delete(engramTags).run();
+      tx.delete(engramScopes).run();
+      tx.delete(engramIndex).run();
+
+      for (const entry of rowsToInsert) {
+        tx.insert(engramIndex).values(entry.row).run();
+        if (entry.scopes.length > 0) {
+          tx.insert(engramScopes)
+            .values(entry.scopes.map((scope) => ({ engramId: entry.row.id, scope })))
+            .run();
+        }
+        if (entry.tags.length > 0) {
+          tx.insert(engramTags)
+            .values(entry.tags.map((tag) => ({ engramId: entry.row.id, tag })))
+            .run();
+        }
+        if (entry.links.length > 0) {
+          tx.insert(engramLinks)
+            .values(entry.links.map((targetId) => ({ sourceId: entry.row.id, targetId })))
+            .run();
+        }
+      }
+    });
+
+    return { indexed: rowsToInsert.length };
+  }
+
+  private mutateFrontmatter(
+    id: string,
+    transform: (fm: EngramFrontmatter) => EngramFrontmatter
+  ): void {
+    const row = this.getIndexRow(id);
+    const content = readFileSync(this.absolutePath(row.file_path), 'utf8');
+    const { frontmatter, body } = parseEngramFile(content);
+    const next = transform(frontmatter);
+    const file = serializeEngram(next, body);
+    this.writeFileAtomic(row.file_path, file);
+    const customFields = row.custom_fields ? parseCustomFields(row.custom_fields) : {};
+    this.upsertIndex({ id, filePath: row.file_path, frontmatter: next, body, customFields });
+  }
+
+  private isIdTaken(candidate: string, type: string): boolean {
+    if (!ENGRAM_ID_PATTERN.test(candidate)) return false;
+    const [row] = this.db
+      .select({ id: engramIndex.id })
+      .from(engramIndex)
+      .where(eq(engramIndex.id, candidate))
+      .all();
+    if (row) return true;
+    return existsSync(this.absolutePath(join(type, `${candidate}.md`)));
+  }
+
+  private upsertIndex(args: {
+    id: string;
+    filePath: string;
+    frontmatter: EngramFrontmatter;
+    body: string;
+    customFields: Record<string, unknown>;
+  }): void {
+    const { id, filePath, frontmatter, body, customFields } = args;
+    const title = deriveTitle(body);
+    const contentHash = sha256(serializeEngram(frontmatter, body));
+    const wordCount = countWords(body);
+
+    this.db.transaction((tx) => {
+      tx.delete(engramIndex).where(eq(engramIndex.id, id)).run();
+      tx.insert(engramIndex)
+        .values({
+          id,
+          filePath,
+          type: frontmatter.type,
+          source: frontmatter.source,
+          status: frontmatter.status,
+          template: frontmatter.template ?? null,
+          createdAt: frontmatter.created,
+          modifiedAt: frontmatter.modified,
+          title,
+          contentHash,
+          wordCount,
+          customFields: Object.keys(customFields).length > 0 ? JSON.stringify(customFields) : null,
+        })
+        .run();
+
+      if (frontmatter.scopes.length > 0) {
+        tx.insert(engramScopes)
+          .values(frontmatter.scopes.map((scope) => ({ engramId: id, scope })))
+          .run();
+      }
+      if (frontmatter.tags && frontmatter.tags.length > 0) {
+        tx.insert(engramTags)
+          .values(frontmatter.tags.map((tag) => ({ engramId: id, tag })))
+          .run();
+      }
+      if (frontmatter.links && frontmatter.links.length > 0) {
+        tx.insert(engramLinks)
+          .values(frontmatter.links.map((targetId) => ({ sourceId: id, targetId })))
+          .run();
+      }
+    });
+  }
+
+  private loadEngram(id: string): Engram {
+    const row = this.getIndexRow(id);
+    return this.loadEngramFromRow(row);
+  }
+
+  private loadEngramFromRow(row: IndexRow): Engram {
+    const scopes = this.db
+      .select({ scope: engramScopes.scope })
+      .from(engramScopes)
+      .where(eq(engramScopes.engramId, row.id))
+      .all()
+      .map((r) => r.scope);
+    const tags = this.db
+      .select({ tag: engramTags.tag })
+      .from(engramTags)
+      .where(eq(engramTags.engramId, row.id))
+      .all()
+      .map((r) => r.tag);
+    const links = this.db
+      .select({ targetId: engramLinks.targetId })
+      .from(engramLinks)
+      .where(eq(engramLinks.sourceId, row.id))
+      .all()
+      .map((r) => r.targetId);
+
+    return {
+      id: row.id,
+      type: row.type,
+      scopes,
+      tags,
+      links,
+      created: row.created_at,
+      modified: row.modified_at,
+      source: row.source as EngramSource,
+      status: row.status as EngramStatus,
+      template: row.template,
+      title: row.title,
+      filePath: row.file_path,
+      contentHash: row.content_hash,
+      wordCount: row.word_count,
+      customFields: parseCustomFields(row.custom_fields),
+    };
+  }
+
+  private getIndexRow(id: string): IndexRow {
+    const row = this.findIndexRow(id);
+    if (!row) throw new NotFoundError('Engram', id);
+    return row;
+  }
+
+  private findIndexRow(id: string): IndexRow | null {
+    const [row] = this.db.select().from(engramIndex).where(eq(engramIndex.id, id)).all();
+    return row ? indexRowFromDrizzle(row) : null;
+  }
+
+  private writeFileAtomic(relPath: string, contents: string): void {
+    writeFileAtomic(this.absolutePath(relPath), contents);
+  }
+
+  private absolutePath(relPath: string): string {
+    return join(this.root, relPath);
+  }
+
+  private listEngramFiles(): string[] {
+    const result: string[] = [];
+    const walk = (dir: string): void => {
+      const entries = readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          if (dir === this.root && WELL_KNOWN_DIRS.has(entry.name)) continue;
+          walk(join(dir, entry.name));
+        } else if (entry.isFile() && entry.name.endsWith('.md')) {
+          const rel = relative(this.root, join(dir, entry.name));
+          result.push(rel.split(sep).join('/'));
+        }
+      }
+    };
+    if (!existsSync(this.root)) return [];
+    walk(this.root);
+    return result;
+  }
+}
+
+type IndexRow = {
+  id: string;
+  file_path: string;
+  type: string;
+  source: string;
+  status: string;
+  template: string | null;
+  created_at: string;
+  modified_at: string;
+  title: string;
+  content_hash: string;
+  word_count: number;
+  custom_fields: string | null;
+};
+
+function indexRowFromDrizzle(row: typeof engramIndex.$inferSelect): IndexRow {
+  return {
+    id: row.id,
+    file_path: row.filePath,
+    type: row.type,
+    source: row.source,
+    status: row.status,
+    template: row.template,
+    created_at: row.createdAt,
+    modified_at: row.modifiedAt,
+    title: row.title,
+    content_hash: row.contentHash,
+    word_count: row.wordCount,
+    custom_fields: row.customFields,
+  };
+}
+
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+function parseCustomFields(json: string | null): Record<string, unknown> {
+  if (!json) return {};
+  try {
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+const KNOWN_FRONTMATTER_KEYS = new Set<string>([
+  'id',
+  'type',
+  'scopes',
+  'created',
+  'modified',
+  'source',
+  'tags',
+  'links',
+  'status',
+  'template',
+]);
+
+function splitCustomFields(fm: EngramFrontmatter): {
+  customFields: Record<string, unknown>;
+} {
+  const customFields: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(fm)) {
+    if (!KNOWN_FRONTMATTER_KEYS.has(key)) customFields[key] = value;
+  }
+  return { customFields };
+}
+
+/**
+ * Apply an updated title by rewriting the first H1 in the body, or prepending
+ * one if none exists.
+ */
+function applyTitleChange(body: string, newTitle: string | undefined): string {
+  if (!newTitle) return body;
+  const lines = body.split('\n');
+  const h1Index = lines.findIndex((line) => /^#\s+/.test(line.trim()));
+  if (h1Index >= 0) {
+    lines[h1Index] = `# ${newTitle}`;
+    return lines.join('\n');
+  }
+  return `# ${newTitle}\n\n${body.trimStart()}`;
+}
+
+function writeFileAtomic(absPath: string, contents: string): void {
+  mkdirSync(dirname(absPath), { recursive: true });
+  const tmp = `${absPath}.tmp.${randomUUID()}`;
+  writeFileSync(tmp, contents, 'utf8');
+  renameSync(tmp, absPath);
+}

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.ts
@@ -49,6 +49,33 @@ const CONFIG_DIR = '.config';
 const INDEX_DIR = '.index';
 const WELL_KNOWN_DIRS = new Set([ARCHIVE_DIR, TEMPLATES_DIR, CONFIG_DIR, INDEX_DIR]);
 
+/**
+ * An engram `type` becomes a directory name (`{type}/{id}.md`). Constrain it
+ * to a single filesystem-safe segment so API input can never traverse out of
+ * `ENGRAM_ROOT` or collide with reserved directories.
+ */
+const TYPE_SEGMENT_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+function assertSafeType(type: string): void {
+  if (!TYPE_SEGMENT_PATTERN.test(type) || WELL_KNOWN_DIRS.has(type) || type === 'engrams') {
+    throw new ValidationError({
+      message: `invalid engram type '${type}' — must be a short lowercase segment`,
+    });
+  }
+}
+
+/** Return a new array with duplicates removed, preserving first-seen order. */
+function dedupe<T>(values: readonly T[]): T[] {
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const v of values) {
+    if (seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}
+
 export interface CreateEngramInput {
   type: string;
   title: string;
@@ -127,14 +154,17 @@ export class EngramService {
     let customFields: Record<string, unknown> = input.customFields ?? {};
     let templateName: string | undefined = input.template;
     let mergedScopes = scopes;
+    let type = input.type || 'capture';
 
     if (templateName) {
       const template = this.templates.get(templateName);
       if (!template) {
         console.warn(
-          `[cerebrum] Template '${templateName}' not found — creating a 'capture' engram instead.`
+          `[cerebrum] Template '${templateName}' not found — falling back to a 'capture' engram.`
         );
         templateName = undefined;
+        // PRD-077 US-02: unknown template ⇒ capture-type engram, no scaffolding.
+        type = 'capture';
       } else {
         const applied = applyTemplate({
           template,
@@ -153,7 +183,7 @@ export class EngramService {
       throw new ValidationError({ message: 'at least one scope is required' });
     }
 
-    const type = templateName ? input.type : input.type || 'capture';
+    assertSafeType(type);
     const id = generateEngramId({
       title: input.title,
       now: this.now(),
@@ -164,13 +194,13 @@ export class EngramService {
     const frontmatter: EngramFrontmatter = {
       id,
       type,
-      scopes: mergedScopes,
+      scopes: dedupe(mergedScopes),
       created: nowIso,
       modified: nowIso,
       source,
       status: 'active',
-      ...(tags.length > 0 ? { tags } : {}),
-      ...(input.links && input.links.length > 0 ? { links: input.links } : {}),
+      ...(tags.length > 0 ? { tags: dedupe(tags) } : {}),
+      ...(input.links && input.links.length > 0 ? { links: dedupe(input.links) } : {}),
       ...(templateName ? { template: templateName } : {}),
       ...customFields,
     };
@@ -344,22 +374,26 @@ export class EngramService {
     if (opts.status) conditions.push(eq(engramIndex.status, opts.status));
     if (opts.search) conditions.push(like(engramIndex.title, `%${opts.search}%`));
     if (opts.scopes && opts.scopes.length > 0) {
-      const scopeIds = this.db
-        .selectDistinct({ engramId: engramScopes.engramId })
-        .from(engramScopes)
-        .where(inArray(engramScopes.scope, opts.scopes))
-        .all()
-        .map((r) => r.engramId);
-      conditions.push(scopeIds.length > 0 ? inArray(engramIndex.id, scopeIds) : sql`0 = 1`);
+      conditions.push(
+        inArray(
+          engramIndex.id,
+          this.db
+            .select({ engramId: engramScopes.engramId })
+            .from(engramScopes)
+            .where(inArray(engramScopes.scope, opts.scopes))
+        )
+      );
     }
     if (opts.tags && opts.tags.length > 0) {
-      const tagIds = this.db
-        .selectDistinct({ engramId: engramTags.engramId })
-        .from(engramTags)
-        .where(inArray(engramTags.tag, opts.tags))
-        .all()
-        .map((r) => r.engramId);
-      conditions.push(tagIds.length > 0 ? inArray(engramIndex.id, tagIds) : sql`0 = 1`);
+      conditions.push(
+        inArray(
+          engramIndex.id,
+          this.db
+            .select({ engramId: engramTags.engramId })
+            .from(engramTags)
+            .where(inArray(engramTags.tag, opts.tags))
+        )
+      );
     }
 
     const where = conditions.length === 0 ? undefined : and(...conditions);
@@ -386,9 +420,59 @@ export class EngramService {
     const [totalRow] = (where ? totalQuery.where(where) : totalQuery).all();
 
     return {
-      engrams: rows.map((row) => this.loadEngramFromRow(indexRowFromDrizzle(row))),
+      engrams: this.hydrateEngrams(rows.map(indexRowFromDrizzle)),
       total: totalRow?.total ?? 0,
     };
+  }
+
+  /**
+   * Batch-fetch scopes, tags, and links for a page of index rows.
+   * Three queries total regardless of page size — avoids the N+1 of looking
+   * each junction table up per-engram.
+   */
+  private hydrateEngrams(rows: IndexRow[]): Engram[] {
+    if (rows.length === 0) return [];
+    const ids = rows.map((r) => r.id);
+
+    const scopesByEngram = bucket(
+      this.db
+        .select({ engramId: engramScopes.engramId, value: engramScopes.scope })
+        .from(engramScopes)
+        .where(inArray(engramScopes.engramId, ids))
+        .all()
+    );
+    const tagsByEngram = bucket(
+      this.db
+        .select({ engramId: engramTags.engramId, value: engramTags.tag })
+        .from(engramTags)
+        .where(inArray(engramTags.engramId, ids))
+        .all()
+    );
+    const linksByEngram = bucket(
+      this.db
+        .select({ engramId: engramLinks.sourceId, value: engramLinks.targetId })
+        .from(engramLinks)
+        .where(inArray(engramLinks.sourceId, ids))
+        .all()
+    );
+
+    return rows.map((row) => ({
+      id: row.id,
+      type: row.type,
+      scopes: scopesByEngram.get(row.id) ?? [],
+      tags: tagsByEngram.get(row.id) ?? [],
+      links: linksByEngram.get(row.id) ?? [],
+      created: row.created_at,
+      modified: row.modified_at,
+      source: row.source as EngramSource,
+      status: row.status as EngramStatus,
+      template: row.template,
+      title: row.title,
+      filePath: row.file_path,
+      contentHash: row.content_hash,
+      wordCount: row.word_count,
+      customFields: parseCustomFields(row.custom_fields),
+    }));
   }
 
   reindex(): { indexed: number } {
@@ -430,9 +514,11 @@ export class EngramService {
           wordCount,
           customFields: Object.keys(customFields).length > 0 ? JSON.stringify(customFields) : null,
         },
-        scopes: frontmatter.scopes,
-        tags: frontmatter.tags ?? [],
-        links: frontmatter.links ?? [],
+        // Dedupe so a hand-edited file with a repeated scope/tag/link doesn't
+        // blow up the rebuild with a UNIQUE constraint violation.
+        scopes: dedupe(frontmatter.scopes),
+        tags: dedupe(frontmatter.tags ?? []),
+        links: dedupe(frontmatter.links ?? []),
       });
     }
 
@@ -521,19 +607,23 @@ export class EngramService {
         })
         .run();
 
-      if (frontmatter.scopes.length > 0) {
+      // Dedupe defends against hand-edited frontmatter with repeats.
+      const scopes = dedupe(frontmatter.scopes);
+      if (scopes.length > 0) {
         tx.insert(engramScopes)
-          .values(frontmatter.scopes.map((scope) => ({ engramId: id, scope })))
+          .values(scopes.map((scope) => ({ engramId: id, scope })))
           .run();
       }
-      if (frontmatter.tags && frontmatter.tags.length > 0) {
+      const tags = dedupe(frontmatter.tags ?? []);
+      if (tags.length > 0) {
         tx.insert(engramTags)
-          .values(frontmatter.tags.map((tag) => ({ engramId: id, tag })))
+          .values(tags.map((tag) => ({ engramId: id, tag })))
           .run();
       }
-      if (frontmatter.links && frontmatter.links.length > 0) {
+      const links = dedupe(frontmatter.links ?? []);
+      if (links.length > 0) {
         tx.insert(engramLinks)
-          .values(frontmatter.links.map((targetId) => ({ sourceId: id, targetId })))
+          .values(links.map((targetId) => ({ sourceId: id, targetId })))
           .run();
       }
     });
@@ -541,46 +631,9 @@ export class EngramService {
 
   private loadEngram(id: string): Engram {
     const row = this.getIndexRow(id);
-    return this.loadEngramFromRow(row);
-  }
-
-  private loadEngramFromRow(row: IndexRow): Engram {
-    const scopes = this.db
-      .select({ scope: engramScopes.scope })
-      .from(engramScopes)
-      .where(eq(engramScopes.engramId, row.id))
-      .all()
-      .map((r) => r.scope);
-    const tags = this.db
-      .select({ tag: engramTags.tag })
-      .from(engramTags)
-      .where(eq(engramTags.engramId, row.id))
-      .all()
-      .map((r) => r.tag);
-    const links = this.db
-      .select({ targetId: engramLinks.targetId })
-      .from(engramLinks)
-      .where(eq(engramLinks.sourceId, row.id))
-      .all()
-      .map((r) => r.targetId);
-
-    return {
-      id: row.id,
-      type: row.type,
-      scopes,
-      tags,
-      links,
-      created: row.created_at,
-      modified: row.modified_at,
-      source: row.source as EngramSource,
-      status: row.status as EngramStatus,
-      template: row.template,
-      title: row.title,
-      filePath: row.file_path,
-      contentHash: row.content_hash,
-      wordCount: row.word_count,
-      customFields: parseCustomFields(row.custom_fields),
-    };
+    const [engram] = this.hydrateEngrams([row]);
+    if (!engram) throw new NotFoundError('Engram', id);
+    return engram;
   }
 
   private getIndexRow(id: string): IndexRow {
@@ -656,6 +709,17 @@ function indexRowFromDrizzle(row: typeof engramIndex.$inferSelect): IndexRow {
 
 function sha256(input: string): string {
   return createHash('sha256').update(input).digest('hex');
+}
+
+/** Group `{ engramId, value }` rows into a map keyed by engramId. */
+function bucket(rows: { engramId: string; value: string }[]): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (const row of rows) {
+    const existing = out.get(row.engramId);
+    if (existing) existing.push(row.value);
+    else out.set(row.engramId, [row.value]);
+  }
+  return out;
 }
 
 function parseCustomFields(json: string | null): Record<string, unknown> {

--- a/apps/pops-api/src/modules/cerebrum/engrams/types.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Public shapes returned from the engram service and tRPC layer.
+ */
+import type { EngramFrontmatter, EngramSource, EngramStatus } from './schema.js';
+
+/**
+ * An engram summary — all the frontmatter plus index-derived metadata (path,
+ * content hash, word count). Equivalent to an `engram_index` row expanded with
+ * its scopes, tags, and links.
+ */
+export interface Engram {
+  id: string;
+  type: string;
+  scopes: string[];
+  tags: string[];
+  links: string[];
+  created: string;
+  modified: string;
+  source: EngramSource;
+  status: EngramStatus;
+  template: string | null;
+  title: string;
+  filePath: string;
+  contentHash: string;
+  wordCount: number;
+  customFields: Record<string, unknown>;
+}
+
+/** Project a validated frontmatter + index-derived metadata into an Engram. */
+export function buildEngram(
+  frontmatter: EngramFrontmatter,
+  meta: {
+    filePath: string;
+    title: string;
+    contentHash: string;
+    wordCount: number;
+    customFields: Record<string, unknown>;
+  }
+): Engram {
+  return {
+    id: frontmatter.id,
+    type: frontmatter.type,
+    scopes: [...frontmatter.scopes],
+    tags: [...(frontmatter.tags ?? [])],
+    links: [...(frontmatter.links ?? [])],
+    created: frontmatter.created,
+    modified: frontmatter.modified,
+    source: frontmatter.source,
+    status: frontmatter.status,
+    template: frontmatter.template ?? null,
+    title: meta.title,
+    filePath: meta.filePath,
+    contentHash: meta.contentHash,
+    wordCount: meta.wordCount,
+    customFields: meta.customFields,
+  };
+}

--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Cerebrum domain — engram storage and retrieval.
+ * See docs/themes/06-cerebrum for the full spec.
+ */
+import { router } from '../../trpc.js';
+import { engramsRouter } from './engrams/router.js';
+import { templatesRouter } from './templates/router.js';
+
+export const cerebrumRouter = router({
+  engrams: engramsRouter,
+  templates: templatesRouter,
+});

--- a/apps/pops-api/src/modules/cerebrum/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/instance.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared cerebrum runtime wiring.
+ *
+ * The engram root directory and template registry are process-scoped (config,
+ * not per-request), so they live in module-level singletons. The Drizzle
+ * instance is resolved per-call so env-scoped DB context (AsyncLocalStorage)
+ * is honoured like every other module in this repo.
+ */
+import { join } from 'node:path';
+
+import { getDrizzle } from '../../db.js';
+import { EngramService } from './engrams/service.js';
+import { TemplateRegistry } from './templates/registry.js';
+import { seedDefaultTemplates } from './templates/seed.js';
+
+function resolveRoot(): string {
+  return process.env['ENGRAM_ROOT'] ?? join(process.cwd(), 'data', 'engrams');
+}
+
+let cachedRoot: string | null = null;
+let cachedRegistry: TemplateRegistry | null = null;
+
+/** Return the engram root directory. Cached after first resolve. */
+export function getEngramRoot(): string {
+  if (!cachedRoot) cachedRoot = resolveRoot();
+  return cachedRoot;
+}
+
+/**
+ * Return the shared template registry, seeding bundled defaults into the
+ * engram root on first access.
+ */
+export function getTemplateRegistry(): TemplateRegistry {
+  if (!cachedRegistry) {
+    const templatesDir = join(getEngramRoot(), '.templates');
+    try {
+      seedDefaultTemplates(templatesDir);
+    } catch (err) {
+      console.warn(
+        `[cerebrum] Failed to seed default templates into ${templatesDir}: ${(err as Error).message}`
+      );
+    }
+    cachedRegistry = new TemplateRegistry(templatesDir);
+  }
+  return cachedRegistry;
+}
+
+/** Build an EngramService bound to the current request's drizzle context. */
+export function getEngramService(): EngramService {
+  return new EngramService({
+    root: getEngramRoot(),
+    db: getDrizzle(),
+    templates: getTemplateRegistry(),
+  });
+}
+
+/** Test hook — drop the cached root + registry so tests can rebind roots. */
+export function resetCerebrumCache(): void {
+  cachedRoot = null;
+  cachedRegistry = null;
+}

--- a/apps/pops-api/src/modules/cerebrum/templates/apply.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/templates/apply.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { ValidationError } from '../../../shared/errors.js';
+import { applyTemplate } from './apply.js';
+
+import type { Template } from './schema.js';
+
+const decisionTemplate: Template = {
+  name: 'decision',
+  description: 'A decision',
+  required_fields: ['decision'],
+  suggested_sections: ['Context', 'Decision'],
+  default_scopes: ['work'],
+  custom_fields: {
+    decision: { type: 'string', description: 'what was decided' },
+    alternatives: { type: 'string[]', description: 'options' },
+    confidence: { type: 'string', description: 'low|medium|high' },
+  },
+  body: '# {{title}}\n\n## Decision\n\n{{decision}}\n',
+};
+
+describe('applyTemplate', () => {
+  it('merges default_scopes with user scopes without duplication', () => {
+    const result = applyTemplate({
+      template: decisionTemplate,
+      title: 'Pick runtime',
+      scopes: ['work', 'personal'],
+      customFields: { decision: 'Node' },
+    });
+    expect(result.scopes).toEqual(['work', 'personal']);
+  });
+
+  it('throws when a required field is missing', () => {
+    expect(() =>
+      applyTemplate({
+        template: decisionTemplate,
+        title: 'Pick runtime',
+        scopes: [],
+        customFields: {},
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it('replaces {{title}} and field placeholders in the body', () => {
+    const result = applyTemplate({
+      template: decisionTemplate,
+      title: 'Pick runtime',
+      scopes: [],
+      customFields: { decision: 'Use Node' },
+    });
+    expect(result.body).toContain('# Pick runtime');
+    expect(result.body).toContain('## Decision\n\nUse Node');
+  });
+
+  it('serialises array fields with comma separation in placeholders', () => {
+    const t: Template = {
+      ...decisionTemplate,
+      body: 'Alts: {{alternatives}}',
+      required_fields: [],
+    };
+    const result = applyTemplate({
+      template: t,
+      title: 'x',
+      scopes: [],
+      customFields: { alternatives: ['Bun', 'Deno'] },
+    });
+    expect(result.body).toBe('Alts: Bun, Deno');
+  });
+
+  it('scaffolds body from suggested_sections when the template has no body', () => {
+    const t: Template = { ...decisionTemplate, body: '', required_fields: [] };
+    const result = applyTemplate({
+      template: t,
+      title: 'X',
+      scopes: [],
+      customFields: {},
+    });
+    expect(result.body).toContain('# X');
+    expect(result.body).toContain('## Context');
+    expect(result.body).toContain('## Decision');
+  });
+
+  it('uses the provided body when given, skipping scaffold', () => {
+    const result = applyTemplate({
+      template: decisionTemplate,
+      title: 'X',
+      body: '# custom body',
+      scopes: [],
+      customFields: { decision: 'Y' },
+    });
+    expect(result.body).toBe('# custom body');
+  });
+
+  it('rejects custom fields that fail type checks', () => {
+    expect(() =>
+      applyTemplate({
+        template: decisionTemplate,
+        title: 'X',
+        scopes: [],
+        customFields: { decision: 'Y', alternatives: 'not-an-array' as unknown as string[] },
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it('drops custom fields the template does not declare', () => {
+    const result = applyTemplate({
+      template: decisionTemplate,
+      title: 'X',
+      scopes: [],
+      customFields: { decision: 'Y', secret: 'nope' as unknown as string },
+    });
+    expect(result.customFields).not.toHaveProperty('secret');
+    expect(result.customFields['decision']).toBe('Y');
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/templates/apply.ts
+++ b/apps/pops-api/src/modules/cerebrum/templates/apply.ts
@@ -123,7 +123,13 @@ function assertTypeMatches(key: string, spec: TemplateCustomField, value: unknow
       case 'boolean':
         return typeof v === 'boolean';
       default:
-        return true;
+        // Reject unknown types loudly instead of silently accepting. The
+        // template schema's Zod enum prevents this reaching here at load
+        // time, but a registry bypass (e.g. a test injecting a raw Template)
+        // would otherwise disable all validation for the field.
+        throw new ValidationError({
+          message: `Template declares unsupported type '${spec.type}' for field '${key}'`,
+        });
     }
   };
   const ok = isArray ? Array.isArray(value) && value.every(check) : check(value);

--- a/apps/pops-api/src/modules/cerebrum/templates/apply.ts
+++ b/apps/pops-api/src/modules/cerebrum/templates/apply.ts
@@ -1,0 +1,135 @@
+/**
+ * Apply a template to an engram at creation time.
+ *
+ * Responsibilities:
+ *  - Merge the template's `default_scopes` into the engram scopes.
+ *  - Validate that every `required_field` is supplied in customFields.
+ *  - Scaffold the body from `suggested_sections` when no body was provided.
+ *  - Replace `{{placeholder}}` markers from user-supplied values or
+ *    `{{title}}` with the engram title.
+ *  - Validate + project customFields against the template's declared types.
+ */
+import { ValidationError } from '../../../shared/errors.js';
+
+import type { Template, TemplateCustomField } from './schema.js';
+
+export interface ApplyTemplateInput {
+  template: Template;
+  title: string;
+  body?: string;
+  scopes: string[];
+  customFields?: Record<string, unknown>;
+}
+
+export interface ApplyTemplateResult {
+  body: string;
+  scopes: string[];
+  customFields: Record<string, unknown>;
+}
+
+export function applyTemplate(input: ApplyTemplateInput): ApplyTemplateResult {
+  const { template, title, scopes, customFields = {} } = input;
+  const providedBody = input.body?.trim();
+
+  const missing = (template.required_fields ?? []).filter(
+    (field) => customFields[field] === undefined || customFields[field] === null
+  );
+  if (missing.length > 0) {
+    throw new ValidationError({
+      message: `Template '${template.name}' requires: ${missing.join(', ')}`,
+      missing,
+    });
+  }
+
+  const typedFields = projectCustomFields(template, customFields);
+
+  const scaffold = providedBody ?? scaffoldBody(template, title);
+  const body = replacePlaceholders(scaffold, {
+    title,
+    ...stringifyForPlaceholders(typedFields),
+  });
+
+  const mergedScopes = dedupe([...(template.default_scopes ?? []), ...scopes]);
+
+  return { body, scopes: mergedScopes, customFields: typedFields };
+}
+
+function dedupe(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    if (seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}
+
+function scaffoldBody(template: Template, title: string): string {
+  if (template.body.trim().length > 0) return template.body;
+  const sections = template.suggested_sections ?? [];
+  const lines = [`# ${title}`, ''];
+  for (const section of sections) {
+    lines.push(`## ${section}`, '', '', '');
+  }
+  return lines.join('\n');
+}
+
+function replacePlaceholders(body: string, values: Record<string, string>): string {
+  return body.replaceAll(/\{\{\s*([\w-]+)\s*\}\}/g, (match, rawKey: string) => {
+    const key = rawKey.trim();
+    const replacement = values[key];
+    return replacement === undefined ? match : replacement;
+  });
+}
+
+function stringifyForPlaceholders(fields: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === null || value === undefined) continue;
+    out[key] = Array.isArray(value) ? value.join(', ') : String(value);
+  }
+  return out;
+}
+
+/**
+ * Validate each custom field against its declared template type and return
+ * only the fields the template knows about. Extra unrelated keys are dropped
+ * so the engram frontmatter stays close to the template's contract.
+ */
+function projectCustomFields(
+  template: Template,
+  input: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const declared = template.custom_fields ?? {};
+  for (const [key, spec] of Object.entries(declared)) {
+    if (input[key] === undefined) continue;
+    assertTypeMatches(key, spec, input[key]);
+    out[key] = input[key];
+  }
+  return out;
+}
+
+function assertTypeMatches(key: string, spec: TemplateCustomField, value: unknown): void {
+  const isArray = spec.type.endsWith('[]');
+  const baseType = isArray ? spec.type.slice(0, -2) : spec.type;
+  const check = (v: unknown): boolean => {
+    switch (baseType) {
+      case 'string':
+        return typeof v === 'string';
+      case 'number':
+        return typeof v === 'number';
+      case 'boolean':
+        return typeof v === 'boolean';
+      default:
+        return true;
+    }
+  };
+  const ok = isArray ? Array.isArray(value) && value.every(check) : check(value);
+  if (!ok) {
+    throw new ValidationError({
+      message: `Field '${key}' should be of type '${spec.type}'`,
+    });
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/templates/defaults/capture.md
+++ b/apps/pops-api/src/modules/cerebrum/templates/defaults/capture.md
@@ -1,0 +1,8 @@
+---
+name: capture
+description: Unstructured input to be classified later
+required_fields: []
+suggested_sections: []
+default_scopes: []
+custom_fields: {}
+---

--- a/apps/pops-api/src/modules/cerebrum/templates/defaults/decision.md
+++ b/apps/pops-api/src/modules/cerebrum/templates/defaults/decision.md
@@ -1,0 +1,49 @@
+---
+name: decision
+description: A decision made with rationale and outcome tracking
+required_fields:
+  - decision
+  - alternatives
+suggested_sections:
+  - Context
+  - Decision
+  - Alternatives
+  - Rationale
+  - Outcome
+default_scopes: []
+custom_fields:
+  decision:
+    type: string
+    description: 'The decision that was made'
+  alternatives:
+    type: string[]
+    description: 'Options that were considered'
+  outcome:
+    type: string
+    description: 'Result of the decision'
+  confidence:
+    type: string
+    description: 'low | medium | high'
+---
+
+# {{title}}
+
+## Context
+
+{{Why this decision needed to be made}}
+
+## Decision
+
+{{decision}}
+
+## Alternatives
+
+{{alternatives}}
+
+## Rationale
+
+{{Why this option was chosen}}
+
+## Outcome
+
+_To be filled in after the decision plays out._

--- a/apps/pops-api/src/modules/cerebrum/templates/defaults/idea.md
+++ b/apps/pops-api/src/modules/cerebrum/templates/defaults/idea.md
@@ -1,0 +1,25 @@
+---
+name: idea
+description: A nascent idea — what, why, what would it take
+required_fields: []
+suggested_sections:
+  - The idea
+  - Why it matters
+  - What it would take
+default_scopes: []
+custom_fields: {}
+---
+
+# {{title}}
+
+## The idea
+
+{{A paragraph describing the idea}}
+
+## Why it matters
+
+{{What problem it solves or what it unlocks}}
+
+## What it would take
+
+{{Sketch of effort, constraints, dependencies}}

--- a/apps/pops-api/src/modules/cerebrum/templates/defaults/journal.md
+++ b/apps/pops-api/src/modules/cerebrum/templates/defaults/journal.md
@@ -1,0 +1,28 @@
+---
+name: journal
+description: A journal entry — a first-person account of a moment, day, or thought
+required_fields: []
+suggested_sections:
+  - What happened
+  - How I feel
+  - What I learned
+default_scopes: []
+custom_fields:
+  mood:
+    type: string
+    description: "Mood word or phrase (e.g. 'focused', 'restless')"
+---
+
+# {{title}}
+
+## What happened
+
+{{What happened}}
+
+## How I feel
+
+{{How I feel}}
+
+## What I learned
+
+{{What I learned}}

--- a/apps/pops-api/src/modules/cerebrum/templates/defaults/meeting.md
+++ b/apps/pops-api/src/modules/cerebrum/templates/defaults/meeting.md
@@ -1,0 +1,41 @@
+---
+name: meeting
+description: A meeting record — attendees, agenda, outcomes, follow-ups
+required_fields: []
+suggested_sections:
+  - Attendees
+  - Agenda
+  - Notes
+  - Decisions
+  - Follow-ups
+default_scopes: []
+custom_fields:
+  project:
+    type: string
+    description: 'Project the meeting belongs to'
+  attendees:
+    type: string[]
+    description: 'People in the room'
+---
+
+# {{title}}
+
+## Attendees
+
+{{attendees}}
+
+## Agenda
+
+{{What was discussed}}
+
+## Notes
+
+{{Key points raised}}
+
+## Decisions
+
+{{What was decided}}
+
+## Follow-ups
+
+{{Who owns what, by when}}

--- a/apps/pops-api/src/modules/cerebrum/templates/defaults/note.md
+++ b/apps/pops-api/src/modules/cerebrum/templates/defaults/note.md
@@ -1,0 +1,10 @@
+---
+name: note
+description: A general-purpose note with minimal structure
+required_fields: []
+suggested_sections: []
+default_scopes: []
+custom_fields: {}
+---
+
+# {{title}}

--- a/apps/pops-api/src/modules/cerebrum/templates/defaults/research.md
+++ b/apps/pops-api/src/modules/cerebrum/templates/defaults/research.md
@@ -1,0 +1,33 @@
+---
+name: research
+description: A research note on a topic — links, findings, open questions
+required_fields: []
+suggested_sections:
+  - Summary
+  - Findings
+  - Sources
+  - Open questions
+default_scopes: []
+custom_fields:
+  topic:
+    type: string
+    description: 'The research topic'
+---
+
+# {{title}}
+
+## Summary
+
+{{One-paragraph summary of the research}}
+
+## Findings
+
+{{Key findings and observations}}
+
+## Sources
+
+{{Links, papers, conversations}}
+
+## Open questions
+
+{{What is still unresolved}}

--- a/apps/pops-api/src/modules/cerebrum/templates/registry.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/templates/registry.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { TemplateRegistry } from './registry.js';
+import { seedDefaultTemplates } from './seed.js';
+
+describe('TemplateRegistry + default seed', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cerebrum-templates-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('seeds all seven default templates', () => {
+    const written = seedDefaultTemplates(dir);
+    const names = new Set(written);
+    for (const name of ['journal', 'decision', 'research', 'meeting', 'idea', 'note', 'capture']) {
+      expect(names.has(`${name}.md`)).toBe(true);
+    }
+  });
+
+  it('seeds are idempotent — a second call writes nothing', () => {
+    seedDefaultTemplates(dir);
+    expect(seedDefaultTemplates(dir)).toEqual([]);
+  });
+
+  it('loads seeded templates into the registry', () => {
+    seedDefaultTemplates(dir);
+    const registry = new TemplateRegistry(dir);
+    const names = registry.list().map((t) => t.name);
+    expect(names).toEqual([
+      'capture',
+      'decision',
+      'idea',
+      'journal',
+      'meeting',
+      'note',
+      'research',
+    ]);
+    expect(registry.get('decision')?.required_fields).toEqual(['decision', 'alternatives']);
+  });
+
+  it('returns an empty list when the directory does not exist', () => {
+    const registry = new TemplateRegistry(join(dir, 'missing'));
+    expect(registry.list()).toEqual([]);
+    expect(registry.has('anything')).toBe(false);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/templates/registry.ts
+++ b/apps/pops-api/src/modules/cerebrum/templates/registry.ts
@@ -1,0 +1,60 @@
+/**
+ * Template registry.
+ *
+ * Loads templates from disk at startup (and re-loads on demand). Templates
+ * are `.md` files with YAML frontmatter, so the Markdown body doubles as
+ * scaffold content for new engrams.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import matter from 'gray-matter';
+
+import { type Template, templateFrontmatterSchema } from './schema.js';
+
+export class TemplateRegistry {
+  private templates = new Map<string, Template>();
+
+  constructor(private readonly dir: string) {
+    this.reload();
+  }
+
+  list(): Template[] {
+    return [...this.templates.values()].toSorted((a, b) => a.name.localeCompare(b.name));
+  }
+
+  get(name: string): Template | undefined {
+    return this.templates.get(name);
+  }
+
+  has(name: string): boolean {
+    return this.templates.has(name);
+  }
+
+  /** Re-scan the template directory. Useful after an operator edits files. */
+  reload(): void {
+    const loaded = new Map<string, Template>();
+    let files: string[];
+    try {
+      files = readdirSync(this.dir).filter((f) => f.endsWith('.md'));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        this.templates = loaded;
+        return;
+      }
+      throw err;
+    }
+
+    for (const file of files) {
+      const content = readFileSync(join(this.dir, file), 'utf8');
+      const { data, content: body } = matter(content);
+      const parsed = templateFrontmatterSchema.safeParse(data);
+      if (!parsed.success) {
+        console.warn(`[cerebrum] Skipping invalid template file ${file}: ${parsed.error.message}`);
+        continue;
+      }
+      loaded.set(parsed.data.name, { ...parsed.data, body });
+    }
+    this.templates = loaded;
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/templates/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/templates/router.ts
@@ -1,0 +1,29 @@
+/**
+ * tRPC router for cerebrum.templates.
+ *
+ * Templates are read-only at runtime — the operator edits `.md` files
+ * directly on disk. The router exposes list/get for UIs that let the user
+ * pick a template when creating an engram.
+ */
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { protectedProcedure, router } from '../../../trpc.js';
+import { getTemplateRegistry } from '../instance.js';
+
+export const templatesRouter = router({
+  list: protectedProcedure.query(() => {
+    const templates = getTemplateRegistry()
+      .list()
+      .map(({ body: _body, ...rest }) => rest);
+    return { templates };
+  }),
+
+  get: protectedProcedure.input(z.object({ name: z.string().min(1) })).query(({ input }) => {
+    const template = getTemplateRegistry().get(input.name);
+    if (!template) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: `Template '${input.name}' not found` });
+    }
+    return { template };
+  }),
+});

--- a/apps/pops-api/src/modules/cerebrum/templates/schema.ts
+++ b/apps/pops-api/src/modules/cerebrum/templates/schema.ts
@@ -7,8 +7,19 @@
  */
 import { z } from 'zod';
 
+/** Primitive types a template custom field can declare. `[]` suffix = array. */
+export const TEMPLATE_FIELD_TYPES = [
+  'string',
+  'number',
+  'boolean',
+  'string[]',
+  'number[]',
+  'boolean[]',
+] as const;
+export type TemplateFieldType = (typeof TEMPLATE_FIELD_TYPES)[number];
+
 export const templateCustomFieldSchema = z.object({
-  type: z.string().min(1),
+  type: z.enum(TEMPLATE_FIELD_TYPES),
   description: z.string().min(1),
 });
 export type TemplateCustomField = z.infer<typeof templateCustomFieldSchema>;

--- a/apps/pops-api/src/modules/cerebrum/templates/schema.ts
+++ b/apps/pops-api/src/modules/cerebrum/templates/schema.ts
@@ -1,0 +1,29 @@
+/**
+ * Template schema.
+ *
+ * Templates describe the shape of an engram type. They're declarative, stored
+ * as Markdown files, and read-only at runtime — users add or change templates
+ * by editing files on disk, not via API.
+ */
+import { z } from 'zod';
+
+export const templateCustomFieldSchema = z.object({
+  type: z.string().min(1),
+  description: z.string().min(1),
+});
+export type TemplateCustomField = z.infer<typeof templateCustomFieldSchema>;
+
+export const templateFrontmatterSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+  required_fields: z.array(z.string().min(1)).optional(),
+  suggested_sections: z.array(z.string().min(1)).optional(),
+  default_scopes: z.array(z.string().min(1)).optional(),
+  custom_fields: z.record(z.string(), templateCustomFieldSchema).optional(),
+});
+export type TemplateFrontmatter = z.infer<typeof templateFrontmatterSchema>;
+
+export interface Template extends TemplateFrontmatter {
+  /** Raw Markdown body — may contain `{{placeholder}}` markers. */
+  body: string;
+}

--- a/apps/pops-api/src/modules/cerebrum/templates/seed.ts
+++ b/apps/pops-api/src/modules/cerebrum/templates/seed.ts
@@ -1,0 +1,35 @@
+/**
+ * Seed default templates into the engram root.
+ *
+ * On first boot (or whenever the operator adds a new default template to the
+ * repo), copy any template that is not yet present on disk. Existing templates
+ * are never overwritten — the user's copies are the source of truth.
+ */
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const DEFAULTS_DIR = join(here, 'defaults');
+
+/**
+ * Copy any bundled defaults that are missing from `targetDir`. Idempotent.
+ * Returns the names of templates that were written on this call.
+ */
+export function seedDefaultTemplates(targetDir: string): string[] {
+  mkdirSync(targetDir, { recursive: true });
+
+  const files = readdirSync(DEFAULTS_DIR).filter((f) => f.endsWith('.md'));
+  const written: string[] = [];
+  for (const file of files) {
+    const target = join(targetDir, file);
+    if (existsSync(target)) continue;
+    copyFileSync(join(DEFAULTS_DIR, file), target);
+    written.push(file);
+  }
+  return written;
+}
+
+export function getBundledDefaultsDir(): string {
+  return DEFAULTS_DIR;
+}

--- a/apps/pops-api/src/router.ts
+++ b/apps/pops-api/src/router.ts
@@ -2,13 +2,15 @@
  * Main tRPC app router — combines domain routers.
  *
  * Domain structure:
- *   core     — entities, ai-usage, corrections
- *   finance  — transactions, budgets, imports, wishlist
+ *   core      — entities, ai-usage, corrections
+ *   finance   — transactions, budgets, imports, wishlist
  *   inventory — items
- *   media    — comparisons
+ *   media     — comparisons
+ *   cerebrum  — engrams, templates
  *
  * Note: envs is an Express router (not tRPC) — mounted directly in app.ts.
  */
+import { cerebrumRouter } from './modules/cerebrum/index.js';
 import { coreRouter } from './modules/core/index.js';
 import { financeRouter } from './modules/finance/index.js';
 import { inventoryRouter } from './modules/inventory/index.js';
@@ -20,6 +22,7 @@ import { router } from './trpc.js';
  * All tRPC procedures are nested under their domain group.
  */
 export const appRouter = router({
+  cerebrum: cerebrumRouter,
   core: coreRouter,
   finance: financeRouter,
   inventory: inventoryRouter,

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -539,6 +539,47 @@ export function createTestDb(): Database {
     CREATE UNIQUE INDEX IF NOT EXISTS idx_rotation_exclusions_tmdb_id
       ON rotation_exclusions(tmdb_id);
 
+    CREATE TABLE IF NOT EXISTS engram_index (
+      id            TEXT PRIMARY KEY,
+      file_path     TEXT NOT NULL UNIQUE,
+      type          TEXT NOT NULL,
+      source        TEXT NOT NULL,
+      status        TEXT NOT NULL,
+      template      TEXT,
+      created_at    TEXT NOT NULL,
+      modified_at   TEXT NOT NULL,
+      title         TEXT NOT NULL,
+      content_hash  TEXT NOT NULL,
+      word_count    INTEGER NOT NULL,
+      custom_fields TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_engram_index_type ON engram_index(type);
+    CREATE INDEX IF NOT EXISTS idx_engram_index_source ON engram_index(source);
+    CREATE INDEX IF NOT EXISTS idx_engram_index_status ON engram_index(status);
+    CREATE INDEX IF NOT EXISTS idx_engram_index_created_at ON engram_index(created_at);
+    CREATE INDEX IF NOT EXISTS idx_engram_index_content_hash ON engram_index(content_hash);
+
+    CREATE TABLE IF NOT EXISTS engram_scopes (
+      engram_id TEXT NOT NULL REFERENCES engram_index(id) ON DELETE CASCADE,
+      scope     TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_engram_scopes_pair ON engram_scopes(engram_id, scope);
+    CREATE INDEX IF NOT EXISTS idx_engram_scopes_scope ON engram_scopes(scope);
+
+    CREATE TABLE IF NOT EXISTS engram_tags (
+      engram_id TEXT NOT NULL REFERENCES engram_index(id) ON DELETE CASCADE,
+      tag       TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_engram_tags_pair ON engram_tags(engram_id, tag);
+    CREATE INDEX IF NOT EXISTS idx_engram_tags_tag ON engram_tags(tag);
+
+    CREATE TABLE IF NOT EXISTS engram_links (
+      source_id TEXT NOT NULL REFERENCES engram_index(id) ON DELETE CASCADE,
+      target_id TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_engram_links_pair ON engram_links(source_id, target_id);
+    CREATE INDEX IF NOT EXISTS idx_engram_links_target ON engram_links(target_id);
+
     CREATE TABLE IF NOT EXISTS rotation_log (
       id                    INTEGER PRIMARY KEY AUTOINCREMENT,
       executed_at           TEXT    NOT NULL,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -126,12 +126,12 @@ Live status of every theme and epic. Updated as work completes.
 
 ### Cerebrum — Phase 1 (MVP)
 
-| Epic                          | Status      | Notes                                                               |
-| ----------------------------- | ----------- | ------------------------------------------------------------------- |
-| Engram Storage (format, CRUD) | Not started | File format, templates, directory, scope model, API                 |
-| Thalamus (indexing/retrieval) | Not started | File watcher, frontmatter sync, embedding trigger, retrieval engine |
-| Ingest (input pipeline)       | Not started | Manual, agent, capture channels + classification + scope inference  |
-| Emit (output production)      | Not started | Query engine, document generation, proactive nudges                 |
+| Epic                          | Status      | Notes                                                                                                 |
+| ----------------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
+| Engram Storage (format, CRUD) | Partial     | PRD-077 done (format, templates, index schema, CRUD, tRPC, provisioning); PRD-078 scope model pending |
+| Thalamus (indexing/retrieval) | Not started | File watcher, frontmatter sync, embedding trigger, retrieval engine                                   |
+| Ingest (input pipeline)       | Not started | Manual, agent, capture channels + classification + scope inference                                    |
+| Emit (output production)      | Not started | Query engine, document generation, proactive nudges                                                   |
 
 ### Cerebrum — Phase 2 (Curation & Interface)
 

--- a/docs/themes/06-cerebrum/README.md
+++ b/docs/themes/06-cerebrum/README.md
@@ -39,7 +39,7 @@ Cerebrum is a subsystem umbrella containing multiple named components:
 
 | #   | Epic                                         | Summary                                                                        | Status      |
 | --- | -------------------------------------------- | ------------------------------------------------------------------------------ | ----------- |
-| 0   | [Engram Storage](epics/00-engram-storage.md) | File format, templates, directory structure, scope model, CRUD operations      | Not started |
+| 0   | [Engram Storage](epics/00-engram-storage.md) | File format, templates, directory structure, scope model, CRUD operations      | Partial     |
 | 1   | [Thalamus](epics/01-thalamus.md)             | File watcher, frontmatter indexing, embedding sync, cross-source retrieval     | Not started |
 | 2   | [Ingest](epics/02-ingest.md)                 | Manual/agent/capture input, classification, entity extraction, scope inference | Not started |
 | 3   | [Emit](epics/03-emit.md)                     | Query engine, document generation, proactive nudges                            | Not started |

--- a/docs/themes/06-cerebrum/epics/00-engram-storage.md
+++ b/docs/themes/06-cerebrum/epics/00-engram-storage.md
@@ -10,7 +10,7 @@ Define the engram file format, template system, directory structure, and scope m
 
 | #   | PRD                                                                        | Summary                                                                                    | Status      |
 | --- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------- |
-| 077 | [Engram File Format & Directory](../prds/077-engram-file-format/README.md) | File format spec, YAML frontmatter schema, template system, directory layout, CRUD service | Not started |
+| 077 | [Engram File Format & Directory](../prds/077-engram-file-format/README.md) | File format spec, YAML frontmatter schema, template system, directory layout, CRUD service | Done        |
 | 078 | [Scope Model](../prds/078-scope-model/README.md)                           | Hierarchical dot-notation scopes, scope rules, filtering, secret scope protection          | Not started |
 
 PRD-077 must complete before PRD-078 — scopes are stored in engram frontmatter, so the file format must be defined first.

--- a/docs/themes/06-cerebrum/prds/077-engram-file-format/README.md
+++ b/docs/themes/06-cerebrum/prds/077-engram-file-format/README.md
@@ -1,7 +1,7 @@
 # PRD-077: Engram File Format & Directory Structure
 
 > Epic: [00 — Engram Storage](../../epics/00-engram-storage.md)
-> Status: Not started
+> Status: Done
 
 ## Overview
 
@@ -203,14 +203,14 @@ _To be filled in after the decision plays out._
 
 ## User Stories
 
-| #   | Story                                                     | Summary                                                                                     | Status      | Parallelisable          |
-| --- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ----------- | ----------------------- |
-| 01  | [us-01-file-format](us-01-file-format.md)                 | Define and validate the engram file format — frontmatter schema, ID generation, file naming | Not started | No (first)              |
-| 02  | [us-02-template-system](us-02-template-system.md)         | Template files, registry, template-based engram creation with field validation              | Not started | Blocked by us-01        |
-| 03  | [us-03-directory-structure](us-03-directory-structure.md) | Server-side directory layout, permissions, Ansible provisioning, backup integration         | Not started | Yes                     |
-| 04  | [us-04-index-schema](us-04-index-schema.md)               | Drizzle schema for engram_index, engram_scopes, engram_tags, engram_links tables            | Not started | Yes                     |
-| 05  | [us-05-crud-service](us-05-crud-service.md)               | Service layer for engram CRUD — file operations + index sync, link management               | Not started | Blocked by us-01, us-04 |
-| 06  | [us-06-api-procedures](us-06-api-procedures.md)           | tRPC procedures for all engram and template operations                                      | Not started | Blocked by us-05        |
+| #   | Story                                                     | Summary                                                                                     | Status | Parallelisable          |
+| --- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------ | ----------------------- |
+| 01  | [us-01-file-format](us-01-file-format.md)                 | Define and validate the engram file format — frontmatter schema, ID generation, file naming | Done   | No (first)              |
+| 02  | [us-02-template-system](us-02-template-system.md)         | Template files, registry, template-based engram creation with field validation              | Done   | Blocked by us-01        |
+| 03  | [us-03-directory-structure](us-03-directory-structure.md) | Server-side directory layout, permissions, Ansible provisioning, backup integration         | Done   | Yes                     |
+| 04  | [us-04-index-schema](us-04-index-schema.md)               | Drizzle schema for engram_index, engram_scopes, engram_tags, engram_links tables            | Done   | Yes                     |
+| 05  | [us-05-crud-service](us-05-crud-service.md)               | Service layer for engram CRUD — file operations + index sync, link management               | Done   | Blocked by us-01, us-04 |
+| 06  | [us-06-api-procedures](us-06-api-procedures.md)           | tRPC procedures for all engram and template operations                                      | Done   | Blocked by us-05        |
 
 US-03 and US-04 can parallelise with each other and with US-02. US-05 depends on both the file format (us-01) and the index schema (us-04). US-06 wraps the service layer.
 

--- a/docs/themes/06-cerebrum/prds/077-engram-file-format/us-01-file-format.md
+++ b/docs/themes/06-cerebrum/prds/077-engram-file-format/us-01-file-format.md
@@ -1,7 +1,7 @@
 # US-01: Engram File Format Specification
 
 > PRD: [PRD-077: Engram File Format & Directory Structure](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As the Cerebrum system, I need a well-defined engram file format with validated 
 
 ## Acceptance Criteria
 
-- [ ] Engram files use `.md` extension with YAML frontmatter delimited by `---` fences
-- [ ] A Zod schema (`engramFrontmatterSchema`) validates all frontmatter fields per the PRD's Frontmatter Schema table: `id` (string, required), `type` (string, required), `scopes` (string array, min 1, required), `created` (ISO 8601 string, required), `modified` (ISO 8601 string, required), `source` (enum of `manual | agent | moltbot | cli | plexus:*`, required), `tags` (string array, optional), `links` (string array, optional), `status` (enum of `active | archived | consolidated | stale`, required), `template` (string, optional)
-- [ ] ID generation produces the format `eng_{YYYYMMDD}_{HHmm}_{slug}` where the slug is derived from the title (lowercased, hyphenated, max 40 characters, alphanumeric and hyphens only)
-- [ ] Duplicate ID detection appends a counter suffix (`_2`, `_3`, etc.) when a collision is found on disk
-- [ ] File naming follows the convention `{type}/{id}.md` (e.g., `research/eng_20260417_0942_agent-coordination.md`)
-- [ ] A `parseEngramFile(content: string)` function parses a raw file into validated frontmatter and a Markdown body string, throwing a typed error on invalid frontmatter
-- [ ] A `serializeEngram(frontmatter, body: string)` function produces a valid engram file string with YAML frontmatter and body separated by `---`
-- [ ] Status lifecycle transitions are enforced: `active` can move to `archived | consolidated | stale`; `archived` can move to `active`; `consolidated` and `stale` are terminal
+- [x] Engram files use `.md` extension with YAML frontmatter delimited by `---` fences
+- [x] A Zod schema (`engramFrontmatterSchema`) validates all frontmatter fields per the PRD's Frontmatter Schema table: `id` (string, required), `type` (string, required), `scopes` (string array, min 1, required), `created` (ISO 8601 string, required), `modified` (ISO 8601 string, required), `source` (enum of `manual | agent | moltbot | cli | plexus:*`, required), `tags` (string array, optional), `links` (string array, optional), `status` (enum of `active | archived | consolidated | stale`, required), `template` (string, optional)
+- [x] ID generation produces the format `eng_{YYYYMMDD}_{HHmm}_{slug}` where the slug is derived from the title (lowercased, hyphenated, max 40 characters, alphanumeric and hyphens only)
+- [x] Duplicate ID detection appends a counter suffix (`_2`, `_3`, etc.) when a collision is found on disk
+- [x] File naming follows the convention `{type}/{id}.md` (e.g., `research/eng_20260417_0942_agent-coordination.md`)
+- [x] A `parseEngramFile(content: string)` function parses a raw file into validated frontmatter and a Markdown body string, throwing a typed error on invalid frontmatter
+- [x] A `serializeEngram(frontmatter, body: string)` function produces a valid engram file string with YAML frontmatter and body separated by `---`
+- [x] Status lifecycle transitions are enforced: `active` can move to `archived | consolidated | stale`; `archived` can move to `active`; `consolidated` and `stale` are terminal
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/077-engram-file-format/us-02-template-system.md
+++ b/docs/themes/06-cerebrum/prds/077-engram-file-format/us-02-template-system.md
@@ -1,7 +1,7 @@
 # US-02: Template System
 
 > PRD: [PRD-077: Engram File Format & Directory Structure](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a user creating engrams, I want to select from predefined templates (journal,
 
 ## Acceptance Criteria
 
-- [ ] Template files exist in `engrams/.templates/` as `.md` files with YAML frontmatter defining `name`, `description`, `required_fields`, `suggested_sections`, `default_scopes`, and `custom_fields`
-- [ ] A `TemplateRegistryService` loads all templates from disk at startup and exposes `list()` and `get(name: string)` methods
-- [ ] The template frontmatter schema is validated with Zod: `name` (string, required), `description` (string, required), `required_fields` (string array, optional), `suggested_sections` (string array, optional), `default_scopes` (string array, optional), `custom_fields` (record of `{ type: string, description: string }`, optional)
-- [ ] Creating an engram with a `template` parameter merges the template's `default_scopes` into the engram's scopes, validates that all `required_fields` are provided, and scaffolds the body with `suggested_sections` as `## Heading` blocks
-- [ ] Creating an engram with a template that does not exist logs a warning and falls back to creating a `capture`-type engram without template scaffolding
-- [ ] Custom fields defined by the template are validated against their declared types and included in the engram's frontmatter
-- [ ] The default set of templates is created: `journal`, `decision`, `research`, `meeting`, `idea`, `note`, `capture` (minimal, for unstructured input)
-- [ ] Template body content supports `{{placeholder}}` markers that are replaced with user-provided values or left as-is for manual completion
+- [x] Template files exist in `engrams/.templates/` as `.md` files with YAML frontmatter defining `name`, `description`, `required_fields`, `suggested_sections`, `default_scopes`, and `custom_fields`
+- [x] A `TemplateRegistryService` loads all templates from disk at startup and exposes `list()` and `get(name: string)` methods
+- [x] The template frontmatter schema is validated with Zod: `name` (string, required), `description` (string, required), `required_fields` (string array, optional), `suggested_sections` (string array, optional), `default_scopes` (string array, optional), `custom_fields` (record of `{ type: string, description: string }`, optional)
+- [x] Creating an engram with a `template` parameter merges the template's `default_scopes` into the engram's scopes, validates that all `required_fields` are provided, and scaffolds the body with `suggested_sections` as `## Heading` blocks
+- [x] Creating an engram with a template that does not exist logs a warning and falls back to creating a `capture`-type engram without template scaffolding
+- [x] Custom fields defined by the template are validated against their declared types and included in the engram's frontmatter
+- [x] The default set of templates is created: `journal`, `decision`, `research`, `meeting`, `idea`, `note`, `capture` (minimal, for unstructured input)
+- [x] Template body content supports `{{placeholder}}` markers that are replaced with user-provided values or left as-is for manual completion
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/077-engram-file-format/us-03-directory-structure.md
+++ b/docs/themes/06-cerebrum/prds/077-engram-file-format/us-03-directory-structure.md
@@ -1,7 +1,7 @@
 # US-03: Directory Structure & Provisioning
 
 > PRD: [PRD-077: Engram File Format & Directory Structure](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As the system operator, I need the engram directory structure provisioned at `/o
 
 ## Acceptance Criteria
 
-- [ ] The directory tree is created at `/opt/pops/engrams/` matching the PRD layout: `.templates/`, `.config/`, `.archive/`, `.index/`, `journal/`, `decisions/`, `research/`, `meetings/`, `ideas/`, `notes/`, `captures/`
-- [ ] All directories under `/opt/pops/engrams/` have permissions `0700` owned by the `pops` service user
-- [ ] An Ansible task in the existing provisioning playbook creates the directory structure idempotently (running it twice produces no changes)
-- [ ] The `.archive/` directory preserves the original type subdirectory structure (e.g., archived research engrams go to `.archive/research/`)
-- [ ] The engram root `/opt/pops/engrams/` is added to the existing rclone+age backup pipeline configuration so that engram files are encrypted and synced on the backup schedule
-- [ ] A `.gitignore` at the repository root excludes `/opt/pops/engrams/` (or the engrams path is confirmed to be outside the repository tree and not at risk of accidental commit)
-- [ ] The `.config/` directory is seeded with empty scaffold files: `scope-rules.toml`, `glia.toml`, `reflexes.toml`
+- [x] The directory tree is created at `/opt/pops/engrams/` matching the PRD layout: `.templates/`, `.config/`, `.archive/`, `.index/`, `journal/`, `decisions/`, `research/`, `meetings/`, `ideas/`, `notes/`, `captures/`
+- [x] All directories under `/opt/pops/engrams/` have permissions `0700` owned by the `pops` service user
+- [x] An Ansible task in the existing provisioning playbook creates the directory structure idempotently (running it twice produces no changes)
+- [x] The `.archive/` directory preserves the original type subdirectory structure (e.g., archived research engrams go to `.archive/research/`)
+- [x] The engram root `/opt/pops/engrams/` is added to the existing rclone+age backup pipeline configuration so that engram files are encrypted and synced on the backup schedule
+- [x] A `.gitignore` at the repository root excludes `/opt/pops/engrams/` (or the engrams path is confirmed to be outside the repository tree and not at risk of accidental commit)
+- [x] The `.config/` directory is seeded with empty scaffold files: `scope-rules.toml`, `glia.toml`, `reflexes.toml`
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/077-engram-file-format/us-04-index-schema.md
+++ b/docs/themes/06-cerebrum/prds/077-engram-file-format/us-04-index-schema.md
@@ -1,7 +1,7 @@
 # US-04: Index Database Schema
 
 > PRD: [PRD-077: Engram File Format & Directory Structure](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As the Cerebrum system, I need SQLite tables for `engram_index`, `engram_scopes`
 
 ## Acceptance Criteria
 
-- [ ] A Drizzle schema defines `engram_index` with columns: `id` (text, PK), `file_path` (text, not null, unique), `type` (text, not null), `source` (text, not null), `status` (text, not null), `template` (text, nullable), `created_at` (text, not null), `modified_at` (text, not null), `title` (text, not null), `content_hash` (text, not null), `word_count` (integer, not null), `custom_fields` (text, nullable)
-- [ ] A Drizzle schema defines `engram_scopes` with columns: `engram_id` (text, FK to `engram_index.id`, not null), `scope` (text, not null), with a composite unique index on `(engram_id, scope)` and a standalone index on `scope`
-- [ ] A Drizzle schema defines `engram_tags` with columns: `engram_id` (text, FK to `engram_index.id`, not null), `tag` (text, not null), with a composite unique index on `(engram_id, tag)` and a standalone index on `tag`
-- [ ] A Drizzle schema defines `engram_links` with columns: `source_id` (text, FK to `engram_index.id`, not null), `target_id` (text, not null), with a composite unique index on `(source_id, target_id)` and a standalone index on `target_id`
-- [ ] Indexes exist on `engram_index` for columns: `type`, `source`, `status`, `created_at`, `content_hash`
-- [ ] A Drizzle migration is generated and applies cleanly to a fresh SQLite database
-- [ ] TypeScript types for all tables are exported from `@pops/db-types` (e.g., `EngramIndex`, `EngramScope`, `EngramTag`, `EngramLink`) using Drizzle's `$inferSelect` / `$inferInsert`
-- [ ] Foreign key cascades are set to `ON DELETE CASCADE` on all junction tables so that deleting an engram index row cleans up scopes, tags, and links
+- [x] A Drizzle schema defines `engram_index` with columns: `id` (text, PK), `file_path` (text, not null, unique), `type` (text, not null), `source` (text, not null), `status` (text, not null), `template` (text, nullable), `created_at` (text, not null), `modified_at` (text, not null), `title` (text, not null), `content_hash` (text, not null), `word_count` (integer, not null), `custom_fields` (text, nullable)
+- [x] A Drizzle schema defines `engram_scopes` with columns: `engram_id` (text, FK to `engram_index.id`, not null), `scope` (text, not null), with a composite unique index on `(engram_id, scope)` and a standalone index on `scope`
+- [x] A Drizzle schema defines `engram_tags` with columns: `engram_id` (text, FK to `engram_index.id`, not null), `tag` (text, not null), with a composite unique index on `(engram_id, tag)` and a standalone index on `tag`
+- [x] A Drizzle schema defines `engram_links` with columns: `source_id` (text, FK to `engram_index.id`, not null), `target_id` (text, not null), with a composite unique index on `(source_id, target_id)` and a standalone index on `target_id`
+- [x] Indexes exist on `engram_index` for columns: `type`, `source`, `status`, `created_at`, `content_hash`
+- [x] A Drizzle migration is generated and applies cleanly to a fresh SQLite database
+- [x] TypeScript types for all tables are exported from `@pops/db-types` (e.g., `EngramIndex`, `EngramScope`, `EngramTag`, `EngramLink`) using Drizzle's `$inferSelect` / `$inferInsert`
+- [x] Foreign key cascades are set to `ON DELETE CASCADE` on all junction tables so that deleting an engram index row cleans up scopes, tags, and links
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/077-engram-file-format/us-05-crud-service.md
+++ b/docs/themes/06-cerebrum/prds/077-engram-file-format/us-05-crud-service.md
@@ -1,7 +1,7 @@
 # US-05: Engram CRUD Service
 
 > PRD: [PRD-077: Engram File Format & Directory Structure](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As the Cerebrum system, I need a service layer that performs engram CRUD operati
 
 ## Acceptance Criteria
 
-- [ ] `createEngram(input)` generates an ID, writes a valid engram `.md` file to `{type}/{id}.md`, then inserts the corresponding rows into `engram_index`, `engram_scopes`, `engram_tags`, and `engram_links` — file write happens before index insert
-- [ ] `readEngram(id)` looks up the file path from the index, reads the file from disk, parses it with `parseEngramFile`, and returns both the validated frontmatter and the Markdown body
-- [ ] `updateEngram(id, changes)` reads the existing file, merges changes into frontmatter and/or body, updates the `modified` timestamp, writes the file, then updates all affected index rows (including re-syncing scopes, tags, and links)
-- [ ] `archiveEngram(id)` moves the file from `{type}/{id}.md` to `.archive/{type}/{id}.md`, sets `status` to `archived` in the index, and updates the `file_path` column
-- [ ] `linkEngrams(sourceId, targetId)` adds `targetId` to the source file's `links` array and `sourceId` to the target file's `links` array, writes both files, and inserts rows in `engram_links` for both directions
-- [ ] `unlinkEngrams(sourceId, targetId)` removes the link from both files' `links` arrays, writes both files, and deletes the corresponding `engram_links` rows in both directions
-- [ ] `reindex()` scans all `.md` files under the engram root (excluding `.archive/` and `.templates/`), parses each file, and rebuilds the entire index — existing index data is replaced, orphaned index entries are removed
-- [ ] All file write operations compute and store a SHA-256 `content_hash` and `word_count` (body only, excluding frontmatter) in the index
+- [x] `createEngram(input)` generates an ID, writes a valid engram `.md` file to `{type}/{id}.md`, then inserts the corresponding rows into `engram_index`, `engram_scopes`, `engram_tags`, and `engram_links` — file write happens before index insert
+- [x] `readEngram(id)` looks up the file path from the index, reads the file from disk, parses it with `parseEngramFile`, and returns both the validated frontmatter and the Markdown body
+- [x] `updateEngram(id, changes)` reads the existing file, merges changes into frontmatter and/or body, updates the `modified` timestamp, writes the file, then updates all affected index rows (including re-syncing scopes, tags, and links)
+- [x] `archiveEngram(id)` moves the file from `{type}/{id}.md` to `.archive/{type}/{id}.md`, sets `status` to `archived` in the index, and updates the `file_path` column
+- [x] `linkEngrams(sourceId, targetId)` adds `targetId` to the source file's `links` array and `sourceId` to the target file's `links` array, writes both files, and inserts rows in `engram_links` for both directions
+- [x] `unlinkEngrams(sourceId, targetId)` removes the link from both files' `links` arrays, writes both files, and deletes the corresponding `engram_links` rows in both directions
+- [x] `reindex()` scans all `.md` files under the engram root (excluding `.archive/` and `.templates/`), parses each file, and rebuilds the entire index — existing index data is replaced, orphaned index entries are removed
+- [x] All file write operations compute and store a SHA-256 `content_hash` and `word_count` (body only, excluding frontmatter) in the index
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/077-engram-file-format/us-06-api-procedures.md
+++ b/docs/themes/06-cerebrum/prds/077-engram-file-format/us-06-api-procedures.md
@@ -1,7 +1,7 @@
 # US-06: tRPC API Procedures
 
 > PRD: [PRD-077: Engram File Format & Directory Structure](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a client application, I need tRPC procedures that expose all engram and templ
 
 ## Acceptance Criteria
 
-- [ ] A tRPC router at `src/modules/cerebrum/engrams/router.ts` exposes procedures under the `cerebrum.engrams` namespace: `create`, `get`, `update`, `delete`, `list`, `link`, `unlink`
-- [ ] A tRPC router exposes template procedures under the `cerebrum.templates` namespace: `list`, `get`
-- [ ] `create` accepts `{ type, title, body, scopes?, tags?, template?, customFields? }`, calls `createEngram`, and returns `{ engram: Engram }`
-- [ ] `list` accepts `{ type?, scopes?, tags?, status?, search?, limit?, offset?, sort? }`, queries the index tables (not the filesystem), and returns `{ engrams: Engram[], total: number }` with correct pagination
-- [ ] `delete` calls `archiveEngram` (not a physical delete) and returns `{ success: boolean }`
-- [ ] `link` and `unlink` accept `{ sourceId, targetId }` and delegate to `linkEngrams` / `unlinkEngrams` respectively, returning `{ success: boolean }`
-- [ ] All procedure inputs are validated with Zod schemas that match the PRD's API Surface table — invalid input returns a typed tRPC error, not an unhandled exception
-- [ ] `templates.list` returns all registered templates with their metadata (name, description, required fields, custom fields) and `templates.get` returns a single template by name or throws a `NOT_FOUND` error
+- [x] A tRPC router at `src/modules/cerebrum/engrams/router.ts` exposes procedures under the `cerebrum.engrams` namespace: `create`, `get`, `update`, `delete`, `list`, `link`, `unlink`
+- [x] A tRPC router exposes template procedures under the `cerebrum.templates` namespace: `list`, `get`
+- [x] `create` accepts `{ type, title, body, scopes?, tags?, template?, customFields? }`, calls `createEngram`, and returns `{ engram: Engram }`
+- [x] `list` accepts `{ type?, scopes?, tags?, status?, search?, limit?, offset?, sort? }`, queries the index tables (not the filesystem), and returns `{ engrams: Engram[], total: number }` with correct pagination
+- [x] `delete` calls `archiveEngram` (not a physical delete) and returns `{ success: boolean }`
+- [x] `link` and `unlink` accept `{ sourceId, targetId }` and delegate to `linkEngrams` / `unlinkEngrams` respectively, returning `{ success: boolean }`
+- [x] All procedure inputs are validated with Zod schemas that match the PRD's API Surface table — invalid input returns a typed tRPC error, not an unhandled exception
+- [x] `templates.list` returns all registered templates with their metadata (name, description, required fields, custom fields) and `templates.get` returns a single template by name or throws a `NOT_FOUND` error
 
 ## Notes
 

--- a/infra/ansible/inventory/group_vars/pops_servers/vars.yml
+++ b/infra/ansible/inventory/group_vars/pops_servers/vars.yml
@@ -13,6 +13,7 @@ sqlite_data_dir: /opt/pops/data/sqlite
 paperless_data_dir: /opt/pops/data/paperless
 metabase_data_dir: /opt/pops/data/metabase
 secrets_dir: /opt/pops/secrets
+engram_root: /opt/pops/engrams
 
 # Schedules
 backup_schedule: '*-*-* 03:00:00' # systemd OnCalendar: 3am daily

--- a/infra/ansible/roles/backups/templates/backup.sh.j2
+++ b/infra/ansible/roles/backups/templates/backup.sh.j2
@@ -13,12 +13,14 @@ sqlite3 "${SQLITE_PATH}" ".backup ${BACKUP_DIR}/pops-backup.db"
 
 # 2. Create tar archive
 # Engrams are namespaced under `engrams/` in the archive so restored
-# Markdown files don't collide with other data directories.
+# Markdown files don't collide with other data directories. Quote the
+# Jinja expansion so spaces or shell metacharacters in engram_root cannot
+# break the command substitution.
 tar cf "${ARCHIVE}" \
   -C "${BACKUP_DIR}" pops-backup.db \
   -C "{{ paperless_data_dir }}" . \
   -C "{{ metabase_data_dir }}" . \
-  -C "$(dirname {{ engram_root }})" "$(basename {{ engram_root }})"
+  -C "$(dirname "{{ engram_root }}")" "$(basename "{{ engram_root }}")"
 
 # 3. Encrypt with age
 age --encrypt \

--- a/infra/ansible/roles/backups/templates/backup.sh.j2
+++ b/infra/ansible/roles/backups/templates/backup.sh.j2
@@ -12,10 +12,13 @@ echo "[$(date)] Starting POPS backup..."
 sqlite3 "${SQLITE_PATH}" ".backup ${BACKUP_DIR}/pops-backup.db"
 
 # 2. Create tar archive
+# Engrams are namespaced under `engrams/` in the archive so restored
+# Markdown files don't collide with other data directories.
 tar cf "${ARCHIVE}" \
   -C "${BACKUP_DIR}" pops-backup.db \
   -C "{{ paperless_data_dir }}" . \
-  -C "{{ metabase_data_dir }}" .
+  -C "{{ metabase_data_dir }}" . \
+  -C "$(dirname {{ engram_root }})" "$(basename {{ engram_root }})"
 
 # 3. Encrypt with age
 age --encrypt \

--- a/infra/ansible/roles/pops-deploy/defaults/main.yml
+++ b/infra/ansible/roles/pops-deploy/defaults/main.yml
@@ -1,3 +1,23 @@
 ---
 pops_repo_url: 'https://github.com/knoxio/pops.git'
 pops_branch: main
+
+# Cerebrum — engram directory layout on the server. `engram_root` lives in
+# group_vars so other roles (e.g. backups) can reference it.
+engram_type_dirs:
+  - journal
+  - decisions
+  - research
+  - meetings
+  - ideas
+  - notes
+  - captures
+engram_dot_dirs:
+  - .templates
+  - .config
+  - .archive
+  - .index
+engram_config_scaffolds:
+  - scope-rules.toml
+  - glia.toml
+  - reflexes.toml

--- a/infra/ansible/roles/pops-deploy/tasks/main.yml
+++ b/infra/ansible/roles/pops-deploy/tasks/main.yml
@@ -12,6 +12,42 @@
     - '{{ paperless_data_dir }}'
     - '{{ metabase_data_dir }}'
 
+- name: Create Cerebrum engram root
+  ansible.builtin.file:
+    path: '{{ engram_root }}'
+    state: directory
+    owner: '{{ pops_user }}'
+    group: '{{ pops_user }}'
+    mode: '0700'
+
+- name: Create Cerebrum engram type subdirectories
+  ansible.builtin.file:
+    path: '{{ engram_root }}/{{ item }}'
+    state: directory
+    owner: '{{ pops_user }}'
+    group: '{{ pops_user }}'
+    mode: '0700'
+  loop: '{{ engram_type_dirs }}'
+
+- name: Create Cerebrum engram reserved directories
+  ansible.builtin.file:
+    path: '{{ engram_root }}/{{ item }}'
+    state: directory
+    owner: '{{ pops_user }}'
+    group: '{{ pops_user }}'
+    mode: '0700'
+  loop: '{{ engram_dot_dirs }}'
+
+- name: Scaffold Cerebrum config files
+  ansible.builtin.copy:
+    content: "# Cerebrum {{ item }} — populate per docs/themes/06-cerebrum\n"
+    dest: '{{ engram_root }}/.config/{{ item }}'
+    owner: '{{ pops_user }}'
+    group: '{{ pops_user }}'
+    mode: '0600'
+    force: false
+  loop: '{{ engram_config_scaffolds }}'
+
 - name: Clone or update POPS repository
   ansible.builtin.git:
     repo: '{{ pops_repo_url }}'

--- a/packages/db-types/src/index.ts
+++ b/packages/db-types/src/index.ts
@@ -18,6 +18,7 @@ import type { debriefResults } from './schema/debrief-results.js';
 import type { debriefSessions } from './schema/debrief-sessions.js';
 import type { debriefStatus } from './schema/debrief-status.js';
 import type { dismissedDiscover } from './schema/dismissed-discover.js';
+import type { engramIndex, engramLinks, engramScopes, engramTags } from './schema/engrams.js';
 import type { entities } from './schema/entities.js';
 import type { environments } from './schema/environments.js';
 import type { episodes } from './schema/episodes.js';
@@ -58,6 +59,10 @@ export {
   debriefSessions,
   debriefStatus,
   dismissedDiscover,
+  engramIndex,
+  engramLinks,
+  engramScopes,
+  engramTags,
   entities,
   environments,
   episodes,
@@ -143,6 +148,14 @@ export type SyncJobResultRow = InferSelectModel<typeof syncJobResults>;
 export type SyncJobResultInsert = InferInsertModel<typeof syncJobResults>;
 export type DismissedDiscoverRow = InferSelectModel<typeof dismissedDiscover>;
 export type DismissedDiscoverInsert = InferInsertModel<typeof dismissedDiscover>;
+export type EngramIndexRow = InferSelectModel<typeof engramIndex>;
+export type EngramIndexInsert = InferInsertModel<typeof engramIndex>;
+export type EngramScopeRow = InferSelectModel<typeof engramScopes>;
+export type EngramScopeInsert = InferInsertModel<typeof engramScopes>;
+export type EngramTagRow = InferSelectModel<typeof engramTags>;
+export type EngramTagInsert = InferInsertModel<typeof engramTags>;
+export type EngramLinkRow = InferSelectModel<typeof engramLinks>;
+export type EngramLinkInsert = InferInsertModel<typeof engramLinks>;
 export type ComparisonSkipCooloffRow = InferSelectModel<typeof comparisonSkipCooloffs>;
 export type ComparisonSkipCooloffInsert = InferInsertModel<typeof comparisonSkipCooloffs>;
 export type ComparisonStalenessRow = InferSelectModel<typeof comparisonStaleness>;

--- a/packages/db-types/src/schema/engrams.ts
+++ b/packages/db-types/src/schema/engrams.ts
@@ -1,0 +1,79 @@
+/**
+ * Cerebrum engram index schema.
+ *
+ * Engrams are Markdown files on disk; this schema mirrors their frontmatter
+ * into SQLite so queries (list, filter by scope, search by tag, reverse-link
+ * lookup) can be served without parsing files. The filesystem remains the
+ * source of truth — the index is regenerable from `.md` files.
+ */
+import { index, integer, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+
+export const engramIndex = sqliteTable(
+  'engram_index',
+  {
+    id: text('id').primaryKey(),
+    filePath: text('file_path').notNull().unique(),
+    type: text('type').notNull(),
+    source: text('source').notNull(),
+    status: text('status').notNull(),
+    template: text('template'),
+    createdAt: text('created_at').notNull(),
+    modifiedAt: text('modified_at').notNull(),
+    title: text('title').notNull(),
+    contentHash: text('content_hash').notNull(),
+    wordCount: integer('word_count').notNull(),
+    customFields: text('custom_fields'),
+  },
+  (table) => [
+    index('idx_engram_index_type').on(table.type),
+    index('idx_engram_index_source').on(table.source),
+    index('idx_engram_index_status').on(table.status),
+    index('idx_engram_index_created_at').on(table.createdAt),
+    index('idx_engram_index_content_hash').on(table.contentHash),
+  ]
+);
+
+export const engramScopes = sqliteTable(
+  'engram_scopes',
+  {
+    engramId: text('engram_id')
+      .notNull()
+      .references(() => engramIndex.id, { onDelete: 'cascade' }),
+    scope: text('scope').notNull(),
+  },
+  (table) => [
+    unique('uq_engram_scopes_pair').on(table.engramId, table.scope),
+    index('idx_engram_scopes_scope').on(table.scope),
+  ]
+);
+
+export const engramTags = sqliteTable(
+  'engram_tags',
+  {
+    engramId: text('engram_id')
+      .notNull()
+      .references(() => engramIndex.id, { onDelete: 'cascade' }),
+    tag: text('tag').notNull(),
+  },
+  (table) => [
+    unique('uq_engram_tags_pair').on(table.engramId, table.tag),
+    index('idx_engram_tags_tag').on(table.tag),
+  ]
+);
+
+// target_id intentionally has no FK — links may reference engrams that have not
+// yet been indexed (referenced in frontmatter before the target file is
+// processed). The indexer reconciles orphaned targets when the target lands.
+export const engramLinks = sqliteTable(
+  'engram_links',
+  {
+    sourceId: text('source_id')
+      .notNull()
+      .references(() => engramIndex.id, { onDelete: 'cascade' }),
+    targetId: text('target_id').notNull(),
+  },
+  (table) => [
+    unique('uq_engram_links_pair').on(table.sourceId, table.targetId),
+    index('idx_engram_links_target').on(table.targetId),
+  ]
+);

--- a/packages/db-types/src/schema/index.ts
+++ b/packages/db-types/src/schema/index.ts
@@ -9,6 +9,7 @@ export { debriefResults } from './debrief-results.js';
 export { debriefSessions } from './debrief-sessions.js';
 export { debriefStatus } from './debrief-status.js';
 export { dismissedDiscover } from './dismissed-discover.js';
+export { engramIndex, engramLinks, engramScopes, engramTags } from './engrams.js';
 export { entities } from './entities.js';
 export { environments } from './environments.js';
 export { episodes } from './episodes.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,15 @@ importers:
       express-rate-limit:
         specifier: ^8.3.2
         version: 8.3.2(express@5.2.1)
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       helmet:
         specifier: ^8.0.0
         version: 8.1.0
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -90,6 +96,9 @@ importers:
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/jsonwebtoken':
         specifier: ^9.0.10
         version: 9.0.10
@@ -3423,6 +3432,9 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
@@ -3598,6 +3610,9 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -4320,6 +4335,10 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -4487,6 +4506,10 @@ packages:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -4620,6 +4643,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -4718,6 +4745,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -4766,6 +4797,10 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -5599,6 +5634,10 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -5714,6 +5753,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -5773,6 +5815,10 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -8366,6 +8412,8 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
@@ -8546,6 +8594,10 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -9217,6 +9269,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   extend@3.0.2: {}
 
   fast-copy@4.0.2: {}
@@ -9378,6 +9434,13 @@ snapshots:
 
   graphql@16.13.2: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -9508,6 +9571,8 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-extendable@0.1.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -9567,6 +9632,11 @@ snapshots:
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
+
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -9642,6 +9712,8 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
 
@@ -10686,6 +10758,11 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
@@ -10879,6 +10956,8 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sprintf-js@1.0.3: {}
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -10954,6 +11033,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 


### PR DESCRIPTION
## Summary

Lands the foundation of Theme 06 — Cerebrum. Engrams are Markdown files with YAML frontmatter on disk; a SQLite index mirrors frontmatter for fast queries and remains regenerable from files.

Ships every user story in PRD-077:

- **US-01 File format** — Zod schema + `parseEngramFile` / `serializeEngram` using `gray-matter` with a `js-yaml` JSON-schema engine so ISO timestamps stay as strings (timezone offsets preserved). Deterministic `eng_{YYYYMMDD}_{HHmm}_{slug}` IDs, status-lifecycle enforcement.
- **US-02 Templates** — `TemplateRegistry` loads `.md` files from disk; `applyTemplate` merges default scopes, validates required fields + types, substitutes `{{placeholder}}` markers. Seven bundled defaults (journal, decision, research, meeting, idea, note, capture) copied into the engram root on first boot.
- **US-03 Provisioning** — Ansible tasks create `/opt/pops/engrams/` (0700, owned by `pops`), subdirs per type, and scaffolds `.config/{scope-rules,glia,reflexes}.toml`. `engram_root` lives in group_vars so the backups role can tar engrams under a namespaced path.
- **US-04 Index schema** — `engram_index` plus `engram_scopes` / `engram_tags` / `engram_links` junctions with cascading FKs and the prescribed indexes. Fresh DBs pick up DDL from `initializeSchema()`; existing DBs get Drizzle migration `0031_romantic_hannibal_king`.
- **US-05 CRUD service** — atomic file writes (temp + rename), file-first / index-second ordering, bidirectional link management with a ghost-target escape hatch (target file may not exist yet), archive-on-delete, full reindex in a single transaction, SHA-256 content hash + word count stored per write.
- **US-06 tRPC** — `cerebrum.engrams.{create,get,update,delete,list,link,unlink}` and `cerebrum.templates.{list,get}`, plumbed through `EngramService` with per-request `getDrizzle()` so env-scoped DB context is honoured.

Docs (per Documentation Sync Rule): PRD-077 + all six USs → Done; Epic 00 → PRD-077 Done; Theme README → Epic 00 Partial (PRD-078 scope model still pending); roadmap tracker updated.

## Test plan

- [x] `pnpm typecheck` across monorepo (16 tasks green)
- [x] `pnpm oxlint` — zero new warnings (one pre-existing `express-rate-limit` warning unchanged)
- [x] `pnpm exec oxfmt --check .` clean
- [x] `pnpm exec vitest run` — 142 files / 2608 tests pass (28 new cerebrum tests)
- [x] In-memory DB round-trip: create → read → list → archive via tRPC caller
- [x] Template-driven create scaffolds sections, merges scopes, validates required fields
- [x] Link/unlink is bidirectional in both files and index
- [x] `reindex()` rebuilds the index after a direct `DELETE FROM engram_index`
- [ ] Ansible dry-run against a real host (not available in this environment)
- [ ] Restore from a backup tar containing `engrams/` (not available in this environment)

https://claude.ai/code/session_01DdsoGraWsBqNxw4HsQMxhy