### PR TITLE
refactor(pops-api): decompose API god-functions toward agent-optimal targets (#2085)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -207,10 +207,10 @@
         "max-lines": ["error", { "max": 600, "skipBlankLines": true, "skipComments": true }],
         "max-lines-per-function": [
           "error",
-          { "max": 260, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
+          { "max": 200, "skipBlankLines": true, "skipComments": true, "IIFEs": true }
         ],
-        "complexity": ["error", 45],
-        "max-depth": ["error", 5],
+        "complexity": ["error", 30],
+        "max-depth": ["error", 4],
         "max-params": ["error", 8],
         "no-nested-ternary": "off",
         "typescript/explicit-function-return-type": [

--- a/apps/pops-api/src/modules/core/tag-rules/service.ts
+++ b/apps/pops-api/src/modules/core/tag-rules/service.ts
@@ -62,54 +62,77 @@ export function applyTagRuleChangeSet(changeSet: TagRuleChangeSet): TagRuleRow[]
   });
 }
 
-function applyOp(tx: ReturnType<typeof getDrizzle>, op: TagRuleChangeSetOp): void {
-  if (op.op === 'add') {
-    tx.insert(transactionTagRules)
-      .values({
-        descriptionPattern: op.data.descriptionPattern,
-        matchType: op.data.matchType,
-        entityId: op.data.entityId ?? null,
-        tags: JSON.stringify(op.data.tags ?? []),
-        confidence: op.data.confidence ?? 0.95,
-        isActive: op.data.isActive ?? true,
-        priority: op.data.priority ?? 0,
-        timesApplied: 0,
-      })
-      .run();
-    return;
-  }
-  if (op.op === 'edit') {
-    const existing = tx
-      .select({ id: transactionTagRules.id })
-      .from(transactionTagRules)
-      .where(eq(transactionTagRules.id, op.id))
-      .get();
-    if (!existing) throw new NotFoundError('transaction_tag_rules', op.id);
+type TagRulesTx = ReturnType<typeof getDrizzle>;
 
-    tx.update(transactionTagRules)
-      .set({
-        entityId: op.data.entityId !== undefined ? op.data.entityId : undefined,
-        tags: op.data.tags ? JSON.stringify(op.data.tags) : undefined,
-        confidence: op.data.confidence ?? undefined,
-        isActive: op.data.isActive ?? undefined,
-        priority: op.data.priority ?? undefined,
-      })
-      .where(eq(transactionTagRules.id, op.id))
-      .run();
-    return;
-  }
-  if (op.op === 'disable') {
-    const res = tx
-      .update(transactionTagRules)
-      .set({ isActive: false })
-      .where(eq(transactionTagRules.id, op.id))
-      .run();
-    if (res.changes === 0) throw new NotFoundError('transaction_tag_rules', op.id);
-    return;
-  }
-  if (op.op === 'remove') {
-    const res = tx.delete(transactionTagRules).where(eq(transactionTagRules.id, op.id)).run();
-    if (res.changes === 0) throw new NotFoundError('transaction_tag_rules', op.id);
+function addTagRule(
+  tx: TagRulesTx,
+  data: Extract<TagRuleChangeSetOp, { op: 'add' }>['data']
+): void {
+  tx.insert(transactionTagRules)
+    .values({
+      descriptionPattern: data.descriptionPattern,
+      matchType: data.matchType,
+      entityId: data.entityId ?? null,
+      tags: JSON.stringify(data.tags ?? []),
+      confidence: data.confidence ?? 0.95,
+      isActive: data.isActive ?? true,
+      priority: data.priority ?? 0,
+      timesApplied: 0,
+    })
+    .run();
+}
+
+function editTagRule(
+  tx: TagRulesTx,
+  id: string,
+  data: Extract<TagRuleChangeSetOp, { op: 'edit' }>['data']
+): void {
+  const existing = tx
+    .select({ id: transactionTagRules.id })
+    .from(transactionTagRules)
+    .where(eq(transactionTagRules.id, id))
+    .get();
+  if (!existing) throw new NotFoundError('transaction_tag_rules', id);
+
+  tx.update(transactionTagRules)
+    .set({
+      entityId: data.entityId !== undefined ? data.entityId : undefined,
+      tags: data.tags ? JSON.stringify(data.tags) : undefined,
+      confidence: data.confidence ?? undefined,
+      isActive: data.isActive ?? undefined,
+      priority: data.priority ?? undefined,
+    })
+    .where(eq(transactionTagRules.id, id))
+    .run();
+}
+
+function disableTagRule(tx: TagRulesTx, id: string): void {
+  const res = tx
+    .update(transactionTagRules)
+    .set({ isActive: false })
+    .where(eq(transactionTagRules.id, id))
+    .run();
+  if (res.changes === 0) throw new NotFoundError('transaction_tag_rules', id);
+}
+
+function removeTagRule(tx: TagRulesTx, id: string): void {
+  const res = tx.delete(transactionTagRules).where(eq(transactionTagRules.id, id)).run();
+  if (res.changes === 0) throw new NotFoundError('transaction_tag_rules', id);
+}
+
+function applyOp(tx: TagRulesTx, op: TagRuleChangeSetOp): void {
+  switch (op.op) {
+    case 'add':
+      addTagRule(tx, op.data);
+      return;
+    case 'edit':
+      editTagRule(tx, op.id, op.data);
+      return;
+    case 'disable':
+      disableTagRule(tx, op.id);
+      return;
+    case 'remove':
+      removeTagRule(tx, op.id);
   }
 }
 

--- a/apps/pops-api/src/modules/finance/imports/lib/process-transaction.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/process-transaction.ts
@@ -1,0 +1,250 @@
+/**
+ * Core processing logic for a single transaction during import.
+ *
+ * Extracted from service.ts to keep functions small and auditable.
+ */
+import { formatImportError } from '../../../../lib/errors.js';
+import { logger } from '../../../../lib/logger.js';
+import { AiCategorizationError, categorizeWithAi } from './ai-categorizer.js';
+import { applyLearnedCorrection } from './correction-application.js';
+import { matchEntity } from './entity-matcher.js';
+import { buildSuggestedTags } from './tag-management.js';
+
+import type { ParsedTransaction, ProcessedTransaction } from '../types.js';
+import type { EntityEntry } from './entity-lookup.js';
+import type { AliasMap, EntityLookupMap } from './entity-matcher.js';
+
+export interface AiCounters {
+  aiError: AiCategorizationError | null;
+  aiFailureCount: number;
+  aiApiCalls: number;
+  aiCacheHits: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+}
+
+export interface ProcessContext {
+  entityLookup: EntityLookupMap;
+  aliases: AliasMap;
+  knownTags: string[];
+  importBatchId: string;
+}
+
+export interface TransactionProcessResult {
+  matched?: ProcessedTransaction;
+  uncertain?: ProcessedTransaction;
+  failed?: ProcessedTransaction;
+  batchStatus: 'success' | 'failed';
+  errorEntry?: { description: string; error: string };
+}
+
+export function createAiCounters(): AiCounters {
+  return {
+    aiError: null,
+    aiFailureCount: 0,
+    aiApiCalls: 0,
+    aiCacheHits: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCostUsd: 0,
+  };
+}
+
+function buildMatchedFromEntity(
+  transaction: ParsedTransaction,
+  entry: EntityEntry,
+  matchType: 'alias' | 'exact' | 'prefix' | 'contains' | 'ai',
+  category: string | null,
+  knownTags: string[]
+): ProcessedTransaction {
+  return {
+    ...transaction,
+    entity: {
+      entityId: entry.id,
+      entityName: entry.name,
+      matchType,
+    },
+    status: 'matched',
+    suggestedTags: buildSuggestedTags(transaction.description, entry.id, [], category, knownTags),
+  };
+}
+
+function buildUncertainFromAi(
+  transaction: ParsedTransaction,
+  entityName: string,
+  category: string | null,
+  knownTags: string[]
+): ProcessedTransaction {
+  return {
+    ...transaction,
+    entity: {
+      entityName,
+      matchType: 'ai',
+      confidence: 0.7,
+    },
+    status: 'uncertain',
+    suggestedTags: buildSuggestedTags(transaction.description, null, [], category, knownTags),
+  };
+}
+
+function buildUncertainNoMatch(
+  transaction: ParsedTransaction,
+  reason: string,
+  knownTags: string[]
+): ProcessedTransaction {
+  return {
+    ...transaction,
+    entity: { matchType: 'none' },
+    status: 'uncertain',
+    error: reason,
+    suggestedTags: buildSuggestedTags(transaction.description, null, [], null, knownTags),
+  };
+}
+
+function tryEntityMatch(
+  transaction: ParsedTransaction,
+  context: ProcessContext
+): ProcessedTransaction | null {
+  const match = matchEntity(transaction.description, context.entityLookup, context.aliases);
+  if (!match) return null;
+
+  const entityEntry = context.entityLookup.get(match.entityName.toLowerCase());
+  if (!entityEntry) {
+    throw new Error(`Entity lookup failed for matched entity: ${match.entityName}`);
+  }
+  return buildMatchedFromEntity(transaction, entityEntry, match.matchType, null, context.knownTags);
+}
+
+async function tryAiCategorization(
+  transaction: ParsedTransaction,
+  context: ProcessContext,
+  counters: AiCounters
+): Promise<{ entityName: string | null; category: string | null } | null> {
+  try {
+    const { result, usage } = await categorizeWithAi(transaction.rawRow, context.importBatchId);
+
+    if (usage) {
+      counters.aiApiCalls++;
+      counters.totalInputTokens += usage.inputTokens;
+      counters.totalOutputTokens += usage.outputTokens;
+      counters.totalCostUsd += usage.costUsd;
+    } else {
+      counters.aiCacheHits++;
+    }
+
+    if (!result?.entityName) return null;
+    return { entityName: result.entityName, category: result.category ?? null };
+  } catch (error) {
+    if (error instanceof AiCategorizationError) {
+      counters.aiError = error;
+      counters.aiFailureCount++;
+      return null;
+    }
+    throw error;
+  }
+}
+
+function resolveAiResult(
+  transaction: ParsedTransaction,
+  aiEntityName: string,
+  category: string | null,
+  context: ProcessContext
+): ProcessedTransaction {
+  const entry = context.entityLookup.get(aiEntityName.toLowerCase());
+  if (entry) {
+    return buildMatchedFromEntity(transaction, entry, 'ai', category, context.knownTags);
+  }
+  return buildUncertainFromAi(transaction, aiEntityName, category, context.knownTags);
+}
+
+function buildFailure(
+  transaction: ParsedTransaction,
+  error: unknown
+): {
+  failed: ProcessedTransaction;
+  message: string;
+  errorEntry: { description: string; error: string };
+} {
+  const message = error instanceof Error ? error.message : 'Unknown error';
+  const failed: ProcessedTransaction = {
+    ...transaction,
+    entity: { matchType: 'none' },
+    status: 'failed',
+    error: message,
+  };
+  const formatted = formatImportError(error, { transaction: transaction.description });
+  return {
+    failed,
+    message,
+    errorEntry: {
+      description: transaction.description.slice(0, 50),
+      error: formatted.message + (formatted.suggestion ? ` - ${formatted.suggestion}` : ''),
+    },
+  };
+}
+
+async function classifyTransaction(
+  transaction: ParsedTransaction,
+  context: ProcessContext,
+  counters: AiCounters,
+  index: number,
+  total: number
+): Promise<TransactionProcessResult> {
+  const correctionApplied = applyLearnedCorrection({
+    transaction,
+    minConfidence: 0.7,
+    knownTags: context.knownTags,
+    index,
+    total,
+  });
+  if (correctionApplied) {
+    return {
+      [correctionApplied.bucket]: correctionApplied.processed,
+      batchStatus: 'success',
+    } as TransactionProcessResult;
+  }
+
+  const entityMatched = tryEntityMatch(transaction, context);
+  if (entityMatched) {
+    logger.debug(
+      {
+        index,
+        total,
+        description: transaction.description.slice(0, 50),
+        entityName: entityMatched.entity.entityName,
+        matchType: entityMatched.entity.matchType,
+      },
+      '[Import] Entity matched'
+    );
+    return { matched: entityMatched, batchStatus: 'success' };
+  }
+
+  const aiResult = await tryAiCategorization(transaction, context, counters);
+  if (aiResult?.entityName) {
+    const processed = resolveAiResult(transaction, aiResult.entityName, aiResult.category, context);
+    const bucket = processed.status === 'matched' ? 'matched' : 'uncertain';
+    return { [bucket]: processed, batchStatus: 'success' } as TransactionProcessResult;
+  }
+
+  const reason = counters.aiError ? 'AI categorization unavailable' : 'No entity match found';
+  return {
+    uncertain: buildUncertainNoMatch(transaction, reason, context.knownTags),
+    batchStatus: 'success',
+  };
+}
+
+export async function processTransactionSafely(
+  transaction: ParsedTransaction,
+  context: ProcessContext,
+  counters: AiCounters,
+  index: number,
+  total: number
+): Promise<TransactionProcessResult> {
+  try {
+    return await classifyTransaction(transaction, context, counters, index, total);
+  } catch (error) {
+    const { failed, errorEntry } = buildFailure(transaction, error);
+    return { failed, batchStatus: 'failed', errorEntry };
+  }
+}

--- a/apps/pops-api/src/modules/finance/imports/lib/processing-helpers.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/processing-helpers.ts
@@ -1,0 +1,53 @@
+import type { AiUsageStats, ImportWarning, ProcessedTransaction } from '../types.js';
+/**
+ * Helpers for processing imports — building the per-batch state, AI usage, warnings.
+ */
+import type { AiCounters } from './process-transaction.js';
+
+export interface ProgressBatchItem {
+  description: string;
+  status: 'processing' | 'success' | 'failed';
+  error?: string;
+}
+
+export function appendBatchItem(currentBatch: ProgressBatchItem[], item: ProgressBatchItem): void {
+  currentBatch.push(item);
+  if (currentBatch.length > 5) currentBatch.shift();
+}
+
+export function buildAiUsage(counters: AiCounters): AiUsageStats | undefined {
+  const { aiApiCalls, aiCacheHits, totalInputTokens, totalOutputTokens, totalCostUsd } = counters;
+  if (aiApiCalls === 0 && aiCacheHits === 0) return undefined;
+  return {
+    apiCalls: aiApiCalls,
+    cacheHits: aiCacheHits,
+    totalInputTokens,
+    totalOutputTokens,
+    totalCostUsd,
+    avgCostPerCall: aiApiCalls > 0 ? totalCostUsd / aiApiCalls : 0,
+  };
+}
+
+export function buildAiWarnings(counters: AiCounters): ImportWarning[] {
+  const { aiError, aiFailureCount } = counters;
+  if (!aiError || aiFailureCount === 0) return [];
+  return [
+    {
+      type:
+        aiError.code === 'INSUFFICIENT_CREDITS' ? 'AI_CATEGORIZATION_UNAVAILABLE' : 'AI_API_ERROR',
+      message: aiError.message,
+      affectedCount: aiFailureCount,
+    },
+  ];
+}
+
+export interface ProcessBuckets {
+  matched: ProcessedTransaction[];
+  uncertain: ProcessedTransaction[];
+  failed: ProcessedTransaction[];
+  skipped: ProcessedTransaction[];
+}
+
+export function makeBuckets(): ProcessBuckets {
+  return { matched: [], uncertain: [], failed: [], skipped: [] };
+}

--- a/apps/pops-api/src/modules/finance/imports/lib/tag-management.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/tag-management.ts
@@ -45,18 +45,22 @@ export function loadKnownTags(): string[] {
   }
 
   for (const row of rows) {
-    try {
-      const parsed = JSON.parse(row.tags) as unknown;
-      if (Array.isArray(parsed)) {
-        for (const t of parsed) {
-          if (typeof t === 'string') seen.add(t);
-        }
-      }
-    } catch {
-      /* ignore malformed JSON */
-    }
+    addTagsToSet(seen, row.tags);
   }
   return Array.from(seen);
+}
+
+function addTagsToSet(target: Set<string>, raw: string): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  if (!Array.isArray(parsed)) return;
+  for (const t of parsed) {
+    if (typeof t === 'string') target.add(t);
+  }
 }
 
 /**

--- a/apps/pops-api/src/modules/finance/imports/service.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.ts
@@ -12,22 +12,32 @@ import { entities } from '@pops/db-types';
 import { getDrizzle } from '../../../db.js';
 import { formatImportError } from '../../../lib/errors.js';
 import { logger } from '../../../lib/logger.js';
-import { AiCategorizationError, categorizeWithAi } from './lib/ai-categorizer.js';
 import { applyLearnedCorrection } from './lib/correction-application.js';
 import { findExistingChecksums } from './lib/deduplication.js';
 import { loadEntityMaps } from './lib/entity-lookup.js';
-import { matchEntity } from './lib/entity-matcher.js';
-import { buildSuggestedTags, loadKnownTags } from './lib/tag-management.js';
+import {
+  createAiCounters,
+  processTransactionSafely,
+  type ProcessContext,
+  type AiCounters,
+} from './lib/process-transaction.js';
+import {
+  appendBatchItem,
+  buildAiUsage,
+  buildAiWarnings,
+  makeBuckets,
+  type ProcessBuckets,
+  type ProgressBatchItem,
+} from './lib/processing-helpers.js';
+import { loadKnownTags } from './lib/tag-management.js';
 import { insertTransaction } from './lib/transaction-persistence.js';
 import { updateProgress } from './progress-store.js';
 
 import type {
-  AiUsageStats,
   ConfirmedTransaction,
   CreateEntityOutput,
   ExecuteImportOutput,
   ImportResult,
-  ImportWarning,
   ParsedTransaction,
   ProcessedTransaction,
   ProcessImportOutput,
@@ -42,16 +52,100 @@ export {
 type ImportProgressUpdate = Parameters<typeof updateProgress>[1];
 type ImportProgressCallback = (update: ImportProgressUpdate) => void;
 
-async function processImportCore(args: {
+interface ProcessCoreInput {
   transactions: ParsedTransaction[];
   account: string;
   importBatchId: string;
   onProgress?: ImportProgressCallback;
-}): Promise<{
+}
+
+interface ProcessCoreOutput {
   output: ProcessImportOutput;
   errors: Array<{ description: string; error: string }>;
   processedNewCount: number;
+}
+
+function partitionByChecksum(transactions: ParsedTransaction[]): {
+  newTransactions: ParsedTransaction[];
+  duplicates: ParsedTransaction[];
+} {
+  const checksums = transactions.map((t) => t.checksum);
+  const existing = findExistingChecksums(checksums);
+  return {
+    newTransactions: transactions.filter((t) => !existing.has(t.checksum)),
+    duplicates: transactions.filter((t) => existing.has(t.checksum)),
+  };
+}
+
+function buildSkippedBucket(duplicates: ParsedTransaction[]): ProcessedTransaction[] {
+  return duplicates.map((t) => ({
+    ...t,
+    entity: { matchType: 'none' as const },
+    status: 'skipped' as const,
+    skipReason: 'Duplicate transaction (checksum match)',
+  }));
+}
+
+function pushClassified(
+  buckets: ProcessBuckets,
+  result: ReturnType<typeof processTransactionSafely> extends Promise<infer R> ? R : never
+): void {
+  if (result.matched) buckets.matched.push(result.matched);
+  if (result.uncertain) buckets.uncertain.push(result.uncertain);
+  if (result.failed) buckets.failed.push(result.failed);
+}
+
+interface ProcessLoopArgs {
+  newTransactions: ParsedTransaction[];
+  context: ProcessContext;
+  counters: AiCounters;
+  buckets: ProcessBuckets;
+  onProgress?: ImportProgressCallback;
+}
+
+async function runProcessLoop(args: ProcessLoopArgs): Promise<{
+  errors: Array<{ description: string; error: string }>;
 }> {
+  const { newTransactions, context, counters, buckets, onProgress } = args;
+  const currentBatch: ProgressBatchItem[] = [];
+  const errors: Array<{ description: string; error: string }> = [];
+
+  for (let i = 0; i < newTransactions.length; i++) {
+    const transaction = newTransactions[i];
+    if (!transaction) continue;
+
+    const batchItem: ProgressBatchItem = {
+      description: transaction.description.slice(0, 50),
+      status: 'processing',
+    };
+
+    if (onProgress) {
+      appendBatchItem(currentBatch, batchItem);
+      onProgress({ processedCount: i + 1, currentBatch: [...currentBatch] });
+    }
+
+    const result = await processTransactionSafely(
+      transaction,
+      context,
+      counters,
+      i + 1,
+      newTransactions.length
+    );
+
+    pushClassified(buckets, result);
+    batchItem.status = result.batchStatus;
+    if (result.errorEntry) {
+      batchItem.error = result.errorEntry.error;
+      if (onProgress) errors.push(result.errorEntry);
+    }
+
+    if (onProgress) onProgress({ currentBatch: [...currentBatch] });
+  }
+
+  return { errors };
+}
+
+async function processImportCore(args: ProcessCoreInput): Promise<ProcessCoreOutput> {
   const { transactions, account, importBatchId, onProgress } = args;
 
   logger.info(
@@ -59,283 +153,52 @@ async function processImportCore(args: {
     '[Import] Starting processImport'
   );
 
-  // Step 1: Checksum-based deduplication against SQLite
   onProgress?.({ currentStep: 'deduplicating', processedCount: 0 });
-  logger.info(
-    { checksumCount: transactions.length },
-    '[Import] Querying SQLite for existing checksums'
-  );
-  const checksums = transactions.map((t) => t.checksum);
-  const existingChecksums = findExistingChecksums(checksums);
+  const { newTransactions, duplicates } = partitionByChecksum(transactions);
 
   logger.info(
-    {
-      duplicateCount: existingChecksums.size,
-      newCount: transactions.length - existingChecksums.size,
-    },
+    { duplicateCount: duplicates.length, newCount: newTransactions.length },
     '[Import] Deduplication complete'
   );
 
-  const newTransactions = transactions.filter((t) => !existingChecksums.has(t.checksum));
-  const duplicates = transactions.filter((t) => existingChecksums.has(t.checksum));
-
-  // Step 2: Load entity lookup, aliases, and known tags (once per batch)
   onProgress?.({ currentStep: 'matching', processedCount: 0 });
   const { entityLookup, aliasMap: aliases } = loadEntityMaps();
   const knownTags = loadKnownTags();
 
-  // Step 3: Match entities for each transaction
-  const matched: ProcessedTransaction[] = [];
-  const uncertain: ProcessedTransaction[] = [];
-  const failed: ProcessedTransaction[] = [];
-  const skipped: ProcessedTransaction[] = duplicates.map((t) => ({
-    ...t,
-    entity: { matchType: 'none' as const },
-    status: 'skipped' as const,
-    skipReason: 'Duplicate transaction (checksum match)',
-  }));
+  const buckets = makeBuckets();
+  buckets.skipped = buildSkippedBucket(duplicates);
 
-  // Track AI categorization issues and usage
-  let aiError: AiCategorizationError | null = null;
-  let aiFailureCount = 0;
-  let aiApiCalls = 0;
-  let aiCacheHits = 0;
-  let totalInputTokens = 0;
-  let totalOutputTokens = 0;
-  let totalCostUsd = 0;
+  const counters = createAiCounters();
+  const context: ProcessContext = { entityLookup, aliases, knownTags, importBatchId };
 
-  const currentBatch: Array<{
-    description: string;
-    status: 'processing' | 'success' | 'failed';
-    error?: string;
-  }> = [];
-  const errors: Array<{ description: string; error: string }> = [];
+  const { errors } = await runProcessLoop({
+    newTransactions,
+    context,
+    counters,
+    buckets,
+    onProgress,
+  });
 
-  for (let i = 0; i < newTransactions.length; i++) {
-    const transaction = newTransactions[i];
-    if (!transaction) continue;
-
-    const batchItem: {
-      description: string;
-      status: 'processing' | 'success' | 'failed';
-      error?: string;
-    } = {
-      description: transaction.description.slice(0, 50),
-      status: 'processing',
-    };
-
-    if (onProgress) {
-      currentBatch.push(batchItem);
-      if (currentBatch.length > 5) currentBatch.shift();
-      onProgress({ processedCount: i + 1, currentBatch: [...currentBatch] });
-    }
-
-    try {
-      // Step 1: Apply learned corrections (highest priority)
-      // When a correction matches, skip all subsequent matching stages.
-      const correctionApplied = applyLearnedCorrection({
-        transaction,
-        minConfidence: 0.7,
-        knownTags,
-        index: i + 1,
-        total: newTransactions.length,
-      });
-
-      if (correctionApplied) {
-        if (correctionApplied.bucket === 'matched') matched.push(correctionApplied.processed);
-        else uncertain.push(correctionApplied.processed);
-
-        batchItem.status = 'success';
-        continue;
-      }
-
-      // Step 2: Try universal entity matching
-      const match = matchEntity(transaction.description, entityLookup, aliases);
-
-      if (match) {
-        logger.debug(
-          {
-            index: i + 1,
-            total: newTransactions.length,
-            description: transaction.description.slice(0, 50),
-            entityName: match.entityName,
-            matchType: match.matchType,
-          },
-          '[Import] Entity matched'
-        );
-
-        const entityEntry = entityLookup.get(match.entityName.toLowerCase());
-        if (!entityEntry) {
-          throw new Error(`Entity lookup failed for matched entity: ${match.entityName}`);
-        }
-
-        matched.push({
-          ...transaction,
-          entity: {
-            entityId: entityEntry.id,
-            entityName: entityEntry.name,
-            matchType: match.matchType,
-          },
-          status: 'matched',
-          suggestedTags: buildSuggestedTags(
-            transaction.description,
-            entityEntry.id,
-            [],
-            null,
-            knownTags
-          ),
-        });
-
-        batchItem.status = 'success';
-      } else {
-        // No match - try AI categorization
-        let aiResult = null;
-
-        try {
-          const { result, usage } = await categorizeWithAi(transaction.rawRow, importBatchId);
-          aiResult = result;
-
-          if (usage) {
-            aiApiCalls++;
-            totalInputTokens += usage.inputTokens;
-            totalOutputTokens += usage.outputTokens;
-            totalCostUsd += usage.costUsd;
-          } else {
-            aiCacheHits++;
-          }
-        } catch (error) {
-          if (error instanceof AiCategorizationError) {
-            aiError = error;
-            aiFailureCount++;
-          } else {
-            throw error;
-          }
-        }
-
-        if (aiResult && aiResult.entityName) {
-          const entityEntry = entityLookup.get(aiResult.entityName.toLowerCase());
-
-          if (entityEntry) {
-            matched.push({
-              ...transaction,
-              entity: {
-                entityId: entityEntry.id,
-                entityName: entityEntry.name,
-                matchType: 'ai',
-              },
-              status: 'matched',
-              suggestedTags: buildSuggestedTags(
-                transaction.description,
-                entityEntry.id,
-                [],
-                aiResult.category,
-                knownTags
-              ),
-            });
-
-            batchItem.status = 'success';
-          } else {
-            uncertain.push({
-              ...transaction,
-              entity: {
-                entityName: aiResult.entityName,
-                matchType: 'ai',
-                confidence: 0.7,
-              },
-              status: 'uncertain',
-              suggestedTags: buildSuggestedTags(
-                transaction.description,
-                null,
-                [],
-                aiResult.category,
-                knownTags
-              ),
-            });
-
-            batchItem.status = 'success';
-          }
-        } else {
-          const reason = aiError ? 'AI categorization unavailable' : 'No entity match found';
-          uncertain.push({
-            ...transaction,
-            entity: { matchType: 'none' },
-            status: 'uncertain',
-            error: reason,
-            suggestedTags: buildSuggestedTags(transaction.description, null, [], null, knownTags),
-          });
-
-          batchItem.status = 'success';
-        }
-      }
-    } catch (error) {
-      failed.push({
-        ...transaction,
-        entity: { matchType: 'none' },
-        status: 'failed',
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-
-      batchItem.status = 'failed';
-      batchItem.error = error instanceof Error ? error.message : 'Unknown error';
-
-      if (onProgress) {
-        const formattedError = formatImportError(error, { transaction: transaction.description });
-        errors.push({
-          description: transaction.description.slice(0, 50),
-          error:
-            formattedError.message +
-            (formattedError.suggestion ? ` - ${formattedError.suggestion}` : ''),
-        });
-      }
-    } finally {
-      if (onProgress) onProgress({ currentBatch: [...currentBatch] });
-    }
-  }
-
-  // Build warnings array
-  const warnings: ImportWarning[] = [];
-  if (aiError && aiFailureCount > 0) {
-    warnings.push({
-      type:
-        aiError.code === 'INSUFFICIENT_CREDITS' ? 'AI_CATEGORIZATION_UNAVAILABLE' : 'AI_API_ERROR',
-      message: aiError.message,
-      affectedCount: aiFailureCount,
-    });
-  }
-
-  // Build AI usage stats if any AI calls were made
-  const aiUsage: AiUsageStats | undefined =
-    aiApiCalls > 0 || aiCacheHits > 0
-      ? {
-          apiCalls: aiApiCalls,
-          cacheHits: aiCacheHits,
-          totalInputTokens,
-          totalOutputTokens,
-          totalCostUsd,
-          avgCostPerCall: aiApiCalls > 0 ? totalCostUsd / aiApiCalls : 0,
-        }
-      : undefined;
+  const warnings = buildAiWarnings(counters);
+  const aiUsage = buildAiUsage(counters);
 
   logger.info(
     {
       importBatchId,
-      matchedCount: matched.length,
-      uncertainCount: uncertain.length,
-      failedCount: failed.length,
-      skippedCount: skipped.length,
-      aiApiCalls,
-      aiCacheHits,
-      totalCostUsd: totalCostUsd.toFixed(6),
+      matchedCount: buckets.matched.length,
+      uncertainCount: buckets.uncertain.length,
+      failedCount: buckets.failed.length,
+      skippedCount: buckets.skipped.length,
+      aiApiCalls: counters.aiApiCalls,
+      aiCacheHits: counters.aiCacheHits,
+      totalCostUsd: counters.totalCostUsd.toFixed(6),
     },
     '[Import] processImport complete'
   );
 
   return {
     output: {
-      matched,
-      uncertain,
-      failed,
-      skipped,
+      ...buckets,
       warnings: warnings.length > 0 ? warnings : undefined,
       aiUsage,
     },
@@ -356,109 +219,124 @@ export async function processImport(
   return output;
 }
 
-function executeImportCore(args: {
+interface ExecuteCoreInput {
   transactions: ConfirmedTransaction[];
   onProgress?: ImportProgressCallback;
-}): {
+}
+
+interface ExecuteCoreOutput {
   output: ExecuteImportOutput;
   errors: Array<{ description: string; error: string }>;
   processedCount: number;
+}
+
+function resolveTransactionType(t: ConfirmedTransaction): string {
+  if (t.transactionType === 'transfer') return 'Transfer';
+  if (t.transactionType === 'income') return 'Income';
+  return 'Expense';
+}
+
+function writeConfirmedTransaction(transaction: ConfirmedTransaction): {
+  result: ImportResult;
 } {
+  const type = resolveTransactionType(transaction);
+  const row = insertTransaction({
+    description: transaction.description,
+    account: transaction.account,
+    amount: transaction.amount,
+    date: transaction.date,
+    type,
+    tags: transaction.tags ?? [],
+    entityId: transaction.entityId ?? null,
+    entityName: transaction.entityName ?? null,
+    location: transaction.location ?? null,
+    rawRow: transaction.rawRow,
+    checksum: transaction.checksum,
+  });
+  return { result: { transaction, success: true, pageId: row.id } };
+}
+
+function tryWriteTransaction(
+  transaction: ConfirmedTransaction,
+  index: number,
+  total: number
+): { result: ImportResult; ok: boolean; message?: string } {
+  try {
+    const { result } = writeConfirmedTransaction(transaction);
+    logger.debug(
+      {
+        index,
+        total,
+        description: transaction.description.slice(0, 50),
+        id: result.pageId,
+      },
+      '[Import] Transaction written'
+    );
+    return { result, ok: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    logger.error(
+      {
+        index,
+        total,
+        description: transaction.description.slice(0, 50),
+        error: message,
+      },
+      '[Import] Transaction write failed'
+    );
+    return {
+      result: { transaction, success: false, error: message },
+      ok: false,
+      message,
+    };
+  }
+}
+
+function executeImportCore(args: ExecuteCoreInput): ExecuteCoreOutput {
   const { transactions, onProgress } = args;
 
   const results: ImportResult[] = [];
   let imported = 0;
   const skipped = 0;
 
-  const currentBatch: Array<{
-    description: string;
-    status: 'processing' | 'success' | 'failed';
-    error?: string;
-  }> = [];
+  const currentBatch: ProgressBatchItem[] = [];
   const errors: Array<{ description: string; error: string }> = [];
 
   for (let i = 0; i < transactions.length; i++) {
     const transaction = transactions[i];
     if (!transaction) continue;
 
-    const batchItem: {
-      description: string;
-      status: 'processing' | 'success' | 'failed';
-      error?: string;
-    } = {
+    const batchItem: ProgressBatchItem = {
       description: transaction.description.slice(0, 50),
       status: 'processing',
     };
 
     if (onProgress) {
-      currentBatch.push(batchItem);
-      if (currentBatch.length > 5) currentBatch.shift();
+      appendBatchItem(currentBatch, batchItem);
       onProgress({ processedCount: i + 1, currentBatch: [...currentBatch] });
     }
 
-    try {
-      const type =
-        transaction.transactionType === 'transfer'
-          ? 'Transfer'
-          : transaction.transactionType === 'income'
-            ? 'Income'
-            : 'Expense';
+    const writeResult = tryWriteTransaction(transaction, i + 1, transactions.length);
+    results.push(writeResult.result);
 
-      const row = insertTransaction({
-        description: transaction.description,
-        account: transaction.account,
-        amount: transaction.amount,
-        date: transaction.date,
-        type,
-        tags: transaction.tags ?? [],
-        entityId: transaction.entityId ?? null,
-        entityName: transaction.entityName ?? null,
-        location: transaction.location ?? null,
-        rawRow: transaction.rawRow,
-        checksum: transaction.checksum,
-      });
-
-      logger.debug(
-        {
-          index: i + 1,
-          total: transactions.length,
-          description: transaction.description.slice(0, 50),
-          id: row.id,
-        },
-        '[Import] Transaction written'
-      );
-
-      results.push({ transaction, success: true, pageId: row.id });
+    if (writeResult.ok) {
       imported++;
       batchItem.status = 'success';
-    } catch (error) {
-      logger.error(
-        {
-          index: i + 1,
-          total: transactions.length,
-          description: transaction.description.slice(0, 50),
-          error: error instanceof Error ? error.message : String(error),
-        },
-        '[Import] Transaction write failed'
-      );
-
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      results.push({ transaction, success: false, error: message });
+    } else {
       batchItem.status = 'failed';
-      batchItem.error = message;
-
+      batchItem.error = writeResult.message;
       if (onProgress) {
-        const formattedError = formatImportError(error, { transaction: transaction.description });
+        const formatted = formatImportError(writeResult.result.error, {
+          transaction: transaction.description,
+        });
         errors.push({
           description: transaction.description.slice(0, 50),
-          error:
-            formattedError.message +
-            (formattedError.suggestion ? ` - ${formattedError.suggestion}` : ''),
+          error: formatted.message + (formatted.suggestion ? ` - ${formatted.suggestion}` : ''),
         });
       }
-    } finally {
-      if (onProgress) onProgress({ currentBatch: [...currentBatch] });
     }
+
+    if (onProgress) onProgress({ currentBatch: [...currentBatch] });
   }
 
   const failed = results.filter((r) => !r.success);
@@ -499,6 +377,44 @@ export function createEntity(name: string): CreateEntityOutput {
   return { entityId, entityName: name };
 }
 
+function logBackgroundImportComplete(
+  importBatchId: string,
+  sessionId: string,
+  result: ProcessImportOutput
+): void {
+  logger.info(
+    {
+      importBatchId,
+      sessionId,
+      matchedCount: result.matched.length,
+      uncertainCount: result.uncertain.length,
+      failedCount: result.failed.length,
+      skippedCount: result.skipped.length,
+      aiApiCalls: result.aiUsage?.apiCalls ?? 0,
+      aiCacheHits: result.aiUsage?.cacheHits ?? 0,
+      totalCostUsd: (result.aiUsage?.totalCostUsd ?? 0).toFixed(6),
+    },
+    '[Import] Background processImport complete'
+  );
+}
+
+function reportBackgroundFailure(sessionId: string, error: unknown, stage: string): void {
+  logger.error({ sessionId, error: error instanceof Error ? error.message : String(error) }, stage);
+
+  const formattedError = formatImportError(error);
+  updateProgress(sessionId, {
+    status: 'failed',
+    errors: [
+      {
+        description: 'System',
+        error:
+          formattedError.message +
+          (formattedError.suggestion ? ` - ${formattedError.suggestion}` : ''),
+      },
+    ],
+  });
+}
+
 /**
  * Process import with real-time progress updates.
  * This is an async wrapper that updates progress store as transactions are processed.
@@ -529,45 +445,16 @@ export async function processImportWithProgress(
       },
     });
 
-    logger.info(
-      {
-        importBatchId,
-        sessionId,
-        matchedCount: result.matched.length,
-        uncertainCount: result.uncertain.length,
-        failedCount: result.failed.length,
-        skippedCount: result.skipped.length,
-        aiApiCalls: result.aiUsage?.apiCalls ?? 0,
-        aiCacheHits: result.aiUsage?.cacheHits ?? 0,
-        totalCostUsd: (result.aiUsage?.totalCostUsd ?? 0).toFixed(6),
-      },
-      '[Import] Background processImport complete'
-    );
+    logBackgroundImportComplete(importBatchId, sessionId, result);
 
     updateProgress(sessionId, {
       status: 'completed',
-      processedCount: processedNewCount, // Set final count to total new
+      processedCount: processedNewCount,
       result,
       errors,
     });
   } catch (error) {
-    logger.error(
-      { sessionId, error: error instanceof Error ? error.message : String(error) },
-      '[Import] Background processing failed'
-    );
-
-    const formattedError = formatImportError(error);
-    updateProgress(sessionId, {
-      status: 'failed',
-      errors: [
-        {
-          description: 'System',
-          error:
-            formattedError.message +
-            (formattedError.suggestion ? ` - ${formattedError.suggestion}` : ''),
-        },
-      ],
-    });
+    reportBackgroundFailure(sessionId, error, '[Import] Background processing failed');
   }
 }
 
@@ -615,28 +502,12 @@ export function executeImportWithProgress(
 
     updateProgress(sessionId, {
       status: 'completed',
-      processedCount, // Set final count to total
+      processedCount,
       result,
       errors,
     });
   } catch (error) {
-    logger.error(
-      { sessionId, error: error instanceof Error ? error.message : String(error) },
-      '[Import] Background execution failed'
-    );
-
-    const formattedError = formatImportError(error);
-    updateProgress(sessionId, {
-      status: 'failed',
-      errors: [
-        {
-          description: 'System',
-          error:
-            formattedError.message +
-            (formattedError.suggestion ? ` - ${formattedError.suggestion}` : ''),
-        },
-      ],
-    });
+    reportBackgroundFailure(sessionId, error, '[Import] Background execution failed');
   }
 }
 

--- a/apps/pops-api/src/modules/finance/imports/service.ts
+++ b/apps/pops-api/src/modules/finance/imports/service.ts
@@ -260,7 +260,7 @@ function tryWriteTransaction(
   transaction: ConfirmedTransaction,
   index: number,
   total: number
-): { result: ImportResult; ok: boolean; message?: string } {
+): { result: ImportResult; ok: boolean; message?: string; error?: unknown } {
   try {
     const { result } = writeConfirmedTransaction(transaction);
     logger.debug(
@@ -288,6 +288,7 @@ function tryWriteTransaction(
       result: { transaction, success: false, error: message },
       ok: false,
       message,
+      error,
     };
   }
 }
@@ -326,7 +327,7 @@ function executeImportCore(args: ExecuteCoreInput): ExecuteCoreOutput {
       batchItem.status = 'failed';
       batchItem.error = writeResult.message;
       if (onProgress) {
-        const formatted = formatImportError(writeResult.result.error, {
+        const formatted = formatImportError(writeResult.error ?? new Error(writeResult.message), {
           transaction: transaction.description,
         });
         errors.push({

--- a/apps/pops-api/src/modules/finance/transactions/router.ts
+++ b/apps/pops-api/src/modules/finance/transactions/router.ts
@@ -199,26 +199,32 @@ export const transactionsRouter = router({
    * Used for autocomplete in tag editors — reflects the actual tags in the SQLite database.
    * Returns an empty array when no transactions exist yet; callers allow free-form input.
    */
