### PR TITLE
docs: sync finance status — corrections Done, import pipeline PRDs updated

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,9 +71,9 @@ Live status of every theme and epic. Updated as work completes.
 | Area                                          | Status  | Notes                                                                                                    |
 | --------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
 | Transaction ledger (CRUD, filtering, tagging) | Done    | 6 pages, inline editing                                                                                  |
-| Import pipeline (CSV wizard, entity matching) | Partial | 7-step wizard; atomic `commitImport` path still blocked by Tag Review `executeImport` (knoxio/pops#1740) |
+| Import pipeline (CSV wizard, entity matching) | Partial | 6 of 7 PRDs done; ANZ PDF parser (PRD-022 US-07) not started                                            |
 | Entity registry                               | Done    | Aliases, default tags, AI fallback                                                                       |
-| Corrections (learned rules)                   | Partial | Classification + proposals + tag-rule wizard (PRD-029 Done); rule manager gaps #1742–#1744               |
+| Corrections (learned rules)                   | Done    | Classification, proposals, tag-rule wizard, global rule manager — all 4 PRDs complete                   |
 | Budgets                                       | Done    | Monthly/yearly, active/inactive                                                                          |
 | Wishlist                                      | Done    | Savings goals with progress                                                                              |
 | AI categorisation                             | Done    | Claude Haiku, disk-cached, cost-tracked                                                                  |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,15 +68,15 @@ Live status of every theme and epic. Updated as work completes.
 
 #### Finance
 
-| Area                                          | Status  | Notes                                                                                                    |
-| --------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
-| Transaction ledger (CRUD, filtering, tagging) | Done    | 6 pages, inline editing                                                                                  |
-| Import pipeline (CSV wizard, entity matching) | Partial | 6 of 7 PRDs done; ANZ PDF parser (PRD-022 US-07) not started                                            |
-| Entity registry                               | Done    | Aliases, default tags, AI fallback                                                                       |
-| Corrections (learned rules)                   | Done    | Classification, proposals, tag-rule wizard, global rule manager — all 4 PRDs complete                   |
-| Budgets                                       | Done    | Monthly/yearly, active/inactive                                                                          |
-| Wishlist                                      | Done    | Savings goals with progress                                                                              |
-| AI categorisation                             | Done    | Claude Haiku, disk-cached, cost-tracked                                                                  |
+| Area                                          | Status  | Notes                                                                                 |
+| --------------------------------------------- | ------- | ------------------------------------------------------------------------------------- |
+| Transaction ledger (CRUD, filtering, tagging) | Done    | 6 pages, inline editing                                                               |
+| Import pipeline (CSV wizard, entity matching) | Partial | 6 of 7 PRDs done; ANZ PDF parser (PRD-022 US-07) not started                          |
+| Entity registry                               | Done    | Aliases, default tags, AI fallback                                                    |
+| Corrections (learned rules)                   | Done    | Classification, proposals, tag-rule wizard, global rule manager — all 4 PRDs complete |
+| Budgets                                       | Done    | Monthly/yearly, active/inactive                                                       |
+| Wishlist                                      | Done    | Savings goals with progress                                                           |
+| AI categorisation                             | Done    | Claude Haiku, disk-cached, cost-tracked                                               |
 
 #### Media
 

--- a/docs/themes/02-finance/README.md
+++ b/docs/themes/02-finance/README.md
@@ -21,7 +21,7 @@ Build a finance app that tracks every transaction across multiple bank accounts,
 | 0   | [Transactions](epics/00-transactions.md)          | Transaction ledger — CRUD, filtering, sorting, inline tag editing                                           | Done    |
 | 1   | [Import Pipeline](epics/01-import-pipeline.md)    | Multi-step wizard for bank CSV imports with entity matching, deduplication, review flow                     | Partial |
 | 2   | [Entities](epics/02-entities.md)                  | Merchant/payee registry — names, types, aliases, default tags                                               | Partial |
-| 3   | [Corrections](epics/03-corrections.md)            | Learned classification + tag rules — pattern matching, proposals, priority                                  | Partial |
+| 3   | [Corrections](epics/03-corrections.md)            | Learned classification + tag rules — pattern matching, proposals, priority                                  | Done    |
 | 4   | [Budgets](epics/04-budgets.md)                    | Spending categories with period limits (monthly/yearly)                                                     | Partial |
 | 5   | [Wishlist](epics/05-wishlist.md)                  | Savings goals with target amounts and progress tracking                                                     | Done    |
 | 6   | [AI Rule Creation](epics/06-ai-categorisation.md) | AI observes user corrections during import, creates matching rules that apply immediately to remaining rows | Partial |

--- a/docs/themes/02-finance/epics/01-import-pipeline.md
+++ b/docs/themes/02-finance/epics/01-import-pipeline.md
@@ -10,13 +10,13 @@ Build the multi-step import wizard for ingesting bank data into the transaction 
 
 | #   | PRD                                                                        | Summary                                                                                                                                        | Status      |
 | --- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 020 | [Import Wizard UI](../prds/020-import-wizard-ui/README.md)                 | 7-step flow: upload, column mapping, processing, review, tags, final review & commit, summary                                                  | Partial     |
-| 021 | [Entity Matching Engine](../prds/021-entity-matching-engine/README.md)     | Matching chain: aliases → exact → prefix → contains → AI fallback. Per-bank alias maps. Full pipeline including Claude Haiku as final strategy | Partial     |
+| 020 | [Import Wizard UI](../prds/020-import-wizard-ui/README.md)                 | 7-step flow: upload, column mapping, processing, review, tags, final review & commit, summary                                                  | Done        |
+| 021 | [Entity Matching Engine](../prds/021-entity-matching-engine/README.md)     | Matching chain: aliases → exact → prefix → contains → AI fallback. Per-bank alias maps. Full pipeline including Claude Haiku as final strategy | Done        |
 | 022 | [Deduplication & Parsers](../prds/022-deduplication-parsers/README.md)     | Date + amount count-based dedup, per-bank CSV parsers (ANZ, Amex, ING), Up Bank API batch import                                               | Partial     |
-| 029 | [Tag Rule Proposals](../prds/029-tag-rule-proposals/README.md)             | Tag-rule learning proposals for import tagging                                                                                                 | Partial     |
-| 030 | [Local-First Import State Layer](../prds/030-local-first-import/README.md) | Pending entity/rule stores in zustand, merged state layer, local re-evaluation, commit payload builder                                         | In progress |
-| 031 | [Final Review & Commit Step](../prds/031-final-review-commit/README.md)    | Step 6: pending changes summary, atomic commit endpoint, retroactive reclassification                                                          | Partial     |
-| 069 | [Drop online field](../prds/069-drop-online-field/README.md)               | Remove the `online` boolean from import pipeline; "online vs in-person" expressed as a tag rule                                                | Partial     |
+| 029 | [Tag Rule Proposals](../prds/029-tag-rule-proposals/README.md)             | Tag-rule learning proposals for import tagging                                                                                                 | Done        |
+| 030 | [Local-First Import State Layer](../prds/030-local-first-import/README.md) | Pending entity/rule stores in zustand, merged state layer, local re-evaluation, commit payload builder                                         | Done        |
+| 031 | [Final Review & Commit Step](../prds/031-final-review-commit/README.md)    | Step 6: pending changes summary, atomic commit endpoint, retroactive reclassification                                                          | Done        |
+| 069 | [Drop online field](../prds/069-drop-online-field/README.md)               | Remove the `online` boolean from import pipeline; "online vs in-person" expressed as a tag rule                                                | Done        |
 
 PRD-021 and PRD-022 are backend and can be built in parallel. PRD-020 depends on both (the wizard calls the matching and dedup engines).
 

--- a/docs/themes/02-finance/epics/01-import-pipeline.md
+++ b/docs/themes/02-finance/epics/01-import-pipeline.md
@@ -8,15 +8,15 @@ Build the multi-step import wizard for ingesting bank data into the transaction 
 
 ## PRDs
 
-| #   | PRD                                                                        | Summary                                                                                                                                        | Status      |
-| --- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 020 | [Import Wizard UI](../prds/020-import-wizard-ui/README.md)                 | 7-step flow: upload, column mapping, processing, review, tags, final review & commit, summary                                                  | Done        |
-| 021 | [Entity Matching Engine](../prds/021-entity-matching-engine/README.md)     | Matching chain: aliases → exact → prefix → contains → AI fallback. Per-bank alias maps. Full pipeline including Claude Haiku as final strategy | Done        |
-| 022 | [Deduplication & Parsers](../prds/022-deduplication-parsers/README.md)     | Date + amount count-based dedup, per-bank CSV parsers (ANZ, Amex, ING), Up Bank API batch import                                               | Partial     |
-| 029 | [Tag Rule Proposals](../prds/029-tag-rule-proposals/README.md)             | Tag-rule learning proposals for import tagging                                                                                                 | Done        |
-| 030 | [Local-First Import State Layer](../prds/030-local-first-import/README.md) | Pending entity/rule stores in zustand, merged state layer, local re-evaluation, commit payload builder                                         | Done        |
-| 031 | [Final Review & Commit Step](../prds/031-final-review-commit/README.md)    | Step 6: pending changes summary, atomic commit endpoint, retroactive reclassification                                                          | Done        |
-| 069 | [Drop online field](../prds/069-drop-online-field/README.md)               | Remove the `online` boolean from import pipeline; "online vs in-person" expressed as a tag rule                                                | Done        |
+| #   | PRD                                                                        | Summary                                                                                                                                        | Status  |
+| --- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| 020 | [Import Wizard UI](../prds/020-import-wizard-ui/README.md)                 | 7-step flow: upload, column mapping, processing, review, tags, final review & commit, summary                                                  | Done    |
+| 021 | [Entity Matching Engine](../prds/021-entity-matching-engine/README.md)     | Matching chain: aliases → exact → prefix → contains → AI fallback. Per-bank alias maps. Full pipeline including Claude Haiku as final strategy | Done    |
+| 022 | [Deduplication & Parsers](../prds/022-deduplication-parsers/README.md)     | Date + amount count-based dedup, per-bank CSV parsers (ANZ, Amex, ING), Up Bank API batch import                                               | Partial |
+| 029 | [Tag Rule Proposals](../prds/029-tag-rule-proposals/README.md)             | Tag-rule learning proposals for import tagging                                                                                                 | Done    |
+| 030 | [Local-First Import State Layer](../prds/030-local-first-import/README.md) | Pending entity/rule stores in zustand, merged state layer, local re-evaluation, commit payload builder                                         | Done    |
+| 031 | [Final Review & Commit Step](../prds/031-final-review-commit/README.md)    | Step 6: pending changes summary, atomic commit endpoint, retroactive reclassification                                                          | Done    |
+| 069 | [Drop online field](../prds/069-drop-online-field/README.md)               | Remove the `online` boolean from import pipeline; "online vs in-person" expressed as a tag rule                                                | Done    |
 
 PRD-021 and PRD-022 are backend and can be built in parallel. PRD-020 depends on both (the wizard calls the matching and dedup engines).
 

--- a/docs/themes/02-finance/epics/03-corrections.md
+++ b/docs/themes/02-finance/epics/03-corrections.md
@@ -10,10 +10,10 @@ Build the corrections system — learned **classification** rules (and separate 
 
 | #   | PRD                                                                                    | Summary                                                                                                                | Status      |
 | --- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 024 | [Corrections](../prds/024-corrections/README.md)                                       | Classification corrections: pattern matching, confidence/activation semantics, transfer-only support                   | Partial     |
+| 024 | [Corrections](../prds/024-corrections/README.md)                                       | Classification corrections: pattern matching, confidence/activation semantics, transfer-only support                   | Done        |
 | 028 | [Correction Proposal Engine](../prds/028-correction-proposal-engine/README.md)         | Bundled ChangeSet proposals with impact preview, approve/apply, reject-with-feedback                                   | Done        |
 | 029 | [Tag Rule Proposals](../prds/029-tag-rule-proposals/README.md)                         | Tag-rule learning proposals, separate from classification rules                                                        | Done        |
-| 032 | [Global Rule Manager & Priority Ordering](../prds/032-rule-manager-priority/README.md) | Browse-all mode for CorrectionProposalDialog, priority column, drag-to-reorder, override indicators, orphaned entities | In progress |
+| 032 | [Global Rule Manager & Priority Ordering](../prds/032-rule-manager-priority/README.md) | Browse-all mode for CorrectionProposalDialog, priority column, drag-to-reorder, override indicators, orphaned entities | Done        |
 
 ## Dependencies
 

--- a/docs/themes/02-finance/epics/03-corrections.md
+++ b/docs/themes/02-finance/epics/03-corrections.md
@@ -8,12 +8,12 @@ Build the corrections system — learned **classification** rules (and separate 
 
 ## PRDs
 
-| #   | PRD                                                                                    | Summary                                                                                                                | Status      |
-| --- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------- |
-| 024 | [Corrections](../prds/024-corrections/README.md)                                       | Classification corrections: pattern matching, confidence/activation semantics, transfer-only support                   | Done        |
-| 028 | [Correction Proposal Engine](../prds/028-correction-proposal-engine/README.md)         | Bundled ChangeSet proposals with impact preview, approve/apply, reject-with-feedback                                   | Done        |
-| 029 | [Tag Rule Proposals](../prds/029-tag-rule-proposals/README.md)                         | Tag-rule learning proposals, separate from classification rules                                                        | Done        |
-| 032 | [Global Rule Manager & Priority Ordering](../prds/032-rule-manager-priority/README.md) | Browse-all mode for CorrectionProposalDialog, priority column, drag-to-reorder, override indicators, orphaned entities | Done        |
+| #   | PRD                                                                                    | Summary                                                                                                                | Status |
+| --- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------ |
+| 024 | [Corrections](../prds/024-corrections/README.md)                                       | Classification corrections: pattern matching, confidence/activation semantics, transfer-only support                   | Done   |
+| 028 | [Correction Proposal Engine](../prds/028-correction-proposal-engine/README.md)         | Bundled ChangeSet proposals with impact preview, approve/apply, reject-with-feedback                                   | Done   |
+| 029 | [Tag Rule Proposals](../prds/029-tag-rule-proposals/README.md)                         | Tag-rule learning proposals, separate from classification rules                                                        | Done   |
+| 032 | [Global Rule Manager & Priority Ordering](../prds/032-rule-manager-priority/README.md) | Browse-all mode for CorrectionProposalDialog, priority column, drag-to-reorder, override indicators, orphaned entities | Done   |
 
 ## Dependencies
 

--- a/docs/themes/02-finance/prds/020-import-wizard-ui/README.md
+++ b/docs/themes/02-finance/prds/020-import-wizard-ui/README.md
@@ -1,7 +1,7 @@
 # PRD-020: Import Wizard UI
 
 > Epic: [01 — Import Pipeline](../../epics/01-import-pipeline.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Epic 03 Corrections: marks all 4 PRDs Done (PRD-024, PRD-028, PRD-029, PRD-032) — all issues #1742–#1744 closed, rule manager complete
- Epic 01 Import Pipeline: PRD-020, PRD-021, PRD-029, PRD-030, PRD-031, PRD-069 updated to Done in epic table; PRD-022 remains Partial (US-07 ANZ PDF parser not started)
- Finance theme README: corrections epic status → Done
- Roadmap: corrections row → Done; import pipeline note updated to reflect actual remaining work (ANZ PDF parser only)

## Test plan

- [ ] Verify no broken links in updated tables
- [ ] Verify all referenced PRD READMEs actually show Done status