### PR TITLE
test(prd-029): transaction-scope rule dialog tests + mark US-03 Done

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,7 +73,7 @@ Live status of every theme and epic. Updated as work completes.
 | Transaction ledger (CRUD, filtering, tagging) | Done    | 6 pages, inline editing                                                                                  |
 | Import pipeline (CSV wizard, entity matching) | Partial | 7-step wizard; atomic `commitImport` path still blocked by Tag Review `executeImport` (knoxio/pops#1740) |
 | Entity registry                               | Done    | Aliases, default tags, AI fallback                                                                       |
-| Corrections (learned rules)                   | Partial | Classification + proposals; tag-rule wizard UI open (knoxio/pops#1741); rule manager gaps #1742–#1744    |
+| Corrections (learned rules)                   | Partial | Classification + proposals + tag-rule wizard (PRD-029 Done); rule manager gaps #1742–#1744               |
 | Budgets                                       | Done    | Monthly/yearly, active/inactive                                                                          |
 | Wishlist                                      | Done    | Savings goals with progress                                                                              |
 | AI categorisation                             | Done    | Claude Haiku, disk-cached, cost-tracked                                                                  |

--- a/docs/themes/02-finance/epics/03-corrections.md
+++ b/docs/themes/02-finance/epics/03-corrections.md
@@ -12,7 +12,7 @@ Build the corrections system — learned **classification** rules (and separate 
 | --- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------- |
 | 024 | [Corrections](../prds/024-corrections/README.md)                                       | Classification corrections: pattern matching, confidence/activation semantics, transfer-only support                   | Partial     |
 | 028 | [Correction Proposal Engine](../prds/028-correction-proposal-engine/README.md)         | Bundled ChangeSet proposals with impact preview, approve/apply, reject-with-feedback                                   | Done        |
-| 029 | [Tag Rule Proposals](../prds/029-tag-rule-proposals/README.md)                         | Tag-rule learning proposals, separate from classification rules                                                        | Partial     |
+| 029 | [Tag Rule Proposals](../prds/029-tag-rule-proposals/README.md)                         | Tag-rule learning proposals, separate from classification rules                                                        | Done        |
 | 032 | [Global Rule Manager & Priority Ordering](../prds/032-rule-manager-priority/README.md) | Browse-all mode for CorrectionProposalDialog, priority column, drag-to-reorder, override indicators, orphaned entities | In progress |
 
 ## Dependencies

--- a/docs/themes/02-finance/prds/029-tag-rule-proposals/README.md
+++ b/docs/themes/02-finance/prds/029-tag-rule-proposals/README.md
@@ -1,7 +1,7 @@
 # PRD-029: Tag Rule Proposals
 
 > Epic: [03 — Corrections](../../epics/03-corrections.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -111,17 +111,17 @@ The UI must support accepting/rejecting suggestions at either scope:
 
 ## User Stories
 
-| #   | Story                                                                       | Summary                                                       | Status  | Parallelisable   |
-| --- | --------------------------------------------------------------------------- | ------------------------------------------------------------- | ------- | ---------------- |
-| 01  | [us-01-tag-rule-contract](us-01-tag-rule-contract.md)                       | Define tag rule model + ChangeSet operations + impact preview | Done    | No (first)       |
-| 02  | [us-02-generate-tag-proposal](us-02-generate-tag-proposal.md)               | Generate bundled tag-rule proposal from tag edits             | Done    | Blocked by us-01 |
-| 03  | [us-03-approve-reject-tag-proposals](us-03-approve-reject-tag-proposals.md) | Approve/apply or reject-with-feedback tag rule ChangeSets     | Partial | Blocked by us-01 |
+| #   | Story                                                                       | Summary                                                       | Status | Parallelisable   |
+| --- | --------------------------------------------------------------------------- | ------------------------------------------------------------- | ------ | ---------------- |
+| 01  | [us-01-tag-rule-contract](us-01-tag-rule-contract.md)                       | Define tag rule model + ChangeSet operations + impact preview | Done   | No (first)       |
+| 02  | [us-02-generate-tag-proposal](us-02-generate-tag-proposal.md)               | Generate bundled tag-rule proposal from tag edits             | Done   | Blocked by us-01 |
+| 03  | [us-03-approve-reject-tag-proposals](us-03-approve-reject-tag-proposals.md) | Approve/apply or reject-with-feedback tag rule ChangeSets     | Done   | Blocked by us-01 |
 
 ## Verification
 
-- Tag edits in the current import can produce a proposal that increases the quality of future tag suggestions. _`TagRuleProposalDialog` is wired into `TagReviewStep` via "Save tag rule…" per entity group (knoxio/pops#1886). Group-scope signal is fully wired; transaction-scope signal is not yet connected._
-- Approving a tag rule proposal immediately improves suggested tags for remaining transactions in the current import without altering entity/type classification. _(Apply is wired and stores the ChangeSet in the import store. Live re-suggestion is now implemented: `handleTagRuleApplied` propagates `preview.affected` into `localTags` and `suggestedTagMeta` for non-user-edited transactions.)_
+- Tag edits in the current import can produce a proposal that increases the quality of future tag suggestions. _`TagRuleProposalDialog` is wired into `TagReviewStep` at both scopes: group-scope via "Save tag rule…" per entity group (knoxio/pops#1886, knoxio/pops#1940) and transaction-scope via "Save rule…" per individual row (closes knoxio/pops#1954)._
+- Approving a tag rule proposal immediately improves suggested tags for remaining transactions in the current import without altering entity/type classification. _Apply is wired and stores the ChangeSet in the import store. Live re-suggestion propagates `preview.affected` into `localTags` and `suggestedTagMeta` for non-user-edited transactions at both scopes._
 
 ## Drift Check
 
-last checked: 2026-04-18
+last checked: 2026-04-19

--- a/docs/themes/02-finance/prds/029-tag-rule-proposals/us-03-approve-reject-tag-proposals.md
+++ b/docs/themes/02-finance/prds/029-tag-rule-proposals/us-03-approve-reject-tag-proposals.md
@@ -1,7 +1,7 @@
 # US-03: Approve/reject tag rule proposals
 
 > PRD: [029 — Tag Rule Proposals](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -16,4 +16,4 @@ As a user, I want to approve or reject tag rule proposals with feedback, so that
 - [x] Accepting a **New** tag makes it part of the user’s tag vocabulary going forward — the dialog presents new tags as checkboxes and passes `acceptedNewTags` to `applyTagRuleChangeSet`.
 - [x] Approving updates suggested tags for remaining transactions in the current import session live — `handleTagRuleApplied` applies `preview.affected` items to `localTags` and `suggestedTagMeta` for non-user-edited transactions.
 - [x] A follow-up proposal can be generated incorporating rejection feedback **in the wizard** — `rejectTagRuleChangeSet` accepts the original signal and returns a `followUpProposal`; `TagRuleProposalDialog` shows it in-place instead of closing (knoxio/pops#1929).
-- [ ] Tag rule application at transaction scope (single-transaction accept/reject) is not yet wired — only group scope is supported (knoxio/pops#1954).
+- [x] Tag rule application at transaction scope (single-transaction accept/reject) is wired — clicking "Save rule…" on a transaction row opens `TagRuleProposalDialog` with the transaction's description as pattern, the transaction's entityId, and current tags (closes knoxio/pops#1954).

--- a/packages/app-finance/src/components/imports/TagReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/TagReviewStep.test.tsx
@@ -157,12 +157,20 @@ vi.mock('@pops/ui', async () => {
 // eslint-disable-next-line prefer-const
 let mockOnAppliedFn: ((...args: unknown[]) => void) | null = null;
 
+/** Captures the last signal and previewTransactions passed to TagRuleProposalDialog. */
+const mockDialogCapture = {
+  signal: null as unknown,
+  previewTransactions: null as unknown[] | null,
+};
+
 vi.mock('./TagRuleProposalDialog', async () => {
   const React = await import('react');
   return {
     TagRuleProposalDialog: ({
       onApplied,
       open,
+      signal,
+      previewTransactions,
     }: {
       onApplied?: (...args: unknown[]) => void;
       open: boolean;
@@ -173,6 +181,8 @@ vi.mock('./TagRuleProposalDialog', async () => {
       if (onApplied) {
         mockOnAppliedFn = onApplied;
       }
+      mockDialogCapture.signal = signal;
+      mockDialogCapture.previewTransactions = previewTransactions;
       if (!open) return null;
       return React.createElement('div', { 'data-testid': 'dialog' });
     },
@@ -294,6 +304,8 @@ function renderTagReviewStep() {
 beforeEach(() => {
   mockConfirmedTransactions.length = 0;
   mockOnAppliedFn = null;
+  mockDialogCapture.signal = null;
+  mockDialogCapture.previewTransactions = null;
   mockAddPendingTagRuleChangeSet.mockReset();
   mockUpdateTransactionTags.mockReset();
   mockNextStep.mockReset();
@@ -374,6 +386,90 @@ describe('TagReviewStep — Save tag rule wiring (PRD-029 US-02 / US-03)', () =>
       expect(mockToastInfo).toHaveBeenCalledWith(expect.stringContaining('Add at least one tag'));
     });
     expect(screen.queryByTestId('dialog')).not.toBeInTheDocument();
+  });
+
+  it('passes correct signal (description, matchType, entityId, tags) for transaction-scope dialog', async () => {
+    seedTransactions([woolworthsTx1]);
+    renderTagReviewStep();
+
+    const saveBtn = screen.getByLabelText('Save tag rule for WOOLWORTHS METRO');
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dialog')).toBeInTheDocument();
+    });
+
+    expect(mockDialogCapture.signal).toMatchObject({
+      descriptionPattern: 'WOOLWORTHS METRO',
+      matchType: 'contains',
+      entityId: 'woolworths-id',
+      tags: expect.arrayContaining(['Groceries']),
+    });
+  });
+
+  it('passes full previewTransactions list (not only the clicked row) to dialog', async () => {
+    seedTransactions([woolworthsTx1, netflixTx]);
+    renderTagReviewStep();
+
+    const saveBtn = screen.getByLabelText('Save tag rule for WOOLWORTHS METRO');
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dialog')).toBeInTheDocument();
+    });
+
+    expect(mockDialogCapture.previewTransactions).toHaveLength(2);
+    expect(mockDialogCapture.previewTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ description: 'WOOLWORTHS METRO' }),
+        expect.objectContaining({ description: 'NETFLIX.COM' }),
+      ])
+    );
+  });
+
+  it('approving from transaction-scope dialog propagates tags via handleTagRuleApplied', () => {
+    const CHECKSUM = woolworthsTx1.checksum;
+    seedTransactions([woolworthsTx1]);
+    renderTagReviewStep();
+
+    const saveBtn = screen.getByLabelText('Save tag rule for WOOLWORTHS METRO');
+    fireEvent.click(saveBtn);
+
+    act(() => {
+      mockOnAppliedFn!(
+        {
+          ops: [
+            {
+              op: 'add',
+              data: {
+                descriptionPattern: 'WOOLWORTHS METRO',
+                matchType: 'contains',
+                tags: ['Groceries', 'Food'],
+              },
+            },
+          ],
+        },
+        [
+          {
+            transactionId: CHECKSUM,
+            description: 'WOOLWORTHS METRO',
+            before: { suggestedTags: [] },
+            after: {
+              suggestedTags: [
+                { tag: 'Groceries', source: 'tag_rule' as const },
+                { tag: 'Food', source: 'tag_rule' as const },
+              ],
+            },
+          },
+        ]
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue to final review/i }));
+    expect(mockUpdateTransactionTags).toHaveBeenCalledWith(
+      CHECKSUM,
+      expect.arrayContaining(['Groceries', 'Food'])
+    );
   });
 
   it('shows empty state when there are no confirmed transactions', () => {


### PR DESCRIPTION
## Summary

- Add 3 targeted tests for the transaction-scope "Save rule…" dialog path in `TagReviewStep`:
  - Signal correctness: `descriptionPattern`, `matchType`, `entityId`, and `tags` are populated from the clicked row
  - `previewTransactions` passed to the dialog is the full import list, not just the clicked row
  - Approving from the transaction-scope dialog propagates tag changes via `handleTagRuleApplied`
- Enhance `TagRuleProposalDialog` mock to capture `signal` and `previewTransactions` for assertion
- Mark US-03 acceptance criteria fully checked; update status to `Done`
- Update PRD-029 README, epic table (03-corrections), and roadmap to reflect Done

The implementation was already merged (PR #1940, PR #1947). This PR closes the documentation gap and adds the missing targeted tests.

## Test plan

- [ ] `pnpm test --run TagReviewStep` passes all 21 tests
- [ ] `npx turbo run typecheck --filter=@pops/app-finance` passes clean

Closes #1954