### PR TITLE
feat(finance): manual transaction create/edit/delete UI (#2185)

### DIFF
--- a/apps/pops-shell/e2e/finance-transactions-crud.spec.ts
+++ b/apps/pops-shell/e2e/finance-transactions-crud.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * E2E test — Finance transactions CRUD (#2106)
+ *
+ * Exercises the full create → confirm → edit (amount + entity) → confirm →
+ * delete → confirm flow at `/finance/transactions` against the seeded e2e
+ * SQLite environment.
+ *
+ * Design notes
+ * ------------
+ * - Serial describe mode: the three tests share a single transaction created
+ *   by the first test, edited by the second, deleted by the third.
+ * - Idempotent: a unique-per-run description avoids collisions with the 16
+ *   seeded transactions and with parallel workers. The afterAll hook attempts
+ *   a best-effort cleanup so repeated local runs stay clean even if a test
+ *   bails out mid-flight.
+ * - Semantic locators only — role/name, placeholder, scoped row filters.
+ *   `TextInput` labels are visual-only (not linked via htmlFor), so inputs
+ *   are targeted by placeholder or by react-hook-form `name=` attr.
+ * - Auto-retrying `expect` handles tRPC invalidation latency.
+ * - pageerror + console-error listeners are registered before navigation and
+ *   asserted in afterEach so every test enforces the no-crash requirement.
+ */
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+import { useRealApi } from './helpers/use-real-api';
+
+// Unique per test run so we don't collide with seeded items or parallel workers.
+const RUN_ID = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const DESCRIPTION = `E2E Txn ${RUN_ID}`;
+const INITIAL_AMOUNT = '-12.34';
+const UPDATED_AMOUNT = '-99.99';
+const ACCOUNT = 'E2E CRUD';
+
+/** Row locator scoped to the transaction we created for this run. */
+function targetRow(page: Page): Locator {
+  return page.getByRole('row').filter({ hasText: DESCRIPTION });
+}
+
+/** The form dialog (Radix Dialog renders with role="dialog"). */
+function formDialog(page: Page): Locator {
+  return page.getByRole('dialog');
+}
+
+/** The delete confirmation dialog (Radix AlertDialog renders with role="alertdialog"). */
+function deleteDialog(page: Page): Locator {
+  return page.getByRole('alertdialog');
+}
+
+/**
+ * Fill the form fields. The form is brand-new for create flows, partially
+ * pre-populated for edit flows; only the fields passed in `fields` are filled
+ * (or replaced). Empty-string values clear an existing field first.
+ */
+async function fillForm(
+  dialog: Locator,
+  fields: { date?: string; amount?: string; description?: string; account?: string }
+) {
+  if (fields.date !== undefined) {
+    const date = dialog.locator('input[name="date"]');
+    await date.fill(fields.date);
+  }
+  if (fields.amount !== undefined) {
+    const amount = dialog.locator('input[name="amount"]');
+    await amount.fill(fields.amount);
+  }
+  if (fields.description !== undefined) {
+    const description = dialog.locator('input[name="description"]');
+    await description.fill(fields.description);
+  }
+  if (fields.account !== undefined) {
+    const account = dialog.locator('input[name="account"]');
+    await account.fill(fields.account);
+  }
+}
+
+test.describe('Finance — transactions CRUD', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let pageErrors: string[] = [];
+  let consoleErrors: string[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    pageErrors = [];
+    consoleErrors = [];
+    await useRealApi(page);
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    await page.goto('/finance/transactions');
+    // Wait for the list to hydrate so the "Add Transaction" button is
+    // interactive and the DataTable is mounted. The first seeded row always
+    // renders.
+    await expect(page.getByRole('heading', { name: /transactions/i })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByRole('row').filter({ hasText: 'Coles Local' }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    const realConsoleErrors = consoleErrors.filter(
+      (e) =>
+        !e.includes('React Router') &&
+        !e.includes('Download the React DevTools') &&
+        !e.includes('Failed to load resource')
+    );
+    expect(pageErrors).toHaveLength(0);
+    expect(realConsoleErrors).toHaveLength(0);
+  });
+
+  // Best-effort cleanup: if a test above bailed out, navigate back in and
+  // remove the leftover row so repeat runs stay deterministic.
+  test.afterAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await useRealApi(page);
+      await page.goto('/finance/transactions');
+      const row = page.getByRole('row').filter({ hasText: DESCRIPTION });
+      if (
+        await row
+          .first()
+          .isVisible()
+          .catch(() => false)
+      ) {
+        await row
+          .first()
+          .getByRole('button', { name: /actions/i })
+          .click();
+        await page.getByRole('menuitem', { name: /delete/i }).click();
+        const confirm = page.getByRole('alertdialog').getByRole('button', { name: /^delete$/i });
+        await confirm.click();
+        await expect(row).toHaveCount(0, { timeout: 5_000 });
+      }
+    } catch {
+      // Cleanup is best-effort — swallow failures so they don't mask real test
+      // failures.
+    } finally {
+      await page.close();
+      await context.close();
+    }
+  });
+
+  test('creates a new transaction and it appears in the list', async ({ page }) => {
+    await page.getByRole('button', { name: /add transaction/i }).click();
+
+    const dialog = formDialog(page);
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(/new transaction/i)).toBeVisible();
+
+    await fillForm(dialog, {
+      date: '2026-04-26',
+      amount: INITIAL_AMOUNT,
+      description: DESCRIPTION,
+      account: ACCOUNT,
+    });
+    // Type — the only <select> in the dialog (Type field).
+    await dialog.locator('select').selectOption('Expense');
+
+    await dialog.getByRole('button', { name: /^create$/i }).click();
+
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+
+    const row = targetRow(page).first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row).toContainText(ACCOUNT);
+    // Amount column renders -$12.34 (sign prefix + absolute value).
+    await expect(row).toContainText('12.34');
+  });
+
+  test('edits the amount and entity and the list reflects the new values', async ({ page }) => {
+    const row = targetRow(page).first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row).toContainText('12.34');
+
+    await row.getByRole('button', { name: /actions/i }).click();
+    await page.getByRole('menuitem', { name: /edit/i }).click();
+
+    const dialog = formDialog(page);
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(/edit transaction/i)).toBeVisible();
+
+    // Update the amount.
+    await fillForm(dialog, { amount: UPDATED_AMOUNT });
+
+    // Pick an entity via the EntitySelect combobox. The seeded e2e DB has
+    // "Woolworths" as the first entity. The combobox renders as a button with
+    // role="combobox"; clicking it opens a Popover with a CommandInput.
+    await dialog.getByRole('combobox').click();
+    const popover = page.locator('[data-slot="popover-content"]');
+    await expect(popover).toBeVisible();
+    await popover
+      .getByRole('option')
+      .filter({ hasText: /^Woolworths/ })
+      .first()
+      .click();
+    // Popover closes on selection.
+    await expect(popover).toHaveCount(0);
+
+    await dialog.getByRole('button', { name: /^update$/i }).click();
+
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+
+    // Auto-retrying expect handles tRPC invalidation → refetch latency. The
+    // entityName renders below the description in the same row.
+    await expect(row).toContainText('99.99', { timeout: 10_000 });
+    await expect(row).toContainText('Woolworths');
+    await expect(row).not.toContainText('12.34');
+  });
+
+  test('deletes the transaction and it is removed from the list', async ({ page }) => {
+    const row = targetRow(page).first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    await row.getByRole('button', { name: /actions/i }).click();
+    await page.getByRole('menuitem', { name: /delete/i }).click();
+
+    const confirm = deleteDialog(page);
+    await expect(confirm).toBeVisible();
+    await expect(confirm.getByText(/permanently delete/i)).toBeVisible();
+
+    await confirm.getByRole('button', { name: /^delete$/i }).click();
+
+    await expect(confirm).not.toBeVisible({ timeout: 10_000 });
+    await expect(targetRow(page)).toHaveCount(0, { timeout: 10_000 });
+  });
+});

