### PR TITLE
feat(tag-rules): live re-suggestion after ChangeSet apply (PRD-029 US-03)

### DIFF
--- a/docs/themes/02-finance/prds/029-tag-rule-proposals/README.md
+++ b/docs/themes/02-finance/prds/029-tag-rule-proposals/README.md
@@ -120,7 +120,7 @@ The UI must support accepting/rejecting suggestions at either scope:
 ## Verification
 
 - Tag edits in the current import can produce a proposal that increases the quality of future tag suggestions. _`TagRuleProposalDialog` is wired into `TagReviewStep` via "Save tag rule…" per entity group (knoxio/pops#1886). Group-scope signal is fully wired; transaction-scope signal is not yet connected._
-- Approving a tag rule proposal immediately improves suggested tags for remaining transactions in the current import without altering entity/type classification. _(Apply is wired and stores the ChangeSet in the import store. Live re-suggestion of remaining transactions after apply is not yet implemented.)_
+- Approving a tag rule proposal immediately improves suggested tags for remaining transactions in the current import without altering entity/type classification. _(Apply is wired and stores the ChangeSet in the import store. Live re-suggestion is now implemented: `handleTagRuleApplied` propagates `preview.affected` into `localTags` and `suggestedTagMeta` for non-user-edited transactions.)_
 
 ## Drift Check
 

--- a/docs/themes/02-finance/prds/029-tag-rule-proposals/us-03-approve-reject-tag-proposals.md
+++ b/docs/themes/02-finance/prds/029-tag-rule-proposals/us-03-approve-reject-tag-proposals.md
@@ -14,6 +14,6 @@ As a user, I want to approve or reject tag rule proposals with feedback, so that
 - [x] Approving applies the ChangeSet atomically via `applyTagRuleChangeSet` and stores it in the import store so it is included with the final commit.
 - [x] Rejecting requires a feedback message and applies no changes **in the wizard** — the dialog enforces non-empty feedback before calling `rejectTagRuleChangeSet`.
 - [x] Accepting a **New** tag makes it part of the user’s tag vocabulary going forward — the dialog presents new tags as checkboxes and passes `acceptedNewTags` to `applyTagRuleChangeSet`.
-- [ ] Approving updates suggested tags for remaining transactions in the current import session live (not yet re-fetched after apply).
+- [x] Approving updates suggested tags for remaining transactions in the current import session live — `handleTagRuleApplied` applies `preview.affected` items to `localTags` and `suggestedTagMeta` for non-user-edited transactions.
 - [ ] A follow-up proposal can be generated incorporating rejection feedback **in the wizard** (not yet wired).
 - [ ] Tag rule application at transaction scope (single-transaction accept/reject) is not yet wired — only group scope is supported.

--- a/packages/app-finance/src/components/imports/TagReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
@@ -151,12 +151,58 @@ vi.mock('@pops/ui', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// Mock TagEditor — stub to avoid complex sub-component rendering
+// Mock TagRuleProposalDialog — captures onApplied for handleTagRuleApplied tests
 // ---------------------------------------------------------------------------
 
-vi.mock('../TagEditor', () => ({
-  TagEditor: () => null,
-}));
+// eslint-disable-next-line prefer-const
+let mockOnAppliedFn: ((...args: unknown[]) => void) | null = null;
+
+vi.mock('./TagRuleProposalDialog', async () => {
+  const React = await import('react');
+  return {
+    TagRuleProposalDialog: ({
+      onApplied,
+      open,
+    }: {
+      onApplied?: (...args: unknown[]) => void;
+      open: boolean;
+      onOpenChange: (v: boolean) => void;
+      signal: unknown;
+      previewTransactions: unknown[];
+    }) => {
+      if (onApplied) {
+        mockOnAppliedFn = onApplied;
+      }
+      if (!open) return null;
+      return React.createElement('div', { 'data-testid': 'dialog' });
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock TagEditor — stub that exposes a trigger to simulate user edits
+// ---------------------------------------------------------------------------
+
+vi.mock('../TagEditor', async () => {
+  const React = await import('react');
+  return {
+    TagEditor: ({
+      onSave,
+      currentTags,
+    }: {
+      onSave: (tags: string[]) => void;
+      currentTags: string[];
+    }) =>
+      React.createElement(
+        'button',
+        {
+          'data-testid': 'tag-editor-trigger-edit',
+          onClick: () => onSave([...currentTags, 'EditedByUser']),
+        },
+        'Simulate Edit'
+      ),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Mock lib/utils — cn is used by GroupTagBar
@@ -172,6 +218,7 @@ vi.mock('../../lib/utils', () => ({
 
 import { TagReviewStep } from './TagReviewStep';
 
+import type { TagRuleChangeSet, TagRuleImpactItem } from '@pops/api/modules/core/tag-rules/types';
 import type { ConfirmedTransaction } from '@pops/api/modules/finance/imports';
 
 // ---------------------------------------------------------------------------
@@ -246,6 +293,7 @@ function renderTagReviewStep() {
 
 beforeEach(() => {
   mockConfirmedTransactions.length = 0;
+  mockOnAppliedFn = null;
   mockAddPendingTagRuleChangeSet.mockReset();
   mockUpdateTransactionTags.mockReset();
   mockNextStep.mockReset();
@@ -377,5 +425,146 @@ describe('TagReviewStep — Accept All Suggestions', () => {
     expect(
       screen.queryByRole('button', { name: /Accept All Suggestions/i })
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('TagReviewStep — handleTagRuleApplied live re-suggestion (PRD-029 US-03)', () => {
+  const CHECKSUM_A = 'test-checksum-aaa';
+  const CHECKSUM_B = 'test-checksum-bbb';
+
+  const txA = makeTransaction({
+    description: 'SUPERMARKET TX',
+    amount: -45.0,
+    entityName: 'Supermarket',
+    entityId: 'super-id',
+    checksum: CHECKSUM_A,
+    tags: ['Groceries'],
+    suggestedTags: [{ tag: 'Groceries', source: 'ai' }],
+  });
+
+  const txB = makeTransaction({
+    description: 'PHARMACY TX',
+    amount: -20.0,
+    entityName: 'Pharmacy',
+    entityId: 'pharma-id',
+    checksum: CHECKSUM_B,
+    tags: ['Health'],
+    suggestedTags: [{ tag: 'Health', source: 'entity' }],
+  });
+
+  function makeChangeSet(): TagRuleChangeSet {
+    return {
+      ops: [
+        {
+          op: 'add',
+          data: { descriptionPattern: 'test', matchType: 'contains', tags: ['NewTag'] },
+        },
+      ],
+    };
+  }
+
+  function makeAffected(checksum: string, tags: string[]): TagRuleImpactItem[] {
+    return [
+      {
+        transactionId: checksum,
+        description: 'SUPERMARKET TX',
+        before: { suggestedTags: [] },
+        after: { suggestedTags: tags.map((tag) => ({ tag, source: 'tag_rule' as const })) },
+      },
+    ];
+  }
+
+  it('merges rule-suggested tags into non-edited transaction tags', () => {
+    seedTransactions([txA]);
+    renderTagReviewStep();
+
+    act(() => {
+      mockOnAppliedFn!(makeChangeSet(), makeAffected(CHECKSUM_A, ['Transport']));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue to final review/i }));
+    expect(mockUpdateTransactionTags).toHaveBeenCalledWith(
+      CHECKSUM_A,
+      expect.arrayContaining(['Groceries', 'Transport'])
+    );
+  });
+
+  it('does not replace existing tags — only adds missing ones', () => {
+    seedTransactions([txA]);
+    renderTagReviewStep();
+
+    // Rule suggests both an existing tag and a new tag
+    act(() => {
+      mockOnAppliedFn!(makeChangeSet(), makeAffected(CHECKSUM_A, ['Groceries', 'Food']));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue to final review/i }));
+    const call = mockUpdateTransactionTags.mock.calls.find(([cs]) => cs === CHECKSUM_A);
+    const tags = call?.[1] as string[] | undefined;
+    expect(tags).toEqual(expect.arrayContaining(['Groceries', 'Food']));
+    // Groceries should not be duplicated (Set dedup)
+    expect(tags?.filter((t) => t === 'Groceries')).toHaveLength(1);
+  });
+
+  it('skips transactions that the user has manually edited', () => {
+    seedTransactions([txA]);
+    renderTagReviewStep();
+
+    // Simulate user editing the transaction (adds 'EditedByUser', marks checksum as edited)
+    fireEvent.click(screen.getByTestId('tag-editor-trigger-edit'));
+
+    act(() => {
+      mockOnAppliedFn!(makeChangeSet(), makeAffected(CHECKSUM_A, ['Transport']));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue to final review/i }));
+    const call = mockUpdateTransactionTags.mock.calls.find(([cs]) => cs === CHECKSUM_A);
+    expect(call?.[1]).not.toContain('Transport');
+    expect(call?.[1]).toContain('EditedByUser');
+  });
+
+  it('only updates matching transactions, not unrelated ones', () => {
+    seedTransactions([txA, txB]);
+    renderTagReviewStep();
+
+    act(() => {
+      mockOnAppliedFn!(makeChangeSet(), makeAffected(CHECKSUM_A, ['Transport']));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue to final review/i }));
+
+    const callA = mockUpdateTransactionTags.mock.calls.find(([cs]) => cs === CHECKSUM_A);
+    const callB = mockUpdateTransactionTags.mock.calls.find(([cs]) => cs === CHECKSUM_B);
+    expect(callA?.[1]).toContain('Transport');
+    expect(callB?.[1]).not.toContain('Transport');
+  });
+
+  it('calls addPendingTagRuleChangeSet with the change set and source', () => {
+    seedTransactions([txA]);
+    renderTagReviewStep();
+
+    const changeSet = makeChangeSet();
+    act(() => {
+      mockOnAppliedFn!(changeSet, []);
+    });
+
+    expect(mockAddPendingTagRuleChangeSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changeSet,
+        source: expect.stringContaining('tag-review:'),
+      })
+    );
+  });
+
+  it('handles empty affected list without mutating any tags', () => {
+    seedTransactions([txA]);
+    renderTagReviewStep();
+
+    act(() => {
+      mockOnAppliedFn!(makeChangeSet(), []);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue to final review/i }));
+    expect(mockUpdateTransactionTags).toHaveBeenCalledWith(CHECKSUM_A, ['Groceries']);
   });
 });

--- a/packages/app-finance/src/components/imports/TagReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.tsx
@@ -257,8 +257,14 @@ export function TagReviewStep() {
       setLocalTags((prev) => {
         const next = { ...prev };
         for (const item of affected) {
-          if (!editedChecksumsRef.current.has(item.transactionId)) {
-            next[item.transactionId] = item.after.suggestedTags.map((s) => s.tag);
+          // transactionId is the checksum — same key used throughout localTags/suggestedTagMeta
+          const checksum = item.transactionId;
+          if (!editedChecksumsRef.current.has(checksum)) {
+            // Merge rule tags additively — the preview only returns rule-sourced tags,
+            // so we must keep AI/entity suggestions rather than replacing them.
+            const newRuleTags = item.after.suggestedTags.map((s) => s.tag);
+            const existingTags = prev[checksum] ?? [];
+            next[checksum] = [...new Set([...existingTags, ...newRuleTags])];
           }
         }
         return next;
@@ -267,11 +273,20 @@ export function TagReviewStep() {
       setSuggestedTagMeta((prev) => {
         const next = { ...prev };
         for (const item of affected) {
-          next[item.transactionId] = item.after.suggestedTags.map((s) => ({
+          const checksum = item.transactionId;
+          const ruleSuggestedTags = item.after.suggestedTags.map((s) => ({
             tag: s.tag,
             source: (s.source === 'tag_rule' ? 'rule' : s.source) as SuggestedTag['source'],
             pattern: s.pattern,
           }));
+          // Merge: keep existing AI/entity entries for tags not covered by the rule,
+          // replace entries for tags the rule now owns (rule takes precedence for badges).
+          const ruleSuggestedTagSet = new Set(ruleSuggestedTags.map((s) => s.tag));
+          const existingMeta = prev[checksum] ?? [];
+          next[checksum] = [
+            ...existingMeta.filter((entry) => !ruleSuggestedTagSet.has(entry.tag)),
+            ...ruleSuggestedTags,
+          ];
         }
         return next;
       });
@@ -399,7 +414,7 @@ function EntityGroup({
   const currentTagsPerTx = group.transactions.map((t) => localTags[t.checksum] ?? []);
   const currentUnion = unionTags(currentTagsPerTx);
 
-  // Suggested union from original suggestions (for "apply suggestions to all" button)
+  // Suggested union from current suggestion metadata (for "apply suggestions to all" button)
   const suggestedUnion = useMemo(() => {
     return unionTags(
       group.transactions.map((t) => (suggestedTagMeta[t.checksum] ?? []).map((s) => s.tag))

--- a/packages/app-finance/src/components/imports/TagReviewStep.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.tsx
@@ -11,7 +11,7 @@ import { useImportStore } from '../../store/importStore';
 import { TagEditor, type TagMetaEntry } from '../TagEditor';
 import { TagRuleProposalDialog, type TagRuleLearnSignal } from './TagRuleProposalDialog';
 
-import type { TagRuleChangeSet } from '@pops/api/modules/core/tag-rules/types';
+import type { TagRuleChangeSet, TagRuleImpactItem } from '@pops/api/modules/core/tag-rules/types';
 import type { ConfirmedTransaction, SuggestedTag } from '@pops/api/modules/finance/imports';
 
 // ---------------------------------------------------------------------------
@@ -99,9 +99,19 @@ export function TagReviewStep() {
     Object.fromEntries(confirmedTransactions.map((t) => [t.checksum, t.tags ?? []]))
   );
 
+  // Tracks checksums edited by the user so live re-suggestion skips them.
+  const editedChecksumsRef = useRef<Set<string>>(new Set());
+
+  // Suggested tag metadata per checksum — drives source badges in TagEditor.
+  // Starts from the confirmed transaction snapshot and updates live when rules are applied.
+  const [suggestedTagMeta, setSuggestedTagMeta] = useState<Record<string, SuggestedTag[]>>(() =>
+    Object.fromEntries(confirmedTransactions.map((t) => [t.checksum, t.suggestedTags ?? []]))
+  );
+
   // If the user returns from Step 6, remount may reuse flow; keep local state aligned
   // when confirmed transaction tag lists change from the store.
   useEffect(() => {
+    editedChecksumsRef.current = new Set();
     setLocalTags((prev) => {
       const next = { ...prev };
       for (const t of confirmedTransactions) {
@@ -113,13 +123,10 @@ export function TagReviewStep() {
       }
       return next;
     });
+    setSuggestedTagMeta(
+      Object.fromEntries(confirmedTransactions.map((t) => [t.checksum, t.suggestedTags ?? []]))
+    );
   }, [confirmedTransactions]);
-
-  // Immutable snapshot of original suggested tags per checksum — for source badges
-  const originalSuggestedTags = useMemo<Record<string, SuggestedTag[]>>(
-    () => Object.fromEntries(confirmedTransactions.map((t) => [t.checksum, t.suggestedTags ?? []])),
-    [confirmedTransactions]
-  );
 
   const groups = useMemo(() => groupByEntity(confirmedTransactions), [confirmedTransactions]);
 
@@ -134,6 +141,7 @@ export function TagReviewStep() {
 
   const updateTag = useCallback((checksum: string, tags: string[]) => {
     setLocalTags((prev) => ({ ...prev, [checksum]: tags }));
+    editedChecksumsRef.current.add(checksum);
   }, []);
 
   /** Accept all pre-suggested tags for every transaction (resets to original suggestions). */
@@ -233,14 +241,39 @@ export function TagReviewStep() {
 
   /**
    * Called by the dialog after `applyTagRuleChangeSet` succeeds.
-   * Stores the applied ChangeSet in the import store so it is bundled
-   * with the commit at Final Review (PRD-029 / PRD-030).
+   * Stores the applied ChangeSet in the import store and performs live
+   * re-suggestion: updates localTags and source badges for transactions
+   * that match the new rule and haven't been manually edited (PRD-029 US-03).
    */
   const handleTagRuleApplied = useCallback(
-    (changeSet: TagRuleChangeSet) => {
+    (changeSet: TagRuleChangeSet, affected: TagRuleImpactItem[]) => {
       addPendingTagRuleChangeSet({
         changeSet,
         source: `tag-review:${dialogGroupNameRef.current ?? 'unknown'}`,
+      });
+
+      if (affected.length === 0) return;
+
+      setLocalTags((prev) => {
+        const next = { ...prev };
+        for (const item of affected) {
+          if (!editedChecksumsRef.current.has(item.transactionId)) {
+            next[item.transactionId] = item.after.suggestedTags.map((s) => s.tag);
+          }
+        }
+        return next;
+      });
+
+      setSuggestedTagMeta((prev) => {
+        const next = { ...prev };
+        for (const item of affected) {
+          next[item.transactionId] = item.after.suggestedTags.map((s) => ({
+            tag: s.tag,
+            source: (s.source === 'tag_rule' ? 'rule' : s.source) as SuggestedTag['source'],
+            pattern: s.pattern,
+          }));
+        }
+        return next;
       });
     },
     [addPendingTagRuleChangeSet]
@@ -281,7 +314,7 @@ export function TagReviewStep() {
             key={group.entityName}
             group={group}
             localTags={localTags}
-            originalSuggestedTags={originalSuggestedTags}
+            suggestedTagMeta={suggestedTagMeta}
             availableTags={availableTags ?? []}
             onUpdateTag={updateTag}
             onApplyGroupTags={handleApplyGroupTags}
@@ -334,7 +367,7 @@ export function TagReviewStep() {
 interface EntityGroupProps {
   group: ConfirmedGroup;
   localTags: Record<string, string[]>;
-  originalSuggestedTags: Record<string, SuggestedTag[]>;
+  suggestedTagMeta: Record<string, SuggestedTag[]>;
   availableTags: string[];
   onUpdateTag: (checksum: string, tags: string[]) => void;
   onApplyGroupTags: (group: ConfirmedGroup, tags: string[]) => void;
@@ -353,7 +386,7 @@ interface EntityGroupProps {
 function EntityGroup({
   group,
   localTags,
-  originalSuggestedTags,
+  suggestedTagMeta,
   availableTags,
   onUpdateTag,
   onApplyGroupTags,
@@ -369,9 +402,9 @@ function EntityGroup({
   // Suggested union from original suggestions (for "apply suggestions to all" button)
   const suggestedUnion = useMemo(() => {
     return unionTags(
-      group.transactions.map((t) => (originalSuggestedTags[t.checksum] ?? []).map((s) => s.tag))
+      group.transactions.map((t) => (suggestedTagMeta[t.checksum] ?? []).map((s) => s.tag))
     );
-  }, [group.transactions, originalSuggestedTags]);
+  }, [group.transactions, suggestedTagMeta]);
 
   // Staged tags for group-level bulk application
   const [groupStagedTags, setGroupStagedTags] = useState<string[]>([]);
@@ -493,7 +526,7 @@ function EntityGroup({
                 key={t.checksum}
                 transaction={t}
                 tags={localTags[t.checksum] ?? []}
-                originalSuggestedTags={originalSuggestedTags[t.checksum] ?? []}
+                suggestedTagMeta={suggestedTagMeta[t.checksum] ?? []}
                 availableTags={availableTags}
                 onSave={(tags) => {
                   onUpdateTag(t.checksum, tags);
@@ -684,7 +717,7 @@ function GroupTagBar({
 interface TransactionTagRowProps {
   transaction: ConfirmedTransaction;
   tags: string[];
-  originalSuggestedTags: SuggestedTag[];
+  suggestedTagMeta: SuggestedTag[];
   availableTags: string[];
   onSave: (tags: string[]) => void;
   onSaveTagRule?: (transaction: ConfirmedTransaction, tags: string[]) => void;
@@ -698,7 +731,7 @@ interface TransactionTagRowProps {
 function TransactionTagRow({
   transaction,
   tags,
-  originalSuggestedTags,
+  suggestedTagMeta,
   availableTags,
   onSave,
   onSaveTagRule,
@@ -707,7 +740,7 @@ function TransactionTagRow({
   const isNegative = amount < 0;
 
   // Build tagMeta map for source badges in TagEditor
-  const tagMeta = useMemo(() => buildTagMetaMap(originalSuggestedTags), [originalSuggestedTags]);
+  const tagMeta = useMemo(() => buildTagMetaMap(suggestedTagMeta), [suggestedTagMeta]);
 
   return (
     <div className="flex items-center gap-3 px-4 py-2 hover:bg-muted/20 transition-colors group/txrow">

--- a/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
@@ -42,9 +42,13 @@ export interface TagRuleProposalDialogProps {
   }>;
   /**
    * Called after the ChangeSet is applied successfully.
-   * Receives the applied ChangeSet so callers can store it (e.g. import store).
+   * Receives the applied ChangeSet and the affected preview items so callers
+   * can update live tag suggestions for matching transactions.
    */
-  onApplied?: (changeSet: ProposeOutput['changeSet']) => void;
+  onApplied?: (
+    changeSet: ProposeOutput['changeSet'],
+    affected: ProposeOutput['preview']['affected']
+  ) => void;
 }
 
 export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
@@ -161,7 +165,7 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
     });
     await utils.core.tagRules.listVocabulary.invalidate();
     toast.success('Tag rule saved');
-    onApplied?.(changeSet);
+    onApplied?.(changeSet, proposal.preview.affected);
     onOpenChange(false);
   }, [proposal, applyMutation, acceptedNewTags, utils, onApplied, onOpenChange]);
 


### PR DESCRIPTION
## Summary

Closes #1927

When a tag rule ChangeSet is applied in TagReviewStep, affected transactions that haven't been manually edited now receive updated tag suggestions and source badges immediately.

- `TagRuleProposalDialog.onApplied` now passes `preview.affected` alongside the `changeSet` so callers can propagate suggestion diffs
- `TagReviewStep` tracks user-edited checksums via `editedChecksumsRef` (a `useRef<Set<string>>`)
- `handleTagRuleApplied` merges `after.suggestedTags` into `localTags` for non-edited affected transactions, and refreshes `suggestedTagMeta` (source badges) with new rule attribution (`tag_rule` → `rule` mapped to match `SuggestedTag` schema)
- `suggestedTagMeta` is now `useState` (was `useMemo`) so it can be updated live; reset + sync on `confirmedTransactions` change is preserved in the existing `useEffect`

## Gaps (tracked)

- #1929 — follow-up proposal incorporating rejection feedback (still deferred)

## Test plan

- [ ] Open the import wizard with transactions, reach Tag Review step
- [ ] Click "Save tag rule…" on a group, apply a rule with a `contains` pattern matching multiple transactions
- [ ] Verify: affected transactions (that haven't been manually edited) now show the rule's tags as suggestions with a 📋 Rule badge
- [ ] Manually edit one transaction's tags, then apply another rule — verify the manually-edited transaction is NOT overridden
- [ ] Click "Accept All Suggestions" then apply a rule — verify affected transactions receive new suggestions
- [ ] Verify previously applied rule's suggestions carry through to Final Review via the commit payload

https://claude.ai/code/session_01172yc5y1Vnvo9MxWxmfAXq