### PR TITLE
refactor: extract BreakdownTable, ConfidenceSlider, and SearchResultItem

### DIFF
--- a/packages/app-ai/src/components/BreakdownTable.tsx
+++ b/packages/app-ai/src/components/BreakdownTable.tsx
@@ -1,0 +1,65 @@
+import { DataTable, SortableHeader } from '@pops/ui';
+
+import type { ColumnDef } from '@tanstack/react-table';
+
+interface BreakdownRow {
+  key: string;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
+export function BreakdownTable({ title, data }: { title: string; data: BreakdownRow[] }) {
+  const columns: ColumnDef<BreakdownRow>[] = [
+    {
+      accessorKey: 'key',
+      header: title,
+      cell: ({ row }) => <span className="font-mono text-sm">{row.original.key}</span>,
+    },
+    {
+      accessorKey: 'calls',
+      header: ({ column }) => (
+        <div className="flex justify-end">
+          <SortableHeader column={column}>Calls</SortableHeader>
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="text-right tabular-nums">{row.original.calls.toLocaleString()}</div>
+      ),
+    },
+    {
+      id: 'tokens',
+      header: () => <div className="text-right">Tokens</div>,
+      cell: ({ row }) => (
+        <div className="text-right text-sm tabular-nums text-muted-foreground">
+          {(row.original.inputTokens + row.original.outputTokens).toLocaleString()}
+        </div>
+      ),
+    },
+    {
+      accessorKey: 'costUsd',
+      header: ({ column }) => (
+        <div className="flex justify-end">
+          <SortableHeader column={column}>Cost</SortableHeader>
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="text-right font-mono font-medium tabular-nums">
+          ${row.original.costUsd.toFixed(4)}
+        </div>
+      ),
+    },
+  ];
+
+  if (data.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <h3 className="font-semibold text-sm text-muted-foreground uppercase tracking-wide">
+        By {title}
+      </h3>
+      <DataTable columns={columns} data={data} />
+    </div>
+  );
+}

--- a/packages/app-ai/src/components/ConfidenceSlider.tsx
+++ b/packages/app-ai/src/components/ConfidenceSlider.tsx
@@ -53,7 +53,7 @@ export function ConfidenceSlider({ ruleId, initial, onAutoDelete }: ConfidenceSl
   };
 
   return (
-    <div className="flex items-center gap-2 min-w-35">
+    <div className="flex items-center gap-2 min-w-36">
       <Slider
         min={0}
         max={1}

--- a/packages/app-ai/src/components/ConfidenceSlider.tsx
+++ b/packages/app-ai/src/components/ConfidenceSlider.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { trpc } from '@pops/api-client';
+import { Slider, useDebouncedCallback } from '@pops/ui';
+
+interface ConfidenceSliderProps {
+  ruleId: string;
+  initial: number;
+  onAutoDelete: (id: string) => void;
+}
+
+export function ConfidenceSlider({ ruleId, initial, onAutoDelete }: ConfidenceSliderProps) {
+  const [value, setValue] = useState(initial);
+  const initialRef = useRef(initial);
+  const utils = trpc.useUtils();
+
+  // Keep initialRef in sync when the prop changes (e.g. after query invalidation)
+  useEffect(() => {
+    initialRef.current = initial;
+    setValue(initial);
+  }, [initial]);
+
+  const adjustMutation = trpc.core.corrections.adjustConfidence.useMutation({
+    onSuccess: () => {
+      void utils.core.corrections.list.invalidate();
+    },
+  });
+
+  const commit = useCallback(
+    (newValue: number) => {
+      const delta = newValue - initialRef.current;
+      if (Math.abs(delta) < 0.001) return;
+      adjustMutation.mutate(
+        { id: ruleId, delta },
+        {
+          onSuccess: () => {
+            if (newValue < 0.3) {
+              onAutoDelete(ruleId);
+            }
+          },
+        }
+      );
+    },
+    [ruleId, adjustMutation, onAutoDelete]
+  );
+
+  const debouncedCommit = useDebouncedCallback(commit, 400);
+
+  const handleChange = (values: number[]) => {
+    const next = values[0] ?? value;
+    setValue(next);
+    debouncedCommit(next);
+  };
+
+  return (
+    <div className="flex items-center gap-2 min-w-35">
+      <Slider
+        min={0}
+        max={1}
+        step={0.01}
+        value={[value]}
+        onValueChange={handleChange}
+        className="w-20"
+        aria-label={`Confidence for rule ${ruleId}`}
+      />
+      <span className="text-xs tabular-nums w-10 text-right">{(value * 100).toFixed(0)}%</span>
+    </div>
+  );
+}

--- a/packages/app-ai/src/pages/AiUsagePage.tsx
+++ b/packages/app-ai/src/pages/AiUsagePage.tsx
@@ -37,9 +37,9 @@ import {
   StatCard,
 } from '@pops/ui';
 
-import type { ColumnDef } from '@tanstack/react-table';
-
 import { BreakdownTable } from '../components/BreakdownTable';
+
+import type { ColumnDef } from '@tanstack/react-table';
 
 function CacheManagement() {
   const utils = trpc.useUtils();

--- a/packages/app-ai/src/pages/AiUsagePage.tsx
+++ b/packages/app-ai/src/pages/AiUsagePage.tsx
@@ -39,6 +39,8 @@ import {
 
 import type { ColumnDef } from '@tanstack/react-table';
 
+import { BreakdownTable } from '../components/BreakdownTable';
+
 function CacheManagement() {
   const utils = trpc.useUtils();
   const [staleDays, setStaleDays] = useState(30);
@@ -391,73 +393,6 @@ function LatencySection({ startDate, endDate }: { startDate: string; endDate: st
           </div>
         </Card>
       )}
-    </div>
-  );
-}
-
-function BreakdownTable({
-  title,
-  data,
-}: {
-  title: string;
-  data: {
-    key: string;
-    calls: number;
-    inputTokens: number;
-    outputTokens: number;
-    costUsd: number;
-  }[];
-}) {
-  type Row = (typeof data)[number];
-  const columns: ColumnDef<Row>[] = [
-    {
-      accessorKey: 'key',
-      header: title,
-      cell: ({ row }) => <span className="font-mono text-sm">{row.original.key}</span>,
-    },
-    {
-      accessorKey: 'calls',
-      header: ({ column }) => (
-        <div className="flex justify-end">
-          <SortableHeader column={column}>Calls</SortableHeader>
-        </div>
-      ),
-      cell: ({ row }) => (
-        <div className="text-right tabular-nums">{row.original.calls.toLocaleString()}</div>
-      ),
-    },
-    {
-      id: 'tokens',
-      header: () => <div className="text-right">Tokens</div>,
-      cell: ({ row }) => (
-        <div className="text-right text-sm tabular-nums text-muted-foreground">
-          {(row.original.inputTokens + row.original.outputTokens).toLocaleString()}
-        </div>
-      ),
-    },
-    {
-      accessorKey: 'costUsd',
-      header: ({ column }) => (
-        <div className="flex justify-end">
-          <SortableHeader column={column}>Cost</SortableHeader>
-        </div>
-      ),
-      cell: ({ row }) => (
-        <div className="text-right font-mono font-medium tabular-nums">
-          ${row.original.costUsd.toFixed(4)}
-        </div>
-      ),
-    },
-  ];
-
-  if (data.length === 0) return null;
-
-  return (
-    <div className="space-y-2">
-      <h3 className="font-semibold text-sm text-muted-foreground uppercase tracking-wide">
-        By {title}
-      </h3>
-      <DataTable columns={columns} data={data} />
     </div>
   );
 }

--- a/packages/app-ai/src/pages/RulesBrowserPage.tsx
+++ b/packages/app-ai/src/pages/RulesBrowserPage.tsx
@@ -1,5 +1,5 @@
 import { BookOpen, Trash2 } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { trpc } from '@pops/api-client';
 /**
@@ -24,11 +24,11 @@ import {
   Select,
   type SelectOption,
   Skeleton,
-  Slider,
   SortableHeader,
   TextInput,
-  useDebouncedCallback,
 } from '@pops/ui';
+
+import { ConfidenceSlider } from '../components/ConfidenceSlider';
 
 import type { ColumnDef } from '@tanstack/react-table';
 
@@ -57,73 +57,6 @@ const MATCH_TYPE_OPTIONS: SelectOption[] = [
 ];
 
 const PAGE_SIZE = 50;
-
-function ConfidenceSlider({
-  ruleId,
-  initial,
-  onAutoDelete,
-}: {
-  ruleId: string;
-  initial: number;
-  onAutoDelete: (id: string) => void;
-}) {
-  const [value, setValue] = useState(initial);
-  const initialRef = useRef(initial);
-  const utils = trpc.useUtils();
-
-  // Keep initialRef in sync when the prop changes (e.g. after query invalidation)
-  useEffect(() => {
-    initialRef.current = initial;
-    setValue(initial);
-  }, [initial]);
-
-  const adjustMutation = trpc.core.corrections.adjustConfidence.useMutation({
-    onSuccess: () => {
-      void utils.core.corrections.list.invalidate();
-    },
-  });
-
-  const commit = useCallback(
-    (newValue: number) => {
-      const delta = newValue - initialRef.current;
-      if (Math.abs(delta) < 0.001) return;
-      adjustMutation.mutate(
-        { id: ruleId, delta },
-        {
-          onSuccess: () => {
-            if (newValue < 0.3) {
-              onAutoDelete(ruleId);
-            }
-          },
-        }
-      );
-    },
-    [ruleId, adjustMutation, onAutoDelete]
-  );
-
-  const debouncedCommit = useDebouncedCallback(commit, 400);
-
-  const handleChange = (values: number[]) => {
-    const next = values[0] ?? value;
-    setValue(next);
-    debouncedCommit(next);
-  };
-
-  return (
-    <div className="flex items-center gap-2 min-w-35">
-      <Slider
-        min={0}
-        max={1}
-        step={0.01}
-        value={[value]}
-        onValueChange={handleChange}
-        className="w-20"
-        aria-label={`Confidence for rule ${ruleId}`}
-      />
-      <span className="text-xs tabular-nums w-10 text-right">{(value * 100).toFixed(0)}%</span>
-    </div>
-  );
-}
 
 export function RulesBrowserPage(): React.ReactElement {
   const [matchType, setMatchType] = useState('');

--- a/packages/app-finance/src/components/search/BudgetResult.test.tsx
+++ b/packages/app-finance/src/components/search/BudgetResult.test.tsx
@@ -63,7 +63,7 @@ describe('BudgetResult', () => {
   });
 
   it('hides period when null', () => {
-    const { container } = render(
+    render(
       <BudgetResult
         data={{
           category: 'Misc',
@@ -73,8 +73,9 @@ describe('BudgetResult', () => {
       />
     );
 
-    // Only category and amount shown — no period element
-    expect(container.querySelectorAll('.text-sm')).toHaveLength(1); // just the amount
+    expect(screen.queryByText('Monthly')).not.toBeInTheDocument();
+    expect(screen.queryByText('Yearly')).not.toBeInTheDocument();
+    expect(screen.getByText('$100.00')).toBeInTheDocument();
   });
 
   it('renders date-like period as-is', () => {

--- a/packages/app-finance/src/components/search/BudgetResult.tsx
+++ b/packages/app-finance/src/components/search/BudgetResult.tsx
@@ -1,5 +1,5 @@
 import { registerResultComponent, type ResultComponentProps } from '@pops/navigation';
-import { formatCurrency, highlightMatch } from '@pops/ui';
+import { formatCurrency, highlightMatch, SearchResultItem } from '@pops/ui';
 
 function formatAmount(amount: number | null | undefined): string {
   if (amount == null) return '—';
@@ -25,17 +25,15 @@ export function BudgetResult({ data }: ResultComponentProps) {
   const shouldHighlight = matchField === 'category' && query;
 
   return (
-    <div className="flex items-center justify-between gap-2">
-      <div className="min-w-0 flex-1">
-        <div className="truncate font-medium">
-          {shouldHighlight ? highlightMatch(category, query, matchType) : category}
+    <SearchResultItem
+      title={shouldHighlight ? highlightMatch(category, query, matchType) : category}
+      meta={period ? [<span key="period">{formatPeriod(period)}</span>] : undefined}
+      trailing={
+        <div className="text-muted-foreground shrink-0 text-sm font-medium">
+          {formatAmount(amount)}
         </div>
-        {period && <div className="text-muted-foreground text-sm">{formatPeriod(period)}</div>}
-      </div>
-      <div className="text-muted-foreground shrink-0 text-sm font-medium">
-        {formatAmount(amount)}
-      </div>
-    </div>
+      }
+    />
   );
 }
 

--- a/packages/app-finance/src/components/search/EntitiesResultComponent.tsx
+++ b/packages/app-finance/src/components/search/EntitiesResultComponent.tsx
@@ -30,7 +30,11 @@ export function EntitiesResultComponent({ data }: ResultComponentProps) {
       title={highlightMatch(name, query ?? '')}
       meta={
         aliases.length > 0
-          ? [<span key="aliases" className="truncate">{aliases.join(', ')}</span>]
+          ? [
+              <span key="aliases" className="truncate">
+                {aliases.join(', ')}
+              </span>,
+            ]
           : undefined
       }
       trailing={

--- a/packages/app-finance/src/components/search/EntitiesResultComponent.tsx
+++ b/packages/app-finance/src/components/search/EntitiesResultComponent.tsx
@@ -31,7 +31,7 @@ export function EntitiesResultComponent({ data }: ResultComponentProps) {
       meta={
         aliases.length > 0
           ? [
-              <span key="aliases" className="truncate">
+              <span key="aliases" className="min-w-0 truncate">
                 {aliases.join(', ')}
               </span>,
             ]

--- a/packages/app-finance/src/components/search/EntitiesResultComponent.tsx
+++ b/packages/app-finance/src/components/search/EntitiesResultComponent.tsx
@@ -1,5 +1,5 @@
 import { registerResultComponent } from '@pops/navigation';
-import { Badge, highlightMatch } from '@pops/ui';
+import { Badge, highlightMatch, SearchResultItem } from '@pops/ui';
 
 import type { ResultComponentProps } from '@pops/navigation';
 
@@ -26,20 +26,22 @@ export function EntitiesResultComponent({ data }: ResultComponentProps) {
   const style = entityTypeStyles[type] || 'bg-muted text-muted-foreground border-transparent';
 
   return (
-    <div className="flex items-center gap-2 min-w-0">
-      <div className="flex flex-col min-w-0">
-        <span className="text-sm font-medium truncate">{highlightMatch(name, query ?? '')}</span>
-        {aliases.length > 0 && (
-          <span className="text-xs text-muted-foreground truncate">{aliases.join(', ')}</span>
-        )}
-      </div>
-      <Badge
-        variant="outline"
-        className={`text-2xs uppercase tracking-wider font-semibold py-0 px-1.5 h-5 shrink-0 ${style}`}
-      >
-        {type}
-      </Badge>
-    </div>
+    <SearchResultItem
+      title={highlightMatch(name, query ?? '')}
+      meta={
+        aliases.length > 0
+          ? [<span key="aliases" className="truncate">{aliases.join(', ')}</span>]
+          : undefined
+      }
+      trailing={
+        <Badge
+          variant="outline"
+          className={`text-2xs uppercase tracking-wider font-semibold py-0 px-1.5 h-5 shrink-0 ${style}`}
+        >
+          {type}
+        </Badge>
+      }
+    />
   );
 }
 

--- a/packages/app-finance/src/components/search/TransactionsResultComponent.tsx
+++ b/packages/app-finance/src/components/search/TransactionsResultComponent.tsx
@@ -1,5 +1,5 @@
 import { registerResultComponent } from '@pops/navigation';
-import { formatCurrency, formatDate, highlightMatch } from '@pops/ui';
+import { formatCurrency, formatDate, highlightMatch, SearchResultItem } from '@pops/ui';
 
 import type { ResultComponentProps } from '@pops/navigation';
 
@@ -27,26 +27,22 @@ export function TransactionsResultComponent({ data, query, matchField }: ResultC
   const shouldHighlight = matchField === 'description' && query;
 
   return (
-    <div className="flex items-center justify-between gap-2 min-w-0">
-      <div className="flex flex-col min-w-0">
-        <span className="text-sm font-medium truncate">
-          {shouldHighlight ? highlightMatch(tx.description, query) : tx.description}
-        </span>
-        {tx.entityName && (
-          <span className="text-xs text-muted-foreground truncate">{tx.entityName}</span>
-        )}
-      </div>
-      <div className="flex flex-col items-end shrink-0">
-        <span className={`text-sm font-medium ${amountColorClass(tx.type)}`}>
-          {tx.type === 'income' ? '+' : tx.type === 'expense' ? '-' : ''}
-          {formatCurrency(Math.abs(tx.amount), {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
-          })}
-        </span>
-        <span className="text-xs text-muted-foreground">{formatDate(tx.date)}</span>
-      </div>
-    </div>
+    <SearchResultItem
+      title={shouldHighlight ? highlightMatch(tx.description, query) : tx.description}
+      meta={tx.entityName ? [<span key="entity">{tx.entityName}</span>] : undefined}
+      trailing={
+        <div className="flex flex-col items-end shrink-0">
+          <span className={`text-sm font-medium ${amountColorClass(tx.type)}`}>
+            {tx.type === 'income' ? '+' : tx.type === 'expense' ? '-' : ''}
+            {formatCurrency(Math.abs(tx.amount), {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}
+          </span>
+          <span className="text-xs text-muted-foreground">{formatDate(tx.date)}</span>
+        </div>
+      }
+    />
   );
 }
 

--- a/packages/app-inventory/src/components/search/InventoryItemSearchResult.tsx
+++ b/packages/app-inventory/src/components/search/InventoryItemSearchResult.tsx
@@ -44,10 +44,7 @@ export function InventoryItemSearchResult({ data }: ResultComponentProps) {
       ]}
       trailing={
         replacementValue != null ? (
-          <span
-            className="shrink-0 text-xs font-medium text-muted-foreground"
-            data-testid="value"
-          >
+          <span className="shrink-0 text-xs font-medium text-muted-foreground" data-testid="value">
             {formatAUD(replacementValue)}
           </span>
         ) : undefined

--- a/packages/app-inventory/src/components/search/InventoryItemSearchResult.tsx
+++ b/packages/app-inventory/src/components/search/InventoryItemSearchResult.tsx
@@ -1,6 +1,6 @@
 import { Package } from 'lucide-react';
 
-import { formatAUD, highlightMatch } from '@pops/ui';
+import { formatAUD, highlightMatch, SearchResultItem } from '@pops/ui';
 
 /**
  * InventoryItemSearchResult — ResultComponent for inventory-items search hits.
@@ -30,30 +30,28 @@ export function InventoryItemSearchResult({ data }: ResultComponentProps) {
   const locationText = [room, location].filter(Boolean).join(' · ');
 
   return (
-    <div className="flex items-center gap-3 py-1" data-testid="inventory-item-search-result">
-      {/* Icon */}
-      <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded bg-muted text-muted-foreground">
-        <Package className="h-5 w-5 opacity-50" />
-      </div>
-
-      {/* Text content */}
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate text-sm font-medium leading-tight">
-          {highlightMatch(itemName, query, matchType)}
-        </span>
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          {brand && <span>{brand}</span>}
-          {brand && locationText && <span>·</span>}
-          {locationText && <span>{locationText}</span>}
+    <SearchResultItem
+      data-testid="inventory-item-search-result"
+      leading={
+        <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded bg-muted text-muted-foreground">
+          <Package className="h-5 w-5 opacity-50" />
         </div>
-      </div>
-
-      {/* Value */}
-      {replacementValue != null && (
-        <span className="shrink-0 text-xs font-medium text-muted-foreground" data-testid="value">
-          {formatAUD(replacementValue)}
-        </span>
-      )}
-    </div>
+      }
+      title={highlightMatch(itemName, query, matchType)}
+      meta={[
+        brand && <span key="brand">{brand}</span>,
+        locationText && <span key="location">{locationText}</span>,
+      ]}
+      trailing={
+        replacementValue != null ? (
+          <span
+            className="shrink-0 text-xs font-medium text-muted-foreground"
+            data-testid="value"
+          >
+            {formatAUD(replacementValue)}
+          </span>
+        ) : undefined
+      }
+    />
   );
 }

