### PR TITLE
test(settings): add unit tests for registry and bulk procedures (US-01 #1967)

### DIFF
--- a/apps/pops-api/src/modules/core/settings/registry.ts
+++ b/apps/pops-api/src/modules/core/settings/registry.ts
@@ -1,6 +1,6 @@
 import type { SettingsManifest } from '@pops/types';
 
-class SettingsRegistry {
+export class SettingsRegistry {
   private manifests = new Map<string, SettingsManifest>();
 
   register(manifest: SettingsManifest): void {

--- a/apps/pops-api/src/modules/core/settings/settings.test.ts
+++ b/apps/pops-api/src/modules/core/settings/settings.test.ts
@@ -3,8 +3,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createCaller, seedSetting, setupTestContext } from '../../../shared/test-utils.js';
 import { SETTINGS_KEYS } from './keys.js';
+import { SettingsRegistry } from './registry.js';
 
 import type { Database } from 'better-sqlite3';
+
+import type { SettingsManifest } from '@pops/types';
 
 import type { Setting } from './types.js';
 
@@ -140,5 +143,118 @@ describe('settings.delete', () => {
     ).rejects.toMatchObject({
       code: 'NOT_FOUND',
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SettingsRegistry unit tests
+// ---------------------------------------------------------------------------
+
+function makeManifest(id: string, order: number, keys: string[]): SettingsManifest {
+  return {
+    id,
+    title: id,
+    order,
+    groups: [
+      {
+        id: 'g',
+        title: 'Group',
+        fields: keys.map((key) => ({ key, label: key, type: 'text' as const })),
+      },
+    ],
+  };
+}
+
+describe('SettingsRegistry', () => {
+  it('getAll() returns manifests sorted by order', () => {
+    const registry = new SettingsRegistry();
+    registry.register(makeManifest('beta', 200, ['beta.key']));
+    registry.register(makeManifest('alpha', 100, ['alpha.key']));
+
+    const all = registry.getAll();
+    expect(all).toHaveLength(2);
+    expect(all[0]!.id).toBe('alpha');
+    expect(all[1]!.id).toBe('beta');
+  });
+
+  it('throws when a key is shared between two manifests', () => {
+    const registry = new SettingsRegistry();
+    registry.register(makeManifest('manifest-a', 100, ['shared.key', 'a.only']));
+
+    expect(() =>
+      registry.register(makeManifest('manifest-b', 200, ['b.only', 'shared.key']))
+    ).toThrow(/shared\.key.*manifest-a.*manifest-b|manifest-a.*shared\.key.*manifest-b/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// settings.getBulk / settings.setBulk tRPC procedure tests
+// ---------------------------------------------------------------------------
+
+describe('settings.getBulk', () => {
+  it('returns only the keys that exist in the database', async () => {
+    seedSetting(db, { key: 'bulk.key.1', value: 'v1' });
+    seedSetting(db, { key: 'bulk.key.2', value: 'v2' });
+    seedSetting(db, { key: 'bulk.key.3', value: 'v3' });
+
+    const result = await caller.core.settings.getBulk({
+      keys: ['bulk.key.1', 'bulk.key.2', 'bulk.key.3', 'bulk.key.4', 'bulk.key.5'],
+    });
+
+    expect(Object.keys(result.settings)).toHaveLength(3);
+    expect(result.settings['bulk.key.1']).toBe('v1');
+    expect(result.settings['bulk.key.2']).toBe('v2');
+    expect(result.settings['bulk.key.3']).toBe('v3');
+    expect(result.settings['bulk.key.4']).toBeUndefined();
+    expect(result.settings['bulk.key.5']).toBeUndefined();
+  });
+});
+
+describe('settings.setBulk', () => {
+  it('saves all 3 entries and makes them retrievable', async () => {
+    await caller.core.settings.setBulk({
+      entries: [
+        { key: 'set.bulk.a', value: 'alpha' },
+        { key: 'set.bulk.b', value: 'beta' },
+        { key: 'set.bulk.c', value: 'gamma' },
+      ],
+    });
+
+    const result = await caller.core.settings.getBulk({
+      keys: ['set.bulk.a', 'set.bulk.b', 'set.bulk.c'],
+    });
+
+    expect(Object.keys(result.settings)).toHaveLength(3);
+    expect(result.settings['set.bulk.a']).toBe('alpha');
+    expect(result.settings['set.bulk.b']).toBe('beta');
+    expect(result.settings['set.bulk.c']).toBe('gamma');
+  });
+
+  it('rolls back all entries when one write fails mid-transaction', async () => {
+    // Force a DB error on the 3rd insert by adding a trigger that aborts
+    // when the settings table already has 2 rows
+    db.exec(`
+      CREATE TRIGGER test_settings_limit
+      BEFORE INSERT ON settings
+      WHEN (SELECT COUNT(*) FROM settings) >= 2
+      BEGIN
+        SELECT RAISE(ABORT, 'test: too many settings');
+      END
+    `);
+
+    await expect(
+      caller.core.settings.setBulk({
+        entries: [
+          { key: 'tx.key.1', value: 'v1' },
+          { key: 'tx.key.2', value: 'v2' },
+          { key: 'tx.key.3', value: 'v3' },
+        ],
+      })
+    ).rejects.toThrow();
+
+    const result = await caller.core.settings.getBulk({
+      keys: ['tx.key.1', 'tx.key.2', 'tx.key.3'],
+    });
+    expect(Object.keys(result.settings)).toHaveLength(0);
   });
 });

--- a/docs/themes/01-foundation/prds/093-unified-settings/us-01-settings-registry.md
+++ b/docs/themes/01-foundation/prds/093-unified-settings/us-01-settings-registry.md
@@ -31,11 +31,11 @@ As the system, I need a typed settings manifest registry and bulk read/write tRP
 
 ### Tests
 
-- [ ] Unit test: register two manifests with different keys and orders, call `getAll()`, verify both returned and sorted by `order`
-- [ ] Unit test: register a manifest, then register a second manifest that shares a key with the first — verify the error is thrown with both manifest IDs and the duplicate key in the message
-- [ ] Unit test: `getBulk` with 5 keys where 3 exist in the database — verify the returned record contains exactly the 3 existing keys
-- [ ] Unit test: `setBulk` with 3 valid entries — verify all 3 are saved and retrievable
-- [ ] Unit test: `setBulk` where one entry causes a database error — verify none of the entries are saved (transaction rollback)
+- [x] Unit test: register two manifests with different keys and orders, call `getAll()`, verify both returned and sorted by `order`
+- [x] Unit test: register a manifest, then register a second manifest that shares a key with the first — verify the error is thrown with both manifest IDs and the duplicate key in the message
+- [x] Unit test: `getBulk` with 5 keys where 3 exist in the database — verify the returned record contains exactly the 3 existing keys
+- [x] Unit test: `setBulk` with 3 valid entries — verify all 3 are saved and retrievable
+- [x] Unit test: `setBulk` where one entry causes a database error — verify none of the entries are saved (transaction rollback)
 
 ## Notes
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Export `SettingsRegistry` class from `registry.ts` to allow isolated instantiation in tests
- Add 5 unit tests covering all acceptance criteria from US-01 (#1967):
  - `SettingsRegistry.getAll()` returns manifests sorted by `order`
  - `SettingsRegistry.register()` throws with both manifest IDs and duplicate key in message
  - `settings.getBulk` returns only the 3 existing keys when 5 are requested
  - `settings.setBulk` saves all 3 entries and makes them retrievable
  - `settings.setBulk` rolls back the entire transaction when one write fails (verified via SQLite trigger)
- Tick off all 5 test acceptance criteria in `us-01-settings-registry.md`

## Test plan

- [x] `pnpm test` — 18 tests pass in `settings.test.ts` (13 existing + 5 new)
- [x] `pnpm typecheck` — passes across all packages
- [x] `pnpm oxlint` — 0 errors (pre-existing warning unrelated to this change)

## Gaps (tracked)

None.

https://claude.ai/code/session_01SZ25hCAkeNNz582hquT97j
EOF
)