### PR TITLE
feat(cerebrum): PRD-078 scope model — validation, rule engine, filtering, tRPC API

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -67,6 +67,7 @@
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "sharp": "^0.34.5",
+    "smol-toml": "^1.6.1",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.test.ts
@@ -1,0 +1,195 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { describe, expect, it, afterEach, beforeEach } from 'vitest';
+
+import { createTestDb } from '../../../shared/test-utils.js';
+import { TemplateRegistry } from '../templates/registry.js';
+import { seedDefaultTemplates } from '../templates/seed.js';
+import { filterByScopes, inferScopesFromContext } from './scope-filter.js';
+import { EngramService } from './service.js';
+
+import type { Database } from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+/** A fixed clock that advances one minute per call. */
+function makeClock(start = new Date('2026-04-18T09:00:00Z')): () => Date {
+  let t = start.getTime();
+  return () => {
+    const d = new Date(t);
+    t += 60_000;
+    return d;
+  };
+}
+
+describe('filterByScopes', () => {
+  let rawDb: Database;
+  let db: BetterSQLite3Database;
+  let service: EngramService;
+  let root: string;
+
+  beforeEach(() => {
+    rawDb = createTestDb();
+    db = drizzle(rawDb);
+    root = mkdtempSync(join(tmpdir(), 'scope-filter-'));
+    const templatesDir = join(root, '.templates');
+    seedDefaultTemplates(templatesDir);
+    service = new EngramService({
+      root,
+      db,
+      templates: new TemplateRegistry(templatesDir),
+      now: makeClock(),
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    rawDb.close();
+  });
+
+  it('returns engrams matching a top-level scope prefix', () => {
+    service.create({ type: 'note', title: 'W1', body: '# W1', scopes: ['work.projects'] });
+    service.create({ type: 'note', title: 'P1', body: '# P1', scopes: ['personal.journal'] });
+
+    const result = filterByScopes({ scopes: ['work'], db });
+    expect(result.engramIds).toHaveLength(1);
+  });
+
+  it('matches nested scopes via prefix', () => {
+    service.create({ type: 'note', title: 'A', body: '# A', scopes: ['work.projects.karbon'] });
+    service.create({ type: 'note', title: 'B', body: '# B', scopes: ['work.meetings'] });
+    service.create({ type: 'note', title: 'C', body: '# C', scopes: ['personal.journal'] });
+
+    const result = filterByScopes({ scopes: ['work'], db });
+    expect(result.engramIds).toHaveLength(2);
+  });
+
+  it('hard-blocks secret-scoped engrams by default', () => {
+    service.create({ type: 'note', title: 'S', body: '# S', scopes: ['work.secret.jobsearch'] });
+    service.create({ type: 'note', title: 'P', body: '# P', scopes: ['work.projects'] });
+
+    const result = filterByScopes({ scopes: ['work'], db });
+    expect(result.engramIds).toHaveLength(1); // secret blocked
+  });
+
+  it('includes secret-scoped engrams when includeSecret is true', () => {
+    service.create({ type: 'note', title: 'S', body: '# S', scopes: ['work.secret.jobsearch'] });
+    service.create({ type: 'note', title: 'P', body: '# P', scopes: ['work.projects'] });
+
+    const result = filterByScopes({ scopes: ['work'], db, includeSecret: true });
+    expect(result.engramIds).toHaveLength(2);
+  });
+
+  it('engram with BOTH secret and non-secret scope is blocked without opt-in', () => {
+    service.create({
+      type: 'note',
+      title: 'Mixed',
+      body: '# Mixed',
+      scopes: ['work.projects.karbon', 'work.secret.jobsearch'],
+    });
+
+    const result = filterByScopes({ scopes: ['work'], db });
+    expect(result.engramIds).toHaveLength(0); // most restrictive wins
+  });
+
+  it('engram with mixed scopes is included with includeSecret', () => {
+    service.create({
+      type: 'note',
+      title: 'Mixed',
+      body: '# Mixed',
+      scopes: ['work.projects.karbon', 'work.secret.jobsearch'],
+    });
+
+    const result = filterByScopes({ scopes: ['work'], db, includeSecret: true });
+    expect(result.engramIds).toHaveLength(1);
+  });
+
+  it('empty scopes returns all non-secret engrams', () => {
+    service.create({ type: 'note', title: 'A', body: '# A', scopes: ['work.projects'] });
+    service.create({ type: 'note', title: 'B', body: '# B', scopes: ['personal.journal'] });
+    service.create({ type: 'note', title: 'S', body: '# S', scopes: ['personal.secret.therapy'] });
+
+    const result = filterByScopes({ scopes: [], db });
+    expect(result.engramIds).toHaveLength(2); // secret blocked
+  });
+
+  it('empty scopes with includeSecret returns all engrams', () => {
+    service.create({ type: 'note', title: 'A', body: '# A', scopes: ['work.projects'] });
+    service.create({ type: 'note', title: 'S', body: '# S', scopes: ['personal.secret.therapy'] });
+
+    const result = filterByScopes({ scopes: [], db, includeSecret: true });
+    expect(result.engramIds).toHaveLength(2);
+  });
+
+  it('non-matching prefix returns empty result', () => {
+    service.create({ type: 'note', title: 'A', body: '# A', scopes: ['personal.journal'] });
+
+    const result = filterByScopes({ scopes: ['storage'], db });
+    expect(result.engramIds).toHaveLength(0);
+  });
+
+  it('multiple prefixes return union of matching engrams', () => {
+    service.create({ type: 'note', title: 'A', body: '# A', scopes: ['work.projects'] });
+    service.create({ type: 'note', title: 'B', body: '# B', scopes: ['personal.journal'] });
+    service.create({ type: 'note', title: 'C', body: '# C', scopes: ['storage.recipes'] });
+
+    const result = filterByScopes({ scopes: ['work', 'personal'], db });
+    expect(result.engramIds).toHaveLength(2);
+  });
+
+  it('exact scope match works', () => {
+    service.create({ type: 'note', title: 'A', body: '# A', scopes: ['work.projects'] });
+
+    const result = filterByScopes({ scopes: ['work.projects'], db });
+    expect(result.engramIds).toHaveLength(1);
+  });
+
+  it('returns no duplicates even when engram has multiple matching scopes', () => {
+    service.create({
+      type: 'note',
+      title: 'A',
+      body: '# A',
+      scopes: ['work.projects', 'work.meetings'],
+    });
+
+    const result = filterByScopes({ scopes: ['work'], db });
+    expect(result.engramIds).toHaveLength(1); // only once
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferScopesFromContext (pure function)
+// ---------------------------------------------------------------------------
+
+describe('inferScopesFromContext', () => {
+  it('maps "work" to ["work"]', () => {
+    expect(inferScopesFromContext('work')).toEqual(['work']);
+  });
+
+  it('maps "at work" to ["work"]', () => {
+    expect(inferScopesFromContext('at work')).toEqual(['work']);
+  });
+
+  it('maps "personal" to ["personal"]', () => {
+    expect(inferScopesFromContext('personal')).toEqual(['personal']);
+  });
+
+  it('maps "journal" to ["personal.journal"]', () => {
+    expect(inferScopesFromContext('journal')).toEqual(['personal.journal']);
+  });
+
+  it('is case-insensitive', () => {
+    expect(inferScopesFromContext('WORK')).toEqual(['work']);
+    expect(inferScopesFromContext('Personal')).toEqual(['personal']);
+  });
+
+  it('returns empty array for unknown hint', () => {
+    expect(inferScopesFromContext('completely unknown context xyz')).toEqual([]);
+  });
+
+  it('trims whitespace', () => {
+    expect(inferScopesFromContext('  work  ')).toEqual(['work']);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.ts
@@ -1,0 +1,141 @@
+/**
+ * Query-time scope filtering.
+ *
+ * `filterByScopes` is the only exported function that touches the database.
+ * `inferScopesFromContext` is a pure keyword map with no side effects.
+ *
+ * Secret scope hard-blocking: any engram with at least one `*.secret.*` scope
+ * is excluded unless the caller explicitly sets `includeSecret: true`.
+ */
+import { like, or, sql } from 'drizzle-orm';
+
+import { engramScopes } from '@pops/db-types';
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+export interface FilterByScopesOptions {
+  /** Scope prefixes to match. Empty array = no scope filter (all engrams). */
+  scopes: string[];
+  /** When true, secret-scoped engrams are included. Default: false. */
+  includeSecret?: boolean;
+  db: BetterSQLite3Database;
+}
+
+export interface FilterByScopesResult {
+  /** Engram IDs that satisfy the scope filter. */
+  engramIds: string[];
+}
+
+/**
+ * Return the set of engram IDs that match the requested scope prefixes,
+ * excluding secret-scoped engrams unless `includeSecret` is true.
+ *
+ * An empty `scopes` array means "no scope restriction" — returns all engram
+ * IDs that are not excluded by the secret rule.
+ *
+ * Uses the `scope` index on `engram_scopes` for prefix queries.
+ */
+export function filterByScopes(opts: FilterByScopesOptions): FilterByScopesResult {
+  const { scopes, includeSecret = false, db } = opts;
+
+  // Step 1: Collect IDs of secret-scoped engrams (for hard-blocking).
+  const secretIds = includeSecret ? new Set<string>() : getSecretEngramIds(db);
+
+  // Step 2: Collect IDs matching the scope prefixes.
+  let matchingIds: string[];
+  if (scopes.length === 0) {
+    // No scope filter — get all engram IDs from the index table.
+    matchingIds = getAllEngramIds(db);
+  } else {
+    matchingIds = getScopeMatchingIds(db, scopes);
+  }
+
+  // Step 3: Remove secret-scoped engrams unless opted in.
+  const result = matchingIds.filter((id) => !secretIds.has(id));
+  return { engramIds: result };
+}
+
+/** Fetch all engram IDs that have at least one secret scope. */
+function getSecretEngramIds(db: BetterSQLite3Database): Set<string> {
+  // A scope contains 'secret' as a segment — use LIKE patterns for each boundary.
+  // We query for scopes where '.secret.' appears in the middle, OR starts with 'secret.',
+  // OR ends with '.secret'. The last two are technically invalid (secret is never the
+  // first or last segment in a valid scope), but we guard defensively.
+  const rows = db
+    .select({ engramId: engramScopes.engramId })
+    .from(engramScopes)
+    .where(
+      or(
+        like(engramScopes.scope, '%.secret.%'),
+        like(engramScopes.scope, 'secret.%'),
+        like(engramScopes.scope, '%.secret')
+      )
+    )
+    .all();
+  return new Set(rows.map((r) => r.engramId));
+}
+
+/** Fetch all engram IDs from the scopes table (distinct). */
+function getAllEngramIds(db: BetterSQLite3Database): string[] {
+  const rows = db.selectDistinct({ engramId: engramScopes.engramId }).from(engramScopes).all();
+  return rows.map((r) => r.engramId);
+}
+
+/**
+ * Return engram IDs where at least one stored scope matches any of the
+ * requested prefix patterns. Uses SQL LIKE for prefix queries.
+ */
+function getScopeMatchingIds(db: BetterSQLite3Database, scopes: string[]): string[] {
+  // Build a LIKE condition per prefix. A stored scope matches prefix `p` when:
+  //   scope = p           (exact match)
+  //   scope LIKE 'p.%'   (child scope)
+  const conditions = scopes.flatMap((prefix) => [
+    sql`${engramScopes.scope} = ${prefix}`,
+    like(engramScopes.scope, `${prefix}.%`),
+  ]);
+
+  const rows = db
+    .selectDistinct({ engramId: engramScopes.engramId })
+    .from(engramScopes)
+    .where(or(...conditions))
+    .all();
+
+  return rows.map((r) => r.engramId);
+}
+
+// ---------------------------------------------------------------------------
+// Context inference
+// ---------------------------------------------------------------------------
+
+/** Map from keyword to scope prefix. */
+const CONTEXT_MAP: Record<string, string[]> = {
+  work: ['work'],
+  'at work': ['work'],
+  'work context': ['work'],
+  personal: ['personal'],
+  'personal context': ['personal'],
+  storage: ['storage'],
+  journal: ['personal.journal'],
+  captures: ['personal.captures'],
+};
+
+/**
+ * Map free-text contextual hints to scope prefix arrays.
+ * This is a simple keyword map — LLM-based inference is out of scope (PRD-081).
+ *
+ * @example
+ * inferScopesFromContext("at work")   // ["work"]
+ * inferScopesFromContext("personal")  // ["personal"]
+ */
+export function inferScopesFromContext(hint: string): string[] {
+  const normalised = hint.trim().toLowerCase();
+  const mapped = CONTEXT_MAP[normalised];
+  if (mapped) return mapped;
+
+  // Fall back to checking if any key is contained in the hint
+  for (const [key, prefixes] of Object.entries(CONTEXT_MAP)) {
+    if (normalised.includes(key)) return prefixes;
+  }
+
+  return [];
+}

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.ts
@@ -4,8 +4,9 @@
  * `filterByScopes` is the only exported function that touches the database.
  * `inferScopesFromContext` is a pure keyword map with no side effects.
  *
- * Secret scope hard-blocking: any engram with at least one `*.secret.*` scope
- * is excluded unless the caller explicitly sets `includeSecret: true`.
+ * Secret scope hard-blocking: any engram with at least one scope containing a
+ * segment named exactly `secret` (at any position) is excluded unless the
+ * caller explicitly sets `includeSecret: true`.
  */
 import { like, or, sql } from 'drizzle-orm';
 

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-filter.ts
@@ -57,10 +57,8 @@ export function filterByScopes(opts: FilterByScopesOptions): FilterByScopesResul
 
 /** Fetch all engram IDs that have at least one secret scope. */
 function getSecretEngramIds(db: BetterSQLite3Database): Set<string> {
-  // A scope contains 'secret' as a segment — use LIKE patterns for each boundary.
-  // We query for scopes where '.secret.' appears in the middle, OR starts with 'secret.',
-  // OR ends with '.secret'. The last two are technically invalid (secret is never the
-  // first or last segment in a valid scope), but we guard defensively.
+  // Any scope containing a segment exactly named 'secret' is treated as secret,
+  // regardless of position. Three LIKE patterns cover middle, start, and end.
   const rows = db
     .select({ engramId: engramScopes.engramId })
     .from(engramScopes)

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-rules.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-rules.test.ts
@@ -1,0 +1,258 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, afterEach, beforeEach } from 'vitest';
+
+import { ScopeRuleEngine, resolveScopes } from './scope-rules.js';
+
+import type { ScopeRulesConfig } from './scope-rules.js';
+
+// ---------------------------------------------------------------------------
+// resolveScopes (pure function tests — no filesystem)
+// ---------------------------------------------------------------------------
+
+const baseConfig: ScopeRulesConfig = {
+  defaults: { fallback_scope: 'personal.captures' },
+  rules: [
+    { match: { source: 'github' }, assign: ['work.projects'], priority: 10 },
+    { match: { source: 'moltbot' }, assign: ['personal.captures'], priority: 20 },
+    {
+      match: { source: 'manual', tags: ['therapy'] },
+      assign: ['personal.secret.therapy'],
+      priority: 30,
+    },
+    { match: { type: 'journal' }, assign: ['personal.journal'], priority: 5 },
+  ],
+};
+
+describe('resolveScopes', () => {
+  it('returns explicit scopes when provided', () => {
+    const result = resolveScopes({ source: 'github', explicitScopes: ['work.custom'] }, baseConfig);
+    expect(result).toEqual(['work.custom']);
+  });
+
+  it('matches single condition and assigns scopes', () => {
+    expect(resolveScopes({ source: 'github' }, baseConfig)).toEqual(['work.projects']);
+    expect(resolveScopes({ source: 'moltbot' }, baseConfig)).toEqual(['personal.captures']);
+  });
+
+  it('applies all matching rules additively', () => {
+    const config: ScopeRulesConfig = {
+      defaults: { fallback_scope: 'personal.captures' },
+      rules: [
+        { match: { source: 'github' }, assign: ['work.projects'], priority: 10 },
+        { match: { type: 'meeting' }, assign: ['work.meetings'], priority: 5 },
+      ],
+    };
+    const result = resolveScopes({ source: 'github', type: 'meeting' }, config);
+    expect(result).toContain('work.projects');
+    expect(result).toContain('work.meetings');
+    expect(result).toHaveLength(2);
+  });
+
+  it('falls back to fallback_scope when no rules match', () => {
+    expect(resolveScopes({ source: 'cli' }, baseConfig)).toEqual(['personal.captures']);
+  });
+
+  it('falls back when input is empty', () => {
+    expect(resolveScopes({}, baseConfig)).toEqual(['personal.captures']);
+  });
+
+  it('matches tag-based rule with set intersection', () => {
+    // Rule requires tag 'therapy' — engram has ['therapy', 'extra']
+    const result = resolveScopes({ source: 'manual', tags: ['therapy', 'extra'] }, baseConfig);
+    expect(result).toContain('personal.secret.therapy');
+  });
+
+  it('does not match tag rule if required tag missing', () => {
+    const result = resolveScopes({ source: 'manual', tags: ['other'] }, baseConfig);
+    expect(result).not.toContain('personal.secret.therapy');
+    expect(result).toEqual(['personal.captures']); // fallback
+  });
+
+  it('deduplicates scopes from multiple matching rules', () => {
+    const config: ScopeRulesConfig = {
+      defaults: { fallback_scope: 'personal.captures' },
+      rules: [
+        { match: { source: 'github' }, assign: ['work.projects'], priority: 10 },
+        { match: { type: 'meeting' }, assign: ['work.projects'], priority: 5 },
+      ],
+    };
+    const result = resolveScopes({ source: 'github', type: 'meeting' }, config);
+    expect(result).toEqual(['work.projects']);
+  });
+
+  it('deduplicates explicit scopes', () => {
+    const result = resolveScopes(
+      { explicitScopes: ['work.projects', 'work.projects', 'personal.journal'] },
+      baseConfig
+    );
+    expect(result).toEqual(['work.projects', 'personal.journal']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ScopeRuleEngine (filesystem tests)
+// ---------------------------------------------------------------------------
+
+describe('ScopeRuleEngine', () => {
+  let root: string;
+  let configDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'scope-rules-'));
+    configDir = join(root, '.config');
+    mkdirSync(configDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function writeToml(content: string): void {
+    writeFileSync(join(configDir, 'scope-rules.toml'), content, 'utf8');
+  }
+
+  it('parses a valid scope-rules.toml', () => {
+    writeToml(`
+[defaults]
+fallback_scope = "personal.captures"
+
+[[rules]]
+match = { source = "github" }
+assign = ["work.projects"]
+priority = 10
+
+[[rules]]
+match = { type = "journal" }
+assign = ["personal.journal"]
+priority = 5
+`);
+    const engine = new ScopeRuleEngine(root);
+    const config = engine.getConfig();
+    expect(config.defaults.fallback_scope).toBe('personal.captures');
+    expect(config.rules).toHaveLength(2);
+  });
+
+  it('falls back to personal.captures when file is missing', () => {
+    const engine = new ScopeRuleEngine(root);
+    expect(engine.inferScopes({ source: 'anything' })).toEqual(['personal.captures']);
+  });
+
+  it('falls back to personal.captures on parse error', () => {
+    writeToml('this is not valid toml ===== !!!');
+    const engine = new ScopeRuleEngine(root);
+    expect(engine.inferScopes({})).toEqual(['personal.captures']);
+  });
+
+  it('skips rules with invalid assign scopes (logs warning)', () => {
+    writeToml(`
+[defaults]
+fallback_scope = "personal.captures"
+
+[[rules]]
+match = { source = "github" }
+assign = ["INVALID"]
+priority = 10
+
+[[rules]]
+match = { source = "moltbot" }
+assign = ["personal.captures"]
+priority = 5
+`);
+    const engine = new ScopeRuleEngine(root);
+    const config = engine.getConfig();
+    // First rule had only invalid assigns → skipped; second rule is valid
+    expect(config.rules).toHaveLength(1);
+    expect(config.rules[0]?.match.source).toBe('moltbot');
+  });
+
+  it('normalises fallback_scope to lowercase', () => {
+    writeToml(`
+[defaults]
+fallback_scope = "Personal.Captures"
+`);
+    const engine = new ScopeRuleEngine(root);
+    expect(engine.getConfig().defaults.fallback_scope).toBe('personal.captures');
+  });
+
+  it('inferScopes returns explicit scopes bypassing rules', () => {
+    writeToml(`
+[defaults]
+fallback_scope = "personal.captures"
+
+[[rules]]
+match = { source = "github" }
+assign = ["work.projects"]
+priority = 10
+`);
+    const engine = new ScopeRuleEngine(root);
+    expect(engine.inferScopes({ source: 'github', explicitScopes: ['work.custom'] })).toEqual([
+      'work.custom',
+    ]);
+  });
+
+  it('resetCache forces config reload', () => {
+    const engine = new ScopeRuleEngine(root);
+    expect(engine.inferScopes({})).toEqual(['personal.captures']); // missing file fallback
+
+    writeToml(`
+[defaults]
+fallback_scope = "work.projects"
+`);
+    // Without reset, still returns old config
+    expect(engine.inferScopes({})).toEqual(['personal.captures']);
+
+    engine.resetCache();
+    expect(engine.inferScopes({})).toEqual(['work.projects']);
+  });
+
+  it('matches all rules additively when multiple match', () => {
+    writeToml(`
+[defaults]
+fallback_scope = "personal.captures"
+
+[[rules]]
+match = { source = "github" }
+assign = ["work.projects"]
+priority = 10
+
+[[rules]]
+match = { type = "meeting" }
+assign = ["work.meetings"]
+priority = 5
+`);
+    const engine = new ScopeRuleEngine(root);
+    const result = engine.inferScopes({ source: 'github', type: 'meeting' });
+    expect(result).toContain('work.projects');
+    expect(result).toContain('work.meetings');
+  });
+
+  it('handles missing match in rule gracefully', () => {
+    writeToml(`
+[defaults]
+fallback_scope = "personal.captures"
+
+[[rules]]
+assign = ["work.projects"]
+priority = 10
+`);
+    const engine = new ScopeRuleEngine(root);
+    // Rule without match should be skipped
+    expect(engine.getConfig().rules).toHaveLength(0);
+  });
+
+  it('handles missing assign in rule gracefully', () => {
+    writeToml(`
+[defaults]
+fallback_scope = "personal.captures"
+
+[[rules]]
+match = { source = "github" }
+priority = 10
+`);
+    const engine = new ScopeRuleEngine(root);
+    expect(engine.getConfig().rules).toHaveLength(0);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-rules.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-rules.ts
@@ -1,0 +1,221 @@
+/**
+ * Scope rules engine — reads scope-rules.toml and auto-assigns scopes.
+ *
+ * Config loading and rule evaluation are kept separate so the engine can be
+ * used as a pure function in tests (pass the config directly to `resolveScopes`).
+ * The `ScopeRuleEngine` class owns config loading; `resolveScopes` is the
+ * pure evaluation function.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { parse as parseToml } from 'smol-toml';
+
+import { normaliseScope, scopeStringSchema } from './scope-schema.js';
+
+const DEFAULT_FALLBACK_SCOPE = 'personal.captures';
+
+export interface ScopeRule {
+  match: {
+    source?: string;
+    type?: string;
+    tags?: string[];
+  };
+  assign: string[];
+  priority: number;
+}
+
+export interface ScopeRulesConfig {
+  defaults: {
+    fallback_scope: string;
+  };
+  rules: ScopeRule[];
+}
+
+export interface ResolveInput {
+  source?: string;
+  type?: string;
+  tags?: string[];
+  /** Explicit scopes already on the engram — these always win. */
+  explicitScopes?: string[];
+}
+
+/**
+ * Parse and validate the raw TOML value into a `ScopeRulesConfig`.
+ * Invalid rules are skipped with a console warning.
+ */
+function parseConfig(raw: unknown): ScopeRulesConfig {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('scope-rules.toml must be a TOML object at the root level');
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  const fallbackRaw =
+    typeof obj['defaults'] === 'object' &&
+    obj['defaults'] !== null &&
+    typeof (obj['defaults'] as Record<string, unknown>)['fallback_scope'] === 'string'
+      ? ((obj['defaults'] as Record<string, unknown>)['fallback_scope'] as string)
+      : DEFAULT_FALLBACK_SCOPE;
+
+  const fallback_scope = normaliseScope(fallbackRaw);
+
+  const rawRules = Array.isArray(obj['rules']) ? (obj['rules'] as unknown[]) : [];
+  const rules: ScopeRule[] = [];
+
+  for (const r of rawRules) {
+    if (typeof r !== 'object' || r === null) {
+      console.warn('[cerebrum] scope-rules.toml: skipping non-object rule entry');
+      continue;
+    }
+    const entry = r as Record<string, unknown>;
+    const matchRaw = entry['match'];
+    if (typeof matchRaw !== 'object' || matchRaw === null) {
+      console.warn('[cerebrum] scope-rules.toml: rule missing "match" object — skipping');
+      continue;
+    }
+    const matchObj = matchRaw as Record<string, unknown>;
+
+    const assignRaw = entry['assign'];
+    if (!Array.isArray(assignRaw)) {
+      console.warn('[cerebrum] scope-rules.toml: rule missing "assign" array — skipping');
+      continue;
+    }
+
+    const validAssign: string[] = [];
+    for (const a of assignRaw) {
+      const parsed = scopeStringSchema.safeParse(a);
+      if (!parsed.success) {
+        console.warn(
+          `[cerebrum] scope-rules.toml: invalid assign scope '${String(a)}' — skipping rule scope`
+        );
+        continue;
+      }
+      validAssign.push(parsed.data);
+    }
+
+    if (validAssign.length === 0) {
+      console.warn('[cerebrum] scope-rules.toml: rule has no valid assign scopes — skipping');
+      continue;
+    }
+
+    const priority = typeof entry['priority'] === 'number' ? entry['priority'] : 0;
+
+    const match: ScopeRule['match'] = {};
+    if (typeof matchObj['source'] === 'string') match.source = matchObj['source'];
+    if (typeof matchObj['type'] === 'string') match.type = matchObj['type'];
+    if (Array.isArray(matchObj['tags'])) {
+      match.tags = (matchObj['tags'] as unknown[]).filter(
+        (t): t is string => typeof t === 'string'
+      );
+    }
+
+    rules.push({ match, assign: validAssign, priority });
+  }
+
+  // Sort by priority descending so highest-priority rules are first
+  rules.sort((a, b) => b.priority - a.priority);
+
+  return {
+    defaults: { fallback_scope },
+    rules,
+  };
+}
+
+/** Returns `true` when a rule's match conditions are all satisfied by `input`. */
+function ruleMatches(rule: ScopeRule, input: ResolveInput): boolean {
+  if (rule.match.source !== undefined && rule.match.source !== input.source) return false;
+  if (rule.match.type !== undefined && rule.match.type !== input.type) return false;
+  if (rule.match.tags !== undefined && rule.match.tags.length > 0) {
+    const engramTags = new Set(input.tags ?? []);
+    if (!rule.match.tags.every((t) => engramTags.has(t))) return false;
+  }
+  return true;
+}
+
+/**
+ * Pure scope resolution function.
+ *
+ * Priority:
+ * 1. Explicit scopes (if any) — returned as-is (after deduplication)
+ * 2. All matching rules contribute their scopes additively
+ * 3. Fallback to `config.defaults.fallback_scope` if still empty
+ */
+export function resolveScopes(input: ResolveInput, config: ScopeRulesConfig): string[] {
+  const explicit = input.explicitScopes ?? [];
+  if (explicit.length > 0) return dedupe(explicit);
+
+  const assigned: string[] = [];
+  for (const rule of config.rules) {
+    if (ruleMatches(rule, input)) {
+      assigned.push(...rule.assign);
+    }
+  }
+
+  if (assigned.length > 0) return dedupe(assigned);
+  return [config.defaults.fallback_scope];
+}
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+/**
+ * Loads and caches scope-rules.toml from the engram config directory.
+ * Falls back gracefully if the file is missing or malformed.
+ */
+export class ScopeRuleEngine {
+  private readonly configPath: string;
+  private cachedConfig: ScopeRulesConfig | null = null;
+
+  constructor(engramRoot: string) {
+    this.configPath = join(engramRoot, '.config', 'scope-rules.toml');
+  }
+
+  /** Infer scopes for a new engram. Delegates to `resolveScopes`. */
+  inferScopes(input: ResolveInput): string[] {
+    return resolveScopes(input, this.getConfig());
+  }
+
+  /** Expose the parsed config for testing. */
+  getConfig(): ScopeRulesConfig {
+    if (!this.cachedConfig) {
+      this.cachedConfig = this.loadConfig();
+    }
+    return this.cachedConfig;
+  }
+
+  /** Drop the config cache (e.g. after editing the TOML file). */
+  resetCache(): void {
+    this.cachedConfig = null;
+  }
+
+  private loadConfig(): ScopeRulesConfig {
+    let raw: string;
+    try {
+      raw = readFileSync(this.configPath, 'utf8');
+    } catch {
+      console.warn(
+        `[cerebrum] scope-rules.toml not found at ${this.configPath} — using default scope`
+      );
+      return defaultConfig();
+    }
+
+    try {
+      const parsed = parseToml(raw);
+      return parseConfig(parsed);
+    } catch (err) {
+      console.warn(
+        `[cerebrum] scope-rules.toml parse error: ${(err as Error).message} — using default scope`
+      );
+      return defaultConfig();
+    }
+  }
+}
+
+function defaultConfig(): ScopeRulesConfig {
+  return {
+    defaults: { fallback_scope: DEFAULT_FALLBACK_SCOPE },
+    rules: [],
+  };
+}

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-rules.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-rules.ts
@@ -11,7 +11,7 @@ import { join } from 'node:path';
 
 import { parse as parseToml } from 'smol-toml';
 
-import { normaliseScope, scopeStringSchema } from './scope-schema.js';
+import { scopeStringSchema } from './scope-schema.js';
 
 const DEFAULT_FALLBACK_SCOPE = 'personal.captures';
 
@@ -58,7 +58,13 @@ function parseConfig(raw: unknown): ScopeRulesConfig {
       ? ((obj['defaults'] as Record<string, unknown>)['fallback_scope'] as string)
       : DEFAULT_FALLBACK_SCOPE;
 
-  const fallback_scope = normaliseScope(fallbackRaw);
+  const parsedFallback = scopeStringSchema.safeParse(fallbackRaw);
+  if (!parsedFallback.success) {
+    console.warn(
+      `[cerebrum] scope-rules.toml: invalid defaults.fallback_scope '${String(fallbackRaw)}' — using default '${DEFAULT_FALLBACK_SCOPE}'`
+    );
+  }
+  const fallback_scope = parsedFallback.success ? parsedFallback.data : DEFAULT_FALLBACK_SCOPE;
 
   const rawRules = Array.isArray(obj['rules']) ? (obj['rules'] as unknown[]) : [];
   const rules: ScopeRule[] = [];

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-schema.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-schema.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isSecretScope,
+  matchesPrefix,
+  normaliseScope,
+  parseScope,
+  scopeArraySchema,
+  scopeStringSchema,
+  validateScope,
+} from './scope-schema.js';
+
+describe('normaliseScope', () => {
+  it('lowercases and trims', () => {
+    expect(normaliseScope('  Work.Projects.Karbon  ')).toBe('work.projects.karbon');
+    expect(normaliseScope('Personal.Journal')).toBe('personal.journal');
+    expect(normaliseScope('work.projects')).toBe('work.projects');
+  });
+});
+
+describe('scopeStringSchema (Zod)', () => {
+  const valid = (input: string, expected?: string) => {
+    const result = scopeStringSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success && expected !== undefined) expect(result.data).toBe(expected);
+  };
+  const invalid = (input: string) => {
+    expect(scopeStringSchema.safeParse(input).success).toBe(false);
+  };
+
+  it('accepts valid two-segment scope', () => valid('personal.journal', 'personal.journal'));
+  it('accepts valid three-segment scope', () =>
+    valid('work.projects.karbon', 'work.projects.karbon'));
+  it('accepts scope with hyphens', () => valid('work.my-project.v2', 'work.my-project.v2'));
+  it('accepts max depth (6 segments)', () => valid('a.b.c.d.e.f'));
+  it('normalises uppercase to lowercase', () =>
+    valid('Work.Projects.Karbon', 'work.projects.karbon'));
+  it('normalises with spaces', () => valid('  Work.Projects  ', 'work.projects'));
+
+  it('rejects empty string', () => invalid(''));
+  it('rejects single segment', () => invalid('personal'));
+  it('rejects trailing dot', () => invalid('work.projects.'));
+  it('rejects leading dot', () => invalid('.work.projects'));
+  it('rejects consecutive dots', () => invalid('work..projects'));
+  it('rejects 7+ segments', () => invalid('a.b.c.d.e.f.g'));
+  it('rejects segment exceeding 32 chars', () => invalid(`work.${'a'.repeat(33)}`));
+  it('rejects uppercase after normalisation only if chars are invalid', () => {
+    // After normalising 'WORK.PROJECTS' → 'work.projects' → valid
+    valid('WORK.PROJECTS', 'work.projects');
+  });
+  it('rejects segment with special chars', () => invalid('work.proj@ect'));
+  it('rejects segment with underscore', () => invalid('work.proj_ect'));
+});
+
+describe('scopeArraySchema', () => {
+  it('accepts array of valid scopes and normalises each', () => {
+    const result = scopeArraySchema.safeParse(['Personal.Journal', 'Work.Projects']);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(['personal.journal', 'work.projects']);
+    }
+  });
+
+  it('rejects empty array', () => {
+    expect(scopeArraySchema.safeParse([]).success).toBe(false);
+  });
+
+  it('rejects array with invalid scope', () => {
+    expect(scopeArraySchema.safeParse(['personal.journal', 'bad']).success).toBe(false);
+  });
+});
+
+describe('parseScope', () => {
+  it('parses a two-segment scope', () => {
+    const s = parseScope('personal.journal');
+    expect(s.segments).toEqual(['personal', 'journal']);
+    expect(s.depth).toBe(2);
+    expect(s.topLevel).toBe('personal');
+    expect(s.isSecret).toBe(false);
+    expect(s.raw).toBe('personal.journal');
+  });
+
+  it('detects secret segment', () => {
+    expect(parseScope('personal.secret.therapy').isSecret).toBe(true);
+    expect(parseScope('work.secret.jobsearch').isSecret).toBe(true);
+    expect(parseScope('personal.journal').isSecret).toBe(false);
+    expect(parseScope('work.projects.karbon').isSecret).toBe(false);
+  });
+
+  it('sets topLevel correctly', () => {
+    expect(parseScope('work.projects.karbon').topLevel).toBe('work');
+    expect(parseScope('storage.recipes').topLevel).toBe('storage');
+  });
+});
+
+describe('matchesPrefix', () => {
+  it('matches same scope exactly', () => {
+    expect(matchesPrefix('work.projects', 'work.projects')).toBe(true);
+  });
+
+  it('matches child scopes', () => {
+    expect(matchesPrefix('work.projects.karbon', 'work')).toBe(true);
+    expect(matchesPrefix('work.projects.karbon', 'work.projects')).toBe(true);
+  });
+
+  it('does not match sibling scopes', () => {
+    expect(matchesPrefix('work.projects.karbon', 'work.project')).toBe(false);
+    expect(matchesPrefix('personal.journal', 'work')).toBe(false);
+  });
+
+  it('does not match partial segment', () => {
+    // 'work.pro' should NOT match 'work.projects.karbon'
+    expect(matchesPrefix('work.projects.karbon', 'work.pro')).toBe(false);
+  });
+
+  it('handles secret scopes', () => {
+    expect(matchesPrefix('work.secret.jobsearch', 'work')).toBe(true);
+    expect(matchesPrefix('work.secret.jobsearch', 'work.secret')).toBe(true);
+  });
+});
+
+describe('isSecretScope', () => {
+  it('returns true for secret scopes', () => {
+    expect(isSecretScope('personal.secret.therapy')).toBe(true);
+    expect(isSecretScope('work.secret.jobsearch')).toBe(true);
+    expect(isSecretScope('a.secret.b.c')).toBe(true);
+  });
+
+  it('returns false for non-secret scopes', () => {
+    expect(isSecretScope('personal.journal')).toBe(false);
+    expect(isSecretScope('work.projects.karbon')).toBe(false);
+    expect(isSecretScope('storage.recipes')).toBe(false);
+  });
+
+  it('does not match partial word "secret"', () => {
+    expect(isSecretScope('personal.secretnotes')).toBe(false);
+  });
+});
+
+describe('validateScope', () => {
+  it('returns valid for correct scope', () => {
+    const result = validateScope('work.projects.karbon');
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.scope).toBe('work.projects.karbon');
+  });
+
+  it('normalises and validates', () => {
+    const result = validateScope(' Work.Projects ');
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.scope).toBe('work.projects');
+  });
+
+  it('returns errors for invalid scope', () => {
+    const result = validateScope('bad');
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toMatch(/at least 2 segments/);
+    }
+  });
+
+  it('returns multiple errors when applicable', () => {
+    const result = validateScope('a.b.c.d.e.f.g'); // too deep
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-schema.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-schema.ts
@@ -1,0 +1,136 @@
+/**
+ * Scope format validation, parsing, and prefix-match utilities.
+ *
+ * A scope is a dot-separated hierarchical identifier (e.g. `work.projects.karbon`).
+ * Scopes are normalised to lowercase before any validation so callers never need
+ * to pre-normalise. All functions in this module are pure — no I/O, no DB.
+ */
+import { z } from 'zod';
+
+/** Pattern for a single scope segment: lowercase alphanumeric + hyphens, 1-32 chars. */
+const SCOPE_SEGMENT = /^[a-z0-9][a-z0-9-]{0,31}$/;
+
+const MIN_DEPTH = 2;
+const MAX_DEPTH = 6;
+
+/**
+ * Validate a single (already-lowercased) scope string.
+ * Returns an array of error messages — empty means valid.
+ */
+function validateNormalised(scope: string): string[] {
+  const errors: string[] = [];
+
+  if (scope.length === 0) {
+    errors.push('scope must not be empty');
+    return errors;
+  }
+  if (scope.startsWith('.') || scope.endsWith('.')) {
+    errors.push('scope must not start or end with a dot');
+  }
+  if (scope.includes('..')) {
+    errors.push('scope must not contain consecutive dots');
+  }
+
+  const segments = scope.split('.');
+  if (segments.length < MIN_DEPTH) {
+    errors.push(`scope must have at least ${MIN_DEPTH} segments (got ${segments.length})`);
+  }
+  if (segments.length > MAX_DEPTH) {
+    errors.push(`scope must have at most ${MAX_DEPTH} segments (got ${segments.length})`);
+  }
+
+  for (const seg of segments) {
+    if (seg.length === 0) continue; // already caught by consecutive-dot check
+    if (!SCOPE_SEGMENT.test(seg)) {
+      errors.push(
+        `segment '${seg}' is invalid — must be lowercase alphanumeric/hyphens, 1-32 chars`
+      );
+    }
+  }
+
+  return errors;
+}
+
+/** Zod schema for a normalised scope string. Normalises before validating. */
+export const scopeStringSchema = z
+  .string()
+  .transform((val) => normaliseScope(val))
+  .superRefine((val, ctx) => {
+    for (const err of validateNormalised(val)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: err });
+    }
+  });
+
+/** Zod schema for an array of scope strings (normalises each element). */
+export const scopeArraySchema = z.array(scopeStringSchema).min(1, 'at least one scope is required');
+
+export interface Scope {
+  /** Original normalised string, e.g. `work.projects.karbon`. */
+  raw: string;
+  /** Individual segments. */
+  segments: string[];
+  /** Number of segments. */
+  depth: number;
+  /** First segment. */
+  topLevel: string;
+  /** True when any segment equals `secret`. */
+  isSecret: boolean;
+}
+
+/**
+ * Lowercase and trim a scope string.
+ * Call this before any other operation when accepting user input.
+ */
+export function normaliseScope(scope: string): string {
+  return scope.trim().toLowerCase();
+}
+
+/**
+ * Split a normalised scope string into a typed `Scope` object.
+ * Does NOT validate — callers should validate with `scopeStringSchema` first
+ * or be working with known-good values.
+ */
+export function parseScope(scope: string): Scope {
+  const segments = scope.split('.');
+  return {
+    raw: scope,
+    segments,
+    depth: segments.length,
+    topLevel: segments[0] ?? '',
+    isSecret: segments.includes('secret'),
+  };
+}
+
+/**
+ * Return `true` when `scope` matches the given `prefix` at a segment boundary.
+ *
+ * @example
+ * matchesPrefix("work.projects.karbon", "work")          // true
+ * matchesPrefix("work.projects.karbon", "work.projects") // true
+ * matchesPrefix("work.projects.karbon", "personal")      // false
+ */
+export function matchesPrefix(scope: string, prefix: string): boolean {
+  if (scope === prefix) return true;
+  return scope.startsWith(`${prefix}.`);
+}
+
+/**
+ * Return `true` when the scope contains `.secret.` as a segment (i.e. any
+ * segment named exactly `secret`).
+ */
+export function isSecretScope(scope: string): boolean {
+  return parseScope(scope).isSecret;
+}
+
+/**
+ * Validate a scope string and return structured result.
+ * Normalises before validating so callers get the normalised form on success.
+ */
+export function validateScope(
+  raw: string
+): { valid: true; scope: string } | { valid: false; errors: string[] } {
+  const normalised = normaliseScope(raw);
+  const errors = validateNormalised(normalised);
+  if (errors.length === 0) return { valid: true, scope: normalised };
+  return { valid: false, errors };
+}

--- a/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createTestDb } from '../../../shared/test-utils.js';
+import { TemplateRegistry } from '../templates/registry.js';
+import { seedDefaultTemplates } from '../templates/seed.js';
+import { listScopes } from './scopes-router.js';
+import { EngramService } from './service.js';
+
+import type { Database } from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+/** A fixed clock that advances one minute per call. */
+function makeClock(start = new Date('2026-04-18T09:00:00Z')): () => Date {
+  let t = start.getTime();
+  return () => {
+    const d = new Date(t);
+    t += 60_000;
+    return d;
+  };
+}
+
+function makeService(db: BetterSQLite3Database, root: string): EngramService {
+  const templatesDir = join(root, '.templates');
+  seedDefaultTemplates(templatesDir);
+  return new EngramService({
+    root,
+    db,
+    templates: new TemplateRegistry(templatesDir),
+    now: makeClock(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// listScopes (pure DB helper)
+// ---------------------------------------------------------------------------
+
+describe('listScopes', () => {
+  let rawDb: Database;
+  let db: BetterSQLite3Database;
+  let service: EngramService;
+  let root: string;
+
+  beforeEach(() => {
+    rawDb = createTestDb();
+    db = drizzle(rawDb);
+    root = mkdtempSync(join(tmpdir(), 'scopes-router-'));
+    service = makeService(db, root);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    rawDb.close();
+  });
+
+  it('returns all scopes with counts', () => {
+    service.create({ type: 'note', title: 'A', body: '# A', scopes: ['work.projects'] });
+    service.create({ type: 'note', title: 'B', body: '# B', scopes: ['work.projects'] });
+    service.create({ type: 'note', title: 'C', body: '# C', scopes: ['personal.journal'] });
+
+    const scopes = listScopes(db);
+    const wp = scopes.find((s) => s.scope === 'work.projects');
+    const pj = scopes.find((s) => s.scope === 'personal.journal');
+    expect(wp?.count).toBe(2);
+    expect(pj?.count).toBe(1);
+  });
+
+  it('filters by prefix', () => {
+    service.create({ type: 'note', title: 'A', body: '# A', scopes: ['work.projects'] });
+    service.create({ type: 'note', title: 'B', body: '# B', scopes: ['personal.journal'] });
+
+    const scopes = listScopes(db, 'work');
+    expect(scopes).toHaveLength(1);
+    expect(scopes[0]?.scope).toBe('work.projects');
+  });
+
+  it('returns empty when no engrams', () => {
+    expect(listScopes(db)).toHaveLength(0);
+  });
+
+  it('handles engram with multiple scopes', () => {
+    service.create({
+      type: 'note',
+      title: 'Multi',
+      body: '# M',
+      scopes: ['work.projects', 'work.meetings'],
+    });
+    const scopes = listScopes(db, 'work');
+    expect(scopes).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EngramService scope inference integration
+// ---------------------------------------------------------------------------
+
+describe('EngramService.create scope inference', () => {
+  let rawDb: Database;
+  let db: BetterSQLite3Database;
+  let root: string;
+
+  beforeEach(() => {
+    rawDb = createTestDb();
+    db = drizzle(rawDb);
+    root = mkdtempSync(join(tmpdir(), 'scope-infer-'));
+    mkdirSync(join(root, '.config'), { recursive: true });
+    mkdirSync(join(root, '.templates'), { recursive: true });
+    seedDefaultTemplates(join(root, '.templates'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    rawDb.close();
+  });
+
+  it('uses explicit scopes when provided (no rule engine needed)', () => {
+    const service = makeService(db, root);
+    const engram = service.create({
+      type: 'note',
+      title: 'Explicit',
+      body: '# E',
+      scopes: ['work.projects'],
+    });
+    expect(engram.scopes).toEqual(['work.projects']);
+  });
+
+  it('still throws without scopes when no rule engine configured', () => {
+    const service = makeService(db, root);
+    expect(() => service.create({ type: 'note', title: 'No scope', body: '# x' })).toThrow();
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.test.ts
@@ -5,7 +5,10 @@ import { join } from 'node:path';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { closeDb, setDb } from '../../../db.js';
+import { appRouter } from '../../../router.js';
 import { createTestDb } from '../../../shared/test-utils.js';
+import { resetCerebrumCache } from '../instance.js';
 import { TemplateRegistry } from '../templates/registry.js';
 import { seedDefaultTemplates } from '../templates/seed.js';
 import { listScopes } from './scopes-router.js';
@@ -131,5 +134,324 @@ describe('EngramService.create scope inference', () => {
   it('still throws without scopes when no rule engine configured', () => {
     const service = makeService(db, root);
     expect(() => service.create({ type: 'note', title: 'No scope', body: '# x' })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cerebrum.scopes tRPC procedures
+// ---------------------------------------------------------------------------
+
+function createCaller() {
+  return appRouter.createCaller({ user: { email: 'test@example.com' } });
+}
+
+describe('cerebrum.scopes tRPC procedures', () => {
+  let rawDb: Database;
+  let root: string;
+  let previousRoot: string | undefined;
+
+  beforeEach(() => {
+    rawDb = createTestDb();
+    setDb(rawDb);
+    root = mkdtempSync(join(tmpdir(), 'scopes-trpc-'));
+    previousRoot = process.env['ENGRAM_ROOT'];
+    process.env['ENGRAM_ROOT'] = root;
+    resetCerebrumCache();
+  });
+
+  afterEach(() => {
+    closeDb();
+    rmSync(root, { recursive: true, force: true });
+    if (previousRoot === undefined) delete process.env['ENGRAM_ROOT'];
+    else process.env['ENGRAM_ROOT'] = previousRoot;
+    resetCerebrumCache();
+  });
+
+  // ---- assign ----
+
+  describe('assign', () => {
+    it('adds scopes to an engram', async () => {
+      const caller = createCaller();
+      const { engram } = await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Assign target',
+        body: '# x',
+        scopes: ['work.projects'],
+      });
+      const { engram: updated } = await caller.cerebrum.scopes.assign({
+        engramId: engram.id,
+        scopes: ['personal.journal'],
+      });
+      expect(updated.scopes).toContain('work.projects');
+      expect(updated.scopes).toContain('personal.journal');
+    });
+
+    it('deduplicates scopes — assigning an existing scope is a no-op', async () => {
+      const caller = createCaller();
+      const { engram } = await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Dup',
+        body: '# x',
+        scopes: ['work.projects'],
+      });
+      const { engram: updated } = await caller.cerebrum.scopes.assign({
+        engramId: engram.id,
+        scopes: ['work.projects'],
+      });
+      expect(updated.scopes.filter((s) => s === 'work.projects')).toHaveLength(1);
+    });
+
+    it('rejects invalid scope format', async () => {
+      const caller = createCaller();
+      const { engram } = await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Fmt',
+        body: '# x',
+        scopes: ['work.projects'],
+      });
+      await expect(
+        caller.cerebrum.scopes.assign({ engramId: engram.id, scopes: ['bad scope!'] })
+      ).rejects.toThrow();
+    });
+
+    it('rejects 1-segment scope (assign requires full scope, not prefix)', async () => {
+      const caller = createCaller();
+      const { engram } = await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Seg',
+        body: '# x',
+        scopes: ['work.projects'],
+      });
+      await expect(
+        caller.cerebrum.scopes.assign({ engramId: engram.id, scopes: ['work'] })
+      ).rejects.toThrow();
+    });
+  });
+
+  // ---- remove ----
+
+  describe('remove', () => {
+    it('removes a scope from an engram', async () => {
+      const caller = createCaller();
+      const { engram } = await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Remove target',
+        body: '# x',
+        scopes: ['work.projects', 'personal.journal'],
+      });
+      const { engram: updated } = await caller.cerebrum.scopes.remove({
+        engramId: engram.id,
+        scopes: ['work.projects'],
+      });
+      expect(updated.scopes).not.toContain('work.projects');
+      expect(updated.scopes).toContain('personal.journal');
+    });
+
+    it('rejects removing the last scope', async () => {
+      const caller = createCaller();
+      const { engram } = await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Last',
+        body: '# x',
+        scopes: ['work.projects'],
+      });
+      await expect(
+        caller.cerebrum.scopes.remove({ engramId: engram.id, scopes: ['work.projects'] })
+      ).rejects.toThrow(/last scope/i);
+    });
+  });
+
+  // ---- reclassify ----
+
+  describe('reclassify', () => {
+    it('renames a scope prefix across matching engrams', async () => {
+      const caller = createCaller();
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'A',
+        body: '# A',
+        scopes: ['work.projects'],
+      });
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'B',
+        body: '# B',
+        scopes: ['work.meetings'],
+      });
+
+      const result = await caller.cerebrum.scopes.reclassify({
+        fromScope: 'work',
+        toScope: 'office',
+      });
+      expect(result.affected).toBe(2);
+
+      const { scopes } = await caller.cerebrum.scopes.list({ prefix: 'office' });
+      const scopeNames = scopes.map((s) => s.scope);
+      expect(scopeNames).toContain('office.projects');
+      expect(scopeNames).toContain('office.meetings');
+
+      const workScopes = await caller.cerebrum.scopes.list({ prefix: 'work' });
+      expect(workScopes.scopes).toHaveLength(0);
+    });
+
+    it('reclassifies with single-segment fromScope and toScope', async () => {
+      const caller = createCaller();
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Deep',
+        body: '# D',
+        scopes: ['work.team.alpha'],
+      });
+
+      const result = await caller.cerebrum.scopes.reclassify({
+        fromScope: 'work',
+        toScope: 'job',
+      });
+      expect(result.affected).toBe(1);
+
+      const { scopes } = await caller.cerebrum.scopes.list({ prefix: 'job' });
+      expect(scopes.map((s) => s.scope)).toContain('job.team.alpha');
+    });
+
+    it('dry-run returns count without modifying anything', async () => {
+      const caller = createCaller();
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Dry',
+        body: '# D',
+        scopes: ['work.projects'],
+      });
+
+      const result = await caller.cerebrum.scopes.reclassify({
+        fromScope: 'work',
+        toScope: 'office',
+        dryRun: true,
+      });
+      expect(result.affected).toBe(1);
+
+      // Scope should remain unchanged after dry run.
+      const { scopes } = await caller.cerebrum.scopes.list({ prefix: 'work' });
+      expect(scopes.map((s) => s.scope)).toContain('work.projects');
+    });
+
+    it('returns affected: 0 when no engrams match fromScope', async () => {
+      const caller = createCaller();
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Unrelated',
+        body: '# U',
+        scopes: ['personal.journal'],
+      });
+
+      const result = await caller.cerebrum.scopes.reclassify({
+        fromScope: 'work',
+        toScope: 'office',
+      });
+      expect(result.affected).toBe(0);
+    });
+  });
+
+  // ---- filter ----
+
+  describe('filter', () => {
+    it('returns engrams matching the scope prefix', async () => {
+      const caller = createCaller();
+      const { engram: a } = await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Work note',
+        body: '# Work note',
+        scopes: ['work.projects'],
+      });
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Personal note',
+        body: '# Personal note',
+        scopes: ['personal.journal'],
+      });
+
+      const { engrams } = await caller.cerebrum.scopes.filter({ scopes: ['work'] });
+      expect(engrams).toHaveLength(1);
+      expect(engrams[0]?.id).toBe(a.id);
+    });
+
+    it('hard-blocks secret-scoped engrams by default', async () => {
+      const caller = createCaller();
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Secret note',
+        body: '# Secret note',
+        scopes: ['work.secret.jobsearch'],
+      });
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Public note',
+        body: '# Public note',
+        scopes: ['work.projects'],
+      });
+
+      const { engrams } = await caller.cerebrum.scopes.filter({ scopes: ['work'] });
+      const titles = engrams.map((e) => e.title);
+      expect(titles).not.toContain('Secret note');
+      expect(titles).toContain('Public note');
+    });
+
+    it('includes secret-scoped engrams when includeSecret is true', async () => {
+      const caller = createCaller();
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Secret note',
+        body: '# Secret note',
+        scopes: ['work.secret.jobsearch'],
+      });
+
+      const { engrams } = await caller.cerebrum.scopes.filter({
+        scopes: ['work'],
+        includeSecret: true,
+      });
+      expect(engrams.map((e) => e.title)).toContain('Secret note');
+    });
+
+    it('hard-blocks secret scopes at any segment position', async () => {
+      const caller = createCaller();
+      // secret in the middle
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Mid secret',
+        body: '# Mid secret',
+        scopes: ['work.secret.jobs'],
+      });
+      // secret at the end
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Trailing secret',
+        body: '# Trailing secret',
+        scopes: ['work.plans.secret'],
+      });
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Public',
+        body: '# Public',
+        scopes: ['work.projects'],
+      });
+
+      const { engrams } = await caller.cerebrum.scopes.filter({ scopes: ['work'] });
+      const titles = engrams.map((e) => e.title);
+      expect(titles).not.toContain('Mid secret');
+      expect(titles).not.toContain('Trailing secret');
+      expect(titles).toContain('Public');
+    });
+
+    it('returns empty array when no scopes match', async () => {
+      const caller = createCaller();
+      await caller.cerebrum.engrams.create({
+        type: 'note',
+        title: 'Work note',
+        body: '# Work note',
+        scopes: ['work.projects'],
+      });
+
+      const { engrams } = await caller.cerebrum.scopes.filter({ scopes: ['personal'] });
+      expect(engrams).toHaveLength(0);
+    });
   });
 });