--- a/packages/app-media/src/components/search/MovieSearchResult.tsx
+++ b/packages/app-media/src/components/search/MovieSearchResult.tsx
@@ -70,7 +70,11 @@ export function MovieSearchResult({ data }: ResultComponentProps) {
       meta={[
         year && <span key="year">{year}</span>,
         voteAverage != null && <Rating key="rating" value={voteAverage} />,
-        runtimeLabel && <span key="runtime" data-testid="runtime">{runtimeLabel}</span>,
+        runtimeLabel && (
+          <span key="runtime" data-testid="runtime">
+            {runtimeLabel}
+          </span>
+        ),
       ]}
     />
   );

--- a/packages/app-media/src/components/search/MovieSearchResult.tsx
+++ b/packages/app-media/src/components/search/MovieSearchResult.tsx
@@ -1,6 +1,6 @@
 import { Film, Star } from 'lucide-react';
 
-import { highlightMatch } from '@pops/ui';
+import { highlightMatch, SearchResultItem } from '@pops/ui';
 
 /**
  * MovieSearchResult — ResultComponent for movies search hits.
@@ -48,36 +48,30 @@ export function MovieSearchResult({ data }: ResultComponentProps) {
   const runtimeLabel = formatRuntime(runtime ?? null);
 
   return (
-    <div className="flex items-center gap-3 py-1" data-testid="movie-search-result">
-      {/* Poster thumbnail */}
-      <div className="relative h-12 w-8 shrink-0 overflow-hidden rounded bg-muted">
-        {posterUrl ? (
-          <img
-            src={posterUrl}
-            alt={`${title} poster`}
-            className="h-full w-full object-cover"
-            loading="lazy"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-            <Film className="h-4 w-4 opacity-40" />
-          </div>
-        )}
-      </div>
-
-      {/* Text content */}
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate text-sm font-medium leading-tight">
-          {highlightMatch(title, query, matchType)}
-        </span>
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          {year && <span>{year}</span>}
-          {year && voteAverage != null && <span>·</span>}
-          <Rating value={voteAverage} />
-          {(year || voteAverage != null) && runtimeLabel && <span>·</span>}
-          {runtimeLabel && <span data-testid="runtime">{runtimeLabel}</span>}
+    <SearchResultItem
+      data-testid="movie-search-result"
+      leading={
+        <div className="relative h-12 w-8 shrink-0 overflow-hidden rounded bg-muted">
+          {posterUrl ? (
+            <img
+              src={posterUrl}
+              alt={`${title} poster`}
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+              <Film className="h-4 w-4 opacity-40" />
+            </div>
+          )}
         </div>
-      </div>
-    </div>
+      }
+      title={highlightMatch(title, query, matchType)}
+      meta={[
+        year && <span key="year">{year}</span>,
+        voteAverage != null && <Rating key="rating" value={voteAverage} />,
+        runtimeLabel && <span key="runtime" data-testid="runtime">{runtimeLabel}</span>,
+      ]}
+    />
   );
 }