-  availableTags: protectedProcedure.query(() => {
-    const db = getDb();
-    const rows = db
-      .prepare("SELECT tags FROM transactions WHERE tags IS NOT NULL AND tags != '[]'")
-      .all() as { tags: string }[];
-
-    const tagSet = new Set<string>();
-    for (const row of rows) {
-      try {
-        const parsed = JSON.parse(row.tags) as unknown;
-        if (Array.isArray(parsed)) {
-          for (const t of parsed) {
-            if (typeof t === 'string' && t.trim()) tagSet.add(t.trim());
-          }
-        }
-      } catch {
-        // malformed JSON — ignore
-      }
-    }
-
-    return [...tagSet].toSorted();
-  }),
+  availableTags: protectedProcedure.query(() => collectAvailableTags()),
 });
+
+function collectAvailableTags(): string[] {
+  const db = getDb();
+  const rows = db
+    .prepare("SELECT tags FROM transactions WHERE tags IS NOT NULL AND tags != '[]'")
+    .all() as { tags: string }[];
+
+  const tagSet = new Set<string>();
+  for (const row of rows) {
+    addTagsFromJson(tagSet, row.tags);
+  }
+
+  return [...tagSet].toSorted();
+}
+
+function addTagsFromJson(tagSet: Set<string>, raw: string): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  if (!Array.isArray(parsed)) return;
+  for (const t of parsed) {
+    if (typeof t === 'string' && t.trim()) tagSet.add(t.trim());
+  }
+}

