### PR TITLE
fix(inventory): item form checkboxes via Controller; tighten reset (#2175)

### DIFF
--- a/apps/pops-shell/e2e/inventory-locations-tree.spec.ts
+++ b/apps/pops-shell/e2e/inventory-locations-tree.spec.ts
@@ -90,11 +90,9 @@ async function createChildLocation(
  * Open the item edit page, pick the target location via LocationPicker, save.
  * Uses the search field to filter to the freshly-created location.
  *
- * Known product bug (#2157): the update mutation's onSuccess navigate() back
- * to the detail page does not reliably fire in e2e — the toast and cache
- * invalidation succeed, but the URL can stay on `/edit`. To avoid depending
- * on that redirect we treat the success toast as the positive completion
- * signal; tree-side assertions in the sibling test prove the write persisted.
+ * Treat the success toast as the positive completion signal rather than the
+ * post-save redirect; tree-side assertions in the sibling test prove the
+ * write persisted.
  */
 async function assignItemToLocation(
   page: Page,
@@ -158,23 +156,12 @@ async function deleteEmptyLocation(page: Page, name: string): Promise<void> {
 }
 
 /*
- * Skipped until the underlying item-edit-form bug lands: on WebKit under the
- * e2e harness, react-hook-form's `reset(itemToFormValues(item))` populates
- * selects/dates/notes but leaves the registered text inputs (itemName, brand,
- * model, itemId, assetId) and checkboxes (inUse, deductible) empty. Clicking
- * Save Changes then trips the `itemName is required` validation, the update
- * mutation never fires, and the success toast the assignment flow waits for
- * never appears.
- *
- * Product bugs tracking the underlying failures:
- *   - #2175 — form reset() does not sync text inputs + checkboxes on WebKit
- *   - #2157 — post-save navigate() silently drops (separate but adjacent)
- *
- * Once #2175 is fixed, flip the `.skip` back to a normal `test.describe` and
- * re-enable both scenarios. The tree CRUD half of the flow is already covered
- * indirectly by the location helpers below.
+ * End-to-end coverage for the locations tree: parent/child CRUD plus the
+ * assignment of a seeded item to the new child via the item edit form's
+ * LocationPicker. The serial pair verifies that the assignment persists in
+ * the tree contents panel after navigation.
  */
-test.describe.skip('Inventory — locations tree CRUD and item assignment', () => {
+test.describe('Inventory — locations tree CRUD and item assignment', () => {
   test.describe.configure({ mode: 'serial' });
 
   // Shared across the serial tests in this describe block.
@@ -215,7 +202,7 @@ test.describe.skip('Inventory — locations tree CRUD and item assignment', () =
     await createChildLocation(page, parentName, childName);
 
     // Assigning the item to the new child persists the link that the next
-    // test verifies from the tree UI. Blocked by #2175 on WebKit.
+    // test verifies from the tree UI.
     await assignItemToLocation(page, SEEDED_ITEM_ID, childName);
   });
 
@@ -252,9 +239,7 @@ test.describe.skip('Inventory — locations tree CRUD and item assignment', () =
       await useRealApi(page);
 
       // 1. Reassign the seeded item back to its original seeded location.
-      //    Same form-reset bug (#2175) + nav bug (#2157) apply here — assert
-      //    on the success toast rather than the post-save URL redirect which
-      //    may not fire.
+      //    Assert on the success toast rather than the post-save URL redirect.
       await page.goto(`/inventory/items/${SEEDED_ITEM_ID}/edit`);
       await expect(page.getByRole('heading', { name: /edit item/i })).toBeVisible({
         timeout: 10_000,

--- a/packages/app-inventory/src/pages/ItemFormPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.test.tsx
@@ -719,3 +719,108 @@ describe('ItemFormPage — Navigation order on save (#2157)', () => {
     expect(navOrder).toBeLessThan(listOrder);
   });
 });
+
+// ---------- checkbox population (#2175) ----------
+
+/**
+ * Edit-mode regression coverage for #2175. The Radix `CheckboxInput` exposes
+ * `checked` / `onCheckedChange`, which is incompatible with RHF's `register()`
+ * spread. The form now wires `inUse` / `deductible` through `Controller`, so
+ * `reset(itemToFormValues(item))` must propagate the seeded boolean values
+ * into the rendered `<button role="checkbox">` elements.
+ */
+function seededItem(overrides: { inUse?: boolean; deductible?: boolean } = {}) {
+  return {
+    id: 'item-1',
+    itemName: 'MacBook',
+    brand: null,
+    model: null,
+    itemId: null,
+    type: 'Electronics',
+    condition: 'good',
+    room: null,
+    inUse: overrides.inUse ?? false,
+    deductible: overrides.deductible ?? false,
+    purchaseDate: null,
+    warrantyExpires: null,
+    replacementValue: null,
+    resaleValue: null,
+    purchasePrice: null,
+    assetId: 'ELEC01',
+    notes: null,
+    locationId: null,
+    lastEditedTime: '2026-01-01',
+    purchaseTransactionId: null,
+    purchasedFromId: null,
+    purchasedFromName: null,
+  };
+}
+
+describe('ItemFormPage — checkbox population (#2175)', () => {
+  it('populates In Use checkbox from seeded item in edit mode', async () => {
+    mockItemQuery.mockReturnValue({
+      data: { data: seededItem({ inUse: true }) },
+      isLoading: false,
+      error: null,
+    });
+
+    renderEdit('item-1');
+
+    const inUse = await screen.findByRole('checkbox', { name: /in use/i });
+    await vi.waitFor(() => {
+      expect(inUse.getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  it('populates Tax Deductible checkbox from seeded item in edit mode', async () => {
+    mockItemQuery.mockReturnValue({
+      data: { data: seededItem({ deductible: true }) },
+      isLoading: false,
+      error: null,
+    });
+
+    renderEdit('item-1');
+
+    const deductible = await screen.findByRole('checkbox', { name: /tax deductible/i });
+    await vi.waitFor(() => {
+      expect(deductible.getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  it('toggles the In Use checkbox in create mode', () => {
+    renderCreate();
+
+    const inUse = screen.getByRole('checkbox', { name: /in use/i });
+    expect(inUse.getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(inUse);
+    expect(inUse.getAttribute('aria-checked')).toBe('true');
+
+    fireEvent.click(inUse);
+    expect(inUse.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('submits the toggled inUse value in the create payload', async () => {
+    renderCreate();
+
+    const inUse = screen.getByRole('checkbox', { name: /in use/i });
+    expect(inUse.getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(inUse);
+    expect(inUse.getAttribute('aria-checked')).toBe('true');
+
+    // Required fields for the create submit path.
+    const nameInput = document.querySelector('input[name="itemName"]') as HTMLInputElement;
+    const typeSelect = document.querySelector('select[name="type"]') as HTMLSelectElement;
+    fireEvent.change(nameInput, { target: { value: 'New Gadget' } });
+    fireEvent.change(typeSelect, { target: { value: 'Electronics' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /create item/i }));
+
+    await vi.waitFor(() => {
+      expect(mockCreateMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ inUse: true, deductible: false })
+      );
+    });
+  });
+});

--- a/packages/app-inventory/src/pages/ItemFormPage.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.tsx
@@ -65,6 +65,7 @@ function CoreSection({ model }: { model: Model }) {
   const {
     form: {
       register,
+      control,
       watch,
       setValue,
       formState: { errors },
@@ -80,6 +81,7 @@ function CoreSection({ model }: { model: Model }) {
   return (
     <CoreFieldsSection
       register={register}
+      control={control}
       watch={watch}
       setValue={setValue}
       errors={errors}

--- a/packages/app-inventory/src/pages/item-form-page/sections/CoreFieldsSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/CoreFieldsSection.tsx
@@ -3,12 +3,19 @@ import { BasicInfoSection } from './core-fields/BasicInfoSection';
 import { ClassificationSection } from './core-fields/ClassificationSection';
 import { DatesAndValuesSection } from './core-fields/DatesAndValuesSection';
 
-import type { FieldErrors, UseFormRegister, UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import type {
+  Control,
+  FieldErrors,
+  UseFormRegister,
+  UseFormSetValue,
+  UseFormWatch,
+} from 'react-hook-form';
 
 import type { LocationTreeNode } from '../../location-tree-page/utils';
 
 interface CoreFieldsSectionProps {
   register: UseFormRegister<ItemFormValues>;
+  control: Control<ItemFormValues>;
   watch: UseFormWatch<ItemFormValues>;
   setValue: UseFormSetValue<ItemFormValues>;
   errors: FieldErrors<ItemFormValues>;
@@ -23,6 +30,7 @@ interface CoreFieldsSectionProps {
 
 export function CoreFieldsSection({
   register,
+  control,
   watch,
   setValue,
   errors,
@@ -49,6 +57,7 @@ export function CoreFieldsSection({
       />
       <ClassificationSection
         register={register}
+        control={control}
         watch={watch}
         setValue={setValue}
         errors={errors}

--- a/packages/app-inventory/src/pages/item-form-page/sections/core-fields/ClassificationSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/core-fields/ClassificationSection.tsx
@@ -1,10 +1,19 @@
+import { Controller } from 'react-hook-form';
+
 import { CheckboxInput, Select } from '@pops/ui';
 
 import { LocationPicker } from '../../../../components/LocationPicker';
 import { type ItemFormValues } from '../../useItemFormPageModel';
 import { FormField } from './FormField';
 
-import type { FieldErrors, UseFormRegister, UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import type {
+  Control,
+  FieldErrors,
+  FieldPath,
+  UseFormRegister,
+  UseFormSetValue,
+  UseFormWatch,
+} from 'react-hook-form';
 
 import type { LocationTreeNode } from '../../../location-tree-page/utils';
 
@@ -27,8 +36,43 @@ const CONDITIONS = [
   { value: 'broken', label: 'Broken' },
 ];
 
+/**
+ * Restricts the field path to only those whose value type is a boolean. The
+ * underlying Radix CheckboxInput uses `checked` / `onCheckedChange`, which is
+ * incompatible with RHF's `register()` spread, so we wire boolean fields via
+ * Controller (#2175).
+ */
+type BooleanFieldPath = {
+  [K in FieldPath<ItemFormValues>]: ItemFormValues[K] extends boolean ? K : never;
+}[FieldPath<ItemFormValues>];
+
+interface BooleanCheckboxProps {
+  name: BooleanFieldPath;
+  control: Control<ItemFormValues>;
+  label: string;
+}
+
+/**
+ * Adapter that bridges RHF's controller `field` API to Radix's checkbox
+ * `checked` / `onCheckedChange` API. The `CheckboxInput` wrapper types
+ * `onCheckedChange` as `(checked: boolean) => void`, so the value lands as a
+ * plain boolean — no indeterminate coercion needed here.
+ */
+function BooleanCheckbox({ name, control, label }: BooleanCheckboxProps) {
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field }) => (
+        <CheckboxInput label={label} checked={field.value} onCheckedChange={field.onChange} />
+      )}
+    />
+  );
+}
+
 interface ClassificationSectionProps {
   register: UseFormRegister<ItemFormValues>;
+  control: Control<ItemFormValues>;
   watch: UseFormWatch<ItemFormValues>;
   setValue: UseFormSetValue<ItemFormValues>;
   errors: FieldErrors<ItemFormValues>;
@@ -38,6 +82,7 @@ interface ClassificationSectionProps {
 
 export function ClassificationSection({
   register,
+  control,
   watch,
   setValue,
   errors,
@@ -77,8 +122,8 @@ export function ClassificationSection({
         />
       </FormField>
       <div className="flex gap-6 p-4 rounded-xl bg-app-accent/5">
-        <CheckboxInput label="In Use" {...register('inUse')} />
-        <CheckboxInput label="Tax Deductible" {...register('deductible')} />
+        <BooleanCheckbox name="inUse" control={control} label="In Use" />
+        <BooleanCheckbox name="deductible" control={control} label="Tax Deductible" />
       </div>
     </section>
   );

--- a/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
@@ -69,10 +69,11 @@ function useResetFromItem(
   itemData: ItemQueryResult | undefined,
   reset: (values: ItemFormValues) => void
 ): void {
+  const item = itemData?.data;
   useEffect(() => {
-    if (!itemData?.data) return;
-    reset(itemToFormValues(itemData.data));
-  }, [itemData, reset]);
+    if (!item) return;
+    reset(itemToFormValues(item));
+  }, [item, reset]);
 }
 
 function useUnsavedChangesGuard(isDirty: boolean): void {


### PR DESCRIPTION
## Summary

Fixes the checkbox half of #2175. The Radix `CheckboxInput` exposes `checked` / `onCheckedChange`, which is incompatible with React Hook Form's `register()` spread (`{ name, onChange, onBlur, ref }`). On WebKit, calling `form.reset({ inUse: true, deductible: true })` updated RHF state but the Radix `<button role="checkbox">` never re-rendered with the new checked state, so the In Use / Tax Deductible checkboxes appeared empty after edit-mode load.

The text-input half of #2175 is fixed in #2181 (`fix(ui): TextInput renders uncontrolled when no value prop`). The two PRs together close the bug.

## Changes

- `packages/app-inventory/src/pages/item-form-page/sections/core-fields/ClassificationSection.tsx`
  - Added a `BooleanCheckbox` adapter component that wraps `Controller` and bridges `field.value` / `field.onChange` to `checked` / `onCheckedChange`.
  - Extracted the wiring as a typed helper (`BooleanFieldPath`) so only boolean form fields can be passed to it.
- `packages/app-inventory/src/pages/item-form-page/sections/CoreFieldsSection.tsx`, `packages/app-inventory/src/pages/ItemFormPage.tsx` — propagate `control` from `useForm()` through to the section.
- `packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts` — narrow `useResetFromItem` deps to the inner `item` (the tRPC wrapper object identity changed every render and re-fired the reset effect, which could race with user input on WebKit).
- `apps/pops-shell/e2e/inventory-locations-tree.spec.ts` — un-skipped (#2175 + #2157 both addressed); cleaned obsolete inline references to the now-fixed bugs.
- `packages/app-inventory/src/pages/ItemFormPage.test.tsx` — added regression coverage:
  - In Use checkbox populates from seeded item (`aria-checked="true"`).
  - Tax Deductible checkbox populates from seeded item.
  - In Use toggles in create mode (bidirectional Controller wiring).
  - Create payload reflects the toggled `inUse` value end-to-end.

## Test plan

- [x] `pnpm test` in `packages/app-inventory` — 362/362 pass.
- [x] `pnpm typecheck` in `packages/app-inventory` and `apps/pops-shell`.
- [x] `mise typecheck` (16/16) and `mise lint` (0 errors).
- [ ] CI runs the un-skipped `inventory-locations-tree.spec.ts` against the seeded e2e env.

Closes #2175