### PR TITLE
fix(inventory): navigate before cache invalidation on item save (#2157)

### DIFF
--- a/packages/app-inventory/src/pages/ItemFormPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.test.tsx
@@ -4,6 +4,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { extractPrefix } from './ItemFormPage';
 
+const mockNavigate = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
 // ---------- prefix extraction tests (pure function) ----------
 
 describe('extractPrefix', () => {
@@ -78,6 +88,8 @@ const mockAttachMutate = vi.fn();
 const mockRemoveMutate = vi.fn();
 const mockReorderMutate = vi.fn();
 const mockRefetchPhotos = vi.fn();
+const mockListInvalidate = vi.fn();
+const mockGetInvalidate = vi.fn();
 
 vi.mock('@pops/api-client', () => ({
   trpc: {
@@ -153,8 +165,8 @@ vi.mock('@pops/api-client', () => ({
     useUtils: () => ({
       inventory: {
         items: {
-          list: { invalidate: vi.fn() },
-          get: { invalidate: vi.fn() },
+          list: { invalidate: mockListInvalidate },
+          get: { invalidate: mockGetInvalidate },
           searchByAssetId: { fetch: mockSearchByAssetIdFetch },
           countByAssetPrefix: { fetch: mockCountByAssetPrefixFetch },
         },
@@ -613,5 +625,97 @@ describe('ItemFormPage — Form gaps (#1851)', () => {
     const editBtn = screen.getByRole('button', { name: /edit/i });
     fireEvent.click(editBtn);
     expect(document.querySelector('textarea[name="notes"]')).toBeInTheDocument();
+  });
+});
+
+describe('ItemFormPage — Navigation order on save (#2157)', () => {
+  it('navigates to detail page before invalidating cache on update', async () => {
+    mockItemQuery.mockReturnValue({
+      data: {
+        data: {
+          id: 'item-1',
+          itemName: 'MacBook',
+          brand: null,
+          model: null,
+          itemId: null,
+          type: 'Electronics',
+          condition: 'good',
+          room: null,
+          inUse: false,
+          deductible: false,
+          purchaseDate: null,
+          warrantyExpires: null,
+          replacementValue: null,
+          resaleValue: null,
+          purchasePrice: null,
+          assetId: null,
+          notes: null,
+          locationId: null,
+          lastEditedTime: '2026-01-01',
+          purchaseTransactionId: null,
+          purchasedFromId: null,
+          purchasedFromName: null,
+        },
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderEdit('item-1');
+
+    // Save the form (no field changes required — RHF submits current values).
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await vi.waitFor(() => {
+      expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+    });
+
+    // Navigate must be called with the detail URL.
+    expect(mockNavigate).toHaveBeenCalledWith('/inventory/items/item-1');
+
+    // Both invalidations must run after navigation.
+    expect(mockListInvalidate).toHaveBeenCalled();
+    expect(mockGetInvalidate).toHaveBeenCalledWith({ id: 'item-1' });
+
+    // Assert call order via Vitest's invocation call order: navigate must
+    // happen BEFORE either invalidate to avoid the React 19 race that drops
+    // the navigation when the cache invalidation triggers a refetch + rerender.
+    const [navOrder] = mockNavigate.mock.invocationCallOrder;
+    const [listOrder] = mockListInvalidate.mock.invocationCallOrder;
+    const [getOrder] = mockGetInvalidate.mock.invocationCallOrder;
+    if (navOrder === undefined || listOrder === undefined || getOrder === undefined) {
+      throw new Error('Expected navigate, list.invalidate and get.invalidate to be called');
+    }
+    expect(navOrder).toBeLessThan(listOrder);
+    expect(navOrder).toBeLessThan(getOrder);
+  });
+
+  it('navigates to detail page before invalidating cache on create', async () => {
+    renderCreate();
+
+    const nameInput = document.querySelector('input[name="itemName"]') as HTMLInputElement;
+    const typeSelect = document.querySelector('select[name="type"]') as HTMLSelectElement;
+    fireEvent.change(nameInput, { target: { value: 'New Item' } });
+    fireEvent.change(typeSelect, { target: { value: 'Electronics' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /create item/i }));
+
+    await vi.waitFor(() => {
+      expect(mockCreateMutate).toHaveBeenCalledTimes(1);
+    });
+
+    // mockCreateMutate's onSuccess returns { data: { id: 'new-id' } }.
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/inventory/items/new-id');
+    });
+
+    expect(mockListInvalidate).toHaveBeenCalled();
+
+    const [navOrder] = mockNavigate.mock.invocationCallOrder;
+    const [listOrder] = mockListInvalidate.mock.invocationCallOrder;
+    if (navOrder === undefined || listOrder === undefined) {
+      throw new Error('Expected navigate and list.invalidate to be called');
+    }
+    expect(navOrder).toBeLessThan(listOrder);
   });
 });

--- a/packages/app-inventory/src/pages/item-form-page/useItemMutations.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useItemMutations.ts
@@ -81,8 +81,11 @@ export function useItemMutations({ id, isEditMode, pendingConnections }: UseItem
       const newItemId = result.data.id;
       const connected = await applyConnections(newItemId, pendingConnections, connectMutation);
       reportCreateSuccess(connected, pendingConnections.length > 0);
-      void utils.inventory.items.list.invalidate();
+      // Navigate BEFORE invalidations to avoid a race where the cache invalidation
+      // triggers a refetch + re-render of the current page that drops the
+      // navigate call (observed in React 19; see issue #2157).
       void navigate(`/inventory/items/${newItemId}`);
+      void utils.inventory.items.list.invalidate();
     },
     onError: (err) => toast.error(`Failed to create: ${err.message}`),
   });
@@ -90,9 +93,13 @@ export function useItemMutations({ id, isEditMode, pendingConnections }: UseItem
   const updateMutation = trpc.inventory.items.update.useMutation({
     onSuccess: () => {
       toast.success('Item updated');
+      // Navigate BEFORE invalidations to avoid a race where the cache invalidation
+      // triggers a refetch + re-render of the edit page that silently drops the
+      // navigate call (observed in React 19; see issue #2157). The destination
+      // detail page fetches fresh data on mount via its own queries.
+      void navigate(`/inventory/items/${id}`);
       void utils.inventory.items.list.invalidate();
       void utils.inventory.items.get.invalidate({ id: id ?? '' });
-      void navigate(`/inventory/items/${id}`);
     },
     onError: (err) => toast.error(`Failed to update: ${err.message}`),
   });


### PR DESCRIPTION
## Summary

- Fixes #2157: Item edit "Save Changes" succeeded silently — DB updated, toast fired, cache invalidated, but the user remained on `/inventory/items/:id/edit` instead of being redirected to the detail page.
- Root cause: `onSuccess` invalidated `inventory.items.get` (and `list`) before calling `navigate()`. The invalidation triggers a refetch + re-render of the still-mounted edit page; under React 19 this race silently drops the queued `navigate()` call.
- Fix: in both `updateMutation.onSuccess` and `createMutation.onSuccess`, call `navigate()` BEFORE the cache invalidations. The destination detail page fetches fresh data on mount via its own queries, so no functional change beyond ordering.

## Files

- `packages/app-inventory/src/pages/item-form-page/useItemMutations.ts` — reorder `navigate` before invalidations in both mutations; comments explain the race.
- `packages/app-inventory/src/pages/ItemFormPage.test.tsx` — mock `useNavigate`, capture invalidate spies, and assert call order via `mock.invocationCallOrder` for both update and create flows.

## Test plan

- [x] `cd packages/app-inventory && pnpm test` — 360 passing, including 2 new tests in `ItemFormPage — Navigation order on save (#2157)`.
- [x] `mise typecheck` — green.
- [x] `mise lint` — 0 errors (pre-existing warnings only, none in the touched files).
- [ ] Manual: edit an inventory item, click Save, confirm browser navigates to the detail page.

Closes #2157