### PR TITLE
refactor(lint): enforce agent-optimal complexity limits with tiered debt overrides [Step 0]

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,15 +8,15 @@
     "perf": "warn"
   },
   "rules": {
-    "max-lines": ["error", { "max": 1200, "skipBlankLines": true, "skipComments": true }],
+    "max-lines": ["error", { "max": 200, "skipBlankLines": true, "skipComments": true }],
     "max-lines-per-function": [
       "error",
-      { "max": 600, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+      { "max": 60, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
     ],
-    "complexity": ["error", 45],
+    "complexity": ["error", 12],
     "max-statements": ["error", 160],
     "max-params": ["error", 6],
-    "max-depth": ["error", 5],
+    "max-depth": ["error", 3],
     "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-inline-comments": "off",
     "no-negated-condition": "off",
@@ -202,6 +202,7 @@
           { "max": 450, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
         ],
         "complexity": ["error", 42],
+        "max-depth": ["error", 5],
         "max-params": ["error", 10],
         "typescript/no-non-null-assertion": "error",
         "typescript/explicit-function-return-type": [
@@ -216,24 +217,77 @@
       }
     },
     {
-      "files": ["apps/pops-api/src/db/schema.ts", "apps/pops-api/src/db/seeder.ts"],
-      "rules": {
-        "max-lines": "off",
-        "max-lines-per-function": "off",
-        "complexity": "off",
-        "max-statements": "off",
-        "max-params": "off",
-        "max-depth": "off"
-      }
-    },
-    {
       "files": ["packages/import-tools/src/**/*.ts"],
       "rules": {
         "no-console": "off",
+        "max-lines": ["error", { "max": 400, "skipBlankLines": true, "skipComments": true }],
+        "max-lines-per-function": [
+          "error",
+          { "max": 200, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+        ],
+        "complexity": ["error", 20],
+        "max-depth": ["error", 4],
         "typescript/explicit-function-return-type": "off",
         "typescript/require-await": "off",
         "typescript/no-unnecessary-type-assertion": "error",
         "typescript/no-floating-promises": "error"
+      }
+    },
+    {
+      "files": ["apps/pops-shell/src/**/*.{ts,tsx}"],
+      "rules": {
+        "max-lines": ["error", { "max": 550, "skipBlankLines": true, "skipComments": true }],
+        "max-lines-per-function": [
+          "error",
+          { "max": 300, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+        ],
+        "complexity": ["error", 40],
+        "max-depth": ["error", 4]
+      }
+    },
+    {
+      "files": ["packages/ui/src/**/*.{ts,tsx}"],
+      "rules": {
+        "max-lines": ["error", { "max": 400, "skipBlankLines": true, "skipComments": true }],
+        "max-lines-per-function": [
+          "error",
+          { "max": 300, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+        ],
+        "complexity": ["error", 25],
+        "max-depth": ["error", 4],
+        "jsx-a11y/alt-text": "warn",
+        "jsx-a11y/aria-role": "warn",
+        "jsx-a11y/click-events-have-key-events": "warn"
+      }
+    },
+    {
+      "files": [
+        "packages/app-*/src/components/**/*.{ts,tsx}",
+        "packages/app-*/src/hooks/**/*.{ts,tsx}",
+        "packages/app-*/src/store/**/*.{ts,tsx}",
+        "packages/app-*/src/lib/**/*.{ts,tsx}",
+        "packages/navigation/src/**/*.{ts,tsx}"
+      ],
+      "rules": {
+        "max-lines": ["error", { "max": 500, "skipBlankLines": true, "skipComments": true }],
+        "max-lines-per-function": [
+          "error",
+          { "max": 300, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+        ],
+        "complexity": ["error", 25],
+        "max-depth": ["error", 4]
+      }
+    },
+    {
+      "files": ["packages/app-*/src/pages/**/*.{ts,tsx}"],
+      "rules": {
+        "max-lines": ["error", { "max": 600, "skipBlankLines": true, "skipComments": true }],
+        "max-lines-per-function": [
+          "error",
+          { "max": 500, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+        ],
+        "complexity": ["error", 25],
+        "max-depth": ["error", 4]
       }
     },
     {
@@ -244,7 +298,8 @@
           "error",
           { "max": 650, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
         ],
-        "complexity": ["error", 50]
+        "complexity": ["error", 50],
+        "max-depth": ["error", 4]
       }
     },
     {
@@ -260,30 +315,110 @@
       }
     },
     {
-      "files": ["packages/app-inventory/src/pages/ItemFormPage.tsx"],
-      "rules": {
-        "max-lines-per-function": [
-          "error",
-          { "max": 750, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
-        ]
-      }
-    },
-    {
       "files": ["packages/app-media/src/pages/**/*.tsx"],
       "rules": {
-        "complexity": ["error", 105],
+        "max-lines": ["error", { "max": 950, "skipBlankLines": true, "skipComments": true }],
         "max-lines-per-function": [
           "error",
           { "max": 650, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+        ],
+        "complexity": ["error", 105],
+        "max-depth": ["error", 4]
+      }
+    },
+    {
+      "files": ["packages/app-inventory/src/pages/ItemFormPage.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 950, "skipBlankLines": true, "skipComments": true }],
+        "max-lines-per-function": [
+          "error",
+          { "max": 750, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+        ],
+        "complexity": ["error", 45]
+      }
+    },
+    {
+      "files": ["packages/app-inventory/src/pages/LocationTreePage.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 1050, "skipBlankLines": true, "skipComments": true }],
+        "max-lines-per-function": [
+          "error",
+          { "max": 1050, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+        ],
+        "complexity": ["error", 50]
+      }
+    },
+    {
+      "files": ["packages/app-inventory/src/pages/ItemDetailPage.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 800, "skipBlankLines": true, "skipComments": true }],
+        "max-lines-per-function": [
+          "error",
+          { "max": 800, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+        ],
+        "complexity": ["error", 40]
+      }
+    },
+    {
+      "files": ["packages/app-ai/src/pages/AiUsagePage.tsx"],
+      "rules": {
+        "max-lines": ["error", { "max": 800, "skipBlankLines": true, "skipComments": true }],
+        "max-lines-per-function": [
+          "error",
+          { "max": 800, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+        ],
+        "complexity": ["error", 35]
+      }
+    },
+    {
+      "files": [
+        "packages/app-media/src/components/RequestSeriesModal.tsx",
+        "packages/app-media/src/components/RequestMovieModal.tsx",
+        "packages/app-media/src/components/SourceManagementSection.tsx",
+        "packages/app-media/src/components/DiscoverCard.tsx",
+        "packages/app-media/src/components/SearchResultCard.tsx",
+        "packages/app-media/src/components/MovieActionButtons.tsx"
+      ],
+      "rules": {
+        "complexity": ["error", 40]
+      }
+    },
+    {
+      "files": ["packages/app-media/src/components/DimensionManager.tsx"],
+      "rules": {
+        "max-lines-per-function": [
+          "error",
+          { "max": 325, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
         ]
       }
     },
     {
-      "files": ["packages/ui/src/**/*.{ts,tsx}"],
+      "files": ["packages/app-media/src/hooks/useSyncJob.ts"],
       "rules": {
-        "jsx-a11y/alt-text": "warn",
-        "jsx-a11y/aria-role": "warn",
-        "jsx-a11y/click-events-have-key-events": "warn"
+        "complexity": ["error", 30]
+      }
+    },
+    {
+      "files": ["packages/app-inventory/src/components/InventoryCard.tsx"],
+      "rules": {
+        "complexity": ["error", 35]
+      }
+    },
+    {
+      "files": ["packages/app-inventory/src/pages/ItemsPage.tsx"],
+      "rules": {
+        "complexity": ["error", 35]
+      }
+    },
+    {
+      "files": ["apps/pops-api/src/db/schema.ts", "apps/pops-api/src/db/seeder.ts"],
+      "rules": {
+        "max-lines": "off",
+        "max-lines-per-function": "off",
+        "complexity": "off",
+        "max-statements": "off",
+        "max-params": "off",
+        "max-depth": "off"
       }
     },
     {
@@ -310,6 +445,9 @@
     {
       "files": ["**/*.stories.{ts,tsx}"],
       "rules": {
+        "max-lines": "off",
+        "max-lines-per-function": "off",
+        "complexity": "off",
         "no-console": "off",
         "react/no-array-index-key": "off",
         "react-hooks/rules-of-hooks": "off"
@@ -322,6 +460,10 @@
         "services/*/src/scripts/**/*.ts"
       ],
       "rules": {
+        "max-lines": "off",
+        "max-lines-per-function": "off",
+        "complexity": "off",
+        "max-depth": "off",
         "no-console": "off"
       }
     }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -343,7 +343,7 @@
         "max-lines": ["error", { "max": 1050, "skipBlankLines": true, "skipComments": true }],
         "max-lines-per-function": [
           "error",
-          { "max": 1050, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+          { "max": 460, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
         ],
         "complexity": ["error", 50]
       }
@@ -354,7 +354,7 @@
         "max-lines": ["error", { "max": 800, "skipBlankLines": true, "skipComments": true }],
         "max-lines-per-function": [
           "error",
-          { "max": 800, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+          { "max": 320, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
         ],
         "complexity": ["error", 40]
       }
@@ -365,7 +365,7 @@
         "max-lines": ["error", { "max": 800, "skipBlankLines": true, "skipComments": true }],
         "max-lines-per-function": [
           "error",
-          { "max": 800, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+          { "max": 310, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
         ],
         "complexity": ["error", 35]
       }
@@ -448,6 +448,8 @@
         "max-lines": "off",
         "max-lines-per-function": "off",
         "complexity": "off",
+        "max-depth": "off",
+        "max-statements": "off",
         "no-console": "off",
         "react/no-array-index-key": "off",
         "react-hooks/rules-of-hooks": "off"


### PR DESCRIPTION
## Summary

- Drops global lint limits from their lenient previous values to **agent-optimal targets** — new code written anywhere in the codebase must meet these standards
- Introduces a **three-tier override system** that documents all existing debt explicitly, so CI stays green while Groups A–E are refactored
- Stories and e2e files are now fully exempt from all complexity rules (they were partially exempt before)

## New global limits (new code target)

| Rule | Before | After |
|------|--------|-------|
| `max-lines` | 1,200 | **200** |
| `max-lines-per-function` | 600 | **60** |
| `complexity` | 45 | **12** |
| `max-depth` | 5 | **3** |

## Override tiers

**Tier 1 — Primary debt (god files, removed as Groups A–E merge):**
Per-file overrides pinned to each file's current size. Each group issue removes its slice.
- `LocationTreePage.tsx` → #2038
- `ItemFormPage.tsx`, `ItemDetailPage.tsx` → #2038
- `TagReviewStep.tsx`, `CorrectionProposalDialog.tsx` → #2039
- `WatchlistPage.tsx`, `AiUsagePage.tsx` (+ other media pages) → #2040
- `watch-history/service.ts`, `arr/router.ts`, `rotation/router.ts` → #2041
- `corrections/service.ts`, `engrams/service.ts` → #2042

**Tier 2 — Secondary debt (broad directory overrides, tightened in Final step):**
| Scope | max-lines | max-fn | complexity | max-depth |
|-------|-----------|--------|------------|-----------|
| `app-*/components`, hooks, store, lib | 500 | 300 | 25 | 4 |
| `app-*/pages` | 600 | 500 | 25 | 4 |
| `pops-shell/src` | 550 | 300 | 40 | 4 |
| `packages/ui` | 400 | 300 | 25 | 4 |
| `import-tools` | 400 | 200 | 20 | 4 |
| API backend | 2000 | 450 | 42 | **5** (was missing) |
Plus 13 targeted per-file complexity overrides for components with complexity 26–45.

**Tier 3 — Always exempt (unchanged):**
`db/schema`, `db/seeder`, `*.test.*`, `*.stories.*`, `e2e/**`

## Result

`npx oxlint` → **0 errors, 82 warnings** (warnings are pre-existing `exhaustive-deps` / `react/no-array-index-key`, unchanged).

## Downstream issues

All parallel refactor groups depend on this PR:
- #2038 Group A — Inventory UI
- #2039 Group B — Finance Imports UI
- #2040 Group C — Media Frontend
- #2041 Group D — Media Backend
- #2042 Group E — Core Backend
- #2043 Final — Remove all overrides, enforce agent-optimal everywhere

## Gaps (tracked)

None — this is a lint config change only, no production logic modified.

https://claude.ai/code/session_018CaY1WFYcKQAK5B6TjmbWS