--- a/apps/pops-shell/e2e/finance-transactions-crud.spec.ts
+++ b/apps/pops-shell/e2e/finance-transactions-crud.spec.ts
@@ -187,9 +187,10 @@ test.describe('Finance — transactions CRUD', () => {
     await fillForm(dialog, { amount: UPDATED_AMOUNT });
 
     // Pick an entity via the EntitySelect combobox. The seeded e2e DB has
-    // "Woolworths" as the first entity. The combobox renders as a button with
-    // role="combobox"; clicking it opens a Popover with a CommandInput.
-    await dialog.getByRole('combobox').click();
+    // "Woolworths" as the first entity. The form contains two role="combobox"
+    // elements (the type <select> and the entity Popover trigger) — scope to
+    // the entity trigger by its placeholder so strict mode resolves to one.
+    await dialog.getByRole('combobox').filter({ hasText: 'Choose entity' }).click();
     const popover = page.locator('[data-slot="popover-content"]');
     await expect(popover).toBeVisible();
     await popover

--- a/packages/app-finance/src/pages/TransactionsPage.tsx
+++ b/packages/app-finance/src/pages/TransactionsPage.tsx
@@ -1,3 +1,4 @@
+import { Plus } from 'lucide-react';
 import { useCallback } from 'react';
 
 import { trpc } from '@pops/api-client';
@@ -5,6 +6,9 @@ import { useSetPageContext } from '@pops/navigation';
 import { Alert, Button, DataTable, PageHeader, Skeleton } from '@pops/ui';
 
 import { buildColumns, TRANSACTION_TABLE_FILTERS, type Transaction } from './transactions/columns';
+import { DeleteTransactionDialog } from './transactions/DeleteTransactionDialog';
+import { TransactionFormDialog } from './transactions/TransactionFormDialog';
+import { useTransactionsPage } from './transactions/useTransactionsPage';
 
 function ErrorView({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
@@ -81,21 +85,54 @@ function useTagHandlers() {
 
 export function TransactionsPage() {
   useSetPageContext({ page: 'transactions' });
-  const { data, isLoading, error, refetch } = trpc.finance.transactions.list.useQuery({
-    limit: 100,
-  });
-  const { data: availableTags } = trpc.finance.transactions.availableTags.useQuery();
+  const state = useTransactionsPage();
   const { onTagSave, onTagSuggest } = useTagHandlers();
-  const columns = buildColumns({ availableTags: availableTags ?? [], onTagSave, onTagSuggest });
 
-  if (error) return <ErrorView message={error.message} onRetry={() => refetch()} />;
+  if (state.query.error) {
+    return <ErrorView message={state.query.error.message} onRetry={() => state.query.refetch()} />;
+  }
+
+  const columns = buildColumns({
+    availableTags: state.availableTags,
+    onTagSave,
+    onTagSuggest,
+    onEdit: state.handleEdit,
+    onDelete: state.setDeletingId,
+  });
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Transactions"
-        description={data ? `${data.pagination.total} total transactions` : undefined}
+        description={
+          state.query.data ? `${state.query.data.pagination.total} total transactions` : undefined
+        }
+        actions={
+          <Button onClick={state.handleAdd}>
+            <Plus className="mr-2 h-4 w-4" /> Add Transaction
+          </Button>
+        }
       />
-      <TableContent isLoading={isLoading} transactions={data?.data} columns={columns} />
+      <TableContent
+        isLoading={state.query.isLoading}
+        transactions={state.query.data?.data}
+        columns={columns}
+      />
+      <TransactionFormDialog
+        open={state.isDialogOpen}
+        onOpenChange={state.setIsDialogOpen}
+        editingTransaction={state.editingTransaction}
+        form={state.form}
+        isSubmitting={state.isSubmitting}
+        onSubmit={state.onSubmit}
+        entities={state.entities}
+      />
+      <DeleteTransactionDialog
+        deletingId={state.deletingId}
+        setDeletingId={state.setDeletingId}
+        isDeleting={state.deleteMutation.isPending}
+        onConfirm={(id) => state.deleteMutation.mutate({ id })}
+      />
     </div>
   );
 }

--- a/packages/app-finance/src/pages/transactions/DeleteTransactionDialog.tsx
+++ b/packages/app-finance/src/pages/transactions/DeleteTransactionDialog.tsx
@@ -1,0 +1,47 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@pops/ui';
+
+interface Props {
+  deletingId: string | null;
+  setDeletingId: (id: string | null) => void;
+  isDeleting: boolean;
+  onConfirm: (id: string) => void;
+}
+
+export function DeleteTransactionDialog({
+  deletingId,
+  setDeletingId,
+  isDeleting,
+  onConfirm,
+}: Props) {
+  return (
+    <AlertDialog open={!!deletingId} onOpenChange={() => setDeletingId(null)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete this transaction.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            onClick={() => deletingId && onConfirm(deletingId)}
+            disabled={isDeleting}
+          >
+            {isDeleting ? 'Deleting...' : 'Delete'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/app-finance/src/pages/transactions/TransactionFormDialog.tsx
+++ b/packages/app-finance/src/pages/transactions/TransactionFormDialog.tsx
@@ -1,0 +1,185 @@
+import { Loader2 } from 'lucide-react';
+import { Controller, type UseFormReturn } from 'react-hook-form';
+
+import {
+  Button,
+  ChipInput,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  EntitySelect,
+  Label,
+  Select,
+  Textarea,
+  TextInput,
+} from '@pops/ui';
+
+import { type Transaction, TRANSACTION_TYPE_OPTIONS, type TransactionFormValues } from './types';
+
+interface DialogProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  editingTransaction: Transaction | null;
+  form: UseFormReturn<TransactionFormValues>;
+  isSubmitting: boolean;
+  onSubmit: (values: TransactionFormValues) => void;
+  entities: Array<{ id: string; name: string; type: string }>;
+}
+
+function PrimaryFields({ form }: { form: UseFormReturn<TransactionFormValues> }) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <TextInput
+        type="date"
+        label="Date"
+        {...form.register('date')}
+        error={form.formState.errors.date?.message}
+      />
+      <TextInput
+        type="number"
+        step="0.01"
+        label="Amount"
+        placeholder="0.00"
+        prefix="$"
+        {...form.register('amount')}
+        error={form.formState.errors.amount?.message}
+      />
+    </div>
+  );
+}
+
+function DescriptionField({ form }: { form: UseFormReturn<TransactionFormValues> }) {
+  return (
+    <TextInput
+      label="Description"
+      placeholder="e.g. Woolworths Metro"
+      {...form.register('description')}
+      error={form.formState.errors.description?.message}
+    />
+  );
+}
+
+function AccountAndType({ form }: { form: UseFormReturn<TransactionFormValues> }) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <TextInput
+        label="Account"
+        placeholder="e.g. Bank Account"
+        {...form.register('account')}
+        error={form.formState.errors.account?.message}
+      />
+      <Select
+        label="Type"
+        options={TRANSACTION_TYPE_OPTIONS}
+        {...form.register('type')}
+        error={form.formState.errors.type?.message}
+      />
+    </div>
+  );
+}
+
+function EntityField({
+  form,
+  entities,
+}: {
+  form: UseFormReturn<TransactionFormValues>;
+  entities: DialogProps['entities'];
+}) {
+  return (
+    <div className="space-y-2">
+      <Label>Entity (Optional)</Label>
+      <Controller
+        control={form.control}
+        name="entityId"
+        render={({ field }) => (
+          <EntitySelect
+            entities={entities.map((e) => ({
+              id: e.id,
+              name: e.name,
+              type: e.type,
+            }))}
+            value={field.value || undefined}
+            onChange={(entityId) => field.onChange(entityId)}
+            placeholder="Choose entity..."
+          />
+        )}
+      />
+    </div>
+  );
+}
+
+function TagsField({ form }: { form: UseFormReturn<TransactionFormValues> }) {
+  return (
+    <div className="space-y-2">
+      <Label>Tags</Label>
+      <Controller
+        control={form.control}
+        name="tags"
+        render={({ field }) => (
+          <ChipInput
+            placeholder="Type and press Enter..."
+            value={field.value}
+            onChange={field.onChange}
+          />
+        )}
+      />
+    </div>
+  );
+}
+
+function NotesField({ form }: { form: UseFormReturn<TransactionFormValues> }) {
+  return (
+    <div className="space-y-2">
+      <Label>Notes (Optional)</Label>
+      <Textarea placeholder="Additional details..." {...form.register('notes')} />
+    </div>
+  );
+}
+
+function FormFields(props: {
+  form: UseFormReturn<TransactionFormValues>;
+  entities: DialogProps['entities'];
+}) {
+  return (
+    <div className="grid gap-4 py-4">
+      <PrimaryFields form={props.form} />
+      <DescriptionField form={props.form} />
+      <AccountAndType form={props.form} />
+      <EntityField form={props.form} entities={props.entities} />
+      <TagsField form={props.form} />
+      <NotesField form={props.form} />
+    </div>
+  );
+}
+
+export function TransactionFormDialog(props: DialogProps) {
+  const { open, onOpenChange, editingTransaction, form, isSubmitting, onSubmit, entities } = props;
+  return (
+    <Dialog open={open} onOpenChange={(v) => !isSubmitting && onOpenChange(v)}>
+      <DialogContent className="sm:max-w-125">
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <DialogHeader>
+            <DialogTitle>{editingTransaction ? 'Edit Transaction' : 'New Transaction'}</DialogTitle>
+          </DialogHeader>
+          <FormFields form={form} entities={entities} />
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {editingTransaction ? 'Update' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app-finance/src/pages/transactions/columns.tsx
+++ b/packages/app-finance/src/pages/transactions/columns.tsx
@@ -1,21 +1,23 @@
-import { Badge, type ColumnFilter, dateRangeFilter, SortableHeader } from '@pops/ui';
+import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+
+import {
+  Badge,
+  Button,
+  type ColumnFilter,
+  dateRangeFilter,
+  DropdownMenu,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  SortableHeader,
+} from '@pops/ui';
 
 import { TagEditor } from '../../components/TagEditor';
 
 import type { ColumnDef } from '@tanstack/react-table';
 
-export interface Transaction {
-  id: string;
-  description: string;
-  account: string;
-  amount: number;
-  date: string;
-  type: string;
-  tags: string[];
-  entityId: string | null;
-  entityName: string | null;
-  location: string | null;
-}
+import type { Transaction } from './types';
+
+export type { Transaction } from './types';
 
 interface BuildColumnsArgs {
   availableTags: string[];
@@ -25,6 +27,8 @@ interface BuildColumnsArgs {
     description: string
   ) => (tags: string[]) => Promise<void>;
   onTagSuggest: (description: string, entityId: string | null) => () => Promise<string[]>;
+  onEdit: (transaction: Transaction) => void;
+  onDelete: (id: string) => void;
 }
 
 const dateColumn: ColumnDef<Transaction> = {
@@ -122,6 +126,35 @@ function buildTagsColumn(args: BuildColumnsArgs): ColumnDef<Transaction> {
   };
 }
 
+function buildActionsColumn(args: BuildColumnsArgs): ColumnDef<Transaction> {
+  return {
+    id: 'actions',
+    cell: ({ row }) => (
+      <div className="text-right">
+        <DropdownMenu
+          trigger={
+            <Button variant="ghost" size="icon" aria-label="Actions">
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          }
+          align="end"
+        >
+          <DropdownMenuItem onClick={() => args.onEdit(row.original)}>
+            <Pencil className="mr-2 h-4 w-4" /> Edit
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => args.onDelete(row.original.id)}
+          >
+            <Trash2 className="mr-2 h-4 w-4" /> Delete
+          </DropdownMenuItem>
+        </DropdownMenu>
+      </div>
+    ),
+  };
+}
+
 export function buildColumns(args: BuildColumnsArgs): ColumnDef<Transaction>[] {
   return [
     dateColumn,
@@ -130,6 +163,7 @@ export function buildColumns(args: BuildColumnsArgs): ColumnDef<Transaction>[] {
     amountColumn,
     typeColumn,
     buildTagsColumn(args),
+    buildActionsColumn(args),
   ];
 }
 

--- a/packages/app-finance/src/pages/transactions/types.ts
+++ b/packages/app-finance/src/pages/transactions/types.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+
+/**
+ * Form-level types for the transaction form dialog.
+ *
+ * The shape is form-friendly: amount and entityId are strings (text inputs +
+ * EntitySelect store strings). The `useTransactionsPage` hook coerces these
+ * to the tRPC contract (`amount: number`, `entityId: string | null`) on submit.
+ */
+
+/** Transaction record from the API list query (camelCase). */
+export interface Transaction {
+  id: string;
+  description: string;
+  account: string;
+  amount: number;
+  date: string;
+  type: string;
+  tags: string[];
+  entityId: string | null;
+  entityName: string | null;
+  location: string | null;
+  country?: string | null;
+  relatedTransactionId?: string | null;
+  notes?: string | null;
+  lastEditedTime?: string;
+}
+
+/** Allowed transaction types. Mirrors the existing TABLE_FILTERS values. */
+export const TRANSACTION_TYPE_OPTIONS = [
+  { label: 'Expense', value: 'Expense' },
+  { label: 'Income', value: 'Income' },
+  { label: 'Transfer', value: 'Transfer' },
+];
+
+/**
+ * Zod schema for the form values. Amount is collected as a free-form numeric
+ * string so the user can type intermediate values like "" or "-" without the
+ * input becoming uncontrolled. Date is enforced as YYYY-MM-DD.
+ */
+export const TransactionFormSchema = z.object({
+  date: z.string().min(1, 'Date is required'),
+  amount: z
+    .string()
+    .min(1, 'Amount is required')
+    .refine((v) => Number.isFinite(Number(v)), 'Amount must be a number'),
+  description: z.string().min(1, 'Description is required'),
+  account: z.string().min(1, 'Account is required'),
+  type: z.string().min(1, 'Type is required'),
+  entityId: z.string(),
+  tags: z.array(z.string()),
+  notes: z.string(),
+});
+
+export type TransactionFormValues = z.infer<typeof TransactionFormSchema>;
+
+export const DEFAULT_TRANSACTION_VALUES: TransactionFormValues = {
+  date: '',
+  amount: '',
+  description: '',
+  account: '',
+  type: 'Expense',
+  entityId: '',
+  tags: [],
+  notes: '',
+};

--- a/packages/app-finance/src/pages/transactions/useTransactionsPage.test.ts
+++ b/packages/app-finance/src/pages/transactions/useTransactionsPage.test.ts
@@ -1,0 +1,363 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Transaction, TransactionFormValues } from './types';
+
+// ---------- mocks ----------
+
+const mockListQuery = vi.fn();
+const mockAvailableTagsQuery = vi.fn();
+const mockEntitiesListQuery = vi.fn();
+const mockCreateMutate = vi.fn();
+const mockUpdateMutate = vi.fn();
+const mockDeleteMutate = vi.fn();
+const mockInvalidate = vi.fn();
+const mockSuggestTagsFetch = vi.fn();
+
+vi.mock('@pops/api-client', () => ({
+  trpc: {
+    finance: {
+      transactions: {
+        list: { useQuery: (...args: unknown[]) => mockListQuery(...args) },
+        availableTags: {
+          useQuery: (...args: unknown[]) => mockAvailableTagsQuery(...args),
+        },
+        create: {
+          useMutation: () => ({
+            mutate: (...args: unknown[]) => mockCreateMutate(...args),
+            isPending: false,
+          }),
+        },
+        update: {
+          useMutation: () => ({
+            mutate: (...args: unknown[]) => mockUpdateMutate(...args),
+            isPending: false,
+          }),
+        },
+        delete: {
+          useMutation: () => ({
+            mutate: (...args: unknown[]) => mockDeleteMutate(...args),
+            isPending: false,
+          }),
+        },
+      },
+    },
+    core: {
+      entities: {
+        list: { useQuery: (...args: unknown[]) => mockEntitiesListQuery(...args) },
+      },
+    },
+    useUtils: () => ({
+      finance: {
+        transactions: {
+          list: { invalidate: mockInvalidate },
+          availableTags: { invalidate: mockInvalidate },
+          suggestTags: { fetch: (...args: unknown[]) => mockSuggestTagsFetch(...args) },
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Import after mocks are registered.
+import { buildTransactionPayload, useTransactionsPage } from './useTransactionsPage';
+
+// ---------- helpers ----------
+
+function makeValues(overrides: Partial<TransactionFormValues> = {}): TransactionFormValues {
+  return {
+    date: '2026-04-26',
+    amount: '-87.45',
+    description: 'Woolworths Metro',
+    account: 'Credit Card',
+    type: 'Expense',
+    entityId: '',
+    tags: [],
+    notes: '',
+    ...overrides,
+  };
+}
+
+function makeTransaction(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'txn-1',
+    date: '2026-02-10',
+    amount: -87.45,
+    description: 'Woolworths Metro',
+    account: 'Credit Card',
+    type: 'Expense',
+    entityId: 'ent-1',
+    entityName: 'Woolworths',
+    location: 'Sydney CBD',
+    country: 'Australia',
+    relatedTransactionId: null,
+    notes: 'Weekly shop',
+    tags: ['Groceries'],
+    lastEditedTime: '2026-02-10T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListQuery.mockReturnValue({
+    data: { data: [], pagination: { total: 0 } },
+    isLoading: false,
+  });
+  mockAvailableTagsQuery.mockReturnValue({ data: [] });
+  mockEntitiesListQuery.mockReturnValue({
+    data: {
+      data: [
+        { id: 'ent-1', name: 'Woolworths', type: 'company' },
+        { id: 'ent-2', name: 'Coles', type: 'company' },
+      ],
+    },
+  });
+});
+
+// ---------- buildTransactionPayload ----------
+
+describe('buildTransactionPayload', () => {
+  it('coerces amount string to number', () => {
+    const payload = buildTransactionPayload({
+      values: makeValues({ amount: '-12.5' }),
+      entityName: null,
+    });
+    expect(payload.amount).toBe(-12.5);
+  });
+
+  it('coerces empty entityId to null and clears entityName', () => {
+    const payload = buildTransactionPayload({
+      values: makeValues({ entityId: '' }),
+      entityName: 'Woolworths',
+    });
+    expect(payload.entityId).toBeNull();
+    expect(payload.entityName).toBeNull();
+  });
+
+  it('keeps entityId and includes entityName when provided', () => {
+    const payload = buildTransactionPayload({
+      values: makeValues({ entityId: 'ent-1' }),
+      entityName: 'Woolworths',
+    });
+    expect(payload.entityId).toBe('ent-1');
+    expect(payload.entityName).toBe('Woolworths');
+  });
+
+  it('coerces empty notes to null', () => {
+    const payload = buildTransactionPayload({
+      values: makeValues({ notes: '' }),
+      entityName: null,
+    });
+    expect(payload.notes).toBeNull();
+  });
+
+  it('passes non-empty notes through unchanged', () => {
+    const payload = buildTransactionPayload({
+      values: makeValues({ notes: 'A note' }),
+      entityName: null,
+    });
+    expect(payload.notes).toBe('A note');
+  });
+
+  it('preserves all required fields verbatim', () => {
+    const payload = buildTransactionPayload({
+      values: makeValues({
+        date: '2026-04-26',
+        description: 'Coles Local',
+        account: 'Debit Card',
+        type: 'Expense',
+        amount: '-50',
+        tags: ['Groceries'],
+      }),
+      entityName: null,
+    });
+    expect(payload).toEqual({
+      date: '2026-04-26',
+      description: 'Coles Local',
+      account: 'Debit Card',
+      type: 'Expense',
+      amount: -50,
+      tags: ['Groceries'],
+      entityId: null,
+      entityName: null,
+      notes: null,
+    });
+  });
+});
+
+// ---------- create path ----------
+
+describe('useTransactionsPage — onSubmit (create)', () => {
+  it('builds a payload with parsed amount and null entity for new transactions', () => {
+    const { result } = renderHook(() => useTransactionsPage());
+
+    act(() => {
+      result.current.onSubmit(makeValues({ amount: '-87.45', notes: '' }));
+    });
+
+    expect(mockCreateMutate).toHaveBeenCalledTimes(1);
+    expect(mockCreateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: -87.45,
+        entityId: null,
+        entityName: null,
+        notes: null,
+      })
+    );
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+  });
+
+  it('resolves entity name from the entities list when entityId is set', () => {
+    const { result } = renderHook(() => useTransactionsPage());
+
+    act(() => {
+      result.current.onSubmit(makeValues({ entityId: 'ent-1' }));
+    });
+
+    expect(mockCreateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ entityId: 'ent-1', entityName: 'Woolworths' })
+    );
+  });
+
+  it('falls back to null entityName when entityId is not in the entities list', () => {
+    const { result } = renderHook(() => useTransactionsPage());
+
+    act(() => {
+      result.current.onSubmit(makeValues({ entityId: 'ent-unknown' }));
+    });
+
+    // entityId is preserved; entityName resolves to null because the id is not
+    // in the loaded entities cache.
+    expect(mockCreateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ entityId: 'ent-unknown', entityName: null })
+    );
+  });
+
+  it('preserves tags as-is on create', () => {
+    const { result } = renderHook(() => useTransactionsPage());
+
+    act(() => {
+      result.current.onSubmit(makeValues({ tags: ['A', 'B'] }));
+    });
+
+    expect(mockCreateMutate).toHaveBeenCalledWith(expect.objectContaining({ tags: ['A', 'B'] }));
+  });
+});
+
+// ---------- update path ----------
+
+describe('useTransactionsPage — onSubmit (update)', () => {
+  it('routes to update when an item is being edited', () => {
+    const { result } = renderHook(() => useTransactionsPage());
+
+    act(() => {
+      result.current.handleEdit(makeTransaction({ id: 'txn-42' }));
+    });
+    act(() => {
+      result.current.onSubmit(
+        makeValues({ amount: '-99.99', entityId: 'ent-2', notes: 'Updated notes' })
+      );
+    });
+
+    expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMutate).toHaveBeenCalledWith({
+      id: 'txn-42',
+      data: expect.objectContaining({
+        amount: -99.99,
+        entityId: 'ent-2',
+        entityName: 'Coles',
+        notes: 'Updated notes',
+      }),
+    });
+    expect(mockCreateMutate).not.toHaveBeenCalled();
+  });
+
+  it('clears entityName when entityId is cleared on update', () => {
+    const { result } = renderHook(() => useTransactionsPage());
+
+    act(() => {
+      result.current.handleEdit(makeTransaction({ id: 'txn-42', entityId: 'ent-1' }));
+    });
+    act(() => {
+      result.current.onSubmit(makeValues({ entityId: '' }));
+    });
+
+    expect(mockUpdateMutate).toHaveBeenCalledWith({
+      id: 'txn-42',
+      data: expect.objectContaining({ entityId: null, entityName: null }),
+    });
+  });
+});
+
+// ---------- form prefill ----------
+
+describe('useTransactionsPage — handleEdit prefill', () => {
+  it('resets form to the transaction values, including entity id', () => {
+    const { result } = renderHook(() => useTransactionsPage());
+
+    act(() => {
+      result.current.handleEdit(
+        makeTransaction({ id: 'txn-42', amount: -123.45, entityId: 'ent-1' })
+      );
+    });
+
+    expect(result.current.form.getValues()).toEqual({
+      date: '2026-02-10',
+      amount: '-123.45',
+      description: 'Woolworths Metro',
+      account: 'Credit Card',
+      type: 'Expense',
+      entityId: 'ent-1',
+      tags: ['Groceries'],
+      notes: 'Weekly shop',
+    });
+    expect(result.current.editingTransaction?.id).toBe('txn-42');
+  });
+
+  it('treats null notes/entity as empty strings on form prefill', () => {
+    const { result } = renderHook(() => useTransactionsPage());
+
+    act(() => {
+      result.current.handleEdit(makeTransaction({ id: 'txn-42', entityId: null, notes: null }));
+    });
+
+    const values = result.current.form.getValues();
+    expect(values.entityId).toBe('');
+    expect(values.notes).toBe('');
+  });
+
+  it('falls back to "Expense" when transaction.type is empty', () => {
+    const { result } = renderHook(() => useTransactionsPage());
+
+    act(() => {
+      result.current.handleEdit(makeTransaction({ id: 'txn-42', type: '' }));
+    });
+
+    expect(result.current.form.getValues().type).toBe('Expense');
+  });
+});
+
+// ---------- delete path ----------
+
+describe('useTransactionsPage — delete', () => {
+  it('exposes a setDeletingId setter that does not auto-fire the delete mutation', () => {
+    const { result } = renderHook(() => useTransactionsPage());
+
+    act(() => {
+      result.current.setDeletingId('txn-42');
+    });
+
+    expect(result.current.deletingId).toBe('txn-42');
+    // The delete only fires when the AlertDialog confirm button calls
+    // deleteMutation.mutate explicitly — not when an id is staged.
+    expect(mockDeleteMutate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-finance/src/pages/transactions/useTransactionsPage.ts
+++ b/packages/app-finance/src/pages/transactions/useTransactionsPage.ts
@@ -1,0 +1,200 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCallback, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+
+import { trpc } from '@pops/api-client';
+
+import {
+  DEFAULT_TRANSACTION_VALUES,
+  type Transaction,
+  type TransactionFormValues,
+  TransactionFormSchema,
+} from './types';
+
+interface MutationDeps {
+  setIsDialogOpen: (v: boolean) => void;
+  setEditingTransaction: (t: Transaction | null) => void;
+  setDeletingId: (id: string | null) => void;
+}
+
+function useTransactionMutations(deps: MutationDeps) {
+  const utils = trpc.useUtils();
+  const createMutation = trpc.finance.transactions.create.useMutation({
+    onSuccess: () => {
+      toast.success('Transaction created');
+      void utils.finance.transactions.list.invalidate();
+      void utils.finance.transactions.availableTags.invalidate();
+      deps.setIsDialogOpen(false);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+  const updateMutation = trpc.finance.transactions.update.useMutation({
+    onSuccess: () => {
+      toast.success('Transaction updated');
+      void utils.finance.transactions.list.invalidate();
+      void utils.finance.transactions.availableTags.invalidate();
+      deps.setIsDialogOpen(false);
+      deps.setEditingTransaction(null);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+  const deleteMutation = trpc.finance.transactions.delete.useMutation({
+    onSuccess: () => {
+      toast.success('Transaction deleted');
+      void utils.finance.transactions.list.invalidate();
+      deps.setDeletingId(null);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+  return { createMutation, updateMutation, deleteMutation };
+}
+
+/**
+ * Build the API payload from the form values.
+ *
+ * - amount: parsed via Number() — schema already validates finiteness
+ * - entityId: '' → null (free-form selection cleared)
+ * - entityName: looked up from the entities list when an id is selected
+ * - notes: '' → null (server contract is `string | null`)
+ */
+export interface BuildPayloadArgs {
+  values: TransactionFormValues;
+  entityName: string | null;
+}
+
+export function buildTransactionPayload({ values, entityName }: BuildPayloadArgs) {
+  const entityId = values.entityId === '' ? null : values.entityId;
+  return {
+    description: values.description,
+    account: values.account,
+    amount: Number(values.amount),
+    date: values.date,
+    type: values.type,
+    tags: values.tags,
+    entityId,
+    entityName: entityId ? entityName : null,
+    notes: values.notes === '' ? null : values.notes,
+  };
+}
+
+interface SubmitDeps {
+  editingTransaction: Transaction | null;
+  createMutation: ReturnType<typeof useTransactionMutations>['createMutation'];
+  updateMutation: ReturnType<typeof useTransactionMutations>['updateMutation'];
+  resolveEntityName: (entityId: string) => string | null;
+}
+
+function buildSubmit(deps: SubmitDeps) {
+  return (values: TransactionFormValues) => {
+    const entityName = values.entityId === '' ? null : deps.resolveEntityName(values.entityId);
+    const payload = buildTransactionPayload({ values, entityName });
+    if (deps.editingTransaction) {
+      deps.updateMutation.mutate({ id: deps.editingTransaction.id, data: payload });
+    } else {
+      deps.createMutation.mutate(payload);
+    }
+  };
+}
+
+/** Map an existing transaction to form values for the edit dialog. */
+function transactionToFormValues(t: Transaction): TransactionFormValues {
+  return {
+    date: t.date,
+    amount: String(t.amount),
+    description: t.description,
+    account: t.account,
+    type: t.type || 'Expense',
+    entityId: t.entityId ?? '',
+    tags: t.tags,
+    notes: t.notes ?? '',
+  };
+}
+
+interface DialogHandlersDeps {
+  form: ReturnType<typeof useForm<TransactionFormValues>>;
+  setEditingTransaction: (t: Transaction | null) => void;
+  setIsDialogOpen: (v: boolean) => void;
+}
+
+function useDialogHandlers(deps: DialogHandlersDeps) {
+  const { form, setEditingTransaction, setIsDialogOpen } = deps;
+  const handleAdd = useCallback(() => {
+    setEditingTransaction(null);
+    form.reset({
+      ...DEFAULT_TRANSACTION_VALUES,
+      // Default to today (YYYY-MM-DD slice). Local date so the user sees today.
+      date: new Date().toISOString().slice(0, 10),
+    });
+    setIsDialogOpen(true);
+  }, [form, setEditingTransaction, setIsDialogOpen]);
+
+  const handleEdit = useCallback(
+    (transaction: Transaction) => {
+      setEditingTransaction(transaction);
+      form.reset(transactionToFormValues(transaction));
+      setIsDialogOpen(true);
+    },
+    [form, setEditingTransaction, setIsDialogOpen]
+  );
+  return { handleAdd, handleEdit };
+}
+
+export function useTransactionsPage() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const query = trpc.finance.transactions.list.useQuery({ limit: 100 });
+  const { data: availableTagsData } = trpc.finance.transactions.availableTags.useQuery();
+  const entitiesQuery = trpc.core.entities.list.useQuery({ limit: 500 });
+
+  const { createMutation, updateMutation, deleteMutation } = useTransactionMutations({
+    setIsDialogOpen,
+    setEditingTransaction,
+    setDeletingId,
+  });
+
+  const form = useForm<TransactionFormValues>({
+    resolver: zodResolver(TransactionFormSchema),
+    defaultValues: DEFAULT_TRANSACTION_VALUES,
+  });
+
+  const { handleAdd, handleEdit } = useDialogHandlers({
+    form,
+    setEditingTransaction,
+    setIsDialogOpen,
+  });
+
+  const resolveEntityName = useCallback(
+    (entityId: string): string | null => {
+      const entity = entitiesQuery.data?.data.find((e) => e.id === entityId);
+      return entity?.name ?? null;
+    },
+    [entitiesQuery.data]
+  );
+
+  const onSubmit = buildSubmit({
+    editingTransaction,
+    createMutation,
+    updateMutation,
+    resolveEntityName,
+  });
+
+  return {
+    query,
+    availableTags: availableTagsData ?? [],
+    entities: entitiesQuery.data?.data ?? [],
+    form,
+    isDialogOpen,
+    setIsDialogOpen,
+    editingTransaction,
+    deletingId,
+    setDeletingId,
+    deleteMutation,
+    handleAdd,
+    handleEdit,
+    onSubmit,
+    isSubmitting: createMutation.isPending || updateMutation.isPending,
+  };
+}


### PR DESCRIPTION
## Summary

- Add manual create / edit / delete UI on `/finance/transactions` so users can fix or backfill transactions outside the import wizard or webhook pipeline.
- Wires the new `TransactionFormDialog` (date, amount, description, account, type, entity autocomplete via `EntitySelect`, tags, notes) and `DeleteTransactionDialog` confirmation through the existing tRPC `create` / `update` / `delete` procedures, mirroring `BudgetFormDialog` / `EntityFormDialog` / `WishlistFormDialog`.
- Cover the full create → edit (amount + entity) → delete flow with a Tier 2 e2e suite against the seeded `e2e` SQLite environment.

## Implementation notes

- **TextInput safety (#2155):** all text fields use spread `{...form.register(...)}`. `TextInput` renders uncontrolled when no `value` prop is passed, so `form.reset()` on edit updates the DOM via the ref without React clobbering it.
- **Controller-driven non-native inputs (#2175 pattern):** the entity autocomplete (`EntitySelect`) and tag list (`ChipInput`) are wired through `<Controller>` since they are controlled components without a native form-input ref.
- **Server contract:** `useTransactionsPage` coerces the form payload (`amount` string → `number`, `entityId` `''` → `null` and clears `entityName`, `notes` `''` → `null`) before hitting the existing `CreateTransactionSchema` / `UpdateTransactionSchema`.
- **Hook tests:** `useTransactionsPage.test.ts` covers the payload coercion, create vs update routing, entity-name resolution from the cached entities list, and the edit-prefill mapping (null notes/entity → `''`, empty type → `'Expense'`).

## Test plan

- [x] `pnpm --filter @pops/app-finance typecheck`
- [x] `pnpm --filter @pops/app-finance test` (all 309 tests pass)
- [x] `pnpm typecheck` (turbo, all 16 packages)
- [x] `pnpm test` (turbo, unit only)
- [x] `pnpm lint` (oxlint, 0 errors in changed files)
- [x] `pnpm format:check` (oxfmt clean)
- [ ] Playwright e2e finance transactions CRUD spec — exercised in CI via `fe-test-e2e` (seeded e2e SQLite env)

Closes #2185
Closes #2106
