### PR TITLE
feat(finance): show spending progress on budgets list (#2186)

### DIFF
--- a/apps/pops-api/src/modules/finance/budgets/budgets.test.ts
+++ b/apps/pops-api/src/modules/finance/budgets/budgets.test.ts
@@ -5,7 +5,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { budgets as budgetsTable } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
-import { createCaller, seedBudget, setupTestContext } from '../../../shared/test-utils.js';
+import {
+  createCaller,
+  seedBudget,
+  seedTransaction,
+  setupTestContext,
+} from '../../../shared/test-utils.js';
+import { periodWindowStart } from './period-window.js';
+import { listBudgets } from './service.js';
 
 import type { Database } from 'better-sqlite3';
 
@@ -63,6 +70,8 @@ describe('budgets.list', () => {
     expect(budget).toHaveProperty('active', true);
     expect(budget).toHaveProperty('notes', 'Monthly grocery budget');
     expect(budget).toHaveProperty('lastEditedTime', '2025-06-15T10:00:00.000Z');
+    expect(budget).toHaveProperty('spent');
+    expect(budget).toHaveProperty('remaining');
     // No snake_case leaking
     expect(budget).not.toHaveProperty('notion_id');
     expect(budget).not.toHaveProperty('last_edited_time');
@@ -447,5 +456,199 @@ describe('budgets.delete', () => {
     // Verify row is gone from SQLite
     const row = getDrizzle().select().from(budgetsTable).where(eq(budgetsTable.id, id)).get();
     expect(row).toBeUndefined();
+  });
+});
+
+/**
+ * Spend aggregation behaviour for `budgets.list`. The service exposes a
+ * `now` override on `listBudgets()` so we can pin the period window to a
+ * deterministic point — the tRPC caller does not expose that knob, so this
+ * suite calls `listBudgets` directly.
+ */
+describe('budgets.list — spend aggregation', () => {
+  // Pin "now" to mid-Feb 2026 so MTD = Feb-1 → today; YTD = Jan-1 → today.
+  const NOW = new Date('2026-02-15T12:00:00.000Z');
+
+  function seedGroceriesBudget(amount: number, period: string | null = 'Monthly'): string {
+    return seedBudget(db, { category: 'Groceries', period, amount, active: 1 });
+  }
+
+  it('reports zero spend when no matching transactions exist', () => {
+    seedGroceriesBudget(800);
+
+    const { rows } = listBudgets({ limit: 10, offset: 0, now: NOW });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.spent).toBe(0);
+    expect(rows[0]!.remaining).toBe(800);
+  });
+
+  it('sums month-to-date outflows that match the budget category', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'Woolworths',
+      amount: -100,
+      date: '2026-02-03',
+      type: 'Expense',
+      tags: JSON.stringify(['Groceries']),
+    });
+    seedTransaction(db, {
+      description: 'Coles',
+      amount: -50.5,
+      date: '2026-02-10',
+      type: 'Expense',
+      tags: JSON.stringify(['Groceries']),
+    });
+
+    const { rows } = listBudgets({ limit: 10, offset: 0, now: NOW });
+    expect(rows[0]!.spent).toBeCloseTo(150.5, 2);
+    expect(rows[0]!.remaining).toBeCloseTo(649.5, 2);
+  });
+
+  it('ignores income (positive amounts) when summing spend', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'Refund',
+      amount: 25,
+      date: '2026-02-05',
+      type: 'Income',
+      tags: JSON.stringify(['Groceries']),
+    });
+
+    const { rows } = listBudgets({ limit: 10, offset: 0, now: NOW });
+    expect(rows[0]!.spent).toBe(0);
+    expect(rows[0]!.remaining).toBe(800);
+  });
+
+  it('ignores transactions with type=Transfer', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'Transfer to Savings',
+      amount: -500,
+      date: '2026-02-05',
+      type: 'Transfer',
+      tags: JSON.stringify(['Groceries', 'Transfer']),
+    });
+
+    const { rows } = listBudgets({ limit: 10, offset: 0, now: NOW });
+    expect(rows[0]!.spent).toBe(0);
+    expect(rows[0]!.remaining).toBe(800);
+  });
+
+  it('ignores transactions tagged with other categories', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'Netflix',
+      amount: -22.99,
+      date: '2026-02-05',
+      type: 'Expense',
+      tags: JSON.stringify(['Entertainment']),
+    });
+
+    const { rows } = listBudgets({ limit: 10, offset: 0, now: NOW });
+    expect(rows[0]!.spent).toBe(0);
+  });
+
+  it('yearly window includes prior months in the same year but excludes prior year', () => {
+    seedGroceriesBudget(5000, 'Yearly');
+    // Inside the YTD window
+    seedTransaction(db, {
+      description: 'January spend',
+      amount: -200,
+      date: '2026-01-15',
+      type: 'Expense',
+      tags: JSON.stringify(['Groceries']),
+    });
+    seedTransaction(db, {
+      description: 'February spend',
+      amount: -100,
+      date: '2026-02-10',
+      type: 'Expense',
+      tags: JSON.stringify(['Groceries']),
+    });
+    // Prior year — should be excluded
+    seedTransaction(db, {
+      description: 'Last year December',
+      amount: -999,
+      date: '2025-12-28',
+      type: 'Expense',
+      tags: JSON.stringify(['Groceries']),
+    });
+
+    const { rows } = listBudgets({ limit: 10, offset: 0, now: NOW });
+    expect(rows[0]!.spent).toBeCloseTo(300, 2);
+    expect(rows[0]!.remaining).toBeCloseTo(4700, 2);
+  });
+
+  it('honours the custom `now` override for the period window', () => {
+    seedGroceriesBudget(800);
+    // Spend in March 2026 — only visible if "now" lands inside March.
+    seedTransaction(db, {
+      description: 'March spend',
+      amount: -120,
+      date: '2026-03-04',
+      type: 'Expense',
+      tags: JSON.stringify(['Groceries']),
+    });
+
+    const febNow = new Date('2026-02-20T12:00:00.000Z');
+    const marchNow = new Date('2026-03-20T12:00:00.000Z');
+
+    const feb = listBudgets({ limit: 10, offset: 0, now: febNow });
+    const march = listBudgets({ limit: 10, offset: 0, now: marchNow });
+
+    expect(feb.rows[0]!.spent).toBe(0);
+    expect(march.rows[0]!.spent).toBeCloseTo(120, 2);
+  });
+
+  it('counts a multi-tag transaction once when it carries the budget category', () => {
+    seedGroceriesBudget(800);
+    seedTransaction(db, {
+      description: 'Groceries + bonus',
+      amount: -75,
+      date: '2026-02-04',
+      type: 'Expense',
+      tags: JSON.stringify(['Groceries', 'Shopping', 'Essentials']),
+    });
+
+    const { rows } = listBudgets({ limit: 10, offset: 0, now: NOW });
+    expect(rows[0]!.spent).toBeCloseTo(75, 2);
+  });
+
+  it('produces a negative `remaining` when spend exceeds the budget amount', () => {
+    seedGroceriesBudget(100);
+    seedTransaction(db, {
+      description: 'Big shop',
+      amount: -250,
+      date: '2026-02-05',
+      type: 'Expense',
+      tags: JSON.stringify(['Groceries']),
+    });
+
+    const { rows } = listBudgets({ limit: 10, offset: 0, now: NOW });
+    expect(rows[0]!.spent).toBeCloseTo(250, 2);
+    expect(rows[0]!.remaining).toBeCloseTo(-150, 2);
+    expect(rows[0]!.remaining! < 0).toBe(true);
+  });
+});
+
+describe('periodWindowStart', () => {
+  it('returns the first day of the current month for "Monthly"', () => {
+    expect(periodWindowStart('Monthly', new Date('2026-02-15T12:00:00.000Z'))).toBe('2026-02-01');
+    expect(periodWindowStart('Monthly', new Date('2026-12-31T23:59:59.000Z'))).toBe('2026-12-01');
+    // Single-digit month should be zero-padded to keep ISO ordering.
+    expect(periodWindowStart('Monthly', new Date('2026-03-04T00:00:00.000Z'))).toBe('2026-03-01');
+  });
+
+  it('returns the first day of the current year for "Yearly"', () => {
+    expect(periodWindowStart('Yearly', new Date('2026-06-15T12:00:00.000Z'))).toBe('2026-01-01');
+    expect(periodWindowStart('Yearly', new Date('2026-01-02T00:00:00.000Z'))).toBe('2026-01-01');
+  });
+
+  it('returns null for null/undefined/unknown periods (all-time)', () => {
+    expect(periodWindowStart(null)).toBeNull();
+    expect(periodWindowStart(undefined)).toBeNull();
+    expect(periodWindowStart('')).toBeNull();
+    expect(periodWindowStart('weekly')).toBeNull();
+    expect(periodWindowStart('Quarterly')).toBeNull();
   });
 });