--- a/apps/pops-api/src/modules/inventory/items/service.ts
+++ b/apps/pops-api/src/modules/inventory/items/service.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 
-import { and, count, eq, inArray, isNotNull, like, sql, sum } from 'drizzle-orm';
+import { and, count, eq, inArray, isNotNull, like, sql, sum, type SQL } from 'drizzle-orm';
 
 /**
  * Inventory service — CRUD operations using Drizzle ORM.
@@ -11,6 +11,7 @@ import { homeInventory } from '@pops/db-types';
 import { getDrizzle } from '../../../db.js';
 import { NotFoundError } from '../../../shared/errors.js';
 import { getDescendantLocationIds } from '../locations/service.js';
+import { buildInventoryUpdate } from './update-builder.js';
 
 import type { CreateInventoryItemInput, InventoryRow, UpdateInventoryItemInput } from './types.js';
 
@@ -37,21 +38,40 @@ export interface ListInventoryItemsOptions {
   includeChildren?: boolean;
 }
 
+function buildInventoryConditions(opts: ListInventoryItemsOptions): SQL[] {
+  const conditions: SQL[] = [];
+  if (opts.search) conditions.push(like(homeInventory.itemName, `%${opts.search}%`));
+  if (opts.room) conditions.push(eq(homeInventory.room, opts.room));
+  if (opts.type) conditions.push(eq(homeInventory.type, opts.type));
+  if (opts.condition) {
+    conditions.push(sql`lower(${homeInventory.condition}) = lower(${opts.condition})`);
+  }
+  if (opts.inUse !== undefined) conditions.push(eq(homeInventory.inUse, opts.inUse ? 1 : 0));
+  if (opts.deductible !== undefined) {
+    conditions.push(eq(homeInventory.deductible, opts.deductible ? 1 : 0));
+  }
+  if (opts.locationId)
+    conditions.push(buildLocationCondition(opts.locationId, opts.includeChildren));
+  if (opts.assetId) conditions.push(eq(homeInventory.assetId, opts.assetId));
+  return conditions;
+}
+
+function buildLocationCondition(locationId: string, includeChildren: boolean | undefined): SQL {
+  if (includeChildren) {
+    const ids = [locationId, ...getDescendantLocationIds(locationId)];
+    return inArray(homeInventory.locationId, ids);
+  }
+  return eq(homeInventory.locationId, locationId);
+}
+
+function combineConditions(conditions: SQL[]): SQL | undefined {
+  if (conditions.length === 0) return undefined;
+  if (conditions.length === 1) return conditions[0];
+  return and(...conditions);
+}
+
 /** List inventory items with optional filters. */
 export function listInventoryItems(opts: ListInventoryItemsOptions): InventoryListResult {
-  const {
-    search,
-    room,
-    type,
-    condition,
-    inUse,
-    deductible,
-    limit,
-    offset,
-    locationId,
-    assetId,
-    includeChildren,
-  } = opts;
   const db = getDrizzle();
 
   let query = db.select().from(homeInventory).$dynamic();
@@ -64,46 +84,14 @@ export function listInventoryItems(opts: ListInventoryItemsOptions): InventoryLi
     .from(homeInventory)
     .$dynamic();
 
-  const conditions = [];
-  if (search) {
-    conditions.push(like(homeInventory.itemName, `%${search}%`));
-  }
-  if (room) {
-    conditions.push(eq(homeInventory.room, room));
-  }
-  if (type) {
-    conditions.push(eq(homeInventory.type, type));
-  }
-  if (condition) {
-    conditions.push(sql`lower(${homeInventory.condition}) = lower(${condition})`);
-  }
-  if (inUse !== undefined) {
-    conditions.push(eq(homeInventory.inUse, inUse ? 1 : 0));
-  }
-  if (deductible !== undefined) {
-    conditions.push(eq(homeInventory.deductible, deductible ? 1 : 0));
-  }
-  if (locationId) {
-    if (includeChildren) {
-      const locationIds = [locationId, ...getDescendantLocationIds(locationId)];
-      conditions.push(inArray(homeInventory.locationId, locationIds));
-    } else {
-      conditions.push(eq(homeInventory.locationId, locationId));
-    }
-  }
-  if (assetId) {
-    conditions.push(eq(homeInventory.assetId, assetId));
-  }
-
-  if (conditions.length > 0) {
-    const where = conditions.length === 1 ? conditions[0] : and(...conditions);
+  const where = combineConditions(buildInventoryConditions(opts));
+  if (where) {
     query = query.where(where);
     countQuery = countQuery.where(where);
     sumQuery = sumQuery.where(where);
   }
 
-  const rows = query.orderBy(homeInventory.itemName).limit(limit).offset(offset).all();
-
+  const rows = query.orderBy(homeInventory.itemName).limit(opts.limit).offset(opts.offset).all();
   const [countResult] = countQuery.all();
   const [sumResult] = sumQuery.all();
 
@@ -163,6 +151,69 @@ export function getInventoryItem(id: string): InventoryRow {
   return row;
 }
 
+function buildCreateValues(
+  id: string,
+  now: string,
+  input: CreateInventoryItemInput
+): typeof homeInventory.$inferInsert {
+  return {
+    id,
+    itemName: input.itemName,
+    inUse: input.inUse ? 1 : 0,
+    deductible: input.deductible ? 1 : 0,
+    lastEditedTime: now,
+    ...nullableStringsFromInput(input),
+    ...nullableNumbersFromInput(input),
+  };
+}
+
+const CREATE_NULLABLE_STRING_KEYS = [
+  'brand',
+  'model',
+  'itemId',
+  'room',
+  'location',
+  'type',
+  'condition',
+  'purchaseDate',
+  'warrantyExpires',
+  'purchaseTransactionId',
+  'purchasedFromId',
+  'purchasedFromName',
+  'assetId',
+  'notes',
+  'locationId',
+] as const satisfies ReadonlyArray<
+  keyof CreateInventoryItemInput & keyof typeof homeInventory.$inferInsert
+>;
+
+const CREATE_NULLABLE_NUMBER_KEYS = [
+  'replacementValue',
+  'resaleValue',
+] as const satisfies ReadonlyArray<
+  keyof CreateInventoryItemInput & keyof typeof homeInventory.$inferInsert
+>;
+
+function nullableStringsFromInput(
+  input: CreateInventoryItemInput
+): Partial<typeof homeInventory.$inferInsert> {
+  const out: Record<string, unknown> = {};
+  for (const key of CREATE_NULLABLE_STRING_KEYS) {
+    out[key] = input[key] ?? null;
+  }
+  return out as Partial<typeof homeInventory.$inferInsert>;
+}
+
+function nullableNumbersFromInput(
+  input: CreateInventoryItemInput
+): Partial<typeof homeInventory.$inferInsert> {
+  const out: Record<string, unknown> = {};
+  for (const key of CREATE_NULLABLE_NUMBER_KEYS) {
+    out[key] = input[key] ?? null;
+  }
+  return out as Partial<typeof homeInventory.$inferInsert>;
+}
+
 /**
  * Create a new inventory item. Returns the created row.
  * Generates a local UUID and inserts directly into SQLite.
@@ -173,30 +224,7 @@ export function createInventoryItem(input: CreateInventoryItemInput): InventoryR
   const now = new Date().toISOString();
 
   db.insert(homeInventory)
-    .values({
-      id,
-      itemName: input.itemName,
-      brand: input.brand ?? null,
-      model: input.model ?? null,
-      itemId: input.itemId ?? null,
-      room: input.room ?? null,
-      location: input.location ?? null,
-      type: input.type ?? null,
-      condition: input.condition ?? null,
-      inUse: input.inUse ? 1 : 0,
-      deductible: input.deductible ? 1 : 0,
-      purchaseDate: input.purchaseDate ?? null,
-      warrantyExpires: input.warrantyExpires ?? null,
-      replacementValue: input.replacementValue ?? null,
-      resaleValue: input.resaleValue ?? null,
-      purchaseTransactionId: input.purchaseTransactionId ?? null,
-      purchasedFromId: input.purchasedFromId ?? null,
-      purchasedFromName: input.purchasedFromName ?? null,
-      assetId: input.assetId ?? null,
-      notes: input.notes ?? null,
-      locationId: input.locationId ?? null,
-      lastEditedTime: now,
-    })
+    .values(buildCreateValues(id, now, input))
     .run();
 
   return getInventoryItem(id);
@@ -207,97 +235,11 @@ export function createInventoryItem(input: CreateInventoryItemInput): InventoryR
  * Updates directly in SQLite.
  */
 export function updateInventoryItem(id: string, input: UpdateInventoryItemInput): InventoryRow {
-  const db = getDrizzle();
-
-  // Verify it exists first
   getInventoryItem(id);
 
-  const updates: Partial<typeof homeInventory.$inferInsert> = {};
-  let hasUpdates = false;
-
-  if (input.itemName !== undefined) {
-    updates.itemName = input.itemName;
-    hasUpdates = true;
-  }
-  if (input.brand !== undefined) {
-    updates.brand = input.brand ?? null;
-    hasUpdates = true;
-  }
-  if (input.model !== undefined) {
-    updates.model = input.model ?? null;
-    hasUpdates = true;
-  }
-  if (input.itemId !== undefined) {
-    updates.itemId = input.itemId ?? null;
-    hasUpdates = true;
-  }
-  if (input.room !== undefined) {
-    updates.room = input.room ?? null;
-    hasUpdates = true;
-  }
-  if (input.location !== undefined) {
-    updates.location = input.location ?? null;
-    hasUpdates = true;
-  }
-  if (input.type !== undefined) {
-    updates.type = input.type ?? null;
-    hasUpdates = true;
-  }
-  if (input.condition !== undefined) {
-    updates.condition = input.condition ?? null;
-    hasUpdates = true;
-  }
-  if (input.inUse !== undefined) {
-    updates.inUse = input.inUse ? 1 : 0;
-    hasUpdates = true;
-  }
-  if (input.deductible !== undefined) {
-    updates.deductible = input.deductible ? 1 : 0;
-    hasUpdates = true;
-  }
-  if (input.purchaseDate !== undefined) {
-    updates.purchaseDate = input.purchaseDate ?? null;
-    hasUpdates = true;
-  }
-  if (input.warrantyExpires !== undefined) {
-    updates.warrantyExpires = input.warrantyExpires ?? null;
-    hasUpdates = true;
-  }
-  if (input.replacementValue !== undefined) {
-    updates.replacementValue = input.replacementValue ?? null;
-    hasUpdates = true;
-  }
-  if (input.resaleValue !== undefined) {
-    updates.resaleValue = input.resaleValue ?? null;
-    hasUpdates = true;
-  }
-  if (input.purchaseTransactionId !== undefined) {
-    updates.purchaseTransactionId = input.purchaseTransactionId ?? null;
-    hasUpdates = true;
-  }
-  if (input.purchasedFromId !== undefined) {
-    updates.purchasedFromId = input.purchasedFromId ?? null;
-    hasUpdates = true;
-  }
-  if (input.purchasedFromName !== undefined) {
-    updates.purchasedFromName = input.purchasedFromName ?? null;
-    hasUpdates = true;
-  }
-  if (input.assetId !== undefined) {
-    updates.assetId = input.assetId ?? null;
-    hasUpdates = true;
-  }
-  if (input.notes !== undefined) {
-    updates.notes = input.notes ?? null;
-    hasUpdates = true;
-  }
-  if (input.locationId !== undefined) {
-    updates.locationId = input.locationId ?? null;
-    hasUpdates = true;
-  }
-
-  if (hasUpdates) {
-    updates.lastEditedTime = new Date().toISOString();
+  const updates = buildInventoryUpdate(input);
+  if (updates) {
+    const db = getDrizzle();
     db.update(homeInventory).set(updates).where(eq(homeInventory.id, id)).run();
   }
 
@@ -309,7 +251,6 @@ export function updateInventoryItem(id: string, input: UpdateInventoryItemInput)
  * Deletes directly from SQLite.
  */
 export function deleteInventoryItem(id: string): void {
-  // Verify it exists first
   getInventoryItem(id);
 
   const db = getDrizzle();

--- a/apps/pops-api/src/modules/inventory/items/update-builder.ts
+++ b/apps/pops-api/src/modules/inventory/items/update-builder.ts
@@ -5,7 +5,10 @@ import type { UpdateInventoryItemInput } from './types.js';
 type InventoryUpdate = Partial<typeof homeInventory.$inferInsert>;
 
 /**
- * Keys where we pass through string|null (setting null when caller passes undefined-as-null).
+ * Keys where we pass through string|null.
+ *
+ * - `undefined` means "leave unchanged" (the key is not written to the update payload)
+ * - `null` means "clear the field" (the key is written with a null value)
  */
 const NULLABLE_STRING_KEYS = [
   'brand',

--- a/apps/pops-api/src/modules/inventory/items/update-builder.ts
+++ b/apps/pops-api/src/modules/inventory/items/update-builder.ts
@@ -1,0 +1,82 @@
+import type { homeInventory } from '@pops/db-types';
+
+import type { UpdateInventoryItemInput } from './types.js';
+
+type InventoryUpdate = Partial<typeof homeInventory.$inferInsert>;
+
+/**
+ * Keys where we pass through string|null (setting null when caller passes undefined-as-null).
+ */
+const NULLABLE_STRING_KEYS = [
+  'brand',
+  'model',
+  'itemId',
+  'room',
+  'location',
+  'type',
+  'condition',
+  'purchaseDate',
+  'warrantyExpires',
+  'purchaseTransactionId',
+  'purchasedFromId',
+  'purchasedFromName',
+  'assetId',
+  'notes',
+  'locationId',
+] as const satisfies ReadonlyArray<keyof UpdateInventoryItemInput & keyof InventoryUpdate>;
+
+const NULLABLE_NUMBER_KEYS = ['replacementValue', 'resaleValue'] as const satisfies ReadonlyArray<
+  keyof UpdateInventoryItemInput & keyof InventoryUpdate
+>;
+
+/**
+ * Build the partial update payload for an inventory item from the input.
+ * Returns `null` when the caller supplied no fields — so callers can skip the DB write.
+ */
+export function buildInventoryUpdate(input: UpdateInventoryItemInput): InventoryUpdate | null {
+  const updates: InventoryUpdate = {};
+  let touched = false;
+
+  if (assignItemName(updates, input)) touched = true;
+  if (assignNullableKeys(updates, input, NULLABLE_STRING_KEYS)) touched = true;
+  if (assignNullableKeys(updates, input, NULLABLE_NUMBER_KEYS)) touched = true;
+  if (assignBooleanFlags(updates, input)) touched = true;
+
+  if (!touched) return null;
+  updates.lastEditedTime = new Date().toISOString();
+  return updates;
+}
+
+function assignItemName(updates: InventoryUpdate, input: UpdateInventoryItemInput): boolean {
+  if (input.itemName === undefined) return false;
+  updates.itemName = input.itemName;
+  return true;
+}
+
+function assignNullableKeys(
+  updates: InventoryUpdate,
+  input: UpdateInventoryItemInput,
+  keys: ReadonlyArray<keyof UpdateInventoryItemInput & keyof InventoryUpdate>
+): boolean {
+  let touched = false;
+  for (const key of keys) {
+    const value = input[key];
+    if (value === undefined) continue;
+    (updates as Record<string, unknown>)[key] = value ?? null;
+    touched = true;
+  }
+  return touched;
+}
+
+function assignBooleanFlags(updates: InventoryUpdate, input: UpdateInventoryItemInput): boolean {
+  let touched = false;
+  if (input.inUse !== undefined) {
+    updates.inUse = input.inUse ? 1 : 0;
+    touched = true;
+  }
+  if (input.deductible !== undefined) {
+    updates.deductible = input.deductible ? 1 : 0;
+    touched = true;
+  }
+  return touched;
+}

--- a/apps/pops-api/src/modules/media/movies/service.ts
+++ b/apps/pops-api/src/modules/media/movies/service.ts
@@ -100,40 +100,64 @@ export function createMovie(input: CreateMovieInput): MovieRow {
   }
 }
 
-/** Update an existing movie. Returns the updated row. */
-export function updateMovie(id: number, input: UpdateMovieInput): MovieRow {
-  // Verify it exists first
-  getMovie(id);
+const MOVIE_REQUIRED_KEYS = ['tmdbId', 'title'] as const satisfies ReadonlyArray<
+  keyof UpdateMovieInput & keyof typeof movies.$inferSelect
+>;
 
-  const updates: Partial<typeof movies.$inferSelect> = {};
+const MOVIE_NULLABLE_KEYS = [
+  'imdbId',
+  'originalTitle',
+  'overview',
+  'tagline',
+  'releaseDate',
+  'runtime',
+  'status',
+  'originalLanguage',
+  'budget',
+  'revenue',
+  'posterPath',
+  'backdropPath',
+  'logoPath',
+  'posterOverridePath',
+  'voteAverage',
+  'voteCount',
+] as const satisfies ReadonlyArray<keyof UpdateMovieInput & keyof typeof movies.$inferSelect>;
 
-  if (input.tmdbId !== undefined) updates.tmdbId = input.tmdbId;
-  if (input.imdbId !== undefined) updates.imdbId = input.imdbId ?? null;
-  if (input.title !== undefined) updates.title = input.title;
-  if (input.originalTitle !== undefined) updates.originalTitle = input.originalTitle ?? null;
-  if (input.overview !== undefined) updates.overview = input.overview ?? null;
-  if (input.tagline !== undefined) updates.tagline = input.tagline ?? null;
-  if (input.releaseDate !== undefined) updates.releaseDate = input.releaseDate ?? null;
-  if (input.runtime !== undefined) updates.runtime = input.runtime ?? null;
-  if (input.status !== undefined) updates.status = input.status ?? null;
-  if (input.originalLanguage !== undefined)
-    updates.originalLanguage = input.originalLanguage ?? null;
-  if (input.budget !== undefined) updates.budget = input.budget ?? null;
-  if (input.revenue !== undefined) updates.revenue = input.revenue ?? null;
-  if (input.posterPath !== undefined) updates.posterPath = input.posterPath ?? null;
-  if (input.backdropPath !== undefined) updates.backdropPath = input.backdropPath ?? null;
-  if (input.logoPath !== undefined) updates.logoPath = input.logoPath ?? null;
-  if (input.posterOverridePath !== undefined)
-    updates.posterOverridePath = input.posterOverridePath ?? null;
-  if (input.voteAverage !== undefined) updates.voteAverage = input.voteAverage ?? null;
-  if (input.voteCount !== undefined) updates.voteCount = input.voteCount ?? null;
-  if (input.genres !== undefined) updates.genres = JSON.stringify(input.genres);
+function buildMovieUpdate(input: UpdateMovieInput): Partial<typeof movies.$inferSelect> | null {
+  const updates: Record<string, unknown> = {};
+  let touched = false;
 
-  if (Object.keys(updates).length > 0) {
-    updates.updatedAt = new Date().toISOString();
-    getDrizzle().update(movies).set(updates).where(eq(movies.id, id)).run();
+  for (const key of MOVIE_REQUIRED_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    updates[key] = value;
+    touched = true;
   }
 
+  for (const key of MOVIE_NULLABLE_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    updates[key] = value ?? null;
+    touched = true;
+  }
+
+  if (input.genres !== undefined) {
+    updates.genres = JSON.stringify(input.genres);
+    touched = true;
+  }
+
+  if (!touched) return null;
+  updates.updatedAt = new Date().toISOString();
+  return updates as Partial<typeof movies.$inferSelect>;
+}
+
+/** Update an existing movie. Returns the updated row. */
+export function updateMovie(id: number, input: UpdateMovieInput): MovieRow {
+  getMovie(id);
+  const updates = buildMovieUpdate(input);
+  if (updates) {
+    getDrizzle().update(movies).set(updates).where(eq(movies.id, id)).run();
+  }
   return getMovie(id);
 }
 

--- a/apps/pops-api/src/modules/media/tv-shows/service.ts
+++ b/apps/pops-api/src/modules/media/tv-shows/service.ts
@@ -119,91 +119,62 @@ export function createTvShow(input: CreateTvShowInput): TvShowRow {
   return row;
 }
 
-export function updateTvShow(id: number, input: UpdateTvShowInput): TvShowRow {
-  const db = getDrizzle();
-  getTvShow(id); // verify exists
+const TV_SHOW_NULLABLE_KEYS = [
+  'originalName',
+  'overview',
+  'firstAirDate',
+  'lastAirDate',
+  'status',
+  'originalLanguage',
+  'numberOfSeasons',
+  'numberOfEpisodes',
+  'episodeRunTime',
+  'posterPath',
+  'backdropPath',
+  'logoPath',
+  'posterOverridePath',
+  'voteAverage',
+  'voteCount',
+] as const satisfies ReadonlyArray<keyof UpdateTvShowInput & keyof typeof tvShows.$inferInsert>;
 
-  const updates: Partial<typeof tvShows.$inferInsert> = {};
-  let hasUpdates = false;
+const TV_SHOW_JSON_KEYS = ['genres', 'networks'] as const satisfies ReadonlyArray<
+  keyof UpdateTvShowInput & keyof typeof tvShows.$inferInsert
+>;
+
+function buildTvShowUpdate(input: UpdateTvShowInput): Partial<typeof tvShows.$inferInsert> | null {
+  const updates: Record<string, unknown> = {};
+  let touched = false;
 
   if (input.name !== undefined) {
     updates.name = input.name;
-    hasUpdates = true;
-  }
-  if (input.originalName !== undefined) {
-    updates.originalName = input.originalName ?? null;
-    hasUpdates = true;
-  }
-  if (input.overview !== undefined) {
-    updates.overview = input.overview ?? null;
-    hasUpdates = true;
-  }
-  if (input.firstAirDate !== undefined) {
-    updates.firstAirDate = input.firstAirDate ?? null;
-    hasUpdates = true;
-  }
-  if (input.lastAirDate !== undefined) {
-    updates.lastAirDate = input.lastAirDate ?? null;
-    hasUpdates = true;
-  }
-  if (input.status !== undefined) {
-    updates.status = input.status ?? null;
-    hasUpdates = true;
-  }
-  if (input.originalLanguage !== undefined) {
-    updates.originalLanguage = input.originalLanguage ?? null;
-    hasUpdates = true;
-  }
-  if (input.numberOfSeasons !== undefined) {
-    updates.numberOfSeasons = input.numberOfSeasons ?? null;
-    hasUpdates = true;
-  }
-  if (input.numberOfEpisodes !== undefined) {
-    updates.numberOfEpisodes = input.numberOfEpisodes ?? null;
-    hasUpdates = true;
-  }
-  if (input.episodeRunTime !== undefined) {
-    updates.episodeRunTime = input.episodeRunTime ?? null;
-    hasUpdates = true;
-  }
-  if (input.posterPath !== undefined) {
-    updates.posterPath = input.posterPath ?? null;
-    hasUpdates = true;
-  }
-  if (input.backdropPath !== undefined) {
-    updates.backdropPath = input.backdropPath ?? null;
-    hasUpdates = true;
-  }
-  if (input.logoPath !== undefined) {
-    updates.logoPath = input.logoPath ?? null;
-    hasUpdates = true;
-  }
-  if (input.posterOverridePath !== undefined) {
-    updates.posterOverridePath = input.posterOverridePath ?? null;
-    hasUpdates = true;
-  }
-  if (input.voteAverage !== undefined) {
-    updates.voteAverage = input.voteAverage ?? null;
-    hasUpdates = true;
-  }
-  if (input.voteCount !== undefined) {
-    updates.voteCount = input.voteCount ?? null;
-    hasUpdates = true;
-  }
-  if (input.genres !== undefined) {
-    updates.genres = JSON.stringify(input.genres);
-    hasUpdates = true;
-  }
-  if (input.networks !== undefined) {
-    updates.networks = JSON.stringify(input.networks);
-    hasUpdates = true;
+    touched = true;
   }
 
-  if (hasUpdates) {
-    updates.updatedAt = new Date().toISOString();
-    db.update(tvShows).set(updates).where(eq(tvShows.id, id)).run();
+  for (const key of TV_SHOW_NULLABLE_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    updates[key] = value ?? null;
+    touched = true;
   }
 
+  for (const key of TV_SHOW_JSON_KEYS) {
+    const value = input[key];
+    if (value === undefined) continue;
+    updates[key] = JSON.stringify(value);
+    touched = true;
+  }
+
+  if (!touched) return null;
+  updates.updatedAt = new Date().toISOString();
+  return updates as Partial<typeof tvShows.$inferInsert>;
+}
+
+export function updateTvShow(id: number, input: UpdateTvShowInput): TvShowRow {
+  getTvShow(id);
+  const updates = buildTvShowUpdate(input);
+  if (updates) {
+    getDrizzle().update(tvShows).set(updates).where(eq(tvShows.id, id)).run();
+  }
   return getTvShow(id);
 }
 

--- a/apps/pops-api/src/modules/media/watch-history/handlers/batch-operations.ts
+++ b/apps/pops-api/src/modules/media/watch-history/handlers/batch-operations.ts
@@ -13,141 +13,161 @@ export interface BatchLogResult {
   skipped: number;
 }
 
+type Tx = Parameters<Parameters<ReturnType<typeof getDrizzle>['transaction']>[0]>[0];
+
+function getEpisodeIdsForBatch(
+  tx: Tx,
+  input: BatchLogWatchInput,
+  airedFilter: ReturnType<typeof and>
+): number[] {
+  if (input.mediaType === 'season') {
+    return tx
+      .select({ id: episodes.id })
+      .from(episodes)
+      .where(and(eq(episodes.seasonId, input.mediaId), airedFilter))
+      .all()
+      .map((r) => r.id);
+  }
+  return tx
+    .select({ id: episodes.id })
+    .from(episodes)
+    .innerJoin(seasons, eq(episodes.seasonId, seasons.id))
+    .where(and(eq(seasons.tvShowId, input.mediaId), airedFilter))
+    .all()
+    .map((r) => r.id);
+}
+
+function getAlreadyWatchedIds(tx: Tx, episodeIds: number[], completed: number): Set<number> {
+  if (completed !== 1) return new Set<number>();
+  const rows = tx
+    .select({ mediaId: watchHistory.mediaId })
+    .from(watchHistory)
+    .where(
+      and(
+        eq(watchHistory.mediaType, 'episode'),
+        eq(watchHistory.completed, 1),
+        inArray(watchHistory.mediaId, episodeIds)
+      )
+    )
+    .all();
+  return new Set(rows.map((r) => r.mediaId));
+}
+
+function getBlacklistedIds(tx: Tx, episodeIds: number[], watchedAt: string): Set<number> {
+  const rows = tx
+    .select({ mediaId: watchHistory.mediaId })
+    .from(watchHistory)
+    .where(
+      and(
+        eq(watchHistory.mediaType, 'episode'),
+        eq(watchHistory.blacklisted, 1),
+        eq(watchHistory.watchedAt, watchedAt),
+        inArray(watchHistory.mediaId, episodeIds)
+      )
+    )
+    .all();
+  return new Set(rows.map((r) => r.mediaId));
+}
+
+function insertWatchEvents(
+  tx: Tx,
+  episodeIds: number[],
+  watchedAt: string,
+  completed: number
+): void {
+  for (const episodeId of episodeIds) {
+    tx.insert(watchHistory)
+      .values({ mediaType: 'episode', mediaId: episodeId, watchedAt, completed })
+      .onConflictDoNothing()
+      .run();
+  }
+}
+
+function resolveTvShowId(tx: Tx, input: BatchLogWatchInput): number | undefined {
+  if (input.mediaType === 'show') return input.mediaId;
+  const season = tx
+    .select({ tvShowId: seasons.tvShowId })
+    .from(seasons)
+    .where(eq(seasons.id, input.mediaId))
+    .get();
+  return season?.tvShowId;
+}
+
+function getAllShowEpisodeIds(tx: Tx, tvShowId: number): number[] {
+  return tx
+    .select({ id: episodes.id })
+    .from(episodes)
+    .innerJoin(seasons, eq(episodes.seasonId, seasons.id))
+    .where(eq(seasons.tvShowId, tvShowId))
+    .all()
+    .map((r) => r.id);
+}
+
+function countWatchedEpisodes(tx: Tx, episodeIds: number[]): number {
+  if (episodeIds.length === 0) return 0;
+  const row = tx
+    .select({ watched: countDistinct(watchHistory.mediaId) })
+    .from(watchHistory)
+    .where(
+      and(
+        eq(watchHistory.mediaType, 'episode'),
+        eq(watchHistory.completed, 1),
+        inArray(watchHistory.mediaId, episodeIds)
+      )
+    )
+    .all()[0];
+  return row?.watched ?? 0;
+}
+
+function maybeRemoveCompletedShowFromWatchlist(tx: Tx, tvShowId: number): void {
+  const allShowEpisodeIds = getAllShowEpisodeIds(tx, tvShowId);
+  if (allShowEpisodeIds.length === 0) return;
+
+  const watched = countWatchedEpisodes(tx, allShowEpisodeIds);
+  if (watched < allShowEpisodeIds.length) return;
+
+  const removeResult = tx
+    .delete(mediaWatchlist)
+    .where(and(eq(mediaWatchlist.mediaType, 'tv_show'), eq(mediaWatchlist.mediaId, tvShowId)))
+    .run();
+  if (removeResult.changes > 0) {
+    resequencePriorities(tx);
+  }
+}
+
+function handleShowSideEffects(tx: Tx, input: BatchLogWatchInput): void {
+  const tvShowId = resolveTvShowId(tx, input);
+  if (tvShowId === undefined) return;
+
+  resetStaleness('tv_show', tvShowId);
+  maybeRemoveCompletedShowFromWatchlist(tx, tvShowId);
+}
+
+function runBatchLogTransaction(input: BatchLogWatchInput, completed: number, watchedAt: string) {
+  return (tx: Tx): BatchLogResult => {
+    const today = new Date().toISOString().slice(0, 10);
+    const airedFilter = and(isNotNull(episodes.airDate), lte(episodes.airDate, today));
+
+    const episodeIds = getEpisodeIdsForBatch(tx, input, airedFilter);
+    if (episodeIds.length === 0) return { logged: 0, skipped: 0 };
+
+    const alreadyWatched = getAlreadyWatchedIds(tx, episodeIds, completed);
+    const blacklistedIds = getBlacklistedIds(tx, episodeIds, watchedAt);
+    const toLog = episodeIds.filter((id) => !alreadyWatched.has(id) && !blacklistedIds.has(id));
+
+    insertWatchEvents(tx, toLog, watchedAt, completed);
+
+    if (completed === 1 && toLog.length > 0) {
+      handleShowSideEffects(tx, input);
+    }
+
+    return { logged: toLog.length, skipped: episodeIds.length - toLog.length };
+  };
+}
+
 export function batchLogWatch(input: BatchLogWatchInput): BatchLogResult {
   const db = getDrizzle();
   const completed = input.completed ?? 1;
   const watchedAt = input.watchedAt ?? new Date().toISOString();
-
-  return db.transaction((tx) => {
-    let episodeIds: number[];
-    const today = new Date().toISOString().slice(0, 10);
-    const airedFilter = and(isNotNull(episodes.airDate), lte(episodes.airDate, today));
-
-    if (input.mediaType === 'season') {
-      episodeIds = tx
-        .select({ id: episodes.id })
-        .from(episodes)
-        .where(and(eq(episodes.seasonId, input.mediaId), airedFilter))
-        .all()
-        .map((r) => r.id);
-    } else {
-      episodeIds = tx
-        .select({ id: episodes.id })
-        .from(episodes)
-        .innerJoin(seasons, eq(episodes.seasonId, seasons.id))
-        .where(and(eq(seasons.tvShowId, input.mediaId), airedFilter))
-        .all()
-        .map((r) => r.id);
-    }
-
-    if (episodeIds.length === 0) {
-      return { logged: 0, skipped: 0 };
-    }
-
-    const alreadyWatched =
-      completed === 1
-        ? new Set(
-            tx
-              .select({ mediaId: watchHistory.mediaId })
-              .from(watchHistory)
-              .where(
-                and(
-                  eq(watchHistory.mediaType, 'episode'),
-                  eq(watchHistory.completed, 1),
-                  inArray(watchHistory.mediaId, episodeIds)
-                )
-              )
-              .all()
-              .map((r) => r.mediaId)
-          )
-        : new Set<number>();
-
-    const blacklistedIds = new Set(
-      tx
-        .select({ mediaId: watchHistory.mediaId })
-        .from(watchHistory)
-        .where(
-          and(
-            eq(watchHistory.mediaType, 'episode'),
-            eq(watchHistory.blacklisted, 1),
-            eq(watchHistory.watchedAt, watchedAt),
-            inArray(watchHistory.mediaId, episodeIds)
-          )
-        )
-        .all()
-        .map((r) => r.mediaId)
-    );
-
-    const toLog = episodeIds.filter((id) => !alreadyWatched.has(id) && !blacklistedIds.has(id));
-
-    for (const episodeId of toLog) {
-      tx.insert(watchHistory)
-        .values({
-          mediaType: 'episode',
-          mediaId: episodeId,
-          watchedAt,
-          completed,
-        })
-        .onConflictDoNothing()
-        .run();
-    }
-
-    if (completed === 1 && toLog.length > 0) {
-      let tvShowId: number | undefined;
-
-      if (input.mediaType === 'show') {
-        tvShowId = input.mediaId;
-      } else {
-        const season = tx
-          .select({ tvShowId: seasons.tvShowId })
-          .from(seasons)
-          .where(eq(seasons.id, input.mediaId))
-          .get();
-        tvShowId = season?.tvShowId;
-      }
-
-      if (tvShowId !== undefined) {
-        resetStaleness('tv_show', tvShowId);
-      }
-
-      if (tvShowId !== undefined) {
-        const allShowEpisodeIds = tx
-          .select({ id: episodes.id })
-          .from(episodes)
-          .innerJoin(seasons, eq(episodes.seasonId, seasons.id))
-          .where(eq(seasons.tvShowId, tvShowId))
-          .all()
-          .map((r) => r.id);
-
-        if (allShowEpisodeIds.length > 0) {
-          const watchedRow2 = tx
-            .select({ watched: countDistinct(watchHistory.mediaId) })
-            .from(watchHistory)
-            .where(
-              and(
-                eq(watchHistory.mediaType, 'episode'),
-                eq(watchHistory.completed, 1),
-                inArray(watchHistory.mediaId, allShowEpisodeIds)
-              )
-            )
-            .all()[0];
-          const watched = watchedRow2?.watched ?? 0;
-
-          if (watched >= allShowEpisodeIds.length) {
-            const removeResult = tx
-              .delete(mediaWatchlist)
-              .where(
-                and(eq(mediaWatchlist.mediaType, 'tv_show'), eq(mediaWatchlist.mediaId, tvShowId))
-              )
-              .run();
-            if (removeResult.changes > 0) {
-              resequencePriorities(tx);
-            }
-          }
-        }
-      }
-    }
-
-    return { logged: toLog.length, skipped: episodeIds.length - toLog.length };
-  });
+  return db.transaction(runBatchLogTransaction(input, completed, watchedAt));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #2085.

Decomposes the large `apps/pops-api/src/**` functions called out in the ticket so the API tier-2 lint override can move toward the global agent-optimal targets (`max-fn 60`, `complexity 12`, `max-depth 3`).

All five known violations are now well under the global targets, and the API tier-2 override has been incrementally tightened.

## Known violations addressed

| File | Before | After |
| --- | --- | --- |
| `modules/finance/imports/service.ts` — `processImportCore` | 259 lines / complexity 31 / depth 5 | ~50 lines / <12 / 3 |
| `modules/finance/imports/service.ts` — `executeImportCore` | complexity 17 | <12 |
| `modules/inventory/items/service.ts` — `updateInventoryItem` | complexity 41 | <12 |
| `modules/inventory/items/service.ts` — `listInventoryItems` / `createInventoryItem` | complexity 20 | <12 |
| `modules/media/watch-history/handlers/batch-operations.ts` | complexity 16 / depth 5 | <12 / 3 |
| `modules/core/tag-rules/service.ts` — `applyOp` | complexity 18 | <12 |
| `modules/finance/transactions/router.ts` — `availableTags` | depth 5 | 3 |
| `modules/finance/imports/lib/tag-management.ts` — `loadKnownTags` | depth 5 | 3 |

A couple of opportunistic neighbours (`updateMovie` complexity 37, `updateTvShow` complexity 35) were also decomposed since they were blocking the override tightening.

## Tier 2 override changes

`apps/pops-api/src/**`:

- `max-lines-per-function`: 260 → **200**
- `complexity`: 45 → **30**
- `max-depth`: 5 → **4**

(Global targets remain 60 / 12 / 3. Further tightening will follow as the remaining medium-complexity functions like `getSmartPair` and the image route handlers get decomposed — this is the incremental plan tracked in #2084.)

## How the decomposition was done

- **`processImportCore`** — extracted into:
  - `lib/process-transaction.ts` — per-transaction classification (`tryEntityMatch`, `tryAiCategorization`, `resolveAiResult`, `processTransactionSafely`) plus AI counter type/builder.
  - `lib/processing-helpers.ts` — `appendBatchItem`, `buildAiUsage`, `buildAiWarnings`, `makeBuckets`.
  - `service.ts` now reads as a small orchestrator: dedupe → load → loop → assemble.
- **`executeImportCore`** — split into `tryWriteTransaction` + `resolveTransactionType` + `writeConfirmedTransaction`.
- **`processImportWithProgress` / `executeImportWithProgress`** — shared `reportBackgroundFailure` and `logBackgroundImportComplete` helpers.
- **`updateInventoryItem`** — moved into `inventory/items/update-builder.ts` with table-driven `NULLABLE_STRING_KEYS` / `NULLABLE_NUMBER_KEYS` + small assigners.
- **`listInventoryItems`** / **`createInventoryItem`** — `buildInventoryConditions` / `buildLocationCondition` / `combineConditions` and `nullableStringsFromInput` / `nullableNumbersFromInput`.
- **`batchLogWatch`** — split the inline transaction body into per-step helpers (`getEpisodeIdsForBatch`, `getAlreadyWatchedIds`, `getBlacklistedIds`, `insertWatchEvents`, `resolveTvShowId`, `maybeRemoveCompletedShowFromWatchlist`, `handleShowSideEffects`, `runBatchLogTransaction`).
- **`tag-rules/service.ts` `applyOp`** — replaced the if-chain with `addTagRule` / `editTagRule` / `disableTagRule` / `removeTagRule` + a `switch`.
- **`transactions/router.ts` `availableTags`** — extracted `collectAvailableTags` + `addTagsFromJson`.
- **`updateMovie` / `updateTvShow`** — table-driven `buildMovieUpdate` / `buildTvShowUpdate` returning `null` when nothing changed.

## Verification

- `pnpm lint` — passes (180 pre-existing nullish-coalescing warnings, **0 errors**).
- `pnpm typecheck` — passes for all 16 packages.
- `pnpm test` in `apps/pops-api` — **2911 / 2911 tests pass** across 164 files.
- All ticket-target files independently checked against the strictest agent targets (`max-fn 60`, `complexity 12`, `max-depth 3`) and pass.

## Behaviour

No behaviour changes — purely structural refactoring with helper extraction. All public service exports keep their existing signatures.

## Relates to

- #2043 (enforce-agent-optimal-targets — final lint PR)
- #2084 (tighten Tier 2 overrides — this PR makes a meaningful step)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccce2a0d-89d8-4cb1-ab00-3cbaeb975fd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccce2a0d-89d8-4cb1-ab00-3cbaeb975fd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

