### PR TITLE
feat(prd-029): re-propose tag rule after rejection with feedback (closes #1929)

### DIFF
--- a/apps/pops-api/src/modules/core/tag-rules/router.ts
+++ b/apps/pops-api/src/modules/core/tag-rules/router.ts
@@ -99,6 +99,30 @@ export const tagRulesRouter = router({
       z.object({
         changeSet: TagRuleChangeSetSchema,
         feedback: z.string().min(1),
+        /**
+         * When provided, a follow-up proposal is generated that incorporates the
+         * rejection feedback as a hint. The original signal is required so the
+         * service can rebuild the ChangeSet with context from the feedback.
+         */
+        signal: z
+          .object({
+            descriptionPattern: z.string().min(1),
+            matchType: z.enum(['exact', 'contains', 'regex']),
+            entityId: z.string().nullable().optional(),
+            tags: z.array(z.string()).min(1),
+          })
+          .optional(),
+        transactions: z
+          .array(
+            z.object({
+              transactionId: z.string().min(1),
+              description: z.string().min(1),
+              entityId: z.string().nullable().optional(),
+              userTags: z.array(z.string()).optional(),
+            })
+          )
+          .optional(),
+        maxPreviewItems: z.coerce.number().int().positive().max(500).default(200),
       })
     )
     .mutation(({ input }) => {
@@ -107,6 +131,18 @@ export const tagRulesRouter = router({
         '[TagRules] Reject ChangeSet'
       );
       // v1: audit persistence can be added later; ensure feedback required and no changes are applied.
-      return { message: 'Tag rule ChangeSet rejected' };
+
+      // Generate a follow-up proposal incorporating the feedback when the caller
+      // provides the original signal (and optionally transactions for preview).
+      const followUpProposal = input.signal
+        ? service.proposeTagRuleChangeSet({
+            signal: input.signal,
+            transactions: input.transactions ?? [],
+            maxPreviewItems: input.maxPreviewItems,
+            rejectionFeedback: input.feedback,
+          })
+        : null;
+
+      return { message: 'Tag rule ChangeSet rejected', followUpProposal };
     }),
 });

--- a/apps/pops-api/src/modules/core/tag-rules/service.ts
+++ b/apps/pops-api/src/modules/core/tag-rules/service.ts
@@ -257,10 +257,14 @@ export function proposeTagRuleChangeSet(args: {
   };
   transactions: PreviewInputTransaction[];
   maxPreviewItems: number;
+  /** Optional feedback from a previous rejection; incorporated into the rationale. */
+  rejectionFeedback?: string;
 }): TagRuleChangeSetProposal {
   const changeSet: TagRuleChangeSet = {
     source: 'tag-edit-signal',
-    reason: 'Create new tag rule from tag edit signal',
+    reason: args.rejectionFeedback
+      ? `Revised tag rule incorporating rejection feedback: ${args.rejectionFeedback}`
+      : 'Create new tag rule from tag edit signal',
     ops: [
       {
         op: 'add',
@@ -282,9 +286,14 @@ export function proposeTagRuleChangeSet(args: {
     maxPreviewItems: args.maxPreviewItems,
   });
 
+  const baseRationale = `Add new tag rule (${args.signal.matchType}:${args.signal.descriptionPattern}) from tag edit signal`;
+  const rationale = args.rejectionFeedback
+    ? `${baseRationale} — revised after rejection: "${args.rejectionFeedback}"`
+    : baseRationale;
+
   return {
     changeSet,
-    rationale: `Add new tag rule (${args.signal.matchType}:${args.signal.descriptionPattern}) from tag edit signal`,
+    rationale,
     preview,
   };
 }

--- a/apps/pops-api/src/modules/core/tag-rules/tag-rules.test.ts
+++ b/apps/pops-api/src/modules/core/tag-rules/tag-rules.test.ts
@@ -253,4 +253,119 @@ describe('tagRules', () => {
     const rules = orm.select().from(transactionTagRules).all();
     expect(rules.length).toBe(0);
   });
+
+  it('reject without signal returns no followUpProposal and applies no changes', async () => {
+    const orm = getDrizzle();
+    orm.delete(transactionTagRules).run();
+
+    const res = await caller.core.tagRules.rejectTagRuleChangeSet({
+      changeSet: {
+        ops: [
+          {
+            op: 'add',
+            data: { descriptionPattern: 'NETFLIX', matchType: 'contains', tags: ['Subscriptions'] },
+          },
+        ],
+      },
+      feedback: 'Too broad a pattern',
+    });
+
+    expect(res.message).toBe('Tag rule ChangeSet rejected');
+    expect(res.followUpProposal).toBeNull();
+
+    // No rules must have been written.
+    const rules = orm.select().from(transactionTagRules).all();
+    expect(rules.length).toBe(0);
+  });
+
+  it('reject with signal and feedback returns a followUpProposal incorporating the feedback', async () => {
+    const orm = getDrizzle();
+    orm.delete(transactionTagRules).run();
+    orm.delete(tagVocabulary).run();
+    orm
+      .insert(tagVocabulary)
+      .values({ tag: 'Subscriptions', source: 'seed', isActive: true })
+      .run();
+
+    const res = await caller.core.tagRules.rejectTagRuleChangeSet({
+      changeSet: {
+        ops: [
+          {
+            op: 'add',
+            data: { descriptionPattern: 'NETFLIX', matchType: 'contains', tags: ['Subscriptions'] },
+          },
+        ],
+      },
+      feedback: 'Use exact match instead',
+      signal: {
+        descriptionPattern: 'NETFLIX',
+        matchType: 'exact',
+        tags: ['Subscriptions'],
+      },
+      transactions: [
+        { transactionId: 't1', description: 'NETFLIX' },
+        { transactionId: 't2', description: 'NETFLIX HD' },
+      ],
+      maxPreviewItems: 200,
+    });
+
+    expect(res.message).toBe('Tag rule ChangeSet rejected');
+    expect(res.followUpProposal).toBeDefined();
+
+    const followUp = res.followUpProposal!;
+
+    // Rationale must reference the feedback.
+    expect(followUp.rationale).toContain('Use exact match instead');
+
+    // The ChangeSet reason must reference the feedback.
+    expect(followUp.changeSet.reason).toContain('Use exact match instead');
+
+    // The follow-up proposal uses the revised signal (exact match).
+    const addOp = followUp.changeSet.ops[0];
+    expect(addOp?.op).toBe('add');
+    if (addOp?.op === 'add') {
+      expect(addOp.data.matchType).toBe('exact');
+      expect(addOp.data.descriptionPattern).toBe('NETFLIX');
+    }
+
+    // No rules were applied — rejection must not persist anything.
+    const rules = orm.select().from(transactionTagRules).all();
+    expect(rules.length).toBe(0);
+  });
+
+  it('reject with signal returns correct preview for the follow-up', async () => {
+    const orm = getDrizzle();
+    orm.delete(transactionTagRules).run();
+    orm.delete(tagVocabulary).run();
+    orm.insert(tagVocabulary).values({ tag: 'Groceries', source: 'seed', isActive: true }).run();
+
+    const res = await caller.core.tagRules.rejectTagRuleChangeSet({
+      changeSet: {
+        ops: [
+          {
+            op: 'add',
+            data: { descriptionPattern: 'SHOP', matchType: 'contains', tags: ['Groceries'] },
+          },
+        ],
+      },
+      feedback: 'Too vague — scope to WOOLWORTHS only',
+      signal: {
+        descriptionPattern: 'WOOLWORTHS',
+        matchType: 'contains',
+        tags: ['Groceries'],
+      },
+      transactions: [
+        { transactionId: 't1', description: 'WOOLWORTHS 1234' },
+        { transactionId: 't2', description: 'COLES 9999' },
+      ],
+      maxPreviewItems: 200,
+    });
+
+    expect(res.followUpProposal).toBeDefined();
+    const followUp = res.followUpProposal!;
+
+    // Only WOOLWORTHS 1234 should be in the preview.
+    expect(followUp.preview.counts.affected).toBe(1);
+    expect(followUp.preview.affected[0]?.transactionId).toBe('t1');
+  });
 });

--- a/docs/themes/02-finance/prds/029-tag-rule-proposals/us-03-approve-reject-tag-proposals.md
+++ b/docs/themes/02-finance/prds/029-tag-rule-proposals/us-03-approve-reject-tag-proposals.md
@@ -15,5 +15,5 @@ As a user, I want to approve or reject tag rule proposals with feedback, so that
 - [x] Rejecting requires a feedback message and applies no changes **in the wizard** — the dialog enforces non-empty feedback before calling `rejectTagRuleChangeSet`.
 - [x] Accepting a **New** tag makes it part of the user’s tag vocabulary going forward — the dialog presents new tags as checkboxes and passes `acceptedNewTags` to `applyTagRuleChangeSet`.
 - [x] Approving updates suggested tags for remaining transactions in the current import session live — `handleTagRuleApplied` applies `preview.affected` items to `localTags` and `suggestedTagMeta` for non-user-edited transactions.
-- [ ] A follow-up proposal can be generated incorporating rejection feedback **in the wizard** (not yet wired).
+- [x] A follow-up proposal can be generated incorporating rejection feedback **in the wizard** — `rejectTagRuleChangeSet` accepts the original signal and returns a `followUpProposal`; `TagRuleProposalDialog` shows it in-place instead of closing (knoxio/pops#1929).
 - [ ] Tag rule application at transaction scope (single-transaction accept/reject) is not yet wired — only group scope is supported.

--- a/packages/app-finance/src/components/imports/TagRuleProposalDialog.test.tsx
+++ b/packages/app-finance/src/components/imports/TagRuleProposalDialog.test.tsx
@@ -1,0 +1,259 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TagRuleProposalDialog } from './TagRuleProposalDialog';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks (referenced inside vi.mock factories)
+// ---------------------------------------------------------------------------
+
+const { mockRejectMutate, mockApplyMutateAsync, mockInvalidate } = vi.hoisted(() => ({
+  mockRejectMutate: vi.fn(),
+  mockApplyMutateAsync: vi.fn(),
+  mockInvalidate: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock trpc
+// ---------------------------------------------------------------------------
+
+type ProposeData = {
+  changeSet: { source?: string; reason?: string; ops: Array<Record<string, unknown>> };
+  rationale: string;
+  preview: {
+    counts: { affected: number; suggestionChanges: number; newTagProposals: number };
+    affected: unknown[];
+  };
+} | null;
+
+let mockProposeData: ProposeData = null;
+let mockRejectOnSuccess:
+  | ((data: { message: string; followUpProposal: ProposeData }) => void)
+  | undefined;
+let _mockRejectOnError: ((err: Error) => void) | undefined;
+
+vi.mock('../../lib/trpc', () => ({
+  trpc: {
+    core: {
+      tagRules: {
+        proposeTagRuleChangeSet: {
+          useQuery: () => ({
+            data: mockProposeData,
+            isLoading: false,
+            isError: false,
+            error: null,
+          }),
+        },
+        applyTagRuleChangeSet: {
+          useMutation: () => ({
+            mutateAsync: mockApplyMutateAsync,
+            isPending: false,
+          }),
+        },
+        rejectTagRuleChangeSet: {
+          useMutation: (opts: {
+            onSuccess?: (data: { message: string; followUpProposal: ProposeData }) => void;
+            onError?: (err: Error) => void;
+          }) => {
+            mockRejectOnSuccess = opts.onSuccess;
+            _mockRejectOnError = opts.onError;
+            return {
+              mutate: (...args: unknown[]) => {
+                mockRejectMutate(...args);
+              },
+              isPending: false,
+            };
+          },
+        },
+        listVocabulary: {
+          invalidate: mockInvalidate,
+        },
+      },
+    },
+    useUtils: () => ({
+      core: {
+        tagRules: {
+          listVocabulary: {
+            invalidate: mockInvalidate,
+          },
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const signal = {
+  descriptionPattern: 'WOOLWORTHS',
+  matchType: 'contains' as const,
+  entityId: null,
+  tags: ['Groceries'],
+};
+
+const baseProposal: ProposeData = {
+  changeSet: {
+    source: 'tag-edit-signal',
+    reason: 'Create new tag rule from tag edit signal',
+    ops: [
+      {
+        op: 'add',
+        data: {
+          descriptionPattern: 'WOOLWORTHS',
+          matchType: 'contains',
+          entityId: null,
+          tags: ['Groceries'],
+          confidence: 0.95,
+          isActive: true,
+        },
+      },
+    ],
+  },
+  rationale: 'Add new tag rule (contains:WOOLWORTHS) from tag edit signal',
+  preview: {
+    counts: { affected: 1, suggestionChanges: 1, newTagProposals: 0 },
+    affected: [
+      {
+        transactionId: 't1',
+        description: 'WOOLWORTHS 1234',
+        before: { suggestedTags: [] },
+        after: { suggestedTags: [{ tag: 'Groceries', source: 'tag_rule', isNew: false }] },
+      },
+    ],
+  },
+};
+
+function renderDialog(onOpenChange = vi.fn(), onApplied = vi.fn()) {
+  return render(
+    <TagRuleProposalDialog
+      open={true}
+      onOpenChange={onOpenChange}
+      signal={signal}
+      previewTransactions={[{ checksum: 't1', description: 'WOOLWORTHS 1234', entityId: null }]}
+      onApplied={onApplied}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TagRuleProposalDialog', () => {
+  beforeEach(() => {
+    mockProposeData = baseProposal;
+    mockRejectOnSuccess = undefined;
+    _mockRejectOnError = undefined;
+    mockRejectMutate.mockReset();
+    mockApplyMutateAsync.mockReset();
+    mockInvalidate.mockReset();
+  });
+
+  it('renders the proposal rationale', () => {
+    renderDialog();
+    expect(screen.getByText(/contains:WOOLWORTHS/i)).toBeDefined();
+  });
+
+  it('shows the reject feedback textarea after clicking "Reject…"', async () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /reject/i }));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/feedback/i)).toBeDefined();
+    });
+  });
+
+  it('calls rejectTagRuleChangeSet with the changeSet, feedback, and signal on confirm', async () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /reject/i }));
+
+    const textarea = await screen.findByLabelText(/feedback/i);
+    fireEvent.change(textarea, { target: { value: 'Too broad' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm reject/i }));
+
+    expect(mockRejectMutate).toHaveBeenCalledOnce();
+    const callArg = mockRejectMutate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.feedback).toBe('Too broad');
+    expect(callArg.signal).toBeDefined();
+    expect(callArg.transactions).toBeDefined();
+  });
+
+  it('closes the dialog when rejection returns no followUpProposal', async () => {
+    const onOpenChange = vi.fn();
+    renderDialog(onOpenChange);
+
+    fireEvent.click(screen.getByRole('button', { name: /reject/i }));
+    const textarea = await screen.findByLabelText(/feedback/i);
+    fireEvent.change(textarea, { target: { value: 'Dismiss it' } });
+    fireEvent.click(screen.getByRole('button', { name: /confirm reject/i }));
+
+    // Simulate the mutation succeeding with no follow-up.
+    mockRejectOnSuccess?.({ message: 'Tag rule ChangeSet rejected', followUpProposal: null });
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('shows revised proposal banner when rejection returns a followUpProposal', async () => {
+    const onOpenChange = vi.fn();
+    renderDialog(onOpenChange);
+
+    fireEvent.click(screen.getByRole('button', { name: /reject/i }));
+    const textarea = await screen.findByLabelText(/feedback/i);
+    fireEvent.change(textarea, { target: { value: 'Use exact match' } });
+    fireEvent.click(screen.getByRole('button', { name: /confirm reject/i }));
+
+    const followUpProposal: ProposeData = {
+      ...baseProposal,
+      rationale:
+        'Add new tag rule (exact:WOOLWORTHS) from tag edit signal — revised after rejection: "Use exact match"',
+      changeSet: {
+        ...baseProposal.changeSet,
+        reason: 'Revised tag rule incorporating rejection feedback: Use exact match',
+      },
+    };
+
+    // Simulate the mutation succeeding with a follow-up.
+    mockRejectOnSuccess?.({
+      message: 'Tag rule ChangeSet rejected',
+      followUpProposal,
+    });
+
+    await waitFor(() => {
+      // The dialog must NOT close.
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+      // The revised-proposal banner must appear.
+      expect(screen.getByText(/revised proposal based on your feedback/i)).toBeDefined();
+    });
+  });
+
+  it('does not close the dialog when a follow-up proposal is shown', async () => {
+    const onOpenChange = vi.fn();
+    renderDialog(onOpenChange);
+
+    fireEvent.click(screen.getByRole('button', { name: /reject/i }));
+    const textarea = await screen.findByLabelText(/feedback/i);
+    fireEvent.change(textarea, { target: { value: 'Some feedback' } });
+    fireEvent.click(screen.getByRole('button', { name: /confirm reject/i }));
+
+    mockRejectOnSuccess?.({
+      message: 'Tag rule ChangeSet rejected',
+      followUpProposal: baseProposal,
+    });
+
+    await waitFor(() => {
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/TagRuleProposalDialog.tsx
@@ -22,6 +22,7 @@ import type { inferRouterOutputs } from '@trpc/server';
 import type { AppRouter } from '@pops/api-client';
 
 type ProposeOutput = inferRouterOutputs<AppRouter>['core']['tagRules']['proposeTagRuleChangeSet'];
+type RejectOutput = inferRouterOutputs<AppRouter>['core']['tagRules']['rejectTagRuleChangeSet'];
 
 export interface TagRuleLearnSignal {
   descriptionPattern: string;
@@ -60,6 +61,12 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
   const [rejectOpen, setRejectOpen] = useState(false);
   const [rejectFeedback, setRejectFeedback] = useState('');
   const [acceptedNewTags, setAcceptedNewTags] = useState<Set<string>>(new Set());
+  /**
+   * Holds a follow-up proposal returned by `rejectTagRuleChangeSet` when feedback
+   * is provided. When set, it overrides the query-derived proposal so the user can
+   * review the revised rule without closing and reopening the dialog.
+   */
+  const [followUpProposal, setFollowUpProposal] = useState<ProposeOutput | null>(null);
 
   const proposeInput = useMemo(() => {
     if (!props.signal) return null;
@@ -107,7 +114,8 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
     }
   );
 
-  const proposal: ProposeOutput | undefined = proposeQuery.data;
+  /** The active proposal — follow-up (from rejection) takes precedence over the query result. */
+  const proposal: ProposeOutput | undefined = followUpProposal ?? proposeQuery.data;
 
   useEffect(() => {
     if (!props.open || !props.signal) return;
@@ -117,6 +125,7 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
     setRejectOpen(false);
     setRejectFeedback('');
     setAcceptedNewTags(new Set());
+    setFollowUpProposal(null);
   }, [props.open, props.signal]);
 
   const newTagNames = useMemo(() => {
@@ -145,9 +154,17 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
   });
 
   const rejectMutation = trpc.core.tagRules.rejectTagRuleChangeSet.useMutation({
-    onSuccess: () => {
-      toast.message('Proposal dismissed');
-      onOpenChange(false);
+    onSuccess: (data: RejectOutput) => {
+      if (data.followUpProposal) {
+        // A revised proposal was generated — show it in the dialog instead of closing.
+        setFollowUpProposal(data.followUpProposal);
+        setRejectOpen(false);
+        setRejectFeedback('');
+        toast.message('Proposal revised based on your feedback');
+      } else {
+        toast.message('Proposal dismissed');
+        onOpenChange(false);
+      }
     },
     onError: (e) => toast.error(e.message),
   });
@@ -170,14 +187,39 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
   }, [proposal, applyMutation, acceptedNewTags, utils, onApplied, onOpenChange]);
 
   const handleReject = useCallback(() => {
-    if (!proposal) return;
+    if (!proposal || !props.signal) return;
     const fb = rejectFeedback.trim();
     if (fb.length === 0) {
       toast.error('Please add a short note explaining why you are rejecting this proposal.');
       return;
     }
-    rejectMutation.mutate({ changeSet: proposal.changeSet, feedback: fb });
-  }, [proposal, rejectMutation, rejectFeedback]);
+    rejectMutation.mutate({
+      changeSet: proposal.changeSet,
+      feedback: fb,
+      // Pass the current signal and transactions so the server can generate a follow-up.
+      signal: {
+        descriptionPattern: pattern.trim() || props.signal.descriptionPattern,
+        matchType,
+        entityId: props.signal.entityId,
+        tags: parseTags(tagsText.trim() ? tagsText : props.signal.tags.join(', ')),
+      },
+      transactions: props.previewTransactions.map((t) => ({
+        transactionId: t.checksum,
+        description: t.description,
+        entityId: t.entityId ?? null,
+      })),
+      maxPreviewItems: 200,
+    });
+  }, [
+    proposal,
+    props.signal,
+    props.previewTransactions,
+    rejectMutation,
+    rejectFeedback,
+    pattern,
+    matchType,
+    tagsText,
+  ]);
 
   const busy = applyMutation.isPending || rejectMutation.isPending;
 
@@ -194,6 +236,11 @@ export function TagRuleProposalDialog(props: TagRuleProposalDialogProps) {
 
         {!props.signal ? null : (
           <div className="space-y-4 text-sm">
+            {followUpProposal && (
+              <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
+                Revised proposal based on your feedback. Review and save or dismiss.
+              </p>
+            )}
             <div className="space-y-2">
               <Label htmlFor="tr-pattern">Description pattern</Label>
               <Input


### PR DESCRIPTION
## Summary

- `rejectTagRuleChangeSet` now accepts an optional `signal` + `transactions` in its input; when provided, it generates a follow-up proposal incorporating the rejection feedback and returns it as `followUpProposal: TagRuleChangeSetProposal | null`
- `proposeTagRuleChangeSet` gains an optional `rejectionFeedback` arg that is woven into the ChangeSet `reason` and `rationale` strings
- `TagRuleProposalDialog` handles `followUpProposal` in `rejectMutation.onSuccess`: when non-null, it replaces the active proposal in-place and shows a "Revised proposal based on your feedback" banner instead of closing the dialog
- PRD-029 US-03 acceptance criterion checked; 3 new API tests + 6 new frontend tests added

## Test plan

- [x] `pnpm --filter @pops/api test --run` — 12 passing (tag-rules suite)
- [x] `pnpm --filter @pops/app-finance test --run` — 272 passing
- [x] `pnpm typecheck` — 16/16 tasks successful
- [x] `pnpm lint` — 0 errors
- [x] `pnpm format:check` — all files correctly formatted

## Gaps (tracked)

- Closing #1929