--- a/apps/pops-api/src/modules/finance/budgets/period-window.ts
+++ b/apps/pops-api/src/modules/finance/budgets/period-window.ts
@@ -1,0 +1,40 @@
+/**
+ * Period window resolution for budget spend aggregation.
+ *
+ * - Monthly  → first day of the current month at 00:00:00 UTC.
+ * - Yearly   → first day of the current year at 00:00:00 UTC.
+ * - null/anything else → null (all-time, no lower bound on transaction date).
+ *
+ * The cutoff is returned as an ISO `YYYY-MM-DD` string because
+ * `transactions.date` is stored as a `YYYY-MM-DD` text column. Inclusive
+ * comparisons (`date >= start`) work directly against this lexicographic form.
+ *
+ * Spend aggregation also clamps the upper bound to today (see
+ * {@link periodWindowEnd}) — Monthly = month-to-date, Yearly = year-to-date.
+ */
+export function periodWindowStart(
+  period: string | null | undefined,
+  now: Date = new Date()
+): string | null {
+  if (period === 'Monthly') {
+    const year = now.getUTCFullYear();
+    const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+    return `${year}-${month}-01`;
+  }
+  if (period === 'Yearly') {
+    return `${now.getUTCFullYear()}-01-01`;
+  }
+  return null;
+}
+
+/**
+ * Inclusive upper bound (`YYYY-MM-DD`) for the spend window. Always clamps to
+ * today regardless of period — future-dated transactions never count toward
+ * MTD/YTD spend.
+ */
+export function periodWindowEnd(now: Date = new Date()): string {
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(now.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}

--- a/apps/pops-api/src/modules/finance/budgets/router.ts
+++ b/apps/pops-api/src/modules/finance/budgets/router.ts
@@ -71,7 +71,7 @@ export const budgetsRouter = router({
     .query(({ input }) => {
       try {
         const row = service.getBudget(input.id);
-        return { data: toBudget(row) };
+        return { data: toBudget(service.withSpend(row)) };
       } catch (err) {
         if (err instanceof NotFoundError) {
           throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
@@ -85,7 +85,7 @@ export const budgetsRouter = router({
     try {
       const row = service.createBudget(input);
       return {
-        data: toBudget(row),
+        data: toBudget(service.withSpend(row)),
         message: 'Budget created',
       };
     } catch (err) {
@@ -108,7 +108,7 @@ export const budgetsRouter = router({
       try {
         const row = service.updateBudget(input.id, input.data);
         return {
-          data: toBudget(row),
+          data: toBudget(service.withSpend(row)),
           message: 'Budget updated',
         };
       } catch (err) {

--- a/apps/pops-api/src/modules/finance/budgets/service.ts
+++ b/apps/pops-api/src/modules/finance/budgets/service.ts
@@ -1,20 +1,27 @@
-import { and, asc, count, eq, isNull, like } from 'drizzle-orm';
+import { and, asc, count, eq, isNull, like, sql } from 'drizzle-orm';
 
 /**
  * Budget service — CRUD operations against SQLite via Drizzle ORM.
  * SQLite is the source of truth. All operations are local.
  */
-import { budgets } from '@pops/db-types';
+import { budgets, transactions } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
+import { periodWindowEnd, periodWindowStart } from './period-window.js';
 
 import type { BudgetRow, CreateBudgetInput, UpdateBudgetInput } from './types.js';
 
 /** Count + rows for a paginated list. */
 export interface BudgetListResult {
-  rows: BudgetRow[];
+  rows: BudgetWithSpend[];
   total: number;
+}
+
+/** A budget row plus aggregated spend over its period. */
+export interface BudgetWithSpend extends BudgetRow {
+  spent: number;
+  remaining: number | null;
 }
 
 export interface ListBudgetsOptions {
@@ -23,10 +30,64 @@ export interface ListBudgetsOptions {
   active?: boolean;
   limit: number;
   offset: number;
+  /**
+   * Reference timestamp used to derive the period window. Defaults to the
+   * current time. Override in tests to make the window deterministic.
+   */
+  now?: Date;
 }
 
 /**
- * List budgets with optional filters.
+ * Compute the total spent against a budget's category, restricted to the
+ * budget's period window when applicable.
+ *
+ * Rules:
+ *   - Match `transactions.tags` (a JSON-encoded text array) against the
+ *     budget's category via SQLite `json_each`.
+ *   - Exclude transactions with `type = 'Transfer'`.
+ *   - Sum the absolute value of negative amounts only — outflows count as
+ *     spend; inflows (Income, refunds) do not.
+ *   - Restrict to `date >= periodWindowStart` for Monthly/Yearly. All-time
+ *     for any other period (including null).
+ */
+export function computeSpent(
+  category: string,
+  period: string | null,
+  now: Date = new Date()
+): number {
+  const windowStart = periodWindowStart(period, now);
+  const db = getDrizzle();
+
+  // The CASE WHEN amount < 0 THEN -amount ELSE 0 END expression turns a mix of
+  // negative outflows and positive inflows into a non-negative spend total
+  // without double-counting refunds against the spend.
+  const conditions = [
+    sql`EXISTS (SELECT 1 FROM json_each(${transactions.tags}) WHERE json_each.value = ${category})`,
+    sql`${transactions.type} != 'Transfer'`,
+  ];
+  if (windowStart !== null) {
+    // Monthly/Yearly windows are explicitly *-to-date — clamp the upper
+    // bound to today so future-dated transactions never count.
+    const windowEnd = periodWindowEnd(now);
+    conditions.push(sql`${transactions.date} >= ${windowStart}`);
+    conditions.push(sql`${transactions.date} <= ${windowEnd}`);
+  }
+
+  const row = db
+    .select({
+      total: sql<number>`COALESCE(SUM(CASE WHEN ${transactions.amount} < 0 THEN -${transactions.amount} ELSE 0 END), 0)`,
+    })
+    .from(transactions)
+    .where(and(...conditions))
+    .get();
+
+  return row?.total ?? 0;
+}
+
+/**
+ * List budgets with optional filters. Each row is enriched with `spent`
+ * (aggregated outflow over the budget's period) and `remaining` (amount −
+ * spent, or null when the budget has no target amount).
  */
 export function listBudgets(opts: ListBudgetsOptions): BudgetListResult {
   const db = getDrizzle();
@@ -37,6 +98,7 @@ export function listBudgets(opts: ListBudgetsOptions): BudgetListResult {
   if (opts.active !== undefined) conditions.push(eq(budgets.active, opts.active ? 1 : 0));
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;
+  const now = opts.now ?? new Date();
 
   const rows = db
     .select()
@@ -46,8 +108,15 @@ export function listBudgets(opts: ListBudgetsOptions): BudgetListResult {
     .limit(opts.limit)
     .offset(opts.offset)
     .all();
+
+  const enriched: BudgetWithSpend[] = rows.map((row) => {
+    const spent = computeSpent(row.category, row.period, now);
+    const remaining = row.amount === null ? null : row.amount - spent;
+    return { ...row, spent, remaining };
+  });
+
   const countRow = db.select({ total: count() }).from(budgets).where(where).all()[0];
-  return { rows, total: countRow?.total ?? 0 };
+  return { rows: enriched, total: countRow?.total ?? 0 };
 }
 
 /** Get a single budget by id. Throws NotFoundError if missing. */
@@ -57,6 +126,17 @@ export function getBudget(id: string): BudgetRow {
 
   if (!row) throw new NotFoundError('Budget', id);
   return row;
+}
+
+/**
+ * Enrich a raw budget row with `spent` and `remaining`. Convenience wrapper
+ * used by single-row endpoints (get/create/update) so they return the same
+ * shape as the list endpoint.
+ */
+export function withSpend(row: BudgetRow, now: Date = new Date()): BudgetWithSpend {
+  const spent = computeSpent(row.category, row.period, now);
+  const remaining = row.amount === null ? null : row.amount - spent;
+  return { ...row, spent, remaining };
 }
 
 /**

--- a/apps/pops-api/src/modules/finance/budgets/types.ts
+++ b/apps/pops-api/src/modules/finance/budgets/types.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 
 import type { BudgetRow } from '@pops/db-types';
 
+import type { BudgetWithSpend } from './service.js';
+
 export type { BudgetRow };
 
 /** API response shape (camelCase). */
@@ -13,13 +15,17 @@ export interface Budget {
   active: boolean;
   notes: string | null;
   lastEditedTime: string;
+  /** Aggregated outflow over the budget's period (always >= 0). */
+  spent: number;
+  /** `amount - spent`, or `null` when the budget has no target amount. */
+  remaining: number | null;
 }
 
 /**
- * Map a SQLite row to the API response shape.
+ * Map a SQLite row (enriched with spend aggregates) to the API response shape.
  * Converts active from INTEGER (0/1) to boolean.
  */
-export function toBudget(row: BudgetRow): Budget {
+export function toBudget(row: BudgetWithSpend): Budget {
   return {
     id: row.id,
     category: row.category,
@@ -28,6 +34,8 @@ export function toBudget(row: BudgetRow): Budget {
     active: row.active === 1,
     notes: row.notes,
     lastEditedTime: row.lastEditedTime,
+    spent: row.spent,
+    remaining: row.remaining,
   };
 }
 
@@ -40,6 +48,8 @@ export const BudgetSchema = z.object({
   active: z.boolean(),
   notes: z.string().nullable(),
   lastEditedTime: z.string(),
+  spent: z.number(),
+  remaining: z.number().nullable(),
 });
 
 /** Zod schema for creating a budget. */

--- a/apps/pops-shell/e2e/finance-budgets-spending-progress.spec.ts
+++ b/apps/pops-shell/e2e/finance-budgets-spending-progress.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * E2E — Finance budgets spending progress (#2108 / #2186)
+ *
+ * Tier 2 flow: prove the freshly-built `Spent` / `% Progress` columns light
+ * up after a matching transaction is created, end-to-end against the seeded
+ * `e2e` SQLite environment.
+ *
+ * Steps:
+ *   1. Navigate to /finance/budgets and confirm the page loads.
+ *   2. Open the Add Budget dialog and create a brand-new monthly budget for
+ *      a uniquely-named category (so we never collide with one of the 8
+ *      seeded budgets, which use stable names like Groceries / Transport).
+ *   3. Confirm the new budget renders with a 0% progress (no transactions
+ *      yet match its category tag).
+ *   4. Create a matching transaction directly via the tRPC create mutation
+ *      against the same `e2e` env (the transactions list page does not yet
+ *      expose a CRUD UI — see in-flight branch #2185 for the matching
+ *      front-end work). The transaction is dated today so it falls inside
+ *      the Monthly MTD window the API computes.
+ *   5. Reload /finance/budgets and assert the new budget's row now shows a
+ *      non-zero `%` and a non-zero `$` Spent amount.
+ *   6. Delete the budget via the row-level Delete action and confirm the
+ *      row vanishes.
+ *
+ * Cleanup:
+ *   The matching transaction is created against the long-lived `e2e` env,
+ *   so `afterEach` removes it (and any leftover budget) so re-runs start
+ *   from the same seeded baseline.
+ */
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+
+import { useRealApi } from './helpers/use-real-api';
+
+const API_URL = process.env['FINANCE_API_URL'] ?? 'http://localhost:3000';
+const ENV_NAME = 'e2e';
+
+/**
+ * Generate a category that is guaranteed unique across runs and across the
+ * seeded budgets/transactions. Including a timestamp + random suffix avoids
+ * any collision with existing data, which matters because the budgets
+ * `(category, period)` index is unique.
+ */
+function uniqueCategory(): string {
+  const stamp = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 6);
+  return `E2E-Spend-${stamp}-${rand}`;
+}
+
+/** Today as `YYYY-MM-DD` (UTC) — matches the API's MTD window exactly. */
+function todayISO(): string {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(now.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+interface CreatedTransaction {
+  id: string;
+}
+
+interface TrpcResponse<T> {
+  result: { data: { data: T } };
+}
+
+interface ListTransactionsResponse {
+  result: { data: { data: { id: string }[] } };
+}
+
+/** Create a transaction in the `e2e` env via the tRPC create mutation. */
+async function createMatchingTransaction(
+  request: APIRequestContext,
+  category: string
+): Promise<CreatedTransaction> {
+  const res = await request.post(`${API_URL}/trpc/finance.transactions.create?env=${ENV_NAME}`, {
+    data: {
+      description: `E2E spend ${category}`,
+      account: 'E2E Account',
+      amount: -123.45,
+      date: todayISO(),
+      type: 'Expense',
+      tags: [category],
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`createMatchingTransaction failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as TrpcResponse<{ id: string }>;
+  return { id: body.result.data.data.id };
+}
+
+/** Best-effort delete of a transaction id; never throws to avoid masking the test failure. */
+async function deleteTransactionSafely(request: APIRequestContext, id: string): Promise<void> {
+  try {
+    await request.post(`${API_URL}/trpc/finance.transactions.delete?env=${ENV_NAME}`, {
+      data: { id },
+    });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Best-effort cleanup that scrubs any transactions matching our unique
+ * category tag — protects subsequent runs from a transaction left behind by
+ * a prematurely-failed test.
+ */
+async function purgeTransactionsByTag(request: APIRequestContext, category: string): Promise<void> {
+  const input = encodeURIComponent(JSON.stringify({ tag: category, limit: 100 }));
+  const res = await request.get(
+    `${API_URL}/trpc/finance.transactions.list?env=${ENV_NAME}&input=${input}`
+  );
+  if (!res.ok()) return;
+  const body = (await res.json()) as ListTransactionsResponse;
+  const ids = body.result.data.data.map((t) => t.id);
+  for (const id of ids) {
+    await deleteTransactionSafely(request, id);
+  }
+}
+
+/** Find the table row for a budget category. */
+function budgetRow(page: Page, category: string) {
+  return page.getByRole('row').filter({ hasText: category });
+}
+
+test.describe('Finance — budgets spending progress (#2108 / #2186)', () => {
+  let pageErrors: string[] = [];
+  let consoleErrors: string[] = [];
+  let category = '';
+
+  test.beforeEach(async ({ page }) => {
+    pageErrors = [];
+    consoleErrors = [];
+    category = uniqueCategory();
+    await useRealApi(page);
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterEach(async ({ page, request }) => {
+    // Delete any transactions we created against our unique tag so other
+    // specs and future runs are unaffected.
+    await purgeTransactionsByTag(request, category);
+    // Best-effort row delete — if the budget is still on the page, kill it.
+    try {
+      await page.goto('/finance/budgets');
+      const row = budgetRow(page, category).first();
+      if (await row.isVisible().catch(() => false)) {
+        await row.getByRole('button', { name: 'Actions' }).click();
+        await page.getByRole('menuitem', { name: /Delete/i }).click();
+        await page
+          .getByRole('button', { name: /Delete/i })
+          .last()
+          .click();
+      }
+    } catch {
+      /* best-effort cleanup */
+    }
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    const realConsoleErrors = consoleErrors.filter(
+      (e) =>
+        !e.includes('React Router') &&
+        !e.includes('Download the React DevTools') &&
+        !e.includes('Failed to load resource')
+    );
+    expect(pageErrors).toHaveLength(0);
+    expect(realConsoleErrors).toHaveLength(0);
+  });
+
+  test('create monthly budget, add matching transaction, verify non-zero spending progress, delete', async ({
+    page,
+    request,
+  }) => {
+    // ---- Step 1: navigate ------------------------------------------------
+    await page.goto('/finance/budgets');
+    await expect(page.getByRole('heading', { name: 'Budgets', level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+    // Wait for the seeded list to render so the "Add Budget" button is interactive.
+    await expect(page.getByRole('row').filter({ hasText: 'Groceries' }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // ---- Step 2: create a Monthly budget for our unique category ---------
+    await page.getByRole('button', { name: /Add Budget/i }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Category — TextInput placeholder is "e.g. Groceries, Entertainment".
+    await dialog.getByPlaceholder(/Groceries, Entertainment/i).fill(category);
+    // Period — native <select>; "Monthly" identifies it uniquely.
+    await dialog
+      .locator('select')
+      .filter({ has: page.locator('option[value="Monthly"]') })
+      .first()
+      .selectOption('Monthly');
+    // Amount — TextInput with type=number, placeholder "0.00".
+    await dialog.getByPlaceholder('0.00').fill('500');
+
+    await dialog.getByRole('button', { name: /^Create$/ }).click();
+    await expect(dialog).toBeHidden({ timeout: 10_000 });
+
+    // ---- Step 3: confirm the row exists with 0% progress -----------------
+    const row = budgetRow(page, category).first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row.getByText('0%')).toBeVisible();
+
+    // ---- Step 4: create a matching transaction via the API ---------------
+    // The transactions list page has no create UI yet (#2185), so we POST
+    // straight to the tRPC procedure under the same `e2e` env.
+    const txn = await createMatchingTransaction(request, category);
+    expect(txn.id).toBeTruthy();
+
+    // ---- Step 5: navigate via /finance/transactions then back, assert non-zero
+    await page.goto('/finance/transactions');
+    await expect(page.getByRole('heading', { name: 'Transactions', level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.goto('/finance/budgets');
+    const refreshedRow = budgetRow(page, category).first();
+    await expect(refreshedRow).toBeVisible({ timeout: 10_000 });
+
+    // The seeded amount is $123.45 against a $500 budget → ~25%. We assert
+    // both that the percentage is non-zero (acceptance criterion) and that
+    // the spent amount appears in the row.
+    await expect(refreshedRow).not.toContainText('0%');
+    await expect(refreshedRow).toContainText(/\$123\.45/);
+    await expect(refreshedRow).toContainText(/%/);
+
+    // ---- Step 6: delete the budget via the row's Actions menu ------------
+    await refreshedRow.getByRole('button', { name: 'Actions' }).click();
+    await page.getByRole('menuitem', { name: /Delete/i }).click();
+    // The DeleteBudgetDialog has a destructive Delete confirmation button.
+    await page
+      .getByRole('button', { name: /Delete/i })
+      .last()
+      .click();
+
+    await expect(budgetRow(page, category)).toHaveCount(0, { timeout: 10_000 });
+  });
+});

--- a/packages/app-finance/src/pages/budgets/columns.tsx
+++ b/packages/app-finance/src/pages/budgets/columns.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenu,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  Progress,
   SortableHeader,
 } from '@pops/ui';
 
@@ -53,6 +54,58 @@ const amountColumn: ColumnDef<Budget> = {
     if (amount === null) return <div className="text-right text-muted-foreground">—</div>;
     return (
       <div className="text-right font-mono font-medium tabular-nums">${amount.toFixed(2)}</div>
+    );
+  },
+};
+
+const spentColumn: ColumnDef<Budget> = {
+  accessorKey: 'spent',
+  header: ({ column }) => (
+    <div className="flex justify-end">
+      <SortableHeader column={column}>Spent</SortableHeader>
+    </div>
+  ),
+  cell: ({ row }) => {
+    const { spent, amount } = row.original;
+    const overBudget = amount !== null && spent > amount;
+    return (
+      <div className="flex justify-end">
+        <Badge variant={overBudget ? 'destructive' : 'default'} className="font-mono tabular-nums">
+          ${spent.toFixed(2)}
+        </Badge>
+      </div>
+    );
+  },
+};
+
+/**
+ * Percentage of the budget consumed by `spent`. Renders a `Progress` bar
+ * capped visually at 100% (overage already surfaced via the Spent badge),
+ * with the numeric percentage alongside. Falls back to "—" when the budget
+ * has no target amount to compare against.
+ */
+const progressColumn: ColumnDef<Budget> = {
+  id: 'progress',
+  header: '% Progress',
+  cell: ({ row }) => {
+    const { spent, amount } = row.original;
+    if (amount === null || amount <= 0) {
+      return <span className="text-muted-foreground">—</span>;
+    }
+    const pct = (spent / amount) * 100;
+    const display = Math.round(pct);
+    const visual = Math.min(100, Math.max(0, pct));
+    return (
+      <div className="flex min-w-[120px] items-center gap-2">
+        <Progress value={visual} className="flex-1" />
+        <span
+          className={`w-12 text-right font-mono text-xs tabular-nums ${
+            pct > 100 ? 'text-destructive' : 'text-muted-foreground'
+          }`}
+        >
+          {display}%
+        </span>
+      </div>
     );
   },
 };
@@ -122,6 +175,8 @@ export function buildBudgetColumns(args: {
     categoryColumn,
     periodColumn,
     amountColumn,
+    spentColumn,
+    progressColumn,
     statusColumn,
     notesColumn,
     buildActionsColumn(args),

--- a/packages/app-finance/src/pages/budgets/types.ts
+++ b/packages/app-finance/src/pages/budgets/types.ts
@@ -8,6 +8,10 @@ export interface Budget {
   active: boolean;
   notes: string | null;
   lastEditedTime: string;
+  /** Aggregated outflow over the budget's period (always >= 0). */
+  spent: number;
+  /** `amount - spent`, or `null` when the budget has no target amount. */
+  remaining: number | null;
 }
 
 export const BudgetFormSchema = z.object({


### PR DESCRIPTION
## Summary

- Extends `finance.budgets.list` to aggregate spend per budget at the API layer: matches `transactions.tags` against the budget category via `json_each`, excludes `type='Transfer'`, sums absolute values of negative amounts only (income/refunds do not offset spend), and applies an MTD/YTD window for `Monthly`/`Yearly` budgets (all-time otherwise). A `now` override on `listBudgets()` keeps the window deterministic in tests, and `service.withSpend` reuses the same computation for `get`/`create`/`update`.
- Adds `Spent` and `% Progress` columns to `/finance/budgets`, inserted after `amountColumn` and built on `@pops/ui`'s `Progress` + `Badge`. The Spent badge flips to `destructive` when `spent > amount`; the percentage label turns destructive past 100%.
- Wires `spent` / `remaining` through `BudgetSchema` (zod), the API `Budget` type, and the front-end `Budget` interface so the new fields flow end-to-end without any client-side aggregation.
- Adds a Tier 2 e2e (`apps/pops-shell/e2e/finance-budgets-spending-progress.spec.ts`) using `useRealApi` against the seeded `e2e` SQLite env: creates a uniquely-named Monthly budget via the Add Budget dialog, seeds a matching transaction via `trpc.finance.transactions.create` (the transactions UI has no CRUD form yet — see in-flight #2185), navigates back, asserts the row's `$` Spent and `%` are non-zero, then deletes the budget. Cleanup purges the seeded transaction so re-runs start from the same baseline.

New unit coverage in `apps/pops-api/src/modules/finance/budgets/budgets.test.ts`:
- spend aggregation: zero spend, MTD outflow sum, ignores income, ignores transfers, ignores other categories, yearly window includes prior months but not prior year, custom `now` override, multi-tag transactions counted once, over-budget produces `remaining < 0`.
- `periodWindowStart` suite covering Monthly / Yearly / null / unknown / empty inputs.

Closes #2186
Closes #2108

## Test plan

- [x] `pnpm lint` (74 pre-existing warnings, 0 errors)
- [x] `pnpm format:check`
- [x] `pnpm typecheck` (16/16 packages)
- [x] `pnpm test` (api: 2932 unit tests, app-finance: 293, shell: 111, all green)
- [x] `cd apps/pops-api && pnpm openapi:validate`
- [ ] Playwright e2e (`finance-budgets-spending-progress.spec.ts`) verified by CI against the live `e2e` env.
