### PR TITLE
feat(ui): add 18 standalone primitives to @pops/ui

### DIFF
--- a/apps/pops-shell/src/app/pages/NotFoundPage.tsx
+++ b/apps/pops-shell/src/app/pages/NotFoundPage.tsx
@@ -1,6 +1,8 @@
 import { FileQuestion } from 'lucide-react';
 import { Link } from 'react-router';
 
+import { Button } from '@pops/ui';
+
 export function NotFoundPage() {
   return (
     <div className="flex flex-col items-center justify-center py-24 text-center">
@@ -9,12 +11,9 @@ export function NotFoundPage() {
       <p className="text-muted-foreground mb-6">
         The page you're looking for doesn't exist or has been moved.
       </p>
-      <Link
-        to="/"
-        className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-      >
-        Go home
-      </Link>
+      <Button asChild>
+        <Link to="/">Go home</Link>
+      </Button>
     </div>
   );
 }

--- a/packages/ui/src/components/ActionButtonWithDetailPicker.tsx
+++ b/packages/ui/src/components/ActionButtonWithDetailPicker.tsx
@@ -1,0 +1,112 @@
+/**
+ * ActionButtonWithDetailPicker — primary action button with an optional
+ * popover for picking details (date, amount, note) and an undo slot.
+ *
+ * The "confirmed" state swaps the action into an "Undo" affordance; an
+ * explicit `onUndo` puts the button back into its unconfirmed state.
+ */
+import { Check } from 'lucide-react';
+import { type ComponentType, type ReactNode, useState } from 'react';
+
+import { cn } from '../lib/utils';
+import { Popover, PopoverContent, PopoverTrigger } from '../primitives/popover';
+import { Button, type ButtonProps } from './Button';
+
+type LucideIcon = ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+
+export interface ActionButtonWithDetailPickerProps<Detail> {
+  label: ReactNode;
+  icon?: LucideIcon;
+  /** Content rendered in the picker popover. */
+  pickerContent: (args: { close: () => void; confirm: (detail: Detail) => void }) => ReactNode;
+  /** Final confirm handler. */
+  onConfirm: (detail: Detail) => void | Promise<void>;
+  /** If provided, renders an "Undo" action once confirmed. */
+  onUndo?: () => void | Promise<void>;
+  /** Externally controlled confirmed state. */
+  confirmed?: boolean;
+  confirmedLabel?: ReactNode;
+  undoLabel?: ReactNode;
+  buttonVariant?: ButtonProps['variant'];
+  buttonSize?: ButtonProps['size'];
+  disabled?: boolean;
+  className?: string;
+}
+
+export function ActionButtonWithDetailPicker<Detail>({
+  label,
+  icon: Icon,
+  pickerContent,
+  onConfirm,
+  onUndo,
+  confirmed,
+  confirmedLabel = 'Done',
+  undoLabel = 'Undo',
+  buttonVariant = 'default',
+  buttonSize = 'default',
+  disabled,
+  className,
+}: ActionButtonWithDetailPickerProps<Detail>) {
+  const [open, setOpen] = useState(false);
+  const [internalConfirmed, setInternalConfirmed] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const isConfirmed = confirmed ?? internalConfirmed;
+
+  const confirm = async (detail: Detail) => {
+    setBusy(true);
+    try {
+      await onConfirm(detail);
+      if (confirmed === undefined) setInternalConfirmed(true);
+      setOpen(false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const undo = async () => {
+    if (!onUndo) return;
+    setBusy(true);
+    try {
+      await onUndo();
+      if (confirmed === undefined) setInternalConfirmed(false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (isConfirmed) {
+    return (
+      <div className={cn('inline-flex items-center gap-2', className)}>
+        <span className="inline-flex items-center gap-1 text-sm font-medium text-success">
+          <Check className="h-3.5 w-3.5" aria-hidden /> {confirmedLabel}
+        </span>
+        {onUndo ? (
+          <Button variant="ghost" size="sm" loading={busy} onClick={undo}>
+            {undoLabel}
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant={buttonVariant}
+          size={buttonSize}
+          prefix={Icon ? <Icon className="h-4 w-4" aria-hidden /> : undefined}
+          disabled={disabled}
+          loading={busy}
+          className={className}
+        >
+          {label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[280px]" align="end">
+        {pickerContent({ close: () => setOpen(false), confirm })}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/ui/src/components/BreakdownChart.tsx
+++ b/packages/ui/src/components/BreakdownChart.tsx
@@ -95,7 +95,7 @@ export function BreakdownChart({
   return (
     <ul className={cn('flex flex-col gap-1.5', className)}>
       {rows.map((row) => {
-        const pct = max === 0 ? 0 : Math.max(2, Math.round((row.value / max) * 100));
+        const pct = max === 0 ? 0 : Math.round((row.value / max) * 100);
         const interactive = typeof onBarClick === 'function';
         return (
           <li key={row.label}>
@@ -114,6 +114,8 @@ export function BreakdownChart({
                   className="h-full rounded-sm transition-all"
                   style={{
                     width: `${pct}%`,
+                    // Keep tiny non-zero bars visible without inflating the %.
+                    minWidth: row.value > 0 ? '2px' : 0,
                     background: row.color ?? 'var(--chart-1, oklch(0.65 0.2 240))',
                   }}
                 />

--- a/packages/ui/src/components/BreakdownChart.tsx
+++ b/packages/ui/src/components/BreakdownChart.tsx
@@ -1,0 +1,130 @@
+/**
+ * BreakdownChart — horizontal-bar breakdown of labelled values.
+ *
+ * Zero-dependency, styled with design tokens. Standard states for loading
+ * and error are provided, plus optional click handler per bar.
+ */
+import { type ReactNode } from 'react';
+
+import { cn } from '../lib/utils';
+import { Button } from '../primitives/button';
+import { Skeleton } from '../primitives/skeleton';
+import { EmptyState } from './EmptyState';
+
+export interface BreakdownDatum {
+  label: string;
+  value: number;
+  /** Optional accent colour for the bar. */
+  color?: string;
+}
+
+export interface BreakdownChartProps {
+  data: BreakdownDatum[];
+  /** Formats bar values for display. */
+  formatter?: (value: number) => string;
+  /** Click handler per bar row. */
+  onBarClick?: (label: string) => void;
+  /** Loading state renders skeleton rows. */
+  loading?: boolean;
+  /** Error state renders an alert with an optional retry. */
+  error?: string | null;
+  onRetry?: () => void;
+  /** Max rows before scroll. Default unlimited. */
+  maxRows?: number;
+  /** Empty-state content when data is empty. */
+  emptyTitle?: ReactNode;
+  emptyDescription?: ReactNode;
+  className?: string;
+}
+
+const defaultFormatter = (v: number) => v.toLocaleString();
+
+export function BreakdownChart({
+  data,
+  formatter = defaultFormatter,
+  onBarClick,
+  loading,
+  error,
+  onRetry,
+  maxRows,
+  emptyTitle = 'No data',
+  emptyDescription,
+  className,
+}: BreakdownChartProps) {
+  if (loading) {
+    return (
+      <div className={cn('flex flex-col gap-2', className)}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-7 w-full" />
+        ))}
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div
+        className={cn(
+          'flex flex-col items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-4 text-sm',
+          className
+        )}
+        role="alert"
+      >
+        <div className="font-medium text-destructive">{error}</div>
+        {onRetry ? (
+          <Button size="sm" variant="outline" onClick={onRetry}>
+            Retry
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
+  if (data.length === 0) {
+    return (
+      <EmptyState
+        title={emptyTitle}
+        description={emptyDescription}
+        size="sm"
+        className={className}
+      />
+    );
+  }
+
+  const rows = typeof maxRows === 'number' ? data.slice(0, maxRows) : data;
+  const max = Math.max(...rows.map((d) => d.value), 0);
+
+  return (
+    <ul className={cn('flex flex-col gap-1.5', className)}>
+      {rows.map((row) => {
+        const pct = max === 0 ? 0 : Math.max(2, Math.round((row.value / max) * 100));
+        const interactive = typeof onBarClick === 'function';
+        return (
+          <li key={row.label}>
+            <button
+              type="button"
+              onClick={interactive ? () => onBarClick!(row.label) : undefined}
+              disabled={!interactive}
+              className={cn(
+                'group relative flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors',
+                interactive && 'hover:bg-accent'
+              )}
+            >
+              <div className="w-32 shrink-0 truncate text-xs font-medium">{row.label}</div>
+              <div className="relative h-5 flex-1 overflow-hidden rounded-sm bg-muted">
+                <div
+                  className="h-full rounded-sm transition-all"
+                  style={{
+                    width: `${pct}%`,
+                    background: row.color ?? 'var(--chart-1, oklch(0.65 0.2 240))',
+                  }}
+                />
+              </div>
+              <div className="w-24 shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+                {formatter(row.value)}
+              </div>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -2,6 +2,7 @@
  * Button component with variants, sizes, states, and icon support
  * Follows shadcn/ui patterns with class-variance-authority
  */
+import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { type ButtonHTMLAttributes, forwardRef, type ReactNode } from 'react';
 
@@ -65,6 +66,12 @@ export interface ButtonProps
    * Accessible label for the loading state
    */
   loadingText?: string;
+  /**
+   * Render the button as its child component (via Radix Slot).
+   * Useful for wrapping links (`<Button asChild><Link to="/" /></Button>`).
+   * Incompatible with `loading`, `prefix`, and `suffix`.
+   */
+  asChild?: boolean;
 }
 
 /**
@@ -90,17 +97,27 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       suffix,
       loading = false,
       loadingText = 'Loading',
+      asChild = false,
       disabled,
       ...props
     },
     ref
   ) => {
     const isDisabled = disabled || loading;
+    const mergedClassName = cn(buttonVariants({ variant, size, shape, className }));
+
+    if (asChild) {
+      return (
+        <Slot ref={ref as never} className={mergedClassName} {...props}>
+          {children}
+        </Slot>
+      );
+    }
 
     return (
       <button
         ref={ref}
-        className={cn(buttonVariants({ variant, size, shape, className }))}
+        className={mergedClassName}
         disabled={isDisabled}
         aria-busy={loading}
         aria-label={loading ? loadingText : undefined}

--- a/packages/ui/src/components/DurationFieldInput.tsx
+++ b/packages/ui/src/components/DurationFieldInput.tsx
@@ -3,7 +3,7 @@
  * with conversion logic. Stores the canonical value in milliseconds and
  * renders a user-friendly unit.
  */
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { cn } from '../lib/utils';
 import { Input } from '../primitives/input';
@@ -65,7 +65,11 @@ export function DurationFieldInput({
   id,
   'aria-label': ariaLabel,
 }: DurationFieldInputProps) {
-  const [unit, setUnit] = useState<DurationUnit>(() => defaultUnit ?? inferUnit(value));
+  const clampUnit = useCallback(
+    (u: DurationUnit): DurationUnit => (units.includes(u) ? u : (units[0] ?? 'ms')),
+    [units]
+  );
+  const [unit, setUnit] = useState<DurationUnit>(() => clampUnit(defaultUnit ?? inferUnit(value)));
   const displayValue = useMemo(() => {
     const multiplier = UNIT_MULTIPLIERS[unit];
     if (value === 0) return '';
@@ -76,8 +80,13 @@ export function DurationFieldInput({
     // Keep unit selection consistent if the value is changed externally.
     if (value === 0) return;
     const multiplier = UNIT_MULTIPLIERS[unit];
-    if (value % multiplier !== 0) setUnit(inferUnit(value));
-  }, [value, unit]);
+    if (value % multiplier !== 0) setUnit(clampUnit(inferUnit(value)));
+  }, [value, unit, clampUnit]);
+
+  useEffect(() => {
+    // Re-clamp if the allowed units change and the current one is no longer valid.
+    if (!units.includes(unit)) setUnit(clampUnit(unit));
+  }, [units, unit, clampUnit]);
 
   const handleNumberChange = (raw: string) => {
     if (raw === '') {

--- a/packages/ui/src/components/DurationFieldInput.tsx
+++ b/packages/ui/src/components/DurationFieldInput.tsx
@@ -1,0 +1,126 @@
+/**
+ * DurationFieldInput — number input + unit selector (ms/seconds/minutes/hours)
+ * with conversion logic. Stores the canonical value in milliseconds and
+ * renders a user-friendly unit.
+ */
+import { useEffect, useMemo, useState } from 'react';
+
+import { cn } from '../lib/utils';
+import { Input } from '../primitives/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../primitives/select';
+
+export type DurationUnit = 'ms' | 'seconds' | 'minutes' | 'hours';
+
+export const UNIT_MULTIPLIERS: Record<DurationUnit, number> = {
+  ms: 1,
+  seconds: 1000,
+  minutes: 60_000,
+  hours: 3_600_000,
+};
+
+export function inferUnit(ms: number): DurationUnit {
+  if (ms === 0) return 'seconds';
+  if (ms % UNIT_MULTIPLIERS.hours === 0) return 'hours';
+  if (ms % UNIT_MULTIPLIERS.minutes === 0) return 'minutes';
+  if (ms % UNIT_MULTIPLIERS.seconds === 0) return 'seconds';
+  return 'ms';
+}
+
+export interface DurationFieldInputProps {
+  /** Current value in milliseconds. */
+  value: number;
+  onChange: (nextMs: number) => void;
+  /** Which units the user can pick. Defaults to all four. */
+  units?: DurationUnit[];
+  /** Override the initial display unit. */
+  defaultUnit?: DurationUnit;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  id?: string;
+  'aria-label'?: string;
+}
+
+const UNIT_LABELS: Record<DurationUnit, string> = {
+  ms: 'ms',
+  seconds: 'seconds',
+  minutes: 'minutes',
+  hours: 'hours',
+};
+
+export function DurationFieldInput({
+  value,
+  onChange,
+  units = ['ms', 'seconds', 'minutes', 'hours'],
+  defaultUnit,
+  disabled,
+  placeholder,
+  className,
+  id,
+  'aria-label': ariaLabel,
+}: DurationFieldInputProps) {
+  const [unit, setUnit] = useState<DurationUnit>(() => defaultUnit ?? inferUnit(value));
+  const displayValue = useMemo(() => {
+    const multiplier = UNIT_MULTIPLIERS[unit];
+    if (value === 0) return '';
+    return String(value / multiplier);
+  }, [value, unit]);
+
+  useEffect(() => {
+    // Keep unit selection consistent if the value is changed externally.
+    if (value === 0) return;
+    const multiplier = UNIT_MULTIPLIERS[unit];
+    if (value % multiplier !== 0) setUnit(inferUnit(value));
+  }, [value, unit]);
+
+  const handleNumberChange = (raw: string) => {
+    if (raw === '') {
+      onChange(0);
+      return;
+    }
+    const num = Number(raw);
+    if (!Number.isFinite(num) || num < 0) return;
+    onChange(Math.round(num * UNIT_MULTIPLIERS[unit]));
+  };
+
+  const handleUnitChange = (nextUnit: string) => {
+    const nu = nextUnit as DurationUnit;
+    setUnit(nu);
+  };
+
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <Input
+        id={id}
+        type="number"
+        min={0}
+        step="any"
+        inputMode="decimal"
+        disabled={disabled}
+        value={displayValue}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        onChange={(e) => handleNumberChange(e.target.value)}
+        className="w-32"
+      />
+      <Select value={unit} onValueChange={handleUnitChange} disabled={disabled}>
+        <SelectTrigger className="w-36">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {units.map((u) => (
+            <SelectItem key={u} value={u}>
+              {UNIT_LABELS[u]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/packages/ui/src/components/EmptyState.tsx
+++ b/packages/ui/src/components/EmptyState.tsx
@@ -1,0 +1,58 @@
+/**
+ * EmptyState — shared empty-state panel used when a list/view has no data.
+ *
+ * Renders an optional icon, title, description, and action slot with
+ * consistent spacing, typography, and muted colour tokens.
+ */
+import { type ComponentType, type ReactNode } from 'react';
+
+import { cn } from '../lib/utils';
+
+export interface EmptyStateProps {
+  /** Optional lucide-react icon component rendered above the title. */
+  icon?: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+  /** Primary heading. */
+  title: ReactNode;
+  /** Optional secondary description. */
+  description?: ReactNode;
+  /** Optional action node (button, link, etc.). */
+  action?: ReactNode;
+  /** Visual density. */
+  size?: 'sm' | 'md' | 'lg';
+  /** Additional classes for the outer wrapper. */
+  className?: string;
+}
+
+const sizeStyles = {
+  sm: { root: 'py-8 gap-2', icon: 'h-8 w-8 mb-2', title: 'text-sm', desc: 'text-xs' },
+  md: { root: 'py-12 gap-3', icon: 'h-10 w-10 mb-3', title: 'text-base', desc: 'text-sm' },
+  lg: { root: 'py-16 gap-4', icon: 'h-12 w-12 mb-4', title: 'text-lg', desc: 'text-sm' },
+} as const;
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  size = 'md',
+  className,
+}: EmptyStateProps) {
+  const styles = sizeStyles[size];
+  return (
+    <div
+      role="status"
+      className={cn(
+        'flex flex-col items-center justify-center text-center px-6',
+        styles.root,
+        className
+      )}
+    >
+      {Icon ? <Icon className={cn('text-muted-foreground/40', styles.icon)} aria-hidden /> : null}
+      <div className={cn('font-semibold text-foreground', styles.title)}>{title}</div>
+      {description ? (
+        <div className={cn('text-muted-foreground max-w-md', styles.desc)}>{description}</div>
+      ) : null}
+      {action ? <div className="mt-2">{action}</div> : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/FileUpload.tsx
+++ b/packages/ui/src/components/FileUpload.tsx
@@ -67,8 +67,29 @@ export function FileUpload({
 
   const validate = useCallback(
     (list: File[]): File[] => {
+      const patterns = accept
+        ? accept
+            .split(',')
+            .map((p) => p.trim())
+            .filter(Boolean)
+        : [];
+      const matches = (file: File): boolean => {
+        if (patterns.length === 0) return true;
+        const name = file.name.toLowerCase();
+        const type = file.type.toLowerCase();
+        return patterns.some((p) => {
+          const pat = p.toLowerCase();
+          if (pat.startsWith('.')) return name.endsWith(pat);
+          if (pat.endsWith('/*')) return type.startsWith(pat.slice(0, -1));
+          return type === pat;
+        });
+      };
       const out: File[] = [];
       for (const file of list) {
+        if (!matches(file)) {
+          onError?.(`${file.name} is not an accepted file type`);
+          continue;
+        }
         if (typeof maxSize === 'number' && file.size > maxSize) {
           onError?.(`${file.name} exceeds max size of ${formatBytes(maxSize)}`);
           continue;
@@ -81,7 +102,7 @@ export function FileUpload({
       }
       return out;
     },
-    [maxSize, maxFiles, onError]
+    [accept, maxSize, maxFiles, onError]
   );
 
   const handleFiles = useCallback(
@@ -155,7 +176,7 @@ export function FileUpload({
         <ul className="flex flex-col gap-1.5 text-sm">
           {files.map((file, i) => (
             <li
-              key={`${file.name}-${i}`}
+              key={`${file.name}-${file.size}-${file.lastModified}`}
               className="flex items-center justify-between rounded-md border border-border bg-muted/30 px-3 py-2"
             >
               <div className="min-w-0 flex-1">

--- a/packages/ui/src/components/FileUpload.tsx
+++ b/packages/ui/src/components/FileUpload.tsx
@@ -1,0 +1,182 @@
+/**
+ * FileUpload — drag-and-drop file input primitive for single or multi-file uploads.
+ *
+ * Handles drop target, accept filter, size validation, and renders an optional
+ * list of selected files with a simple preview. Domain-specific behaviour
+ * (CSV parsing, image preprocessing) stays with the consumer through the
+ * onFilesSelected callback.
+ */
+import { Upload, X } from 'lucide-react';
+import {
+  type ChangeEvent,
+  type DragEvent,
+  type ReactNode,
+  useCallback,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+
+import { formatBytes } from '../lib/format';
+import { cn } from '../lib/utils';
+import { Button } from '../primitives/button';
+
+export interface FileUploadProps {
+  /** Whether multiple files can be selected. Default `false`. */
+  multiple?: boolean;
+  /** Accept attribute / MIME filter passed to the native input. */
+  accept?: string;
+  /** Max size per file, in bytes. Files over this are rejected. */
+  maxSize?: number;
+  /** Max number of files when `multiple`. */
+  maxFiles?: number;
+  /** Called whenever the user picks files that pass validation. */
+  onFilesSelected: (files: File[]) => void;
+  /** Called when a user-visible validation error occurs. */
+  onError?: (message: string) => void;
+  /** Currently selected/pending files, rendered as a simple list. */
+  files?: File[];
+  /** Remove-one handler; if provided, a delete button renders per file. */
+  onRemoveFile?: (index: number) => void;
+  /** Slot for a camera-capture button (mobile image flows). */
+  captureSlot?: ReactNode;
+  /** Override the prompt text in the drop zone. */
+  prompt?: ReactNode;
+  /** Disable the entire control. */
+  disabled?: boolean;
+  className?: string;
+}
+
+export function FileUpload({
+  multiple = false,
+  accept,
+  maxSize,
+  maxFiles,
+  onFilesSelected,
+  onError,
+  files,
+  onRemoveFile,
+  captureSlot,
+  prompt,
+  disabled,
+  className,
+}: FileUploadProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const inputId = useId();
+  const [isDragging, setIsDragging] = useState(false);
+
+  const validate = useCallback(
+    (list: File[]): File[] => {
+      const out: File[] = [];
+      for (const file of list) {
+        if (typeof maxSize === 'number' && file.size > maxSize) {
+          onError?.(`${file.name} exceeds max size of ${formatBytes(maxSize)}`);
+          continue;
+        }
+        out.push(file);
+      }
+      if (typeof maxFiles === 'number' && out.length > maxFiles) {
+        onError?.(`You can upload at most ${maxFiles} file${maxFiles === 1 ? '' : 's'}`);
+        return out.slice(0, maxFiles);
+      }
+      return out;
+    },
+    [maxSize, maxFiles, onError]
+  );
+
+  const handleFiles = useCallback(
+    (list: FileList | null) => {
+      if (!list || list.length === 0) return;
+      const arr = Array.from(list);
+      const valid = validate(multiple ? arr : arr.slice(0, 1));
+      if (valid.length > 0) onFilesSelected(valid);
+    },
+    [multiple, onFilesSelected, validate]
+  );
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+    if (disabled) return;
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    handleFiles(e.target.files);
+    // Reset so the same file can be selected again after removal.
+    e.target.value = '';
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <div
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-disabled={disabled || undefined}
+        onKeyDown={(e) => {
+          if (disabled) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+        onClick={() => !disabled && inputRef.current?.click()}
+        onDragOver={(e) => {
+          e.preventDefault();
+          if (!disabled) setIsDragging(true);
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        onDrop={handleDrop}
+        className={cn(
+          'flex flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed border-input bg-background p-8 text-center transition-colors',
+          'hover:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          isDragging && 'border-ring bg-accent/40',
+          disabled && 'opacity-50 pointer-events-none'
+        )}
+      >
+        <Upload className="h-8 w-8 text-muted-foreground" aria-hidden />
+        <div className="text-sm font-medium">
+          {prompt ?? <>Drag {multiple ? 'files' : 'a file'} here, or click to browse</>}
+        </div>
+        {accept ? <div className="text-xs text-muted-foreground">Accepts {accept}</div> : null}
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="file"
+          accept={accept}
+          multiple={multiple}
+          disabled={disabled}
+          onChange={handleChange}
+          className="sr-only"
+        />
+      </div>
+      {captureSlot ? <div>{captureSlot}</div> : null}
+      {files && files.length > 0 ? (
+        <ul className="flex flex-col gap-1.5 text-sm">
+          {files.map((file, i) => (
+            <li
+              key={`${file.name}-${i}`}
+              className="flex items-center justify-between rounded-md border border-border bg-muted/30 px-3 py-2"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-medium">{file.name}</div>
+                <div className="text-xs text-muted-foreground">{formatBytes(file.size)}</div>
+              </div>
+              {onRemoveFile ? (
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  onClick={() => onRemoveFile(i)}
+                  aria-label={`Remove ${file.name}`}
+                >
+                  <X />
+                </Button>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/ForceGraph.tsx
+++ b/packages/ui/src/components/ForceGraph.tsx
@@ -237,6 +237,22 @@ export function ForceGraph({
     return () => ro.disconnect();
   }, [height]);
 
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper || !enableZoom) return;
+    // Native non-passive wheel listener so preventDefault stops page scroll.
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const delta = -e.deltaY * 0.001;
+      setTransform((t) => ({
+        ...t,
+        k: Math.min(4, Math.max(0.25, t.k * (1 + delta))),
+      }));
+    };
+    wrapper.addEventListener('wheel', onWheel, { passive: false });
+    return () => wrapper.removeEventListener('wheel', onWheel);
+  }, [enableZoom]);
+
   const toWorld = (clientX: number, clientY: number) => {
     const canvas = canvasRef.current!;
     const rect = canvas.getBoundingClientRect();
@@ -286,11 +302,15 @@ export function ForceGraph({
         if (nextId !== hoverRef.current) {
           hoverRef.current = nextId;
           onNodeHover?.(nextId);
+          const canvas = canvasRef.current;
+          if (canvas) canvas.style.cursor = nextId ? 'pointer' : 'default';
         }
       }}
       onMouseLeave={() => {
         hoverRef.current = null;
         onNodeHover?.(null);
+        const canvas = canvasRef.current;
+        if (canvas) canvas.style.cursor = 'default';
       }}
       onMouseDown={(e) => {
         const hit = pickNode(e.clientX, e.clientY);
@@ -319,20 +339,8 @@ export function ForceGraph({
         const hit = pickNode(e.clientX, e.clientY);
         if (hit && onNodeClick) onNodeClick(hit.id);
       }}
-      onWheel={(e) => {
-        if (!enableZoom) return;
-        const delta = -e.deltaY * 0.001;
-        setTransform((t) => ({
-          ...t,
-          k: Math.min(4, Math.max(0.25, t.k * (1 + delta))),
-        }));
-      }}
     >
-      <canvas
-        ref={canvasRef}
-        className="block"
-        style={{ cursor: hoverRef.current ? 'pointer' : 'default' }}
-      />
+      <canvas ref={canvasRef} className="block" style={{ cursor: 'default' }} />
     </div>
   );
 }

--- a/packages/ui/src/components/ForceGraph.tsx
+++ b/packages/ui/src/components/ForceGraph.tsx
@@ -1,0 +1,338 @@
+/**
+ * ForceGraph — Canvas-based force-directed graph primitive.
+ *
+ * Self-contained, framework-agnostic physics (a small Verlet-ish simulation
+ * with spring edges, charge repulsion, and centring). Consumers provide
+ * node/edge data, optional colour maps, and click/hover handlers. No
+ * external d3 dependency is required so this works anywhere in the
+ * workspace.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { cn } from '../lib/utils';
+
+export interface ForceNode {
+  id: string;
+  /** Optional initial position. Randomised if absent. */
+  x?: number;
+  y?: number;
+  /** Optional display label. */
+  label?: string;
+  /** Fill colour. Defaults to the `defaultNodeColor` prop. */
+  color?: string;
+  /** Radius in CSS pixels. Default 8. */
+  radius?: number;
+}
+
+export interface ForceEdge {
+  source: string;
+  target: string;
+  /** Target edge length for the spring. */
+  length?: number;
+}
+
+export interface ForceGraphProps {
+  nodes: ForceNode[];
+  edges: ForceEdge[];
+  /** Fallback colour when a node has no `color`. */
+  defaultNodeColor?: string;
+  /** Edge stroke colour. Uses CSS currentColor fallback if omitted. */
+  edgeColor?: string;
+  /** Label text colour. */
+  labelColor?: string;
+  /** Called when a node is clicked. */
+  onNodeClick?: (id: string) => void;
+  /** Called when hover changes (null = left canvas). */
+  onNodeHover?: (id: string | null) => void;
+  /** Simulation iterations per animation frame. Default 1. */
+  iterationsPerFrame?: number;
+  /** Enable zoom/pan. Default true. */
+  enableZoom?: boolean;
+  className?: string;
+  /** Height in CSS pixels. Width is filled from the parent. */
+  height?: number;
+}
+
+interface InternalNode extends ForceNode {
+  vx: number;
+  vy: number;
+  fx: number;
+  fy: number;
+}
+
+const DEFAULT_EDGE_LENGTH = 80;
+const SPRING = 0.02;
+const CHARGE = 3000;
+const DAMPING = 0.85;
+const CENTRE_PULL = 0.002;
+
+export function ForceGraph({
+  nodes,
+  edges,
+  defaultNodeColor = '#64748b',
+  edgeColor = '#cbd5e1',
+  labelColor = '#334155',
+  onNodeClick,
+  onNodeHover,
+  iterationsPerFrame = 1,
+  enableZoom = true,
+  className,
+  height = 480,
+}: ForceGraphProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const nodesRef = useRef<Map<string, InternalNode>>(new Map());
+  const [transform, setTransform] = useState({ x: 0, y: 0, k: 1 });
+  const hoverRef = useRef<string | null>(null);
+  const draggingRef = useRef<{ id: string; dx: number; dy: number } | null>(null);
+  const panningRef = useRef<{ sx: number; sy: number; ox: number; oy: number } | null>(null);
+
+  // Seed or update internal node state when inputs change.
+  useEffect(() => {
+    const next = new Map<string, InternalNode>();
+    for (const n of nodes) {
+      const prev = nodesRef.current.get(n.id);
+      next.set(n.id, {
+        ...n,
+        x: prev?.x ?? n.x ?? (Math.random() - 0.5) * 200,
+        y: prev?.y ?? n.y ?? (Math.random() - 0.5) * 200,
+        vx: prev?.vx ?? 0,
+        vy: prev?.vy ?? 0,
+        fx: 0,
+        fy: 0,
+      });
+    }
+    nodesRef.current = next;
+  }, [nodes]);
+
+  const step = useCallback(() => {
+    const map = nodesRef.current;
+    const list = Array.from(map.values());
+    for (const n of list) {
+      n.fx = 0;
+      n.fy = 0;
+    }
+    for (let i = 0; i < list.length; i++) {
+      for (let j = i + 1; j < list.length; j++) {
+        const a = list[i]!;
+        const b = list[j]!;
+        const dx = (a.x ?? 0) - (b.x ?? 0);
+        const dy = (a.y ?? 0) - (b.y ?? 0);
+        const dist2 = Math.max(dx * dx + dy * dy, 25);
+        const f = CHARGE / dist2;
+        const dist = Math.sqrt(dist2);
+        const nx = dx / dist;
+        const ny = dy / dist;
+        a.fx += nx * f;
+        a.fy += ny * f;
+        b.fx -= nx * f;
+        b.fy -= ny * f;
+      }
+    }
+    for (const e of edges) {
+      const a = map.get(e.source);
+      const b = map.get(e.target);
+      if (!a || !b) continue;
+      const dx = (b.x ?? 0) - (a.x ?? 0);
+      const dy = (b.y ?? 0) - (a.y ?? 0);
+      const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+      const target = e.length ?? DEFAULT_EDGE_LENGTH;
+      const f = (dist - target) * SPRING;
+      const nx = dx / dist;
+      const ny = dy / dist;
+      a.fx += nx * f;
+      a.fy += ny * f;
+      b.fx -= nx * f;
+      b.fy -= ny * f;
+    }
+    for (const n of list) {
+      n.fx += -(n.x ?? 0) * CENTRE_PULL;
+      n.fy += -(n.y ?? 0) * CENTRE_PULL;
+      n.vx = (n.vx + n.fx) * DAMPING;
+      n.vy = (n.vy + n.fy) * DAMPING;
+      n.x = (n.x ?? 0) + n.vx;
+      n.y = (n.y ?? 0) + n.vy;
+    }
+  }, [edges]);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const { width, height: h } = canvas;
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, width, h);
+    const dpr = window.devicePixelRatio || 1;
+    ctx.setTransform(
+      dpr * transform.k,
+      0,
+      0,
+      dpr * transform.k,
+      dpr * (width / 2 / dpr + transform.x),
+      dpr * (h / 2 / dpr + transform.y)
+    );
+
+    ctx.strokeStyle = edgeColor;
+    ctx.lineWidth = 1;
+    for (const e of edges) {
+      const a = nodesRef.current.get(e.source);
+      const b = nodesRef.current.get(e.target);
+      if (!a || !b) continue;
+      ctx.beginPath();
+      ctx.moveTo(a.x ?? 0, a.y ?? 0);
+      ctx.lineTo(b.x ?? 0, b.y ?? 0);
+      ctx.stroke();
+    }
+
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    for (const n of nodesRef.current.values()) {
+      const r = n.radius ?? 8;
+      ctx.fillStyle = n.color ?? defaultNodeColor;
+      ctx.beginPath();
+      ctx.arc(n.x ?? 0, n.y ?? 0, r, 0, Math.PI * 2);
+      ctx.fill();
+      if (hoverRef.current === n.id) {
+        ctx.strokeStyle = '#1d4ed8';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+      if (n.label) {
+        ctx.fillStyle = labelColor;
+        ctx.fillText(n.label, n.x ?? 0, (n.y ?? 0) + r + 10);
+      }
+    }
+  }, [edges, defaultNodeColor, edgeColor, labelColor, transform]);
+
+  useEffect(() => {
+    const loop = () => {
+      for (let i = 0; i < iterationsPerFrame; i++) step();
+      draw();
+      rafRef.current = requestAnimationFrame(loop);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [step, draw, iterationsPerFrame]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrapper = wrapperRef.current;
+    if (!canvas || !wrapper) return;
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = wrapper.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${height}px`;
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(wrapper);
+    return () => ro.disconnect();
+  }, [height]);
+
+  const toWorld = (clientX: number, clientY: number) => {
+    const canvas = canvasRef.current!;
+    const rect = canvas.getBoundingClientRect();
+    const cx = clientX - rect.left - rect.width / 2 - transform.x;
+    const cy = clientY - rect.top - rect.height / 2 - transform.y;
+    return { x: cx / transform.k, y: cy / transform.k };
+  };
+
+  const pickNode = (clientX: number, clientY: number): InternalNode | null => {
+    const { x, y } = toWorld(clientX, clientY);
+    for (const n of nodesRef.current.values()) {
+      const r = n.radius ?? 8;
+      const dx = (n.x ?? 0) - x;
+      const dy = (n.y ?? 0) - y;
+      if (dx * dx + dy * dy <= r * r) return n;
+    }
+    return null;
+  };
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={cn('relative w-full overflow-hidden rounded-md border border-border', className)}
+      style={{ height }}
+      onMouseMove={(e) => {
+        if (draggingRef.current) {
+          const { x, y } = toWorld(e.clientX, e.clientY);
+          const node = nodesRef.current.get(draggingRef.current.id);
+          if (node) {
+            node.x = x - draggingRef.current.dx;
+            node.y = y - draggingRef.current.dy;
+            node.vx = 0;
+            node.vy = 0;
+          }
+          return;
+        }
+        if (panningRef.current && enableZoom) {
+          setTransform((t) => ({
+            ...t,
+            x: panningRef.current!.ox + (e.clientX - panningRef.current!.sx),
+            y: panningRef.current!.oy + (e.clientY - panningRef.current!.sy),
+          }));
+          return;
+        }
+        const hit = pickNode(e.clientX, e.clientY);
+        const nextId = hit?.id ?? null;
+        if (nextId !== hoverRef.current) {
+          hoverRef.current = nextId;
+          onNodeHover?.(nextId);
+        }
+      }}
+      onMouseLeave={() => {
+        hoverRef.current = null;
+        onNodeHover?.(null);
+      }}
+      onMouseDown={(e) => {
+        const hit = pickNode(e.clientX, e.clientY);
+        if (hit) {
+          const { x, y } = toWorld(e.clientX, e.clientY);
+          draggingRef.current = {
+            id: hit.id,
+            dx: x - (hit.x ?? 0),
+            dy: y - (hit.y ?? 0),
+          };
+        } else if (enableZoom) {
+          panningRef.current = {
+            sx: e.clientX,
+            sy: e.clientY,
+            ox: transform.x,
+            oy: transform.y,
+          };
+        }
+      }}
+      onMouseUp={(e) => {
+        if (draggingRef.current) {
+          draggingRef.current = null;
+          return;
+        }
+        panningRef.current = null;
+        const hit = pickNode(e.clientX, e.clientY);
+        if (hit && onNodeClick) onNodeClick(hit.id);
+      }}
+      onWheel={(e) => {
+        if (!enableZoom) return;
+        const delta = -e.deltaY * 0.001;
+        setTransform((t) => ({
+          ...t,
+          k: Math.min(4, Math.max(0.25, t.k * (1 + delta))),
+        }));
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        className="block"
+        style={{ cursor: hoverRef.current ? 'pointer' : 'default' }}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/components/ImageGallery.tsx
+++ b/packages/ui/src/components/ImageGallery.tsx
@@ -1,0 +1,167 @@
+/**
+ * ImageGallery — primary photo + thumbnail strip + lightbox overlay with
+ * keyboard navigation. Reusable across any domain with image galleries.
+ */
+import { ChevronLeft, ChevronRight, Trash2, X } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+import { cn } from '../lib/utils';
+import { Button } from '../primitives/button';
+
+export interface ImageGalleryItem {
+  id: string;
+  src: string;
+  caption?: string;
+  alt?: string;
+}
+
+export interface ImageGalleryProps {
+  items: ImageGalleryItem[];
+  /** Optional delete callback per item. If provided, renders a delete button. */
+  onDelete?: (id: string) => void;
+  /** Enable arrow-key navigation in the lightbox. Default `true`. */
+  keyboardNav?: boolean;
+  className?: string;
+}
+
+export function ImageGallery({
+  items,
+  onDelete,
+  keyboardNav = true,
+  className,
+}: ImageGalleryProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+
+  const active = items[activeIndex];
+
+  const goPrev = useCallback(() => {
+    setActiveIndex((i) => (i === 0 ? items.length - 1 : i - 1));
+  }, [items.length]);
+
+  const goNext = useCallback(() => {
+    setActiveIndex((i) => (i === items.length - 1 ? 0 : i + 1));
+  }, [items.length]);
+
+  useEffect(() => {
+    if (!lightboxOpen || !keyboardNav) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') goPrev();
+      else if (e.key === 'ArrowRight') goNext();
+      else if (e.key === 'Escape') setLightboxOpen(false);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [lightboxOpen, keyboardNav, goPrev, goNext]);
+
+  useEffect(() => {
+    if (activeIndex >= items.length) setActiveIndex(Math.max(0, items.length - 1));
+  }, [items.length, activeIndex]);
+
+  if (items.length === 0 || !active) return null;
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <button
+        type="button"
+        onClick={() => setLightboxOpen(true)}
+        className="group relative overflow-hidden rounded-md border border-border bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <img
+          src={active.src}
+          alt={active.alt ?? active.caption ?? ''}
+          className="aspect-video w-full object-contain transition-transform group-hover:scale-[1.01]"
+        />
+        {active.caption ? (
+          <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-3 text-left text-sm text-white">
+            {active.caption}
+          </div>
+        ) : null}
+      </button>
+
+      {items.length > 1 ? (
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {items.map((item, i) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => setActiveIndex(i)}
+              aria-label={`Show image ${i + 1}`}
+              aria-current={i === activeIndex}
+              className={cn(
+                'relative h-16 w-16 shrink-0 overflow-hidden rounded-md border-2 transition-all',
+                i === activeIndex
+                  ? 'border-ring'
+                  : 'border-transparent opacity-70 hover:opacity-100'
+              )}
+            >
+              <img src={item.src} alt={item.alt ?? ''} className="h-full w-full object-cover" />
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {lightboxOpen ? (
+        <div
+          role="dialog"
+          aria-modal
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-4"
+          onClick={() => setLightboxOpen(false)}
+        >
+          <div className="relative max-h-full max-w-6xl" onClick={(e) => e.stopPropagation()}>
+            <img
+              src={active.src}
+              alt={active.alt ?? active.caption ?? ''}
+              className="max-h-[calc(100vh-6rem)] max-w-full object-contain"
+            />
+            {active.caption ? (
+              <div className="mt-2 text-center text-sm text-white/80">{active.caption}</div>
+            ) : null}
+            <div className="absolute right-2 top-2 flex gap-1">
+              {onDelete ? (
+                <Button
+                  size="icon-sm"
+                  variant="destructive"
+                  aria-label="Delete image"
+                  onClick={() => onDelete(active.id)}
+                >
+                  <Trash2 />
+                </Button>
+              ) : null}
+              <Button
+                size="icon-sm"
+                variant="secondary"
+                aria-label="Close gallery"
+                onClick={() => setLightboxOpen(false)}
+              >
+                <X />
+              </Button>
+            </div>
+            {items.length > 1 ? (
+              <>
+                <Button
+                  size="icon-sm"
+                  variant="secondary"
+                  aria-label="Previous image"
+                  onClick={goPrev}
+                  className="absolute left-2 top-1/2 -translate-y-1/2"
+                >
+                  <ChevronLeft />
+                </Button>
+                <Button
+                  size="icon-sm"
+                  variant="secondary"
+                  aria-label="Next image"
+                  onClick={goNext}
+                  className="absolute right-2 top-1/2 -translate-y-1/2"
+                >
+                  <ChevronRight />
+                </Button>
+              </>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/ImageWithFallback.tsx
+++ b/packages/ui/src/components/ImageWithFallback.tsx
@@ -1,0 +1,85 @@
+/**
+ * ImageWithFallback — image that shows a skeleton while loading, a fallback
+ * source on error, and a placeholder icon when no source is available.
+ */
+import { type ComponentType, useEffect, useState } from 'react';
+
+import { cn } from '../lib/utils';
+import { Skeleton } from '../primitives/skeleton';
+
+export interface ImageWithFallbackProps {
+  src?: string | null;
+  /** Secondary source used when `src` fails to load. */
+  fallbackSrc?: string | null;
+  alt: string;
+  /** Icon shown when no src resolves. */
+  placeholderIcon?: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+  /** Tailwind aspect-ratio utility e.g. `aspect-[2/3]`. */
+  aspectRatio?: string;
+  /** Object-fit mode. Default `cover`. */
+  fit?: 'cover' | 'contain';
+  className?: string;
+  imgClassName?: string;
+  /** Set to `eager` to disable lazy loading. Default `lazy`. */
+  loading?: 'lazy' | 'eager';
+}
+
+export function ImageWithFallback({
+  src,
+  fallbackSrc,
+  alt,
+  placeholderIcon: Placeholder,
+  aspectRatio,
+  fit = 'cover',
+  className,
+  imgClassName,
+  loading = 'lazy',
+}: ImageWithFallbackProps) {
+  const initialSrc = src ?? fallbackSrc ?? null;
+  const [activeSrc, setActiveSrc] = useState<string | null>(initialSrc);
+  const [loaded, setLoaded] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const next = src ?? fallbackSrc ?? null;
+    setActiveSrc(next);
+    setLoaded(false);
+    setFailed(next === null);
+  }, [src, fallbackSrc]);
+
+  const handleError = () => {
+    if (activeSrc === src && fallbackSrc) {
+      setActiveSrc(fallbackSrc);
+      setLoaded(false);
+      return;
+    }
+    setFailed(true);
+  };
+
+  const showPlaceholder = failed || activeSrc === null;
+
+  return (
+    <div className={cn('relative overflow-hidden bg-muted', aspectRatio, className)}>
+      {!loaded && !showPlaceholder ? <Skeleton className="absolute inset-0 h-full w-full" /> : null}
+      {showPlaceholder ? (
+        <div className="absolute inset-0 flex items-center justify-center text-muted-foreground/50">
+          {Placeholder ? <Placeholder className="h-10 w-10" aria-hidden /> : null}
+        </div>
+      ) : (
+        <img
+          src={activeSrc ?? undefined}
+          alt={alt}
+          loading={loading}
+          onLoad={() => setLoaded(true)}
+          onError={handleError}
+          className={cn(
+            'h-full w-full transition-opacity duration-300',
+            fit === 'cover' ? 'object-cover' : 'object-contain',
+            loaded ? 'opacity-100' : 'opacity-0',
+            imgClassName
+          )}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/MediaCard.tsx
+++ b/packages/ui/src/components/MediaCard.tsx
@@ -1,0 +1,98 @@
+/**
+ * MediaCard — generic image-card primitive.
+ *
+ * Wraps ImageWithFallback with title, subtitle, and badge/overlay slots.
+ * Designed to be a thin shared base for domain-specific cards (MediaCard,
+ * InventoryCard, etc.).
+ */
+import { type ComponentType, type MouseEvent, type ReactNode } from 'react';
+
+import { cn } from '../lib/utils';
+import { Card } from '../primitives/card';
+import { ImageWithFallback } from './ImageWithFallback';
+
+export interface MediaCardProps {
+  src?: string | null;
+  fallbackSrc?: string | null;
+  alt: string;
+  placeholderIcon?: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+  aspectRatio?: string;
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  /** Slot layered over the top-left of the image. */
+  overlayTopLeft?: ReactNode;
+  /** Slot layered over the top-right of the image. */
+  overlayTopRight?: ReactNode;
+  /** Slot layered over the bottom-left of the image. */
+  overlayBottomLeft?: ReactNode;
+  /** Slot below the image, after title/subtitle. */
+  footer?: ReactNode;
+  onClick?: (e: MouseEvent<HTMLDivElement>) => void;
+  className?: string;
+  imageClassName?: string;
+}
+
+export function MediaCard({
+  src,
+  fallbackSrc,
+  alt,
+  placeholderIcon,
+  aspectRatio = 'aspect-[2/3]',
+  title,
+  subtitle,
+  overlayTopLeft,
+  overlayTopRight,
+  overlayBottomLeft,
+  footer,
+  onClick,
+  className,
+  imageClassName,
+}: MediaCardProps) {
+  const interactive = typeof onClick === 'function';
+  return (
+    <Card
+      role={interactive ? 'button' : undefined}
+      tabIndex={interactive ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (!interactive) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick?.(e as unknown as MouseEvent<HTMLDivElement>);
+        }
+      }}
+      className={cn(
+        'overflow-hidden p-0 gap-0',
+        interactive && 'cursor-pointer transition-transform hover:-translate-y-0.5',
+        className
+      )}
+    >
+      <div className="relative">
+        <ImageWithFallback
+          src={src}
+          fallbackSrc={fallbackSrc}
+          alt={alt}
+          placeholderIcon={placeholderIcon}
+          aspectRatio={aspectRatio}
+          className={imageClassName}
+        />
+        {overlayTopLeft ? <div className="absolute left-2 top-2 z-10">{overlayTopLeft}</div> : null}
+        {overlayTopRight ? (
+          <div className="absolute right-2 top-2 z-10">{overlayTopRight}</div>
+        ) : null}
+        {overlayBottomLeft ? (
+          <div className="absolute bottom-2 left-2 z-10">{overlayBottomLeft}</div>
+        ) : null}
+      </div>
+      {(title || subtitle || footer) && (
+        <div className="flex flex-col gap-0.5 p-3">
+          {title ? <div className="truncate text-sm font-medium">{title}</div> : null}
+          {subtitle ? (
+            <div className="truncate text-xs text-muted-foreground">{subtitle}</div>
+          ) : null}
+          {footer ? <div className="mt-1.5">{footer}</div> : null}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/packages/ui/src/components/RadarChart.tsx
+++ b/packages/ui/src/components/RadarChart.tsx
@@ -1,0 +1,130 @@
+/**
+ * RadarChart — pure-SVG spider/radar chart primitive.
+ *
+ * Renders one or more polygons against a labelled axis grid. Intentionally
+ * framework-free — no Recharts, no D3.
+ */
+import { type CSSProperties } from 'react';
+
+import { cn } from '../lib/utils';
+
+export interface RadarSeries {
+  id?: string;
+  label?: string;
+  /** Must be the same length as `axes`. */
+  values: number[];
+  /** Stroke colour. */
+  color?: string;
+  /** Fill opacity 0-1. Default 0.2. */
+  fillOpacity?: number;
+}
+
+export interface RadarChartProps {
+  axes: string[];
+  series: RadarSeries[];
+  /** Max value for the outer ring. Default = max of all series values. */
+  max?: number;
+  /** Number of concentric grid rings. Default 4. */
+  rings?: number;
+  /** Chart size in pixels. Default 320. */
+  size?: number;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const DEFAULT_COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6'];
+
+function pointOn(cx: number, cy: number, r: number, angle: number): [number, number] {
+  return [cx + r * Math.cos(angle), cy + r * Math.sin(angle)];
+}
+
+export function RadarChart({
+  axes,
+  series,
+  max,
+  rings = 4,
+  size = 320,
+  className,
+  style,
+}: RadarChartProps) {
+  const cx = size / 2;
+  const cy = size / 2;
+  const radius = size / 2 - 40;
+  const step = (Math.PI * 2) / Math.max(1, axes.length);
+  const startAngle = -Math.PI / 2;
+
+  const computedMax =
+    max ?? Math.max(1, ...series.flatMap((s) => s.values.filter((v) => Number.isFinite(v))));
+
+  return (
+    <svg
+      viewBox={`0 0 ${size} ${size}`}
+      className={cn('h-auto w-full', className)}
+      style={style}
+      role="img"
+      aria-label={`Radar chart over ${axes.length} axes`}
+    >
+      {/* Grid rings */}
+      {Array.from({ length: rings }).map((_, r) => {
+        const ratio = (r + 1) / rings;
+        const points = axes
+          .map((_, i) => {
+            const [x, y] = pointOn(cx, cy, radius * ratio, startAngle + i * step);
+            return `${x},${y}`;
+          })
+          .join(' ');
+        return (
+          <polygon key={r} points={points} fill="none" stroke="currentColor" strokeOpacity={0.15} />
+        );
+      })}
+      {/* Axes spokes */}
+      {axes.map((label, i) => {
+        const [x2, y2] = pointOn(cx, cy, radius, startAngle + i * step);
+        const [lx, ly] = pointOn(cx, cy, radius + 16, startAngle + i * step);
+        return (
+          <g key={`${label}-${i}`}>
+            <line x1={cx} y1={cy} x2={x2} y2={y2} stroke="currentColor" strokeOpacity={0.2} />
+            <text
+              x={lx}
+              y={ly}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              className="fill-muted-foreground"
+              fontSize={11}
+            >
+              {label}
+            </text>
+          </g>
+        );
+      })}
+      {/* Series polygons */}
+      {series.map((s, si) => {
+        const color = s.color ?? DEFAULT_COLORS[si % DEFAULT_COLORS.length];
+        const fillOpacity = s.fillOpacity ?? 0.2;
+        const points = s.values
+          .map((v, i) => {
+            const ratio = Math.max(0, Math.min(1, v / computedMax));
+            const [x, y] = pointOn(cx, cy, radius * ratio, startAngle + i * step);
+            return `${x},${y}`;
+          })
+          .join(' ');
+        return (
+          <g key={s.id ?? si}>
+            <polygon
+              points={points}
+              fill={color}
+              fillOpacity={fillOpacity}
+              stroke={color}
+              strokeWidth={2}
+            />
+            {s.values.map((v, i) => {
+              const ratio = Math.max(0, Math.min(1, v / computedMax));
+              const [x, y] = pointOn(cx, cy, radius * ratio, startAngle + i * step);
+              return <circle key={i} cx={x} cy={y} r={3} fill={color} />;
+            })}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/packages/ui/src/components/ResponsiveCardGrid.tsx
+++ b/packages/ui/src/components/ResponsiveCardGrid.tsx
@@ -1,0 +1,71 @@
+/**
+ * ResponsiveCardGrid — responsive CSS grid wrapper with per-breakpoint
+ * column counts. Retires inline `grid grid-cols-N md:…` class strings.
+ */
+import { type CSSProperties, type HTMLAttributes, type ReactNode } from 'react';
+
+import { cn } from '../lib/utils';
+
+export interface ResponsiveCardGridCols {
+  base?: number;
+  sm?: number;
+  md?: number;
+  lg?: number;
+  xl?: number;
+  '2xl'?: number;
+}
+
+export interface ResponsiveCardGridProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  /** Columns per breakpoint. Default `{ base: 2, md: 3, lg: 4, xl: 6 }`. */
+  cols?: ResponsiveCardGridCols;
+  /** Gap scale token. Default `gap-3`. */
+  gapClassName?: string;
+}
+
+const breakpointVars: Record<keyof ResponsiveCardGridCols, string> = {
+  base: '--grid-cols-base',
+  sm: '--grid-cols-sm',
+  md: '--grid-cols-md',
+  lg: '--grid-cols-lg',
+  xl: '--grid-cols-xl',
+  '2xl': '--grid-cols-2xl',
+};
+
+const responsiveClasses = [
+  'grid-cols-[repeat(var(--grid-cols-base),minmax(0,1fr))]',
+  'sm:grid-cols-[repeat(var(--grid-cols-sm,var(--grid-cols-base)),minmax(0,1fr))]',
+  'md:grid-cols-[repeat(var(--grid-cols-md,var(--grid-cols-sm,var(--grid-cols-base))),minmax(0,1fr))]',
+  'lg:grid-cols-[repeat(var(--grid-cols-lg,var(--grid-cols-md,var(--grid-cols-sm,var(--grid-cols-base)))),minmax(0,1fr))]',
+  'xl:grid-cols-[repeat(var(--grid-cols-xl,var(--grid-cols-lg,var(--grid-cols-md,var(--grid-cols-sm,var(--grid-cols-base))))),minmax(0,1fr))]',
+  '2xl:grid-cols-[repeat(var(--grid-cols-2xl,var(--grid-cols-xl,var(--grid-cols-lg,var(--grid-cols-md,var(--grid-cols-sm,var(--grid-cols-base)))))),minmax(0,1fr))]',
+].join(' ');
+
+export function ResponsiveCardGrid({
+  children,
+  cols = { base: 2, md: 3, lg: 4, xl: 6 },
+  gapClassName = 'gap-3',
+  className,
+  style,
+  ...rest
+}: ResponsiveCardGridProps) {
+  const varStyle: CSSProperties = {};
+  (Object.keys(cols) as (keyof ResponsiveCardGridCols)[]).forEach((k) => {
+    const v = cols[k];
+    if (typeof v === 'number') {
+      (varStyle as Record<string, string>)[breakpointVars[k]] = String(v);
+    }
+  });
+
+  return (
+    <div
+      className={cn('grid', responsiveClasses, gapClassName, className)}
+      style={{ ...varStyle, ...style }}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+export { ResponsiveCardGrid as MediaGrid };

--- a/packages/ui/src/components/ScrollShelf.tsx
+++ b/packages/ui/src/components/ScrollShelf.tsx
@@ -4,7 +4,7 @@
  * lazy loader for offscreen shelves.
  */
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { cn } from '../lib/utils';
 import { Button } from '../primitives/button';
@@ -123,41 +123,83 @@ export function LazyScrollShelf<T>({
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const [items, setItems] = useState<T[] | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [retryTick, setRetryTick] = useState(0);
 
   useEffect(() => {
     const el = wrapperRef.current;
     if (!el || items !== null) return;
+    let cancelled = false;
+    let triggered = false;
     const io = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
-          if (entry.isIntersecting) {
-            setLoading(true);
-            loadItems()
-              .then((data) => setItems(data))
-              .finally(() => setLoading(false));
-            io.disconnect();
-            break;
-          }
+          if (!entry.isIntersecting || triggered) continue;
+          triggered = true;
+          setLoading(true);
+          setError(null);
+          loadItems()
+            .then((data) => {
+              if (cancelled) return;
+              setItems(data);
+              io.disconnect();
+            })
+            .catch((e: unknown) => {
+              if (cancelled) return;
+              setError(e instanceof Error ? e.message : 'Failed to load');
+              // Allow the observer to retrigger on a subsequent intersect.
+              triggered = false;
+            })
+            .finally(() => {
+              if (!cancelled) setLoading(false);
+            });
+          break;
         }
       },
       { rootMargin: '200px' }
     );
     io.observe(el);
-    return () => io.disconnect();
-  }, [loadItems, items]);
+    return () => {
+      cancelled = true;
+      io.disconnect();
+    };
+  }, [loadItems, items, retryTick]);
 
   const itemWidth = rest.itemWidth ?? 192;
+  const placeholderIds = useMemo(
+    () => Array.from({ length: placeholderCount }, (_, i) => `ph-${placeholderCount}-${i}`),
+    [placeholderCount]
+  );
 
   return (
     <div ref={wrapperRef}>
       {items === null ? (
         <section className={cn('flex flex-col gap-3', rest.className)}>
           {rest.title ? <h2 className="text-sm font-semibold">{rest.title}</h2> : null}
-          <div className="flex gap-3 overflow-hidden">
-            {Array.from({ length: placeholderCount }).map((_, i) => (
-              <Skeleton key={i} className="shrink-0 h-48" style={{ width: itemWidth }} />
-            ))}
-          </div>
+          {error ? (
+            <div
+              role="alert"
+              className="flex items-center justify-between gap-3 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+            >
+              <span>{error}</span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setError(null);
+                  setRetryTick((t) => t + 1);
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : (
+            <div className="flex gap-3 overflow-hidden">
+              {placeholderIds.map((id) => (
+                <Skeleton key={id} className="shrink-0 h-48" style={{ width: itemWidth }} />
+              ))}
+            </div>
+          )}
         </section>
       ) : (
         <ScrollShelf {...rest} items={items} />

--- a/packages/ui/src/components/ScrollShelf.tsx
+++ b/packages/ui/src/components/ScrollShelf.tsx
@@ -1,0 +1,168 @@
+/**
+ * ScrollShelf + LazyScrollShelf — horizontal "shelf" of items with
+ * left/right scroll buttons and an optional IntersectionObserver-based
+ * lazy loader for offscreen shelves.
+ */
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+
+import { cn } from '../lib/utils';
+import { Button } from '../primitives/button';
+import { Skeleton } from '../primitives/skeleton';
+
+export interface ScrollShelfProps<T> {
+  title?: ReactNode;
+  /** Optional trailing slot (e.g. "See all" link). */
+  action?: ReactNode;
+  items: T[];
+  renderItem: (item: T, index: number) => ReactNode;
+  getKey: (item: T, index: number) => string | number;
+  /** Item width in pixels, used to compute scroll distance. Default 192. */
+  itemWidth?: number;
+  className?: string;
+}
+
+export function ScrollShelf<T>({
+  title,
+  action,
+  items,
+  renderItem,
+  getKey,
+  itemWidth = 192,
+  className,
+}: ScrollShelfProps<T>) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateButtons = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 8);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 8);
+  }, []);
+
+  useEffect(() => {
+    updateButtons();
+    const el = scrollRef.current;
+    if (!el) return;
+    const handler = () => updateButtons();
+    el.addEventListener('scroll', handler, { passive: true });
+    window.addEventListener('resize', handler);
+    return () => {
+      el.removeEventListener('scroll', handler);
+      window.removeEventListener('resize', handler);
+    };
+  }, [updateButtons, items.length]);
+
+  const scrollBy = (direction: 1 | -1) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distance = Math.max(itemWidth * 2, Math.round(el.clientWidth * 0.8));
+    el.scrollBy({ left: direction * distance, behavior: 'smooth' });
+  };
+
+  return (
+    <section className={cn('flex flex-col gap-3', className)}>
+      {(title || action) && (
+        <div className="flex items-center justify-between gap-3">
+          {title ? <h2 className="text-sm font-semibold">{title}</h2> : <span />}
+          {action}
+        </div>
+      )}
+      <div className="relative">
+        <div
+          ref={scrollRef}
+          className="flex snap-x snap-mandatory gap-3 overflow-x-auto scroll-smooth pb-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        >
+          {items.map((item, i) => (
+            <div key={getKey(item, i)} className="snap-start shrink-0" style={{ width: itemWidth }}>
+              {renderItem(item, i)}
+            </div>
+          ))}
+        </div>
+        {canScrollLeft ? (
+          <Button
+            size="icon-sm"
+            variant="secondary"
+            aria-label="Scroll left"
+            onClick={() => scrollBy(-1)}
+            className="absolute left-1 top-1/2 -translate-y-1/2 shadow-md"
+          >
+            <ChevronLeft />
+          </Button>
+        ) : null}
+        {canScrollRight ? (
+          <Button
+            size="icon-sm"
+            variant="secondary"
+            aria-label="Scroll right"
+            onClick={() => scrollBy(1)}
+            className="absolute right-1 top-1/2 -translate-y-1/2 shadow-md"
+          >
+            <ChevronRight />
+          </Button>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+export interface LazyScrollShelfProps<T> extends Omit<ScrollShelfProps<T>, 'items'> {
+  /** Loader fired once the shelf becomes visible. */
+  loadItems: () => Promise<T[]>;
+  /** Skeleton placeholder count. Default 6. */
+  placeholderCount?: number;
+}
+
+export function LazyScrollShelf<T>({
+  loadItems,
+  placeholderCount = 6,
+  ...rest
+}: LazyScrollShelfProps<T>) {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [items, setItems] = useState<T[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el || items !== null) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setLoading(true);
+            loadItems()
+              .then((data) => setItems(data))
+              .finally(() => setLoading(false));
+            io.disconnect();
+            break;
+          }
+        }
+      },
+      { rootMargin: '200px' }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [loadItems, items]);
+
+  const itemWidth = rest.itemWidth ?? 192;
+
+  return (
+    <div ref={wrapperRef}>
+      {items === null ? (
+        <section className={cn('flex flex-col gap-3', rest.className)}>
+          {rest.title ? <h2 className="text-sm font-semibold">{rest.title}</h2> : null}
+          <div className="flex gap-3 overflow-hidden">
+            {Array.from({ length: placeholderCount }).map((_, i) => (
+              <Skeleton key={i} className="shrink-0 h-48" style={{ width: itemWidth }} />
+            ))}
+          </div>
+        </section>
+      ) : (
+        <ScrollShelf {...rest} items={items} />
+      )}
+      {loading && items === null ? <span className="sr-only">Loading</span> : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/SettingsForm.tsx
+++ b/packages/ui/src/components/SettingsForm.tsx
@@ -104,6 +104,27 @@ export function SettingsForm({
     {}
   );
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (saveTimer.current) {
+        clearTimeout(saveTimer.current);
+        saveTimer.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    // Cancel any pending autosave when the save handler or mode changes so we
+    // don't fire a stale callback with old values.
+    if (saveTimer.current) {
+      clearTimeout(saveTimer.current);
+      saveTimer.current = null;
+    }
+  }, [onSave, autoSave]);
 
   useEffect(() => {
     for (const field of section.fields) {
@@ -150,11 +171,12 @@ export function SettingsForm({
       if (autoSave && onSave && valid) {
         if (saveTimer.current) clearTimeout(saveTimer.current);
         saveTimer.current = setTimeout(async () => {
+          if (!mountedRef.current) return;
           setSaving(true);
           try {
             await onSave(next);
           } finally {
-            setSaving(false);
+            if (mountedRef.current) setSaving(false);
           }
         }, 400);
       }

--- a/packages/ui/src/components/SettingsForm.tsx
+++ b/packages/ui/src/components/SettingsForm.tsx
@@ -1,0 +1,345 @@
+/**
+ * SettingsForm — renders a declarative settings manifest (text, number,
+ * toggle, select, password, json, duration, textarea) with validation,
+ * async option loaders, auto-save, and test actions.
+ *
+ * Generic over a values record. The manifest is data-driven so any app
+ * can register its own settings section and mount the renderer. Each
+ * field's value is stored under its `id` in the returned values object.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { cn } from '../lib/utils';
+import { Checkbox } from '../primitives/checkbox';
+import { Input } from '../primitives/input';
+import { Label } from '../primitives/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../primitives/select';
+import { Textarea } from '../primitives/textarea';
+import { Button } from './Button';
+import { DurationFieldInput } from './DurationFieldInput';
+
+export type SettingsFieldKind =
+  | 'text'
+  | 'number'
+  | 'toggle'
+  | 'select'
+  | 'password'
+  | 'json'
+  | 'duration'
+  | 'textarea';
+
+export interface SettingsOption {
+  value: string;
+  label: string;
+}
+
+export interface SettingsField {
+  id: string;
+  kind: SettingsFieldKind;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  required?: boolean;
+  /** Static options for `select`. */
+  options?: SettingsOption[];
+  /** Async loader for `select` options. */
+  loadOptions?: () => Promise<SettingsOption[]>;
+  /** Custom validator. Return error string or null. */
+  validate?: (value: unknown, values: Record<string, unknown>) => string | null;
+  /** For `number`, optional min/max. */
+  min?: number;
+  max?: number;
+  /** For `duration`: canonical value is ms. */
+  defaultValue?: unknown;
+  /** Environment fallback label when set externally. */
+  envFallbackLabel?: string;
+}
+
+export interface SettingsTestAction {
+  id: string;
+  label: string;
+  run: (values: Record<string, unknown>) => Promise<{ ok: boolean; message?: string }>;
+}
+
+export interface SettingsSection {
+  id: string;
+  title: string;
+  description?: string;
+  fields: SettingsField[];
+  testActions?: SettingsTestAction[];
+}
+
+export interface SettingsFormProps {
+  section: SettingsSection;
+  values: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+  /** Called when the form is committed. Omit for auto-save on change. */
+  onSave?: (values: Record<string, unknown>) => Promise<void> | void;
+  /** If true and `onSave` is set, save on field change instead of via button. */
+  autoSave?: boolean;
+  /** Extra read-only badges shown in the header. */
+  headerSlot?: React.ReactNode;
+  className?: string;
+}
+
+export function SettingsForm({
+  section,
+  values,
+  onChange,
+  onSave,
+  autoSave = false,
+  headerSlot,
+  className,
+}: SettingsFormProps) {
+  const [errors, setErrors] = useState<Record<string, string | null>>({});
+  const [loadedOptions, setLoadedOptions] = useState<Record<string, SettingsOption[]>>({});
+  const [saving, setSaving] = useState(false);
+  const [testStatus, setTestStatus] = useState<Record<string, { ok: boolean; message?: string }>>(
+    {}
+  );
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    for (const field of section.fields) {
+      if (field.kind === 'select' && field.loadOptions && !loadedOptions[field.id]) {
+        field
+          .loadOptions()
+          .then((opts) => setLoadedOptions((s) => ({ ...s, [field.id]: opts })))
+          .catch(() => setLoadedOptions((s) => ({ ...s, [field.id]: [] })));
+      }
+    }
+  }, [section.fields, loadedOptions]);
+
+  const runValidation = useCallback(
+    (next: Record<string, unknown>): boolean => {
+      const errs: Record<string, string | null> = {};
+      let hasError = false;
+      for (const field of section.fields) {
+        const v = next[field.id];
+        let err: string | null = null;
+        if (field.required && (v === undefined || v === null || v === '')) {
+          err = `${field.label} is required`;
+        } else if (field.kind === 'json' && typeof v === 'string' && v.trim()) {
+          try {
+            JSON.parse(v);
+          } catch {
+            err = 'Invalid JSON';
+          }
+        }
+        if (!err && field.validate) err = field.validate(v, next);
+        if (err) hasError = true;
+        errs[field.id] = err;
+      }
+      setErrors(errs);
+      return !hasError;
+    },
+    [section.fields]
+  );
+
+  const update = useCallback(
+    (id: string, value: unknown) => {
+      const next = { ...values, [id]: value };
+      onChange(next);
+      const valid = runValidation(next);
+      if (autoSave && onSave && valid) {
+        if (saveTimer.current) clearTimeout(saveTimer.current);
+        saveTimer.current = setTimeout(async () => {
+          setSaving(true);
+          try {
+            await onSave(next);
+          } finally {
+            setSaving(false);
+          }
+        }, 400);
+      }
+    },
+    [values, onChange, runValidation, autoSave, onSave]
+  );
+
+  const handleCommit = async () => {
+    if (!onSave) return;
+    if (!runValidation(values)) return;
+    setSaving(true);
+    try {
+      await onSave(values);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const renderControl = (
+    field: SettingsField,
+    value: unknown,
+    fieldId: string,
+    error: string | null | undefined
+  ): React.ReactNode => {
+    const common = { id: fieldId, disabled: saving, 'aria-invalid': !!error || undefined };
+    switch (field.kind) {
+      case 'text':
+      case 'password':
+        return (
+          <Input
+            {...common}
+            type={field.kind === 'password' ? 'password' : 'text'}
+            value={typeof value === 'string' ? value : ''}
+            placeholder={field.placeholder}
+            onChange={(e) => update(field.id, e.target.value)}
+          />
+        );
+      case 'number':
+        return (
+          <Input
+            {...common}
+            type="number"
+            min={field.min}
+            max={field.max}
+            value={typeof value === 'number' ? value : value === '' ? '' : Number(value) || 0}
+            placeholder={field.placeholder}
+            onChange={(e) => update(field.id, e.target.value === '' ? '' : Number(e.target.value))}
+          />
+        );
+      case 'toggle':
+        return (
+          <Checkbox
+            id={fieldId}
+            disabled={saving}
+            checked={!!value}
+            onCheckedChange={(v) => update(field.id, v === true)}
+          />
+        );
+      case 'select': {
+        const opts = field.options ?? loadedOptions[field.id] ?? [];
+        return (
+          <Select
+            value={typeof value === 'string' ? value : ''}
+            onValueChange={(v) => update(field.id, v)}
+            disabled={saving}
+          >
+            <SelectTrigger id={fieldId}>
+              <SelectValue placeholder={field.placeholder} />
+            </SelectTrigger>
+            <SelectContent>
+              {opts.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        );
+      }
+      case 'textarea':
+      case 'json':
+        return (
+          <Textarea
+            {...common}
+            rows={field.kind === 'json' ? 6 : 3}
+            value={typeof value === 'string' ? value : ''}
+            placeholder={field.placeholder}
+            onChange={(e) => update(field.id, e.target.value)}
+          />
+        );
+      case 'duration':
+        return (
+          <DurationFieldInput
+            id={fieldId}
+            disabled={saving}
+            value={typeof value === 'number' ? value : 0}
+            onChange={(next) => update(field.id, next)}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  const renderField = (field: SettingsField) => {
+    const value = values[field.id] ?? field.defaultValue ?? '';
+    const error = errors[field.id];
+    const fieldId = `settings-${section.id}-${field.id}`;
+
+    return (
+      <div key={field.id} className="flex flex-col gap-1.5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-0.5">
+            <Label htmlFor={fieldId}>
+              {field.label}
+              {field.required ? <span className="text-destructive"> *</span> : null}
+            </Label>
+            {field.description ? (
+              <div className="text-xs text-muted-foreground">{field.description}</div>
+            ) : null}
+          </div>
+          {field.envFallbackLabel ? (
+            <span className="text-xs text-muted-foreground">{field.envFallbackLabel}</span>
+          ) : null}
+        </div>
+        <div>{renderControl(field, value, fieldId, error)}</div>
+        {error ? <div className="text-xs text-destructive">{error}</div> : null}
+      </div>
+    );
+  };
+
+  const testActions = section.testActions ?? [];
+
+  const handleRunTest = async (action: SettingsTestAction) => {
+    const result = await action.run(values);
+    setTestStatus((s) => ({ ...s, [action.id]: result }));
+  };
+
+  const showFooter = useMemo(() => !autoSave && typeof onSave === 'function', [autoSave, onSave]);
+
+  return (
+    <section className={cn('flex flex-col gap-5', className)}>
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">{section.title}</h2>
+          {section.description ? (
+            <p className="text-sm text-muted-foreground">{section.description}</p>
+          ) : null}
+        </div>
+        {headerSlot}
+      </header>
+      <div className="flex flex-col gap-4">{section.fields.map(renderField)}</div>
+      {testActions.length > 0 ? (
+        <div className="flex flex-col gap-2 rounded-md border border-border bg-muted/20 p-3">
+          <div className="text-sm font-medium">Test actions</div>
+          <div className="flex flex-wrap gap-2">
+            {testActions.map((action) => {
+              const status = testStatus[action.id];
+              return (
+                <div key={action.id} className="flex items-center gap-2">
+                  <Button size="sm" variant="outline" onClick={() => handleRunTest(action)}>
+                    {action.label}
+                  </Button>
+                  {status ? (
+                    <span
+                      className={cn('text-xs', status.ok ? 'text-success' : 'text-destructive')}
+                    >
+                      {status.message ?? (status.ok ? 'OK' : 'Failed')}
+                    </span>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+      {showFooter ? (
+        <footer className="flex justify-end gap-2">
+          <Button onClick={handleCommit} loading={saving}>
+            Save
+          </Button>
+        </footer>
+      ) : null}
+    </section>
+  );
+}
+
+export { SettingsForm as SectionRenderer };

--- a/packages/ui/src/components/SortableGrid.tsx
+++ b/packages/ui/src/components/SortableGrid.tsx
@@ -36,6 +36,9 @@ export function SortableGrid<T>({
     if (disabled) return;
     setDragIndex(i);
     e.dataTransfer.effectAllowed = 'move';
+    // Firefox requires some data payload for the drag to initiate.
+    const item = items[i];
+    if (item !== undefined) e.dataTransfer.setData('text/plain', String(getKey(item, i)));
   };
 
   const handleDragOver = (i: number) => (e: React.DragEvent<HTMLDivElement>) => {

--- a/packages/ui/src/components/SortableGrid.tsx
+++ b/packages/ui/src/components/SortableGrid.tsx
@@ -1,0 +1,94 @@
+/**
+ * SortableGrid — HTML5 drag-drop reorder grid.
+ *
+ * Domain-agnostic reorder mechanics. Consumers provide a `renderItem`
+ * callback and an `onReorder` handler that receives the new array.
+ */
+import { type ReactNode, useState } from 'react';
+
+import { cn } from '../lib/utils';
+
+export interface SortableGridProps<T> {
+  items: T[];
+  getKey: (item: T, index: number) => string | number;
+  renderItem: (item: T, index: number, state: { isDragging: boolean }) => ReactNode;
+  onReorder: (nextOrder: T[]) => void;
+  /** Tailwind grid classes. Default `grid-cols-3`. */
+  columnsClassName?: string;
+  /** Disable drag-drop. */
+  disabled?: boolean;
+  className?: string;
+}
+
+export function SortableGrid<T>({
+  items,
+  getKey,
+  renderItem,
+  onReorder,
+  columnsClassName = 'grid-cols-3',
+  disabled,
+  className,
+}: SortableGridProps<T>) {
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+
+  const handleDragStart = (i: number) => (e: React.DragEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    setDragIndex(i);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (i: number) => (e: React.DragEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    if (overIndex !== i) setOverIndex(i);
+  };
+
+  const handleDrop = (i: number) => (e: React.DragEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    e.preventDefault();
+    if (dragIndex === null || dragIndex === i) {
+      setDragIndex(null);
+      setOverIndex(null);
+      return;
+    }
+    const next = items.slice();
+    const [moved] = next.splice(dragIndex, 1);
+    if (moved !== undefined) next.splice(i, 0, moved);
+    onReorder(next);
+    setDragIndex(null);
+    setOverIndex(null);
+  };
+
+  const handleDragEnd = () => {
+    setDragIndex(null);
+    setOverIndex(null);
+  };
+
+  return (
+    <div className={cn('grid gap-3', columnsClassName, className)}>
+      {items.map((item, i) => {
+        const isDragging = dragIndex === i;
+        const isOver = overIndex === i && dragIndex !== i;
+        return (
+          <div
+            key={getKey(item, i)}
+            draggable={!disabled}
+            onDragStart={handleDragStart(i)}
+            onDragOver={handleDragOver(i)}
+            onDrop={handleDrop(i)}
+            onDragEnd={handleDragEnd}
+            className={cn(
+              'transition-all',
+              isDragging && 'opacity-40',
+              isOver && 'ring-2 ring-ring ring-offset-2'
+            )}
+          >
+            {renderItem(item, i, { isDragging })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/ui/src/components/TierListBoard.tsx
+++ b/packages/ui/src/components/TierListBoard.tsx
@@ -19,7 +19,10 @@ export interface TierDefinition {
 
 export interface TierListBoardProps<T> {
   tiers: TierDefinition[];
-  /** Current assignment of items to tiers. `null` = unranked pool. */
+  /**
+   * Current assignment of items to tiers. Keyed by tier id; the reserved
+   * `__pool` key holds unranked items that render in the bottom pool row.
+   */
   assignments: Record<string, string[]>;
   /** All items, keyed by id used inside `assignments`. */
   items: Record<string, T>;
@@ -32,7 +35,9 @@ export interface TierListBoardProps<T> {
   className?: string;
 }
 
-const POOL = '__pool';
+/** Reserved key in `assignments` for unranked items. */
+export const UNRANKED_POOL_KEY = '__pool';
+const POOL = UNRANKED_POOL_KEY;
 const DISMISS = '__dismiss';
 
 export function TierListBoard<T>({
@@ -108,7 +113,12 @@ export function TierListBoard<T>({
                   <div
                     key={id}
                     draggable
-                    onDragStart={() => setDragId(id)}
+                    onDragStart={(e) => {
+                      // Firefox requires some data payload for the drag to initiate.
+                      e.dataTransfer.setData('text/plain', id);
+                      e.dataTransfer.effectAllowed = 'move';
+                      setDragId(id);
+                    }}
                     onDragEnd={() => setDragId(null)}
                     className={cn(
                       'cursor-grab active:cursor-grabbing transition-opacity',

--- a/packages/ui/src/components/TierListBoard.tsx
+++ b/packages/ui/src/components/TierListBoard.tsx
@@ -1,0 +1,144 @@
+/**
+ * TierListBoard — drag-drop tier-list ranking board.
+ *
+ * Generic over item data. Uses HTML5 drag-and-drop (no external dnd
+ * library required). Tiers are ordered rows; unranked items sit in a
+ * pool at the bottom and a "dismiss" zone optionally removes items.
+ */
+import { X } from 'lucide-react';
+import { type ReactNode, useState } from 'react';
+
+import { cn } from '../lib/utils';
+
+export interface TierDefinition {
+  id: string;
+  label: string;
+  /** Accent colour for the tier row. */
+  color?: string;
+}
+
+export interface TierListBoardProps<T> {
+  tiers: TierDefinition[];
+  /** Current assignment of items to tiers. `null` = unranked pool. */
+  assignments: Record<string, string[]>;
+  /** All items, keyed by id used inside `assignments`. */
+  items: Record<string, T>;
+  renderItem: (item: T, id: string) => ReactNode;
+  onAssignmentsChange: (next: Record<string, string[]>) => void;
+  /** Enable the "dismiss" drop zone. Default false. */
+  showDismissZone?: boolean;
+  onDismiss?: (id: string) => void;
+  unrankedLabel?: ReactNode;
+  className?: string;
+}
+
+const POOL = '__pool';
+const DISMISS = '__dismiss';
+
+export function TierListBoard<T>({
+  tiers,
+  assignments,
+  items,
+  renderItem,
+  onAssignmentsChange,
+  showDismissZone = false,
+  onDismiss,
+  unrankedLabel = 'Unranked',
+  className,
+}: TierListBoardProps<T>) {
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [overZone, setOverZone] = useState<string | null>(null);
+
+  const rows = [
+    ...tiers.map((t) => ({ id: t.id, label: t.label, color: t.color })),
+    { id: POOL, label: unrankedLabel, color: undefined },
+  ];
+
+  const handleDrop = (zone: string) => (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setOverZone(null);
+    if (!dragId) return;
+    if (zone === DISMISS) {
+      const next: Record<string, string[]> = {};
+      for (const [k, v] of Object.entries(assignments)) next[k] = v.filter((id) => id !== dragId);
+      onAssignmentsChange(next);
+      onDismiss?.(dragId);
+      setDragId(null);
+      return;
+    }
+    const next: Record<string, string[]> = {};
+    for (const [k, v] of Object.entries(assignments)) next[k] = v.filter((id) => id !== dragId);
+    const current = next[zone] ?? [];
+    next[zone] = [...current, dragId];
+    onAssignmentsChange(next);
+    setDragId(null);
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-2', className)}>
+      {rows.map((row) => {
+        const zoneItems = assignments[row.id] ?? [];
+        const isOver = overZone === row.id;
+        return (
+          <div
+            key={row.id}
+            onDragOver={(e) => {
+              e.preventDefault();
+              if (overZone !== row.id) setOverZone(row.id);
+            }}
+            onDragLeave={() => setOverZone((z) => (z === row.id ? null : z))}
+            onDrop={handleDrop(row.id)}
+            className={cn(
+              'flex min-h-[72px] items-stretch gap-3 rounded-md border border-border bg-card p-2 transition-colors',
+              isOver && 'ring-2 ring-ring',
+              row.id === POOL && 'bg-muted/40'
+            )}
+          >
+            <div
+              className="flex w-20 shrink-0 items-center justify-center rounded-sm px-2 text-sm font-semibold text-white"
+              style={{ background: row.color ?? 'var(--muted)' }}
+            >
+              {row.label}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {zoneItems.map((id) => {
+                const item = items[id];
+                if (!item) return null;
+                return (
+                  <div
+                    key={id}
+                    draggable
+                    onDragStart={() => setDragId(id)}
+                    onDragEnd={() => setDragId(null)}
+                    className={cn(
+                      'cursor-grab active:cursor-grabbing transition-opacity',
+                      dragId === id && 'opacity-40'
+                    )}
+                  >
+                    {renderItem(item, id)}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+      {showDismissZone ? (
+        <div
+          onDragOver={(e) => {
+            e.preventDefault();
+            if (overZone !== DISMISS) setOverZone(DISMISS);
+          }}
+          onDragLeave={() => setOverZone((z) => (z === DISMISS ? null : z))}
+          onDrop={handleDrop(DISMISS)}
+          className={cn(
+            'flex min-h-[56px] items-center justify-center gap-2 rounded-md border-2 border-dashed border-destructive/40 p-2 text-sm text-destructive transition-colors',
+            overZone === DISMISS && 'bg-destructive/10'
+          )}
+        >
+          <X className="h-4 w-4" aria-hidden /> Drop here to remove
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/TreePicker.tsx
+++ b/packages/ui/src/components/TreePicker.tsx
@@ -1,0 +1,141 @@
+/**
+ * TreePicker — TreeView inside a Popover with search and optional inline create.
+ *
+ * Generic over the node data. Consumers resolve display labels through
+ * `getLabel(data)`. Filter is a recursive substring match on labels.
+ */
+import { Check, Plus, Search } from 'lucide-react';
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
+
+import { cn } from '../lib/utils';
+import { Button } from '../primitives/button';
+import { Input } from '../primitives/input';
+import { Popover, PopoverContent, PopoverTrigger } from '../primitives/popover';
+import { type TreeNode, TreeView } from './TreeView';
+
+export interface TreePickerProps<T> {
+  nodes: TreeNode<T>[];
+  getLabel: (data: T) => string;
+  selectedId?: string | null;
+  onSelect: (node: TreeNode<T>) => void;
+  /** Optional inline create action. */
+  onCreate?: (query: string, parent: TreeNode<T> | null) => void;
+  placeholder?: string;
+  trigger?: ReactNode;
+  triggerLabel?: ReactNode;
+  disabled?: boolean;
+  className?: string;
+}
+
+function filterNodes<T>(nodes: TreeNode<T>[], predicate: (data: T) => boolean): TreeNode<T>[] {
+  const out: TreeNode<T>[] = [];
+  for (const n of nodes) {
+    const kids = filterNodes(n.children, predicate);
+    if (predicate(n.data) || kids.length > 0) {
+      out.push({ ...n, children: kids });
+    }
+  }
+  return out;
+}
+
+function collectIds<T>(nodes: TreeNode<T>[], into: Set<string> = new Set()): Set<string> {
+  for (const n of nodes) {
+    into.add(n.id);
+    collectIds(n.children, into);
+  }
+  return into;
+}
+
+export function TreePicker<T>({
+  nodes,
+  getLabel,
+  selectedId = null,
+  onSelect,
+  onCreate,
+  placeholder = 'Search…',
+  trigger,
+  triggerLabel,
+  disabled,
+  className,
+}: TreePickerProps<T>) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return nodes;
+    const needle = query.toLowerCase();
+    return filterNodes(nodes, (d) => getLabel(d).toLowerCase().includes(needle));
+  }, [nodes, query, getLabel]);
+
+  const expandedIds = useMemo(() => {
+    if (query.trim()) return collectIds(filtered);
+    return new Set<string>();
+  }, [filtered, query]);
+
+  const handleSelect = useCallback(
+    (node: TreeNode<T>) => {
+      onSelect(node);
+      setOpen(false);
+      setQuery('');
+    },
+    [onSelect]
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        {trigger ?? (
+          <Button variant="outline" disabled={disabled} className={className}>
+            {triggerLabel ?? 'Select…'}
+          </Button>
+        )}
+      </PopoverTrigger>
+      <PopoverContent className="w-[320px] p-0" align="start">
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+          <Search className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+          <Input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={placeholder}
+            className="h-7 border-0 p-0 focus-visible:ring-0 shadow-none"
+          />
+        </div>
+        <div className="max-h-[320px] overflow-y-auto p-1.5">
+          {filtered.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-6 text-sm text-muted-foreground">
+              <div>No matches for &ldquo;{query}&rdquo;</div>
+              {onCreate && query.trim() ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    onCreate(query.trim(), null);
+                    setQuery('');
+                  }}
+                >
+                  <Plus /> Create &ldquo;{query.trim()}&rdquo;
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            <TreeView
+              nodes={filtered}
+              selectedId={selectedId}
+              onSelect={handleSelect}
+              expandedIds={expandedIds.size > 0 ? expandedIds : undefined}
+              renderNode={(node, { selected }) => (
+                <div className="flex min-w-0 items-center justify-between gap-2 text-sm">
+                  <span className={cn('truncate', selected && 'font-medium')}>
+                    {getLabel(node.data)}
+                  </span>
+                  {selected ? <Check className="h-3.5 w-3.5 text-primary" aria-hidden /> : null}
+                </div>
+              )}
+            />
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/ui/src/components/TreeView.tsx
+++ b/packages/ui/src/components/TreeView.tsx
@@ -1,8 +1,9 @@
 /**
  * TreeView — recursive read-only tree with expand/collapse and keyboard nav.
  *
- * Generic over the node data shape. Consumers pass a `getChildren` resolver
- * and a `renderNode` renderer. Selection and expansion are controlled or
+ * Generic over the node data shape. Consumers pass pre-built `TreeNode<T>`
+ * objects via `nodes`, where each node includes its `children`, along with a
+ * `renderNode` renderer. Selection and expansion are controlled or
  * uncontrolled via `defaultExpandedIds` / `expandedIds` + `onExpandedChange`.
  */
 import { ChevronRight } from 'lucide-react';

--- a/packages/ui/src/components/TreeView.tsx
+++ b/packages/ui/src/components/TreeView.tsx
@@ -1,0 +1,139 @@
+/**
+ * TreeView — recursive read-only tree with expand/collapse and keyboard nav.
+ *
+ * Generic over the node data shape. Consumers pass a `getChildren` resolver
+ * and a `renderNode` renderer. Selection and expansion are controlled or
+ * uncontrolled via `defaultExpandedIds` / `expandedIds` + `onExpandedChange`.
+ */
+import { ChevronRight } from 'lucide-react';
+import { type KeyboardEvent, type ReactNode, useCallback, useMemo, useState } from 'react';
+
+import { cn } from '../lib/utils';
+
+export interface TreeNode<T> {
+  id: string;
+  data: T;
+  children: TreeNode<T>[];
+}
+
+export interface TreeViewProps<T> {
+  nodes: TreeNode<T>[];
+  renderNode: (
+    node: TreeNode<T>,
+    state: { level: number; expanded: boolean; selected: boolean }
+  ) => ReactNode;
+  selectedId?: string | null;
+  onSelect?: (node: TreeNode<T>) => void;
+  expandedIds?: Set<string>;
+  defaultExpandedIds?: Iterable<string>;
+  onExpandedChange?: (next: Set<string>) => void;
+  className?: string;
+}
+
+export function TreeView<T>({
+  nodes,
+  renderNode,
+  selectedId = null,
+  onSelect,
+  expandedIds,
+  defaultExpandedIds,
+  onExpandedChange,
+  className,
+}: TreeViewProps<T>) {
+  const [internalExpanded, setInternalExpanded] = useState<Set<string>>(
+    () => new Set(defaultExpandedIds ?? [])
+  );
+  const expanded = expandedIds ?? internalExpanded;
+
+  const toggle = useCallback(
+    (id: string) => {
+      const next = new Set(expanded);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      if (!expandedIds) setInternalExpanded(next);
+      onExpandedChange?.(next);
+    },
+    [expanded, expandedIds, onExpandedChange]
+  );
+
+  const flat = useMemo(() => {
+    const out: { node: TreeNode<T>; level: number }[] = [];
+    const walk = (list: TreeNode<T>[], level: number) => {
+      for (const n of list) {
+        out.push({ node: n, level });
+        if (expanded.has(n.id)) walk(n.children, level + 1);
+      }
+    };
+    walk(nodes, 0);
+    return out;
+  }, [nodes, expanded]);
+
+  const handleKeyDown = (index: number) => (e: KeyboardEvent<HTMLLIElement>) => {
+    const entry = flat[index];
+    if (!entry) return;
+    const { node } = entry;
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      if (node.children.length > 0 && !expanded.has(node.id)) toggle(node.id);
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      if (expanded.has(node.id)) toggle(node.id);
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onSelect?.(node);
+    }
+  };
+
+  return (
+    <ul role="tree" className={cn('flex flex-col', className)}>
+      {flat.map((entry, i) => {
+        const { node, level } = entry;
+        const isExpanded = expanded.has(node.id);
+        const hasChildren = node.children.length > 0;
+        const isSelected = node.id === selectedId;
+        return (
+          <li
+            key={node.id}
+            role="treeitem"
+            aria-expanded={hasChildren ? isExpanded : undefined}
+            aria-selected={isSelected}
+            aria-level={level + 1}
+            tabIndex={0}
+            onKeyDown={handleKeyDown(i)}
+            className="outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+          >
+            <div
+              className={cn(
+                'flex items-center gap-1 py-1',
+                isSelected && 'bg-accent text-accent-foreground rounded-sm'
+              )}
+              style={{ paddingLeft: `${level * 14}px` }}
+            >
+              {hasChildren ? (
+                <button
+                  type="button"
+                  aria-label={isExpanded ? 'Collapse' : 'Expand'}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggle(node.id);
+                  }}
+                  className="p-0.5 text-muted-foreground hover:text-foreground"
+                >
+                  <ChevronRight
+                    className={cn('h-3.5 w-3.5 transition-transform', isExpanded && 'rotate-90')}
+                    aria-hidden
+                  />
+                </button>
+              ) : (
+                <span className="inline-block w-[18px]" aria-hidden />
+              )}
+              <div className="flex-1 min-w-0 cursor-pointer" onClick={() => onSelect?.(node)}>
+                {renderNode(node, { level, expanded: isExpanded, selected: isSelected })}
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/ui/src/hooks/useImageProcessor.ts
+++ b/packages/ui/src/hooks/useImageProcessor.ts
@@ -8,8 +8,10 @@
  *
  * External packages (`heic2any`, `browser-image-compression`) are loaded
  * dynamically so consumers only pay for them when this hook is used.
- * If those packages are not installed, calls fall back to raw resize +
- * re-encode via canvas, which strips EXIF as a side-effect.
+ * If `browser-image-compression` is not installed, processing falls back
+ * to raw resize + re-encode via canvas, which strips EXIF as a
+ * side-effect. HEIC/HEIF inputs do not have a canvas fallback: they
+ * require `heic2any`, and processing throws when that package is missing.
  */
 import { useCallback } from 'react';
 

--- a/packages/ui/src/hooks/useImageProcessor.ts
+++ b/packages/ui/src/hooks/useImageProcessor.ts
@@ -1,0 +1,152 @@
+/**
+ * useImageProcessor — client-side image preprocessing for uploads.
+ *
+ * - HEIC/HEIF → JPEG conversion
+ * - Optional compression (browser-image-compression)
+ * - Dimension cap with canvas resize
+ * - EXIF strip (via canvas re-encode)
+ *
+ * External packages (`heic2any`, `browser-image-compression`) are loaded
+ * dynamically so consumers only pay for them when this hook is used.
+ * If those packages are not installed, calls fall back to raw resize +
+ * re-encode via canvas, which strips EXIF as a side-effect.
+ */
+import { useCallback } from 'react';
+
+export interface ImageProcessorOptions {
+  /** Max width/height in pixels. Default 1920. */
+  maxDimension?: number;
+  /** Target max size in MB when compression is available. Default 1. */
+  maxSizeMB?: number;
+  /** JPEG quality (0-1) when re-encoding via canvas. Default 0.85. */
+  quality?: number;
+  /** Output MIME type. Default `image/jpeg`. */
+  outputType?: string;
+}
+
+const HEIC_MIME = ['image/heic', 'image/heif'];
+
+function isHeic(file: File): boolean {
+  const lower = file.name.toLowerCase();
+  return HEIC_MIME.includes(file.type) || lower.endsWith('.heic') || lower.endsWith('.heif');
+}
+
+async function dynamicImport<T>(name: string): Promise<T | null> {
+  try {
+    return (await import(/* @vite-ignore */ name)) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function convertHeicToJpeg(file: File, quality: number): Promise<Blob> {
+  const mod = await dynamicImport<{ default: (args: unknown) => Promise<Blob | Blob[]> }>(
+    'heic2any'
+  );
+  if (!mod) {
+    throw new Error(
+      'HEIC conversion requires "heic2any". Install the package to enable this flow.'
+    );
+  }
+  const result = await mod.default({ blob: file, toType: 'image/jpeg', quality });
+  return Array.isArray(result) ? (result[0] as Blob) : result;
+}
+
+async function resizeAndEncode(
+  blob: Blob,
+  maxDimension: number,
+  quality: number,
+  outputType: string
+): Promise<Blob> {
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const image = new Image();
+      image.onload = () => resolve(image);
+      image.onerror = () => reject(new Error('Could not load image'));
+      image.src = url;
+    });
+    const { width, height } = img;
+    const scale = Math.min(1, maxDimension / Math.max(width, height));
+    const targetW = Math.round(width * scale);
+    const targetH = Math.round(height * scale);
+    const canvas = document.createElement('canvas');
+    canvas.width = targetW;
+    canvas.height = targetH;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Canvas 2D context unavailable');
+    ctx.drawImage(img, 0, 0, targetW, targetH);
+    const result = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, outputType, quality)
+    );
+    if (!result) throw new Error('Canvas encode failed');
+    return result;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+async function compressIfAvailable(
+  blob: Blob,
+  name: string,
+  opts: { maxSizeMB: number; maxWidthOrHeight: number; quality: number; outputType: string }
+): Promise<Blob> {
+  const mod = await dynamicImport<{
+    default: (file: File, options: Record<string, unknown>) => Promise<Blob>;
+  }>('browser-image-compression');
+  if (!mod) return blob;
+  const file = blob instanceof File ? blob : new File([blob], name, { type: opts.outputType });
+  return mod.default(file, {
+    maxSizeMB: opts.maxSizeMB,
+    maxWidthOrHeight: opts.maxWidthOrHeight,
+    initialQuality: opts.quality,
+    fileType: opts.outputType,
+    useWebWorker: true,
+  });
+}
+
+export interface ProcessedImage {
+  file: File;
+  originalSize: number;
+  processedSize: number;
+}
+
+export function useImageProcessor(options: ImageProcessorOptions = {}) {
+  const { maxDimension = 1920, maxSizeMB = 1, quality = 0.85, outputType = 'image/jpeg' } = options;
+
+  const processFile = useCallback(
+    async (file: File): Promise<ProcessedImage> => {
+      const originalSize = file.size;
+      let working: Blob = file;
+      let name = file.name;
+
+      if (isHeic(file)) {
+        working = await convertHeicToJpeg(file, quality);
+        name = name.replace(/\.(heic|heif)$/i, '.jpg');
+      }
+
+      working = await resizeAndEncode(working, maxDimension, quality, outputType);
+      working = await compressIfAvailable(working, name, {
+        maxSizeMB,
+        maxWidthOrHeight: maxDimension,
+        quality,
+        outputType,
+      });
+
+      const processed = new File([working], name, { type: outputType });
+      return { file: processed, originalSize, processedSize: processed.size };
+    },
+    [maxDimension, maxSizeMB, quality, outputType]
+  );
+
+  const processFiles = useCallback(
+    async (files: File[]): Promise<ProcessedImage[]> => {
+      const out: ProcessedImage[] = [];
+      for (const f of files) out.push(await processFile(f));
+      return out;
+    },
+    [processFile]
+  );
+
+  return { processFile, processFiles };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -104,3 +104,25 @@ export * from './components/ConditionBadge';
 export * from './components/LocationBreadcrumb';
 export * from './components/TypeBadge';
 export * from './components/WarrantyBadge';
+
+// Additional standalone primitives (feedback, uploads, media, data viz, layout)
+export * from './components/EmptyState';
+export * from './components/FileUpload';
+export * from './components/ImageWithFallback';
+export * from './components/MediaCard';
+export * from './components/ImageGallery';
+export * from './components/SortableGrid';
+export * from './components/TreeView';
+export * from './components/TreePicker';
+export * from './components/ForceGraph';
+export * from './components/BreakdownChart';
+export * from './components/ScrollShelf';
+export * from './components/ResponsiveCardGrid';
+export * from './components/RadarChart';
+export * from './components/TierListBoard';
+export * from './components/ActionButtonWithDetailPicker';
+export * from './components/DurationFieldInput';
+export * from './components/SettingsForm';
+
+// Hooks
+export * from './hooks/useImageProcessor';


### PR DESCRIPTION
## Summary

Pure additions to `packages/ui/` introducing 18 general-purpose primitives plus one hook so downstream apps can compose richer flows without rebuilding the same behaviour per feature. All additions are self-contained — no new runtime dependencies beyond what `@pops/ui` already has (Radix, lucide, CVA, Tailwind). Heavy optional deps (`heic2any`, `browser-image-compression`) are imported dynamically so consumers only pay for them when they use the relevant hook.

### Components

- **EmptyState** — icon/title/description/action with sm/md/lg size variants
- **FileUpload** — drag-drop uploader with size/count validation, file preview, and a `captureSlot` for mobile camera flows
- **ImageWithFallback** + **MediaCard** — loading skeleton, cascading fallback srcs, overlay/title/subtitle slots
- **ImageGallery** — primary image, thumbnail strip, keyboard-driven lightbox with optional delete
- **SortableGrid** — HTML5 drag-drop reorder via `getKey` / `renderItem` / `onReorder`
- **TreeView** + **TreePicker** — recursive expand/collapse with arrow-key navigation; picker wraps it in a `Popover` with search + inline create
- **ForceGraph** — canvas-based force-directed graph; self-contained verlet physics (spring / charge / centre), zoom & pan, drag, hover/click
- **BreakdownChart** — horizontal bar breakdown with loading/error/empty states
- **ScrollShelf** + **LazyScrollShelf** — horizontal scroller with `IntersectionObserver`-gated rendering
- **ResponsiveCardGrid** (alias **MediaGrid**) — CSS-variable driven responsive grid column count per breakpoint
- **RadarChart** — pure SVG spider chart
- **TierListBoard** — HTML5 drag-drop tier rows with optional dismiss zone
- **ActionButtonWithDetailPicker** — `Button` + `Popover` picker with confirmed/undo states
- **DurationFieldInput** — number + unit selector with multiplier + unit inference
- **SettingsForm** (alias **SectionRenderer**) — manifest-driven form supporting text/number/toggle/select/password/json/duration/textarea fields, auto-save, and test actions

### Hook

- **useImageProcessor** — HEIC→JPEG conversion, canvas resize + EXIF-strip; dynamic imports keep `heic2any` and `browser-image-compression` optional

### Also

- `Button` composite now forwards `asChild` via `@radix-ui/react-slot`
- `NotFoundPage` uses `Button asChild` instead of a `Link` with button classes

### On #2061 (BuildVersion)

Deferred per the issue's own guidance — the BuildVersion widget renders shell-level build metadata that lives outside `@pops/ui`'s scope (env-injected version strings). Keeping it shell-only avoids pulling build-time concerns into the reusable primitives package. Closing for now; can be reopened if a truly generic version primitive proves useful.

## Test plan

- [x] `pnpm lint` — 0 errors (91 pre-existing warnings unrelated to this change)
- [x] `pnpm format:check` — clean
- [x] `pnpm typecheck` — all 16 packages pass
- [x] `@pops/ui` tests — 18/18 pass
- [ ] Storybook / app-level visual smoke test (deferred to consumers as primitives ship unwired)

Closes #1999
Closes #2000
Closes #2002
Closes #2003
Closes #2004
Closes #2005
Closes #2006
Closes #2007
Closes #2008
Closes #2009
Closes #2010
Closes #2011
Closes #2012
Closes #2013
Closes #2014
Closes #2015
Closes #2016
Closes #2061