### PR TITLE
fix(settings): scroll spy, sticky sidebar, and nav/card design consistency

### DIFF
--- a/apps/pops-shell/src/app/pages/SettingsPage.tsx
+++ b/apps/pops-shell/src/app/pages/SettingsPage.tsx
@@ -1,6 +1,8 @@
 import { SectionRenderer } from '@/components/settings/SectionRenderer';
 import { trpc } from '@/lib/trpc';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { Select } from '@pops/ui';
 
 import { SectionNav } from './settings-page/SectionNav';
 import { SettingsEmpty, SettingsLoading } from './settings-page/SettingsLoading';
@@ -11,9 +13,8 @@ import type { SettingsManifest } from '@pops/types';
 
 export function SettingsPage() {
   const { data, isLoading } = trpc.core.settings.getManifests.useQuery();
-  const contentRef = useRef<HTMLDivElement>(null);
   const manifests = useMemo(() => (data?.manifests ?? []) as SettingsManifest[], [data?.manifests]);
-  const activeId = useSectionObserver(manifests, contentRef);
+  const activeId = useSectionObserver(manifests);
   const handleTestAction = useTestActionHandler();
 
   // Handle hash-based deep linking on load
@@ -38,7 +39,8 @@ export function SettingsPage() {
 
   return (
     <div className="flex gap-8 p-6 max-w-5xl mx-auto">
-      <aside className="w-48 shrink-0 hidden md:block sticky top-6 self-start">
+      {/* Sidebar — hidden on mobile; top-20 clears the fixed TopBar (h-16 = 4rem) */}
+      <aside className="w-48 shrink-0 hidden md:block sticky top-20 self-start max-h-[calc(100vh-5rem)] overflow-y-auto">
         <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3 px-3">
           Settings
         </p>
@@ -46,22 +48,16 @@ export function SettingsPage() {
       </aside>
 
       <div className="md:hidden w-full mb-4">
-        <select
+        <Select
           value={activeId}
           onChange={(e) => scrollToSection(e.target.value)}
-          className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-        >
-          {manifests.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.title}
-            </option>
-          ))}
-        </select>
+          options={manifests.map((m) => ({ value: m.id, label: m.title }))}
+        />
       </div>
 
-      <div ref={contentRef} className="flex-1 space-y-10 min-w-0">
+      <div className="flex-1 space-y-10 min-w-0">
         {manifests.map((manifest) => (
-          <section key={manifest.id} id={manifest.id}>
+          <section key={manifest.id} id={manifest.id} className="scroll-mt-20">
             <h2 className="text-lg font-semibold mb-4">{manifest.title}</h2>
             <SectionRenderer manifest={manifest} onTestAction={handleTestAction} />
           </section>

--- a/apps/pops-shell/src/app/pages/SettingsPage.tsx
+++ b/apps/pops-shell/src/app/pages/SettingsPage.tsx
@@ -58,7 +58,7 @@ export function SettingsPage() {
 
       <div className="flex-1 space-y-10 min-w-0">
         {manifests.map((manifest) => (
-          <section key={manifest.id} id={manifest.id} className="scroll-mt-20">
+          <section key={manifest.id} id={manifest.id} className="scroll-mt-14 md:scroll-mt-20">
             <h2 className="text-lg font-semibold mb-4">{manifest.title}</h2>
             <SectionRenderer manifest={manifest} onTestAction={handleTestAction} />
           </section>

--- a/apps/pops-shell/src/app/pages/SettingsPage.tsx
+++ b/apps/pops-shell/src/app/pages/SettingsPage.tsx
@@ -49,7 +49,8 @@ export function SettingsPage() {
 
       <div className="md:hidden w-full mb-4">
         <Select
-          value={activeId}
+          aria-label="Settings section"
+          value={activeId || (manifests[0]?.id ?? '')}
           onChange={(e) => scrollToSection(e.target.value)}
           options={manifests.map((m) => ({ value: m.id, label: m.title }))}
         />

--- a/apps/pops-shell/src/app/pages/settings-page/SectionNav.tsx
+++ b/apps/pops-shell/src/app/pages/settings-page/SectionNav.tsx
@@ -21,13 +21,22 @@ export function SectionNav({ manifests, activeId, onSelect }: SectionNavProps) {
             key={m.id}
             onClick={() => onSelect(m.id)}
             className={cn(
-              'w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors text-left',
+              'w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 text-left group',
               isActive
-                ? 'bg-accent text-accent-foreground font-medium'
-                : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                ? 'bg-app-accent text-app-accent-foreground shadow-sm'
+                : 'text-foreground/80 hover:bg-muted hover:text-foreground'
             )}
           >
-            {Icon && <Icon className="h-4 w-4 shrink-0" />}
+            {Icon && (
+              <Icon
+                className={cn(
+                  'h-4 w-4 shrink-0 transition-colors',
+                  isActive
+                    ? 'text-app-accent-foreground'
+                    : 'text-app-accent/70 group-hover:text-foreground'
+                )}
+              />
+            )}
             <span>{m.title}</span>
           </button>
         );

--- a/apps/pops-shell/src/app/pages/settings-page/constants.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/constants.ts
@@ -1,3 +1,4 @@
-// Matches aside sticky offset (top-20), section scroll-mt-20, and max-h-[calc(100vh-5rem)]
-// When changing the TopBar height, update this value AND the three Tailwind classes in SettingsPage.tsx
-export const SETTINGS_HEADER_OFFSET = 80;
+// TopBar is h-14 (56px) on mobile, h-16 (64px) on md+ with sticky top-20 (80px)
+export const SETTINGS_HEADER_OFFSET_MOBILE = 56;
+export const SETTINGS_HEADER_OFFSET_DESKTOP = 80;
+export const SETTINGS_MD_BREAKPOINT = '(min-width: 768px)';

--- a/apps/pops-shell/src/app/pages/settings-page/constants.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/constants.ts
@@ -1,0 +1,3 @@
+// Matches aside sticky offset (top-20), section scroll-mt-20, and max-h-[calc(100vh-5rem)]
+// When changing the TopBar height, update this value AND the three Tailwind classes in SettingsPage.tsx
+export const SETTINGS_HEADER_OFFSET = 80;

--- a/apps/pops-shell/src/app/pages/settings-page/useSectionObserver.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useSectionObserver.ts
@@ -1,22 +1,23 @@
 import { useEffect, useState } from 'react';
 
-import { SETTINGS_HEADER_OFFSET } from './constants';
+import {
+  SETTINGS_HEADER_OFFSET_DESKTOP,
+  SETTINGS_HEADER_OFFSET_MOBILE,
+  SETTINGS_MD_BREAKPOINT,
+} from './constants';
 
 import type { SettingsManifest } from '@pops/types';
 
 export function useSectionObserver(manifests: SettingsManifest[]) {
   const [activeId, setActiveId] = useState<string>('');
 
-  // Initialize from URL hash or first section — guarded so a tRPC refetch
-  // (focus/reconnect) doesn't reset the active section after the user scrolls.
+  // Only initialize once (when activeId is still empty) so tRPC refetches
+  // never overwrite scroll-derived state.
   useEffect(() => {
-    if (!manifests.length) return;
+    if (!manifests.length || activeId) return;
     const hash = window.location.hash.slice(1);
     const hasValidHash = hash !== '' && manifests.some((m) => m.id === hash);
-    const initialId = hasValidHash ? hash : (manifests[0]?.id ?? '');
-    if (!initialId) return;
-    if (activeId && (!hasValidHash || activeId === hash)) return;
-    setActiveId(initialId);
+    setActiveId(hasValidHash ? hash : (manifests[0]?.id ?? ''));
   }, [activeId, manifests]);
 
   useEffect(() => {
@@ -25,12 +26,15 @@ export function useSectionObserver(manifests: SettingsManifest[]) {
     const elements = manifests.map((m) => document.getElementById(m.id));
     let rafId: number | null = null;
     const update = () => {
+      const offset = window.matchMedia(SETTINGS_MD_BREAKPOINT).matches
+        ? SETTINGS_HEADER_OFFSET_DESKTOP
+        : SETTINGS_HEADER_OFFSET_MOBILE;
       let current = manifests[0]?.id ?? '';
       for (let i = 0; i < manifests.length; i++) {
         const el = elements[i];
         const manifest = manifests[i];
         if (!el || !manifest) continue;
-        if (el.getBoundingClientRect().top <= SETTINGS_HEADER_OFFSET) current = manifest.id;
+        if (el.getBoundingClientRect().top <= offset) current = manifest.id;
       }
       setActiveId(current);
       rafId = null;

--- a/apps/pops-shell/src/app/pages/settings-page/useSectionObserver.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useSectionObserver.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 
-import type { SettingsManifest } from '@pops/types';
-
 import { SETTINGS_HEADER_OFFSET } from './constants';
+
+import type { SettingsManifest } from '@pops/types';
 
 export function useSectionObserver(manifests: SettingsManifest[]) {
   const [activeId, setActiveId] = useState<string>('');
@@ -21,7 +21,6 @@ export function useSectionObserver(manifests: SettingsManifest[]) {
 
   useEffect(() => {
     if (!manifests.length) return;
-    const HEADER_OFFSET = SETTINGS_HEADER_OFFSET;
     // Cache elements once so the scroll handler avoids repeated DOM queries
     const elements = manifests.map((m) => document.getElementById(m.id));
     let rafId: number | null = null;
@@ -31,7 +30,7 @@ export function useSectionObserver(manifests: SettingsManifest[]) {
         const el = elements[i];
         const manifest = manifests[i];
         if (!el || !manifest) continue;
-        if (el.getBoundingClientRect().top <= HEADER_OFFSET) current = manifest.id;
+        if (el.getBoundingClientRect().top <= SETTINGS_HEADER_OFFSET) current = manifest.id;
       }
       setActiveId(current);
       rafId = null;

--- a/apps/pops-shell/src/app/pages/settings-page/useSectionObserver.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useSectionObserver.ts
@@ -28,8 +28,9 @@ export function useSectionObserver(manifests: SettingsManifest[]) {
       let current = manifests[0]?.id ?? '';
       for (let i = 0; i < manifests.length; i++) {
         const el = elements[i];
-        if (!el) continue;
-        if (el.getBoundingClientRect().top <= HEADER_OFFSET) current = manifests[i]!.id;
+        const manifest = manifests[i];
+        if (!el || !manifest) continue;
+        if (el.getBoundingClientRect().top <= HEADER_OFFSET) current = manifest.id;
       }
       setActiveId(current);
       rafId = null;

--- a/apps/pops-shell/src/app/pages/settings-page/useSectionObserver.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useSectionObserver.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 import type { SettingsManifest } from '@pops/types';
 
+import { SETTINGS_HEADER_OFFSET } from './constants';
+
 export function useSectionObserver(manifests: SettingsManifest[]) {
   const [activeId, setActiveId] = useState<string>('');
 
@@ -19,8 +21,7 @@ export function useSectionObserver(manifests: SettingsManifest[]) {
 
   useEffect(() => {
     if (!manifests.length) return;
-    // Must match aside sticky offset (top-20 = 5rem = 80px) and section scroll-mt-20
-    const HEADER_OFFSET = 80;
+    const HEADER_OFFSET = SETTINGS_HEADER_OFFSET;
     // Cache elements once so the scroll handler avoids repeated DOM queries
     const elements = manifests.map((m) => document.getElementById(m.id));
     let rafId: number | null = null;

--- a/apps/pops-shell/src/app/pages/settings-page/useSectionObserver.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useSectionObserver.ts
@@ -2,42 +2,48 @@ import { useEffect, useState } from 'react';
 
 import type { SettingsManifest } from '@pops/types';
 
-export function useSectionObserver(
-  manifests: SettingsManifest[],
-  contentRef: React.RefObject<HTMLDivElement | null>
-) {
+export function useSectionObserver(manifests: SettingsManifest[]) {
   const [activeId, setActiveId] = useState<string>('');
 
-  // Default to first manifest when data loads and no section is active yet
+  // Initialize from URL hash or first section — guarded so a tRPC refetch
+  // (focus/reconnect) doesn't reset the active section after the user scrolls.
   useEffect(() => {
-    if (manifests.length > 0 && !activeId) {
-      const hash = window.location.hash.slice(1);
-      setActiveId(hash && manifests.some((m) => m.id === hash) ? hash : (manifests[0]?.id ?? ''));
-    }
-  }, [manifests, activeId]);
+    if (!manifests.length) return;
+    const hash = window.location.hash.slice(1);
+    const hasValidHash = hash !== '' && manifests.some((m) => m.id === hash);
+    const initialId = hasValidHash ? hash : (manifests[0]?.id ?? '');
+    if (!initialId) return;
+    if (activeId && (!hasValidHash || activeId === hash)) return;
+    setActiveId(initialId);
+  }, [activeId, manifests]);
 
   useEffect(() => {
-    if (!manifests.length || !contentRef.current) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visible = entries
-          .filter((e) => e.isIntersecting)
-          .toSorted((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-        if (visible.length > 0 && visible[0]) {
-          setActiveId(visible[0].target.id);
-        }
-      },
-      { root: null, rootMargin: '-10% 0px -70% 0px', threshold: 0 }
-    );
-
-    for (const m of manifests) {
-      const el = document.getElementById(m.id);
-      if (el) observer.observe(el);
-    }
-
-    return () => observer.disconnect();
-  }, [manifests, contentRef]);
+    if (!manifests.length) return;
+    // Must match aside sticky offset (top-20 = 5rem = 80px) and section scroll-mt-20
+    const HEADER_OFFSET = 80;
+    // Cache elements once so the scroll handler avoids repeated DOM queries
+    const elements = manifests.map((m) => document.getElementById(m.id));
+    let rafId: number | null = null;
+    const update = () => {
+      let current = manifests[0]?.id ?? '';
+      for (let i = 0; i < manifests.length; i++) {
+        const el = elements[i];
+        if (!el) continue;
+        if (el.getBoundingClientRect().top <= HEADER_OFFSET) current = manifests[i]!.id;
+      }
+      setActiveId(current);
+      rafId = null;
+    };
+    const onScroll = () => {
+      if (rafId === null) rafId = requestAnimationFrame(update);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    update();
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [manifests]);
 
   return activeId;
 }

--- a/apps/pops-shell/src/components/settings/section-renderer/GroupRenderer.tsx
+++ b/apps/pops-shell/src/components/settings/section-renderer/GroupRenderer.tsx
@@ -1,3 +1,5 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@pops/ui';
+
 import { FieldInput } from './FieldInput';
 
 import type { SettingsGroup } from '@pops/types';
@@ -24,14 +26,12 @@ export function GroupRenderer({
   loadingOptionKeys,
 }: GroupRendererProps) {
   return (
-    <div className="rounded-lg border bg-card p-5 space-y-4">
-      <div>
-        <h3 className="font-medium text-sm">{group.title}</h3>
-        {group.description && (
-          <p className="text-xs text-muted-foreground mt-0.5">{group.description}</p>
-        )}
-      </div>
-      <div className="space-y-4">
+    <Card>
+      <CardHeader>
+        <CardTitle>{group.title}</CardTitle>
+        {group.description && <CardDescription>{group.description}</CardDescription>}
+      </CardHeader>
+      <CardContent className="space-y-4">
         {group.fields.map((field) => (
           <FieldInput
             key={field.key}
@@ -44,7 +44,7 @@ export function GroupRenderer({
             isOptionsLoading={loadingOptionKeys.has(field.key)}
           />
         ))}
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary

- **Scroll spy fixed**: replaces the broken `IntersectionObserver` approach (which froze active state when no section fell inside the narrow 20% detection band) with a `scroll` event listener that always picks the last section whose top edge is at or above the header offset
- **Sticky sidebar fixed**: `top-6` (24px) was behind the fixed TopBar (64px on md+); changed to `top-20` (80px) with `max-h` + `overflow-y-auto` so the nav follows the user and scrolls independently when there are many sections
- **Design consistency**: `SectionNav` buttons now match `PageNav` exactly — `rounded-lg`, `font-medium`, `bg-app-accent` active state, icon colour transitions; mobile dropdown replaced with `@pops/ui` `Select`; `GroupRenderer` raw card div replaced with `Card`/`CardHeader`/`CardTitle`/`CardContent` from `@pops/ui`

## Test plan

- [ ] Scroll down the `/settings` page — the active sidebar item should update as each section enters view
- [ ] Sidebar stays visible as you scroll (no longer disappears behind the TopBar)
- [ ] Active nav item uses the app accent colour, matching the PageNav style in the rest of the shell
- [ ] On mobile, the section dropdown is the standard Select component (not a bare `<select>`)
- [ ] Settings groups render as standard Cards matching the rest of the UI

https://claude.ai/code/session_01TM93MTLDPDgk6zvozJ4hMx