### PR TITLE
lint: enable no-nested-ternary globally across all packages

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -212,7 +212,6 @@
         "complexity": ["error", 30],
         "max-depth": ["error", 4],
         "max-params": ["error", 8],
-        "no-nested-ternary": "off",
         "typescript/explicit-function-return-type": [
           "error",
           {
@@ -251,7 +250,6 @@
         ],
         "complexity": ["error", 40],
         "max-depth": ["error", 4],
-        "no-nested-ternary": "off",
         "typescript/explicit-function-return-type": "off"
       }
     },
@@ -265,7 +263,6 @@
         ],
         "complexity": ["error", 45],
         "max-depth": ["error", 4],
-        "no-nested-ternary": "off",
         "typescript/explicit-function-return-type": "off",
         "jsx-a11y/alt-text": "warn",
         "jsx-a11y/aria-role": "warn",
@@ -288,7 +285,6 @@
         ],
         "complexity": ["error", 45],
         "max-depth": ["error", 4],
-        "no-nested-ternary": "off",
         "typescript/explicit-function-return-type": "off"
       }
     },
@@ -302,7 +298,6 @@
         ],
         "complexity": ["error", 70],
         "max-depth": ["error", 4],
-        "no-nested-ternary": "off",
         "typescript/explicit-function-return-type": "off"
       }
     },
@@ -322,7 +317,6 @@
         ],
         "complexity": ["error", 55],
         "max-depth": ["error", 4],
