### PR TITLE
feat(settings): loading placeholder while async select options load

### DIFF
--- a/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
@@ -277,6 +277,93 @@ describe('SectionRenderer', () => {
     });
   });
 
+  describe('async options loader', () => {
+    it('shows a disabled loading placeholder while in-flight and enables the select after resolve', async () => {
+      let resolveLoader!: (opts: { value: string; label: string }[]) => void;
+      const loaderPromise = new Promise<{ value: string; label: string }[]>((res) => {
+        resolveLoader = res;
+      });
+
+      const manifest = makeManifest({
+        groups: [
+          {
+            id: 'g1',
+            title: 'Async Select',
+            fields: [
+              { key: 'library', label: 'Library', type: 'select', default: '', options: [] },
+            ],
+          },
+        ],
+      });
+
+      render(
+        <SectionRenderer manifest={manifest} optionsLoaders={{ library: () => loaderPromise }} />
+      );
+
+      await act(async () => {});
+
+      // While loading — select is disabled with the placeholder text
+      const select = screen.getByRole('combobox');
+      expect(select).toBeDisabled();
+      expect(screen.getByText('Loading options\u2026')).toBeInTheDocument();
+
+      // Resolve the loader with options
+      await act(async () => {
+        resolveLoader([{ value: 'movies', label: 'Movies' }]);
+        await loaderPromise;
+      });
+
+      // Select is now interactive with the loaded options
+      expect(screen.getByRole('combobox')).not.toBeDisabled();
+      expect(screen.getByText('Movies')).toBeInTheDocument();
+      expect(screen.queryByText('Loading options\u2026')).not.toBeInTheDocument();
+    });
+
+    it('enables the select after the loader rejects, falling back to static options', async () => {
+      let rejectLoader!: (err: Error) => void;
+      const loaderPromise = new Promise<{ value: string; label: string }[]>((_, rej) => {
+        rejectLoader = rej;
+      });
+
+      const manifest = makeManifest({
+        groups: [
+          {
+            id: 'g1',
+            title: 'Async Select',
+            fields: [
+              {
+                key: 'library',
+                label: 'Library',
+                type: 'select',
+                default: '',
+                options: [{ value: 'fallback', label: 'Fallback Option' }],
+              },
+            ],
+          },
+        ],
+      });
+
+      render(
+        <SectionRenderer manifest={manifest} optionsLoaders={{ library: () => loaderPromise }} />
+      );
+
+      await act(async () => {});
+
+      // While loading
+      expect(screen.getByRole('combobox')).toBeDisabled();
+
+      // Reject the loader
+      await act(async () => {
+        rejectLoader(new Error('Network error'));
+        await loaderPromise.catch(() => {});
+      });
+
+      // Select is enabled with static fallback options
+      expect(screen.getByRole('combobox')).not.toBeDisabled();
+      expect(screen.getByText('Fallback Option')).toBeInTheDocument();
+    });
+  });
+
   describe('test action button', () => {
     it('calls onTestAction with the procedure when the test button is clicked', async () => {
       vi.useFakeTimers();

--- a/apps/pops-shell/src/components/settings/SectionRenderer.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.tsx
@@ -414,7 +414,9 @@ export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: Sect
   useEffect(() => {
     if (!optionsLoaders) return;
     let cancelled = false;
+    const keysStarted = new Set<string>();
     for (const [key, loader] of Object.entries(optionsLoaders)) {
+      keysStarted.add(key);
       setLoadingOptionKeys((prev) => new Set([...prev, key]));
       Promise.resolve()
         .then(loader)
@@ -435,6 +437,11 @@ export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: Sect
     }
     return () => {
       cancelled = true;
+      setLoadingOptionKeys((prev) => {
+        const next = new Set(prev);
+        for (const key of keysStarted) next.delete(key);
+        return next;
+      });
     };
   }, [optionsLoaders]);
 

--- a/apps/pops-shell/src/components/settings/SectionRenderer.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.tsx
@@ -413,21 +413,29 @@ export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: Sect
 
   useEffect(() => {
     if (!optionsLoaders) return;
+    let cancelled = false;
     for (const [key, loader] of Object.entries(optionsLoaders)) {
       setLoadingOptionKeys((prev) => new Set([...prev, key]));
-      loader()
-        .then((opts) => setDynamicOptions((prev) => ({ ...prev, [key]: opts })))
+      Promise.resolve()
+        .then(loader)
+        .then((opts) => {
+          if (!cancelled) setDynamicOptions((prev) => ({ ...prev, [key]: opts }));
+        })
         .catch(() => {
           /* fall back to static options */
         })
         .finally(() => {
-          setLoadingOptionKeys((prev) => {
-            const next = new Set(prev);
-            next.delete(key);
-            return next;
-          });
+          if (!cancelled)
+            setLoadingOptionKeys((prev) => {
+              const next = new Set(prev);
+              next.delete(key);
+              return next;
+            });
         });
     }
+    return () => {
+      cancelled = true;
+    };
   }, [optionsLoaders]);
 
   const debounceRefs = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());

--- a/apps/pops-shell/src/components/settings/SectionRenderer.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.tsx
@@ -17,6 +17,7 @@ interface FieldProps {
   onTestAction: (procedure: string) => Promise<void>;
   envFallbackActive: boolean;
   saveState: SaveState;
+  isOptionsLoading?: boolean;
 }
 
 function FieldWrapper({
@@ -119,6 +120,7 @@ function FieldInput({
   onTestAction,
   envFallbackActive,
   saveState,
+  isOptionsLoading,
 }: FieldProps) {
   const [revealed, setRevealed] = useState(false);
   const [testState, setTestState] = useState<TestState>('idle');
@@ -207,11 +209,15 @@ function FieldInput({
   if (field.type === 'select') {
     return (
       <FieldWrapper field={field} saveState={saveState}>
-        <Select
-          options={field.options ?? []}
-          value={value}
-          onChange={(e) => handleChange(e.target.value)}
-        />
+        {isOptionsLoading ? (
+          <Select disabled options={[]} placeholder="Loading options…" value="" />
+        ) : (
+          <Select
+            options={field.options ?? []}
+            value={value}
+            onChange={(e) => handleChange(e.target.value)}
+          />
+        )}
         {envLabel}
       </FieldWrapper>
     );
@@ -333,6 +339,7 @@ interface GroupRendererProps {
   onTestAction: (procedure: string) => Promise<void>;
   dbValues: Record<string, string>;
   saveStates: Record<string, SaveState>;
+  loadingOptionKeys: Set<string>;
 }
 
 function GroupRenderer({
@@ -342,6 +349,7 @@ function GroupRenderer({
   onTestAction,
   dbValues,
   saveStates,
+  loadingOptionKeys,
 }: GroupRendererProps) {
   return (
     <div className="rounded-lg border bg-card p-5 space-y-4">
@@ -361,6 +369,7 @@ function GroupRenderer({
             onTestAction={onTestAction}
             envFallbackActive={!!field.envFallback && !(field.key in dbValues)}
             saveState={saveStates[field.key] ?? 'idle'}
+            isOptionsLoading={loadingOptionKeys.has(field.key)}
           />
         ))}
       </div>
@@ -386,6 +395,7 @@ export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: Sect
     Record<string, { value: string; label: string }[]>
   >({});
   const [saveStates, setSaveStates] = useState<Record<string, SaveState>>({});
+  const [loadingOptionKeys, setLoadingOptionKeys] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (!data?.settings) return;
@@ -404,10 +414,18 @@ export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: Sect
   useEffect(() => {
     if (!optionsLoaders) return;
     for (const [key, loader] of Object.entries(optionsLoaders)) {
+      setLoadingOptionKeys((prev) => new Set([...prev, key]));
       loader()
         .then((opts) => setDynamicOptions((prev) => ({ ...prev, [key]: opts })))
         .catch(() => {
           /* fall back to static options */
+        })
+        .finally(() => {
+          setLoadingOptionKeys((prev) => {
+            const next = new Set(prev);
+            next.delete(key);
+            return next;
+          });
         });
     }
   }, [optionsLoaders]);
@@ -518,6 +536,7 @@ export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: Sect
           onTestAction={handleTestAction}
           dbValues={loadedKeys}
           saveStates={saveStates}
+          loadingOptionKeys={loadingOptionKeys}
         />
       ))}
     </div>

--- a/docs/themes/01-foundation/prds/093-unified-settings/us-03-section-renderer.md
+++ b/docs/themes/01-foundation/prds/093-unified-settings/us-03-section-renderer.md
@@ -61,7 +61,7 @@ As a user, I want settings fields to render as appropriate input widgets with in
 
 - [x] `SectionRenderer` accepts an optional `optionsLoaders` map: `Record<string, () => Promise<{ value: string; label: string }[]>>`
 - [x] For select fields whose key appears in `optionsLoaders`, options are loaded asynchronously instead of using the static `options` array from the manifest
-- [ ] While options are loading, the select shows a loading placeholder
+- [x] While options are loading, the select shows a loading placeholder
 - [x] If the async load fails, the select shows the static `options` as a fallback (if any) and an error indicator
 
 ### Tests


### PR DESCRIPTION
## Summary

- Tracks per-key loading state in `SectionRenderer` for `optionsLoaders`
- While a loader is in flight, the select renders as a disabled `<Select>` with placeholder `"Loading options…"`
- Once the loader resolves (success or failure), the select becomes interactive with loaded or static fallback options

Closes #1970

## Test plan

- [ ] Open a settings page that uses `optionsLoaders` (e.g. Plex library sections in US-04)
- [ ] Verify the select shows "Loading options…" and is non-interactive while the loader is in flight
- [ ] Verify the select becomes interactive once options load

https://claude.ai/code/session_01BN9bkassSvmJw2m7BSYaYs