### PR TITLE
docs(roadmap): mark PRD-073/074/076 Done; PRD-075 In progress

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,12 +44,12 @@ Live status of every theme and epic. Updated as work completes.
 
 #### Cortex Infrastructure
 
-| Epic                         | Status      | Notes                                                              |
-| ---------------------------- | ----------- | ------------------------------------------------------------------ |
-| Redis container & connection | Not started | Redis 7 Alpine, ioredis, Ansible provisioning                      |
-| Job queue (BullMQ)           | In progress | Typed queues, worker process, migrate Plex sync from in-memory     |
-| OpenAPI secondary contract   | Not started | trpc-openapi, spec at /api/docs, CI validation                     |
-| Vector storage (sqlite-vec)  | Not started | Embedding schema, similarity search, background embedding pipeline |
+| Epic                         | Status      | Notes                                                                                           |
+| ---------------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| Redis container & connection | Done        | Redis 7 Alpine, ioredis v5, Ansible role, persistence disabled, healthcheck (#1945)             |
+| Job queue (BullMQ)           | Done        | Typed queues, worker process, DLQ, Plex sync migrated, jobs management API (#1946)              |
+| OpenAPI secondary contract   | In progress | trpc-openapi, spec at /api/docs, CI validation                                                  |
+| Vector storage (sqlite-vec)  | Done        | sqlite-vec extension, embedding schema, similarity search, chunker, background pipeline (#1948) |
 
 ### Phase 1 — Foundation
 


### PR DESCRIPTION
## Summary
- Redis container & connection (PRD-073): Not started → Done (#1945)
- Job queue BullMQ (PRD-074): Not started → Done (#1946)
- Vector storage sqlite-vec (PRD-076): Not started → Done (#1948)
- OpenAPI secondary contract (PRD-075): Not started → In progress

## Test plan
- [ ] Roadmap table renders correctly on GitHub