--- a/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts
@@ -1,0 +1,367 @@
+/**
+ * tRPC router for cerebrum.scopes.
+ *
+ * Procedures: assign, remove, reclassify, list, validate, filter.
+ * All file writes use temp-and-rename for atomicity. reclassify additionally
+ * rolls back all file writes if any single engram fails.
+ */
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { TRPCError } from '@trpc/server';
+import { count, eq, inArray, like, or, sql } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { engramIndex, engramScopes } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
+import { HttpError, NotFoundError, ValidationError } from '../../../shared/errors.js';
+import { protectedProcedure, router } from '../../../trpc.js';
+import { getEngramRoot, getEngramService } from '../instance.js';
+import { parseEngramFile, serializeEngram } from './file.js';
+import { filterByScopes } from './scope-filter.js';
+import { matchesPrefix, normaliseScope, scopeStringSchema, validateScope } from './scope-schema.js';
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+// ---------------------------------------------------------------------------
+// Input schemas
+// ---------------------------------------------------------------------------
+
+const engramIdSchema = z.string().regex(/^eng_\d{8}_\d{4}_[a-z0-9-]+$/);
+const scopeInputSchema = scopeStringSchema;
+const scopesArraySchema = z.array(scopeInputSchema).min(1);
+
+// ---------------------------------------------------------------------------
+// Service helpers (stateless, exported for testing)
+// ---------------------------------------------------------------------------
+
+export interface ScopeInfo {
+  scope: string;
+  count: number;
+}
+
+/**
+ * List all distinct scopes with engram counts. If `prefix` is provided,
+ * only scopes that are equal to or children of the prefix are returned.
+ */
+export function listScopes(db: BetterSQLite3Database, prefix?: string): ScopeInfo[] {
+  const rows = db
+    .select({ scope: engramScopes.scope, total: count() })
+    .from(engramScopes)
+    .groupBy(engramScopes.scope)
+    .all();
+
+  if (!prefix) return rows.map((r) => ({ scope: r.scope, count: r.total }));
+
+  const norm = normaliseScope(prefix);
+  return rows
+    .filter((r) => matchesPrefix(r.scope, norm))
+    .map((r) => ({ scope: r.scope, count: r.total }));
+}
+
+/**
+ * Find all engram IDs + their scopes that match the given fromScope prefix,
+ * computing what new scope each old scope maps to.
+ */
+function findReclassifyTargets(
+  db: BetterSQLite3Database,
+  fromScope: string,
+  toScope: string
+): { engramId: string; oldScope: string; newScope: string }[] {
+  const rows = db
+    .select({ engramId: engramScopes.engramId, scope: engramScopes.scope })
+    .from(engramScopes)
+    .where(or(eq(engramScopes.scope, fromScope), like(engramScopes.scope, `${fromScope}.%`)))
+    .all();
+
+  return rows.map((r) => ({
+    engramId: r.engramId,
+    oldScope: r.scope,
+    newScope: r.scope === fromScope ? toScope : `${toScope}${r.scope.slice(fromScope.length)}`,
+  }));
+}
+
+/** Write content to an absolute path via a temp file (atomic). */
+function writeFileAtomic(absPath: string, contents: string): void {
+  mkdirSync(dirname(absPath), { recursive: true });
+  const tmp = `${absPath}.tmp.${randomUUID()}`;
+  writeFileSync(tmp, contents, 'utf8');
+  renameSync(tmp, absPath);
+}
+
+// ---------------------------------------------------------------------------
+// tRPC error converter
+// ---------------------------------------------------------------------------
+
+function toTrpcError(err: unknown): never {
+  if (err instanceof NotFoundError) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+  }
+  if (err instanceof ValidationError) {
+    const details = err.details;
+    const message =
+      typeof details === 'string'
+        ? details
+        : typeof details === 'object' &&
+            details !== null &&
+            typeof (details as { message?: unknown }).message === 'string'
+          ? (details as { message: string }).message
+          : err.message;
+    throw new TRPCError({ code: 'BAD_REQUEST', message, cause: err });
+  }
+  if (err instanceof HttpError) {
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: err.message });
+  }
+  throw err;
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+export const scopesRouter = router({
+  /**
+   * Add scopes to an engram. Validates each scope, updates the file and index.
+   */
+  assign: protectedProcedure
+    .input(
+      z.object({
+        engramId: engramIdSchema,
+        scopes: scopesArraySchema,
+      })
+    )
+    .mutation(({ input }) => {
+      try {
+        const svc = getEngramService();
+        const { engram } = svc.read(input.engramId);
+        const merged = [...new Set([...engram.scopes, ...input.scopes])];
+        const updated = svc.update(input.engramId, { scopes: merged });
+        return { engram: updated };
+      } catch (err) {
+        toTrpcError(err);
+      }
+    }),
+
+  /**
+   * Remove scopes from an engram. Rejects if it would leave zero scopes.
+   */
+  remove: protectedProcedure
+    .input(
+      z.object({
+        engramId: engramIdSchema,
+        scopes: scopesArraySchema,
+      })
+    )
+    .mutation(({ input }) => {
+      try {
+        const svc = getEngramService();
+        const { engram } = svc.read(input.engramId);
+        const toRemove = new Set(input.scopes);
+        const remaining = engram.scopes.filter((s) => !toRemove.has(s));
+        if (remaining.length === 0) {
+          throw new ValidationError({
+            message: 'cannot remove the last scope — an engram must have at least one scope',
+          });
+        }
+        const updated = svc.update(input.engramId, { scopes: remaining });
+        return { engram: updated };
+      } catch (err) {
+        toTrpcError(err);
+      }
+    }),
+
+  /**
+   * Bulk rename: replace `fromScope` prefix across all matching engrams.
+   * Atomic — rolls back all file writes if any single write fails.
+   * When `dryRun` is true, returns the count and IDs without modifying anything.
+   */
+  reclassify: protectedProcedure
+    .input(
+      z.object({
+        fromScope: scopeInputSchema,
+        toScope: scopeInputSchema,
+        dryRun: z.boolean().optional(),
+      })
+    )
+    .mutation(({ input }) => {
+      try {
+        const db = getDrizzle();
+        const root = getEngramRoot();
+
+        const targets = findReclassifyTargets(db, input.fromScope, input.toScope);
+
+        if (targets.length === 0) {
+          return { affected: 0 };
+        }
+
+        // Group by engram to build the full new-scopes list per engram.
+        const byEngram = new Map<
+          string,
+          { oldScopes: Set<string>; newScopes: Map<string, string> }
+        >();
+        for (const t of targets) {
+          let entry = byEngram.get(t.engramId);
+          if (!entry) {
+            entry = { oldScopes: new Set(), newScopes: new Map() };
+            byEngram.set(t.engramId, entry);
+          }
+          entry.oldScopes.add(t.oldScope);
+          entry.newScopes.set(t.oldScope, t.newScope);
+        }
+
+        const affectedIds = [...byEngram.keys()];
+
+        if (input.dryRun) {
+          return { affected: affectedIds.length, engrams: affectedIds };
+        }
+
+        // Load file paths for affected engrams.
+        const indexRows = db
+          .select({ id: engramIndex.id, filePath: engramIndex.filePath })
+          .from(engramIndex)
+          .where(inArray(engramIndex.id, affectedIds))
+          .all();
+
+        // Prepare (absPath, originalContent, newContent) for each engram.
+        type WorkItem = {
+          absPath: string;
+          originalContent: string;
+          newContent: string;
+          id: string;
+          newScopesList: string[];
+          oldScopeSet: Set<string>;
+        };
+        const work: WorkItem[] = [];
+
+        for (const row of indexRows) {
+          const entry = byEngram.get(row.id);
+          if (!entry) continue;
+
+          const absPath = join(root, row.filePath);
+          const originalContent = readFileSync(absPath, 'utf8');
+          const { frontmatter, body } = parseEngramFile(originalContent);
+
+          const newScopesList = frontmatter.scopes.map((s) => entry.newScopes.get(s) ?? s);
+          const newFrontmatter = {
+            ...frontmatter,
+            scopes: [...new Set(newScopesList)],
+            modified: new Date().toISOString(),
+          };
+          const newContent = serializeEngram(newFrontmatter, body);
+          work.push({
+            absPath,
+            originalContent,
+            newContent,
+            id: row.id,
+            newScopesList: newFrontmatter.scopes,
+            oldScopeSet: entry.oldScopes,
+          });
+        }
+
+        // Atomic file writes with rollback.
+        const written: WorkItem[] = [];
+        try {
+          for (const item of work) {
+            writeFileAtomic(item.absPath, item.newContent);
+            written.push(item);
+          }
+        } catch (err) {
+          // Rollback: restore every file we already wrote.
+          for (const item of written) {
+            try {
+              writeFileAtomic(item.absPath, item.originalContent);
+            } catch (restoreErr) {
+              console.error(
+                `[cerebrum] reclassify rollback: failed to restore ${item.absPath}: ${(restoreErr as Error).message}`
+              );
+            }
+          }
+          throw new ValidationError({
+            message: `reclassify failed and was rolled back: ${(err as Error).message}`,
+          });
+        }
+
+        // All files written — update DB atomically.
+        db.transaction((tx) => {
+          for (const item of work) {
+            // Remove old scopes that were replaced.
+            for (const oldScope of item.oldScopeSet) {
+              tx.delete(engramScopes)
+                .where(
+                  sql`${engramScopes.engramId} = ${item.id} AND ${engramScopes.scope} = ${oldScope}`
+                )
+                .run();
+            }
+            // Insert new scopes.
+            for (const newScope of item.newScopesList) {
+              tx.insert(engramScopes)
+                .values({ engramId: item.id, scope: newScope })
+                .onConflictDoNothing()
+                .run();
+            }
+            // Update modified_at in index.
+            tx.update(engramIndex)
+              .set({ modifiedAt: new Date().toISOString() })
+              .where(eq(engramIndex.id, item.id))
+              .run();
+          }
+        });
+
+        return { affected: affectedIds.length };
+      } catch (err) {
+        toTrpcError(err);
+      }
+    }),
+
+  /**
+   * List all known scopes with engram counts, optionally filtered by prefix.
+   */
+  list: protectedProcedure
+    .input(z.object({ prefix: z.string().optional() }).optional())
+    .query(({ input }) => {
+      const db = getDrizzle();
+      const scopes = listScopes(db, input?.prefix);
+      return { scopes };
+    }),
+
+  /**
+   * Validate a scope string. Returns structured error messages on failure.
+   */
+  validate: protectedProcedure.input(z.object({ scope: z.string() })).query(({ input }) => {
+    const result = validateScope(input.scope);
+    if (result.valid) return { valid: true as const, scope: result.scope };
+    return { valid: false as const, errors: result.errors };
+  }),
+
+  /**
+   * Return engrams matching scope prefixes with optional secret opt-in.
+   */
+  filter: protectedProcedure
+    .input(
+      z.object({
+        scopes: z.array(scopeInputSchema),
+        includeSecret: z.boolean().optional(),
+      })
+    )
+    .query(({ input }) => {
+      try {
+        const db = getDrizzle();
+        const { engramIds } = filterByScopes({
+          scopes: input.scopes,
+          includeSecret: input.includeSecret,
+          db,
+        });
+
+        if (engramIds.length === 0) return { engrams: [] };
+
+        const svc = getEngramService();
+        const { engrams } = svc.list({ limit: 500 });
+        const idSet = new Set(engramIds);
+        return { engrams: engrams.filter((e) => idSet.has(e.id)) };
+      } catch (err) {
+        toTrpcError(err);
+      }
+    }),
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts
@@ -208,8 +208,8 @@ export const scopesRouter = router({
   reclassify: protectedProcedure
     .input(
       z.object({
-        fromScope: scopeInputSchema,
-        toScope: scopeInputSchema,
+        fromScope: scopePrefixSchema,
+        toScope: scopePrefixSchema,
         dryRun: z.boolean().optional(),
       })
     )

--- a/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts
@@ -21,7 +21,7 @@ import { protectedProcedure, router } from '../../../trpc.js';
 import { getEngramRoot, getEngramService } from '../instance.js';
 import { parseEngramFile, serializeEngram } from './file.js';
 import { filterByScopes } from './scope-filter.js';
-import { matchesPrefix, normaliseScope, scopeStringSchema, validateScope } from './scope-schema.js';
+import { normaliseScope, scopeStringSchema, validateScope } from './scope-schema.js';
 
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
@@ -32,6 +32,34 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 const engramIdSchema = z.string().regex(/^eng_\d{8}_\d{4}_[a-z0-9-]+$/);
 const scopeInputSchema = scopeStringSchema;
 const scopesArraySchema = z.array(scopeInputSchema).min(1);
+
+// Prefix schema: 1–6 segments (vs. full scopes which require 2–6). Used for
+// filter.scopes and list.prefix where single-segment prefixes like "work" are valid.
+const SCOPE_PREFIX_SEGMENT = /^[a-z0-9][a-z0-9-]{0,31}$/;
+const scopePrefixSchema = z
+  .string()
+  .transform((val) => normaliseScope(val))
+  .superRefine((val, ctx) => {
+    if (val.length === 0 || val.startsWith('.') || val.endsWith('.') || val.includes('..')) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'invalid scope prefix format' });
+      return;
+    }
+    const segs = val.split('.');
+    if (segs.length > 6) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'scope prefix must have at most 6 segments',
+      });
+    }
+    for (const seg of segs) {
+      if (!SCOPE_PREFIX_SEGMENT.test(seg)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `segment '${seg}' is invalid — must be lowercase alphanumeric/hyphens, 1-32 chars`,
+        });
+      }
+    }
+  });
 
 // ---------------------------------------------------------------------------
 // Service helpers (stateless, exported for testing)
