### PR TITLE
e2e: media discovery page loads with content (#2133)

### DIFF
--- a/apps/pops-shell/e2e/media-discover.spec.ts
+++ b/apps/pops-shell/e2e/media-discover.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * Smoke test — Media discover page (#2133)
+ *
+ * Tier 3: confirms that `/media/discover` loads, renders at least one
+ * recommendation card with title + image (or placeholder), and does not
+ * throw console / page errors.
+ *
+ * The discover session assembly runs a full pipeline of shelves, several of
+ * which depend on TMDB (external). We mock the three queries the page makes
+ * via `trpc.media.discovery.*` so the test is hermetic and deterministic:
+ *
+ *   - `media.discovery.assembleSession` — returns a single shelf with
+ *     three items (title + posterUrl + tmdbId).
+ *   - `media.discovery.profile`         — totalComparisons above the unlock
+ *     threshold so the CTA is not shown.
+ *   - `media.discovery.getDismissed`    — empty list.
+ *
+ * Crash detection is wired into beforeEach/afterEach (pageerror + console
+ * errors) so no separate crash test is needed.
+ */
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Fixture data
+// ---------------------------------------------------------------------------
+
+interface MockShelfItem {
+  tmdbId: number;
+  title: string;
+  releaseDate: string;
+  posterPath: string | null;
+  posterUrl: string | null;
+  voteAverage: number;
+  inLibrary: boolean;
+  isWatched?: boolean;
+  onWatchlist?: boolean;
+}
+
+interface MockShelf {
+  shelfId: string;
+  title: string;
+  subtitle?: string;
+  emoji?: string;
+  items: MockShelfItem[];
+  hasMore: boolean;
+}
+
+interface MockAssembleSession {
+  shelves: MockShelf[];
+}
+
+interface MockProfile {
+  totalComparisons: number;
+  totalMoviesWatched: number;
+  genreAffinities: never[];
+  dimensionWeights: never[];
+}
+
+const MOCK_SHELF: MockShelf = {
+  shelfId: 'trending-tmdb',
+  title: 'Trending Now',
+  subtitle: 'What everyone is watching',
+  items: [
+    {
+      tmdbId: 101,
+      title: 'Interstellar',
+      releaseDate: '2014-11-07',
+      posterPath: '/interstellar.jpg',
+      posterUrl: 'https://example.test/posters/interstellar.jpg',
+      voteAverage: 8.4,
+      inLibrary: false,
+    },
+    {
+      tmdbId: 102,
+      title: 'The Dark Knight',
+      releaseDate: '2008-07-18',
+      posterPath: '/dark-knight.jpg',
+      posterUrl: 'https://example.test/posters/dark-knight.jpg',
+      voteAverage: 9.0,
+      inLibrary: false,
+    },
+    {
+      tmdbId: 103,
+      title: 'Inception',
+      releaseDate: '2010-07-16',
+      // Exercise the placeholder path — posterUrl null triggers <ImageOff />.
+      posterPath: null,
+      posterUrl: null,
+      voteAverage: 8.8,
+      inLibrary: false,
+    },
+  ],
+  hasMore: false,
+};
+
+const MOCK_SESSION: MockAssembleSession = { shelves: [MOCK_SHELF] };
+
+const MOCK_PROFILE: MockProfile = {
+  totalComparisons: 10,
+  totalMoviesWatched: 10,
+  genreAffinities: [],
+  dimensionWeights: [],
+};
+
+const MOCK_DISMISSED: number[] = [];
+
+// ---------------------------------------------------------------------------
+// Mock helpers — tRPC httpBatchLink combines procedures with "," in the path
+// (e.g. /trpc/media.discovery.assembleSession,media.discovery.profile).
+// A single route must return a batch array indexed in the same order the
+// procedures appear in the URL path.
+// ---------------------------------------------------------------------------
+
+/** Result shape tRPC expects for a successful query. */
+function trpcOk<T>(data: T): { result: { data: T } } {
+  return { result: { data } };
+}
+
+/** Ordered procedure list used to index a batched response. */
+function extractProcedures(url: URL): string[] {
+  // URL path looks like `/trpc/a.b,c.d,e.f`. strip the prefix and split.
+  const prefix = '/trpc/';
+  const tail = url.pathname.startsWith(prefix) ? url.pathname.slice(prefix.length) : url.pathname;
+  return tail.split(',');
+}
+
+/** Build a result for a single procedure name. */
+function buildResult(procedure: string): unknown {
+  if (procedure === 'media.discovery.assembleSession') {
+    return trpcOk(MOCK_SESSION);
+  }
+  if (procedure === 'media.discovery.profile') {
+    return trpcOk({ data: MOCK_PROFILE });
+  }
+  if (procedure === 'media.discovery.getDismissed') {
+    return trpcOk({ data: MOCK_DISMISSED });
+  }
+  // Fallthrough — should not happen given the route regex below, but keep
+  // the response well-formed rather than crash the client.
+  return trpcOk(null);
+}
+
+async function handleDiscoveryRoute(route: Route): Promise<void> {
+  const url = new URL(route.request().url());
+  const isBatch = url.searchParams.has('batch');
+  const procedures = extractProcedures(url);
+  const body = isBatch ? procedures.map(buildResult) : buildResult(procedures[0] ?? '');
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+async function mockDiscoveryEndpoints(page: Page): Promise<void> {
+  // Batched URL contains all three procedure names joined by "," so this
+  // regex catches the combined request as well as any individual call.
+  await page.route(
+    /\/trpc\/[^?]*media\.discovery\.(assembleSession|profile|getDismissed)/,
+    handleDiscoveryRoute
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Media — discover page smoke test', () => {
+  let pageErrors: string[] = [];
+  let consoleErrors: string[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    pageErrors = [];
+    consoleErrors = [];
+    await mockDiscoveryEndpoints(page);
+    // Register before navigation so first-load errors are captured.
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    await page.goto('/media/discover');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    const realConsoleErrors = consoleErrors.filter(
+      (e) =>
+        !e.includes('React Router') &&
+        !e.includes('Download the React DevTools') &&
+        // Mock posterUrls point at example.test — WebKit logs the network
+        // failure as console.error. These are expected for the test.
+        !e.includes('Failed to load resource')
+    );
+    expect(pageErrors).toHaveLength(0);
+    expect(realConsoleErrors).toHaveLength(0);
+  });
+
+  test('renders recommendation cards with titles and imagery', async ({ page }) => {
+    // Page header — confirms the route resolved and the component mounted.
+    await expect(page.getByRole('heading', { level: 1, name: 'Discover' })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Shelf title — confirms the assembleSession data reached the UI.
+    await expect(page.getByRole('heading', { level: 2, name: 'Trending Now' })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // At least one card's title must be visible — locator is semantic,
+    // .first() guards against any duplicate node (e.g. overlay/visually-hidden).
+    await expect(
+      page.getByRole('heading', { level: 3, name: 'Interstellar' }).first()
+    ).toBeVisible();
+
+    // Card with a real posterUrl renders an <img alt="<title> poster">.
+    await expect(page.getByRole('img', { name: 'Interstellar poster' }).first()).toBeVisible();
+
+    // Card with null posterUrl falls back to the placeholder icon — the
+    // title is still rendered, which satisfies the "title + image (or
+    // placeholder)" requirement from the issue.
+    await expect(page.getByRole('heading', { level: 3, name: 'Inception' }).first()).toBeVisible();
+  });
+});

--- a/apps/pops-shell/e2e/media-discover.spec.ts
+++ b/apps/pops-shell/e2e/media-discover.spec.ts
@@ -54,6 +54,7 @@ interface MockProfile {
   totalMoviesWatched: number;
   genreAffinities: never[];
   dimensionWeights: never[];
+  genreDistribution: never[];
 }
 
 const MOCK_SHELF: MockShelf = {
@@ -100,6 +101,7 @@ const MOCK_PROFILE: MockProfile = {
   totalMoviesWatched: 10,
   genreAffinities: [],
   dimensionWeights: [],
+  genreDistribution: [],
 };
 
 const MOCK_DISMISSED: number[] = [];


### PR DESCRIPTION
## Summary
- New Playwright smoke test at `apps/pops-shell/e2e/media-discover.spec.ts` covering `/media/discover` (Tier 3 — issue #2133).
- Mocks the three tRPC queries the page fires (`media.discovery.assembleSession`, `profile`, `getDismissed`) via `page.route()`; `assembleSession` transitively depends on TMDB, so a hermetic mock is the correct call.
- Asserts: Discover header renders, shelf heading renders, at least one card title (`<h3>`) is visible, a card with `posterUrl` renders `<img alt="<title> poster">`, and a card with `posterUrl: null` falls back to the placeholder while still rendering its title.
- Crash detection wired into `beforeEach`/`afterEach` (pageerror + console-error filter — ignores React Router dev noise, devtools banner, and image 404s from mock hosts).

## Test plan
- [ ] `pnpm format:check` — clean
- [ ] `pnpm lint` — clean for the new file
- [ ] `pnpm typecheck` — passes (turbo, 16/16 tasks)
- [ ] `pnpm --filter @pops/shell test:e2e media-discover` locally

Closes #2133