### PR TITLE
test(settings): unit tests for SectionRenderer field components (US-03)

### DIFF
--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -37,10 +37,13 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@tanstack/react-query-devtools": "^5.99.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25.6.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
+    "jsdom": "^29.0.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.8",
     "vitest": "^4.1.4"

--- a/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
@@ -108,8 +108,14 @@ describe('SectionRenderer', () => {
       // toggle — renders a checkbox role (Switch)
       expect(screen.getByRole('switch')).toBeInTheDocument();
 
-      // select — renders a combobox
-      expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(1);
+      // select — renders its own combobox distinct from the duration unit selector
+      const selectField = screen.getAllByRole('combobox').find((el) => {
+        const optionValues = Array.from((el as HTMLSelectElement).options).map((o) => o.value);
+        return !optionValues.every((v) =>
+          ['milliseconds', 'seconds', 'minutes', 'hours'].includes(v)
+        );
+      });
+      expect(selectField).toBeInTheDocument();
 
       // password — renders <input type="password">
       const passwordInput = document.querySelector('input[type="password"]');
@@ -273,40 +279,49 @@ describe('SectionRenderer', () => {
 
   describe('test action button', () => {
     it('calls onTestAction with the procedure when the test button is clicked', async () => {
-      const onTestAction = vi.fn().mockResolvedValue(undefined);
+      vi.useFakeTimers();
 
-      const manifest = makeManifest({
-        groups: [
-          {
-            id: 'g1',
-            title: 'Connection',
-            fields: [
-              {
-                key: 'plex_url',
-                label: 'Plex URL',
-                type: 'url',
-                default: 'http://plex.local',
-                testAction: {
-                  procedure: 'media.plex.testConnection',
-                  label: 'Test Connection',
+      try {
+        const onTestAction = vi.fn().mockResolvedValue(undefined);
+
+        const manifest = makeManifest({
+          groups: [
+            {
+              id: 'g1',
+              title: 'Connection',
+              fields: [
+                {
+                  key: 'plex_url',
+                  label: 'Plex URL',
+                  type: 'url',
+                  default: 'http://plex.local',
+                  testAction: {
+                    procedure: 'media.plex.testConnection',
+                    label: 'Test Connection',
+                  },
                 },
-              },
-            ],
-          },
-        ],
-      });
+              ],
+            },
+          ],
+        });
 
-      render(<SectionRenderer manifest={manifest} onTestAction={onTestAction} />);
+        render(<SectionRenderer manifest={manifest} onTestAction={onTestAction} />);
 
-      const testButton = screen.getByRole('button', { name: /test connection/i });
-      fireEvent.click(testButton);
+        const testButton = screen.getByRole('button', { name: /test connection/i });
+        fireEvent.click(testButton);
 
-      await act(async () => {
-        await Promise.resolve();
-      });
+        await act(async () => {
+          await Promise.resolve();
+        });
 
-      expect(onTestAction).toHaveBeenCalledOnce();
-      expect(onTestAction).toHaveBeenCalledWith('media.plex.testConnection');
+        expect(onTestAction).toHaveBeenCalledOnce();
+        expect(onTestAction).toHaveBeenCalledWith('media.plex.testConnection');
+      } finally {
+        await act(async () => {
+          await vi.runAllTimersAsync();
+        });
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
@@ -1,0 +1,312 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  getBulk: vi.fn(),
+  setBulkMutate: vi.fn(),
+}));
+
+vi.mock('@/lib/trpc', () => ({
+  trpc: {
+    core: {
+      settings: {
+        getBulk: {
+          useQuery: (input: unknown) => mocks.getBulk(input),
+        },
+        setBulk: {
+          useMutation: () => ({ mutate: mocks.setBulkMutate }),
+        },
+      },
+    },
+  },
+}));
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+
+import { SectionRenderer } from './SectionRenderer';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeManifest(overrides: Record<string, any> = {}): any {
+  return {
+    id: 'test',
+    title: 'Test',
+    order: 0,
+    groups: [],
+    ...overrides,
+  };
+}
+
+function defaultBulkData(settings: Record<string, string> = {}) {
+  return { data: { settings }, isLoading: false };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SectionRenderer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getBulk.mockReturnValue(defaultBulkData());
+  });
+
+  describe('field type rendering', () => {
+    it('renders the correct widget for each field type', () => {
+      const manifest = makeManifest({
+        groups: [
+          {
+            id: 'g1',
+            title: 'All Types',
+            fields: [
+              { key: 'f_text', label: 'Text Field', type: 'text', default: '' },
+              { key: 'f_number', label: 'Number Field', type: 'number', default: '0' },
+              {
+                key: 'f_toggle',
+                label: 'Toggle Field',
+                type: 'toggle',
+                default: 'false',
+              },
+              {
+                key: 'f_select',
+                label: 'Select Field',
+                type: 'select',
+                default: 'a',
+                options: [
+                  { value: 'a', label: 'Option A' },
+                  { value: 'b', label: 'Option B' },
+                ],
+              },
+              { key: 'f_password', label: 'Password Field', type: 'password', default: '' },
+              { key: 'f_url', label: 'URL Field', type: 'url', default: '' },
+              { key: 'f_duration', label: 'Duration Field', type: 'duration', default: '60000' },
+              { key: 'f_json', label: 'JSON Field', type: 'json', default: '{}' },
+            ],
+          },
+        ],
+      });
+
+      render(<SectionRenderer manifest={manifest} />);
+
+      // text — renders <input type="text">
+      const textInput = screen
+        .getAllByRole('textbox')
+        .find((el) => el.getAttribute('type') === 'text' || el.getAttribute('type') === null);
+      expect(textInput).toBeInTheDocument();
+
+      // number — renders <input type="number">
+      const numberInputs = screen.getAllByRole('spinbutton');
+      expect(numberInputs.length).toBeGreaterThanOrEqual(2); // number + duration
+
+      // toggle — renders a checkbox role (Switch)
+      expect(screen.getByRole('switch')).toBeInTheDocument();
+
+      // select — renders a combobox
+      expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(1);
+
+      // password — renders <input type="password">
+      const passwordInput = document.querySelector('input[type="password"]');
+      expect(passwordInput).toBeInTheDocument();
+
+      // url — renders <input type="url">
+      const urlInput = document.querySelector('input[type="url"]');
+      expect(urlInput).toBeInTheDocument();
+
+      // duration — number input + unit selector
+      const durationUnitSelect = screen
+        .getAllByRole('combobox')
+        .find((el) =>
+          ['milliseconds', 'seconds', 'minutes', 'hours'].includes((el as HTMLSelectElement).value)
+        );
+      expect(durationUnitSelect).toBeInTheDocument();
+
+      // json — renders a <textarea>
+      const textarea = document.querySelector('textarea');
+      expect(textarea).toBeInTheDocument();
+    });
+  });
+
+  describe('debounced auto-save', () => {
+    it('calls setBulk after 500ms and not before', async () => {
+      vi.useFakeTimers();
+
+      const manifest = makeManifest({
+        groups: [
+          {
+            id: 'g1',
+            title: 'Auto-save',
+            fields: [{ key: 'api_url', label: 'API URL', type: 'text', default: '' }],
+          },
+        ],
+      });
+
+      render(<SectionRenderer manifest={manifest} />);
+
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'https://example.com' } });
+
+      // Not called immediately
+      expect(mocks.setBulkMutate).not.toHaveBeenCalled();
+
+      // Not called at 499ms
+      await act(async () => {
+        vi.advanceTimersByTime(499);
+      });
+      expect(mocks.setBulkMutate).not.toHaveBeenCalled();
+
+      // Called at 500ms
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(mocks.setBulkMutate).toHaveBeenCalledOnce();
+      expect(mocks.setBulkMutate).toHaveBeenCalledWith(
+        { entries: [{ key: 'api_url', value: 'https://example.com' }] },
+        expect.any(Object)
+      );
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('pattern validation', () => {
+    it('shows error and does not call setBulk when value fails pattern', async () => {
+      vi.useFakeTimers();
+
+      const manifest = makeManifest({
+        groups: [
+          {
+            id: 'g1',
+            title: 'Validation',
+            fields: [
+              {
+                key: 'port',
+                label: 'Port',
+                type: 'text',
+                default: '',
+                validation: {
+                  pattern: '^\\d+$',
+                  message: 'Must be a number',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      render(<SectionRenderer manifest={manifest} />);
+
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'not-a-number' } });
+
+      // Error message shown
+      expect(screen.getByText('Must be a number')).toBeInTheDocument();
+
+      // Even after 500ms, setBulk must not have been called
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(mocks.setBulkMutate).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('environment variable fallback', () => {
+    it('shows "Using environment variable" label when no DB value exists', () => {
+      const manifest = makeManifest({
+        groups: [
+          {
+            id: 'g1',
+            title: 'Env Fallback',
+            fields: [
+              {
+                key: 'plex_token',
+                label: 'Plex Token',
+                type: 'password',
+                envFallback: 'PLEX_TOKEN',
+              },
+            ],
+          },
+        ],
+      });
+
+      // DB returns no value for plex_token
+      mocks.getBulk.mockReturnValue(defaultBulkData({}));
+
+      render(<SectionRenderer manifest={manifest} />);
+
+      expect(screen.getByText('Using environment variable PLEX_TOKEN')).toBeInTheDocument();
+    });
+
+    it('does not show the label when a DB value exists', () => {
+      const manifest = makeManifest({
+        groups: [
+          {
+            id: 'g1',
+            title: 'Env Fallback',
+            fields: [
+              {
+                key: 'plex_token',
+                label: 'Plex Token',
+                type: 'password',
+                envFallback: 'PLEX_TOKEN',
+              },
+            ],
+          },
+        ],
+      });
+
+      mocks.getBulk.mockReturnValue(defaultBulkData({ plex_token: 'my-secret-token' }));
+
+      render(<SectionRenderer manifest={manifest} />);
+
+      expect(screen.queryByText('Using environment variable PLEX_TOKEN')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('test action button', () => {
+    it('calls onTestAction with the procedure when the test button is clicked', async () => {
+      const onTestAction = vi.fn().mockResolvedValue(undefined);
+
+      const manifest = makeManifest({
+        groups: [
+          {
+            id: 'g1',
+            title: 'Connection',
+            fields: [
+              {
+                key: 'plex_url',
+                label: 'Plex URL',
+                type: 'url',
+                default: 'http://plex.local',
+                testAction: {
+                  procedure: 'media.plex.testConnection',
+                  label: 'Test Connection',
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      render(<SectionRenderer manifest={manifest} onTestAction={onTestAction} />);
+
+      const testButton = screen.getByRole('button', { name: /test connection/i });
+      fireEvent.click(testButton);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(onTestAction).toHaveBeenCalledOnce();
+      expect(onTestAction).toHaveBeenCalledWith('media.plex.testConnection');
+    });
+  });
+});

--- a/apps/pops-shell/src/test-setup.ts
+++ b/apps/pops-shell/src/test-setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest';
+
+globalThis.ResizeObserver ??= class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};

--- a/apps/pops-shell/vite.config.ts
+++ b/apps/pops-shell/vite.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
   },
   plugins: [react(), tailwindcss()],
   test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test-setup.ts'],
     exclude: ['e2e/**', 'node_modules/**'],
   },
   resolve: {

--- a/docs/themes/01-foundation/prds/093-unified-settings/us-03-section-renderer.md
+++ b/docs/themes/01-foundation/prds/093-unified-settings/us-03-section-renderer.md
@@ -66,11 +66,11 @@ As a user, I want settings fields to render as appropriate input widgets with in
 
 ### Tests
 
-- [ ] Unit test: render a section with one field of each type — verify the correct widget is rendered for each
-- [ ] Unit test: change a text field value — verify `core.settings.set` is called after the debounce period and not before
-- [ ] Unit test: enter an invalid value in a field with a `pattern` validation rule — verify the error message is displayed and `set` is not called
-- [ ] Unit test: render a field with `envFallback` and no database value — verify the "Using environment variable" label is shown
-- [ ] Unit test: render a field with `testAction`, click the test button — verify the specified procedure is called
+- [x] Unit test: render a section with one field of each type — verify the correct widget is rendered for each
+- [x] Unit test: change a text field value — verify `core.settings.set` is called after the debounce period and not before
+- [x] Unit test: enter an invalid value in a field with a `pattern` validation rule — verify the error message is displayed and `set` is not called
+- [x] Unit test: render a field with `envFallback` and no database value — verify the "Using environment variable" label is shown
+- [x] Unit test: render a field with `testAction`, click the test button — verify the specified procedure is called
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/093-unified-settings/us-03-section-renderer.md
+++ b/docs/themes/01-foundation/prds/093-unified-settings/us-03-section-renderer.md
@@ -67,8 +67,8 @@ As a user, I want settings fields to render as appropriate input widgets with in
 ### Tests
 
 - [x] Unit test: render a section with one field of each type — verify the correct widget is rendered for each
-- [x] Unit test: change a text field value — verify `core.settings.set` is called after the debounce period and not before
-- [x] Unit test: enter an invalid value in a field with a `pattern` validation rule — verify the error message is displayed and `set` is not called
+- [x] Unit test: change a text field value — verify `core.settings.setBulk` is called after the debounce period and not before
+- [x] Unit test: enter an invalid value in a field with a `pattern` validation rule — verify the error message is displayed and `setBulk` is not called
 - [x] Unit test: render a field with `envFallback` and no database value — verify the "Using environment variable" label is shown
 - [x] Unit test: render a field with `testAction`, click the test button — verify the specified procedure is called
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,12 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.99.0
         version: 5.99.0(@tanstack/react-query@5.99.0(react@19.2.5))(react@19.2.5)
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -238,6 +244,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -5145,10 +5154,6 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
-  lru-cache@11.3.2:
-    resolution: {integrity: sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==}
-    engines: {node: 20 || >=22}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -10141,7 +10146,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.3.2
+      lru-cache: 11.3.5
       parse5: 8.0.0
       saxes: 6.0.0
       symbol-tree: 3.2.4
@@ -10309,8 +10314,6 @@ snapshots:
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
-
-  lru-cache@11.3.2: {}
 
   lru-cache@11.3.5: {}
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #1971

- Adds `@testing-library/react`, `@testing-library/jest-dom`, and `jsdom` to `pops-shell` devDependencies and configures vitest with `environment: 'jsdom'` + a `test-setup.ts`
- Adds `apps/pops-shell/src/components/settings/SectionRenderer.test.tsx` with 6 tests covering all 5 acceptance criteria from US-03:
  - **Field-type rendering** — verifies the correct widget is rendered for each of `text`, `number`, `toggle`, `select`, `password`, `url`, `duration`, and `json`
  - **Debounced auto-save** — verifies `core.settings.setBulk` is called after exactly 500 ms and not before
  - **Pattern validation** — verifies the error message appears and `setBulk` is not called when a value fails the `pattern` rule
  - **envFallback label (present)** — verifies "Using environment variable X" is shown when no DB value exists
  - **envFallback label (absent)** — verifies the label disappears once a DB value is set
  - **testAction button** — verifies clicking the test button calls `onTestAction` with the correct procedure name
- Marks all test acceptance criteria in `us-03-section-renderer.md` as `[x]`

## Test plan

- [x] `pnpm test` in `apps/pops-shell` — 100/100 tests pass (10 test files)
- [x] `mise typecheck` — all 16 packages pass (pre-existing errors in `SectionRenderer.tsx` and `SettingsPage.tsx` remain unchanged)

https://claude.ai/code/session_01XFz8GPq9X1ravHyJjqYZR3
EOF
)