-        "no-nested-ternary": "off",
         "typescript/explicit-function-return-type": "off"
       }
     },

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/list-engrams.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/list-engrams.ts
@@ -66,10 +66,11 @@ export function listEngrams(
   const where = conditions.length === 0 ? undefined : and(...conditions);
   const sortField = opts.sort?.field ?? 'modified_at';
   const sortDir = opts.sort?.direction ?? 'desc';
-  let orderColumn;
-  if (sortField === 'title') orderColumn = engramIndex.title;
-  else if (sortField === 'created_at') orderColumn = engramIndex.createdAt;
-  else orderColumn = engramIndex.modifiedAt;
+  const orderColumn = (() => {
+    if (sortField === 'title') return engramIndex.title;
+    if (sortField === 'created_at') return engramIndex.createdAt;
+    return engramIndex.modifiedAt;
+  })();
 
   const limit = opts.ids && opts.limit === undefined ? opts.ids.length : (opts.limit ?? 50);
   const offset = opts.offset ?? 0;

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/list-engrams.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/list-engrams.ts
@@ -66,12 +66,10 @@ export function listEngrams(
   const where = conditions.length === 0 ? undefined : and(...conditions);
   const sortField = opts.sort?.field ?? 'modified_at';
   const sortDir = opts.sort?.direction ?? 'desc';
-  const orderColumn =
-    sortField === 'title'
-      ? engramIndex.title
-      : sortField === 'created_at'
-        ? engramIndex.createdAt
-        : engramIndex.modifiedAt;
+  let orderColumn;
+  if (sortField === 'title') orderColumn = engramIndex.title;
+  else if (sortField === 'created_at') orderColumn = engramIndex.createdAt;
+  else orderColumn = engramIndex.modifiedAt;
 
   const limit = opts.ids && opts.limit === undefined ? opts.ids.length : (opts.limit ?? 50);
   const offset = opts.offset ?? 0;

--- a/apps/pops-api/src/modules/cerebrum/engrams/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/router.ts
@@ -73,14 +73,18 @@ function toTrpcError(err: unknown): never {
     // reason is stashed in `details`. Surface it so clients can show
     // actionable feedback (e.g. "decision, alternatives are required").
     const details = err.details;
-    const message =
-      typeof details === 'string'
-        ? details
-        : typeof details === 'object' &&
-            details !== null &&
-            typeof (details as { message?: unknown }).message === 'string'
-          ? (details as { message: string }).message
-          : err.message;
+    let message: string;
+    if (typeof details === 'string') {
+      message = details;
+    } else if (
+      typeof details === 'object' &&
+      details !== null &&
+      typeof (details as { message?: unknown }).message === 'string'
+    ) {
+      message = (details as { message: string }).message;
+    } else {
+      message = err.message;
+    }
     throw new TRPCError({ code: 'BAD_REQUEST', message, cause: err });
   }
   if (err instanceof HttpError) {

--- a/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scopes-router.ts
@@ -129,14 +129,18 @@ function toTrpcError(err: unknown): never {
   }
   if (err instanceof ValidationError) {
     const details = err.details;
-    const message =
-      typeof details === 'string'
-        ? details
-        : typeof details === 'object' &&
-            details !== null &&
-            typeof (details as { message?: unknown }).message === 'string'
-          ? (details as { message: string }).message
-          : err.message;
+    let message: string;
+    if (typeof details === 'string') {
+      message = details;
+    } else if (
+      typeof details === 'object' &&
+      details !== null &&
+      typeof (details as { message?: unknown }).message === 'string'
+    ) {
+      message = (details as { message: string }).message;
+    } else {
+      message = err.message;
+    }
     throw new TRPCError({ code: 'BAD_REQUEST', message, cause: err });
   }
   if (err instanceof HttpError) {

--- a/apps/pops-api/src/modules/cerebrum/ingest/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/ingest/router.ts
@@ -23,14 +23,18 @@ function toTrpcError(err: unknown): never {
   }
   if (err instanceof ValidationError) {
     const details = err.details;
-    const message =
-      typeof details === 'string'
-        ? details
-        : typeof details === 'object' &&
-            details !== null &&
-            typeof (details as { message?: unknown }).message === 'string'
-          ? (details as { message: string }).message
-          : err.message;
+    let message: string;
+    if (typeof details === 'string') {
+      message = details;
+    } else if (
+      typeof details === 'object' &&
+      details !== null &&
+      typeof (details as { message?: unknown }).message === 'string'
+    ) {
+      message = (details as { message: string }).message;
+    } else {
+      message = err.message;
+    }
     throw new TRPCError({ code: 'BAD_REQUEST', message, cause: err });
   }
   if (err instanceof HttpError) {

--- a/apps/pops-api/src/modules/core/ai-usage/service.ts
+++ b/apps/pops-api/src/modules/core/ai-usage/service.ts
@@ -85,12 +85,10 @@ export function getHistory(startDate?: string, endDate?: string): AiUsageHistory
     conditions.push(lte(sql`DATE(${aiUsage.createdAt})`, endDate));
   }
 
-  const where =
-    conditions.length > 0
-      ? conditions.length === 1
-        ? conditions[0]
-        : and(...conditions)
-      : undefined;
+  let where;
+  if (conditions.length === 0) where = undefined;
+  else if (conditions.length === 1) where = conditions[0];
+  else where = and(...conditions);
 
   // Get daily aggregated stats
   const records = db

--- a/apps/pops-api/src/modules/core/ai-usage/service.ts
+++ b/apps/pops-api/src/modules/core/ai-usage/service.ts
@@ -85,10 +85,11 @@ export function getHistory(startDate?: string, endDate?: string): AiUsageHistory
     conditions.push(lte(sql`DATE(${aiUsage.createdAt})`, endDate));
   }
 
-  let where;
-  if (conditions.length === 0) where = undefined;
-  else if (conditions.length === 1) where = conditions[0];
-  else where = and(...conditions);
+  const where = (() => {
+    if (conditions.length === 0) return undefined;
+    if (conditions.length === 1) return conditions[0];
+    return and(...conditions);
+  })();
 
   // Get daily aggregated stats
   const records = db

--- a/apps/pops-api/src/modules/core/corrections/pure-service.ts
+++ b/apps/pops-api/src/modules/core/corrections/pure-service.ts
@@ -31,7 +31,12 @@ export function findAllMatchingCorrectionFromRules(
   const normalized = normalizeDescription(description);
   const eligible = rules
     .filter((r) => r.isActive && r.confidence >= minConfidence)
-    .toSorted((a, b) => a.priority - b.priority || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+    .toSorted((a, b) => {
+      if (a.priority !== b.priority) return a.priority - b.priority;
+      if (a.id < b.id) return -1;
+      if (a.id > b.id) return 1;
+      return 0;
+    });
 
   return eligible.filter((rule) => ruleMatchesDescription(rule, normalized));
 }

--- a/apps/pops-api/src/modules/core/tag-rules/service.ts
+++ b/apps/pops-api/src/modules/core/tag-rules/service.ts
@@ -239,18 +239,18 @@ function suggestFromRules(
   for (const rule of rules) {
     if (rule.entityId && rule.entityId !== entityId) continue;
     const pattern = rule.descriptionPattern.toUpperCase();
-    const matches =
-      rule.matchType === 'exact'
-        ? normalized === pattern
-        : rule.matchType === 'contains'
-          ? normalized.includes(pattern)
-          : (() => {
-              try {
-                return new RegExp(rule.descriptionPattern, 'i').test(description);
-              } catch {
-                return false;
-              }
-            })();
+    let matches: boolean;
+    if (rule.matchType === 'exact') {
+      matches = normalized === pattern;
+    } else if (rule.matchType === 'contains') {
+      matches = normalized.includes(pattern);
+    } else {
+      try {
+        matches = new RegExp(rule.descriptionPattern, 'i').test(description);
+      } catch {
+        matches = false;
+      }
+    }
 
     if (!matches) continue;
     for (const tag of rule.tags) {

--- a/apps/pops-api/src/modules/finance/budgets/router.ts
+++ b/apps/pops-api/src/modules/finance/budgets/router.ts
@@ -37,8 +37,10 @@ export const budgetsRouter = router({
       const limit = input.limit ?? DEFAULT_LIMIT;
       const offset = input.offset ?? DEFAULT_OFFSET;
 
-      const activeFilter =
-        input.active === 'true' ? true : input.active === 'false' ? false : undefined;
+      let activeFilter: boolean | undefined;
+      if (input.active === 'true') activeFilter = true;
+      else if (input.active === 'false') activeFilter = false;
+      else activeFilter = undefined;
 
       const { rows, total } = service.listBudgets(
         input.search,

--- a/apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/transaction-persistence.ts
@@ -259,12 +259,10 @@ export function commitImport(payload: CommitPayload): CommitResult {
         : txn.entityId;
 
       try {
-        const type =
-          txn.transactionType === 'transfer'
-            ? 'Transfer'
-            : txn.transactionType === 'income'
-              ? 'Income'
-              : 'Expense';
+        let type: 'Transfer' | 'Income' | 'Expense';
+        if (txn.transactionType === 'transfer') type = 'Transfer';
+        else if (txn.transactionType === 'income') type = 'Income';
+        else type = 'Expense';
 
         insertTransaction({
           description: txn.description,
@@ -372,13 +370,11 @@ function reclassifyExistingTransactions(
 
       const rule = match.correction;
       const newEntityId = rule.entityId ?? null;
-      const newType = rule.transactionType
-        ? rule.transactionType === 'transfer'
-          ? 'Transfer'
-          : rule.transactionType === 'income'
-            ? 'Income'
-            : 'Expense'
-        : null;
+      let newType: 'Transfer' | 'Income' | 'Expense' | null;
+      if (!rule.transactionType) newType = null;
+      else if (rule.transactionType === 'transfer') newType = 'Transfer';
+      else if (rule.transactionType === 'income') newType = 'Income';
+      else newType = 'Expense';
       const newLocation = rule.location ?? null;
 
       // Check if classification actually changed

--- a/apps/pops-api/src/modules/inventory/items/router.ts
+++ b/apps/pops-api/src/modules/inventory/items/router.ts
@@ -43,9 +43,13 @@ export const inventoryRouter = router({
       const limit = input.limit ?? DEFAULT_LIMIT;
       const offset = input.offset ?? DEFAULT_OFFSET;
 
-      const inUse = input.inUse === 'true' ? true : input.inUse === 'false' ? false : undefined;
-      const deductible =
-        input.deductible === 'true' ? true : input.deductible === 'false' ? false : undefined;
+      const parseTriBool = (value: string | undefined): boolean | undefined => {
+        if (value === 'true') return true;
+        if (value === 'false') return false;
+        return undefined;
+      };
+      const inUse = parseTriBool(input.inUse);
+      const deductible = parseTriBool(input.deductible);
 
       const { rows, total, totalReplacementValue, totalResaleValue } = service.listInventoryItems({
         search: input.search,

--- a/apps/pops-api/src/modules/media/arr/radarr-router.ts
+++ b/apps/pops-api/src/modules/media/arr/radarr-router.ts
@@ -25,6 +25,12 @@ export function resolveApiKey(formKey: string, service: 'radarr' | 'sonarr'): st
   return (service === 'radarr' ? s.radarrApiKey : s.sonarrApiKey) ?? null;
 }
 
+function describeArrError(err: unknown): string {
+  if (err instanceof ArrApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
 export const radarrProcedures = {
   /** Get configuration state for both services. */
   getConfig: protectedProcedure.query(() => {
@@ -92,8 +98,7 @@ export const radarrProcedures = {
         message: 'Radarr connection successful',
       };
     } catch (err) {
-      const errorMsg =
-        err instanceof ArrApiError ? err.message : err instanceof Error ? err.message : String(err);
+      const errorMsg = describeArrError(err);
       return { data: { configured: true, connected: false, error: errorMsg } };
     }
   }),
@@ -127,8 +132,7 @@ export const radarrProcedures = {
         message: 'Radarr connection successful',
       };
     } catch (err) {
-      const errorMsg =
-        err instanceof ArrApiError ? err.message : err instanceof Error ? err.message : String(err);
+      const errorMsg = describeArrError(err);
       return { data: { configured: true, connected: false, error: errorMsg } };
     }
   }),

--- a/apps/pops-api/src/modules/media/arr/sonarr-router.ts
+++ b/apps/pops-api/src/modules/media/arr/sonarr-router.ts
@@ -7,6 +7,12 @@ import * as arrService from './service.js';
 import { SonarrClient } from './sonarr-client.js';
 import { ArrApiError } from './types.js';
 
+function describeArrError(err: unknown): string {
+  if (err instanceof ArrApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
 const TestConnectionInput = z.object({
   url: z.string().min(1),
   apiKey: z.string().min(1),
@@ -36,8 +42,7 @@ export const sonarrProcedures = {
         message: 'Sonarr connection successful',
       };
     } catch (err) {
-      const errorMsg =
-        err instanceof ArrApiError ? err.message : err instanceof Error ? err.message : String(err);
+      const errorMsg = describeArrError(err);
       return { data: { configured: true, connected: false, error: errorMsg } };
     }
   }),
@@ -71,8 +76,7 @@ export const sonarrProcedures = {
         message: 'Sonarr connection successful',
       };
     } catch (err) {
-      const errorMsg =
-        err instanceof ArrApiError ? err.message : err instanceof Error ? err.message : String(err);
+      const errorMsg = describeArrError(err);
       return { data: { configured: true, connected: false, error: errorMsg } };
     }
   }),

--- a/apps/pops-api/src/modules/media/comparisons/lib/score-management.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/score-management.ts
@@ -65,11 +65,14 @@ export function updateEloScores(input: RecordComparisonInput): { deltaA: number;
 
   const isDraw = input.winnerId === 0;
   const drawOutcome = isDraw ? drawTierOutcome(input.drawTier) : 0.5;
-  const actualA = isDraw
-    ? drawOutcome
-    : input.winnerType === input.mediaAType && input.winnerId === input.mediaAId
-      ? 1
-      : 0;
+  let actualA: number;
+  if (isDraw) {
+    actualA = drawOutcome;
+  } else if (input.winnerType === input.mediaAType && input.winnerId === input.mediaAId) {
+    actualA = 1;
+  } else {
+    actualA = 0;
+  }
   const actualB = isDraw ? drawOutcome : 1 - actualA;
 
   const newScoreA = scoreA.score + ELO_K * (actualA - expectedA);

--- a/apps/pops-api/src/modules/media/comparisons/lib/tier-list.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/tier-list.ts
@@ -152,6 +152,12 @@ export function getTierListMovies(dimensionId: number): TierListMovie[] {
   return selected.map(toTierListMovie);
 }
 
+function getMoviePosterUrl(override: string | null, tmdbId: number | null): string | null {
+  if (override) return override;
+  if (tmdbId) return `/media/images/movie/${tmdbId}/poster.jpg`;
+  return null;
+}
+
 function toTierListMovie(row: {
   mediaId: number;
   title: string;
@@ -166,11 +172,7 @@ function toTierListMovie(row: {
     title: row.title,
     // Always generate the URL when tmdbId is available — the images endpoint
     // handles the case where poster_path is null by fetching from TMDB on demand.
-    posterUrl: row.moviePosterOverride
-      ? row.moviePosterOverride
-      : row.movieTmdbId
-        ? `/media/images/movie/${row.movieTmdbId}/poster.jpg`
-        : null,
+    posterUrl: getMoviePosterUrl(row.moviePosterOverride, row.movieTmdbId),
     score: Math.round(row.score * 10) / 10,
     comparisonCount: row.comparisonCount,
   };

--- a/apps/pops-api/src/modules/media/plex/router.ts
+++ b/apps/pops-api/src/modules/media/plex/router.ts
@@ -71,12 +71,10 @@ function requirePlexClient(): PlexClient {
 }
 
 function bullmqJobToSyncJob(job: Job<SyncQueueJobData>): SyncJob {
-  const state =
-    job.finishedOn != null && !job.failedReason
-      ? 'completed'
-      : job.failedReason
-        ? 'failed'
-        : 'running';
+  let state: 'completed' | 'failed' | 'running';
+  if (job.finishedOn != null && !job.failedReason) state = 'completed';
+  else if (job.failedReason) state = 'failed';
+  else state = 'running';
   const progress = (job.progress ?? {
     processed: 0,
     total: 0,

--- a/apps/pops-api/src/modules/media/plex/sync-discover-watches.test.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-watches.test.ts
@@ -140,8 +140,10 @@ function makePlexClient(overrides: Partial<PlexClient> = {}): PlexClient {
 
 function mockFetchResponses(responses: Array<{ url: string; body: unknown }>): void {
   vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
-    const url =
-      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    let url: string;
+    if (typeof input === 'string') url = input;
+    else if (input instanceof URL) url = input.toString();
+    else url = input.url;
     for (const r of responses) {
       if (url.includes(r.url)) {
         return new Response(JSON.stringify(r.body), {

--- a/apps/pops-api/src/modules/media/search/router.ts
+++ b/apps/pops-api/src/modules/media/search/router.ts
@@ -32,12 +32,10 @@ export const searchRouter = router({
       };
     } catch (err) {
       if (err instanceof TRPCError) throw err;
-      const message =
-        err instanceof TmdbApiError
-          ? `TMDB API error: ${err.message}`
-          : err instanceof Error
-            ? err.message
-            : 'Unknown error searching movies';
+      let message: string;
+      if (err instanceof TmdbApiError) message = `TMDB API error: ${err.message}`;
+      else if (err instanceof Error) message = err.message;
+      else message = 'Unknown error searching movies';
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message,
@@ -53,12 +51,10 @@ export const searchRouter = router({
       return { results };
     } catch (err) {
       if (err instanceof TRPCError) throw err;
-      const message =
-        err instanceof TvdbApiError
-          ? `TheTVDB API error: ${err.message}`
-          : err instanceof Error
-            ? err.message
-            : 'Unknown error searching TV shows';
+      let message: string;
+      if (err instanceof TvdbApiError) message = `TheTVDB API error: ${err.message}`;
+      else if (err instanceof Error) message = err.message;
+      else message = 'Unknown error searching TV shows';
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message,

--- a/apps/pops-api/src/routes/media/images.ts
+++ b/apps/pops-api/src/routes/media/images.ts
@@ -188,8 +188,10 @@ router.get('/media/images/:mediaType/:id/:filename', async (req, res): Promise<v
     const db = getDb();
     const table = mediaType === 'movie' ? 'movies' : 'tv_shows';
     const idColumn = mediaType === 'movie' ? 'tmdb_id' : 'tvdb_id';
-    const pathColumn =
-      imageType === 'poster' ? 'poster_path' : imageType === 'logo' ? 'logo_path' : 'backdrop_path';
+    let pathColumn: string;
+    if (imageType === 'poster') pathColumn = 'poster_path';
+    else if (imageType === 'logo') pathColumn = 'logo_path';
+    else pathColumn = 'backdrop_path';
 
     const record = db
       .prepare(`SELECT ${pathColumn} AS path FROM ${table} WHERE ${idColumn} = ?`)

--- a/apps/pops-shell/src/components/settings/SectionRenderer.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.tsx
@@ -63,6 +63,19 @@ function inferUnit(ms: number): string {
   return 'milliseconds';
 }
 
+function TestActionIcon({ state, fallback }: { state: TestState; fallback: React.ReactNode }) {
+  if (state === 'loading') return <Loader2 className="h-3.5 w-3.5 animate-spin" />;
+  if (state === 'success') return <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />;
+  if (state === 'error') return <XCircle className="h-3.5 w-3.5 text-destructive" />;
+  return <>{fallback}</>;
+}
+
+function getInputType(type: SettingsField['type']): 'number' | 'url' | 'text' {
+  if (type === 'number') return 'number';
+  if (type === 'url') return 'url';
+  return 'text';
+}
+
 function DurationFieldInput({
   field,
   value,
@@ -268,15 +281,7 @@ function FieldInput({
               disabled={testState === 'loading'}
               type="button"
             >
-              {testState === 'loading' ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : testState === 'success' ? (
-                <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
-              ) : testState === 'error' ? (
-                <XCircle className="h-3.5 w-3.5 text-destructive" />
-              ) : (
-                <RefreshCw className="h-3.5 w-3.5" />
-              )}
+              <TestActionIcon state={testState} fallback={<RefreshCw className="h-3.5 w-3.5" />} />
               <span className="ml-1">{field.testAction.label}</span>
             </Button>
           )}
@@ -290,8 +295,7 @@ function FieldInput({
     );
   }
 
-  // text, number, url
-  const inputType = field.type === 'number' ? 'number' : field.type === 'url' ? 'url' : 'text';
+  const inputType = getInputType(field.type);
 
   return (
     <FieldWrapper field={field} saveState={saveState}>
@@ -312,13 +316,7 @@ function FieldInput({
             disabled={testState === 'loading'}
             type="button"
           >
-            {testState === 'loading' ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : testState === 'success' ? (
-              <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
-            ) : testState === 'error' ? (
-              <XCircle className="h-3.5 w-3.5 text-destructive" />
-            ) : null}
+            <TestActionIcon state={testState} fallback={null} />
             <span className={cn(testState !== 'idle' && 'ml-1')}>{field.testAction.label}</span>
           </Button>
         )}

--- a/packages/app-finance/src/components/TagEditor.tsx
+++ b/packages/app-finance/src/components/TagEditor.tsx
@@ -186,12 +186,12 @@ export function TagEditor({
           ) : (
             tags.slice(0, 3).map((tag) => {
               const meta = tagMeta?.get(tag);
-              const tooltipText =
-                meta?.source === 'rule' && meta?.pattern
-                  ? `Rule: "${meta.pattern}"`
-                  : meta?.source
-                    ? `${meta.source} suggestion`
-                    : undefined;
+              let tooltipText: string | undefined;
+              if (meta?.source === 'rule' && meta?.pattern) {
+                tooltipText = `Rule: "${meta.pattern}"`;
+              } else if (meta?.source) {
+                tooltipText = `${meta.source} suggestion`;
+              }
               const style = hashToColor(tag);
               return (
                 <Badge

--- a/packages/app-finance/src/components/imports/ImportWizard.tsx
+++ b/packages/app-finance/src/components/imports/ImportWizard.tsx
@@ -36,49 +36,54 @@ export function ImportWizard() {
       {/* Progress indicator */}
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          {steps.map((step) => (
-            <div
-              key={step.number}
-              className={`flex items-center gap-2 ${
-                step.number === currentStep
-                  ? 'text-info font-semibold'
-                  : step.number < currentStep
-                    ? 'text-success'
-                    : 'text-gray-400 dark:text-gray-600'
-              }`}
-            >
-              <div
-                className={`
-                  w-8 h-8 rounded-full flex items-center justify-center text-sm
-                  ${
-                    step.number === currentStep
-                      ? 'bg-info/10 border-2 border-info'
-                      : step.number < currentStep
-                        ? 'bg-success/10 border-2 border-success'
-                        : 'bg-gray-100 dark:bg-gray-800 border-2 border-gray-300 dark:border-gray-700'
-                  }
-                `}
-              >
-                {step.number}
+          {steps.map((step) => {
+            let textClass: string;
+            if (step.number === currentStep) {
+              textClass = 'text-info font-semibold';
+            } else if (step.number < currentStep) {
+              textClass = 'text-success';
+            } else {
+              textClass = 'text-gray-400 dark:text-gray-600';
+            }
+            let circleClass: string;
+            if (step.number === currentStep) {
+              circleClass = 'bg-info/10 border-2 border-info';
+            } else if (step.number < currentStep) {
+              circleClass = 'bg-success/10 border-2 border-success';
+            } else {
+              circleClass =
+                'bg-gray-100 dark:bg-gray-800 border-2 border-gray-300 dark:border-gray-700';
+            }
+            return (
+              <div key={step.number} className={`flex items-center gap-2 ${textClass}`}>
+                <div
+                  className={`w-8 h-8 rounded-full flex items-center justify-center text-sm ${circleClass}`}
+                >
+                  {step.number}
+                </div>
+                <span className="text-sm hidden sm:inline">{step.label}</span>
               </div>
-              <span className="text-sm hidden sm:inline">{step.label}</span>
-            </div>
-          ))}
+            );
+          })}
         </div>
         <Progress value={progress} className="h-2" />
       </div>
 
       {/* Current step content */}
       <div className="bg-white dark:bg-gray-900 rounded-lg border shadow-sm p-6">
-        {currentStep === 4 ? (
-          <Suspense fallback={<div className="text-sm text-muted-foreground">Loading review…</div>}>
-            <ReviewStep />
-          </Suspense>
-        ) : CurrentStepComponent ? (
-          <CurrentStepComponent />
-        ) : (
-          <div>Unknown step</div>
-        )}
+        {(() => {
+          if (currentStep === 4) {
+            return (
+              <Suspense
+                fallback={<div className="text-sm text-muted-foreground">Loading review…</div>}
+              >
+                <ReviewStep />
+              </Suspense>
+            );
+          }
+          if (CurrentStepComponent) return <CurrentStepComponent />;
+          return <div>Unknown step</div>;
+        })()}
       </div>
     </div>
   );

--- a/packages/app-finance/src/components/imports/ProcessingStep.tsx
+++ b/packages/app-finance/src/components/imports/ProcessingStep.tsx
@@ -146,23 +146,26 @@ export function ProcessingStep() {
       ? (progress.processedCount / progress.totalTransactions) * 100
       : undefined;
 
+  type StepStatus = 'pending' | 'in_progress' | 'done';
+  const dedupStatus: StepStatus = (() => {
+    if (progress?.currentStep === 'deduplicating') return 'in_progress';
+    if (['matching', 'writing'].includes(progress?.currentStep ?? '')) return 'done';
+    return 'pending';
+  })();
+  const matchingStatus: StepStatus = (() => {
+    if (progress?.currentStep === 'matching') return 'in_progress';
+    if (progress?.currentStep === 'writing') return 'done';
+    return 'pending';
+  })();
   const steps = isProcessing
     ? [
         {
           label: 'Checking for duplicates',
-          status: (progress?.currentStep === 'deduplicating'
-            ? 'in_progress'
-            : ['matching', 'writing'].includes(progress?.currentStep ?? '')
-              ? 'done'
-              : 'pending') as 'pending' | 'in_progress' | 'done',
+          status: dedupStatus,
         },
         {
           label: 'Matching entities',
-          status: (progress?.currentStep === 'matching'
-            ? 'in_progress'
-            : progress?.currentStep === 'writing'
-              ? 'done'
-              : 'pending') as 'pending' | 'in_progress' | 'done',
+          status: matchingStatus,
         },
       ]
     : undefined;

--- a/packages/app-finance/src/components/imports/RulePicker.tsx
+++ b/packages/app-finance/src/components/imports/RulePicker.tsx
@@ -116,55 +116,60 @@ export function RulePicker(props: RulePickerProps) {
             onValueChange={setSearch}
           />
           <CommandList>
-            {listQuery.isLoading ? (
-              <CommandEmpty>Loading rules…</CommandEmpty>
-            ) : listQuery.isError ? (
-              <CommandEmpty>Failed to load rules: {listQuery.error.message}</CommandEmpty>
-            ) : filteredRules.length === 0 ? (
-              <CommandEmpty>No matching rules.</CommandEmpty>
-            ) : (
-              <CommandGroup>
-                {filteredRules.map((rule) => (
-                  <CommandItem
-                    key={rule.id}
-                    value={rule.id}
-                    onSelect={() => {
-                      props.onChange(rule);
-                      setOpen(false);
-                      setSearch('');
-                    }}
-                  >
-                    <Check
-                      className={`mr-2 h-4 w-4 ${
-                        props.value === rule.id ? 'opacity-100' : 'opacity-0'
-                      }`}
-                    />
-                    <div className="flex flex-col min-w-0 flex-1 gap-0.5">
-                      <div className="flex items-center gap-2">
-                        <code className="truncate text-xs font-mono">
-                          {rule.descriptionPattern}
-                        </code>
-                        <Badge variant="outline" className="text-[10px] shrink-0">
-                          {rule.matchType}
-                        </Badge>
-                        {!rule.isActive && (
-                          <Badge variant="secondary" className="text-[10px] shrink-0">
-                            off
+            {(() => {
+              if (listQuery.isLoading) {
+                return <CommandEmpty>Loading rules…</CommandEmpty>;
+              }
+              if (listQuery.isError) {
+                return <CommandEmpty>Failed to load rules: {listQuery.error.message}</CommandEmpty>;
+              }
+              if (filteredRules.length === 0) {
+                return <CommandEmpty>No matching rules.</CommandEmpty>;
+              }
+              return (
+                <CommandGroup>
+                  {filteredRules.map((rule) => (
+                    <CommandItem
+                      key={rule.id}
+                      value={rule.id}
+                      onSelect={() => {
+                        props.onChange(rule);
+                        setOpen(false);
+                        setSearch('');
+                      }}
+                    >
+                      <Check
+                        className={`mr-2 h-4 w-4 ${
+                          props.value === rule.id ? 'opacity-100' : 'opacity-0'
+                        }`}
+                      />
+                      <div className="flex flex-col min-w-0 flex-1 gap-0.5">
+                        <div className="flex items-center gap-2">
+                          <code className="truncate text-xs font-mono">
+                            {rule.descriptionPattern}
+                          </code>
+                          <Badge variant="outline" className="text-[10px] shrink-0">
+                            {rule.matchType}
                           </Badge>
+                          {!rule.isActive && (
+                            <Badge variant="secondary" className="text-[10px] shrink-0">
+                              off
+                            </Badge>
+                          )}
+                        </div>
+                        {(rule.entityName || rule.location || rule.transactionType) && (
+                          <div className="text-[11px] text-muted-foreground truncate">
+                            {[rule.entityName, rule.location, rule.transactionType]
+                              .filter(Boolean)
+                              .join(' · ')}
+                          </div>
                         )}
                       </div>
-                      {(rule.entityName || rule.location || rule.transactionType) && (
-                        <div className="text-[11px] text-muted-foreground truncate">
-                          {[rule.entityName, rule.location, rule.transactionType]
-                            .filter(Boolean)
-                            .join(' · ')}
-                        </div>
-                      )}
-                    </div>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              );
+            })()}
           </CommandList>
         </Command>
       </PopoverContent>

--- a/packages/app-finance/src/components/imports/TransactionCard.tsx
+++ b/packages/app-finance/src/components/imports/TransactionCard.tsx
@@ -69,19 +69,23 @@ export function TransactionCard({
   }
 
   // Border and background colors based on variant
-  const borderColor =
-    variant === 'uncertain'
-      ? 'border-warning/20'
-      : variant === 'failed'
-        ? 'border-destructive/20'
-        : 'border-gray-200 dark:border-gray-700';
+  let borderColor: string;
+  if (variant === 'uncertain') {
+    borderColor = 'border-warning/20';
+  } else if (variant === 'failed') {
+    borderColor = 'border-destructive/20';
+  } else {
+    borderColor = 'border-gray-200 dark:border-gray-700';
+  }
 
-  const bgColor =
-    variant === 'uncertain'
-      ? 'bg-warning/5'
-      : variant === 'failed'
-        ? 'bg-destructive/5'
-        : 'bg-white dark:bg-gray-800';
+  let bgColor: string;
+  if (variant === 'uncertain') {
+    bgColor = 'bg-warning/5';
+  } else if (variant === 'failed') {
+    bgColor = 'bg-destructive/5';
+  } else {
+    bgColor = 'bg-white dark:bg-gray-800';
+  }
 
   return (
     <div

--- a/packages/app-finance/src/components/imports/correction-proposal/CorrectionProposalWorkflow.tsx
+++ b/packages/app-finance/src/components/imports/correction-proposal/CorrectionProposalWorkflow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 
 import { trpc } from '@pops/api-client';
 import { Button, WorkflowDialog } from '@pops/ui';
@@ -38,6 +38,25 @@ function previewLabel(view: PreviewView, hasSelectedOp: boolean): string {
   if (view === 'combined') return 'Combined effect of entire ChangeSet';
   if (hasSelectedOp) return 'Effect of selected operation';
   return 'No operation selected';
+}
+
+function renderProposalBodyState(
+  signal: CorrectionSignal | null,
+  proposeQuery: { isError: boolean; isLoading: boolean; error?: { message: string } | null },
+  hasOps: boolean
+): ReactNode {
+  if (!signal) {
+    return (
+      <div className="px-6 pb-6 text-sm text-muted-foreground">No proposal signal provided.</div>
+    );
+  }
+  if (proposeQuery.isError) {
+    return <div className="px-6 pb-6 text-sm text-destructive">{proposeQuery.error?.message}</div>;
+  }
+  if (proposeQuery.isLoading && !hasOps) {
+    return <div className="px-6 pb-6 text-sm text-muted-foreground">Generating proposal…</div>;
+  }
+  return null;
 }
 
 export function CorrectionProposalWorkflow({
@@ -206,11 +225,11 @@ export function CorrectionProposalWorkflow({
   const proposalFooter = (
     <>
       <div className="flex-1 text-xs text-muted-foreground">
-        {hasDirty ? (
-          <span>Preview stale — re-run before applying.</span>
-        ) : localOps.length === 0 ? (
-          <span>ChangeSet is empty.</span>
-        ) : null}
+        {(() => {
+          if (hasDirty) return <span>Preview stale — re-run before applying.</span>;
+          if (localOps.length === 0) return <span>ChangeSet is empty.</span>;
+          return null;
+        })()}
       </div>
       <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isBusy}>
         Cancel
@@ -233,13 +252,8 @@ export function CorrectionProposalWorkflow({
   const isProposalGridReady =
     Boolean(signal) && !proposeQuery.isError && !(proposeQuery.isLoading && localOps.length === 0);
 
-  const proposalBody = !signal ? (
-    <div className="px-6 pb-6 text-sm text-muted-foreground">No proposal signal provided.</div>
-  ) : proposeQuery.isError ? (
-    <div className="px-6 pb-6 text-sm text-destructive">{proposeQuery.error.message}</div>
-  ) : proposeQuery.isLoading && localOps.length === 0 ? (
-    <div className="px-6 pb-6 text-sm text-muted-foreground">Generating proposal…</div>
-  ) : (
+  const proposalBodyState = renderProposalBodyState(signal, proposeQuery, localOps.length > 0);
+  const proposalBody: ReactNode = proposalBodyState ?? (
     <>
       <OpsListPanel
         ops={localOps}

--- a/packages/app-finance/src/components/imports/correction-proposal/CorrectionRuleManagerDialog.tsx
+++ b/packages/app-finance/src/components/imports/correction-proposal/CorrectionRuleManagerDialog.tsx
@@ -363,12 +363,14 @@ function RuleManagerBody(props: {
     return <div className="px-6 pb-6 text-sm text-muted-foreground">Loading rules…</div>;
   }
 
-  const label =
-    props.previewView === 'combined'
-      ? 'Combined effect of all pending changes'
-      : props.selectedOp
-        ? 'Effect of selected operation'
-        : 'No operation selected';
+  let label: string;
+  if (props.previewView === 'combined') {
+    label = 'Combined effect of all pending changes';
+  } else if (props.selectedOp) {
+    label = 'Effect of selected operation';
+  } else {
+    label = 'No operation selected';
+  }
 
   const previewResult =
     props.previewView === 'combined' ? props.previewCombined : props.previewSelected;
@@ -430,26 +432,33 @@ function RuleManagerBody(props: {
       </div>
 
       <div className="flex flex-col min-h-0 overflow-auto">
-        {props.selectedOp ? (
-          <DetailPanel
-            op={props.selectedOp}
-            onChange={(mutator) => {
-              if (props.selectedOp) props.onChangeSelectedOp(props.selectedOp.clientId, mutator);
-            }}
-            disabled={false}
-          />
-        ) : props.selectedRule ? (
-          <BrowseRuleDetailPanel
-            rule={props.selectedRule}
-            onEdit={props.onEditRule}
-            onDisable={props.onDisableRule}
-            onRemove={props.onRemoveRule}
-          />
-        ) : (
-          <div className="p-6 text-sm text-muted-foreground">
-            Select a rule on the left to view or edit it.
-          </div>
-        )}
+        {(() => {
+          const selectedOp = props.selectedOp;
+          if (selectedOp) {
+            return (
+              <DetailPanel
+                op={selectedOp}
+                onChange={(mutator) => props.onChangeSelectedOp(selectedOp.clientId, mutator)}
+                disabled={false}
+              />
+            );
+          }
+          if (props.selectedRule) {
+            return (
+              <BrowseRuleDetailPanel
+                rule={props.selectedRule}
+                onEdit={props.onEditRule}
+                onDisable={props.onDisableRule}
+                onRemove={props.onRemoveRule}
+              />
+            );
+          }
+          return (
+            <div className="p-6 text-sm text-muted-foreground">
+              Select a rule on the left to view or edit it.
+            </div>
+          );
+        })()}
       </div>
 
       <ImpactPanel

--- a/packages/app-finance/src/components/imports/correction-proposal/ImpactPanel.tsx
+++ b/packages/app-finance/src/components/imports/correction-proposal/ImpactPanel.tsx
@@ -152,45 +152,55 @@ export function ImpactPanel(props: {
         )}
       </div>
       <div className="flex-1 overflow-auto px-4 pb-4">
-        {previewError ? (
-          <div className="text-sm text-destructive">{previewError}</div>
-        ) : props.isPending && !previewResult ? (
-          <div className="text-sm text-muted-foreground">Computing preview…</div>
-        ) : !previewResult ? (
-          <div className="text-sm text-muted-foreground">No preview yet.</div>
-        ) : hasTwoSections ? (
-          <div className="space-y-4">
-            <div>
-              <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-                Import transactions
+        {(() => {
+          if (previewError) {
+            return <div className="text-sm text-destructive">{previewError}</div>;
+          }
+          if (props.isPending && !previewResult) {
+            return <div className="text-sm text-muted-foreground">Computing preview…</div>;
+          }
+          if (!previewResult) {
+            return <div className="text-sm text-muted-foreground">No preview yet.</div>;
+          }
+          if (hasTwoSections) {
+            return (
+              <div className="space-y-4">
+                <div>
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                    Import transactions
+                  </div>
+                  <ImpactContent result={previewResult} />
+                </div>
+                <div className="border-t pt-3">
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground mb-2 flex items-center gap-1.5">
+                    Existing transactions
+                    {props.dbTruncated && props.dbTotal !== undefined && (
+                      <span
+                        className="text-amber-600 normal-case font-normal"
+                        title={`Preview truncated — showing first ${PREVIEW_CHANGESET_MAX_TRANSACTIONS} of ${props.dbTotal} existing transactions.`}
+                      >
+                        (preview truncated — first {PREVIEW_CHANGESET_MAX_TRANSACTIONS} of{' '}
+                        {props.dbTotal})
+                      </span>
+                    )}
+                  </div>
+                  {(() => {
+                    if (dbPreviewResult) return <ImpactContent result={dbPreviewResult} />;
+                    if (props.isPending) {
+                      return <div className="text-xs text-muted-foreground">Computing…</div>;
+                    }
+                    return (
+                      <div className="text-xs text-muted-foreground">
+                        No existing transactions match.
+                      </div>
+                    );
+                  })()}
+                </div>
               </div>
-              <ImpactContent result={previewResult} />
-            </div>
-            <div className="border-t pt-3">
-              <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground mb-2 flex items-center gap-1.5">
-                Existing transactions
-                {props.dbTruncated && props.dbTotal !== undefined && (
-                  <span
-                    className="text-amber-600 normal-case font-normal"
-                    title={`Preview truncated — showing first ${PREVIEW_CHANGESET_MAX_TRANSACTIONS} of ${props.dbTotal} existing transactions.`}
-                  >
-                    (preview truncated — first {PREVIEW_CHANGESET_MAX_TRANSACTIONS} of{' '}
-                    {props.dbTotal})
-                  </span>
-                )}
-              </div>
-              {dbPreviewResult ? (
-                <ImpactContent result={dbPreviewResult} />
-              ) : props.isPending ? (
-                <div className="text-xs text-muted-foreground">Computing…</div>
-              ) : (
-                <div className="text-xs text-muted-foreground">No existing transactions match.</div>
-              )}
-            </div>
-          </div>
-        ) : (
-          <ImpactContent result={previewResult} />
-        )}
+            );
+          }
+          return <ImpactContent result={previewResult} />;
+        })()}
       </div>
     </div>
   );

--- a/packages/app-finance/src/components/search/TransactionsResultComponent.tsx
+++ b/packages/app-finance/src/components/search/TransactionsResultComponent.tsx
@@ -33,7 +33,11 @@ export function TransactionsResultComponent({ data, query, matchField }: ResultC
       trailing={
         <div className="flex flex-col items-end shrink-0">
           <span className={`text-sm font-medium ${amountColorClass(tx.type)}`}>
-            {tx.type === 'income' ? '+' : tx.type === 'expense' ? '-' : ''}
+            {(() => {
+              if (tx.type === 'income') return '+';
+              if (tx.type === 'expense') return '-';
+              return '';
+            })()}
             {formatCurrency(Math.abs(tx.amount), {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,

--- a/packages/app-finance/src/lib/correction-browse-reorder.ts
+++ b/packages/app-finance/src/lib/correction-browse-reorder.ts
@@ -7,7 +7,9 @@ import type { CorrectionRule } from '../components/imports/RulePicker';
 export function compareRulesForBrowse(a: CorrectionRule, b: CorrectionRule): number {
   const pa = a.priority - b.priority;
   if (pa !== 0) return pa;
-  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
 }
 
 export function effectiveRulePriority(rule: CorrectionRule, localOps: LocalOp[]): number {

--- a/packages/app-finance/src/pages/DashboardPage.tsx
+++ b/packages/app-finance/src/pages/DashboardPage.tsx
@@ -55,36 +55,42 @@ export function DashboardPage() {
 
       {/* Stats Grid */}
       <section>
-        {transactionsLoading ? (
-          <SkeletonGrid count={4} itemHeight="h-32" cols="sm:grid-cols-2 lg:grid-cols-4" />
-        ) : stats ? (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <StatCard
-              title="Total Transactions"
-              value={stats.totalTransactions.toLocaleString()}
-              description="All-time transactions"
-              color="slate"
-            />
-            <StatCard
-              title="Recent Income"
-              value={`$${stats.totalIncome.toFixed(2)}`}
-              description="Last 10 transactions"
-              color="emerald"
-            />
-            <StatCard
-              title="Recent Expenses"
-              value={`$${stats.totalExpenses.toFixed(2)}`}
-              description="Last 10 transactions"
-              color="rose"
-            />
-            <StatCard
-              title="Net Balance"
-              value={`$${(stats.totalIncome - stats.totalExpenses).toFixed(2)}`}
-              description="Last 10 transactions"
-              color={stats.totalIncome > stats.totalExpenses ? 'emerald' : 'rose'}
-            />
-          </div>
-        ) : null}
+        {(() => {
+          if (transactionsLoading) {
+            return (
+              <SkeletonGrid count={4} itemHeight="h-32" cols="sm:grid-cols-2 lg:grid-cols-4" />
+            );
+          }
+          if (!stats) return null;
+          return (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <StatCard
+                title="Total Transactions"
+                value={stats.totalTransactions.toLocaleString()}
+                description="All-time transactions"
+                color="slate"
+              />
+              <StatCard
+                title="Recent Income"
+                value={`$${stats.totalIncome.toFixed(2)}`}
+                description="Last 10 transactions"
+                color="emerald"
+              />
+              <StatCard
+                title="Recent Expenses"
+                value={`$${stats.totalExpenses.toFixed(2)}`}
+                description="Last 10 transactions"
+                color="rose"
+              />
+              <StatCard
+                title="Net Balance"
+                value={`$${(stats.totalIncome - stats.totalExpenses).toFixed(2)}`}
+                description="Last 10 transactions"
+                color={stats.totalIncome > stats.totalExpenses ? 'emerald' : 'rose'}
+              />
+            </div>
+          );
+        })()}
       </section>
 
       {/* Recent Transactions */}
@@ -92,102 +98,113 @@ export function DashboardPage() {
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-semibold tracking-tight">Recent Transactions</h2>
         </div>
-        {transactionsLoading ? (
-          <SkeletonGrid count={3} itemHeight="h-16" cols="grid-cols-1" gap="gap-3" />
-        ) : transactions && transactions.data.length > 0 ? (
-          <Card className="overflow-hidden p-0">
-            <div className="divide-y divide-border">
-              {transactions.data.map((transaction: Transaction) => (
-                <div
-                  key={transaction.id}
-                  className="p-4 flex items-center justify-between gap-4 hover:bg-muted/50 transition-colors"
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <p className="font-medium truncate text-base">{transaction.description}</p>
-                      {transaction.tags.includes('Online') && (
-                        <Badge
-                          variant="secondary"
-                          className="hidden sm:inline-flex text-2xs uppercase tracking-wider px-1.5 py-0"
-                        >
-                          Online
-                        </Badge>
-                      )}
+        {(() => {
+          if (transactionsLoading) {
+            return <SkeletonGrid count={3} itemHeight="h-16" cols="grid-cols-1" gap="gap-3" />;
+          }
+          if (!transactions || transactions.data.length === 0) {
+            return (
+              <Card className="p-12 text-center text-muted-foreground border-dashed">
+                No transactions found
+              </Card>
+            );
+          }
+          return (
+            <Card className="overflow-hidden p-0">
+              <div className="divide-y divide-border">
+                {transactions.data.map((transaction: Transaction) => (
+                  <div
+                    key={transaction.id}
+                    className="p-4 flex items-center justify-between gap-4 hover:bg-muted/50 transition-colors"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="font-medium truncate text-base">{transaction.description}</p>
+                        {transaction.tags.includes('Online') && (
+                          <Badge
+                            variant="secondary"
+                            className="hidden sm:inline-flex text-2xs uppercase tracking-wider px-1.5 py-0"
+                          >
+                            Online
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 mt-0.5">
+                        <p className="text-xs text-muted-foreground">
+                          {new Date(transaction.date).toLocaleDateString('en-AU')}
+                        </p>
+                        {transaction.entityName && (
+                          <>
+                            <span className="text-muted-foreground/50 text-2xs">•</span>
+                            <p className="text-xs text-muted-foreground truncate">
+                              {transaction.entityName}
+                            </p>
+                          </>
+                        )}
+                      </div>
                     </div>
-                    <div className="flex items-center gap-2 mt-0.5">
-                      <p className="text-xs text-muted-foreground">
-                        {new Date(transaction.date).toLocaleDateString('en-AU')}
+                    <div className="flex items-center gap-4 shrink-0">
+                      <Badge
+                        variant="outline"
+                        className="hidden sm:inline-flex text-2xs uppercase tracking-wider px-1.5 py-0 text-muted-foreground font-normal"
+                      >
+                        {transaction.account}
+                      </Badge>
+                      <p
+                        className={`text-lg font-bold tabular-nums tracking-tight ${
+                          transaction.amount < 0 ? 'text-destructive' : 'text-success'
+                        }`}
+                      >
+                        {transaction.amount < 0 ? '-' : '+'}$
+                        {Math.abs(transaction.amount).toFixed(2)}
                       </p>
-                      {transaction.entityName && (
-                        <>
-                          <span className="text-muted-foreground/50 text-2xs">•</span>
-                          <p className="text-xs text-muted-foreground truncate">
-                            {transaction.entityName}
-                          </p>
-                        </>
-                      )}
                     </div>
                   </div>
-                  <div className="flex items-center gap-4 shrink-0">
-                    <Badge
-                      variant="outline"
-                      className="hidden sm:inline-flex text-2xs uppercase tracking-wider px-1.5 py-0 text-muted-foreground font-normal"
-                    >
-                      {transaction.account}
-                    </Badge>
-                    <p
-                      className={`text-lg font-bold tabular-nums tracking-tight ${
-                        transaction.amount < 0 ? 'text-destructive' : 'text-success'
-                      }`}
-                    >
-                      {transaction.amount < 0 ? '-' : '+'}${Math.abs(transaction.amount).toFixed(2)}
-                    </p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </Card>
-        ) : (
-          <Card className="p-12 text-center text-muted-foreground border-dashed">
-            No transactions found
-          </Card>
-        )}
+                ))}
+              </div>
+            </Card>
+          );
+        })()}
       </section>
 
       {/* Active Budgets */}
       <section className="space-y-4">
         <h2 className="text-xl font-semibold tracking-tight">Active Budgets</h2>
-        {budgetsLoading ? (
-          <SkeletonGrid count={3} itemHeight="h-32" cols="md:grid-cols-3" />
-        ) : budgets && budgets.data.length > 0 ? (
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {budgets.data.slice(0, 3).map((budget: Budget) => (
-              <Card key={budget.id} className="p-5 flex flex-col justify-between h-full">
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <h3 className="font-medium text-muted-foreground uppercase text-2xs tracking-widest">
-                      {budget.category}
-                    </h3>
-                    <Badge
-                      variant={budget.active ? 'default' : 'secondary'}
-                      className="text-2xs h-5"
-                    >
-                      {budget.active ? 'Active' : 'Inactive'}
-                    </Badge>
+        {(() => {
+          if (budgetsLoading) {
+            return <SkeletonGrid count={3} itemHeight="h-32" cols="md:grid-cols-3" />;
+          }
+          if (!budgets || budgets.data.length === 0) {
+            return <p className="text-sm text-muted-foreground">No active budgets found</p>;
+          }
+          return (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {budgets.data.slice(0, 3).map((budget: Budget) => (
+                <Card key={budget.id} className="p-5 flex flex-col justify-between h-full">
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <h3 className="font-medium text-muted-foreground uppercase text-2xs tracking-widest">
+                        {budget.category}
+                      </h3>
+                      <Badge
+                        variant={budget.active ? 'default' : 'secondary'}
+                        className="text-2xs h-5"
+                      >
+                        {budget.active ? 'Active' : 'Inactive'}
+                      </Badge>
+                    </div>
+                    <div className="flex items-baseline gap-1">
+                      <span className="text-2xl font-bold">
+                        ${budget.amount ? budget.amount.toFixed(2) : '0.00'}
+                      </span>
+                      <span className="text-xs text-muted-foreground">/ {budget.period}</span>
+                    </div>
                   </div>
-                  <div className="flex items-baseline gap-1">
-                    <span className="text-2xl font-bold">
-                      ${budget.amount ? budget.amount.toFixed(2) : '0.00'}
-                    </span>
-                    <span className="text-xs text-muted-foreground">/ {budget.period}</span>
-                  </div>
-                </div>
-              </Card>
-            ))}
-          </div>
-        ) : (
-          <p className="text-sm text-muted-foreground">No active budgets found</p>
-        )}
+                </Card>
+              ))}
+            </div>
+          );
+        })()}
       </section>
     </div>
   );

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -349,13 +349,11 @@ export function EntitiesPage() {
     <div className="space-y-6">
       <PageHeader
         title="Entities"
-        description={
-          data
-            ? showOrphanedOnly
-              ? `${data.pagination.total} orphaned entities`
-              : `${data.pagination.total} total entities`
-            : 'Manage merchants and payees'
-        }
+        description={(() => {
+          if (!data) return 'Manage merchants and payees';
+          if (showOrphanedOnly) return `${data.pagination.total} orphaned entities`;
+          return `${data.pagination.total} total entities`;
+        })()}
         actions={
           <Button onClick={handleAdd}>
             <Plus className="mr-2 h-4 w-4" /> Add Entity

--- a/packages/app-finance/src/pages/TransactionsPage.tsx
+++ b/packages/app-finance/src/pages/TransactionsPage.tsx
@@ -207,24 +207,30 @@ export function TransactionsPage() {
         description={data ? `${data.pagination.total} total transactions` : undefined}
       />
 
-      {isLoading ? (
-        <div className="space-y-4">
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-64 w-full" />
-        </div>
-      ) : data ? (
-        <DataTable
-          columns={columns}
-          data={data.data}
-          searchable
-          searchColumn="description"
-          searchPlaceholder="Search transactions..."
-          paginated
-          defaultPageSize={50}
-          pageSizeOptions={[25, 50, 100]}
-          filters={tableFilters}
-        />
-      ) : null}
+      {(() => {
+        if (isLoading) {
+          return (
+            <div className="space-y-4">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-64 w-full" />
+            </div>
+          );
+        }
+        if (!data) return null;
+        return (
+          <DataTable
+            columns={columns}
+            data={data.data}
+            searchable
+            searchColumn="description"
+            searchPlaceholder="Search transactions..."
+            paginated
+            defaultPageSize={50}
+            pageSizeOptions={[25, 50, 100]}
+            filters={tableFilters}
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/packages/app-finance/src/pages/WishlistPage.tsx
+++ b/packages/app-finance/src/pages/WishlistPage.tsx
@@ -175,15 +175,15 @@ export function WishlistPage() {
       cell: ({ row }) => {
         const priority = row.original.priority;
         if (!priority) return <span className="text-muted-foreground">—</span>;
-        return (
-          <Badge
-            variant={
-              priority === 'Needing' ? 'default' : priority === 'Soon' ? 'secondary' : 'outline'
-            }
-          >
-            {priority}
-          </Badge>
-        );
+        let badgeVariant: 'default' | 'secondary' | 'outline';
+        if (priority === 'Needing') {
+          badgeVariant = 'default';
+        } else if (priority === 'Soon') {
+          badgeVariant = 'secondary';
+        } else {
+          badgeVariant = 'outline';
+        }
+        return <Badge variant={badgeVariant}>{priority}</Badge>;
       },
     },
     {

--- a/packages/app-inventory/src/components/LocationContentsPanel.tsx
+++ b/packages/app-inventory/src/components/LocationContentsPanel.tsx
@@ -121,30 +121,36 @@ export function LocationContentsPanel({
         </Button>
       }
     >
-      {isLoading ? (
-        <div className="space-y-2">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-10 w-full" />
-          ))}
-        </div>
-      ) : allItems.length > 0 ? (
-        <ul className="space-y-1">
-          {allItems.map((item: InventoryItem) => (
-            <li key={item.id}>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="w-full justify-start gap-2 h-auto px-2 py-1.5 text-left"
-                onClick={() => navigate(`/inventory/items/${item.id}`)}
-              >
-                <span className="font-medium truncate flex-1">{item.itemName}</span>
-                {item.assetId && <AssetIdBadge assetId={item.assetId} />}
-                {item.type && <TypeBadge type={item.type} />}
-              </Button>
-            </li>
-          ))}
-        </ul>
-      ) : null}
+      {(() => {
+        if (isLoading) {
+          return (
+            <div className="space-y-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          );
+        }
+        if (allItems.length === 0) return null;
+        return (
+          <ul className="space-y-1">
+            {allItems.map((item: InventoryItem) => (
+              <li key={item.id}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full justify-start gap-2 h-auto px-2 py-1.5 text-left"
+                  onClick={() => navigate(`/inventory/items/${item.id}`)}
+                >
+                  <span className="font-medium truncate flex-1">{item.itemName}</span>
+                  {item.assetId && <AssetIdBadge assetId={item.assetId} />}
+                  {item.type && <TypeBadge type={item.type} />}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        );
+      })()}
     </ContainerPanel>
   );
 }

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -310,44 +310,49 @@ export function ItemsPage() {
       )}
 
       {/* Content */}
-      {isLoading ? (
-        <ItemsPageSkeleton />
-      ) : items.length === 0 ? (
-        <div className="flex flex-col items-center justify-center h-64 text-muted-foreground gap-4">
-          <Package className="h-12 w-12 opacity-40" />
-          {search || hasActiveFilters ? (
-            <p>No items match your filters.</p>
-          ) : (
-            <>
-              <p>No inventory items yet.</p>
-              <Button
-                prefix={<Plus className="h-4 w-4" />}
-                onClick={() => navigate('/inventory/items/new')}
-              >
-                Add your first item
-              </Button>
-            </>
-          )}
-        </div>
-      ) : viewMode === 'table' ? (
-        <InventoryTable items={items} locationPathMap={locationPathMap} />
-      ) : (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-          {items.map((item: InventoryItem) => (
-            <InventoryCard
-              key={item.id}
-              id={item.id}
-              itemName={item.itemName}
-              assetId={item.assetId}
-              type={item.type}
-              condition={item.condition as Condition | null}
-              locationName={item.location}
-              layout="vertical"
-              onClick={() => navigate(`/inventory/items/${item.id}`)}
-            />
-          ))}
-        </div>
-      )}
+      {(() => {
+        if (isLoading) return <ItemsPageSkeleton />;
+        if (items.length === 0) {
+          return (
+            <div className="flex flex-col items-center justify-center h-64 text-muted-foreground gap-4">
+              <Package className="h-12 w-12 opacity-40" />
+              {search || hasActiveFilters ? (
+                <p>No items match your filters.</p>
+              ) : (
+                <>
+                  <p>No inventory items yet.</p>
+                  <Button
+                    prefix={<Plus className="h-4 w-4" />}
+                    onClick={() => navigate('/inventory/items/new')}
+                  >
+                    Add your first item
+                  </Button>
+                </>
+              )}
+            </div>
+          );
+        }
+        if (viewMode === 'table') {
+          return <InventoryTable items={items} locationPathMap={locationPathMap} />;
+        }
+        return (
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+            {items.map((item: InventoryItem) => (
+              <InventoryCard
+                key={item.id}
+                id={item.id}
+                itemName={item.itemName}
+                assetId={item.assetId}
+                type={item.type}
+                condition={item.condition as Condition | null}
+                locationName={item.location}
+                layout="vertical"
+                onClick={() => navigate(`/inventory/items/${item.id}`)}
+              />
+            ))}
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/packages/app-inventory/src/pages/WarrantiesPage.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.tsx
@@ -329,88 +329,95 @@ export function WarrantiesPage() {
         }
       />
 
-      {isLoading ? (
-        <WarrantySkeleton />
-      ) : isError ? (
-        <div className="text-center py-16">
-          <AlertCircle className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
-          <p className="text-muted-foreground mb-4">Could not load warranties — try again</p>
-          <Button onClick={() => refetch()}>
-            <RefreshCw className="h-4 w-4" />
-            Retry
-          </Button>
-        </div>
-      ) : totalItems === 0 ? (
-        <div className="text-center py-16">
-          <ShieldCheck className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
-          <p className="text-muted-foreground mb-4">
-            No items with warranty dates. Add warranty expiry dates to your inventory items to track
-            them here.
-          </p>
-          <Link
-            to="/inventory/items"
-            className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            Browse Items
-          </Link>
-        </div>
-      ) : (
-        <div className="space-y-4">
-          {/* Expiring tiers — always expanded, not collapsible */}
-          <ExpiringSection
-            tier="critical"
-            items={critical}
-            paperlessBaseUrl={paperlessBaseUrl}
-            onItemClick={(id) => navigate(`/inventory/items/${id}`)}
-          />
-          <ExpiringSection
-            tier="warning"
-            items={warning}
-            paperlessBaseUrl={paperlessBaseUrl}
-            onItemClick={(id) => navigate(`/inventory/items/${id}`)}
-          />
-          <ExpiringSection
-            tier="caution"
-            items={caution}
-            paperlessBaseUrl={paperlessBaseUrl}
-            onItemClick={(id) => navigate(`/inventory/items/${id}`)}
-          />
+      {(() => {
+        if (isLoading) return <WarrantySkeleton />;
+        if (isError) {
+          return (
+            <div className="text-center py-16">
+              <AlertCircle className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
+              <p className="text-muted-foreground mb-4">Could not load warranties — try again</p>
+              <Button onClick={() => refetch()}>
+                <RefreshCw className="h-4 w-4" />
+                Retry
+              </Button>
+            </div>
+          );
+        }
+        if (totalItems === 0) {
+          return (
+            <div className="text-center py-16">
+              <ShieldCheck className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
+              <p className="text-muted-foreground mb-4">
+                No items with warranty dates. Add warranty expiry dates to your inventory items to
+                track them here.
+              </p>
+              <Link
+                to="/inventory/items"
+                className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Browse Items
+              </Link>
+            </div>
+          );
+        }
+        return (
+          <div className="space-y-4">
+            {/* Expiring tiers — always expanded, not collapsible */}
+            <ExpiringSection
+              tier="critical"
+              items={critical}
+              paperlessBaseUrl={paperlessBaseUrl}
+              onItemClick={(id) => navigate(`/inventory/items/${id}`)}
+            />
+            <ExpiringSection
+              tier="warning"
+              items={warning}
+              paperlessBaseUrl={paperlessBaseUrl}
+              onItemClick={(id) => navigate(`/inventory/items/${id}`)}
+            />
+            <ExpiringSection
+              tier="caution"
+              items={caution}
+              paperlessBaseUrl={paperlessBaseUrl}
+              onItemClick={(id) => navigate(`/inventory/items/${id}`)}
+            />
 
-          {/* Active — collapsible, expanded by default */}
-          {active.length > 0 && (
-            <CollapsibleSection title="Active" count={active.length} defaultOpen>
-              {active.map((item) => (
-                <WarrantyRow
-                  key={item.id}
-                  item={item}
-                  daysRemaining={item.daysRemaining}
-                  paperlessBaseUrl={paperlessBaseUrl}
-                  onClick={() => navigate(`/inventory/items/${item.id}`)}
-                />
-              ))}
-            </CollapsibleSection>
-          )}
+            {/* Active — collapsible, expanded by default */}
+            {active.length > 0 && (
+              <CollapsibleSection title="Active" count={active.length} defaultOpen>
+                {active.map((item) => (
+                  <WarrantyRow
+                    key={item.id}
+                    item={item}
+                    daysRemaining={item.daysRemaining}
+                    paperlessBaseUrl={paperlessBaseUrl}
+                    onClick={() => navigate(`/inventory/items/${item.id}`)}
+                  />
+                ))}
+              </CollapsibleSection>
+            )}
 
-          {/* Expired — collapsible, collapsed by default */}
-          {expired.length > 0 && (
-            <CollapsibleSection
-              title="Expired"
-              count={expired.length}
-              defaultOpen={!hasExpiringItems && active.length === 0}
-            >
-              {expired.map((item) => (
-                <WarrantyRow
-                  key={item.id}
-                  item={item}
-                  daysRemaining={item.daysRemaining}
-                  paperlessBaseUrl={paperlessBaseUrl}
-                  onClick={() => navigate(`/inventory/items/${item.id}`)}
-                />
-              ))}
-            </CollapsibleSection>
-          )}
-        </div>
-      )}
+            {/* Expired — collapsible, collapsed by default */}
+            {expired.length > 0 && (
+              <CollapsibleSection
+                title="Expired"
+                count={expired.length}
+                defaultOpen={!hasExpiringItems && active.length === 0}
+              >
+                {expired.map((item) => (
+                  <WarrantyRow
+                    key={item.id}
+                    item={item}
+                    daysRemaining={item.daysRemaining}
+                    paperlessBaseUrl={paperlessBaseUrl}
+                    onClick={() => navigate(`/inventory/items/${item.id}`)}
+                  />
+                ))}
+              </CollapsibleSection>
+            )}
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/packages/app-inventory/src/pages/item-detail-page/sections/ConnectionsSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/ConnectionsSection.tsx
@@ -110,25 +110,31 @@ export function ConnectionsSection({
           <ConnectDialog currentItemId={itemId} onConnected={onConnected} />
         </div>
 
-        {connectionsLoading ? (
-          <div className="space-y-2">
-            <Skeleton className="h-12 w-full" />
-            <Skeleton className="h-12 w-full" />
-          </div>
-        ) : connections.length ? (
-          <div className="space-y-2">
-            {connections.map((conn: ItemConnection) => (
-              <ConnectionRow
-                key={conn.id}
-                connectedItemId={conn.itemAId === itemId ? conn.itemBId : conn.itemAId}
-                onDisconnect={() => onDisconnect(conn)}
-                isDisconnecting={isDisconnecting}
-              />
-            ))}
-          </div>
-        ) : (
-          <p className="text-muted-foreground text-sm">No connected items yet.</p>
-        )}
+        {(() => {
+          if (connectionsLoading) {
+            return (
+              <div className="space-y-2">
+                <Skeleton className="h-12 w-full" />
+                <Skeleton className="h-12 w-full" />
+              </div>
+            );
+          }
+          if (connections.length) {
+            return (
+              <div className="space-y-2">
+                {connections.map((conn: ItemConnection) => (
+                  <ConnectionRow
+                    key={conn.id}
+                    connectedItemId={conn.itemAId === itemId ? conn.itemBId : conn.itemAId}
+                    onDisconnect={() => onDisconnect(conn)}
+                    isDisconnecting={isDisconnecting}
+                  />
+                ))}
+              </div>
+            );
+          }
+          return <p className="text-muted-foreground text-sm">No connected items yet.</p>;
+        })()}
       </section>
 
       {connections.length ? (

--- a/packages/app-inventory/src/pages/item-detail-page/sections/DetailHeaderSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/DetailHeaderSection.tsx
@@ -33,10 +33,10 @@ function LocationBreadcrumb({
   return (
     <div className="mb-8 flex items-center gap-1.5 text-sm" data-testid="location-breadcrumb">
       <MapPin className="h-4 w-4 text-muted-foreground shrink-0" />
-      {!locationId ? (
-        <span className="text-muted-foreground">No location assigned</span>
-      ) : locationPath ? (
-        locationPath.map((loc, i) => (
+      {(() => {
+        if (!locationId) return <span className="text-muted-foreground">No location assigned</span>;
+        if (!locationPath) return <Skeleton className="h-4 w-32" />;
+        return locationPath.map((loc, i) => (
           <span key={loc.id} className="flex items-center gap-1.5">
             {i > 0 && <ChevronRight className="h-3 w-3 text-muted-foreground" />}
             <Link
@@ -46,10 +46,8 @@ function LocationBreadcrumb({
               {loc.name}
             </Link>
           </span>
-        ))
-      ) : (
-        <Skeleton className="h-4 w-32" />
-      )}
+        ));
+      })()}
     </div>
   );
 }

--- a/packages/app-inventory/src/pages/item-detail-page/sections/DocumentsSection.tsx
+++ b/packages/app-inventory/src/pages/item-detail-page/sections/DocumentsSection.tsx
@@ -90,69 +90,75 @@ function DocumentsList({
           onLinked={() => void utils.inventory.documents.listForItem.invalidate({ itemId })}
         />
       </div>
-      {isLoading ? (
-        <div className="space-y-2">
-          <Skeleton className="h-12 w-full" />
-          <Skeleton className="h-12 w-full" />
-        </div>
-      ) : docs.length > 0 ? (
-        <div className="space-y-4">
-          {sortedTypes.map((type) => (
-            <div key={type}>
-              <h3 className="text-sm font-medium text-muted-foreground mb-2">
-                {DOCUMENT_TYPE_LABELS[type] ?? type}
-              </h3>
-              <div className="space-y-1.5">
-                {grouped.get(type)?.map((doc) => (
-                  <div
-                    key={doc.id}
-                    className="flex items-center justify-between p-3 rounded-lg border"
-                  >
-                    <div className="flex items-center gap-3 flex-1 min-w-0">
-                      <DocumentThumbnail documentId={doc.paperlessDocumentId} />
-                      <div className="min-w-0 flex-1">
-                        <span className="font-medium text-sm truncate block">
-                          {doc.title ?? `Document #${doc.paperlessDocumentId}`}
-                        </span>
-                        <span className="text-xs text-muted-foreground">
-                          Linked {new Date(doc.createdAt).toLocaleDateString()}
-                        </span>
+      {(() => {
+        if (isLoading) {
+          return (
+            <div className="space-y-2">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          );
+        }
+        if (docs.length === 0) {
+          return <p className="text-muted-foreground text-sm">No documents linked yet.</p>;
+        }
+        return (
+          <div className="space-y-4">
+            {sortedTypes.map((type) => (
+              <div key={type}>
+                <h3 className="text-sm font-medium text-muted-foreground mb-2">
+                  {DOCUMENT_TYPE_LABELS[type] ?? type}
+                </h3>
+                <div className="space-y-1.5">
+                  {grouped.get(type)?.map((doc) => (
+                    <div
+                      key={doc.id}
+                      className="flex items-center justify-between p-3 rounded-lg border"
+                    >
+                      <div className="flex items-center gap-3 flex-1 min-w-0">
+                        <DocumentThumbnail documentId={doc.paperlessDocumentId} />
+                        <div className="min-w-0 flex-1">
+                          <span className="font-medium text-sm truncate block">
+                            {doc.title ?? `Document #${doc.paperlessDocumentId}`}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            Linked {new Date(doc.createdAt).toLocaleDateString()}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-1 shrink-0">
+                        {paperlessBaseUrl && (
+                          <a
+                            href={`${paperlessBaseUrl}/documents/${doc.paperlessDocumentId}/details`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="relative inline-flex items-center justify-center size-9 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent before:absolute before:content-[''] before:-inset-1"
+                            title="View in Paperless"
+                            aria-label="View in Paperless"
+                          >
+                            <ExternalLink className="h-4 w-4" />
+                          </a>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="text-destructive hover:text-destructive shrink-0"
+                          onClick={() => unlinkMutation.mutate({ id: doc.id })}
+                          disabled={unlinkMutation.isPending}
+                          title="Unlink document"
+                          aria-label="Unlink document"
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
                       </div>
                     </div>
-                    <div className="flex items-center gap-1 shrink-0">
-                      {paperlessBaseUrl && (
-                        <a
-                          href={`${paperlessBaseUrl}/documents/${doc.paperlessDocumentId}/details`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="relative inline-flex items-center justify-center size-9 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent before:absolute before:content-[''] before:-inset-1"
-                          title="View in Paperless"
-                          aria-label="View in Paperless"
-                        >
-                          <ExternalLink className="h-4 w-4" />
-                        </a>
-                      )}
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="text-destructive hover:text-destructive shrink-0"
-                        onClick={() => unlinkMutation.mutate({ id: doc.id })}
-                        disabled={unlinkMutation.isPending}
-                        title="Unlink document"
-                        aria-label="Unlink document"
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <p className="text-muted-foreground text-sm">No documents linked yet.</p>
-      )}
+            ))}
+          </div>
+        );
+      })()}
     </section>
   );
 }

--- a/packages/app-inventory/src/pages/item-form-page/sections/ConnectionsSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/ConnectionsSection.tsx
@@ -70,15 +70,21 @@ export function ConnectionsSection({
 
       {connectionSearch.length >= 2 && (
         <div className="max-h-48 overflow-y-auto border rounded-lg divide-y">
-          {searchLoading ? (
-            <div className="space-y-2 p-2">
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-            </div>
-          ) : filtered.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-3 text-center">No items found</p>
-          ) : (
-            filtered.map((item: InventoryItem) => (
+          {(() => {
+            if (searchLoading) {
+              return (
+                <div className="space-y-2 p-2">
+                  <Skeleton className="h-10 w-full" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              );
+            }
+            if (filtered.length === 0) {
+              return (
+                <p className="text-sm text-muted-foreground py-3 text-center">No items found</p>
+              );
+            }
+            return filtered.map((item: InventoryItem) => (
               <Button
                 key={item.id}
                 variant="ghost"
@@ -97,8 +103,8 @@ export function ConnectionsSection({
                 </div>
                 <Link2 className="h-4 w-4 text-app-accent/50 shrink-0 ml-2" />
               </Button>
-            ))
-          )}
+            ));
+          })()}
         </div>
       )}
     </section>

--- a/packages/app-media/src/components/ComparisonMovieCard.tsx
+++ b/packages/app-media/src/components/ComparisonMovieCard.tsx
@@ -164,13 +164,12 @@ export function ComparisonMovieCard({
   return (
     <div className="flex flex-col gap-2" data-testid={`comparison-movie-card-${movie.id}`}>
       <div
-        className={`relative rounded-lg overflow-hidden transition-all ${
-          isWinner
-            ? 'ring-2 ring-success shadow-lg scale-[1.02]'
-            : isWinner === false && scoreDelta != null
-              ? 'ring-2 ring-destructive/50 opacity-75'
-              : ''
-        }`}
+        className={`relative rounded-lg overflow-hidden transition-all ${(() => {
+          if (isWinner) return 'ring-2 ring-success shadow-lg scale-[1.02]';
+          if (isWinner === false && scoreDelta != null)
+            return 'ring-2 ring-destructive/50 opacity-75';
+          return '';
+        })()}`}
       >
         <CardWithActionOverlay
           src={movie.posterUrl}

--- a/packages/app-media/src/components/DebriefResultsSummary.tsx
+++ b/packages/app-media/src/components/DebriefResultsSummary.tsx
@@ -100,22 +100,30 @@ export function DebriefResultsSummary({ mediaType, mediaId }: DebriefResultsSumm
                     {score != null && (
                       <span className="text-xs text-muted-foreground">{Math.round(score)}</span>
                     )}
-                    {dim.status === 'complete' && dim.comparisonId !== null ? (
-                      <Badge variant="default" className="gap-1">
-                        <CheckCircle className="h-3 w-3" />
-                        Compared
-                      </Badge>
-                    ) : dim.status === 'complete' && dim.comparisonId === null ? (
-                      <Badge variant="secondary" className="gap-1">
-                        <XCircle className="h-3 w-3" />
-                        Skipped
-                      </Badge>
-                    ) : (
-                      <Badge variant="outline" className="gap-1">
-                        <Clock className="h-3 w-3" />
-                        Pending
-                      </Badge>
-                    )}
+                    {(() => {
+                      if (dim.status === 'complete' && dim.comparisonId !== null) {
+                        return (
+                          <Badge variant="default" className="gap-1">
+                            <CheckCircle className="h-3 w-3" />
+                            Compared
+                          </Badge>
+                        );
+                      }
+                      if (dim.status === 'complete' && dim.comparisonId === null) {
+                        return (
+                          <Badge variant="secondary" className="gap-1">
+                            <XCircle className="h-3 w-3" />
+                            Skipped
+                          </Badge>
+                        );
+                      }
+                      return (
+                        <Badge variant="outline" className="gap-1">
+                          <Clock className="h-3 w-3" />
+                          Pending
+                        </Badge>
+                      );
+                    })()}
                   </div>
                 </div>
               );
@@ -140,22 +148,18 @@ export function DebriefResultsSummary({ mediaType, mediaId }: DebriefResultsSumm
                       <div className="flex items-center gap-1.5">
                         <span className="font-medium">{Math.round(s.score)}</span>
                         <span
-                          className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                            isPositive
-                              ? 'bg-success/20 text-success'
-                              : isNegative
-                                ? 'bg-destructive/20 text-destructive'
-                                : 'bg-muted text-muted-foreground'
-                          }`}
+                          className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs font-medium ${(() => {
+                            if (isPositive) return 'bg-success/20 text-success';
+                            if (isNegative) return 'bg-destructive/20 text-destructive';
+                            return 'bg-muted text-muted-foreground';
+                          })()}`}
                           data-testid={`score-delta-${s.dimensionId}`}
                         >
-                          {isPositive ? (
-                            <ArrowUpRight className="h-3 w-3" />
-                          ) : isNegative ? (
-                            <ArrowDownRight className="h-3 w-3" />
-                          ) : (
-                            <Minus className="h-3 w-3" />
-                          )}
+                          {(() => {
+                            if (isPositive) return <ArrowUpRight className="h-3 w-3" />;
+                            if (isNegative) return <ArrowDownRight className="h-3 w-3" />;
+                            return <Minus className="h-3 w-3" />;
+                          })()}
                           {isPositive ? '+' : ''}
                           {delta}
                         </span>

--- a/packages/app-media/src/components/DimensionManager.tsx
+++ b/packages/app-media/src/components/DimensionManager.tsx
@@ -425,44 +425,50 @@ export function DimensionManager() {
           showForm={showAddForm}
           form={addForm}
         >
-          {isLoading ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">Loading...</p>
-          ) : sorted.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">
-              No dimensions yet. Add one above.
-            </p>
-          ) : (
-            <div className="space-y-1 max-h-64 overflow-y-auto">
-              {sorted.map((dim, idx) => (
-                <DimensionListItem
-                  key={dim.id}
-                  dim={dim}
-                  idx={idx}
-                  isLast={idx === sorted.length - 1}
-                  editing={editing}
-                  setEditing={setEditing}
-                  onSaveEdit={handleSaveEdit}
-                  onReorder={(direction) => {
-                    handleReorder(dim, direction);
-                  }}
-                  onStartEdit={() => {
-                    handleStartEdit(dim);
-                  }}
-                  onToggleActive={() => {
-                    handleToggleActive(dim);
-                  }}
-                  onWeightDrag={(v) => {
-                    handleWeightDrag(dim.id, v);
-                  }}
-                  onWeightCommit={(v) => {
-                    handleWeightCommit(dim, v);
-                  }}
-                  localWeight={localWeights.get(dim.id) ?? dim.weight}
-                  isPending={updateMutation.isPending}
-                />
-              ))}
-            </div>
-          )}
+          {(() => {
+            if (isLoading) {
+              return <p className="text-sm text-muted-foreground py-4 text-center">Loading...</p>;
+            }
+            if (sorted.length === 0) {
+              return (
+                <p className="text-sm text-muted-foreground py-4 text-center">
+                  No dimensions yet. Add one above.
+                </p>
+              );
+            }
+            return (
+              <div className="space-y-1 max-h-64 overflow-y-auto">
+                {sorted.map((dim, idx) => (
+                  <DimensionListItem
+                    key={dim.id}
+                    dim={dim}
+                    idx={idx}
+                    isLast={idx === sorted.length - 1}
+                    editing={editing}
+                    setEditing={setEditing}
+                    onSaveEdit={handleSaveEdit}
+                    onReorder={(direction) => {
+                      handleReorder(dim, direction);
+                    }}
+                    onStartEdit={() => {
+                      handleStartEdit(dim);
+                    }}
+                    onToggleActive={() => {
+                      handleToggleActive(dim);
+                    }}
+                    onWeightDrag={(v) => {
+                      handleWeightDrag(dim.id, v);
+                    }}
+                    onWeightCommit={(v) => {
+                      handleWeightCommit(dim, v);
+                    }}
+                    localWeight={localWeights.get(dim.id) ?? dim.weight}
+                    isPending={updateMutation.isPending}
+                  />
+                ))}
+              </div>
+            );
+          })()}
         </CRUDManagementSection>
       </DialogContent>
     </Dialog>

--- a/packages/app-media/src/components/DiscoverCard.tsx
+++ b/packages/app-media/src/components/DiscoverCard.tsx
@@ -74,17 +74,26 @@ export function DiscoverCard({
       </Badge>
     ) : undefined;
 
-  const topRight = isWatched ? (
-    <Badge variant="secondary" className="gap-0.5 text-xs">
-      <Eye className="h-3 w-3" />
-      Watched
-    </Badge>
-  ) : inLibrary ? (
-    <Badge variant="secondary" className="gap-0.5 text-xs">
-      <Check className="h-3 w-3" />
-      Owned
-    </Badge>
-  ) : undefined;
+  const renderTopRight = () => {
+    if (isWatched) {
+      return (
+        <Badge variant="secondary" className="gap-0.5 text-xs">
+          <Eye className="h-3 w-3" />
+          Watched
+        </Badge>
+      );
+    }
+    if (inLibrary) {
+      return (
+        <Badge variant="secondary" className="gap-0.5 text-xs">
+          <Check className="h-3 w-3" />
+          Owned
+        </Badge>
+      );
+    }
+    return undefined;
+  };
+  const topRight = renderTopRight();
 
   const overlay = (
     <div className="flex gap-1">
@@ -114,13 +123,13 @@ export function DiscoverCard({
         title={onWatchlist ? 'Remove from Watchlist' : 'Add to Watchlist'}
         aria-label={onWatchlist ? 'Remove from Watchlist' : 'Add to Watchlist'}
       >
-        {isAddingToWatchlist || isRemovingFromWatchlist ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        ) : onWatchlist ? (
-          <BookmarkCheck className="h-3.5 w-3.5" />
-        ) : (
-          <Bookmark className="h-3.5 w-3.5" />
-        )}
+        {(() => {
+          if (isAddingToWatchlist || isRemovingFromWatchlist) {
+            return <Loader2 className="h-3.5 w-3.5 animate-spin" />;
+          }
+          if (onWatchlist) return <BookmarkCheck className="h-3.5 w-3.5" />;
+          return <Bookmark className="h-3.5 w-3.5" />;
+        })()}
       </Button>
       {isWatched ? (
         <Button
@@ -201,11 +210,11 @@ export function DiscoverCard({
             <span
               className={cn(
                 'text-xs font-semibold',
-                matchPercentage >= 85
-                  ? 'text-success'
-                  : matchPercentage >= 70
-                    ? 'text-success/70'
-                    : 'text-muted-foreground'
+                (() => {
+                  if (matchPercentage >= 85) return 'text-success';
+                  if (matchPercentage >= 70) return 'text-success/70';
+                  return 'text-muted-foreground';
+                })()
               )}
             >
               {matchPercentage}% Match

--- a/packages/app-media/src/components/ExpandableListRow.tsx
+++ b/packages/app-media/src/components/ExpandableListRow.tsx
@@ -71,20 +71,16 @@ export function ExpandableListRow({
               onToggleWatched(item.id, !isWatched);
             }}
             disabled={isToggling || isUpcoming}
-            aria-label={
-              isUpcoming
-                ? `Episode ${item.episodeNumber} upcoming`
-                : isWatched
-                  ? `Mark episode ${item.episodeNumber} as unwatched`
-                  : `Mark episode ${item.episodeNumber} as watched`
-            }
-            className={`mt-0.5 shrink-0 flex items-center justify-center h-5 w-5 rounded border transition-colors ${
-              isToggling || isUpcoming
-                ? 'opacity-50 cursor-not-allowed border-muted'
-                : isWatched
-                  ? 'bg-primary border-primary text-primary-foreground'
-                  : 'border-muted-foreground/40 hover:border-primary'
-            }`}
+            aria-label={(() => {
+              if (isUpcoming) return `Episode ${item.episodeNumber} upcoming`;
+              if (isWatched) return `Mark episode ${item.episodeNumber} as unwatched`;
+              return `Mark episode ${item.episodeNumber} as watched`;
+            })()}
+            className={`mt-0.5 shrink-0 flex items-center justify-center h-5 w-5 rounded border transition-colors ${(() => {
+              if (isToggling || isUpcoming) return 'opacity-50 cursor-not-allowed border-muted';
+              if (isWatched) return 'bg-primary border-primary text-primary-foreground';
+              return 'border-muted-foreground/40 hover:border-primary';
+            })()}`}
           >
             {isWatched && <Check className="h-3.5 w-3.5" />}
           </button>

--- a/packages/app-media/src/components/QuickPickDialog.tsx
+++ b/packages/app-media/src/components/QuickPickDialog.tsx
@@ -93,36 +93,48 @@ export function QuickPickDialog() {
         </DialogHeader>
 
         <div className="px-6 pb-6 pt-4">
-          {isLoading ? (
-            <div className="space-y-3">
-              <Skeleton className="aspect-[2/3] w-full rounded-lg" />
-              <Skeleton className="h-6 w-3/4" />
-              <Skeleton className="h-4 w-1/2" />
-            </div>
-          ) : movies.length === 0 ? (
-            <div className="text-center py-8">
-              <p className="text-muted-foreground">
-                No picks available — all movies are watched or on your watchlist.
-              </p>
-            </div>
-          ) : isFinished ? (
-            <div className="text-center py-8 space-y-4">
-              <Sparkles className="h-10 w-10 mx-auto text-app-accent" />
-              <p className="text-muted-foreground">You&apos;ve seen all the picks!</p>
-              <Button onClick={handleRefresh} variant="outline">
-                Get More Picks
-              </Button>
-            </div>
-          ) : currentMovie ? (
-            <PickCard
-              movie={currentMovie}
-              index={currentIndex}
-              total={movies.length}
-              onSkip={handleSkip}
-              onWatch={handleWatch}
-              isAdding={addToWatchlist.isPending}
-            />
-          ) : null}
+          {(() => {
+            if (isLoading) {
+              return (
+                <div className="space-y-3">
+                  <Skeleton className="aspect-[2/3] w-full rounded-lg" />
+                  <Skeleton className="h-6 w-3/4" />
+                  <Skeleton className="h-4 w-1/2" />
+                </div>
+              );
+            }
+            if (movies.length === 0) {
+              return (
+                <div className="text-center py-8">
+                  <p className="text-muted-foreground">
+                    No picks available — all movies are watched or on your watchlist.
+                  </p>
+                </div>
+              );
+            }
+            if (isFinished) {
+              return (
+                <div className="text-center py-8 space-y-4">
+                  <Sparkles className="h-10 w-10 mx-auto text-app-accent" />
+                  <p className="text-muted-foreground">You&apos;ve seen all the picks!</p>
+                  <Button onClick={handleRefresh} variant="outline">
+                    Get More Picks
+                  </Button>
+                </div>
+              );
+            }
+            if (!currentMovie) return null;
+            return (
+              <PickCard
+                movie={currentMovie}
+                index={currentIndex}
+                total={movies.length}
+                onSkip={handleSkip}
+                onWatch={handleWatch}
+                isAdding={addToWatchlist.isPending}
+              />
+            );
+          })()}
         </div>
       </DialogContent>
     </Dialog>

--- a/packages/app-media/src/components/RequestMovieModal.tsx
+++ b/packages/app-media/src/components/RequestMovieModal.tsx
@@ -119,56 +119,65 @@ export function RequestMovieModal({
     }
   };
 
-  const formContent = isDownloadMode ? (
-    <p className="text-sm text-muted-foreground">
-      This movie will be added to Radarr using your rotation settings and marked as protected.
-    </p>
-  ) : profileList.length === 0 || folderList.length === 0 ? (
-    <div className="text-center py-4 space-y-2">
-      <p className="text-sm text-destructive/80">
-        {profileList.length === 0 ? 'No quality profiles found' : 'No root folders found'}.
-      </p>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => {
-          void profiles.refetch();
-          void folders.refetch();
-        }}
-      >
-        Retry
-      </Button>
-    </div>
-  ) : (
-    <>
-      <Select
-        label="Quality Profile"
-        id="quality-profile"
-        value={String(qualityProfileId ?? '')}
-        onChange={(e) => {
-          setQualityProfileId(Number(e.target.value));
-        }}
-        disabled={isPending || success}
-        options={profileList.map((p) => ({
-          value: String(p.id),
-          label: p.name,
-        }))}
-      />
-      <Select
-        label="Root Folder"
-        id="root-folder"
-        value={rootFolderPath}
-        onChange={(e) => {
-          setRootFolderPath(e.target.value);
-        }}
-        disabled={isPending || success}
-        options={folderList.map((f) => ({
-          value: f.path,
-          label: `${f.path} (${formatBytes(f.freeSpace)} free)`,
-        }))}
-      />
-    </>
-  );
+  const renderFormContent = () => {
+    if (isDownloadMode) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          This movie will be added to Radarr using your rotation settings and marked as protected.
+        </p>
+      );
+    }
+    if (profileList.length === 0 || folderList.length === 0) {
+      return (
+        <div className="text-center py-4 space-y-2">
+          <p className="text-sm text-destructive/80">
+            {profileList.length === 0 ? 'No quality profiles found' : 'No root folders found'}.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              void profiles.refetch();
+              void folders.refetch();
+            }}
+          >
+            Retry
+          </Button>
+        </div>
+      );
+    }
+    return (
+      <>
+        <Select
+          label="Quality Profile"
+          id="quality-profile"
+          value={String(qualityProfileId ?? '')}
+          onChange={(e) => {
+            setQualityProfileId(Number(e.target.value));
+          }}
+          disabled={isPending || success}
+          options={profileList.map((p) => ({
+            value: String(p.id),
+            label: p.name,
+          }))}
+        />
+        <Select
+          label="Root Folder"
+          id="root-folder"
+          value={rootFolderPath}
+          onChange={(e) => {
+            setRootFolderPath(e.target.value);
+          }}
+          disabled={isPending || success}
+          options={folderList.map((f) => ({
+            value: f.path,
+            label: `${f.path} (${formatBytes(f.freeSpace)} free)`,
+          }))}
+        />
+      </>
+    );
+  };
+  const formContent = renderFormContent();
 
   return (
     <RequestDialog

--- a/packages/app-media/src/components/RequestSeriesModal.tsx
+++ b/packages/app-media/src/components/RequestSeriesModal.tsx
@@ -162,11 +162,11 @@ export function RequestSeriesModal({
     profileList.length === 0 || folderList.length === 0 || languageList.length === 0 ? (
       <div className="text-center py-4 space-y-2">
         <p className="text-sm text-destructive/80">
-          {profileList.length === 0
-            ? 'No quality profiles found'
-            : folderList.length === 0
-              ? 'No root folders found'
-              : 'No language profiles found'}
+          {(() => {
+            if (profileList.length === 0) return 'No quality profiles found';
+            if (folderList.length === 0) return 'No root folders found';
+            return 'No language profiles found';
+          })()}
           .
         </p>
         <Button

--- a/packages/app-media/src/components/SourceManagementSection.tsx
+++ b/packages/app-media/src/components/SourceManagementSection.tsx
@@ -295,32 +295,36 @@ function SourceForm({ mode, initialValues, sourceTypes, onClose }: SourceFormPro
       {type === 'plex_friends' && (
         <div className="space-y-1.5">
           <Label className="text-muted-foreground">Plex Friend</Label>
-          {plexFriendsQuery.isLoading ? (
-            <p className="text-xs text-muted-foreground">Loading friends...</p>
-          ) : plexFriendsQuery.data?.error ? (
-            <p className="text-xs text-destructive/80">{plexFriendsQuery.data.error}</p>
-          ) : (
-            <Select
-              value={(configValues.friendUuid as string) ?? ''}
-              onChange={(e) => {
-                const friend = plexFriendsQuery.data?.friends.find(
-                  (f) => f.uuid === e.target.value
-                );
-                setConfigValues({
-                  friendUuid: e.target.value,
-                  friendUsername: friend?.username ?? '',
-                });
-              }}
-              options={[
-                { value: '', label: 'Select a friend...' },
-                ...(plexFriendsQuery.data?.friends.map((f) => ({
-                  value: f.uuid,
-                  label: f.username,
-                })) ?? []),
-              ]}
-              size="sm"
-            />
-          )}
+          {(() => {
+            if (plexFriendsQuery.isLoading) {
+              return <p className="text-xs text-muted-foreground">Loading friends...</p>;
+            }
+            if (plexFriendsQuery.data?.error) {
+              return <p className="text-xs text-destructive/80">{plexFriendsQuery.data.error}</p>;
+            }
+            return (
+              <Select
+                value={(configValues.friendUuid as string) ?? ''}
+                onChange={(e) => {
+                  const friend = plexFriendsQuery.data?.friends.find(
+                    (f) => f.uuid === e.target.value
+                  );
+                  setConfigValues({
+                    friendUuid: e.target.value,
+                    friendUsername: friend?.username ?? '',
+                  });
+                }}
+                options={[
+                  { value: '', label: 'Select a friend...' },
+                  ...(plexFriendsQuery.data?.friends.map((f) => ({
+                    value: f.uuid,
+                    label: f.username,
+                  })) ?? []),
+                ]}
+                size="sm"
+              />
+            );
+          })()}
         </div>
       )}
 
@@ -433,12 +437,14 @@ export function SourceManagementSection() {
         ) : undefined
       }
     >
-      {sourcesQuery.isLoading ? (
-        <p className="text-sm text-muted-foreground">Loading sources...</p>
-      ) : !sourcesQuery.data?.length ? (
-        <p className="text-sm text-muted-foreground">No sources configured</p>
-      ) : (
-        sourcesQuery.data.map((source) => (
+      {(() => {
+        if (sourcesQuery.isLoading) {
+          return <p className="text-sm text-muted-foreground">Loading sources...</p>;
+        }
+        if (!sourcesQuery.data?.length) {
+          return <p className="text-sm text-muted-foreground">No sources configured</p>;
+        }
+        return sourcesQuery.data.map((source) => (
           <SourceCard
             key={source.id}
             source={source}
@@ -446,8 +452,8 @@ export function SourceManagementSection() {
               handleEdit(source);
             }}
           />
-        ))
-      )}
+        ));
+      })()}
     </CRUDManagementSection>
   );
 }

--- a/packages/app-media/src/components/TierListSummary.tsx
+++ b/packages/app-media/src/components/TierListSummary.tsx
@@ -57,22 +57,18 @@ export function TierListSummary({
                 <span className="text-muted-foreground">→</span>
                 <span className="text-sm font-medium">{Math.round(change.newScore)}</span>
                 <span
-                  className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                    isPositive
-                      ? 'bg-success/20 text-success'
-                      : isNegative
-                        ? 'bg-destructive/20 text-destructive'
-                        : 'bg-muted text-muted-foreground'
-                  }`}
+                  className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs font-medium ${(() => {
+                    if (isPositive) return 'bg-success/20 text-success';
+                    if (isNegative) return 'bg-destructive/20 text-destructive';
+                    return 'bg-muted text-muted-foreground';
+                  })()}`}
                   data-testid={`delta-${change.movieId}`}
                 >
-                  {isPositive ? (
-                    <ArrowUpRight className="h-3 w-3" />
-                  ) : isNegative ? (
-                    <ArrowDownRight className="h-3 w-3" />
-                  ) : (
-                    <Minus className="h-3 w-3" />
-                  )}
+                  {(() => {
+                    if (isPositive) return <ArrowUpRight className="h-3 w-3" />;
+                    if (isNegative) return <ArrowDownRight className="h-3 w-3" />;
+                    return <Minus className="h-3 w-3" />;
+                  })()}
                   {isPositive ? '+' : ''}
                   {delta}
                 </span>

--- a/packages/app-media/src/hooks/useSyncJob.ts
+++ b/packages/app-media/src/hooks/useSyncJob.ts
@@ -160,7 +160,11 @@ export function useSyncJob(jobType: SyncJobType): UseSyncJobReturn {
     error: job?.status === 'failed' ? job.error : null,
     durationMs: job?.durationMs ?? null,
     completedAt: job?.completedAt ?? null,
-    status: isRestoring ? 'running' : !job ? 'idle' : job.status,
+    status: (() => {
+      if (isRestoring) return 'running';
+      if (!job) return 'idle';
+      return job.status;
+    })(),
   };
 }
 

--- a/packages/app-media/src/pages/CandidateQueuePage.tsx
+++ b/packages/app-media/src/pages/CandidateQueuePage.tsx
@@ -229,53 +229,61 @@ function CandidateList({ status, actions }: CandidateListProps) {
         </div>
       </div>
 
-      {query.isLoading ? (
-        <div className="space-y-2">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton key={i} className="h-22 w-full rounded-md" />
-          ))}
-        </div>
-      ) : !query.data?.items.length ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">No candidates found</p>
-      ) : (
-        <>
-          <div className="space-y-2">
-            {query.data.items.map((c) => (
-              <CandidateCard key={c.id} candidate={c} actions={actions} />
-            ))}
-          </div>
-
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between pt-2">
-              <span className="text-xs text-muted-foreground">
-                {query.data.total} total &middot; page {page + 1} of {totalPages}
-              </span>
-              <div className="flex items-center gap-1">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    setPage((p) => Math.max(0, p - 1));
-                  }}
-                  disabled={page === 0}
-                >
-                  <ChevronLeft className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    setPage((p) => Math.min(totalPages - 1, p + 1));
-                  }}
-                  disabled={page >= totalPages - 1}
-                >
-                  <ChevronRight className="h-3.5 w-3.5" />
-                </Button>
-              </div>
+      {(() => {
+        if (query.isLoading) {
+          return (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-22 w-full rounded-md" />
+              ))}
             </div>
-          )}
-        </>
-      )}
+          );
+        }
+        if (!query.data?.items.length) {
+          return (
+            <p className="text-sm text-muted-foreground py-8 text-center">No candidates found</p>
+          );
+        }
+        return (
+          <>
+            <div className="space-y-2">
+              {query.data.items.map((c) => (
+                <CandidateCard key={c.id} candidate={c} actions={actions} />
+              ))}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between pt-2">
+                <span className="text-xs text-muted-foreground">
+                  {query.data.total} total &middot; page {page + 1} of {totalPages}
+                </span>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setPage((p) => Math.max(0, p - 1));
+                    }}
+                    disabled={page === 0}
+                  >
+                    <ChevronLeft className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setPage((p) => Math.min(totalPages - 1, p + 1));
+                    }}
+                    disabled={page >= totalPages - 1}
+                  >
+                    <ChevronRight className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
+        );
+      })()}
     </div>
   );
 }

--- a/packages/app-media/src/pages/ComparisonHistoryPage.tsx
+++ b/packages/app-media/src/pages/ComparisonHistoryPage.tsx
@@ -148,49 +148,57 @@ export function ComparisonHistoryPage() {
         )}
       </div>
 
-      {isLoading ? (
-        <div className="space-y-3">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton key={i} className="h-16 w-full rounded-lg" />
-          ))}
-        </div>
-      ) : comparisons.length === 0 ? (
-        <Card>
-          <CardContent className="p-8 text-center text-muted-foreground">
-            No comparisons yet. Head to the{' '}
-            <Link to="/media/compare" className="text-primary underline">
-              Compare Arena
-            </Link>{' '}
-            to start comparing movies.
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="space-y-2">
-          {comparisons.map(
-            (comp: {
-              id: number;
-              dimensionId: number;
-              mediaAType: string;
-              mediaAId: number;
-              mediaBType: string;
-              mediaBId: number;
-              winnerType: string;
-              winnerId: number;
-              deltaA: number | null;
-              deltaB: number | null;
-              drawTier: string | null;
-              comparedAt: string;
-            }) => (
-              <ComparisonRow
-                key={comp.id}
-                comparison={comp}
-                dimensionName={dimensionMap.get(comp.dimensionId) ?? 'Unknown'}
-                onDelete={handleDelete}
-              />
-            )
-          )}
-        </div>
-      )}
+      {(() => {
+        if (isLoading) {
+          return (
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-16 w-full rounded-lg" />
+              ))}
+            </div>
+          );
+        }
+        if (comparisons.length === 0) {
+          return (
+            <Card>
+              <CardContent className="p-8 text-center text-muted-foreground">
+                No comparisons yet. Head to the{' '}
+                <Link to="/media/compare" className="text-primary underline">
+                  Compare Arena
+                </Link>{' '}
+                to start comparing movies.
+              </CardContent>
+            </Card>
+          );
+        }
+        return (
+          <div className="space-y-2">
+            {comparisons.map(
+              (comp: {
+                id: number;
+                dimensionId: number;
+                mediaAType: string;
+                mediaAId: number;
+                mediaBType: string;
+                mediaBId: number;
+                winnerType: string;
+                winnerId: number;
+                deltaA: number | null;
+                deltaB: number | null;
+                drawTier: string | null;
+                comparedAt: string;
+              }) => (
+                <ComparisonRow
+                  key={comp.id}
+                  comparison={comp}
+                  dimensionName={dimensionMap.get(comp.dimensionId) ?? 'Unknown'}
+                  onDelete={handleDelete}
+                />
+              )
+            )}
+          </div>
+        );
+      })()}
 
       {totalPages > 1 && (
         <div className="flex items-center justify-center gap-2">
@@ -228,13 +236,11 @@ function EloDelta({ delta }: { delta: number | null }) {
   const isPositive = delta > 0;
   return (
     <span
-      className={`text-2xs font-mono tabular-nums px-1 py-0.5 rounded ${
-        isPositive
-          ? 'text-success bg-success/10'
-          : delta < 0
-            ? 'text-destructive bg-destructive/10'
-            : 'text-muted-foreground'
-      }`}
+      className={`text-2xs font-mono tabular-nums px-1 py-0.5 rounded ${(() => {
+        if (isPositive) return 'text-success bg-success/10';
+        if (delta < 0) return 'text-destructive bg-destructive/10';
+        return 'text-muted-foreground';
+      })()}`}
     >
       {isPositive ? '+' : ''}
       {delta}

--- a/packages/app-media/src/pages/HistoryPage.tsx
+++ b/packages/app-media/src/pages/HistoryPage.tsx
@@ -408,88 +408,99 @@ export function HistoryPage() {
         ))}
       </div>
 
-      {error ? (
-        <Alert variant="destructive">
-          <AlertTitle>Error</AlertTitle>
-          <AlertDescription>{error.message}</AlertDescription>
-        </Alert>
-      ) : isLoading ? (
-        <HistorySkeleton />
-      ) : entries.length === 0 ? (
-        <div className="text-center py-16">
-          <p className="text-muted-foreground">
-            {filter === 'all'
-              ? 'No watch history yet. Start watching something!'
-              : `No ${filter === 'movie' ? 'movies' : 'episodes'} in your history.`}
-          </p>
-          <Link to="/media" className="mt-4 inline-block text-sm text-primary underline">
-            Browse library
-          </Link>
-        </div>
-      ) : (
-        <>
-          {/* Mobile: compact list */}
-          <div className="space-y-2 md:hidden">
-            {entries.map((entry: HistoryEntry) => (
-              <HistoryItem
-                key={entry.id}
-                entry={entry}
-                onDelete={handleDeleteClick}
-                isDeleting={deleteMutation.isPending}
-                debriefSessionId={
-                  entry.mediaType === 'movie' ? (debriefByMovieId.get(entry.mediaId) ?? null) : null
-                }
-              />
-            ))}
-          </div>
-
-          {/* Desktop: poster card grid */}
-          <div className="hidden md:grid grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-            {entries.map((entry: HistoryEntry) => (
-              <HistoryCard
-                key={entry.id}
-                entry={entry}
-                onDelete={handleDeleteClick}
-                isDeleting={deleteMutation.isPending}
-                debriefSessionId={
-                  entry.mediaType === 'movie' ? (debriefByMovieId.get(entry.mediaId) ?? null) : null
-                }
-              />
-            ))}
-          </div>
-
-          {/* Pagination */}
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">
-              Showing {Math.min(offset + PAGE_SIZE, total)} of {total}
-            </p>
-            <div className="flex gap-2">
-              {offset > 0 && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    setOffset(Math.max(0, offset - PAGE_SIZE));
-                  }}
-                >
-                  Previous
-                </Button>
-              )}
-              {hasMore && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    setOffset(offset + PAGE_SIZE);
-                  }}
-                >
-                  Next
-                </Button>
-              )}
+      {(() => {
+        if (error) {
+          return (
+            <Alert variant="destructive">
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>{error.message}</AlertDescription>
+            </Alert>
+          );
+        }
+        if (isLoading) return <HistorySkeleton />;
+        if (entries.length === 0) {
+          return (
+            <div className="text-center py-16">
+              <p className="text-muted-foreground">
+                {filter === 'all'
+                  ? 'No watch history yet. Start watching something!'
+                  : `No ${filter === 'movie' ? 'movies' : 'episodes'} in your history.`}
+              </p>
+              <Link to="/media" className="mt-4 inline-block text-sm text-primary underline">
+                Browse library
+              </Link>
             </div>
-          </div>
-        </>
-      )}
+          );
+        }
+        return (
+          <>
+            {/* Mobile: compact list */}
+            <div className="space-y-2 md:hidden">
+              {entries.map((entry: HistoryEntry) => (
+                <HistoryItem
+                  key={entry.id}
+                  entry={entry}
+                  onDelete={handleDeleteClick}
+                  isDeleting={deleteMutation.isPending}
+                  debriefSessionId={
+                    entry.mediaType === 'movie'
+                      ? (debriefByMovieId.get(entry.mediaId) ?? null)
+                      : null
+                  }
+                />
+              ))}
+            </div>
+
+            {/* Desktop: poster card grid */}
+            <div className="hidden md:grid grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+              {entries.map((entry: HistoryEntry) => (
+                <HistoryCard
+                  key={entry.id}
+                  entry={entry}
+                  onDelete={handleDeleteClick}
+                  isDeleting={deleteMutation.isPending}
+                  debriefSessionId={
+                    entry.mediaType === 'movie'
+                      ? (debriefByMovieId.get(entry.mediaId) ?? null)
+                      : null
+                  }
+                />
+              ))}
+            </div>
+
+            {/* Pagination */}
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Showing {Math.min(offset + PAGE_SIZE, total)} of {total}
+              </p>
+              <div className="flex gap-2">
+                {offset > 0 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setOffset(Math.max(0, offset - PAGE_SIZE));
+                    }}
+                  >
+                    Previous
+                  </Button>
+                )}
+                {hasMore && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setOffset(offset + PAGE_SIZE);
+                    }}
+                  >
+                    Next
+                  </Button>
+                )}
+              </div>
+            </div>
+          </>
+        );
+      })()}
 
       {/* Delete confirmation dialog */}
       <AlertDialog

--- a/packages/app-media/src/pages/HistoryPage.tsx
+++ b/packages/app-media/src/pages/HistoryPage.tsx
@@ -56,6 +56,12 @@ function formatShortDate(iso: string): string {
   });
 }
 
+function getEmptyHistoryMessage(filter: MediaTypeFilter): string {
+  if (filter === 'all') return 'No watch history yet. Start watching something!';
+  if (filter === 'movie') return 'No movies in your history.';
+  return 'No episodes in your history.';
+}
+
 function HistorySkeleton() {
   return (
     <>
@@ -421,11 +427,7 @@ export function HistoryPage() {
         if (entries.length === 0) {
           return (
             <div className="text-center py-16">
-              <p className="text-muted-foreground">
-                {filter === 'all'
-                  ? 'No watch history yet. Start watching something!'
-                  : `No ${filter === 'movie' ? 'movies' : 'episodes'} in your history.`}
-              </p>
+              <p className="text-muted-foreground">{getEmptyHistoryMessage(filter)}</p>
               <Link to="/media" className="mt-4 inline-block text-sm text-primary underline">
                 Browse library
               </Link>

--- a/packages/app-media/src/pages/LibraryPage.tsx
+++ b/packages/app-media/src/pages/LibraryPage.tsx
@@ -346,85 +346,95 @@ export function LibraryPage() {
       </div>
 
       {/* Content */}
-      {isLoading ? (
-        <LibrarySkeleton count={pageSize} />
-      ) : error ? (
-        <div className="text-center py-16">
-          <AlertCircle className="mx-auto h-10 w-10 text-muted-foreground mb-3" />
-          <p className="text-muted-foreground">Something went wrong loading your library.</p>
-          <Button variant="outline" size="sm" className="mt-4" onClick={() => void refetch()}>
-            Retry
-          </Button>
-        </div>
-      ) : isLibraryEmpty ? (
-        <div className="text-center py-16">
-          <p className="text-muted-foreground">
-            Your library is empty. Search for movies and shows to get started.
-          </p>
-          <Link to="/media/search" className="mt-4 inline-block text-sm text-primary underline">
-            Search for media
-          </Link>
-        </div>
-      ) : items.length === 0 ? (
-        <div className="text-center py-16">
-          {debouncedSearch ? (
-            <>
-              <p className="text-muted-foreground">
-                No results for &ldquo;{debouncedSearch}&rdquo;
-              </p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="mt-4"
-                onClick={() => {
-                  setLocalSearch('');
-                }}
-              >
-                Clear search
+      {(() => {
+        if (isLoading) return <LibrarySkeleton count={pageSize} />;
+        if (error) {
+          return (
+            <div className="text-center py-16">
+              <AlertCircle className="mx-auto h-10 w-10 text-muted-foreground mb-3" />
+              <p className="text-muted-foreground">Something went wrong loading your library.</p>
+              <Button variant="outline" size="sm" className="mt-4" onClick={() => void refetch()}>
+                Retry
               </Button>
-            </>
-          ) : (
-            <p className="text-muted-foreground">No results match your filters.</p>
-          )}
-        </div>
-      ) : (
-        <>
-          <MediaGrid>
-            {items.map((item) => (
-              <MediaCard
-                key={`${item.type}-${item.id}`}
-                id={item.id}
-                type={item.type}
-                title={item.title}
-                year={item.year}
-                posterUrl={item.cdnPosterUrl ?? item.posterUrl}
-                fallbackPosterUrl={item.cdnPosterUrl ? item.posterUrl : undefined}
-                showTypeBadge={showTypeBadge}
-              />
-            ))}
-          </MediaGrid>
-          <PaginationControls
-            page={clampedPage}
-            totalPages={totalPages}
-            pageSize={pageSize}
-            totalItems={totalItems}
-            onPageChange={(p) => {
-              setParam('page', String(p));
-            }}
-            onPageSizeChange={(s) => {
-              setSearchParams(
-                (prev) => {
-                  const next = new URLSearchParams(prev);
-                  next.set('pageSize', String(s));
-                  next.set('page', '1');
-                  return next;
-                },
-                { replace: true }
-              );
-            }}
-          />
-        </>
-      )}
+            </div>
+          );
+        }
+        if (isLibraryEmpty) {
+          return (
+            <div className="text-center py-16">
+              <p className="text-muted-foreground">
+                Your library is empty. Search for movies and shows to get started.
+              </p>
+              <Link to="/media/search" className="mt-4 inline-block text-sm text-primary underline">
+                Search for media
+              </Link>
+            </div>
+          );
+        }
+        if (items.length === 0) {
+          return (
+            <div className="text-center py-16">
+              {debouncedSearch ? (
+                <>
+                  <p className="text-muted-foreground">
+                    No results for &ldquo;{debouncedSearch}&rdquo;
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="mt-4"
+                    onClick={() => {
+                      setLocalSearch('');
+                    }}
+                  >
+                    Clear search
+                  </Button>
+                </>
+              ) : (
+                <p className="text-muted-foreground">No results match your filters.</p>
+              )}
+            </div>
+          );
+        }
+        return (
+          <>
+            <MediaGrid>
+              {items.map((item) => (
+                <MediaCard
+                  key={`${item.type}-${item.id}`}
+                  id={item.id}
+                  type={item.type}
+                  title={item.title}
+                  year={item.year}
+                  posterUrl={item.cdnPosterUrl ?? item.posterUrl}
+                  fallbackPosterUrl={item.cdnPosterUrl ? item.posterUrl : undefined}
+                  showTypeBadge={showTypeBadge}
+                />
+              ))}
+            </MediaGrid>
+            <PaginationControls
+              page={clampedPage}
+              totalPages={totalPages}
+              pageSize={pageSize}
+              totalItems={totalItems}
+              onPageChange={(p) => {
+                setParam('page', String(p));
+              }}
+              onPageSizeChange={(s) => {
+                setSearchParams(
+                  (prev) => {
+                    const next = new URLSearchParams(prev);
+                    next.set('pageSize', String(s));
+                    next.set('page', '1');
+                    return next;
+                  },
+                  { replace: true }
+                );
+              }}
+            />
+          </>
+        );
+      })()}
 
       {/* Quick Pick FAB */}
       <Link

--- a/packages/app-media/src/pages/RankingsPage.tsx
+++ b/packages/app-media/src/pages/RankingsPage.tsx
@@ -69,9 +69,11 @@ function RankingRow({
       <span className="w-8 text-right text-sm font-bold text-muted-foreground tabular-nums">
         {rank <= 3 ? (
           <span
-            className={
-              rank === 1 ? 'text-warning' : rank === 2 ? 'text-zinc-400' : 'text-amber-700'
-            }
+            className={(() => {
+              if (rank === 1) return 'text-warning';
+              if (rank === 2) return 'text-zinc-400';
+              return 'text-amber-700';
+            })()}
           >
             #{rank}
           </span>
@@ -114,11 +116,11 @@ function RankingRow({
           <div
             className={cn(
               'text-xs tabular-nums',
-              confidence >= 0.7
-                ? 'text-success'
-                : confidence >= 0.4
-                  ? 'text-warning'
-                  : 'text-destructive'
+              (() => {
+                if (confidence >= 0.7) return 'text-success';
+                if (confidence >= 0.4) return 'text-warning';
+                return 'text-destructive';
+              })()
             )}
           >
             {Math.round(confidence * 100)}% conf
@@ -267,50 +269,50 @@ export function RankingsPage() {
         <h1 className="text-2xl font-bold">Rankings</h1>
       </div>
 
-      {dimsLoading ? (
-        <RankingsSkeleton />
-      ) : showTabs ? (
-        <Tabs value={dimensionParam} onValueChange={handleTabChange}>
-          <div className="flex flex-wrap justify-center gap-2" role="tablist">
-            {[
-              { value: 'overall', label: 'Overall' },
-              ...activeDimensions.map((dim: { id: number; name: string }) => ({
-                value: String(dim.id),
-                label: dim.name,
-              })),
-            ].map((chip) => (
-              <button
-                key={chip.value}
-                role="tab"
-                aria-selected={dimensionParam === chip.value}
-                onClick={() => {
-                  handleTabChange(chip.value);
-                }}
-                className={cn(
-                  'rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
-                  dimensionParam === chip.value
-                    ? 'bg-primary text-primary-foreground border-primary'
-                    : 'bg-muted/50 text-muted-foreground border-border hover:bg-muted hover:text-foreground'
-                )}
-              >
-                {chip.label}
-              </button>
-            ))}
-          </div>
+      {(() => {
+        if (dimsLoading) return <RankingsSkeleton />;
+        if (!showTabs) return <RankingsList />;
+        return (
+          <Tabs value={dimensionParam} onValueChange={handleTabChange}>
+            <div className="flex flex-wrap justify-center gap-2" role="tablist">
+              {[
+                { value: 'overall', label: 'Overall' },
+                ...activeDimensions.map((dim: { id: number; name: string }) => ({
+                  value: String(dim.id),
+                  label: dim.name,
+                })),
+              ].map((chip) => (
+                <button
+                  key={chip.value}
+                  role="tab"
+                  aria-selected={dimensionParam === chip.value}
+                  onClick={() => {
+                    handleTabChange(chip.value);
+                  }}
+                  className={cn(
+                    'rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
+                    dimensionParam === chip.value
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-muted/50 text-muted-foreground border-border hover:bg-muted hover:text-foreground'
+                  )}
+                >
+                  {chip.label}
+                </button>
+              ))}
+            </div>
 
-          <TabsContent value="overall" className="mt-4">
-            <RankingsList />
-          </TabsContent>
-
-          {activeDimensions.map((dim: { id: number; name: string }) => (
-            <TabsContent key={dim.id} value={String(dim.id)} className="mt-4">
-              <RankingsList dimensionId={dim.id} />
+            <TabsContent value="overall" className="mt-4">
+              <RankingsList />
             </TabsContent>
-          ))}
-        </Tabs>
-      ) : (
-        <RankingsList />
-      )}
+
+            {activeDimensions.map((dim: { id: number; name: string }) => (
+              <TabsContent key={dim.id} value={String(dim.id)} className="mt-4">
+                <RankingsList dimensionId={dim.id} />
+              </TabsContent>
+            ))}
+          </Tabs>
+        );
+      })()}
     </div>
   );
 }

--- a/packages/app-media/src/pages/RotationLogPage.tsx
+++ b/packages/app-media/src/pages/RotationLogPage.tsx
@@ -76,64 +76,78 @@ export function RotationLogPage() {
       />
 
       {/* Summary stats */}
-      {statsLoading ? (
-        <div className="grid gap-4 sm:grid-cols-3">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <Skeleton key={i} className="h-20 w-full rounded-lg" />
-          ))}
-        </div>
-      ) : stats ? (
-        <div className="grid gap-4 sm:grid-cols-3">
-          <div className="rounded-lg border bg-card p-4">
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <RotateCw className="h-4 w-4" />
-              Total Rotated
+      {(() => {
+        if (statsLoading) {
+          return (
+            <div className="grid gap-4 sm:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-20 w-full rounded-lg" />
+              ))}
             </div>
-            <p className="mt-1 text-2xl font-bold tabular-nums">{stats.totalRotated}</p>
-          </div>
-          <div className="rounded-lg border bg-card p-4">
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <TrendingUp className="h-4 w-4" />
-              Avg / Day
+          );
+        }
+        if (!stats) return null;
+        return (
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-lg border bg-card p-4">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <RotateCw className="h-4 w-4" />
+                Total Rotated
+              </div>
+              <p className="mt-1 text-2xl font-bold tabular-nums">{stats.totalRotated}</p>
             </div>
-            <p className="mt-1 text-2xl font-bold tabular-nums">{stats.avgPerDay}</p>
-          </div>
-          <div className="rounded-lg border bg-card p-4">
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <ScrollText className="h-4 w-4" />
-              Streak
+            <div className="rounded-lg border bg-card p-4">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <TrendingUp className="h-4 w-4" />
+                Avg / Day
+              </div>
+              <p className="mt-1 text-2xl font-bold tabular-nums">{stats.avgPerDay}</p>
             </div>
-            <p className="mt-1 text-2xl font-bold tabular-nums">
-              {stats.streak} cycle{stats.streak !== 1 ? 's' : ''}
-            </p>
+            <div className="rounded-lg border bg-card p-4">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <ScrollText className="h-4 w-4" />
+                Streak
+              </div>
+              <p className="mt-1 text-2xl font-bold tabular-nums">
+                {stats.streak} cycle{stats.streak !== 1 ? 's' : ''}
+              </p>
+            </div>
           </div>
-        </div>
-      ) : null}
+        );
+      })()}
 
       {/* Log entries */}
-      {isLoading ? (
-        <div className="space-y-3">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton key={i} className="h-20 w-full rounded-lg" />
-          ))}
-        </div>
-      ) : items.length === 0 ? (
-        <Card>
-          <CardContent className="p-8 text-center text-muted-foreground">
-            No rotation cycles have run yet. Enable rotation in{' '}
-            <Link to="/media/rotation" className="text-primary underline">
-              Settings
-            </Link>{' '}
-            to get started.
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="space-y-2">
-          {items.map((entry) => (
-            <LogEntry key={entry.id} entry={entry} />
-          ))}
-        </div>
-      )}
+      {(() => {
+        if (isLoading) {
+          return (
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-20 w-full rounded-lg" />
+              ))}
+            </div>
+          );
+        }
+        if (items.length === 0) {
+          return (
+            <Card>
+              <CardContent className="p-8 text-center text-muted-foreground">
+                No rotation cycles have run yet. Enable rotation in{' '}
+                <Link to="/media/rotation" className="text-primary underline">
+                  Settings
+                </Link>{' '}
+                to get started.
+              </CardContent>
+            </Card>
+          );
+        }
+        return (
+          <div className="space-y-2">
+            {items.map((entry) => (
+              <LogEntry key={entry.id} entry={entry} />
+            ))}
+          </div>
+        );
+      })()}
 
       {/* Pagination */}
       {totalPages > 1 && (
@@ -188,7 +202,9 @@ function LogEntry({
   const hasError = entry.removalsFailed > 0;
   const wasSkipped = !!entry.skippedReason;
 
-  const borderClass = hasError ? 'border-destructive/50' : wasSkipped ? 'border-amber-500/50' : '';
+  let borderClass = '';
+  if (hasError) borderClass = 'border-destructive/50';
+  else if (wasSkipped) borderClass = 'border-amber-500/50';
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>

--- a/packages/app-media/src/pages/TierListPage.tsx
+++ b/packages/app-media/src/pages/TierListPage.tsx
@@ -215,99 +215,112 @@ export function TierListPage() {
         <h1 className="text-2xl font-bold">Tier List</h1>
       </div>
 
-      {dimsLoading ? (
-        <PoolSkeleton />
-      ) : activeDimensions.length === 0 ? (
-        <div className="text-center py-16">
-          <p className="text-muted-foreground">No active dimensions. Create one to get started.</p>
-        </div>
-      ) : (
-        <>
-          <div
-            className="flex flex-wrap justify-center gap-2"
-            role="tablist"
-            aria-label="Dimension selector"
-          >
-            {activeDimensions.map((dim: { id: number; name: string }) => (
-              <button
-                key={dim.id}
-                role="tab"
-                aria-selected={effectiveDimension === dim.id}
-                onClick={() => {
-                  handleDimensionChange(dim.id);
-                }}
-                className={cn(
-                  'rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
-                  effectiveDimension === dim.id
-                    ? 'bg-primary text-primary-foreground border-primary'
-                    : 'bg-muted/50 text-muted-foreground border-border hover:bg-muted hover:text-foreground'
-                )}
-              >
-                {dim.name}
-              </button>
-            ))}
-          </div>
+      {(() => {
+        if (dimsLoading) return <PoolSkeleton />;
+        if (activeDimensions.length === 0) {
+          return (
+            <div className="text-center py-16">
+              <p className="text-muted-foreground">
+                No active dimensions. Create one to get started.
+              </p>
+            </div>
+          );
+        }
+        return (
+          <>
+            <div
+              className="flex flex-wrap justify-center gap-2"
+              role="tablist"
+              aria-label="Dimension selector"
+            >
+              {activeDimensions.map((dim: { id: number; name: string }) => (
+                <button
+                  key={dim.id}
+                  role="tab"
+                  aria-selected={effectiveDimension === dim.id}
+                  onClick={() => {
+                    handleDimensionChange(dim.id);
+                  }}
+                  className={cn(
+                    'rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
+                    effectiveDimension === dim.id
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-muted/50 text-muted-foreground border-border hover:bg-muted hover:text-foreground'
+                  )}
+                >
+                  {dim.name}
+                </button>
+              ))}
+            </div>
 
-          {submitError && (
-            <Alert variant="destructive">
-              <AlertTitle>Submission Failed</AlertTitle>
-              <AlertDescription>{submitError.message}</AlertDescription>
-            </Alert>
-          )}
+            {submitError && (
+              <Alert variant="destructive">
+                <AlertTitle>Submission Failed</AlertTitle>
+                <AlertDescription>{submitError.message}</AlertDescription>
+              </Alert>
+            )}
 
-          {result ? (
-            <TierListSummary
-              comparisonsRecorded={result.comparisonsRecorded}
-              scoreChanges={result.scoreChanges}
-              onDoAnother={handleDoAnother}
-              onDone={handleDone}
-            />
-          ) : (
-            effectiveDimension && (
-              <div className="space-y-3">
-                <div className="flex justify-end">
-                  <button
-                    type="button"
-                    onClick={() => refetch()}
-                    disabled={isFetching}
-                    className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline disabled:text-muted-foreground disabled:no-underline"
-                    aria-label="Refresh movie pool"
-                  >
-                    <RefreshCw className={cn('h-3.5 w-3.5', isFetching && 'animate-spin')} />
-                    Refresh
-                  </button>
-                </div>
-
-                {moviesError ? (
-                  <Alert variant="destructive">
-                    <AlertTitle>Error</AlertTitle>
-                    <AlertDescription>Failed to load movies for tier list.</AlertDescription>
-                  </Alert>
-                ) : moviesLoading ? (
-                  <PoolSkeleton />
-                ) : movies.length === 0 ? (
-                  <div className="text-center py-16">
-                    <LayoutGrid className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
-                    <p className="text-muted-foreground">
-                      No eligible movies for this dimension. Compare more movies or check your
-                      exclusions.
-                    </p>
+            {result ? (
+              <TierListSummary
+                comparisonsRecorded={result.comparisonsRecorded}
+                scoreChanges={result.scoreChanges}
+                onDoAnother={handleDoAnother}
+                onDone={handleDone}
+              />
+            ) : (
+              effectiveDimension && (
+                <div className="space-y-3">
+                  <div className="flex justify-end">
+                    <button
+                      type="button"
+                      onClick={() => refetch()}
+                      disabled={isFetching}
+                      className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline disabled:text-muted-foreground disabled:no-underline"
+                      aria-label="Refresh movie pool"
+                    >
+                      <RefreshCw className={cn('h-3.5 w-3.5', isFetching && 'animate-spin')} />
+                      Refresh
+                    </button>
                   </div>
-                ) : (
-                  <TierListBoard
-                    movies={movies}
-                    onSubmit={handleSubmit}
-                    submitPending={isPending}
-                    onNotWatched={handleNotWatched}
-                    onMarkStale={handleMarkStale}
-                    onNA={handleNA}
-                  />
-                )}
-              </div>
-            )
-          )}
-        </>
-      )}
+
+                  {(() => {
+                    if (moviesError) {
+                      return (
+                        <Alert variant="destructive">
+                          <AlertTitle>Error</AlertTitle>
+                          <AlertDescription>Failed to load movies for tier list.</AlertDescription>
+                        </Alert>
+                      );
+                    }
+                    if (moviesLoading) return <PoolSkeleton />;
+                    if (movies.length === 0) {
+                      return (
+                        <div className="text-center py-16">
+                          <LayoutGrid className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
+                          <p className="text-muted-foreground">
+                            No eligible movies for this dimension. Compare more movies or check your
+                            exclusions.
+                          </p>
+                        </div>
+                      );
+                    }
+                    return (
+                      <TierListBoard
+                        movies={movies}
+                        onSubmit={handleSubmit}
+                        submitPending={isPending}
+                        onNotWatched={handleNotWatched}
+                        onMarkStale={handleMarkStale}
+                        onNA={handleNA}
+                      />
+                    );
+                  })()}
+                </div>
+              )
+            )}
+          </>
+        );
+      })()}
 
       {/* Blacklist confirmation dialog */}
       <AlertDialog

--- a/packages/app-media/src/pages/WatchlistPage.tsx
+++ b/packages/app-media/src/pages/WatchlistPage.tsx
@@ -58,41 +58,41 @@ export function WatchlistPage() {
 
       <WatchlistFilterTabs filter={filter} onFilterChange={setFilter} />
 
-      {loading ? (
-        <WatchlistSkeleton />
-      ) : entries.length === 0 ? (
-        <WatchlistEmptyState filter={filter} />
-      ) : (
-        <>
-          <WatchlistMobileList
-            sortedEntries={sortedEntries}
-            hasManyItems={hasManyItems}
-            isReordering={isReordering}
-            removingId={removingId}
-            updateErrorId={updateErrorId}
-            updateErrorMsg={updateErrorMsg}
-            getMetaForEntry={getMetaForEntry}
-            onMove={handleMove}
-            onRemove={onRemove}
-            onUpdateNotes={onUpdateNotes}
-            isUpdatingEntry={isUpdatingEntry}
-          />
+      {(() => {
+        if (loading) return <WatchlistSkeleton />;
+        if (entries.length === 0) return <WatchlistEmptyState filter={filter} />;
+        return (
+          <>
+            <WatchlistMobileList
+              sortedEntries={sortedEntries}
+              hasManyItems={hasManyItems}
+              isReordering={isReordering}
+              removingId={removingId}
+              updateErrorId={updateErrorId}
+              updateErrorMsg={updateErrorMsg}
+              getMetaForEntry={getMetaForEntry}
+              onMove={handleMove}
+              onRemove={onRemove}
+              onUpdateNotes={onUpdateNotes}
+              isUpdatingEntry={isUpdatingEntry}
+            />
 
-          <WatchlistDesktopDnd
-            sensors={sensors}
-            collisionDetection={collisionDetection}
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-            onDragCancel={handleDragCancel}
-            sortedEntries={sortedEntries}
-            hasManyItems={hasManyItems}
-            removingId={removingId}
-            activeId={activeId}
-            getMetaForEntry={getMetaForEntry}
-            onRemove={onRemove}
-          />
-        </>
-      )}
+            <WatchlistDesktopDnd
+              sensors={sensors}
+              collisionDetection={collisionDetection}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+              onDragCancel={handleDragCancel}
+              sortedEntries={sortedEntries}
+              hasManyItems={hasManyItems}
+              removingId={removingId}
+              activeId={activeId}
+              getMetaForEntry={getMetaForEntry}
+              onRemove={onRemove}
+            />
+          </>
+        );
+      })()}
     </div>
   );
 }

--- a/packages/app-media/src/pages/compare-arena/scoreDelta.ts
+++ b/packages/app-media/src/pages/compare-arena/scoreDelta.ts
@@ -11,7 +11,11 @@ export function computeDrawDelta(
   scoreB: number,
   tier: DrawTier | null | undefined
 ): number {
-  const drawOutcome = tier === 'high' ? 0.7 : tier === 'low' ? 0.3 : 0.5;
+  const drawOutcome = (() => {
+    if (tier === 'high') return 0.7;
+    if (tier === 'low') return 0.3;
+    return 0.5;
+  })();
   return Math.round(ELO_K * (drawOutcome - expectedScore(scoreA, scoreB)));
 }
 

--- a/packages/app-media/src/pages/debrief/DimensionProgress.tsx
+++ b/packages/app-media/src/pages/debrief/DimensionProgress.tsx
@@ -9,19 +9,22 @@ interface DimensionProgressProps {
   currentDimensionId: number | null;
 }
 
+function getBadgeVariant(
+  status: DebriefDimension['status'],
+  isCurrent: boolean
+): 'default' | 'outline' | 'secondary' {
+  if (status === 'complete') return 'default';
+  if (isCurrent) return 'outline';
+  return 'secondary';
+}
+
 export function DimensionProgress({ dimensions, currentDimensionId }: DimensionProgressProps) {
   return (
     <div className="flex flex-wrap gap-2" data-testid="dimension-progress">
       {dimensions.map((dim) => (
         <Badge
           key={dim.dimensionId}
-          variant={
-            dim.status === 'complete'
-              ? 'default'
-              : currentDimensionId === dim.dimensionId
-                ? 'outline'
-                : 'secondary'
-          }
+          variant={getBadgeVariant(dim.status, currentDimensionId === dim.dimensionId)}
           className="gap-1"
         >
           {dim.status === 'complete' ? (

--- a/packages/app-media/src/pages/watchlist/WatchlistEmptyState.tsx
+++ b/packages/app-media/src/pages/watchlist/WatchlistEmptyState.tsx
@@ -3,12 +3,14 @@ import { Link } from 'react-router';
 import type { WatchlistFilter } from './types';
 
 export function WatchlistEmptyState({ filter }: { filter: WatchlistFilter }) {
-  const message =
-    filter === 'all'
-      ? 'Your watchlist is empty. Browse your library or search for something to watch.'
-      : filter === 'movie'
-        ? 'No movies on your watchlist.'
-        : 'No TV shows on your watchlist.';
+  let message: string;
+  if (filter === 'all') {
+    message = 'Your watchlist is empty. Browse your library or search for something to watch.';
+  } else if (filter === 'movie') {
+    message = 'No movies on your watchlist.';
+  } else {
+    message = 'No TV shows on your watchlist.';
+  }
 
   return (
     <div className="text-center py-16">

--- a/packages/app-media/src/pages/watchlist/WatchlistItem.tsx
+++ b/packages/app-media/src/pages/watchlist/WatchlistItem.tsx
@@ -167,67 +167,75 @@ export function WatchlistItem({
           </Button>
         </div>
 
-        {editing ? (
-          <div className="mt-1.5 space-y-1">
-            <Textarea
-              ref={textareaRef}
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Add a note..."
-              rows={2}
-              maxLength={500}
-              aria-label={`Notes for ${title}`}
-              className="text-xs min-h-0 resize-none"
-            />
-            <div className="flex items-center gap-2">
+        {(() => {
+          if (editing) {
+            return (
+              <div className="mt-1.5 space-y-1">
+                <Textarea
+                  ref={textareaRef}
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Add a note..."
+                  rows={2}
+                  maxLength={500}
+                  aria-label={`Notes for ${title}`}
+                  className="text-xs min-h-0 resize-none"
+                />
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={handleSave}
+                    disabled={isUpdating}
+                    aria-label="Save note"
+                    className="text-xs text-primary"
+                  >
+                    {isUpdating ? 'Saving...' : 'Save'}
+                  </Button>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={handleCancel}
+                    disabled={isUpdating}
+                    aria-label="Cancel editing"
+                    className="text-xs text-muted-foreground"
+                  >
+                    Cancel
+                  </Button>
+                  <span className="text-xs text-muted-foreground ml-auto">
+                    {draft.length}/500 · Ctrl+Enter to save
+                  </span>
+                </div>
+                {updateError && <p className="text-xs text-destructive">{updateError}</p>}
+              </div>
+            );
+          }
+          if (entry.notes) {
+            return (
               <Button
-                variant="link"
+                variant="ghost"
                 size="sm"
-                onClick={handleSave}
-                disabled={isUpdating}
-                aria-label="Save note"
-                className="text-xs text-primary"
+                onClick={() => setEditing(true)}
+                aria-label={`Edit notes for ${title}`}
+                className="mt-1.5 text-xs text-muted-foreground line-clamp-2 text-left hover:text-foreground justify-start"
               >
-                {isUpdating ? 'Saving...' : 'Save'}
+                {entry.notes}
               </Button>
-              <Button
-                variant="link"
-                size="sm"
-                onClick={handleCancel}
-                disabled={isUpdating}
-                aria-label="Cancel editing"
-                className="text-xs text-muted-foreground"
-              >
-                Cancel
-              </Button>
-              <span className="text-xs text-muted-foreground ml-auto">
-                {draft.length}/500 · Ctrl+Enter to save
-              </span>
-            </div>
-            {updateError && <p className="text-xs text-destructive">{updateError}</p>}
-          </div>
-        ) : entry.notes ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setEditing(true)}
-            aria-label={`Edit notes for ${title}`}
-            className="mt-1.5 text-xs text-muted-foreground line-clamp-2 text-left hover:text-foreground justify-start"
-          >
-            {entry.notes}
-          </Button>
-        ) : (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setEditing(true)}
-            aria-label={`Add notes for ${title}`}
-            className="mt-1.5 text-xs text-muted-foreground/60 hover:text-muted-foreground"
-          >
-            Add note...
-          </Button>
-        )}
+            );
+          }
+          return (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setEditing(true)}
+              aria-label={`Add notes for ${title}`}
+              className="mt-1.5 text-xs text-muted-foreground/60 hover:text-muted-foreground"
+            >
+              Add note...
+            </Button>
+          );
+        })()}
       </div>
     </div>
   );

--- a/packages/ui/src/components/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect.tsx
@@ -108,7 +108,12 @@ export function ComboboxSelect({
   className,
 }: ComboboxSelectProps) {
   const [open, setOpen] = useState(false);
-  const selectedValues = Array.isArray(value) ? value : value ? [value] : [];
+  const getSelectedValues = (): string[] => {
+    if (Array.isArray(value)) return value;
+    if (value) return [value];
+    return [];
+  };
+  const selectedValues = getSelectedValues();
 
   const toggleOption = (optionValue: string) => {
     if (multiple) {
@@ -132,13 +137,13 @@ export function ComboboxSelect({
     return options.find((opt) => opt.value === val)?.label ?? val;
   };
 
-  const displayText = multiple
-    ? selectedValues.length > 0
-      ? `${selectedValues.length} selected`
-      : placeholder
-    : selectedValues.length > 0
-      ? getOptionLabel(selectedValues[0] ?? '')
-      : placeholder;
+  const getDisplayText = (): string => {
+    if (multiple) {
+      return selectedValues.length > 0 ? `${selectedValues.length} selected` : placeholder;
+    }
+    return selectedValues.length > 0 ? getOptionLabel(selectedValues[0] ?? '') : placeholder;
+  };
+  const displayText = getDisplayText();
 
   return (
     <div className={cn('flex flex-col gap-2', className)}>

--- a/packages/ui/src/components/CompletionSummary.tsx
+++ b/packages/ui/src/components/CompletionSummary.tsx
@@ -52,27 +52,38 @@ export function CompletionSummary({
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="space-y-2">
-          {data.dimensions.map((dim) => (
-            <div key={dim.dimensionId} className="flex items-center justify-between text-sm">
-              <span>{dim.name}</span>
-              {dim.status === 'complete' && dim.comparisonId !== null ? (
-                <Badge variant="default" className="gap-1">
-                  <CheckCircle className="h-3 w-3" />
-                  Compared
-                </Badge>
-              ) : dim.status === 'complete' && dim.comparisonId === null ? (
-                <Badge variant="secondary" className="gap-1">
-                  <XCircle className="h-3 w-3" />
-                  Skipped
-                </Badge>
-              ) : (
+          {data.dimensions.map((dim) => {
+            const renderBadge = () => {
+              if (dim.status === 'complete' && dim.comparisonId !== null) {
+                return (
+                  <Badge variant="default" className="gap-1">
+                    <CheckCircle className="h-3 w-3" />
+                    Compared
+                  </Badge>
+                );
+              }
+              if (dim.status === 'complete' && dim.comparisonId === null) {
+                return (
+                  <Badge variant="secondary" className="gap-1">
+                    <XCircle className="h-3 w-3" />
+                    Skipped
+                  </Badge>
+                );
+              }
+              return (
                 <Badge variant="outline" className="gap-1">
                   <Clock className="h-3 w-3" />
                   Pending
                 </Badge>
-              )}
-            </div>
-          ))}
+              );
+            };
+            return (
+              <div key={dim.dimensionId} className="flex items-center justify-between text-sm">
+                <span>{dim.name}</span>
+                {renderBadge()}
+              </div>
+            );
+          })}
         </div>
 
         <div className="text-muted-foreground border-t pt-3 text-sm">

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -260,34 +260,40 @@ export function DataTable<TData, TValue>({
             ))}
           </TableHeader>
           <TableBody>
-            {loading ? (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="h-24 text-center">
-                  Loading...
-                </TableCell>
-              </TableRow>
-            ) : table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && 'selected'}
-                  onClick={() => onRowClick?.(row.original)}
-                  className={cn(onRowClick && 'cursor-pointer')}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            {(() => {
+              if (loading) {
+                return (
+                  <TableRow>
+                    <TableCell colSpan={columns.length} className="h-24 text-center">
+                      Loading...
                     </TableCell>
-                  ))}
+                  </TableRow>
+                );
+              }
+              if (table.getRowModel().rows?.length) {
+                return table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    data-state={row.getIsSelected() && 'selected'}
+                    onClick={() => onRowClick?.(row.original)}
+                    className={cn(onRowClick && 'cursor-pointer')}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ));
+              }
+              return (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-24 text-center">
+                    {emptyState || 'No results.'}
+                  </TableCell>
                 </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="h-24 text-center">
-                  {emptyState || 'No results.'}
-                </TableCell>
-              </TableRow>
-            )}
+              );
+            })()}
           </TableBody>
         </Table>
       </div>

--- a/packages/ui/src/components/DropdownMenu.tsx
+++ b/packages/ui/src/components/DropdownMenu.tsx
@@ -90,42 +90,47 @@ export function DropdownMenu({
   children,
   className,
 }: DropdownMenuProps) {
+  const renderItems = () => {
+    if (groups) {
+      return groups.map((group, groupIndex) => (
+        <div key={groupIndex}>
+          {group.label && <DropdownMenuLabel>{group.label}</DropdownMenuLabel>}
+          {group.items.map((item) => (
+            <DropdownMenuItem
+              key={item.value}
+              disabled={item.disabled}
+              variant={item.variant}
+              onSelect={item.onSelect}
+            >
+              {item.icon}
+              {item.label}
+            </DropdownMenuItem>
+          ))}
+          {groupIndex < groups.length - 1 && <DropdownMenuSeparator />}
+        </div>
+      ));
+    }
+    if (items) {
+      return items.map((item) => (
+        <DropdownMenuItem
+          key={item.value}
+          disabled={item.disabled}
+          variant={item.variant}
+          onSelect={item.onSelect}
+        >
+          {item.icon}
+          {item.label}
+        </DropdownMenuItem>
+      ));
+    }
+    return null;
+  };
+
   return (
     <DropdownMenuPrimitive>
       <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
       <DropdownMenuContent align={align} side={side} className={className}>
-        {children ||
-          (groups
-            ? groups.map((group, groupIndex) => (
-                <div key={groupIndex}>
-                  {group.label && <DropdownMenuLabel>{group.label}</DropdownMenuLabel>}
-                  {group.items.map((item) => (
-                    <DropdownMenuItem
-                      key={item.value}
-                      disabled={item.disabled}
-                      variant={item.variant}
-                      onSelect={item.onSelect}
-                    >
-                      {item.icon}
-                      {item.label}
-                    </DropdownMenuItem>
-                  ))}
-                  {groupIndex < groups.length - 1 && <DropdownMenuSeparator />}
-                </div>
-              ))
-            : items
-              ? items.map((item) => (
-                  <DropdownMenuItem
-                    key={item.value}
-                    disabled={item.disabled}
-                    variant={item.variant}
-                    onSelect={item.onSelect}
-                  >
-                    {item.icon}
-                    {item.label}
-                  </DropdownMenuItem>
-                ))
-              : null)}
+        {children || renderItems()}
       </DropdownMenuContent>
     </DropdownMenuPrimitive>
   );

--- a/packages/ui/src/components/EditableCell.tsx
+++ b/packages/ui/src/components/EditableCell.tsx
@@ -185,64 +185,83 @@ export function EditableCell<T = unknown>({
     );
   }
 
+  const renderEditor = () => {
+    if (CustomEditor) {
+      return (
+        <CustomEditor
+          value={value}
+          onChange={setValue}
+          onSave={handleSave}
+          onCancel={handleCancel}
+        />
+      );
+    }
+    if (type === 'text') {
+      return (
+        <TextInput
+          ref={inputRef}
+          value={value as string}
+          onChange={(e) => {
+            setValue(e.target.value as T);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="h-8"
+          disabled={saving}
+        />
+      );
+    }
+    if (type === 'number') {
+      return (
+        <NumberInput
+          ref={inputRef}
+          value={value as number}
+          onChange={(val) => {
+            setValue(val as T);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="h-8"
+          disabled={saving}
+        />
+      );
+    }
+    if (type === 'date') {
+      return (
+        <DateTimeInput
+          value={value as string}
+          onChange={(val) => {
+            setValue(val as T);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="h-8"
+          disabled={saving}
+        />
+      );
+    }
+    if (type === 'select') {
+      return (
+        <Select
+          value={value as string}
+          onChange={(e) => {
+            setValue(e.target.value as T);
+          }}
+          options={options}
+          placeholder={placeholder}
+          className="h-8"
+          disabled={saving}
+        />
+      );
+    }
+    return null;
+  };
+
   // Edit mode
   return (
     <div className={cn('flex items-center gap-2', className)}>
       <div className="flex-1">
-        {CustomEditor ? (
-          <CustomEditor
-            value={value}
-            onChange={setValue}
-            onSave={handleSave}
-            onCancel={handleCancel}
-          />
-        ) : type === 'text' ? (
-          <TextInput
-            ref={inputRef}
-            value={value as string}
-            onChange={(e) => {
-              setValue(e.target.value as T);
-            }}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            className="h-8"
-            disabled={saving}
-          />
-        ) : type === 'number' ? (
-          <NumberInput
-            ref={inputRef}
-            value={value as number}
-            onChange={(val) => {
-              setValue(val as T);
-            }}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            className="h-8"
-            disabled={saving}
-          />
-        ) : type === 'date' ? (
-          <DateTimeInput
-            value={value as string}
-            onChange={(val) => {
-              setValue(val as T);
-            }}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            className="h-8"
-            disabled={saving}
-          />
-        ) : type === 'select' ? (
-          <Select
-            value={value as string}
-            onChange={(e) => {
-              setValue(e.target.value as T);
-            }}
-            options={options}
-            placeholder={placeholder}
-            className="h-8"
-            disabled={saving}
-          />
-        ) : null}
+        {renderEditor()}
         {error && <p className="text-xs text-destructive mt-1">{error}</p>}
       </div>
       <div className="flex gap-1">

--- a/packages/ui/src/components/LoadingProgressStep.tsx
+++ b/packages/ui/src/components/LoadingProgressStep.tsx
@@ -73,18 +73,19 @@ export function LoadingProgressStep({
 
       {steps && steps.length > 0 && (
         <div className="w-full max-w-md text-xs text-muted-foreground space-y-1">
-          {steps.map((step) => (
-            <div key={step.label} className="flex justify-between">
-              <span>{step.label}</span>
-              <span>
-                {step.status === 'in_progress'
-                  ? 'In progress...'
-                  : step.status === 'done'
-                    ? 'Complete'
-                    : 'Pending'}
-              </span>
-            </div>
-          ))}
+          {steps.map((step) => {
+            const statusLabel = (() => {
+              if (step.status === 'in_progress') return 'In progress...';
+              if (step.status === 'done') return 'Complete';
+              return 'Pending';
+            })();
+            return (
+              <div key={step.label} className="flex justify-between">
+                <span>{step.label}</span>
+                <span>{statusLabel}</span>
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/packages/ui/src/components/RequestDialog.tsx
+++ b/packages/ui/src/components/RequestDialog.tsx
@@ -76,19 +76,25 @@ export function RequestDialog({
               Cancel
             </Button>
             <Button onClick={onSubmit} disabled={!canSubmit}>
-              {isSuccess ? (
-                <>
-                  <CheckCircle2 className="h-4 w-4 mr-1.5" />
-                  {successLabel}
-                </>
-              ) : isPending ? (
-                <>
-                  <RefreshCw className="h-4 w-4 mr-1.5 animate-spin" />
-                  {pendingLabel}
-                </>
-              ) : (
-                submitLabel
-              )}
+              {(() => {
+                if (isSuccess) {
+                  return (
+                    <>
+                      <CheckCircle2 className="h-4 w-4 mr-1.5" />
+                      {successLabel}
+                    </>
+                  );
+                }
+                if (isPending) {
+                  return (
+                    <>
+                      <RefreshCw className="h-4 w-4 mr-1.5 animate-spin" />
+                      {pendingLabel}
+                    </>
+                  );
+                }
+                return submitLabel;
+              })()}
             </Button>
           </div>
         </div>

--- a/packages/ui/src/components/SearchPickerDialog.tsx
+++ b/packages/ui/src/components/SearchPickerDialog.tsx
@@ -73,23 +73,32 @@ export function SearchPickerDialog<T>({
         </div>
 
         <div className={`${maxResultsHeight} overflow-y-auto space-y-1`}>
-          {search.length < minChars ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">
-              Type at least {minChars} characters to search
-            </p>
-          ) : isLoading ? (
-            <div className="space-y-2 py-2">
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-            </div>
-          ) : results.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">{emptyMessage}</p>
-          ) : (
-            results.map((item) => (
+          {(() => {
+            if (search.length < minChars) {
+              return (
+                <p className="text-sm text-muted-foreground py-4 text-center">
+                  Type at least {minChars} characters to search
+                </p>
+              );
+            }
+            if (isLoading) {
+              return (
+                <div className="space-y-2 py-2">
+                  <Skeleton className="h-10 w-full" />
+                  <Skeleton className="h-10 w-full" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              );
+            }
+            if (results.length === 0) {
+              return (
+                <p className="text-sm text-muted-foreground py-4 text-center">{emptyMessage}</p>
+              );
+            }
+            return results.map((item) => (
               <React.Fragment key={getResultKey(item)}>{renderResult(item)}</React.Fragment>
-            ))
-          )}
+            ));
+          })()}
         </div>
       </DialogContent>
     </Dialog>

--- a/packages/ui/src/components/SettingsForm.tsx
+++ b/packages/ui/src/components/SettingsForm.tsx
@@ -88,6 +88,12 @@ export interface SettingsFormProps {
   className?: string;
 }
 
+function getNumberFieldValue(value: unknown): number | string {
+  if (typeof value === 'number') return value;
+  if (value === '') return '';
+  return Number(value) || 0;
+}
+
 export function SettingsForm({
   section,
   values,
@@ -221,7 +227,7 @@ export function SettingsForm({
             type="number"
             min={field.min}
             max={field.max}
-            value={typeof value === 'number' ? value : value === '' ? '' : Number(value) || 0}
+            value={getNumberFieldValue(value)}
             placeholder={field.placeholder}
             onChange={(e) => update(field.id, e.target.value === '' ? '' : Number(e.target.value))}
           />

--- a/packages/ui/src/components/StatCard.tsx
+++ b/packages/ui/src/components/StatCard.tsx
@@ -135,24 +135,37 @@ export function StatCard({
         <p className={cn('text-3xl font-bold tabular-nums tracking-normal', styles.text)}>
           {value}
         </p>
-        {trend && (
-          <div
-            className={cn(
-              'flex items-center gap-1 text-2xs font-semibold',
-              trendIconClass[trend.direction]
-            )}
-          >
-            {trend.direction === 'up' ? (
-              <TrendingUp className="h-3 w-3" aria-hidden="true" />
-            ) : trend.direction === 'down' ? (
-              <TrendingDown className="h-3 w-3" aria-hidden="true" />
-            ) : null}
-            <span>
-              {trend.direction === 'up' ? '+' : trend.direction === 'down' ? '-' : ''}
-              {Math.abs(trend.value)}%
-            </span>
-          </div>
-        )}
+        {trend &&
+          (() => {
+            const renderTrendIcon = () => {
+              if (trend.direction === 'up') {
+                return <TrendingUp className="h-3 w-3" aria-hidden="true" />;
+              }
+              if (trend.direction === 'down') {
+                return <TrendingDown className="h-3 w-3" aria-hidden="true" />;
+              }
+              return null;
+            };
+            const trendSign = (() => {
+              if (trend.direction === 'up') return '+';
+              if (trend.direction === 'down') return '-';
+              return '';
+            })();
+            return (
+              <div
+                className={cn(
+                  'flex items-center gap-1 text-2xs font-semibold',
+                  trendIconClass[trend.direction]
+                )}
+              >
+                {renderTrendIcon()}
+                <span>
+                  {trendSign}
+                  {Math.abs(trend.value)}%
+                </span>
+              </div>
+            );
+          })()}
       </div>
       {description && (
         <div className="text-2xs text-muted-foreground font-medium uppercase tracking-normal opacity-70 relative z-10">

--- a/packages/ui/src/primitives/slider.tsx
+++ b/packages/ui/src/primitives/slider.tsx
@@ -13,10 +13,11 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () => (Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min, max]),
-    [value, defaultValue, min, max]
-  );
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value;
+    if (Array.isArray(defaultValue)) return defaultValue;
+    return [min, max];
+  }, [value, defaultValue, min, max]);
 
   return (
     <SliderPrimitive.Root


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2082.

## Summary

`no-nested-ternary` was set as the global lint target in `.oxlintrc.json` but suppressed in every Tier‑2 override (frontend packages and pops-api). This PR removes those suppressions so the rule is enforced everywhere, and refactors all 131 existing nested ternaries across the repo.

The original issue scoped this to frontend packages, but per the follow-up direction it covers the whole repo (frontend + API).

## Changes

**Config**

- `.oxlintrc.json`: removed `"no-nested-ternary": "off"` from the `apps/pops-api`, `apps/pops-shell`, `packages/ui`, `packages/app-*/components|hooks|store|lib`, `packages/app-*/pages`, and the bespoke `app-finance/imports/*` overrides. The global `"no-nested-ternary": "error"` rule now applies everywhere.

**Refactors** (131 nested ternaries fixed across 75 files, plus 2 new violations introduced by parallel main branch work):

- `packages/ui` — 17 violations across 11 files
- `packages/app-finance` — 27 violations across 14 files
- `packages/app-inventory` — 9 violations across 7 files
- `packages/app-media` — 48 violations across 23 files (plus `compare-arena/scoreDelta.ts` and `debrief/DimensionProgress.tsx` from rebased main)
- `apps/pops-shell` — 5 violations in `SectionRenderer.tsx`
- `apps/pops-api` — 25 violations across 19 files

## Refactoring patterns used

- **Inside JSX**: extracted small named helpers returning `ReactNode` or used `(() => { if (...) return ...; })()` IIFEs for branchy renders.
- **In assignments**: replaced `cond1 ? a : cond2 ? b : c` with typed IIFE `const x = (() => { … })()` — using IIFE not `let` so we keep narrow types under `strict: true`.
- **Repeated chains**: factored to module-local helpers (e.g. `describeArrError` for `radarr-router.ts`/`sonarr-router.ts`, `getMoviePosterUrl` in `tier-list.ts`, `parseTriBool` in `inventory/items/router.ts`, `renderProposalBodyState` in `CorrectionProposalWorkflow.tsx`, `getEmptyHistoryMessage` in `HistoryPage.tsx`, `getBadgeVariant` in `DimensionProgress.tsx`).

Behaviour is preserved exactly in every case.

## Verification

- `pnpm lint` → `Found 174 warnings and 0 errors.`
- `pnpm typecheck` → all 16 packages pass
- `pnpm test` → all tests pass

## Relates to

- #2043 (enforce-agent-optimal-targets — final lint PR)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c195ca06-7b5a-4406-a321-abed498f0a62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c195ca06-7b5a-4406-a321-abed498f0a62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

