### PR TITLE
docs(ideas): spikes for deployment split, modular apps, feature toggles

### DIFF
--- a/docs/ideas/deployment-split-spike.md
+++ b/docs/ideas/deployment-split-spike.md
@@ -20,11 +20,11 @@ The ansible roles are already clean (they don't import app code). The compose fi
 
 ## Three ways to split
 
-| Option | What moves to `mu-deploy` | What stays in `pops` | Build model |
-| --- | --- | --- | --- |
-| **A. Full split** | `infra/ansible/`, `infra/docker-compose.yml`, `deploy.sh`, `scripts/setup-github-runner.sh`, all vault secrets | Dockerfiles, source | POPS publishes tagged images to a registry; `mu-deploy` pulls + runs |
-| **B. Ansible-only split** | `infra/ansible/`, `deploy.sh`, `scripts/setup-github-runner.sh` | Dockerfiles, `infra/docker-compose.yml` | POPS still builds locally on the server via compose; `mu-deploy` clones it and drives the build |
-| **C. Generic infra only** | `common`, `docker`, `github-runner`, `cloudflare-tunnel`, `monitoring`, `backups`, `secrets` | `pops-deploy` role, `docker-compose.yml`, Dockerfiles, `deploy.sh` | POPS owns its deploy; `mu-deploy` owns the host |
+| Option                    | What moves to `mu-deploy`                                                                                      | What stays in `pops`                                               | Build model                                                                                     |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| **A. Full split**         | `infra/ansible/`, `infra/docker-compose.yml`, `deploy.sh`, `scripts/setup-github-runner.sh`, all vault secrets | Dockerfiles, source                                                | POPS publishes tagged images to a registry; `mu-deploy` pulls + runs                            |
+| **B. Ansible-only split** | `infra/ansible/`, `deploy.sh`, `scripts/setup-github-runner.sh`                                                | Dockerfiles, `infra/docker-compose.yml`                            | POPS still builds locally on the server via compose; `mu-deploy` clones it and drives the build |
+| **C. Generic infra only** | `common`, `docker`, `github-runner`, `cloudflare-tunnel`, `monitoring`, `backups`, `secrets`                   | `pops-deploy` role, `docker-compose.yml`, Dockerfiles, `deploy.sh` | POPS owns its deploy; `mu-deploy` owns the host                                                 |
 
 Option C is the lightest: `mu-deploy` becomes a "my home server" repo that provisions Docker, runners, tunnels, backups, and monitoring on any box. Each hosted service (POPS, a future moltbot-standalone, anything else) keeps its own compose and deploy playbook and registers itself with the host.
 

--- a/docs/ideas/deployment-split-spike.md
+++ b/docs/ideas/deployment-split-spike.md
@@ -26,7 +26,7 @@ The ansible roles are already clean (they don't import app code). The compose fi
 | **B. Ansible-only split** | `infra/ansible/`, `deploy.sh`, `scripts/setup-github-runner.sh`                                                | Dockerfiles, `infra/docker-compose.yml`                            | POPS still builds locally on the server via compose; `mu-deploy` clones it and drives the build |
 | **C. Generic infra only** | `common`, `docker`, `github-runner`, `cloudflare-tunnel`, `monitoring`, `backups`, `secrets`                   | `pops-deploy` role, `docker-compose.yml`, Dockerfiles, `deploy.sh` | POPS owns its deploy; `mu-deploy` owns the host                                                 |
 
-Option C is the lightest: `mu-deploy` becomes a "my home server" repo that provisions Docker, runners, tunnels, backups, and monitoring on any box. Each hosted service (POPS, a future moltbot-standalone, anything else) keeps its own compose and deploy playbook and registers itself with the host.
+Option C is the lightest; Option A is the one that actually achieves "no infra on POPS". The chosen direction is **A**, phased so we don't hit the image-registry tax before the rest of the split is wired up. `mu-deploy` becomes a "my home server" repo that provisions Docker, runners, tunnels, backups, monitoring, and runs each service from published images pulled by tag.
 
 ## Advantages
 
@@ -51,33 +51,80 @@ Today POPS is already built in Docker. The gap to "fully isolated" is small:
 
 1. **Published images** — tag on push, push to GHCR. Compose pulls by tag instead of building locally. This is the main change.
 2. **No implicit host paths** — `../secrets/*` bind mounts get replaced with a documented `.env`-driven secrets directory and/or Docker secrets loaded by the operator.
-3. **A "what POPS needs" manifest** — a single file (`infra/DEPLOY.md` or a `deploy.yaml`) describing required env vars, ports, volumes, and optional services. `mu-deploy` reads this to configure the host.
+3. **A "what POPS needs" manifest** — a single file (`DEPLOY.md` or `deploy.yaml` in the POPS repo) describing required env vars, ports, volumes, and optional services. `mu-deploy` reads this to configure the host.
 4. **Migrations baked into the image** — already true. `pops-api` runs drizzle migrations on startup.
 
 None of this requires architectural change, just discipline.
 
+## Images: friction check
+
+> "Would going to images create friction? Can deploy/upgrade be automated?"
+
+Friction exists but is one-sided and disappears after setup:
+
+**Build-on-server (today)** — friction is every deploy. A push takes 3-8 minutes of server-side `docker build` before anything restarts. Fine for an occasional deploy, painful when iterating. No CI gate (broken build on server = downtime).
+
+**GHCR + pull-by-tag** — friction is the one-time setup (publish workflow, auth, tag strategy) and waiting on CI for each deploy (~2-4 min for tests + image build). After that each _server-side_ deploy is a 10-second `docker compose pull && up -d`. CI blocks broken images from ever reaching the server.
+
+With auto-deploy on merge the flow becomes:
+
+```
+merge to main → CI runs tests + typecheck + lint → CI builds + pushes image to GHCR
+              → webhook to mu-deploy runner → pull + compose up -d → done
+```
+
+No manual step. The friction-per-deploy is lower than today. The only new failure mode is "registry unavailable", which you can mitigate by retaining the N most recent images locally as a fallback.
+
+## Deploy automation
+
+Chosen model: **auto-deploy on merge**.
+
+Two implementation paths:
+
+1. **Self-hosted runner on the server** — GHA job with `runs-on: self-hosted` runs `docker compose pull && up -d` after the image publish job succeeds. Same runner that lives today. Simplest.
+2. **Webhook into `mu-deploy`** — GHA job POSTs to a small endpoint on the server after image publish. `mu-deploy` validates, pulls, redeploys. Requires an auth token but decouples POPS from runner knowledge.
+
+Option 1 is the pragmatic answer given the runner already exists. Move the runner's ownership to `mu-deploy` (it's a host-level thing), but keep the self-hosted path.
+
+**Pause switch**: `mu-deploy` stores a per-service `deploy_enabled` flag (config file on the server). When `false`, incoming webhooks/runner jobs skip the restart step but keep publishing images. Useful for freezes, holidays, or mid-debug.
+
 ## Open questions
 
-- Registry: GHCR, self-hosted, or both (public mirror + private)?
-- Image tagging: git sha, semver, or both?
-- Does `mu-deploy` stay private (it knows your host), or is it templated so others can fork it?
-- Do we keep a thin `docker-compose.yml` in POPS for local dev and a "production overlay" in `mu-deploy`, or ship one file and have `mu-deploy` provide overrides?
-- Moltbot — it already uses an upstream image; does it still belong in the POPS compose, or become its own service in `mu-deploy`?
+- Registry: GHCR (simplest, same auth as GitHub). Self-hosted registry only if we want fully offline setups later.
+- Image tagging: `main`, `sha-<short>`, and `v<semver>` (on release tags) — deploy-on-merge targets the sha tag, so rollback is `docker compose pull pops-api:sha-<prev>`.
+- `mu-deploy` stays private (it knows your host), templated copy for public consumption is a follow-up.
+- `docker-compose.yml` — canonical file lives in `mu-deploy` (it describes how the host runs things); POPS ships a minimal `docker-compose.dev.yml` for local dev that builds locally.
+- Moltbot — separate service in `mu-deploy` (it already uses an upstream image; it only depends on POPS via `FINANCE_API_URL`, which is a host-level concern).
+- Local dev — `mise dev` and `mise docker:up` must keep working from POPS alone. Ship a `docker-compose.dev.yml` that replaces the `image:` lines with `build:` contexts.
 
 ## Recommendation
 
-Option C first. Cheapest, reversible, and it doesn't force the image-registry work before we're ready. Migration steps:
+Target **Option A** (no infra in POPS), phased:
 
-1. Create `mu-deploy` repo with the generic roles (`common`, `docker`, `github-runner`, `cloudflare-tunnel`, `monitoring`, `backups`, `secrets` scaffolding only — the vault stays scoped per host).
+**Phase 1 — Extract generic infra (Option C equivalent)** (~3-5 days)
+
+1. Create `mu-deploy` repo, move `common`, `docker`, `github-runner`, `cloudflare-tunnel`, `monitoring`, `backups`, `secrets` roles.
 2. Move `scripts/setup-github-runner.sh` and vault management there.
-3. Keep `infra/docker-compose.yml`, `infra/ansible/roles/pops-deploy`, and `deploy.sh` in POPS. The POPS deploy role becomes the contract `mu-deploy` invokes.
-4. Add `infra/DEPLOY.md` to POPS documenting the expected env vars, secrets, ports, and volumes.
-5. Re-point `.github/workflows/root-deploy.yml` at the new split (runner lives in `mu-deploy`, triggers `pops-deploy` role).
+3. Self-hosted runner's repo-binding moves to `mu-deploy`.
+4. POPS still builds + deploys as today from its own `infra/`.
 
-Graduating to Option A (published images, no local build) is a follow-up once the split is stable and an image registry is in place.
+**Phase 2 — Publish images + flip the source of truth** (~1-2 weeks)
+
+5. Add a GHA job to POPS that builds `pops-api`, `pops-worker`, `pops-shell` images and pushes to GHCR on merge to `main` and on release tags.
+6. Move `docker-compose.yml` from POPS to `mu-deploy`, rewriting `build:` to `image: ghcr.io/knoxio/pops-api:main` (or tag).
+7. Add `DEPLOY.md` / `deploy.yaml` in POPS describing required env vars, ports, volumes, and optional services. `mu-deploy` reads this.
+8. POPS ships a `docker-compose.dev.yml` that keeps local `docker build` working.
+9. Delete `infra/` from POPS entirely.
+
+**Phase 3 — Auto-deploy on merge** (~2-3 days)
+
+10. GHA job after image publish triggers the self-hosted runner (now in `mu-deploy`) to `docker compose pull && up -d`.
+11. Add the `deploy_enabled` pause flag in `mu-deploy`.
+12. Rollback: `mu-deploy` records the last N running image tags; rollback is a `mu-deploy rollback pops` command that flips to the previous sha.
 
 ## Next steps if we proceed
 
-- Open an epic under theme `00-infrastructure` with PRDs for: (1) `mu-deploy` repo scaffolding, (2) `infra/DEPLOY.md` contract, (3) CI split, (4) secrets/vault migration.
+- Open an epic under theme `00-infrastructure`: "Extract deployment to mu-deploy".
+- PRDs: (1) mu-deploy repo scaffolding, (2) DEPLOY.md / deploy.yaml contract, (3) GHCR image publish + tagging, (4) auto-deploy webhook + pause flag, (5) rollback via mu-deploy CLI.
 - Snapshot the current vault before moving anything.
-- Decide on repo visibility + registry before doing the image work.
+- Confirm the self-hosted runner can be re-registered against `mu-deploy` without losing history.

--- a/docs/ideas/deployment-split-spike.md
+++ b/docs/ideas/deployment-split-spike.md
@@ -1,6 +1,6 @@
 # Spike — Extract deployment to a separate repo
 
-Investigation. Not committed. Sibling spikes: [modular-apps](./modular-apps-spike.md), [feature-toggles](./feature-toggles-spike.md).
+Investigation only — recommendations, no code changes. Sibling spikes: [modular-apps](./modular-apps-spike.md), [feature-toggles](./feature-toggles-spike.md).
 
 ## Question
 
@@ -9,7 +9,7 @@ Should the deployment surface move out of this repo into a dedicated `mu-deploy`
 ## Current coupling
 
 - `deploy.sh` — root-level script; expects to be run from the repo
-- `infra/docker-compose.yml` — references `../apps/pops-api/Dockerfile`, `../apps/pops-shell/Dockerfile`, `../packages/import-tools`, `../apps/moltbot/config`, `../secrets/*`
+- `infra/docker-compose.yml` — uses `context: ..` with `dockerfile: apps/pops-api/Dockerfile` and `dockerfile: apps/pops-shell/Dockerfile`; also references `../packages/import-tools`, `../apps/moltbot/config`, `../secrets/*`
 - `infra/ansible/` — 8 roles, most of which are **server-generic** (`common`, `docker`, `github-runner`, `secrets`, `cloudflare-tunnel`, `monitoring`, `backups`) and one that is **pops-specific** (`pops-deploy`)
 - `.github/workflows/root-deploy.yml` and `infra-quality.yml` — couple CI to the co-located infra
 - `scripts/setup-github-runner.sh` — generic server bootstrap, not pops-specific

--- a/docs/ideas/deployment-split-spike.md
+++ b/docs/ideas/deployment-split-spike.md
@@ -1,0 +1,83 @@
+# Spike — Extract deployment to a separate repo
+
+Investigation. Not committed. Sibling spikes: [modular-apps](./modular-apps-spike.md), [feature-toggles](./feature-toggles-spike.md).
+
+## Question
+
+Should the deployment surface move out of this repo into a dedicated `mu-deploy` (or similar) repo that manages the home-server fleet, leaving POPS as a self-contained dockerised app that anyone can `docker compose up`?
+
+## Current coupling
+
+- `deploy.sh` — root-level script; expects to be run from the repo
+- `infra/docker-compose.yml` — references `../apps/pops-api/Dockerfile`, `../apps/pops-shell/Dockerfile`, `../packages/import-tools`, `../apps/moltbot/config`, `../secrets/*`
+- `infra/ansible/` — 8 roles, most of which are **server-generic** (`common`, `docker`, `github-runner`, `secrets`, `cloudflare-tunnel`, `monitoring`, `backups`) and one that is **pops-specific** (`pops-deploy`)
+- `.github/workflows/root-deploy.yml` and `infra-quality.yml` — couple CI to the co-located infra
+- `scripts/setup-github-runner.sh` — generic server bootstrap, not pops-specific
+- `mise.toml` — ansible and docker tasks assume both code and infra live here
+- Dockerfiles copy workspace paths (`packages/app-*`, `packages/db-types`, `apps/pops-api/src/db/migrations`) — build context is the repo root
+
+The ansible roles are already clean (they don't import app code). The compose file is the main bridge.
+
+## Three ways to split
+
+| Option | What moves to `mu-deploy` | What stays in `pops` | Build model |
+| --- | --- | --- | --- |
+| **A. Full split** | `infra/ansible/`, `infra/docker-compose.yml`, `deploy.sh`, `scripts/setup-github-runner.sh`, all vault secrets | Dockerfiles, source | POPS publishes tagged images to a registry; `mu-deploy` pulls + runs |
+| **B. Ansible-only split** | `infra/ansible/`, `deploy.sh`, `scripts/setup-github-runner.sh` | Dockerfiles, `infra/docker-compose.yml` | POPS still builds locally on the server via compose; `mu-deploy` clones it and drives the build |
+| **C. Generic infra only** | `common`, `docker`, `github-runner`, `cloudflare-tunnel`, `monitoring`, `backups`, `secrets` | `pops-deploy` role, `docker-compose.yml`, Dockerfiles, `deploy.sh` | POPS owns its deploy; `mu-deploy` owns the host |
+
+Option C is the lightest: `mu-deploy` becomes a "my home server" repo that provisions Docker, runners, tunnels, backups, and monitoring on any box. Each hosted service (POPS, a future moltbot-standalone, anything else) keeps its own compose and deploy playbook and registers itself with the host.
+
+## Advantages
+
+- `mu-deploy` can host services other than POPS without POPS having to know
+- POPS becomes genuinely installable by a third party — `git clone && cp .env.example .env && docker compose up` (this directly supports the [modularisation spike](./modular-apps-spike.md))
+- POPS PRs no longer couple to infra PRs; CI for the app stops waiting on ansible lint
+- Vault/secrets lifecycle moves to where it belongs (the host, not the app)
+- Rebuilding / reprovisioning the server doesn't touch app history
+- Forces a clearer contract: POPS publishes what it needs (ports, volumes, env vars, secret names) and nothing more
+
+## Disadvantages / risks
+
+- Two repos to keep in lockstep — compose changes, env var additions, new secrets must propagate
+- Atomic rollback across app + infra changes is harder (can't `git revert` both in one PR)
+- Bootstrap chicken-and-egg: the self-hosted runner currently lives in the same repo it deploys — splitting means the runner has to bootstrap from `mu-deploy` first
+- Image registry becomes a dependency (GHCR is fine, but it's a new moving part)
+- Local dev story may regress if people currently lean on `mise docker:up` — need to keep that working from POPS alone
+
+## "Fully isolated in docker" — what it actually means
+
+Today POPS is already built in Docker. The gap to "fully isolated" is small:
+
+1. **Published images** — tag on push, push to GHCR. Compose pulls by tag instead of building locally. This is the main change.
+2. **No implicit host paths** — `../secrets/*` bind mounts get replaced with a documented `.env`-driven secrets directory and/or Docker secrets loaded by the operator.
+3. **A "what POPS needs" manifest** — a single file (`infra/DEPLOY.md` or a `deploy.yaml`) describing required env vars, ports, volumes, and optional services. `mu-deploy` reads this to configure the host.
+4. **Migrations baked into the image** — already true. `pops-api` runs drizzle migrations on startup.
+
+None of this requires architectural change, just discipline.
+
+## Open questions
+
+- Registry: GHCR, self-hosted, or both (public mirror + private)?
+- Image tagging: git sha, semver, or both?
+- Does `mu-deploy` stay private (it knows your host), or is it templated so others can fork it?
+- Do we keep a thin `docker-compose.yml` in POPS for local dev and a "production overlay" in `mu-deploy`, or ship one file and have `mu-deploy` provide overrides?
+- Moltbot — it already uses an upstream image; does it still belong in the POPS compose, or become its own service in `mu-deploy`?
+
+## Recommendation
+
+Option C first. Cheapest, reversible, and it doesn't force the image-registry work before we're ready. Migration steps:
+
+1. Create `mu-deploy` repo with the generic roles (`common`, `docker`, `github-runner`, `cloudflare-tunnel`, `monitoring`, `backups`, `secrets` scaffolding only — the vault stays scoped per host).
+2. Move `scripts/setup-github-runner.sh` and vault management there.
+3. Keep `infra/docker-compose.yml`, `infra/ansible/roles/pops-deploy`, and `deploy.sh` in POPS. The POPS deploy role becomes the contract `mu-deploy` invokes.
+4. Add `infra/DEPLOY.md` to POPS documenting the expected env vars, secrets, ports, and volumes.
+5. Re-point `.github/workflows/root-deploy.yml` at the new split (runner lives in `mu-deploy`, triggers `pops-deploy` role).
+
+Graduating to Option A (published images, no local build) is a follow-up once the split is stable and an image registry is in place.
+
+## Next steps if we proceed
+
+- Open an epic under theme `00-infrastructure` with PRDs for: (1) `mu-deploy` repo scaffolding, (2) `infra/DEPLOY.md` contract, (3) CI split, (4) secrets/vault migration.
+- Snapshot the current vault before moving anything.
+- Decide on repo visibility + registry before doing the image work.

--- a/docs/ideas/feature-toggles-spike.md
+++ b/docs/ideas/feature-toggles-spike.md
@@ -21,16 +21,16 @@ Some features should be toggleable — at install time, at runtime, or both. Exa
   - `tools` (on-demand import runner)
 - **Capability detection**: `sqlite-vec` loaded → vector search available; not loaded → search gracefully returns an "unavailable" error
 
-What's *missing* is a coherent story. Today a feature can be controlled by (a) an env var, (b) a secret, (c) a row in `settings`, (d) a compose profile, or (e) nothing at all — and the choice has been per-feature, case-by-case.
+What's _missing_ is a coherent story. Today a feature can be controlled by (a) an env var, (b) a secret, (c) a row in `settings`, (d) a compose profile, or (e) nothing at all — and the choice has been per-feature, case-by-case.
 
 ## Four categories — different answers for each
 
-| Category | Examples | Where the toggle lives | Install vs runtime |
-| --- | --- | --- | --- |
-| **Whole app** | finance, media, inventory, ego | App registry (see [modular-apps](./modular-apps-spike.md)) | Install (Tier 1) / runtime (Tier 2) |
-| **External integration** | Plex, Sonarr, Radarr, TMDB, TVDB, Up Bank, Paperless, Notion | Credentials presence + admin UI | Install via env; runtime enable/disable in admin |
-| **Sub-feature flag** | Rotation carousel, AI categoriser fallback, vector search, inventory connected-status indicator, debrief jobs | `settings` table, read per-request | Runtime only (default sensible, user toggles) |
-| **Experimental / preview** | Anything in-flight | Same as sub-feature, but tagged `preview: true` | Runtime |
+| Category                   | Examples                                                                                                      | Where the toggle lives                                     | Install vs runtime                               |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------ |
+| **Whole app**              | finance, media, inventory, ego                                                                                | App registry (see [modular-apps](./modular-apps-spike.md)) | Install (Tier 1) / runtime (Tier 2)              |
+| **External integration**   | Plex, Sonarr, Radarr, TMDB, TVDB, Up Bank, Paperless, Notion                                                  | Credentials presence + admin UI                            | Install via env; runtime enable/disable in admin |
+| **Sub-feature flag**       | Rotation carousel, AI categoriser fallback, vector search, inventory connected-status indicator, debrief jobs | `settings` table, read per-request                         | Runtime only (default sensible, user toggles)    |
+| **Experimental / preview** | Anything in-flight                                                                                            | Same as sub-feature, but tagged `preview: true`            | Runtime                                          |
 
 Rule of thumb:
 
@@ -90,7 +90,7 @@ Backed by a cached read from the `settings` table keyed by `<module>.<flag>`. Re
 
 - `.env` / Docker secrets: credentials only. Not feature state.
 - `POPS_APPS` env: which modules to mount (see [modular-apps](./modular-apps-spike.md)). This is the install-time coarse grain.
-- Compose profiles: optional *containers* (moltbot, tools). Keep as-is.
+- Compose profiles: optional _containers_ (moltbot, tools). Keep as-is.
 - `settings` table: all runtime feature state. Admin UI reads and writes here.
 - User preferences: in `settings` with user scope (or a separate `user_settings` table if we need per-user defaults).
 

--- a/docs/ideas/feature-toggles-spike.md
+++ b/docs/ideas/feature-toggles-spike.md
@@ -25,12 +25,12 @@ What's _missing_ is a coherent story. Today a feature can be controlled by (a) a
 
 ## Four categories — different answers for each
 
-| Category                   | Examples                                                                                                      | Where the toggle lives                                     | Install vs runtime                               |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------ |
-| **Whole app**              | finance, media, inventory, ego                                                                                | App registry (see [modular-apps](./modular-apps-spike.md)) | Install (Tier 1) / runtime (Tier 2)              |
-| **External integration**   | Plex, Sonarr, Radarr, TMDB, TVDB, Up Bank, Paperless, Notion                                                  | Credentials presence + admin UI                            | Install via env; runtime enable/disable in admin |
-| **Sub-feature flag**       | Rotation carousel, AI categoriser fallback, vector search, inventory connected-status indicator, debrief jobs | `settings` table, read per-request                         | Runtime only (default sensible, user toggles)    |
-| **Experimental / preview** | Anything in-flight                                                                                            | Same as sub-feature, but tagged `preview: true`            | Runtime                                          |
+| Category                   | Examples                                                                                                      | Where the toggle lives                                        | Install vs runtime                               |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------ |
+| **Whole module**           | App: finance, media, inventory, engrams, ai-admin. Overlay: search, ego                                       | Module registry (see [modular-apps](./modular-apps-spike.md)) | Install-time via `POPS_APPS` / `POPS_OVERLAYS`   |
+| **External integration**   | Plex, Sonarr, Radarr, TMDB, TVDB, Up Bank, Paperless, Notion                                                  | Credentials presence + admin UI                               | Install via env; runtime enable/disable in admin |
+| **Sub-feature flag**       | Rotation carousel, AI categoriser fallback, vector search, inventory connected-status indicator, debrief jobs | `settings` table, read per-request                            | Runtime only (default sensible, user toggles)    |
+| **Experimental / preview** | Anything in-flight                                                                                            | Same as sub-feature, but tagged `preview: true`               | Runtime                                          |
 
 Rule of thumb:
 

--- a/docs/ideas/feature-toggles-spike.md
+++ b/docs/ideas/feature-toggles-spike.md
@@ -1,0 +1,155 @@
+# Spike — Feature toggles (install-time and runtime)
+
+Investigation. Not committed. Sibling spikes: [deployment-split](./deployment-split-spike.md), [modular-apps](./modular-apps-spike.md).
+
+## Question
+
+Some features should be toggleable — at install time, at runtime, or both. Examples given: Plex, Sonarr/Radarr, the "connected status" on inventory. What is the right layering so we don't end up with a flag graveyard?
+
+## What already exists
+
+- **Runtime settings** (`settings` table, read at request time):
+  - `PLEX_SCHEDULER_ENABLED` — gates the Plex sync cron
+  - `ROTATION_ENABLED` — gates the carousel rotation feature
+- **Credentials-as-toggle** (env / Docker secrets):
+  - Paperless — absent `PAPERLESS_BASE_URL` / `PAPERLESS_API_TOKEN` disables the integration; thumbnail endpoint returns 404 gracefully
+  - Radarr/Sonarr, TMDB, TVDB — no credentials ⇒ routes compile but calls fail soft
+  - Up Bank webhook — only active if secret is set
+  - Redis — API starts in a degraded mode without it (queues + cache disabled)
+- **Compose profiles** for optional containers:
+  - `moltbot` (opt-in Telegram bot)
+  - `tools` (on-demand import runner)
+- **Capability detection**: `sqlite-vec` loaded → vector search available; not loaded → search gracefully returns an "unavailable" error
+
+What's *missing* is a coherent story. Today a feature can be controlled by (a) an env var, (b) a secret, (c) a row in `settings`, (d) a compose profile, or (e) nothing at all — and the choice has been per-feature, case-by-case.
+
+## Four categories — different answers for each
+
+| Category | Examples | Where the toggle lives | Install vs runtime |
+| --- | --- | --- | --- |
+| **Whole app** | finance, media, inventory, ego | App registry (see [modular-apps](./modular-apps-spike.md)) | Install (Tier 1) / runtime (Tier 2) |
+| **External integration** | Plex, Sonarr, Radarr, TMDB, TVDB, Up Bank, Paperless, Notion | Credentials presence + admin UI | Install via env; runtime enable/disable in admin |
+| **Sub-feature flag** | Rotation carousel, AI categoriser fallback, vector search, inventory connected-status indicator, debrief jobs | `settings` table, read per-request | Runtime only (default sensible, user toggles) |
+| **Experimental / preview** | Anything in-flight | Same as sub-feature, but tagged `preview: true` | Runtime |
+
+Rule of thumb:
+
+- **If the user might flip it more than once → runtime setting.**
+- **If flipping it changes migrations or mounted routers → install-time (a module decision, not a flag).**
+- **If the feature depends on an external service's existence → credentials-presence is the toggle, admin UI reads from there.**
+
+## Proposed model
+
+### 1. Per-module settings manifest
+
+Each app declares what it can toggle:
+
+```ts
+// packages/app-media/src/features.ts
+export const mediaFeatures: FeatureManifest = {
+  plex: {
+    label: 'Plex sync',
+    description: 'Background job that pulls library + watch history from Plex.',
+    default: false,
+    requires: ['PLEX_URL', 'PLEX_TOKEN'],
+    scope: 'system',
+  },
+  arr: {
+    label: 'Radarr / Sonarr',
+    description: 'Request downloads for watchlist items.',
+    default: false,
+    requires: ['RADARR_URL', 'RADARR_API_KEY'],
+    scope: 'system',
+  },
+  rotation: {
+    label: 'Rotation carousel',
+    description: 'Cycles featured titles on the home page.',
+    default: true,
+    scope: 'system',
+  },
+};
+```
+
+- `scope: 'system'` — admin-only toggle.
+- `scope: 'user'` — per-user preference (e.g. "show connected-status badges on inventory items").
+- `requires: [...]` — names of env vars / secrets that must resolve. If missing, the toggle is visible but disabled with a "configure credentials first" hint.
+
+The shell builds the admin Features page from the union of all active modules' manifests. No per-module ad-hoc pages.
+
+### 2. Single read path
+
+One helper, everywhere:
+
+```ts
+const enabled = await features.isEnabled('media.plex', { user });
+```
+
+Backed by a cached read from the `settings` table keyed by `<module>.<flag>`. Replaces the scattered `if (process.env.X === 'true')` checks.
+
+### 3. Install-time vs runtime — what lives where
+
+- `.env` / Docker secrets: credentials only. Not feature state.
+- `POPS_APPS` env: which modules to mount (see [modular-apps](./modular-apps-spike.md)). This is the install-time coarse grain.
+- Compose profiles: optional *containers* (moltbot, tools). Keep as-is.
+- `settings` table: all runtime feature state. Admin UI reads and writes here.
+- User preferences: in `settings` with user scope (or a separate `user_settings` table if we need per-user defaults).
+
+### 4. Credential lifecycle
+
+Credentials presence already acts as an implicit enable. Formalise:
+
+- A feature that `requires: [...]` env vars is **gated** — the flag can only be `on` if the vars resolve.
+- Admin UI shows the state: "Plex: credentials missing" vs "Plex: configured, enabled" vs "Plex: configured, disabled".
+- Flipping credentials (rotate a token) shouldn't flip feature state — they're independent.
+
+## The "connected status on inventory" case, concretely
+
+This is a display-level affordance (badge on inventory items showing they're linked to Paperless receipts / photos / etc). Proper home:
+
+- **User-scoped** runtime toggle under inventory's feature manifest: `inventory.show_connected_status`, default `true`.
+- Displayed in inventory's settings section (rendered from the module's manifest).
+- Implementation reads once per session via the features helper.
+
+Not a system-wide toggle. Not an env var. Not a compile-time option.
+
+## Advantages
+
+- One mental model for the user: "look in the Features admin page"
+- One read path for engineers: `features.isEnabled('x.y')`
+- No more ad-hoc env-var checks scattered across modules
+- Plays well with modular apps — each module's manifest only contributes flags when the module is installed
+- Credentials and feature state stay independent, so rotating tokens doesn't lose settings
+- Trivial to add "preview" / experimental flagging later
+
+## Disadvantages / risks
+
+- **Flag fatigue** — too many flags become unmanageable. Mitigate: every flag gets a sunset plan; quarterly review; `deprecated: true` field surfaces in a report.
+- **Flag inconsistency across processes** — the API worker and the web API must see the same flag value. Cache invalidation on flag change, or short TTL (30s is fine for a single-user system).
+- **Testing surface** — matrix of flag combinations explodes. Discipline: default paths are the tested path; off-by-default flags are experimental until promoted.
+- **Overlap with modular apps** — a "whole module" is not a flag. Keep them separate to avoid one being used to simulate the other.
+- **Silent footguns** — a flag that's off but whose dependent data still exists can confuse users. Admin UI should warn: "Disabling this will stop sync; existing data is preserved."
+
+## Open questions
+
+- Do we need per-user flags, or is system-scope enough for a single-user deployment? (Probably system-scope is enough; design the API for both anyway.)
+- Cache strategy — TTL vs pub/sub? Redis is already optional (degraded mode), so TTL is the safer default.
+- Do feature flags version with the app manifest? If the media app adds a new flag, does `POPS_APPS=media@1.1` matter, or do flags migrate freely?
+- Should credentials live in the `settings` admin UI too (read-only, managed via secrets), or stay opaque (secrets only, admin UI just shows "configured yes/no")?
+
+## Recommendation
+
+Yes to this layering. Order of implementation:
+
+1. Define the `FeatureManifest` type and the `features.isEnabled` helper. Small, contained.
+2. Migrate existing ad-hoc toggles (`PLEX_SCHEDULER_ENABLED`, `ROTATION_ENABLED`, paperless gating) into manifests. No behaviour change, just centralisation.
+3. Build the admin Features page that renders from manifests.
+4. Add `requires: [...]` credential-gating.
+5. When modular apps land (see [modular-apps](./modular-apps-spike.md)), each module registers its manifest on install.
+
+This is the smallest of the three spikes and the one with the clearest ROI. Worth doing even if we delay the other two.
+
+## Next steps if we proceed
+
+- PRD under theme `01-foundation`: "Feature flag framework".
+- ADR: "Feature flags in the `settings` table, per-module manifests, one read path".
+- Audit existing env-var checks in `apps/pops-api/src/` and migrate them one per PR.

--- a/docs/ideas/feature-toggles-spike.md
+++ b/docs/ideas/feature-toggles-spike.md
@@ -1,6 +1,6 @@
 # Spike — Feature toggles (install-time and runtime)
 
-Investigation. Not committed. Sibling spikes: [deployment-split](./deployment-split-spike.md), [modular-apps](./modular-apps-spike.md).
+Investigation only — recommendations, no code changes. Sibling spikes: [deployment-split](./deployment-split-spike.md), [modular-apps](./modular-apps-spike.md).
 
 ## Question
 
@@ -51,14 +51,21 @@ export const mediaFeatures: FeatureManifest = {
     label: 'Plex sync',
     description: 'Background job that pulls library + watch history from Plex.',
     default: false,
-    requires: ['PLEX_URL', 'PLEX_TOKEN'],
+    requires: ['plex_url', 'plex_token'], // settings keys (env fallback supported)
     scope: 'system',
   },
-  arr: {
-    label: 'Radarr / Sonarr',
-    description: 'Request downloads for watchlist items.',
+  radarr: {
+    label: 'Radarr',
+    description: 'Request movie downloads for watchlist items.',
     default: false,
-    requires: ['RADARR_URL', 'RADARR_API_KEY'],
+    requires: ['radarr_url', 'radarr_api_key'],
+    scope: 'system',
+  },
+  sonarr: {
+    label: 'Sonarr',
+    description: 'Request TV downloads for watchlist items.',
+    default: false,
+    requires: ['sonarr_url', 'sonarr_api_key'],
     scope: 'system',
   },
   rotation: {
@@ -72,7 +79,7 @@ export const mediaFeatures: FeatureManifest = {
 
 - `scope: 'system'` — admin-only toggle.
 - `scope: 'user'` — per-user preference (e.g. "show connected-status badges on inventory items").
-- `requires: [...]` — names of env vars / secrets that must resolve. If missing, the toggle is visible but disabled with a "configure credentials first" hint.
+- `requires: [...]` — settings keys (see `packages/types/src/settings-keys.ts`) that must resolve to a non-empty value. Credentials live in the `settings` table today, with env-var fallback for some keys via the `envFallback` pattern. If any required key is empty in both settings and env, the toggle is visible but disabled with a "configure credentials first" hint.
 
 The shell builds the admin Features page from the union of all active modules' manifests. No per-module ad-hoc pages.
 
@@ -84,7 +91,7 @@ One helper, everywhere:
 const enabled = await features.isEnabled('media.plex', { user });
 ```
 
-Backed by a cached read from the `settings` table keyed by `<module>.<flag>`. Replaces the scattered `if (process.env.X === 'true')` checks.
+Backed by a cached read from the `settings` table keyed by `<module>.<flag>`. Centralises runtime settings lookups and standardises credential/capability gating so each module isn't rolling its own "is the Plex scheduler enabled and do we have the credentials?" logic.
 
 ### 3. Install-time vs runtime — what lives where
 

--- a/docs/ideas/feature-toggles-spike.md
+++ b/docs/ideas/feature-toggles-spike.md
@@ -9,8 +9,8 @@ Some features should be toggleable — at install time, at runtime, or both. Exa
 ## What already exists
 
 - **Runtime settings** (`settings` table, read at request time):
-  - `PLEX_SCHEDULER_ENABLED` — gates the Plex sync cron
-  - `ROTATION_ENABLED` — gates the carousel rotation feature
+  - `plex_scheduler_enabled` — gates the Plex sync cron
+  - `rotation_enabled` — gates the carousel rotation feature
 - **Credentials-as-toggle** (env / Docker secrets):
   - Paperless — absent `PAPERLESS_BASE_URL` / `PAPERLESS_API_TOKEN` disables the integration; thumbnail endpoint returns 404 gracefully
   - Radarr/Sonarr, TMDB, TVDB — no credentials ⇒ routes compile but calls fail soft
@@ -141,7 +141,7 @@ Not a system-wide toggle. Not an env var. Not a compile-time option.
 Yes to this layering. Order of implementation:
 
 1. Define the `FeatureManifest` type and the `features.isEnabled` helper. Small, contained.
-2. Migrate existing ad-hoc toggles (`PLEX_SCHEDULER_ENABLED`, `ROTATION_ENABLED`, paperless gating) into manifests. No behaviour change, just centralisation.
+2. Migrate existing ad-hoc toggles (`plex_scheduler_enabled`, `rotation_enabled`, paperless gating) into manifests. No behaviour change, just centralisation.
 3. Build the admin Features page that renders from manifests.
 4. Add `requires: [...]` credential-gating.
 5. When modular apps land (see [modular-apps](./modular-apps-spike.md)), each module registers its manifest on install.

--- a/docs/ideas/modular-apps-spike.md
+++ b/docs/ideas/modular-apps-spike.md
@@ -23,23 +23,23 @@ So the architecture is already close. The remaining work is to make app presence
 
 Always present (the "shell"):
 
-| Surface | Provided by |
-| --- | --- |
-| Auth, user, admin | `apps/pops-api/src/modules/core/*`, `@pops/auth` |
-| Settings | `apps/pops-shell/src/app/pages/SettingsPage.tsx`, `core/settings` |
-| Navigation, search | `packages/navigation`, shell layout |
-| UI library | `packages/ui` |
-| API client + types | `packages/api-client`, `packages/db-types` (core schema) |
-| Shared entities | `core/entities` ([ADR-005](../architecture/adr-005-shared-entities.md)) |
+| Surface            | Provided by                                                             |
+| ------------------ | ----------------------------------------------------------------------- |
+| Auth, user, admin  | `apps/pops-api/src/modules/core/*`, `@pops/auth`                        |
+| Settings           | `apps/pops-shell/src/app/pages/SettingsPage.tsx`, `core/settings`       |
+| Navigation, search | `packages/navigation`, shell layout                                     |
+| UI library         | `packages/ui`                                                           |
+| API client + types | `packages/api-client`, `packages/db-types` (core schema)                |
+| Shared entities    | `core/entities` ([ADR-005](../architecture/adr-005-shared-entities.md)) |
 
 Optional (the "apps"):
 
-| App | Tables owned | Notes |
-| --- | --- | --- |
-| finance | `transactions`, `budgets`, `wishlist`, `transaction_tag_rules` | Uses `entities` FK |
-| media | `movies`, `tv_shows`, `comparisons`, `watch_history`, `watchlist`, `rotation_*`, ~11 tables | Heaviest; external integrations (Plex, TMDB, TVDB, Arr) |
-| inventory | `home_inventory`, `item_connections`, `item_documents`, `item_photos`, `locations` | Uses `entities` FK |
-| ai / ego / cerebrum | `engrams`, `embeddings`, `ai_usage`, `debrief_*` | See open question on "ego" below |
+| App                 | Tables owned                                                                                | Notes                                                   |
+| ------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| finance             | `transactions`, `budgets`, `wishlist`, `transaction_tag_rules`                              | Uses `entities` FK                                      |
+| media               | `movies`, `tv_shows`, `comparisons`, `watch_history`, `watchlist`, `rotation_*`, ~11 tables | Heaviest; external integrations (Plex, TMDB, TVDB, Arr) |
+| inventory           | `home_inventory`, `item_connections`, `item_documents`, `item_photos`, `locations`          | Uses `entities` FK                                      |
+| ai / ego / cerebrum | `engrams`, `embeddings`, `ai_usage`, `debrief_*`                                            | See open question on "ego" below                        |
 
 ## What has to change
 
@@ -77,7 +77,7 @@ Today, cross-app comms is implicit (shared `entities` FK, implicit URI resolutio
 
 - **Typed contracts**: `packages/contracts/` defines versioned interfaces (e.g. `core.entity@1`, `finance.transaction@1`). Apps consume via tRPC calls only.
 - **No cross-app imports at code level** (already enforced — keep enforcing).
-- **Optional dependencies**: an app that *can* link to an object type from another app (e.g. inventory item linked from a finance transaction note) must declare it as optional and degrade when that app is absent. The URI resolver ([ADR-012](../architecture/adr-012-universal-object-uri.md)) needs to tolerate missing resolvers.
+- **Optional dependencies**: an app that _can_ link to an object type from another app (e.g. inventory item linked from a finance transaction note) must declare it as optional and degrade when that app is absent. The URI resolver ([ADR-012](../architecture/adr-012-universal-object-uri.md)) needs to tolerate missing resolvers.
 - **FK hygiene**: cross-app FKs become nullable with `ON DELETE SET NULL`. No cascading deletes across app boundaries.
 
 ### 4. Database — the real cost
@@ -86,8 +86,8 @@ SQLite is one file, and today's FKs cross boundaries. Two sub-problems:
 
 - **Install**: run that app's migrations against the shared DB. Each app owns a migration folder; `drizzle-kit` run scoped per app. The existing single-migrations model ([ADR-013](../architecture/adr-013-drizzle-orm.md)) needs to be sliced per app.
 - **Uninstall**: what happens to the data?
-  - *Soft uninstall* (default): routes hidden, router unmounted, jobs stopped, data retained. Reinstall is instant.
-  - *Hard uninstall*: export (JSON) → drop tables → null cross-refs. Needs a per-app export format and user confirmation.
+  - _Soft uninstall_ (default): routes hidden, router unmounted, jobs stopped, data retained. Reinstall is instant.
+  - _Hard uninstall_: export (JSON) → drop tables → null cross-refs. Needs a per-app export format and user confirmation.
   - Cross-app references (e.g. inventory items referenced from finance) must be scanned before hard uninstall. Show "this will break N links in finance" before proceeding.
 
 ### 5. Progressive add/remove UX

--- a/docs/ideas/modular-apps-spike.md
+++ b/docs/ideas/modular-apps-spike.md
@@ -19,7 +19,9 @@ The bones are already here:
 
 So the architecture is already close. The remaining work is to make app presence a runtime decision instead of a compile-time one, and to formalise contracts.
 
-## The shell / app boundary
+## The shell / app / overlay boundary
+
+Three categories, not two. This falls out of the ego question — ego is not a page-routed app, it's a system-wide overlay (like search) that is still installable/removable.
 
 Always present (the "shell"):
 
@@ -32,36 +34,63 @@ Always present (the "shell"):
 | API client + types | `packages/api-client`, `packages/db-types` (core schema)                                                          |
 | Shared entities    | `core/entities` ([ADR-005](../architecture/adr-005-shared-entities.md))                                           |
 
-Optional (the "apps"):
+Optional page-routed apps (own navigation, pages, domain data):
 
-| App                 | Tables owned                                                                                | Notes                                                   |
-| ------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| finance             | `transactions`, `budgets`, `wishlist`, `transaction_tag_rules`                              | Uses `entities` FK                                      |
-| media               | `movies`, `tv_shows`, `comparisons`, `watch_history`, `watchlist`, `rotation_*`, ~11 tables | Heaviest; external integrations (Plex, TMDB, TVDB, Arr) |
-| inventory           | `home_inventory`, `item_connections`, `item_documents`, `item_photos`, `locations`          | Uses `entities` FK                                      |
-| ai / ego / cerebrum | `engrams`, `embeddings`, `ai_usage`, `debrief_*`                                            | See open question on "ego" below                        |
+| App                 | Tables owned                                                                                | Notes                                                               |
+| ------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| finance             | `transactions`, `budgets`, `wishlist`, `transaction_tag_rules`                              | Uses `entities` FK                                                  |
+| media               | `movies`, `tv_shows`, `comparisons`, `watch_history`, `watchlist`, `rotation_*`, ~11 tables | Heaviest; external integrations (Plex, TMDB, TVDB, Arr)             |
+| inventory           | `home_inventory`, `item_connections`, `item_documents`, `item_photos`, `locations`          | Uses `entities` FK                                                  |
+| ai-admin (`app-ai`) | `ai_usage`, `ai_providers`, `ai_model_pricing`, `ai_inference_log`, `ai_budgets`            | Admin surface for AI providers + usage; under the cerebrum umbrella |
+| engrams             | `engrams`, `debrief_*`, knowledge/notes schema                                              | Notion-like notes/knowledge app; under the cerebrum umbrella        |
+| _(future)_          | _(more under cerebrum)_                                                                     | Cerebrum is an umbrella theme, not a single app                     |
+
+Optional overlays (installable/removable, but no dedicated navigation space — they surface through shell chrome):
+
+| Overlay | Summoned from                                              | Owns                                                                    |
+| ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
+| search  | Top-bar icon + keyboard shortcut                           | Search adapters, recent-searches state (currently built into the shell) |
+| ego     | Floating assistant across every page (like a chat overlay) | Conversation history, persona/memory config, AI overlay session state   |
+
+Both categories are _installable_ — they register their routers, migrations, settings, and (for apps) routes. Overlays differ only in how they surface: no dedicated `/path` in the router, instead they hook into shell chrome via a registry. Today search lives inside the shell; under this model it graduates to a first-class overlay module, making ego a sibling rather than a special case.
 
 ## What has to change
 
-### 1. App manifest
+### 1. Module manifest
 
-Each app package exports a manifest instead of bare `routes` + `navConfig`:
+Each module (app or overlay) exports a manifest instead of bare `routes` + `navConfig`:
 
 ```ts
 // packages/app-finance/src/index.ts
-export const manifest: AppManifest = {
+export const manifest: ModuleManifest = {
   id: 'finance',
   name: 'Finance',
   version: '1.0.0',
+  kind: 'app',                    // 'app' | 'overlay'
   frontend: { routes, navConfig, searchAdapters },
   backend: { router: financeRouter, jobs: [...] },
-  schema: financeSchemas,        // drizzle tables owned by this app
-  migrations: './migrations',     // app-owned migrations
+  schema: financeSchemas,        // drizzle tables owned by this module
+  migrations: './migrations',     // module-owned migrations
   dependsOn: ['core.entities'],   // contracts consumed
   provides: ['finance.transaction', 'finance.budget'],
   settings: financeSettingsManifest,
-  onInstall: async (db) => {...}, // hook for first-install side effects
-  onUninstall: async (db, opts) => {...}, // hook for data retention/deletion
+  onInstall: async (db) => {...}, // first-install side effects
+  onUninstall: async (db, opts) => {...}, // opts.mode: 'soft' | 'hard'
+};
+
+// packages/overlay-ego/src/index.ts
+export const manifest: ModuleManifest = {
+  id: 'ego',
+  name: 'Ego',
+  kind: 'overlay',
+  frontend: {
+    chromeSlot: 'assistant',     // where in shell chrome it mounts
+    component: EgoOverlay,
+    settingsRoute: '/settings/ego',
+  },
+  backend: { router: egoRouter, jobs: [...] },
+  schema: egoSchemas,             // owns conversation + memory tables
+  // ...
 };
 ```
 
@@ -99,16 +128,21 @@ SQLite is one file, and today's FKs cross boundaries. Two sub-problems:
 
 ## Two tiers — ship in this order
 
-1. **Tier 1 — Install-time selection** (low risk, high value):
-   - A single `POPS_APPS=finance,inventory` env var at container start decides which apps are mounted.
-   - Migrations run only for listed apps. Others' tables simply don't exist.
-   - Changing the set requires a restart. Data retained if you re-enable.
-   - Covers the "onboarding a new user with only finance" story.
-2. **Tier 2 — Runtime install/uninstall** (builds on Tier 1):
-   - Add `apps` table, admin UI, hot-register, hot-migrate, soft/hard uninstall.
-   - The user's "progressive add/remove" requirement is fully met here.
+Restart-on-change is acceptable, so neither tier needs hot-register/hot-migrate. The difference is how the set of installed modules is _declared_.
 
-Tier 1 is ~1 week. Tier 2 is 2–3 weeks after Tier 1 lands.
+1. **Tier 1 — Declarative via env** (low risk, ~1 week):
+   - `POPS_APPS=finance,inventory,engrams` + `POPS_OVERLAYS=search,ego` at container start decide what gets mounted.
+   - Migrations run only for listed modules on boot.
+   - Changing the set requires a container restart. Default is soft: stopping a module keeps its tables and data intact.
+   - Covers the "third-party installs only finance" story via the operator's env file.
+2. **Tier 2 — Admin-UI driven (still restart to apply)** (~2 weeks after Tier 1):
+   - Admin **Modules** page lists installed, available, and removed modules.
+   - Install / soft-remove writes to an `installed_modules` table and prompts a restart (or triggers one for self-hosted).
+   - **Hard-remove** is a separate destructive action with a preflight:
+     - Scan cross-module FKs, show "this will null N links in finance, M in inventory" before confirming.
+     - Export the module's tables to JSON/SQL backup under `data/exports/<module>/<timestamp>/`.
+     - Drop tables in a transaction, null cross-refs, remove from `installed_modules`.
+   - Soft remains the default everywhere; hard is opt-in and gated behind a typed confirmation.
 
 ## Advantages
 
@@ -121,35 +155,42 @@ Tier 1 is ~1 week. Tier 2 is 2–3 weeks after Tier 1 lands.
 
 ## Disadvantages / risks
 
-- **Schema migrations get harder**: per-app migration folders, cross-app FK ordering, install/uninstall idempotency — real work
-- **Cross-app features degrade**: universal search, URI resolver, the AI overlay (all of which expect every domain to be present) need to handle absent apps
-- **More surface to test**: matrix of installed-app combinations grows quickly (2^4 = 16 today)
-- **"Ego" naming drift**: you mentioned "ego" as an app — the codebase has `app-ai` (frontend) and a `cerebrum` backend module. We need to settle what the user-visible app is called and whether cerebrum's engrams belong to it or to core (see open questions)
+- **Schema migrations get harder**: per-module migration folders, cross-module FK ordering, install/uninstall idempotency — real work
+- **Cross-module features degrade**: universal search, URI resolver, the ego overlay (all of which expect every domain to be present) need to handle absent modules
+- **More surface to test**: matrix of installed-module combinations grows fast. With 4 apps + 2 overlays that's 64 possible sets; test the sensible ones (everything, minimum viable, each-alone) not the full matrix
 - **Data gravity**: media owns the most schema — making it removable is a lot of work for what will probably always be installed on your server
-- **Single SQLite file**: works fine for this model; if someone wants "totally separate databases per app" that's a bigger rethink (and probably not needed)
+- **Single SQLite file**: works fine for this model; if someone wants "totally separate databases per module" that's a bigger rethink (and probably not needed)
 
-## Open questions
+## Resolved
 
-- **Ego / AI / cerebrum.** You wrote "everything but ego". The repo has `app-ai` (frontend: AI usage, prompt templates, rules, cache management, plus a settings redirect) and `cerebrum` (backend: engrams, templates, scopes). Are these the same thing in your head? Is "ego" a rename of the user-facing AI app, or a new fifth app? **This shapes the boundary work.**
-- Should engrams (`cerebrum`) be **core** (shell-level, always present, like entities) or an **app** (removable)? Universal URIs, the AI overlay, and cross-domain context all lean on engrams — arguments for core.
-- Are settings-per-app owned by the app (with the app's manifest registering them) or all in core?
-- Does admin (user management, audit, system settings) live in the shell or become its own mini-app?
-- Are we willing to enforce "no cross-app code imports" via a lint rule, not just convention?
-- Is runtime add/remove (Tier 2) worth it now, or is Tier 1 + a documented reinstall procedure enough?
+- **Cerebrum is an umbrella theme, not an app.** Under it sit independently installable modules: `ego` (overlay), `engrams` (app — Notion-like knowledge/notes), `ai-admin` (app — the current `app-ai`: usage, prompts, rules, cache), and more to come.
+- **Ego is an overlay, not a page-routed app.** It behaves like an app (installable/removable, has settings, owns its data) but surfaces as a system-wide overlay like search. This justifies the `kind: 'overlay'` distinction in the manifest.
+- **Audience is both** — architectural hygiene for the current server AND third-party installability. Design contracts and manifests tight enough that `git clone && docker compose up` with `POPS_APPS=finance` produces a working single-app install.
+- **Restart-on-change is acceptable**, so hot-register is not on the critical path. Soft-remove is the default; hard-remove is a separately-gated destructive action.
+
+## Still open
+
+- Are per-module settings owned by the module (manifest registers them) or all in core? Manifest-owned feels right; revisit when the feature-toggle framework lands.
+- Does admin (user management, audit, system settings) live in the shell or become its own mini-app? Lean shell for now.
+- Are we willing to enforce "no cross-module code imports" via a lint rule (eslint-plugin-boundaries or dependency-cruiser), not just convention?
+- Where does `packages/app-ai` rename land? To `packages/app-ai-admin` (clearer) or stay `app-ai` with an updated description?
+- Does `packages/navigation` stay shell-level (search coexists with `ego` there) or split into `packages/overlay-search` + `packages/overlay-ego` once overlays are a formal category?
 
 ## Recommendation
 
-Yes — this is worth doing, and the current architecture is already mostly aligned. Phase it:
+Yes. Sequence:
 
-1. Settle the ego/AI/cerebrum naming + boundary (blocker for the rest)
-2. Formalise contracts and add the app manifest type
-3. Ship Tier 1 (`POPS_APPS` env var, per-app migrations, registry-based composition)
-4. Revisit Tier 2 once Tier 1 is stable — likely worth it for the clean UX but not urgent
-5. Enforce "no cross-app imports" with an eslint/dependency-cruiser rule so the boundary stops being honour-system
+1. Formalise the manifest + `kind: 'app' | 'overlay'` distinction
+2. Graduate `search` from shell-internal to a first-class overlay (no behaviour change, just the shape we want)
+3. Add the contracts package and the per-module migration layout
+4. Ship Tier 1 (`POPS_APPS` / `POPS_OVERLAYS` env, per-module migrations, registry-based composition)
+5. Build the admin **Modules** page with soft-install/remove + destructive hard-remove with preflight scan (Tier 2)
+6. Enforce "no cross-module imports" with a lint rule so the boundary stops being honour-system
+7. In parallel, start the split under the cerebrum umbrella: extract `engrams` as its own app, rename/repurpose `app-ai` → ai-admin, scaffold `overlay-ego`
 
 ## Next steps if we proceed
 
-- Open an epic under theme `01-foundation` or a new `07-shell` theme: "Modular app runtime".
-- PRDs: (1) app manifest + registry, (2) per-app migrations, (3) frontend dynamic load, (4) contracts package, (5) admin Apps page (Tier 2).
-- Write an ADR superseding [ADR-002](../architecture/adr-002-shell-architecture.md) or extending [ADR-004](../architecture/adr-004-api-domain-modules.md) to lock in the registry model.
-- Pre-work: clarify ego/cerebrum naming; audit cross-app FKs in `packages/db-types/src/schema/`.
+- Open an epic under a new `07-shell` theme (or extend `01-foundation`): "Modular module runtime".
+- PRDs: (1) manifest + registry, (2) per-module migrations, (3) frontend dynamic load, (4) contracts package, (5) admin Modules page incl. hard-remove preflight, (6) overlay category + ego scaffold, (7) engrams app extraction.
+- Write an ADR extending [ADR-002](../architecture/adr-002-shell-architecture.md) / [ADR-004](../architecture/adr-004-api-domain-modules.md) to lock in app-vs-overlay + the registry model.
+- Pre-work: audit cross-module FKs in `packages/db-types/src/schema/`, scope the split of `cerebrum` backend module into ego + engrams + ai-admin backends.

--- a/docs/ideas/modular-apps-spike.md
+++ b/docs/ideas/modular-apps-spike.md
@@ -1,0 +1,155 @@
+# Spike — POPS as a suite of apps on a shell
+
+Investigation. Not committed. Sibling spikes: [deployment-split](./deployment-split-spike.md), [feature-toggles](./feature-toggles-spike.md).
+
+## Question
+
+Restructure POPS so someone can install **only** finance, or **only** media, or "everything but ego", etc. The shell (auth, user, admin, settings, navigation, shared UI) is always present. Each app owns its data, API, and pages. Cross-app communication goes through well-defined contracts. **Apps can be added or removed progressively after install, not just at install time.**
+
+## Current state — better than expected
+
+The bones are already here:
+
+- `apps/pops-shell/src/app/router.tsx:10-13` — shell statically imports four app packages (`@pops/app-finance`, `@pops/app-media`, `@pops/app-inventory`, `@pops/app-ai`) and mounts their exported routes
+- `apps/pops-api/src/router.ts:24-30` — tRPC root manually composes per-domain routers (`finance`, `media`, `inventory`, `cerebrum`, `core`)
+- `packages/app-*` — each app is a proper workspace package with its own `src/index.ts`, routes, pages, store. Research confirms **no app imports another app** — they only depend on `@pops/ui`, `@pops/api-client`, `@pops/navigation`, `@pops/db-types`
+- [ADR-002](../architecture/adr-002-shell-architecture.md) explicitly states "apps import from `@pops/ui` and shared packages, never from other apps. Cross-app communication goes through the API or shared stores"
+- [ADR-004](../architecture/adr-004-api-domain-modules.md) limits backend modules to importing from `core/` only
+- `@pops/navigation` already uses a **side-effect registry** (`registerResultComponent`) for search adapters — the seed of the right pattern
+
+So the architecture is already close. The remaining work is to make app presence a runtime decision instead of a compile-time one, and to formalise contracts.
+
+## The shell / app boundary
+
+Always present (the "shell"):
+
+| Surface | Provided by |
+| --- | --- |
+| Auth, user, admin | `apps/pops-api/src/modules/core/*`, `@pops/auth` |
+| Settings | `apps/pops-shell/src/app/pages/SettingsPage.tsx`, `core/settings` |
+| Navigation, search | `packages/navigation`, shell layout |
+| UI library | `packages/ui` |
+| API client + types | `packages/api-client`, `packages/db-types` (core schema) |
+| Shared entities | `core/entities` ([ADR-005](../architecture/adr-005-shared-entities.md)) |
+
+Optional (the "apps"):
+
+| App | Tables owned | Notes |
+| --- | --- | --- |
+| finance | `transactions`, `budgets`, `wishlist`, `transaction_tag_rules` | Uses `entities` FK |
+| media | `movies`, `tv_shows`, `comparisons`, `watch_history`, `watchlist`, `rotation_*`, ~11 tables | Heaviest; external integrations (Plex, TMDB, TVDB, Arr) |
+| inventory | `home_inventory`, `item_connections`, `item_documents`, `item_photos`, `locations` | Uses `entities` FK |
+| ai / ego / cerebrum | `engrams`, `embeddings`, `ai_usage`, `debrief_*` | See open question on "ego" below |
+
+## What has to change
+
+### 1. App manifest
+
+Each app package exports a manifest instead of bare `routes` + `navConfig`:
+
+```ts
+// packages/app-finance/src/index.ts
+export const manifest: AppManifest = {
+  id: 'finance',
+  name: 'Finance',
+  version: '1.0.0',
+  frontend: { routes, navConfig, searchAdapters },
+  backend: { router: financeRouter, jobs: [...] },
+  schema: financeSchemas,        // drizzle tables owned by this app
+  migrations: './migrations',     // app-owned migrations
+  dependsOn: ['core.entities'],   // contracts consumed
+  provides: ['finance.transaction', 'finance.budget'],
+  settings: financeSettingsManifest,
+  onInstall: async (db) => {...}, // hook for first-install side effects
+  onUninstall: async (db, opts) => {...}, // hook for data retention/deletion
+};
+```
+
+### 2. Runtime registry (shell + API)
+
+- **Backend**: replace the manual `appRouter` composition with a loader that reads an "installed apps" list (from the DB `apps` table) and composes only those routers. Migrations run per-app on install.
+- **Frontend**: replace the four static imports in `router.tsx` with a fetch to `/api/shell/manifest` that returns which apps are installed, then dynamic `import()` of each. Vite already code-splits per app chunk — this works today if we switch the import style.
+- Routes for uninstalled apps redirect to a "not installed" page rather than 404, so links from other apps degrade gracefully.
+
+### 3. Contracts for cross-app communication
+
+Today, cross-app comms is implicit (shared `entities` FK, implicit URI resolution in `@pops/navigation`). Formalise as:
+
+- **Typed contracts**: `packages/contracts/` defines versioned interfaces (e.g. `core.entity@1`, `finance.transaction@1`). Apps consume via tRPC calls only.
+- **No cross-app imports at code level** (already enforced — keep enforcing).
+- **Optional dependencies**: an app that *can* link to an object type from another app (e.g. inventory item linked from a finance transaction note) must declare it as optional and degrade when that app is absent. The URI resolver ([ADR-012](../architecture/adr-012-universal-object-uri.md)) needs to tolerate missing resolvers.
+- **FK hygiene**: cross-app FKs become nullable with `ON DELETE SET NULL`. No cascading deletes across app boundaries.
+
+### 4. Database — the real cost
+
+SQLite is one file, and today's FKs cross boundaries. Two sub-problems:
+
+- **Install**: run that app's migrations against the shared DB. Each app owns a migration folder; `drizzle-kit` run scoped per app. The existing single-migrations model ([ADR-013](../architecture/adr-013-drizzle-orm.md)) needs to be sliced per app.
+- **Uninstall**: what happens to the data?
+  - *Soft uninstall* (default): routes hidden, router unmounted, jobs stopped, data retained. Reinstall is instant.
+  - *Hard uninstall*: export (JSON) → drop tables → null cross-refs. Needs a per-app export format and user confirmation.
+  - Cross-app references (e.g. inventory items referenced from finance) must be scanned before hard uninstall. Show "this will break N links in finance" before proceeding.
+
+### 5. Progressive add/remove UX
+
+- New admin page: **Apps**. Lists installed apps, available-but-not-installed apps, and a button to install/uninstall.
+- Install: runs migrations, seeds default settings, hot-registers the backend router, triggers shell manifest refresh.
+- Uninstall: soft by default; "Remove data" is a separate destructive confirmation.
+- Shell re-renders on manifest change without a full reload (React Router supports dynamic route trees; easier: reload on install/uninstall — fine for self-hosted single-user).
+
+## Two tiers — ship in this order
+
+1. **Tier 1 — Install-time selection** (low risk, high value):
+   - A single `POPS_APPS=finance,inventory` env var at container start decides which apps are mounted.
+   - Migrations run only for listed apps. Others' tables simply don't exist.
+   - Changing the set requires a restart. Data retained if you re-enable.
+   - Covers the "onboarding a new user with only finance" story.
+2. **Tier 2 — Runtime install/uninstall** (builds on Tier 1):
+   - Add `apps` table, admin UI, hot-register, hot-migrate, soft/hard uninstall.
+   - The user's "progressive add/remove" requirement is fully met here.
+
+Tier 1 is ~1 week. Tier 2 is 2–3 weeks after Tier 1 lands.
+
+## Advantages
+
+- Third-party installability — someone can run "just media" on their own server with no finance data model present
+- Smaller install footprint when features aren't wanted (fewer tables, fewer env vars required, fewer cron jobs)
+- Clearer architectural boundaries — contracts become explicit instead of implicit
+- Enables independent app versioning later if we want
+- Supports [deployment-split](./deployment-split-spike.md) — a split deploy repo can compose different POPS images for different hosts
+- Pairs with [feature-toggles](./feature-toggles-spike.md) — modules are the coarse grain, toggles the fine grain
+
+## Disadvantages / risks
+
+- **Schema migrations get harder**: per-app migration folders, cross-app FK ordering, install/uninstall idempotency — real work
+- **Cross-app features degrade**: universal search, URI resolver, the AI overlay (all of which expect every domain to be present) need to handle absent apps
+- **More surface to test**: matrix of installed-app combinations grows quickly (2^4 = 16 today)
+- **"Ego" naming drift**: you mentioned "ego" as an app — the codebase has `app-ai` (frontend) and a `cerebrum` backend module. We need to settle what the user-visible app is called and whether cerebrum's engrams belong to it or to core (see open questions)
+- **Data gravity**: media owns the most schema — making it removable is a lot of work for what will probably always be installed on your server
+- **Single SQLite file**: works fine for this model; if someone wants "totally separate databases per app" that's a bigger rethink (and probably not needed)
+
+## Open questions
+
+- **Ego / AI / cerebrum.** You wrote "everything but ego". The repo has `app-ai` (frontend: AI usage, budgets, model config) and `cerebrum` (backend: engrams, templates, scopes). Are these the same thing in your head? Is "ego" a rename of the user-facing AI app, or a new fifth app? **This shapes the boundary work.**
+- Should engrams (`cerebrum`) be **core** (shell-level, always present, like entities) or an **app** (removable)? Universal URIs, the AI overlay, and cross-domain context all lean on engrams — arguments for core.
+- Are settings-per-app owned by the app (with the app's manifest registering them) or all in core?
+- Does admin (user management, audit, system settings) live in the shell or become its own mini-app?
+- Are we willing to enforce "no cross-app code imports" via a lint rule, not just convention?
+- Is runtime add/remove (Tier 2) worth it now, or is Tier 1 + a documented reinstall procedure enough?
+
+## Recommendation
+
+Yes — this is worth doing, and the current architecture is already mostly aligned. Phase it:
+
+1. Settle the ego/AI/cerebrum naming + boundary (blocker for the rest)
+2. Formalise contracts and add the app manifest type
+3. Ship Tier 1 (`POPS_APPS` env var, per-app migrations, registry-based composition)
+4. Revisit Tier 2 once Tier 1 is stable — likely worth it for the clean UX but not urgent
+5. Enforce "no cross-app imports" with an eslint/dependency-cruiser rule so the boundary stops being honour-system
+
+## Next steps if we proceed
+
+- Open an epic under theme `01-foundation` or a new `07-shell` theme: "Modular app runtime".
+- PRDs: (1) app manifest + registry, (2) per-app migrations, (3) frontend dynamic load, (4) contracts package, (5) admin Apps page (Tier 2).
+- Write an ADR superseding [ADR-002](../architecture/adr-002-shell-architecture.md) or extending [ADR-004](../architecture/adr-004-api-domain-modules.md) to lock in the registry model.
+- Pre-work: clarify ego/cerebrum naming; audit cross-app FKs in `packages/db-types/src/schema/`.

--- a/docs/ideas/modular-apps-spike.md
+++ b/docs/ideas/modular-apps-spike.md
@@ -1,6 +1,6 @@
 # Spike — POPS as a suite of apps on a shell
 
-Investigation. Not committed. Sibling spikes: [deployment-split](./deployment-split-spike.md), [feature-toggles](./feature-toggles-spike.md).
+Investigation only — recommendations, no code changes. Sibling spikes: [deployment-split](./deployment-split-spike.md), [feature-toggles](./feature-toggles-spike.md).
 
 ## Question
 
@@ -12,7 +12,7 @@ The bones are already here:
 
 - `apps/pops-shell/src/app/router.tsx:10-13` — shell statically imports four app packages (`@pops/app-finance`, `@pops/app-media`, `@pops/app-inventory`, `@pops/app-ai`) and mounts their exported routes
 - `apps/pops-api/src/router.ts:24-30` — tRPC root manually composes per-domain routers (`finance`, `media`, `inventory`, `cerebrum`, `core`)
-- `packages/app-*` — each app is a proper workspace package with its own `src/index.ts`, routes, pages, store. Research confirms **no app imports another app** — they only depend on `@pops/ui`, `@pops/api-client`, `@pops/navigation`, `@pops/db-types`
+- `packages/app-*` — each app is a proper workspace package with its own `src/index.ts`, routes, pages, store. Research confirms **no app imports another app** — apps import shared workspace packages (`@pops/ui`, `@pops/api-client`, `@pops/navigation`, `@pops/db-types`, `@pops/types`, etc.) and external libraries as needed
 - [ADR-002](../architecture/adr-002-shell-architecture.md) explicitly states "apps import from `@pops/ui` and shared packages, never from other apps. Cross-app communication goes through the API or shared stores"
 - [ADR-004](../architecture/adr-004-api-domain-modules.md) limits backend modules to importing from `core/` only
 - `@pops/navigation` already uses a **side-effect registry** (`registerResultComponent`) for search result components; backend search adapters are a separate registry (`registerSearchAdapter`) in `apps/pops-api/src/modules/core/search` — the seed of the right pattern

--- a/docs/ideas/modular-apps-spike.md
+++ b/docs/ideas/modular-apps-spike.md
@@ -15,7 +15,7 @@ The bones are already here:
 - `packages/app-*` — each app is a proper workspace package with its own `src/index.ts`, routes, pages, store. Research confirms **no app imports another app** — they only depend on `@pops/ui`, `@pops/api-client`, `@pops/navigation`, `@pops/db-types`
 - [ADR-002](../architecture/adr-002-shell-architecture.md) explicitly states "apps import from `@pops/ui` and shared packages, never from other apps. Cross-app communication goes through the API or shared stores"
 - [ADR-004](../architecture/adr-004-api-domain-modules.md) limits backend modules to importing from `core/` only
-- `@pops/navigation` already uses a **side-effect registry** (`registerResultComponent`) for search adapters — the seed of the right pattern
+- `@pops/navigation` already uses a **side-effect registry** (`registerResultComponent`) for search result components; backend search adapters are a separate registry (`registerSearchAdapter`) in `apps/pops-api/src/modules/core/search` — the seed of the right pattern
 
 So the architecture is already close. The remaining work is to make app presence a runtime decision instead of a compile-time one, and to formalise contracts.
 
@@ -23,14 +23,14 @@ So the architecture is already close. The remaining work is to make app presence
 
 Always present (the "shell"):
 
-| Surface            | Provided by                                                             |
-| ------------------ | ----------------------------------------------------------------------- |
-| Auth, user, admin  | `apps/pops-api/src/modules/core/*`, `@pops/auth`                        |
-| Settings           | `apps/pops-shell/src/app/pages/SettingsPage.tsx`, `core/settings`       |
-| Navigation, search | `packages/navigation`, shell layout                                     |
-| UI library         | `packages/ui`                                                           |
-| API client + types | `packages/api-client`, `packages/db-types` (core schema)                |
-| Shared entities    | `core/entities` ([ADR-005](../architecture/adr-005-shared-entities.md)) |
+| Surface            | Provided by                                                                                                       |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| Auth, user, admin  | `apps/pops-api/src/modules/core/*`, `apps/pops-api/src/trpc.ts`, `apps/pops-api/src/middleware/cloudflare-jwt.ts` |
+| Settings           | `apps/pops-shell/src/app/pages/SettingsPage.tsx`, `core/settings`                                                 |
+| Navigation, search | `packages/navigation`, shell layout                                                                               |
+| UI library         | `packages/ui`                                                                                                     |
+| API client + types | `packages/api-client`, `packages/db-types` (core schema)                                                          |
+| Shared entities    | `core/entities` ([ADR-005](../architecture/adr-005-shared-entities.md))                                           |
 
 Optional (the "apps"):
 
@@ -130,7 +130,7 @@ Tier 1 is ~1 week. Tier 2 is 2–3 weeks after Tier 1 lands.
 
 ## Open questions
 
-- **Ego / AI / cerebrum.** You wrote "everything but ego". The repo has `app-ai` (frontend: AI usage, budgets, model config) and `cerebrum` (backend: engrams, templates, scopes). Are these the same thing in your head? Is "ego" a rename of the user-facing AI app, or a new fifth app? **This shapes the boundary work.**
+- **Ego / AI / cerebrum.** You wrote "everything but ego". The repo has `app-ai` (frontend: AI usage, prompt templates, rules, cache management, plus a settings redirect) and `cerebrum` (backend: engrams, templates, scopes). Are these the same thing in your head? Is "ego" a rename of the user-facing AI app, or a new fifth app? **This shapes the boundary work.**
 - Should engrams (`cerebrum`) be **core** (shell-level, always present, like entities) or an **app** (removable)? Universal URIs, the AI overlay, and cross-domain context all lean on engrams — arguments for core.
 - Are settings-per-app owned by the app (with the app's manifest registering them) or all in core?
 - Does admin (user management, audit, system settings) live in the shell or become its own mini-app?


### PR DESCRIPTION
## Summary

Three investigation spikes under `docs/ideas/` responding to the architectural questions raised:

- **[deployment-split-spike.md](../blob/claude/investigate-modular-architecture-7jo3J/docs/ideas/deployment-split-spike.md)** — Extract deployment into a separate `mu-deploy` repo; keep POPS fully isolated in Docker. Three options compared; recommends starting with generic-infra-only extraction (Option C), graduating to published images later.
- **[modular-apps-spike.md](../blob/claude/investigate-modular-architecture-7jo3J/docs/ideas/modular-apps-spike.md)** — POPS as a suite of installable apps on a shell (auth/user/admin/settings/nav/UI). Current architecture is already close (ADR-002, ADR-004, no cross-app imports today). Proposes app manifest + runtime registry, two-tier rollout (install-time `POPS_APPS` env first, runtime add/remove second), and formal cross-app contracts. Flags ego/AI/cerebrum naming as a blocker to settle first.
- **[feature-toggles-spike.md](../blob/claude/investigate-modular-architecture-7jo3J/docs/ideas/feature-toggles-spike.md)** — Four categories (whole app / external integration / sub-feature / experimental) with different homes. Centralises existing ad-hoc toggles (`PLEX_SCHEDULER_ENABLED`, `ROTATION_ENABLED`, paperless gating) behind a per-module `FeatureManifest` + `features.isEnabled('x.y')` helper. Smallest scope, clearest ROI.

All three are cross-linked. They are research/recommendation documents — no code changes.

## Open questions called out

- Ego / AI / cerebrum naming (modular-apps spike) — needs a product call before the boundary work can start
- Image registry + tagging strategy (deployment-split spike)
- Runtime vs install-time for Tier 2 modularisation
- Per-user vs system-only feature flag scope

## Test plan

- [ ] Review the three spike docs and decide which to promote to PRDs
- [ ] Confirm ego/AI/cerebrum boundary before modular-apps work starts
- [ ] Decide whether to split deployment first or modularise first (they compose either way)
