### PR TITLE
fix(api): mount /api/inventory/photos route + default INVENTORY_IMAGES_DIR (#2178)

### DIFF
--- a/apps/pops-api/src/app.ts
+++ b/apps/pops-api/src/app.ts
@@ -12,6 +12,7 @@ import { openApiDocument } from './openapi.js';
 import { appRouter } from './router.js';
 import healthRouter from './routes/health.js';
 import documentThumbnailRouter from './routes/inventory/documents.js';
+import inventoryPhotosRouter from './routes/inventory/photos.js';
 import mediaImagesRouter from './routes/media/images.js';
 import upBankRouter from './routes/webhooks/up-bank.js';
 import { createContext } from './trpc.js';
@@ -49,6 +50,10 @@ export function createApp(): express.Express {
 
   // Document thumbnail proxy — proxies Paperless-ngx thumbnails
   app.use(documentThumbnailRouter);
+
+  // Inventory photo serving — static files from INVENTORY_IMAGES_DIR.
+  // Placed before authMiddleware so <img> tags can render without JWT cookies.
+  app.use(inventoryPhotosRouter);
 
   // Cloudflare Access JWT auth — validates cf-access-jwt-assertion header.
   // Placed after health/webhook/media routes (those skip auth or use their own).

--- a/apps/pops-api/src/modules/inventory/photos/paths.ts
+++ b/apps/pops-api/src/modules/inventory/photos/paths.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared filesystem path helpers for inventory photos.
+ *
+ * Used by both the upload service (writes files) and the static file route
+ * (reads files), so the env var resolution and default fallback are kept in
+ * one place to avoid drift.
+ */
+import { resolve } from 'node:path';
+
+const DEFAULT_INVENTORY_IMAGES_DIR = './data/inventory/images';
+
+/**
+ * Resolve the absolute base directory for inventory item photos.
+ *
+ * Reads `INVENTORY_IMAGES_DIR` from the environment, falling back to
+ * `./data/inventory/images` (relative to the API process cwd).
+ */
+export function getInventoryImagesDir(): string {
+  const dir = process.env.INVENTORY_IMAGES_DIR ?? DEFAULT_INVENTORY_IMAGES_DIR;
+  return resolve(dir);
+}

--- a/apps/pops-api/src/modules/inventory/photos/photos.test.ts
+++ b/apps/pops-api/src/modules/inventory/photos/photos.test.ts
@@ -189,25 +189,46 @@ describe('inventory.photos.upload', () => {
     }
   });
 
-  it('throws BAD_REQUEST when INVENTORY_IMAGES_DIR is not set', async () => {
+  it('falls back to ./data/inventory/images when INVENTORY_IMAGES_DIR is unset', async () => {
+    // Run the upload from a temp cwd so the default relative path
+    // (`./data/inventory/images`) resolves inside a sandbox we can clean up,
+    // rather than polluting the repo working tree.
+    const { default: sharp } = await import('sharp');
+    const fakeJpegBuffer = await sharp({
+      create: { width: 50, height: 50, channels: 3, background: { r: 0, g: 0, b: 0 } },
+    })
+      .jpeg()
+      .toBuffer();
+
+    const sandboxCwd = join(tmpdir(), `pops-upload-default-${Date.now()}`);
+    mkdirSync(sandboxCwd, { recursive: true });
+    const originalCwd = process.cwd();
     const originalEnv = process.env.INVENTORY_IMAGES_DIR;
     delete process.env.INVENTORY_IMAGES_DIR;
+    process.chdir(sandboxCwd);
 
     try {
       const itemId = seedInventoryItem(db, { item_name: 'Camera' });
-      const fakeBase64 = Buffer.from('fake-data').toString('base64');
 
-      await expect(
-        caller.inventory.photos.upload({ itemId, fileBase64: fakeBase64 })
-      ).rejects.toThrow(TRPCError);
+      const result = await caller.inventory.photos.upload({
+        itemId,
+        fileBase64: fakeJpegBuffer.toString('base64'),
+      });
 
-      try {
-        await caller.inventory.photos.upload({ itemId, fileBase64: fakeBase64 });
-      } catch (err) {
-        expect((err as TRPCError).code).toBe('BAD_REQUEST');
-      }
+      expect(result.message).toBe('Photo uploaded');
+      expect(result.data.filePath).toMatch(/^items\/.+\/photo_001\.jpg$/);
+      // The file should land under the resolved default dir.
+      expect(
+        existsSync(join(sandboxCwd, 'data', 'inventory', 'images', result.data.filePath))
+      ).toBe(true);
     } finally {
-      process.env.INVENTORY_IMAGES_DIR = originalEnv;
+      process.chdir(originalCwd);
+      if (originalEnv === undefined) {
+        delete process.env.INVENTORY_IMAGES_DIR;
+      } else {
+        process.env.INVENTORY_IMAGES_DIR = originalEnv;
+      }
+      rmSync(sandboxCwd, { recursive: true, force: true });
     }
   });
 

--- a/apps/pops-api/src/modules/inventory/photos/service.ts
+++ b/apps/pops-api/src/modules/inventory/photos/service.ts
@@ -11,6 +11,7 @@ import { homeInventory, itemPhotos } from '@pops/db-types';
 
 import { getDb, getDrizzle } from '../../../db.js';
 import { NotFoundError, ValidationError } from '../../../shared/errors.js';
+import { getInventoryImagesDir } from './paths.js';
 
 import type {
   AttachPhotoInput,
@@ -89,10 +90,7 @@ export async function uploadPhoto(input: UploadPhotoInput): Promise<ItemPhotoRow
 
   assertItemExists(input.itemId);
 
-  const baseDir = process.env.INVENTORY_IMAGES_DIR;
-  if (!baseDir) {
-    throw new ValidationError('INVENTORY_IMAGES_DIR is not configured');
-  }
+  const baseDir = getInventoryImagesDir();
 
   // Compress the image (resize, convert HEIC→JPEG, strip EXIF)
   const compressed = await compressImage(input.buffer);
@@ -144,12 +142,10 @@ export function removePhoto(id: number): void {
   const photo = getPhoto(id); // Validates existence
 
   // Delete file from disk (best-effort — missing file is not an error)
-  const baseDir = process.env.INVENTORY_IMAGES_DIR;
-  if (baseDir) {
-    const fullPath = resolve(baseDir, photo.filePath);
-    if (existsSync(fullPath)) {
-      unlinkSync(fullPath);
-    }
+  const baseDir = getInventoryImagesDir();
+  const fullPath = resolve(baseDir, photo.filePath);
+  if (existsSync(fullPath)) {
+    unlinkSync(fullPath);
   }
 
   const db = getDrizzle();

--- a/apps/pops-api/src/routes/inventory/photos.test.ts
+++ b/apps/pops-api/src/routes/inventory/photos.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for the inventory photo static-file route.
+ *
+ * The route is filesystem-only (no DB), so we exercise it with real fixture
+ * files in a temp dir set as INVENTORY_IMAGES_DIR.
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import photosRouter from './photos.js';
+
+let tempDir: string;
+let originalEnv: string | undefined;
+
+function createTestApp(): express.Express {
+  const app = express();
+  app.use(photosRouter);
+  return app;
+}
+
+const ITEM_ID = 'abc123def456789012345678901234ab';
+
+beforeEach(() => {
+  tempDir = join(
+    tmpdir(),
+    `pops-photos-route-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(tempDir, { recursive: true });
+  originalEnv = process.env.INVENTORY_IMAGES_DIR;
+  process.env.INVENTORY_IMAGES_DIR = tempDir;
+});
+
+afterEach(() => {
+  if (originalEnv === undefined) {
+    delete process.env.INVENTORY_IMAGES_DIR;
+  } else {
+    process.env.INVENTORY_IMAGES_DIR = originalEnv;
+  }
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('GET /api/inventory/photos/items/:itemId/:filename', () => {
+  describe('successful serving', () => {
+    it('serves an existing photo file with correct content-type and cache headers', async () => {
+      const itemDir = join(tempDir, 'items', ITEM_ID);
+      mkdirSync(itemDir, { recursive: true });
+      const fileBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]); // JPEG magic
+      writeFileSync(join(itemDir, 'photo_001.jpg'), fileBytes);
+
+      const app = createTestApp();
+      const res = await request(app).get(`/api/inventory/photos/items/${ITEM_ID}/photo_001.jpg`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('image/jpeg');
+      expect(res.headers['cache-control']).toBe('private, max-age=3600');
+      expect(res.headers['etag']).toBeDefined();
+      expect(res.body).toEqual(fileBytes);
+    });
+
+    it('returns 304 Not Modified on matching If-None-Match', async () => {
+      const itemDir = join(tempDir, 'items', ITEM_ID);
+      mkdirSync(itemDir, { recursive: true });
+      writeFileSync(join(itemDir, 'photo_002.jpg'), Buffer.from([0x00, 0x01, 0x02, 0x03]));
+
+      const app = createTestApp();
+      const first = await request(app).get(`/api/inventory/photos/items/${ITEM_ID}/photo_002.jpg`);
+      const etag = first.headers['etag'];
+      expect(typeof etag).toBe('string');
+      if (typeof etag !== 'string') return; // type narrow for the next call
+
+      const second = await request(app)
+        .get(`/api/inventory/photos/items/${ITEM_ID}/photo_002.jpg`)
+        .set('If-None-Match', etag);
+
+      expect(second.status).toBe(304);
+    });
+  });
+
+  describe('not found', () => {
+    it('returns 404 when the item directory does not exist', async () => {
+      const app = createTestApp();
+      const res = await request(app).get(`/api/inventory/photos/items/${ITEM_ID}/photo_001.jpg`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Photo not found');
+    });
+
+    it('returns 404 when the file is missing inside an existing item dir', async () => {
+      mkdirSync(join(tempDir, 'items', ITEM_ID), { recursive: true });
+      const app = createTestApp();
+
+      const res = await request(app).get(`/api/inventory/photos/items/${ITEM_ID}/photo_999.jpg`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Photo not found');
+    });
+  });
+
+  describe('parameter validation', () => {
+    it('returns 400 for invalid filename pattern (.png)', async () => {
+      const app = createTestApp();
+      const res = await request(app).get(`/api/inventory/photos/items/${ITEM_ID}/cover.png`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid filename');
+    });
+
+    it('returns 400 for filename without sequence number', async () => {
+      const app = createTestApp();
+      const res = await request(app).get(`/api/inventory/photos/items/${ITEM_ID}/photo_.jpg`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid filename');
+    });
+
+    it('returns 400 for an itemId containing path traversal segments', async () => {
+      // The route is `/api/inventory/photos/items/:itemId/:filename`. A request to
+      // `/api/inventory/photos/items/..%2Fetc%2Fpasswd` decodes the params before
+      // matching, so itemId arrives as `../etc/passwd` and is rejected by the
+      // ITEM_ID_RE / `..` checks before the FS is touched.
+      const app = createTestApp();
+      const res = await request(app).get(
+        '/api/inventory/photos/items/..%2Fetc%2Fpasswd/photo_001.jpg'
+      );
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid item id');
+    });
+
+    it('returns 400 for an itemId with disallowed characters', async () => {
+      const app = createTestApp();
+      const res = await request(app).get('/api/inventory/photos/items/foo$bar/photo_001.jpg');
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid item id');
+    });
+  });
+
+  describe('default INVENTORY_IMAGES_DIR fallback', () => {
+    it('does not throw when env var is unset (uses default ./data/inventory/images)', async () => {
+      delete process.env.INVENTORY_IMAGES_DIR;
+      const app = createTestApp();
+
+      // The default dir likely doesn't exist in the test runner — we just want
+      // a clean 404, NOT a 500 from the route imploding on missing config.
+      const res = await request(app).get(`/api/inventory/photos/items/${ITEM_ID}/photo_001.jpg`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/apps/pops-api/src/routes/inventory/photos.ts
+++ b/apps/pops-api/src/routes/inventory/photos.ts
@@ -1,0 +1,85 @@
+/**
+ * Express route for serving uploaded inventory item photos.
+ *
+ * GET /api/inventory/photos/items/:itemId/:filename
+ *
+ * Static file serving from `INVENTORY_IMAGES_DIR` (default: `./data/inventory/images`).
+ * Mounted before auth middleware — these are user-uploaded image bytes that the
+ * frontend pulls via plain `<img>` tags, so cookie/JWT auth would block rendering.
+ *
+ * Path resolution is sandboxed: the resolved file path must live inside the
+ * configured base dir, and `itemId` / `filename` are validated against strict
+ * patterns to reject path traversal attempts.
+ */
+import { resolve } from 'node:path';
+
+import { type Router as ExpressRouter, type Request, Router } from 'express';
+
+import { getInventoryImagesDir } from '../../modules/inventory/photos/paths.js';
+import { tryServeFile } from '../media/images-helpers.js';
+
+/** Cache for one hour — uploaded photos can change on re-upload. */
+const CACHE_CONTROL = 'private, max-age=3600';
+
+/** Item IDs in the home_inventory table are 32-char lowercase hex blobs. */
+const ITEM_ID_RE = /^[a-z0-9-]+$/i;
+
+/** Photo filenames follow the convention written by `service.ts:nextPhotoFilename`. */
+const FILENAME_RE = /^photo_\d+\.jpg$/;
+
+interface ValidationFailure {
+  status: number;
+  body: { error: string };
+}
+
+interface ValidatedParams {
+  itemId: string;
+  filename: string;
+}
+
+function validateParams(req: Request): ValidatedParams | ValidationFailure {
+  const itemId = String(req.params['itemId'] ?? '');
+  const filename = String(req.params['filename'] ?? '');
+
+  if (!itemId || itemId.includes('..') || itemId.includes('/') || !ITEM_ID_RE.test(itemId)) {
+    return { status: 400, body: { error: `Invalid item id: ${itemId}` } };
+  }
+  if (!FILENAME_RE.test(filename)) {
+    return { status: 400, body: { error: `Invalid filename: ${filename}` } };
+  }
+  return { itemId, filename };
+}
+
+function isValidationFailure(
+  value: ValidatedParams | ValidationFailure
+): value is ValidationFailure {
+  return 'status' in value;
+}
+
+const router: ExpressRouter = Router();
+
+router.get('/api/inventory/photos/items/:itemId/:filename', async (req, res): Promise<void> => {
+  const params = validateParams(req);
+  if (isValidationFailure(params)) {
+    res.status(params.status).json(params.body);
+    return;
+  }
+
+  const baseDir = getInventoryImagesDir();
+  const filePath = resolve(baseDir, 'items', params.itemId, params.filename);
+
+  // Sandbox check: the resolved path must live inside the base dir.
+  // Without this, a crafted itemId/filename could escape via `..` even though
+  // the regexes already block obvious cases.
+  if (!filePath.startsWith(baseDir + '/') && filePath !== baseDir) {
+    res.status(400).json({ error: 'Invalid path' });
+    return;
+  }
+
+  const served = await tryServeFile(filePath, res, CACHE_CONTROL);
+  if (served) return;
+
+  res.status(404).json({ error: 'Photo not found' });
+});
+
+export default router;

--- a/apps/pops-api/src/routes/media/images-helpers.ts
+++ b/apps/pops-api/src/routes/media/images-helpers.ts
@@ -84,8 +84,20 @@ async function sendFileWithErrorHandling(res: Response, filePath: string): Promi
   });
 }
 
-/** Try to serve a file with cache headers. Returns true if the file was served. */
-export async function tryServeFile(filePath: string, res: Response): Promise<boolean> {
+/**
+ * Try to serve a file with cache headers. Returns true if the file was served.
+ *
+ * @param filePath absolute path to the file on disk
+ * @param res Express response
+ * @param cacheControl override the default `Cache-Control` header. Defaults to
+ *   `public, max-age=604800` (suitable for immutable media images). Pass a
+ *   stricter value (e.g. `private, max-age=3600`) for user-uploaded content.
+ */
+export async function tryServeFile(
+  filePath: string,
+  res: Response,
+  cacheControl: string = CACHE_CONTROL
+): Promise<boolean> {
   try {
     const fileStat = await stat(filePath);
     const ext = extname(filePath);
@@ -94,7 +106,7 @@ export async function tryServeFile(filePath: string, res: Response): Promise<boo
 
     res.set({
       'Content-Type': contentType,
-      'Cache-Control': CACHE_CONTROL,
+      'Cache-Control': cacheControl,
       ETag: `"${etag}"`,
     });
 

--- a/packages/app-inventory/src/components/PhotoGallery.tsx
+++ b/packages/app-inventory/src/components/PhotoGallery.tsx
@@ -68,8 +68,12 @@ export function PhotoGallery({
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
   const sorted = [...photos].toSorted((a, b) => a.sortOrder - b.sortOrder);
+  // Encode each path segment individually so slashes survive the URL.
+  // `encodeURIComponent(filePath)` would turn `items/{id}/photo_001.jpg` into
+  // `items%2F{id}%2Fphoto_001.jpg`, which Express routes as a single segment
+  // and would not match `/items/:itemId/:filename`.
   const photoSrc = useCallback(
-    (filePath: string) => `${baseUrl}/${encodeURIComponent(filePath)}`,
+    (filePath: string) => `${baseUrl}/${filePath.split('/').map(encodeURIComponent).join('/')}`,
     [baseUrl]
   );
 

--- a/packages/app-inventory/src/components/SortablePhotoGrid.test.tsx
+++ b/packages/app-inventory/src/components/SortablePhotoGrid.test.tsx
@@ -98,10 +98,25 @@ describe('SortablePhotoGrid', () => {
     });
   });
 
-  it('uses custom baseUrl for image sources', () => {
+  it('uses custom baseUrl for image sources, encoding each path segment', () => {
     render(<SortablePhotoGrid photos={photos} onReorder={vi.fn()} baseUrl="/custom/url" />);
     const imgs = screen.getAllByRole('img');
-    expect(imgs[0]).toHaveAttribute('src', '/custom/url/item-1%2Fphoto-a.jpg');
+    // Slashes are preserved so the URL maps to /items/:itemId/:filename on the API.
+    expect(imgs[0]).toHaveAttribute('src', '/custom/url/item-1/photo-a.jpg');
+  });
+
+  it('percent-encodes special characters in path segments', () => {
+    const tricky: PhotoItem[] = [
+      { id: 1, filePath: 'item with space/photo a.jpg', caption: null, sortOrder: 0 },
+    ];
+    render(
+      <SortablePhotoGrid photos={tricky} onReorder={vi.fn()} baseUrl="/api/inventory/photos" />
+    );
+    const imgs = screen.getAllByRole('img');
+    expect(imgs[0]).toHaveAttribute(
+      'src',
+      '/api/inventory/photos/item%20with%20space/photo%20a.jpg'
+    );
   });
 
   it('clears drag state on dragEnd', () => {

--- a/packages/app-inventory/src/components/SortablePhotoGrid.tsx
+++ b/packages/app-inventory/src/components/SortablePhotoGrid.tsx
@@ -185,7 +185,7 @@ export function SortablePhotoGrid({
           key={photo.id}
           photo={photo}
           index={index}
-          src={`${baseUrl}/${encodeURIComponent(photo.filePath)}`}
+          src={`${baseUrl}/${photo.filePath.split('/').map(encodeURIComponent).join('/')}`}
           canReorder={canReorder}
           isReordering={isReordering}
           isDragging={dragIndex === index}


### PR DESCRIPTION
## Bug

Uploaded inventory item photos were 404ing in the gallery. The frontend
renders `<img src="/api/inventory/photos/<filePath>">` (where `filePath`
is `items/{itemId}/photo_NNN.jpg`), but `apps/pops-api/src/app.ts` never
mounted any handler at `/api/inventory/photos/*` — only
`mediaImagesRouter` and `documentThumbnailRouter` were registered.

Two related papercuts surfaced while fixing:

- `INVENTORY_IMAGES_DIR` had no default fallback (unlike `MEDIA_IMAGES_DIR`),
  so an unset env var hard-failed every upload with `BAD_REQUEST`.
- The frontend used `encodeURIComponent(filePath)` on the whole path,
  encoding `/` as `%2F`. Even with the route mounted, the URL would land
  as a single Express path segment and never match `/items/:itemId/:filename`.

## Fix

- Add `apps/pops-api/src/routes/inventory/photos.ts` exposing
  `GET /api/inventory/photos/items/:itemId/:filename` — strict regex
  validation on `itemId` (hex/dash only, no `..` or `/`) and `filename`
  (`/^photo_\d+\.jpg$/`), absolute-path sandbox check after `resolve()`,
  served via the existing `tryServeFile` helper with a `private, max-age=3600`
  cache header.
- Extract `getInventoryImagesDir()` into
  `apps/pops-api/src/modules/inventory/photos/paths.ts` so the route and
  the upload service share the env-var resolution and the
  `./data/inventory/images` default. The service stops throwing on a
  missing env var.
- Mount the new router in `apps/pops-api/src/app.ts` next to the other
  static-file routers (before `authMiddleware`, since `<img>` tags can't
  carry a JWT).
- Add an optional `cacheControl` parameter to `tryServeFile` so callers
  can override the media-image default of `public, max-age=604800` with
  the stricter `private, max-age=3600` for user uploads.
- Update the photo gallery components to encode each path segment
  individually (`split('/').map(encodeURIComponent).join('/')`) so
  slashes survive into the URL.

## Tests

- `apps/pops-api/src/routes/inventory/photos.test.ts` — 9 new supertest
  cases (200 + JPEG bytes, 304 If-None-Match, 404s, 400 for invalid
  filename / disallowed `itemId` chars / `..%2F` traversal, default-dir
  fallback when env unset).
- `apps/pops-api/src/modules/inventory/photos/photos.test.ts` — replaced
  the now-obsolete "throws BAD_REQUEST when env unset" test with one
  that asserts uploads succeed under the new default dir (sandboxed via
  `process.chdir`).
- Updated `SortablePhotoGrid.test.tsx` to assert the new per-segment
  encoding plus a regression test for special characters in path segments.

## Manual verification

- [ ] `pnpm --filter @pops/api test` (passes locally — 2920 tests).
- [ ] `pnpm --filter @pops/app-inventory test` (passes locally — 359 tests).
- [ ] `pnpm typecheck && pnpm lint && pnpm format:check` (all clean).
- [ ] Run the API + shell against an inventory item that has uploaded
      photos and confirm the gallery thumbnails and lightbox load
      (`200 OK`, `Content-Type: image/jpeg`).

Closes #2178
