### PR TITLE
feat(cerebrum): implement PRD-080 retrieval engine

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -5,6 +5,7 @@
 import { router } from '../../trpc.js';
 import { engramsRouter } from './engrams/router.js';
 import { scopesRouter } from './engrams/scopes-router.js';
+import { retrievalRouter } from './retrieval/router.js';
 import { templatesRouter } from './templates/router.js';
 import { indexRouter } from './thalamus/router.js';
 
@@ -13,4 +14,5 @@ export const cerebrumRouter = router({
   scopes: scopesRouter,
   templates: templatesRouter,
   index: indexRouter,
+  retrieval: retrievalRouter,
 });

--- a/apps/pops-api/src/modules/cerebrum/retrieval/context-assembly.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/context-assembly.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { ContextAssemblyService } from './context-assembly.js';
+
+import type { RetrievalResult } from './types.js';
+
+function makeResult(sourceId: string, overrides: Partial<RetrievalResult> = {}): RetrievalResult {
+  return {
+    sourceType: 'engram',
+    sourceId,
+    title: `Engram ${sourceId}`,
+    contentPreview: 'Some content here.',
+    score: 0.9,
+    matchType: 'semantic',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('ContextAssemblyService', () => {
+  const svc = new ContextAssemblyService();
+
+  it('returns preamble with query when results are empty', () => {
+    const out = svc.assemble({ query: 'hello world', results: [] });
+    expect(out.context).toContain('Query: hello world');
+    expect(out.sources).toHaveLength(0);
+    expect(out.truncated).toBe(false);
+    expect(out.tokenEstimate).toBeGreaterThan(0);
+  });
+
+  it('includes result sections in context', () => {
+    const results = [makeResult('e1', { title: 'My Note', contentPreview: 'Body text.' })];
+    const out = svc.assemble({ query: 'q', results, includeMetadata: false });
+    expect(out.context).toContain('[engram:e1] My Note');
+    expect(out.context).toContain('Body text.');
+    expect(out.sources).toHaveLength(1);
+    expect(out.sources[0]?.sourceId).toBe('e1');
+    expect(out.sources[0]?.relevanceScore).toBe(0.9);
+  });
+
+  it('deduplicates results by contentHash', () => {
+    const results = [
+      makeResult('e1', { metadata: { contentHash: 'abc' } }),
+      makeResult('e2', { metadata: { contentHash: 'abc' } }),
+    ];
+    const out = svc.assemble({ query: 'q', results, includeMetadata: false });
+    expect(out.sources).toHaveLength(1);
+    expect(out.sources[0]?.sourceId).toBe('e1');
+  });
+
+  it('deduplicates results by source identity when no contentHash', () => {
+    const results = [makeResult('e1'), makeResult('e1')];
+    const out = svc.assemble({ query: 'q', results, includeMetadata: false });
+    expect(out.sources).toHaveLength(1);
+  });
+
+  it('truncates long content when token budget is tight', () => {
+    const longContent = 'word '.repeat(300);
+    const results = [makeResult('e1', { contentPreview: longContent })];
+    const out = svc.assemble({ query: 'q', results, tokenBudget: 50, includeMetadata: false });
+    expect(out.truncated).toBe(true);
+    expect(out.context).toContain('[truncated]');
+  });
+
+  it('stops adding results when budget is exhausted', () => {
+    const results = [
+      makeResult('e1', { contentPreview: 'word '.repeat(200) }),
+      makeResult('e2', { contentPreview: 'word '.repeat(200) }),
+    ];
+    const out = svc.assemble({ query: 'q', results, tokenBudget: 100, includeMetadata: false });
+    expect(out.sources.length).toBeLessThan(2);
+  });
+
+  it('handles budget so small even truncated result does not fit', () => {
+    const results = [makeResult('e1', { contentPreview: 'word '.repeat(100) })];
+    const out = svc.assemble({ query: 'q', results, tokenBudget: 3, includeMetadata: false });
+    expect(out.truncated || out.sources.length === 0).toBe(true);
+  });
+
+  it('includes metadata fields when includeMetadata is true', () => {
+    const results = [
+      makeResult('e1', {
+        metadata: { type: 'note', scopes: ['personal'], tags: ['important'] },
+      }),
+    ];
+    const out = svc.assemble({ query: 'q', results, includeMetadata: true });
+    expect(out.context).toContain('type: note');
+    expect(out.context).toContain('scopes: personal');
+    expect(out.context).toContain('tags: important');
+  });
+
+  it('omits metadata line when includeMetadata is false', () => {
+    const results = [makeResult('e1', { metadata: { type: 'note', scopes: ['personal'] } })];
+    const out = svc.assemble({ query: 'q', results, includeMetadata: false });
+    expect(out.context).not.toContain('type: note');
+  });
+
+  it('tokenEstimate increases with more results', () => {
+    const r1 = svc.assemble({ query: 'q', results: [makeResult('e1')] });
+    const r2 = svc.assemble({ query: 'q', results: [makeResult('e1'), makeResult('e2')] });
+    expect(r2.tokenEstimate).toBeGreaterThan(r1.tokenEstimate);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/retrieval/context-assembly.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/context-assembly.ts
@@ -17,11 +17,14 @@ function estimateTokens(text: string): number {
 }
 
 function truncateToTokenBudget(text: string, budget: number): { text: string; truncated: boolean } {
+  if (budget <= 0) return { text: '[truncated]', truncated: true };
   const estimated = estimateTokens(text);
   if (estimated <= budget) return { text, truncated: false };
 
-  // Binary-search for the approximate character count that fits.
-  const targetWords = Math.floor(budget / WORDS_TO_TOKENS);
+  // Approximate character count that fits.
+  const targetWords = Math.max(0, Math.floor(budget / WORDS_TO_TOKENS));
+  if (targetWords === 0) return { text: '[truncated]', truncated: true };
+
   const words = text.split(/\s+/);
   const sliced = words.slice(0, targetWords).join(' ');
 
@@ -80,16 +83,15 @@ export class ContextAssemblyService {
     const seen = new Set<string>();
     const sections: string[] = [];
     const sources: SourceAttribution[] = [];
-    let remaining = tokenBudget;
     let anyTruncated = false;
 
-    // Preamble.
+    // Preamble — clamp remaining to 0 if preamble alone exceeds the budget.
     const preamble = `Query: ${query}\n`;
     const preambleTokens = estimateTokens(preamble);
-    remaining -= preambleTokens;
+    let remaining = Math.max(0, tokenBudget - preambleTokens);
 
     for (const result of results) {
-      // Dedup by content hash if available.
+      // Dedup by content hash when available, otherwise by source identity.
       const hashKey = (result.metadata['contentHash'] as string | undefined) ?? '';
       const dedupeKey = hashKey || `${result.sourceType}:${result.sourceId}`;
       if (seen.has(dedupeKey)) continue;
@@ -109,7 +111,7 @@ export class ContextAssemblyService {
         relevanceScore: result.score,
       });
 
-      remaining -= usedTokens;
+      remaining = Math.max(0, remaining - usedTokens);
       if (truncated) {
         anyTruncated = true;
         break;

--- a/apps/pops-api/src/modules/cerebrum/retrieval/context-assembly.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/context-assembly.ts
@@ -1,0 +1,124 @@
+/**
+ * ContextAssemblyService — assembles a token-budgeted context window from
+ * retrieval results, formatted for LLM consumption with source attribution.
+ *
+ * Token counting: word_count * 1.3 approximation (no tokeniser dependency).
+ * Truncation: at a sentence boundary (regex /[.!?]\s/) or hard at budget.
+ */
+import type { RetrievalResult, SourceAttribution } from './types.js';
+
+const DEFAULT_TOKEN_BUDGET = 4096;
+const WORDS_TO_TOKENS = 1.3;
+const SENTENCE_BOUNDARY = /[.!?]\s/;
+
+function estimateTokens(text: string): number {
+  const wordCount = text.trim().split(/\s+/).filter(Boolean).length;
+  return Math.ceil(wordCount * WORDS_TO_TOKENS);
+}
+
+function truncateToTokenBudget(text: string, budget: number): { text: string; truncated: boolean } {
+  const estimated = estimateTokens(text);
+  if (estimated <= budget) return { text, truncated: false };
+
+  // Binary-search for the approximate character count that fits.
+  const targetWords = Math.floor(budget / WORDS_TO_TOKENS);
+  const words = text.split(/\s+/);
+  const sliced = words.slice(0, targetWords).join(' ');
+
+  // Try to find a sentence boundary within the last 20% of sliced text.
+  const lookback = Math.floor(sliced.length * 0.2);
+  const searchRegion = sliced.slice(sliced.length - lookback);
+  const match = searchRegion.search(SENTENCE_BOUNDARY);
+
+  if (match !== -1) {
+    const cutPos = sliced.length - lookback + match + 1;
+    return { text: sliced.slice(0, cutPos).trimEnd() + ' [truncated]', truncated: true };
+  }
+
+  return { text: sliced.trimEnd() + ' [truncated]', truncated: true };
+}
+
+function formatSection(result: RetrievalResult, includeMetadata: boolean): string {
+  const header = `[${result.sourceType}:${result.sourceId}] ${result.title}`;
+
+  let meta = '';
+  if (includeMetadata) {
+    const parts: string[] = [];
+    if (result.metadata['type']) parts.push(`type: ${result.metadata['type']}`);
+    const scopes = result.metadata['scopes'] as string[] | undefined;
+    if (scopes?.length) parts.push(`scopes: ${scopes.join(', ')}`);
+    const tags = result.metadata['tags'] as string[] | undefined;
+    if (tags?.length) parts.push(`tags: ${tags.join(', ')}`);
+    if (result.metadata['createdAt']) parts.push(`date: ${result.metadata['createdAt']}`);
+    if (parts.length) meta = `(${parts.join(' | ')})`;
+  }
+
+  const body = result.contentPreview || '(no preview)';
+  const headerLine = meta ? `${header} ${meta}` : header;
+
+  return `---\n${headerLine}\n${body}`;
+}
+
+export interface ContextAssemblyInput {
+  query: string;
+  results: RetrievalResult[];
+  tokenBudget?: number;
+  includeMetadata?: boolean;
+}
+
+export interface ContextAssemblyOutput {
+  context: string;
+  sources: SourceAttribution[];
+  truncated: boolean;
+  tokenEstimate: number;
+}
+
+export class ContextAssemblyService {
+  assemble(input: ContextAssemblyInput): ContextAssemblyOutput {
+    const { query, results, tokenBudget = DEFAULT_TOKEN_BUDGET, includeMetadata = true } = input;
+
+    const seen = new Set<string>();
+    const sections: string[] = [];
+    const sources: SourceAttribution[] = [];
+    let remaining = tokenBudget;
+    let anyTruncated = false;
+
+    // Preamble.
+    const preamble = `Query: ${query}\n`;
+    const preambleTokens = estimateTokens(preamble);
+    remaining -= preambleTokens;
+
+    for (const result of results) {
+      // Dedup by content hash if available.
+      const hashKey = (result.metadata['contentHash'] as string | undefined) ?? '';
+      const dedupeKey = hashKey || `${result.sourceType}:${result.sourceId}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+
+      if (remaining <= 0) break;
+
+      const section = formatSection(result, includeMetadata);
+      const { text: fitted, truncated } = truncateToTokenBudget(section, remaining);
+      const usedTokens = estimateTokens(fitted);
+
+      sections.push(fitted);
+      sources.push({
+        sourceType: result.sourceType,
+        sourceId: result.sourceId,
+        title: result.title,
+        relevanceScore: result.score,
+      });
+
+      remaining -= usedTokens;
+      if (truncated) {
+        anyTruncated = true;
+        break;
+      }
+    }
+
+    const context = sections.length > 0 ? `${preamble}\n${sections.join('\n')}` : preamble;
+    const tokenEstimate = tokenBudget - remaining;
+
+    return { context, sources, truncated: anyTruncated, tokenEstimate };
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.ts
@@ -1,0 +1,137 @@
+import { SemanticSearchService } from './semantic-search.js';
+import { StructuredQueryService } from './structured-query.js';
+
+/**
+ * HybridSearchService — orchestrates SemanticSearchService and
+ * StructuredQueryService, merges results with reciprocal rank fusion (RRF),
+ * and routes the unified `search` procedure.
+ *
+ * RRF formula: score = sum(1 / (k + rank_i)) where k = 60.
+ */
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+import type { RetrievalFilters, RetrievalResult } from './types.js';
+
+const RRF_K = 60;
+const DEFAULT_LIMIT = 20;
+const DEFAULT_THRESHOLD = 0.8;
+
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+/** Apply RRF to merge two ranked lists. Returns merged list sorted by descending score. */
+function reciprocalRankFusion(
+  semanticResults: RetrievalResult[],
+  structuredResults: RetrievalResult[],
+  limit: number
+): RetrievalResult[] {
+  const scores = new Map<string, { score: number; result: RetrievalResult; inBoth: boolean }>();
+
+  for (const [i, r] of semanticResults.entries()) {
+    const key = `${r.sourceType}:${r.sourceId}`;
+    const contribution = 1 / (RRF_K + i + 1);
+    const existing = scores.get(key);
+    if (existing) {
+      existing.score += contribution;
+      existing.inBoth = true;
+    } else {
+      scores.set(key, { score: contribution, result: r, inBoth: false });
+    }
+  }
+
+  for (const [i, r] of structuredResults.entries()) {
+    const key = `${r.sourceType}:${r.sourceId}`;
+    const contribution = 1 / (RRF_K + i + 1);
+    const existing = scores.get(key);
+    if (existing) {
+      existing.score += contribution;
+      existing.inBoth = true;
+      // Merge metadata from structured result (richer for engrams).
+      existing.result = {
+        ...existing.result,
+        metadata: { ...existing.result.metadata, ...r.metadata },
+      };
+    } else {
+      scores.set(key, { score: contribution, result: r, inBoth: false });
+    }
+  }
+
+  return [...scores.values()]
+    .toSorted((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ score, result, inBoth }) => ({
+      ...result,
+      score,
+      matchType: inBoth ? ('both' as const) : result.matchType,
+    }));
+}
+
+export class HybridSearchService {
+  private readonly semanticSvc: SemanticSearchService;
+  private readonly structuredSvc: StructuredQueryService;
+
+  constructor(db: BetterSQLite3Database) {
+    this.semanticSvc = new SemanticSearchService(db);
+    this.structuredSvc = new StructuredQueryService(db);
+  }
+
+  /** Run hybrid search: both semantic + structured, merged with RRF. */
+  async hybrid(
+    query: string,
+    filters: RetrievalFilters = {},
+    limit = DEFAULT_LIMIT,
+    threshold = DEFAULT_THRESHOLD
+  ): Promise<RetrievalResult[]> {
+    const fetchLimit = limit * 3;
+
+    const [semanticResults, structuredResults] = await Promise.all([
+      this.semanticSvc.search(query, filters, fetchLimit, threshold),
+      this.structuredSvc.query(filters, fetchLimit),
+    ]);
+
+    const merged = reciprocalRankFusion(semanticResults, structuredResults, limit);
+
+    // Final secret-scope exclusion pass on merged set.
+    if (!filters.includeSecret) {
+      return merged.filter((r) => {
+        const scopes = (r.metadata['scopes'] as string[] | undefined) ?? [];
+        return !scopes.some(isSecretScope);
+      });
+    }
+
+    return merged;
+  }
+
+  /** Semantic-only search. */
+  async semanticSearch(
+    query: string,
+    filters: RetrievalFilters = {},
+    limit = DEFAULT_LIMIT,
+    threshold = DEFAULT_THRESHOLD
+  ): Promise<RetrievalResult[]> {
+    return this.semanticSvc.search(query, filters, limit, threshold);
+  }
+
+  /** Structured-only search. */
+  structuredOnly(filters: RetrievalFilters, limit = DEFAULT_LIMIT, offset = 0): RetrievalResult[] {
+    return this.structuredSvc.query(filters, limit, offset);
+  }
+
+  /**
+   * Find engrams similar to the given engram by its existing embedding vector.
+   * No embedding API call — reads the vector directly from embeddings_vec.
+   */
+  async similar(
+    engramId: string,
+    filters: RetrievalFilters = {},
+    limit = DEFAULT_LIMIT,
+    threshold = DEFAULT_THRESHOLD
+  ): Promise<RetrievalResult[]> {
+    const vector = this.semanticSvc.getVectorForEngram(engramId);
+    if (!vector) {
+      return [];
+    }
+    return this.semanticSvc.searchByVector(vector, engramId, filters, limit, threshold);
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.ts
@@ -85,8 +85,10 @@ export class HybridSearchService {
   ): Promise<RetrievalResult[]> {
     const fetchLimit = limit * 3;
 
+    // Pass `limit` (not fetchLimit) to semantic search — it over-fetches 3x internally.
+    // Structured query gets fetchLimit since it doesn't over-fetch.
     const [semanticResults, structuredResults] = await Promise.all([
-      this.semanticSvc.search(query, filters, fetchLimit, threshold),
+      this.semanticSvc.search(query, filters, limit, threshold),
       this.structuredSvc.query(filters, fetchLimit),
     ]);
 

--- a/apps/pops-api/src/modules/cerebrum/retrieval/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/router.ts
@@ -1,0 +1,196 @@
+/**
+ * cerebrum.retrieval tRPC router — unified retrieval API (search, context,
+ * similar, stats).
+ *
+ * Procedures:
+ *   search  — semantic | structured | hybrid (default)
+ *   context — hybrid search + context window assembly for LLM consumption
+ *   similar — k-NN from an existing engram's vector (no re-embedding)
+ *   stats   — retrieval layer health and coverage counts
+ */
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { embeddings, engramIndex } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
+import { protectedProcedure, router } from '../../../trpc.js';
+import { ContextAssemblyService } from './context-assembly.js';
+import { HybridSearchService } from './hybrid-search.js';
+
+import type { RetrievalFilters } from './types.js';
+
+const filtersSchema = z
+  .object({
+    types: z.array(z.string()).optional(),
+    scopes: z.array(z.string()).optional(),
+    tags: z.array(z.string()).optional(),
+    dateRange: z.object({ from: z.string().optional(), to: z.string().optional() }).optional(),
+    status: z.array(z.string()).optional(),
+    sourceTypes: z.array(z.string()).optional(),
+    customFields: z.record(z.string(), z.unknown()).optional(),
+    includeSecret: z.boolean().optional(),
+  })
+  .optional();
+
+export const retrievalRouter = router({
+  /**
+   * Unified search endpoint. Routes to semantic, structured, or hybrid (default).
+   */
+  search: protectedProcedure
+    .input(
+      z.object({
+        query: z.string().optional(),
+        mode: z.enum(['semantic', 'structured', 'hybrid']).default('hybrid'),
+        filters: filtersSchema,
+        limit: z.number().int().positive().max(100).default(20),
+        threshold: z.number().min(0).max(2).default(0.8),
+        offset: z.number().int().min(0).default(0),
+      })
+    )
+    .query(async ({ input }) => {
+      const db = getDrizzle();
+      const svc = new HybridSearchService(db);
+      const filters: RetrievalFilters = input.filters ?? {};
+
+      if (input.mode === 'semantic' || input.mode === 'hybrid') {
+        if (!input.query?.trim()) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Query is required for semantic and hybrid search modes',
+          });
+        }
+      }
+
+      if (input.mode === 'structured') {
+        const hasFilters =
+          filters.types?.length ||
+          filters.scopes?.length ||
+          filters.tags?.length ||
+          filters.dateRange?.from ||
+          filters.dateRange?.to ||
+          filters.status?.length ||
+          filters.customFields;
+        if (!hasFilters) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Structured search requires at least one filter',
+          });
+        }
+      }
+
+      // query is guaranteed non-empty for semantic/hybrid by the guard above
+      const query = input.query ?? '';
+
+      let results;
+      switch (input.mode) {
+        case 'semantic':
+          results = await svc.semanticSearch(query, filters, input.limit, input.threshold);
+          break;
+        case 'structured':
+          results = svc.structuredOnly(filters, input.limit, input.offset);
+          break;
+        case 'hybrid':
+        default:
+          results = await svc.hybrid(query, filters, input.limit, input.threshold);
+      }
+
+      return {
+        results,
+        meta: {
+          total: results.length,
+          mode: input.mode,
+        },
+      };
+    }),
+
+  /**
+   * Assemble a token-budgeted context window for LLM consumption.
+   * Runs hybrid search internally, then assembles and returns formatted context.
+   */
+  context: protectedProcedure
+    .input(
+      z.object({
+        query: z.string(),
+        filters: filtersSchema,
+        tokenBudget: z.number().int().positive().default(4096),
+        includeMetadata: z.boolean().default(true),
+        maxResults: z.number().int().positive().max(100).default(20),
+      })
+    )
+    .query(async ({ input }) => {
+      if (!input.query.trim()) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Query is required for context assembly',
+        });
+      }
+
+      const db = getDrizzle();
+      const svc = new HybridSearchService(db);
+      const assembler = new ContextAssemblyService();
+      const filters: RetrievalFilters = input.filters ?? {};
+
+      const results = await svc.hybrid(input.query, filters, input.maxResults, 0.8);
+      const output = assembler.assemble({
+        query: input.query,
+        results,
+        tokenBudget: input.tokenBudget,
+        includeMetadata: input.includeMetadata,
+      });
+
+      return output;
+    }),
+
+  /**
+   * Find engrams similar to the given engram by its existing embedding vector.
+   * Does not call the embedding API — reads the vector directly.
+   */
+  similar: protectedProcedure
+    .input(
+      z.object({
+        engramId: z.string(),
+        limit: z.number().int().positive().max(100).default(20),
+        threshold: z.number().min(0).max(2).default(0.8),
+        filters: filtersSchema,
+      })
+    )
+    .query(async ({ input }) => {
+      const db = getDrizzle();
+      const svc = new HybridSearchService(db);
+      const filters: RetrievalFilters = input.filters ?? {};
+
+      const results = await svc.similar(input.engramId, filters, input.limit, input.threshold);
+      return { results };
+    }),
+
+  /**
+   * Retrieval layer health and coverage counts.
+   */
+  stats: protectedProcedure.query(() => {
+    const db = getDrizzle();
+
+    const indexed = db.select().from(engramIndex).all().length;
+
+    const embeddingRows = db.select().from(embeddings).all();
+    const embedded = embeddingRows.length;
+
+    const sourceTypeCounts = embeddingRows.reduce<Record<string, number>>((acc, row) => {
+      acc[row.sourceType] = (acc[row.sourceType] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    const lastUpdated =
+      embeddingRows
+        .map((r) => r.createdAt)
+        .toSorted()
+        .at(-1) ?? null;
+
+    return {
+      indexed,
+      embedded,
+      sourceTypes: sourceTypeCounts,
+      lastUpdated,
+    };
+  }),
+});

--- a/apps/pops-api/src/modules/cerebrum/retrieval/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/router.ts
@@ -9,6 +9,7 @@
  *   stats   — retrieval layer health and coverage counts
  */
 import { TRPCError } from '@trpc/server';
+import { count, sql } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { embeddings, engramIndex } from '@pops/db-types';
@@ -70,6 +71,7 @@ export const retrievalRouter = router({
           filters.dateRange?.from ||
           filters.dateRange?.to ||
           filters.status?.length ||
+          filters.sourceTypes?.length ||
           filters.customFields;
         if (!hasFilters) {
           throw new TRPCError({
@@ -170,27 +172,28 @@ export const retrievalRouter = router({
   stats: protectedProcedure.query(() => {
     const db = getDrizzle();
 
-    const indexed = db.select().from(engramIndex).all().length;
+    const [indexedRow] = db.select({ count: count() }).from(engramIndex).all();
+    const indexed = indexedRow?.count ?? 0;
 
-    const embeddingRows = db.select().from(embeddings).all();
-    const embedded = embeddingRows.length;
+    const sourceTypeRows = db
+      .select({ sourceType: embeddings.sourceType, count: count() })
+      .from(embeddings)
+      .groupBy(embeddings.sourceType)
+      .all();
 
-    const sourceTypeCounts = embeddingRows.reduce<Record<string, number>>((acc, row) => {
-      acc[row.sourceType] = (acc[row.sourceType] ?? 0) + 1;
-      return acc;
-    }, {});
+    const embedded = sourceTypeRows.reduce((sum, r) => sum + r.count, 0);
+    const sourceTypeCounts = Object.fromEntries(sourceTypeRows.map((r) => [r.sourceType, r.count]));
 
-    const lastUpdated =
-      embeddingRows
-        .map((r) => r.createdAt)
-        .toSorted()
-        .at(-1) ?? null;
+    const [lastRow] = db
+      .select({ lastUpdated: sql<string | null>`max(${embeddings.createdAt})` })
+      .from(embeddings)
+      .all();
 
     return {
       indexed,
       embedded,
       sourceTypes: sourceTypeCounts,
-      lastUpdated,
+      lastUpdated: lastRow?.lastUpdated ?? null,
     };
   }),
 });

--- a/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search.ts
@@ -1,7 +1,9 @@
 /**
  * SemanticSearchService — wraps core semanticSearch with Thalamus metadata
- * resolution, scope filtering, and RetrievalResult shaping.
+ * resolution, scope/type/status filtering, and RetrievalResult shaping.
  */
+import { createHash } from 'node:crypto';
+
 import { eq } from 'drizzle-orm';
 
 import {
@@ -13,9 +15,9 @@ import {
   tvShows,
 } from '@pops/db-types';
 
-import { getDb } from '../../../db.js';
-import { isVecAvailable } from '../../../db.js';
+import { getDb, isVecAvailable } from '../../../db.js';
 import { getEmbedding, getEmbeddingConfig } from '../../../shared/embedding-client.js';
+import { getRedis, isRedisAvailable, redisKey } from '../../../shared/redis-client.js';
 
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
@@ -23,6 +25,7 @@ import type { RetrievalFilters, RetrievalResult } from './types.js';
 
 const DEFAULT_LIMIT = 20;
 const DEFAULT_THRESHOLD = 0.8;
+const QUERY_CACHE_TTL_SECONDS = 300; // 5 minutes
 
 function vecUnavailableError(): Error {
   return Object.assign(new Error('Vector features unavailable: sqlite-vec extension not loaded'), {
@@ -51,6 +54,24 @@ function isSecretScope(scope: string): boolean {
   return scope.split('.').includes('secret');
 }
 
+/** Embed a query string, using Redis to cache repeated identical queries. */
+async function embedQuery(query: string): Promise<number[]> {
+  const config = getEmbeddingConfig();
+  const queryHash = createHash('sha256').update(query.trim()).digest('hex');
+  const cacheKey = redisKey('query_vec', queryHash);
+
+  const redis = getRedis();
+  if (isRedisAvailable() && redis) {
+    const cached = await redis.get(cacheKey);
+    if (cached) return JSON.parse(cached) as number[];
+    const vector = await getEmbedding(query, config);
+    await redis.set(cacheKey, JSON.stringify(vector), 'EX', QUERY_CACHE_TTL_SECONDS);
+    return vector;
+  }
+
+  return getEmbedding(query, config);
+}
+
 export class SemanticSearchService {
   constructor(private readonly db: BetterSQLite3Database) {}
 
@@ -67,11 +88,10 @@ export class SemanticSearchService {
     }
     if (!isVecAvailable()) throw vecUnavailableError();
 
-    const config = getEmbeddingConfig();
-    const queryVector = await getEmbedding(query, config);
+    const queryVector = await embedQuery(query);
     const vectorBlob = Float32Array.from(queryVector);
 
-    // Fetch more candidates than requested so we can filter and still hit the limit.
+    // Over-fetch so post-filtering still hits the limit.
     const fetchLimit = limit * 3;
 
     const rawDb = getDb();
@@ -104,7 +124,7 @@ export class SemanticSearchService {
     // Apply distance threshold.
     const candidates = rows.filter((r) => r.distance <= threshold);
 
-    // Resolve metadata and apply filters, deduplicating by sourceId (keep best chunk).
+    // Deduplicate by sourceId — keep the closest chunk per source.
     const seen = new Map<string, (typeof candidates)[number]>();
     for (const row of candidates) {
       const key = `${row.source_type}:${row.source_id}`;
@@ -117,7 +137,7 @@ export class SemanticSearchService {
       if (filters.sourceTypes && !filters.sourceTypes.includes(row.source_type)) continue;
 
       const metadata = await this.resolveMetadata(row.source_type, row.source_id, filters);
-      if (!metadata) continue; // orphaned or filtered out
+      if (!metadata) continue; // orphaned, secret-scoped, or filtered out
 
       results.push({
         sourceType: row.source_type,
@@ -127,7 +147,10 @@ export class SemanticSearchService {
         score: Math.max(0, 1 - row.distance),
         distance: row.distance,
         matchType: 'semantic',
-        metadata: metadata.fields,
+        metadata: {
+          ...metadata.fields,
+          contentHash: row.content_hash,
+        },
       });
 
       if (results.length >= limit) break;
@@ -137,7 +160,7 @@ export class SemanticSearchService {
   }
 
   /**
-   * Run a k-NN search using an existing vector (by embeddings.id = rowid).
+   * Run a k-NN search using an existing vector blob (read from embeddings_vec).
    * Used by the `similar` endpoint — no embedding API call needed.
    */
   async searchByVector(
@@ -202,7 +225,10 @@ export class SemanticSearchService {
         score: Math.max(0, 1 - row.distance),
         distance: row.distance,
         matchType: 'semantic',
-        metadata: metadata.fields,
+        metadata: {
+          ...metadata.fields,
+          contentHash: row.content_hash,
+        },
       });
 
       if (results.length >= limit) break;
@@ -241,6 +267,16 @@ export class SemanticSearchService {
       const row = rows[0];
       if (!row || row.status === 'orphaned') return null;
 
+      // Apply type filter.
+      if (filters.types && filters.types.length > 0 && !filters.types.includes(row.type)) {
+        return null;
+      }
+
+      // Apply status filter (when explicitly set — orphaned is excluded by default above).
+      if (filters.status && filters.status.length > 0 && !filters.status.includes(row.status)) {
+        return null;
+      }
+
       // Apply scope filter and secret exclusion.
       const scopes = this.db
         .select({ scope: engramScopes.scope })
@@ -273,7 +309,7 @@ export class SemanticSearchService {
       };
     }
 
-    // Cross-source domain rows — scope filter does not apply.
+    // Cross-source domain rows — scope/type/status filters do not apply.
     const domainRow = this.fetchDomainRow(sourceType, sourceId);
     if (!domainRow) return null;
 

--- a/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search.ts
@@ -1,0 +1,318 @@
+/**
+ * SemanticSearchService — wraps core semanticSearch with Thalamus metadata
+ * resolution, scope filtering, and RetrievalResult shaping.
+ */
+import { eq } from 'drizzle-orm';
+
+import {
+  engramIndex,
+  engramScopes,
+  homeInventory,
+  movies,
+  transactions,
+  tvShows,
+} from '@pops/db-types';
+
+import { getDb } from '../../../db.js';
+import { isVecAvailable } from '../../../db.js';
+import { getEmbedding, getEmbeddingConfig } from '../../../shared/embedding-client.js';
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+import type { RetrievalFilters, RetrievalResult } from './types.js';
+
+const DEFAULT_LIMIT = 20;
+const DEFAULT_THRESHOLD = 0.8;
+
+function vecUnavailableError(): Error {
+  return Object.assign(new Error('Vector features unavailable: sqlite-vec extension not loaded'), {
+    code: 'VEC_UNAVAILABLE',
+  });
+}
+
+/** Derive a human-readable title for a non-engram source row. */
+function crossSourceTitle(sourceType: string, row: Record<string, unknown>): string {
+  switch (sourceType) {
+    case 'transaction':
+      return (row['description'] as string | undefined) ?? 'Transaction';
+    case 'movie':
+      return (row['title'] as string | undefined) ?? 'Movie';
+    case 'tv_show':
+      return (row['name'] as string | undefined) ?? 'TV Show';
+    case 'inventory':
+      return (row['itemName'] as string | undefined) ?? 'Inventory item';
+    default:
+      return sourceType;
+  }
+}
+
+/** Check if a scope contains a secret segment. */
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+export class SemanticSearchService {
+  constructor(private readonly db: BetterSQLite3Database) {}
+
+  async search(
+    query: string,
+    filters: RetrievalFilters = {},
+    limit = DEFAULT_LIMIT,
+    threshold = DEFAULT_THRESHOLD
+  ): Promise<RetrievalResult[]> {
+    if (!query.trim()) {
+      throw Object.assign(new Error('Query is required for semantic search'), {
+        code: 'EMPTY_QUERY',
+      });
+    }
+    if (!isVecAvailable()) throw vecUnavailableError();
+
+    const config = getEmbeddingConfig();
+    const queryVector = await getEmbedding(query, config);
+    const vectorBlob = Float32Array.from(queryVector);
+
+    // Fetch more candidates than requested so we can filter and still hit the limit.
+    const fetchLimit = limit * 3;
+
+    const rawDb = getDb();
+    const rows = rawDb
+      .prepare(
+        `
+        SELECT
+          e.source_type,
+          e.source_id,
+          e.chunk_index,
+          e.content_preview,
+          e.content_hash,
+          ev.distance
+        FROM embeddings_vec ev
+        JOIN embeddings e ON e.id = ev.rowid
+        WHERE ev.vector MATCH ?
+          AND ev.k = ?
+        ORDER BY ev.distance
+      `
+      )
+      .all(vectorBlob, fetchLimit) as {
+      source_type: string;
+      source_id: string;
+      chunk_index: number;
+      content_preview: string;
+      content_hash: string;
+      distance: number;
+    }[];
+
+    // Apply distance threshold.
+    const candidates = rows.filter((r) => r.distance <= threshold);
+
+    // Resolve metadata and apply filters, deduplicating by sourceId (keep best chunk).
+    const seen = new Map<string, (typeof candidates)[number]>();
+    for (const row of candidates) {
+      const key = `${row.source_type}:${row.source_id}`;
+      if (!seen.has(key)) seen.set(key, row);
+    }
+
+    const results: RetrievalResult[] = [];
+
+    for (const [, row] of seen) {
+      if (filters.sourceTypes && !filters.sourceTypes.includes(row.source_type)) continue;
+
+      const metadata = await this.resolveMetadata(row.source_type, row.source_id, filters);
+      if (!metadata) continue; // orphaned or filtered out
+
+      results.push({
+        sourceType: row.source_type,
+        sourceId: row.source_id,
+        title: metadata.title,
+        contentPreview: row.content_preview.slice(0, 200),
+        score: Math.max(0, 1 - row.distance),
+        distance: row.distance,
+        matchType: 'semantic',
+        metadata: metadata.fields,
+      });
+
+      if (results.length >= limit) break;
+    }
+
+    return results;
+  }
+
+  /**
+   * Run a k-NN search using an existing vector (by embeddings.id = rowid).
+   * Used by the `similar` endpoint — no embedding API call needed.
+   */
+  async searchByVector(
+    vectorBlob: Float32Array,
+    sourceIdToExclude: string,
+    filters: RetrievalFilters = {},
+    limit = DEFAULT_LIMIT,
+    threshold = DEFAULT_THRESHOLD
+  ): Promise<RetrievalResult[]> {
+    if (!isVecAvailable()) throw vecUnavailableError();
+
+    const rawDb = getDb();
+    const fetchLimit = limit * 3;
+
+    const rows = rawDb
+      .prepare(
+        `
+        SELECT
+          e.source_type,
+          e.source_id,
+          e.chunk_index,
+          e.content_preview,
+          e.content_hash,
+          ev.distance
+        FROM embeddings_vec ev
+        JOIN embeddings e ON e.id = ev.rowid
+        WHERE ev.vector MATCH ?
+          AND ev.k = ?
+        ORDER BY ev.distance
+      `
+      )
+      .all(vectorBlob, fetchLimit) as {
+      source_type: string;
+      source_id: string;
+      chunk_index: number;
+      content_preview: string;
+      content_hash: string;
+      distance: number;
+    }[];
+
+    const candidates = rows.filter(
+      (r) => r.distance <= threshold && r.source_id !== sourceIdToExclude
+    );
+
+    const seen = new Map<string, (typeof candidates)[number]>();
+    for (const row of candidates) {
+      const key = `${row.source_type}:${row.source_id}`;
+      if (!seen.has(key)) seen.set(key, row);
+    }
+
+    const results: RetrievalResult[] = [];
+    for (const [, row] of seen) {
+      if (filters.sourceTypes && !filters.sourceTypes.includes(row.source_type)) continue;
+      const metadata = await this.resolveMetadata(row.source_type, row.source_id, filters);
+      if (!metadata) continue;
+
+      results.push({
+        sourceType: row.source_type,
+        sourceId: row.source_id,
+        title: metadata.title,
+        contentPreview: row.content_preview.slice(0, 200),
+        score: Math.max(0, 1 - row.distance),
+        distance: row.distance,
+        matchType: 'semantic',
+        metadata: metadata.fields,
+      });
+
+      if (results.length >= limit) break;
+    }
+
+    return results;
+  }
+
+  /** Retrieve the embedding vector blob for an engram by its source ID. */
+  getVectorForEngram(engramId: string): Float32Array | null {
+    const rawDb = getDb();
+    const row = rawDb
+      .prepare(
+        `
+        SELECT ev.vector
+        FROM embeddings_vec ev
+        JOIN embeddings e ON e.id = ev.rowid
+        WHERE e.source_type = 'engram' AND e.source_id = ?
+        ORDER BY e.chunk_index
+        LIMIT 1
+      `
+      )
+      .get(engramId) as { vector: Buffer } | undefined;
+
+    if (!row) return null;
+    return new Float32Array(row.vector.buffer, row.vector.byteOffset, row.vector.byteLength / 4);
+  }
+
+  private async resolveMetadata(
+    sourceType: string,
+    sourceId: string,
+    filters: RetrievalFilters
+  ): Promise<{ title: string; fields: Record<string, unknown> } | null> {
+    if (sourceType === 'engram') {
+      const rows = this.db.select().from(engramIndex).where(eq(engramIndex.id, sourceId)).all();
+      const row = rows[0];
+      if (!row || row.status === 'orphaned') return null;
+
+      // Apply scope filter and secret exclusion.
+      const scopes = this.db
+        .select({ scope: engramScopes.scope })
+        .from(engramScopes)
+        .where(eq(engramScopes.engramId, sourceId))
+        .all()
+        .map((s) => s.scope);
+
+      if (!filters.includeSecret && scopes.some(isSecretScope)) return null;
+
+      if (filters.scopes && filters.scopes.length > 0) {
+        const scopeFilters = filters.scopes;
+        const matchesScope = scopes.some((s) =>
+          scopeFilters.some((f) => s === f || s.startsWith(f + '.'))
+        );
+        if (!matchesScope) return null;
+      }
+
+      return {
+        title: row.title,
+        fields: {
+          type: row.type,
+          source: row.source,
+          status: row.status,
+          scopes,
+          createdAt: row.createdAt,
+          modifiedAt: row.modifiedAt,
+          wordCount: row.wordCount,
+        },
+      };
+    }
+
+    // Cross-source domain rows — scope filter does not apply.
+    const domainRow = this.fetchDomainRow(sourceType, sourceId);
+    if (!domainRow) return null;
+
+    const title = crossSourceTitle(sourceType, domainRow);
+    return { title, fields: domainRow };
+  }
+
+  private fetchDomainRow(sourceType: string, sourceId: string): Record<string, unknown> | null {
+    switch (sourceType) {
+      case 'transaction': {
+        const rows = this.db.select().from(transactions).where(eq(transactions.id, sourceId)).all();
+        return (rows[0] as Record<string, unknown> | undefined) ?? null;
+      }
+      case 'movie': {
+        const rows = this.db
+          .select()
+          .from(movies)
+          .where(eq(movies.id, Number(sourceId)))
+          .all();
+        return (rows[0] as Record<string, unknown> | undefined) ?? null;
+      }
+      case 'tv_show': {
+        const rows = this.db
+          .select()
+          .from(tvShows)
+          .where(eq(tvShows.id, Number(sourceId)))
+          .all();
+        return (rows[0] as Record<string, unknown> | undefined) ?? null;
+      }
+      case 'inventory': {
+        const rows = this.db
+          .select()
+          .from(homeInventory)
+          .where(eq(homeInventory.id, sourceId))
+          .all();
+        return (rows[0] as Record<string, unknown> | undefined) ?? null;
+      }
+      default:
+        return null;
+    }
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/retrieval/structured-query.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/structured-query.test.ts
@@ -1,0 +1,193 @@
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createTestDb } from '../../../shared/test-utils.js';
+import { StructuredQueryService } from './structured-query.js';
+
+import type { Database } from 'better-sqlite3';
+
+function seedEngram(
+  db: Database,
+  opts: {
+    id: string;
+    title?: string;
+    type?: string;
+    status?: string;
+    created_at?: string;
+    modified_at?: string;
+    content_hash?: string;
+    scopes?: string[];
+    tags?: string[];
+    preview?: string;
+  }
+): void {
+  db.prepare(
+    `INSERT INTO engram_index (id, file_path, type, source, status, created_at, modified_at, title, content_hash, word_count)
+     VALUES (@id, @file_path, @type, @source, @status, @created_at, @modified_at, @title, @content_hash, @word_count)`
+  ).run({
+    id: opts.id,
+    file_path: `note/${opts.id}.md`,
+    type: opts.type ?? 'note',
+    source: 'manual',
+    status: opts.status ?? 'active',
+    created_at: opts.created_at ?? '2026-01-01T00:00:00Z',
+    modified_at: opts.modified_at ?? '2026-01-01T00:00:00Z',
+    title: opts.title ?? `Engram ${opts.id}`,
+    content_hash: opts.content_hash ?? `hash_${opts.id}`,
+    word_count: 10,
+  });
+
+  for (const scope of opts.scopes ?? []) {
+    db.prepare(`INSERT INTO engram_scopes (engram_id, scope) VALUES (?, ?)`).run(opts.id, scope);
+  }
+
+  for (const tag of opts.tags ?? []) {
+    db.prepare(`INSERT INTO engram_tags (engram_id, tag) VALUES (?, ?)`).run(opts.id, tag);
+  }
+
+  if (opts.preview) {
+    db.prepare(
+      `INSERT INTO embeddings (source_type, source_id, chunk_index, content_preview, content_hash)
+       VALUES ('engram', ?, 0, ?, ?)`
+    ).run(opts.id, opts.preview, opts.content_hash ?? `hash_${opts.id}`);
+  }
+}
+
+describe('StructuredQueryService', () => {
+  let db: Database;
+  let svc: StructuredQueryService;
+
+  beforeEach(() => {
+    db = createTestDb();
+    svc = new StructuredQueryService(drizzle(db));
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('returns empty array when sourceTypes excludes engram', () => {
+    seedEngram(db, { id: 'e1' });
+    expect(svc.query({ sourceTypes: ['movie'] })).toHaveLength(0);
+  });
+
+  it('returns all active engrams with no filters', () => {
+    seedEngram(db, { id: 'e1' });
+    seedEngram(db, { id: 'e2' });
+    expect(svc.query({})).toHaveLength(2);
+  });
+
+  it('excludes orphaned engrams by default', () => {
+    seedEngram(db, { id: 'e1', status: 'active' });
+    seedEngram(db, { id: 'e2', status: 'orphaned' });
+    const ids = svc.query({}).map((r) => r.sourceId);
+    expect(ids).toContain('e1');
+    expect(ids).not.toContain('e2');
+  });
+
+  it('includes only the requested status when status filter is set', () => {
+    seedEngram(db, { id: 'e1', status: 'active' });
+    seedEngram(db, { id: 'e2', status: 'archived' });
+    seedEngram(db, { id: 'e3', status: 'orphaned' });
+    const ids = svc.query({ status: ['archived'] }).map((r) => r.sourceId);
+    expect(ids).toEqual(['e2']);
+  });
+
+  it('filters by type', () => {
+    seedEngram(db, { id: 'e1', type: 'note' });
+    seedEngram(db, { id: 'e2', type: 'project' });
+    const ids = svc.query({ types: ['note'] }).map((r) => r.sourceId);
+    expect(ids).toEqual(['e1']);
+  });
+
+  it('filters by scope with prefix matching', () => {
+    seedEngram(db, { id: 'e1', scopes: ['personal.notes'] });
+    seedEngram(db, { id: 'e2', scopes: ['work.projects'] });
+    const ids = svc.query({ scopes: ['personal'] }).map((r) => r.sourceId);
+    expect(ids).toEqual(['e1']);
+  });
+
+  it('matches exact scope when no children exist', () => {
+    seedEngram(db, { id: 'e1', scopes: ['personal'] });
+    seedEngram(db, { id: 'e2', scopes: ['work'] });
+    const ids = svc.query({ scopes: ['personal'] }).map((r) => r.sourceId);
+    expect(ids).toEqual(['e1']);
+  });
+
+  it('excludes secret-scoped engrams by default', () => {
+    seedEngram(db, { id: 'e1', scopes: ['personal'] });
+    seedEngram(db, { id: 'e2', scopes: ['personal.secret'] });
+    seedEngram(db, { id: 'e3', scopes: ['secret.notes'] });
+    const ids = svc.query({}).map((r) => r.sourceId);
+    expect(ids).toContain('e1');
+    expect(ids).not.toContain('e2');
+    expect(ids).not.toContain('e3');
+  });
+
+  it('includes secret-scoped engrams when includeSecret is true', () => {
+    seedEngram(db, { id: 'e1', scopes: ['personal'] });
+    seedEngram(db, { id: 'e2', scopes: ['personal.secret'] });
+    expect(svc.query({ includeSecret: true })).toHaveLength(2);
+  });
+
+  it('applies tag AND semantics — all tags must be present', () => {
+    seedEngram(db, { id: 'e1', tags: ['alpha', 'beta'] });
+    seedEngram(db, { id: 'e2', tags: ['alpha'] });
+    seedEngram(db, { id: 'e3', tags: ['beta'] });
+    const ids = svc.query({ tags: ['alpha', 'beta'] }).map((r) => r.sourceId);
+    expect(ids).toEqual(['e1']);
+  });
+
+  it('filters by date range (from)', () => {
+    seedEngram(db, { id: 'e1', created_at: '2026-03-01T00:00:00Z' });
+    seedEngram(db, { id: 'e2', created_at: '2026-01-01T00:00:00Z' });
+    const ids = svc.query({ dateRange: { from: '2026-02-01T00:00:00Z' } }).map((r) => r.sourceId);
+    expect(ids).toContain('e1');
+    expect(ids).not.toContain('e2');
+  });
+
+  it('filters by date range (to)', () => {
+    seedEngram(db, { id: 'e1', created_at: '2026-01-01T00:00:00Z' });
+    seedEngram(db, { id: 'e2', created_at: '2026-03-01T00:00:00Z' });
+    const ids = svc.query({ dateRange: { to: '2026-02-01T00:00:00Z' } }).map((r) => r.sourceId);
+    expect(ids).toContain('e1');
+    expect(ids).not.toContain('e2');
+  });
+
+  it('paginates with limit and offset ordered by modified_at desc', () => {
+    seedEngram(db, { id: 'e1', modified_at: '2026-01-03T00:00:00Z' });
+    seedEngram(db, { id: 'e2', modified_at: '2026-01-02T00:00:00Z' });
+    seedEngram(db, { id: 'e3', modified_at: '2026-01-01T00:00:00Z' });
+    const page1 = svc.query({}, 2, 0).map((r) => r.sourceId);
+    const page2 = svc.query({}, 2, 2).map((r) => r.sourceId);
+    expect(page1).toEqual(['e1', 'e2']);
+    expect(page2).toEqual(['e3']);
+  });
+
+  it('populates scopes and tags in result metadata', () => {
+    seedEngram(db, { id: 'e1', scopes: ['home', 'home.living'], tags: ['important', 'todo'] });
+    const [result] = svc.query({});
+    expect(result?.metadata['scopes']).toEqual(expect.arrayContaining(['home', 'home.living']));
+    expect(result?.metadata['tags']).toEqual(expect.arrayContaining(['important', 'todo']));
+  });
+
+  it('populates contentPreview from embeddings when available', () => {
+    seedEngram(db, { id: 'e1', preview: 'This is the preview text.' });
+    const [result] = svc.query({});
+    expect(result?.contentPreview).toBe('This is the preview text.');
+  });
+
+  it('falls back to empty contentPreview when no embedding row', () => {
+    seedEngram(db, { id: 'e1' }); // no preview seeded
+    const [result] = svc.query({});
+    expect(result?.contentPreview).toBe('');
+  });
+
+  it('all results have matchType structured and score 1', () => {
+    seedEngram(db, { id: 'e1' });
+    const [result] = svc.query({});
+    expect(result?.matchType).toBe('structured');
+    expect(result?.score).toBe(1);
+    expect(result?.sourceType).toBe('engram');
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/retrieval/structured-query.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/structured-query.ts
@@ -1,10 +1,14 @@
 /**
  * StructuredQueryService — filters engram_index and junction tables using
  * parameterised SQL. Returns RetrievalResult[] with matchType: 'structured'.
+ *
+ * Scope/tag/secret filtering is pushed into SQL (EXISTS/COUNT subqueries).
+ * Pagination is SQL-side. Junction tables and embeddings are batch-prefetched
+ * for the result page to avoid N+1 queries.
  */
 import { and, desc, eq, gte, inArray, lte, ne, sql } from 'drizzle-orm';
 
-import { engramIndex, engramScopes, engramTags } from '@pops/db-types';
+import { embeddings, engramIndex, engramScopes, engramTags } from '@pops/db-types';
 
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
@@ -13,23 +17,19 @@ import type { RetrievalFilters, RetrievalResult } from './types.js';
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
 
-/** Check if a scope contains a secret segment. */
-function isSecretScope(scope: string): boolean {
-  return scope.split('.').includes('secret');
-}
-
 export class StructuredQueryService {
   constructor(private readonly db: BetterSQLite3Database) {}
 
   query(filters: RetrievalFilters, limit = DEFAULT_LIMIT, offset = 0): RetrievalResult[] {
-    const cappedLimit = Math.min(limit, MAX_LIMIT);
+    // Structured search only ever returns engrams — skip if caller excluded them.
+    if (filters.sourceTypes && !filters.sourceTypes.includes('engram')) return [];
 
-    // Build conditions list.
+    const cappedLimit = Math.min(limit, MAX_LIMIT);
     const conditions = [ne(engramIndex.status, 'orphaned')];
 
     if (filters.status && filters.status.length > 0) {
-      // If caller explicitly asks for orphaned, allow it.
-      conditions.splice(0, 1); // remove the default exclusion
+      // Caller explicitly requests certain statuses — replace default orphan exclusion.
+      conditions.splice(0, 1);
       conditions.push(inArray(engramIndex.status, filters.status));
     }
 
@@ -44,93 +44,130 @@ export class StructuredQueryService {
       conditions.push(lte(engramIndex.createdAt, filters.dateRange.to));
     }
 
-    // Custom field filter via json_extract.
     if (filters.customFields) {
       for (const [key, value] of Object.entries(filters.customFields)) {
         conditions.push(sql`json_extract(${engramIndex.customFields}, ${`$.${key}`}) = ${value}`);
       }
     }
 
-    // Run main query.
-    let rows = this.db
+    // Secret-scope exclusion via NOT EXISTS — no in-memory pass needed.
+    if (!filters.includeSecret) {
+      conditions.push(sql`not exists (
+        select 1 from ${engramScopes}
+        where ${engramScopes.engramId} = ${engramIndex.id}
+          and (
+            ${engramScopes.scope} = 'secret'
+            or ${engramScopes.scope} like '%.secret.%'
+            or ${engramScopes.scope} like 'secret.%'
+            or ${engramScopes.scope} like '%.secret'
+          )
+      )`);
+    }
+
+    // Scope prefix filter via EXISTS — any matching scope passes.
+    const scopeFilters = filters.scopes;
+    if (scopeFilters && scopeFilters.length > 0) {
+      const scopePredicates = scopeFilters.map((f) => {
+        const prefix = `${f}.%`;
+        return sql`(${engramScopes.scope} = ${f} or ${engramScopes.scope} like ${prefix})`;
+      });
+      conditions.push(sql`exists (
+        select 1 from ${engramScopes}
+        where ${engramScopes.engramId} = ${engramIndex.id}
+          and (${sql.join(scopePredicates, sql` or `)})
+      )`);
+    }
+
+    // Tag AND-filter via COUNT subquery — all required tags must be present.
+    const tagFilters = filters.tags ? [...new Set(filters.tags)] : undefined;
+    if (tagFilters && tagFilters.length > 0) {
+      const tagParams = tagFilters.map((t) => sql`${t}`);
+      conditions.push(sql`(
+        select count(distinct ${engramTags.tag})
+        from ${engramTags}
+        where ${engramTags.engramId} = ${engramIndex.id}
+          and ${engramTags.tag} in (${sql.join(tagParams, sql`, `)})
+      ) = ${tagFilters.length}`);
+    }
+
+    // SQL-side pagination — no full table scan.
+    const rows = this.db
       .select()
       .from(engramIndex)
       .where(and(...conditions))
       .orderBy(desc(engramIndex.modifiedAt))
+      .limit(cappedLimit)
+      .offset(offset)
       .all();
 
-    // Apply scope-based filtering in-memory (requires junction table).
-    const scopeFilters = filters.scopes;
-    if ((scopeFilters && scopeFilters.length > 0) || !filters.includeSecret) {
-      rows = rows.filter((row) => {
-        const scopes = this.db
-          .select({ scope: engramScopes.scope })
-          .from(engramScopes)
-          .where(eq(engramScopes.engramId, row.id))
-          .all()
-          .map((s) => s.scope);
+    if (rows.length === 0) return [];
 
-        if (!filters.includeSecret && scopes.some(isSecretScope)) return false;
+    // Batch-prefetch junction tables and embedding previews for the page.
+    const rowIds = rows.map((r) => r.id);
 
-        if (scopeFilters && scopeFilters.length > 0) {
-          return scopes.some((s) => scopeFilters.some((f) => s === f || s.startsWith(f + '.')));
-        }
+    const scopeRows = this.db
+      .select({ engramId: engramScopes.engramId, scope: engramScopes.scope })
+      .from(engramScopes)
+      .where(inArray(engramScopes.engramId, rowIds))
+      .all();
 
-        return true;
-      });
+    const tagRows = this.db
+      .select({ engramId: engramTags.engramId, tag: engramTags.tag })
+      .from(engramTags)
+      .where(inArray(engramTags.engramId, rowIds))
+      .all();
+
+    const previewRows = this.db
+      .select({ sourceId: embeddings.sourceId, contentPreview: embeddings.contentPreview })
+      .from(embeddings)
+      .where(
+        and(
+          eq(embeddings.sourceType, 'engram'),
+          inArray(embeddings.sourceId, rowIds),
+          eq(embeddings.chunkIndex, 0)
+        )
+      )
+      .all();
+
+    // Build lookup maps from batch results.
+    const scopesByEngramId = new Map<string, string[]>();
+    for (const { engramId, scope } of scopeRows) {
+      const arr = scopesByEngramId.get(engramId);
+      if (arr) arr.push(scope);
+      else scopesByEngramId.set(engramId, [scope]);
     }
 
-    // Apply tag AND-filter in-memory.
-    const tagFilters = filters.tags;
-    if (tagFilters && tagFilters.length > 0) {
-      rows = rows.filter((row) => {
-        const tags = this.db
-          .select({ tag: engramTags.tag })
-          .from(engramTags)
-          .where(eq(engramTags.engramId, row.id))
-          .all()
-          .map((t) => t.tag);
-        return tagFilters.every((required) => tags.includes(required));
-      });
+    const tagsByEngramId = new Map<string, string[]>();
+    for (const { engramId, tag } of tagRows) {
+      const arr = tagsByEngramId.get(engramId);
+      if (arr) arr.push(tag);
+      else tagsByEngramId.set(engramId, [tag]);
     }
 
-    // Paginate and shape.
-    const page = rows.slice(offset, offset + cappedLimit);
+    const previewByEngramId = new Map<string, string>();
+    for (const { sourceId, contentPreview } of previewRows) {
+      previewByEngramId.set(sourceId, contentPreview);
+    }
 
-    return page.map((row) => {
-      const scopes = this.db
-        .select({ scope: engramScopes.scope })
-        .from(engramScopes)
-        .where(eq(engramScopes.engramId, row.id))
-        .all()
-        .map((s) => s.scope);
-
-      const tags = this.db
-        .select({ tag: engramTags.tag })
-        .from(engramTags)
-        .where(eq(engramTags.engramId, row.id))
-        .all()
-        .map((t) => t.tag);
-
-      return {
-        sourceType: 'engram',
-        sourceId: row.id,
-        title: row.title,
-        contentPreview: '',
-        score: 1,
-        matchType: 'structured' as const,
-        metadata: {
-          type: row.type,
-          source: row.source,
-          status: row.status,
-          scopes,
-          tags,
-          createdAt: row.createdAt,
-          modifiedAt: row.modifiedAt,
-          wordCount: row.wordCount,
-          customFields: row.customFields,
-        },
-      };
-    });
+    return rows.map((row) => ({
+      sourceType: 'engram',
+      sourceId: row.id,
+      title: row.title,
+      contentPreview: previewByEngramId.get(row.id) ?? '',
+      score: 1,
+      matchType: 'structured' as const,
+      metadata: {
+        type: row.type,
+        source: row.source,
+        status: row.status,
+        scopes: scopesByEngramId.get(row.id) ?? [],
+        tags: tagsByEngramId.get(row.id) ?? [],
+        createdAt: row.createdAt,
+        modifiedAt: row.modifiedAt,
+        wordCount: row.wordCount,
+        customFields: row.customFields,
+        contentHash: row.contentHash,
+      },
+    }));
   }
 }

--- a/apps/pops-api/src/modules/cerebrum/retrieval/structured-query.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/structured-query.ts
@@ -1,0 +1,136 @@
+/**
+ * StructuredQueryService — filters engram_index and junction tables using
+ * parameterised SQL. Returns RetrievalResult[] with matchType: 'structured'.
+ */
+import { and, desc, eq, gte, inArray, lte, ne, sql } from 'drizzle-orm';
+
+import { engramIndex, engramScopes, engramTags } from '@pops/db-types';
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+import type { RetrievalFilters, RetrievalResult } from './types.js';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+/** Check if a scope contains a secret segment. */
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+export class StructuredQueryService {
+  constructor(private readonly db: BetterSQLite3Database) {}
+
+  query(filters: RetrievalFilters, limit = DEFAULT_LIMIT, offset = 0): RetrievalResult[] {
+    const cappedLimit = Math.min(limit, MAX_LIMIT);
+
+    // Build conditions list.
+    const conditions = [ne(engramIndex.status, 'orphaned')];
+
+    if (filters.status && filters.status.length > 0) {
+      // If caller explicitly asks for orphaned, allow it.
+      conditions.splice(0, 1); // remove the default exclusion
+      conditions.push(inArray(engramIndex.status, filters.status));
+    }
+
+    if (filters.types && filters.types.length > 0) {
+      conditions.push(inArray(engramIndex.type, filters.types));
+    }
+
+    if (filters.dateRange?.from) {
+      conditions.push(gte(engramIndex.createdAt, filters.dateRange.from));
+    }
+    if (filters.dateRange?.to) {
+      conditions.push(lte(engramIndex.createdAt, filters.dateRange.to));
+    }
+
+    // Custom field filter via json_extract.
+    if (filters.customFields) {
+      for (const [key, value] of Object.entries(filters.customFields)) {
+        conditions.push(sql`json_extract(${engramIndex.customFields}, ${`$.${key}`}) = ${value}`);
+      }
+    }
+
+    // Run main query.
+    let rows = this.db
+      .select()
+      .from(engramIndex)
+      .where(and(...conditions))
+      .orderBy(desc(engramIndex.modifiedAt))
+      .all();
+
+    // Apply scope-based filtering in-memory (requires junction table).
+    const scopeFilters = filters.scopes;
+    if ((scopeFilters && scopeFilters.length > 0) || !filters.includeSecret) {
+      rows = rows.filter((row) => {
+        const scopes = this.db
+          .select({ scope: engramScopes.scope })
+          .from(engramScopes)
+          .where(eq(engramScopes.engramId, row.id))
+          .all()
+          .map((s) => s.scope);
+
+        if (!filters.includeSecret && scopes.some(isSecretScope)) return false;
+
+        if (scopeFilters && scopeFilters.length > 0) {
+          return scopes.some((s) => scopeFilters.some((f) => s === f || s.startsWith(f + '.')));
+        }
+
+        return true;
+      });
+    }
+
+    // Apply tag AND-filter in-memory.
+    const tagFilters = filters.tags;
+    if (tagFilters && tagFilters.length > 0) {
+      rows = rows.filter((row) => {
+        const tags = this.db
+          .select({ tag: engramTags.tag })
+          .from(engramTags)
+          .where(eq(engramTags.engramId, row.id))
+          .all()
+          .map((t) => t.tag);
+        return tagFilters.every((required) => tags.includes(required));
+      });
+    }
+
+    // Paginate and shape.
+    const page = rows.slice(offset, offset + cappedLimit);
+
+    return page.map((row) => {
+      const scopes = this.db
+        .select({ scope: engramScopes.scope })
+        .from(engramScopes)
+        .where(eq(engramScopes.engramId, row.id))
+        .all()
+        .map((s) => s.scope);
+
+      const tags = this.db
+        .select({ tag: engramTags.tag })
+        .from(engramTags)
+        .where(eq(engramTags.engramId, row.id))
+        .all()
+        .map((t) => t.tag);
+
+      return {
+        sourceType: 'engram',
+        sourceId: row.id,
+        title: row.title,
+        contentPreview: '',
+        score: 1,
+        matchType: 'structured' as const,
+        metadata: {
+          type: row.type,
+          source: row.source,
+          status: row.status,
+          scopes,
+          tags,
+          createdAt: row.createdAt,
+          modifiedAt: row.modifiedAt,
+          wordCount: row.wordCount,
+          customFields: row.customFields,
+        },
+      };
+    });
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/retrieval/types.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/types.ts
@@ -1,0 +1,29 @@
+export interface RetrievalResult {
+  sourceType: string;
+  sourceId: string;
+  title: string;
+  contentPreview: string;
+  score: number;
+  distance?: number;
+  matchType: 'semantic' | 'structured' | 'both';
+  metadata: Record<string, unknown>;
+}
+
+export interface SourceAttribution {
+  sourceType: string;
+  sourceId: string;
+  title: string;
+  relevanceScore: number;
+  chunkRange?: [number, number];
+}
+
+export interface RetrievalFilters {
+  types?: string[];
+  scopes?: string[];
+  tags?: string[];
+  dateRange?: { from?: string; to?: string };
+  status?: string[];
+  sourceTypes?: string[];
+  customFields?: Record<string, unknown>;
+  includeSecret?: boolean;
+}

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -580,6 +580,19 @@ export function createTestDb(): Database {
     CREATE UNIQUE INDEX IF NOT EXISTS uq_engram_links_pair ON engram_links(source_id, target_id);
     CREATE INDEX IF NOT EXISTS idx_engram_links_target ON engram_links(target_id);
 
+    CREATE TABLE IF NOT EXISTS embeddings (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_type   TEXT NOT NULL,
+      source_id     TEXT NOT NULL,
+      chunk_index   INTEGER NOT NULL DEFAULT 0,
+      content_preview TEXT NOT NULL DEFAULT '',
+      content_hash  TEXT NOT NULL DEFAULT '',
+      created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_embeddings_chunk
+      ON embeddings(source_type, source_id, chunk_index);
+    CREATE INDEX IF NOT EXISTS idx_embeddings_source ON embeddings(source_type, source_id);
+
     CREATE TABLE IF NOT EXISTS rotation_log (
       id                    INTEGER PRIMARY KEY AUTOINCREMENT,
       executed_at           TEXT    NOT NULL,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -126,12 +126,12 @@ Live status of every theme and epic. Updated as work completes.
 
 ### Cerebrum — Phase 1 (MVP)
 
-| Epic                          | Status      | Notes                                                                                                                         |
-| ----------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| Engram Storage (format, CRUD) | Done        | PRD-077 (format, templates, index schema, CRUD, tRPC, provisioning) + PRD-078 (scope model) complete                          |
-| Thalamus (indexing/retrieval) | Partial     | PRD-079 Done: file watcher, frontmatter sync, embedding trigger, cross-source indexer. PRD-080 (retrieval engine) not started |
-| Ingest (input pipeline)       | Not started | Manual, agent, capture channels + classification + scope inference                                                            |
-| Emit (output production)      | Not started | Query engine, document generation, proactive nudges                                                                           |
+| Epic                          | Status      | Notes                                                                                                         |
+| ----------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------- |
+| Engram Storage (format, CRUD) | Done        | PRD-077 (format, templates, index schema, CRUD, tRPC, provisioning) + PRD-078 (scope model) complete          |
+| Thalamus (indexing/retrieval) | Done        | PRD-079 (indexing/sync) + PRD-080 (retrieval engine: semantic, structured, hybrid, context assembly) complete |
+| Ingest (input pipeline)       | Not started | Manual, agent, capture channels + classification + scope inference                                            |
+| Emit (output production)      | Not started | Query engine, document generation, proactive nudges                                                           |
 
 ### Cerebrum — Phase 2 (Curation & Interface)
 

--- a/docs/themes/06-cerebrum/epics/01-thalamus.md
+++ b/docs/themes/06-cerebrum/epics/01-thalamus.md
@@ -8,10 +8,10 @@ Build the indexing and retrieval middleware that makes engrams queryable. Thalam
 
 ## PRDs
 
-| #   | PRD                                                             | Summary                                                                                        | Status      |
-| --- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------- |
-| 079 | [Engram Indexing & Sync](../prds/079-engram-indexing/README.md) | File watcher, frontmatter-to-SQLite sync, embedding trigger, cross-source indexing             | Done        |
-| 080 | [Retrieval Engine](../prds/080-retrieval-engine/README.md)      | Semantic search, structured queries, hybrid search, scope-filtered retrieval, context assembly | Not started |
+| #   | PRD                                                             | Summary                                                                                        | Status |
+| --- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------ |
+| 079 | [Engram Indexing & Sync](../prds/079-engram-indexing/README.md) | File watcher, frontmatter-to-SQLite sync, embedding trigger, cross-source indexing             | Done   |
+| 080 | [Retrieval Engine](../prds/080-retrieval-engine/README.md)      | Semantic search, structured queries, hybrid search, scope-filtered retrieval, context assembly | Done   |
 
 PRD-079 must complete before PRD-080 — the retrieval engine queries indexes that the sync system builds.
 

--- a/docs/themes/06-cerebrum/prds/080-retrieval-engine/README.md
+++ b/docs/themes/06-cerebrum/prds/080-retrieval-engine/README.md
@@ -1,7 +1,7 @@
 # PRD-080: Retrieval Engine
 
 > Epic: [01 — Thalamus](../../epics/01-thalamus.md)
-> Status: Not started
+> Status: Done
 
 ## Overview
 
@@ -57,12 +57,12 @@ Build the unified query layer that combines semantic search (vector k-NN via sql
 
 ## User Stories
 
-| #   | Story                                                   | Summary                                                                                  | Status      | Parallelisable          |
-| --- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------- | ----------------------- |
-| 01  | [us-01-semantic-search](us-01-semantic-search.md)       | Natural language query embedding and k-NN search with ranked results                     | Not started | No (first)              |
-| 02  | [us-02-structured-queries](us-02-structured-queries.md) | Filter engrams by type, scope, date range, tags, and custom fields via SQLite            | Not started | Yes                     |
-| 03  | [us-03-hybrid-search](us-03-hybrid-search.md)           | Combine semantic and structured search with reciprocal rank fusion                       | Not started | Blocked by us-01, us-02 |
-| 04  | [us-04-context-assembly](us-04-context-assembly.md)     | Assemble context windows for LLM consumption with token budgeting and source attribution | Not started | Blocked by us-03        |
+| #   | Story                                                   | Summary                                                                                  | Status | Parallelisable          |
+| --- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------ | ----------------------- |
+| 01  | [us-01-semantic-search](us-01-semantic-search.md)       | Natural language query embedding and k-NN search with ranked results                     | Done   | No (first)              |
+| 02  | [us-02-structured-queries](us-02-structured-queries.md) | Filter engrams by type, scope, date range, tags, and custom fields via SQLite            | Done   | Yes                     |
+| 03  | [us-03-hybrid-search](us-03-hybrid-search.md)           | Combine semantic and structured search with reciprocal rank fusion                       | Done   | Blocked by us-01, us-02 |
+| 04  | [us-04-context-assembly](us-04-context-assembly.md)     | Assemble context windows for LLM consumption with token budgeting and source attribution | Done   | Blocked by us-03        |
 
 US-01 and US-02 can parallelise. US-03 merges their outputs and requires both. US-04 builds on the unified search results from US-03.
 

--- a/docs/themes/06-cerebrum/prds/080-retrieval-engine/us-01-semantic-search.md
+++ b/docs/themes/06-cerebrum/prds/080-retrieval-engine/us-01-semantic-search.md
@@ -1,7 +1,7 @@
 # US-01: Semantic Search
 
 > PRD: [PRD-080: Retrieval Engine](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a system querying Thalamus, I want to submit a natural language query and rec
 
 ## Acceptance Criteria
 
-- [ ] A `SemanticSearchService` accepts a query string, embeds it using the same model and pipeline as content embeddings (PRD-076), and runs a k-NN query against the `embeddings_vec` virtual table
-- [ ] Results are returned as `RetrievalResult[]` ordered by ascending distance (closest = most relevant), including `sourceType`, `sourceId`, `title`, `contentPreview` (first 200 characters of the source content), `score` (normalised 0-1 where 1 is most relevant), and `distance` (raw cosine distance)
-- [ ] A configurable distance threshold (default 0.8) excludes results beyond the threshold — they are not included in the output
-- [ ] The `limit` parameter caps the number of results returned (default 20, max 100)
-- [ ] Results join back to `engram_index` (for engram sources) or the originating domain table (for cross-source data) to populate `title` and metadata
-- [ ] Orphaned index entries (`status: orphaned`) are excluded from results
-- [ ] An empty or whitespace-only query returns a validation error — no embedding API call is made
-- [ ] The query embedding is not persisted — it is used for the single k-NN query and discarded
+- [x] A `SemanticSearchService` accepts a query string, embeds it using the same model and pipeline as content embeddings (PRD-076), and runs a k-NN query against the `embeddings_vec` virtual table
+- [x] Results are returned as `RetrievalResult[]` ordered by ascending distance (closest = most relevant), including `sourceType`, `sourceId`, `title`, `contentPreview` (first 200 characters of the source content), `score` (normalised 0-1 where 1 is most relevant), and `distance` (raw cosine distance)
+- [x] A configurable distance threshold (default 0.8) excludes results beyond the threshold — they are not included in the output
+- [x] The `limit` parameter caps the number of results returned (default 20, max 100)
+- [x] Results join back to `engram_index` (for engram sources) or the originating domain table (for cross-source data) to populate `title` and metadata
+- [x] Orphaned index entries (`status: orphaned`) are excluded from results
+- [x] An empty or whitespace-only query returns a validation error — no embedding API call is made
+- [x] The query embedding is not persisted — it is used for the single k-NN query and discarded
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/080-retrieval-engine/us-02-structured-queries.md
+++ b/docs/themes/06-cerebrum/prds/080-retrieval-engine/us-02-structured-queries.md
@@ -1,7 +1,7 @@
 # US-02: Structured Queries
 
 > PRD: [PRD-080: Retrieval Engine](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a system querying Thalamus, I want to filter engrams by type, scope, date ran
 
 ## Acceptance Criteria
 
-- [ ] A `StructuredQueryService` accepts a filters object and builds a parameterised SQL query against `engram_index` and its junction tables (`engram_scopes`, `engram_tags`)
-- [ ] Supported filters: `types` (array of type strings, OR match), `scopes` (array of scope prefixes, OR match using `LIKE 'prefix%'`), `tags` (array of tag strings, AND match — engram must have all specified tags), `dateRange` (from/to ISO 8601 strings filtering on `created_at`), `status` (array of status strings, OR match), `customFields` (key-value pairs queried via `json_extract()` on the `custom_fields` column)
-- [ ] Scope filtering excludes engrams with any `.secret.` scope segment unless `filters.includeSecret` is explicitly `true`
-- [ ] Results are returned as `RetrievalResult[]` with `matchType: 'structured'`, ordered by `modified_at` descending by default
-- [ ] The `limit` parameter caps results (default 20, max 100); an `offset` parameter supports pagination
-- [ ] Results include full metadata from the index: `type`, `source`, `status`, `scopes` (from junction table), `tags` (from junction table), `created_at`, `modified_at`, `word_count`, and `custom_fields`
-- [ ] Orphaned index entries (`status: orphaned`) are excluded from results unless explicitly included via `status: ['orphaned']`
-- [ ] A query with no filters and no query text returns a validation error — at least one filter must be provided
+- [x] A `StructuredQueryService` accepts a filters object and builds a parameterised SQL query against `engram_index` and its junction tables (`engram_scopes`, `engram_tags`)
+- [x] Supported filters: `types` (array of type strings, OR match), `scopes` (array of scope prefixes, OR match using `LIKE 'prefix%'`), `tags` (array of tag strings, AND match — engram must have all specified tags), `dateRange` (from/to ISO 8601 strings filtering on `created_at`), `status` (array of status strings, OR match), `customFields` (key-value pairs queried via `json_extract()` on the `custom_fields` column)
+- [x] Scope filtering excludes engrams with any `.secret.` scope segment unless `filters.includeSecret` is explicitly `true`
+- [x] Results are returned as `RetrievalResult[]` with `matchType: 'structured'`, ordered by `modified_at` descending by default
+- [x] The `limit` parameter caps results (default 20, max 100); an `offset` parameter supports pagination
+- [x] Results include full metadata from the index: `type`, `source`, `status`, `scopes` (from junction table), `tags` (from junction table), `created_at`, `modified_at`, `word_count`, and `custom_fields`
+- [x] Orphaned index entries (`status: orphaned`) are excluded from results unless explicitly included via `status: ['orphaned']`
+- [x] A query with no filters and no query text returns a validation error — at least one filter must be provided
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/080-retrieval-engine/us-03-hybrid-search.md
+++ b/docs/themes/06-cerebrum/prds/080-retrieval-engine/us-03-hybrid-search.md
@@ -1,7 +1,7 @@
 # US-03: Hybrid Search
 
 > PRD: [PRD-080: Retrieval Engine](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,15 +9,15 @@ As a system querying Thalamus, I want to combine semantic similarity with struct
 
 ## Acceptance Criteria
 
-- [ ] A `HybridSearchService` orchestrates both semantic search (US-01) and structured queries (US-02) in parallel, then merges their results using reciprocal rank fusion (RRF)
-- [ ] RRF scoring: `score = sum(1 / (k + rank_i))` where `k = 60` (constant) and `rank_i` is the 1-based position in each result list — results appearing in both lists receive contributions from both ranks
-- [ ] Results appearing in both semantic and structured result sets are deduplicated into a single entry with `matchType: 'both'` and the RRF-computed score
-- [ ] Results appearing in only one set receive a score contribution from that set only, with `matchType` set to `'semantic'` or `'structured'` accordingly
-- [ ] The merged results are sorted by descending RRF score and capped at the requested `limit`
-- [ ] Structured filters (type, scope, tags, date range, status, custom fields) are applied to the structured query component; the semantic component searches without filters but results are intersected with filter criteria post-retrieval
-- [ ] Scope filtering with secret-scope exclusion applies to the final merged result set — a secret-scoped engram is excluded even if it ranks highly in the semantic component
-- [ ] The unified `cerebrum.retrieval.search` procedure routes to semantic-only, structured-only, or hybrid based on the `mode` parameter, defaulting to `hybrid`
-- [ ] The `cerebrum.retrieval.similar` procedure accepts an engram ID, retrieves its embedding vector, and runs a k-NN search without re-embedding — optional filters are applied post-retrieval
+- [x] A `HybridSearchService` orchestrates both semantic search (US-01) and structured queries (US-02) in parallel, then merges their results using reciprocal rank fusion (RRF)
+- [x] RRF scoring: `score = sum(1 / (k + rank_i))` where `k = 60` (constant) and `rank_i` is the 1-based position in each result list — results appearing in both lists receive contributions from both ranks
+- [x] Results appearing in both semantic and structured result sets are deduplicated into a single entry with `matchType: 'both'` and the RRF-computed score
+- [x] Results appearing in only one set receive a score contribution from that set only, with `matchType` set to `'semantic'` or `'structured'` accordingly
+- [x] The merged results are sorted by descending RRF score and capped at the requested `limit`
+- [x] Structured filters (type, scope, tags, date range, status, custom fields) are applied to the structured query component; the semantic component searches without filters but results are intersected with filter criteria post-retrieval
+- [x] Scope filtering with secret-scope exclusion applies to the final merged result set — a secret-scoped engram is excluded even if it ranks highly in the semantic component
+- [x] The unified `cerebrum.retrieval.search` procedure routes to semantic-only, structured-only, or hybrid based on the `mode` parameter, defaulting to `hybrid`
+- [x] The `cerebrum.retrieval.similar` procedure accepts an engram ID, retrieves its embedding vector, and runs a k-NN search without re-embedding — optional filters are applied post-retrieval
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/080-retrieval-engine/us-04-context-assembly.md
+++ b/docs/themes/06-cerebrum/prds/080-retrieval-engine/us-04-context-assembly.md
@@ -1,7 +1,7 @@
 # US-04: Context Assembly
 
 > PRD: [PRD-080: Retrieval Engine](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,15 +9,15 @@ As a system preparing input for an LLM, I want to take a query and its retrieval
 
 ## Acceptance Criteria
 
-- [ ] A `ContextAssemblyService` accepts a query string, retrieval results (from hybrid search), a `tokenBudget` (default 4096), and an `includeMetadata` flag (default `true`)
-- [ ] Results are added to the context in descending relevance order — each result is formatted as a delimited section with a header containing source attribution (`[source_type:source_id] title`) followed by the content body
-- [ ] Token counting uses a fast approximation: `word_count * 1.3` — this avoids importing a full tokeniser while staying within ~10% accuracy for English text
-- [ ] Results are added until the next result would exceed the remaining token budget — partially fitting results are truncated at a sentence boundary (or the budget limit if no sentence boundary is found) with a `[truncated]` marker appended
-- [ ] If the token budget is smaller than the first result, that result is truncated to fit and a `truncated: true` flag is set in the response metadata
-- [ ] Duplicate content is detected by `content_hash` — if two results share the same hash (e.g., an engram and its chunk overlap), only the higher-ranked one is included
-- [ ] The `cerebrum.retrieval.context` procedure runs a hybrid search internally (using `cerebrum.retrieval.search`), then assembles the context from the results — it is a convenience wrapper, not a separate retrieval path
-- [ ] The response includes `sources: SourceAttribution[]` listing every result included in the context with `sourceType`, `sourceId`, `title`, and `relevanceScore` — this enables the LLM to cite its sources
-- [ ] When `includeMetadata` is `true`, each section's header includes type, scopes, tags, and date in addition to title and source attribution
+- [x] A `ContextAssemblyService` accepts a query string, retrieval results (from hybrid search), a `tokenBudget` (default 4096), and an `includeMetadata` flag (default `true`)
+- [x] Results are added to the context in descending relevance order — each result is formatted as a delimited section with a header containing source attribution (`[source_type:source_id] title`) followed by the content body
+- [x] Token counting uses a fast approximation: `word_count * 1.3` — this avoids importing a full tokeniser while staying within ~10% accuracy for English text
+- [x] Results are added until the next result would exceed the remaining token budget — partially fitting results are truncated at a sentence boundary (or the budget limit if no sentence boundary is found) with a `[truncated]` marker appended
+- [x] If the token budget is smaller than the first result, that result is truncated to fit and a `truncated: true` flag is set in the response metadata
+- [x] Duplicate content is detected by `content_hash` — if two results share the same hash (e.g., an engram and its chunk overlap), only the higher-ranked one is included
+- [x] The `cerebrum.retrieval.context` procedure runs a hybrid search internally (using `cerebrum.retrieval.search`), then assembles the context from the results — it is a convenience wrapper, not a separate retrieval path
+- [x] The response includes `sources: SourceAttribution[]` listing every result included in the context with `sourceType`, `sourceId`, `title`, and `relevanceScore` — this enables the LLM to cite its sources
+- [x] When `includeMetadata` is `true`, each section's header includes type, scopes, tags, and date in addition to title and source attribution
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Implements PRD-080 (Retrieval Engine) — all 4 user stories, closes #1829.

- **US-01 SemanticSearchService** — embeds query text on-the-fly, runs k-NN against `embeddings_vec`, resolves titles/metadata for engrams and cross-source domain rows (transactions, movies, TV shows, inventory), applies distance threshold and scope/secret filtering
- **US-02 StructuredQueryService** — parameterised SQL against `engram_index` + junction tables; supports type/scope/tag/date-range/status/custom-field filters; AND semantics for tags, OR for types/scopes; secret-scope exclusion
- **US-03 HybridSearchService** — runs semantic + structured in parallel, merges with reciprocal rank fusion (RRF, k=60); deduplicates with `matchType: 'both'`; `similar` endpoint reads existing vector without re-embedding
- **US-04 ContextAssemblyService** — token-budgeted context window (word×1.3 approximation), sentence-boundary truncation, dedup by content hash, source attribution list

### New tRPC procedures

| Procedure | Description |
|---|---|
| `cerebrum.retrieval.search` | Semantic \| structured \| hybrid (default), with filters |
| `cerebrum.retrieval.context` | Hybrid search + context window assembly for LLM input |
| `cerebrum.retrieval.similar` | k-NN from existing engram vector — no embedding API call |
| `cerebrum.retrieval.stats` | Index coverage counts per source type |

## Test plan

- [ ] `cerebrum.retrieval.search` with `mode: 'semantic'` returns ranked results by distance
- [ ] `cerebrum.retrieval.search` with `mode: 'structured'` and type/scope/tag filters returns correct engrams
- [ ] `cerebrum.retrieval.search` with `mode: 'hybrid'` (default) merges both result sets via RRF
- [ ] Empty query in semantic/hybrid mode returns `BAD_REQUEST`
- [ ] Structured mode with no filters returns `BAD_REQUEST`
- [ ] Secret-scoped engrams excluded unless `includeSecret: true`
- [ ] `cerebrum.retrieval.similar` returns results without embedding API call
- [ ] `cerebrum.retrieval.context` returns formatted string under token budget with `sources[]`
- [ ] `cerebrum.retrieval.stats` returns indexed/embedded counts and lastUpdated

## Docs updated

- All 4 US files: acceptance criteria ticked, status → Done
- PRD-080 README: status → Done, user story table updated
- Epic 01-thalamus: PRD-080 → Done (epic now fully Done)
- roadmap.md: Thalamus row → Done

https://claude.ai/code/session_01HTB464DN93rzcN6BnhdpVV