### PR TITLE
fix(ui): TextInput renders uncontrolled when no value prop (#2155)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,8 +53,14 @@
   "devDependencies": {
     "@storybook/react-vite": "^10.3.5",
     "@tailwindcss/vite": "4.2.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.0.2",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "typescript": "^6.0.3",
     "vite": "^8.0.9",
     "vitest": "^4.1.5"

--- a/packages/ui/src/components/TextInput.hooks.ts
+++ b/packages/ui/src/components/TextInput.hooks.ts
@@ -7,6 +7,20 @@ export interface UseTextInputArgs {
   onClear?: () => void;
 }
 
+/**
+ * State + handlers for {@link TextInput}.
+ *
+ * Operates in two modes:
+ * - **Controlled**: when `controlledValue !== undefined` the parent owns the
+ *   value. The hook simply forwards onChange and surfaces the controlled value.
+ * - **Uncontrolled**: when no controlled value is supplied, the input is
+ *   rendered without a `value` prop (using `defaultValue` only). The hook keeps
+ *   internal state purely to drive UI affordances such as the clear button
+ *   visibility — it does NOT push that state back into the input. This is
+ *   important so that ref-based libraries (e.g. react-hook-form's `register()`,
+ *   which writes via `inputRef.current.value` on `form.reset()`) can update the
+ *   DOM without React clobbering the value on the next render.
+ */
 export function useTextInput({
   controlledValue,
   defaultValue,
@@ -24,6 +38,11 @@ export function useTextInput({
     onChange?.(e);
   };
 
+  /**
+   * Clear handler used in controlled mode. In uncontrolled mode the consumer
+   * should clear the DOM value imperatively and dispatch a native input event
+   * so downstream listeners (e.g. RHF) observe the change.
+   */
   const handleClear = () => {
     if (!isControlled) setInternalValue('');
     onClear?.();
@@ -31,5 +50,15 @@ export function useTextInput({
     onChange?.(synthetic);
   };
 
-  return { value, hasValue, isFocused, setIsFocused, handleChange, handleClear };
+  return {
+    value,
+    hasValue,
+    isFocused,
+    setIsFocused,
+    handleChange,
+    handleClear,
+    isControlled,
+    defaultValue,
+    setInternalValue,
+  };
 }

--- a/packages/ui/src/components/TextInput.test.tsx
+++ b/packages/ui/src/components/TextInput.test.tsx
@@ -1,0 +1,187 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useEffect, useRef, useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TextInput } from './TextInput';
+
+/**
+ * Mounts a controlled TextInput where the parent owns the value via React
+ * state. Mirrors typical controlled usage where consumers pass `value` and
+ * `onChange`.
+ */
+function ControlledHarness({
+  initial = '',
+  onChange,
+  clearable = false,
+}: {
+  initial?: string;
+  onChange?: (next: string) => void;
+  clearable?: boolean;
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <TextInput
+      placeholder="enter"
+      value={value}
+      clearable={clearable}
+      onChange={(e) => {
+        setValue(e.target.value);
+        onChange?.(e.target.value);
+      }}
+    />
+  );
+}
+
+describe('TextInput — uncontrolled', () => {
+  it('renders the input without a `value` attribute when no `value` prop is supplied', () => {
+    render(<TextInput placeholder="search" />);
+    const input = screen.getByPlaceholderText('search') as HTMLInputElement;
+    // React-controlled inputs always set the `value` attribute. Uncontrolled
+    // inputs leave it absent so the DOM owns the value.
+    expect(input.hasAttribute('value')).toBe(false);
+  });
+
+  it('reflects `defaultValue` as the initial DOM value', () => {
+    render(<TextInput placeholder="search" defaultValue="hello" />);
+    const input = screen.getByPlaceholderText('search') as HTMLInputElement;
+    expect(input.value).toBe('hello');
+  });
+
+  it('fires onChange when the user types, and the DOM value updates', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TextInput placeholder="search" onChange={onChange} />);
+    const input = screen.getByPlaceholderText('search') as HTMLInputElement;
+    await user.type(input, 'abc');
+    expect(input.value).toBe('abc');
+    expect(onChange).toHaveBeenCalled();
+    // Last call should reflect the final character event.
+    const lastCall = onChange.mock.calls.at(-1);
+    expect(lastCall?.[0].target.value).toBe('abc');
+  });
+
+  it('clear button clears the DOM value AND fires onChange with an empty string', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TextInput placeholder="search" defaultValue="seed" clearable onChange={onChange} />);
+    const input = screen.getByPlaceholderText('search') as HTMLInputElement;
+    expect(input.value).toBe('seed');
+
+    const clear = screen.getByRole('button', { name: /clear input/i });
+    await user.click(clear);
+
+    expect(input.value).toBe('');
+    // The native input event dispatched by the clear handler is normalised by
+    // React into an onChange call with the cleared value.
+    const cleared = onChange.mock.calls.find((c) => c[0].target.value === '');
+    expect(cleared).toBeTruthy();
+  });
+
+  it('keeps a ref-driven DOM update across re-renders (RHF reset() pattern)', () => {
+    /**
+     * Simulates how `react-hook-form`'s `register()` writes to the input via
+     * the ref on `form.reset()`: directly mutating `inputRef.current.value`.
+     * If TextInput rendered React-controlled, the next render would clobber
+     * this value back to '' — that's the bug we're guarding against.
+     */
+    function RefHarness({ trigger }: { trigger: number }) {
+      const inputRef = useRef<HTMLInputElement | null>(null);
+      useEffect(() => {
+        if (inputRef.current && trigger > 0) {
+          inputRef.current.value = 'reset-value';
+        }
+      }, [trigger]);
+      return <TextInput placeholder="rhf" ref={inputRef} />;
+    }
+
+    const { rerender } = render(<RefHarness trigger={0} />);
+    const input = screen.getByPlaceholderText('rhf') as HTMLInputElement;
+    expect(input.value).toBe('');
+
+    // Trigger the ref-driven write; mirrors form.reset({ field: 'reset-value' }).
+    rerender(<RefHarness trigger={1} />);
+    expect(input.value).toBe('reset-value');
+
+    // Force another render with no further ref writes — value MUST persist.
+    rerender(<RefHarness trigger={1} />);
+    expect(input.value).toBe('reset-value');
+  });
+
+  it('clear button visibility tracks user-driven hasValue', async () => {
+    const user = userEvent.setup();
+    render(<TextInput placeholder="search" clearable />);
+    const input = screen.getByPlaceholderText('search') as HTMLInputElement;
+    // No value yet → no clear button.
+    expect(screen.queryByRole('button', { name: /clear input/i })).toBeNull();
+    await user.type(input, 'x');
+    expect(screen.getByRole('button', { name: /clear input/i })).toBeInTheDocument();
+  });
+});
+
+describe('TextInput — controlled', () => {
+  it('renders the input with the controlled `value` attribute', () => {
+    render(<TextInput placeholder="search" value="hi" onChange={() => {}} />);
+    const input = screen.getByPlaceholderText('search') as HTMLInputElement;
+    expect(input.value).toBe('hi');
+    expect(input.getAttribute('value')).toBe('hi');
+  });
+
+  it('re-asserts the controlled value when the parent prop changes', () => {
+    /**
+     * In controlled mode the value attribute on the rendered element always
+     * reflects the parent's prop. Changing the prop on a subsequent render
+     * updates the DOM.
+     */
+    const { rerender } = render(
+      <TextInput placeholder="search" value="first" onChange={() => {}} />
+    );
+    const input = screen.getByPlaceholderText('search') as HTMLInputElement;
+    expect(input.value).toBe('first');
+    rerender(<TextInput placeholder="search" value="second" onChange={() => {}} />);
+    expect(input.value).toBe('second');
+  });
+
+  it('does not update the DOM when typing if the parent does not re-render with the new value', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    // No state harness — value is locked to 'fixed' regardless of typing.
+    render(<TextInput placeholder="search" value="fixed" onChange={onChange} />);
+    const input = screen.getByPlaceholderText('search') as HTMLInputElement;
+    await user.type(input, 'X');
+    // onChange fires once for the keystroke but the controlled value sticks.
+    expect(onChange).toHaveBeenCalled();
+    expect(input.value).toBe('fixed');
+  });
+
+  it('updates when the parent state updates through onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ControlledHarness onChange={onChange} />);
+    const input = screen.getByPlaceholderText('enter') as HTMLInputElement;
+    await user.type(input, 'go');
+    expect(input.value).toBe('go');
+    expect(onChange).toHaveBeenLastCalledWith('go');
+  });
+
+  it('clear button fires onChange with empty string and updates DOM via parent state', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ControlledHarness initial="seed" clearable onChange={onChange} />);
+    const input = screen.getByPlaceholderText('enter') as HTMLInputElement;
+    expect(input.value).toBe('seed');
+    const clear = screen.getByRole('button', { name: /clear input/i });
+    await user.click(clear);
+    expect(onChange).toHaveBeenLastCalledWith('');
+    expect(input.value).toBe('');
+  });
+
+  it('clear button visibility tracks the controlled value', () => {
+    const { rerender } = render(
+      <TextInput placeholder="search" value="" onChange={() => {}} clearable />
+    );
+    expect(screen.queryByRole('button', { name: /clear input/i })).toBeNull();
+    rerender(<TextInput placeholder="search" value="x" onChange={() => {}} clearable />);
+    expect(screen.getByRole('button', { name: /clear input/i })).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/TextInput.tsx
+++ b/packages/ui/src/components/TextInput.tsx
@@ -3,7 +3,7 @@
  * Supports controlled and uncontrolled modes
  */
 import { type VariantProps } from 'class-variance-authority';
-import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react';
+import { forwardRef, useMemo, useRef, type InputHTMLAttributes, type ReactNode } from 'react';
 
 import { cn } from '../lib/utils';
 import { useTextInput } from './TextInput.hooks';
@@ -50,12 +50,21 @@ export interface TextInputProps
 /**
  * TextInput component
  *
+ * Modes:
+ * - **Controlled** — pass `value` and `onChange`. The component renders a
+ *   controlled input and React owns the value.
+ * - **Uncontrolled** — omit `value`. The component renders an uncontrolled
+ *   input (no `value` prop, only `defaultValue`). This is what
+ *   `react-hook-form`'s `register()` expects: it writes to the input via the
+ *   ref on `form.reset()`, and React must not clobber that value on re-render.
+ *
  * @example
  * ```tsx
  * <TextInput placeholder="Enter text..." />
  * <TextInput variant="ghost" clearable />
  * <TextInput prefix={<SearchIcon />} />
  * <TextInput suffix={<Icon />} clearable />
+ * <TextInput {...form.register('name')} defaultValue={item?.name} />
  * ```
  */
 interface TextInputBodyProps {
@@ -72,6 +81,30 @@ interface TextInputBodyProps {
   inputProps: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
+/**
+ * Imperatively clear an uncontrolled input and notify listeners. Uses the
+ * native value setter so React's synthetic event system sees the change, and
+ * dispatches a bubbling `input` event so ref-based subscribers (e.g.
+ * react-hook-form) react to the cleared value.
+ */
+function clearUncontrolledInput(el: HTMLInputElement) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(el, '');
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+/** Merge a local ref with a forwarded ref (callback or object). */
+function mergeRefs(
+  local: React.RefObject<HTMLInputElement | null>,
+  forwarded: React.Ref<HTMLInputElement>
+) {
+  return (el: HTMLInputElement | null) => {
+    local.current = el;
+    if (typeof forwarded === 'function') forwarded(el);
+    else if (forwarded) forwarded.current = el;
+  };
+}
+
 function TextInputBody({
   ti,
   inputRef,
@@ -85,14 +118,22 @@ function TextInputBody({
   inputClassName,
   inputProps,
 }: TextInputBodyProps) {
+  const localRef = useRef<HTMLInputElement | null>(null);
   const showClearButton = clearable && ti.hasValue && !disabled;
+  const setRef = useMemo(() => mergeRefs(localRef, inputRef), [inputRef]);
+
+  const handleClear = () => {
+    if (!ti.isControlled && localRef.current) clearUncontrolledInput(localRef.current);
+    ti.handleClear();
+  };
+
   return (
     <>
       {prefix && <span className="flex-shrink-0 text-muted-foreground">{prefix}</span>}
       <input
-        ref={inputRef}
+        ref={setRef}
         className={inputClassName}
-        value={ti.value}
+        {...(ti.isControlled ? { value: ti.value } : { defaultValue: ti.defaultValue })}
         onChange={ti.handleChange}
         onFocus={(e) => {
           ti.setIsFocused(true);
@@ -106,7 +147,7 @@ function TextInputBody({
         aria-invalid={!!error}
         {...inputProps}
       />
-      <TrailingSlot showClearButton={showClearButton} suffix={suffix} onClear={ti.handleClear} />
+      <TrailingSlot showClearButton={showClearButton} suffix={suffix} onClear={handleClear} />
     </>
   );
 }

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    environment: 'jsdom',
     globals: true,
+    setupFiles: ['./src/test-setup.ts'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -814,12 +814,6 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react:
-        specifier: ^19.0.0
-        version: 19.2.5
-      react-dom:
-        specifier: ^19.0.0
-        version: 19.2.5(react@19.2.5)
       shadcn:
         specifier: ^4.4.0
         version: 4.4.0(@types/node@25.6.0)(typescript@6.0.3)
@@ -842,12 +836,30 @@ importers:
       '@tailwindcss/vite':
         specifier: 4.2.4
         version: 4.2.4(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

`TextInput` previously rendered as a React-controlled input on every render — even when no `value` prop was passed — by reading from `useTextInput`'s internal state. The result: ref-driven writes (e.g. react-hook-form's `register()` setting `inputRef.current.value` from `form.reset()`) were clobbered on the next render, so edit dialogs that rely on `register()` opened with empty fields and immediately failed validation on submit.

## The bug

`react-hook-form`'s `register()` returns `{ name, onChange, onBlur, ref }` — notably **no `value`**. RHF then writes to the input via the ref on `form.reset(...)`. Because `TextInput` always rendered `<input value={ti.value} ... />`, the next render reset the DOM value back to the internal state (`''`), and the user saw an empty input despite RHF holding the correct form state.

## Fix

`TextInput` now picks its mode based on whether a `value` prop is supplied:

- **Controlled** (`value` defined) — renders `<input value={...}>` as before.
- **Uncontrolled** (no `value`) — renders `<input defaultValue={...}>` and lets the DOM own the value. The internal state in `useTextInput` is still used to drive UI affordances (clear-button visibility, focus styles) but is no longer pushed back into the input.

The clear button now branches by mode:

- Controlled — calls the hook's `handleClear`, which dispatches a synthetic onChange (existing behaviour).
- Uncontrolled — uses the native `HTMLInputElement.prototype.value` setter to write `''` and dispatches a bubbling `input` event, so React's synthetic onChange and ref-based subscribers (RHF) both observe the cleared value.

## Tests

Adds `packages/ui/src/components/TextInput.test.tsx` (and a jsdom + `@testing-library/react` setup for the `@pops/ui` package) covering:

- Uncontrolled: no `value` attribute, `defaultValue` reflected, typing fires `onChange`, clear button clears the DOM and fires `onChange('')`, ref-driven mutation persists across re-renders.
- Controlled: `value` attribute set, prop changes update the DOM, typing without a state harness leaves the value pinned, clear via the parent state pipeline.
- Both modes: clear-button visibility tracks `hasValue`.

Closes #2155

## Test plan

- [x] `pnpm --filter @pops/ui test` — 30 passing, 0 failing
- [x] `pnpm --filter @pops/ui typecheck`
- [x] `pnpm -r typecheck`
- [x] `pnpm lint` — 0 errors (pre-existing 74 warnings unchanged)
- [x] `pnpm format:check` for the touched files