--- a/packages/app-media/src/components/search/TvShowSearchResult.tsx
+++ b/packages/app-media/src/components/search/TvShowSearchResult.tsx
@@ -1,6 +1,6 @@
 import { Tv } from 'lucide-react';
 
-import { Badge, cn, highlightMatch } from '@pops/ui';
+import { Badge, cn, highlightMatch, SearchResultItem } from '@pops/ui';
 
 /**
  * TvShowSearchResult — ResultComponent for tv-shows search hits.
@@ -44,43 +44,34 @@ export function TvShowSearchResult({ data }: ResultComponentProps) {
   const matchType = hit._matchType ?? 'contains';
 
   return (
-    <div className="flex items-center gap-3 py-1" data-testid="tv-show-search-result">
-      {/* Poster thumbnail */}
-      <div className="relative h-12 w-8 shrink-0 overflow-hidden rounded bg-muted">
-        {posterUrl ? (
-          <img
-            src={posterUrl}
-            alt={`${name} poster`}
-            className="h-full w-full object-cover"
-            loading="lazy"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-            <Tv className="h-4 w-4 opacity-40" />
-          </div>
-        )}
-      </div>
-
-      {/* Text content */}
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="text-sm font-medium leading-tight truncate">
-          {highlightMatch(name, query, matchType)}
-        </span>
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          {year && <span>{year}</span>}
-          {numberOfSeasons != null && (
-            <>
-              {year && <span>·</span>}
-              <span>
-                {numberOfSeasons} {numberOfSeasons === 1 ? 'season' : 'seasons'}
-              </span>
-            </>
+    <SearchResultItem
+      data-testid="tv-show-search-result"
+      leading={
+        <div className="relative h-12 w-8 shrink-0 overflow-hidden rounded bg-muted">
+          {posterUrl ? (
+            <img
+              src={posterUrl}
+              alt={`${name} poster`}
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+              <Tv className="h-4 w-4 opacity-40" />
+            </div>
           )}
         </div>
-      </div>
-
-      {/* Status badge */}
-      <StatusBadge status={status} />
-    </div>
+      }
+      title={highlightMatch(name, query, matchType)}
+      meta={[
+        year && <span key="year">{year}</span>,
+        numberOfSeasons != null && (
+          <span key="seasons">
+            {numberOfSeasons} {numberOfSeasons === 1 ? 'season' : 'seasons'}
+          </span>
+        ),
+      ]}
+      trailing={<StatusBadge status={status} />}
+    />
   );
 }

