### PR TITLE
feat(settings): restart-required toast after saving requiresRestart fields (US-03)

### DIFF
--- a/apps/pops-shell/src/components/settings/SectionRenderer.test.ts
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.test.ts
@@ -9,7 +9,12 @@ describe('SectionRenderer: fieldsByKey lookup', () => {
 
   it('maps field keys to their field definitions', () => {
     const groups = [
-      { fields: [{ key: 'a.key', requiresRestart: false }, { key: 'b.key', requiresRestart: true }] },
+      {
+        fields: [
+          { key: 'a.key', requiresRestart: false },
+          { key: 'b.key', requiresRestart: true },
+        ],
+      },
     ];
     const map = buildFieldsByKey(groups);
     expect(map['a.key']?.requiresRestart).toBe(false);
@@ -58,18 +63,14 @@ describe('SectionRenderer: restart-required toast trigger', () => {
     expect(toastInfo).not.toHaveBeenCalled();
   });
 
-  it('does not fire toast when save errors (only error toast fires on onError path)', () => {
+  it('does not fire toast on the error path', () => {
     const toastInfo = vi.fn();
     const toastError = vi.fn();
-    const fieldsByKey: FieldMap = { 'server.port': { requiresRestart: true } };
-    const onSuccess = makeOnSuccess(fieldsByKey, toastInfo);
-    const onError = (key: string, message: string) => toastError(`Failed to save ${key}: ${message}`);
+    const onError = (key: string, message: string) =>
+      toastError(`Failed to save ${key}: ${message}`);
 
     onError('server.port', 'Network error');
     expect(toastError).toHaveBeenCalledWith('Failed to save server.port: Network error');
-    expect(toastInfo).not.toHaveBeenCalled();
-
-    // onSuccess was never called — confirm toast still silent
     expect(toastInfo).not.toHaveBeenCalled();
   });
 });

--- a/apps/pops-shell/src/components/settings/SectionRenderer.test.ts
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── fieldsByKey lookup ────────────────────────────────────────────────
 
@@ -78,6 +78,14 @@ describe('SectionRenderer: restart-required toast trigger', () => {
 // ── debounced save ────────────────────────────────────────────────────
 
 describe('SectionRenderer: debounced save', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function makeHandleChange(mutate: (args: unknown) => void) {
     const debounceRefs = new Map<string, ReturnType<typeof setTimeout>>();
     return (key: string, value: string) => {
@@ -92,7 +100,6 @@ describe('SectionRenderer: debounced save', () => {
   }
 
   it('does not call mutate before the 500ms debounce expires', () => {
-    vi.useFakeTimers();
     const mutate = vi.fn();
     const handleChange = makeHandleChange(mutate);
 
@@ -102,11 +109,9 @@ describe('SectionRenderer: debounced save', () => {
 
     vi.advanceTimersByTime(1);
     expect(mutate).toHaveBeenCalledTimes(1);
-    vi.useRealTimers();
   });
 
   it('debounces rapid changes — only the last value is saved', () => {
-    vi.useFakeTimers();
     const mutate = vi.fn();
     const handleChange = makeHandleChange(mutate);
 
@@ -118,11 +123,9 @@ describe('SectionRenderer: debounced save', () => {
     vi.advanceTimersByTime(500);
     expect(mutate).toHaveBeenCalledTimes(1);
     expect(mutate).toHaveBeenCalledWith({ entries: [{ key: 'server.port', value: '8080' }] });
-    vi.useRealTimers();
   });
 
-  it('saves immediately for different keys without blocking each other', () => {
-    vi.useFakeTimers();
+  it('saves independently for different keys', () => {
     const mutate = vi.fn();
     const handleChange = makeHandleChange(mutate);
 
@@ -131,6 +134,5 @@ describe('SectionRenderer: debounced save', () => {
 
     vi.advanceTimersByTime(500);
     expect(mutate).toHaveBeenCalledTimes(2);
-    vi.useRealTimers();
   });
 });

--- a/apps/pops-shell/src/components/settings/SectionRenderer.test.ts
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// ── fieldsByKey lookup ────────────────────────────────────────────────
+
+describe('SectionRenderer: fieldsByKey lookup', () => {
+  function buildFieldsByKey(groups: { fields: { key: string; requiresRestart?: boolean }[] }[]) {
+    return Object.fromEntries(groups.flatMap((g) => g.fields.map((f) => [f.key, f])));
+  }
+
+  it('maps field keys to their field definitions', () => {
+    const groups = [
+      { fields: [{ key: 'a.key', requiresRestart: false }, { key: 'b.key', requiresRestart: true }] },
+    ];
+    const map = buildFieldsByKey(groups);
+    expect(map['a.key']?.requiresRestart).toBe(false);
+    expect(map['b.key']?.requiresRestart).toBe(true);
+  });
+
+  it('returns undefined for unknown keys', () => {
+    const groups = [{ fields: [{ key: 'x', requiresRestart: true }] }];
+    const map = buildFieldsByKey(groups);
+    expect(map['missing']).toBeUndefined();
+  });
+
+  it('handles fields without requiresRestart set', () => {
+    const groups = [{ fields: [{ key: 'plain' }] }];
+    const map = buildFieldsByKey(groups);
+    expect(map['plain']?.requiresRestart).toBeFalsy();
+  });
+});
+
+// ── restart toast trigger ─────────────────────────────────────────────
+
+describe('SectionRenderer: restart-required toast trigger', () => {
+  type FieldMap = Record<string, { requiresRestart?: boolean }>;
+
+  function makeOnSuccess(fieldsByKey: FieldMap, toastInfo: (msg: string) => void) {
+    return (key: string) => {
+      if (fieldsByKey[key]?.requiresRestart) {
+        toastInfo('Setting saved — restart required for this change to take effect');
+      }
+    };
+  }
+
+  it('fires info toast when a requiresRestart field saves successfully', () => {
+    const toastInfo = vi.fn();
+    const fieldsByKey: FieldMap = { 'server.port': { requiresRestart: true } };
+    makeOnSuccess(fieldsByKey, toastInfo)('server.port');
+    expect(toastInfo).toHaveBeenCalledWith(
+      'Setting saved — restart required for this change to take effect'
+    );
+  });
+
+  it('does not fire toast for fields without requiresRestart', () => {
+    const toastInfo = vi.fn();
+    const fieldsByKey: FieldMap = { 'plex.url': { requiresRestart: false } };
+    makeOnSuccess(fieldsByKey, toastInfo)('plex.url');
+    expect(toastInfo).not.toHaveBeenCalled();
+  });
+
+  it('does not fire toast when save errors (only error toast fires on onError path)', () => {
+    const toastInfo = vi.fn();
+    const toastError = vi.fn();
+    const fieldsByKey: FieldMap = { 'server.port': { requiresRestart: true } };
+    const onSuccess = makeOnSuccess(fieldsByKey, toastInfo);
+    const onError = (key: string, message: string) => toastError(`Failed to save ${key}: ${message}`);
+
+    onError('server.port', 'Network error');
+    expect(toastError).toHaveBeenCalledWith('Failed to save server.port: Network error');
+    expect(toastInfo).not.toHaveBeenCalled();
+
+    // onSuccess was never called — confirm toast still silent
+    expect(toastInfo).not.toHaveBeenCalled();
+  });
+});
+
+// ── debounced save ────────────────────────────────────────────────────
+
+describe('SectionRenderer: debounced save', () => {
+  function makeHandleChange(mutate: (args: unknown) => void) {
+    const debounceRefs = new Map<string, ReturnType<typeof setTimeout>>();
+    return (key: string, value: string) => {
+      const existing = debounceRefs.get(key);
+      if (existing) clearTimeout(existing);
+      const timer = setTimeout(() => {
+        debounceRefs.delete(key);
+        mutate({ entries: [{ key, value }] });
+      }, 500);
+      debounceRefs.set(key, timer);
+    };
+  }
+
+  it('does not call mutate before the 500ms debounce expires', () => {
+    vi.useFakeTimers();
+    const mutate = vi.fn();
+    const handleChange = makeHandleChange(mutate);
+
+    handleChange('server.port', '8080');
+    vi.advanceTimersByTime(499);
+    expect(mutate).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(mutate).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('debounces rapid changes — only the last value is saved', () => {
+    vi.useFakeTimers();
+    const mutate = vi.fn();
+    const handleChange = makeHandleChange(mutate);
+
+    handleChange('server.port', '8');
+    handleChange('server.port', '80');
+    handleChange('server.port', '808');
+    handleChange('server.port', '8080');
+
+    vi.advanceTimersByTime(500);
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith({ entries: [{ key: 'server.port', value: '8080' }] });
+    vi.useRealTimers();
+  });
+
+  it('saves immediately for different keys without blocking each other', () => {
+    vi.useFakeTimers();
+    const mutate = vi.fn();
+    const handleChange = makeHandleChange(mutate);
+
+    handleChange('key.a', 'val-a');
+    handleChange('key.b', 'val-b');
+
+    vi.advanceTimersByTime(500);
+    expect(mutate).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+});

--- a/apps/pops-shell/src/components/settings/SectionRenderer.test.ts
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // ── fieldsByKey lookup ────────────────────────────────────────────────
 
@@ -72,67 +72,5 @@ describe('SectionRenderer: restart-required toast trigger', () => {
     onError('server.port', 'Network error');
     expect(toastError).toHaveBeenCalledWith('Failed to save server.port: Network error');
     expect(toastInfo).not.toHaveBeenCalled();
-  });
-});
-
-// ── debounced save ────────────────────────────────────────────────────
-
-describe('SectionRenderer: debounced save', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  function makeHandleChange(mutate: (args: unknown) => void) {
-    const debounceRefs = new Map<string, ReturnType<typeof setTimeout>>();
-    return (key: string, value: string) => {
-      const existing = debounceRefs.get(key);
-      if (existing) clearTimeout(existing);
-      const timer = setTimeout(() => {
-        debounceRefs.delete(key);
-        mutate({ entries: [{ key, value }] });
-      }, 500);
-      debounceRefs.set(key, timer);
-    };
-  }
-
-  it('does not call mutate before the 500ms debounce expires', () => {
-    const mutate = vi.fn();
-    const handleChange = makeHandleChange(mutate);
-
-    handleChange('server.port', '8080');
-    vi.advanceTimersByTime(499);
-    expect(mutate).not.toHaveBeenCalled();
-
-    vi.advanceTimersByTime(1);
-    expect(mutate).toHaveBeenCalledTimes(1);
-  });
-
-  it('debounces rapid changes — only the last value is saved', () => {
-    const mutate = vi.fn();
-    const handleChange = makeHandleChange(mutate);
-
-    handleChange('server.port', '8');
-    handleChange('server.port', '80');
-    handleChange('server.port', '808');
-    handleChange('server.port', '8080');
-
-    vi.advanceTimersByTime(500);
-    expect(mutate).toHaveBeenCalledTimes(1);
-    expect(mutate).toHaveBeenCalledWith({ entries: [{ key: 'server.port', value: '8080' }] });
-  });
-
-  it('saves independently for different keys', () => {
-    const mutate = vi.fn();
-    const handleChange = makeHandleChange(mutate);
-
-    handleChange('key.a', 'val-a');
-    handleChange('key.b', 'val-b');
-
-    vi.advanceTimersByTime(500);
-    expect(mutate).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
@@ -25,7 +25,7 @@ vi.mock('@/lib/trpc', () => ({
   },
 }));
 
-vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), info: vi.fn() } }));
 
 import { SectionRenderer } from './SectionRenderer';
 

--- a/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
@@ -8,6 +8,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   getBulk: vi.fn(),
   setBulkMutate: vi.fn(),
+  toastError: vi.fn(),
+  toastInfo: vi.fn(),
 }));
 
 vi.mock('@/lib/trpc', () => ({
@@ -25,7 +27,7 @@ vi.mock('@/lib/trpc', () => ({
   },
 }));
 
-vi.mock('sonner', () => ({ toast: { error: vi.fn(), info: vi.fn() } }));
+vi.mock('sonner', () => ({ toast: { error: mocks.toastError, info: mocks.toastInfo } }));
 
 import { SectionRenderer } from './SectionRenderer';
 
@@ -316,6 +318,135 @@ describe('SectionRenderer', () => {
 
         expect(onTestAction).toHaveBeenCalledOnce();
         expect(onTestAction).toHaveBeenCalledWith('media.plex.testConnection');
+      } finally {
+        await act(async () => {
+          await vi.runAllTimersAsync();
+        });
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('restart-required toast', () => {
+    it('fires toast.info when a requiresRestart field saves successfully', async () => {
+      vi.useFakeTimers();
+      try {
+        const manifest = makeManifest({
+          groups: [
+            {
+              id: 'g1',
+              title: 'Server',
+              fields: [
+                {
+                  key: 'server.port',
+                  label: 'Port',
+                  type: 'text',
+                  default: '',
+                  requiresRestart: true,
+                },
+              ],
+            },
+          ],
+        });
+        render(<SectionRenderer manifest={manifest} />);
+
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: '9000' } });
+        await act(async () => {
+          vi.advanceTimersByTime(500);
+        });
+
+        expect(mocks.setBulkMutate).toHaveBeenCalledOnce();
+        const [, callbacks] = mocks.setBulkMutate.mock.calls[0] as [
+          unknown,
+          { onSuccess: () => void },
+        ];
+        await act(async () => {
+          callbacks.onSuccess();
+        });
+
+        expect(mocks.toastInfo).toHaveBeenCalledWith(
+          'Setting saved — restart required for this change to take effect'
+        );
+      } finally {
+        await act(async () => {
+          await vi.runAllTimersAsync();
+        });
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not fire toast.info for non-requiresRestart fields on success', async () => {
+      vi.useFakeTimers();
+      try {
+        const manifest = makeManifest({
+          groups: [
+            {
+              id: 'g1',
+              title: 'Server',
+              fields: [{ key: 'plex.url', label: 'URL', type: 'text', default: '' }],
+            },
+          ],
+        });
+        render(<SectionRenderer manifest={manifest} />);
+
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'http://plex.local' } });
+        await act(async () => {
+          vi.advanceTimersByTime(500);
+        });
+
+        const [, callbacks] = mocks.setBulkMutate.mock.calls[0] as [
+          unknown,
+          { onSuccess: () => void },
+        ];
+        await act(async () => {
+          callbacks.onSuccess();
+        });
+
+        expect(mocks.toastInfo).not.toHaveBeenCalled();
+      } finally {
+        await act(async () => {
+          await vi.runAllTimersAsync();
+        });
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not fire toast.info on error even for requiresRestart fields', async () => {
+      vi.useFakeTimers();
+      try {
+        const manifest = makeManifest({
+          groups: [
+            {
+              id: 'g1',
+              title: 'Server',
+              fields: [
+                {
+                  key: 'server.port',
+                  label: 'Port',
+                  type: 'text',
+                  default: '',
+                  requiresRestart: true,
+                },
+              ],
+            },
+          ],
+        });
+        render(<SectionRenderer manifest={manifest} />);
+
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: '9000' } });
+        await act(async () => {
+          vi.advanceTimersByTime(500);
+        });
+
+        const [, callbacks] = mocks.setBulkMutate.mock.calls[0] as [
+          unknown,
+          { onError: (err: Error) => void },
+        ];
+        await act(async () => {
+          callbacks.onError(new Error('save failed'));
+        });
+
+        expect(mocks.toastInfo).not.toHaveBeenCalled();
       } finally {
         await act(async () => {
           await vi.runAllTimersAsync();

--- a/apps/pops-shell/src/components/settings/SectionRenderer.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.tsx
@@ -376,6 +376,9 @@ interface SectionRendererProps {
 
 export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: SectionRendererProps) {
   const allKeys = manifest.groups.flatMap((g) => g.fields.map((f) => f.key));
+  const fieldsByKey = Object.fromEntries(
+    manifest.groups.flatMap((g) => g.fields.map((f) => [f.key, f]))
+  );
 
   const { data, isLoading } = trpc.core.settings.getBulk.useQuery({ keys: allKeys });
   const setBulkMutation = trpc.core.settings.setBulk.useMutation();
@@ -461,6 +464,9 @@ export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: Sect
                 );
               }, 2000);
               savedTimerRefs.current.set(key, savedTimer);
+              if (fieldsByKey[key]?.requiresRestart) {
+                toast.info('Setting saved — restart required for this change to take effect');
+              }
             },
             onError: (err) => {
               if (saveVersionRefs.current.get(key) !== version) return;
@@ -473,7 +479,7 @@ export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: Sect
 
       debounceRefs.current.set(key, timer);
     },
-    [setBulkMutation]
+    [setBulkMutation, fieldsByKey]
   );
 
   const handleTestAction = useCallback(

--- a/apps/pops-shell/src/components/settings/SectionRenderer.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.tsx
@@ -1,6 +1,6 @@
 import { trpc } from '@/lib/trpc';
 import { CheckCircle2, Loader2, RefreshCw, XCircle } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { Badge, Button, Input, Label, Select, Skeleton, Switch, Textarea, cn } from '@pops/ui';
@@ -375,9 +375,13 @@ interface SectionRendererProps {
 }
 
 export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: SectionRendererProps) {
-  const allKeys = manifest.groups.flatMap((g) => g.fields.map((f) => f.key));
-  const fieldsByKey = Object.fromEntries(
-    manifest.groups.flatMap((g) => g.fields.map((f) => [f.key, f]))
+  const allKeys = useMemo(
+    () => manifest.groups.flatMap((g) => g.fields.map((f) => f.key)),
+    [manifest.groups]
+  );
+  const fieldsByKey = useMemo(
+    () => Object.fromEntries(manifest.groups.flatMap((g) => g.fields.map((f) => [f.key, f]))),
+    [manifest.groups]
   );
 
   const { data, isLoading } = trpc.core.settings.getBulk.useQuery({ keys: allKeys });

--- a/docs/themes/01-foundation/prds/093-unified-settings/us-03-section-renderer.md
+++ b/docs/themes/01-foundation/prds/093-unified-settings/us-03-section-renderer.md
@@ -47,7 +47,7 @@ As a user, I want settings fields to render as appropriate input widgets with in
 ### Requires Restart Badge
 
 - [x] Fields with `requiresRestart: true` display an amber "Requires restart" badge next to the field label
-- [ ] When the user changes such a field, a non-blocking toast confirms the change and notes that a restart is needed
+- [x] When the user changes such a field, a non-blocking toast confirms the change and notes that a restart is needed
 
 ### Test Action Button
 


### PR DESCRIPTION
## Summary

- After the debounced save succeeds for a field with `requiresRestart: true`, fires a non-blocking `sonner` info toast: "Setting saved — restart required for this change to take effect"
- Builds a `fieldsByKey` lookup map from the manifest inside `SectionRenderer` to check `requiresRestart` by key at save time
- Adds `fieldsByKey` to the `useCallback` dependency array for `handleChange`
- Marks the acceptance criterion as `[x]` in `us-03-section-renderer.md`

Closes #1969

## Test plan

- [ ] Change a field with `requiresRestart: true` — verify the amber badge is still shown and a toast appears after the 500ms debounce save completes
- [ ] Change a field without `requiresRestart` — verify no restart toast appears
- [ ] Trigger a save error — verify only the error toast fires, not the restart toast

https://claude.ai/code/session_01AynyCyvZWPed7ve2UEtM8D