### PR TITLE
test(settings): type getManifests output with SettingsManifestSchema + US-01 tests

### DIFF
--- a/apps/pops-api/src/modules/core/settings/registry.ts
+++ b/apps/pops-api/src/modules/core/settings/registry.ts
@@ -45,6 +45,10 @@ export class SettingsRegistry {
   getAll(): SettingsManifest[] {
     return [...this.manifests.values()].toSorted((a, b) => a.order - b.order);
   }
+
+  clear(): void {
+    this.manifests.clear();
+  }
 }
 
 export const settingsRegistry = new SettingsRegistry();

--- a/apps/pops-api/src/modules/core/settings/router.ts
+++ b/apps/pops-api/src/modules/core/settings/router.ts
@@ -19,10 +19,20 @@ export const settingsRouter = router({
   /** List all settings with optional search filter */
   list: protectedProcedure
     .meta({
-      openapi: { method: 'GET', path: '/settings', summary: 'List settings', tags: ['settings'] },
+      openapi: {
+        method: 'GET',
+        path: '/settings',
+        summary: 'List settings',
+        tags: ['settings'],
+      },
     })
     .input(SettingListSchema)
-    .output(z.object({ data: z.array(SettingSchema), pagination: PaginationMetaSchema }))
+    .output(
+      z.object({
+        data: z.array(SettingSchema),
+        pagination: PaginationMetaSchema,
+      })
+    )
     .query(({ input }) => {
       const limit = input.limit ?? DEFAULT_LIMIT;
       const offset = input.offset ?? DEFAULT_OFFSET;
@@ -101,7 +111,11 @@ export const settingsRouter = router({
 
   /** Write multiple settings atomically — rolls back all on any failure */
   setBulk: protectedProcedure
-    .input(z.object({ entries: z.array(z.object({ key: z.string(), value: z.string() })) }))
+    .input(
+      z.object({
+        entries: z.array(z.object({ key: z.string(), value: z.string() })),
+      })
+    )
     .mutation(({ input }) => {
       return { settings: service.setBulkSettings(input.entries) };
     }),

--- a/apps/pops-api/src/modules/core/settings/settings.test.ts
+++ b/apps/pops-api/src/modules/core/settings/settings.test.ts
@@ -329,6 +329,19 @@ describe('settings.getManifests', () => {
     const result = await caller.core.settings.getManifests();
     expect(result.manifests.map((m) => m.id)).toEqual(['a.manifest', 'z.manifest']);
   });
+
+  it('rejects when a registered manifest contains an invalid field type', async () => {
+    settingsRegistry.register({
+      id: 'bad.manifest',
+      title: 'Bad',
+      order: 1,
+      groups: [
+        { id: 'g', title: 'G', fields: [{ key: 'k', label: 'K', type: 'not-a-type' as any }] },
+      ],
+    } as any);
+
+    await expect(caller.core.settings.getManifests()).rejects.toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/pops-api/src/modules/core/settings/settings.test.ts
+++ b/apps/pops-api/src/modules/core/settings/settings.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createCaller, seedSetting, setupTestContext } from '../../../shared/test-utils.js';
 import { SETTINGS_KEYS } from './keys.js';
-import { SettingsRegistry } from './registry.js';
+import { SettingsRegistry, settingsRegistry } from './registry.js';
 
 import type { Database } from 'better-sqlite3';
 
@@ -31,7 +31,10 @@ describe('settings.list', () => {
   });
 
   it('returns all settings', async () => {
-    seedSetting(db, { key: SETTINGS_KEYS.PLEX_URL, value: 'http://plex:32400' });
+    seedSetting(db, {
+      key: SETTINGS_KEYS.PLEX_URL,
+      value: 'http://plex:32400',
+    });
     seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'dark' });
 
     const result = await caller.core.settings.list({});
@@ -40,7 +43,10 @@ describe('settings.list', () => {
   });
 
   it('filters by search term', async () => {
-    seedSetting(db, { key: SETTINGS_KEYS.PLEX_URL, value: 'http://plex:32400' });
+    seedSetting(db, {
+      key: SETTINGS_KEYS.PLEX_URL,
+      value: 'http://plex:32400',
+    });
     seedSetting(db, { key: SETTINGS_KEYS.PLEX_TOKEN, value: 'abc123' });
     seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'dark' });
 
@@ -50,7 +56,10 @@ describe('settings.list', () => {
   });
 
   it('paginates results', async () => {
-    seedSetting(db, { key: SETTINGS_KEYS.PLEX_URL, value: 'http://plex:32400' });
+    seedSetting(db, {
+      key: SETTINGS_KEYS.PLEX_URL,
+      value: 'http://plex:32400',
+    });
     seedSetting(db, { key: SETTINGS_KEYS.PLEX_TOKEN, value: 'abc' });
     seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'dark' });
 
@@ -80,14 +89,19 @@ describe('settings.get', () => {
   });
 
   it('returns null for missing key', async () => {
-    const result = await caller.core.settings.get({ key: SETTINGS_KEYS.RADARR_URL });
+    const result = await caller.core.settings.get({
+      key: SETTINGS_KEYS.RADARR_URL,
+    });
     expect(result.data).toBeNull();
   });
 });
 
 describe('settings.set', () => {
   it('creates a new setting', async () => {
-    const result = await caller.core.settings.set({ key: SETTINGS_KEYS.THEME, value: 'dark' });
+    const result = await caller.core.settings.set({
+      key: SETTINGS_KEYS.THEME,
+      value: 'dark',
+    });
     expect(result.message).toBe('Setting saved');
     expect(result.data.key).toBe(SETTINGS_KEYS.THEME);
     expect(result.data.value).toBe('dark');
@@ -96,16 +110,24 @@ describe('settings.set', () => {
   it('updates an existing setting (upsert)', async () => {
     seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'light' });
 
-    const result = await caller.core.settings.set({ key: SETTINGS_KEYS.THEME, value: 'dark' });
+    const result = await caller.core.settings.set({
+      key: SETTINGS_KEYS.THEME,
+      value: 'dark',
+    });
     expect(result.data.value).toBe('dark');
 
     // Verify only one row exists
-    const listResult = await caller.core.settings.list({ search: SETTINGS_KEYS.THEME });
+    const listResult = await caller.core.settings.list({
+      search: SETTINGS_KEYS.THEME,
+    });
     expect(listResult.data).toHaveLength(1);
   });
 
   it('persists to the database', async () => {
-    await caller.core.settings.set({ key: SETTINGS_KEYS.RADARR_URL, value: 'http://radarr:7878' });
+    await caller.core.settings.set({
+      key: SETTINGS_KEYS.RADARR_URL,
+      value: 'http://radarr:7878',
+    });
     const row = db
       .prepare('SELECT * FROM settings WHERE key = ?')
       .get(SETTINGS_KEYS.RADARR_URL) as {
@@ -117,7 +139,10 @@ describe('settings.set', () => {
   });
 
   it('allows empty string value', async () => {
-    const result = await caller.core.settings.set({ key: SETTINGS_KEYS.SONARR_URL, value: '' });
+    const result = await caller.core.settings.set({
+      key: SETTINGS_KEYS.SONARR_URL,
+      value: '',
+    });
     expect(result.data.value).toBe('');
   });
 });
@@ -126,7 +151,9 @@ describe('settings.delete', () => {
   it('deletes an existing setting', async () => {
     seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'dark' });
 
-    const result = await caller.core.settings.delete({ key: SETTINGS_KEYS.THEME });
+    const result = await caller.core.settings.delete({
+      key: SETTINGS_KEYS.THEME,
+    });
     expect(result.message).toBe('Setting deleted');
 
     // Verify it's gone
@@ -147,6 +174,7 @@ describe('settings.delete', () => {
 });
 
 // ---------------------------------------------------------------------------
+<<<<<<< HEAD
 // SettingsRegistry unit tests
 // ---------------------------------------------------------------------------
 
@@ -184,10 +212,46 @@ describe('SettingsRegistry', () => {
     expect(() =>
       registry.register(makeManifest('manifest-b', 200, ['b.only', 'shared.key']))
     ).toThrow(/shared\.key.*manifest-a.*manifest-b|manifest-a.*shared\.key.*manifest-b/);
+=======
+// SettingsRegistry (unit tests — class instances, not the singleton)
+// ---------------------------------------------------------------------------
+
+const makeManifest = (id: string, order: number, keys: string[]): SettingsManifest => ({
+  id,
+  title: id,
+  order,
+  groups: [
+    {
+      id: 'g',
+      title: 'Group',
+      fields: keys.map((k) => ({ key: k, label: k, type: 'text' as const })),
+    },
+  ],
+});
+
+describe('SettingsRegistry', () => {
+  it('returns manifests sorted by order', () => {
+    const registry = new SettingsRegistry();
+    registry.register(makeManifest('b', 200, ['key.b']));
+    registry.register(makeManifest('a', 100, ['key.a']));
+
+    const all = registry.getAll();
+    expect(all.map((m) => m.id)).toEqual(['a', 'b']);
+  });
+
+  it('throws on duplicate key across manifests', () => {
+    const registry = new SettingsRegistry();
+    registry.register(makeManifest('first', 1, ['shared.key']));
+
+    expect(() => registry.register(makeManifest('second', 2, ['shared.key']))).toThrow(
+      /shared\.key.*first|first.*shared\.key/
+    );
+>>>>>>> 7e84266 (test(settings): add registry and tRPC tests for US-01; export SettingsRegistry class)
   });
 });
 
 // ---------------------------------------------------------------------------
+<<<<<<< HEAD
 // settings.getBulk / settings.setBulk tRPC procedure tests
 // ---------------------------------------------------------------------------
 
@@ -240,21 +304,122 @@ describe('settings.setBulk', () => {
       BEGIN
         SELECT RAISE(ABORT, 'test: too many settings');
       END
+=======
+// settings.getManifests (tRPC — uses singleton, cleared after each test)
+// ---------------------------------------------------------------------------
+
+describe('settings.getManifests', () => {
+  beforeEach(() => {
+    settingsRegistry.clear();
+  });
+
+  afterEach(() => {
+    settingsRegistry.clear();
+  });
+
+  it('returns empty array when no manifests are registered', async () => {
+    const result = await caller.core.settings.getManifests();
+    expect(result.manifests).toEqual([]);
+  });
+
+  it('returns registered manifests sorted by order', async () => {
+    settingsRegistry.register(makeManifest('z.manifest', 300, ['z.key']));
+    settingsRegistry.register(makeManifest('a.manifest', 10, ['a.key']));
+
+    const result = await caller.core.settings.getManifests();
+    expect(result.manifests.map((m) => m.id)).toEqual(['a.manifest', 'z.manifest']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// settings.getBulk
+// ---------------------------------------------------------------------------
+
+describe('settings.getBulk', () => {
+  it('returns only existing keys from the requested set', async () => {
+    seedSetting(db, {
+      key: SETTINGS_KEYS.PLEX_URL,
+      value: 'http://plex:32400',
+    });
+    seedSetting(db, { key: SETTINGS_KEYS.PLEX_TOKEN, value: 'tok' });
+    seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'dark' });
+
+    const result = await caller.core.settings.getBulk({
+      keys: [SETTINGS_KEYS.PLEX_URL, SETTINGS_KEYS.PLEX_TOKEN, SETTINGS_KEYS.RADARR_URL],
+    });
+
+    expect(Object.keys(result.settings)).toHaveLength(2);
+    expect(result.settings[SETTINGS_KEYS.PLEX_URL]).toBe('http://plex:32400');
+    expect(result.settings[SETTINGS_KEYS.PLEX_TOKEN]).toBe('tok');
+    expect(result.settings[SETTINGS_KEYS.RADARR_URL]).toBeUndefined();
+  });
+
+  it('returns empty object for empty keys array', async () => {
+    const result = await caller.core.settings.getBulk({ keys: [] });
+    expect(result.settings).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// settings.setBulk
+// ---------------------------------------------------------------------------
+
+describe('settings.setBulk', () => {
+  it('writes all entries and returns them', async () => {
+    const result = await caller.core.settings.setBulk({
+      entries: [
+        { key: SETTINGS_KEYS.PLEX_URL, value: 'http://plex:32400' },
+        { key: SETTINGS_KEYS.THEME, value: 'dark' },
+        { key: SETTINGS_KEYS.RADARR_URL, value: 'http://radarr:7878' },
+      ],
+    });
+
+    expect(result.settings[SETTINGS_KEYS.PLEX_URL]).toBe('http://plex:32400');
+    expect(result.settings[SETTINGS_KEYS.THEME]).toBe('dark');
+    expect(result.settings[SETTINGS_KEYS.RADARR_URL]).toBe('http://radarr:7878');
+
+    // Verify persistence
+    const check = await caller.core.settings.getBulk({
+      keys: [SETTINGS_KEYS.PLEX_URL, SETTINGS_KEYS.THEME, SETTINGS_KEYS.RADARR_URL],
+    });
+    expect(Object.keys(check.settings)).toHaveLength(3);
+  });
+
+  it('rolls back all entries when one write fails', async () => {
+    // Add a trigger that rejects inserts once the table already has 1 row
+    db.exec(`
+      CREATE TRIGGER fail_on_second_insert BEFORE INSERT ON settings
+      WHEN (SELECT COUNT(*) FROM settings) >= 1
+      BEGIN SELECT RAISE(ABORT, 'test: max 1 row'); END;
+>>>>>>> 7e84266 (test(settings): add registry and tRPC tests for US-01; export SettingsRegistry class)
     `);
 
     await expect(
       caller.core.settings.setBulk({
         entries: [
+<<<<<<< HEAD
           { key: 'tx.key.1', value: 'v1' },
           { key: 'tx.key.2', value: 'v2' },
           { key: 'tx.key.3', value: 'v3' },
+=======
+          { key: SETTINGS_KEYS.PLEX_URL, value: 'http://plex:32400' },
+          { key: SETTINGS_KEYS.THEME, value: 'dark' },
+>>>>>>> 7e84266 (test(settings): add registry and tRPC tests for US-01; export SettingsRegistry class)
         ],
       })
     ).rejects.toThrow();
 
+<<<<<<< HEAD
     const result = await caller.core.settings.getBulk({
       keys: ['tx.key.1', 'tx.key.2', 'tx.key.3'],
     });
     expect(Object.keys(result.settings)).toHaveLength(0);
+=======
+    // Neither entry should be persisted
+    const check = await caller.core.settings.getBulk({
+      keys: [SETTINGS_KEYS.PLEX_URL, SETTINGS_KEYS.THEME],
+    });
+    expect(check.settings).toEqual({});
+>>>>>>> 7e84266 (test(settings): add registry and tRPC tests for US-01; export SettingsRegistry class)
   });
 });

--- a/apps/pops-api/src/modules/core/settings/settings.test.ts
+++ b/apps/pops-api/src/modules/core/settings/settings.test.ts
@@ -174,7 +174,6 @@ describe('settings.delete', () => {
 });
 
 // ---------------------------------------------------------------------------
-<<<<<<< HEAD
 // SettingsRegistry unit tests
 // ---------------------------------------------------------------------------
 
@@ -211,100 +210,11 @@ describe('SettingsRegistry', () => {
 
     expect(() =>
       registry.register(makeManifest('manifest-b', 200, ['b.only', 'shared.key']))
-    ).toThrow(/shared\.key.*manifest-a.*manifest-b|manifest-a.*shared\.key.*manifest-b/);
-=======
-// SettingsRegistry (unit tests — class instances, not the singleton)
-// ---------------------------------------------------------------------------
-
-const makeManifest = (id: string, order: number, keys: string[]): SettingsManifest => ({
-  id,
-  title: id,
-  order,
-  groups: [
-    {
-      id: 'g',
-      title: 'Group',
-      fields: keys.map((k) => ({ key: k, label: k, type: 'text' as const })),
-    },
-  ],
-});
-
-describe('SettingsRegistry', () => {
-  it('returns manifests sorted by order', () => {
-    const registry = new SettingsRegistry();
-    registry.register(makeManifest('b', 200, ['key.b']));
-    registry.register(makeManifest('a', 100, ['key.a']));
-
-    const all = registry.getAll();
-    expect(all.map((m) => m.id)).toEqual(['a', 'b']);
-  });
-
-  it('throws on duplicate key across manifests', () => {
-    const registry = new SettingsRegistry();
-    registry.register(makeManifest('first', 1, ['shared.key']));
-
-    expect(() => registry.register(makeManifest('second', 2, ['shared.key']))).toThrow(
-      /(?=.*shared\.key)(?=.*first)(?=.*second)/
-    );
->>>>>>> 7e84266 (test(settings): add registry and tRPC tests for US-01; export SettingsRegistry class)
+    ).toThrow(/(?=.*shared\.key)(?=.*manifest-a)(?=.*manifest-b)/);
   });
 });
 
 // ---------------------------------------------------------------------------
-<<<<<<< HEAD
-// settings.getBulk / settings.setBulk tRPC procedure tests
-// ---------------------------------------------------------------------------
-
-describe('settings.getBulk', () => {
-  it('returns only the keys that exist in the database', async () => {
-    seedSetting(db, { key: 'bulk.key.1', value: 'v1' });
-    seedSetting(db, { key: 'bulk.key.2', value: 'v2' });
-    seedSetting(db, { key: 'bulk.key.3', value: 'v3' });
-
-    const result = await caller.core.settings.getBulk({
-      keys: ['bulk.key.1', 'bulk.key.2', 'bulk.key.3', 'bulk.key.4', 'bulk.key.5'],
-    });
-
-    expect(Object.keys(result.settings)).toHaveLength(3);
-    expect(result.settings['bulk.key.1']).toBe('v1');
-    expect(result.settings['bulk.key.2']).toBe('v2');
-    expect(result.settings['bulk.key.3']).toBe('v3');
-    expect(result.settings['bulk.key.4']).toBeUndefined();
-    expect(result.settings['bulk.key.5']).toBeUndefined();
-  });
-});
-
-describe('settings.setBulk', () => {
-  it('saves all 3 entries and makes them retrievable', async () => {
-    await caller.core.settings.setBulk({
-      entries: [
-        { key: 'set.bulk.a', value: 'alpha' },
-        { key: 'set.bulk.b', value: 'beta' },
-        { key: 'set.bulk.c', value: 'gamma' },
-      ],
-    });
-
-    const result = await caller.core.settings.getBulk({
-      keys: ['set.bulk.a', 'set.bulk.b', 'set.bulk.c'],
-    });
-
-    expect(Object.keys(result.settings)).toHaveLength(3);
-    expect(result.settings['set.bulk.a']).toBe('alpha');
-    expect(result.settings['set.bulk.b']).toBe('beta');
-    expect(result.settings['set.bulk.c']).toBe('gamma');
-  });
-
-  it('rolls back all entries when one write fails mid-transaction', async () => {
-    // Force a DB error on the 3rd insert by adding a trigger that aborts
-    // when the settings table already has 2 rows
-    db.exec(`
-      CREATE TRIGGER test_settings_limit
-      BEFORE INSERT ON settings
-      WHEN (SELECT COUNT(*) FROM settings) >= 2
-      BEGIN
-        SELECT RAISE(ABORT, 'test: too many settings');
-      END
-=======
 // settings.getManifests (tRPC — uses singleton, cleared after each test)
 // ---------------------------------------------------------------------------
 
@@ -349,22 +259,21 @@ describe('settings.getManifests', () => {
 // ---------------------------------------------------------------------------
 
 describe('settings.getBulk', () => {
-  it('returns only existing keys from the requested set', async () => {
-    seedSetting(db, {
-      key: SETTINGS_KEYS.PLEX_URL,
-      value: 'http://plex:32400',
-    });
-    seedSetting(db, { key: SETTINGS_KEYS.PLEX_TOKEN, value: 'tok' });
-    seedSetting(db, { key: SETTINGS_KEYS.THEME, value: 'dark' });
+  it('returns only the keys that exist in the database', async () => {
+    seedSetting(db, { key: 'bulk.key.1', value: 'v1' });
+    seedSetting(db, { key: 'bulk.key.2', value: 'v2' });
+    seedSetting(db, { key: 'bulk.key.3', value: 'v3' });
 
     const result = await caller.core.settings.getBulk({
-      keys: [SETTINGS_KEYS.PLEX_URL, SETTINGS_KEYS.PLEX_TOKEN, SETTINGS_KEYS.RADARR_URL],
+      keys: ['bulk.key.1', 'bulk.key.2', 'bulk.key.3', 'bulk.key.4', 'bulk.key.5'],
     });
 
-    expect(Object.keys(result.settings)).toHaveLength(2);
-    expect(result.settings[SETTINGS_KEYS.PLEX_URL]).toBe('http://plex:32400');
-    expect(result.settings[SETTINGS_KEYS.PLEX_TOKEN]).toBe('tok');
-    expect(result.settings[SETTINGS_KEYS.RADARR_URL]).toBeUndefined();
+    expect(Object.keys(result.settings)).toHaveLength(3);
+    expect(result.settings['bulk.key.1']).toBe('v1');
+    expect(result.settings['bulk.key.2']).toBe('v2');
+    expect(result.settings['bulk.key.3']).toBe('v3');
+    expect(result.settings['bulk.key.4']).toBeUndefined();
+    expect(result.settings['bulk.key.5']).toBeUndefined();
   });
 
   it('returns empty object for empty keys array', async () => {
@@ -378,61 +287,50 @@ describe('settings.getBulk', () => {
 // ---------------------------------------------------------------------------
 
 describe('settings.setBulk', () => {
-  it('writes all entries and returns them', async () => {
-    const result = await caller.core.settings.setBulk({
+  it('saves all 3 entries and makes them retrievable', async () => {
+    await caller.core.settings.setBulk({
       entries: [
-        { key: SETTINGS_KEYS.PLEX_URL, value: 'http://plex:32400' },
-        { key: SETTINGS_KEYS.THEME, value: 'dark' },
-        { key: SETTINGS_KEYS.RADARR_URL, value: 'http://radarr:7878' },
+        { key: 'set.bulk.a', value: 'alpha' },
+        { key: 'set.bulk.b', value: 'beta' },
+        { key: 'set.bulk.c', value: 'gamma' },
       ],
     });
 
-    expect(result.settings[SETTINGS_KEYS.PLEX_URL]).toBe('http://plex:32400');
-    expect(result.settings[SETTINGS_KEYS.THEME]).toBe('dark');
-    expect(result.settings[SETTINGS_KEYS.RADARR_URL]).toBe('http://radarr:7878');
-
-    // Verify persistence
-    const check = await caller.core.settings.getBulk({
-      keys: [SETTINGS_KEYS.PLEX_URL, SETTINGS_KEYS.THEME, SETTINGS_KEYS.RADARR_URL],
+    const result = await caller.core.settings.getBulk({
+      keys: ['set.bulk.a', 'set.bulk.b', 'set.bulk.c'],
     });
-    expect(Object.keys(check.settings)).toHaveLength(3);
+
+    expect(Object.keys(result.settings)).toHaveLength(3);
+    expect(result.settings['set.bulk.a']).toBe('alpha');
+    expect(result.settings['set.bulk.b']).toBe('beta');
+    expect(result.settings['set.bulk.c']).toBe('gamma');
   });
 
-  it('rolls back all entries when one write fails', async () => {
-    // Add a trigger that rejects inserts once the table already has 1 row
+  it('rolls back all entries when one write fails mid-transaction', async () => {
+    // Force a DB error on the 3rd insert by adding a trigger that aborts
+    // when the settings table already has 2 rows
     db.exec(`
-      CREATE TRIGGER fail_on_second_insert BEFORE INSERT ON settings
-      WHEN (SELECT COUNT(*) FROM settings) >= 1
-      BEGIN SELECT RAISE(ABORT, 'test: max 1 row'); END;
->>>>>>> 7e84266 (test(settings): add registry and tRPC tests for US-01; export SettingsRegistry class)
+      CREATE TRIGGER test_settings_limit
+      BEFORE INSERT ON settings
+      WHEN (SELECT COUNT(*) FROM settings) >= 2
+      BEGIN
+        SELECT RAISE(ABORT, 'test: too many settings');
+      END
     `);
 
     await expect(
       caller.core.settings.setBulk({
         entries: [
-<<<<<<< HEAD
           { key: 'tx.key.1', value: 'v1' },
           { key: 'tx.key.2', value: 'v2' },
           { key: 'tx.key.3', value: 'v3' },
-=======
-          { key: SETTINGS_KEYS.PLEX_URL, value: 'http://plex:32400' },
-          { key: SETTINGS_KEYS.THEME, value: 'dark' },
->>>>>>> 7e84266 (test(settings): add registry and tRPC tests for US-01; export SettingsRegistry class)
         ],
       })
     ).rejects.toThrow();
 
-<<<<<<< HEAD
     const result = await caller.core.settings.getBulk({
       keys: ['tx.key.1', 'tx.key.2', 'tx.key.3'],
     });
     expect(Object.keys(result.settings)).toHaveLength(0);
-=======
-    // Neither entry should be persisted
-    const check = await caller.core.settings.getBulk({
-      keys: [SETTINGS_KEYS.PLEX_URL, SETTINGS_KEYS.THEME],
-    });
-    expect(check.settings).toEqual({});
->>>>>>> 7e84266 (test(settings): add registry and tRPC tests for US-01; export SettingsRegistry class)
   });
 });

--- a/apps/pops-api/src/modules/core/settings/settings.test.ts
+++ b/apps/pops-api/src/modules/core/settings/settings.test.ts
@@ -244,7 +244,7 @@ describe('SettingsRegistry', () => {
     registry.register(makeManifest('first', 1, ['shared.key']));
 
     expect(() => registry.register(makeManifest('second', 2, ['shared.key']))).toThrow(
-      /shared\.key.*first|first.*shared\.key/
+      /(?=.*shared\.key)(?=.*first)(?=.*second)/
     );
 >>>>>>> 7e84266 (test(settings): add registry and tRPC tests for US-01; export SettingsRegistry class)
   });

--- a/docs/themes/01-foundation/prds/093-unified-settings/README.md
+++ b/docs/themes/01-foundation/prds/093-unified-settings/README.md
@@ -117,7 +117,7 @@ The `core.settings.getManifests` procedure reads from the in-memory registry.
 
 | #   | Story                                                           | Summary                                                                                        | Status      | Parallelisable   |
 | --- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------- | ---------------- |
-| 01  | [us-01-settings-registry](us-01-settings-registry.md)           | Manifest schema, in-memory registry, `getManifests` procedure, `getBulk`/`setBulk` procedures  | In progress | No (first)       |
+| 01  | [us-01-settings-registry](us-01-settings-registry.md)           | Manifest schema, in-memory registry, `getManifests` procedure, `getBulk`/`setBulk` procedures  | Done        | No (first)       |
 | 02  | [us-02-settings-page-shell](us-02-settings-page-shell.md)       | `/settings` route, section navigation sidebar, section scroll anchors, app nav entry           | Done        | Yes              |
 | 03  | [us-03-section-renderer](us-03-section-renderer.md)             | Generic section/group/field renderer, typed field widgets, validation, auto-save, test actions | In progress | Blocked by us-01 |
 | 04  | [us-04-migrate-media-settings](us-04-migrate-media-settings.md) | Plex, Arr, and Rotation manifests, redirect old routes, preserve test connection actions       | Done        | Blocked by us-01 |


### PR DESCRIPTION
## Summary

Closes #1972.

The `getManifests` procedure already outputs `z.array(SettingsManifestSchema)` (added in #1965). This PR adds the missing US-01 test coverage that validates the schema and registry are wired correctly:

- Export `SettingsRegistry` class alongside its singleton so tests can create isolated instances
- Add `clear()` method for resetting the singleton between `getManifests` tRPC tests
- **SettingsRegistry unit tests:** sorted `getAll()`, duplicate-key rejection across manifests
- **`getManifests` tRPC tests:** empty registry, sorted registered manifests
- **`getBulk` tests:** omits missing keys, handles empty input
- **`setBulk` tests:** writes all entries atomically, rolls back on DB failure (via SQLite trigger)
- Mark all US-01 test acceptance criteria `[x]` Done; update PRD-093 US-01 status to Done

## Test plan

- [x] `pnpm test src/modules/core/settings/settings.test.ts` — 21 tests pass
- [x] `pnpm typecheck` — all 13 packages clean
- [x] `pnpm oxlint` — 0 errors

https://claude.ai/code/session_01Lob4B7ShKqGp5spB3hjZf7