--- a/packages/ui/src/components/SearchResultItem.stories.tsx
+++ b/packages/ui/src/components/SearchResultItem.stories.tsx
@@ -1,6 +1,6 @@
 import { Film, Package, Star } from 'lucide-react';
 
-import { Badge } from './Badge';
+import { Badge } from '../primitives/badge';
 import { SearchResultItem } from './SearchResultItem';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';

--- a/packages/ui/src/components/SearchResultItem.stories.tsx
+++ b/packages/ui/src/components/SearchResultItem.stories.tsx
@@ -1,0 +1,85 @@
+import { Film, Package, Star } from 'lucide-react';
+
+import { Badge } from './Badge';
+import { SearchResultItem } from './SearchResultItem';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof SearchResultItem> = {
+  title: 'Layout/SearchResultItem',
+  component: SearchResultItem,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TitleOnly: Story = {
+  args: {
+    title: 'MacBook Pro 14"',
+  },
+};
+
+export const WithMeta: Story = {
+  args: {
+    title: 'The Shawshank Redemption',
+    meta: [
+      <span key="year">1994</span>,
+      <span key="rating" className="flex items-center gap-0.5">
+        <Star className="h-3 w-3 fill-warning text-warning" />
+        9.3
+      </span>,
+      <span key="runtime">142m</span>,
+    ],
+  },
+};
+
+export const WithLeading: Story = {
+  args: {
+    leading: (
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded bg-muted text-muted-foreground">
+        <Package className="h-5 w-5 opacity-50" />
+      </div>
+    ),
+    title: 'Sony Headphones WH-1000XM5',
+    meta: [<span key="brand">Sony</span>, <span key="location">Living Room · Storage</span>],
+    trailing: <span className="shrink-0 text-xs font-medium text-muted-foreground">$549.00</span>,
+  },
+};
+
+export const WithPosterLeading: Story = {
+  args: {
+    leading: (
+      <div className="flex h-12 w-8 shrink-0 items-center justify-center rounded bg-muted text-muted-foreground">
+        <Film className="h-4 w-4 opacity-40" />
+      </div>
+    ),
+    title: 'Inception',
+    meta: [<span key="year">2010</span>, <span key="runtime">148m</span>],
+  },
+};
+
+export const WithTrailingBadge: Story = {
+  args: {
+    title: 'Anthropic',
+    meta: [<span key="aliases">Anthropic PBC, Anthropic AI</span>],
+    trailing: (
+      <Badge variant="outline" className="shrink-0 text-2xs uppercase tracking-wider">
+        company
+      </Badge>
+    ),
+  },
+};
+
+export const TitleHighlighted: Story = {
+  args: {
+    title: (
+      <span>
+        Mac<mark className="bg-warning/30 rounded-sm px-0.5">Book</mark> Pro 14&quot;
+      </span>
+    ),
+    meta: [<span key="brand">Apple</span>, <span key="location">Office</span>],
+    trailing: <span className="shrink-0 text-xs font-medium text-muted-foreground">$3,499.00</span>,
+  },
+};

--- a/packages/ui/src/components/SearchResultItem.tsx
+++ b/packages/ui/src/components/SearchResultItem.tsx
@@ -2,19 +2,21 @@ import { Fragment } from 'react';
 
 import { cn } from '../lib/utils';
 
-interface SearchResultItemProps extends React.HTMLAttributes<HTMLDivElement> {
+import type { HTMLAttributes, ReactNode } from 'react';
+
+interface SearchResultItemProps extends HTMLAttributes<HTMLDivElement> {
   /** Icon, thumbnail, or avatar displayed before the text content. */
-  leading?: React.ReactNode;
+  leading?: ReactNode;
   /** Primary title line — pass a highlighted node or plain string. */
-  title: React.ReactNode;
+  title: ReactNode;
   /**
    * Metadata chips rendered below the title.
    * Falsy items are filtered out; a `·` separator is inserted between the
    * remaining items automatically.
    */
-  meta?: React.ReactNode[];
+  meta?: ReactNode[];
   /** Value, badge, or any trailing node anchored to the right. */
-  trailing?: React.ReactNode;
+  trailing?: ReactNode;
 }
 
 export function SearchResultItem({

--- a/packages/ui/src/components/SearchResultItem.tsx
+++ b/packages/ui/src/components/SearchResultItem.tsx
@@ -4,7 +4,7 @@ import { cn } from '../lib/utils';
 
 import type { HTMLAttributes, ReactNode } from 'react';
 
-interface SearchResultItemProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+interface SearchResultItemProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title' | 'children'> {
   /** Icon, thumbnail, or avatar displayed before the text content. */
   leading?: ReactNode;
   /** Primary title line — pass a highlighted node or plain string. */
@@ -27,7 +27,7 @@ export function SearchResultItem({
   className,
   ...props
 }: SearchResultItemProps) {
-  const visibleMeta = meta?.filter(Boolean) ?? [];
+  const visibleMeta = meta?.filter((item) => item !== null && item !== undefined && item !== false) ?? [];
 
   return (
     <div className={cn('flex items-center gap-3 py-1', className)} {...props}>

--- a/packages/ui/src/components/SearchResultItem.tsx
+++ b/packages/ui/src/components/SearchResultItem.tsx
@@ -27,7 +27,8 @@ export function SearchResultItem({
   className,
   ...props
 }: SearchResultItemProps) {
-  const visibleMeta = meta?.filter((item) => item !== null && item !== undefined && item !== false) ?? [];
+  const visibleMeta =
+    meta?.filter((item) => item !== null && item !== undefined && item !== false) ?? [];
 
   return (
     <div className={cn('flex items-center gap-3 py-1', className)} {...props}>

--- a/packages/ui/src/components/SearchResultItem.tsx
+++ b/packages/ui/src/components/SearchResultItem.tsx
@@ -1,0 +1,49 @@
+import { Fragment } from 'react';
+
+import { cn } from '../lib/utils';
+
+interface SearchResultItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Icon, thumbnail, or avatar displayed before the text content. */
+  leading?: React.ReactNode;
+  /** Primary title line — pass a highlighted node or plain string. */
+  title: React.ReactNode;
+  /**
+   * Metadata chips rendered below the title.
+   * Falsy items are filtered out; a `·` separator is inserted between the
+   * remaining items automatically.
+   */
+  meta?: React.ReactNode[];
+  /** Value, badge, or any trailing node anchored to the right. */
+  trailing?: React.ReactNode;
+}
+
+export function SearchResultItem({
+  leading,
+  title,
+  meta,
+  trailing,
+  className,
+  ...props
+}: SearchResultItemProps) {
+  const visibleMeta = meta?.filter(Boolean) ?? [];
+
+  return (
+    <div className={cn('flex items-center gap-3 py-1', className)} {...props}>
+      {leading}
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="truncate text-sm font-medium leading-tight">{title}</span>
+        {visibleMeta.length > 0 && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            {visibleMeta.map((item, i) => (
+              <Fragment key={i}>
+                {i > 0 && <span aria-hidden>·</span>}
+                {item}
+              </Fragment>
+            ))}
+          </div>
+        )}
+      </div>
+      {trailing}
+    </div>
+  );
+}

--- a/packages/ui/src/components/SearchResultItem.tsx
+++ b/packages/ui/src/components/SearchResultItem.tsx
@@ -4,7 +4,7 @@ import { cn } from '../lib/utils';
 
 import type { HTMLAttributes, ReactNode } from 'react';
 
-interface SearchResultItemProps extends HTMLAttributes<HTMLDivElement> {
+interface SearchResultItemProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   /** Icon, thumbnail, or avatar displayed before the text content. */
   leading?: ReactNode;
   /** Primary title line — pass a highlighted node or plain string. */

--- a/packages/ui/src/components/SearchResultItem.tsx
+++ b/packages/ui/src/components/SearchResultItem.tsx
@@ -28,7 +28,8 @@ export function SearchResultItem({
   ...props
 }: SearchResultItemProps) {
   const visibleMeta =
-    meta?.filter((item) => item !== null && item !== undefined && item !== false) ?? [];
+    meta?.filter((item) => item !== null && item !== undefined && item !== false && item !== '') ??
+    [];
 
   return (
     <div className={cn('flex items-center gap-3 py-1', className)} {...props}>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -96,6 +96,7 @@ export * from './components/TextInput';
 
 // Layout composites
 export * from './components/PageHeader';
+export * from './components/SearchResultItem';
 export * from './components/ViewToggleGroup';
 
 // Inventory composites


### PR DESCRIPTION
## Summary

Implements three related component-extraction refactors in one PR.

- **BreakdownTable** (`app-ai/components/BreakdownTable.tsx`) — moved out of `AiUsagePage.tsx` where it was defined inline and called 4× (by Provider, Model, Operation, Domain)
- **ConfidenceSlider** (`app-ai/components/ConfidenceSlider.tsx`) — moved out of `RulesBrowserPage.tsx`; uses the existing `useDebouncedCallback` from `@pops/ui`
- **SearchResultItem** (`@pops/ui`) — new shared composite with `leading / title / meta / trailing` slots; all 6 domain search-result components (finance ×3, inventory ×1, media ×2) now use it instead of duplicating the same flex layout

## Changes

| File | Change |
|---|---|
| `app-ai/components/BreakdownTable.tsx` | New — extracted from AiUsagePage |
| `app-ai/components/ConfidenceSlider.tsx` | New — extracted from RulesBrowserPage |
| `ui/components/SearchResultItem.tsx` | New — shared search result primitive |
| `ui/src/index.ts` | Export SearchResultItem |
| `app-ai/pages/AiUsagePage.tsx` | Import BreakdownTable from components/ |
| `app-ai/pages/RulesBrowserPage.tsx` | Import ConfidenceSlider from components/ |
| All 6 search result components | Use SearchResultItem; domain logic only |

## Closes

Closes #2058
Closes #2032
Closes #2060
Closes #2033
Closes #2044
Closes #2017

## Test plan

- [ ] All existing search result tests pass (InventoryItemSearchResult, MovieSearchResult, TvShowSearchResult)
- [ ] AiUsagePage renders breakdowns correctly (4× BreakdownTable usage preserved)
- [ ] RulesBrowserPage confidence slider still commits on idle and auto-deletes below 0.3
- [ ] Lint passes (0 errors; 1 pre-existing-style `no-array-index-key` warning in SearchResultItem separator)

https://claude.ai/code/session_01GVG889QVdBQWrebNrGWS3Q