### PR TITLE
feat(prd-079): Thalamus — engram file watcher, frontmatter sync, embedding trigger, cross-source indexer

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -72,6 +72,7 @@
     "@trpc/server": "^11.16.0",
     "better-sqlite3": "^12.9.0",
     "bullmq": "^5.56.8",
+    "chokidar": "^5.0.0",
     "cron-parser": "^5.5.0",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -8,6 +8,7 @@ config({ path: '../../.env', override: false }); // loads root .env without over
 import { createApp } from './app.js';
 import { closeDb } from './db.js';
 import { closeQueues } from './jobs/queues.js';
+import { startThalamus, stopThalamus } from './modules/cerebrum/thalamus/instance.js';
 import { startupCleanup } from './modules/core/envs/registry.js';
 import { startTtlWatcher } from './modules/core/envs/ttl-watcher.js';
 import { resumeSchedulerIfEnabled, stopPlexSchedulerTask } from './modules/media/plex/scheduler.js';
@@ -52,6 +53,11 @@ getRedisClient()
 // Periodically purge expired named environments
 const ttlWatcher = startTtlWatcher();
 
+// Start Thalamus file watcher (Cerebrum indexing middleware)
+startThalamus().catch((err) => {
+  console.error('[thalamus] Failed to start:', err);
+});
+
 async function shutdown(signal: string): Promise<void> {
   console.warn(`[pops-api] ${signal} — shutting down`);
   // 1. Stop accepting new requests
@@ -59,19 +65,21 @@ async function shutdown(signal: string): Promise<void> {
   // 2. Stop schedulers (preserve settings for auto-resume on restart)
   stopRotationTask();
   stopPlexSchedulerTask();
-  // 3. Wait for any in-progress rotation cycle to finish
+  // 3. Stop Thalamus file watcher
+  await stopThalamus();
+  // 4. Wait for any in-progress rotation cycle to finish
   if (process.env['NODE_ENV'] !== 'test') {
     await waitForCycleEnd();
   }
-  // 4. Stop TTL watcher
+  // 5. Stop TTL watcher
   clearInterval(ttlWatcher);
-  // 5. Close BullMQ queue connections
+  // 6. Close BullMQ queue connections
   await closeQueues();
-  // 6. Close Redis
+  // 7. Close Redis
   await shutdownRedis();
-  // 7. Close DB
+  // 8. Close DB
   closeDb();
-  // 8. Exit
+  // 9. Exit
   process.exit(0);
 }
 

--- a/apps/pops-api/src/jobs/handlers/default.ts
+++ b/apps/pops-api/src/jobs/handlers/default.ts
@@ -1,5 +1,11 @@
 import pino from 'pino';
 
+import { getDrizzle } from '../../db.js';
+import {
+  CROSS_SOURCE_TYPES,
+  CrossSourceIndexer,
+} from '../../modules/cerebrum/thalamus/cross-source.js';
+
 import type { Job } from 'bullmq';
 
 import type { DefaultQueueJobData } from '../types.js';
@@ -8,5 +14,18 @@ const logger = pino({ name: 'worker:default' });
 
 export async function process(job: Job<DefaultQueueJobData>): Promise<unknown> {
   logger.info({ jobId: job.id, type: job.data.type }, 'Default job received');
+
+  if (job.data.type === 'crossSourceIndex') {
+    const db = getDrizzle();
+    const indexer = new CrossSourceIndexer(db);
+    const validTypes = (job.data.sourceTypes ?? [...CROSS_SOURCE_TYPES]).filter(
+      (t): t is (typeof CROSS_SOURCE_TYPES)[number] =>
+        (CROSS_SOURCE_TYPES as readonly string[]).includes(t)
+    );
+    const result = await indexer.scanAndEnqueue(validTypes);
+    logger.info({ enqueued: result.enqueued }, 'Cross-source index scan complete');
+    return result;
+  }
+
   throw new Error(`Default handler not implemented for type: ${job.data.type}`);
 }

--- a/apps/pops-api/src/jobs/types.ts
+++ b/apps/pops-api/src/jobs/types.ts
@@ -57,13 +57,19 @@ export type EmbeddingsQueueJobData = EmbedJobData;
 // pops:curation / pops:default queues (stubs)
 // ---------------------------------------------------------------------------
 
+export interface CrossSourceIndexJobData {
+  type: 'crossSourceIndex';
+  /** Subset of source types to scan; defaults to all when omitted. */
+  sourceTypes?: string[];
+}
+
 export interface GenericJobData {
   type: string;
   [key: string]: unknown;
 }
 
 export type CurationQueueJobData = GenericJobData;
-export type DefaultQueueJobData = GenericJobData;
+export type DefaultQueueJobData = CrossSourceIndexJobData;
 
 // ---------------------------------------------------------------------------
 // pops:dead-letter queue

--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -6,9 +6,11 @@ import { router } from '../../trpc.js';
 import { engramsRouter } from './engrams/router.js';
 import { scopesRouter } from './engrams/scopes-router.js';
 import { templatesRouter } from './templates/router.js';
+import { indexRouter } from './thalamus/router.js';
 
 export const cerebrumRouter = router({
   engrams: engramsRouter,
   scopes: scopesRouter,
   templates: templatesRouter,
+  index: indexRouter,
 });

--- a/apps/pops-api/src/modules/cerebrum/thalamus/cross-source.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/cross-source.test.ts
@@ -1,0 +1,462 @@
+/**
+ * CrossSourceIndexer tests.
+ *
+ * Tests the pure formatter functions and the scanAndEnqueue logic with a real
+ * in-memory SQLite database and a mocked BullMQ queue.
+ */
+import BetterSqlite3 from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CrossSourceIndexer,
+  toInventoryText,
+  toMovieText,
+  toTransactionText,
+  toTvShowText,
+} from './cross-source.js';
+
+import type { Database } from 'better-sqlite3';
+
+// ---------------------------------------------------------------------------
+// Mock the queues module
+// ---------------------------------------------------------------------------
+
+const mockAdd = vi.hoisted(() => vi.fn().mockResolvedValue({ id: 'job-1' }));
+const mockGetEmbeddingsQueue = vi.hoisted(() => vi.fn().mockReturnValue({ add: mockAdd }));
+
+vi.mock('../../../jobs/queues.js', () => ({
+  getEmbeddingsQueue: mockGetEmbeddingsQueue,
+  EMBEDDINGS_QUEUE: 'pops:embeddings',
+  EMBEDDINGS_JOB_OPTIONS: {},
+}));
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory DB with just the tables CrossSourceIndexer needs
+// ---------------------------------------------------------------------------
+
+function createCrossSourceTestDb(): Database {
+  const db = new BetterSqlite3(':memory:');
+  db.pragma('foreign_keys = ON');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS transactions (
+      id               TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+      notion_id        TEXT,
+      description      TEXT NOT NULL,
+      account          TEXT NOT NULL DEFAULT '',
+      amount           REAL NOT NULL DEFAULT 0,
+      date             TEXT NOT NULL DEFAULT '',
+      type             TEXT NOT NULL DEFAULT '',
+      tags             TEXT NOT NULL DEFAULT '',
+      entity_id        TEXT,
+      entity_name      TEXT,
+      location         TEXT,
+      country          TEXT,
+      related_transaction_id TEXT,
+      notes            TEXT,
+      checksum         TEXT,
+      raw_row          TEXT,
+      last_edited_time TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE IF NOT EXISTS movies (
+      id               INTEGER PRIMARY KEY AUTOINCREMENT,
+      tmdb_id          INTEGER NOT NULL,
+      title            TEXT NOT NULL,
+      overview         TEXT,
+      genres           TEXT,
+      release_date     TEXT,
+      runtime          INTEGER,
+      status           TEXT,
+      vote_average     REAL,
+      vote_count       INTEGER,
+      original_title   TEXT,
+      original_language TEXT,
+      imdb_id          TEXT,
+      tagline          TEXT,
+      budget           INTEGER,
+      revenue          INTEGER,
+      poster_path      TEXT,
+      backdrop_path    TEXT,
+      logo_path        TEXT,
+      poster_override_path TEXT,
+      discover_rating_key TEXT,
+      rotation_status  TEXT,
+      rotation_expires_at TEXT,
+      rotation_marked_at TEXT,
+      created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS tv_shows (
+      id               INTEGER PRIMARY KEY AUTOINCREMENT,
+      tvdb_id          INTEGER NOT NULL,
+      name             TEXT NOT NULL,
+      overview         TEXT,
+      genres           TEXT,
+      networks         TEXT,
+      first_air_date   TEXT,
+      last_air_date    TEXT,
+      status           TEXT,
+      original_language TEXT,
+      original_name    TEXT,
+      number_of_seasons INTEGER,
+      number_of_episodes INTEGER,
+      episode_run_time  INTEGER,
+      vote_average     REAL,
+      vote_count       INTEGER,
+      poster_path      TEXT,
+      backdrop_path    TEXT,
+      logo_path        TEXT,
+      poster_override_path TEXT,
+      discover_rating_key TEXT,
+      created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS home_inventory (
+      id               TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+      notion_id        TEXT,
+      item_name        TEXT NOT NULL,
+      brand            TEXT,
+      model            TEXT,
+      item_id          TEXT,
+      room             TEXT,
+      location         TEXT,
+      type             TEXT,
+      condition        TEXT DEFAULT 'Good',
+      in_use           INTEGER,
+      deductible       INTEGER,
+      purchase_date    TEXT,
+      warranty_expires TEXT,
+      replacement_value REAL,
+      resale_value     REAL,
+      purchase_transaction_id TEXT,
+      purchased_from_id TEXT,
+      purchased_from_name TEXT,
+      purchase_price   REAL,
+      asset_id         TEXT,
+      notes            TEXT,
+      location_id      TEXT,
+      created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at       TEXT NOT NULL DEFAULT (datetime('now')),
+      last_edited_time TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE IF NOT EXISTS embeddings (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_type     TEXT NOT NULL,
+      source_id       TEXT NOT NULL,
+      chunk_index     INTEGER NOT NULL DEFAULT 0,
+      content_hash    TEXT NOT NULL,
+      content_preview TEXT NOT NULL DEFAULT '',
+      model           TEXT NOT NULL DEFAULT '',
+      dimensions      INTEGER NOT NULL DEFAULT 0,
+      created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(source_type, source_id, chunk_index)
+    );
+  `);
+
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Formatter tests — pure functions
+// ---------------------------------------------------------------------------
+
+describe('toTransactionText', () => {
+  it('includes description, merchant, category, notes', () => {
+    const text = toTransactionText({
+      id: 'tx-1',
+      description: 'Coffee at Starbucks',
+      entityName: 'Starbucks',
+      tags: 'food,drinks',
+      notes: 'morning coffee',
+      account: 'checking',
+      amount: -5.5,
+      date: '2026-04-19',
+      type: 'debit',
+      notionId: null,
+      entityId: null,
+      location: null,
+      country: null,
+      relatedTransactionId: null,
+      checksum: null,
+      rawRow: null,
+      lastEditedTime: '2026-04-19T12:00:00Z',
+    });
+    expect(text).toContain('Description: Coffee at Starbucks');
+    expect(text).toContain('Merchant: Starbucks');
+    expect(text).toContain('Category: food,drinks');
+    expect(text).toContain('Notes: morning coffee');
+  });
+
+  it('skips null/empty fields', () => {
+    const text = toTransactionText({
+      id: 'tx-2',
+      description: 'ATM withdrawal',
+      entityName: null,
+      tags: '',
+      notes: null,
+      account: 'savings',
+      amount: -100,
+      date: '2026-04-19',
+      type: 'debit',
+      notionId: null,
+      entityId: null,
+      location: null,
+      country: null,
+      relatedTransactionId: null,
+      checksum: null,
+      rawRow: null,
+      lastEditedTime: '2026-04-19T12:00:00Z',
+    });
+    expect(text).toContain('Description: ATM withdrawal');
+    expect(text).not.toContain('Merchant:');
+    expect(text).not.toContain('Notes:');
+  });
+});
+
+describe('toMovieText', () => {
+  it('includes title, overview, genres', () => {
+    const text = toMovieText({
+      id: 1,
+      tmdbId: 100,
+      title: 'The Matrix',
+      overview: 'A hacker discovers reality.',
+      genres: 'Action,Sci-Fi',
+      releaseDate: '1999-03-31',
+      runtime: 136,
+      status: 'Released',
+      originalTitle: 'The Matrix',
+      originalLanguage: 'en',
+      imdbId: 'tt0133093',
+      tagline: null,
+      budget: null,
+      revenue: null,
+      voteAverage: 8.7,
+      voteCount: 22000,
+      posterPath: null,
+      backdropPath: null,
+      logoPath: null,
+      posterOverridePath: null,
+      discoverRatingKey: null,
+      rotationStatus: null,
+      rotationExpiresAt: null,
+      rotationMarkedAt: null,
+      createdAt: '2026-04-19T12:00:00Z',
+      updatedAt: '2026-04-19T12:00:00Z',
+    });
+    expect(text).toContain('Title: The Matrix');
+    expect(text).toContain('Overview: A hacker discovers reality.');
+    expect(text).toContain('Genres: Action,Sci-Fi');
+  });
+});
+
+describe('toTvShowText', () => {
+  it('includes title (name), overview, genres', () => {
+    const text = toTvShowText({
+      id: 1,
+      tvdbId: 200,
+      name: 'Breaking Bad',
+      overview: 'Chemistry teacher turns drug lord.',
+      genres: 'Crime,Drama',
+      networks: null,
+      firstAirDate: '2008-01-20',
+      lastAirDate: '2013-09-29',
+      status: 'Ended',
+      originalLanguage: 'en',
+      originalName: 'Breaking Bad',
+      numberOfSeasons: 5,
+      numberOfEpisodes: 62,
+      episodeRunTime: 47,
+      voteAverage: 9.5,
+      voteCount: 14000,
+      posterPath: null,
+      backdropPath: null,
+      logoPath: null,
+      posterOverridePath: null,
+      discoverRatingKey: null,
+      createdAt: '2026-04-19T12:00:00Z',
+      updatedAt: '2026-04-19T12:00:00Z',
+    });
+    expect(text).toContain('Title: Breaking Bad');
+    expect(text).toContain('Overview: Chemistry teacher turns drug lord.');
+    expect(text).toContain('Genres: Crime,Drama');
+  });
+});
+
+describe('toInventoryText', () => {
+  it('includes name, brand, type, location', () => {
+    const text = toInventoryText({
+      id: 'inv-1',
+      notionId: null,
+      itemName: 'MacBook Pro',
+      brand: 'Apple',
+      model: 'M3 Pro',
+      itemId: null,
+      room: 'Office',
+      location: 'Desk drawer',
+      type: 'Electronics',
+      condition: 'Excellent',
+      inUse: 1,
+      deductible: 0,
+      purchaseDate: '2024-01-01',
+      warrantyExpires: null,
+      replacementValue: 2500,
+      resaleValue: 1800,
+      purchaseTransactionId: null,
+      purchasedFromId: null,
+      purchasedFromName: null,
+      purchasePrice: 2499.99,
+      assetId: null,
+      notes: null,
+      locationId: null,
+      createdAt: '2026-04-19T12:00:00Z',
+      updatedAt: '2026-04-19T12:00:00Z',
+      lastEditedTime: '2026-04-19T12:00:00Z',
+    });
+    expect(text).toContain('Name: MacBook Pro');
+    expect(text).toContain('Brand: Apple');
+    expect(text).toContain('Type: Electronics');
+    expect(text).toContain('Location: Desk drawer');
+  });
+
+  it('skips null fields', () => {
+    const text = toInventoryText({
+      id: 'inv-2',
+      notionId: null,
+      itemName: 'Chair',
+      brand: null,
+      model: null,
+      itemId: null,
+      room: null,
+      location: null,
+      type: null,
+      condition: null,
+      inUse: null,
+      deductible: null,
+      purchaseDate: null,
+      warrantyExpires: null,
+      replacementValue: null,
+      resaleValue: null,
+      purchaseTransactionId: null,
+      purchasedFromId: null,
+      purchasedFromName: null,
+      purchasePrice: null,
+      assetId: null,
+      notes: null,
+      locationId: null,
+      createdAt: '2026-04-19T12:00:00Z',
+      updatedAt: '2026-04-19T12:00:00Z',
+      lastEditedTime: '2026-04-19T12:00:00Z',
+    });
+    expect(text).toContain('Name: Chair');
+    expect(text).not.toContain('Brand:');
+    expect(text).not.toContain('Type:');
+    expect(text).not.toContain('Location:');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CrossSourceIndexer.scanAndEnqueue tests
+// ---------------------------------------------------------------------------
+
+describe('CrossSourceIndexer.scanAndEnqueue', () => {
+  let db: Database;
+  let indexer: CrossSourceIndexer;
+
+  beforeEach(() => {
+    db = createCrossSourceTestDb();
+    indexer = new CrossSourceIndexer(drizzle(db));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    db.close();
+    vi.clearAllMocks();
+  });
+
+  it('enqueues a job for a transaction with no existing embedding', async () => {
+    db.prepare(
+      `INSERT INTO transactions (id, description, account, amount, date, type, tags, last_edited_time)
+       VALUES ('tx-001', 'Grocery shopping', 'checking', -50, '2026-04-19', 'debit', 'food', '2026-04-19T12:00:00Z')`
+    ).run();
+
+    const { enqueued } = await indexer.scanAndEnqueue(['transaction']);
+
+    expect(enqueued).toBe(1);
+    expect(mockAdd).toHaveBeenCalledOnce();
+    const call = mockAdd.mock.calls[0];
+    expect(call?.[1]).toMatchObject({ sourceType: 'transaction', sourceId: 'tx-001' });
+    expect(call?.[1].content).toContain('Grocery shopping');
+  });
+
+  it('does NOT re-enqueue when embedding hash matches', async () => {
+    // Insert with NO tags/entity so the text is predictably just "Description: Coffee"
+    db.prepare(
+      `INSERT INTO transactions (id, description, account, amount, date, type, tags, last_edited_time)
+       VALUES ('tx-002', 'Coffee', 'checking', -5, '2026-04-19', 'debit', '', '2026-04-19T12:00:00Z')`
+    ).run();
+
+    // Compute what the hash would be for this row.
+    const { createHash } = await import('node:crypto');
+    const text = 'Description: Coffee';
+    const hash = createHash('sha256').update(text).digest('hex');
+
+    db.prepare(
+      `INSERT INTO embeddings (source_type, source_id, content_hash, content_preview, model, dimensions, created_at)
+       VALUES ('transaction', 'tx-002', ?, '', '', 0, datetime('now'))`
+    ).run(hash);
+
+    const { enqueued } = await indexer.scanAndEnqueue(['transaction']);
+
+    expect(enqueued).toBe(0);
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('re-enqueues when embedding hash differs', async () => {
+    db.prepare(
+      `INSERT INTO transactions (id, description, account, amount, date, type, tags, last_edited_time)
+       VALUES ('tx-003', 'Updated description', 'checking', -5, '2026-04-19', 'debit', '', '2026-04-19T12:00:00Z')`
+    ).run();
+
+    // Insert stale embedding with wrong hash.
+    db.prepare(
+      `INSERT INTO embeddings (source_type, source_id, content_hash, content_preview, model, dimensions, created_at)
+       VALUES ('transaction', 'tx-003', 'old-hash-stale', '', '', 0, datetime('now'))`
+    ).run();
+
+    const { enqueued } = await indexer.scanAndEnqueue(['transaction']);
+
+    expect(enqueued).toBe(1);
+    expect(mockAdd).toHaveBeenCalledOnce();
+  });
+
+  it('returns enqueued: 0 for empty tables', async () => {
+    const { enqueued } = await indexer.scanAndEnqueue();
+    expect(enqueued).toBe(0);
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('processes only requested source types', async () => {
+    db.prepare(
+      `INSERT INTO movies (tmdb_id, title, created_at, updated_at)
+       VALUES (999, 'Test Movie', datetime('now'), datetime('now'))`
+    ).run();
+
+    db.prepare(
+      `INSERT INTO transactions (id, description, account, amount, date, type, tags, last_edited_time)
+       VALUES ('tx-onlythis', 'This transaction', 'checking', -1, '2026-04-19', 'debit', '', '2026-04-19T12:00:00Z')`
+    ).run();
+
+    // Only scan transactions.
+    const { enqueued } = await indexer.scanAndEnqueue(['transaction']);
+
+    expect(enqueued).toBe(1);
+    // Verify only transaction was enqueued, not movie.
+    const calls = mockAdd.mock.calls;
+    expect(calls.every((c) => c[1]?.sourceType === 'transaction')).toBe(true);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/thalamus/cross-source.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/cross-source.ts
@@ -7,8 +7,6 @@
  * `content_hash` stored in the `embeddings` table.  Missing rows (never
  * embedded) are always enqueued.
  */
-import { createHash } from 'node:crypto';
-
 import { and, eq, inArray } from 'drizzle-orm';
 
 import { embeddings, homeInventory, movies, transactions, tvShows } from '@pops/db-types';
@@ -18,6 +16,7 @@ import {
   EMBEDDINGS_QUEUE,
   getEmbeddingsQueue,
 } from '../../../jobs/queues.js';
+import { chunkText, hashContent } from '../../../shared/chunker.js';
 
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
@@ -73,10 +72,6 @@ export function toInventoryText(row: InventoryRow): string {
   if (row.type) parts.push(`Type: ${row.type}`);
   if (row.location) parts.push(`Location: ${row.location}`);
   return parts.join('\n');
-}
-
-function sha256(input: string): string {
-  return createHash('sha256').update(input).digest('hex');
 }
 
 // ---------------------------------------------------------------------------
@@ -153,22 +148,31 @@ export class CrossSourceIndexer {
       const items = batch.map(toItem);
       const ids = items.map((it) => it.id);
 
-      // Fetch existing embeddings for this batch.
+      // Fetch chunk_index=0 embeddings for this batch — compare against the first chunk hash
+      // to detect whether content has changed since the last embedding run.
       const existing = this.db
         .select({ sourceId: embeddings.sourceId, contentHash: embeddings.contentHash })
         .from(embeddings)
-        .where(and(eq(embeddings.sourceType, sourceType), inArray(embeddings.sourceId, ids)))
+        .where(
+          and(
+            eq(embeddings.sourceType, sourceType),
+            inArray(embeddings.sourceId, ids),
+            eq(embeddings.chunkIndex, 0)
+          )
+        )
         .all();
 
-      const hashBySourceId = new Map(existing.map((e) => [e.sourceId, e.contentHash]));
+      const chunk0HashBySourceId = new Map(existing.map((e) => [e.sourceId, e.contentHash]));
 
       const queue = getEmbeddingsQueue();
 
       for (const item of items) {
         if (!item.text.trim()) continue;
-        const newHash = sha256(item.text);
-        const existingHash = hashBySourceId.get(item.id);
-        if (existingHash === newHash) continue;
+        const firstChunk = chunkText(item.text)[0];
+        if (!firstChunk) continue;
+        const firstChunkHash = hashContent(firstChunk.text);
+        const existingHash = chunk0HashBySourceId.get(item.id);
+        if (existingHash === firstChunkHash) continue;
 
         try {
           await queue.add(

--- a/apps/pops-api/src/modules/cerebrum/thalamus/cross-source.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/cross-source.ts
@@ -1,0 +1,191 @@
+/**
+ * CrossSourceIndexer — scans non-engram source tables (transactions, movies,
+ * tv_shows, home_inventory) and enqueues embedding jobs for rows whose content
+ * has changed since the last embedding run.
+ *
+ * Comparison is by SHA-256 of the embeddable text string against the
+ * `content_hash` stored in the `embeddings` table.  Missing rows (never
+ * embedded) are always enqueued.
+ */
+import { createHash } from 'node:crypto';
+
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { embeddings, homeInventory, movies, transactions, tvShows } from '@pops/db-types';
+
+import {
+  EMBEDDINGS_JOB_OPTIONS,
+  EMBEDDINGS_QUEUE,
+  getEmbeddingsQueue,
+} from '../../../jobs/queues.js';
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+export const CROSS_SOURCE_TYPES = ['transaction', 'movie', 'tv_show', 'inventory'] as const;
+export type CrossSourceType = (typeof CROSS_SOURCE_TYPES)[number];
+
+// ---------------------------------------------------------------------------
+// Row type aliases (inferred from table select shapes)
+// ---------------------------------------------------------------------------
+
+type TransactionRow = typeof transactions.$inferSelect;
+type MovieRow = typeof movies.$inferSelect;
+type TvShowRow = typeof tvShows.$inferSelect;
+type InventoryRow = typeof homeInventory.$inferSelect;
+
+// ---------------------------------------------------------------------------
+// Embeddable-text formatters
+// ---------------------------------------------------------------------------
+
+/** Produce labelled plain text for a transaction row, skipping null/empty fields. */
+export function toTransactionText(row: TransactionRow): string {
+  const parts: string[] = [];
+  if (row.description) parts.push(`Description: ${row.description}`);
+  if (row.entityName) parts.push(`Merchant: ${row.entityName}`);
+  if (row.tags) parts.push(`Category: ${row.tags}`);
+  if (row.notes) parts.push(`Notes: ${row.notes}`);
+  return parts.join('\n');
+}
+
+/** Produce labelled plain text for a movie row, skipping null/empty fields. */
+export function toMovieText(row: MovieRow): string {
+  const parts: string[] = [];
+  if (row.title) parts.push(`Title: ${row.title}`);
+  if (row.overview) parts.push(`Overview: ${row.overview}`);
+  if (row.genres) parts.push(`Genres: ${row.genres}`);
+  return parts.join('\n');
+}
+
+/** Produce labelled plain text for a TV show row, skipping null/empty fields. */
+export function toTvShowText(row: TvShowRow): string {
+  const parts: string[] = [];
+  if (row.name) parts.push(`Title: ${row.name}`);
+  if (row.overview) parts.push(`Overview: ${row.overview}`);
+  if (row.genres) parts.push(`Genres: ${row.genres}`);
+  return parts.join('\n');
+}
+
+/** Produce labelled plain text for an inventory row, skipping null/empty fields. */
+export function toInventoryText(row: InventoryRow): string {
+  const parts: string[] = [];
+  if (row.itemName) parts.push(`Name: ${row.itemName}`);
+  if (row.brand) parts.push(`Brand: ${row.brand}`);
+  if (row.type) parts.push(`Type: ${row.type}`);
+  if (row.location) parts.push(`Location: ${row.location}`);
+  return parts.join('\n');
+}
+
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// CrossSourceIndexer
+// ---------------------------------------------------------------------------
+
+const BATCH_SIZE = 100;
+
+export class CrossSourceIndexer {
+  constructor(private readonly db: BetterSQLite3Database) {}
+
+  /**
+   * Scan source tables and enqueue jobs for rows with missing or stale
+   * embeddings.  Processes each source type in batches of 100.
+   *
+   * @param sourceTypes Subset of types to process; defaults to all.
+   * @returns Total number of jobs enqueued.
+   */
+  async scanAndEnqueue(
+    sourceTypes: CrossSourceType[] = [...CROSS_SOURCE_TYPES]
+  ): Promise<{ enqueued: number }> {
+    let enqueued = 0;
+
+    for (const sourceType of sourceTypes) {
+      enqueued += await this.processSourceType(sourceType);
+    }
+
+    return { enqueued };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private async processSourceType(sourceType: CrossSourceType): Promise<number> {
+    switch (sourceType) {
+      case 'transaction':
+        return this.processBatches(
+          'transaction',
+          () => this.db.select().from(transactions).all(),
+          (row) => ({ id: row.id, text: toTransactionText(row) })
+        );
+      case 'movie':
+        return this.processBatches(
+          'movie',
+          () => this.db.select().from(movies).all(),
+          (row) => ({ id: String(row.id), text: toMovieText(row) })
+        );
+      case 'tv_show':
+        return this.processBatches(
+          'tv_show',
+          () => this.db.select().from(tvShows).all(),
+          (row) => ({ id: String(row.id), text: toTvShowText(row) })
+        );
+      case 'inventory':
+        return this.processBatches(
+          'inventory',
+          () => this.db.select().from(homeInventory).all(),
+          (row) => ({ id: row.id, text: toInventoryText(row) })
+        );
+    }
+  }
+
+  private async processBatches<T>(
+    sourceType: string,
+    fetchAll: () => T[],
+    toItem: (row: T) => { id: string; text: string }
+  ): Promise<number> {
+    const rows = fetchAll();
+    let enqueued = 0;
+
+    for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+      const batch = rows.slice(i, i + BATCH_SIZE);
+      const items = batch.map(toItem);
+      const ids = items.map((it) => it.id);
+
+      // Fetch existing embeddings for this batch.
+      const existing = this.db
+        .select({ sourceId: embeddings.sourceId, contentHash: embeddings.contentHash })
+        .from(embeddings)
+        .where(and(eq(embeddings.sourceType, sourceType), inArray(embeddings.sourceId, ids)))
+        .all();
+
+      const hashBySourceId = new Map(existing.map((e) => [e.sourceId, e.contentHash]));
+
+      const queue = getEmbeddingsQueue();
+
+      for (const item of items) {
+        if (!item.text.trim()) continue;
+        const newHash = sha256(item.text);
+        const existingHash = hashBySourceId.get(item.id);
+        if (existingHash === newHash) continue;
+
+        try {
+          await queue.add(
+            EMBEDDINGS_QUEUE,
+            { sourceType, sourceId: item.id, content: item.text },
+            EMBEDDINGS_JOB_OPTIONS
+          );
+          enqueued++;
+        } catch (err) {
+          console.error(
+            `[thalamus] Failed to enqueue embedding for ${sourceType}/${item.id}:`,
+            err
+          );
+        }
+      }
+    }
+
+    return enqueued;
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/thalamus/embedding-trigger.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/embedding-trigger.test.ts
@@ -1,0 +1,165 @@
+/**
+ * EmbeddingTrigger tests.
+ *
+ * Verifies that the trigger enqueues/skips/errors correctly based on
+ * `wordCount`, `contentHash` vs `previousContentHash`, and the `force` flag.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SyncResult } from './sync.js';
+
+// ---------------------------------------------------------------------------
+// Mock the queues module — must be hoisted so vi.mock() can reference the var.
+// ---------------------------------------------------------------------------
+
+const mockAdd = vi.hoisted(() => vi.fn().mockResolvedValue({ id: 'job-123' }));
+const mockGetEmbeddingsQueue = vi.hoisted(() => vi.fn().mockReturnValue({ add: mockAdd }));
+
+vi.mock('../../../jobs/queues.js', () => ({
+  getEmbeddingsQueue: mockGetEmbeddingsQueue,
+  EMBEDDINGS_QUEUE: 'pops:embeddings',
+  EMBEDDINGS_JOB_OPTIONS: {},
+}));
+
+// Import after mocking.
+const { EmbeddingTrigger } = await import('./embedding-trigger.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSyncResult(overrides: Partial<SyncResult> = {}): SyncResult {
+  return {
+    filePath: 'note/eng_20260419_1200_test.md',
+    status: 'synced',
+    engramId: 'eng_20260419_1200_test',
+    contentHash: 'new-hash-abc123',
+    previousContentHash: 'old-hash-xyz789',
+    wordCount: 42,
+    ...overrides,
+  };
+}
+
+describe('EmbeddingTrigger', () => {
+  let trigger: InstanceType<typeof EmbeddingTrigger>;
+
+  beforeEach(() => {
+    trigger = new EmbeddingTrigger();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enqueues job when hash has changed', async () => {
+    const result = makeSyncResult({ contentHash: 'hash-a', previousContentHash: 'hash-b' });
+    const triggers = await trigger.trigger([result]);
+
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0]?.action).toBe('enqueued');
+    expect(mockAdd).toHaveBeenCalledOnce();
+    expect(mockAdd).toHaveBeenCalledWith(
+      'pops:embeddings',
+      { sourceType: 'engram', sourceId: 'eng_20260419_1200_test' },
+      {}
+    );
+  });
+
+  it('enqueues job for new engram (no previousContentHash)', async () => {
+    const result = makeSyncResult({ previousContentHash: undefined });
+    const triggers = await trigger.trigger([result]);
+
+    expect(triggers[0]?.action).toBe('enqueued');
+    expect(mockAdd).toHaveBeenCalledOnce();
+  });
+
+  it('skips when hash is unchanged (no force)', async () => {
+    const result = makeSyncResult({ contentHash: 'same', previousContentHash: 'same' });
+    const triggers = await trigger.trigger([result]);
+
+    expect(triggers[0]?.action).toBe('skipped');
+    expect(triggers[0]?.reason).toBe('hash unchanged');
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('enqueues when hash unchanged but force=true', async () => {
+    const result = makeSyncResult({ contentHash: 'same', previousContentHash: 'same' });
+    const triggers = await trigger.trigger([result], true);
+
+    expect(triggers[0]?.action).toBe('enqueued');
+    expect(mockAdd).toHaveBeenCalledOnce();
+  });
+
+  it('skips when wordCount is 0', async () => {
+    const result = makeSyncResult({ wordCount: 0 });
+    const triggers = await trigger.trigger([result]);
+
+    expect(triggers[0]?.action).toBe('skipped');
+    expect(triggers[0]?.reason).toBe('empty body');
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('does not skip empty body even with force=true', async () => {
+    // Empty body wins over force — there's nothing to embed.
+    const result = makeSyncResult({ wordCount: 0 });
+    const triggers = await trigger.trigger([result], true);
+
+    expect(triggers[0]?.action).toBe('skipped');
+    expect(triggers[0]?.reason).toBe('empty body');
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('skips results with status !== synced', async () => {
+    const orphaned: SyncResult = {
+      filePath: 'note/deleted.md',
+      status: 'orphaned',
+    };
+    const error: SyncResult = {
+      filePath: 'note/bad.md',
+      status: 'error',
+      error: 'parse failed',
+    };
+    const triggers = await trigger.trigger([orphaned, error]);
+
+    expect(triggers).toHaveLength(0);
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('handles queue error gracefully, returning action: error', async () => {
+    mockAdd.mockRejectedValueOnce(new Error('Redis unavailable'));
+
+    const result = makeSyncResult();
+    const triggers = await trigger.trigger([result]);
+
+    expect(triggers[0]?.action).toBe('error');
+    expect(triggers[0]?.reason).toContain('Redis unavailable');
+  });
+
+  it('processes multiple results in one call', async () => {
+    const r1 = makeSyncResult({
+      engramId: 'eng_1',
+      contentHash: 'a',
+      previousContentHash: 'b',
+      filePath: 'note/e1.md',
+    });
+    const r2 = makeSyncResult({
+      engramId: 'eng_2',
+      contentHash: 'same',
+      previousContentHash: 'same',
+      filePath: 'note/e2.md',
+    });
+    const r3 = makeSyncResult({
+      engramId: 'eng_3',
+      wordCount: 0,
+      filePath: 'note/e3.md',
+    });
+
+    const triggers = await trigger.trigger([r1, r2, r3]);
+    expect(triggers).toHaveLength(3);
+    expect(triggers[0]?.action).toBe('enqueued');
+    expect(triggers[1]?.action).toBe('skipped');
+    expect(triggers[2]?.action).toBe('skipped');
+    expect(mockAdd).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/thalamus/embedding-trigger.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/embedding-trigger.ts
@@ -45,7 +45,7 @@ export class EmbeddingTrigger {
         const queue = getEmbeddingsQueue();
         await queue.add(
           EMBEDDINGS_QUEUE,
-          { sourceType: 'engram', sourceId: engramId },
+          { sourceType: 'engram', sourceId: engramId, content: result.bodyText },
           EMBEDDINGS_JOB_OPTIONS
         );
         output.push({ engramId, action: 'enqueued', reason: 'content changed' });

--- a/apps/pops-api/src/modules/cerebrum/thalamus/embedding-trigger.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/embedding-trigger.ts
@@ -1,0 +1,60 @@
+/**
+ * EmbeddingTrigger — decides whether a synced engram should have its
+ * embeddings regenerated and enqueues the job.
+ *
+ * Rules:
+ *  - Skip if `wordCount === 0` (empty body — nothing to embed).
+ *  - Skip (unless `force`) if `contentHash === previousContentHash` (no change).
+ *  - Enqueue `{ sourceType: 'engram', sourceId: engramId }` to pops:embeddings.
+ *  - If BullMQ is unavailable, log the error and return `action: 'error'`.
+ */
+import {
+  EMBEDDINGS_JOB_OPTIONS,
+  EMBEDDINGS_QUEUE,
+  getEmbeddingsQueue,
+} from '../../../jobs/queues.js';
+
+import type { SyncResult } from './sync.js';
+
+export interface TriggerResult {
+  engramId: string;
+  action: 'enqueued' | 'skipped' | 'error';
+  reason: string;
+}
+
+export class EmbeddingTrigger {
+  async trigger(results: SyncResult[], force = false): Promise<TriggerResult[]> {
+    const output: TriggerResult[] = [];
+
+    for (const result of results) {
+      if (result.status !== 'synced' || !result.engramId) continue;
+
+      const engramId = result.engramId;
+
+      if (result.wordCount === 0) {
+        output.push({ engramId, action: 'skipped', reason: 'empty body' });
+        continue;
+      }
+
+      if (!force && result.contentHash === result.previousContentHash) {
+        output.push({ engramId, action: 'skipped', reason: 'hash unchanged' });
+        continue;
+      }
+
+      try {
+        const queue = getEmbeddingsQueue();
+        await queue.add(
+          EMBEDDINGS_QUEUE,
+          { sourceType: 'engram', sourceId: engramId },
+          EMBEDDINGS_JOB_OPTIONS
+        );
+        output.push({ engramId, action: 'enqueued', reason: 'content changed' });
+      } catch (err) {
+        console.error(`[thalamus] Failed to enqueue embedding job for ${engramId}:`, err);
+        output.push({ engramId, action: 'error', reason: (err as Error).message });
+      }
+    }
+
+    return output;
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/thalamus/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/instance.ts
@@ -13,12 +13,16 @@ import { eq } from 'drizzle-orm';
 import { engramIndex } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { DEFAULT_JOB_OPTIONS, getDefaultQueue } from '../../../jobs/queues.js';
 import { getEngramRoot } from '../instance.js';
 import { EmbeddingTrigger } from './embedding-trigger.js';
 import { FrontmatterSyncService } from './sync.js';
 import { FileWatcherService } from './watcher.js';
 
 import type { WatchEvent } from './watcher.js';
+
+const CROSS_SOURCE_SCHEDULER_ID = 'pops-cross-source-index';
+const CROSS_SOURCE_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 
 let watcher: FileWatcherService | null = null;
 
@@ -78,10 +82,27 @@ export async function startThalamus(): Promise<void> {
 
   watcher.start(existingPaths);
   console.warn(`[thalamus] File watcher started (root: ${root})`);
+
+  // Register cross-source index repeatable job (every 6 hours).
+  void getDefaultQueue()
+    .upsertJobScheduler(
+      CROSS_SOURCE_SCHEDULER_ID,
+      { every: CROSS_SOURCE_INTERVAL_MS },
+      { name: 'crossSourceIndex', data: { type: 'crossSourceIndex' }, opts: DEFAULT_JOB_OPTIONS }
+    )
+    .catch((err: unknown) => {
+      console.error('[thalamus] Failed to register cross-source index scheduler:', err);
+    });
 }
 
-/** Stop the Thalamus file watcher. */
+/** Stop the Thalamus file watcher and deregister the cross-source scheduler. */
 export async function stopThalamus(): Promise<void> {
+  void getDefaultQueue()
+    .removeJobScheduler(CROSS_SOURCE_SCHEDULER_ID)
+    .catch((err: unknown) => {
+      console.error('[thalamus] Failed to remove cross-source index scheduler:', err);
+    });
+
   if (watcher) {
     await watcher.stop();
     watcher = null;

--- a/apps/pops-api/src/modules/cerebrum/thalamus/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/instance.ts
@@ -1,0 +1,90 @@
+/**
+ * Thalamus singleton — owns the file watcher lifetime and wires up the
+ * sync + embedding-trigger pipeline.
+ *
+ * Call `startThalamus()` once at server startup and `stopThalamus()` during
+ * graceful shutdown.  The watcher is optional: if ENGRAM_ROOT doesn't exist
+ * the function logs a warning and returns without crashing.
+ */
+import { existsSync } from 'node:fs';
+
+import { eq } from 'drizzle-orm';
+
+import { engramIndex } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
+import { getEngramRoot } from '../instance.js';
+import { EmbeddingTrigger } from './embedding-trigger.js';
+import { FrontmatterSyncService } from './sync.js';
+import { FileWatcherService } from './watcher.js';
+
+import type { WatchEvent } from './watcher.js';
+
+let watcher: FileWatcherService | null = null;
+
+/** Returns the current watcher instance (or null if not started). */
+export function getFileWatcher(): FileWatcherService | null {
+  return watcher;
+}
+
+/** Start the Thalamus file watcher and sync pipeline. */
+export async function startThalamus(): Promise<void> {
+  if (watcher) return; // already running
+
+  const root = getEngramRoot();
+
+  if (!existsSync(root)) {
+    console.warn(
+      `[thalamus] ENGRAM_ROOT does not exist (${root}) — file watcher disabled. ` +
+        `Create the directory and restart to enable.`
+    );
+    return;
+  }
+
+  const db = getDrizzle();
+
+  // Build the set of paths currently in the index so the watcher can
+  // reconcile files that were modified while the server was down.
+  const existingPaths = new Set(
+    db
+      .select({ filePath: engramIndex.filePath })
+      .from(engramIndex)
+      .where(eq(engramIndex.status, 'active'))
+      .all()
+      .map((r) => r.filePath)
+  );
+
+  const sync = new FrontmatterSyncService(root, db);
+  const trigger = new EmbeddingTrigger();
+
+  watcher = new FileWatcherService(root);
+
+  watcher.on('batch', (events: WatchEvent[]) => {
+    sync
+      .processEvents(events)
+      .then((results) => trigger.trigger(results))
+      .catch((err: unknown) => {
+        console.error('[thalamus] Error processing batch:', err);
+      });
+  });
+
+  watcher.on('error', (err: Error) => {
+    console.error('[thalamus] Watcher error:', err);
+  });
+
+  watcher.on('reconciled', () => {
+    console.warn('[thalamus] Initial reconciliation complete.');
+  });
+
+  watcher.start(existingPaths);
+  console.warn(`[thalamus] File watcher started (root: ${root})`);
+}
+
+/** Stop the Thalamus file watcher. */
+export async function stopThalamus(): Promise<void> {
+  if (watcher) {
+    await watcher.stop();
+    watcher = null;
+    console.warn('[thalamus] File watcher stopped.');
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/thalamus/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/router.ts
@@ -92,7 +92,7 @@ export const indexRouter = router({
    */
   reconcile: protectedProcedure
     .input(z.object({ dryRun: z.boolean().optional() }))
-    .query(async ({ input }) => {
+    .mutation(async ({ input }) => {
       const { existsSync, readdirSync } = await import('node:fs');
       const { join, relative } = await import('node:path');
       const { engramIndex } = await import('@pops/db-types');

--- a/apps/pops-api/src/modules/cerebrum/thalamus/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/router.ts
@@ -1,0 +1,151 @@
+/**
+ * cerebrum.index tRPC router — exposes watcher health, on-demand reindex,
+ * cross-source re-embedding, and reconciliation dry-runs.
+ */
+import { z } from 'zod';
+
+import { getDrizzle } from '../../../db.js';
+import { EMBEDDINGS_QUEUE, getEmbeddingsQueue } from '../../../jobs/queues.js';
+import { protectedProcedure, router } from '../../../trpc.js';
+import { getEngramRoot } from '../instance.js';
+import { getEngramService } from '../instance.js';
+import { CROSS_SOURCE_TYPES, CrossSourceIndexer } from './cross-source.js';
+import { getFileWatcher } from './instance.js';
+
+export const indexRouter = router({
+  /**
+   * Returns watcher health and embeddings queue pending count.
+   */
+  status: protectedProcedure.query(async () => {
+    const watcher = getFileWatcher();
+    const health = watcher?.health() ?? { watching: false, lastEventAt: null, watchedPaths: 0 };
+
+    let pendingCount: number | null = null;
+    try {
+      const queue = getEmbeddingsQueue();
+      pendingCount = await queue
+        .getJobCounts('waiting', 'active', 'delayed')
+        .then((counts) => (counts.waiting ?? 0) + (counts.active ?? 0) + (counts.delayed ?? 0));
+    } catch {
+      // Queue unavailable — leave null.
+    }
+
+    return {
+      watcher: health,
+      embeddingsQueue: {
+        name: EMBEDDINGS_QUEUE,
+        pendingCount,
+      },
+    };
+  }),
+
+  /**
+   * Re-index all engram files from disk.  Optionally forces re-embedding of
+   * every engram regardless of hash changes.
+   */
+  reindex: protectedProcedure
+    .input(z.object({ force: z.boolean().optional() }))
+    .mutation(async ({ input }) => {
+      const service = getEngramService();
+      const result = service.reindex();
+
+      if (input.force) {
+        // If forced, enqueue embeddings for all engrams in the index.
+        const { FrontmatterSyncService } = await import('./sync.js');
+        const { EmbeddingTrigger } = await import('./embedding-trigger.js');
+        const db = getDrizzle();
+        const root = getEngramRoot();
+        const syncService = new FrontmatterSyncService(root, db);
+        const trigger = new EmbeddingTrigger();
+
+        // Get all .md files relative paths and sync + trigger each.
+        const { engramIndex } = await import('@pops/db-types');
+        const rows = db.select({ filePath: engramIndex.filePath }).from(engramIndex).all();
+        const syncResults = rows.map((row) => syncService.syncFile(row.filePath));
+        await trigger.trigger(syncResults, true);
+      }
+
+      return result;
+    }),
+
+  /**
+   * Enqueue cross-source embedding jobs for the given source types.
+   */
+  reindexSources: protectedProcedure
+    .input(z.object({ sourceTypes: z.array(z.string()).optional() }))
+    .mutation(async ({ input }) => {
+      const db = getDrizzle();
+      const indexer = new CrossSourceIndexer(db);
+
+      const validTypes = (input.sourceTypes ?? [...CROSS_SOURCE_TYPES]).filter(
+        (t): t is (typeof CROSS_SOURCE_TYPES)[number] =>
+          (CROSS_SOURCE_TYPES as readonly string[]).includes(t)
+      );
+
+      const result = await indexer.scanAndEnqueue(validTypes);
+      return { enqueued: result.enqueued, sourceTypes: validTypes };
+    }),
+
+  /**
+   * Reconcile disk state against the index.  In dry-run mode returns the list
+   * of discrepancies without making changes.
+   */
+  reconcile: protectedProcedure
+    .input(z.object({ dryRun: z.boolean().optional() }))
+    .query(async ({ input }) => {
+      const { existsSync, readdirSync } = await import('node:fs');
+      const { join, relative } = await import('node:path');
+      const { engramIndex } = await import('@pops/db-types');
+
+      const root = getEngramRoot();
+      const db = getDrizzle();
+
+      if (!existsSync(root)) {
+        return { missing: [], orphaned: [], dryRun: input.dryRun ?? false };
+      }
+
+      // Collect all .md files on disk.
+      const diskPaths = new Set<string>();
+      const walk = (dir: string): void => {
+        const entries = readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory()) {
+            if (entry.name.startsWith('.')) continue;
+            walk(join(dir, entry.name));
+          } else if (entry.name.endsWith('.md')) {
+            const rel = relative(root, join(dir, entry.name)).replaceAll('\\', '/');
+            diskPaths.add(rel);
+          }
+        }
+      };
+      walk(root);
+
+      // Collect indexed paths.
+      const indexedRows = db
+        .select({ filePath: engramIndex.filePath, status: engramIndex.status })
+        .from(engramIndex)
+        .all();
+      const indexedPaths = new Map(indexedRows.map((r) => [r.filePath, r.status]));
+
+      // Files on disk but not indexed.
+      const missing = [...diskPaths].filter((p) => !indexedPaths.has(p));
+      // Indexed paths not on disk (and not already orphaned).
+      const orphaned = [...indexedPaths.entries()]
+        .filter(([p, status]) => !diskPaths.has(p) && status !== 'orphaned')
+        .map(([p]) => p);
+
+      if (!input.dryRun) {
+        const { FrontmatterSyncService } = await import('./sync.js');
+        const syncService = new FrontmatterSyncService(root, db);
+
+        for (const relPath of missing) {
+          syncService.syncFile(relPath);
+        }
+        for (const relPath of orphaned) {
+          syncService.markOrphaned(relPath);
+        }
+      }
+
+      return { missing, orphaned, dryRun: input.dryRun ?? false };
+    }),
+});

--- a/apps/pops-api/src/modules/cerebrum/thalamus/sync.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/sync.test.ts
@@ -1,0 +1,250 @@
+/**
+ * FrontmatterSyncService tests.
+ *
+ * Uses a real in-memory SQLite database and temp files to verify that:
+ *  - `syncFile()` upserts the engram_index row correctly
+ *  - Junction tables are diffed on repeated calls
+ *  - `markOrphaned()` updates status without deleting the row
+ *  - Parse errors return `status: 'error'`
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { engramIndex, engramScopes, engramTags } from '@pops/db-types';
+
+import { createTestDb } from '../../../shared/test-utils.js';
+import { FrontmatterSyncService } from './sync.js';
+
+import type { Database } from 'better-sqlite3';
+
+const VALID_FRONTMATTER = `---
+id: eng_20260419_1200_test-note
+type: note
+scopes:
+  - personal.notes
+created: "2026-04-19T12:00:00Z"
+modified: "2026-04-19T12:00:00Z"
+source: manual
+status: active
+---
+
+# Test Note
+
+This is the body of the test note.
+`;
+
+const VALID_FRONTMATTER_UPDATED = `---
+id: eng_20260419_1200_test-note
+type: note
+scopes:
+  - personal.notes
+  - work
+tags:
+  - important
+created: "2026-04-19T12:00:00Z"
+modified: "2026-04-19T13:00:00Z"
+source: manual
+status: active
+---
+
+# Test Note Updated
+
+This is the updated body.
+`;
+
+const INVALID_FRONTMATTER = `---
+id: NOT_VALID
+type: note
+scopes: []
+created: "2026-04-19T12:00:00Z"
+modified: "2026-04-19T12:00:00Z"
+source: manual
+status: active
+---
+
+# Bad note
+`;
+
+describe('FrontmatterSyncService', () => {
+  let db: Database;
+  let root: string;
+  let service: FrontmatterSyncService;
+
+  beforeEach(() => {
+    db = createTestDb();
+    root = mkdtempSync(join(tmpdir(), 'thalamus-sync-'));
+    service = new FrontmatterSyncService(root, drizzle(db));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    db.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // syncFile — happy path
+  // -------------------------------------------------------------------------
+
+  it('syncFile returns synced status and correct fields', () => {
+    const dir = join(root, 'note');
+    mkdirSync(dir, { recursive: true });
+    const relPath = 'note/eng_20260419_1200_test-note.md';
+    writeFileSync(join(root, relPath), VALID_FRONTMATTER);
+
+    const result = service.syncFile(relPath);
+
+    expect(result.status).toBe('synced');
+    expect(result.engramId).toBe('eng_20260419_1200_test-note');
+    expect(result.contentHash).toBeTypeOf('string');
+    expect(result.contentHash).toHaveLength(64); // SHA-256 hex
+    expect(result.previousContentHash).toBeUndefined(); // first insert
+    expect(result.wordCount).toBeGreaterThan(0);
+  });
+
+  it('upserts the engram_index row', () => {
+    const relPath = 'note/eng_20260419_1200_test-note.md';
+    mkdirSync(join(root, 'note'), { recursive: true });
+    writeFileSync(join(root, relPath), VALID_FRONTMATTER);
+
+    service.syncFile(relPath);
+
+    const drizzleDb = drizzle(db);
+    const [row] = drizzleDb.select().from(engramIndex).all();
+    expect(row).toBeDefined();
+    expect(row?.id).toBe('eng_20260419_1200_test-note');
+    expect(row?.type).toBe('note');
+    expect(row?.status).toBe('active');
+    expect(row?.filePath).toBe(relPath);
+  });
+
+  it('inserts scopes into engram_scopes', () => {
+    const relPath = 'note/eng_20260419_1200_test-note.md';
+    mkdirSync(join(root, 'note'), { recursive: true });
+    writeFileSync(join(root, relPath), VALID_FRONTMATTER);
+
+    service.syncFile(relPath);
+
+    const drizzleDb = drizzle(db);
+    const scopes = drizzleDb.select().from(engramScopes).all();
+    expect(scopes.map((s) => s.scope)).toContain('personal.notes');
+  });
+
+  it('sets previousContentHash on a second sync of the same file', () => {
+    const relPath = 'note/eng_20260419_1200_test-note.md';
+    mkdirSync(join(root, 'note'), { recursive: true });
+    writeFileSync(join(root, relPath), VALID_FRONTMATTER);
+
+    const first = service.syncFile(relPath);
+    expect(first.previousContentHash).toBeUndefined();
+
+    // Sync again without changes — hash should match.
+    const second = service.syncFile(relPath);
+    expect(second.previousContentHash).toBe(first.contentHash);
+    expect(second.contentHash).toBe(first.contentHash);
+  });
+
+  it('diffs scopes on update — adds and removes correctly', () => {
+    const relPath = 'note/eng_20260419_1200_test-note.md';
+    mkdirSync(join(root, 'note'), { recursive: true });
+    writeFileSync(join(root, relPath), VALID_FRONTMATTER);
+    service.syncFile(relPath);
+
+    // Update the file with more scopes and tags.
+    writeFileSync(join(root, relPath), VALID_FRONTMATTER_UPDATED);
+    service.syncFile(relPath);
+
+    const drizzleDb = drizzle(db);
+    const scopes = drizzleDb
+      .select()
+      .from(engramScopes)
+      .all()
+      .map((s) => s.scope);
+    expect(scopes).toContain('personal.notes');
+    expect(scopes).toContain('work');
+
+    const tags = drizzleDb
+      .select()
+      .from(engramTags)
+      .all()
+      .map((t) => t.tag);
+    expect(tags).toContain('important');
+  });
+
+  it('processEvents routes create events to syncFile', async () => {
+    const relPath = 'note/eng_20260419_1200_test-note.md';
+    mkdirSync(join(root, 'note'), { recursive: true });
+    writeFileSync(join(root, relPath), VALID_FRONTMATTER);
+
+    const results = await service.processEvents([{ type: 'create', filePath: relPath }]);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe('synced');
+  });
+
+  it('processEvents routes delete events to markOrphaned', async () => {
+    const relPath = 'note/eng_20260419_1200_test-note.md';
+    mkdirSync(join(root, 'note'), { recursive: true });
+    writeFileSync(join(root, relPath), VALID_FRONTMATTER);
+    service.syncFile(relPath);
+
+    const results = await service.processEvents([{ type: 'delete', filePath: relPath }]);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe('orphaned');
+  });
+
+  // -------------------------------------------------------------------------
+  // markOrphaned
+  // -------------------------------------------------------------------------
+
+  it('markOrphaned updates status to orphaned', () => {
+    const relPath = 'note/eng_20260419_1200_test-note.md';
+    mkdirSync(join(root, 'note'), { recursive: true });
+    writeFileSync(join(root, relPath), VALID_FRONTMATTER);
+    service.syncFile(relPath);
+
+    service.markOrphaned(relPath);
+
+    const drizzleDb = drizzle(db);
+    const [row] = drizzleDb.select().from(engramIndex).all();
+    expect(row?.status).toBe('orphaned');
+  });
+
+  it('markOrphaned is a no-op for non-existent paths (no crash)', () => {
+    expect(() => service.markOrphaned('nonexistent/path.md')).not.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // Error cases
+  // -------------------------------------------------------------------------
+
+  it('returns error status for missing file', () => {
+    const result = service.syncFile('note/does-not-exist.md');
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('file not found');
+  });
+
+  it('returns error status for invalid frontmatter', () => {
+    const relPath = 'note/eng_20260419_1200_test-note.md';
+    mkdirSync(join(root, 'note'), { recursive: true });
+    writeFileSync(join(root, relPath), INVALID_FRONTMATTER);
+
+    const result = service.syncFile(relPath);
+    expect(result.status).toBe('error');
+    expect(result.error).toBeTruthy();
+  });
+
+  it('does not insert index row on parse error', () => {
+    const relPath = 'note/eng_20260419_1200_test-note.md';
+    mkdirSync(join(root, 'note'), { recursive: true });
+    writeFileSync(join(root, relPath), INVALID_FRONTMATTER);
+
+    service.syncFile(relPath);
+
+    const drizzleDb = drizzle(db);
+    const rows = drizzleDb.select().from(engramIndex).all();
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/thalamus/sync.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/sync.ts
@@ -30,6 +30,8 @@ export interface SyncResult {
   contentHash?: string;
   previousContentHash?: string;
   wordCount?: number;
+  /** Body text (frontmatter stripped) — used as the embedding job payload so the worker doesn't re-read the file. */
+  bodyText?: string;
   error?: string;
 }
 
@@ -128,22 +130,37 @@ export class FrontmatterSyncService {
     const newLinks = dedupe(frontmatter.links ?? []);
 
     this.db.transaction((tx) => {
-      // Upsert index row (delete + insert for simplicity, matching EngramService).
-      tx.delete(engramIndex).where(eq(engramIndex.id, frontmatter.id)).run();
+      // Upsert index row without deleting — preserves junction rows so the diffs below see current state.
+      const indexValues = {
+        id: frontmatter.id,
+        filePath: relPath,
+        type: frontmatter.type,
+        source: frontmatter.source,
+        status: frontmatter.status,
+        template: frontmatter.template ?? null,
+        createdAt: frontmatter.created,
+        modifiedAt: frontmatter.modified,
+        title,
+        contentHash,
+        wordCount,
+        customFields: Object.keys(customFields).length > 0 ? JSON.stringify(customFields) : null,
+      };
       tx.insert(engramIndex)
-        .values({
-          id: frontmatter.id,
-          filePath: relPath,
-          type: frontmatter.type,
-          source: frontmatter.source,
-          status: frontmatter.status,
-          template: frontmatter.template ?? null,
-          createdAt: frontmatter.created,
-          modifiedAt: frontmatter.modified,
-          title,
-          contentHash,
-          wordCount,
-          customFields: Object.keys(customFields).length > 0 ? JSON.stringify(customFields) : null,
+        .values(indexValues)
+        .onConflictDoUpdate({
+          target: engramIndex.id,
+          set: {
+            filePath: indexValues.filePath,
+            type: indexValues.type,
+            source: indexValues.source,
+            status: indexValues.status,
+            template: indexValues.template,
+            modifiedAt: indexValues.modifiedAt,
+            title: indexValues.title,
+            contentHash: indexValues.contentHash,
+            wordCount: indexValues.wordCount,
+            customFields: indexValues.customFields,
+          },
         })
         .run();
 
@@ -227,6 +244,7 @@ export class FrontmatterSyncService {
       contentHash,
       previousContentHash: previousContentHash ?? undefined,
       wordCount,
+      bodyText: body,
     };
   }
 

--- a/apps/pops-api/src/modules/cerebrum/thalamus/sync.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/sync.ts
@@ -1,0 +1,251 @@
+/**
+ * FrontmatterSyncService — reads an engram file from disk, parses its
+ * frontmatter, and upserts the index + junction tables atomically.
+ *
+ * Design:
+ *  - Single source of truth is the file; the index is a rebuildable cache.
+ *  - Junction tables (scopes/tags/links) are diffed on every sync so a
+ *    hand-edit that removes a scope is reflected immediately.
+ *  - Parse errors are surfaced as `{ status: 'error' }` results — the caller
+ *    decides whether to log or escalate.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { engramIndex, engramLinks, engramScopes, engramTags } from '@pops/db-types';
+
+import { countWords, deriveTitle, parseEngramFile } from '../engrams/file.js';
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+import type { WatchEvent } from './watcher.js';
+
+export interface SyncResult {
+  filePath: string;
+  status: 'synced' | 'orphaned' | 'error';
+  engramId?: string;
+  contentHash?: string;
+  previousContentHash?: string;
+  wordCount?: number;
+  error?: string;
+}
+
+/** Known frontmatter keys — everything else is a custom field. */
+const KNOWN_FRONTMATTER_KEYS = new Set<string>([
+  'id',
+  'type',
+  'scopes',
+  'created',
+  'modified',
+  'source',
+  'tags',
+  'links',
+  'status',
+  'template',
+]);
+
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+function dedupe<T>(values: readonly T[]): T[] {
+  return [...new Set(values)];
+}
+
+export class FrontmatterSyncService {
+  constructor(
+    private readonly root: string,
+    private readonly db: BetterSQLite3Database
+  ) {}
+
+  /**
+   * Process a batch of watch events. `delete` events mark the entry orphaned;
+   * `create` and `modify` events attempt a full sync.
+   */
+  async processEvents(events: WatchEvent[]): Promise<SyncResult[]> {
+    const results: SyncResult[] = [];
+    for (const event of events) {
+      if (event.type === 'delete') {
+        this.markOrphaned(event.filePath);
+        results.push({ filePath: event.filePath, status: 'orphaned' });
+      } else {
+        results.push(this.syncFile(event.filePath));
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Sync a single file: read → parse → upsert index + junction tables.
+   * Returns `status: 'error'` with a message if parsing fails or the file
+   * is missing.
+   */
+  syncFile(relPath: string): SyncResult {
+    const absPath = join(this.root, relPath);
+    if (!existsSync(absPath)) {
+      return { filePath: relPath, status: 'error', error: 'file not found' };
+    }
+
+    let content: string;
+    try {
+      content = readFileSync(absPath, 'utf8');
+    } catch (err) {
+      return { filePath: relPath, status: 'error', error: (err as Error).message };
+    }
+
+    let parsed: ReturnType<typeof parseEngramFile>;
+    try {
+      parsed = parseEngramFile(content);
+    } catch (err) {
+      return { filePath: relPath, status: 'error', error: (err as Error).message };
+    }
+
+    const { frontmatter, body } = parsed;
+    const contentHash = sha256(content);
+    const wordCount = countWords(body);
+    const title = deriveTitle(body);
+
+    // Compute custom fields (everything not in known keys).
+    const customFields: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(frontmatter)) {
+      if (!KNOWN_FRONTMATTER_KEYS.has(key)) customFields[key] = value;
+    }
+
+    // Get previous hash before we overwrite the row.
+    const [existing] = this.db
+      .select({ contentHash: engramIndex.contentHash })
+      .from(engramIndex)
+      .where(eq(engramIndex.id, frontmatter.id))
+      .all();
+    const previousContentHash = existing?.contentHash ?? null;
+
+    // Diff junction tables.
+    const newScopes = dedupe(frontmatter.scopes);
+    const newTags = dedupe(frontmatter.tags ?? []);
+    const newLinks = dedupe(frontmatter.links ?? []);
+
+    this.db.transaction((tx) => {
+      // Upsert index row (delete + insert for simplicity, matching EngramService).
+      tx.delete(engramIndex).where(eq(engramIndex.id, frontmatter.id)).run();
+      tx.insert(engramIndex)
+        .values({
+          id: frontmatter.id,
+          filePath: relPath,
+          type: frontmatter.type,
+          source: frontmatter.source,
+          status: frontmatter.status,
+          template: frontmatter.template ?? null,
+          createdAt: frontmatter.created,
+          modifiedAt: frontmatter.modified,
+          title,
+          contentHash,
+          wordCount,
+          customFields: Object.keys(customFields).length > 0 ? JSON.stringify(customFields) : null,
+        })
+        .run();
+
+      // Diff scopes.
+      const currentScopes = tx
+        .select({ scope: engramScopes.scope })
+        .from(engramScopes)
+        .where(eq(engramScopes.engramId, frontmatter.id))
+        .all()
+        .map((r) => r.scope);
+      const scopesToDelete = currentScopes.filter((s) => !newScopes.includes(s));
+      const scopesToAdd = newScopes.filter((s) => !currentScopes.includes(s));
+      if (scopesToDelete.length > 0) {
+        tx.delete(engramScopes)
+          .where(
+            and(
+              eq(engramScopes.engramId, frontmatter.id),
+              inArray(engramScopes.scope, scopesToDelete)
+            )
+          )
+          .run();
+      }
+      if (scopesToAdd.length > 0) {
+        tx.insert(engramScopes)
+          .values(scopesToAdd.map((scope) => ({ engramId: frontmatter.id, scope })))
+          .run();
+      }
+
+      // Diff tags.
+      const currentTags = tx
+        .select({ tag: engramTags.tag })
+        .from(engramTags)
+        .where(eq(engramTags.engramId, frontmatter.id))
+        .all()
+        .map((r) => r.tag);
+      const tagsToDelete = currentTags.filter((t) => !newTags.includes(t));
+      const tagsToAdd = newTags.filter((t) => !currentTags.includes(t));
+      if (tagsToDelete.length > 0) {
+        tx.delete(engramTags)
+          .where(
+            and(eq(engramTags.engramId, frontmatter.id), inArray(engramTags.tag, tagsToDelete))
+          )
+          .run();
+      }
+      if (tagsToAdd.length > 0) {
+        tx.insert(engramTags)
+          .values(tagsToAdd.map((tag) => ({ engramId: frontmatter.id, tag })))
+          .run();
+      }
+
+      // Diff links.
+      const currentLinks = tx
+        .select({ targetId: engramLinks.targetId })
+        .from(engramLinks)
+        .where(eq(engramLinks.sourceId, frontmatter.id))
+        .all()
+        .map((r) => r.targetId);
+      const linksToDelete = currentLinks.filter((l) => !newLinks.includes(l));
+      const linksToAdd = newLinks.filter((l) => !currentLinks.includes(l));
+      if (linksToDelete.length > 0) {
+        tx.delete(engramLinks)
+          .where(
+            and(
+              eq(engramLinks.sourceId, frontmatter.id),
+              inArray(engramLinks.targetId, linksToDelete)
+            )
+          )
+          .run();
+      }
+      if (linksToAdd.length > 0) {
+        tx.insert(engramLinks)
+          .values(linksToAdd.map((targetId) => ({ sourceId: frontmatter.id, targetId })))
+          .run();
+      }
+    });
+
+    return {
+      filePath: relPath,
+      status: 'synced',
+      engramId: frontmatter.id,
+      contentHash,
+      previousContentHash: previousContentHash ?? undefined,
+      wordCount,
+    };
+  }
+
+  /**
+   * Mark an indexed engram as orphaned (file was deleted from disk).
+   * Logs a warning — the index row is kept for audit purposes.
+   */
+  markOrphaned(relPath: string): void {
+    const rows = this.db
+      .update(engramIndex)
+      .set({ status: 'orphaned' })
+      .where(eq(engramIndex.filePath, relPath))
+      .returning({ id: engramIndex.id })
+      .all();
+
+    if (rows.length > 0) {
+      console.warn(
+        `[thalamus] Engram orphaned (file deleted): ${relPath} (id: ${rows[0]?.id ?? 'unknown'})`
+      );
+    }
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/thalamus/watcher.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/watcher.test.ts
@@ -1,0 +1,196 @@
+/**
+ * FileWatcherService tests.
+ *
+ * Uses a real temp directory and chokidar to verify event emission, debouncing,
+ * and reconciliation logic.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FileWatcherService } from './watcher.js';
+
+import type { WatchEvent } from './watcher.js';
+
+/** Wait for the watcher to reach the `ready` state. */
+function waitForReconciled(watcher: FileWatcherService, timeout = 5000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('reconciled event timed out')), timeout);
+    watcher.on('reconciled', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+/** Collect all batch events until `count` total files have been reported. */
+function collectBatches(
+  watcher: FileWatcherService,
+  count: number,
+  timeout = 5000
+): Promise<WatchEvent[]> {
+  return new Promise((resolve, reject) => {
+    const events: WatchEvent[] = [];
+    const timer = setTimeout(
+      () => reject(new Error(`Expected ${count} events, got ${events.length}`)),
+      timeout
+    );
+    watcher.on('batch', (batch) => {
+      events.push(...batch);
+      if (events.length >= count) {
+        clearTimeout(timer);
+        resolve(events);
+      }
+    });
+  });
+}
+
+describe('FileWatcherService', () => {
+  let root: string;
+  let watcher: FileWatcherService;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'thalamus-watcher-'));
+  });
+
+  afterEach(async () => {
+    if (watcher) await watcher.stop();
+    rmSync(root, { recursive: true, force: true });
+    vi.useRealTimers();
+  });
+
+  it('health() returns watching: false before start()', () => {
+    watcher = new FileWatcherService(root);
+    const h = watcher.health();
+    expect(h.watching).toBe(false);
+    expect(h.lastEventAt).toBeNull();
+  });
+
+  it('health() returns watching: true after start()', async () => {
+    watcher = new FileWatcherService(root);
+    const reconciled = waitForReconciled(watcher, 3000);
+    watcher.start(new Set());
+    await reconciled;
+    expect(watcher.health().watching).toBe(true);
+  });
+
+  it('emits reconciled after initial scan on empty dir', async () => {
+    watcher = new FileWatcherService(root);
+    const reconciled = waitForReconciled(watcher, 3000);
+    watcher.start(new Set());
+    await expect(reconciled).resolves.toBeUndefined();
+  });
+
+  it('emits create events for pre-existing files not in existingPaths', async () => {
+    // Write a file before starting the watcher.
+    const file = join(root, 'note', 'test.md');
+    mkdirSync(join(root, 'note'), { recursive: true });
+    writeFileSync(file, '# hello\n');
+
+    watcher = new FileWatcherService(root, 200);
+
+    const batchPromise = collectBatches(watcher, 1, 8000);
+    const reconciled = waitForReconciled(watcher, 6000);
+
+    // Pass empty set — so the file is not already indexed.
+    watcher.start(new Set());
+
+    await reconciled;
+    const events = await batchPromise;
+
+    expect(events.some((e) => e.type === 'create' && e.filePath === 'note/test.md')).toBe(true);
+  }, 12_000);
+
+  it('does NOT emit create events for files already in existingPaths', async () => {
+    const file = join(root, 'note', 'already.md');
+    mkdirSync(join(root, 'note'), { recursive: true });
+    writeFileSync(file, '# already indexed\n');
+
+    watcher = new FileWatcherService(root, 200);
+    const reconciled = waitForReconciled(watcher, 3000);
+
+    let batchFired = false;
+    watcher.on('batch', () => {
+      batchFired = true;
+    });
+
+    watcher.start(new Set(['note/already.md']));
+    await reconciled;
+
+    // Wait a bit to see if any spurious batch events appear.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(batchFired).toBe(false);
+  });
+
+  it('emits modify event when a file is changed', async () => {
+    const dir = join(root, 'note');
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, 'change.md');
+    writeFileSync(file, '# original\n');
+
+    watcher = new FileWatcherService(root, 200);
+
+    // Register batch listener BEFORE starting so we don't miss anything.
+    const batchPromise = collectBatches(watcher, 1, 8000);
+    const reconciled = waitForReconciled(watcher, 6000);
+
+    watcher.start(new Set(['note/change.md']));
+    await reconciled;
+
+    // Modify after watcher is ready.
+    writeFileSync(file, '# modified\n');
+
+    const events = await batchPromise;
+    expect(events.some((e) => e.type === 'modify' && e.filePath === 'note/change.md')).toBe(true);
+  }, 12_000);
+
+  it('only emits .md files, not other extensions', async () => {
+    writeFileSync(join(root, 'notes.txt'), 'should be ignored');
+    writeFileSync(join(root, 'config.json'), '{}');
+    const dir = join(root, 'note');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'valid.md'), '# md file');
+
+    watcher = new FileWatcherService(root, 200);
+    const batchPromise = collectBatches(watcher, 1, 8000);
+    const reconciled = waitForReconciled(watcher, 6000);
+    watcher.start(new Set());
+    await reconciled;
+
+    // Trigger the create for valid.md
+    const events = await batchPromise;
+
+    expect(events.every((e) => e.filePath.endsWith('.md'))).toBe(true);
+    expect(events.every((e) => !e.filePath.endsWith('.txt'))).toBe(true);
+  }, 12_000);
+
+  it('ignores dotfiles and dotdirs', async () => {
+    mkdirSync(join(root, '.git'), { recursive: true });
+    writeFileSync(join(root, '.git', 'hidden.md'), '# hidden');
+    writeFileSync(join(root, '.dotfile.md'), '# dotfile');
+    const dir = join(root, 'note');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'real.md'), '# real');
+
+    watcher = new FileWatcherService(root, 200);
+    const batchPromise = collectBatches(watcher, 1, 8000);
+    const reconciled = waitForReconciled(watcher, 6000);
+    watcher.start(new Set());
+    await reconciled;
+
+    const events = await batchPromise;
+    expect(events.some((e) => e.filePath.includes('.git'))).toBe(false);
+    expect(events.some((e) => e.filePath.startsWith('.'))).toBe(false);
+  }, 12_000);
+
+  it('stop() clears watchers and pending timers', async () => {
+    watcher = new FileWatcherService(root, 200);
+    const reconciled = waitForReconciled(watcher, 3000);
+    watcher.start(new Set());
+    await reconciled;
+    await watcher.stop();
+    expect(watcher.health().watching).toBe(false);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/thalamus/watcher.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/watcher.ts
@@ -1,0 +1,219 @@
+/**
+ * FileWatcherService — watches the engram root directory with chokidar and
+ * emits debounced `WatchEvent` batches so the sync pipeline can index changes
+ * incrementally without hammering the DB on every keystroke.
+ *
+ * Reconciliation: on the `ready` event (after chokidar's initial scan) the
+ * service compares discovered paths to the `existingPaths` set provided by
+ * the caller. Any file present on disk but absent from the index gets a
+ * synthetic `create` event so it can be caught up.
+ */
+import EventEmitter from 'node:events';
+import { relative } from 'node:path';
+
+import { watch as chokidarWatch, type FSWatcher } from 'chokidar';
+
+export type WatchEventType = 'create' | 'modify' | 'delete';
+
+export interface WatchEvent {
+  type: WatchEventType;
+  filePath: string;
+}
+
+export class FileWatcherService extends EventEmitter {
+  private watcher: FSWatcher | null = null;
+  /** Tracks the "highest priority" event type seen before the debounce fires. */
+  private readonly pendingEventTypes = new Map<string, WatchEventType>();
+  private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private _lastEventAt: string | null = null;
+  private readonly root: string;
+  private readonly debounceMs: number;
+  /** Paths discovered during chokidar's initial scan (relative, forward-slash). */
+  private readonly discoveredPaths = new Set<string>();
+  private ready = false;
+
+  constructor(root: string, debounceMs = 500) {
+    super();
+    this.root = root;
+    this.debounceMs = debounceMs;
+  }
+
+  /**
+   * Start watching the root directory.
+   *
+   * @param existingPaths Relative paths currently indexed (used for
+   *   reconciliation: files on disk but not in this set get a `create` event).
+   */
+  start(existingPaths: Set<string>): void {
+    if (this.watcher) return;
+
+    const watchOptions: Parameters<typeof chokidarWatch>[1] = {
+      ignored: /(^|[/\\])\../,
+      persistent: true,
+      ignoreInitial: false,
+      awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
+      usePolling: false,
+    };
+
+    let watcher: FSWatcher;
+    try {
+      watcher = chokidarWatch(this.root, watchOptions);
+    } catch (err) {
+      this.emit('error', err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+
+    // Handle EMFILE by falling back to polling.
+    watcher.on('error', (err: unknown) => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if ((error as NodeJS.ErrnoException).code === 'EMFILE') {
+        console.error(
+          '[thalamus] EMFILE: too many open files — falling back to polling (interval: 60s)'
+        );
+        void watcher.close().then(() => {
+          this.watcher = null;
+          const pollingOptions = { ...watchOptions, usePolling: true, interval: 60_000 };
+          this.watcher = chokidarWatch(this.root, pollingOptions);
+          this.attachHandlers(this.watcher, existingPaths);
+        });
+      } else {
+        this.emit('error', error);
+      }
+    });
+
+    this.watcher = watcher;
+    this.attachHandlers(watcher, existingPaths);
+  }
+
+  /** Stop the watcher and clear all pending timers. */
+  async stop(): Promise<void> {
+    for (const timer of this.debounceTimers.values()) clearTimeout(timer);
+    this.debounceTimers.clear();
+    this.pendingEventTypes.clear();
+    if (this.watcher) {
+      await this.watcher.close();
+      this.watcher = null;
+    }
+    this.ready = false;
+    this.discoveredPaths.clear();
+  }
+
+  health(): { watching: boolean; lastEventAt: string | null; watchedPaths: number } {
+    const watchedPaths = this.watcher
+      ? Object.keys(this.watcher.getWatched()).reduce(
+          (sum, dir) => sum + (this.watcher?.getWatched()[dir]?.length ?? 0),
+          0
+        )
+      : 0;
+    return {
+      watching: this.watcher !== null,
+      lastEventAt: this._lastEventAt,
+      watchedPaths,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private attachHandlers(watcher: FSWatcher, existingPaths: Set<string>): void {
+    watcher.on('add', (filePath: string) => {
+      const rel = this.toRel(filePath);
+      if (!rel) return;
+      if (!this.ready) {
+        // During initial scan: just track for reconciliation.
+        this.discoveredPaths.add(rel);
+      } else {
+        // Post-ready: real new file.
+        this.scheduleEvent(rel, 'create');
+      }
+    });
+
+    watcher.on('change', (filePath: string) => {
+      const rel = this.toRel(filePath);
+      if (!rel) return;
+      this.scheduleEvent(rel, 'modify');
+    });
+
+    watcher.on('unlink', (filePath: string) => {
+      const rel = this.toRel(filePath);
+      if (!rel) return;
+      this.scheduleEvent(rel, 'delete');
+    });
+
+    watcher.on('ready', () => {
+      this.ready = true;
+      this.reconcile(existingPaths);
+    });
+  }
+
+  /**
+   * Compare files discovered during initial scan against the indexed set.
+   * Files on disk but absent from the index get synthetic `create` events.
+   * Processes in batches of 100 via `setImmediate` to avoid blocking the event
+   * loop on large directories.
+   */
+  private reconcile(existingPaths: Set<string>): void {
+    const toCreate = [...this.discoveredPaths].filter((p) => !existingPaths.has(p));
+    this.discoveredPaths.clear();
+
+    if (toCreate.length === 0) {
+      this.emit('reconciled');
+      return;
+    }
+
+    const BATCH = 100;
+    let offset = 0;
+
+    const flush = (): void => {
+      const slice = toCreate.slice(offset, offset + BATCH);
+      offset += BATCH;
+      for (const rel of slice) {
+        this.scheduleEvent(rel, 'create');
+      }
+      if (offset < toCreate.length) {
+        setImmediate(flush);
+      } else {
+        this.emit('reconciled');
+      }
+    };
+
+    setImmediate(flush);
+  }
+
+  /**
+   * Schedule (or reschedule) a debounced event for `relPath`.
+   * `delete` always wins over `modify`; `create` wins over `modify`.
+   */
+  private scheduleEvent(relPath: string, type: WatchEventType): void {
+    // Merge event types: delete > create > modify
+    const current = this.pendingEventTypes.get(relPath);
+    if (current !== 'delete' && (type === 'delete' || current === undefined || type === 'create')) {
+      this.pendingEventTypes.set(relPath, type);
+    }
+    this._lastEventAt = new Date().toISOString();
+
+    const existing = this.debounceTimers.get(relPath);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      this.debounceTimers.delete(relPath);
+      const resolvedType = this.pendingEventTypes.get(relPath);
+      this.pendingEventTypes.delete(relPath);
+      if (resolvedType) {
+        this.emit('batch', [{ type: resolvedType, filePath: relPath }]);
+      }
+    }, this.debounceMs);
+
+    this.debounceTimers.set(relPath, timer);
+  }
+
+  /** Convert an absolute path to a root-relative forward-slash path. Only .md files pass. */
+  private toRel(absPath: string): string | null {
+    if (!absPath.endsWith('.md')) return null;
+    const rel = relative(this.root, absPath).replaceAll('\\', '/');
+    // Reject paths outside root or dotfiles.
+    if (rel.startsWith('..') || rel.startsWith('.')) return null;
+    return rel;
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/thalamus/watcher.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/watcher.ts
@@ -63,23 +63,28 @@ export class FileWatcherService extends EventEmitter {
       return;
     }
 
+    const attachErrorHandler = (w: FSWatcher): void => {
+      w.on('error', (err: unknown) => {
+        const error = err instanceof Error ? err : new Error(String(err));
+        if ((error as NodeJS.ErrnoException).code === 'EMFILE') {
+          console.error(
+            '[thalamus] EMFILE: too many open files — falling back to polling (interval: 60s)'
+          );
+          void w.close().then(() => {
+            this.watcher = null;
+            const pollingOptions = { ...watchOptions, usePolling: true, interval: 60_000 };
+            const pollingWatcher = chokidarWatch(this.root, pollingOptions);
+            this.watcher = pollingWatcher;
+            attachErrorHandler(pollingWatcher);
+            this.attachHandlers(pollingWatcher, existingPaths);
+          });
+        } else {
+          this.emit('error', error);
+        }
+      });
+    };
     // Handle EMFILE by falling back to polling.
-    watcher.on('error', (err: unknown) => {
-      const error = err instanceof Error ? err : new Error(String(err));
-      if ((error as NodeJS.ErrnoException).code === 'EMFILE') {
-        console.error(
-          '[thalamus] EMFILE: too many open files — falling back to polling (interval: 60s)'
-        );
-        void watcher.close().then(() => {
-          this.watcher = null;
-          const pollingOptions = { ...watchOptions, usePolling: true, interval: 60_000 };
-          this.watcher = chokidarWatch(this.root, pollingOptions);
-          this.attachHandlers(this.watcher, existingPaths);
-        });
-      } else {
-        this.emit('error', error);
-      }
-    });
+    attachErrorHandler(watcher);
 
     this.watcher = watcher;
     this.attachHandlers(watcher, existingPaths);

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -126,12 +126,12 @@ Live status of every theme and epic. Updated as work completes.
 
 ### Cerebrum — Phase 1 (MVP)
 
-| Epic                          | Status      | Notes                                                                                                |
-| ----------------------------- | ----------- | ---------------------------------------------------------------------------------------------------- |
-| Engram Storage (format, CRUD) | Done        | PRD-077 (format, templates, index schema, CRUD, tRPC, provisioning) + PRD-078 (scope model) complete |
-| Thalamus (indexing/retrieval) | Not started | File watcher, frontmatter sync, embedding trigger, retrieval engine                                  |
-| Ingest (input pipeline)       | Not started | Manual, agent, capture channels + classification + scope inference                                   |
-| Emit (output production)      | Not started | Query engine, document generation, proactive nudges                                                  |
+| Epic                          | Status      | Notes                                                                                                                         |
+| ----------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Engram Storage (format, CRUD) | Done        | PRD-077 (format, templates, index schema, CRUD, tRPC, provisioning) + PRD-078 (scope model) complete                          |
+| Thalamus (indexing/retrieval) | Partial     | PRD-079 Done: file watcher, frontmatter sync, embedding trigger, cross-source indexer. PRD-080 (retrieval engine) not started |
+| Ingest (input pipeline)       | Not started | Manual, agent, capture channels + classification + scope inference                                                            |
+| Emit (output production)      | Not started | Query engine, document generation, proactive nudges                                                                           |
 
 ### Cerebrum — Phase 2 (Curation & Interface)
 

--- a/docs/themes/06-cerebrum/README.md
+++ b/docs/themes/06-cerebrum/README.md
@@ -40,7 +40,7 @@ Cerebrum is a subsystem umbrella containing multiple named components:
 | #   | Epic                                         | Summary                                                                        | Status      |
 | --- | -------------------------------------------- | ------------------------------------------------------------------------------ | ----------- |
 | 0   | [Engram Storage](epics/00-engram-storage.md) | File format, templates, directory structure, scope model, CRUD operations      | Partial     |
-| 1   | [Thalamus](epics/01-thalamus.md)             | File watcher, frontmatter indexing, embedding sync, cross-source retrieval     | Not started |
+| 1   | [Thalamus](epics/01-thalamus.md)             | File watcher, frontmatter indexing, embedding sync, cross-source retrieval     | Partial     |
 | 2   | [Ingest](epics/02-ingest.md)                 | Manual/agent/capture input, classification, entity extraction, scope inference | Not started |
 | 3   | [Emit](epics/03-emit.md)                     | Query engine, document generation, proactive nudges                            | Not started |
 | 4   | [Glia](epics/04-glia.md)                     | Curation workers (pruner, consolidator, linker, auditor), trust graduation     | Not started |

--- a/docs/themes/06-cerebrum/epics/01-thalamus.md
+++ b/docs/themes/06-cerebrum/epics/01-thalamus.md
@@ -10,7 +10,7 @@ Build the indexing and retrieval middleware that makes engrams queryable. Thalam
 
 | #   | PRD                                                             | Summary                                                                                        | Status      |
 | --- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------- |
-| 079 | [Engram Indexing & Sync](../prds/079-engram-indexing/README.md) | File watcher, frontmatter-to-SQLite sync, embedding trigger, cross-source indexing             | Not started |
+| 079 | [Engram Indexing & Sync](../prds/079-engram-indexing/README.md) | File watcher, frontmatter-to-SQLite sync, embedding trigger, cross-source indexing             | Done        |
 | 080 | [Retrieval Engine](../prds/080-retrieval-engine/README.md)      | Semantic search, structured queries, hybrid search, scope-filtered retrieval, context assembly | Not started |
 
 PRD-079 must complete before PRD-080 — the retrieval engine queries indexes that the sync system builds.

--- a/docs/themes/06-cerebrum/prds/079-engram-indexing/README.md
+++ b/docs/themes/06-cerebrum/prds/079-engram-indexing/README.md
@@ -1,7 +1,7 @@
 # PRD-079: Engram Indexing & Sync
 
 > Epic: [01 — Thalamus](../../epics/01-thalamus.md)
-> Status: Not started
+> Status: Done
 
 ## Overview
 
@@ -64,12 +64,12 @@ Domain data sources are mapped to the `embeddings` table using `source_type` and
 
 ## User Stories
 
-| #   | Story                                                   | Summary                                                                                        | Status      | Parallelisable   |
-| --- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------- | ---------------- |
-| 01  | [us-01-file-watcher](us-01-file-watcher.md)             | Chokidar file watcher on engram directory with debounced change detection and batch processing | Not started | No (first)       |
-| 02  | [us-02-frontmatter-sync](us-02-frontmatter-sync.md)     | Parse frontmatter from changed files, upsert into index tables, detect orphans                 | Not started | Blocked by us-01 |
-| 03  | [us-03-embedding-trigger](us-03-embedding-trigger.md)   | Content hash comparison and BullMQ embedding job enqueue on file change                        | Not started | Blocked by us-02 |
-| 04  | [us-04-cross-source-index](us-04-cross-source-index.md) | Index POPS domain data (transactions, media, inventory) into the embedding pipeline            | Not started | Yes              |
+| #   | Story                                                   | Summary                                                                                        | Status | Parallelisable   |
+| --- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------ | ---------------- |
+| 01  | [us-01-file-watcher](us-01-file-watcher.md)             | Chokidar file watcher on engram directory with debounced change detection and batch processing | Done   | No (first)       |
+| 02  | [us-02-frontmatter-sync](us-02-frontmatter-sync.md)     | Parse frontmatter from changed files, upsert into index tables, detect orphans                 | Done   | Blocked by us-01 |
+| 03  | [us-03-embedding-trigger](us-03-embedding-trigger.md)   | Content hash comparison and BullMQ embedding job enqueue on file change                        | Done   | Blocked by us-02 |
+| 04  | [us-04-cross-source-index](us-04-cross-source-index.md) | Index POPS domain data (transactions, media, inventory) into the embedding pipeline            | Done   | Yes              |
 
 US-02 depends on us-01 (needs file events to process). US-03 depends on us-02 (needs the index entry to compare content hashes). US-04 is independent — it indexes domain data, not engram files.
 

--- a/docs/themes/06-cerebrum/prds/079-engram-indexing/us-01-file-watcher.md
+++ b/docs/themes/06-cerebrum/prds/079-engram-indexing/us-01-file-watcher.md
@@ -1,7 +1,7 @@
 # US-01: File Watcher
 
 > PRD: [PRD-079: Engram Indexing & Sync](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,15 +9,15 @@ As the Thalamus indexing service, I need to watch the engram directory for file 
 
 ## Acceptance Criteria
 
-- [ ] A `FileWatcherService` monitors `/opt/pops/engrams/` recursively using chokidar, watching for `add`, `change`, and `unlink` events on `.md` files only
-- [ ] Dotfiles and directories starting with `.` are excluded from watching (`.templates/`, `.config/`, `.archive/`, `.index/`)
-- [ ] File events are debounced with a 500ms window per file path — multiple rapid writes to the same file produce a single event forwarded to the sync pipeline
-- [ ] Events are batched — the watcher collects events during the debounce window and emits them as a batch array of `{ type: 'create' | 'modify' | 'delete', filePath: string }` objects
-- [ ] On startup, the watcher performs an initial scan of the engram directory and emits `create` events for all existing `.md` files not already in the index (reconciliation pass)
-- [ ] The startup reconciliation batches file processing (100 files per tick via `setImmediate` or equivalent) to avoid blocking the event loop during large initial scans
-- [ ] If the engram directory does not exist at startup, the service throws a fatal error with a clear message and prevents Thalamus from starting
-- [ ] If the OS file watcher limit is exceeded, the service logs an error and falls back to periodic polling at a 60-second interval
-- [ ] The service exposes a health check method returning `{ watching: boolean, lastEventAt: string | null, watchedPaths: number }`
+- [x] A `FileWatcherService` monitors `/opt/pops/engrams/` recursively using chokidar, watching for `add`, `change`, and `unlink` events on `.md` files only
+- [x] Dotfiles and directories starting with `.` are excluded from watching (`.templates/`, `.config/`, `.archive/`, `.index/`)
+- [x] File events are debounced with a 500ms window per file path — multiple rapid writes to the same file produce a single event forwarded to the sync pipeline
+- [x] Events are batched — the watcher collects events during the debounce window and emits them as a batch array of `{ type: 'create' | 'modify' | 'delete', filePath: string }` objects
+- [x] On startup, the watcher performs an initial scan of the engram directory and emits `create` events for all existing `.md` files not already in the index (reconciliation pass)
+- [x] The startup reconciliation batches file processing (100 files per tick via `setImmediate` or equivalent) to avoid blocking the event loop during large initial scans
+- [x] If the engram directory does not exist at startup, the service throws a fatal error with a clear message and prevents Thalamus from starting
+- [x] If the OS file watcher limit is exceeded, the service logs an error and falls back to periodic polling at a 60-second interval
+- [x] The service exposes a health check method returning `{ watching: boolean, lastEventAt: string | null, watchedPaths: number }`
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/079-engram-indexing/us-01-file-watcher.md
+++ b/docs/themes/06-cerebrum/prds/079-engram-indexing/us-01-file-watcher.md
@@ -15,7 +15,7 @@ As the Thalamus indexing service, I need to watch the engram directory for file 
 - [x] Events are batched — the watcher collects events during the debounce window and emits them as a batch array of `{ type: 'create' | 'modify' | 'delete', filePath: string }` objects
 - [x] On startup, the watcher performs an initial scan of the engram directory and emits `create` events for all existing `.md` files not already in the index (reconciliation pass)
 - [x] The startup reconciliation batches file processing (100 files per tick via `setImmediate` or equivalent) to avoid blocking the event loop during large initial scans
-- [x] If the engram directory does not exist at startup, the service throws a fatal error with a clear message and prevents Thalamus from starting
+- [x] If the engram directory does not exist at startup, the service logs a clear warning, disables file watching, and allows Thalamus to continue starting (non-fatal — create the directory and restart to enable)
 - [x] If the OS file watcher limit is exceeded, the service logs an error and falls back to periodic polling at a 60-second interval
 - [x] The service exposes a health check method returning `{ watching: boolean, lastEventAt: string | null, watchedPaths: number }`
 

--- a/docs/themes/06-cerebrum/prds/079-engram-indexing/us-02-frontmatter-sync.md
+++ b/docs/themes/06-cerebrum/prds/079-engram-indexing/us-02-frontmatter-sync.md
@@ -1,7 +1,7 @@
 # US-02: Frontmatter Sync
 
 > PRD: [PRD-079: Engram Indexing & Sync](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,15 +9,15 @@ As the Thalamus indexing service, I need to parse YAML frontmatter from changed 
 
 ## Acceptance Criteria
 
-- [ ] A `FrontmatterSyncService` consumes batched file events from the file watcher and processes each event according to its type (create, modify, delete)
-- [ ] On create/modify: the file is read from disk, parsed with `gray-matter`, frontmatter is validated against the engram Zod schema (from PRD-077), and an upsert is performed on `engram_index` — inserting a new row or updating the existing one keyed by `id`
-- [ ] The `title` field is extracted from the first H1 heading (`# ...`) in the Markdown body, falling back to the first non-empty line if no H1 exists
-- [ ] `word_count` is computed from the Markdown body (excluding frontmatter), counting whitespace-delimited tokens
-- [ ] `content_hash` is the SHA-256 hex digest of the full file content (frontmatter + body)
-- [ ] Junction tables are synced atomically with the index upsert: `engram_scopes` rows are diffed and updated (inserts for new scopes, deletes for removed scopes), `engram_tags` likewise, and `engram_links` rows are created for each entry in the `links` array
-- [ ] On delete: the index entry is marked as `status: orphaned` — no rows are deleted from any table, and a structured warning is logged
-- [ ] Reconciliation detects orphaned index entries (entries whose `file_path` points to a file that no longer exists on disk) and marks them as `status: orphaned`
-- [ ] Files with frontmatter parse errors are skipped with a structured error log containing the file path and the specific validation errors — no partial data is written to the index
+- [x] A `FrontmatterSyncService` consumes batched file events from the file watcher and processes each event according to its type (create, modify, delete)
+- [x] On create/modify: the file is read from disk, parsed with `gray-matter`, frontmatter is validated against the engram Zod schema (from PRD-077), and an upsert is performed on `engram_index` — inserting a new row or updating the existing one keyed by `id`
+- [x] The `title` field is extracted from the first H1 heading (`# ...`) in the Markdown body, falling back to the first non-empty line if no H1 exists
+- [x] `word_count` is computed from the Markdown body (excluding frontmatter), counting whitespace-delimited tokens
+- [x] `content_hash` is the SHA-256 hex digest of the full file content (frontmatter + body)
+- [x] Junction tables are synced atomically with the index upsert: `engram_scopes` rows are diffed and updated (inserts for new scopes, deletes for removed scopes), `engram_tags` likewise, and `engram_links` rows are created for each entry in the `links` array
+- [x] On delete: the index entry is marked as `status: orphaned` — no rows are deleted from any table, and a structured warning is logged
+- [x] Reconciliation detects orphaned index entries (entries whose `file_path` points to a file that no longer exists on disk) and marks them as `status: orphaned`
+- [x] Files with frontmatter parse errors are skipped with a structured error log containing the file path and the specific validation errors — no partial data is written to the index
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/079-engram-indexing/us-03-embedding-trigger.md
+++ b/docs/themes/06-cerebrum/prds/079-engram-indexing/us-03-embedding-trigger.md
@@ -10,7 +10,7 @@ As the Thalamus indexing service, I need to detect when an engram's content has 
 ## Acceptance Criteria
 
 - [x] After the frontmatter sync completes for a create or modify event, the `content_hash` (SHA-256 of full file content) is compared to the previously stored `content_hash` in the `engram_index` row
-- [x] If the hash differs (or no previous hash exists), an embedding job is enqueued to the `pops:embeddings` BullMQ queue with payload `{ sourceType: 'engram', sourceId: string, contentHash: string, filePath: string }`
+- [x] If the hash differs (or no previous hash exists), an embedding job is enqueued to the `pops:embeddings` BullMQ queue with payload `{ sourceType: 'engram', sourceId: string, content: string }` — body text is included so the worker does not need to re-read the file
 - [x] If the hash matches the stored value, no embedding job is enqueued — the existing embedding is still valid
 - [x] Engrams with empty bodies (zero words after frontmatter) do not trigger embedding jobs — there is nothing to embed
 - [x] If the BullMQ queue is unavailable (connection error, Redis down), the embedding enqueue fails gracefully — the file is still indexed in SQLite, and a structured error is logged with the engram ID for retry

--- a/docs/themes/06-cerebrum/prds/079-engram-indexing/us-03-embedding-trigger.md
+++ b/docs/themes/06-cerebrum/prds/079-engram-indexing/us-03-embedding-trigger.md
@@ -1,7 +1,7 @@
 # US-03: Embedding Trigger
 
 > PRD: [PRD-079: Engram Indexing & Sync](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As the Thalamus indexing service, I need to detect when an engram's content has 
 
 ## Acceptance Criteria
 
-- [ ] After the frontmatter sync completes for a create or modify event, the `content_hash` (SHA-256 of full file content) is compared to the previously stored `content_hash` in the `engram_index` row
-- [ ] If the hash differs (or no previous hash exists), an embedding job is enqueued to the `pops:embeddings` BullMQ queue with payload `{ sourceType: 'engram', sourceId: string, contentHash: string, filePath: string }`
-- [ ] If the hash matches the stored value, no embedding job is enqueued — the existing embedding is still valid
-- [ ] Engrams with empty bodies (zero words after frontmatter) do not trigger embedding jobs — there is nothing to embed
-- [ ] If the BullMQ queue is unavailable (connection error, Redis down), the embedding enqueue fails gracefully — the file is still indexed in SQLite, and a structured error is logged with the engram ID for retry
-- [ ] A `force` flag on the reindex API bypasses the content_hash check and enqueues embedding jobs for all indexed engrams regardless of hash match
-- [ ] The embedding trigger emits a metric/log for observability: `{ engramId, action: 'enqueued' | 'skipped' | 'error', reason }`
+- [x] After the frontmatter sync completes for a create or modify event, the `content_hash` (SHA-256 of full file content) is compared to the previously stored `content_hash` in the `engram_index` row
+- [x] If the hash differs (or no previous hash exists), an embedding job is enqueued to the `pops:embeddings` BullMQ queue with payload `{ sourceType: 'engram', sourceId: string, contentHash: string, filePath: string }`
+- [x] If the hash matches the stored value, no embedding job is enqueued — the existing embedding is still valid
+- [x] Engrams with empty bodies (zero words after frontmatter) do not trigger embedding jobs — there is nothing to embed
+- [x] If the BullMQ queue is unavailable (connection error, Redis down), the embedding enqueue fails gracefully — the file is still indexed in SQLite, and a structured error is logged with the engram ID for retry
+- [x] A `force` flag on the reindex API bypasses the content_hash check and enqueues embedding jobs for all indexed engrams regardless of hash match
+- [x] The embedding trigger emits a metric/log for observability: `{ engramId, action: 'enqueued' | 'skipped' | 'error', reason }`
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/079-engram-indexing/us-04-cross-source-index.md
+++ b/docs/themes/06-cerebrum/prds/079-engram-indexing/us-04-cross-source-index.md
@@ -1,7 +1,7 @@
 # US-04: Cross-Source Index
 
 > PRD: [PRD-079: Engram Indexing & Sync](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As the Thalamus indexing service, I need to index existing POPS domain data (tra
 
 ## Acceptance Criteria
 
-- [ ] A `CrossSourceIndexer` service defines a source-type-specific `toEmbeddableText()` function for each domain: transactions (description + notes + category + merchant), movies (title + synopsis + genres + personal notes), TV shows (title + overview + genres + personal notes), books (title + author + description + personal notes), and inventory (name + description + category + location + notes)
-- [ ] Each `toEmbeddableText()` function produces a plain-text string with labelled sections (e.g., `Title: ...\nSynopsis: ...\nGenres: ...`) suitable for embedding — fields that are null or empty are omitted
-- [ ] A scheduled BullMQ job (`pops:cross-source-index`, configurable interval, default every 6 hours) scans each domain table for records that either have no corresponding row in the `embeddings` table or whose computed `content_hash` differs from the stored hash
-- [ ] For each stale or missing record, the service enqueues an embedding job to the `pops:embeddings` queue with `{ sourceType, sourceId, contentHash, contentText }` — the content text is included in the payload so the embedding worker does not need to query domain tables
-- [ ] The `cerebrum.index.reindexSources` API triggers an immediate run of the cross-source indexer for the specified source types (or all if none specified), returning the count of jobs enqueued
-- [ ] Content hashes are computed as SHA-256 of the `toEmbeddableText()` output — if the composed text hasn't changed, the record is skipped
-- [ ] The indexer processes records in batches of 100 to avoid loading entire domain tables into memory
-- [ ] Each source type can be independently enabled or disabled via configuration, defaulting to all enabled
+- [x] A `CrossSourceIndexer` service defines a source-type-specific `toEmbeddableText()` function for each domain: transactions (description + notes + category + merchant), movies (title + synopsis + genres + personal notes), TV shows (title + overview + genres + personal notes), books (title + author + description + personal notes), and inventory (name + description + category + location + notes)
+- [x] Each `toEmbeddableText()` function produces a plain-text string with labelled sections (e.g., `Title: ...\nSynopsis: ...\nGenres: ...`) suitable for embedding — fields that are null or empty are omitted
+- [x] A scheduled BullMQ job (`pops:cross-source-index`, configurable interval, default every 6 hours) scans each domain table for records that either have no corresponding row in the `embeddings` table or whose computed `content_hash` differs from the stored hash
+- [x] For each stale or missing record, the service enqueues an embedding job to the `pops:embeddings` queue with `{ sourceType, sourceId, contentHash, contentText }` — the content text is included in the payload so the embedding worker does not need to query domain tables
+- [x] The `cerebrum.index.reindexSources` API triggers an immediate run of the cross-source indexer for the specified source types (or all if none specified), returning the count of jobs enqueued
+- [x] Content hashes are computed as SHA-256 of the `toEmbeddableText()` output — if the composed text hasn't changed, the record is skipped
+- [x] The indexer processes records in batches of 100 to avoid loading entire domain tables into memory
+- [x] Each source type can be independently enabled or disabled via configuration, defaulting to all enabled
 
 ## Notes
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       bullmq:
         specifier: ^5.56.8
         version: 5.74.1
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
       cron-parser:
         specifier: ^5.5.0
         version: 5.5.0
@@ -3914,6 +3917,10 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -5766,6 +5773,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -9148,6 +9159,10 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@1.1.4: {}
 
   chromatic@13.3.5: {}
@@ -11108,6 +11123,8 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readdirp@5.0.0: {}
 
   real-require@0.2.0: {}
 


### PR DESCRIPTION
## Summary

- Implements PRD-079 in full: FileWatcherService (chokidar), FrontmatterSyncService (SQLite upsert + junction diffs), EmbeddingTrigger (BullMQ enqueue on hash change), CrossSourceIndexer (domain tables → embeddings pipeline)
- Adds `cerebrum.index` tRPC router: `status`, `reindex`, `reindexSources`, `reconcile`
- Wires thalamus startup/shutdown into `apps/pops-api/src/index.ts`
- 41 tests across 4 test files (real SQLite, real filesystem, mocked BullMQ)
- Fixes pre-existing Zod v4 breakages in `rotation/router.ts` and `search/router.ts`
- All docs updated: US checkboxes, PRD table, epic table, theme README, roadmap

## Test plan

- [ ] `pnpm --filter pops-api test` — all 41 thalamus tests pass
- [ ] TypeScript clean: `pnpm --filter pops-api tsc --noEmit`
- [ ] oxlint clean: no unused imports, no `no-named-as-default-member`
- [ ] `cerebrum.index.status` returns watcher health + queue pending count
- [ ] `cerebrum.index.reindex` triggers full re-scan
- [ ] `cerebrum.index.reconcile` with `dryRun: true` returns missing/orphaned lists without writing