@@ -45,20 +73,20 @@ export interface ScopeInfo {
 /**
  * List all distinct scopes with engram counts. If `prefix` is provided,
  * only scopes that are equal to or children of the prefix are returned.
+ * The prefix filter is pushed into SQL so the DB can use the scope index.
  */
 export function listScopes(db: BetterSQLite3Database, prefix?: string): ScopeInfo[] {
-  const rows = db
-    .select({ scope: engramScopes.scope, total: count() })
-    .from(engramScopes)
+  const norm = prefix !== undefined && prefix.trim() !== '' ? normaliseScope(prefix) : undefined;
+
+  const q = db.select({ scope: engramScopes.scope, total: count() }).from(engramScopes).$dynamic();
+
+  const rows = (
+    norm ? q.where(or(eq(engramScopes.scope, norm), like(engramScopes.scope, `${norm}.%`))) : q
+  )
     .groupBy(engramScopes.scope)
     .all();
 
-  if (!prefix) return rows.map((r) => ({ scope: r.scope, count: r.total }));
-
-  const norm = normaliseScope(prefix);
-  return rows
-    .filter((r) => matchesPrefix(r.scope, norm))
-    .map((r) => ({ scope: r.scope, count: r.total }));
+  return rows.map((r) => ({ scope: r.scope, count: r.total }));
 }
 
 /**
@@ -283,31 +311,48 @@ export const scopesRouter = router({
           });
         }
 
-        // All files written — update DB atomically.
-        db.transaction((tx) => {
-          for (const item of work) {
-            // Remove old scopes that were replaced.
-            for (const oldScope of item.oldScopeSet) {
-              tx.delete(engramScopes)
-                .where(
-                  sql`${engramScopes.engramId} = ${item.id} AND ${engramScopes.scope} = ${oldScope}`
-                )
+        // All files written — update DB atomically. If the DB update fails,
+        // restore the written files so the filesystem and DB stay consistent.
+        try {
+          db.transaction((tx) => {
+            for (const item of work) {
+              // Remove old scopes that were replaced.
+              for (const oldScope of item.oldScopeSet) {
+                tx.delete(engramScopes)
+                  .where(
+                    sql`${engramScopes.engramId} = ${item.id} AND ${engramScopes.scope} = ${oldScope}`
+                  )
+                  .run();
+              }
+              // Insert new scopes.
+              for (const newScope of item.newScopesList) {
+                tx.insert(engramScopes)
+                  .values({ engramId: item.id, scope: newScope })
+                  .onConflictDoNothing()
+                  .run();
+              }
+              // Update modified_at in index.
+              tx.update(engramIndex)
+                .set({ modifiedAt: new Date().toISOString() })
+                .where(eq(engramIndex.id, item.id))
                 .run();
             }
-            // Insert new scopes.
-            for (const newScope of item.newScopesList) {
-              tx.insert(engramScopes)
-                .values({ engramId: item.id, scope: newScope })
-                .onConflictDoNothing()
-                .run();
+          });
+        } catch (dbErr) {
+          // DB failed — restore all file writes to keep filesystem and DB in sync.
+          for (const item of written) {
+            try {
+              writeFileAtomic(item.absPath, item.originalContent);
+            } catch (restoreErr) {
+              console.error(
+                `[cerebrum] reclassify DB rollback: failed to restore ${item.absPath}: ${(restoreErr as Error).message}`
+              );
             }
-            // Update modified_at in index.
-            tx.update(engramIndex)
-              .set({ modifiedAt: new Date().toISOString() })
-              .where(eq(engramIndex.id, item.id))
-              .run();
           }
-        });
+          throw new ValidationError({
+            message: `reclassify DB update failed and file changes were rolled back: ${(dbErr as Error).message}`,
+          });
+        }
 
         return { affected: affectedIds.length };
       } catch (err) {
@@ -319,7 +364,7 @@ export const scopesRouter = router({
    * List all known scopes with engram counts, optionally filtered by prefix.
    */
   list: protectedProcedure
-    .input(z.object({ prefix: z.string().optional() }).optional())
+    .input(z.object({ prefix: scopePrefixSchema.optional() }).optional())
     .query(({ input }) => {
       const db = getDrizzle();
       const scopes = listScopes(db, input?.prefix);
@@ -341,7 +386,7 @@ export const scopesRouter = router({
   filter: protectedProcedure
     .input(
       z.object({
-        scopes: z.array(scopeInputSchema),
+        scopes: z.array(scopePrefixSchema),
         includeSecret: z.boolean().optional(),
       })
     )
@@ -357,9 +402,8 @@ export const scopesRouter = router({
         if (engramIds.length === 0) return { engrams: [] };
 
         const svc = getEngramService();
-        const { engrams } = svc.list({ limit: 500 });
-        const idSet = new Set(engramIds);
-        return { engrams: engrams.filter((e) => idSet.has(e.id)) };
+        const { engrams } = svc.list({ ids: engramIds });
+        return { engrams };
       } catch (err) {
         toTrpcError(err);
       }

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.ts
@@ -42,6 +42,7 @@ import { buildEngram, type Engram } from './types.js';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 import type { TemplateRegistry } from '../templates/registry.js';
+import type { ScopeRuleEngine } from './scope-rules.js';
 
 const ARCHIVE_DIR = '.archive';
 const TEMPLATES_DIR = '.templates';
@@ -121,6 +122,8 @@ export interface EngramServiceOptions {
   root: string;
   db: BetterSQLite3Database;
   templates: TemplateRegistry;
+  /** Optional rule engine for auto-assigning scopes during create. */
+  scopeRuleEngine?: ScopeRuleEngine;
   /** Override for deterministic tests. Defaults to `new Date()`. */
   now?: () => Date;
 }
@@ -129,12 +132,14 @@ export class EngramService {
   private readonly root: string;
   private readonly db: BetterSQLite3Database;
   private readonly templates: TemplateRegistry;
+  private readonly scopeRuleEngine: ScopeRuleEngine | undefined;
   private readonly now: () => Date;
 
   constructor(options: EngramServiceOptions) {
     this.root = options.root;
     this.db = options.db;
     this.templates = options.templates;
+    this.scopeRuleEngine = options.scopeRuleEngine;
     this.now = options.now ?? (() => new Date());
   }
 
@@ -145,7 +150,7 @@ export class EngramService {
 
     if (scopes.length === 0) {
       // A template may supply default_scopes — defer the min-1 check until after applyTemplate.
-      if (!input.template) {
+      if (!input.template && !this.scopeRuleEngine) {
         throw new ValidationError({ message: 'at least one scope is required' });
       }
     }
@@ -177,6 +182,16 @@ export class EngramService {
         mergedScopes = applied.scopes;
         customFields = applied.customFields;
       }
+    }
+
+    // Tier 2: rule-based inference — only when no explicit scopes and no template supplied them.
+    if (mergedScopes.length === 0 && this.scopeRuleEngine) {
+      mergedScopes = this.scopeRuleEngine.inferScopes({
+        source,
+        type,
+        tags,
+        explicitScopes: [],
+      });
     }
 
     if (mergedScopes.length === 0) {

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.ts
@@ -102,6 +102,7 @@ export interface ListEngramsOptions {
   type?: string;
   scopes?: string[];
   tags?: string[];
+  ids?: string[];
   status?: EngramStatus;
   search?: string;
   limit?: number;
@@ -410,6 +411,9 @@ export class EngramService {
         )
       );
     }
+    if (opts.ids && opts.ids.length > 0) {
+      conditions.push(inArray(engramIndex.id, opts.ids));
+    }
 
     const where = conditions.length === 0 ? undefined : and(...conditions);
     const sortField = opts.sort?.field ?? 'modified_at';
@@ -421,7 +425,8 @@ export class EngramService {
           ? engramIndex.createdAt
           : engramIndex.modifiedAt;
 
-    const limit = opts.limit ?? 50;
+    // When filtering by explicit IDs, use the ID count as the limit (all match or none).
+    const limit = opts.ids && opts.limit === undefined ? opts.ids.length : (opts.limit ?? 50);
     const offset = opts.offset ?? 0;
 
     const rowsQuery = this.db.select().from(engramIndex).$dynamic();

--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -4,9 +4,11 @@
  */
 import { router } from '../../trpc.js';
 import { engramsRouter } from './engrams/router.js';
+import { scopesRouter } from './engrams/scopes-router.js';
 import { templatesRouter } from './templates/router.js';
 
 export const cerebrumRouter = router({
   engrams: engramsRouter,
+  scopes: scopesRouter,
   templates: templatesRouter,
 });

--- a/apps/pops-api/src/modules/cerebrum/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/instance.ts
@@ -9,6 +9,7 @@
 import { join } from 'node:path';
 
 import { getDrizzle } from '../../db.js';
+import { ScopeRuleEngine } from './engrams/scope-rules.js';
 import { EngramService } from './engrams/service.js';
 import { TemplateRegistry } from './templates/registry.js';
 import { seedDefaultTemplates } from './templates/seed.js';
@@ -19,6 +20,7 @@ function resolveRoot(): string {
 
 let cachedRoot: string | null = null;
 let cachedRegistry: TemplateRegistry | null = null;
+let cachedScopeRuleEngine: ScopeRuleEngine | null = null;
 
 /** Return the engram root directory. Cached after first resolve. */
 export function getEngramRoot(): string {
@@ -45,12 +47,21 @@ export function getTemplateRegistry(): TemplateRegistry {
   return cachedRegistry;
 }
 
+/** Return the shared ScopeRuleEngine singleton. */
+export function getScopeRuleEngine(): ScopeRuleEngine {
+  if (!cachedScopeRuleEngine) {
+    cachedScopeRuleEngine = new ScopeRuleEngine(getEngramRoot());
+  }
+  return cachedScopeRuleEngine;
+}
+
 /** Build an EngramService bound to the current request's drizzle context. */
 export function getEngramService(): EngramService {
   return new EngramService({
     root: getEngramRoot(),
     db: getDrizzle(),
     templates: getTemplateRegistry(),
+    scopeRuleEngine: getScopeRuleEngine(),
   });
 }
 
@@ -58,4 +69,5 @@ export function getEngramService(): EngramService {
 export function resetCerebrumCache(): void {
   cachedRoot = null;
   cachedRegistry = null;
+  cachedScopeRuleEngine = null;
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -126,12 +126,12 @@ Live status of every theme and epic. Updated as work completes.
 
 ### Cerebrum — Phase 1 (MVP)
 
-| Epic                          | Status      | Notes                                                                                                 |
-| ----------------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
-| Engram Storage (format, CRUD) | Partial     | PRD-077 done (format, templates, index schema, CRUD, tRPC, provisioning); PRD-078 scope model pending |
-| Thalamus (indexing/retrieval) | Not started | File watcher, frontmatter sync, embedding trigger, retrieval engine                                   |
-| Ingest (input pipeline)       | Not started | Manual, agent, capture channels + classification + scope inference                                    |
-| Emit (output production)      | Not started | Query engine, document generation, proactive nudges                                                   |
+| Epic                          | Status      | Notes                                                                                                |
+| ----------------------------- | ----------- | ---------------------------------------------------------------------------------------------------- |
+| Engram Storage (format, CRUD) | Done        | PRD-077 (format, templates, index schema, CRUD, tRPC, provisioning) + PRD-078 (scope model) complete |
+| Thalamus (indexing/retrieval) | Not started | File watcher, frontmatter sync, embedding trigger, retrieval engine                                  |
+| Ingest (input pipeline)       | Not started | Manual, agent, capture channels + classification + scope inference                                   |
+| Emit (output production)      | Not started | Query engine, document generation, proactive nudges                                                  |
 
 ### Cerebrum — Phase 2 (Curation & Interface)
 

--- a/docs/themes/06-cerebrum/epics/00-engram-storage.md
+++ b/docs/themes/06-cerebrum/epics/00-engram-storage.md
@@ -8,10 +8,10 @@ Define the engram file format, template system, directory structure, and scope m
 
 ## PRDs
 
-| #   | PRD                                                                        | Summary                                                                                    | Status      |
-| --- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------- |
-| 077 | [Engram File Format & Directory](../prds/077-engram-file-format/README.md) | File format spec, YAML frontmatter schema, template system, directory layout, CRUD service | Done        |
-| 078 | [Scope Model](../prds/078-scope-model/README.md)                           | Hierarchical dot-notation scopes, scope rules, filtering, secret scope protection          | Not started |
+| #   | PRD                                                                        | Summary                                                                                    | Status |
+| --- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------ |
+| 077 | [Engram File Format & Directory](../prds/077-engram-file-format/README.md) | File format spec, YAML frontmatter schema, template system, directory layout, CRUD service | Done   |
+| 078 | [Scope Model](../prds/078-scope-model/README.md)                           | Hierarchical dot-notation scopes, scope rules, filtering, secret scope protection          | Done   |
 
 PRD-077 must complete before PRD-078 — scopes are stored in engram frontmatter, so the file format must be defined first.
 

--- a/docs/themes/06-cerebrum/prds/078-scope-model/README.md
+++ b/docs/themes/06-cerebrum/prds/078-scope-model/README.md
@@ -1,7 +1,7 @@
 # PRD-078: Scope Model
 
 > Epic: [00 — Engram Storage](../../epics/00-engram-storage.md)
-> Status: Not started
+> Status: Done
 
 ## Overview
 
@@ -122,12 +122,12 @@ Defined in PRD-077. Junction table linking engrams to their scopes:
 
 ## User Stories
 
-| #   | Story                                                       | Summary                                                                            | Status      | Parallelisable                 |
-| --- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------- | ------------------------------ |
-| 01  | [us-01-scope-schema](us-01-scope-schema.md)                 | Scope format validation, hierarchy parsing, prefix matching utilities              | Not started | No (first)                     |
-| 02  | [us-02-scope-rules](us-02-scope-rules.md)                   | Rule engine reading scope-rules.toml — pattern matching, auto-assignment, defaults | Not started | Blocked by us-01               |
-| 03  | [us-03-scope-filtering](us-03-scope-filtering.md)           | Query-time scope filtering with prefix matching and secret scope hard-blocking     | Not started | Blocked by us-01               |
-| 04  | [us-04-scope-management-api](us-04-scope-management-api.md) | tRPC procedures for scope CRUD, reclassify, listing, and validation                | Not started | Blocked by us-01, us-02, us-03 |
+| #   | Story                                                       | Summary                                                                            | Status | Parallelisable                 |
+| --- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------ | ------------------------------ |
+| 01  | [us-01-scope-schema](us-01-scope-schema.md)                 | Scope format validation, hierarchy parsing, prefix matching utilities              | Done   | No (first)                     |
+| 02  | [us-02-scope-rules](us-02-scope-rules.md)                   | Rule engine reading scope-rules.toml — pattern matching, auto-assignment, defaults | Done   | Blocked by us-01               |
+| 03  | [us-03-scope-filtering](us-03-scope-filtering.md)           | Query-time scope filtering with prefix matching and secret scope hard-blocking     | Done   | Blocked by us-01               |
+| 04  | [us-04-scope-management-api](us-04-scope-management-api.md) | tRPC procedures for scope CRUD, reclassify, listing, and validation                | Done   | Blocked by us-01, us-02, us-03 |
 
 US-02 and US-03 can parallelise with each other after US-01 is complete. US-04 depends on all three prior stories.
 

--- a/docs/themes/06-cerebrum/prds/078-scope-model/us-01-scope-schema.md
+++ b/docs/themes/06-cerebrum/prds/078-scope-model/us-01-scope-schema.md
@@ -1,7 +1,7 @@
 # US-01: Scope Schema & Validation
 
 > PRD: [Scope Model](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a system, I need a scope format specification with parsing and validation uti
 
 ## Acceptance Criteria
 
-- [ ] A Zod schema validates scope strings against the format: lowercase alphanumeric segments separated by dots, 2-6 segments deep, 1-32 characters per segment, hyphens allowed within segments
-- [ ] Validation rejects invalid inputs: trailing dots, consecutive dots, uppercase (after normalisation), single-segment scopes, empty strings, segments exceeding 32 characters, scopes exceeding 6 segments
-- [ ] A `parseScope` utility splits a scope string into its segment array and returns a typed `Scope` object with `segments`, `depth`, `topLevel`, and `isSecret` properties
-- [ ] A `matchesPrefix` utility returns `true` when a scope matches a given prefix — `matchesPrefix("work.projects.karbon", "work")` and `matchesPrefix("work.projects.karbon", "work.projects")` both return `true`
-- [ ] The `.secret.` segment is detected reliably — `isSecretScope("personal.secret.therapy")` returns `true`, `isSecretScope("personal.journal")` returns `false`, `isSecretScope("work.secret.jobsearch")` returns `true`
-- [ ] A `normaliseScope` utility lowercases and trims the input before validation, so `" Work.Projects.Karbon "` becomes `"work.projects.karbon"`
-- [ ] The `scopes` array in engram frontmatter is validated using the scope schema — an engram with an invalid scope is rejected at creation/update time
-- [ ] All utilities are exported from a single module (`scope-schema.ts` or equivalent) with full JSDoc documentation
+- [x] A Zod schema validates scope strings against the format: lowercase alphanumeric segments separated by dots, 2-6 segments deep, 1-32 characters per segment, hyphens allowed within segments
+- [x] Validation rejects invalid inputs: trailing dots, consecutive dots, uppercase (after normalisation), single-segment scopes, empty strings, segments exceeding 32 characters, scopes exceeding 6 segments
+- [x] A `parseScope` utility splits a scope string into its segment array and returns a typed `Scope` object with `segments`, `depth`, `topLevel`, and `isSecret` properties
+- [x] A `matchesPrefix` utility returns `true` when a scope matches a given prefix — `matchesPrefix("work.projects.karbon", "work")` and `matchesPrefix("work.projects.karbon", "work.projects")` both return `true`
+- [x] The `.secret.` segment is detected reliably — `isSecretScope("personal.secret.therapy")` returns `true`, `isSecretScope("personal.journal")` returns `false`, `isSecretScope("work.secret.jobsearch")` returns `true`
+- [x] A `normaliseScope` utility lowercases and trims the input before validation, so `" Work.Projects.Karbon "` becomes `"work.projects.karbon"`
+- [x] The `scopes` array in engram frontmatter is validated using the scope schema — an engram with an invalid scope is rejected at creation/update time
+- [x] All utilities are exported from a single module (`scope-schema.ts` or equivalent) with full JSDoc documentation
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/078-scope-model/us-02-scope-rules.md
+++ b/docs/themes/06-cerebrum/prds/078-scope-model/us-02-scope-rules.md
@@ -1,7 +1,7 @@
 # US-02: Scope Rules Engine
 
 > PRD: [Scope Model](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a system, I need a rule engine that reads `scope-rules.toml` and automaticall
 
 ## Acceptance Criteria
 
-- [ ] The rule engine parses `engrams/.config/scope-rules.toml` and validates each rule's structure: `match` conditions (any combination of `source`, `type`, `tags`), `assign` array (validated against the scope schema from US-01), and `priority` number
-- [ ] A `resolveScopes` function accepts an engram's metadata (source, type, tags, explicit scopes) and returns the final scopes array — explicit scopes take precedence, then matching rules add their scopes, then fallback applies if the result is empty
-- [ ] All matching rules are applied additively — if both `source:github` and `type:meeting` match, both rules' scopes are assigned
-- [ ] When no rules match and no explicit scopes are provided, the `defaults.fallback_scope` from the config is assigned
-- [ ] The `assign` values in rules are validated against the scope schema at config load time — invalid scopes in the config cause a logged warning and the rule is skipped
-- [ ] The rule engine handles a missing or malformed `scope-rules.toml` gracefully: logs a warning and falls back to `personal.captures` as the default scope
-- [ ] Rules are evaluated in priority order (highest first) but all matching rules contribute scopes — priority is used to resolve contradictions when documented in the config
-- [ ] The rule engine is a pure function with no side effects — it receives metadata and the parsed config, and returns scopes. Config loading is a separate concern
+- [x] The rule engine parses `engrams/.config/scope-rules.toml` and validates each rule's structure: `match` conditions (any combination of `source`, `type`, `tags`), `assign` array (validated against the scope schema from US-01), and `priority` number
+- [x] A `resolveScopes` function accepts an engram's metadata (source, type, tags, explicit scopes) and returns the final scopes array — explicit scopes take precedence, then matching rules add their scopes, then fallback applies if the result is empty
+- [x] All matching rules are applied additively — if both `source:github` and `type:meeting` match, both rules' scopes are assigned
+- [x] When no rules match and no explicit scopes are provided, the `defaults.fallback_scope` from the config is assigned
+- [x] The `assign` values in rules are validated against the scope schema at config load time — invalid scopes in the config cause a logged warning and the rule is skipped
+- [x] The rule engine handles a missing or malformed `scope-rules.toml` gracefully: logs a warning and falls back to `personal.captures` as the default scope
+- [x] Rules are evaluated in priority order (highest first) but all matching rules contribute scopes — priority is used to resolve contradictions when documented in the config
+- [x] The rule engine is a pure function with no side effects — it receives metadata and the parsed config, and returns scopes. Config loading is a separate concern
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/078-scope-model/us-03-scope-filtering.md
+++ b/docs/themes/06-cerebrum/prds/078-scope-model/us-03-scope-filtering.md
@@ -1,7 +1,7 @@
 # US-03: Scope Filtering Service
 
 > PRD: [Scope Model](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a system, I need a query-time scope filtering service so that outputs only in
 
 ## Acceptance Criteria
 
-- [ ] A `filterByScopes` function queries the `engram_scopes` table using SQL prefix matching (`WHERE scope LIKE 'work.%'`) and returns engram IDs that match any of the requested scope prefixes
-- [ ] Secret scope hard-blocking: engrams with any `*.secret.*` scope are excluded from results by default — even if the engram also has a non-secret scope that matches the query
-- [ ] Secret scopes are included only when the caller explicitly passes `includeSecret: true` — there is no implicit way to access secret content
-- [ ] Prefix matching handles all hierarchy levels: querying `work` matches all stored scopes starting with `work.` (e.g., `work.projects`, `work.projects.karbon`, `work.secret.jobsearch`). Filter prefixes can be 1+ segments — this is distinct from stored scopes which must be 2-6 segments. The last example is excluded unless secret opt-in is active
-- [ ] An empty scopes array in the query input returns all non-secret engrams (no scope filter applied, but secret blocking still active)
-- [ ] The service supports context-inferred scope selection: a `inferScopesFromContext` utility maps contextual hints (e.g., `"at work"` maps to `["work"]`, `"personal"` maps to `["personal"]`) to scope prefixes for downstream filtering
-- [ ] The filtering service composes with the existing `cerebrum.engrams.list` query — it provides a scope filter clause that integrates into the list query's WHERE conditions rather than being a separate post-filter
-- [ ] Performance: prefix matching uses the `scope` index on `engram_scopes` — no full table scans for scope filtering
+- [x] A `filterByScopes` function queries the `engram_scopes` table using SQL prefix matching (`WHERE scope LIKE 'work.%'`) and returns engram IDs that match any of the requested scope prefixes
+- [x] Secret scope hard-blocking: engrams with any `*.secret.*` scope are excluded from results by default — even if the engram also has a non-secret scope that matches the query
+- [x] Secret scopes are included only when the caller explicitly passes `includeSecret: true` — there is no implicit way to access secret content
+- [x] Prefix matching handles all hierarchy levels: querying `work` matches all stored scopes starting with `work.` (e.g., `work.projects`, `work.projects.karbon`, `work.secret.jobsearch`). Filter prefixes can be 1+ segments — this is distinct from stored scopes which must be 2-6 segments. The last example is excluded unless secret opt-in is active
+- [x] An empty scopes array in the query input returns all non-secret engrams (no scope filter applied, but secret blocking still active)
+- [x] The service supports context-inferred scope selection: a `inferScopesFromContext` utility maps contextual hints (e.g., `"at work"` maps to `["work"]`, `"personal"` maps to `["personal"]`) to scope prefixes for downstream filtering
+- [x] The filtering service composes with the existing `cerebrum.engrams.list` query — it provides a scope filter clause that integrates into the list query's WHERE conditions rather than being a separate post-filter
+- [x] Performance: prefix matching uses the `scope` index on `engram_scopes` — no full table scans for scope filtering
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/078-scope-model/us-04-scope-management-api.md
+++ b/docs/themes/06-cerebrum/prds/078-scope-model/us-04-scope-management-api.md
@@ -1,7 +1,7 @@
 # US-04: Scope Management API
 
 > PRD: [Scope Model](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a user, I want tRPC procedures for managing scopes on engrams so that I can a
 
 ## Acceptance Criteria
 
-- [ ] `cerebrum.scopes.assign` adds one or more scopes to an engram — validates each scope string (US-01), updates the engram's frontmatter `scopes` array, writes the file, and updates the `engram_scopes` index table
-- [ ] `cerebrum.scopes.remove` removes one or more scopes from an engram — rejects the operation if it would leave the engram with zero scopes, updates file and index
-- [ ] `cerebrum.scopes.reclassify` performs a bulk scope rename: replaces `fromScope` prefix with `toScope` across all matching engrams, updates every affected file's frontmatter and the index, and is atomic (rolls back all changes if any single file write fails)
-- [ ] `cerebrum.scopes.reclassify` supports a `dryRun` flag that returns the count and list of affected engram IDs without modifying anything
-- [ ] `cerebrum.scopes.list` returns all distinct scopes from the `engram_scopes` table with the count of engrams per scope, optionally filtered by a prefix parameter
-- [ ] `cerebrum.scopes.validate` accepts a scope string and returns `{ valid: true }` or `{ valid: false, errors: [...] }` with specific validation error messages (uses the schema from US-01)
-- [ ] `cerebrum.scopes.filter` accepts scope prefixes and an optional `includeSecret` flag, delegates to the filtering service (US-03), and returns matching engrams
-- [ ] All procedures use Zod input validation with the scope schema from US-01 — malformed scope strings are rejected before any database or file operations
+- [x] `cerebrum.scopes.assign` adds one or more scopes to an engram — validates each scope string (US-01), updates the engram's frontmatter `scopes` array, writes the file, and updates the `engram_scopes` index table
+- [x] `cerebrum.scopes.remove` removes one or more scopes from an engram — rejects the operation if it would leave the engram with zero scopes, updates file and index
+- [x] `cerebrum.scopes.reclassify` performs a bulk scope rename: replaces `fromScope` prefix with `toScope` across all matching engrams, updates every affected file's frontmatter and the index, and is atomic (rolls back all changes if any single file write fails)
+- [x] `cerebrum.scopes.reclassify` supports a `dryRun` flag that returns the count and list of affected engram IDs without modifying anything
+- [x] `cerebrum.scopes.list` returns all distinct scopes from the `engram_scopes` table with the count of engrams per scope, optionally filtered by a prefix parameter
+- [x] `cerebrum.scopes.validate` accepts a scope string and returns `{ valid: true }` or `{ valid: false, errors: [...] }` with specific validation error messages (uses the schema from US-01)
+- [x] `cerebrum.scopes.filter` accepts scope prefixes and an optional `includeSecret` flag, delegates to the filtering service (US-03), and returns matching engrams
+- [x] All procedures use Zod input validation with the scope schema from US-01 — malformed scope strings are rejected before any database or file operations
 
 ## Notes
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      smol-toml:
+        specifier: ^1.6.1
+        version: 1.6.1
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -5726,6 +5729,10 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -10933,6 +10940,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  smol-toml@1.6.1: {}
 
   sonic-boom@4.2.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Implements PRD-078 (Scope Model) in full: scope format validation, rule-based auto-assignment, query-time filtering with secret-scope hard-blocking, and the tRPC management API
- Adds `smol-toml` dependency for parsing `scope-rules.toml` configuration
- Wires `ScopeRuleEngine` singleton into `instance.ts` and `EngramService.create` for automatic scope inference on engram creation

## What's included

**New production files:**
- `scope-schema.ts` — Zod schema, `parseScope`, `matchesPrefix`, `isSecretScope`, `validateScope` pure utilities
- `scope-rules.ts` — `resolveScopes` pure function + `ScopeRuleEngine` class (TOML loading, caching, graceful fallback)
- `scope-filter.ts` — `filterByScopes` (SQL LIKE prefix matching + secret hard-blocking) + `inferScopesFromContext`
- `scopes-router.ts` — tRPC router: `assign`, `remove`, `reclassify` (atomic with file-write rollback), `list`, `validate`, `filter`

**Modified files:**
- `service.ts` — `EngramService` now accepts `ScopeRuleEngine` and calls `inferScopes` when no explicit scopes are provided
- `instance.ts` — `ScopeRuleEngine` singleton wired into `getEngramService()`
- `cerebrum/index.ts` — `scopesRouter` registered as `cerebrum.scopes.*`

**Tests:** 8 test files, 75+ new test cases across all four modules.

**Docs:** All US, PRD, Epic, and roadmap entries updated to Done.

## Test plan

- [ ] `pnpm typecheck` passes across all packages
- [ ] `pnpm oxlint` passes (no unused imports, no non-null assertions)
- [ ] `pnpm exec oxfmt --check .` passes
- [ ] `pnpm exec vitest run` — all 2690+ tests pass including 75 new scope tests
- [ ] `cerebrum.scopes.validate` rejects `Work..Projects.` and accepts `work.projects.karbon`
- [ ] `cerebrum.scopes.filter` excludes `work.secret.jobsearch` engrams from `work.*` queries unless `includeSecret: true`
- [ ] `cerebrum.scopes.reclassify` rolls back all file writes if any single write fails

https://claude.ai/code/session_017N2JGmtxaDSmn2stGqjkok