### PR TITLE
refactor(inventory): decompose page god-files + extract @pops/ui composites

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -327,39 +327,6 @@
       }
     },
     {
-      "files": ["packages/app-inventory/src/pages/ItemFormPage.tsx"],
-      "rules": {
-        "max-lines": ["error", { "max": 950, "skipBlankLines": true, "skipComments": true }],
-        "max-lines-per-function": [
-          "error",
-          { "max": 750, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
-        ],
-        "complexity": ["error", 45]
-      }
-    },
-    {
-      "files": ["packages/app-inventory/src/pages/LocationTreePage.tsx"],
-      "rules": {
-        "max-lines": ["error", { "max": 1050, "skipBlankLines": true, "skipComments": true }],
-        "max-lines-per-function": [
-          "error",
-          { "max": 460, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
-        ],
-        "complexity": ["error", 50]
-      }
-    },
-    {
-      "files": ["packages/app-inventory/src/pages/ItemDetailPage.tsx"],
-      "rules": {
-        "max-lines": ["error", { "max": 800, "skipBlankLines": true, "skipComments": true }],
-        "max-lines-per-function": [
-          "error",
-          { "max": 320, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
-        ],
-        "complexity": ["error", 40]
-      }
-    },
-    {
       "files": ["packages/app-ai/src/pages/AiUsagePage.tsx"],
       "rules": {
         "max-lines": ["error", { "max": 800, "skipBlankLines": true, "skipComments": true }],

--- a/packages/app-inventory/src/components/ConnectDialog.tsx
+++ b/packages/app-inventory/src/components/ConnectDialog.tsx
@@ -56,6 +56,7 @@ export function ConnectDialog({ currentItemId, onConnected }: ConnectDialogProps
       description="Search for an item to connect by name or asset ID."
       searchPlaceholder="Search items..."
       emptyMessage="No items found"
+      getResultKey={(item: InventoryItem) => item.id}
       search={search}
       onSearchChange={setSearch}
       isLoading={isLoading}

--- a/packages/app-inventory/src/components/ConnectDialog.tsx
+++ b/packages/app-inventory/src/components/ConnectDialog.tsx
@@ -1,26 +1,9 @@
-import { Link2, Search } from 'lucide-react';
+import { Link2 } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
 import { trpc } from '@pops/api-client';
-/**
- * ConnectDialog — search and connect inventory items.
- * Opens a dialog with a search input that queries inventory.items.list,
- * displays results, and connects the selected item.
- */
-import {
-  AssetIdBadge,
-  Button,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-  Skeleton,
-  TextInput,
-  TypeBadge,
-} from '@pops/ui';
+import { AssetIdBadge, Button, SearchPickerDialog, TypeBadge } from '@pops/ui';
 
 import type { InventoryItem } from '@pops/api/modules/inventory/items/types';
 
@@ -54,92 +37,55 @@ export function ConnectDialog({ currentItemId, onConnected }: ConnectDialogProps
     },
   });
 
-  const handleConnect = (targetId: string) => {
-    connectMutation.mutate({ itemAId: currentItemId, itemBId: targetId });
-  };
-
-  // Filter out the current item from results
   const results = data?.data.filter((item: InventoryItem) => item.id !== currentItemId) ?? [];
 
   return (
-    <Dialog
+    <SearchPickerDialog
       open={open}
       onOpenChange={(v) => {
         setOpen(v);
         if (!v) setSearch('');
       }}
-    >
-      <DialogTrigger asChild>
+      trigger={
         <Button variant="outline" size="sm">
           <Link2 className="h-4 w-4 mr-1.5" />
           Connect Item
         </Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Connect Item</DialogTitle>
-          <DialogDescription>Search for an item to connect by name or asset ID.</DialogDescription>
-        </DialogHeader>
-
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <TextInput
-            value={search}
-            onChange={(e) => {
-              setSearch(e.target.value);
-            }}
-            placeholder="Search items..."
-            className="pl-9"
-            autoFocus
-          />
-        </div>
-
-        <div className="max-h-64 overflow-y-auto space-y-1">
-          {search.length < 2 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">
-              Type at least 2 characters to search
-            </p>
-          ) : isLoading ? (
-            <div className="space-y-2 py-2">
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-            </div>
-          ) : results.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">No items found</p>
-          ) : (
-            results.map((item: InventoryItem) => (
-              <Button
-                key={item.id}
-                variant="ghost"
-                className="w-full flex items-center justify-between p-2.5 h-auto text-left"
-                onClick={() => {
-                  handleConnect(item.id);
-                }}
-                disabled={connectMutation.isPending}
-              >
-                <div className="flex-1 min-w-0">
-                  <div className="font-medium text-sm">{item.itemName}</div>
-                  {item.brand || item.model || item.assetId || item.type ? (
-                    <div className="flex flex-wrap items-center gap-1 mt-0.5">
-                      {(item.brand || item.model) && (
-                        <span className="text-xs text-muted-foreground">
-                          {[item.brand, item.model].filter(Boolean).join(' · ')}
-                        </span>
-                      )}
-                      {item.assetId && <AssetIdBadge assetId={item.assetId} />}
-                      {item.type && <TypeBadge type={item.type} />}
-                    </div>
-                  ) : (
-                    <span className="text-xs text-muted-foreground mt-0.5">No details</span>
-                  )}
-                </div>
-                <Link2 className="h-4 w-4 text-muted-foreground shrink-0 ml-2" />
-              </Button>
-            ))
-          )}
-        </div>
-      </DialogContent>
-    </Dialog>
+      }
+      title="Connect Item"
+      description="Search for an item to connect by name or asset ID."
+      searchPlaceholder="Search items..."
+      emptyMessage="No items found"
+      search={search}
+      onSearchChange={setSearch}
+      isLoading={isLoading}
+      results={results}
+      renderResult={(item: InventoryItem) => (
+        <Button
+          variant="ghost"
+          className="w-full flex items-center justify-between p-2.5 h-auto text-left"
+          onClick={() => connectMutation.mutate({ itemAId: currentItemId, itemBId: item.id })}
+          disabled={connectMutation.isPending}
+        >
+          <div className="flex-1 min-w-0">
+            <div className="font-medium text-sm">{item.itemName}</div>
+            {item.brand || item.model || item.assetId || item.type ? (
+              <div className="flex flex-wrap items-center gap-1 mt-0.5">
+                {(item.brand || item.model) && (
+                  <span className="text-xs text-muted-foreground">
+                    {[item.brand, item.model].filter(Boolean).join(' · ')}
+                  </span>
+                )}
+                {item.assetId && <AssetIdBadge assetId={item.assetId} />}
+                {item.type && <TypeBadge type={item.type} />}
+              </div>
+            ) : (
+              <span className="text-xs text-muted-foreground mt-0.5">No details</span>
+            )}
+          </div>
+          <Link2 className="h-4 w-4 text-muted-foreground shrink-0 ml-2" />
+        </Button>
+      )}
+    />
   );
 }

--- a/packages/app-inventory/src/components/ConnectionsList.tsx
+++ b/packages/app-inventory/src/components/ConnectionsList.tsx
@@ -28,9 +28,7 @@ export function ConnectionsList({
         <h4 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
           <Link2 className="h-4 w-4 text-muted-foreground" />
           Connections
-          <span className="text-xs font-normal text-muted-foreground">
-            ({connections.length})
-          </span>
+          <span className="text-xs font-normal text-muted-foreground">({connections.length})</span>
         </h4>
       </div>
 

--- a/packages/app-inventory/src/components/ConnectionsList.tsx
+++ b/packages/app-inventory/src/components/ConnectionsList.tsx
@@ -1,11 +1,6 @@
 import { Link2, Plus } from 'lucide-react';
 
-/**
- * ConnectionsList — displays linked inventory items for a given item.
- * Shows connection count header, list of connected items with badges,
- * and a "Connect to…" button placeholder.
- */
-import { AssetIdBadge, Button, cn, TypeBadge } from '@pops/ui';
+import { AssetIdBadge, Button, cn, RelatedItemsList, TypeBadge } from '@pops/ui';
 
 export interface ConnectedItem {
   id: string;
@@ -29,55 +24,51 @@ export function ConnectionsList({
 }: ConnectionsListProps) {
   return (
     <div className={cn('space-y-2', className)}>
-      {/* Header */}
       <div className="flex items-center justify-between">
         <h4 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
           <Link2 className="h-4 w-4 text-muted-foreground" />
           Connections
-          <span className="text-xs font-normal text-muted-foreground">({connections.length})</span>
+          <span className="text-xs font-normal text-muted-foreground">
+            ({connections.length})
+          </span>
         </h4>
       </div>
 
-      {/* List */}
-      {connections.length === 0 ? (
-        <p className="py-3 text-center text-sm text-muted-foreground">No connected items</p>
-      ) : (
-        <ul className="divide-y divide-border rounded-md border">
-          {connections.map((item) => (
-            <li key={item.id}>
-              <button
-                type="button"
-                className={cn(
-                  'flex w-full items-center gap-2 px-3 py-2 text-left text-sm',
-                  'transition-colors hover:bg-accent/50',
-                  onItemClick && 'cursor-pointer'
-                )}
-                onClick={() => onItemClick?.(item.id)}
-                disabled={!onItemClick}
-              >
-                <span className="flex-1 truncate font-medium">{item.itemName}</span>
-                <div className="flex shrink-0 items-center gap-1">
-                  {item.assetId && <AssetIdBadge assetId={item.assetId} />}
-                  {item.type && <TypeBadge type={item.type} />}
-                </div>
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {/* Connect button */}
-      {onConnect && (
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full border-dashed text-muted-foreground hover:text-foreground"
-          prefix={<Plus className="h-3.5 w-3.5" />}
-          onClick={onConnect}
-        >
-          Connect to item…
-        </Button>
-      )}
+      <RelatedItemsList
+        items={connections}
+        emptyMessage="No connected items"
+        renderItem={(item) => (
+          <button
+            type="button"
+            className={cn(
+              'flex w-full items-center gap-2 px-3 py-2 text-left text-sm',
+              'transition-colors hover:bg-accent/50',
+              onItemClick && 'cursor-pointer'
+            )}
+            onClick={() => onItemClick?.(item.id)}
+            disabled={!onItemClick}
+          >
+            <span className="flex-1 truncate font-medium">{item.itemName}</span>
+            <div className="flex shrink-0 items-center gap-1">
+              {item.assetId && <AssetIdBadge assetId={item.assetId} />}
+              {item.type && <TypeBadge type={item.type} />}
+            </div>
+          </button>
+        )}
+        action={
+          onConnect ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full border-dashed text-muted-foreground hover:text-foreground"
+              prefix={<Plus className="h-3.5 w-3.5" />}
+              onClick={onConnect}
+            >
+              Connect to item…
+            </Button>
+          ) : undefined
+        }
+      />
     </div>
   );
 }

--- a/packages/app-inventory/src/components/DashboardWidgets.tsx
+++ b/packages/app-inventory/src/components/DashboardWidgets.tsx
@@ -55,8 +55,13 @@ export function DashboardWidgets() {
 
   if (!data?.data) return null;
 
-  const { itemCount, totalReplacementValue, totalResaleValue, warrantiesExpiringSoon, recentlyAdded } =
-    data.data;
+  const {
+    itemCount,
+    totalReplacementValue,
+    totalResaleValue,
+    warrantiesExpiringSoon,
+    recentlyAdded,
+  } = data.data;
 
   return (
     <div className="grid grid-cols-2 gap-4">

--- a/packages/app-inventory/src/components/DashboardWidgets.tsx
+++ b/packages/app-inventory/src/components/DashboardWidgets.tsx
@@ -1,15 +1,16 @@
-import { Clock, DollarSign, Package, Shield } from 'lucide-react';
+import { Clock, Shield } from 'lucide-react';
 import { useNavigate } from 'react-router';
 
 import { trpc } from '@pops/api-client';
-/**
- * DashboardWidgets — summary statistics for the inventory report dashboard.
- *
- * Renders four stat cards (item count, replacement value, resale value,
- * expiring warranties) plus a recently-added items list. Data is fetched
- * via a single aggregation query. PRD-051/US-01.
- */
-import { Card, CardContent, formatAUD, formatRelativeTime, Skeleton, TypeBadge } from '@pops/ui';
+import {
+  Card,
+  CardContent,
+  formatAUD,
+  formatRelativeTime,
+  Skeleton,
+  StatCard,
+  TypeBadge,
+} from '@pops/ui';
 
 import { ValueByLocationCard, ValueByTypeCard } from './ValueBreakdown';
 
@@ -54,69 +55,29 @@ export function DashboardWidgets() {
 
   if (!data?.data) return null;
 
-  const {
-    itemCount,
-    totalReplacementValue,
-    totalResaleValue,
-    warrantiesExpiringSoon,
-    recentlyAdded,
-  } = data.data;
+  const { itemCount, totalReplacementValue, totalResaleValue, warrantiesExpiringSoon, recentlyAdded } =
+    data.data;
 
   return (
     <div className="grid grid-cols-2 gap-4">
-      <Card>
-        <CardContent className="p-4">
-          <div className="flex items-center gap-2 text-muted-foreground mb-1">
-            <Package className="h-4 w-4" />
-            <span className="text-xs font-medium">Items</span>
-          </div>
-          <div className="text-2xl font-bold tabular-nums">{itemCount}</div>
-        </CardContent>
-      </Card>
+      <StatCard title="Items" value={itemCount} color="slate" />
 
-      <Card>
-        <CardContent className="p-4">
-          <div className="flex items-center gap-2 text-muted-foreground mb-1">
-            <DollarSign className="h-4 w-4" />
-            <span className="text-xs font-medium">Replacement</span>
-          </div>
-          <div className="text-2xl font-bold tabular-nums">{formatAUD(totalReplacementValue)}</div>
-        </CardContent>
-      </Card>
+      <StatCard title="Replacement" value={formatAUD(totalReplacementValue)} color="sky" />
 
-      <Card>
-        <CardContent className="p-4">
-          <div className="flex items-center gap-2 text-muted-foreground mb-1">
-            <DollarSign className="h-4 w-4" />
-            <span className="text-xs font-medium">Resale</span>
-          </div>
-          <div className="text-2xl font-bold tabular-nums">{formatAUD(totalResaleValue)}</div>
-        </CardContent>
-      </Card>
+      <StatCard title="Resale" value={formatAUD(totalResaleValue)} color="violet" />
 
-      <Card
-        role="button"
-        tabIndex={0}
-        className="cursor-pointer hover:bg-muted/50 transition-colors"
+      <StatCard
+        title="Warranties"
+        value={warrantiesExpiringSoon}
+        color={warrantiesExpiringSoon > 0 ? 'amber' : 'slate'}
+        description={
+          <span className="flex items-center gap-1">
+            <Shield className="h-3 w-3" />
+            expiring soon
+          </span>
+        }
         onClick={() => navigate('/inventory/warranties')}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            navigate('/inventory/warranties');
-          }
-        }}
-      >
-        <CardContent className="p-4">
-          <div className="flex items-center gap-2 text-muted-foreground mb-1">
-            <Shield className="h-4 w-4" />
-            <span className="text-xs font-medium">Warranties</span>
-          </div>
-          <div className="text-2xl font-bold tabular-nums">
-            {warrantiesExpiringSoon}
-            <span className="text-sm font-normal text-muted-foreground ml-1">expiring</span>
-          </div>
-        </CardContent>
-      </Card>
+      />
 
       <Card className="col-span-full">
         <CardContent className="p-4">

--- a/packages/app-inventory/src/components/DashboardWidgets.tsx
+++ b/packages/app-inventory/src/components/DashboardWidgets.tsx
@@ -78,7 +78,7 @@ export function DashboardWidgets() {
         description={
           <span className="flex items-center gap-1">
             <Shield className="h-3 w-3" />
-            expiring soon
+            expiring
           </span>
         }
         onClick={() => navigate('/inventory/warranties')}

--- a/packages/app-inventory/src/components/LinkDocumentDialog.tsx
+++ b/packages/app-inventory/src/components/LinkDocumentDialog.tsx
@@ -1,27 +1,10 @@
-import { FileText, Link2, Search } from 'lucide-react';
+import { FileText, Link2 } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
 import { trpc } from '@pops/api-client';
-/**
- * LinkDocumentDialog — search Paperless-ngx and link a document to an inventory item.
- * Opens a dialog with search input, results with thumbnails, document type selector,
- * and link action per result.
- */
-import {
-  Button,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-  Select,
-  Skeleton,
-  TextInput,
-} from '@pops/ui';
+import { Button, SearchPickerDialog, Select } from '@pops/ui';
 
-/** Shape of a document info result from the paperless search API. */
 interface PaperlessDocResult {
   id: number;
   title: string;
@@ -66,20 +49,10 @@ export function LinkDocumentDialog({ itemId, onLinked }: LinkDocumentDialogProps
     },
   });
 
-  const handleLink = (docId: number, title: string) => {
-    setLinkingId(docId);
-    linkMutation.mutate({
-      itemId,
-      paperlessDocumentId: docId,
-      documentType: docType,
-      title,
-    });
-  };
-
   const results: PaperlessDocResult[] = data?.data ?? [];
 
   return (
-    <Dialog
+    <SearchPickerDialog
       open={open}
       onOpenChange={(v) => {
         setOpen(v);
@@ -88,103 +61,64 @@ export function LinkDocumentDialog({ itemId, onLinked }: LinkDocumentDialogProps
           setLinkingId(null);
         }
       }}
-    >
-      <DialogTrigger asChild>
+      trigger={
         <Button variant="outline" size="sm">
           <FileText className="h-4 w-4 mr-1.5" />
           Link Document
         </Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Link Document</DialogTitle>
-          <DialogDescription>
-            Search Paperless-ngx for a document to link to this item.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="flex items-center gap-2">
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <TextInput
-              value={search}
-              onChange={(e) => {
-                setSearch(e.target.value);
-              }}
-              placeholder="Search documents..."
-              className="pl-9"
-              autoFocus
-            />
-          </div>
-          <Select
-            value={docType}
-            onChange={(e) => {
-              setDocType(e.target.value as typeof docType);
-            }}
-            size="sm"
-            options={DOCUMENT_TYPES.map((t) => ({
-              value: t,
-              label: t.charAt(0).toUpperCase() + t.slice(1),
-            }))}
-          />
-        </div>
-
-        <div className="max-h-72 overflow-y-auto space-y-1">
-          {search.length < 2 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">
-              Type at least 2 characters to search
-            </p>
-          ) : isLoading ? (
-            <div className="space-y-2 py-2">
-              <Skeleton className="h-14 w-full" />
-              <Skeleton className="h-14 w-full" />
-              <Skeleton className="h-14 w-full" />
-            </div>
-          ) : results.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">No documents found</p>
+      }
+      title="Link Document"
+      description="Search Paperless-ngx for a document to link to this item."
+      searchPlaceholder="Search documents..."
+      search={search}
+      onSearchChange={setSearch}
+      isLoading={isLoading}
+      results={results}
+      maxResultsHeight="max-h-72"
+      trailing={
+        <Select
+          value={docType}
+          onChange={(e) => setDocType(e.target.value as typeof docType)}
+          size="sm"
+          options={DOCUMENT_TYPES.map((t) => ({
+            value: t,
+            label: t.charAt(0).toUpperCase() + t.slice(1),
+          }))}
+        />
+      }
+      renderResult={(doc: PaperlessDocResult) => (
+        <div className="flex items-center gap-3 p-2.5 rounded-md hover:bg-accent transition-colors">
+          {doc.thumbnailUrl ? (
+            <img src={doc.thumbnailUrl} alt="" className="h-10 w-10 rounded object-cover shrink-0" />
           ) : (
-            results.map((doc) => (
-              <div
-                key={doc.id}
-                className="flex items-center gap-3 p-2.5 rounded-md hover:bg-accent transition-colors"
-              >
-                {doc.thumbnailUrl ? (
-                  <img
-                    src={doc.thumbnailUrl}
-                    alt=""
-                    className="h-10 w-10 rounded object-cover shrink-0"
-                  />
-                ) : (
-                  <div className="h-10 w-10 rounded bg-muted flex items-center justify-center shrink-0">
-                    <FileText className="h-5 w-5 text-muted-foreground" />
-                  </div>
-                )}
-                <div className="flex-1 min-w-0">
-                  <div className="font-medium text-sm truncate">{doc.title}</div>
-                  <div className="text-xs text-muted-foreground">
-                    {doc.created ? new Date(doc.created).toLocaleDateString() : 'No date'}
-                    {doc.originalFileName ? ` · ${doc.originalFileName}` : ''}
-                  </div>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    handleLink(doc.id, doc.title);
-                  }}
-                  disabled={linkMutation.isPending}
-                >
-                  {linkingId === doc.id ? (
-                    <span className="text-xs">Linking...</span>
-                  ) : (
-                    <Link2 className="h-4 w-4" />
-                  )}
-                </Button>
-              </div>
-            ))
+            <div className="h-10 w-10 rounded bg-muted flex items-center justify-center shrink-0">
+              <FileText className="h-5 w-5 text-muted-foreground" />
+            </div>
           )}
+          <div className="flex-1 min-w-0">
+            <div className="font-medium text-sm truncate">{doc.title}</div>
+            <div className="text-xs text-muted-foreground">
+              {doc.created ? new Date(doc.created).toLocaleDateString() : 'No date'}
+              {doc.originalFileName ? ` · ${doc.originalFileName}` : ''}
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setLinkingId(doc.id);
+              linkMutation.mutate({ itemId, paperlessDocumentId: doc.id, documentType: docType, title: doc.title });
+            }}
+            disabled={linkMutation.isPending}
+          >
+            {linkingId === doc.id ? (
+              <span className="text-xs">Linking...</span>
+            ) : (
+              <Link2 className="h-4 w-4" />
+            )}
+          </Button>
         </div>
-      </DialogContent>
-    </Dialog>
+      )}
+    />
   );
 }

--- a/packages/app-inventory/src/components/LinkDocumentDialog.tsx
+++ b/packages/app-inventory/src/components/LinkDocumentDialog.tsx
@@ -74,6 +74,7 @@ export function LinkDocumentDialog({ itemId, onLinked }: LinkDocumentDialogProps
       onSearchChange={setSearch}
       isLoading={isLoading}
       results={results}
+      getResultKey={(doc: PaperlessDocResult) => doc.id}
       maxResultsHeight="max-h-72"
       trailing={
         <Select
@@ -89,7 +90,11 @@ export function LinkDocumentDialog({ itemId, onLinked }: LinkDocumentDialogProps
       renderResult={(doc: PaperlessDocResult) => (
         <div className="flex items-center gap-3 p-2.5 rounded-md hover:bg-accent transition-colors">
           {doc.thumbnailUrl ? (
-            <img src={doc.thumbnailUrl} alt="" className="h-10 w-10 rounded object-cover shrink-0" />
+            <img
+              src={doc.thumbnailUrl}
+              alt=""
+              className="h-10 w-10 rounded object-cover shrink-0"
+            />
           ) : (
             <div className="h-10 w-10 rounded bg-muted flex items-center justify-center shrink-0">
               <FileText className="h-5 w-5 text-muted-foreground" />
@@ -107,7 +112,12 @@ export function LinkDocumentDialog({ itemId, onLinked }: LinkDocumentDialogProps
             size="sm"
             onClick={() => {
               setLinkingId(doc.id);
-              linkMutation.mutate({ itemId, paperlessDocumentId: doc.id, documentType: docType, title: doc.title });
+              linkMutation.mutate({
+                itemId,
+                paperlessDocumentId: doc.id,
+                documentType: docType,
+                title: doc.title,
+              });
             }}
             disabled={linkMutation.isPending}
           >

--- a/packages/app-inventory/src/components/LocationContentsPanel.tsx
+++ b/packages/app-inventory/src/components/LocationContentsPanel.tsx
@@ -3,14 +3,14 @@ import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { trpc } from '@pops/api-client';
-/**
- * LocationContentsPanel — shows inventory items at a selected location.
- *
- * Displays item list with name, asset ID badge, and type badge.
- * Supports "Include sub-locations" toggle, shows item count + total value,
- * and provides navigation to item detail and item creation.
- */
-import { AssetIdBadge, Button, formatAUD, Label, Skeleton, Switch, TypeBadge } from '@pops/ui';
+import {
+  AssetIdBadge,
+  Button,
+  ContainerPanel,
+  formatAUD,
+  Skeleton,
+  TypeBadge,
+} from '@pops/ui';
 
 import type { InventoryItem } from '@pops/api/modules/inventory/items/types';
 
@@ -22,7 +22,6 @@ interface LocationTreeNode {
   children: LocationTreeNode[];
 }
 
-/** Collect all descendant location IDs (excluding the node itself). */
 function collectDescendantIds(node: LocationTreeNode): string[] {
   const ids: string[] = [];
   for (const child of node.children) {
@@ -51,13 +50,11 @@ export function LocationContentsPanel({
   const descendantIds = useMemo(() => collectDescendantIds(node), [node]);
   const hasSubLocations = descendantIds.length > 0;
 
-  // Query items for this location
   const { data: directData, isLoading: directLoading } = trpc.inventory.items.list.useQuery({
     locationId,
     limit: 200,
   });
 
-  // Query items for sub-locations (only when toggled on and sub-locations exist)
   const subLocationQueries = trpc.useQueries((t) =>
     includeSubLocations && hasSubLocations
       ? descendantIds.map((id) => t.inventory.items.list({ locationId: id, limit: 200 }))
@@ -80,58 +77,56 @@ export function LocationContentsPanel({
   }, [directData, includeSubLocations, subLocationItems]);
 
   const totalValue = useMemo(
-    () =>
-      allItems.reduce((sum: number, item: InventoryItem) => sum + (item.replacementValue ?? 0), 0),
+    () => allItems.reduce((sum: number, item: InventoryItem) => sum + (item.replacementValue ?? 0), 0),
     [allItems]
   );
 
+  const summary = isLoading ? (
+    <Skeleton className="h-4 w-36" />
+  ) : (
+    <>
+      {allItems.length} {allItems.length === 1 ? 'item' : 'items'}
+      {totalValue > 0 && <span> · {formatAUD(totalValue)}</span>}
+    </>
+  );
+
+  const emptyState = (
+    <div className="flex flex-col items-center py-8 text-muted-foreground gap-2">
+      <Package className="h-8 w-8 opacity-40" />
+      <p className="text-sm">No items at this location.</p>
+    </div>
+  );
+
   return (
-    <div className="border rounded-lg p-4 space-y-4">
-      {/* Header */}
-      <div>
-        <p className="text-xs text-muted-foreground">{breadcrumb.join(' / ')}</p>
-        <h2 className="text-lg font-semibold mt-1">{locationName}</h2>
-      </div>
-
-      {/* Sub-locations toggle */}
-      {hasSubLocations && (
-        <div className="flex items-center gap-2">
-          <Switch
-            id="include-sub"
-            checked={includeSubLocations}
-            onCheckedChange={setIncludeSubLocations}
-          />
-          <Label htmlFor="include-sub" className="text-sm">
-            Include sub-locations
-          </Label>
-        </div>
-      )}
-
-      {/* Summary */}
-      <div className="text-sm text-muted-foreground">
-        {isLoading ? (
-          <Skeleton className="h-4 w-36" />
-        ) : (
-          <>
-            {allItems.length} {allItems.length === 1 ? 'item' : 'items'}
-            {totalValue > 0 && <span> · {formatAUD(totalValue)}</span>}
-          </>
-        )}
-      </div>
-
-      {/* Item list */}
+    <ContainerPanel
+      title={locationName}
+      subtitle={breadcrumb.join(' / ')}
+      toggle={
+        hasSubLocations
+          ? { label: 'Include sub-locations', value: includeSubLocations, onChange: setIncludeSubLocations, id: 'include-sub' }
+          : undefined
+      }
+      summary={summary}
+      emptyState={!isLoading && allItems.length === 0 ? emptyState : undefined}
+      action={
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full"
+          onClick={() => navigate(`/inventory/items/new?locationId=${encodeURIComponent(locationId)}`)}
+        >
+          <Plus className="h-4 w-4 mr-1.5" />
+          Add Item Here
+        </Button>
+      }
+    >
       {isLoading ? (
         <div className="space-y-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} className="h-10 w-full" />
           ))}
         </div>
-      ) : allItems.length === 0 ? (
-        <div className="flex flex-col items-center py-8 text-muted-foreground gap-2">
-          <Package className="h-8 w-8 opacity-40" />
-          <p className="text-sm">No items at this location.</p>
-        </div>
-      ) : (
+      ) : allItems.length > 0 ? (
         <ul className="space-y-1">
           {allItems.map((item: InventoryItem) => (
             <li key={item.id}>
@@ -148,20 +143,7 @@ export function LocationContentsPanel({
             </li>
           ))}
         </ul>
-      )}
-
-      {/* Add Item Here */}
-      <Button
-        variant="outline"
-        size="sm"
-        className="w-full"
-        onClick={() =>
-          navigate(`/inventory/items/new?locationId=${encodeURIComponent(locationId)}`)
-        }
-      >
-        <Plus className="h-4 w-4 mr-1.5" />
-        Add Item Here
-      </Button>
-    </div>
+      ) : null}
+    </ContainerPanel>
   );
 }

--- a/packages/app-inventory/src/components/LocationContentsPanel.tsx
+++ b/packages/app-inventory/src/components/LocationContentsPanel.tsx
@@ -3,14 +3,7 @@ import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { trpc } from '@pops/api-client';
-import {
-  AssetIdBadge,
-  Button,
-  ContainerPanel,
-  formatAUD,
-  Skeleton,
-  TypeBadge,
-} from '@pops/ui';
+import { AssetIdBadge, Button, ContainerPanel, formatAUD, Skeleton, TypeBadge } from '@pops/ui';
 
 import type { InventoryItem } from '@pops/api/modules/inventory/items/types';
 
@@ -77,7 +70,8 @@ export function LocationContentsPanel({
   }, [directData, includeSubLocations, subLocationItems]);
 
   const totalValue = useMemo(
-    () => allItems.reduce((sum: number, item: InventoryItem) => sum + (item.replacementValue ?? 0), 0),
+    () =>
+      allItems.reduce((sum: number, item: InventoryItem) => sum + (item.replacementValue ?? 0), 0),
     [allItems]
   );
 
@@ -103,7 +97,12 @@ export function LocationContentsPanel({
       subtitle={breadcrumb.join(' / ')}
       toggle={
         hasSubLocations
-          ? { label: 'Include sub-locations', value: includeSubLocations, onChange: setIncludeSubLocations, id: 'include-sub' }
+          ? {
+              label: 'Include sub-locations',
+              value: includeSubLocations,
+              onChange: setIncludeSubLocations,
+              id: 'include-sub',
+            }
           : undefined
       }
       summary={summary}
@@ -113,7 +112,9 @@ export function LocationContentsPanel({
           variant="outline"
           size="sm"
           className="w-full"
-          onClick={() => navigate(`/inventory/items/new?locationId=${encodeURIComponent(locationId)}`)}
+          onClick={() =>
+            navigate(`/inventory/items/new?locationId=${encodeURIComponent(locationId)}`)
+          }
         >
           <Plus className="h-4 w-4 mr-1.5" />
           Add Item Here

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -1,30 +1,6 @@
-import {
-  Camera,
-  ChevronRight,
-  ExternalLink,
-  FileText,
-  GitBranch,
-  Link2,
-  MapPin,
-  Network,
-  Pencil,
-  Store,
-  Trash2,
-  Unlink,
-  X,
-} from 'lucide-react';
-import { useMemo, useState } from 'react';
-import Markdown from 'react-markdown';
-import { Link, useNavigate, useParams } from 'react-router';
-import rehypeSanitize from 'rehype-sanitize';
-import { toast } from 'sonner';
+import { Pencil, Trash2 } from 'lucide-react';
+import { Link } from 'react-router';
 
-import { trpc } from '@pops/api-client';
-/**
- * Item detail page — shows item info and connected items.
- * Route: /inventory/items/:id
- */
-import { useSetPageContext } from '@pops/navigation';
 import {
   Alert,
   AlertDescription,
@@ -38,84 +14,23 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
   AlertTitle,
-  AssetIdBadge,
-  Badge,
   Button,
-  type Condition,
-  ConditionBadge,
   PageHeader,
   Skeleton,
-  TypeBadge,
-  WarrantyBadge,
 } from '@pops/ui';
 
-import { PhotoGallery } from '../components/PhotoGallery';
-import { SortablePhotoGrid } from '../components/SortablePhotoGrid';
-
-import type { ItemConnection } from '@pops/api/modules/inventory/connections/types';
-
-const DOCUMENT_TYPE_LABELS: Record<string, string> = {
-  receipt: 'Receipts',
-  warranty: 'Warranties',
-  manual: 'Manuals',
-  invoice: 'Invoices',
-  other: 'Other',
-};
-import { ConnectDialog } from '../components/ConnectDialog';
-import { ConnectionGraph } from '../components/ConnectionGraph';
-import { ConnectionTracePanel } from '../components/ConnectionTracePanel';
-import { LinkDocumentDialog } from '../components/LinkDocumentDialog';
+import { ConnectionsSection } from './item-detail-page/sections/ConnectionsSection';
+import { DetailHeaderSection } from './item-detail-page/sections/DetailHeaderSection';
+import { DocumentsSection } from './item-detail-page/sections/DocumentsSection';
+import { PhotoGallerySection } from './item-detail-page/sections/PhotoGallerySection';
+import { useItemDetailPageModel } from './item-detail-page/useItemDetailPageModel';
 
 export function ItemDetailPage() {
-  const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
-  const utils = trpc.useUtils();
-
   const {
-    data: itemData,
-    isLoading,
-    error,
-  } = trpc.inventory.items.get.useQuery({ id: id! }, { enabled: !!id });
-
-  const { data: connectionsData, isLoading: connectionsLoading } =
-    trpc.inventory.connections.listForItem.useQuery({ itemId: id! }, { enabled: !!id });
-
-  const { data: photosData } = trpc.inventory.photos.listForItem.useQuery(
-    { itemId: id! },
-    { enabled: !!id }
-  );
-
-  const [showGraph, setShowGraph] = useState(false);
-
-  const deleteMutation = trpc.inventory.items.delete.useMutation({
-    onSuccess: () => {
-      toast.success('Item deleted');
-      void navigate('/inventory');
-    },
-    onError: (err) => {
-      toast.error(`Failed to delete: ${err.message}`);
-    },
-  });
-
-  const disconnectMutation = trpc.inventory.connections.disconnect.useMutation({
-    onSuccess: () => {
-      toast.success('Items disconnected');
-      void utils.inventory.connections.listForItem.invalidate({ itemId: id! });
-    },
-    onError: (err) => {
-      toast.error(`Failed to disconnect: ${err.message}`);
-    },
-  });
-
-  const itemEntity = useMemo(
-    () => ({
-      uri: `pops:inventory/item/${id ?? ''}`,
-      type: 'item' as const,
-      title: itemData?.data?.itemName ?? '',
-    }),
-    [id, itemData?.data?.itemName]
-  );
-  useSetPageContext({ page: 'item-detail', pageType: 'drill-down', entity: itemEntity });
+    id, itemData, isLoading, error,
+    connectionsData, connectionsLoading,
+    photosData, deleteMutation, disconnectMutation, utils,
+  } = useItemDetailPageModel();
 
   if (isLoading) {
     return (
@@ -123,10 +38,7 @@ export function ItemDetailPage() {
         <Skeleton className="h-8 w-48" />
         <Skeleton className="h-6 w-32" />
         <div className="grid grid-cols-2 gap-4">
-          <Skeleton className="h-20" />
-          <Skeleton className="h-20" />
-          <Skeleton className="h-20" />
-          <Skeleton className="h-20" />
+          {Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-20" />)}
         </div>
       </div>
     );
@@ -140,10 +52,7 @@ export function ItemDetailPage() {
           <AlertTitle>{is404 ? 'Item not found' : 'Error'}</AlertTitle>
           <AlertDescription>{is404 ? "This item doesn't exist." : error.message}</AlertDescription>
         </Alert>
-        <Link
-          to="/inventory"
-          className="mt-4 inline-block text-sm text-app-accent hover:text-app-accent/80 underline font-medium"
-        >
+        <Link to="/inventory" className="mt-4 inline-block text-sm text-app-accent hover:text-app-accent/80 underline font-medium">
           Back to inventory
         </Link>
       </div>
@@ -151,7 +60,6 @@ export function ItemDetailPage() {
   }
 
   if (!itemData) return null;
-
   const item = itemData.data;
 
   return (
@@ -159,9 +67,7 @@ export function ItemDetailPage() {
       <PageHeader
         title={
           <div>
-            <span className="text-2xl md:text-3xl font-extrabold tracking-tight">
-              {item.itemName}
-            </span>
+            <span className="text-2xl md:text-3xl font-extrabold tracking-tight">{item.itemName}</span>
             {(item.brand || item.model) && (
               <p className="text-muted-foreground font-medium uppercase text-xs tracking-widest opacity-80 mt-1">
                 {[item.brand, item.model].filter(Boolean).join(' • ')}
@@ -174,11 +80,7 @@ export function ItemDetailPage() {
         actions={
           <div className="flex items-center gap-2">
             <Link to={`/inventory/items/${id}/edit`}>
-              <Button
-                variant="outline"
-                size="sm"
-                className="font-bold border-app-accent/20 hover:border-app-accent/50 hover:bg-app-accent/5 transition-colors"
-              >
+              <Button variant="outline" size="sm" className="font-bold border-app-accent/20 hover:border-app-accent/50 hover:bg-app-accent/5 transition-colors">
                 <Pencil className="h-4 w-4 mr-2 text-app-accent" />
                 Edit
               </Button>
@@ -194,21 +96,12 @@ export function ItemDetailPage() {
                 <AlertDialogHeader>
                   <AlertDialogTitle>Delete {item.itemName}?</AlertDialogTitle>
                   <AlertDialogDescription>
-                    This will also remove {connectionsData?.data.length ?? 0} connection
-                    {(connectionsData?.data.length ?? 0) !== 1 ? 's' : ''} and{' '}
-                    {photosData?.pagination?.total ?? 0} photo
-                    {(photosData?.pagination?.total ?? 0) !== 1 ? 's' : ''}.
+                    This will also remove {connectionsData?.data.length ?? 0} connection{(connectionsData?.data.length ?? 0) !== 1 ? 's' : ''} and {photosData?.pagination?.total ?? 0} photo{(photosData?.pagination?.total ?? 0) !== 1 ? 's' : ''}.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
                   <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
-                    variant="ghost"
-                    className="text-destructive hover:text-destructive"
-                    onClick={() => {
-                      deleteMutation.mutate({ id: id! });
-                    }}
-                  >
+                  <AlertDialogAction variant="ghost" className="text-destructive hover:text-destructive" onClick={() => deleteMutation.mutate({ id: id! })}>
                     Delete
                   </AlertDialogAction>
                 </AlertDialogFooter>
@@ -220,531 +113,19 @@ export function ItemDetailPage() {
         className="mb-8"
       />
 
-      {/* Details Grid */}
-      <div className="bg-card border-2 border-app-accent/10 rounded-2xl overflow-hidden mb-8 shadow-sm shadow-app-accent/5">
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-6 p-6">
-          {item.type && <DetailField label="Type" value={<TypeBadge type={item.type} />} />}
-          {item.condition && (
-            <DetailField
-              label="Condition"
-              value={<ConditionBadge condition={item.condition as Condition} />}
-            />
-          )}
-          <DetailField
-            label="Warranty"
-            value={<WarrantyBadge warrantyExpiry={item.warrantyExpires ?? null} />}
-          />
-          {item.room && <DetailField label="Room" value={item.room} />}
-          {item.assetId && (
-            <DetailField
-              label="Asset ID"
-              value={
-                <Badge variant="outline" className="font-mono bg-muted/50">
-                  {item.assetId}
-                </Badge>
-              }
-            />
-          )}
-          <DetailField
-            label="Status"
-            value={
-              item.inUse ? (
-                <Badge className="bg-app-accent/10 text-app-accent border-app-accent/20 hover:bg-app-accent/15">
-                  In Use
-                </Badge>
-              ) : (
-                <Badge variant="secondary">Stored</Badge>
-              )
-            }
-          />
-          {item.purchaseDate && (
-            <DetailField
-              label="Purchased"
-              value={new Date(item.purchaseDate).toLocaleDateString('en-AU', {
-                year: 'numeric',
-                month: 'short',
-              })}
-            />
-          )}
-          {item.replacementValue !== null && (
-            <DetailField
-              label="Replacement"
-              value={
-                <span className="text-app-accent font-bold">{`$${item.replacementValue.toLocaleString()}`}</span>
-              }
-            />
-          )}
-        </div>
-      </div>
+      <DetailHeaderSection item={item} />
+      <PhotoGallerySection itemId={id!} />
 
-      {/* Location Breadcrumb */}
-      <LocationBreadcrumb locationId={item.locationId} />
-
-      {/* Purchase Info */}
-      <PurchaseLinkSection
-        purchaseTransactionId={item.purchaseTransactionId}
-        purchasedFromId={item.purchasedFromId}
-        purchasedFromName={item.purchasedFromName}
+      <ConnectionsSection
+        itemId={id!}
+        connections={connectionsData?.data ?? []}
+        connectionsLoading={connectionsLoading}
+        isDisconnecting={disconnectMutation.isPending}
+        onConnected={() => void utils.inventory.connections.listForItem.invalidate({ itemId: id! })}
+        onDisconnect={(conn) => disconnectMutation.mutate({ itemAId: conn.itemAId, itemBId: conn.itemBId })}
       />
 
-      {item.notes && (
-        <div className="mb-8">
-          <h2 className="text-lg font-semibold mb-2">Notes</h2>
-          <div className="text-muted-foreground prose prose-sm dark:prose-invert max-w-none">
-            <Markdown rehypePlugins={[rehypeSanitize]}>{item.notes}</Markdown>
-          </div>
-        </div>
-      )}
-
-      {/* Photos */}
-      <PhotosSection itemId={id!} />
-
-      {/* Connections */}
-      <section>
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold flex items-center gap-2">
-            <Link2 className="h-5 w-5" />
-            Connected Items
-          </h2>
-          <ConnectDialog
-            currentItemId={id!}
-            onConnected={() => {
-              void utils.inventory.connections.listForItem.invalidate({
-                itemId: id!,
-              });
-            }}
-          />
-        </div>
-
-        {connectionsLoading ? (
-          <div className="space-y-2">
-            <Skeleton className="h-12 w-full" />
-            <Skeleton className="h-12 w-full" />
-          </div>
-        ) : connectionsData?.data.length ? (
-          <div className="space-y-2">
-            {connectionsData.data.map((conn: ItemConnection) => (
-              <ConnectionRow
-                key={conn.id}
-                connectedItemId={conn.itemAId === id ? conn.itemBId : conn.itemAId}
-                onDisconnect={() => {
-                  disconnectMutation.mutate({ itemAId: conn.itemAId, itemBId: conn.itemBId });
-                }}
-                isDisconnecting={disconnectMutation.isPending}
-              />
-            ))}
-          </div>
-        ) : (
-          <p className="text-muted-foreground text-sm">No connected items yet.</p>
-        )}
-      </section>
-
-      {/* Connection Chain Trace */}
-      {connectionsData?.data.length ? (
-        <section>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold flex items-center gap-2">
-              <GitBranch className="h-5 w-5" />
-              Connection Chain
-            </h2>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setShowGraph((v) => !v);
-              }}
-            >
-              <Network className="h-4 w-4 mr-1.5" />
-              {showGraph ? 'Hide Graph' : 'View Graph'}
-            </Button>
-          </div>
-          {showGraph ? <ConnectionGraph itemId={id!} /> : <ConnectionTracePanel itemId={id!} />}
-        </section>
-      ) : null}
-
-      {/* Documents — hidden when Paperless-ngx not configured */}
       <DocumentsSection itemId={id!} />
-    </div>
-  );
-}
-
-function LocationBreadcrumb({ locationId }: { locationId: string | null }) {
-  const { data: pathData } = trpc.inventory.locations.getPath.useQuery(
-    { id: locationId! },
-    { enabled: !!locationId }
-  );
-
-  return (
-    <div className="mb-8 flex items-center gap-1.5 text-sm" data-testid="location-breadcrumb">
-      <MapPin className="h-4 w-4 text-muted-foreground shrink-0" />
-      {!locationId ? (
-        <span className="text-muted-foreground">No location assigned</span>
-      ) : pathData?.data ? (
-        pathData.data.map((loc, i) => (
-          <span key={loc.id} className="flex items-center gap-1.5">
-            {i > 0 && <ChevronRight className="h-3 w-3 text-muted-foreground" />}
-            <Link
-              to={`/inventory?location=${loc.id}`}
-              className="text-app-accent hover:text-app-accent/80 hover:underline font-medium"
-            >
-              {loc.name}
-            </Link>
-          </span>
-        ))
-      ) : (
-        <Skeleton className="h-4 w-32" />
-      )}
-    </div>
-  );
-}
-
-function PurchaseLinkSection({
-  purchaseTransactionId,
-  purchasedFromId,
-  purchasedFromName,
-}: {
-  purchaseTransactionId: string | null;
-  purchasedFromId: string | null;
-  purchasedFromName: string | null;
-}) {
-  if (!purchaseTransactionId && !purchasedFromId) return null;
-
-  return (
-    <div className="mb-8 flex items-center gap-4 text-sm" data-testid="purchase-link-section">
-      {purchaseTransactionId && (
-        <Link
-          to={`/finance/transactions/${purchaseTransactionId}`}
-          className="flex items-center gap-1.5 text-app-accent hover:text-app-accent/80 hover:underline font-medium"
-        >
-          <ExternalLink className="h-4 w-4" />
-          View transaction
-        </Link>
-      )}
-      {purchasedFromId && purchasedFromName && (
-        <span className="flex items-center gap-1.5 text-muted-foreground">
-          <Store className="h-4 w-4" />
-          {purchasedFromName}
-        </span>
-      )}
-    </div>
-  );
-}
-
-function DetailField({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div>
-      <dt className="text-xs font-bold text-muted-foreground uppercase tracking-widest mb-1">
-        {label}
-      </dt>
-      <dd className="font-semibold text-foreground">{value}</dd>
-    </div>
-  );
-}
-
-function DocumentsSection({ itemId }: { itemId: string }) {
-  const { data: statusData, isLoading: statusLoading } = trpc.inventory.paperless.status.useQuery();
-
-  const status = statusData?.data;
-
-  // Not configured — hide entirely
-  if (!statusLoading && !status?.configured) return null;
-
-  // Loading status check
-  if (statusLoading) {
-    return (
-      <section className="mt-8">
-        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
-          <FileText className="h-5 w-5" />
-          Documents
-        </h2>
-        <Skeleton className="h-12 w-full" />
-      </section>
-    );
-  }
-
-  // Configured but unreachable
-  if (!status?.available) {
-    return (
-      <section className="mt-8">
-        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
-          <FileText className="h-5 w-5" />
-          Documents
-        </h2>
-        <p className="text-sm text-muted-foreground">Paperless-ngx unavailable</p>
-      </section>
-    );
-  }
-
-  return <DocumentsList itemId={itemId} paperlessBaseUrl={status?.baseUrl ?? null} />;
-}
-
-function DocumentsList({
-  itemId,
-  paperlessBaseUrl,
-}: {
-  itemId: string;
-  paperlessBaseUrl: string | null;
-}) {
-  const utils = trpc.useUtils();
-  const { data, isLoading } = trpc.inventory.documents.listForItem.useQuery({
-    itemId,
-  });
-
-  const unlinkMutation = trpc.inventory.documents.unlink.useMutation({
-    onSuccess: () => {
-      toast.success('Document unlinked');
-      void utils.inventory.documents.listForItem.invalidate({ itemId });
-    },
-    onError: (err: { message: string }) => {
-      toast.error(`Failed to unlink: ${err.message}`);
-    },
-  });
-
-  // Group documents by type
-  const grouped = new Map<string, typeof docs>();
-  const docs = data?.data ?? [];
-  for (const doc of docs) {
-    const type = doc.documentType;
-    const list = grouped.get(type) ?? [];
-    list.push(doc);
-    grouped.set(type, list);
-  }
-
-  const typeOrder = ['receipt', 'warranty', 'manual', 'invoice', 'other'];
-  const sortedTypes = [...grouped.keys()].toSorted(
-    (a, b) => (typeOrder.indexOf(a) ?? 99) - (typeOrder.indexOf(b) ?? 99)
-  );
-
-  return (
-    <section className="mt-8">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold flex items-center gap-2">
-          <FileText className="h-5 w-5" />
-          Documents
-          {docs.length > 0 ? (
-            <span className="text-sm font-normal text-muted-foreground">({docs.length})</span>
-          ) : null}
-        </h2>
-        <LinkDocumentDialog
-          itemId={itemId}
-          onLinked={() => {
-            void utils.inventory.documents.listForItem.invalidate({ itemId });
-          }}
-        />
-      </div>
-      {isLoading ? (
-        <div className="space-y-2">
-          <Skeleton className="h-12 w-full" />
-          <Skeleton className="h-12 w-full" />
-        </div>
-      ) : docs.length > 0 ? (
-        <div className="space-y-4">
-          {sortedTypes.map((type) => (
-            <div key={type}>
-              <h3 className="text-sm font-medium text-muted-foreground mb-2">
-                {DOCUMENT_TYPE_LABELS[type] ?? type}
-              </h3>
-              <div className="space-y-1.5">
-                {grouped.get(type)?.map((doc) => (
-                  <div
-                    key={doc.id}
-                    className="flex items-center justify-between p-3 rounded-lg border"
-                  >
-                    <div className="flex items-center gap-3 flex-1 min-w-0">
-                      <DocumentThumbnail documentId={doc.paperlessDocumentId} />
-                      <div className="min-w-0 flex-1">
-                        <span className="font-medium text-sm truncate block">
-                          {doc.title ?? `Document #${doc.paperlessDocumentId}`}
-                        </span>
-                        <span className="text-xs text-muted-foreground">
-                          Linked {new Date(doc.createdAt).toLocaleDateString()}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-1 shrink-0">
-                      {paperlessBaseUrl && (
-                        <a
-                          href={`${paperlessBaseUrl}/documents/${doc.paperlessDocumentId}/details`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="relative inline-flex items-center justify-center size-9 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent before:absolute before:content-[''] before:-inset-1"
-                          title="View in Paperless"
-                          aria-label="View in Paperless"
-                        >
-                          <ExternalLink className="h-4 w-4" />
-                        </a>
-                      )}
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="text-destructive hover:text-destructive shrink-0"
-                        onClick={() => {
-                          unlinkMutation.mutate({ id: doc.id });
-                        }}
-                        disabled={unlinkMutation.isPending}
-                        title="Unlink document"
-                        aria-label="Unlink document"
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <p className="text-muted-foreground text-sm">No documents linked yet.</p>
-      )}
-    </section>
-  );
-}
-
-function DocumentThumbnail({ documentId }: { documentId: number }) {
-  const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
-  const src = `/inventory/documents/${documentId}/thumbnail`;
-
-  if (status === 'error') {
-    return (
-      <div
-        className="h-12 w-10 rounded bg-muted flex items-center justify-center shrink-0"
-        title="Document unavailable"
-      >
-        <FileText className="h-5 w-5 text-muted-foreground" />
-      </div>
-    );
-  }
-
-  return (
-    <div className="h-12 w-10 shrink-0 relative">
-      {status === 'loading' && <Skeleton className="absolute inset-0 rounded" />}
-      <img
-        src={src}
-        alt="Document thumbnail"
-        className="h-12 w-10 rounded object-cover"
-        onLoad={() => {
-          setStatus('loaded');
-        }}
-        onError={() => {
-          setStatus('error');
-        }}
-      />
-    </div>
-  );
-}
-
-function PhotosSection({ itemId }: { itemId: string }) {
-  const utils = trpc.useUtils();
-  const { data, isLoading } = trpc.inventory.photos.listForItem.useQuery({ itemId });
-
-  const reorderMutation = trpc.inventory.photos.reorder.useMutation({
-    onSuccess: () => {
-      void utils.inventory.photos.listForItem.invalidate({ itemId });
-    },
-    onError: (err) => {
-      toast.error(`Failed to reorder photos: ${err.message}`);
-    },
-  });
-
-  const photos = data?.data ?? [];
-
-  if (isLoading) {
-    return (
-      <section className="mb-8">
-        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
-          <Camera className="h-5 w-5" />
-          Photos
-        </h2>
-        <Skeleton className="h-48 w-full rounded-lg" />
-      </section>
-    );
-  }
-
-  const baseUrl = '/api/inventory/photos';
-
-  return (
-    <section className="mb-8">
-      <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
-        <Camera className="h-5 w-5" />
-        Photos
-        {photos.length > 0 && (
-          <span className="text-sm font-normal text-muted-foreground">({photos.length})</span>
-        )}
-      </h2>
-
-      {/* Primary photo + thumbnail strip + lightbox (or placeholder) */}
-      <PhotoGallery photos={photos} baseUrl={baseUrl} />
-
-      {/* Drag-and-drop reorder */}
-      {photos.length > 1 && (
-        <div className="mt-4">
-          <p className="text-xs text-muted-foreground mb-2">Drag to reorder</p>
-          <SortablePhotoGrid
-            photos={photos}
-            baseUrl={baseUrl}
-            isReordering={reorderMutation.isPending}
-            onReorder={(orderedIds) => {
-              reorderMutation.mutate({ itemId, orderedIds });
-            }}
-          />
-        </div>
-      )}
-    </section>
-  );
-}
-
-function ConnectionRow({
-  connectedItemId,
-  onDisconnect,
-  isDisconnecting,
-}: {
-  connectedItemId: string;
-  onDisconnect: () => void;
-  isDisconnecting: boolean;
-}) {
-  const { data } = trpc.inventory.items.get.useQuery({ id: connectedItemId });
-  const item = data?.data;
-  const itemName = item?.itemName ?? connectedItemId;
-
-  return (
-    <div className="flex items-center justify-between p-3 rounded-lg border">
-      <Link to={`/inventory/items/${connectedItemId}`} className="flex-1 min-w-0 hover:underline">
-        <span className="font-medium">{itemName}</span>
-        {item?.brand && <span className="text-muted-foreground text-sm ml-2">{item.brand}</span>}
-        {(item?.assetId || item?.type) && (
-          <div className="flex flex-wrap items-center gap-1 mt-0.5">
-            {item.assetId && <AssetIdBadge assetId={item.assetId} />}
-            {item.type && <TypeBadge type={item.type} />}
-          </div>
-        )}
-      </Link>
-      <AlertDialog>
-        <AlertDialogTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-destructive hover:text-destructive shrink-0"
-            disabled={isDisconnecting}
-            title="Disconnect"
-            aria-label="Disconnect"
-          >
-            <Unlink className="h-4 w-4" />
-          </Button>
-        </AlertDialogTrigger>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Disconnect {itemName}?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will remove the connection between these items.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={onDisconnect}>Disconnect</AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   );
 }

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -31,9 +31,12 @@ export function ItemDetailPage() {
     itemData,
     isLoading,
     error,
+    locationPath,
     connectionsData,
     connectionsLoading,
     photosData,
+    photosLoading,
+    reorderPhotosMutation,
     deleteMutation,
     disconnectMutation,
     utils,
@@ -138,8 +141,13 @@ export function ItemDetailPage() {
         className="mb-8"
       />
 
-      <DetailHeaderSection item={item} />
-      <PhotoGallerySection itemId={id!} />
+      <DetailHeaderSection item={item} locationPath={locationPath} />
+      <PhotoGallerySection
+        photos={photosData?.data ?? []}
+        isLoading={photosLoading}
+        isReordering={reorderPhotosMutation.isPending}
+        onReorder={(orderedIds) => reorderPhotosMutation.mutate({ itemId: id!, orderedIds })}
+      />
 
       <ConnectionsSection
         itemId={id!}

--- a/packages/app-inventory/src/pages/ItemDetailPage.tsx
+++ b/packages/app-inventory/src/pages/ItemDetailPage.tsx
@@ -27,9 +27,16 @@ import { useItemDetailPageModel } from './item-detail-page/useItemDetailPageMode
 
 export function ItemDetailPage() {
   const {
-    id, itemData, isLoading, error,
-    connectionsData, connectionsLoading,
-    photosData, deleteMutation, disconnectMutation, utils,
+    id,
+    itemData,
+    isLoading,
+    error,
+    connectionsData,
+    connectionsLoading,
+    photosData,
+    deleteMutation,
+    disconnectMutation,
+    utils,
   } = useItemDetailPageModel();
 
   if (isLoading) {
@@ -38,7 +45,9 @@ export function ItemDetailPage() {
         <Skeleton className="h-8 w-48" />
         <Skeleton className="h-6 w-32" />
         <div className="grid grid-cols-2 gap-4">
-          {Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-20" />)}
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-20" />
+          ))}
         </div>
       </div>
     );
@@ -52,7 +61,10 @@ export function ItemDetailPage() {
           <AlertTitle>{is404 ? 'Item not found' : 'Error'}</AlertTitle>
           <AlertDescription>{is404 ? "This item doesn't exist." : error.message}</AlertDescription>
         </Alert>
-        <Link to="/inventory" className="mt-4 inline-block text-sm text-app-accent hover:text-app-accent/80 underline font-medium">
+        <Link
+          to="/inventory"
+          className="mt-4 inline-block text-sm text-app-accent hover:text-app-accent/80 underline font-medium"
+        >
           Back to inventory
         </Link>
       </div>
@@ -67,7 +79,9 @@ export function ItemDetailPage() {
       <PageHeader
         title={
           <div>
-            <span className="text-2xl md:text-3xl font-extrabold tracking-tight">{item.itemName}</span>
+            <span className="text-2xl md:text-3xl font-extrabold tracking-tight">
+              {item.itemName}
+            </span>
             {(item.brand || item.model) && (
               <p className="text-muted-foreground font-medium uppercase text-xs tracking-widest opacity-80 mt-1">
                 {[item.brand, item.model].filter(Boolean).join(' • ')}
@@ -80,7 +94,11 @@ export function ItemDetailPage() {
         actions={
           <div className="flex items-center gap-2">
             <Link to={`/inventory/items/${id}/edit`}>
-              <Button variant="outline" size="sm" className="font-bold border-app-accent/20 hover:border-app-accent/50 hover:bg-app-accent/5 transition-colors">
+              <Button
+                variant="outline"
+                size="sm"
+                className="font-bold border-app-accent/20 hover:border-app-accent/50 hover:bg-app-accent/5 transition-colors"
+              >
                 <Pencil className="h-4 w-4 mr-2 text-app-accent" />
                 Edit
               </Button>
@@ -96,12 +114,19 @@ export function ItemDetailPage() {
                 <AlertDialogHeader>
                   <AlertDialogTitle>Delete {item.itemName}?</AlertDialogTitle>
                   <AlertDialogDescription>
-                    This will also remove {connectionsData?.data.length ?? 0} connection{(connectionsData?.data.length ?? 0) !== 1 ? 's' : ''} and {photosData?.pagination?.total ?? 0} photo{(photosData?.pagination?.total ?? 0) !== 1 ? 's' : ''}.
+                    This will also remove {connectionsData?.data.length ?? 0} connection
+                    {(connectionsData?.data.length ?? 0) !== 1 ? 's' : ''} and{' '}
+                    {photosData?.pagination?.total ?? 0} photo
+                    {(photosData?.pagination?.total ?? 0) !== 1 ? 's' : ''}.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
                   <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction variant="ghost" className="text-destructive hover:text-destructive" onClick={() => deleteMutation.mutate({ id: id! })}>
+                  <AlertDialogAction
+                    variant="ghost"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() => deleteMutation.mutate({ id: id! })}
+                  >
                     Delete
                   </AlertDialogAction>
                 </AlertDialogFooter>
@@ -122,7 +147,9 @@ export function ItemDetailPage() {
         connectionsLoading={connectionsLoading}
         isDisconnecting={disconnectMutation.isPending}
         onConnected={() => void utils.inventory.connections.listForItem.invalidate({ itemId: id! })}
-        onDisconnect={(conn) => disconnectMutation.mutate({ itemAId: conn.itemAId, itemBId: conn.itemBId })}
+        onDisconnect={(conn) =>
+          disconnectMutation.mutate({ itemAId: conn.itemAId, itemBId: conn.itemBId })
+        }
       />
 
       <DocumentsSection itemId={id!} />

--- a/packages/app-inventory/src/pages/ItemFormPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.test.tsx
@@ -128,7 +128,7 @@ vi.mock('@pops/api-client', () => ({
             return { ...result, refetch: mockRefetchPhotos };
           },
         },
-        attach: {
+        upload: {
           useMutation: (opts?: Record<string, unknown>) => ({
             mutateAsync: mockAttachMutate,
             isPending: false,

--- a/packages/app-inventory/src/pages/ItemFormPage.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.tsx
@@ -1,14 +1,7 @@
 import { Save } from 'lucide-react';
 import { Link } from 'react-router';
 
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-  Button,
-  PageHeader,
-  Skeleton,
-} from '@pops/ui';
+import { Alert, AlertDescription, AlertTitle, Button, PageHeader, Skeleton } from '@pops/ui';
 
 import { ConnectionsSection } from './item-form-page/sections/ConnectionsSection';
 import { CoreFieldsSection } from './item-form-page/sections/CoreFieldsSection';
@@ -21,17 +14,49 @@ export { extractPrefix } from './item-form-page/useItemFormPageModel';
 export function ItemFormPage() {
   const model = useItemFormPageModel();
   const {
-    id, isEditMode, form, assetIdError, assetIdChecking, generating,
-    notesPreview, setNotesPreview, uploadFiles, deleteConfirmId, setDeleteConfirmId,
-    existingPhotos, imageProcessing, pendingConnections, setPendingConnections,
-    connectionSearch, setConnectionSearch, searchResults, searchLoading,
-    locationTree, createLocationMutation, itemData, isLoading, error,
-    reorderMutation, photoDeleteMutation, isMutating,
-    handleFilesSelected, handleRemoveUpload, handleDeletePhoto, confirmDeletePhoto,
-    validateAssetIdUniqueness, handleAutoGenerate, onSubmit,
+    id,
+    isEditMode,
+    form,
+    assetIdError,
+    assetIdChecking,
+    generating,
+    notesPreview,
+    setNotesPreview,
+    uploadFiles,
+    deleteConfirmId,
+    setDeleteConfirmId,
+    existingPhotos,
+    imageProcessing,
+    pendingConnections,
+    setPendingConnections,
+    connectionSearch,
+    setConnectionSearch,
+    searchResults,
+    searchLoading,
+    locationTree,
+    createLocationMutation,
+    itemData,
+    isLoading,
+    error,
+    reorderMutation,
+    photoDeleteMutation,
+    isMutating,
+    handleFilesSelected,
+    handleRemoveUpload,
+    handleDeletePhoto,
+    confirmDeletePhoto,
+    validateAssetIdUniqueness,
+    handleAutoGenerate,
+    onSubmit,
   } = model;
 
-  const { register, handleSubmit, watch, setValue, formState: { errors } } = form;
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors },
+  } = form;
 
   if (isEditMode && isLoading) {
     return (
@@ -52,7 +77,10 @@ export function ItemFormPage() {
           <AlertTitle>{is404 ? 'Item not found' : 'Error'}</AlertTitle>
           <AlertDescription>{is404 ? "This item doesn't exist." : error.message}</AlertDescription>
         </Alert>
-        <Link to="/inventory" className="mt-4 inline-block text-sm text-app-accent hover:text-app-accent/80 underline font-medium">
+        <Link
+          to="/inventory"
+          className="mt-4 inline-block text-sm text-app-accent hover:text-app-accent/80 underline font-medium"
+        >
           Back to inventory
         </Link>
       </div>
@@ -68,7 +96,11 @@ export function ItemFormPage() {
         backHref={isEditMode && id ? `/inventory/items/${id}` : '/inventory'}
         breadcrumbs={
           isEditMode && editItemName
-            ? [{ label: 'Inventory', href: '/inventory' }, { label: editItemName, href: `/inventory/items/${id}` }, { label: 'Edit' }]
+            ? [
+                { label: 'Inventory', href: '/inventory' },
+                { label: editItemName, href: `/inventory/items/${id}` },
+                { label: 'Edit' },
+              ]
             : [{ label: 'Inventory', href: '/inventory' }, { label: 'New Item' }]
         }
         renderLink={Link}
@@ -92,7 +124,6 @@ export function ItemFormPage() {
 
         <PhotoUploadSection
           isEditMode={isEditMode}
-          itemId={id}
           existingPhotos={existingPhotos}
           uploadFiles={uploadFiles}
           imageProcessing={imageProcessing}
@@ -121,8 +152,12 @@ export function ItemFormPage() {
             searchResults={searchResults}
             searchLoading={searchLoading}
             onSearchChange={setConnectionSearch}
-            onAdd={(item) => setPendingConnections((prev) => [...prev, { id: item.id, itemName: item.itemName }])}
-            onRemove={(itemId) => setPendingConnections((prev) => prev.filter((c) => c.id !== itemId))}
+            onAdd={(item) =>
+              setPendingConnections((prev) => [...prev, { id: item.id, itemName: item.itemName }])
+            }
+            onRemove={(itemId) =>
+              setPendingConnections((prev) => prev.filter((c) => c.id !== itemId))
+            }
           />
         )}
 
@@ -138,7 +173,12 @@ export function ItemFormPage() {
             {isEditMode ? 'Save Changes' : 'Create Item'}
           </Button>
           <Link to="/inventory">
-            <Button type="button" variant="outline" size="lg" className="px-8 font-bold border-app-accent/20 hover:bg-app-accent/5">
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className="px-8 font-bold border-app-accent/20 hover:bg-app-accent/5"
+            >
               Cancel
             </Button>
           </Link>

--- a/packages/app-inventory/src/pages/ItemFormPage.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.tsx
@@ -1,482 +1,37 @@
-import { Eye, ImageIcon, Link2, Loader2, PenLine, Save, Search, Wand2, X } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import Markdown from 'react-markdown';
-import { Link, useNavigate, useParams } from 'react-router';
-import rehypeSanitize from 'rehype-sanitize';
-import { toast } from 'sonner';
+import { Save } from 'lucide-react';
+import { Link } from 'react-router';
 
-import { trpc } from '@pops/api-client';
-/**
- * Item create/edit form page.
- * Supports /inventory/items/new (create) and /inventory/items/:id/edit (edit).
- */
 import {
   Alert,
   AlertDescription,
   AlertTitle,
-  Badge,
   Button,
-  CheckboxInput,
-  DateInput,
-  Label,
   PageHeader,
-  Select,
   Skeleton,
-  Textarea,
-  TextInput,
 } from '@pops/ui';
 
-import { LocationPicker } from '../components/LocationPicker';
-import { PhotoUpload, type UploadedFile } from '../components/PhotoUpload';
-import { SortablePhotoGrid } from '../components/SortablePhotoGrid';
-import { useImageProcessor } from '../hooks/useImageProcessor';
+import { ConnectionsSection } from './item-form-page/sections/ConnectionsSection';
+import { CoreFieldsSection } from './item-form-page/sections/CoreFieldsSection';
+import { NotesSection } from './item-form-page/sections/NotesSection';
+import { PhotoUploadSection } from './item-form-page/sections/PhotoUploadSection';
+import { useItemFormPageModel } from './item-form-page/useItemFormPageModel';
 
-import type { InventoryItem } from '@pops/api/modules/inventory/items/types';
-
-import type { PhotoItem } from '../components/PhotoGallery';
-
-interface PendingConnection {
-  id: string;
-  itemName: string;
-}
-
-interface ItemFormValues {
-  itemName: string;
-  brand: string;
-  model: string;
-  itemId: string;
-  type: string;
-  condition: string;
-  locationId: string;
-  inUse: boolean;
-  deductible: boolean;
-  purchaseDate: string;
-  warrantyExpires: string;
-  purchasePrice: string;
-  replacementValue: string;
-  resaleValue: string;
-  assetId: string;
-  notes: string;
-}
-
-const ITEM_TYPES = [
-  'Electronics',
-  'Furniture',
-  'Appliance',
-  'Clothing',
-  'Tools',
-  'Sports',
-  'Kitchen',
-  'Office',
-  'Other',
-];
-
-const CONDITIONS = [
-  { value: 'new', label: 'New' },
-  { value: 'good', label: 'Good' },
-  { value: 'fair', label: 'Fair' },
-  { value: 'poor', label: 'Poor' },
-  { value: 'broken', label: 'Broken' },
-];
-
-const defaultValues: ItemFormValues = {
-  itemName: '',
-  brand: '',
-  model: '',
-  itemId: '',
-  type: '',
-  condition: 'good',
-  locationId: '',
-  inUse: false,
-  deductible: false,
-  purchaseDate: '',
-  warrantyExpires: '',
-  purchasePrice: '',
-  replacementValue: '',
-  resaleValue: '',
-  assetId: '',
-  notes: '',
-};
-
-/** Extract a 4-6 character uppercase prefix from an item type for asset ID generation. */
-export function extractPrefix(type: string): string {
-  const firstWord = type.split(/\s+/)[0] ?? '';
-  const upper = firstWord.toUpperCase();
-  // Truncate to 4 chars, unless the word is 5-6 chars — keep up to 6
-  return upper.length <= 6 ? upper : upper.slice(0, 4);
-}
-
-function FormField({
-  label,
-  error,
-  children,
-}: {
-  label: string;
-  error?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div>
-      <Label className="mb-1.5 block">{label}</Label>
-      {children}
-      {error && <p className="text-sm text-destructive mt-1">{error}</p>}
-    </div>
-  );
-}
+export { extractPrefix } from './item-form-page/useItemFormPageModel';
 
 export function ItemFormPage() {
-  const { id } = useParams<{ id: string }>();
-  const isEditMode = !!id;
-  const navigate = useNavigate();
-  const utils = trpc.useUtils();
-
+  const model = useItemFormPageModel();
   const {
-    register,
-    handleSubmit,
-    reset,
-    watch,
-    setValue,
-    formState: { errors, isDirty },
-  } = useForm<ItemFormValues>({ defaultValues });
+    id, isEditMode, form, assetIdError, assetIdChecking, generating,
+    notesPreview, setNotesPreview, uploadFiles, deleteConfirmId, setDeleteConfirmId,
+    existingPhotos, imageProcessing, pendingConnections, setPendingConnections,
+    connectionSearch, setConnectionSearch, searchResults, searchLoading,
+    locationTree, createLocationMutation, itemData, isLoading, error,
+    reorderMutation, photoDeleteMutation, isMutating,
+    handleFilesSelected, handleRemoveUpload, handleDeletePhoto, confirmDeletePhoto,
+    validateAssetIdUniqueness, handleAutoGenerate, onSubmit,
+  } = model;
 
-  const typeValue = watch('type');
-
-  // Asset ID uniqueness validation
-  const [assetIdError, setAssetIdError] = useState<string | null>(null);
-  const [assetIdChecking, setAssetIdChecking] = useState(false);
-  const [generating, setGenerating] = useState(false);
-  const [notesPreview, setNotesPreview] = useState(false);
-
-  const validateAssetIdUniqueness = useCallback(
-    async (value: string) => {
-      if (!value.trim()) {
-        setAssetIdError(null);
-        return;
-      }
-      setAssetIdChecking(true);
-      try {
-        const result = await utils.inventory.items.searchByAssetId.fetch({
-          assetId: value.trim(),
-        });
-        if (result.data && result.data.id !== id) {
-          setAssetIdError(`Asset ID already in use by ${result.data.itemName}`);
-        } else {
-          setAssetIdError(null);
-        }
-      } catch {
-        setAssetIdError(null);
-      } finally {
-        setAssetIdChecking(false);
-      }
-    },
-    [id, utils]
-  );
-
-  const handleAutoGenerate = useCallback(async () => {
-    if (!typeValue) return;
-    setGenerating(true);
-    try {
-      const prefix = extractPrefix(typeValue);
-      const result = await utils.inventory.items.countByAssetPrefix.fetch({ prefix });
-      const nextNum = result.data + 1;
-      const padded = nextNum >= 100 ? String(nextNum) : String(nextNum).padStart(2, '0');
-      const newAssetId = `${prefix}${padded}`;
-      setValue('assetId', newAssetId, { shouldDirty: true });
-      setAssetIdError(null);
-      void validateAssetIdUniqueness(newAssetId);
-    } catch {
-      toast.error('Failed to generate asset ID');
-    } finally {
-      setGenerating(false);
-    }
-  }, [typeValue, utils, setValue, validateAssetIdUniqueness]);
-
-  // Photo upload state
-  const [uploadFiles, setUploadFiles] = useState<UploadedFile[]>([]);
-  const { processFiles, processing: imageProcessing } = useImageProcessor();
-  const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null);
-
-  // Existing photos (edit mode)
-  const { data: photosData, refetch: refetchPhotos } = trpc.inventory.photos.listForItem.useQuery(
-    { itemId: id! },
-    { enabled: isEditMode }
-  );
-  const existingPhotos: PhotoItem[] = photosData?.data ?? [];
-
-  const attachMutation = trpc.inventory.photos.attach.useMutation({
-    onSuccess: () => {
-      void refetchPhotos();
-    },
-  });
-
-  const deleteMutation = trpc.inventory.photos.remove.useMutation({
-    onSuccess: () => {
-      void refetchPhotos();
-      setDeleteConfirmId(null);
-    },
-  });
-
-  const reorderMutation = trpc.inventory.photos.reorder.useMutation({
-    onSuccess: () => {
-      void refetchPhotos();
-    },
-  });
-
-  const handleFilesSelected = useCallback(
-    async (files: File[]) => {
-      // Create pending entries
-      const pending: UploadedFile[] = files.map((file, i) => ({
-        localId: `${Date.now()}-${i}`,
-        file,
-        previewUrl: '',
-        status: 'pending' as const,
-      }));
-      setUploadFiles((prev) => [...prev, ...pending]);
-
-      // Process images (compress, convert HEIC)
-      try {
-        const processed = await processFiles(files);
-
-        // Update with preview URLs and sizes
-        setUploadFiles((prev) =>
-          prev.map((f) => {
-            const idx = pending.findIndex((p) => p.localId === f.localId);
-            const match = idx >= 0 ? processed[idx] : undefined;
-            if (!match) return f;
-            return {
-              ...f,
-              previewUrl: match.previewUrl,
-              originalSize: match.originalSize,
-              processedSize: match.processedSize,
-              status: 'uploading' as const,
-              progress: 0,
-            };
-          })
-        );
-
-        // Upload each file
-        for (let i = 0; i < processed.length; i++) {
-          const localId = pending[i]!.localId;
-          const p = processed[i]!;
-
-          try {
-            // Simulate progress for tRPC (no XHR progress)
-            setUploadFiles((prev) =>
-              prev.map((f) => (f.localId === localId ? { ...f, progress: 50 } : f))
-            );
-
-            const fileName = `${Date.now()}-${p.original.name.replace(/\.[^.]+$/, '.jpg')}`;
-
-            if (isEditMode && id) {
-              await attachMutation.mutateAsync({
-                itemId: id,
-                filePath: fileName,
-                sortOrder: existingPhotos.length + i,
-              });
-            }
-
-            setUploadFiles((prev) =>
-              prev.map((f) =>
-                f.localId === localId ? { ...f, status: 'done' as const, progress: 100 } : f
-              )
-            );
-          } catch (err: unknown) {
-            setUploadFiles((prev) =>
-              prev.map((f) =>
-                f.localId === localId
-                  ? {
-                      ...f,
-                      status: 'error' as const,
-                      error: err instanceof Error ? err.message : 'Upload failed',
-                    }
-                  : f
-              )
-            );
-            toast.error(`Failed to upload ${p.original.name}`);
-          }
-        }
-      } catch {
-        // Processing failure — mark all pending as error
-        setUploadFiles((prev) =>
-          prev.map((f) =>
-            pending.some((p) => p.localId === f.localId)
-              ? { ...f, status: 'error' as const, error: 'Image processing failed' }
-              : f
-          )
-        );
-        toast.error('Failed to process images');
-      }
-    },
-    [processFiles, isEditMode, id, attachMutation, existingPhotos.length]
-  );
-
-  const handleRemoveUpload = useCallback((localId: string) => {
-    setUploadFiles((prev) => {
-      const file = prev.find((f) => f.localId === localId);
-      if (file?.previewUrl) URL.revokeObjectURL(file.previewUrl);
-      return prev.filter((f) => f.localId !== localId);
-    });
-  }, []);
-
-  const handleDeletePhoto = useCallback((photoId: number) => {
-    setDeleteConfirmId(photoId);
-  }, []);
-
-  const confirmDeletePhoto = useCallback(() => {
-    if (deleteConfirmId !== null) {
-      deleteMutation.mutate({ id: deleteConfirmId });
-    }
-  }, [deleteConfirmId, deleteMutation]);
-
-  // Pending connections for create mode
-  const [pendingConnections, setPendingConnections] = useState<PendingConnection[]>([]);
-  const [connectionSearch, setConnectionSearch] = useState('');
-
-  const { data: searchResults, isLoading: searchLoading } = trpc.inventory.items.list.useQuery(
-    { search: connectionSearch, limit: 10 },
-    { enabled: !isEditMode && connectionSearch.length >= 2 }
-  );
-
-  const connectMutation = trpc.inventory.connections.connect.useMutation();
-
-  // Location tree for LocationPicker
-  const { data: locationsData } = trpc.inventory.locations.tree.useQuery();
-  const locationTree = locationsData?.data ?? [];
-
-  const createLocationMutation = trpc.inventory.locations.create.useMutation({
-    onSuccess: () => {
-      toast.success('Location created');
-      void utils.inventory.locations.tree.invalidate();
-    },
-    onError: (err) => toast.error(`Failed to create location: ${err.message}`),
-  });
-
-  // Fetch existing item for edit mode
-  const {
-    data: itemData,
-    isLoading,
-    error,
-  } = trpc.inventory.items.get.useQuery({ id: id! }, { enabled: isEditMode });
-
-  // Populate form when item loads
-  useEffect(() => {
-    if (itemData?.data) {
-      const item = itemData.data;
-      reset({
-        itemName: item.itemName,
-        brand: item.brand ?? '',
-        model: item.model ?? '',
-        itemId: item.itemId ?? '',
-        type: item.type ?? '',
-        condition: item.condition ?? '',
-        locationId: item.locationId ?? '',
-        inUse: item.inUse,
-        deductible: item.deductible,
-        purchaseDate: item.purchaseDate ?? '',
-        warrantyExpires: item.warrantyExpires ?? '',
-        purchasePrice: item.purchasePrice?.toString() ?? '',
-        replacementValue: item.replacementValue?.toString() ?? '',
-        resaleValue: item.resaleValue?.toString() ?? '',
-        assetId: item.assetId ?? '',
-        notes: item.notes ?? '',
-      });
-    }
-  }, [itemData, reset]);
-
-  // Unsaved changes warning
-  useEffect(() => {
-    if (!isDirty) return;
-    const handler = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-    };
-    window.addEventListener('beforeunload', handler);
-    return () => {
-      window.removeEventListener('beforeunload', handler);
-    };
-  }, [isDirty]);
-
-  const createMutation = trpc.inventory.items.create.useMutation({
-    onSuccess: async (result) => {
-      const newItemId = result.data.id;
-
-      // Create pending connections sequentially
-      if (pendingConnections.length > 0) {
-        let connected = 0;
-        for (const conn of pendingConnections) {
-          try {
-            await connectMutation.mutateAsync({
-              itemAId: newItemId,
-              itemBId: conn.id,
-            });
-            connected++;
-          } catch {
-            // Skip failed connections (e.g. conflict)
-          }
-        }
-        if (connected > 0) {
-          toast.success(`Item created with ${connected} connection${connected > 1 ? 's' : ''}`);
-        } else {
-          toast.success('Item created');
-        }
-      } else {
-        toast.success('Item created');
-      }
-
-      void utils.inventory.items.list.invalidate();
-      navigate(`/inventory/items/${newItemId}`);
-    },
-    onError: (err) => {
-      toast.error(`Failed to create: ${err.message}`);
-    },
-  });
-
-  const updateMutation = trpc.inventory.items.update.useMutation({
-    onSuccess: () => {
-      toast.success('Item updated');
-      void utils.inventory.items.list.invalidate();
-      void utils.inventory.items.get.invalidate({ id: id! });
-      navigate(`/inventory/items/${id}`);
-    },
-    onError: (err) => {
-      toast.error(`Failed to update: ${err.message}`);
-    },
-  });
-
-  const onSubmit = (values: ItemFormValues) => {
-    if (!values.itemName.trim()) {
-      toast.error('Item name is required');
-      return;
-    }
-
-    const payload = {
-      itemName: values.itemName.trim(),
-      brand: values.brand || null,
-      model: values.model || null,
-      itemId: values.itemId || null,
-      type: values.type || null,
-      condition: values.condition || null,
-      room: null,
-      locationId: values.locationId || null,
-      inUse: values.inUse,
-      deductible: values.deductible,
-      purchaseDate: values.purchaseDate || null,
-      warrantyExpires: values.warrantyExpires || null,
-      purchasePrice: values.purchasePrice ? parseFloat(values.purchasePrice) : null,
-      replacementValue: values.replacementValue ? parseFloat(values.replacementValue) : null,
-      resaleValue: values.resaleValue ? parseFloat(values.resaleValue) : null,
-      assetId: values.assetId || null,
-      notes: values.notes || null,
-    };
-
-    if (isEditMode) {
-      updateMutation.mutate({ id: id, data: payload });
-    } else {
-      createMutation.mutate(payload);
-    }
-  };
-
-  const isMutating = createMutation.isPending || updateMutation.isPending;
+  const { register, handleSubmit, watch, setValue, formState: { errors } } = form;
 
   if (isEditMode && isLoading) {
     return (
@@ -497,10 +52,7 @@ export function ItemFormPage() {
           <AlertTitle>{is404 ? 'Item not found' : 'Error'}</AlertTitle>
           <AlertDescription>{is404 ? "This item doesn't exist." : error.message}</AlertDescription>
         </Alert>
-        <Link
-          to="/inventory"
-          className="mt-4 inline-block text-sm text-app-accent hover:text-app-accent/80 underline font-medium"
-        >
+        <Link to="/inventory" className="mt-4 inline-block text-sm text-app-accent hover:text-app-accent/80 underline font-medium">
           Back to inventory
         </Link>
       </div>
@@ -516,11 +68,7 @@ export function ItemFormPage() {
         backHref={isEditMode && id ? `/inventory/items/${id}` : '/inventory'}
         breadcrumbs={
           isEditMode && editItemName
-            ? [
-                { label: 'Inventory', href: '/inventory' },
-                { label: editItemName, href: `/inventory/items/${id}` },
-                { label: 'Edit' },
-              ]
+            ? [{ label: 'Inventory', href: '/inventory' }, { label: editItemName, href: `/inventory/items/${id}` }, { label: 'Edit' }]
             : [{ label: 'Inventory', href: '/inventory' }, { label: 'New Item' }]
         }
         renderLink={Link}
@@ -528,359 +76,56 @@ export function ItemFormPage() {
       />
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
-        {/* Basic Info */}
-        <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
-          <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
-            <span className="w-1.5 h-1.5 rounded-full bg-app-accent" />
-            Basic Information
-          </h2>
+        <CoreFieldsSection
+          register={register}
+          watch={watch}
+          setValue={setValue}
+          errors={errors}
+          assetIdError={assetIdError}
+          assetIdChecking={assetIdChecking}
+          generating={generating}
+          locationTree={locationTree}
+          onAutoGenerate={() => void handleAutoGenerate()}
+          onValidateAssetId={(v) => void validateAssetIdUniqueness(v)}
+          onCreateLocation={(name, parentId) => createLocationMutation.mutate({ name, parentId })}
+        />
 
-          <FormField label="Item Name *" error={errors.itemName?.message}>
-            <TextInput
-              {...register('itemName', {
-                required: 'Item name is required',
-              })}
-              placeholder="e.g. MacBook Pro 16-inch"
-              className="font-semibold"
-            />
-          </FormField>
+        <PhotoUploadSection
+          isEditMode={isEditMode}
+          itemId={id}
+          existingPhotos={existingPhotos}
+          uploadFiles={uploadFiles}
+          imageProcessing={imageProcessing}
+          isReordering={reorderMutation.isPending}
+          deleteConfirmId={deleteConfirmId}
+          isDeleting={photoDeleteMutation.isPending}
+          onFilesSelected={handleFilesSelected}
+          onRemoveUpload={handleRemoveUpload}
+          onDeletePhoto={handleDeletePhoto}
+          onConfirmDelete={confirmDeletePhoto}
+          onCancelDelete={() => setDeleteConfirmId(null)}
+          onReorder={(orderedIds) => reorderMutation.mutate({ itemId: id!, orderedIds })}
+        />
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <FormField label="Brand">
-              <TextInput {...register('brand')} placeholder="e.g. Apple" />
-            </FormField>
-            <FormField label="Model">
-              <TextInput {...register('model')} placeholder="e.g. M3 Max" />
-            </FormField>
-          </div>
+        <NotesSection
+          register={register}
+          watch={watch}
+          notesPreview={notesPreview}
+          onTogglePreview={() => setNotesPreview((v) => !v)}
+        />
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <FormField label="Item ID / SKU">
-              <TextInput {...register('itemId')} />
-            </FormField>
-            <FormField label="Asset ID" error={assetIdError ?? undefined}>
-              <div className="flex gap-2">
-                <div className="relative flex-1">
-                  <TextInput
-                    {...register('assetId')}
-                    className="font-mono"
-                    onBlur={(e) => void validateAssetIdUniqueness(e.target.value)}
-                  />
-                  {assetIdChecking && (
-                    <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
-                  )}
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  disabled={!typeValue || generating}
-                  onClick={() => void handleAutoGenerate()}
-                  className="shrink-0 whitespace-nowrap"
-                  title={
-                    typeValue ? `Generate ${extractPrefix(typeValue)}XX` : 'Select a type first'
-                  }
-                >
-                  {generating ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Wand2 className="h-4 w-4 mr-1" />
-                  )}
-                  Auto-generate
-                </Button>
-              </div>
-            </FormField>
-          </div>
-        </section>
-
-        {/* Classification */}
-        <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
-          <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
-            <span className="w-1.5 h-1.5 rounded-full bg-app-accent" />
-            Classification
-          </h2>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <FormField label="Type *" error={errors.type?.message}>
-              <Select
-                {...register('type', { required: 'Type is required' })}
-                options={[
-                  { value: '', label: 'Select type...' },
-                  ...ITEM_TYPES.map((t) => ({ value: t, label: t })),
-                ]}
-              />
-            </FormField>
-            <FormField label="Condition">
-              <Select
-                {...register('condition')}
-                options={[{ value: '', label: 'Select condition...' }, ...CONDITIONS]}
-              />
-            </FormField>
-          </div>
-
-          <FormField label="Location">
-            <LocationPicker
-              locations={locationTree}
-              value={watch('locationId') || null}
-              onChange={(id) => {
-                setValue('locationId', id ?? '', { shouldDirty: true });
-              }}
-              onCreateLocation={(name, parentId) => {
-                createLocationMutation.mutate({ name, parentId });
-              }}
-              placeholder="Select location…"
-            />
-          </FormField>
-
-          <div className="flex gap-6 p-4 rounded-xl bg-app-accent/5">
-            <CheckboxInput label="In Use" {...register('inUse')} />
-            <CheckboxInput label="Tax Deductible" {...register('deductible')} />
-          </div>
-        </section>
-
-        {/* Dates & Values */}
-        <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
-          <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
-            <span className="w-1.5 h-1.5 rounded-full bg-app-accent" />
-            Dates & Values
-          </h2>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <FormField label="Purchase Date">
-              <DateInput {...register('purchaseDate')} />
-            </FormField>
-            <FormField label="Warranty Expires">
-              <DateInput {...register('warrantyExpires')} />
-            </FormField>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <FormField label="Purchase Price ($)">
-              <TextInput
-                type="number"
-                step="0.01"
-                min="0"
-                {...register('purchasePrice')}
-                placeholder="0.00"
-              />
-            </FormField>
-            <FormField label="Replacement Value ($)">
-              <TextInput
-                type="number"
-                step="0.01"
-                min="0"
-                {...register('replacementValue')}
-                placeholder="0.00"
-                className="font-bold text-app-accent"
-              />
-            </FormField>
-            <FormField label="Resale Value ($)">
-              <TextInput
-                type="number"
-                step="0.01"
-                min="0"
-                {...register('resaleValue')}
-                placeholder="0.00"
-              />
-            </FormField>
-          </div>
-        </section>
-
-        {/* Photos */}
-        <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
-          <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
-            <ImageIcon className="h-5 w-5 text-app-accent" />
-            Photos
-          </h2>
-
-          {/* Existing photos grid (edit mode) */}
-          {isEditMode && existingPhotos.length > 0 && (
-            <SortablePhotoGrid
-              photos={existingPhotos}
-              onReorder={(orderedIds) => {
-                reorderMutation.mutate({ itemId: id!, orderedIds });
-              }}
-              onDelete={handleDeletePhoto}
-              isReordering={reorderMutation.isPending}
-            />
-          )}
-
-          {/* Delete confirmation */}
-          {deleteConfirmId !== null && (
-            <div className="flex items-center gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
-              <p className="text-sm flex-1">Delete this photo? This cannot be undone.</p>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setDeleteConfirmId(null);
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                className="bg-destructive text-white hover:bg-destructive/80"
-                onClick={confirmDeletePhoto}
-                loading={deleteMutation.isPending}
-                loadingText="Deleting..."
-              >
-                Delete
-              </Button>
-            </div>
-          )}
-
-          <PhotoUpload
-            onFilesSelected={(files) => void handleFilesSelected(files)}
-            files={uploadFiles}
-            onRemove={handleRemoveUpload}
-            disabled={imageProcessing}
-            accept="image/jpeg,image/png,image/webp,image/heic,image/heif,.heic,.heif"
-          />
-        </section>
-
-        {/* Notes */}
-        <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
-          <div className="flex items-center justify-between">
-            <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
-              <span className="w-1.5 h-1.5 rounded-full bg-app-accent" />
-              Notes
-            </h2>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setNotesPreview((v) => !v);
-              }}
-              className="text-xs text-muted-foreground"
-            >
-              {notesPreview ? (
-                <>
-                  <PenLine className="h-3.5 w-3.5 mr-1" /> Edit
-                </>
-              ) : (
-                <>
-                  <Eye className="h-3.5 w-3.5 mr-1" /> Preview
-                </>
-              )}
-            </Button>
-          </div>
-          {notesPreview ? (
-            <div className="prose prose-sm dark:prose-invert max-w-none min-h-[6.5rem] p-3 rounded-md border bg-muted/30">
-              {watch('notes') ? (
-                <Markdown rehypePlugins={[rehypeSanitize]}>{watch('notes')}</Markdown>
-              ) : (
-                <p className="text-muted-foreground italic">Nothing to preview</p>
-              )}
-            </div>
-          ) : (
-            <Textarea
-              {...register('notes')}
-              rows={4}
-              placeholder="Add notes about this item... (supports markdown)"
-              className="w-full bg-transparent"
-            />
-          )}
-        </section>
-
-        {/* Connected Items (create mode only) */}
         {!isEditMode && (
-          <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
-            <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
-              <Link2 className="h-5 w-5 text-app-accent" />
-              Connected Items
-            </h2>
-
-            {pendingConnections.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                {pendingConnections.map((conn) => (
-                  <Badge
-                    key={conn.id}
-                    variant="secondary"
-                    className="flex items-center gap-1.5 pl-3 pr-1.5 py-1 bg-app-accent/10 text-app-accent border-app-accent/20"
-                  >
-                    {conn.itemName}
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-4 w-4 rounded-full hover:bg-app-accent/20"
-                      onClick={() => {
-                        setPendingConnections((prev) => prev.filter((c) => c.id !== conn.id));
-                      }}
-                    >
-                      <X className="h-3 w-3" />
-                    </Button>
-                  </Badge>
-                ))}
-              </div>
-            )}
-
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <TextInput
-                value={connectionSearch}
-                onChange={(e) => {
-                  setConnectionSearch(e.target.value);
-                }}
-                placeholder="Search items to connect..."
-                className="pl-9"
-              />
-            </div>
-
-            {connectionSearch.length >= 2 && (
-              <div className="max-h-48 overflow-y-auto border rounded-lg divide-y">
-                {searchLoading ? (
-                  <div className="space-y-2 p-2">
-                    <Skeleton className="h-10 w-full" />
-                    <Skeleton className="h-10 w-full" />
-                  </div>
-                ) : (
-                  (() => {
-                    const pendingIds = new Set(pendingConnections.map((c) => c.id));
-                    const filtered =
-                      searchResults?.data.filter(
-                        (item: InventoryItem) => !pendingIds.has(item.id)
-                      ) ?? [];
-                    return filtered.length === 0 ? (
-                      <p className="text-sm text-muted-foreground py-3 text-center">
-                        No items found
-                      </p>
-                    ) : (
-                      filtered.map((item: InventoryItem) => (
-                        <Button
-                          key={item.id}
-                          variant="ghost"
-                          className="w-full flex items-center justify-between p-2.5 h-auto text-left"
-                          onClick={() => {
-                            setPendingConnections((prev) => [
-                              ...prev,
-                              { id: item.id, itemName: item.itemName },
-                            ]);
-                            setConnectionSearch('');
-                          }}
-                        >
-                          <div>
-                            <div className="font-medium text-sm">{item.itemName}</div>
-                            <div className="text-xs text-muted-foreground">
-                              {[item.brand, item.model, item.assetId].filter(Boolean).join(' · ') ||
-                                'No details'}
-                            </div>
-                          </div>
-                          <Link2 className="h-4 w-4 text-app-accent/50 shrink-0 ml-2" />
-                        </Button>
-                      ))
-                    );
-                  })()
-                )}
-              </div>
-            )}
-          </section>
+          <ConnectionsSection
+            pendingConnections={pendingConnections}
+            connectionSearch={connectionSearch}
+            searchResults={searchResults}
+            searchLoading={searchLoading}
+            onSearchChange={setConnectionSearch}
+            onAdd={(item) => setPendingConnections((prev) => [...prev, { id: item.id, itemName: item.itemName }])}
+            onRemove={(itemId) => setPendingConnections((prev) => prev.filter((c) => c.id !== itemId))}
+          />
         )}
 
-        {/* Actions */}
         <div className="flex gap-4 pt-6 border-t">
           <Button
             type="submit"
@@ -893,12 +138,7 @@ export function ItemFormPage() {
             {isEditMode ? 'Save Changes' : 'Create Item'}
           </Button>
           <Link to="/inventory">
-            <Button
-              type="button"
-              variant="outline"
-              size="lg"
-              className="px-8 font-bold border-app-accent/20 hover:bg-app-accent/5"
-            >
+            <Button type="button" variant="outline" size="lg" className="px-8 font-bold border-app-accent/20 hover:bg-app-accent/5">
               Cancel
             </Button>
           </Link>

--- a/packages/app-inventory/src/pages/LocationTreePage.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.tsx
@@ -12,18 +12,37 @@ import { buildBreadcrumb } from './location-tree-page/utils';
 
 export function LocationTreePage() {
   const {
-    treeNodes, nodeMap, isLoading, error,
-    selectedId, addingChildOf, addingRoot, setAddingRoot, setAddingChildOf,
-    movingId, setMovingId, activeId, overId,
-    deleteConfirm, setDeleteConfirm,
+    treeNodes,
+    nodeMap,
+    isLoading,
+    error,
+    selectedId,
+    addingChildOf,
+    addingRoot,
+    setAddingRoot,
+    setAddingChildOf,
+    movingId,
+    setMovingId,
+    activeId,
+    overId,
+    deleteConfirm,
+    setDeleteConfirm,
     deleteMutation,
-    handleSelect, handleAddChild, handleRename,
-    handleNewChildSave, handleNewChildCancel,
-    handleNewRootSave, handleNewRootCancel,
-    handleDelete, handleDeleteConfirm,
-    handleMoveStart, handleMoveTo,
+    handleSelect,
+    handleAddChild,
+    handleRename,
+    handleNewChildSave,
+    handleNewChildCancel,
+    handleNewRootSave,
+    handleNewRootCancel,
+    handleDelete,
+    handleDeleteConfirm,
+    handleMoveStart,
+    handleMoveTo,
     handleReorder,
-    handleDragStart, handleDragOver, handleDragEnd,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
   } = useLocationTreePageModel();
 
   const activeNode = activeId ? nodeMap.get(activeId) : null;
@@ -45,7 +64,10 @@ export function LocationTreePage() {
         icon={<MapPin className="h-6 w-6 text-muted-foreground" />}
         actions={
           <>
-            <Link to="/inventory/report/insurance" className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
+            <Link
+              to="/inventory/report/insurance"
+              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+            >
               <FileText className="h-4 w-4" />
               Insurance Report
             </Link>
@@ -54,7 +76,10 @@ export function LocationTreePage() {
               size="sm"
               className="text-app-accent hover:text-app-accent/80"
               prefix={<Plus className="h-4 w-4" />}
-              onClick={() => { setAddingRoot(true); setAddingChildOf(null); }}
+              onClick={() => {
+                setAddingRoot(true);
+                setAddingChildOf(null);
+              }}
             >
               Add Root Location
             </Button>
@@ -65,7 +90,9 @@ export function LocationTreePage() {
       {!isLoading && treeNodes.length === 0 && !addingRoot ? (
         <div className="text-center py-16">
           <MapPin className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
-          <p className="text-muted-foreground">No locations yet. Add your first location to start organising.</p>
+          <p className="text-muted-foreground">
+            No locations yet. Add your first location to start organising.
+          </p>
         </div>
       ) : (
         <div className="flex flex-col md:flex-row gap-6">

--- a/packages/app-inventory/src/pages/LocationTreePage.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.tsx
@@ -1,804 +1,30 @@
-/**
- * LocationTreePage — hierarchical tree display of all locations.
- *
- * Uses inventory.locations.tree tRPC query to render an expand/collapse
- * tree with item count badges. Supports adding root/child locations,
- * inline renaming, move-to-parent modal, and sibling reordering.
- */
-import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  type DragOverEvent,
-  DragOverlay,
-  type DragStartEvent,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core';
-import {
-  arrayMove,
-  SortableContext,
-  useSortable,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
-import {
-  ArrowDown,
-  ArrowUp,
-  ChevronDown,
-  ChevronRight,
-  FileText,
-  Folder,
-  FolderOpen,
-  FolderPlus,
-  GripVertical,
-  MapPin,
-  MoveRight,
-  Plus,
-  Trash2,
-} from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FileText, MapPin, Plus } from 'lucide-react';
 import { Link } from 'react-router';
-import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
-import {
-  Badge,
-  Button,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  PageHeader,
-  Skeleton,
-} from '@pops/ui';
+import { Button, PageHeader } from '@pops/ui';
 
 import { LocationContentsPanel } from '../components/LocationContentsPanel';
-
-interface LocationTreeNode {
-  id: string;
-  name: string;
-  parentId: string | null;
-  sortOrder: number;
-  children: LocationTreeNode[];
-}
-
-function TreeSkeleton() {
-  return (
-    <div className="space-y-2 p-4">
-      {Array.from({ length: 6 }).map((_, i) => (
-        <div
-          key={i}
-          className="flex items-center gap-2"
-          style={{ paddingLeft: `calc(${i % 3} * var(--tree-indent-step))` }}
-        >
-          <Skeleton className="h-4 w-4" />
-          <Skeleton className="h-4 w-32" />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function buildBreadcrumb(nodeId: string, nodeMap: Map<string, LocationTreeNode>): string[] {
-  const path: string[] = [];
-  let current = nodeMap.get(nodeId);
-  while (current) {
-    path.unshift(current.name);
-    current = current.parentId ? nodeMap.get(current.parentId) : undefined;
-  }
-  return path;
-}
-
-function buildNodeMap(nodes: LocationTreeNode[], map: Map<string, LocationTreeNode>): void {
-  for (const node of nodes) {
-    map.set(node.id, node);
-    buildNodeMap(node.children, map);
-  }
-}
-
-function countDescendants(node: LocationTreeNode): number {
-  let count = node.children.length;
-  for (const child of node.children) {
-    count += countDescendants(child);
-  }
-  return count;
-}
-
-/** Check if targetId is a descendant of nodeId (prevents circular moves). */
-function isDescendant(
-  nodeId: string,
-  targetId: string,
-  nodeMap: Map<string, LocationTreeNode>
-): boolean {
-  const node = nodeMap.get(nodeId);
-  if (!node) return false;
-  for (const child of node.children) {
-    if (child.id === targetId || isDescendant(child.id, targetId, nodeMap)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/** Get siblings of a node (including itself). */
-function getSiblings(
-  nodeId: string,
-  treeNodes: LocationTreeNode[],
-  nodeMap: Map<string, LocationTreeNode>
-): LocationTreeNode[] {
-  const node = nodeMap.get(nodeId);
-  if (!node) return [];
-  if (!node.parentId) return treeNodes;
-  const parent = nodeMap.get(node.parentId);
-  return parent?.children ?? [];
-}
-
-/** Inline text input for creating/renaming locations. */
-function InlineInput({
-  defaultValue,
-  onSave,
-  onCancel,
-  placeholder,
-}: {
-  defaultValue?: string;
-  onSave: (value: string) => void;
-  onCancel: () => void;
-  placeholder?: string;
-}) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [value, setValue] = useState(defaultValue ?? '');
-
-  useEffect(() => {
-    inputRef.current?.focus();
-    inputRef.current?.select();
-  }, []);
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      const trimmed = value.trim();
-      if (trimmed) onSave(trimmed);
-    } else if (e.key === 'Escape') {
-      onCancel();
-    }
-  };
-
-  return (
-    <input
-      ref={inputRef}
-      type="text"
-      value={value}
-      onChange={(e) => {
-        setValue(e.target.value);
-      }}
-      onKeyDown={handleKeyDown}
-      onBlur={onCancel}
-      placeholder={placeholder}
-      className="text-sm font-medium bg-transparent border-b border-app-accent outline-none px-0.5 py-0 w-full max-w-50"
-    />
-  );
-}
-
-/** Simplified tree picker for the "Move To" dialog. */
-function MoveTargetPicker({
-  nodes,
-  movingId,
-  nodeMap,
-  onSelect,
-  depth = 0,
-}: {
-  nodes: LocationTreeNode[];
-  movingId: string;
-  nodeMap: Map<string, LocationTreeNode>;
-  onSelect: (parentId: string | null) => void;
-  depth?: number;
-}) {
-  return (
-    <>
-      {nodes
-        .filter((n) => n.id !== movingId)
-        .map((node) => {
-          const disabled = isDescendant(movingId, node.id, nodeMap);
-          return (
-            <div key={node.id}>
-              <button
-                type="button"
-                disabled={disabled}
-                onClick={() => {
-                  onSelect(node.id);
-                }}
-                className={`w-full text-left flex items-center gap-1.5 py-1.5 px-2 rounded-md transition-colors ${
-                  disabled ? 'opacity-40 cursor-not-allowed' : 'hover:bg-muted/50 cursor-pointer'
-                }`}
-                style={{
-                  paddingLeft: `calc(${depth} * var(--tree-picker-step) + var(--tree-indent-base))`,
-                }}
-              >
-                <Folder className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                <span className="text-sm truncate">{node.name}</span>
-              </button>
-              {node.children.length > 0 && (
-                <MoveTargetPicker
-                  nodes={node.children}
-                  movingId={movingId}
-                  nodeMap={nodeMap}
-                  onSelect={onSelect}
-                  depth={depth + 1}
-                />
-              )}
-            </div>
-          );
-        })}
-    </>
-  );
-}
-
-/** Lightweight node preview shown while dragging. */
-function DragOverlayNode({ node }: { node: LocationTreeNode }) {
-  return (
-    <div className="flex items-center gap-2 bg-background border rounded-md px-3 py-2 shadow-lg">
-      <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
-      <Folder className="h-4 w-4 text-muted-foreground" />
-      <span className="text-sm font-medium">{node.name}</span>
-      {node.children.length > 0 && (
-        <Badge variant="secondary" className="text-xs">
-          {countDescendants(node) + 1}
-        </Badge>
-      )}
-    </div>
-  );
-}
-
-/** Visual drop indicator line shown between siblings during drag. */
-function DropIndicatorLine({ depth }: { depth: number }) {
-  return (
-    <div
-      className="relative h-0.5 my-[-1px] z-10"
-      style={{
-        marginLeft: `calc(${depth} * var(--tree-indent-step) + var(--tree-indent-base))`,
-        marginRight: '8px',
-      }}
-      data-testid="drop-indicator"
-    >
-      <div className="absolute inset-0 bg-app-accent rounded-full" />
-      <div className="absolute left-0 top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-app-accent -ml-1" />
-    </div>
-  );
-}
-
-interface LocationNodeProps {
-  node: LocationTreeNode;
-  depth: number;
-  selectedId: string | null;
-  onSelect: (id: string) => void;
-  onAddChild: (parentId: string) => void;
-  onRename: (id: string, newName: string) => void;
-  onMoveStart: (id: string) => void;
-  onReorder: (id: string, direction: 'up' | 'down') => void;
-  onDelete: (id: string) => void;
-  addingChildOf: string | null;
-  onNewChildSave: (name: string) => void;
-  onNewChildCancel: () => void;
-  siblingIndex: number;
-  siblingCount: number;
-  /** ID of the node currently being dragged over (for drop indicator). */
-  overId: string | null;
-  /** ID of the node currently being dragged. */
-  activeId: string | null;
-}
-
-function LocationNode({
-  node,
-  depth,
-  selectedId,
-  onSelect,
-  onAddChild,
-  onRename,
-  onMoveStart,
-  onReorder,
-  onDelete,
-  addingChildOf,
-  onNewChildSave,
-  onNewChildCancel,
-  siblingIndex,
-  siblingCount,
-  overId,
-  activeId,
-}: LocationNodeProps) {
-  const [open, setOpen] = useState(depth < 1);
-  const [renaming, setRenaming] = useState(false);
-  const hasChildren = node.children.length > 0;
-  const isSelected = selectedId === node.id;
-  const isAddingChild = addingChildOf === node.id;
-
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    setActivatorNodeRef,
-    transform,
-    transition,
-    isDragging,
-    isOver,
-  } = useSortable({ id: node.id });
-
-  const sortableStyle = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.4 : 1,
-  };
-
-  // Show drop indicator line when this node is the drop target during a same-parent reorder
-  const showDropLine =
-    overId === node.id && activeId !== null && activeId !== node.id && !isDragging;
-
-  // Auto-expand when adding a child
-  useEffect(() => {
-    if (isAddingChild && !open) setOpen(true);
-  }, [isAddingChild, open]);
-
-  return (
-    <div ref={setNodeRef} style={sortableStyle}>
-      {showDropLine && <DropIndicatorLine depth={depth} />}
-      <Collapsible open={open} onOpenChange={setOpen}>
-        <div
-          className={`group flex items-center gap-1.5 py-1.5 px-2 rounded-md cursor-pointer transition-colors hover:bg-app-accent/10 ${
-            isSelected
-              ? 'bg-app-accent/20 text-foreground font-bold border-l-2 border-app-accent rounded-l-none ml-[-2px]'
-              : ''
-          } ${isOver && !isDragging ? 'ring-2 ring-app-accent/50 bg-app-accent/5' : ''}`}
-          style={{
-            paddingLeft: `calc(${depth} * var(--tree-indent-step) + var(--tree-indent-base))`,
-          }}
-          onClick={() => {
-            onSelect(node.id);
-          }}
-          onDoubleClick={(e) => {
-            e.stopPropagation();
-            setRenaming(true);
-          }}
-          role="treeitem"
-          aria-selected={isSelected}
-          aria-expanded={hasChildren ? open : undefined}
-        >
-          {/* Drag handle — fine pointer only (mouse/trackpad), visible on hover */}
-          <button
-            ref={setActivatorNodeRef}
-            {...attributes}
-            {...listeners}
-            type="button"
-            className="p-0.5 rounded hover:bg-muted cursor-grab active:cursor-grabbing hidden [@media(pointer:fine)]:flex opacity-0 group-hover:opacity-100 transition-opacity touch-none"
-            aria-label={`Drag ${node.name}`}
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
-          >
-            <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
-          </button>
-
-          {hasChildren ? (
-            <CollapsibleTrigger
-              asChild
-              onClick={(e) => {
-                e.stopPropagation();
-              }}
-            >
-              <button
-                type="button"
-                className="p-0.5 rounded hover:bg-muted"
-                aria-label={open ? 'Collapse' : 'Expand'}
-              >
-                {open ? (
-                  <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                ) : (
-                  <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-                )}
-              </button>
-            </CollapsibleTrigger>
-          ) : (
-            <span className="w-5.5" />
-          )}
-
-          {hasChildren && open ? (
-            <FolderOpen className="h-4 w-4 text-muted-foreground shrink-0" />
-          ) : (
-            <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
-          )}
-
-          {renaming ? (
-            <InlineInput
-              defaultValue={node.name}
-              onSave={(name) => {
-                setRenaming(false);
-                if (name !== node.name) onRename(node.id, name);
-              }}
-              onCancel={() => {
-                setRenaming(false);
-              }}
-            />
-          ) : (
-            <span className="text-sm font-medium truncate">{node.name}</span>
-          )}
-
-          <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity ml-auto shrink-0">
-            {siblingCount > 1 && siblingIndex > 0 && (
-              <button
-                type="button"
-                className="p-0.5 rounded hover:bg-muted hidden [@media(pointer:coarse)]:inline-flex"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onReorder(node.id, 'up');
-                }}
-                aria-label="Move up"
-                title="Move up"
-              >
-                <ArrowUp className="h-3 w-3 text-muted-foreground" />
-              </button>
-            )}
-            {siblingCount > 1 && siblingIndex < siblingCount - 1 && (
-              <button
-                type="button"
-                className="p-0.5 rounded hover:bg-muted hidden [@media(pointer:coarse)]:inline-flex"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onReorder(node.id, 'down');
-                }}
-                aria-label="Move down"
-                title="Move down"
-              >
-                <ArrowDown className="h-3 w-3 text-muted-foreground" />
-              </button>
-            )}
-            <button
-              type="button"
-              className="p-0.5 rounded hover:bg-muted"
-              onClick={(e) => {
-                e.stopPropagation();
-                onMoveStart(node.id);
-              }}
-              aria-label={`Move ${node.name}`}
-              title="Move to..."
-            >
-              <MoveRight className="h-3 w-3 text-muted-foreground" />
-            </button>
-            <button
-              type="button"
-              className="p-0.5 rounded hover:bg-muted"
-              onClick={(e) => {
-                e.stopPropagation();
-                onAddChild(node.id);
-              }}
-              aria-label={`Add child to ${node.name}`}
-              title="Add child location"
-            >
-              <FolderPlus className="h-3.5 w-3.5 text-muted-foreground" />
-            </button>
-            <Link
-              to={`/inventory/report/insurance?locationId=${node.id}`}
-              onClick={(e) => {
-                e.stopPropagation();
-              }}
-              className="p-0.5 rounded hover:bg-muted"
-              title={`Insurance report for ${node.name}`}
-            >
-              <FileText className="h-3.5 w-3.5 text-muted-foreground" />
-            </Link>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-5 w-5 p-0.5 text-destructive"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(node.id);
-              }}
-              aria-label={`Delete ${node.name}`}
-              title="Delete location"
-            >
-              <Trash2 className="h-3 w-3" />
-            </Button>
-          </div>
-
-          {hasChildren && (
-            <Badge variant="secondary" className="text-xs shrink-0">
-              {countDescendants(node) + 1}
-            </Badge>
-          )}
-        </div>
-
-        {(hasChildren || isAddingChild) && (
-          <CollapsibleContent forceMount={isAddingChild ? true : undefined}>
-            <SortableContext
-              items={node.children.map((c) => c.id)}
-              strategy={verticalListSortingStrategy}
-            >
-              <div role="group">
-                {node.children.map((child, i) => (
-                  <LocationNode
-                    key={child.id}
-                    node={child}
-                    depth={depth + 1}
-                    selectedId={selectedId}
-                    onSelect={onSelect}
-                    onAddChild={onAddChild}
-                    onRename={onRename}
-                    onMoveStart={onMoveStart}
-                    onReorder={onReorder}
-                    onDelete={onDelete}
-                    addingChildOf={addingChildOf}
-                    onNewChildSave={onNewChildSave}
-                    onNewChildCancel={onNewChildCancel}
-                    siblingIndex={i}
-                    siblingCount={node.children.length}
-                    overId={overId}
-                    activeId={activeId}
-                  />
-                ))}
-                {isAddingChild && (
-                  <div
-                    className="flex items-center gap-1.5 py-1.5 px-2"
-                    style={{
-                      paddingLeft: `calc(${depth + 1} * var(--tree-indent-step) + var(--tree-indent-base))`,
-                    }}
-                  >
-                    <span className="w-5.5" />
-                    <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
-                    <InlineInput
-                      onSave={onNewChildSave}
-                      onCancel={onNewChildCancel}
-                      placeholder="Location name"
-                    />
-                  </div>
-                )}
-              </div>
-            </SortableContext>
-          </CollapsibleContent>
-        )}
-      </Collapsible>
-    </div>
-  );
-}
+import { DeleteDialog } from './location-tree-page/sections/DeleteDialog';
+import { MoveDialog } from './location-tree-page/sections/MoveDialog';
+import { TreeSection } from './location-tree-page/sections/TreeSection';
+import { useLocationTreePageModel } from './location-tree-page/useLocationTreePageModel';
+import { buildBreadcrumb } from './location-tree-page/utils';
 
 export function LocationTreePage() {
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [addingChildOf, setAddingChildOf] = useState<string | null>(null);
-  const [addingRoot, setAddingRoot] = useState(false);
-  const [movingId, setMovingId] = useState<string | null>(null);
-  const [activeId, setActiveId] = useState<string | null>(null);
-  const [overId, setOverId] = useState<string | null>(null);
-
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
-
-  const [deleteConfirm, setDeleteConfirm] = useState<{
-    id: string;
-    name: string;
-    stats: {
-      childCount: number;
-      descendantCount: number;
-      itemCount: number;
-      totalItemCount: number;
-    };
-  } | null>(null);
-
-  const utils = trpc.useUtils();
-  const { data, isLoading, error } = trpc.inventory.locations.tree.useQuery();
-
-  const createMutation = trpc.inventory.locations.create.useMutation({
-    onSuccess: () => {
-      toast.success('Location created');
-      utils.inventory.locations.tree.invalidate();
-      setAddingChildOf(null);
-      setAddingRoot(false);
-    },
-    onError: (err) => toast.error(`Failed to create location: ${err.message}`),
-  });
-
-  const updateMutation = trpc.inventory.locations.update.useMutation({
-    onSuccess: () => {
-      toast.success('Location updated');
-      utils.inventory.locations.tree.invalidate();
-    },
-    onError: (err) => toast.error(`Failed to update location: ${err.message}`),
-  });
-
-  const deleteMutation = trpc.inventory.locations.delete.useMutation({
-    onSuccess: (result) => {
-      if ('requiresConfirmation' in result && result.requiresConfirmation && result.stats) {
-        // Need user confirmation — show dialog
-        const node = deleteConfirm
-          ? { id: deleteConfirm.id, name: deleteConfirm.name }
-          : pendingDeleteRef.current;
-        if (node) {
-          setDeleteConfirm({
-            id: node.id,
-            name: node.name,
-            stats: result.stats,
-          });
-        }
-        return;
-      }
-      toast.success('Location deleted');
-      utils.inventory.locations.tree.invalidate();
-      if (selectedId === pendingDeleteRef.current?.id) {
-        setSelectedId(null);
-      }
-      setDeleteConfirm(null);
-      pendingDeleteRef.current = null;
-    },
-    onError: (err) => {
-      toast.error(`Failed to delete: ${err.message}`);
-      setDeleteConfirm(null);
-      pendingDeleteRef.current = null;
-    },
-  });
-
-  const pendingDeleteRef = useRef<{ id: string; name: string } | null>(null);
-
-  const treeNodes = data?.data ?? [];
-  const nodeMap = useMemo(() => {
-    const map = new Map<string, LocationTreeNode>();
-    if (data?.data) {
-      buildNodeMap(data.data, map);
-    }
-    return map;
-  }, [data?.data]);
-
-  const handleSelect = useCallback((id: string) => {
-    setSelectedId((prev) => (prev === id ? null : id));
-  }, []);
-
-  const handleAddChild = useCallback((parentId: string) => {
-    setAddingChildOf(parentId);
-    setAddingRoot(false);
-  }, []);
-
-  const handleRename = useCallback(
-    (id: string, newName: string) => {
-      updateMutation.mutate({ id, data: { name: newName } });
-    },
-    [updateMutation]
-  );
-
-  const handleNewChildSave = useCallback(
-    (name: string) => {
-      createMutation.mutate({
-        name,
-        parentId: addingChildOf,
-      });
-    },
-    [addingChildOf, createMutation]
-  );
-
-  const handleNewChildCancel = useCallback(() => {
-    setAddingChildOf(null);
-  }, []);
-
-  const handleNewRootSave = useCallback(
-    (name: string) => {
-      createMutation.mutate({ name, parentId: null });
-    },
-    [createMutation]
-  );
-
-  const handleNewRootCancel = useCallback(() => {
-    setAddingRoot(false);
-  }, []);
-
-  const handleDelete = useCallback(
-    (id: string) => {
-      const node = nodeMap.get(id);
-      if (!node) return;
-      pendingDeleteRef.current = { id, name: node.name };
-      // Try without force first — server will return requiresConfirmation if non-empty
-      deleteMutation.mutate({ id });
-    },
-    [nodeMap, deleteMutation]
-  );
-
-  const handleDeleteConfirm = useCallback(() => {
-    if (!deleteConfirm) return;
-    deleteMutation.mutate({ id: deleteConfirm.id, force: true });
-  }, [deleteConfirm, deleteMutation]);
-
-  const handleMoveStart = useCallback((id: string) => {
-    setMovingId(id);
-  }, []);
-
-  const handleMoveTo = useCallback(
-    (newParentId: string | null) => {
-      if (!movingId) return;
-      updateMutation.mutate(
-        { id: movingId, data: { parentId: newParentId } },
-        {
-          onSuccess: () => {
-            setMovingId(null);
-          },
-        }
-      );
-    },
-    [movingId, updateMutation]
-  );
-
-  const handleReorder = useCallback(
-    (id: string, direction: 'up' | 'down') => {
-      const siblings = getSiblings(id, treeNodes, nodeMap);
-      const idx = siblings.findIndex((s) => s.id === id);
-      if (idx < 0) return;
-
-      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
-      if (swapIdx < 0 || swapIdx >= siblings.length) return;
-
-      const current = siblings[idx];
-      const swap = siblings[swapIdx];
-      if (!current || !swap) return;
-
-      // Swap sort orders
-      updateMutation.mutate({
-        id: current.id,
-        data: { sortOrder: swap.sortOrder },
-      });
-      updateMutation.mutate({
-        id: swap.id,
-        data: { sortOrder: current.sortOrder },
-      });
-    },
-    [treeNodes, nodeMap, updateMutation]
-  );
-
-  const handleDragStart = useCallback((event: DragStartEvent) => {
-    setActiveId(event.active.id as string);
-  }, []);
-
-  const handleDragOver = useCallback((event: DragOverEvent) => {
-    setOverId(event.over ? (event.over.id as string) : null);
-  }, []);
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      setActiveId(null);
-      setOverId(null);
-      const { active, over } = event;
-      if (!over || active.id === over.id) return;
-
-      const activeNode = nodeMap.get(active.id as string);
-      const overNode = nodeMap.get(over.id as string);
-      if (!activeNode || !overNode) return;
-
-      // Prevent dropping on own descendants
-      if (isDescendant(active.id as string, over.id as string, nodeMap)) {
-        toast.error('Cannot move a location into its own sub-location');
-        return;
-      }
-
-      if (activeNode.parentId === overNode.parentId) {
-        // Reorder within same parent
-        const siblings = getSiblings(active.id as string, treeNodes, nodeMap);
-        const oldIndex = siblings.findIndex((s) => s.id === active.id);
-        const newIndex = siblings.findIndex((s) => s.id === over.id);
-        if (oldIndex < 0 || newIndex < 0) return;
-
-        const reordered = arrayMove(siblings, oldIndex, newIndex);
-        reordered.forEach((n, index) => {
-          if (n.sortOrder !== index) {
-            updateMutation.mutate({ id: n.id, data: { sortOrder: index } });
-          }
-        });
-      } else {
-        // Different parent → reparent: make active a child of over
-        updateMutation.mutate({
-          id: activeNode.id,
-          data: { parentId: overNode.id },
-        });
-      }
-    },
-    [nodeMap, treeNodes, updateMutation]
-  );
+  const {
+    treeNodes, nodeMap, isLoading, error,
+    selectedId, addingChildOf, addingRoot, setAddingRoot, setAddingChildOf,
+    movingId, setMovingId, activeId, overId,
+    deleteConfirm, setDeleteConfirm,
+    deleteMutation,
+    handleSelect, handleAddChild, handleRename,
+    handleNewChildSave, handleNewChildCancel,
+    handleNewRootSave, handleNewRootCancel,
+    handleDelete, handleDeleteConfirm,
+    handleMoveStart, handleMoveTo,
+    handleReorder,
+    handleDragStart, handleDragOver, handleDragEnd,
+  } = useLocationTreePageModel();
 
   const activeNode = activeId ? nodeMap.get(activeId) : null;
   const movingNode = movingId ? nodeMap.get(movingId) : null;
@@ -819,10 +45,7 @@ export function LocationTreePage() {
         icon={<MapPin className="h-6 w-6 text-muted-foreground" />}
         actions={
           <>
-            <Link
-              to="/inventory/report/insurance"
-              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-            >
+            <Link to="/inventory/report/insurance" className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
               <FileText className="h-4 w-4" />
               Insurance Report
             </Link>
@@ -831,10 +54,7 @@ export function LocationTreePage() {
               size="sm"
               className="text-app-accent hover:text-app-accent/80"
               prefix={<Plus className="h-4 w-4" />}
-              onClick={() => {
-                setAddingRoot(true);
-                setAddingChildOf(null);
-              }}
+              onClick={() => { setAddingRoot(true); setAddingChildOf(null); }}
             >
               Add Root Location
             </Button>
@@ -842,69 +62,36 @@ export function LocationTreePage() {
         }
       />
 
-      {isLoading ? (
-        <TreeSkeleton />
-      ) : treeNodes.length === 0 && !addingRoot ? (
+      {!isLoading && treeNodes.length === 0 && !addingRoot ? (
         <div className="text-center py-16">
           <MapPin className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
-          <p className="text-muted-foreground">
-            No locations yet. Add your first location to start organising.
-          </p>
+          <p className="text-muted-foreground">No locations yet. Add your first location to start organising.</p>
         </div>
       ) : (
         <div className="flex flex-col md:flex-row gap-6">
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
+          <TreeSection
+            treeNodes={treeNodes}
+            isLoading={isLoading}
+            addingRoot={addingRoot}
+            selectedId={selectedId}
+            addingChildOf={addingChildOf}
+            overId={overId}
+            activeId={activeId}
+            activeNode={activeNode}
+            onSelect={handleSelect}
+            onAddChild={handleAddChild}
+            onRename={handleRename}
+            onMoveStart={handleMoveStart}
+            onReorder={handleReorder}
+            onDelete={handleDelete}
+            onNewChildSave={handleNewChildSave}
+            onNewChildCancel={handleNewChildCancel}
+            onNewRootSave={handleNewRootSave}
+            onNewRootCancel={handleNewRootCancel}
             onDragStart={handleDragStart}
             onDragOver={handleDragOver}
             onDragEnd={handleDragEnd}
-          >
-            <div className="md:w-2/5 border rounded-lg py-2" role="tree" aria-label="Location tree">
-              <SortableContext
-                items={treeNodes.map((n) => n.id)}
-                strategy={verticalListSortingStrategy}
-              >
-                {treeNodes.map((node, i) => (
-                  <LocationNode
-                    key={node.id}
-                    node={node}
-                    depth={0}
-                    selectedId={selectedId}
-                    onSelect={handleSelect}
-                    onAddChild={handleAddChild}
-                    onRename={handleRename}
-                    onMoveStart={handleMoveStart}
-                    onReorder={handleReorder}
-                    onDelete={handleDelete}
-                    addingChildOf={addingChildOf}
-                    onNewChildSave={handleNewChildSave}
-                    onNewChildCancel={handleNewChildCancel}
-                    siblingIndex={i}
-                    siblingCount={treeNodes.length}
-                    overId={overId}
-                    activeId={activeId}
-                  />
-                ))}
-              </SortableContext>
-              {addingRoot && (
-                <div
-                  className="flex items-center gap-1.5 py-1.5 px-2"
-                  style={{ paddingLeft: 'var(--tree-indent-base)' }}
-                >
-                  <span className="w-5.5" />
-                  <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
-                  <InlineInput
-                    onSave={handleNewRootSave}
-                    onCancel={handleNewRootCancel}
-                    placeholder="Root location name"
-                  />
-                </div>
-              )}
-            </div>
-            <DragOverlay>{activeNode ? <DragOverlayNode node={activeNode} /> : null}</DragOverlay>
-          </DndContext>
-
+          />
           <div className="md:w-3/5">
             {selectedId && nodeMap.get(selectedId) ? (
               <LocationContentsPanel
@@ -922,86 +109,21 @@ export function LocationTreePage() {
         </div>
       )}
 
-      {/* Move To dialog */}
-      <Dialog open={!!movingId} onOpenChange={(open) => !open && setMovingId(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Move &ldquo;{movingNode?.name}&rdquo;</DialogTitle>
-            <DialogDescription>
-              Select a new parent location, or move to root level.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="max-h-64 overflow-y-auto border rounded-lg py-2">
-            <button
-              type="button"
-              onClick={() => {
-                handleMoveTo(null);
-              }}
-              className="w-full text-left flex items-center gap-1.5 py-1.5 px-2 rounded-md hover:bg-muted/50"
-              style={{ paddingLeft: 'var(--tree-indent-base)' }}
-            >
-              <MapPin className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-              <span className="text-sm font-medium">Root level</span>
-            </button>
-            {movingId && (
-              <MoveTargetPicker
-                nodes={treeNodes}
-                movingId={movingId}
-                nodeMap={nodeMap}
-                onSelect={handleMoveTo}
-              />
-            )}
-          </div>
-        </DialogContent>
-      </Dialog>
+      <MoveDialog
+        movingId={movingId}
+        movingNode={movingNode}
+        treeNodes={treeNodes}
+        nodeMap={nodeMap}
+        onMoveTo={handleMoveTo}
+        onClose={() => setMovingId(null)}
+      />
 
-      {/* Delete confirmation dialog */}
-      <Dialog open={!!deleteConfirm} onOpenChange={(open) => !open && setDeleteConfirm(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete &ldquo;{deleteConfirm?.name}&rdquo;?</DialogTitle>
-            <DialogDescription>This action cannot be undone.</DialogDescription>
-          </DialogHeader>
-          {deleteConfirm && (
-            <div className="space-y-2 text-sm">
-              {deleteConfirm.stats.childCount > 0 && (
-                <p>
-                  This location has <strong>{deleteConfirm.stats.childCount}</strong> direct{' '}
-                  {deleteConfirm.stats.childCount === 1 ? 'sub-location' : 'sub-locations'}
-                  {deleteConfirm.stats.descendantCount > deleteConfirm.stats.childCount &&
-                    ` (${deleteConfirm.stats.descendantCount} total)`}
-                  . They will all be deleted.
-                </p>
-              )}
-              {deleteConfirm.stats.totalItemCount > 0 && (
-                <p>
-                  <strong>{deleteConfirm.stats.totalItemCount}</strong>{' '}
-                  {deleteConfirm.stats.totalItemCount === 1 ? 'item' : 'items'} will become
-                  unlocated.
-                </p>
-              )}
-            </div>
-          )}
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setDeleteConfirm(null);
-              }}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="ghost"
-              className="text-destructive hover:text-destructive"
-              onClick={handleDeleteConfirm}
-              disabled={deleteMutation.isPending}
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <DeleteDialog
+        deleteConfirm={deleteConfirm}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteConfirm(null)}
+        isPending={deleteMutation.isPending}
+      />
     </div>
   );
 }

--- a/packages/app-inventory/src/pages/item-detail-page/sections/ConnectionsSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/ConnectionsSection.tsx
@@ -26,7 +26,9 @@ import { ConnectionTracePanel } from '../../../components/ConnectionTracePanel';
 import type { ItemConnection } from '@pops/api/modules/inventory/connections/types';
 
 function ConnectionRow({
-  connectedItemId, onDisconnect, isDisconnecting,
+  connectedItemId,
+  onDisconnect,
+  isDisconnecting,
 }: {
   connectedItemId: string;
   onDisconnect: () => void;
@@ -50,14 +52,23 @@ function ConnectionRow({
       </Link>
       <AlertDialog>
         <AlertDialogTrigger asChild>
-          <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive shrink-0" disabled={isDisconnecting} title="Disconnect" aria-label="Disconnect">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-destructive hover:text-destructive shrink-0"
+            disabled={isDisconnecting}
+            title="Disconnect"
+            aria-label="Disconnect"
+          >
             <Unlink className="h-4 w-4" />
           </Button>
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Disconnect {itemName}?</AlertDialogTitle>
-            <AlertDialogDescription>This will remove the connection between these items.</AlertDialogDescription>
+            <AlertDialogDescription>
+              This will remove the connection between these items.
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
@@ -79,7 +90,12 @@ interface ConnectionsSectionProps {
 }
 
 export function ConnectionsSection({
-  itemId, connections, connectionsLoading, isDisconnecting, onConnected, onDisconnect,
+  itemId,
+  connections,
+  connectionsLoading,
+  isDisconnecting,
+  onConnected,
+  onDisconnect,
 }: ConnectionsSectionProps) {
   const [showGraph, setShowGraph] = useState(false);
 
@@ -127,7 +143,11 @@ export function ConnectionsSection({
               {showGraph ? 'Hide Graph' : 'View Graph'}
             </Button>
           </div>
-          {showGraph ? <ConnectionGraph itemId={itemId} /> : <ConnectionTracePanel itemId={itemId} />}
+          {showGraph ? (
+            <ConnectionGraph itemId={itemId} />
+          ) : (
+            <ConnectionTracePanel itemId={itemId} />
+          )}
         </section>
       ) : null}
     </>

--- a/packages/app-inventory/src/pages/item-detail-page/sections/ConnectionsSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/ConnectionsSection.tsx
@@ -1,0 +1,135 @@
+import { GitBranch, Link2, Network, Unlink } from 'lucide-react';
+import { useState } from 'react';
+import { Link } from 'react-router';
+
+import { trpc } from '@pops/api-client';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  AssetIdBadge,
+  Button,
+  Skeleton,
+  TypeBadge,
+} from '@pops/ui';
+
+import { ConnectDialog } from '../../../components/ConnectDialog';
+import { ConnectionGraph } from '../../../components/ConnectionGraph';
+import { ConnectionTracePanel } from '../../../components/ConnectionTracePanel';
+
+import type { ItemConnection } from '@pops/api/modules/inventory/connections/types';
+
+function ConnectionRow({
+  connectedItemId, onDisconnect, isDisconnecting,
+}: {
+  connectedItemId: string;
+  onDisconnect: () => void;
+  isDisconnecting: boolean;
+}) {
+  const { data } = trpc.inventory.items.get.useQuery({ id: connectedItemId });
+  const item = data?.data;
+  const itemName = item?.itemName ?? connectedItemId;
+
+  return (
+    <div className="flex items-center justify-between p-3 rounded-lg border">
+      <Link to={`/inventory/items/${connectedItemId}`} className="flex-1 min-w-0 hover:underline">
+        <span className="font-medium">{itemName}</span>
+        {item?.brand && <span className="text-muted-foreground text-sm ml-2">{item.brand}</span>}
+        {(item?.assetId || item?.type) && (
+          <div className="flex flex-wrap items-center gap-1 mt-0.5">
+            {item.assetId && <AssetIdBadge assetId={item.assetId} />}
+            {item.type && <TypeBadge type={item.type} />}
+          </div>
+        )}
+      </Link>
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive shrink-0" disabled={isDisconnecting} title="Disconnect" aria-label="Disconnect">
+            <Unlink className="h-4 w-4" />
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Disconnect {itemName}?</AlertDialogTitle>
+            <AlertDialogDescription>This will remove the connection between these items.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={onDisconnect}>Disconnect</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+interface ConnectionsSectionProps {
+  itemId: string;
+  connections: ItemConnection[];
+  connectionsLoading: boolean;
+  isDisconnecting: boolean;
+  onConnected: () => void;
+  onDisconnect: (conn: ItemConnection) => void;
+}
+
+export function ConnectionsSection({
+  itemId, connections, connectionsLoading, isDisconnecting, onConnected, onDisconnect,
+}: ConnectionsSectionProps) {
+  const [showGraph, setShowGraph] = useState(false);
+
+  return (
+    <>
+      <section>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <Link2 className="h-5 w-5" />
+            Connected Items
+          </h2>
+          <ConnectDialog currentItemId={itemId} onConnected={onConnected} />
+        </div>
+
+        {connectionsLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        ) : connections.length ? (
+          <div className="space-y-2">
+            {connections.map((conn: ItemConnection) => (
+              <ConnectionRow
+                key={conn.id}
+                connectedItemId={conn.itemAId === itemId ? conn.itemBId : conn.itemAId}
+                onDisconnect={() => onDisconnect(conn)}
+                isDisconnecting={isDisconnecting}
+              />
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">No connected items yet.</p>
+        )}
+      </section>
+
+      {connections.length ? (
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold flex items-center gap-2">
+              <GitBranch className="h-5 w-5" />
+              Connection Chain
+            </h2>
+            <Button variant="outline" size="sm" onClick={() => setShowGraph((v) => !v)}>
+              <Network className="h-4 w-4 mr-1.5" />
+              {showGraph ? 'Hide Graph' : 'View Graph'}
+            </Button>
+          </div>
+          {showGraph ? <ConnectionGraph itemId={itemId} /> : <ConnectionTracePanel itemId={itemId} />}
+        </section>
+      ) : null}
+    </>
+  );
+}

--- a/packages/app-inventory/src/pages/item-detail-page/sections/DetailHeaderSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/DetailHeaderSection.tsx
@@ -1,0 +1,148 @@
+import { ChevronRight, ExternalLink, MapPin, Store } from 'lucide-react';
+import Markdown from 'react-markdown';
+import { Link } from 'react-router';
+import rehypeSanitize from 'rehype-sanitize';
+
+import { trpc } from '@pops/api-client';
+import {
+  Badge,
+  type Condition,
+  ConditionBadge,
+  Skeleton,
+  TypeBadge,
+  WarrantyBadge,
+} from '@pops/ui';
+
+function DetailField({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs font-bold text-muted-foreground uppercase tracking-widest mb-1">{label}</dt>
+      <dd className="font-semibold text-foreground">{value}</dd>
+    </div>
+  );
+}
+
+function LocationBreadcrumb({ locationId }: { locationId: string | null }) {
+  const { data: pathData } = trpc.inventory.locations.getPath.useQuery(
+    { id: locationId! },
+    { enabled: !!locationId }
+  );
+
+  return (
+    <div className="mb-8 flex items-center gap-1.5 text-sm" data-testid="location-breadcrumb">
+      <MapPin className="h-4 w-4 text-muted-foreground shrink-0" />
+      {!locationId ? (
+        <span className="text-muted-foreground">No location assigned</span>
+      ) : pathData?.data ? (
+        pathData.data.map((loc, i) => (
+          <span key={loc.id} className="flex items-center gap-1.5">
+            {i > 0 && <ChevronRight className="h-3 w-3 text-muted-foreground" />}
+            <Link to={`/inventory?location=${loc.id}`} className="text-app-accent hover:text-app-accent/80 hover:underline font-medium">
+              {loc.name}
+            </Link>
+          </span>
+        ))
+      ) : (
+        <Skeleton className="h-4 w-32" />
+      )}
+    </div>
+  );
+}
+
+function PurchaseLinkSection({
+  purchaseTransactionId, purchasedFromId, purchasedFromName,
+}: {
+  purchaseTransactionId: string | null;
+  purchasedFromId: string | null;
+  purchasedFromName: string | null;
+}) {
+  if (!purchaseTransactionId && !purchasedFromId) return null;
+  return (
+    <div className="mb-8 flex items-center gap-4 text-sm" data-testid="purchase-link-section">
+      {purchaseTransactionId && (
+        <Link to={`/finance/transactions/${purchaseTransactionId}`} className="flex items-center gap-1.5 text-app-accent hover:text-app-accent/80 hover:underline font-medium">
+          <ExternalLink className="h-4 w-4" />
+          View transaction
+        </Link>
+      )}
+      {purchasedFromId && purchasedFromName && (
+        <span className="flex items-center gap-1.5 text-muted-foreground">
+          <Store className="h-4 w-4" />
+          {purchasedFromName}
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface DetailHeaderSectionProps {
+  item: {
+    itemName: string;
+    brand?: string | null;
+    model?: string | null;
+    type?: string | null;
+    condition?: string | null;
+    warrantyExpires?: string | null;
+    room?: string | null;
+    assetId?: string | null;
+    inUse: boolean;
+    purchaseDate?: string | null;
+    replacementValue?: number | null;
+    locationId?: string | null;
+    purchaseTransactionId?: string | null;
+    purchasedFromId?: string | null;
+    purchasedFromName?: string | null;
+    notes?: string | null;
+  };
+}
+
+export function DetailHeaderSection({ item }: DetailHeaderSectionProps) {
+  return (
+    <>
+      <div className="bg-card border-2 border-app-accent/10 rounded-2xl overflow-hidden mb-8 shadow-sm shadow-app-accent/5">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6 p-6">
+          {item.type && <DetailField label="Type" value={<TypeBadge type={item.type} />} />}
+          {item.condition && <DetailField label="Condition" value={<ConditionBadge condition={item.condition as Condition} />} />}
+          <DetailField label="Warranty" value={<WarrantyBadge warrantyExpiry={item.warrantyExpires ?? null} />} />
+          {item.room && <DetailField label="Room" value={item.room} />}
+          {item.assetId && (
+            <DetailField label="Asset ID" value={<Badge variant="outline" className="font-mono bg-muted/50">{item.assetId}</Badge>} />
+          )}
+          <DetailField
+            label="Status"
+            value={
+              item.inUse ? (
+                <Badge className="bg-app-accent/10 text-app-accent border-app-accent/20 hover:bg-app-accent/15">In Use</Badge>
+              ) : (
+                <Badge variant="secondary">Stored</Badge>
+              )
+            }
+          />
+          {item.purchaseDate && (
+            <DetailField label="Purchased" value={new Date(item.purchaseDate).toLocaleDateString('en-AU', { year: 'numeric', month: 'short' })} />
+          )}
+          {item.replacementValue !== null && item.replacementValue !== undefined && (
+            <DetailField label="Replacement" value={<span className="text-app-accent font-bold">{`$${item.replacementValue.toLocaleString()}`}</span>} />
+          )}
+        </div>
+      </div>
+
+      <LocationBreadcrumb locationId={item.locationId ?? null} />
+
+      <PurchaseLinkSection
+        purchaseTransactionId={item.purchaseTransactionId ?? null}
+        purchasedFromId={item.purchasedFromId ?? null}
+        purchasedFromName={item.purchasedFromName ?? null}
+      />
+
+      {item.notes && (
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold mb-2">Notes</h2>
+          <div className="text-muted-foreground prose prose-sm dark:prose-invert max-w-none">
+            <Markdown rehypePlugins={[rehypeSanitize]}>{item.notes}</Markdown>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/app-inventory/src/pages/item-detail-page/sections/DetailHeaderSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/DetailHeaderSection.tsx
@@ -16,7 +16,9 @@ import {
 function DetailField({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div>
-      <dt className="text-xs font-bold text-muted-foreground uppercase tracking-widest mb-1">{label}</dt>
+      <dt className="text-xs font-bold text-muted-foreground uppercase tracking-widest mb-1">
+        {label}
+      </dt>
       <dd className="font-semibold text-foreground">{value}</dd>
     </div>
   );
@@ -37,7 +39,10 @@ function LocationBreadcrumb({ locationId }: { locationId: string | null }) {
         pathData.data.map((loc, i) => (
           <span key={loc.id} className="flex items-center gap-1.5">
             {i > 0 && <ChevronRight className="h-3 w-3 text-muted-foreground" />}
-            <Link to={`/inventory?location=${loc.id}`} className="text-app-accent hover:text-app-accent/80 hover:underline font-medium">
+            <Link
+              to={`/inventory?location=${loc.id}`}
+              className="text-app-accent hover:text-app-accent/80 hover:underline font-medium"
+            >
               {loc.name}
             </Link>
           </span>
@@ -50,7 +55,9 @@ function LocationBreadcrumb({ locationId }: { locationId: string | null }) {
 }
 
 function PurchaseLinkSection({
-  purchaseTransactionId, purchasedFromId, purchasedFromName,
+  purchaseTransactionId,
+  purchasedFromId,
+  purchasedFromName,
 }: {
   purchaseTransactionId: string | null;
   purchasedFromId: string | null;
@@ -60,7 +67,10 @@ function PurchaseLinkSection({
   return (
     <div className="mb-8 flex items-center gap-4 text-sm" data-testid="purchase-link-section">
       {purchaseTransactionId && (
-        <Link to={`/finance/transactions/${purchaseTransactionId}`} className="flex items-center gap-1.5 text-app-accent hover:text-app-accent/80 hover:underline font-medium">
+        <Link
+          to={`/finance/transactions/${purchaseTransactionId}`}
+          className="flex items-center gap-1.5 text-app-accent hover:text-app-accent/80 hover:underline font-medium"
+        >
           <ExternalLink className="h-4 w-4" />
           View transaction
         </Link>
@@ -102,27 +112,55 @@ export function DetailHeaderSection({ item }: DetailHeaderSectionProps) {
       <div className="bg-card border-2 border-app-accent/10 rounded-2xl overflow-hidden mb-8 shadow-sm shadow-app-accent/5">
         <div className="grid grid-cols-2 md:grid-cols-3 gap-6 p-6">
           {item.type && <DetailField label="Type" value={<TypeBadge type={item.type} />} />}
-          {item.condition && <DetailField label="Condition" value={<ConditionBadge condition={item.condition as Condition} />} />}
-          <DetailField label="Warranty" value={<WarrantyBadge warrantyExpiry={item.warrantyExpires ?? null} />} />
+          {item.condition && (
+            <DetailField
+              label="Condition"
+              value={<ConditionBadge condition={item.condition as Condition} />}
+            />
+          )}
+          <DetailField
+            label="Warranty"
+            value={<WarrantyBadge warrantyExpiry={item.warrantyExpires ?? null} />}
+          />
           {item.room && <DetailField label="Room" value={item.room} />}
           {item.assetId && (
-            <DetailField label="Asset ID" value={<Badge variant="outline" className="font-mono bg-muted/50">{item.assetId}</Badge>} />
+            <DetailField
+              label="Asset ID"
+              value={
+                <Badge variant="outline" className="font-mono bg-muted/50">
+                  {item.assetId}
+                </Badge>
+              }
+            />
           )}
           <DetailField
             label="Status"
             value={
               item.inUse ? (
-                <Badge className="bg-app-accent/10 text-app-accent border-app-accent/20 hover:bg-app-accent/15">In Use</Badge>
+                <Badge className="bg-app-accent/10 text-app-accent border-app-accent/20 hover:bg-app-accent/15">
+                  In Use
+                </Badge>
               ) : (
                 <Badge variant="secondary">Stored</Badge>
               )
             }
           />
           {item.purchaseDate && (
-            <DetailField label="Purchased" value={new Date(item.purchaseDate).toLocaleDateString('en-AU', { year: 'numeric', month: 'short' })} />
+            <DetailField
+              label="Purchased"
+              value={new Date(item.purchaseDate).toLocaleDateString('en-AU', {
+                year: 'numeric',
+                month: 'short',
+              })}
+            />
           )}
           {item.replacementValue !== null && item.replacementValue !== undefined && (
-            <DetailField label="Replacement" value={<span className="text-app-accent font-bold">{`$${item.replacementValue.toLocaleString()}`}</span>} />
+            <DetailField
+              label="Replacement"
+              value={
+                <span className="text-app-accent font-bold">{`$${item.replacementValue.toLocaleString()}`}</span>
+              }
+            />
           )}
         </div>
       </div>

--- a/packages/app-inventory/src/pages/item-detail-page/sections/DetailHeaderSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/DetailHeaderSection.tsx
@@ -3,7 +3,6 @@ import Markdown from 'react-markdown';
 import { Link } from 'react-router';
 import rehypeSanitize from 'rehype-sanitize';
 
-import { trpc } from '@pops/api-client';
 import {
   Badge,
   type Condition,
@@ -24,19 +23,20 @@ function DetailField({ label, value }: { label: string; value: React.ReactNode }
   );
 }
 
-function LocationBreadcrumb({ locationId }: { locationId: string | null }) {
-  const { data: pathData } = trpc.inventory.locations.getPath.useQuery(
-    { id: locationId! },
-    { enabled: !!locationId }
-  );
-
+function LocationBreadcrumb({
+  locationId,
+  locationPath,
+}: {
+  locationId: string | null;
+  locationPath: { id: string; name: string }[] | null;
+}) {
   return (
     <div className="mb-8 flex items-center gap-1.5 text-sm" data-testid="location-breadcrumb">
       <MapPin className="h-4 w-4 text-muted-foreground shrink-0" />
       {!locationId ? (
         <span className="text-muted-foreground">No location assigned</span>
-      ) : pathData?.data ? (
-        pathData.data.map((loc, i) => (
+      ) : locationPath ? (
+        locationPath.map((loc, i) => (
           <span key={loc.id} className="flex items-center gap-1.5">
             {i > 0 && <ChevronRight className="h-3 w-3 text-muted-foreground" />}
             <Link
@@ -104,9 +104,10 @@ interface DetailHeaderSectionProps {
     purchasedFromName?: string | null;
     notes?: string | null;
   };
+  locationPath: { id: string; name: string }[] | null;
 }
 
-export function DetailHeaderSection({ item }: DetailHeaderSectionProps) {
+export function DetailHeaderSection({ item, locationPath }: DetailHeaderSectionProps) {
   return (
     <>
       <div className="bg-card border-2 border-app-accent/10 rounded-2xl overflow-hidden mb-8 shadow-sm shadow-app-accent/5">
@@ -165,7 +166,7 @@ export function DetailHeaderSection({ item }: DetailHeaderSectionProps) {
         </div>
       </div>
 
-      <LocationBreadcrumb locationId={item.locationId ?? null} />
+      <LocationBreadcrumb locationId={item.locationId ?? null} locationPath={locationPath} />
 
       <PurchaseLinkSection
         purchaseTransactionId={item.purchaseTransactionId ?? null}

--- a/packages/app-inventory/src/pages/item-detail-page/sections/DocumentsSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/DocumentsSection.tsx
@@ -1,0 +1,131 @@
+import { ExternalLink, FileText, X } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { trpc } from '@pops/api-client';
+import { Button, Skeleton } from '@pops/ui';
+
+import { LinkDocumentDialog } from '../../../components/LinkDocumentDialog';
+
+const DOCUMENT_TYPE_LABELS: Record<string, string> = {
+  receipt: 'Receipts', warranty: 'Warranties', manual: 'Manuals', invoice: 'Invoices', other: 'Other',
+};
+
+function DocumentThumbnail({ documentId }: { documentId: number }) {
+  const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
+  const src = `/inventory/documents/${documentId}/thumbnail`;
+
+  if (status === 'error') {
+    return (
+      <div className="h-12 w-10 rounded bg-muted flex items-center justify-center shrink-0" title="Document unavailable">
+        <FileText className="h-5 w-5 text-muted-foreground" />
+      </div>
+    );
+  }
+  return (
+    <div className="h-12 w-10 shrink-0 relative">
+      {status === 'loading' && <Skeleton className="absolute inset-0 rounded" />}
+      <img src={src} alt="Document thumbnail" className="h-12 w-10 rounded object-cover" onLoad={() => setStatus('loaded')} onError={() => setStatus('error')} />
+    </div>
+  );
+}
+
+function DocumentsList({ itemId, paperlessBaseUrl }: { itemId: string; paperlessBaseUrl: string | null }) {
+  const utils = trpc.useUtils();
+  const { data, isLoading } = trpc.inventory.documents.listForItem.useQuery({ itemId });
+
+  const unlinkMutation = trpc.inventory.documents.unlink.useMutation({
+    onSuccess: () => { toast.success('Document unlinked'); void utils.inventory.documents.listForItem.invalidate({ itemId }); },
+    onError: (err: { message: string }) => toast.error(`Failed to unlink: ${err.message}`),
+  });
+
+  const docs = data?.data ?? [];
+  const grouped = new Map<string, typeof docs>();
+  for (const doc of docs) {
+    const list = grouped.get(doc.documentType) ?? [];
+    list.push(doc);
+    grouped.set(doc.documentType, list);
+  }
+  const typeOrder = ['receipt', 'warranty', 'manual', 'invoice', 'other'];
+  const sortedTypes = [...grouped.keys()].toSorted((a, b) => (typeOrder.indexOf(a) ?? 99) - (typeOrder.indexOf(b) ?? 99));
+
+  return (
+    <section className="mt-8">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold flex items-center gap-2">
+          <FileText className="h-5 w-5" />
+          Documents
+          {docs.length > 0 && <span className="text-sm font-normal text-muted-foreground">({docs.length})</span>}
+        </h2>
+        <LinkDocumentDialog itemId={itemId} onLinked={() => void utils.inventory.documents.listForItem.invalidate({ itemId })} />
+      </div>
+      {isLoading ? (
+        <div className="space-y-2"><Skeleton className="h-12 w-full" /><Skeleton className="h-12 w-full" /></div>
+      ) : docs.length > 0 ? (
+        <div className="space-y-4">
+          {sortedTypes.map((type) => (
+            <div key={type}>
+              <h3 className="text-sm font-medium text-muted-foreground mb-2">{DOCUMENT_TYPE_LABELS[type] ?? type}</h3>
+              <div className="space-y-1.5">
+                {grouped.get(type)?.map((doc) => (
+                  <div key={doc.id} className="flex items-center justify-between p-3 rounded-lg border">
+                    <div className="flex items-center gap-3 flex-1 min-w-0">
+                      <DocumentThumbnail documentId={doc.paperlessDocumentId} />
+                      <div className="min-w-0 flex-1">
+                        <span className="font-medium text-sm truncate block">{doc.title ?? `Document #${doc.paperlessDocumentId}`}</span>
+                        <span className="text-xs text-muted-foreground">Linked {new Date(doc.createdAt).toLocaleDateString()}</span>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      {paperlessBaseUrl && (
+                        <a href={`${paperlessBaseUrl}/documents/${doc.paperlessDocumentId}/details`} target="_blank" rel="noopener noreferrer" className="relative inline-flex items-center justify-center size-9 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent before:absolute before:content-[''] before:-inset-1" title="View in Paperless" aria-label="View in Paperless">
+                          <ExternalLink className="h-4 w-4" />
+                        </a>
+                      )}
+                      <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive shrink-0" onClick={() => unlinkMutation.mutate({ id: doc.id })} disabled={unlinkMutation.isPending} title="Unlink document" aria-label="Unlink document">
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-sm">No documents linked yet.</p>
+      )}
+    </section>
+  );
+}
+
+interface DocumentsSectionProps {
+  itemId: string;
+}
+
+export function DocumentsSection({ itemId }: DocumentsSectionProps) {
+  const { data: statusData, isLoading: statusLoading } = trpc.inventory.paperless.status.useQuery();
+  const status = statusData?.data;
+
+  if (!statusLoading && !status?.configured) return null;
+
+  if (statusLoading) {
+    return (
+      <section className="mt-8">
+        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4"><FileText className="h-5 w-5" />Documents</h2>
+        <Skeleton className="h-12 w-full" />
+      </section>
+    );
+  }
+
+  if (!status?.available) {
+    return (
+      <section className="mt-8">
+        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4"><FileText className="h-5 w-5" />Documents</h2>
+        <p className="text-sm text-muted-foreground">Paperless-ngx unavailable</p>
+      </section>
+    );
+  }
+
+  return <DocumentsList itemId={itemId} paperlessBaseUrl={status?.baseUrl ?? null} />;
+}

--- a/packages/app-inventory/src/pages/item-detail-page/sections/DocumentsSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/DocumentsSection.tsx
@@ -8,7 +8,11 @@ import { Button, Skeleton } from '@pops/ui';
 import { LinkDocumentDialog } from '../../../components/LinkDocumentDialog';
 
 const DOCUMENT_TYPE_LABELS: Record<string, string> = {
-  receipt: 'Receipts', warranty: 'Warranties', manual: 'Manuals', invoice: 'Invoices', other: 'Other',
+  receipt: 'Receipts',
+  warranty: 'Warranties',
+  manual: 'Manuals',
+  invoice: 'Invoices',
+  other: 'Other',
 };
 
 function DocumentThumbnail({ documentId }: { documentId: number }) {
@@ -17,7 +21,10 @@ function DocumentThumbnail({ documentId }: { documentId: number }) {
 
   if (status === 'error') {
     return (
-      <div className="h-12 w-10 rounded bg-muted flex items-center justify-center shrink-0" title="Document unavailable">
+      <div
+        className="h-12 w-10 rounded bg-muted flex items-center justify-center shrink-0"
+        title="Document unavailable"
+      >
         <FileText className="h-5 w-5 text-muted-foreground" />
       </div>
     );
@@ -25,17 +32,32 @@ function DocumentThumbnail({ documentId }: { documentId: number }) {
   return (
     <div className="h-12 w-10 shrink-0 relative">
       {status === 'loading' && <Skeleton className="absolute inset-0 rounded" />}
-      <img src={src} alt="Document thumbnail" className="h-12 w-10 rounded object-cover" onLoad={() => setStatus('loaded')} onError={() => setStatus('error')} />
+      <img
+        src={src}
+        alt="Document thumbnail"
+        className="h-12 w-10 rounded object-cover"
+        onLoad={() => setStatus('loaded')}
+        onError={() => setStatus('error')}
+      />
     </div>
   );
 }
 
-function DocumentsList({ itemId, paperlessBaseUrl }: { itemId: string; paperlessBaseUrl: string | null }) {
+function DocumentsList({
+  itemId,
+  paperlessBaseUrl,
+}: {
+  itemId: string;
+  paperlessBaseUrl: string | null;
+}) {
   const utils = trpc.useUtils();
   const { data, isLoading } = trpc.inventory.documents.listForItem.useQuery({ itemId });
 
   const unlinkMutation = trpc.inventory.documents.unlink.useMutation({
-    onSuccess: () => { toast.success('Document unlinked'); void utils.inventory.documents.listForItem.invalidate({ itemId }); },
+    onSuccess: () => {
+      toast.success('Document unlinked');
+      void utils.inventory.documents.listForItem.invalidate({ itemId });
+    },
     onError: (err: { message: string }) => toast.error(`Failed to unlink: ${err.message}`),
   });
 
@@ -47,7 +69,11 @@ function DocumentsList({ itemId, paperlessBaseUrl }: { itemId: string; paperless
     grouped.set(doc.documentType, list);
   }
   const typeOrder = ['receipt', 'warranty', 'manual', 'invoice', 'other'];
-  const sortedTypes = [...grouped.keys()].toSorted((a, b) => (typeOrder.indexOf(a) ?? 99) - (typeOrder.indexOf(b) ?? 99));
+  const sortedTypes = [...grouped.keys()].toSorted((a, b) => {
+    const aIdx = typeOrder.indexOf(a);
+    const bIdx = typeOrder.indexOf(b);
+    return (aIdx === -1 ? 99 : aIdx) - (bIdx === -1 ? 99 : bIdx);
+  });
 
   return (
     <section className="mt-8">
@@ -55,34 +81,66 @@ function DocumentsList({ itemId, paperlessBaseUrl }: { itemId: string; paperless
         <h2 className="text-lg font-semibold flex items-center gap-2">
           <FileText className="h-5 w-5" />
           Documents
-          {docs.length > 0 && <span className="text-sm font-normal text-muted-foreground">({docs.length})</span>}
+          {docs.length > 0 && (
+            <span className="text-sm font-normal text-muted-foreground">({docs.length})</span>
+          )}
         </h2>
-        <LinkDocumentDialog itemId={itemId} onLinked={() => void utils.inventory.documents.listForItem.invalidate({ itemId })} />
+        <LinkDocumentDialog
+          itemId={itemId}
+          onLinked={() => void utils.inventory.documents.listForItem.invalidate({ itemId })}
+        />
       </div>
       {isLoading ? (
-        <div className="space-y-2"><Skeleton className="h-12 w-full" /><Skeleton className="h-12 w-full" /></div>
+        <div className="space-y-2">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
       ) : docs.length > 0 ? (
         <div className="space-y-4">
           {sortedTypes.map((type) => (
             <div key={type}>
-              <h3 className="text-sm font-medium text-muted-foreground mb-2">{DOCUMENT_TYPE_LABELS[type] ?? type}</h3>
+              <h3 className="text-sm font-medium text-muted-foreground mb-2">
+                {DOCUMENT_TYPE_LABELS[type] ?? type}
+              </h3>
               <div className="space-y-1.5">
                 {grouped.get(type)?.map((doc) => (
-                  <div key={doc.id} className="flex items-center justify-between p-3 rounded-lg border">
+                  <div
+                    key={doc.id}
+                    className="flex items-center justify-between p-3 rounded-lg border"
+                  >
                     <div className="flex items-center gap-3 flex-1 min-w-0">
                       <DocumentThumbnail documentId={doc.paperlessDocumentId} />
                       <div className="min-w-0 flex-1">
-                        <span className="font-medium text-sm truncate block">{doc.title ?? `Document #${doc.paperlessDocumentId}`}</span>
-                        <span className="text-xs text-muted-foreground">Linked {new Date(doc.createdAt).toLocaleDateString()}</span>
+                        <span className="font-medium text-sm truncate block">
+                          {doc.title ?? `Document #${doc.paperlessDocumentId}`}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          Linked {new Date(doc.createdAt).toLocaleDateString()}
+                        </span>
                       </div>
                     </div>
                     <div className="flex items-center gap-1 shrink-0">
                       {paperlessBaseUrl && (
-                        <a href={`${paperlessBaseUrl}/documents/${doc.paperlessDocumentId}/details`} target="_blank" rel="noopener noreferrer" className="relative inline-flex items-center justify-center size-9 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent before:absolute before:content-[''] before:-inset-1" title="View in Paperless" aria-label="View in Paperless">
+                        <a
+                          href={`${paperlessBaseUrl}/documents/${doc.paperlessDocumentId}/details`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="relative inline-flex items-center justify-center size-9 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent before:absolute before:content-[''] before:-inset-1"
+                          title="View in Paperless"
+                          aria-label="View in Paperless"
+                        >
                           <ExternalLink className="h-4 w-4" />
                         </a>
                       )}
-                      <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive shrink-0" onClick={() => unlinkMutation.mutate({ id: doc.id })} disabled={unlinkMutation.isPending} title="Unlink document" aria-label="Unlink document">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-destructive hover:text-destructive shrink-0"
+                        onClick={() => unlinkMutation.mutate({ id: doc.id })}
+                        disabled={unlinkMutation.isPending}
+                        title="Unlink document"
+                        aria-label="Unlink document"
+                      >
                         <X className="h-4 w-4" />
                       </Button>
                     </div>
@@ -112,7 +170,10 @@ export function DocumentsSection({ itemId }: DocumentsSectionProps) {
   if (statusLoading) {
     return (
       <section className="mt-8">
-        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4"><FileText className="h-5 w-5" />Documents</h2>
+        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
+          <FileText className="h-5 w-5" />
+          Documents
+        </h2>
         <Skeleton className="h-12 w-full" />
       </section>
     );
@@ -121,7 +182,10 @@ export function DocumentsSection({ itemId }: DocumentsSectionProps) {
   if (!status?.available) {
     return (
       <section className="mt-8">
-        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4"><FileText className="h-5 w-5" />Documents</h2>
+        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
+          <FileText className="h-5 w-5" />
+          Documents
+        </h2>
         <p className="text-sm text-muted-foreground">Paperless-ngx unavailable</p>
       </section>
     );

--- a/packages/app-inventory/src/pages/item-detail-page/sections/PhotoGallerySection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/PhotoGallerySection.tsx
@@ -1,29 +1,25 @@
 import { Camera } from 'lucide-react';
-import { toast } from 'sonner';
 
-import { trpc } from '@pops/api-client';
 import { Skeleton } from '@pops/ui';
 
-import { PhotoGallery } from '../../../components/PhotoGallery';
+import { PhotoGallery, type PhotoItem } from '../../../components/PhotoGallery';
 import { SortablePhotoGrid } from '../../../components/SortablePhotoGrid';
 
 const BASE_URL = '/api/inventory/photos';
 
 interface PhotoGallerySectionProps {
-  itemId: string;
+  photos: PhotoItem[];
+  isLoading: boolean;
+  isReordering: boolean;
+  onReorder: (orderedIds: number[]) => void;
 }
 
-export function PhotoGallerySection({ itemId }: PhotoGallerySectionProps) {
-  const utils = trpc.useUtils();
-  const { data, isLoading } = trpc.inventory.photos.listForItem.useQuery({ itemId });
-
-  const reorderMutation = trpc.inventory.photos.reorder.useMutation({
-    onSuccess: () => void utils.inventory.photos.listForItem.invalidate({ itemId }),
-    onError: (err) => toast.error(`Failed to reorder photos: ${err.message}`),
-  });
-
-  const photos = data?.data ?? [];
-
+export function PhotoGallerySection({
+  photos,
+  isLoading,
+  isReordering,
+  onReorder,
+}: PhotoGallerySectionProps) {
   if (isLoading) {
     return (
       <section className="mb-8">
@@ -54,8 +50,8 @@ export function PhotoGallerySection({ itemId }: PhotoGallerySectionProps) {
           <SortablePhotoGrid
             photos={photos}
             baseUrl={BASE_URL}
-            isReordering={reorderMutation.isPending}
-            onReorder={(orderedIds) => reorderMutation.mutate({ itemId, orderedIds })}
+            isReordering={isReordering}
+            onReorder={onReorder}
           />
         </div>
       )}

--- a/packages/app-inventory/src/pages/item-detail-page/sections/PhotoGallerySection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/PhotoGallerySection.tsx
@@ -1,8 +1,8 @@
 import { Camera } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { trpc } from '@pops/api-client';
 import { Skeleton } from '@pops/ui';
-import { toast } from 'sonner';
 
 import { PhotoGallery } from '../../../components/PhotoGallery';
 import { SortablePhotoGrid } from '../../../components/SortablePhotoGrid';
@@ -41,7 +41,9 @@ export function PhotoGallerySection({ itemId }: PhotoGallerySectionProps) {
       <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
         <Camera className="h-5 w-5" />
         Photos
-        {photos.length > 0 && <span className="text-sm font-normal text-muted-foreground">({photos.length})</span>}
+        {photos.length > 0 && (
+          <span className="text-sm font-normal text-muted-foreground">({photos.length})</span>
+        )}
       </h2>
 
       <PhotoGallery photos={photos} baseUrl={BASE_URL} />

--- a/packages/app-inventory/src/pages/item-detail-page/sections/PhotoGallerySection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/PhotoGallerySection.tsx
@@ -1,0 +1,62 @@
+import { Camera } from 'lucide-react';
+
+import { trpc } from '@pops/api-client';
+import { Skeleton } from '@pops/ui';
+import { toast } from 'sonner';
+
+import { PhotoGallery } from '../../../components/PhotoGallery';
+import { SortablePhotoGrid } from '../../../components/SortablePhotoGrid';
+
+const BASE_URL = '/api/inventory/photos';
+
+interface PhotoGallerySectionProps {
+  itemId: string;
+}
+
+export function PhotoGallerySection({ itemId }: PhotoGallerySectionProps) {
+  const utils = trpc.useUtils();
+  const { data, isLoading } = trpc.inventory.photos.listForItem.useQuery({ itemId });
+
+  const reorderMutation = trpc.inventory.photos.reorder.useMutation({
+    onSuccess: () => void utils.inventory.photos.listForItem.invalidate({ itemId }),
+    onError: (err) => toast.error(`Failed to reorder photos: ${err.message}`),
+  });
+
+  const photos = data?.data ?? [];
+
+  if (isLoading) {
+    return (
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
+          <Camera className="h-5 w-5" />
+          Photos
+        </h2>
+        <Skeleton className="h-48 w-full rounded-lg" />
+      </section>
+    );
+  }
+
+  return (
+    <section className="mb-8">
+      <h2 className="text-lg font-semibold flex items-center gap-2 mb-4">
+        <Camera className="h-5 w-5" />
+        Photos
+        {photos.length > 0 && <span className="text-sm font-normal text-muted-foreground">({photos.length})</span>}
+      </h2>
+
+      <PhotoGallery photos={photos} baseUrl={BASE_URL} />
+
+      {photos.length > 1 && (
+        <div className="mt-4">
+          <p className="text-xs text-muted-foreground mb-2">Drag to reorder</p>
+          <SortablePhotoGrid
+            photos={photos}
+            baseUrl={BASE_URL}
+            isReordering={reorderMutation.isPending}
+            onReorder={(orderedIds) => reorderMutation.mutate({ itemId, orderedIds })}
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/app-inventory/src/pages/item-detail-page/useItemDetailPageModel.ts
+++ b/packages/app-inventory/src/pages/item-detail-page/useItemDetailPageModel.ts
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { toast } from 'sonner';
+
+import { trpc } from '@pops/api-client';
+import { useSetPageContext } from '@pops/navigation';
+
+export function useItemDetailPageModel() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const utils = trpc.useUtils();
+
+  const { data: itemData, isLoading, error } = trpc.inventory.items.get.useQuery(
+    { id: id! },
+    { enabled: !!id }
+  );
+
+  const { data: connectionsData, isLoading: connectionsLoading } =
+    trpc.inventory.connections.listForItem.useQuery({ itemId: id! }, { enabled: !!id });
+
+  const { data: photosData } = trpc.inventory.photos.listForItem.useQuery(
+    { itemId: id! },
+    { enabled: !!id }
+  );
+
+  const deleteMutation = trpc.inventory.items.delete.useMutation({
+    onSuccess: () => { toast.success('Item deleted'); void navigate('/inventory'); },
+    onError: (err) => toast.error(`Failed to delete: ${err.message}`),
+  });
+
+  const disconnectMutation = trpc.inventory.connections.disconnect.useMutation({
+    onSuccess: () => {
+      toast.success('Items disconnected');
+      void utils.inventory.connections.listForItem.invalidate({ itemId: id! });
+    },
+    onError: (err) => toast.error(`Failed to disconnect: ${err.message}`),
+  });
+
+  const itemEntity = useMemo(
+    () => ({ uri: `pops:inventory/item/${id ?? ''}`, type: 'item' as const, title: itemData?.data?.itemName ?? '' }),
+    [id, itemData?.data?.itemName]
+  );
+  useSetPageContext({ page: 'item-detail', pageType: 'drill-down', entity: itemEntity });
+
+  return {
+    id, itemData, isLoading, error,
+    connectionsData, connectionsLoading,
+    photosData,
+    deleteMutation, disconnectMutation,
+    utils,
+  };
+}

--- a/packages/app-inventory/src/pages/item-detail-page/useItemDetailPageModel.ts
+++ b/packages/app-inventory/src/pages/item-detail-page/useItemDetailPageModel.ts
@@ -10,10 +10,11 @@ export function useItemDetailPageModel() {
   const navigate = useNavigate();
   const utils = trpc.useUtils();
 
-  const { data: itemData, isLoading, error } = trpc.inventory.items.get.useQuery(
-    { id: id! },
-    { enabled: !!id }
-  );
+  const {
+    data: itemData,
+    isLoading,
+    error,
+  } = trpc.inventory.items.get.useQuery({ id: id! }, { enabled: !!id });
 
   const { data: connectionsData, isLoading: connectionsLoading } =
     trpc.inventory.connections.listForItem.useQuery({ itemId: id! }, { enabled: !!id });
@@ -24,7 +25,10 @@ export function useItemDetailPageModel() {
   );
 
   const deleteMutation = trpc.inventory.items.delete.useMutation({
-    onSuccess: () => { toast.success('Item deleted'); void navigate('/inventory'); },
+    onSuccess: () => {
+      toast.success('Item deleted');
+      void navigate('/inventory');
+    },
     onError: (err) => toast.error(`Failed to delete: ${err.message}`),
   });
 
@@ -37,16 +41,25 @@ export function useItemDetailPageModel() {
   });
 
   const itemEntity = useMemo(
-    () => ({ uri: `pops:inventory/item/${id ?? ''}`, type: 'item' as const, title: itemData?.data?.itemName ?? '' }),
+    () => ({
+      uri: `pops:inventory/item/${id ?? ''}`,
+      type: 'item' as const,
+      title: itemData?.data?.itemName ?? '',
+    }),
     [id, itemData?.data?.itemName]
   );
   useSetPageContext({ page: 'item-detail', pageType: 'drill-down', entity: itemEntity });
 
   return {
-    id, itemData, isLoading, error,
-    connectionsData, connectionsLoading,
+    id,
+    itemData,
+    isLoading,
+    error,
+    connectionsData,
+    connectionsLoading,
     photosData,
-    deleteMutation, disconnectMutation,
+    deleteMutation,
+    disconnectMutation,
     utils,
   };
 }

--- a/packages/app-inventory/src/pages/item-detail-page/useItemDetailPageModel.ts
+++ b/packages/app-inventory/src/pages/item-detail-page/useItemDetailPageModel.ts
@@ -16,10 +16,17 @@ export function useItemDetailPageModel() {
     error,
   } = trpc.inventory.items.get.useQuery({ id: id! }, { enabled: !!id });
 
+  const locationId = itemData?.data?.locationId ?? null;
+
+  const { data: locationPathData } = trpc.inventory.locations.getPath.useQuery(
+    { id: locationId! },
+    { enabled: !!locationId }
+  );
+
   const { data: connectionsData, isLoading: connectionsLoading } =
     trpc.inventory.connections.listForItem.useQuery({ itemId: id! }, { enabled: !!id });
 
-  const { data: photosData } = trpc.inventory.photos.listForItem.useQuery(
+  const { data: photosData, isLoading: photosLoading } = trpc.inventory.photos.listForItem.useQuery(
     { itemId: id! },
     { enabled: !!id }
   );
@@ -40,6 +47,11 @@ export function useItemDetailPageModel() {
     onError: (err) => toast.error(`Failed to disconnect: ${err.message}`),
   });
 
+  const reorderPhotosMutation = trpc.inventory.photos.reorder.useMutation({
+    onSuccess: () => void utils.inventory.photos.listForItem.invalidate({ itemId: id! }),
+    onError: (err) => toast.error(`Failed to reorder photos: ${err.message}`),
+  });
+
   const itemEntity = useMemo(
     () => ({
       uri: `pops:inventory/item/${id ?? ''}`,
@@ -55,9 +67,12 @@ export function useItemDetailPageModel() {
     itemData,
     isLoading,
     error,
+    locationPath: locationPathData?.data ?? null,
     connectionsData,
     connectionsLoading,
     photosData,
+    photosLoading,
+    reorderPhotosMutation,
     deleteMutation,
     disconnectMutation,
     utils,

--- a/packages/app-inventory/src/pages/item-form-page/sections/ConnectionsSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/ConnectionsSection.tsx
@@ -17,11 +17,17 @@ interface ConnectionsSectionProps {
 }
 
 export function ConnectionsSection({
-  pendingConnections, connectionSearch, searchResults, searchLoading,
-  onSearchChange, onAdd, onRemove,
+  pendingConnections,
+  connectionSearch,
+  searchResults,
+  searchLoading,
+  onSearchChange,
+  onAdd,
+  onRemove,
 }: ConnectionsSectionProps) {
   const pendingIds = new Set(pendingConnections.map((c) => c.id));
-  const filtered = searchResults?.data.filter((item: InventoryItem) => !pendingIds.has(item.id)) ?? [];
+  const filtered =
+    searchResults?.data.filter((item: InventoryItem) => !pendingIds.has(item.id)) ?? [];
 
   return (
     <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
@@ -33,9 +39,18 @@ export function ConnectionsSection({
       {pendingConnections.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {pendingConnections.map((conn) => (
-            <Badge key={conn.id} variant="secondary" className="flex items-center gap-1.5 pl-3 pr-1.5 py-1 bg-app-accent/10 text-app-accent border-app-accent/20">
+            <Badge
+              key={conn.id}
+              variant="secondary"
+              className="flex items-center gap-1.5 pl-3 pr-1.5 py-1 bg-app-accent/10 text-app-accent border-app-accent/20"
+            >
               {conn.itemName}
-              <Button variant="ghost" size="icon" className="h-4 w-4 rounded-full hover:bg-app-accent/20" onClick={() => onRemove(conn.id)}>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-4 w-4 rounded-full hover:bg-app-accent/20"
+                onClick={() => onRemove(conn.id)}
+              >
                 <X className="h-3 w-3" />
               </Button>
             </Badge>
@@ -68,12 +83,16 @@ export function ConnectionsSection({
                 key={item.id}
                 variant="ghost"
                 className="w-full flex items-center justify-between p-2.5 h-auto text-left"
-                onClick={() => { onAdd(item); onSearchChange(''); }}
+                onClick={() => {
+                  onAdd(item);
+                  onSearchChange('');
+                }}
               >
                 <div>
                   <div className="font-medium text-sm">{item.itemName}</div>
                   <div className="text-xs text-muted-foreground">
-                    {[item.brand, item.model, item.assetId].filter(Boolean).join(' · ') || 'No details'}
+                    {[item.brand, item.model, item.assetId].filter(Boolean).join(' · ') ||
+                      'No details'}
                   </div>
                 </div>
                 <Link2 className="h-4 w-4 text-app-accent/50 shrink-0 ml-2" />

--- a/packages/app-inventory/src/pages/item-form-page/sections/ConnectionsSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/ConnectionsSection.tsx
@@ -1,0 +1,87 @@
+import { Link2, Search, X } from 'lucide-react';
+
+import { Badge, Button, Skeleton, TextInput } from '@pops/ui';
+
+import type { InventoryItem } from '@pops/api/modules/inventory/items/types';
+
+import type { PendingConnection } from '../useItemFormPageModel';
+
+interface ConnectionsSectionProps {
+  pendingConnections: PendingConnection[];
+  connectionSearch: string;
+  searchResults: { data: InventoryItem[] } | undefined;
+  searchLoading: boolean;
+  onSearchChange: (value: string) => void;
+  onAdd: (item: InventoryItem) => void;
+  onRemove: (id: string) => void;
+}
+
+export function ConnectionsSection({
+  pendingConnections, connectionSearch, searchResults, searchLoading,
+  onSearchChange, onAdd, onRemove,
+}: ConnectionsSectionProps) {
+  const pendingIds = new Set(pendingConnections.map((c) => c.id));
+  const filtered = searchResults?.data.filter((item: InventoryItem) => !pendingIds.has(item.id)) ?? [];
+
+  return (
+    <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
+      <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
+        <Link2 className="h-5 w-5 text-app-accent" />
+        Connected Items
+      </h2>
+
+      {pendingConnections.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {pendingConnections.map((conn) => (
+            <Badge key={conn.id} variant="secondary" className="flex items-center gap-1.5 pl-3 pr-1.5 py-1 bg-app-accent/10 text-app-accent border-app-accent/20">
+              {conn.itemName}
+              <Button variant="ghost" size="icon" className="h-4 w-4 rounded-full hover:bg-app-accent/20" onClick={() => onRemove(conn.id)}>
+                <X className="h-3 w-3" />
+              </Button>
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <TextInput
+          value={connectionSearch}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search items to connect..."
+          className="pl-9"
+        />
+      </div>
+
+      {connectionSearch.length >= 2 && (
+        <div className="max-h-48 overflow-y-auto border rounded-lg divide-y">
+          {searchLoading ? (
+            <div className="space-y-2 p-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-3 text-center">No items found</p>
+          ) : (
+            filtered.map((item: InventoryItem) => (
+              <Button
+                key={item.id}
+                variant="ghost"
+                className="w-full flex items-center justify-between p-2.5 h-auto text-left"
+                onClick={() => { onAdd(item); onSearchChange(''); }}
+              >
+                <div>
+                  <div className="font-medium text-sm">{item.itemName}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {[item.brand, item.model, item.assetId].filter(Boolean).join(' · ') || 'No details'}
+                  </div>
+                </div>
+                <Link2 className="h-4 w-4 text-app-accent/50 shrink-0 ml-2" />
+              </Button>
+            ))
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/app-inventory/src/pages/item-form-page/sections/ConnectionsSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/ConnectionsSection.tsx
@@ -48,7 +48,7 @@ export function ConnectionsSection({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-4 w-4 rounded-full hover:bg-app-accent/20"
+                className="rounded-full hover:bg-app-accent/20"
                 onClick={() => onRemove(conn.id)}
               >
                 <X className="h-3 w-3" />

--- a/packages/app-inventory/src/pages/item-form-page/sections/CoreFieldsSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/CoreFieldsSection.tsx
@@ -1,0 +1,140 @@
+import { Loader2, Wand2 } from 'lucide-react';
+import type { UseFormRegister, UseFormWatch, UseFormSetValue, FieldErrors } from 'react-hook-form';
+
+import {
+  Button,
+  CheckboxInput,
+  DateInput,
+  Label,
+  Select,
+  TextInput,
+} from '@pops/ui';
+
+import { LocationPicker } from '../../../components/LocationPicker';
+import { extractPrefix, type ItemFormValues } from '../useItemFormPageModel';
+
+import type { LocationTreeNode } from '../../location-tree-page/utils';
+
+const ITEM_TYPES = ['Electronics', 'Furniture', 'Appliance', 'Clothing', 'Tools', 'Sports', 'Kitchen', 'Office', 'Other'];
+const CONDITIONS = [
+  { value: 'new', label: 'New' },
+  { value: 'good', label: 'Good' },
+  { value: 'fair', label: 'Fair' },
+  { value: 'poor', label: 'Poor' },
+  { value: 'broken', label: 'Broken' },
+];
+
+function FormField({ label, error, children }: { label: string; error?: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <Label className="mb-1.5 block">{label}</Label>
+      {children}
+      {error && <p className="text-sm text-destructive mt-1">{error}</p>}
+    </div>
+  );
+}
+
+interface CoreFieldsSectionProps {
+  register: UseFormRegister<ItemFormValues>;
+  watch: UseFormWatch<ItemFormValues>;
+  setValue: UseFormSetValue<ItemFormValues>;
+  errors: FieldErrors<ItemFormValues>;
+  assetIdError: string | null;
+  assetIdChecking: boolean;
+  generating: boolean;
+  locationTree: LocationTreeNode[];
+  onAutoGenerate: () => void;
+  onValidateAssetId: (value: string) => void;
+  onCreateLocation: (name: string, parentId: string | null) => void;
+}
+
+export function CoreFieldsSection({
+  register, watch, setValue, errors,
+  assetIdError, assetIdChecking, generating,
+  locationTree, onAutoGenerate, onValidateAssetId, onCreateLocation,
+}: CoreFieldsSectionProps) {
+  const typeValue = watch('type');
+
+  return (
+    <>
+      <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
+        <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
+          <span className="w-1.5 h-1.5 rounded-full bg-app-accent" />
+          Basic Information
+        </h2>
+        <FormField label="Item Name *" error={errors.itemName?.message}>
+          <TextInput {...register('itemName', { required: 'Item name is required' })} placeholder="e.g. MacBook Pro 16-inch" className="font-semibold" />
+        </FormField>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <FormField label="Brand"><TextInput {...register('brand')} placeholder="e.g. Apple" /></FormField>
+          <FormField label="Model"><TextInput {...register('model')} placeholder="e.g. M3 Max" /></FormField>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <FormField label="Item ID / SKU"><TextInput {...register('itemId')} /></FormField>
+          <FormField label="Asset ID" error={assetIdError ?? undefined}>
+            <div className="flex gap-2">
+              <div className="relative flex-1">
+                <TextInput {...register('assetId')} className="font-mono" onBlur={(e) => onValidateAssetId(e.target.value)} />
+                {assetIdChecking && <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />}
+              </div>
+              <Button type="button" variant="outline" size="sm" disabled={!typeValue || generating} onClick={onAutoGenerate} className="shrink-0 whitespace-nowrap" title={typeValue ? `Generate ${extractPrefix(typeValue)}XX` : 'Select a type first'}>
+                {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Wand2 className="h-4 w-4 mr-1" />}
+                Auto-generate
+              </Button>
+            </div>
+          </FormField>
+        </div>
+      </section>
+
+      <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
+        <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
+          <span className="w-1.5 h-1.5 rounded-full bg-app-accent" />
+          Classification
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <FormField label="Type *" error={errors.type?.message}>
+            <Select {...register('type', { required: 'Type is required' })} options={[{ value: '', label: 'Select type...' }, ...ITEM_TYPES.map((t) => ({ value: t, label: t }))]} />
+          </FormField>
+          <FormField label="Condition">
+            <Select {...register('condition')} options={[{ value: '', label: 'Select condition...' }, ...CONDITIONS]} />
+          </FormField>
+        </div>
+        <FormField label="Location">
+          <LocationPicker
+            locations={locationTree}
+            value={watch('locationId') || null}
+            onChange={(id) => setValue('locationId', id ?? '', { shouldDirty: true })}
+            onCreateLocation={onCreateLocation}
+            placeholder="Select location…"
+          />
+        </FormField>
+        <div className="flex gap-6 p-4 rounded-xl bg-app-accent/5">
+          <CheckboxInput label="In Use" {...register('inUse')} />
+          <CheckboxInput label="Tax Deductible" {...register('deductible')} />
+        </div>
+      </section>
+
+      <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
+        <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
+          <span className="w-1.5 h-1.5 rounded-full bg-app-accent" />
+          Dates & Values
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <FormField label="Purchase Date"><DateInput {...register('purchaseDate')} /></FormField>
+          <FormField label="Warranty Expires"><DateInput {...register('warrantyExpires')} /></FormField>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <FormField label="Purchase Price ($)">
+            <TextInput type="number" step="0.01" min="0" {...register('purchasePrice')} placeholder="0.00" />
+          </FormField>
+          <FormField label="Replacement Value ($)">
+            <TextInput type="number" step="0.01" min="0" {...register('replacementValue')} placeholder="0.00" className="font-bold text-app-accent" />
+          </FormField>
+          <FormField label="Resale Value ($)">
+            <TextInput type="number" step="0.01" min="0" {...register('resaleValue')} placeholder="0.00" />
+          </FormField>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/packages/app-inventory/src/pages/item-form-page/sections/CoreFieldsSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/CoreFieldsSection.tsx
@@ -1,21 +1,25 @@
 import { Loader2, Wand2 } from 'lucide-react';
-import type { UseFormRegister, UseFormWatch, UseFormSetValue, FieldErrors } from 'react-hook-form';
 
-import {
-  Button,
-  CheckboxInput,
-  DateInput,
-  Label,
-  Select,
-  TextInput,
-} from '@pops/ui';
+import { Button, CheckboxInput, DateInput, Label, Select, TextInput } from '@pops/ui';
 
 import { LocationPicker } from '../../../components/LocationPicker';
 import { extractPrefix, type ItemFormValues } from '../useItemFormPageModel';
 
+import type { UseFormRegister, UseFormWatch, UseFormSetValue, FieldErrors } from 'react-hook-form';
+
 import type { LocationTreeNode } from '../../location-tree-page/utils';
 
-const ITEM_TYPES = ['Electronics', 'Furniture', 'Appliance', 'Clothing', 'Tools', 'Sports', 'Kitchen', 'Office', 'Other'];
+const ITEM_TYPES = [
+  'Electronics',
+  'Furniture',
+  'Appliance',
+  'Clothing',
+  'Tools',
+  'Sports',
+  'Kitchen',
+  'Office',
+  'Other',
+];
 const CONDITIONS = [
   { value: 'new', label: 'New' },
   { value: 'good', label: 'Good' },
@@ -24,7 +28,15 @@ const CONDITIONS = [
   { value: 'broken', label: 'Broken' },
 ];
 
-function FormField({ label, error, children }: { label: string; error?: string; children: React.ReactNode }) {
+function FormField({
+  label,
+  error,
+  children,
+}: {
+  label: string;
+  error?: string;
+  children: React.ReactNode;
+}) {
   return (
     <div>
       <Label className="mb-1.5 block">{label}</Label>
@@ -49,9 +61,17 @@ interface CoreFieldsSectionProps {
 }
 
 export function CoreFieldsSection({
-  register, watch, setValue, errors,
-  assetIdError, assetIdChecking, generating,
-  locationTree, onAutoGenerate, onValidateAssetId, onCreateLocation,
+  register,
+  watch,
+  setValue,
+  errors,
+  assetIdError,
+  assetIdChecking,
+  generating,
+  locationTree,
+  onAutoGenerate,
+  onValidateAssetId,
+  onCreateLocation,
 }: CoreFieldsSectionProps) {
   const typeValue = watch('type');
 
@@ -63,22 +83,50 @@ export function CoreFieldsSection({
           Basic Information
         </h2>
         <FormField label="Item Name *" error={errors.itemName?.message}>
-          <TextInput {...register('itemName', { required: 'Item name is required' })} placeholder="e.g. MacBook Pro 16-inch" className="font-semibold" />
+          <TextInput
+            {...register('itemName', { required: 'Item name is required' })}
+            placeholder="e.g. MacBook Pro 16-inch"
+            className="font-semibold"
+          />
         </FormField>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <FormField label="Brand"><TextInput {...register('brand')} placeholder="e.g. Apple" /></FormField>
-          <FormField label="Model"><TextInput {...register('model')} placeholder="e.g. M3 Max" /></FormField>
+          <FormField label="Brand">
+            <TextInput {...register('brand')} placeholder="e.g. Apple" />
+          </FormField>
+          <FormField label="Model">
+            <TextInput {...register('model')} placeholder="e.g. M3 Max" />
+          </FormField>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <FormField label="Item ID / SKU"><TextInput {...register('itemId')} /></FormField>
+          <FormField label="Item ID / SKU">
+            <TextInput {...register('itemId')} />
+          </FormField>
           <FormField label="Asset ID" error={assetIdError ?? undefined}>
             <div className="flex gap-2">
               <div className="relative flex-1">
-                <TextInput {...register('assetId')} className="font-mono" onBlur={(e) => onValidateAssetId(e.target.value)} />
-                {assetIdChecking && <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />}
+                <TextInput
+                  {...register('assetId')}
+                  className="font-mono"
+                  onBlur={(e) => onValidateAssetId(e.target.value)}
+                />
+                {assetIdChecking && (
+                  <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+                )}
               </div>
-              <Button type="button" variant="outline" size="sm" disabled={!typeValue || generating} onClick={onAutoGenerate} className="shrink-0 whitespace-nowrap" title={typeValue ? `Generate ${extractPrefix(typeValue)}XX` : 'Select a type first'}>
-                {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Wand2 className="h-4 w-4 mr-1" />}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!typeValue || generating}
+                onClick={onAutoGenerate}
+                className="shrink-0 whitespace-nowrap"
+                title={typeValue ? `Generate ${extractPrefix(typeValue)}XX` : 'Select a type first'}
+              >
+                {generating ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Wand2 className="h-4 w-4 mr-1" />
+                )}
                 Auto-generate
               </Button>
             </div>
@@ -93,10 +141,19 @@ export function CoreFieldsSection({
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <FormField label="Type *" error={errors.type?.message}>
-            <Select {...register('type', { required: 'Type is required' })} options={[{ value: '', label: 'Select type...' }, ...ITEM_TYPES.map((t) => ({ value: t, label: t }))]} />
+            <Select
+              {...register('type', { required: 'Type is required' })}
+              options={[
+                { value: '', label: 'Select type...' },
+                ...ITEM_TYPES.map((t) => ({ value: t, label: t })),
+              ]}
+            />
           </FormField>
           <FormField label="Condition">
-            <Select {...register('condition')} options={[{ value: '', label: 'Select condition...' }, ...CONDITIONS]} />
+            <Select
+              {...register('condition')}
+              options={[{ value: '', label: 'Select condition...' }, ...CONDITIONS]}
+            />
           </FormField>
         </div>
         <FormField label="Location">
@@ -120,18 +177,41 @@ export function CoreFieldsSection({
           Dates & Values
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <FormField label="Purchase Date"><DateInput {...register('purchaseDate')} /></FormField>
-          <FormField label="Warranty Expires"><DateInput {...register('warrantyExpires')} /></FormField>
+          <FormField label="Purchase Date">
+            <DateInput {...register('purchaseDate')} />
+          </FormField>
+          <FormField label="Warranty Expires">
+            <DateInput {...register('warrantyExpires')} />
+          </FormField>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <FormField label="Purchase Price ($)">
-            <TextInput type="number" step="0.01" min="0" {...register('purchasePrice')} placeholder="0.00" />
+            <TextInput
+              type="number"
+              step="0.01"
+              min="0"
+              {...register('purchasePrice')}
+              placeholder="0.00"
+            />
           </FormField>
           <FormField label="Replacement Value ($)">
-            <TextInput type="number" step="0.01" min="0" {...register('replacementValue')} placeholder="0.00" className="font-bold text-app-accent" />
+            <TextInput
+              type="number"
+              step="0.01"
+              min="0"
+              {...register('replacementValue')}
+              placeholder="0.00"
+              className="font-bold text-app-accent"
+            />
           </FormField>
           <FormField label="Resale Value ($)">
-            <TextInput type="number" step="0.01" min="0" {...register('resaleValue')} placeholder="0.00" />
+            <TextInput
+              type="number"
+              step="0.01"
+              min="0"
+              {...register('resaleValue')}
+              placeholder="0.00"
+            />
           </FormField>
         </div>
       </section>

--- a/packages/app-inventory/src/pages/item-form-page/sections/NotesSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/NotesSection.tsx
@@ -1,9 +1,10 @@
 import { Eye, PenLine } from 'lucide-react';
 import Markdown from 'react-markdown';
 import rehypeSanitize from 'rehype-sanitize';
-import type { UseFormRegister, UseFormWatch } from 'react-hook-form';
 
 import { Button, Textarea } from '@pops/ui';
+
+import type { UseFormRegister, UseFormWatch } from 'react-hook-form';
 
 import type { ItemFormValues } from '../useItemFormPageModel';
 
@@ -14,7 +15,12 @@ interface NotesSectionProps {
   onTogglePreview: () => void;
 }
 
-export function NotesSection({ register, watch, notesPreview, onTogglePreview }: NotesSectionProps) {
+export function NotesSection({
+  register,
+  watch,
+  notesPreview,
+  onTogglePreview,
+}: NotesSectionProps) {
   return (
     <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
       <div className="flex items-center justify-between">
@@ -22,11 +28,21 @@ export function NotesSection({ register, watch, notesPreview, onTogglePreview }:
           <span className="w-1.5 h-1.5 rounded-full bg-app-accent" />
           Notes
         </h2>
-        <Button type="button" variant="ghost" size="sm" onClick={onTogglePreview} className="text-xs text-muted-foreground">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onTogglePreview}
+          className="text-xs text-muted-foreground"
+        >
           {notesPreview ? (
-            <><PenLine className="h-3.5 w-3.5 mr-1" /> Edit</>
+            <>
+              <PenLine className="h-3.5 w-3.5 mr-1" /> Edit
+            </>
           ) : (
-            <><Eye className="h-3.5 w-3.5 mr-1" /> Preview</>
+            <>
+              <Eye className="h-3.5 w-3.5 mr-1" /> Preview
+            </>
           )}
         </Button>
       </div>
@@ -39,7 +55,12 @@ export function NotesSection({ register, watch, notesPreview, onTogglePreview }:
           )}
         </div>
       ) : (
-        <Textarea {...register('notes')} rows={4} placeholder="Add notes about this item... (supports markdown)" className="w-full bg-transparent" />
+        <Textarea
+          {...register('notes')}
+          rows={4}
+          placeholder="Add notes about this item... (supports markdown)"
+          className="w-full bg-transparent"
+        />
       )}
     </section>
   );

--- a/packages/app-inventory/src/pages/item-form-page/sections/NotesSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/NotesSection.tsx
@@ -1,0 +1,46 @@
+import { Eye, PenLine } from 'lucide-react';
+import Markdown from 'react-markdown';
+import rehypeSanitize from 'rehype-sanitize';
+import type { UseFormRegister, UseFormWatch } from 'react-hook-form';
+
+import { Button, Textarea } from '@pops/ui';
+
+import type { ItemFormValues } from '../useItemFormPageModel';
+
+interface NotesSectionProps {
+  register: UseFormRegister<ItemFormValues>;
+  watch: UseFormWatch<ItemFormValues>;
+  notesPreview: boolean;
+  onTogglePreview: () => void;
+}
+
+export function NotesSection({ register, watch, notesPreview, onTogglePreview }: NotesSectionProps) {
+  return (
+    <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
+          <span className="w-1.5 h-1.5 rounded-full bg-app-accent" />
+          Notes
+        </h2>
+        <Button type="button" variant="ghost" size="sm" onClick={onTogglePreview} className="text-xs text-muted-foreground">
+          {notesPreview ? (
+            <><PenLine className="h-3.5 w-3.5 mr-1" /> Edit</>
+          ) : (
+            <><Eye className="h-3.5 w-3.5 mr-1" /> Preview</>
+          )}
+        </Button>
+      </div>
+      {notesPreview ? (
+        <div className="prose prose-sm dark:prose-invert max-w-none min-h-[6.5rem] p-3 rounded-md border bg-muted/30">
+          {watch('notes') ? (
+            <Markdown rehypePlugins={[rehypeSanitize]}>{watch('notes')}</Markdown>
+          ) : (
+            <p className="text-muted-foreground italic">Nothing to preview</p>
+          )}
+        </div>
+      ) : (
+        <Textarea {...register('notes')} rows={4} placeholder="Add notes about this item... (supports markdown)" className="w-full bg-transparent" />
+      )}
+    </section>
+  );
+}

--- a/packages/app-inventory/src/pages/item-form-page/sections/PhotoUploadSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/PhotoUploadSection.tsx
@@ -1,14 +1,14 @@
 import { ImageIcon } from 'lucide-react';
 
-import { Button, Skeleton } from '@pops/ui';
+import { Button } from '@pops/ui';
 
 import { PhotoUpload, type UploadedFile } from '../../../components/PhotoUpload';
 import { SortablePhotoGrid } from '../../../components/SortablePhotoGrid';
+
 import type { PhotoItem } from '../../../components/PhotoGallery';
 
 interface PhotoUploadSectionProps {
   isEditMode: boolean;
-  itemId: string | undefined;
   existingPhotos: PhotoItem[];
   uploadFiles: UploadedFile[];
   imageProcessing: boolean;
@@ -24,9 +24,19 @@ interface PhotoUploadSectionProps {
 }
 
 export function PhotoUploadSection({
-  isEditMode, itemId, existingPhotos, uploadFiles, imageProcessing,
-  isReordering, deleteConfirmId, isDeleting,
-  onFilesSelected, onRemoveUpload, onDeletePhoto, onConfirmDelete, onCancelDelete, onReorder,
+  isEditMode,
+  existingPhotos,
+  uploadFiles,
+  imageProcessing,
+  isReordering,
+  deleteConfirmId,
+  isDeleting,
+  onFilesSelected,
+  onRemoveUpload,
+  onDeletePhoto,
+  onConfirmDelete,
+  onCancelDelete,
+  onReorder,
 }: PhotoUploadSectionProps) {
   return (
     <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
@@ -47,7 +57,9 @@ export function PhotoUploadSection({
       {deleteConfirmId !== null && (
         <div className="flex items-center gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
           <p className="text-sm flex-1">Delete this photo? This cannot be undone.</p>
-          <Button type="button" variant="outline" size="sm" onClick={onCancelDelete}>Cancel</Button>
+          <Button type="button" variant="outline" size="sm" onClick={onCancelDelete}>
+            Cancel
+          </Button>
           <Button
             type="button"
             size="sm"

--- a/packages/app-inventory/src/pages/item-form-page/sections/PhotoUploadSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/PhotoUploadSection.tsx
@@ -1,0 +1,73 @@
+import { ImageIcon } from 'lucide-react';
+
+import { Button, Skeleton } from '@pops/ui';
+
+import { PhotoUpload, type UploadedFile } from '../../../components/PhotoUpload';
+import { SortablePhotoGrid } from '../../../components/SortablePhotoGrid';
+import type { PhotoItem } from '../../../components/PhotoGallery';
+
+interface PhotoUploadSectionProps {
+  isEditMode: boolean;
+  itemId: string | undefined;
+  existingPhotos: PhotoItem[];
+  uploadFiles: UploadedFile[];
+  imageProcessing: boolean;
+  isReordering: boolean;
+  deleteConfirmId: number | null;
+  isDeleting: boolean;
+  onFilesSelected: (files: File[]) => Promise<void>;
+  onRemoveUpload: (localId: string) => void;
+  onDeletePhoto: (photoId: number) => void;
+  onConfirmDelete: () => void;
+  onCancelDelete: () => void;
+  onReorder: (orderedIds: number[]) => void;
+}
+
+export function PhotoUploadSection({
+  isEditMode, itemId, existingPhotos, uploadFiles, imageProcessing,
+  isReordering, deleteConfirmId, isDeleting,
+  onFilesSelected, onRemoveUpload, onDeletePhoto, onConfirmDelete, onCancelDelete, onReorder,
+}: PhotoUploadSectionProps) {
+  return (
+    <section className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5">
+      <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
+        <ImageIcon className="h-5 w-5 text-app-accent" />
+        Photos
+      </h2>
+
+      {isEditMode && existingPhotos.length > 0 && (
+        <SortablePhotoGrid
+          photos={existingPhotos}
+          onReorder={onReorder}
+          onDelete={onDeletePhoto}
+          isReordering={isReordering}
+        />
+      )}
+
+      {deleteConfirmId !== null && (
+        <div className="flex items-center gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
+          <p className="text-sm flex-1">Delete this photo? This cannot be undone.</p>
+          <Button type="button" variant="outline" size="sm" onClick={onCancelDelete}>Cancel</Button>
+          <Button
+            type="button"
+            size="sm"
+            className="bg-destructive text-white hover:bg-destructive/80"
+            onClick={onConfirmDelete}
+            loading={isDeleting}
+            loadingText="Deleting..."
+          >
+            Delete
+          </Button>
+        </div>
+      )}
+
+      <PhotoUpload
+        onFilesSelected={(files) => void onFilesSelected(files)}
+        files={uploadFiles}
+        onRemove={onRemoveUpload}
+        disabled={imageProcessing}
+        accept="image/jpeg,image/png,image/webp,image/heic,image/heif,.heic,.heif"
+      />
+    </section>
+  );
+}

--- a/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
 import { toast } from 'sonner';
@@ -53,6 +53,15 @@ const defaultValues: ItemFormValues = {
   notes: '',
 };
 
+async function blobToBase64(blob: Blob): Promise<string> {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 8192) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
+  }
+  return btoa(binary);
+}
+
 export function extractPrefix(type: string): string {
   const firstWord = type.split(/\s+/)[0] ?? '';
   const upper = firstWord.toUpperCase();
@@ -79,6 +88,16 @@ export function useItemFormPageModel() {
   const [generating, setGenerating] = useState(false);
   const [notesPreview, setNotesPreview] = useState(false);
   const [uploadFiles, setUploadFiles] = useState<UploadedFile[]>([]);
+  const uploadFilesRef = useRef(uploadFiles);
+  uploadFilesRef.current = uploadFiles;
+  useEffect(
+    () => () => {
+      for (const f of uploadFilesRef.current) {
+        if (f.previewUrl) URL.revokeObjectURL(f.previewUrl);
+      }
+    },
+    []
+  );
   const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null);
   const [pendingConnections, setPendingConnections] = useState<PendingConnection[]>([]);
   const [connectionSearch, setConnectionSearch] = useState('');
@@ -91,7 +110,7 @@ export function useItemFormPageModel() {
   );
   const existingPhotos: PhotoItem[] = photosData?.data ?? [];
 
-  const attachMutation = trpc.inventory.photos.attach.useMutation({
+  const uploadMutation = trpc.inventory.photos.upload.useMutation({
     onSuccess: () => void refetchPhotos(),
   });
   const photoDeleteMutation = trpc.inventory.photos.remove.useMutation({
@@ -236,11 +255,10 @@ export function useItemFormPageModel() {
             setUploadFiles((prev) =>
               prev.map((f) => (f.localId === localId ? { ...f, progress: 50 } : f))
             );
-            const fileName = `${Date.now()}-${p.original.name.replace(/\.[^.]+$/, '.jpg')}`;
             if (isEditMode && id) {
-              await attachMutation.mutateAsync({
+              await uploadMutation.mutateAsync({
                 itemId: id,
-                filePath: fileName,
+                fileBase64: await blobToBase64(p.processed),
                 sortOrder: existingPhotos.length + i,
               });
             }
@@ -275,7 +293,7 @@ export function useItemFormPageModel() {
         toast.error('Failed to process images');
       }
     },
-    [processFiles, isEditMode, id, attachMutation, existingPhotos.length]
+    [processFiles, isEditMode, id, uploadMutation, existingPhotos.length]
   );
 
   const createMutation = trpc.inventory.items.create.useMutation({

--- a/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router';
+import { toast } from 'sonner';
+
+import { trpc } from '@pops/api-client';
+
+import { useImageProcessor } from '../../hooks/useImageProcessor';
+import type { PhotoItem } from '../../components/PhotoGallery';
+import type { UploadedFile } from '../../components/PhotoUpload';
+
+export interface PendingConnection {
+  id: string;
+  itemName: string;
+}
+
+export interface ItemFormValues {
+  itemName: string;
+  brand: string;
+  model: string;
+  itemId: string;
+  type: string;
+  condition: string;
+  locationId: string;
+  inUse: boolean;
+  deductible: boolean;
+  purchaseDate: string;
+  warrantyExpires: string;
+  purchasePrice: string;
+  replacementValue: string;
+  resaleValue: string;
+  assetId: string;
+  notes: string;
+}
+
+const defaultValues: ItemFormValues = {
+  itemName: '', brand: '', model: '', itemId: '', type: '', condition: 'good',
+  locationId: '', inUse: false, deductible: false, purchaseDate: '',
+  warrantyExpires: '', purchasePrice: '', replacementValue: '', resaleValue: '',
+  assetId: '', notes: '',
+};
+
+export function extractPrefix(type: string): string {
+  const firstWord = type.split(/\s+/)[0] ?? '';
+  const upper = firstWord.toUpperCase();
+  return upper.length <= 6 ? upper : upper.slice(0, 4);
+}
+
+export function useItemFormPageModel() {
+  const { id } = useParams<{ id: string }>();
+  const isEditMode = !!id;
+  const navigate = useNavigate();
+  const utils = trpc.useUtils();
+
+  const form = useForm<ItemFormValues>({ defaultValues });
+  const { watch, setValue, reset, formState: { isDirty } } = form;
+  const typeValue = watch('type');
+
+  const [assetIdError, setAssetIdError] = useState<string | null>(null);
+  const [assetIdChecking, setAssetIdChecking] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [notesPreview, setNotesPreview] = useState(false);
+  const [uploadFiles, setUploadFiles] = useState<UploadedFile[]>([]);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null);
+  const [pendingConnections, setPendingConnections] = useState<PendingConnection[]>([]);
+  const [connectionSearch, setConnectionSearch] = useState('');
+
+  const { processFiles, processing: imageProcessing } = useImageProcessor();
+
+  const { data: photosData, refetch: refetchPhotos } = trpc.inventory.photos.listForItem.useQuery(
+    { itemId: id! },
+    { enabled: isEditMode }
+  );
+  const existingPhotos: PhotoItem[] = photosData?.data ?? [];
+
+  const attachMutation = trpc.inventory.photos.attach.useMutation({ onSuccess: () => void refetchPhotos() });
+  const photoDeleteMutation = trpc.inventory.photos.remove.useMutation({
+    onSuccess: () => { void refetchPhotos(); setDeleteConfirmId(null); },
+  });
+  const reorderMutation = trpc.inventory.photos.reorder.useMutation({ onSuccess: () => void refetchPhotos() });
+
+  const { data: searchResults, isLoading: searchLoading } = trpc.inventory.items.list.useQuery(
+    { search: connectionSearch, limit: 10 },
+    { enabled: !isEditMode && connectionSearch.length >= 2 }
+  );
+
+  const connectMutation = trpc.inventory.connections.connect.useMutation();
+
+  const { data: locationsData } = trpc.inventory.locations.tree.useQuery();
+  const locationTree = locationsData?.data ?? [];
+
+  const createLocationMutation = trpc.inventory.locations.create.useMutation({
+    onSuccess: () => { toast.success('Location created'); void utils.inventory.locations.tree.invalidate(); },
+    onError: (err) => toast.error(`Failed to create location: ${err.message}`),
+  });
+
+  const { data: itemData, isLoading, error } = trpc.inventory.items.get.useQuery(
+    { id: id! },
+    { enabled: isEditMode }
+  );
+
+  useEffect(() => {
+    if (itemData?.data) {
+      const item = itemData.data;
+      reset({
+        itemName: item.itemName, brand: item.brand ?? '', model: item.model ?? '',
+        itemId: item.itemId ?? '', type: item.type ?? '', condition: item.condition ?? '',
+        locationId: item.locationId ?? '', inUse: item.inUse, deductible: item.deductible,
+        purchaseDate: item.purchaseDate ?? '', warrantyExpires: item.warrantyExpires ?? '',
+        purchasePrice: item.purchasePrice?.toString() ?? '',
+        replacementValue: item.replacementValue?.toString() ?? '',
+        resaleValue: item.resaleValue?.toString() ?? '',
+        assetId: item.assetId ?? '', notes: item.notes ?? '',
+      });
+    }
+  }, [itemData, reset]);
+
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (e: BeforeUnloadEvent) => { e.preventDefault(); };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isDirty]);
+
+  const validateAssetIdUniqueness = useCallback(async (value: string) => {
+    if (!value.trim()) { setAssetIdError(null); return; }
+    setAssetIdChecking(true);
+    try {
+      const result = await utils.inventory.items.searchByAssetId.fetch({ assetId: value.trim() });
+      if (result.data && result.data.id !== id) {
+        setAssetIdError(`Asset ID already in use by ${result.data.itemName}`);
+      } else {
+        setAssetIdError(null);
+      }
+    } catch { setAssetIdError(null); }
+    finally { setAssetIdChecking(false); }
+  }, [id, utils]);
+
+  const handleAutoGenerate = useCallback(async () => {
+    if (!typeValue) return;
+    setGenerating(true);
+    try {
+      const prefix = extractPrefix(typeValue);
+      const result = await utils.inventory.items.countByAssetPrefix.fetch({ prefix });
+      const nextNum = result.data + 1;
+      const padded = nextNum >= 100 ? String(nextNum) : String(nextNum).padStart(2, '0');
+      const newAssetId = `${prefix}${padded}`;
+      setValue('assetId', newAssetId, { shouldDirty: true });
+      setAssetIdError(null);
+      void validateAssetIdUniqueness(newAssetId);
+    } catch { toast.error('Failed to generate asset ID'); }
+    finally { setGenerating(false); }
+  }, [typeValue, utils, setValue, validateAssetIdUniqueness]);
+
+  const handleFilesSelected = useCallback(async (files: File[]) => {
+    const pending: UploadedFile[] = files.map((file, i) => ({
+      localId: `${Date.now()}-${i}`, file, previewUrl: '', status: 'pending' as const,
+    }));
+    setUploadFiles((prev) => [...prev, ...pending]);
+    try {
+      const processed = await processFiles(files);
+      setUploadFiles((prev) => prev.map((f) => {
+        const idx = pending.findIndex((p) => p.localId === f.localId);
+        const match = idx >= 0 ? processed[idx] : undefined;
+        if (!match) return f;
+        return { ...f, previewUrl: match.previewUrl, originalSize: match.originalSize, processedSize: match.processedSize, status: 'uploading' as const, progress: 0 };
+      }));
+      for (let i = 0; i < processed.length; i++) {
+        const localId = pending[i]!.localId;
+        const p = processed[i]!;
+        try {
+          setUploadFiles((prev) => prev.map((f) => f.localId === localId ? { ...f, progress: 50 } : f));
+          const fileName = `${Date.now()}-${p.original.name.replace(/\.[^.]+$/, '.jpg')}`;
+          if (isEditMode && id) {
+            await attachMutation.mutateAsync({ itemId: id, filePath: fileName, sortOrder: existingPhotos.length + i });
+          }
+          setUploadFiles((prev) => prev.map((f) => f.localId === localId ? { ...f, status: 'done' as const, progress: 100 } : f));
+        } catch (err: unknown) {
+          setUploadFiles((prev) => prev.map((f) => f.localId === localId ? { ...f, status: 'error' as const, error: err instanceof Error ? err.message : 'Upload failed' } : f));
+          toast.error(`Failed to upload ${p.original.name}`);
+        }
+      }
+    } catch {
+      setUploadFiles((prev) => prev.map((f) =>
+        pending.some((p) => p.localId === f.localId) ? { ...f, status: 'error' as const, error: 'Image processing failed' } : f
+      ));
+      toast.error('Failed to process images');
+    }
+  }, [processFiles, isEditMode, id, attachMutation, existingPhotos.length]);
+
+  const createMutation = trpc.inventory.items.create.useMutation({
+    onSuccess: async (result) => {
+      const newItemId = result.data.id;
+      if (pendingConnections.length > 0) {
+        let connected = 0;
+        for (const conn of pendingConnections) {
+          try { await connectMutation.mutateAsync({ itemAId: newItemId, itemBId: conn.id }); connected++; } catch { /* skip */ }
+        }
+        toast.success(connected > 0 ? `Item created with ${connected} connection${connected > 1 ? 's' : ''}` : 'Item created');
+      } else {
+        toast.success('Item created');
+      }
+      void utils.inventory.items.list.invalidate();
+      navigate(`/inventory/items/${newItemId}`);
+    },
+    onError: (err) => toast.error(`Failed to create: ${err.message}`),
+  });
+
+  const updateMutation = trpc.inventory.items.update.useMutation({
+    onSuccess: () => {
+      toast.success('Item updated');
+      void utils.inventory.items.list.invalidate();
+      void utils.inventory.items.get.invalidate({ id: id! });
+      navigate(`/inventory/items/${id}`);
+    },
+    onError: (err) => toast.error(`Failed to update: ${err.message}`),
+  });
+
+  const onSubmit = (values: ItemFormValues) => {
+    if (!values.itemName.trim()) { toast.error('Item name is required'); return; }
+    const payload = {
+      itemName: values.itemName.trim(), brand: values.brand || null, model: values.model || null,
+      itemId: values.itemId || null, type: values.type || null, condition: values.condition || null,
+      room: null, locationId: values.locationId || null, inUse: values.inUse, deductible: values.deductible,
+      purchaseDate: values.purchaseDate || null, warrantyExpires: values.warrantyExpires || null,
+      purchasePrice: values.purchasePrice ? parseFloat(values.purchasePrice) : null,
+      replacementValue: values.replacementValue ? parseFloat(values.replacementValue) : null,
+      resaleValue: values.resaleValue ? parseFloat(values.resaleValue) : null,
+      assetId: values.assetId || null, notes: values.notes || null,
+    };
+    if (isEditMode) { updateMutation.mutate({ id: id, data: payload }); }
+    else { createMutation.mutate(payload); }
+  };
+
+  return {
+    id, isEditMode, form, typeValue,
+    assetIdError, assetIdChecking, generating, notesPreview, setNotesPreview,
+    uploadFiles, deleteConfirmId, setDeleteConfirmId, existingPhotos, imageProcessing,
+    pendingConnections, setPendingConnections, connectionSearch, setConnectionSearch,
+    searchResults, searchLoading,
+    locationTree, createLocationMutation,
+    itemData, isLoading, error,
+    reorderMutation, photoDeleteMutation,
+    isMutating: createMutation.isPending || updateMutation.isPending,
+    handleFilesSelected,
+    handleRemoveUpload: (localId: string) => setUploadFiles((prev) => {
+      const file = prev.find((f) => f.localId === localId);
+      if (file?.previewUrl) URL.revokeObjectURL(file.previewUrl);
+      return prev.filter((f) => f.localId !== localId);
+    }),
+    handleDeletePhoto: (photoId: number) => setDeleteConfirmId(photoId),
+    confirmDeletePhoto: () => { if (deleteConfirmId !== null) photoDeleteMutation.mutate({ id: deleteConfirmId }); },
+    validateAssetIdUniqueness, handleAutoGenerate,
+    onSubmit,
+  };
+}

--- a/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import { trpc } from '@pops/api-client';
 
 import { useImageProcessor } from '../../hooks/useImageProcessor';
+
 import type { PhotoItem } from '../../components/PhotoGallery';
 import type { UploadedFile } from '../../components/PhotoUpload';
 
@@ -34,10 +35,22 @@ export interface ItemFormValues {
 }
 
 const defaultValues: ItemFormValues = {
-  itemName: '', brand: '', model: '', itemId: '', type: '', condition: 'good',
-  locationId: '', inUse: false, deductible: false, purchaseDate: '',
-  warrantyExpires: '', purchasePrice: '', replacementValue: '', resaleValue: '',
-  assetId: '', notes: '',
+  itemName: '',
+  brand: '',
+  model: '',
+  itemId: '',
+  type: '',
+  condition: 'good',
+  locationId: '',
+  inUse: false,
+  deductible: false,
+  purchaseDate: '',
+  warrantyExpires: '',
+  purchasePrice: '',
+  replacementValue: '',
+  resaleValue: '',
+  assetId: '',
+  notes: '',
 };
 
 export function extractPrefix(type: string): string {
@@ -53,7 +66,12 @@ export function useItemFormPageModel() {
   const utils = trpc.useUtils();
 
   const form = useForm<ItemFormValues>({ defaultValues });
-  const { watch, setValue, reset, formState: { isDirty } } = form;
+  const {
+    watch,
+    setValue,
+    reset,
+    formState: { isDirty },
+  } = form;
   const typeValue = watch('type');
 
   const [assetIdError, setAssetIdError] = useState<string | null>(null);
@@ -73,11 +91,18 @@ export function useItemFormPageModel() {
   );
   const existingPhotos: PhotoItem[] = photosData?.data ?? [];
 
-  const attachMutation = trpc.inventory.photos.attach.useMutation({ onSuccess: () => void refetchPhotos() });
-  const photoDeleteMutation = trpc.inventory.photos.remove.useMutation({
-    onSuccess: () => { void refetchPhotos(); setDeleteConfirmId(null); },
+  const attachMutation = trpc.inventory.photos.attach.useMutation({
+    onSuccess: () => void refetchPhotos(),
   });
-  const reorderMutation = trpc.inventory.photos.reorder.useMutation({ onSuccess: () => void refetchPhotos() });
+  const photoDeleteMutation = trpc.inventory.photos.remove.useMutation({
+    onSuccess: () => {
+      void refetchPhotos();
+      setDeleteConfirmId(null);
+    },
+  });
+  const reorderMutation = trpc.inventory.photos.reorder.useMutation({
+    onSuccess: () => void refetchPhotos(),
+  });
 
   const { data: searchResults, isLoading: searchLoading } = trpc.inventory.items.list.useQuery(
     { search: connectionSearch, limit: 10 },
@@ -90,51 +115,74 @@ export function useItemFormPageModel() {
   const locationTree = locationsData?.data ?? [];
 
   const createLocationMutation = trpc.inventory.locations.create.useMutation({
-    onSuccess: () => { toast.success('Location created'); void utils.inventory.locations.tree.invalidate(); },
+    onSuccess: () => {
+      toast.success('Location created');
+      void utils.inventory.locations.tree.invalidate();
+    },
     onError: (err) => toast.error(`Failed to create location: ${err.message}`),
   });
 
-  const { data: itemData, isLoading, error } = trpc.inventory.items.get.useQuery(
-    { id: id! },
-    { enabled: isEditMode }
-  );
+  const {
+    data: itemData,
+    isLoading,
+    error,
+  } = trpc.inventory.items.get.useQuery({ id: id! }, { enabled: isEditMode });
 
   useEffect(() => {
     if (itemData?.data) {
       const item = itemData.data;
       reset({
-        itemName: item.itemName, brand: item.brand ?? '', model: item.model ?? '',
-        itemId: item.itemId ?? '', type: item.type ?? '', condition: item.condition ?? '',
-        locationId: item.locationId ?? '', inUse: item.inUse, deductible: item.deductible,
-        purchaseDate: item.purchaseDate ?? '', warrantyExpires: item.warrantyExpires ?? '',
+        itemName: item.itemName,
+        brand: item.brand ?? '',
+        model: item.model ?? '',
+        itemId: item.itemId ?? '',
+        type: item.type ?? '',
+        condition: item.condition ?? '',
+        locationId: item.locationId ?? '',
+        inUse: item.inUse,
+        deductible: item.deductible,
+        purchaseDate: item.purchaseDate ?? '',
+        warrantyExpires: item.warrantyExpires ?? '',
         purchasePrice: item.purchasePrice?.toString() ?? '',
         replacementValue: item.replacementValue?.toString() ?? '',
         resaleValue: item.resaleValue?.toString() ?? '',
-        assetId: item.assetId ?? '', notes: item.notes ?? '',
+        assetId: item.assetId ?? '',
+        notes: item.notes ?? '',
       });
     }
   }, [itemData, reset]);
 
   useEffect(() => {
     if (!isDirty) return;
-    const handler = (e: BeforeUnloadEvent) => { e.preventDefault(); };
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
   }, [isDirty]);
 
-  const validateAssetIdUniqueness = useCallback(async (value: string) => {
-    if (!value.trim()) { setAssetIdError(null); return; }
-    setAssetIdChecking(true);
-    try {
-      const result = await utils.inventory.items.searchByAssetId.fetch({ assetId: value.trim() });
-      if (result.data && result.data.id !== id) {
-        setAssetIdError(`Asset ID already in use by ${result.data.itemName}`);
-      } else {
+  const validateAssetIdUniqueness = useCallback(
+    async (value: string) => {
+      if (!value.trim()) {
         setAssetIdError(null);
+        return;
       }
-    } catch { setAssetIdError(null); }
-    finally { setAssetIdChecking(false); }
-  }, [id, utils]);
+      setAssetIdChecking(true);
+      try {
+        const result = await utils.inventory.items.searchByAssetId.fetch({ assetId: value.trim() });
+        if (result.data && result.data.id !== id) {
+          setAssetIdError(`Asset ID already in use by ${result.data.itemName}`);
+        } else {
+          setAssetIdError(null);
+        }
+      } catch {
+        setAssetIdError(null);
+      } finally {
+        setAssetIdChecking(false);
+      }
+    },
+    [id, utils]
+  );
 
   const handleAutoGenerate = useCallback(async () => {
     if (!typeValue) return;
@@ -148,45 +196,87 @@ export function useItemFormPageModel() {
       setValue('assetId', newAssetId, { shouldDirty: true });
       setAssetIdError(null);
       void validateAssetIdUniqueness(newAssetId);
-    } catch { toast.error('Failed to generate asset ID'); }
-    finally { setGenerating(false); }
+    } catch {
+      toast.error('Failed to generate asset ID');
+    } finally {
+      setGenerating(false);
+    }
   }, [typeValue, utils, setValue, validateAssetIdUniqueness]);
 
-  const handleFilesSelected = useCallback(async (files: File[]) => {
-    const pending: UploadedFile[] = files.map((file, i) => ({
-      localId: `${Date.now()}-${i}`, file, previewUrl: '', status: 'pending' as const,
-    }));
-    setUploadFiles((prev) => [...prev, ...pending]);
-    try {
-      const processed = await processFiles(files);
-      setUploadFiles((prev) => prev.map((f) => {
-        const idx = pending.findIndex((p) => p.localId === f.localId);
-        const match = idx >= 0 ? processed[idx] : undefined;
-        if (!match) return f;
-        return { ...f, previewUrl: match.previewUrl, originalSize: match.originalSize, processedSize: match.processedSize, status: 'uploading' as const, progress: 0 };
+  const handleFilesSelected = useCallback(
+    async (files: File[]) => {
+      const pending: UploadedFile[] = files.map((file, i) => ({
+        localId: `${Date.now()}-${i}`,
+        file,
+        previewUrl: '',
+        status: 'pending' as const,
       }));
-      for (let i = 0; i < processed.length; i++) {
-        const localId = pending[i]!.localId;
-        const p = processed[i]!;
-        try {
-          setUploadFiles((prev) => prev.map((f) => f.localId === localId ? { ...f, progress: 50 } : f));
-          const fileName = `${Date.now()}-${p.original.name.replace(/\.[^.]+$/, '.jpg')}`;
-          if (isEditMode && id) {
-            await attachMutation.mutateAsync({ itemId: id, filePath: fileName, sortOrder: existingPhotos.length + i });
+      setUploadFiles((prev) => [...prev, ...pending]);
+      try {
+        const processed = await processFiles(files);
+        setUploadFiles((prev) =>
+          prev.map((f) => {
+            const idx = pending.findIndex((p) => p.localId === f.localId);
+            const match = idx >= 0 ? processed[idx] : undefined;
+            if (!match) return f;
+            return {
+              ...f,
+              previewUrl: match.previewUrl,
+              originalSize: match.originalSize,
+              processedSize: match.processedSize,
+              status: 'uploading' as const,
+              progress: 0,
+            };
+          })
+        );
+        for (let i = 0; i < processed.length; i++) {
+          const localId = pending[i]!.localId;
+          const p = processed[i]!;
+          try {
+            setUploadFiles((prev) =>
+              prev.map((f) => (f.localId === localId ? { ...f, progress: 50 } : f))
+            );
+            const fileName = `${Date.now()}-${p.original.name.replace(/\.[^.]+$/, '.jpg')}`;
+            if (isEditMode && id) {
+              await attachMutation.mutateAsync({
+                itemId: id,
+                filePath: fileName,
+                sortOrder: existingPhotos.length + i,
+              });
+            }
+            setUploadFiles((prev) =>
+              prev.map((f) =>
+                f.localId === localId ? { ...f, status: 'done' as const, progress: 100 } : f
+              )
+            );
+          } catch (err: unknown) {
+            setUploadFiles((prev) =>
+              prev.map((f) =>
+                f.localId === localId
+                  ? {
+                      ...f,
+                      status: 'error' as const,
+                      error: err instanceof Error ? err.message : 'Upload failed',
+                    }
+                  : f
+              )
+            );
+            toast.error(`Failed to upload ${p.original.name}`);
           }
-          setUploadFiles((prev) => prev.map((f) => f.localId === localId ? { ...f, status: 'done' as const, progress: 100 } : f));
-        } catch (err: unknown) {
-          setUploadFiles((prev) => prev.map((f) => f.localId === localId ? { ...f, status: 'error' as const, error: err instanceof Error ? err.message : 'Upload failed' } : f));
-          toast.error(`Failed to upload ${p.original.name}`);
         }
+      } catch {
+        setUploadFiles((prev) =>
+          prev.map((f) =>
+            pending.some((p) => p.localId === f.localId)
+              ? { ...f, status: 'error' as const, error: 'Image processing failed' }
+              : f
+          )
+        );
+        toast.error('Failed to process images');
       }
-    } catch {
-      setUploadFiles((prev) => prev.map((f) =>
-        pending.some((p) => p.localId === f.localId) ? { ...f, status: 'error' as const, error: 'Image processing failed' } : f
-      ));
-      toast.error('Failed to process images');
-    }
-  }, [processFiles, isEditMode, id, attachMutation, existingPhotos.length]);
+    },
+    [processFiles, isEditMode, id, attachMutation, existingPhotos.length]
+  );
 
   const createMutation = trpc.inventory.items.create.useMutation({
     onSuccess: async (result) => {
@@ -194,9 +284,18 @@ export function useItemFormPageModel() {
       if (pendingConnections.length > 0) {
         let connected = 0;
         for (const conn of pendingConnections) {
-          try { await connectMutation.mutateAsync({ itemAId: newItemId, itemBId: conn.id }); connected++; } catch { /* skip */ }
+          try {
+            await connectMutation.mutateAsync({ itemAId: newItemId, itemBId: conn.id });
+            connected++;
+          } catch {
+            /* skip */
+          }
         }
-        toast.success(connected > 0 ? `Item created with ${connected} connection${connected > 1 ? 's' : ''}` : 'Item created');
+        toast.success(
+          connected > 0
+            ? `Item created with ${connected} connection${connected > 1 ? 's' : ''}`
+            : 'Item created'
+        );
       } else {
         toast.success('Item created');
       }
@@ -217,40 +316,78 @@ export function useItemFormPageModel() {
   });
 
   const onSubmit = (values: ItemFormValues) => {
-    if (!values.itemName.trim()) { toast.error('Item name is required'); return; }
+    if (!values.itemName.trim()) {
+      toast.error('Item name is required');
+      return;
+    }
     const payload = {
-      itemName: values.itemName.trim(), brand: values.brand || null, model: values.model || null,
-      itemId: values.itemId || null, type: values.type || null, condition: values.condition || null,
-      room: null, locationId: values.locationId || null, inUse: values.inUse, deductible: values.deductible,
-      purchaseDate: values.purchaseDate || null, warrantyExpires: values.warrantyExpires || null,
+      itemName: values.itemName.trim(),
+      brand: values.brand || null,
+      model: values.model || null,
+      itemId: values.itemId || null,
+      type: values.type || null,
+      condition: values.condition || null,
+      room: null,
+      locationId: values.locationId || null,
+      inUse: values.inUse,
+      deductible: values.deductible,
+      purchaseDate: values.purchaseDate || null,
+      warrantyExpires: values.warrantyExpires || null,
       purchasePrice: values.purchasePrice ? parseFloat(values.purchasePrice) : null,
       replacementValue: values.replacementValue ? parseFloat(values.replacementValue) : null,
       resaleValue: values.resaleValue ? parseFloat(values.resaleValue) : null,
-      assetId: values.assetId || null, notes: values.notes || null,
+      assetId: values.assetId || null,
+      notes: values.notes || null,
     };
-    if (isEditMode) { updateMutation.mutate({ id: id, data: payload }); }
-    else { createMutation.mutate(payload); }
+    if (isEditMode) {
+      updateMutation.mutate({ id: id, data: payload });
+    } else {
+      createMutation.mutate(payload);
+    }
   };
 
   return {
-    id, isEditMode, form, typeValue,
-    assetIdError, assetIdChecking, generating, notesPreview, setNotesPreview,
-    uploadFiles, deleteConfirmId, setDeleteConfirmId, existingPhotos, imageProcessing,
-    pendingConnections, setPendingConnections, connectionSearch, setConnectionSearch,
-    searchResults, searchLoading,
-    locationTree, createLocationMutation,
-    itemData, isLoading, error,
-    reorderMutation, photoDeleteMutation,
+    id,
+    isEditMode,
+    form,
+    typeValue,
+    assetIdError,
+    assetIdChecking,
+    generating,
+    notesPreview,
+    setNotesPreview,
+    uploadFiles,
+    deleteConfirmId,
+    setDeleteConfirmId,
+    existingPhotos,
+    imageProcessing,
+    pendingConnections,
+    setPendingConnections,
+    connectionSearch,
+    setConnectionSearch,
+    searchResults,
+    searchLoading,
+    locationTree,
+    createLocationMutation,
+    itemData,
+    isLoading,
+    error,
+    reorderMutation,
+    photoDeleteMutation,
     isMutating: createMutation.isPending || updateMutation.isPending,
     handleFilesSelected,
-    handleRemoveUpload: (localId: string) => setUploadFiles((prev) => {
-      const file = prev.find((f) => f.localId === localId);
-      if (file?.previewUrl) URL.revokeObjectURL(file.previewUrl);
-      return prev.filter((f) => f.localId !== localId);
-    }),
+    handleRemoveUpload: (localId: string) =>
+      setUploadFiles((prev) => {
+        const file = prev.find((f) => f.localId === localId);
+        if (file?.previewUrl) URL.revokeObjectURL(file.previewUrl);
+        return prev.filter((f) => f.localId !== localId);
+      }),
     handleDeletePhoto: (photoId: number) => setDeleteConfirmId(photoId),
-    confirmDeletePhoto: () => { if (deleteConfirmId !== null) photoDeleteMutation.mutate({ id: deleteConfirmId }); },
-    validateAssetIdUniqueness, handleAutoGenerate,
+    confirmDeletePhoto: () => {
+      if (deleteConfirmId !== null) photoDeleteMutation.mutate({ id: deleteConfirmId });
+    },
+    validateAssetIdUniqueness,
+    handleAutoGenerate,
     onSubmit,
   };
 }

--- a/packages/app-inventory/src/pages/location-tree-page/sections/DeleteDialog.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/DeleteDialog.tsx
@@ -1,0 +1,61 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@pops/ui';
+
+import type { DeleteConfirmState } from '../useLocationTreePageModel';
+
+interface DeleteDialogProps {
+  deleteConfirm: DeleteConfirmState | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isPending: boolean;
+}
+
+export function DeleteDialog({ deleteConfirm, onConfirm, onCancel, isPending }: DeleteDialogProps) {
+  return (
+    <Dialog open={!!deleteConfirm} onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete &ldquo;{deleteConfirm?.name}&rdquo;?</DialogTitle>
+          <DialogDescription>This action cannot be undone.</DialogDescription>
+        </DialogHeader>
+        {deleteConfirm && (
+          <div className="space-y-2 text-sm">
+            {deleteConfirm.stats.childCount > 0 && (
+              <p>
+                This location has <strong>{deleteConfirm.stats.childCount}</strong> direct{' '}
+                {deleteConfirm.stats.childCount === 1 ? 'sub-location' : 'sub-locations'}
+                {deleteConfirm.stats.descendantCount > deleteConfirm.stats.childCount &&
+                  ` (${deleteConfirm.stats.descendantCount} total)`}
+                . They will all be deleted.
+              </p>
+            )}
+            {deleteConfirm.stats.totalItemCount > 0 && (
+              <p>
+                <strong>{deleteConfirm.stats.totalItemCount}</strong>{' '}
+                {deleteConfirm.stats.totalItemCount === 1 ? 'item' : 'items'} will become unlocated.
+              </p>
+            )}
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>Cancel</Button>
+          <Button
+            variant="ghost"
+            className="text-destructive hover:text-destructive"
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app-inventory/src/pages/location-tree-page/sections/DeleteDialog.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/DeleteDialog.tsx
@@ -45,7 +45,9 @@ export function DeleteDialog({ deleteConfirm, onConfirm, onCancel, isPending }: 
           </div>
         )}
         <DialogFooter>
-          <Button variant="outline" onClick={onCancel}>Cancel</Button>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
           <Button
             variant="ghost"
             className="text-destructive hover:text-destructive"

--- a/packages/app-inventory/src/pages/location-tree-page/sections/LocationNode.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/LocationNode.tsx
@@ -1,3 +1,4 @@
+import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import {
   ArrowDown,
@@ -15,14 +16,7 @@ import {
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router';
 
-import {
-  Badge,
-  Button,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@pops/ui';
-import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { Badge, Button, Collapsible, CollapsibleContent, CollapsibleTrigger } from '@pops/ui';
 
 import { countDescendants, type LocationTreeNode } from '../utils';
 
@@ -104,9 +98,22 @@ export interface LocationNodeProps {
 }
 
 export function LocationNode({
-  node, depth, selectedId, onSelect, onAddChild, onRename, onMoveStart,
-  onReorder, onDelete, addingChildOf, onNewChildSave, onNewChildCancel,
-  siblingIndex, siblingCount, overId, activeId,
+  node,
+  depth,
+  selectedId,
+  onSelect,
+  onAddChild,
+  onRename,
+  onMoveStart,
+  onReorder,
+  onDelete,
+  addingChildOf,
+  onNewChildSave,
+  onNewChildCancel,
+  siblingIndex,
+  siblingCount,
+  overId,
+  activeId,
 }: LocationNodeProps) {
   const [open, setOpen] = useState(depth < 1);
   const [renaming, setRenaming] = useState(false);
@@ -114,11 +121,24 @@ export function LocationNode({
   const isSelected = selectedId === node.id;
   const isAddingChild = addingChildOf === node.id;
 
-  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging, isOver } =
-    useSortable({ id: node.id });
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+    isOver,
+  } = useSortable({ id: node.id });
 
-  const sortableStyle = { transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : 1 };
-  const showDropLine = overId === node.id && activeId !== null && activeId !== node.id && !isDragging;
+  const sortableStyle = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+  const showDropLine =
+    overId === node.id && activeId !== null && activeId !== node.id && !isDragging;
 
   useEffect(() => {
     if (isAddingChild && !open) setOpen(true);
@@ -130,9 +150,14 @@ export function LocationNode({
       <Collapsible open={open} onOpenChange={setOpen}>
         <div
           className={`group flex items-center gap-1.5 py-1.5 px-2 rounded-md cursor-pointer transition-colors hover:bg-app-accent/10 ${isSelected ? 'bg-app-accent/20 text-foreground font-bold border-l-2 border-app-accent rounded-l-none ml-[-2px]' : ''} ${isOver && !isDragging ? 'ring-2 ring-app-accent/50 bg-app-accent/5' : ''}`}
-          style={{ paddingLeft: `calc(${depth} * var(--tree-indent-step) + var(--tree-indent-base))` }}
+          style={{
+            paddingLeft: `calc(${depth} * var(--tree-indent-step) + var(--tree-indent-base))`,
+          }}
           onClick={() => onSelect(node.id)}
-          onDoubleClick={(e) => { e.stopPropagation(); setRenaming(true); }}
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+            setRenaming(true);
+          }}
           role="treeitem"
           aria-selected={isSelected}
           aria-expanded={hasChildren ? open : undefined}
@@ -151,20 +176,35 @@ export function LocationNode({
 
           {hasChildren ? (
             <CollapsibleTrigger asChild onClick={(e) => e.stopPropagation()}>
-              <button type="button" className="p-0.5 rounded hover:bg-muted" aria-label={open ? 'Collapse' : 'Expand'}>
-                {open ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
+              <button
+                type="button"
+                className="p-0.5 rounded hover:bg-muted"
+                aria-label={open ? 'Collapse' : 'Expand'}
+              >
+                {open ? (
+                  <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+                )}
               </button>
             </CollapsibleTrigger>
           ) : (
             <span className="w-5.5" />
           )}
 
-          {hasChildren && open ? <FolderOpen className="h-4 w-4 text-muted-foreground shrink-0" /> : <Folder className="h-4 w-4 text-muted-foreground shrink-0" />}
+          {hasChildren && open ? (
+            <FolderOpen className="h-4 w-4 text-muted-foreground shrink-0" />
+          ) : (
+            <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
+          )}
 
           {renaming ? (
             <InlineInput
               defaultValue={node.name}
-              onSave={(name) => { setRenaming(false); if (name !== node.name) onRename(node.id, name); }}
+              onSave={(name) => {
+                setRenaming(false);
+                if (name !== node.name) onRename(node.id, name);
+              }}
               onCancel={() => setRenaming(false)}
             />
           ) : (
@@ -173,37 +213,94 @@ export function LocationNode({
 
           <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity ml-auto shrink-0">
             {siblingCount > 1 && siblingIndex > 0 && (
-              <button type="button" className="p-0.5 rounded hover:bg-muted hidden [@media(pointer:coarse)]:inline-flex" onClick={(e) => { e.stopPropagation(); onReorder(node.id, 'up'); }} aria-label="Move up" title="Move up">
+              <button
+                type="button"
+                className="p-0.5 rounded hover:bg-muted hidden [@media(pointer:coarse)]:inline-flex"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onReorder(node.id, 'up');
+                }}
+                aria-label="Move up"
+                title="Move up"
+              >
                 <ArrowUp className="h-3 w-3 text-muted-foreground" />
               </button>
             )}
             {siblingCount > 1 && siblingIndex < siblingCount - 1 && (
-              <button type="button" className="p-0.5 rounded hover:bg-muted hidden [@media(pointer:coarse)]:inline-flex" onClick={(e) => { e.stopPropagation(); onReorder(node.id, 'down'); }} aria-label="Move down" title="Move down">
+              <button
+                type="button"
+                className="p-0.5 rounded hover:bg-muted hidden [@media(pointer:coarse)]:inline-flex"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onReorder(node.id, 'down');
+                }}
+                aria-label="Move down"
+                title="Move down"
+              >
                 <ArrowDown className="h-3 w-3 text-muted-foreground" />
               </button>
             )}
-            <button type="button" className="p-0.5 rounded hover:bg-muted" onClick={(e) => { e.stopPropagation(); onMoveStart(node.id); }} aria-label={`Move ${node.name}`} title="Move to...">
+            <button
+              type="button"
+              className="p-0.5 rounded hover:bg-muted"
+              onClick={(e) => {
+                e.stopPropagation();
+                onMoveStart(node.id);
+              }}
+              aria-label={`Move ${node.name}`}
+              title="Move to..."
+            >
               <MoveRight className="h-3 w-3 text-muted-foreground" />
             </button>
-            <button type="button" className="p-0.5 rounded hover:bg-muted" onClick={(e) => { e.stopPropagation(); onAddChild(node.id); }} aria-label={`Add child to ${node.name}`} title="Add child location">
+            <button
+              type="button"
+              className="p-0.5 rounded hover:bg-muted"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAddChild(node.id);
+              }}
+              aria-label={`Add child to ${node.name}`}
+              title="Add child location"
+            >
               <FolderPlus className="h-3.5 w-3.5 text-muted-foreground" />
             </button>
-            <Link to={`/inventory/report/insurance?locationId=${node.id}`} onClick={(e) => e.stopPropagation()} className="p-0.5 rounded hover:bg-muted" title={`Insurance report for ${node.name}`}>
+            <Link
+              to={`/inventory/report/insurance?locationId=${node.id}`}
+              onClick={(e) => e.stopPropagation()}
+              className="p-0.5 rounded hover:bg-muted"
+              title={`Insurance report for ${node.name}`}
+            >
               <FileText className="h-3.5 w-3.5 text-muted-foreground" />
             </Link>
-            <Button type="button" variant="ghost" size="icon" className="h-5 w-5 p-0.5 text-destructive" onClick={(e) => { e.stopPropagation(); onDelete(node.id); }} aria-label={`Delete ${node.name}`} title="Delete location">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-5 w-5 p-0.5 text-destructive"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(node.id);
+              }}
+              aria-label={`Delete ${node.name}`}
+              title="Delete location"
+            >
               <Trash2 className="h-3 w-3" />
             </Button>
           </div>
 
           {hasChildren && (
-            <Badge variant="secondary" className="text-xs shrink-0">{countDescendants(node) + 1}</Badge>
+            <Badge variant="secondary" className="text-xs shrink-0">
+              {countDescendants(node) + 1}
+            </Badge>
           )}
         </div>
 
         {(hasChildren || isAddingChild) && (
           <CollapsibleContent forceMount={isAddingChild ? true : undefined}>
-            <SortableContext items={node.children.map((c) => c.id)} strategy={verticalListSortingStrategy}>
+            <SortableContext
+              items={node.children.map((c) => c.id)}
+              strategy={verticalListSortingStrategy}
+            >
               <div role="group">
                 {node.children.map((child, i) => (
                   <LocationNode
@@ -227,10 +324,19 @@ export function LocationNode({
                   />
                 ))}
                 {isAddingChild && (
-                  <div className="flex items-center gap-1.5 py-1.5 px-2" style={{ paddingLeft: `calc(${depth + 1} * var(--tree-indent-step) + var(--tree-indent-base))` }}>
+                  <div
+                    className="flex items-center gap-1.5 py-1.5 px-2"
+                    style={{
+                      paddingLeft: `calc(${depth + 1} * var(--tree-indent-step) + var(--tree-indent-base))`,
+                    }}
+                  >
                     <span className="w-5.5" />
                     <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
-                    <InlineInput onSave={onNewChildSave} onCancel={onNewChildCancel} placeholder="Location name" />
+                    <InlineInput
+                      onSave={onNewChildSave}
+                      onCancel={onNewChildCancel}
+                      placeholder="Location name"
+                    />
                   </div>
                 )}
               </div>

--- a/packages/app-inventory/src/pages/location-tree-page/sections/LocationNode.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/LocationNode.tsx
@@ -276,7 +276,7 @@ export function LocationNode({
               type="button"
               variant="ghost"
               size="icon"
-              className="h-5 w-5 p-0.5 text-destructive"
+              className="text-destructive"
               onClick={(e) => {
                 e.stopPropagation();
                 onDelete(node.id);

--- a/packages/app-inventory/src/pages/location-tree-page/sections/LocationNode.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/LocationNode.tsx
@@ -1,0 +1,243 @@
+import { CSS } from '@dnd-kit/utilities';
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Folder,
+  FolderOpen,
+  FolderPlus,
+  GripVertical,
+  MoveRight,
+  Trash2,
+} from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router';
+
+import {
+  Badge,
+  Button,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@pops/ui';
+import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+
+import { countDescendants, type LocationTreeNode } from '../utils';
+
+export function InlineInput({
+  defaultValue,
+  onSave,
+  onCancel,
+  placeholder,
+}: {
+  defaultValue?: string;
+  onSave: (value: string) => void;
+  onCancel: () => void;
+  placeholder?: string;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState(defaultValue ?? '');
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      const trimmed = value.trim();
+      if (trimmed) onSave(trimmed);
+    } else if (e.key === 'Escape') {
+      onCancel();
+    }
+  };
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={handleKeyDown}
+      onBlur={onCancel}
+      placeholder={placeholder}
+      className="text-sm font-medium bg-transparent border-b border-app-accent outline-none px-0.5 py-0 w-full max-w-50"
+    />
+  );
+}
+
+function DropIndicatorLine({ depth }: { depth: number }) {
+  return (
+    <div
+      className="relative h-0.5 my-[-1px] z-10"
+      style={{
+        marginLeft: `calc(${depth} * var(--tree-indent-step) + var(--tree-indent-base))`,
+        marginRight: '8px',
+      }}
+      data-testid="drop-indicator"
+    >
+      <div className="absolute inset-0 bg-app-accent rounded-full" />
+      <div className="absolute left-0 top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-app-accent -ml-1" />
+    </div>
+  );
+}
+
+export interface LocationNodeProps {
+  node: LocationTreeNode;
+  depth: number;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onAddChild: (parentId: string) => void;
+  onRename: (id: string, newName: string) => void;
+  onMoveStart: (id: string) => void;
+  onReorder: (id: string, direction: 'up' | 'down') => void;
+  onDelete: (id: string) => void;
+  addingChildOf: string | null;
+  onNewChildSave: (name: string) => void;
+  onNewChildCancel: () => void;
+  siblingIndex: number;
+  siblingCount: number;
+  overId: string | null;
+  activeId: string | null;
+}
+
+export function LocationNode({
+  node, depth, selectedId, onSelect, onAddChild, onRename, onMoveStart,
+  onReorder, onDelete, addingChildOf, onNewChildSave, onNewChildCancel,
+  siblingIndex, siblingCount, overId, activeId,
+}: LocationNodeProps) {
+  const [open, setOpen] = useState(depth < 1);
+  const [renaming, setRenaming] = useState(false);
+  const hasChildren = node.children.length > 0;
+  const isSelected = selectedId === node.id;
+  const isAddingChild = addingChildOf === node.id;
+
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging, isOver } =
+    useSortable({ id: node.id });
+
+  const sortableStyle = { transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : 1 };
+  const showDropLine = overId === node.id && activeId !== null && activeId !== node.id && !isDragging;
+
+  useEffect(() => {
+    if (isAddingChild && !open) setOpen(true);
+  }, [isAddingChild, open]);
+
+  return (
+    <div ref={setNodeRef} style={sortableStyle}>
+      {showDropLine && <DropIndicatorLine depth={depth} />}
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <div
+          className={`group flex items-center gap-1.5 py-1.5 px-2 rounded-md cursor-pointer transition-colors hover:bg-app-accent/10 ${isSelected ? 'bg-app-accent/20 text-foreground font-bold border-l-2 border-app-accent rounded-l-none ml-[-2px]' : ''} ${isOver && !isDragging ? 'ring-2 ring-app-accent/50 bg-app-accent/5' : ''}`}
+          style={{ paddingLeft: `calc(${depth} * var(--tree-indent-step) + var(--tree-indent-base))` }}
+          onClick={() => onSelect(node.id)}
+          onDoubleClick={(e) => { e.stopPropagation(); setRenaming(true); }}
+          role="treeitem"
+          aria-selected={isSelected}
+          aria-expanded={hasChildren ? open : undefined}
+        >
+          <button
+            ref={setActivatorNodeRef}
+            {...attributes}
+            {...listeners}
+            type="button"
+            className="p-0.5 rounded hover:bg-muted cursor-grab active:cursor-grabbing hidden [@media(pointer:fine)]:flex opacity-0 group-hover:opacity-100 transition-opacity touch-none"
+            aria-label={`Drag ${node.name}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
+          </button>
+
+          {hasChildren ? (
+            <CollapsibleTrigger asChild onClick={(e) => e.stopPropagation()}>
+              <button type="button" className="p-0.5 rounded hover:bg-muted" aria-label={open ? 'Collapse' : 'Expand'}>
+                {open ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
+              </button>
+            </CollapsibleTrigger>
+          ) : (
+            <span className="w-5.5" />
+          )}
+
+          {hasChildren && open ? <FolderOpen className="h-4 w-4 text-muted-foreground shrink-0" /> : <Folder className="h-4 w-4 text-muted-foreground shrink-0" />}
+
+          {renaming ? (
+            <InlineInput
+              defaultValue={node.name}
+              onSave={(name) => { setRenaming(false); if (name !== node.name) onRename(node.id, name); }}
+              onCancel={() => setRenaming(false)}
+            />
+          ) : (
+            <span className="text-sm font-medium truncate">{node.name}</span>
+          )}
+
+          <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity ml-auto shrink-0">
+            {siblingCount > 1 && siblingIndex > 0 && (
+              <button type="button" className="p-0.5 rounded hover:bg-muted hidden [@media(pointer:coarse)]:inline-flex" onClick={(e) => { e.stopPropagation(); onReorder(node.id, 'up'); }} aria-label="Move up" title="Move up">
+                <ArrowUp className="h-3 w-3 text-muted-foreground" />
+              </button>
+            )}
+            {siblingCount > 1 && siblingIndex < siblingCount - 1 && (
+              <button type="button" className="p-0.5 rounded hover:bg-muted hidden [@media(pointer:coarse)]:inline-flex" onClick={(e) => { e.stopPropagation(); onReorder(node.id, 'down'); }} aria-label="Move down" title="Move down">
+                <ArrowDown className="h-3 w-3 text-muted-foreground" />
+              </button>
+            )}
+            <button type="button" className="p-0.5 rounded hover:bg-muted" onClick={(e) => { e.stopPropagation(); onMoveStart(node.id); }} aria-label={`Move ${node.name}`} title="Move to...">
+              <MoveRight className="h-3 w-3 text-muted-foreground" />
+            </button>
+            <button type="button" className="p-0.5 rounded hover:bg-muted" onClick={(e) => { e.stopPropagation(); onAddChild(node.id); }} aria-label={`Add child to ${node.name}`} title="Add child location">
+              <FolderPlus className="h-3.5 w-3.5 text-muted-foreground" />
+            </button>
+            <Link to={`/inventory/report/insurance?locationId=${node.id}`} onClick={(e) => e.stopPropagation()} className="p-0.5 rounded hover:bg-muted" title={`Insurance report for ${node.name}`}>
+              <FileText className="h-3.5 w-3.5 text-muted-foreground" />
+            </Link>
+            <Button type="button" variant="ghost" size="icon" className="h-5 w-5 p-0.5 text-destructive" onClick={(e) => { e.stopPropagation(); onDelete(node.id); }} aria-label={`Delete ${node.name}`} title="Delete location">
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          </div>
+
+          {hasChildren && (
+            <Badge variant="secondary" className="text-xs shrink-0">{countDescendants(node) + 1}</Badge>
+          )}
+        </div>
+
+        {(hasChildren || isAddingChild) && (
+          <CollapsibleContent forceMount={isAddingChild ? true : undefined}>
+            <SortableContext items={node.children.map((c) => c.id)} strategy={verticalListSortingStrategy}>
+              <div role="group">
+                {node.children.map((child, i) => (
+                  <LocationNode
+                    key={child.id}
+                    node={child}
+                    depth={depth + 1}
+                    selectedId={selectedId}
+                    onSelect={onSelect}
+                    onAddChild={onAddChild}
+                    onRename={onRename}
+                    onMoveStart={onMoveStart}
+                    onReorder={onReorder}
+                    onDelete={onDelete}
+                    addingChildOf={addingChildOf}
+                    onNewChildSave={onNewChildSave}
+                    onNewChildCancel={onNewChildCancel}
+                    siblingIndex={i}
+                    siblingCount={node.children.length}
+                    overId={overId}
+                    activeId={activeId}
+                  />
+                ))}
+                {isAddingChild && (
+                  <div className="flex items-center gap-1.5 py-1.5 px-2" style={{ paddingLeft: `calc(${depth + 1} * var(--tree-indent-step) + var(--tree-indent-base))` }}>
+                    <span className="w-5.5" />
+                    <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
+                    <InlineInput onSave={onNewChildSave} onCancel={onNewChildCancel} placeholder="Location name" />
+                  </div>
+                )}
+              </div>
+            </SortableContext>
+          </CollapsibleContent>
+        )}
+      </Collapsible>
+    </div>
+  );
+}

--- a/packages/app-inventory/src/pages/location-tree-page/sections/MoveDialog.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/MoveDialog.tsx
@@ -1,0 +1,89 @@
+import { Folder, MapPin } from 'lucide-react';
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@pops/ui';
+
+import { isDescendant, type LocationTreeNode } from '../utils';
+
+function MoveTargetPicker({
+  nodes,
+  movingId,
+  nodeMap,
+  onSelect,
+  depth = 0,
+}: {
+  nodes: LocationTreeNode[];
+  movingId: string;
+  nodeMap: Map<string, LocationTreeNode>;
+  onSelect: (parentId: string | null) => void;
+  depth?: number;
+}) {
+  return (
+    <>
+      {nodes
+        .filter((n) => n.id !== movingId)
+        .map((node) => {
+          const disabled = isDescendant(movingId, node.id, nodeMap);
+          return (
+            <div key={node.id}>
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={() => onSelect(node.id)}
+                className={`w-full text-left flex items-center gap-1.5 py-1.5 px-2 rounded-md transition-colors ${disabled ? 'opacity-40 cursor-not-allowed' : 'hover:bg-muted/50 cursor-pointer'}`}
+                style={{ paddingLeft: `calc(${depth} * var(--tree-picker-step) + var(--tree-indent-base))` }}
+              >
+                <Folder className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                <span className="text-sm truncate">{node.name}</span>
+              </button>
+              {node.children.length > 0 && (
+                <MoveTargetPicker nodes={node.children} movingId={movingId} nodeMap={nodeMap} onSelect={onSelect} depth={depth + 1} />
+              )}
+            </div>
+          );
+        })}
+    </>
+  );
+}
+
+interface MoveDialogProps {
+  movingId: string | null;
+  movingNode: LocationTreeNode | null | undefined;
+  treeNodes: LocationTreeNode[];
+  nodeMap: Map<string, LocationTreeNode>;
+  onMoveTo: (parentId: string | null) => void;
+  onClose: () => void;
+}
+
+export function MoveDialog({ movingId, movingNode, treeNodes, nodeMap, onMoveTo, onClose }: MoveDialogProps) {
+  return (
+    <Dialog open={!!movingId} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Move &ldquo;{movingNode?.name}&rdquo;</DialogTitle>
+          <DialogDescription>Select a new parent location, or move to root level.</DialogDescription>
+        </DialogHeader>
+        <div className="max-h-64 overflow-y-auto border rounded-lg py-2">
+          <button
+            type="button"
+            onClick={() => onMoveTo(null)}
+            className="w-full text-left flex items-center gap-1.5 py-1.5 px-2 rounded-md hover:bg-muted/50"
+            style={{ paddingLeft: 'var(--tree-indent-base)' }}
+          >
+            <MapPin className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="text-sm font-medium">Root level</span>
+          </button>
+          {movingId && (
+            <MoveTargetPicker nodes={treeNodes} movingId={movingId} nodeMap={nodeMap} onSelect={onMoveTo} />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app-inventory/src/pages/location-tree-page/sections/MoveDialog.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/MoveDialog.tsx
@@ -1,13 +1,6 @@
 import { Folder, MapPin } from 'lucide-react';
 
-import {
-  Button,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@pops/ui';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@pops/ui';
 
 import { isDescendant, type LocationTreeNode } from '../utils';
 
@@ -37,13 +30,21 @@ function MoveTargetPicker({
                 disabled={disabled}
                 onClick={() => onSelect(node.id)}
                 className={`w-full text-left flex items-center gap-1.5 py-1.5 px-2 rounded-md transition-colors ${disabled ? 'opacity-40 cursor-not-allowed' : 'hover:bg-muted/50 cursor-pointer'}`}
-                style={{ paddingLeft: `calc(${depth} * var(--tree-picker-step) + var(--tree-indent-base))` }}
+                style={{
+                  paddingLeft: `calc(${depth} * var(--tree-picker-step) + var(--tree-indent-base))`,
+                }}
               >
                 <Folder className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                 <span className="text-sm truncate">{node.name}</span>
               </button>
               {node.children.length > 0 && (
-                <MoveTargetPicker nodes={node.children} movingId={movingId} nodeMap={nodeMap} onSelect={onSelect} depth={depth + 1} />
+                <MoveTargetPicker
+                  nodes={node.children}
+                  movingId={movingId}
+                  nodeMap={nodeMap}
+                  onSelect={onSelect}
+                  depth={depth + 1}
+                />
               )}
             </div>
           );
@@ -61,13 +62,22 @@ interface MoveDialogProps {
   onClose: () => void;
 }
 
-export function MoveDialog({ movingId, movingNode, treeNodes, nodeMap, onMoveTo, onClose }: MoveDialogProps) {
+export function MoveDialog({
+  movingId,
+  movingNode,
+  treeNodes,
+  nodeMap,
+  onMoveTo,
+  onClose,
+}: MoveDialogProps) {
   return (
     <Dialog open={!!movingId} onOpenChange={(open) => !open && onClose()}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Move &ldquo;{movingNode?.name}&rdquo;</DialogTitle>
-          <DialogDescription>Select a new parent location, or move to root level.</DialogDescription>
+          <DialogDescription>
+            Select a new parent location, or move to root level.
+          </DialogDescription>
         </DialogHeader>
         <div className="max-h-64 overflow-y-auto border rounded-lg py-2">
           <button
@@ -80,7 +90,12 @@ export function MoveDialog({ movingId, movingNode, treeNodes, nodeMap, onMoveTo,
             <span className="text-sm font-medium">Root level</span>
           </button>
           {movingId && (
-            <MoveTargetPicker nodes={treeNodes} movingId={movingId} nodeMap={nodeMap} onSelect={onMoveTo} />
+            <MoveTargetPicker
+              nodes={treeNodes}
+              movingId={movingId}
+              nodeMap={nodeMap}
+              onSelect={onMoveTo}
+            />
           )}
         </div>
       </DialogContent>

--- a/packages/app-inventory/src/pages/location-tree-page/sections/TreeSection.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/TreeSection.tsx
@@ -1,0 +1,117 @@
+import {
+  closestCenter,
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { Folder, GripVertical } from 'lucide-react';
+
+import { Badge, Skeleton } from '@pops/ui';
+
+import { countDescendants, type LocationTreeNode } from '../utils';
+import { InlineInput, LocationNode } from './LocationNode';
+
+function TreeSkeleton() {
+  return (
+    <div className="space-y-2 p-4">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-2" style={{ paddingLeft: `calc(${i % 3} * var(--tree-indent-step))` }}>
+          <Skeleton className="h-4 w-4" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DragOverlayNode({ node }: { node: LocationTreeNode }) {
+  return (
+    <div className="flex items-center gap-2 bg-background border rounded-md px-3 py-2 shadow-lg">
+      <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
+      <Folder className="h-4 w-4 text-muted-foreground" />
+      <span className="text-sm font-medium">{node.name}</span>
+      {node.children.length > 0 && (
+        <Badge variant="secondary" className="text-xs">{countDescendants(node) + 1}</Badge>
+      )}
+    </div>
+  );
+}
+
+interface TreeSectionProps {
+  treeNodes: LocationTreeNode[];
+  isLoading: boolean;
+  addingRoot: boolean;
+  selectedId: string | null;
+  addingChildOf: string | null;
+  overId: string | null;
+  activeId: string | null;
+  activeNode: LocationTreeNode | null | undefined;
+  onSelect: (id: string) => void;
+  onAddChild: (parentId: string) => void;
+  onRename: (id: string, newName: string) => void;
+  onMoveStart: (id: string) => void;
+  onReorder: (id: string, direction: 'up' | 'down') => void;
+  onDelete: (id: string) => void;
+  onNewChildSave: (name: string) => void;
+  onNewChildCancel: () => void;
+  onNewRootSave: (name: string) => void;
+  onNewRootCancel: () => void;
+  onDragStart: (event: DragStartEvent) => void;
+  onDragOver: (event: DragOverEvent) => void;
+  onDragEnd: (event: DragEndEvent) => void;
+}
+
+export function TreeSection({
+  treeNodes, isLoading, addingRoot, selectedId, addingChildOf, overId, activeId,
+  activeNode, onSelect, onAddChild, onRename, onMoveStart, onReorder, onDelete,
+  onNewChildSave, onNewChildCancel, onNewRootSave, onNewRootCancel,
+  onDragStart, onDragOver, onDragEnd,
+}: TreeSectionProps) {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+
+  if (isLoading) return <TreeSkeleton />;
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={onDragStart} onDragOver={onDragOver} onDragEnd={onDragEnd}>
+      <div className="md:w-2/5 border rounded-lg py-2" role="tree" aria-label="Location tree">
+        <SortableContext items={treeNodes.map((n) => n.id)} strategy={verticalListSortingStrategy}>
+          {treeNodes.map((node, i) => (
+            <LocationNode
+              key={node.id}
+              node={node}
+              depth={0}
+              selectedId={selectedId}
+              onSelect={onSelect}
+              onAddChild={onAddChild}
+              onRename={onRename}
+              onMoveStart={onMoveStart}
+              onReorder={onReorder}
+              onDelete={onDelete}
+              addingChildOf={addingChildOf}
+              onNewChildSave={onNewChildSave}
+              onNewChildCancel={onNewChildCancel}
+              siblingIndex={i}
+              siblingCount={treeNodes.length}
+              overId={overId}
+              activeId={activeId}
+            />
+          ))}
+        </SortableContext>
+        {addingRoot && (
+          <div className="flex items-center gap-1.5 py-1.5 px-2" style={{ paddingLeft: 'var(--tree-indent-base)' }}>
+            <span className="w-5.5" />
+            <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
+            <InlineInput onSave={onNewRootSave} onCancel={onNewRootCancel} placeholder="Root location name" />
+          </div>
+        )}
+      </div>
+      <DragOverlay>{activeNode ? <DragOverlayNode node={activeNode} /> : null}</DragOverlay>
+    </DndContext>
+  );
+}

--- a/packages/app-inventory/src/pages/location-tree-page/sections/TreeSection.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/TreeSection.tsx
@@ -21,7 +21,11 @@ function TreeSkeleton() {
   return (
     <div className="space-y-2 p-4">
       {Array.from({ length: 6 }).map((_, i) => (
-        <div key={i} className="flex items-center gap-2" style={{ paddingLeft: `calc(${i % 3} * var(--tree-indent-step))` }}>
+        <div
+          key={i}
+          className="flex items-center gap-2"
+          style={{ paddingLeft: `calc(${i % 3} * var(--tree-indent-step))` }}
+        >
           <Skeleton className="h-4 w-4" />
           <Skeleton className="h-4 w-32" />
         </div>
@@ -37,7 +41,9 @@ function DragOverlayNode({ node }: { node: LocationTreeNode }) {
       <Folder className="h-4 w-4 text-muted-foreground" />
       <span className="text-sm font-medium">{node.name}</span>
       {node.children.length > 0 && (
-        <Badge variant="secondary" className="text-xs">{countDescendants(node) + 1}</Badge>
+        <Badge variant="secondary" className="text-xs">
+          {countDescendants(node) + 1}
+        </Badge>
       )}
     </div>
   );
@@ -68,17 +74,40 @@ interface TreeSectionProps {
 }
 
 export function TreeSection({
-  treeNodes, isLoading, addingRoot, selectedId, addingChildOf, overId, activeId,
-  activeNode, onSelect, onAddChild, onRename, onMoveStart, onReorder, onDelete,
-  onNewChildSave, onNewChildCancel, onNewRootSave, onNewRootCancel,
-  onDragStart, onDragOver, onDragEnd,
+  treeNodes,
+  isLoading,
+  addingRoot,
+  selectedId,
+  addingChildOf,
+  overId,
+  activeId,
+  activeNode,
+  onSelect,
+  onAddChild,
+  onRename,
+  onMoveStart,
+  onReorder,
+  onDelete,
+  onNewChildSave,
+  onNewChildCancel,
+  onNewRootSave,
+  onNewRootCancel,
+  onDragStart,
+  onDragOver,
+  onDragEnd,
 }: TreeSectionProps) {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
   if (isLoading) return <TreeSkeleton />;
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={onDragStart} onDragOver={onDragOver} onDragEnd={onDragEnd}>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDragEnd={onDragEnd}
+    >
       <div className="md:w-2/5 border rounded-lg py-2" role="tree" aria-label="Location tree">
         <SortableContext items={treeNodes.map((n) => n.id)} strategy={verticalListSortingStrategy}>
           {treeNodes.map((node, i) => (
@@ -104,10 +133,17 @@ export function TreeSection({
           ))}
         </SortableContext>
         {addingRoot && (
-          <div className="flex items-center gap-1.5 py-1.5 px-2" style={{ paddingLeft: 'var(--tree-indent-base)' }}>
+          <div
+            className="flex items-center gap-1.5 py-1.5 px-2"
+            style={{ paddingLeft: 'var(--tree-indent-base)' }}
+          >
             <span className="w-5.5" />
             <Folder className="h-4 w-4 text-muted-foreground shrink-0" />
-            <InlineInput onSave={onNewRootSave} onCancel={onNewRootCancel} placeholder="Root location name" />
+            <InlineInput
+              onSave={onNewRootSave}
+              onCancel={onNewRootCancel}
+              placeholder="Root location name"
+            />
           </div>
         )}
       </div>

--- a/packages/app-inventory/src/pages/location-tree-page/useLocationTreePageModel.ts
+++ b/packages/app-inventory/src/pages/location-tree-page/useLocationTreePageModel.ts
@@ -1,0 +1,197 @@
+import { arrayMove } from '@dnd-kit/sortable';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+import { trpc } from '@pops/api-client';
+
+import { buildNodeMap, getSiblings, isDescendant, type LocationTreeNode } from './utils';
+
+import type { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
+
+export interface DeleteConfirmState {
+  id: string;
+  name: string;
+  stats: {
+    childCount: number;
+    descendantCount: number;
+    itemCount: number;
+    totalItemCount: number;
+  };
+}
+
+export function useLocationTreePageModel() {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [addingChildOf, setAddingChildOf] = useState<string | null>(null);
+  const [addingRoot, setAddingRoot] = useState(false);
+  const [movingId, setMovingId] = useState<string | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirmState | null>(null);
+  const pendingDeleteRef = useRef<{ id: string; name: string } | null>(null);
+
+  const utils = trpc.useUtils();
+  const { data, isLoading, error } = trpc.inventory.locations.tree.useQuery();
+
+  const createMutation = trpc.inventory.locations.create.useMutation({
+    onSuccess: () => {
+      toast.success('Location created');
+      utils.inventory.locations.tree.invalidate();
+      setAddingChildOf(null);
+      setAddingRoot(false);
+    },
+    onError: (err) => toast.error(`Failed to create location: ${err.message}`),
+  });
+
+  const updateMutation = trpc.inventory.locations.update.useMutation({
+    onSuccess: () => {
+      toast.success('Location updated');
+      utils.inventory.locations.tree.invalidate();
+    },
+    onError: (err) => toast.error(`Failed to update location: ${err.message}`),
+  });
+
+  const deleteMutation = trpc.inventory.locations.delete.useMutation({
+    onSuccess: (result) => {
+      if ('requiresConfirmation' in result && result.requiresConfirmation && result.stats) {
+        const node = pendingDeleteRef.current;
+        if (node) setDeleteConfirm({ id: node.id, name: node.name, stats: result.stats });
+        return;
+      }
+      toast.success('Location deleted');
+      utils.inventory.locations.tree.invalidate();
+      if (selectedId === pendingDeleteRef.current?.id) setSelectedId(null);
+      setDeleteConfirm(null);
+      pendingDeleteRef.current = null;
+    },
+    onError: (err) => {
+      toast.error(`Failed to delete: ${err.message}`);
+      setDeleteConfirm(null);
+      pendingDeleteRef.current = null;
+    },
+  });
+
+  const treeNodes = data?.data ?? [];
+  const nodeMap = useMemo(() => {
+    const map = new Map<string, LocationTreeNode>();
+    if (data?.data) buildNodeMap(data.data, map);
+    return map;
+  }, [data?.data]);
+
+  const handleSelect = useCallback((id: string) => {
+    setSelectedId((prev) => (prev === id ? null : id));
+  }, []);
+
+  const handleAddChild = useCallback((parentId: string) => {
+    setAddingChildOf(parentId);
+    setAddingRoot(false);
+  }, []);
+
+  const handleRename = useCallback(
+    (id: string, newName: string) => updateMutation.mutate({ id, data: { name: newName } }),
+    [updateMutation]
+  );
+
+  const handleNewChildSave = useCallback(
+    (name: string) => createMutation.mutate({ name, parentId: addingChildOf }),
+    [addingChildOf, createMutation]
+  );
+
+  const handleNewRootSave = useCallback(
+    (name: string) => createMutation.mutate({ name, parentId: null }),
+    [createMutation]
+  );
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      const node = nodeMap.get(id);
+      if (!node) return;
+      pendingDeleteRef.current = { id, name: node.name };
+      deleteMutation.mutate({ id });
+    },
+    [nodeMap, deleteMutation]
+  );
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (!deleteConfirm) return;
+    deleteMutation.mutate({ id: deleteConfirm.id, force: true });
+  }, [deleteConfirm, deleteMutation]);
+
+  const handleMoveStart = useCallback((id: string) => setMovingId(id), []);
+
+  const handleMoveTo = useCallback(
+    (newParentId: string | null) => {
+      if (!movingId) return;
+      updateMutation.mutate({ id: movingId, data: { parentId: newParentId } }, {
+        onSuccess: () => setMovingId(null),
+      });
+    },
+    [movingId, updateMutation]
+  );
+
+  const handleReorder = useCallback(
+    (id: string, direction: 'up' | 'down') => {
+      const siblings = getSiblings(id, treeNodes, nodeMap);
+      const idx = siblings.findIndex((s) => s.id === id);
+      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+      if (idx < 0 || swapIdx < 0 || swapIdx >= siblings.length) return;
+      const current = siblings[idx];
+      const swap = siblings[swapIdx];
+      if (!current || !swap) return;
+      updateMutation.mutate({ id: current.id, data: { sortOrder: swap.sortOrder } });
+      updateMutation.mutate({ id: swap.id, data: { sortOrder: current.sortOrder } });
+    },
+    [treeNodes, nodeMap, updateMutation]
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+  }, []);
+
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    setOverId(event.over ? (event.over.id as string) : null);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveId(null);
+      setOverId(null);
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const activeNode = nodeMap.get(active.id as string);
+      const overNode = nodeMap.get(over.id as string);
+      if (!activeNode || !overNode) return;
+      if (isDescendant(active.id as string, over.id as string, nodeMap)) {
+        toast.error('Cannot move a location into its own sub-location');
+        return;
+      }
+      if (activeNode.parentId === overNode.parentId) {
+        const siblings = getSiblings(active.id as string, treeNodes, nodeMap);
+        const oldIndex = siblings.findIndex((s) => s.id === active.id);
+        const newIndex = siblings.findIndex((s) => s.id === over.id);
+        if (oldIndex < 0 || newIndex < 0) return;
+        const reordered = arrayMove(siblings, oldIndex, newIndex);
+        reordered.forEach((n, index) => {
+          if (n.sortOrder !== index) updateMutation.mutate({ id: n.id, data: { sortOrder: index } });
+        });
+      } else {
+        updateMutation.mutate({ id: activeNode.id, data: { parentId: overNode.id } });
+      }
+    },
+    [nodeMap, treeNodes, updateMutation]
+  );
+
+  return {
+    treeNodes, nodeMap, isLoading, error,
+    selectedId, addingChildOf, addingRoot, setAddingRoot, setAddingChildOf,
+    movingId, setMovingId, activeId, overId,
+    deleteConfirm, setDeleteConfirm,
+    deleteMutation,
+    handleSelect, handleAddChild, handleRename,
+    handleNewChildSave, handleNewChildCancel: () => setAddingChildOf(null),
+    handleNewRootSave, handleNewRootCancel: () => setAddingRoot(false),
+    handleDelete, handleDeleteConfirm,
+    handleMoveStart, handleMoveTo,
+    handleReorder,
+    handleDragStart, handleDragOver, handleDragEnd,
+  };
+}

--- a/packages/app-inventory/src/pages/location-tree-page/useLocationTreePageModel.ts
+++ b/packages/app-inventory/src/pages/location-tree-page/useLocationTreePageModel.ts
@@ -70,7 +70,7 @@ export function useLocationTreePageModel() {
     },
   });
 
-  const treeNodes = data?.data ?? [];
+  const treeNodes = useMemo(() => data?.data ?? [], [data]);
   const nodeMap = useMemo(() => {
     const map = new Map<string, LocationTreeNode>();
     if (data?.data) buildNodeMap(data.data, map);
@@ -121,9 +121,12 @@ export function useLocationTreePageModel() {
   const handleMoveTo = useCallback(
     (newParentId: string | null) => {
       if (!movingId) return;
-      updateMutation.mutate({ id: movingId, data: { parentId: newParentId } }, {
-        onSuccess: () => setMovingId(null),
-      });
+      updateMutation.mutate(
+        { id: movingId, data: { parentId: newParentId } },
+        {
+          onSuccess: () => setMovingId(null),
+        }
+      );
     },
     [movingId, updateMutation]
   );
@@ -171,7 +174,8 @@ export function useLocationTreePageModel() {
         if (oldIndex < 0 || newIndex < 0) return;
         const reordered = arrayMove(siblings, oldIndex, newIndex);
         reordered.forEach((n, index) => {
-          if (n.sortOrder !== index) updateMutation.mutate({ id: n.id, data: { sortOrder: index } });
+          if (n.sortOrder !== index)
+            updateMutation.mutate({ id: n.id, data: { sortOrder: index } });
         });
       } else {
         updateMutation.mutate({ id: activeNode.id, data: { parentId: overNode.id } });
@@ -181,17 +185,36 @@ export function useLocationTreePageModel() {
   );
 
   return {
-    treeNodes, nodeMap, isLoading, error,
-    selectedId, addingChildOf, addingRoot, setAddingRoot, setAddingChildOf,
-    movingId, setMovingId, activeId, overId,
-    deleteConfirm, setDeleteConfirm,
+    treeNodes,
+    nodeMap,
+    isLoading,
+    error,
+    selectedId,
+    addingChildOf,
+    addingRoot,
+    setAddingRoot,
+    setAddingChildOf,
+    movingId,
+    setMovingId,
+    activeId,
+    overId,
+    deleteConfirm,
+    setDeleteConfirm,
     deleteMutation,
-    handleSelect, handleAddChild, handleRename,
-    handleNewChildSave, handleNewChildCancel: () => setAddingChildOf(null),
-    handleNewRootSave, handleNewRootCancel: () => setAddingRoot(false),
-    handleDelete, handleDeleteConfirm,
-    handleMoveStart, handleMoveTo,
+    handleSelect,
+    handleAddChild,
+    handleRename,
+    handleNewChildSave,
+    handleNewChildCancel: () => setAddingChildOf(null),
+    handleNewRootSave,
+    handleNewRootCancel: () => setAddingRoot(false),
+    handleDelete,
+    handleDeleteConfirm,
+    handleMoveStart,
+    handleMoveTo,
     handleReorder,
-    handleDragStart, handleDragOver, handleDragEnd,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
   };
 }

--- a/packages/app-inventory/src/pages/location-tree-page/utils.ts
+++ b/packages/app-inventory/src/pages/location-tree-page/utils.ts
@@ -1,0 +1,59 @@
+export interface LocationTreeNode {
+  id: string;
+  name: string;
+  parentId: string | null;
+  sortOrder: number;
+  children: LocationTreeNode[];
+}
+
+export function buildBreadcrumb(nodeId: string, nodeMap: Map<string, LocationTreeNode>): string[] {
+  const path: string[] = [];
+  let current = nodeMap.get(nodeId);
+  while (current) {
+    path.unshift(current.name);
+    current = current.parentId ? nodeMap.get(current.parentId) : undefined;
+  }
+  return path;
+}
+
+export function buildNodeMap(nodes: LocationTreeNode[], map: Map<string, LocationTreeNode>): void {
+  for (const node of nodes) {
+    map.set(node.id, node);
+    buildNodeMap(node.children, map);
+  }
+}
+
+export function countDescendants(node: LocationTreeNode): number {
+  let count = node.children.length;
+  for (const child of node.children) {
+    count += countDescendants(child);
+  }
+  return count;
+}
+
+export function isDescendant(
+  nodeId: string,
+  targetId: string,
+  nodeMap: Map<string, LocationTreeNode>
+): boolean {
+  const node = nodeMap.get(nodeId);
+  if (!node) return false;
+  for (const child of node.children) {
+    if (child.id === targetId || isDescendant(child.id, targetId, nodeMap)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function getSiblings(
+  nodeId: string,
+  treeNodes: LocationTreeNode[],
+  nodeMap: Map<string, LocationTreeNode>
+): LocationTreeNode[] {
+  const node = nodeMap.get(nodeId);
+  if (!node) return [];
+  if (!node.parentId) return treeNodes;
+  const parent = nodeMap.get(node.parentId);
+  return parent?.children ?? [];
+}

--- a/packages/ui/src/components/ContainerPanel.tsx
+++ b/packages/ui/src/components/ContainerPanel.tsx
@@ -32,7 +32,8 @@ export function ContainerPanel({
   children,
   className,
 }: ContainerPanelProps) {
-  const toggleId = toggle?.id ?? 'container-panel-toggle';
+  const generatedToggleId = React.useId();
+  const toggleId = toggle?.id ?? generatedToggleId;
 
   return (
     <div className={cn('border rounded-lg p-4 space-y-4', className)}>
@@ -50,9 +51,7 @@ export function ContainerPanel({
         </div>
       )}
 
-      {summary !== undefined && (
-        <div className="text-sm text-muted-foreground">{summary}</div>
-      )}
+      {summary !== undefined && <div className="text-sm text-muted-foreground">{summary}</div>}
 
       {children ?? emptyState ?? null}
 

--- a/packages/ui/src/components/ContainerPanel.tsx
+++ b/packages/ui/src/components/ContainerPanel.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+
+import { cn } from '../lib/utils';
+import { Label } from '../primitives/label';
+import { Switch } from '../primitives/switch';
+
+export interface ContainerPanelToggle {
+  label: string;
+  value: boolean;
+  onChange: (value: boolean) => void;
+  id?: string;
+}
+
+export interface ContainerPanelProps {
+  title: string;
+  subtitle?: string;
+  toggle?: ContainerPanelToggle;
+  summary?: React.ReactNode;
+  action?: React.ReactNode;
+  emptyState?: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export function ContainerPanel({
+  title,
+  subtitle,
+  toggle,
+  summary,
+  action,
+  emptyState,
+  children,
+  className,
+}: ContainerPanelProps) {
+  const toggleId = toggle?.id ?? 'container-panel-toggle';
+
+  return (
+    <div className={cn('border rounded-lg p-4 space-y-4', className)}>
+      <div>
+        {subtitle && <p className="text-xs text-muted-foreground">{subtitle}</p>}
+        <h2 className="text-lg font-semibold mt-1">{title}</h2>
+      </div>
+
+      {toggle && (
+        <div className="flex items-center gap-2">
+          <Switch id={toggleId} checked={toggle.value} onCheckedChange={toggle.onChange} />
+          <Label htmlFor={toggleId} className="text-sm">
+            {toggle.label}
+          </Label>
+        </div>
+      )}
+
+      {summary !== undefined && (
+        <div className="text-sm text-muted-foreground">{summary}</div>
+      )}
+
+      {children ?? emptyState ?? null}
+
+      {action && <div>{action}</div>}
+    </div>
+  );
+}

--- a/packages/ui/src/components/RelatedItemsList.tsx
+++ b/packages/ui/src/components/RelatedItemsList.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+import { cn } from '../lib/utils';
+
+export interface RelatedItemsListProps<T extends { id: string | number }> {
+  items: T[];
+  renderItem: (item: T) => React.ReactNode;
+  emptyMessage?: string;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export function RelatedItemsList<T extends { id: string | number }>({
+  items,
+  renderItem,
+  emptyMessage = 'No items',
+  action,
+  className,
+}: RelatedItemsListProps<T>) {
+  return (
+    <div className={cn('space-y-2', className)}>
+      {items.length === 0 ? (
+        <p className="py-3 text-center text-sm text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <ul className="divide-y divide-border rounded-md border">
+          {items.map((item) => (
+            <li key={item.id}>{renderItem(item)}</li>
+          ))}
+        </ul>
+      )}
+      {action}
+    </div>
+  );
+}

--- a/packages/ui/src/components/SearchPickerDialog.tsx
+++ b/packages/ui/src/components/SearchPickerDialog.tsx
@@ -1,0 +1,95 @@
+import { Search } from 'lucide-react';
+import * as React from 'react';
+
+import { Skeleton } from '../primitives/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '../primitives/dialog';
+import { TextInput } from './TextInput';
+
+export interface SearchPickerDialogProps<T> {
+  trigger: React.ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  searchPlaceholder?: string;
+  search: string;
+  onSearchChange: (value: string) => void;
+  isLoading: boolean;
+  results: T[];
+  renderResult: (item: T) => React.ReactNode;
+  trailing?: React.ReactNode;
+  minChars?: number;
+  maxResultsHeight?: string;
+  emptyMessage?: string;
+}
+
+export function SearchPickerDialog<T>({
+  trigger,
+  open,
+  onOpenChange,
+  title,
+  description,
+  searchPlaceholder = 'Search...',
+  search,
+  onSearchChange,
+  isLoading,
+  results,
+  renderResult,
+  trailing,
+  minChars = 2,
+  maxResultsHeight = 'max-h-64',
+  emptyMessage = 'No results found',
+}: SearchPickerDialogProps<T>) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+
+        <div className={trailing ? 'flex items-center gap-2' : undefined}>
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <TextInput
+              value={search}
+              onChange={(e) => onSearchChange(e.target.value)}
+              placeholder={searchPlaceholder}
+              className="pl-9"
+              autoFocus
+            />
+          </div>
+          {trailing}
+        </div>
+
+        <div className={`${maxResultsHeight} overflow-y-auto space-y-1`}>
+          {search.length < minChars ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              Type at least {minChars} characters to search
+            </p>
+          ) : isLoading ? (
+            <div className="space-y-2 py-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : results.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">{emptyMessage}</p>
+          ) : (
+            results.map((item, i) => (
+              <React.Fragment key={i}>{renderResult(item)}</React.Fragment>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/ui/src/components/SearchPickerDialog.tsx
+++ b/packages/ui/src/components/SearchPickerDialog.tsx
@@ -13,7 +13,7 @@ import { Skeleton } from '../primitives/skeleton';
 import { TextInput } from './TextInput';
 
 export interface SearchPickerDialogProps<T> {
-  trigger: React.ReactNode;
+  trigger: React.ReactElement;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title: string;

--- a/packages/ui/src/components/SearchPickerDialog.tsx
+++ b/packages/ui/src/components/SearchPickerDialog.tsx
@@ -1,7 +1,6 @@
 import { Search } from 'lucide-react';
 import * as React from 'react';
 
-import { Skeleton } from '../primitives/skeleton';
 import {
   Dialog,
   DialogContent,
@@ -10,6 +9,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '../primitives/dialog';
+import { Skeleton } from '../primitives/skeleton';
 import { TextInput } from './TextInput';
 
 export interface SearchPickerDialogProps<T> {
@@ -24,6 +24,7 @@ export interface SearchPickerDialogProps<T> {
   isLoading: boolean;
   results: T[];
   renderResult: (item: T) => React.ReactNode;
+  getResultKey: (item: T) => string | number;
   trailing?: React.ReactNode;
   minChars?: number;
   maxResultsHeight?: string;
@@ -42,6 +43,7 @@ export function SearchPickerDialog<T>({
   isLoading,
   results,
   renderResult,
+  getResultKey,
   trailing,
   minChars = 2,
   maxResultsHeight = 'max-h-64',
@@ -84,8 +86,8 @@ export function SearchPickerDialog<T>({
           ) : results.length === 0 ? (
             <p className="text-sm text-muted-foreground py-4 text-center">{emptyMessage}</p>
           ) : (
-            results.map((item, i) => (
-              <React.Fragment key={i}>{renderResult(item)}</React.Fragment>
+            results.map((item) => (
+              <React.Fragment key={getResultKey(item)}>{renderResult(item)}</React.Fragment>
             ))
           )}
         </div>

--- a/packages/ui/src/components/StatCard.tsx
+++ b/packages/ui/src/components/StatCard.tsx
@@ -73,6 +73,8 @@ export interface StatCardProps {
   /** Optional trend indicator shown below the value. */
   trend?: StatCardTrend;
   className?: string;
+  /** Makes the card interactive (navigates or triggers an action). */
+  onClick?: () => void;
 }
 
 const trendIconClass = {
@@ -93,17 +95,23 @@ export function StatCard({
   color = 'slate',
   trend,
   className,
+  onClick,
 }: StatCardProps) {
   const styles = statCardColorMap[color];
 
   return (
     <Card
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
       className={cn(
         'p-5 flex flex-col gap-1 justify-between relative overflow-hidden group transition-all duration-300 hover:scale-[1.02]',
+        onClick && 'cursor-pointer hover:bg-muted/50',
         styles.glow,
         styles.border,
         className
       )}
+      onClick={onClick}
+      onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } } : undefined}
     >
       <div
         className={cn(

--- a/packages/ui/src/components/StatCard.tsx
+++ b/packages/ui/src/components/StatCard.tsx
@@ -111,7 +111,16 @@ export function StatCard({
         className
       )}
       onClick={onClick}
-      onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } } : undefined}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
     >
       <div
         className={cn(

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -94,6 +94,11 @@ export * from './components/Select';
 export * from './components/StatCard';
 export * from './components/TextInput';
 
+// Shared composites
+export * from './components/ContainerPanel';
+export * from './components/RelatedItemsList';
+export * from './components/SearchPickerDialog';
+
 // Layout composites
 export * from './components/PageHeader';
 export * from './components/ViewToggleGroup';


### PR DESCRIPTION
## Summary

- **Decompose 3 god-files** into page-shell + `useXPageModel` hook + section components — each page shell is now ≤150 lines, all tRPC calls live in the model hook, sections receive plain props
- **Extract 3 shared composites to `@pops/ui`**: `ContainerPanel`, `RelatedItemsList`, `SearchPickerDialog` — generic, slot-based, domain-agnostic
- **Replace ad-hoc stat tiles** in `DashboardWidgets` with `StatCard` (adds `onClick` support to StatCard for navigable tiles)
- **Remove 3 per-file oxlint overrides** (`max-lines`, `max-lines-per-function`) now that page files meet the limits

## Issues closed

Closes #2038 — Decompose LocationTreePage / ItemFormPage / ItemDetailPage
Closes #2048 — Extract ContainerPanel to @pops/ui
Closes #2026 — Use ContainerPanel in LocationContentsPanel
Closes #2047 — Extract RelatedItemsList to @pops/ui
Closes #2027 — Use RelatedItemsList in ConnectionsList
Closes #2045 — Extract SearchPickerDialog to @pops/ui
Closes #2018 — Use SearchPickerDialog in ConnectDialog + LinkDocumentDialog
Closes #1996 — Replace DashboardWidgets stat tiles with StatCard

## File structure after refactor

```
pages/
  LocationTreePage.tsx          (129 lines — shell only)
  location-tree-page/
    useLocationTreePageModel.ts  (all DnD + tRPC state)
    utils.ts                     (tree helpers)
    sections/
      TreeSection.tsx
      LocationNode.tsx
      MoveDialog.tsx
      DeleteDialog.tsx

  ItemFormPage.tsx               (149 lines — shell only)
  item-form-page/
    useItemFormPageModel.ts      (react-hook-form + tRPC)
    sections/
      CoreFieldsSection.tsx
      PhotoUploadSection.tsx
      NotesSection.tsx
      ConnectionsSection.tsx

  ItemDetailPage.tsx             (131 lines — shell only)
  item-detail-page/
    useItemDetailPageModel.ts    (tRPC queries/mutations)
    sections/
      DetailHeaderSection.tsx
      PhotoGallerySection.tsx
      ConnectionsSection.tsx
      DocumentsSection.tsx
```

## Test plan

- [ ] LocationTreePage: create / rename / delete / reorder (DnD) / move location nodes
- [ ] ItemFormPage: create and edit items — all fields, photo upload, connections, notes
- [ ] ItemDetailPage: view details, photo reorder, connect/disconnect items, documents
- [ ] DashboardWidgets: stat tiles render correctly; Warranties tile navigates to `/inventory/warranties`
- [ ] ConnectDialog: search + connect flow; "No items found" empty state
- [ ] LinkDocumentDialog: search + type filter + link flow
- [ ] ConnectionsList: connect/disconnect renders via RelatedItemsList
- [ ] LocationContentsPanel: toggle sub-locations via ContainerPanel shell
- [ ] `extractPrefix` export from ItemFormPage still works (backward compat)

https://claude.ai/code/session_01URew9w2Wo1PipbYNWCe5ft