### PR TITLE
feat(ui): decompose import wizard god-files → @pops/ui primitives (Group B)

### DIFF
--- a/packages/app-ai/src/pages/AiUsagePage.tsx
+++ b/packages/app-ai/src/pages/AiUsagePage.tsx
@@ -13,7 +13,6 @@ import { toast } from 'sonner';
 
 import { trpc } from '@pops/api-client';
 import {
-  Alert,
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -28,11 +27,13 @@ import {
   Card,
   DataTable,
   DateInput,
+  ErrorAlert,
   formatBytes,
   Input,
   Label,
   PageHeader,
   Skeleton,
+  SkeletonGrid,
   SortableHeader,
   StatCard,
 } from '@pops/ui';
@@ -495,11 +496,7 @@ export function AiUsagePage() {
           title="AI Observability"
           description="Monitor AI usage, costs, latency, and provider health"
         />
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-          {(['cost', 'calls', 'cache', 'error'] as const).map((k) => (
-            <Skeleton key={k} className="h-32" />
-          ))}
-        </div>
+        <SkeletonGrid count={4} itemHeight="h-32" cols="md:grid-cols-2 lg:grid-cols-4" />
         <Skeleton className="h-64" />
       </div>
     );
@@ -509,10 +506,7 @@ export function AiUsagePage() {
     return (
       <div className="space-y-6">
         <PageHeader title="AI Observability" />
-        <Alert variant="destructive">
-          <h3 className="font-semibold">Failed to load observability data</h3>
-          <p className="text-sm mt-1">{error.message}</p>
-        </Alert>
+        <ErrorAlert title="Failed to load observability data" message={error.message} />
       </div>
     );
   }

--- a/packages/app-finance/src/components/TagEditor.tsx
+++ b/packages/app-finance/src/components/TagEditor.tsx
@@ -7,7 +7,15 @@ import { useEffect, useRef, useState } from 'react';
  *
  * This component is tRPC-agnostic — callers wire up the API.
  */
-import { Badge, Button, Chip, hashToColor, Popover, PopoverContent, PopoverTrigger } from '@pops/ui';
+import {
+  Badge,
+  Button,
+  Chip,
+  hashToColor,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@pops/ui';
 
 import { cn } from '../lib/utils';
 
@@ -59,7 +67,6 @@ const SOURCE_ICONS: Record<TagSource, string> = {
   rule: '📋',
   entity: '🏪',
 };
-
 
 export function TagEditor({
   currentTags,

--- a/packages/app-finance/src/components/TagEditor.tsx
+++ b/packages/app-finance/src/components/TagEditor.tsx
@@ -7,7 +7,7 @@ import { useEffect, useRef, useState } from 'react';
  *
  * This component is tRPC-agnostic — callers wire up the API.
  */
-import { Badge, Button, Chip, Popover, PopoverContent, PopoverTrigger } from '@pops/ui';
+import { Badge, Button, Chip, hashToColor, Popover, PopoverContent, PopoverTrigger } from '@pops/ui';
 
 import { cn } from '../lib/utils';
 
@@ -60,23 +60,6 @@ const SOURCE_ICONS: Record<TagSource, string> = {
   entity: '🏪',
 };
 
-/**
- * Deterministic tag coloring based on string hash.
- * Uses OKLCH for perceptually uniform colors that look good in dark mode.
- */
-function getTagStyle(tag: string) {
-  let hash = 0;
-  for (let i = 0; i < tag.length; i++) {
-    hash = tag.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  const hue = Math.abs(hash % 360);
-  // Soft tinted background with high-contrast text for dark mode
-  return {
-    backgroundColor: `oklch(0.3 0.08 ${hue} / 0.4)`,
-    color: `oklch(0.85 0.06 ${hue})`,
-    borderColor: `oklch(0.85 0.06 ${hue} / 0.2)`,
-  };
-}
 
 export function TagEditor({
   currentTags,
@@ -202,7 +185,7 @@ export function TagEditor({
                   : meta?.source
                     ? `${meta.source} suggestion`
                     : undefined;
-              const style = getTagStyle(tag);
+              const style = hashToColor(tag);
               return (
                 <Badge
                   key={tag}
@@ -232,7 +215,7 @@ export function TagEditor({
           {tags.length > 0 && (
             <div className="flex flex-wrap gap-2">
               {tags.map((tag) => {
-                const style = getTagStyle(tag);
+                const style = hashToColor(tag);
                 return (
                   <Chip
                     key={tag}
@@ -265,7 +248,7 @@ export function TagEditor({
           {filteredSuggestions.length > 0 && (
             <div className="flex flex-wrap gap-2">
               {filteredSuggestions.slice(0, 8).map((tag) => {
-                const style = getTagStyle(tag);
+                const style = hashToColor(tag);
                 return (
                   <Button
                     key={tag}

--- a/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
@@ -78,6 +78,12 @@ export interface CorrectionProposalDialogProps {
   onBrowseClose?: (hadChanges: boolean) => void;
 }
 
+function previewLabel(view: PreviewView, hasSelectedOp: boolean): string {
+  if (view === 'combined') return 'Combined effect of entire ChangeSet';
+  if (hasSelectedOp) return 'Effect of selected operation';
+  return 'No operation selected';
+}
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -423,129 +429,126 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
       </>
     );
 
-    const browseBody =
-      browseListQuery.isError ? (
-        <div className="px-6 pb-6 text-sm text-destructive">{browseListQuery.error.message}</div>
-      ) : browseListQuery.isLoading ? (
-        <div className="px-6 pb-6 text-sm text-muted-foreground">Loading rules…</div>
-      ) : (
-        // 3-column grid rendered via WorkflowDialog columns prop
-        <>
-          {/* Sidebar: rule list with search */}
-          <div className="flex flex-col min-h-0 border-r">
-            <div className="px-3 py-2 border-b">
-              <div className="relative">
-                <Search className="absolute left-2 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
-                <Input
-                  value={browseSearch}
-                  onChange={(e) => {
-                    setBrowseSearch(e.target.value);
-                  }}
-                  placeholder="Search rules…"
-                  className="pl-7 h-8 text-xs"
-                />
-              </div>
-            </div>
-            <div className="px-3 py-1.5 text-[10px] text-muted-foreground border-b space-y-0.5">
-              <div>
-                {browseOrderedFiltered.length} rule
-                {browseOrderedFiltered.length === 1 ? '' : 's'}
-                {browseSearch && ` matching "${browseSearch}"`}
-              </div>
-              {browseSearch.trim() !== '' && (
-                <div className="text-[10px] text-muted-foreground/90">
-                  Clear search to drag rules into priority order.
-                </div>
-              )}
-            </div>
-            <div className="flex-1 overflow-auto">
-              <Suspense
-                fallback={<div className="p-3 text-xs text-muted-foreground">Loading…</div>}
-              >
-                <BrowseRulesSidebar
-                  canDragReorder={browseCanDragReorder}
-                  orderedMerged={browseOrderedMerged}
-                  orderedFiltered={browseOrderedFiltered}
-                  selectedRuleId={browseSelectedRuleId}
-                  localOps={localOps}
-                  onSelectRule={handleBrowseSelectRule}
-                  onReorderFullList={handleBrowseReorderFullList}
-                />
-              </Suspense>
-            </div>
-            <div className="border-t p-2">
-              <Button
-                size="sm"
-                variant="outline"
-                className="w-full justify-start"
-                onClick={handleAddNewRuleOp}
-              >
-                <Plus className="mr-1 h-3.5 w-3.5" /> Add new rule
-              </Button>
+    const browseBody = browseListQuery.isError ? (
+      <div className="px-6 pb-6 text-sm text-destructive">{browseListQuery.error.message}</div>
+    ) : browseListQuery.isLoading ? (
+      <div className="px-6 pb-6 text-sm text-muted-foreground">Loading rules…</div>
+    ) : (
+      // 3-column grid rendered via WorkflowDialog columns prop
+      <>
+        {/* Sidebar: rule list with search */}
+        <div className="flex flex-col min-h-0 border-r">
+          <div className="px-3 py-2 border-b">
+            <div className="relative">
+              <Search className="absolute left-2 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+              <Input
+                value={browseSearch}
+                onChange={(e) => {
+                  setBrowseSearch(e.target.value);
+                }}
+                placeholder="Search rules…"
+                className="pl-7 h-8 text-xs"
+              />
             </div>
           </div>
-
-          {/* Detail: show selected rule or selected op editor */}
-          <div className="flex flex-col min-h-0 overflow-auto">
-            {selectedOp ? (
-              <DetailPanel
-                op={selectedOp}
-                onChange={(mutator) => {
-                  if (!selectedOp) return;
-                  updateOp(selectedOp.clientId, mutator);
-                }}
-                disabled={false}
-              />
-            ) : browseSelectedRule ? (
-              <BrowseRuleDetailPanel
-                rule={browseSelectedRule}
-                onEdit={handleBrowseEditRule}
-                onDisable={handleBrowseDisableRule}
-                onRemove={handleBrowseRemoveRule}
-              />
-            ) : (
-              <div className="p-6 text-sm text-muted-foreground">
-                Select a rule on the left to view or edit it.
+          <div className="px-3 py-1.5 text-[10px] text-muted-foreground border-b space-y-0.5">
+            <div>
+              {browseOrderedFiltered.length} rule
+              {browseOrderedFiltered.length === 1 ? '' : 's'}
+              {browseSearch && ` matching "${browseSearch}"`}
+            </div>
+            {browseSearch.trim() !== '' && (
+              <div className="text-[10px] text-muted-foreground/90">
+                Clear search to drag rules into priority order.
               </div>
             )}
           </div>
-
-          {/* Impact preview (PRD-032 US-06) */}
-          {(() => {
-            const browsePreviewResult =
-              previewView === 'combined' ? combinedPreview : selectedOpPreview;
-            const browseDbPreviewResult =
-              previewView === 'combined' ? combinedDbPreview : selectedOpDbPreview;
-            const browsePreviewError =
-              previewView === 'combined' ? combinedPreviewError : selectedOpPreviewError;
-            const browseTruncated =
-              previewView === 'combined' ? combinedPreviewTruncated : selectedOpPreviewTruncated;
-            const browseLabel =
-              previewView === 'combined'
-                ? 'Combined effect of all pending changes'
-                : selectedOp
-                  ? 'Effect of selected operation'
-                  : 'No operation selected';
-            return (
-              <ImpactPanel
-                view={previewView}
-                onViewChange={setPreviewView}
-                label={browseLabel}
-                previewResult={browsePreviewResult}
-                dbPreviewResult={browseDbPreviewResult}
-                dbTruncated={dbTxnsQuery.data?.truncated}
-                dbTotal={dbTxnsQuery.data?.total}
-                previewError={browsePreviewError}
-                isPending={previewMutationPending}
-                stale={hasDirty}
-                truncated={browseTruncated}
-                onRerun={handleRerunPreview}
-                disabled={localOps.length === 0}
+          <div className="flex-1 overflow-auto">
+            <Suspense fallback={<div className="p-3 text-xs text-muted-foreground">Loading…</div>}>
+              <BrowseRulesSidebar
+                canDragReorder={browseCanDragReorder}
+                orderedMerged={browseOrderedMerged}
+                orderedFiltered={browseOrderedFiltered}
+                selectedRuleId={browseSelectedRuleId}
+                localOps={localOps}
+                onSelectRule={handleBrowseSelectRule}
+                onReorderFullList={handleBrowseReorderFullList}
               />
-            );
-          })()}
-        </>
-      );
+            </Suspense>
+          </div>
+          <div className="border-t p-2">
+            <Button
+              size="sm"
+              variant="outline"
+              className="w-full justify-start"
+              onClick={handleAddNewRuleOp}
+            >
+              <Plus className="mr-1 h-3.5 w-3.5" /> Add new rule
+            </Button>
+          </div>
+        </div>
+
+        {/* Detail: show selected rule or selected op editor */}
+        <div className="flex flex-col min-h-0 overflow-auto">
+          {selectedOp ? (
+            <DetailPanel
+              op={selectedOp}
+              onChange={(mutator) => {
+                if (!selectedOp) return;
+                updateOp(selectedOp.clientId, mutator);
+              }}
+              disabled={false}
+            />
+          ) : browseSelectedRule ? (
+            <BrowseRuleDetailPanel
+              rule={browseSelectedRule}
+              onEdit={handleBrowseEditRule}
+              onDisable={handleBrowseDisableRule}
+              onRemove={handleBrowseRemoveRule}
+            />
+          ) : (
+            <div className="p-6 text-sm text-muted-foreground">
+              Select a rule on the left to view or edit it.
+            </div>
+          )}
+        </div>
+
+        {/* Impact preview (PRD-032 US-06) */}
+        {(() => {
+          const browsePreviewResult =
+            previewView === 'combined' ? combinedPreview : selectedOpPreview;
+          const browseDbPreviewResult =
+            previewView === 'combined' ? combinedDbPreview : selectedOpDbPreview;
+          const browsePreviewError =
+            previewView === 'combined' ? combinedPreviewError : selectedOpPreviewError;
+          const browseTruncated =
+            previewView === 'combined' ? combinedPreviewTruncated : selectedOpPreviewTruncated;
+          const browseLabel =
+            previewView === 'combined'
+              ? 'Combined effect of all pending changes'
+              : selectedOp
+                ? 'Effect of selected operation'
+                : 'No operation selected';
+          return (
+            <ImpactPanel
+              view={previewView}
+              onViewChange={setPreviewView}
+              label={browseLabel}
+              previewResult={browsePreviewResult}
+              dbPreviewResult={browseDbPreviewResult}
+              dbTruncated={dbTxnsQuery.data?.truncated}
+              dbTotal={dbTxnsQuery.data?.total}
+              previewError={browsePreviewError}
+              isPending={previewMutationPending}
+              stale={hasDirty}
+              truncated={browseTruncated}
+              onRerun={handleRerunPreview}
+              disabled={localOps.length === 0}
+            />
+          );
+        })()}
+      </>
+    );
 
     const isGridMode = !browseListQuery.isError && !browseListQuery.isLoading;
 
@@ -570,12 +573,7 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
   const previewError = previewView === 'combined' ? combinedPreviewError : selectedOpPreviewError;
   const previewTruncated =
     previewView === 'combined' ? combinedPreviewTruncated : selectedOpPreviewTruncated;
-  const previewLabel =
-    previewView === 'combined'
-      ? 'Combined effect of entire ChangeSet'
-      : selectedOp
-        ? `Effect of selected operation`
-        : 'No operation selected';
+  const currentPreviewLabel = previewLabel(previewView, !!selectedOp);
 
   const proposalFooter = (
     <>
@@ -636,7 +634,7 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
       <ImpactPanel
         view={previewView}
         onViewChange={setPreviewView}
-        label={previewLabel}
+        label={currentPreviewLabel}
         previewResult={previewResult}
         previewError={previewError}
         isPending={previewMutationPending}
@@ -671,15 +669,16 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
       />
     ));
 
-  const proposalContextHeader = isProposalGridReady && props.signal ? (
-    <ContextPanel
-      signal={props.signal}
-      triggeringTransaction={props.triggeringTransaction}
-      rationale={rationale}
-      opCount={localOps.length}
-      combinedSummary={combinedPreview?.summary ?? null}
-    />
-  ) : undefined;
+  const proposalContextHeader =
+    isProposalGridReady && props.signal ? (
+      <ContextPanel
+        signal={props.signal}
+        triggeringTransaction={props.triggeringTransaction}
+        rationale={rationale}
+        opCount={localOps.length}
+        combinedSummary={combinedPreview?.summary ?? null}
+      />
+    ) : undefined;
 
   return (
     <WorkflowDialog

--- a/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
@@ -3,16 +3,7 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import { toast } from 'sonner';
 
 import { trpc } from '@pops/api-client';
-import {
-  Button,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  Input,
-} from '@pops/ui';
+import { Button, Input, WorkflowDialog } from '@pops/ui';
 
 import {
   applyBrowsePriorityReorder,
@@ -414,171 +405,166 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
   // ---- render -------------------------------------------------------------
 
   if (isBrowseMode) {
-    return (
-      <Dialog open={props.open} onOpenChange={handleOpenChange}>
-        <DialogContent
-          className="
-            max-w-(--size-dialog-max-vw) max-h-(--size-dialog-max-vh) w-(--size-dialog-xl)
-            md:max-w-(--size-dialog-max-vw) md:w-(--size-dialog-xl)
-            flex flex-col gap-0 overflow-hidden p-0
-          "
-        >
-          <DialogHeader className="px-6 pt-6 pb-3">
-            <DialogTitle>Manage Rules</DialogTitle>
-            <DialogDescription>
-              Browse, search, and edit classification rules. Changes are buffered locally until
-              import is committed.
-            </DialogDescription>
-          </DialogHeader>
-
-          {browseListQuery.isError ? (
-            <div className="px-6 pb-6 text-sm text-destructive">
-              {browseListQuery.error.message}
-            </div>
-          ) : browseListQuery.isLoading ? (
-            <div className="px-6 pb-6 text-sm text-muted-foreground">Loading rules…</div>
-          ) : (
-            <div className="grid grid-cols-[300px_minmax(0,1fr)_360px] gap-0 border-y flex-1 min-h-0">
-              {/* Sidebar: rule list with search */}
-              <div className="flex flex-col min-h-0 border-r">
-                <div className="px-3 py-2 border-b">
-                  <div className="relative">
-                    <Search className="absolute left-2 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
-                    <Input
-                      value={browseSearch}
-                      onChange={(e) => {
-                        setBrowseSearch(e.target.value);
-                      }}
-                      placeholder="Search rules…"
-                      className="pl-7 h-8 text-xs"
-                    />
-                  </div>
-                </div>
-                <div className="px-3 py-1.5 text-[10px] text-muted-foreground border-b space-y-0.5">
-                  <div>
-                    {browseOrderedFiltered.length} rule
-                    {browseOrderedFiltered.length === 1 ? '' : 's'}
-                    {browseSearch && ` matching "${browseSearch}"`}
-                  </div>
-                  {browseSearch.trim() !== '' && (
-                    <div className="text-[10px] text-muted-foreground/90">
-                      Clear search to drag rules into priority order.
-                    </div>
-                  )}
-                </div>
-                <div className="flex-1 overflow-auto">
-                  <Suspense
-                    fallback={<div className="p-3 text-xs text-muted-foreground">Loading…</div>}
-                  >
-                    <BrowseRulesSidebar
-                      canDragReorder={browseCanDragReorder}
-                      orderedMerged={browseOrderedMerged}
-                      orderedFiltered={browseOrderedFiltered}
-                      selectedRuleId={browseSelectedRuleId}
-                      localOps={localOps}
-                      onSelectRule={handleBrowseSelectRule}
-                      onReorderFullList={handleBrowseReorderFullList}
-                    />
-                  </Suspense>
-                </div>
-                <div className="border-t p-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="w-full justify-start"
-                    onClick={handleAddNewRuleOp}
-                  >
-                    <Plus className="mr-1 h-3.5 w-3.5" /> Add new rule
-                  </Button>
-                </div>
-              </div>
-
-              {/* Detail: show selected rule or selected op editor */}
-              <div className="flex flex-col min-h-0 overflow-auto">
-                {selectedOp ? (
-                  <DetailPanel
-                    op={selectedOp}
-                    onChange={(mutator) => {
-                      if (!selectedOp) return;
-                      updateOp(selectedOp.clientId, mutator);
-                    }}
-                    disabled={false}
-                  />
-                ) : browseSelectedRule ? (
-                  <BrowseRuleDetailPanel
-                    rule={browseSelectedRule}
-                    onEdit={handleBrowseEditRule}
-                    onDisable={handleBrowseDisableRule}
-                    onRemove={handleBrowseRemoveRule}
-                  />
-                ) : (
-                  <div className="p-6 text-sm text-muted-foreground">
-                    Select a rule on the left to view or edit it.
-                  </div>
-                )}
-              </div>
-
-              {/* Impact preview (PRD-032 US-06) */}
-              {(() => {
-                const browsePreviewResult =
-                  previewView === 'combined' ? combinedPreview : selectedOpPreview;
-                const browseDbPreviewResult =
-                  previewView === 'combined' ? combinedDbPreview : selectedOpDbPreview;
-                const browsePreviewError =
-                  previewView === 'combined' ? combinedPreviewError : selectedOpPreviewError;
-                const browseTruncated =
-                  previewView === 'combined'
-                    ? combinedPreviewTruncated
-                    : selectedOpPreviewTruncated;
-                const browseLabel =
-                  previewView === 'combined'
-                    ? 'Combined effect of all pending changes'
-                    : selectedOp
-                      ? 'Effect of selected operation'
-                      : 'No operation selected';
-                return (
-                  <ImpactPanel
-                    view={previewView}
-                    onViewChange={setPreviewView}
-                    label={browseLabel}
-                    previewResult={browsePreviewResult}
-                    dbPreviewResult={browseDbPreviewResult}
-                    dbTruncated={dbTxnsQuery.data?.truncated}
-                    dbTotal={dbTxnsQuery.data?.total}
-                    previewError={browsePreviewError}
-                    isPending={previewMutationPending}
-                    stale={hasDirty}
-                    truncated={browseTruncated}
-                    onRerun={handleRerunPreview}
-                    disabled={localOps.length === 0}
-                  />
-                );
-              })()}
-            </div>
+    const browseFooter = (
+      <>
+        <div className="flex-1 text-xs text-muted-foreground">
+          {localOps.length > 0 && (
+            <span>
+              {localOps.length} unsaved change{localOps.length === 1 ? '' : 's'}
+            </span>
           )}
+        </div>
+        <Button variant="outline" onClick={() => handleOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button onClick={handleBrowseSave} disabled={localOps.length === 0}>
+          Save Changes
+        </Button>
+      </>
+    );
 
-          <DialogFooter className="px-6 py-4 border-t">
-            <div className="flex-1 text-xs text-muted-foreground">
-              {localOps.length > 0 && (
-                <span>
-                  {localOps.length} unsaved change{localOps.length === 1 ? '' : 's'}
-                </span>
+    const browseBody =
+      browseListQuery.isError ? (
+        <div className="px-6 pb-6 text-sm text-destructive">{browseListQuery.error.message}</div>
+      ) : browseListQuery.isLoading ? (
+        <div className="px-6 pb-6 text-sm text-muted-foreground">Loading rules…</div>
+      ) : (
+        // 3-column grid rendered via WorkflowDialog columns prop
+        <>
+          {/* Sidebar: rule list with search */}
+          <div className="flex flex-col min-h-0 border-r">
+            <div className="px-3 py-2 border-b">
+              <div className="relative">
+                <Search className="absolute left-2 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+                <Input
+                  value={browseSearch}
+                  onChange={(e) => {
+                    setBrowseSearch(e.target.value);
+                  }}
+                  placeholder="Search rules…"
+                  className="pl-7 h-8 text-xs"
+                />
+              </div>
+            </div>
+            <div className="px-3 py-1.5 text-[10px] text-muted-foreground border-b space-y-0.5">
+              <div>
+                {browseOrderedFiltered.length} rule
+                {browseOrderedFiltered.length === 1 ? '' : 's'}
+                {browseSearch && ` matching "${browseSearch}"`}
+              </div>
+              {browseSearch.trim() !== '' && (
+                <div className="text-[10px] text-muted-foreground/90">
+                  Clear search to drag rules into priority order.
+                </div>
               )}
             </div>
-            <Button
-              variant="outline"
-              onClick={() => {
-                handleOpenChange(false);
-              }}
-            >
-              Cancel
-            </Button>
-            <Button onClick={handleBrowseSave} disabled={localOps.length === 0}>
-              Save Changes
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            <div className="flex-1 overflow-auto">
+              <Suspense
+                fallback={<div className="p-3 text-xs text-muted-foreground">Loading…</div>}
+              >
+                <BrowseRulesSidebar
+                  canDragReorder={browseCanDragReorder}
+                  orderedMerged={browseOrderedMerged}
+                  orderedFiltered={browseOrderedFiltered}
+                  selectedRuleId={browseSelectedRuleId}
+                  localOps={localOps}
+                  onSelectRule={handleBrowseSelectRule}
+                  onReorderFullList={handleBrowseReorderFullList}
+                />
+              </Suspense>
+            </div>
+            <div className="border-t p-2">
+              <Button
+                size="sm"
+                variant="outline"
+                className="w-full justify-start"
+                onClick={handleAddNewRuleOp}
+              >
+                <Plus className="mr-1 h-3.5 w-3.5" /> Add new rule
+              </Button>
+            </div>
+          </div>
+
+          {/* Detail: show selected rule or selected op editor */}
+          <div className="flex flex-col min-h-0 overflow-auto">
+            {selectedOp ? (
+              <DetailPanel
+                op={selectedOp}
+                onChange={(mutator) => {
+                  if (!selectedOp) return;
+                  updateOp(selectedOp.clientId, mutator);
+                }}
+                disabled={false}
+              />
+            ) : browseSelectedRule ? (
+              <BrowseRuleDetailPanel
+                rule={browseSelectedRule}
+                onEdit={handleBrowseEditRule}
+                onDisable={handleBrowseDisableRule}
+                onRemove={handleBrowseRemoveRule}
+              />
+            ) : (
+              <div className="p-6 text-sm text-muted-foreground">
+                Select a rule on the left to view or edit it.
+              </div>
+            )}
+          </div>
+
+          {/* Impact preview (PRD-032 US-06) */}
+          {(() => {
+            const browsePreviewResult =
+              previewView === 'combined' ? combinedPreview : selectedOpPreview;
+            const browseDbPreviewResult =
+              previewView === 'combined' ? combinedDbPreview : selectedOpDbPreview;
+            const browsePreviewError =
+              previewView === 'combined' ? combinedPreviewError : selectedOpPreviewError;
+            const browseTruncated =
+              previewView === 'combined' ? combinedPreviewTruncated : selectedOpPreviewTruncated;
+            const browseLabel =
+              previewView === 'combined'
+                ? 'Combined effect of all pending changes'
+                : selectedOp
+                  ? 'Effect of selected operation'
+                  : 'No operation selected';
+            return (
+              <ImpactPanel
+                view={previewView}
+                onViewChange={setPreviewView}
+                label={browseLabel}
+                previewResult={browsePreviewResult}
+                dbPreviewResult={browseDbPreviewResult}
+                dbTruncated={dbTxnsQuery.data?.truncated}
+                dbTotal={dbTxnsQuery.data?.total}
+                previewError={browsePreviewError}
+                isPending={previewMutationPending}
+                stale={hasDirty}
+                truncated={browseTruncated}
+                onRerun={handleRerunPreview}
+                disabled={localOps.length === 0}
+              />
+            );
+          })()}
+        </>
+      );
+
+    const isGridMode = !browseListQuery.isError && !browseListQuery.isLoading;
+
+    return (
+      <WorkflowDialog
+        open={props.open}
+        onOpenChange={handleOpenChange}
+        title="Manage Rules"
+        description="Browse, search, and edit classification rules. Changes are buffered locally until import is committed."
+        columns={isGridMode ? 3 : undefined}
+        gridTemplate={isGridMode ? 'grid-cols-[300px_minmax(0,1fr)_360px]' : undefined}
+        footer={browseFooter}
+        className="
+          max-w-(--size-dialog-max-vw) max-h-(--size-dialog-max-vh) w-(--size-dialog-xl)
+          md:max-w-(--size-dialog-max-vw) md:w-(--size-dialog-xl)
+        "
+      >
+        {browseBody}
+      </WorkflowDialog>
     );
   }
 
@@ -595,129 +581,122 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
         ? `Effect of selected operation`
         : 'No operation selected';
 
+  const proposalFooter = (
+    <>
+      <div className="flex-1 text-xs text-muted-foreground">
+        {hasDirty ? (
+          <span>Preview stale — re-run before applying.</span>
+        ) : localOps.length === 0 ? (
+          <span>ChangeSet is empty.</span>
+        ) : null}
+      </div>
+      <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isBusy}>
+        Cancel
+      </Button>
+      {!rejectMode && (
+        <Button
+          variant="outline"
+          onClick={() => setRejectMode(true)}
+          disabled={isBusy || localOps.length === 0}
+        >
+          Reject with feedback
+        </Button>
+      )}
+      <Button onClick={handleApprove} disabled={!canApply}>
+        Apply ChangeSet
+      </Button>
+    </>
+  );
+
+  const isProposalGridReady =
+    props.signal && !proposeQuery.isError && !(proposeQuery.isLoading && localOps.length === 0);
+
+  const proposalBody = !props.signal ? (
+    <div className="px-6 pb-6 text-sm text-muted-foreground">No proposal signal provided.</div>
+  ) : proposeQuery.isError ? (
+    <div className="px-6 pb-6 text-sm text-destructive">{proposeQuery.error.message}</div>
+  ) : proposeQuery.isLoading && localOps.length === 0 ? (
+    <div className="px-6 pb-6 text-sm text-muted-foreground">Generating proposal…</div>
+  ) : (
+    <>
+      <OpsListPanel
+        ops={localOps}
+        selectedClientId={selectedClientId}
+        onSelect={setSelectedClientId}
+        onDelete={handleDeleteOp}
+        onAddNewRule={handleAddNewRuleOp}
+        onAddTargeted={handleAddTargetedOp}
+        excludeIds={excludeIds}
+        disabled={isBusy}
+      />
+      <DetailPanel
+        op={selectedOp}
+        onChange={(mutator) => {
+          if (!selectedOp) return;
+          updateOp(selectedOp.clientId, mutator);
+        }}
+        disabled={isBusy}
+      />
+      <ImpactPanel
+        view={previewView}
+        onViewChange={setPreviewView}
+        label={previewLabel}
+        previewResult={previewResult}
+        previewError={previewError}
+        isPending={previewMutationPending}
+        stale={hasDirty}
+        truncated={previewTruncated}
+        onRerun={handleRerunPreview}
+        disabled={isBusy || localOps.length === 0}
+      />
+    </>
+  );
+
+  const proposalSubpanel =
+    isProposalGridReady &&
+    (rejectMode ? (
+      <RejectPanel
+        feedback={rejectFeedback}
+        onFeedbackChange={setRejectFeedback}
+        onCancel={() => {
+          setRejectMode(false);
+          setRejectFeedback('');
+        }}
+        onConfirm={handleConfirmReject}
+        busy={mutationsHook.rejectMutationPending}
+      />
+    ) : (
+      <AiHelperPanel
+        messages={aiMessages}
+        instruction={aiInstruction}
+        onInstructionChange={setAiInstruction}
+        onSubmit={handleAiSubmit}
+        busy={aiBusy}
+      />
+    ));
+
+  const proposalContextHeader = isProposalGridReady && props.signal ? (
+    <ContextPanel
+      signal={props.signal}
+      triggeringTransaction={props.triggeringTransaction}
+      rationale={rationale}
+      opCount={localOps.length}
+      combinedSummary={combinedPreview?.summary ?? null}
+    />
+  ) : undefined;
+
   return (
-    <Dialog open={props.open} onOpenChange={handleOpenChange}>
-      <DialogContent
-        className="
-          max-w-[92vw] max-h-[88vh] w-[1180px]
-          md:max-w-[92vw] md:w-[1180px]
-          flex flex-col gap-0 overflow-hidden p-0
-        "
-      >
-        <DialogHeader className="px-6 pt-6 pb-3">
-          <DialogTitle>Correction proposal</DialogTitle>
-          <DialogDescription>
-            Edit the proposed rule changes and preview their impact before applying.
-          </DialogDescription>
-        </DialogHeader>
-
-        {!props.signal ? (
-          <div className="px-6 pb-6 text-sm text-muted-foreground">
-            No proposal signal provided.
-          </div>
-        ) : proposeQuery.isError ? (
-          <div className="px-6 pb-6 text-sm text-destructive">{proposeQuery.error.message}</div>
-        ) : proposeQuery.isLoading && localOps.length === 0 ? (
-          <div className="px-6 pb-6 text-sm text-muted-foreground">Generating proposal…</div>
-        ) : (
-          <>
-            <ContextPanel
-              signal={props.signal}
-              triggeringTransaction={props.triggeringTransaction}
-              rationale={rationale}
-              opCount={localOps.length}
-              combinedSummary={combinedPreview?.summary ?? null}
-            />
-
-            <div className="grid grid-cols-[260px_minmax(0,1fr)_360px] gap-0 border-y flex-1 min-h-0">
-              <OpsListPanel
-                ops={localOps}
-                selectedClientId={selectedClientId}
-                onSelect={setSelectedClientId}
-                onDelete={handleDeleteOp}
-                onAddNewRule={handleAddNewRuleOp}
-                onAddTargeted={handleAddTargetedOp}
-                excludeIds={excludeIds}
-                disabled={isBusy}
-              />
-              <DetailPanel
-                op={selectedOp}
-                onChange={(mutator) => {
-                  if (!selectedOp) return;
-                  updateOp(selectedOp.clientId, mutator);
-                }}
-                disabled={isBusy}
-              />
-              <ImpactPanel
-                view={previewView}
-                onViewChange={setPreviewView}
-                label={previewLabel}
-                previewResult={previewResult}
-                previewError={previewError}
-                isPending={previewMutationPending}
-                stale={hasDirty}
-                truncated={previewTruncated}
-                onRerun={handleRerunPreview}
-                disabled={isBusy || localOps.length === 0}
-              />
-            </div>
-
-            {rejectMode ? (
-              <RejectPanel
-                feedback={rejectFeedback}
-                onFeedbackChange={setRejectFeedback}
-                onCancel={() => {
-                  setRejectMode(false);
-                  setRejectFeedback('');
-                }}
-                onConfirm={handleConfirmReject}
-                busy={mutationsHook.rejectMutationPending}
-              />
-            ) : (
-              <AiHelperPanel
-                messages={aiMessages}
-                instruction={aiInstruction}
-                onInstructionChange={setAiInstruction}
-                onSubmit={handleAiSubmit}
-                busy={aiBusy}
-              />
-            )}
-          </>
-        )}
-
-        <DialogFooter className="px-6 py-4 border-t">
-          <div className="flex-1 text-xs text-muted-foreground">
-            {hasDirty ? (
-              <span>Preview stale — re-run before applying.</span>
-            ) : localOps.length === 0 ? (
-              <span>ChangeSet is empty.</span>
-            ) : null}
-          </div>
-          <Button
-            variant="outline"
-            onClick={() => {
-              handleOpenChange(false);
-            }}
-            disabled={isBusy}
-          >
-            Cancel
-          </Button>
-          {!rejectMode && (
-            <Button
-              variant="outline"
-              onClick={() => {
-                setRejectMode(true);
-              }}
-              disabled={isBusy || localOps.length === 0}
-            >
-              Reject with feedback
-            </Button>
-          )}
-          <Button onClick={handleApprove} disabled={!canApply}>
-            Apply ChangeSet
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <WorkflowDialog
+      open={props.open}
+      onOpenChange={handleOpenChange}
+      title="Correction proposal"
+      description="Edit the proposed rule changes and preview their impact before applying."
+      columns={isProposalGridReady ? 3 : undefined}
+      header={proposalContextHeader || undefined}
+      subpanel={proposalSubpanel || undefined}
+      footer={proposalFooter}
+    >
+      {proposalBody}
+    </WorkflowDialog>
   );
 }

--- a/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
+++ b/packages/app-finance/src/components/imports/CorrectionProposalDialog.tsx
@@ -558,10 +558,6 @@ export function CorrectionProposalDialog(props: CorrectionProposalDialogProps) {
         columns={isGridMode ? 3 : undefined}
         gridTemplate={isGridMode ? 'grid-cols-[300px_minmax(0,1fr)_360px]' : undefined}
         footer={browseFooter}
-        className="
-          max-w-(--size-dialog-max-vw) max-h-(--size-dialog-max-vh) w-(--size-dialog-xl)
-          md:max-w-(--size-dialog-max-vw) md:w-(--size-dialog-xl)
-        "
       >
         {browseBody}
       </WorkflowDialog>

--- a/packages/app-finance/src/components/imports/EditableTransactionCard.tsx
+++ b/packages/app-finance/src/components/imports/EditableTransactionCard.tsx
@@ -1,11 +1,16 @@
 import { ChevronRight, Save, X } from 'lucide-react';
 import { useState } from 'react';
 
-import { Button } from '@pops/ui';
-import { Input } from '@pops/ui';
-import { Label } from '@pops/ui';
-import { Select as UiSelect } from '@pops/ui';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@pops/ui';
+import {
+  Button,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  EditableFormCard,
+  Input,
+  Label,
+  Select as UiSelect,
+} from '@pops/ui';
 
 import { EntitySelect } from './EntitySelect';
 
@@ -55,46 +60,30 @@ export function EditableTransactionCard({
     onSave(transaction, editedFields, shouldLearn);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      onCancel();
-    }
-  };
+  const actions = (
+    <>
+      <Button
+        variant="default"
+        size="sm"
+        onClick={() => handleSave(true)}
+        className="bg-purple-600 hover:bg-purple-700"
+      >
+        <Save className="w-4 h-4 mr-1" />
+        Save & Learn
+      </Button>
+      <Button variant="outline" size="sm" onClick={() => handleSave(false)}>
+        <Save className="w-4 h-4 mr-1" />
+        Save Once
+      </Button>
+      <Button variant="outline" size="sm" onClick={onCancel}>
+        <X className="w-4 h-4 mr-1" />
+        Cancel
+      </Button>
+    </>
+  );
 
   return (
-    <div className="border-2 border-info rounded-lg p-4 bg-info/5" onKeyDown={handleKeyDown}>
-      {/* Header */}
-      <div className="flex justify-between items-center mb-4 pb-2 border-b border-info/20">
-        <h3 className="font-semibold text-info">Edit Transaction</h3>
-        <div className="flex gap-2">
-          <Button
-            variant="default"
-            size="sm"
-            onClick={() => {
-              handleSave(true);
-            }}
-            className="bg-purple-600 hover:bg-purple-700"
-          >
-            <Save className="w-4 h-4 mr-1" />
-            Save & Learn
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              handleSave(false);
-            }}
-          >
-            <Save className="w-4 h-4 mr-1" />
-            Save Once
-          </Button>
-          <Button variant="outline" size="sm" onClick={onCancel}>
-            <X className="w-4 h-4 mr-1" />
-            Cancel
-          </Button>
-        </div>
-      </div>
-
+    <EditableFormCard title="Edit Transaction" actions={actions} onEscape={onCancel}>
       {/* Transaction Type */}
       <div className="mb-4 p-3 bg-info/10 rounded-lg">
         <Label htmlFor="transactionType" className="block mb-2 font-semibold">
@@ -230,6 +219,6 @@ export function EditableTransactionCard({
           </pre>
         </CollapsibleContent>
       </Collapsible>
-    </div>
+    </EditableFormCard>
   );
 }

--- a/packages/app-finance/src/components/imports/EntitySelect.tsx
+++ b/packages/app-finance/src/components/imports/EntitySelect.tsx
@@ -1,7 +1,5 @@
 import { EntitySelect as UiEntitySelect } from '@pops/ui';
 
-export type { EntityOption, EntitySelectProps } from '@pops/ui';
-
 export interface FinanceEntityOption {
   id: string;
   name: string;

--- a/packages/app-finance/src/components/imports/EntitySelect.tsx
+++ b/packages/app-finance/src/components/imports/EntitySelect.tsx
@@ -1,102 +1,33 @@
-import { Check, ChevronsUpDown } from 'lucide-react';
-import { useState } from 'react';
+import { EntitySelect as UiEntitySelect } from '@pops/ui';
 
-import {
-  Badge,
-  Button,
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@pops/ui';
+export type { EntityOption, EntitySelectProps } from '@pops/ui';
 
-export interface EntityOption {
+export interface FinanceEntityOption {
   id: string;
   name: string;
   type: string;
 }
 
-export interface EntitySelectProps {
-  entities: EntityOption[];
+interface FinanceEntitySelectProps {
+  entities: FinanceEntityOption[];
   value?: string;
   onChange?: (entityId: string, entityName: string) => void;
   placeholder?: string;
+  disabled?: boolean;
+  className?: string;
 }
 
-export function EntitySelect({
-  entities,
-  value,
-  onChange,
-  placeholder = 'Choose existing entity...',
-}: EntitySelectProps) {
-  const [open, setOpen] = useState(false);
-
-  const selected = entities.find((e) => e.id === value);
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className="w-full justify-between font-normal"
-        >
-          {selected ? (
-            <span className="flex items-center gap-2 truncate">
-              <span className="truncate">{selected.name}</span>
-              <Badge variant="outline" className="text-xs capitalize shrink-0">
-                {selected.type}
-              </Badge>
-            </span>
-          ) : (
-            <span className="text-muted-foreground">{placeholder}</span>
-          )}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
-        <Command>
-          <CommandInput placeholder="Search entities..." />
-          <CommandList>
-            <CommandEmpty>No entities found.</CommandEmpty>
-            <CommandGroup>
-              {entities.map((entity) => (
-                <CommandItem
-                  key={entity.id}
-                  value={`${entity.name} ${entity.type}`}
-                  onSelect={() => {
-                    onChange?.(entity.id, entity.name);
-                    setOpen(false);
-                  }}
-                >
-                  <Check
-                    className={`mr-2 h-4 w-4 ${value === entity.id ? 'opacity-100' : 'opacity-0'}`}
-                  />
-                  <span
-                    className={`truncate ${entity.id.startsWith('temp:entity:') ? 'italic' : ''}`}
-                  >
-                    {entity.name}
-                  </span>
-                  {entity.id.startsWith('temp:entity:') && (
-                    <Badge variant="secondary" className="ml-1 text-xs shrink-0">
-                      Pending
-                    </Badge>
-                  )}
-                  <Badge variant="outline" className="ml-auto text-xs capitalize shrink-0">
-                    {entity.type}
-                  </Badge>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
+/**
+ * Finance-domain wrapper for @pops/ui EntitySelect.
+ * Maps entities with `temp:entity:` IDs to `pending: true` so the "Pending" badge
+ * renders for locally-created entities that haven't been committed yet.
+ */
+export function EntitySelect({ entities, ...props }: FinanceEntitySelectProps) {
+  const mapped = entities.map((e) => ({
+    id: e.id,
+    name: e.name,
+    type: e.type,
+    pending: e.id.startsWith('temp:entity:'),
+  }));
+  return <UiEntitySelect entities={mapped} {...props} />;
 }

--- a/packages/app-finance/src/components/imports/ProcessingStep.tsx
+++ b/packages/app-finance/src/components/imports/ProcessingStep.tsx
@@ -36,10 +36,11 @@ export function ProcessingStep() {
    * and this gate will correctly re-run processing.
    */
   const hasProcessedResults =
-    processedTransactions.matched.length > 0 ||
-    processedTransactions.uncertain.length > 0 ||
-    processedTransactions.failed.length > 0 ||
-    processedTransactions.skipped.length > 0;
+    processedTransactions.matched.length +
+      processedTransactions.uncertain.length +
+      processedTransactions.failed.length +
+      processedTransactions.skipped.length >
+    0;
   const hasAlreadyProcessed =
     hasProcessedResults &&
     processedForFingerprint !== null &&
@@ -149,23 +150,19 @@ export function ProcessingStep() {
     ? [
         {
           label: 'Checking for duplicates',
-          status: (
-            progress?.currentStep === 'deduplicating'
-              ? 'in_progress'
-              : ['matching', 'writing'].includes(progress?.currentStep ?? '')
-                ? 'done'
-                : 'pending'
-          ) as 'pending' | 'in_progress' | 'done',
+          status: (progress?.currentStep === 'deduplicating'
+            ? 'in_progress'
+            : ['matching', 'writing'].includes(progress?.currentStep ?? '')
+              ? 'done'
+              : 'pending') as 'pending' | 'in_progress' | 'done',
         },
         {
           label: 'Matching entities',
-          status: (
-            progress?.currentStep === 'matching'
-              ? 'in_progress'
-              : progress?.currentStep === 'writing'
-                ? 'done'
-                : 'pending'
-          ) as 'pending' | 'in_progress' | 'done',
+          status: (progress?.currentStep === 'matching'
+            ? 'in_progress'
+            : progress?.currentStep === 'writing'
+              ? 'done'
+              : 'pending') as 'pending' | 'in_progress' | 'done',
         },
       ]
     : undefined;
@@ -184,9 +181,7 @@ export function ProcessingStep() {
           .slice(0, 3)
           .map((e) => `${e.description}: ${e.error}`)
           .concat(
-            progress.errors.length > 3
-              ? [`And ${progress.errors.length - 3} more errors...`]
-              : []
+            progress.errors.length > 3 ? [`And ${progress.errors.length - 3} more errors...`] : []
           )
       : undefined;
 
@@ -234,8 +229,8 @@ export function ProcessingStep() {
                 {warning.affectedCount && (
                   <p className="text-xs opacity-80">
                     {warning.affectedCount} transaction
-                    {warning.affectedCount !== 1 ? 's' : ''} could not be automatically
-                    categorized. You can manually categorize them in the review step.
+                    {warning.affectedCount !== 1 ? 's' : ''} could not be automatically categorized.
+                    You can manually categorize them in the review step.
                   </p>
                 )}
               </div>
@@ -250,8 +245,8 @@ export function ProcessingStep() {
           <p>{processImportMutation.error?.message || 'An unexpected error occurred'}</p>
           {progressQuery.data?.errors && progressQuery.data.errors.length > 0 && (
             <div className="mt-2 space-y-1">
-              {progressQuery.data.errors.map((error, idx) => (
-                <p key={idx} className="text-xs">
+              {progressQuery.data.errors.map((error) => (
+                <p key={error.error} className="text-xs">
                   • {error.error}
                 </p>
               ))}

--- a/packages/app-finance/src/components/imports/ProcessingStep.tsx
+++ b/packages/app-finance/src/components/imports/ProcessingStep.tsx
@@ -193,7 +193,7 @@ export function ProcessingStep() {
       : null;
 
   return (
-    <div className="flex flex-col items-center py-12 space-y-6">
+    <div className="flex flex-col items-center space-y-6">
       <LoadingProgressStep
         title="Processing"
         message={

--- a/packages/app-finance/src/components/imports/ProcessingStep.tsx
+++ b/packages/app-finance/src/components/imports/ProcessingStep.tsx
@@ -1,8 +1,8 @@
-import { AlertTriangle, ArrowRight, CheckCircle, Loader2, RefreshCw, XCircle } from 'lucide-react';
+import { AlertTriangle, ArrowRight, RefreshCw } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { trpc } from '@pops/api-client';
-import { Button } from '@pops/ui';
+import { Button, LoadingProgressStep } from '@pops/ui';
 
 import { useImportStore } from '../../store/importStore';
 
@@ -125,13 +125,11 @@ export function ProcessingStep() {
   if (hasAlreadyProcessed) {
     return (
       <div className="flex flex-col items-center justify-center py-12 space-y-6">
-        <CheckCircle className="w-16 h-16 text-success" />
-        <div className="text-center space-y-2">
-          <h2 className="text-2xl font-semibold">Already processed</h2>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            Your transactions are ready for review. Nothing to re-run.
-          </p>
-        </div>
+        <LoadingProgressStep
+          done
+          title="Already processed"
+          message="Your transactions are ready for review. Nothing to re-run."
+        />
         <Button onClick={nextStep}>
           <ArrowRight className="h-4 w-4" />
           Continue to Review
@@ -140,153 +138,112 @@ export function ProcessingStep() {
     );
   }
 
+  const pct =
+    isProcessing && progress
+      ? (progress.processedCount / progress.totalTransactions) * 100
+      : undefined;
+
+  const steps = isProcessing
+    ? [
+        {
+          label: 'Checking for duplicates',
+          status: (
+            progress?.currentStep === 'deduplicating'
+              ? 'in_progress'
+              : ['matching', 'writing'].includes(progress?.currentStep ?? '')
+                ? 'done'
+                : 'pending'
+          ) as 'pending' | 'in_progress' | 'done',
+        },
+        {
+          label: 'Matching entities',
+          status: (
+            progress?.currentStep === 'matching'
+              ? 'in_progress'
+              : progress?.currentStep === 'writing'
+                ? 'done'
+                : 'pending'
+          ) as 'pending' | 'in_progress' | 'done',
+        },
+      ]
+    : undefined;
+
+  const batchItems =
+    isProcessing && progress && progress.currentBatch.length > 0
+      ? progress.currentBatch.map((item) => ({
+          description: item.description,
+          status: item.status as 'processing' | 'success' | 'failed',
+        }))
+      : undefined;
+
+  const warningErrors =
+    progress?.errors && progress.errors.length > 0
+      ? progress.errors
+          .slice(0, 3)
+          .map((e) => `${e.description}: ${e.error}`)
+          .concat(
+            progress.errors.length > 3
+              ? [`And ${progress.errors.length - 3} more errors...`]
+              : []
+          )
+      : undefined;
+
+  // Completed result warnings (AI unavailable etc.)
+  const completedWarnings =
+    progressQuery.data?.result &&
+    (progressQuery.data.result as ProcessImportOutput).warnings?.length
+      ? (progressQuery.data.result as ProcessImportOutput).warnings!
+      : null;
+
   return (
-    <div className="flex flex-col items-center justify-center py-12 space-y-6">
-      <Loader2 className="w-16 h-16 animate-spin text-info" />
-
-      <div className="text-center space-y-2">
-        <h2 className="text-2xl font-semibold">Processing</h2>
-        <p className="text-sm text-gray-600 dark:text-gray-400">
-          {isProcessing && progress
+    <div className="flex flex-col items-center py-12 space-y-6">
+      <LoadingProgressStep
+        title="Processing"
+        message={
+          isProcessing && progress
             ? `Processing ${progress.processedCount}/${progress.totalTransactions} transactions...`
-            : `Analyzing ${parsedTransactions.length} transactions...`}
-        </p>
-      </div>
+            : `Analyzing ${parsedTransactions.length} transactions...`
+        }
+        progress={pct}
+        steps={steps}
+        currentBatch={batchItems}
+        errors={warningErrors}
+      />
 
-      {/* Progress bar */}
-      {isProcessing && progress && (
-        <div className="w-full max-w-md">
-          <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
-            <span>Progress</span>
-            <span>{Math.round((progress.processedCount / progress.totalTransactions) * 100)}%</span>
-          </div>
-          <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-            <div
-              className="bg-info/50 h-2 rounded-full transition-all duration-300"
-              style={{
-                width: `${(progress.processedCount / progress.totalTransactions) * 100}%`,
-              }}
-            />
-          </div>
-        </div>
-      )}
-
-      {/* Current step indicator */}
-      <div className="w-full max-w-md space-y-2">
-        <div className="text-xs text-gray-500 dark:text-gray-400 space-y-1">
-          <div className="flex justify-between">
-            <span>Checking for duplicates</span>
-            <span>
-              {progress?.currentStep === 'deduplicating'
-                ? 'In progress...'
-                : ['matching', 'writing'].includes(progress?.currentStep ?? '')
-                  ? 'Complete'
-                  : 'Pending'}
-            </span>
-          </div>
-          <div className="flex justify-between">
-            <span>Matching entities</span>
-            <span>
-              {progress?.currentStep === 'matching'
-                ? 'In progress...'
-                : progress?.currentStep === 'writing'
-                  ? 'Complete'
-                  : 'Pending'}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      {/* Current batch (up to 5 items) */}
-      {isProcessing && progress && progress.currentBatch.length > 0 && (
-        <div className="w-full max-w-md">
-          <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
-            Currently processing:
-          </p>
-          <div className="space-y-1">
-            {progress.currentBatch.map((item, idx) => (
-              <div
-                key={idx}
-                className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400"
-              >
-                {item.status === 'processing' && <Loader2 className="w-3 h-3 animate-spin" />}
-                {item.status === 'success' && <CheckCircle className="w-3 h-3 text-success" />}
-                {item.status === 'failed' && <XCircle className="w-3 h-3 text-destructive" />}
-                <span className="truncate">{item.description}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Errors during processing */}
-      {progress?.errors && progress.errors.length > 0 && (
-        <div className="w-full max-w-md space-y-2">
-          {progress.errors.slice(0, 3).map((error, idx) => (
-            <div
-              key={idx}
-              className="p-3 text-sm text-warning bg-warning/10 rounded-lg border border-warning/25"
-            >
-              <div className="flex items-start gap-2">
-                <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
-                <div>
-                  <p className="font-medium text-xs">{error.description}</p>
-                  <p className="text-xs opacity-80 mt-0.5">{error.error}</p>
-                </div>
+      {/* Warnings from completed result */}
+      {completedWarnings &&
+        completedWarnings.map((warning: ImportWarning, idx: number) => (
+          <div
+            key={idx}
+            className="w-full max-w-md p-4 text-sm rounded-lg border text-warning bg-warning/10 border-warning/25"
+          >
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5" />
+              <div className="flex-1 space-y-1">
+                <p className="font-medium">
+                  {warning.type === 'AI_CATEGORIZATION_UNAVAILABLE'
+                    ? 'AI Categorization Unavailable'
+                    : 'AI API Error'}
+                </p>
+                <p className="text-xs">{warning.message}</p>
+                {warning.details && (
+                  <p className="text-xs opacity-70 font-mono">{warning.details}</p>
+                )}
+                {warning.affectedCount && (
+                  <p className="text-xs opacity-80">
+                    {warning.affectedCount} transaction
+                    {warning.affectedCount !== 1 ? 's' : ''} could not be automatically
+                    categorized. You can manually categorize them in the review step.
+                  </p>
+                )}
               </div>
             </div>
-          ))}
-          {progress.errors.length > 3 && (
-            <p className="text-xs text-gray-500 text-center">
-              And {progress.errors.length - 3} more errors...
-            </p>
-          )}
-        </div>
-      )}
-
-      {/* Warnings (from completed result) */}
-      {progressQuery.data?.result &&
-        (progressQuery.data.result as ProcessImportOutput).warnings &&
-        (progressQuery.data.result as ProcessImportOutput).warnings!.length > 0 && (
-          <div className="w-full max-w-md space-y-2">
-            {(progressQuery.data.result as ProcessImportOutput).warnings!.map(
-              (warning: ImportWarning, idx: number) => {
-                return (
-                  <div
-                    key={idx}
-                    className="p-4 text-sm rounded-lg border text-warning bg-warning/10 border-warning/25"
-                  >
-                    <div className="flex items-start gap-3">
-                      <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5" />
-                      <div className="flex-1 space-y-1">
-                        <p className="font-medium">
-                          {warning.type === 'AI_CATEGORIZATION_UNAVAILABLE'
-                            ? 'AI Categorization Unavailable'
-                            : 'AI API Error'}
-                        </p>
-                        <p className="text-xs">{warning.message}</p>
-                        {warning.details && (
-                          <p className="text-xs opacity-70 font-mono">{warning.details}</p>
-                        )}
-                        {warning.affectedCount && (
-                          <p className="text-xs opacity-80">
-                            {warning.affectedCount} transaction
-                            {warning.affectedCount !== 1 ? 's' : ''} could not be automatically
-                            categorized. You can manually categorize them in the review step.
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                );
-              }
-            )}
           </div>
-        )}
+        ))}
 
       {/* Fatal errors */}
       {(processImportMutation.isError || progressQuery.data?.status === 'failed') && (
-        <div className="p-4 max-w-md text-sm text-destructive bg-destructive/10 dark:text-destructive/40 rounded-lg">
+        <div className="p-4 max-w-md w-full text-sm text-destructive bg-destructive/10 dark:text-destructive/40 rounded-lg">
           <p className="font-medium mb-1">Processing Failed</p>
           <p>{processImportMutation.error?.message || 'An unexpected error occurred'}</p>
           {progressQuery.data?.errors && progressQuery.data.errors.length > 0 && (

--- a/packages/app-finance/src/components/imports/ProcessingStep.tsx
+++ b/packages/app-finance/src/components/imports/ProcessingStep.tsx
@@ -124,22 +124,24 @@ export function ProcessingStep() {
   // click Continue without re-running the pipeline.
   if (hasAlreadyProcessed) {
     return (
-      <div className="flex flex-col items-center justify-center py-12 space-y-6">
+      <>
         <LoadingProgressStep
           done
           title="Already processed"
           message="Your transactions are ready for review. Nothing to re-run."
         />
-        <Button onClick={nextStep}>
-          <ArrowRight className="h-4 w-4" />
-          Continue to Review
-        </Button>
-      </div>
+        <div className="flex justify-center pb-6">
+          <Button onClick={nextStep}>
+            <ArrowRight className="h-4 w-4" />
+            Continue to Review
+          </Button>
+        </div>
+      </>
     );
   }
 
   const pct =
-    isProcessing && progress
+    isProcessing && progress && progress.totalTransactions > 0
       ? (progress.processedCount / progress.totalTransactions) * 100
       : undefined;
 
@@ -212,9 +214,9 @@ export function ProcessingStep() {
 
       {/* Warnings from completed result */}
       {completedWarnings &&
-        completedWarnings.map((warning: ImportWarning, idx: number) => (
+        completedWarnings.map((warning: ImportWarning) => (
           <div
-            key={idx}
+            key={warning.type}
             className="w-full max-w-md p-4 text-sm rounded-lg border text-warning bg-warning/10 border-warning/25"
           >
             <div className="flex items-start gap-3">

--- a/packages/app-finance/src/components/imports/ReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.test.tsx
@@ -347,6 +347,8 @@ vi.mock('@pops/ui', async () => {
       React.createElement('button', { role: 'tab', 'data-value': value }, children),
     TabsContent: ({ children, value }: { children: React.ReactNode; value: string }) =>
       React.createElement('div', { 'data-testid': `tab-${value}` }, children),
+    EmptyStateTab: ({ message }: { message: string }) =>
+      React.createElement('p', { 'data-testid': 'empty-state-tab' }, message),
   };
 });
 

--- a/packages/app-finance/src/components/imports/SummaryStep.tsx
+++ b/packages/app-finance/src/components/imports/SummaryStep.tsx
@@ -1,7 +1,7 @@
 import { AlertCircle, CheckCircle, List, Plus, RefreshCw, XCircle } from 'lucide-react';
 import { useNavigate } from 'react-router';
 
-import { Button } from '@pops/ui';
+import { Button, SummaryCard } from '@pops/ui';
 
 import { useImportStore } from '../../store/importStore';
 
@@ -43,54 +43,41 @@ export function SummaryStep() {
       </div>
 
       <div className="grid grid-cols-2 gap-4">
-        {/* Entities created */}
-        <div className="bg-success/5 border border-success/20 rounded-lg p-4 text-center">
-          <div className="flex items-center justify-center mb-2">
-            <CheckCircle className="w-5 h-5 text-success" />
-          </div>
-          <div className="text-2xl font-semibold text-success">{commitResult.entitiesCreated}</div>
-          <div className="text-xs text-success dark:text-success/60">Entities Created</div>
-        </div>
+        <SummaryCard
+          icon={<CheckCircle className="w-5 h-5 text-success" />}
+          value={commitResult.entitiesCreated}
+          label="Entities Created"
+          variant="success"
+        />
 
-        {/* Rules applied */}
-        <div className="bg-info/5 border border-info/20 rounded-lg p-4 text-center">
-          <div className="flex items-center justify-center mb-2">
-            <CheckCircle className="w-5 h-5 text-info" />
-          </div>
-          <div className="text-2xl font-semibold text-info">{totalRules}</div>
-          <div className="text-xs text-info">Rules Applied</div>
-        </div>
+        <SummaryCard
+          icon={<CheckCircle className="w-5 h-5 text-info" />}
+          value={totalRules}
+          label="Rules Applied"
+          variant="info"
+        />
 
-        {/* Transactions imported */}
-        <div className="bg-success/5 border border-success/20 rounded-lg p-4 text-center">
-          <div className="flex items-center justify-center mb-2">
-            <CheckCircle className="w-5 h-5 text-success" />
-          </div>
-          <div className="text-2xl font-semibold text-success">
-            {commitResult.transactionsImported}
-          </div>
-          <div className="text-xs text-success dark:text-success/60">Transactions Imported</div>
-        </div>
+        <SummaryCard
+          icon={<CheckCircle className="w-5 h-5 text-success" />}
+          value={commitResult.transactionsImported}
+          label="Transactions Imported"
+          variant="success"
+        />
 
-        {/* Transactions failed */}
         {commitResult.transactionsFailed > 0 ? (
-          <div className="bg-destructive/5 border border-destructive/20 rounded-lg p-4 text-center">
-            <div className="flex items-center justify-center mb-2">
-              <XCircle className="w-5 h-5 text-destructive" />
-            </div>
-            <div className="text-2xl font-semibold text-destructive">
-              {commitResult.transactionsFailed}
-            </div>
-            <div className="text-xs text-destructive">Transactions Failed</div>
-          </div>
+          <SummaryCard
+            icon={<XCircle className="w-5 h-5 text-destructive" />}
+            value={commitResult.transactionsFailed}
+            label="Transactions Failed"
+            variant="destructive"
+          />
         ) : (
-          <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4 text-center">
-            <div className="flex items-center justify-center mb-2">
-              <AlertCircle className="w-5 h-5 text-gray-400" />
-            </div>
-            <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">0</div>
-            <div className="text-xs text-gray-700 dark:text-gray-300">Transactions Failed</div>
-          </div>
+          <SummaryCard
+            icon={<AlertCircle className="w-5 h-5 text-gray-400" />}
+            value={0}
+            label="Transactions Failed"
+            variant="neutral"
+          />
         )}
       </div>
 

--- a/packages/app-finance/src/components/imports/review/FailedTab.tsx
+++ b/packages/app-finance/src/components/imports/review/FailedTab.tsx
@@ -1,6 +1,6 @@
 import { Layers, List } from 'lucide-react';
 
-import { Button } from '@pops/ui';
+import { Button, EmptyStateTab } from '@pops/ui';
 
 import { EditableTransactionCard } from '../EditableTransactionCard';
 import { TransactionCard } from '../TransactionCard';
@@ -49,7 +49,7 @@ export function FailedTab({
   entities,
 }: FailedTabProps) {
   if (transactions.length === 0) {
-    return <div className="text-center py-12 text-gray-500">No failed transactions</div>;
+    return <EmptyStateTab message="No failed transactions" />;
   }
 
   return (

--- a/packages/app-finance/src/components/imports/review/MatchedTab.tsx
+++ b/packages/app-finance/src/components/imports/review/MatchedTab.tsx
@@ -1,3 +1,5 @@
+import { EmptyStateTab } from '@pops/ui';
+
 import { EditableTransactionCard } from '../EditableTransactionCard';
 import { TransactionCard } from '../TransactionCard';
 
@@ -28,7 +30,7 @@ export function MatchedTab({
   entities,
 }: MatchedTabProps) {
   if (transactions.length === 0) {
-    return <div className="text-center py-12 text-gray-500">No matched transactions</div>;
+    return <EmptyStateTab message="No matched transactions" />;
   }
 
   return (

--- a/packages/app-finance/src/components/imports/review/SkippedTab.tsx
+++ b/packages/app-finance/src/components/imports/review/SkippedTab.tsx
@@ -1,3 +1,5 @@
+import { EmptyStateTab } from '@pops/ui';
+
 import type { ProcessedTransaction } from '../../../store/importStore';
 
 interface SkippedTabProps {
@@ -9,7 +11,7 @@ interface SkippedTabProps {
  */
 export function SkippedTab({ transactions }: SkippedTabProps) {
   if (transactions.length === 0) {
-    return <div className="text-center py-12 text-gray-500">No skipped transactions</div>;
+    return <EmptyStateTab message="No skipped transactions" />;
   }
 
   return (

--- a/packages/app-finance/src/components/imports/review/UncertainTab.tsx
+++ b/packages/app-finance/src/components/imports/review/UncertainTab.tsx
@@ -1,6 +1,6 @@
 import { Layers, List } from 'lucide-react';
 
-import { Button } from '@pops/ui';
+import { Button, EmptyStateTab } from '@pops/ui';
 
 import { EditableTransactionCard } from '../EditableTransactionCard';
 import { TransactionCard } from '../TransactionCard';
@@ -49,7 +49,7 @@ export function UncertainTab({
   entities,
 }: UncertainTabProps) {
   if (transactions.length === 0) {
-    return <div className="text-center py-12 text-gray-500">No uncertain transactions</div>;
+    return <EmptyStateTab message="No uncertain transactions" />;
   }
 
   return (

--- a/packages/app-finance/src/pages/DashboardPage.tsx
+++ b/packages/app-finance/src/pages/DashboardPage.tsx
@@ -61,11 +61,11 @@ export function DashboardPage() {
       <PageHeader title="Dashboard" description="Welcome back! Here's your financial overview." />
 
       {/* Stats Grid */}
-      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <section>
         {transactionsLoading ? (
           <SkeletonGrid count={4} itemHeight="h-32" cols="sm:grid-cols-2 lg:grid-cols-4" />
         ) : stats ? (
-          <>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <StatCard
               title="Total Transactions"
               value={stats.totalTransactions.toLocaleString()}
@@ -90,7 +90,7 @@ export function DashboardPage() {
               description="Last 10 transactions"
               color={stats.totalIncome > stats.totalExpenses ? 'emerald' : 'rose'}
             />
-          </>
+          </div>
         ) : null}
       </section>
 

--- a/packages/app-finance/src/pages/DashboardPage.tsx
+++ b/packages/app-finance/src/pages/DashboardPage.tsx
@@ -3,13 +3,11 @@ import { trpc } from '@pops/api-client';
  * Dashboard page - overview of finances
  */
 import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
   Badge,
   Card,
+  ErrorAlert,
   PageHeader,
-  Skeleton,
+  SkeletonGrid,
   StatCard,
 } from '@pops/ui';
 
@@ -49,22 +47,11 @@ export function DashboardPage() {
     return (
       <div className="container mx-auto py-8">
         <PageHeader title="Dashboard" className="mb-6" />
-        <Alert variant="destructive">
-          <AlertTitle>Unable to load dashboard</AlertTitle>
-          <AlertDescription>
-            <p className="mb-2">
-              The backend API is not responding. Make sure the pops-api server is running.
-            </p>
-            <details className="mt-3">
-              <summary className="cursor-pointer hover:underline font-medium text-sm">
-                Show technical details
-              </summary>
-              <code className="block mt-2 p-3 bg-black/10 dark:bg-black/20 rounded text-xs font-mono whitespace-pre-wrap break-all">
-                {transactionsError.message}
-              </code>
-            </details>
-          </AlertDescription>
-        </Alert>
+        <ErrorAlert
+          title="Unable to load dashboard"
+          message="The backend API is not responding. Make sure the pops-api server is running."
+          details={transactionsError.message}
+        />
       </div>
     );
   }
@@ -76,12 +63,7 @@ export function DashboardPage() {
       {/* Stats Grid */}
       <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {transactionsLoading ? (
-          <>
-            <Skeleton className="h-32" />
-            <Skeleton className="h-32" />
-            <Skeleton className="h-32" />
-            <Skeleton className="h-32" />
-          </>
+          <SkeletonGrid count={4} itemHeight="h-32" cols="sm:grid-cols-2 lg:grid-cols-4" />
         ) : stats ? (
           <>
             <StatCard
@@ -118,11 +100,7 @@ export function DashboardPage() {
           <h2 className="text-xl font-semibold tracking-tight">Recent Transactions</h2>
         </div>
         {transactionsLoading ? (
-          <div className="space-y-3">
-            <Skeleton className="h-16" />
-            <Skeleton className="h-16" />
-            <Skeleton className="h-16" />
-          </div>
+          <SkeletonGrid count={3} itemHeight="h-16" cols="grid-cols-1" gap="gap-3" />
         ) : transactions && transactions.data.length > 0 ? (
           <Card className="overflow-hidden p-0">
             <div className="divide-y divide-border">
@@ -187,11 +165,7 @@ export function DashboardPage() {
       <section className="space-y-4">
         <h2 className="text-xl font-semibold tracking-tight">Active Budgets</h2>
         {budgetsLoading ? (
-          <div className="grid gap-4 md:grid-cols-3">
-            <Skeleton className="h-32" />
-            <Skeleton className="h-32" />
-            <Skeleton className="h-32" />
-          </div>
+          <SkeletonGrid count={3} itemHeight="h-32" cols="md:grid-cols-3" />
         ) : budgets && budgets.data.length > 0 ? (
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {budgets.data.slice(0, 3).map((budget: Budget) => (

--- a/packages/app-finance/src/pages/DashboardPage.tsx
+++ b/packages/app-finance/src/pages/DashboardPage.tsx
@@ -2,14 +2,7 @@ import { trpc } from '@pops/api-client';
 /**
  * Dashboard page - overview of finances
  */
-import {
-  Badge,
-  Card,
-  ErrorAlert,
-  PageHeader,
-  SkeletonGrid,
-  StatCard,
-} from '@pops/ui';
+import { Badge, Card, ErrorAlert, PageHeader, SkeletonGrid, StatCard } from '@pops/ui';
 
 import type { Budget } from '@pops/api/modules/finance/budgets/types';
 import type { Transaction } from '@pops/api/modules/finance/transactions/types';

--- a/packages/ui/src/components/EditableFormCard.stories.tsx
+++ b/packages/ui/src/components/EditableFormCard.stories.tsx
@@ -1,0 +1,44 @@
+import { Button } from './Button';
+import { EditableFormCard } from './EditableFormCard';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof EditableFormCard> = {
+  title: 'Forms/EditableFormCard',
+  component: EditableFormCard,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Edit Transaction',
+    children: <p className="text-sm text-muted-foreground">Form fields go here.</p>,
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    title: 'Edit Transaction',
+    actions: (
+      <>
+        <Button variant="ghost" size="sm">
+          Cancel
+        </Button>
+        <Button size="sm">Save</Button>
+      </>
+    ),
+    children: <p className="text-sm text-muted-foreground">Form fields go here.</p>,
+  },
+};
+
+export const NoTitle: Story = {
+  args: {
+    children: <p className="text-sm text-muted-foreground">Content without a header.</p>,
+  },
+};

--- a/packages/ui/src/components/EditableFormCard.tsx
+++ b/packages/ui/src/components/EditableFormCard.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '../lib/utils';
+
+export interface EditableFormCardProps {
+  /** Title shown in the card header */
+  title?: string;
+  /** Action buttons to render in the header (e.g. Save / Cancel) */
+  actions?: ReactNode;
+  /** Card content */
+  children: ReactNode;
+  /** Called when Escape is pressed anywhere inside the card */
+  onEscape?: () => void;
+  className?: string;
+}
+
+/**
+ * Bordered card shell for inline editing forms (entity assignment, transaction edit, etc.).
+ * Provides the header bar with title + actions and an Escape key handler.
+ */
+export function EditableFormCard({
+  title,
+  actions,
+  children,
+  onEscape,
+  className,
+}: EditableFormCardProps) {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') onEscape?.();
+  };
+
+  return (
+    <div
+      className={cn('border-2 border-info rounded-lg p-4 bg-info/5', className)}
+      onKeyDown={handleKeyDown}
+    >
+      {(title || actions) && (
+        <div className="flex justify-between items-center mb-4 pb-2 border-b border-info/20">
+          {title && <h3 className="font-semibold text-info">{title}</h3>}
+          {actions && <div className="flex gap-2">{actions}</div>}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/components/EditableFormCard.tsx
+++ b/packages/ui/src/components/EditableFormCard.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react';
-
 import { cn } from '../lib/utils';
+
+import type { KeyboardEvent, ReactNode } from 'react';
 
 export interface EditableFormCardProps {
   /** Title shown in the card header */
@@ -25,7 +25,7 @@ export function EditableFormCard({
   onEscape,
   className,
 }: EditableFormCardProps) {
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Escape') onEscape?.();
   };
 

--- a/packages/ui/src/components/EmptyStateTab.stories.tsx
+++ b/packages/ui/src/components/EmptyStateTab.stories.tsx
@@ -1,0 +1,30 @@
+import { Inbox } from 'lucide-react';
+
+import { EmptyStateTab } from './EmptyStateTab';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof EmptyStateTab> = {
+  title: 'Feedback/EmptyStateTab',
+  component: EmptyStateTab,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    message: 'No items found.',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    message: 'No transactions matched.',
+    icon: <Inbox className="w-8 h-8" />,
+  },
+};

--- a/packages/ui/src/components/EmptyStateTab.tsx
+++ b/packages/ui/src/components/EmptyStateTab.tsx
@@ -16,7 +16,7 @@ export function EmptyStateTab({ message, icon, className }: EmptyStateTabProps) 
   return (
     <div
       className={cn(
-        'text-center py-12 text-gray-500 dark:text-gray-400 flex flex-col items-center gap-3',
+        'text-center py-12 text-muted-foreground flex flex-col items-center gap-3',
         className
       )}
     >

--- a/packages/ui/src/components/EmptyStateTab.tsx
+++ b/packages/ui/src/components/EmptyStateTab.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '../lib/utils';
+
+export interface EmptyStateTabProps {
+  message: string;
+  /** Optional icon or illustration */
+  icon?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Consistent empty-state placeholder for tab panels (review tabs, list views, etc.).
+ */
+export function EmptyStateTab({ message, icon, className }: EmptyStateTabProps) {
+  return (
+    <div
+      className={cn(
+        'text-center py-12 text-gray-500 dark:text-gray-400 flex flex-col items-center gap-3',
+        className
+      )}
+    >
+      {icon && <div className="opacity-40">{icon}</div>}
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/packages/ui/src/components/EmptyStateTab.tsx
+++ b/packages/ui/src/components/EmptyStateTab.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react';
-
 import { cn } from '../lib/utils';
+
+import type { ReactNode } from 'react';
 
 export interface EmptyStateTabProps {
   message: string;

--- a/packages/ui/src/components/EntitySelect.stories.tsx
+++ b/packages/ui/src/components/EntitySelect.stories.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+import { EntitySelect } from './EntitySelect';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import type { EntityOption } from './EntitySelect';
+
+const meta: Meta<typeof EntitySelect> = {
+  title: 'Forms/EntitySelect',
+  component: EntitySelect,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const ENTITIES: EntityOption[] = [
+  { id: '1', name: 'Woolworths', type: 'merchant' },
+  { id: '2', name: 'Netflix', type: 'subscription' },
+  { id: '3', name: 'New Entity', type: 'merchant', pending: true },
+  { id: '4', name: 'Coles', type: 'merchant' },
+];
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState<string | undefined>(undefined);
+    return (
+      <div className="w-64">
+        <EntitySelect entities={ENTITIES} value={value} onChange={(id) => setValue(id)} />
+      </div>
+    );
+  },
+};
+
+export const WithPendingEntity: Story = {
+  render: () => {
+    const [value, setValue] = useState('3');
+    return (
+      <div className="w-64">
+        <EntitySelect entities={ENTITIES} value={value} onChange={(id) => setValue(id)} />
+      </div>
+    );
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    entities: ENTITIES,
+    disabled: true,
+  },
+};

--- a/packages/ui/src/components/EntitySelect.tsx
+++ b/packages/ui/src/components/EntitySelect.tsx
@@ -2,6 +2,7 @@ import { Check, ChevronsUpDown } from 'lucide-react';
 import { useState } from 'react';
 
 import { cn } from '../lib/utils';
+import { Badge } from '../primitives/badge';
 import {
   Command,
   CommandEmpty,
@@ -11,7 +12,6 @@ import {
   CommandList,
 } from '../primitives/command';
 import { Popover, PopoverContent, PopoverTrigger } from '../primitives/popover';
-import { Badge } from '../primitives/badge';
 import { Button } from './Button';
 
 export interface EntityOption {

--- a/packages/ui/src/components/EntitySelect.tsx
+++ b/packages/ui/src/components/EntitySelect.tsx
@@ -1,0 +1,121 @@
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { useState } from 'react';
+
+import { cn } from '../lib/utils';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '../primitives/command';
+import { Popover, PopoverContent, PopoverTrigger } from '../primitives/popover';
+import { Badge } from '../primitives/badge';
+import { Button } from './Button';
+
+export interface EntityOption {
+  id: string;
+  name: string;
+  /** Optional tag shown as a badge (e.g. entity type) */
+  type?: string;
+  /** When true, renders the name in italic and shows a "Pending" badge */
+  pending?: boolean;
+}
+
+export interface EntitySelectProps {
+  entities: EntityOption[];
+  value?: string;
+  onChange?: (entityId: string, entityName: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Searchable combobox for selecting from a list of named entities.
+ * Supports optional type badges and pending (locally-created) entity indicators.
+ */
+export function EntitySelect({
+  entities,
+  value,
+  onChange,
+  placeholder = 'Choose entity...',
+  searchPlaceholder = 'Search entities...',
+  emptyMessage = 'No entities found.',
+  disabled = false,
+  className,
+}: EntitySelectProps) {
+  const [open, setOpen] = useState(false);
+  const selected = entities.find((e) => e.id === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn('w-full justify-between font-normal', className)}
+        >
+          {selected ? (
+            <span className="flex items-center gap-2 truncate">
+              <span className={cn('truncate', selected.pending && 'italic')}>{selected.name}</span>
+              {selected.pending && (
+                <Badge variant="secondary" className="text-xs shrink-0">
+                  Pending
+                </Badge>
+              )}
+              {selected.type && (
+                <Badge variant="outline" className="text-xs capitalize shrink-0">
+                  {selected.type}
+                </Badge>
+              )}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">{placeholder}</span>
+          )}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyMessage}</CommandEmpty>
+            <CommandGroup>
+              {entities.map((entity) => (
+                <CommandItem
+                  key={entity.id}
+                  value={`${entity.name} ${entity.type ?? ''}`}
+                  onSelect={() => {
+                    onChange?.(entity.id, entity.name);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={`mr-2 h-4 w-4 ${value === entity.id ? 'opacity-100' : 'opacity-0'}`}
+                  />
+                  <span className={cn('truncate', entity.pending && 'italic')}>{entity.name}</span>
+                  {entity.pending && (
+                    <Badge variant="secondary" className="ml-1 text-xs shrink-0">
+                      Pending
+                    </Badge>
+                  )}
+                  {entity.type && (
+                    <Badge variant="outline" className="ml-auto text-xs capitalize shrink-0">
+                      {entity.type}
+                    </Badge>
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/ui/src/components/ErrorAlert.stories.tsx
+++ b/packages/ui/src/components/ErrorAlert.stories.tsx
@@ -1,0 +1,30 @@
+import { ErrorAlert } from './ErrorAlert';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof ErrorAlert> = {
+  title: 'Feedback/ErrorAlert',
+  component: ErrorAlert,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Failed to load data',
+    message: 'The backend API is not responding. Make sure the server is running.',
+  },
+};
+
+export const WithDetails: Story = {
+  args: {
+    title: 'Unexpected error',
+    message: 'Something went wrong while processing your request.',
+    details: 'Error: connect ECONNREFUSED 127.0.0.1:3000\n  at TCPConnectWrap.afterConnect',
+  },
+};

--- a/packages/ui/src/components/ErrorAlert.tsx
+++ b/packages/ui/src/components/ErrorAlert.tsx
@@ -1,0 +1,33 @@
+import { Alert, AlertDescription, AlertTitle } from '../primitives/alert';
+
+export interface ErrorAlertProps {
+  title: string;
+  message: string;
+  /** Optional technical details rendered in a collapsible code block */
+  details?: string;
+  className?: string;
+}
+
+/**
+ * Standardised destructive alert for API/load errors across all pages.
+ */
+export function ErrorAlert({ title, message, details, className }: ErrorAlertProps) {
+  return (
+    <Alert variant="destructive" className={className}>
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>
+        <p className="mb-2">{message}</p>
+        {details && (
+          <details className="mt-3">
+            <summary className="cursor-pointer hover:underline font-medium text-sm">
+              Show technical details
+            </summary>
+            <code className="block mt-2 p-3 bg-black/10 dark:bg-black/20 rounded text-xs font-mono whitespace-pre-wrap break-all">
+              {details}
+            </code>
+          </details>
+        )}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/packages/ui/src/components/LoadingProgressStep.stories.tsx
+++ b/packages/ui/src/components/LoadingProgressStep.stories.tsx
@@ -1,0 +1,50 @@
+import { LoadingProgressStep } from './LoadingProgressStep';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof LoadingProgressStep> = {
+  title: 'Feedback/LoadingProgressStep',
+  component: LoadingProgressStep,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Processing',
+    message: 'Analyzing 42 transactions…',
+  },
+};
+
+export const WithProgress: Story = {
+  args: {
+    title: 'Processing',
+    message: 'Processing 21/42 transactions…',
+    progress: 50,
+    steps: [
+      { label: 'Checking for duplicates', status: 'done' },
+      { label: 'Matching entities', status: 'in_progress' },
+    ],
+  },
+};
+
+export const Done: Story = {
+  args: {
+    title: 'Already processed',
+    message: 'Your transactions are ready for review.',
+    done: true,
+  },
+};
+
+export const WithErrors: Story = {
+  args: {
+    title: 'Processing',
+    message: 'Processing with warnings…',
+    errors: ['Entity lookup failed for: WOOLWORTHS 1234', 'Entity lookup failed for: NETFLIX AU'],
+  },
+};

--- a/packages/ui/src/components/LoadingProgressStep.tsx
+++ b/packages/ui/src/components/LoadingProgressStep.tsx
@@ -1,0 +1,126 @@
+import { CheckCircle, Loader2, XCircle } from 'lucide-react';
+
+import { cn } from '../lib/utils';
+
+export interface ProgressItem {
+  description: string;
+  status: 'processing' | 'success' | 'failed';
+}
+
+export interface ProgressStep {
+  label: string;
+  status: 'pending' | 'in_progress' | 'done';
+}
+
+export interface LoadingProgressStepProps {
+  /** Title shown below the spinner */
+  title: string;
+  /** Subtitle / message */
+  message?: string;
+  /** 0–100 progress percentage. Omit to hide the bar. */
+  progress?: number;
+  /** Named pipeline steps */
+  steps?: ProgressStep[];
+  /** Currently processing items (shows a mini-list) */
+  currentBatch?: ProgressItem[];
+  /** Error messages to show in warning blocks */
+  errors?: string[];
+  /** When true, show a checkmark instead of spinner */
+  done?: boolean;
+  className?: string;
+}
+
+/**
+ * Centered loading UI for long-running async steps in a wizard flow.
+ */
+export function LoadingProgressStep({
+  title,
+  message,
+  progress,
+  steps,
+  currentBatch,
+  errors,
+  done = false,
+  className,
+}: LoadingProgressStepProps) {
+  return (
+    <div className={cn('flex flex-col items-center justify-center py-12 space-y-6', className)}>
+      {done ? (
+        <CheckCircle className="w-16 h-16 text-success" />
+      ) : (
+        <Loader2 className="w-16 h-16 animate-spin text-info" />
+      )}
+
+      <div className="text-center space-y-2">
+        <h2 className="text-2xl font-semibold">{title}</h2>
+        {message && <p className="text-sm text-gray-600 dark:text-gray-400">{message}</p>}
+      </div>
+
+      {progress !== undefined && (
+        <div className="w-full max-w-md">
+          <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
+            <span>Progress</span>
+            <span>{Math.round(progress)}%</span>
+          </div>
+          <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+            <div
+              className="bg-info/50 h-2 rounded-full transition-all duration-300"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {steps && steps.length > 0 && (
+        <div className="w-full max-w-md text-xs text-gray-500 dark:text-gray-400 space-y-1">
+          {steps.map((step) => (
+            <div key={step.label} className="flex justify-between">
+              <span>{step.label}</span>
+              <span>
+                {step.status === 'in_progress'
+                  ? 'In progress...'
+                  : step.status === 'done'
+                    ? 'Complete'
+                    : 'Pending'}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {currentBatch && currentBatch.length > 0 && (
+        <div className="w-full max-w-md">
+          <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Currently processing:
+          </p>
+          <div className="space-y-1">
+            {currentBatch.map((item, idx) => (
+              <div
+                key={idx}
+                className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400"
+              >
+                {item.status === 'processing' && <Loader2 className="w-3 h-3 animate-spin" />}
+                {item.status === 'success' && <CheckCircle className="w-3 h-3 text-success" />}
+                {item.status === 'failed' && <XCircle className="w-3 h-3 text-destructive" />}
+                <span className="truncate">{item.description}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {errors && errors.length > 0 && (
+        <div className="w-full max-w-md space-y-2">
+          {errors.map((error, idx) => (
+            <div
+              key={idx}
+              className="p-3 text-sm text-warning bg-warning/10 rounded-lg border border-warning/25"
+            >
+              <p className="text-xs">{error}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/LoadingProgressStep.tsx
+++ b/packages/ui/src/components/LoadingProgressStep.tsx
@@ -96,7 +96,7 @@ export function LoadingProgressStep({
           <div className="space-y-1">
             {currentBatch.map((item, idx) => (
               <div
-                key={idx}
+                key={`${idx}-${item.description}`}
                 className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400"
               >
                 {item.status === 'processing' && <Loader2 className="w-3 h-3 animate-spin" />}
@@ -111,9 +111,9 @@ export function LoadingProgressStep({
 
       {errors && errors.length > 0 && (
         <div className="w-full max-w-md space-y-2">
-          {errors.map((error, idx) => (
+          {errors.map((error) => (
             <div
-              key={idx}
+              key={error}
               className="p-3 text-sm text-warning bg-warning/10 rounded-lg border border-warning/25"
             >
               <p className="text-xs">{error}</p>

--- a/packages/ui/src/components/LoadingProgressStep.tsx
+++ b/packages/ui/src/components/LoadingProgressStep.tsx
@@ -53,16 +53,16 @@ export function LoadingProgressStep({
 
       <div className="text-center space-y-2">
         <h2 className="text-2xl font-semibold">{title}</h2>
-        {message && <p className="text-sm text-gray-600 dark:text-gray-400">{message}</p>}
+        {message && <p className="text-sm text-muted-foreground">{message}</p>}
       </div>
 
       {progress !== undefined && (
         <div className="w-full max-w-md">
-          <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
+          <div className="flex justify-between text-xs text-muted-foreground mb-1">
             <span>Progress</span>
             <span>{Math.round(progress)}%</span>
           </div>
-          <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+          <div className="w-full bg-muted rounded-full h-2">
             <div
               className="bg-info/50 h-2 rounded-full transition-all duration-300"
               style={{ width: `${progress}%` }}
@@ -72,7 +72,7 @@ export function LoadingProgressStep({
       )}
 
       {steps && steps.length > 0 && (
-        <div className="w-full max-w-md text-xs text-gray-500 dark:text-gray-400 space-y-1">
+        <div className="w-full max-w-md text-xs text-muted-foreground space-y-1">
           {steps.map((step) => (
             <div key={step.label} className="flex justify-between">
               <span>{step.label}</span>
@@ -90,14 +90,12 @@ export function LoadingProgressStep({
 
       {currentBatch && currentBatch.length > 0 && (
         <div className="w-full max-w-md">
-          <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
-            Currently processing:
-          </p>
+          <p className="text-xs font-medium text-foreground mb-2">Currently processing:</p>
           <div className="space-y-1">
             {currentBatch.map((item, idx) => (
               <div
                 key={`${idx}-${item.description}`}
-                className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400"
+                className="flex items-center gap-2 text-xs text-muted-foreground"
               >
                 {item.status === 'processing' && <Loader2 className="w-3 h-3 animate-spin" />}
                 {item.status === 'success' && <CheckCircle className="w-3 h-3 text-success" />}

--- a/packages/ui/src/components/SkeletonGrid.stories.tsx
+++ b/packages/ui/src/components/SkeletonGrid.stories.tsx
@@ -1,0 +1,40 @@
+import { SkeletonGrid } from './SkeletonGrid';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof SkeletonGrid> = {
+  title: 'Feedback/SkeletonGrid',
+  component: SkeletonGrid,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FourColumns: Story = {
+  args: {
+    count: 4,
+    itemHeight: 'h-32',
+    cols: 'sm:grid-cols-2 lg:grid-cols-4',
+  },
+};
+
+export const ThreeColumns: Story = {
+  args: {
+    count: 3,
+    itemHeight: 'h-32',
+    cols: 'md:grid-cols-3',
+  },
+};
+
+export const SingleColumn: Story = {
+  args: {
+    count: 3,
+    itemHeight: 'h-16',
+    cols: 'grid-cols-1',
+    gap: 'gap-3',
+  },
+};

--- a/packages/ui/src/components/SkeletonGrid.tsx
+++ b/packages/ui/src/components/SkeletonGrid.tsx
@@ -1,0 +1,33 @@
+import { cn } from '../lib/utils';
+import { Skeleton } from '../primitives/skeleton';
+
+export interface SkeletonGridProps {
+  /** Number of skeleton cards to render */
+  count: number;
+  /** Height of each skeleton card (Tailwind class, e.g. "h-32") */
+  itemHeight?: string;
+  /** Grid column class (e.g. "sm:grid-cols-2 lg:grid-cols-4") */
+  cols?: string;
+  /** Gap class (e.g. "gap-4") */
+  gap?: string;
+  className?: string;
+}
+
+/**
+ * Renders a responsive grid of skeleton placeholders for loading states.
+ */
+export function SkeletonGrid({
+  count,
+  itemHeight = 'h-32',
+  cols = 'sm:grid-cols-2 lg:grid-cols-4',
+  gap = 'gap-4',
+  className,
+}: SkeletonGridProps) {
+  return (
+    <div className={cn('grid', cols, gap, className)}>
+      {Array.from({ length: count }).map((_, i) => (
+        <Skeleton key={i} className={itemHeight} />
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/SkeletonGrid.tsx
+++ b/packages/ui/src/components/SkeletonGrid.tsx
@@ -25,8 +25,8 @@ export function SkeletonGrid({
 }: SkeletonGridProps) {
   return (
     <div className={cn('grid', cols, gap, className)}>
-      {Array.from({ length: count }).map((_, i) => (
-        <Skeleton key={i} className={itemHeight} />
+      {Array.from({ length: count }, (_, i) => (
+        <Skeleton key={`skeleton-${i}`} className={itemHeight} />
       ))}
     </div>
   );

--- a/packages/ui/src/components/SummaryCard.stories.tsx
+++ b/packages/ui/src/components/SummaryCard.stories.tsx
@@ -1,0 +1,66 @@
+import { CheckCircle, XCircle } from 'lucide-react';
+
+import { SummaryCard } from './SummaryCard';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof SummaryCard> = {
+  title: 'Data Display/SummaryCard',
+  component: SummaryCard,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  args: {
+    icon: <CheckCircle className="w-5 h-5 text-success" />,
+    value: 12,
+    label: 'Entities Created',
+    variant: 'success',
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    icon: <XCircle className="w-5 h-5 text-destructive" />,
+    value: 2,
+    label: 'Transactions Failed',
+    variant: 'destructive',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 gap-4">
+      <SummaryCard
+        icon={<CheckCircle className="w-5 h-5 text-success" />}
+        value={10}
+        label="Imported"
+        variant="success"
+      />
+      <SummaryCard
+        icon={<CheckCircle className="w-5 h-5 text-info" />}
+        value={3}
+        label="Rules Applied"
+        variant="info"
+      />
+      <SummaryCard
+        icon={<XCircle className="w-5 h-5 text-destructive" />}
+        value={1}
+        label="Failed"
+        variant="destructive"
+      />
+      <SummaryCard
+        icon={<CheckCircle className="w-5 h-5" />}
+        value={0}
+        label="Neutral"
+        variant="neutral"
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/SummaryCard.tsx
+++ b/packages/ui/src/components/SummaryCard.tsx
@@ -22,9 +22,9 @@ const variantStyles: Record<SummaryCardVariant, { wrapper: string; value: string
       label: 'text-destructive',
     },
     neutral: {
-      wrapper: 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700',
-      value: 'text-gray-900 dark:text-gray-100',
-      label: 'text-gray-700 dark:text-gray-300',
+      wrapper: 'bg-muted border-border',
+      value: 'text-foreground',
+      label: 'text-muted-foreground',
     },
   };
 

--- a/packages/ui/src/components/SummaryCard.tsx
+++ b/packages/ui/src/components/SummaryCard.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react';
-
 import { cn } from '../lib/utils';
+
+import type { ReactNode } from 'react';
 
 export type SummaryCardVariant = 'success' | 'info' | 'destructive' | 'neutral';
 

--- a/packages/ui/src/components/SummaryCard.tsx
+++ b/packages/ui/src/components/SummaryCard.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '../lib/utils';
+
+export type SummaryCardVariant = 'success' | 'info' | 'destructive' | 'neutral';
+
+const variantStyles: Record<SummaryCardVariant, { wrapper: string; value: string; label: string }> =
+  {
+    success: {
+      wrapper: 'bg-success/5 border-success/20',
+      value: 'text-success',
+      label: 'text-success dark:text-success/60',
+    },
+    info: {
+      wrapper: 'bg-info/5 border-info/20',
+      value: 'text-info',
+      label: 'text-info',
+    },
+    destructive: {
+      wrapper: 'bg-destructive/5 border-destructive/20',
+      value: 'text-destructive',
+      label: 'text-destructive',
+    },
+    neutral: {
+      wrapper: 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700',
+      value: 'text-gray-900 dark:text-gray-100',
+      label: 'text-gray-700 dark:text-gray-300',
+    },
+  };
+
+export interface SummaryCardProps {
+  /** Large number or metric displayed prominently */
+  value: number | string;
+  /** Short label below the value */
+  label: string;
+  /** Icon element rendered above the value */
+  icon: ReactNode;
+  /** Color scheme */
+  variant?: SummaryCardVariant;
+  className?: string;
+}
+
+/**
+ * Compact metric card for import/process summaries (entities created, rules applied, etc.).
+ */
+export function SummaryCard({
+  value,
+  label,
+  icon,
+  variant = 'neutral',
+  className,
+}: SummaryCardProps) {
+  const styles = variantStyles[variant];
+  return (
+    <div className={cn('border rounded-lg p-4 text-center', styles.wrapper, className)}>
+      <div className="flex items-center justify-center mb-2">{icon}</div>
+      <div className={cn('text-2xl font-semibold', styles.value)}>{value}</div>
+      <div className={cn('text-xs', styles.label)}>{label}</div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/WorkflowDialog.stories.tsx
+++ b/packages/ui/src/components/WorkflowDialog.stories.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+
+import { Button } from './Button';
+import { WorkflowDialog } from './WorkflowDialog';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof WorkflowDialog> = {
+  title: 'Overlays/WorkflowDialog',
+  component: WorkflowDialog,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TwoColumn: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+        <WorkflowDialog
+          open={open}
+          onOpenChange={setOpen}
+          title="Two-Column Workflow"
+          description="A wide dialog with a 2-column layout."
+          columns={2}
+          footer={
+            <>
+              <Button variant="outline" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={() => setOpen(false)}>Apply</Button>
+            </>
+          }
+        >
+          <div className="p-6 border-r">
+            <p className="text-sm text-muted-foreground">Left panel content</p>
+          </div>
+          <div className="p-6">
+            <p className="text-sm text-muted-foreground">Right panel content</p>
+          </div>
+        </WorkflowDialog>
+      </>
+    );
+  },
+};
+
+export const FreeForm: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+        <WorkflowDialog
+          open={open}
+          onOpenChange={setOpen}
+          title="Loading State"
+          footer={
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Close
+            </Button>
+          }
+        >
+          <div className="px-6 py-12 text-center text-sm text-muted-foreground">
+            Free-form content area (no columns grid).
+          </div>
+        </WorkflowDialog>
+      </>
+    );
+  },
+};

--- a/packages/ui/src/components/WorkflowDialog.tsx
+++ b/packages/ui/src/components/WorkflowDialog.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '../lib/utils';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../primitives/dialog';
+
+export interface WorkflowDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  /**
+   * Number of columns for the content grid.
+   * Omit (or set to undefined) to skip the grid wrapper and render children directly.
+   */
+  columns?: 2 | 3;
+  /** Column template class override — use when you need non-equal columns */
+  gridTemplate?: string;
+  /** Main content — rendered inside a grid when `columns` is set, otherwise rendered directly */
+  children: ReactNode;
+  /** Content rendered above the grid/body (e.g. context strip) */
+  header?: ReactNode;
+  /** Footer action area */
+  footer?: ReactNode;
+  /** Extra panel rendered between grid and footer (e.g. reject/AI helper panel) */
+  subpanel?: ReactNode;
+  /** className applied to the DialogContent wrapper */
+  className?: string;
+}
+
+const defaultGridTemplate: Record<2 | 3, string> = {
+  2: 'grid-cols-[1fr_360px]',
+  3: 'grid-cols-[260px_minmax(0,1fr)_360px]',
+};
+
+/**
+ * Shell for large multi-panel workflow dialogs (correction proposal, manage rules, etc.).
+ * Renders a wide dialog with header, optional context strip, N-column content grid
+ * (or free-form body when columns is omitted), optional subpanel, and footer.
+ */
+export function WorkflowDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  columns,
+  gridTemplate,
+  children,
+  header,
+  footer,
+  subpanel,
+  className,
+}: WorkflowDialogProps) {
+  const useGrid = columns !== undefined;
+  const templateClass = useGrid ? (gridTemplate ?? defaultGridTemplate[columns]) : undefined;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={cn(
+          'max-w-[92vw] max-h-[88vh] w-[1180px]',
+          'md:max-w-[92vw] md:w-[1180px]',
+          'flex flex-col gap-0 overflow-hidden p-0',
+          className
+        )}
+      >
+        <DialogHeader className="px-6 pt-6 pb-3">
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+
+        {header}
+
+        {useGrid ? (
+          <div className={cn('grid gap-0 border-y flex-1 min-h-0', templateClass)}>
+            {children}
+          </div>
+        ) : (
+          children
+        )}
+
+        {subpanel}
+
+        {footer && <DialogFooter className="px-6 py-4 border-t">{footer}</DialogFooter>}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/ui/src/components/WorkflowDialog.tsx
+++ b/packages/ui/src/components/WorkflowDialog.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from 'react';
-
 import { cn } from '../lib/utils';
 import {
   Dialog,
@@ -9,6 +7,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../primitives/dialog';
+
+import type { ReactNode } from 'react';
 
 export interface WorkflowDialogProps {
   open: boolean;
@@ -64,8 +64,7 @@ export function WorkflowDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className={cn(
-          'max-w-[92vw] max-h-[88vh] w-[1180px]',
-          'md:max-w-[92vw] md:w-[1180px]',
+          'w-(--size-dialog-xl) max-w-(--size-dialog-max-vw) max-h-(--size-dialog-max-vh)',
           'flex flex-col gap-0 overflow-hidden p-0',
           className
         )}

--- a/packages/ui/src/components/WorkflowDialog.tsx
+++ b/packages/ui/src/components/WorkflowDialog.tsx
@@ -77,9 +77,7 @@ export function WorkflowDialog({
         {header}
 
         {useGrid ? (
-          <div className={cn('grid gap-0 border-y flex-1 min-h-0', templateClass)}>
-            {children}
-          </div>
+          <div className={cn('grid gap-0 border-y flex-1 min-h-0', templateClass)}>{children}</div>
         ) : (
           children
         )}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,6 +13,7 @@ export {
 } from './lib/format';
 export type { FormatCurrencyOptions, DateStyle } from './lib/format';
 export { highlightMatch } from './lib/highlightMatch';
+export { hashToColor } from './lib/hashToColor';
 
 // Primitives — non-conflicting exports
 export * from './primitives/accordion';
@@ -126,3 +127,13 @@ export * from './components/SettingsForm';
 
 // Hooks
 export * from './hooks/useImageProcessor';
+
+// Cross-domain primitives extracted from app packages
+export * from './components/EditableFormCard';
+export * from './components/EmptyStateTab';
+export * from './components/EntitySelect';
+export * from './components/ErrorAlert';
+export * from './components/LoadingProgressStep';
+export * from './components/SkeletonGrid';
+export * from './components/SummaryCard';
+export * from './components/WorkflowDialog';

--- a/packages/ui/src/lib/hashToColor.ts
+++ b/packages/ui/src/lib/hashToColor.ts
@@ -1,0 +1,20 @@
+/**
+ * Deterministic tag/label coloring based on string hash.
+ * Uses OKLCH for perceptually uniform colors that look good in dark mode.
+ */
+export function hashToColor(input: string): {
+  backgroundColor: string;
+  color: string;
+  borderColor: string;
+} {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = input.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = Math.abs(hash % 360);
+  return {
+    backgroundColor: `oklch(0.3 0.08 ${hue} / 0.4)`,
+    color: `oklch(0.85 0.06 ${hue})`,
+    borderColor: `oklch(0.85 0.06 ${hue} / 0.2)`,
+  };
+}


### PR DESCRIPTION
## Summary

Extracts reusable primitives from the import wizard god-files into `@pops/ui`, then refactors all consumers to use them. Part of the Group B decomposition effort.

### New `@pops/ui` components

| Component | Extracted from |
|---|---|
| `hashToColor` | `TagEditor.tsx` local `getTagStyle` |
| `ErrorAlert` | Divergent `Alert variant="destructive"` blocks in Dashboard + AI pages |
| `SkeletonGrid` | Ad-hoc `<Skeleton>` grids in Dashboard + AI pages |
| `LoadingProgressStep` | `ProcessingStep.tsx` |
| `SummaryCard` | `SummaryStep.tsx` 2×2 stat grid |
| `EditableFormCard` | `EditableTransactionCard.tsx` card shell |
| `WorkflowDialog` | `CorrectionProposalDialog.tsx` wide-dialog shell (both modes) |
| `EmptyStateTab` | Empty-state `<div>` in all 4 review tabs |
| `EntitySelect` | `EntitySelect.tsx` (generic; finance wrapper re-maps `temp:entity:` → `pending: true`) |

### Consumers refactored

- `TagEditor` → `hashToColor` from `@pops/ui`
- `ProcessingStep` → `LoadingProgressStep`
- `SummaryStep` → `SummaryCard`
- `EditableTransactionCard` → `EditableFormCard`
- `CorrectionProposalDialog` → `WorkflowDialog` (browse + proposal modes)
- `EntitySelect` (finance) → thin wrapper re-exporting `@pops/ui` `EntitySelect`
- `MatchedTab`, `FailedTab`, `UncertainTab`, `SkippedTab` → `EmptyStateTab`
- `DashboardPage` → `ErrorAlert` + `SkeletonGrid`
- `AiUsagePage` → `ErrorAlert` + `SkeletonGrid`

**Note on #1998:** `EditableTransactionCard` already used `@pops/ui Input` for all form fields before this PR — no raw `<input>` tags existed. Confirmed resolved.

## Closes

Closes #2039
Closes #2052
Closes #2020
Closes #2053
Closes #2021
Closes #2054
Closes #2022
Closes #2066
Closes #2036
Closes #2064
Closes #2035
Closes #2063
Closes #2034
Closes #2065
Closes #1995
Closes #1998
Closes #2067

## Test plan

- [ ] Import wizard flow: upload CSV → column map → processing step shows spinner/progress → review tabs show correct empty states → tag review → final review → summary step shows stat cards
- [ ] `CorrectionProposalDialog` opens in both proposal mode (3-col grid + context strip + AI helper) and browse mode (3-col rule browser + search)
- [ ] `DashboardPage` shows skeleton grid while loading, `ErrorAlert` on API failure
- [ ] `AiUsagePage` shows skeleton grid while loading, `ErrorAlert` on API failure
- [ ] Tag editor shows coloured chips using `hashToColor`
- [ ] Entities with `temp:entity:` prefix show "Pending" badge in `EntitySelect`

https://claude.ai/code/session_014WAAMLZAPLLiFT8yqcyMFz