### PR TITLE
feat(ai): manual rule create/edit dialog with preview (#2187)

### DIFF
--- a/apps/pops-api/src/modules/core/corrections/correction-schemas.ts
+++ b/apps/pops-api/src/modules/core/corrections/correction-schemas.ts
@@ -26,6 +26,8 @@ export type CorrectionSignal = z.infer<typeof CorrectionSignalSchema>;
 export const AdaptedSignalSchema = CorrectionSignalSchema;
 
 export const UpdateCorrectionSchema = z.object({
+  descriptionPattern: z.string().min(1).optional(),
+  matchType: z.enum(['exact', 'contains', 'regex']).optional(),
   entityId: z.string().nullable().optional(),
   entityName: z.string().nullable().optional(),
   location: z.string().nullable().optional(),

--- a/apps/pops-api/src/modules/core/corrections/corrections.test.ts
+++ b/apps/pops-api/src/modules/core/corrections/corrections.test.ts
@@ -1092,6 +1092,22 @@ describe('corrections', () => {
 
       expect(updated.data.confidence).toBe(0.9);
     });
+
+    it('updates descriptionPattern (normalised) and matchType', async () => {
+      const created = await caller.core.corrections.createOrUpdate({
+        descriptionPattern: 'AMAZON',
+        matchType: 'contains',
+        tags: ['Shopping'],
+      });
+
+      const updated = await caller.core.corrections.update({
+        id: created.data.id,
+        data: { descriptionPattern: 'amazon prime', matchType: 'exact' },
+      });
+
+      expect(updated.data.descriptionPattern).toBe('AMAZON PRIME');
+      expect(updated.data.matchType).toBe('exact');
+    });
   });
 
   describe('delete', () => {

--- a/apps/pops-api/src/modules/core/corrections/handlers/preview-matches.test.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/preview-matches.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the previewMatches handler — drives the manual rule
+ * create/edit dialog (#2187) and underpins the e2e flows in #2119 / #2135.
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+
+import { seedTransaction, setupTestContext } from '../../../../shared/test-utils.js';
+import { previewMatches } from './preview-matches.js';
+
+const ctx = setupTestContext();
+
+describe('previewMatches', () => {
+  let db: ReturnType<typeof ctx.setup>['db'];
+
+  beforeEach(() => {
+    const result = ctx.setup();
+    db = result.db;
+  });
+
+  afterEach(() => {
+    ctx.teardown();
+  });
+
+  it('returns transactions matching a contains pattern', () => {
+    seedTransaction(db, { description: 'Woolworths Metro' });
+    seedTransaction(db, { description: 'Woolworths' });
+    seedTransaction(db, { description: 'Coles Local' });
+    seedTransaction(db, { description: 'Netflix Subscription' });
+
+    const result = previewMatches({
+      descriptionPattern: 'WOOLWORTHS',
+      matchType: 'contains',
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.matches.map((m) => m.description).toSorted()).toEqual([
+      'Woolworths',
+      'Woolworths Metro',
+    ]);
+    expect(result.scanned).toBe(4);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('returns nothing when no transaction matches', () => {
+    seedTransaction(db, { description: 'Coles Local' });
+    seedTransaction(db, { description: 'Shell Service Station' });
+
+    const result = previewMatches({
+      descriptionPattern: 'WOOLWORTHS',
+      matchType: 'contains',
+    });
+
+    expect(result.total).toBe(0);
+    expect(result.matches).toEqual([]);
+  });
+
+  it('matches exactly when matchType is exact (after normalisation)', () => {
+    seedTransaction(db, { description: 'Netflix' });
+    seedTransaction(db, { description: 'Netflix Subscription' });
+
+    const result = previewMatches({
+      descriptionPattern: 'NETFLIX',
+      matchType: 'exact',
+    });
+
+    // exact mode requires the entire normalised description to equal the
+    // pattern — `Netflix Subscription` should NOT match.
+    expect(result.total).toBe(1);
+    expect(result.matches[0]?.description).toBe('Netflix');
+  });
+
+  it('honours regex matchType', () => {
+    seedTransaction(db, { description: 'Shell Service Station' });
+    seedTransaction(db, { description: 'Coles Express' });
+    seedTransaction(db, { description: 'Woolworths' });
+
+    const result = previewMatches({
+      descriptionPattern: 'SHELL|COLES',
+      matchType: 'regex',
+    });
+
+    expect(result.total).toBe(2);
+    const descriptions = result.matches.map((m) => m.description).toSorted();
+    expect(descriptions).toEqual(['Coles Express', 'Shell Service Station']);
+  });
+
+  it('returns invalid regex as zero matches without throwing', () => {
+    seedTransaction(db, { description: 'Woolworths' });
+
+    const result = previewMatches({
+      descriptionPattern: '([',
+      matchType: 'regex',
+    });
+
+    expect(result.total).toBe(0);
+    expect(result.matches).toEqual([]);
+  });
+
+  it('truncates results to the supplied limit and reports truncated=true', () => {
+    for (let i = 0; i < 5; i += 1) {
+      seedTransaction(db, { description: `Woolworths #${i}` });
+    }
+
+    const result = previewMatches({
+      descriptionPattern: 'WOOLWORTHS',
+      matchType: 'contains',
+      limit: 3,
+    });
+
+    expect(result.total).toBe(5);
+    expect(result.matches).toHaveLength(3);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('returns the transaction shape required by the dialog (id, description, account, amount, date, tags, entityName)', () => {
+    seedTransaction(db, {
+      description: 'Woolworths',
+      account: 'ANZ-Visa',
+      amount: -42.5,
+      date: '2026-04-20',
+      tags: '["Groceries"]',
+      entity_name: 'Woolworths',
+    });
+
+    const result = previewMatches({
+      descriptionPattern: 'WOOLWORTHS',
+      matchType: 'contains',
+    });
+
+    const match = result.matches[0];
+    expect(match).toBeDefined();
+    expect(match?.account).toBe('ANZ-Visa');
+    expect(match?.amount).toBe(-42.5);
+    expect(match?.date).toBe('2026-04-20');
+    expect(match?.tags).toEqual(['Groceries']);
+    expect(match?.entityName).toBe('Woolworths');
+  });
+});

--- a/apps/pops-api/src/modules/core/corrections/handlers/preview-matches.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/preview-matches.ts
@@ -1,0 +1,100 @@
+/**
+ * previewMatches handler — given a candidate (pattern, matchType), returns the
+ * transactions in the DB whose descriptions would be matched by that rule.
+ *
+ * The query mirrors `ruleMatchesDescription` semantics:
+ *   - both pattern and description go through normalizeDescription
+ *   - `regex` is interpreted case-insensitively against the normalized
+ *     description so it matches the production matcher exactly.
+ *
+ * The procedure is intentionally pattern-only: it does NOT consider the
+ * stored `priority` / `confidence` of any rule, because the caller wants to
+ * preview a hypothetical edit before persisting it. To exclude the rule
+ * being edited from a "would this rule still match the same set?" check,
+ * the caller can simply pass the proposed pattern directly.
+ */
+import { desc } from 'drizzle-orm';
+
+import { transactions } from '@pops/db-types';
+
+import { getDrizzle } from '../../../../db.js';
+import { parseJsonStringArray } from '../../../../shared/json.js';
+import { patternMatchesDescription } from '../lib/pattern-match.js';
+
+import type { TransactionRow } from '@pops/db-types';
+
+export type RuleMatchType = 'exact' | 'contains' | 'regex';
+
+export interface PreviewMatchInput {
+  descriptionPattern: string;
+  matchType: RuleMatchType;
+  /** Hard cap on rows returned to the client. */
+  limit?: number;
+}
+
+export interface PreviewMatchTransaction {
+  id: string;
+  description: string;
+  account: string;
+  amount: number;
+  date: string;
+  entityName: string | null;
+  tags: string[];
+}
+
+export interface PreviewMatchResult {
+  matches: PreviewMatchTransaction[];
+  total: number;
+  scanned: number;
+  truncated: boolean;
+}
+
+const DEFAULT_LIMIT = 25;
+const HARD_LIMIT = 200;
+
+function toMatchTransaction(row: TransactionRow): PreviewMatchTransaction {
+  return {
+    id: row.id,
+    description: row.description,
+    account: row.account,
+    amount: row.amount,
+    date: row.date,
+    entityName: row.entityName,
+    tags: parseJsonStringArray(row.tags),
+  };
+}
+
+/**
+ * Run the candidate rule against every transaction in the DB and collect
+ * matching rows. The matcher is pure JS (mirrors production semantics) so
+ * the same logic works for `exact`, `contains`, and `regex` without dialect
+ * gymnastics in SQL.
+ *
+ * The match is computed in JS because the production matcher already runs
+ * in JS at categorise/apply time — pushing the same logic into SQL would
+ * require keeping two implementations in lockstep. With a small SQLite store
+ * scanning all transactions is well within budget.
+ */
+export function previewMatches(input: PreviewMatchInput): PreviewMatchResult {
+  const limit = Math.min(input.limit ?? DEFAULT_LIMIT, HARD_LIMIT);
+  const db = getDrizzle();
+
+  const rows = db.select().from(transactions).orderBy(desc(transactions.date)).all();
+
+  const matched: TransactionRow[] = [];
+  for (const row of rows) {
+    if (patternMatchesDescription(input.descriptionPattern, input.matchType, row.description)) {
+      matched.push(row);
+    }
+  }
+
+  const truncated = matched.length > limit;
+  const sliced = truncated ? matched.slice(0, limit) : matched;
+
+  return {
+    matches: sliced.map(toMatchTransaction),
+    total: matched.length,
+    scanned: rows.length,
+    truncated,
+  };
+}

--- a/apps/pops-api/src/modules/core/corrections/handlers/query-helpers.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/query-helpers.ts
@@ -134,6 +134,16 @@ export function updateCorrection(id: string, input: UpdateCorrectionInput): Corr
   const updates: Partial<typeof transactionCorrections.$inferInsert> = {};
   let hasUpdates = false;
 
+  if (input.descriptionPattern !== undefined) {
+    // Normalise on edit so the stored pattern stays consistent with how
+    // createOrUpdateCorrection persists newly created rules.
+    updates.descriptionPattern = normalizeDescription(input.descriptionPattern);
+    hasUpdates = true;
+  }
+  if (input.matchType !== undefined) {
+    updates.matchType = input.matchType;
+    hasUpdates = true;
+  }
   if (input.entityId !== undefined) {
     updates.entityId = input.entityId;
     hasUpdates = true;

--- a/apps/pops-api/src/modules/core/corrections/router-crud.ts
+++ b/apps/pops-api/src/modules/core/corrections/router-crud.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta } from '../../../shared/pagination.js';
 import { protectedProcedure, router } from '../../../trpc.js';
+import { previewMatches } from './handlers/preview-matches.js';
 import { analyzeCorrection, generateRules } from './lib/rule-generator.js';
 import * as service from './service.js';
 import {
@@ -114,6 +115,25 @@ export const crudRouter = router({
     )
     .mutation(async ({ input }) => {
       const result = await analyzeCorrection(input);
+      return { data: result };
+    }),
+
+  /**
+   * Preview which transactions a candidate (pattern, matchType) would match
+   * against the live transactions table. Used by the manual rule create/edit
+   * dialog (#2187) to show users which rows their rule will affect before
+   * they save it.
+   */
+  previewMatches: protectedProcedure
+    .input(
+      z.object({
+        descriptionPattern: z.string().min(1),
+        matchType: z.enum(['exact', 'contains', 'regex']),
+        limit: z.number().int().positive().max(200).optional(),
+      })
+    )
+    .query(({ input }) => {
+      const result = previewMatches(input);
       return { data: result };
     }),
 

--- a/apps/pops-api/src/modules/core/corrections/service.ts
+++ b/apps/pops-api/src/modules/core/corrections/service.ts
@@ -22,6 +22,14 @@ export {
   findMatchingCorrection,
 } from './handlers/pattern-match.js';
 
+export type {
+  PreviewMatchInput,
+  PreviewMatchResult,
+  PreviewMatchTransaction,
+  RuleMatchType,
+} from './handlers/preview-matches.js';
+export { previewMatches } from './handlers/preview-matches.js';
+
 export {
   adjustConfidence,
   createOrUpdateCorrection,

--- a/apps/pops-shell/e2e/ai-rules-create-edit.spec.ts
+++ b/apps/pops-shell/e2e/ai-rules-create-edit.spec.ts
@@ -76,7 +76,11 @@ function uniqueAlphaSuffix(): string {
 }
 
 async function expectPreviewIncludes(dialog: Locator, description: string): Promise<void> {
-  await expect(previewMatchRows(dialog).filter({ hasText: description })).toBeVisible({
+  // Multiple seeded transactions can match a single description fragment
+  // (e.g. "Woolworths Metro" + "Woolworths" + "Woolworths Petrol"), so scope
+  // the visibility check to the first match — the preview just needs to
+  // surface at least one row containing the description.
+  await expect(previewMatchRows(dialog).filter({ hasText: description }).first()).toBeVisible({
     timeout: 10_000,
   });
 }

--- a/apps/pops-shell/e2e/ai-rules-create-edit.spec.ts
+++ b/apps/pops-shell/e2e/ai-rules-create-edit.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * E2E tests — AI rules: create + preview, edit + verify updated preview.
+ *
+ * Closes:
+ *   - #2119  Tier 2 — create a new rule and confirm preview matches against
+ *            seeded transactions.
+ *   - #2135  Tier 3 — edit an existing rule's pattern and confirm the
+ *            updated preview reflects the new match set, then save and
+ *            assert persistence across reload.
+ *
+ * Both flows run against the real `/ai/rules` page, hitting the seeded `e2e`
+ * SQLite environment via the standard `useRealApi` helper. The seeded data
+ * (see `apps/pops-api/src/db/seeder.ts`) provides:
+ *   - 16 transactions including `Woolworths Metro`, `Woolworths`,
+ *     `Netflix Subscription`, `Shell Service Station`, `Coles Local`
+ *   - 2 corrections: `WOOLWORTHS%` (contains, Groceries) and
+ *     `NETFLIX` (exact, Entertainment/Subscriptions)
+ *
+ * Locator strategy mirrors `entities-create-alias.spec.ts`:
+ *   - The dialog is portaled, so we always scope through `getByRole('dialog')`.
+ *   - TextInput and Select labels in @pops/ui render without `htmlFor`, so
+ *     we reach inputs by placeholder / accessible name where possible.
+ *   - Each test seeds a unique pattern derived from `Date.now()` to keep
+ *     repeated runs against the same long-lived `e2e` env from colliding
+ *     with the unique-pattern constraint enforced by `createOrUpdate`.
+ *
+ * Crash detection: pageerror and real console errors are asserted empty in
+ * afterEach so every step in the flow also guards against JS crashes.
+ */
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+import { useRealApi } from './helpers/use-real-api';
+
+function rulesDialog(page: Page): Locator {
+  return page.getByRole('dialog');
+}
+
+function previewMatchRows(dialog: Locator): Locator {
+  return dialog.locator('[data-testid="preview-match-row"]');
+}
+
+async function fillPattern(dialog: Locator, pattern: string): Promise<void> {
+  const input = dialog.getByPlaceholder('e.g. WOOLWORTHS');
+  await input.fill('');
+  await input.fill(pattern);
+}
+
+async function selectMatchType(
+  dialog: Locator,
+  value: 'exact' | 'contains' | 'regex'
+): Promise<void> {
+  // The Match Type Select is the only one in the dialog with a `contains` option.
+  await dialog
+    .locator('select')
+    .filter({ has: dialog.page().locator('option[value="contains"]') })
+    .selectOption(value);
+}
+
+async function clickRunPreview(dialog: Locator): Promise<void> {
+  await dialog.locator('[data-testid="rule-preview-run"]').click();
+}
+
+/**
+ * normalizeDescription (server-side) strips digits, so unique suffixes for
+ * idempotent runs need to use only [A-Z]. This converts a number to a
+ * letter-only string by base-26 encoding (one letter per digit-pair).
+ */
+function uniqueAlphaSuffix(): string {
+  let n = Date.now();
+  let out = '';
+  while (n > 0) {
+    out = String.fromCharCode(65 + (n % 26)) + out;
+    n = Math.floor(n / 26);
+  }
+  return out;
+}
+
+async function expectPreviewIncludes(dialog: Locator, description: string): Promise<void> {
+  await expect(previewMatchRows(dialog).filter({ hasText: description })).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+async function expectPreviewExcludes(dialog: Locator, description: string): Promise<void> {
+  // Wait until the preview list has rendered before asserting absence so the
+  // assertion can't pass on the still-empty initial state.
+  await expect(previewMatchRows(dialog).first()).toBeVisible({ timeout: 10_000 });
+  await expect(previewMatchRows(dialog).filter({ hasText: description })).toHaveCount(0);
+}
+
+test.describe('AI rules — manual create/edit + preview', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let pageErrors: string[] = [];
+  let consoleErrors: string[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    pageErrors = [];
+    consoleErrors = [];
+    await useRealApi(page);
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    await page.goto('/ai/rules');
+    await expect(page.getByRole('heading', { name: 'Categorisation Rules' })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    const realConsoleErrors = consoleErrors.filter(
+      (e) =>
+        !e.includes('React Router') &&
+        !e.includes('Download the React DevTools') &&
+        !e.includes('Failed to load resource')
+    );
+    expect(pageErrors).toHaveLength(0);
+    expect(realConsoleErrors).toHaveLength(0);
+  });
+
+  test('#2119 — creates a rule and confirms preview matches seeded transactions', async ({
+    page,
+  }) => {
+    // Use a regex matchType so the unique (pattern,matchType) tuple won't
+    // collide with the seeded `WOOLWORTHS%`/contains correction even after
+    // pattern normalisation — letting the test run idempotently against the
+    // long-lived seeded env. The suffix uses A-Z only because the server
+    // pattern normaliser strips digits before persisting.
+    const uniqueSuffix = uniqueAlphaSuffix();
+    const pattern = `WOOLWORTHS${uniqueSuffix}|WOOLWORTHS`;
+
+    // --- Step 1: open create dialog ------------------------------------
+    await page.getByRole('button', { name: /add rule/i }).click();
+    const dialog = rulesDialog(page);
+    await expect(dialog.getByText('New Rule')).toBeVisible();
+
+    // --- Step 2: fill the form ----------------------------------------
+    await fillPattern(dialog, pattern);
+    await selectMatchType(dialog, 'regex');
+
+    // --- Step 3: trigger preview ---------------------------------------
+    await clickRunPreview(dialog);
+
+    // --- Step 4: confirm preview shows seeded matches ------------------
+    await expectPreviewIncludes(dialog, 'Woolworths');
+    // …and excludes a transaction that should NOT match (Netflix).
+    await expectPreviewExcludes(dialog, 'Netflix Subscription');
+
+    // --- Step 5: save the rule -----------------------------------------
+    await dialog.getByRole('button', { name: 'Create' }).click();
+    await expect(dialog).toBeHidden();
+
+    // The new rule appears in the table after the list invalidates. Match
+    // by the unique alpha suffix because the stored pattern is the
+    // normalised form of the input (uppercase, digits stripped).
+    await expect(page.getByRole('row').filter({ hasText: uniqueSuffix })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test('#2135 — edits an existing rule and verifies the updated preview, then persists', async ({
+    page,
+  }) => {
+    // Create a rule we can then edit. Two reasons:
+    //   1. The seeded WOOLWORTHS rule may collide with concurrent specs.
+    //   2. The flow asserts persistence — we want to own the data lifecycle
+    //      end-to-end so the cleanup story is just "delete this row" if the
+    //      test author wants to wire it later.
+    // A-Z only: server normaliser strips digits, so timestamp suffixes are
+    // expressed via uniqueAlphaSuffix to keep the unique constraint honest.
+    const original = `EEEDIT${uniqueAlphaSuffix()}`;
+    const refined = `${original}NETFLIX`;
+
+    // --- Step 1: create a contains rule that matches a broad set --------
+    await page.getByRole('button', { name: /add rule/i }).click();
+    const createDialog = rulesDialog(page);
+    await fillPattern(createDialog, original);
+    await selectMatchType(createDialog, 'contains');
+    await createDialog.getByRole('button', { name: 'Create' }).click();
+    await expect(createDialog).toBeHidden();
+
+    // --- Step 2: open the row's edit action ----------------------------
+    const newRow = page.getByRole('row').filter({ hasText: original });
+    await expect(newRow).toBeVisible({ timeout: 10_000 });
+    await newRow.getByRole('button', { name: new RegExp(`Edit rule ${original}`, 'i') }).click();
+
+    const editDialog = rulesDialog(page);
+    await expect(editDialog.getByText('Edit Rule')).toBeVisible();
+
+    // --- Step 3: change the pattern to a narrower match ----------------
+    // First broaden to NETFLIX to verify we hit Netflix Subscription.
+    await fillPattern(editDialog, 'NETFLIX');
+    await selectMatchType(editDialog, 'contains');
+    await clickRunPreview(editDialog);
+    await expectPreviewIncludes(editDialog, 'Netflix Subscription');
+
+    // Then narrow to a pattern that should NOT match anything seeded.
+    await fillPattern(editDialog, refined);
+    await clickRunPreview(editDialog);
+    await expect(editDialog.locator('[data-testid="preview-no-matches"]')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // --- Step 4: save the edit -----------------------------------------
+    await editDialog.getByRole('button', { name: 'Update' }).click();
+    await expect(editDialog).toBeHidden();
+
+    // --- Step 5: reload and confirm the new pattern persists ----------
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Categorisation Rules' })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByRole('row').filter({ hasText: refined })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/packages/app-ai/package.json
+++ b/packages/app-ai/package.json
@@ -10,6 +10,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@pops/api-client": "workspace:*",
     "@pops/navigation": "workspace:*",
     "@pops/types": "workspace:*",
@@ -18,9 +19,11 @@
     "@tanstack/react-table": "8.21.3",
     "lucide-react": "^1.8.0",
     "react": "^19.2.5",
+    "react-hook-form": "^7.73.1",
     "react-router": "^7.14.2",
     "recharts": "^3.8.1",
-    "sonner": "^2.0.7"
+    "sonner": "^2.0.7",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/app-ai/src/pages/RulesBrowserPage.test.tsx
+++ b/packages/app-ai/src/pages/RulesBrowserPage.test.tsx
@@ -7,11 +7,21 @@ const mockDeleteMutate = vi.fn();
 const mockAdjustMutate = vi.fn();
 const mockInvalidate = vi.fn();
 
+const mockCreateMutate = vi.fn();
+const mockUpdateMutate = vi.fn();
+const mockPreviewQuery = vi.fn((..._args: unknown[]) => ({
+  data: undefined,
+  isFetching: false,
+  error: null,
+  refetch: vi.fn(),
+}));
+
 vi.mock('@pops/api-client', () => ({
   trpc: {
     core: {
       corrections: {
         list: { useQuery: (...args: unknown[]) => mockListQuery(...args) },
+        previewMatches: { useQuery: (...args: unknown[]) => mockPreviewQuery(...args) },
         delete: {
           useMutation: (opts: { onSuccess?: () => void }) => ({
             mutate: (...args: unknown[]) => {
@@ -25,9 +35,26 @@ vi.mock('@pops/api-client', () => ({
           useMutation: (opts: { onSuccess?: () => void }) => ({
             mutate: (...args: unknown[]) => {
               mockAdjustMutate(...args);
-              // call onSuccess from the second arg if provided
               const callOpts = args[1] as { onSuccess?: () => void } | undefined;
               callOpts?.onSuccess?.();
+              opts.onSuccess?.();
+            },
+            isPending: false,
+          }),
+        },
+        createOrUpdate: {
+          useMutation: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => ({
+            mutate: (...args: unknown[]) => {
+              mockCreateMutate(...args);
+              opts.onSuccess?.();
+            },
+            isPending: false,
+          }),
+        },
+        update: {
+          useMutation: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => ({
+            mutate: (...args: unknown[]) => {
+              mockUpdateMutate(...args);
               opts.onSuccess?.();
             },
             isPending: false,
@@ -157,11 +184,14 @@ vi.mock('@pops/ui', async () => {
       open: boolean;
       onOpenChange: (v: boolean) => void;
     }) => {
-      dialogCloseRef = open
-        ? () => {
-            onOpenChange(false);
-          }
-        : null;
+      // Only update the ref when the dialog is actually open so a sibling
+      // closed Dialog doesn't reset the ref of the open one (RuleFormDialog
+      // and DeleteRuleDialog now coexist on the page).
+      if (open) {
+        dialogCloseRef = () => {
+          onOpenChange(false);
+        };
+      }
       return open
         ? React.createElement(
             'div',
@@ -241,6 +271,60 @@ vi.mock('@pops/ui', async () => {
         timer = setTimeout(() => fn(...args), delay);
       };
     },
+    useDebouncedValue: (value: string) => value,
+    Label: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('label', null, children),
+    ChipInput: ({
+      value,
+      onChange,
+      placeholder,
+    }: {
+      value?: string[];
+      onChange?: (next: string[]) => void;
+      placeholder?: string;
+    }) =>
+      React.createElement('input', {
+        'data-testid': 'chip-input',
+        placeholder,
+        value: (value ?? []).join(','),
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+          onChange?.(e.target.value ? e.target.value.split(',') : []),
+      }),
+    CheckboxInput: ({
+      checked,
+      onCheckedChange,
+      label,
+    }: {
+      checked?: boolean;
+      onCheckedChange?: (next: boolean) => void;
+      label?: React.ReactNode;
+    }) =>
+      React.createElement(
+        'label',
+        null,
+        React.createElement('input', {
+          type: 'checkbox',
+          checked: !!checked,
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) => onCheckedChange?.(e.target.checked),
+          'aria-label': typeof label === 'string' ? label : undefined,
+        }),
+        label as React.ReactNode
+      ),
+    NumberInput: ({
+      value,
+      onChange,
+      ...rest
+    }: {
+      value?: number;
+      onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+      'aria-label'?: string;
+    }) =>
+      React.createElement('input', {
+        type: 'number',
+        value: value ?? 0,
+        onChange,
+        ...rest,
+      }),
   };
 });
 
@@ -260,6 +344,8 @@ const mockRules = [
     location: null,
     tags: [],
     transactionType: null,
+    isActive: true,
+    priority: 0,
   },
   {
     id: 'rule-2',
@@ -274,6 +360,8 @@ const mockRules = [
     location: null,
     tags: [],
     transactionType: null,
+    isActive: true,
+    priority: 0,
   },
   {
     id: 'rule-3',
@@ -288,6 +376,8 @@ const mockRules = [
     location: null,
     tags: [],
     transactionType: null,
+    isActive: true,
+    priority: 0,
   },
 ];
 

--- a/packages/app-ai/src/pages/RulesBrowserPage.tsx
+++ b/packages/app-ai/src/pages/RulesBrowserPage.tsx
@@ -1,8 +1,12 @@
-import { PageHeader } from '@pops/ui';
+import { Plus } from 'lucide-react';
 
+import { Button, PageHeader } from '@pops/ui';
+
+import { RuleFormDialog } from './rules-browser/rule-form/RuleFormDialog';
+import { useRulePreview } from './rules-browser/rule-form/useRulePreview';
 /**
  * RulesBrowserPage — browse, filter, adjust, and delete AI categorisation rules.
- * PRD-053/US-02 (tb-542).
+ * PRD-053/US-02 (tb-542). #2187 adds manual create/edit + preview.
  */
 import { DeleteRuleDialog } from './rules-browser/sections/DeleteRuleDialog';
 import { RulesErrorState } from './rules-browser/sections/RulesErrorState';
@@ -12,57 +16,81 @@ import { RulesPagination } from './rules-browser/sections/RulesPagination';
 import { RulesTable } from './rules-browser/sections/RulesTable';
 import { PAGE_SIZE, useRulesBrowserModel } from './rules-browser/useRulesBrowserModel';
 
-export function RulesBrowserPage(): React.ReactElement {
-  const model = useRulesBrowserModel();
+type Model = ReturnType<typeof useRulesBrowserModel>;
 
-  if (model.isLoading) return <RulesLoadingState />;
-  if (model.isError) return <RulesErrorState onRetry={() => model.refetch()} />;
+function FiltersSection({ model }: { model: Model }) {
+  return (
+    <RulesFilters
+      matchType={model.matchType}
+      minConfidence={model.minConfidence}
+      onMatchTypeChange={(value) => {
+        model.setMatchType(value);
+        model.resetPage();
+      }}
+      onMinConfidenceChange={(value) => {
+        model.setMinConfidence(value);
+        model.resetPage();
+      }}
+      onClear={() => {
+        model.setMatchType('');
+        model.setMinConfidence('');
+        model.resetPage();
+      }}
+    />
+  );
+}
+
+function PaginationSection({ model }: { model: Model }) {
+  if (!model.pagination) return null;
+  return (
+    <RulesPagination
+      total={model.pagination.total}
+      offset={model.offset}
+      currentPage={model.currentPage}
+      totalPages={model.totalPages}
+      onPrevious={() => {
+        model.setOffset(Math.max(0, model.offset - PAGE_SIZE));
+      }}
+      onNext={() => {
+        model.setOffset(model.offset + PAGE_SIZE);
+      }}
+    />
+  );
+}
+
+function RulesBrowserBody({ model }: { model: Model }) {
+  // Watch the form's pattern + matchType so the preview pane stays in sync
+  // with the user's edits without having to re-open the dialog.
+  const watchedPattern = model.ruleForm.form.watch('descriptionPattern');
+  const watchedMatchType = model.ruleForm.form.watch('matchType');
+  const preview = useRulePreview({
+    pattern: watchedPattern,
+    matchType: watchedMatchType,
+    enabled: model.isFormOpen,
+  });
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Categorisation Rules"
         description="Browse and manage AI categorisation rules"
+        actions={
+          <Button onClick={model.handleAddRule}>
+            <Plus className="mr-2 h-4 w-4" /> Add Rule
+          </Button>
+        }
       />
 
-      <RulesFilters
-        matchType={model.matchType}
-        minConfidence={model.minConfidence}
-        onMatchTypeChange={(value) => {
-          model.setMatchType(value);
-          model.resetPage();
-        }}
-        onMinConfidenceChange={(value) => {
-          model.setMinConfidence(value);
-          model.resetPage();
-        }}
-        onClear={() => {
-          model.setMatchType('');
-          model.setMinConfidence('');
-          model.resetPage();
-        }}
-      />
+      <FiltersSection model={model} />
 
       <RulesTable
         corrections={model.corrections}
         onAutoDelete={model.handleAutoDelete}
         onDeleteClick={model.setDeleteId}
+        onEditClick={model.handleEditRule}
       />
 
-      {model.pagination && (
-        <RulesPagination
-          total={model.pagination.total}
-          offset={model.offset}
-          currentPage={model.currentPage}
-          totalPages={model.totalPages}
-          onPrevious={() => {
-            model.setOffset(Math.max(0, model.offset - PAGE_SIZE));
-          }}
-          onNext={() => {
-            model.setOffset(model.offset + PAGE_SIZE);
-          }}
-        />
-      )}
+      <PaginationSection model={model} />
 
       <DeleteRuleDialog
         open={!!model.deleteId}
@@ -72,6 +100,24 @@ export function RulesBrowserPage(): React.ReactElement {
         onConfirm={model.handleDelete}
         isPending={model.deleteMutation.isPending}
       />
+
+      <RuleFormDialog
+        open={model.isFormOpen}
+        onOpenChange={model.setIsFormOpen}
+        editingRule={model.ruleForm.editingRule}
+        form={model.ruleForm.form}
+        isSubmitting={model.ruleForm.isSubmitting}
+        onSubmit={model.ruleForm.onSubmit}
+        preview={preview}
+      />
     </div>
   );
+}
+
+export function RulesBrowserPage(): React.ReactElement {
+  const model = useRulesBrowserModel();
+
+  if (model.isLoading) return <RulesLoadingState />;
+  if (model.isError) return <RulesErrorState onRetry={() => model.refetch()} />;
+  return <RulesBrowserBody model={model} />;
 }

--- a/packages/app-ai/src/pages/rules-browser/columns.tsx
+++ b/packages/app-ai/src/pages/rules-browser/columns.tsx
@@ -1,4 +1,4 @@
-import { Trash2 } from 'lucide-react';
+import { Pencil, Trash2 } from 'lucide-react';
 
 import { Badge, Button, formatDate, SortableHeader } from '@pops/ui';
 
@@ -11,6 +11,7 @@ import type { Correction } from './types';
 type BuildOptions = {
   onAutoDelete: (id: string) => void;
   onDeleteClick: (id: string) => void;
+  onEditClick: (rule: Correction) => void;
 };
 
 const patternColumn: ColumnDef<Correction> = {
@@ -67,22 +68,38 @@ function confidenceColumn(onAutoDelete: BuildOptions['onAutoDelete']): ColumnDef
   };
 }
 
-function actionsColumn(onDeleteClick: BuildOptions['onDeleteClick']): ColumnDef<Correction> {
+function actionsColumn(
+  onDeleteClick: BuildOptions['onDeleteClick'],
+  onEditClick: BuildOptions['onEditClick']
+): ColumnDef<Correction> {
   return {
     id: 'actions',
     header: '',
     cell: ({ row }) => (
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={(e) => {
-          e.stopPropagation();
-          onDeleteClick(row.original.id);
-        }}
-        aria-label={`Delete rule ${row.original.descriptionPattern}`}
-      >
-        <Trash2 className="h-4 w-4 text-destructive" />
-      </Button>
+      <div className="flex items-center justify-end gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            onEditClick(row.original);
+          }}
+          aria-label={`Edit rule ${row.original.descriptionPattern}`}
+        >
+          <Pencil className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeleteClick(row.original.id);
+          }}
+          aria-label={`Delete rule ${row.original.descriptionPattern}`}
+        >
+          <Trash2 className="h-4 w-4 text-destructive" />
+        </Button>
+      </div>
     ),
   };
 }
@@ -90,6 +107,7 @@ function actionsColumn(onDeleteClick: BuildOptions['onDeleteClick']): ColumnDef<
 export function buildRulesColumns({
   onAutoDelete,
   onDeleteClick,
+  onEditClick,
 }: BuildOptions): ColumnDef<Correction>[] {
   return [
     patternColumn,
@@ -98,6 +116,6 @@ export function buildRulesColumns({
     confidenceColumn(onAutoDelete),
     timesAppliedColumn,
     lastUsedColumn,
-    actionsColumn(onDeleteClick),
+    actionsColumn(onDeleteClick, onEditClick),
   ];
 }

--- a/packages/app-ai/src/pages/rules-browser/rule-form/RuleFormDialog.tsx
+++ b/packages/app-ai/src/pages/rules-browser/rule-form/RuleFormDialog.tsx
@@ -1,0 +1,167 @@
+/**
+ * RuleFormDialog — manual create/edit surface for AI categorisation rules.
+ *
+ * Closes #2187 and unblocks the e2e flows in #2119 / #2135. The dialog
+ * mirrors `EntityFormDialog`'s shape (Controller for ChipInput / boolean
+ * toggle, register for TextInput) and adds a side preview pane showing the
+ * transactions the candidate (pattern, matchType) would match against the
+ * live transactions table.
+ */
+import { Loader2 } from 'lucide-react';
+import { Controller, type UseFormReturn } from 'react-hook-form';
+
+import {
+  Button,
+  CheckboxInput,
+  ChipInput,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Label,
+  NumberInput,
+  Select,
+  TextInput,
+} from '@pops/ui';
+
+import { RulePreviewPanel, type RulePreviewPanelProps } from './RulePreviewPanel';
+import { MATCH_TYPE_OPTIONS, type RuleFormValues } from './types';
+
+import type { Correction } from '../types';
+
+interface RuleFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  editingRule: Correction | null;
+  form: UseFormReturn<RuleFormValues>;
+  isSubmitting: boolean;
+  onSubmit: (values: RuleFormValues) => void;
+  preview: RulePreviewPanelProps['preview'];
+}
+
+function PriorityField({ form }: { form: UseFormReturn<RuleFormValues> }) {
+  return (
+    <Controller
+      control={form.control}
+      name="priority"
+      render={({ field }) => (
+        <div className="flex flex-col gap-1.5 w-full">
+          <Label>Priority</Label>
+          <NumberInput
+            min={0}
+            value={field.value}
+            onChange={(e) => {
+              const next = Number(e.currentTarget.value);
+              field.onChange(Number.isFinite(next) ? next : 0);
+            }}
+            aria-label="Priority"
+          />
+        </div>
+      )}
+    />
+  );
+}
+
+function PatternAndType({ form }: { form: UseFormReturn<RuleFormValues> }) {
+  return (
+    <>
+      <TextInput
+        label="Pattern"
+        placeholder="e.g. WOOLWORTHS"
+        {...form.register('descriptionPattern')}
+        error={form.formState.errors.descriptionPattern?.message}
+      />
+      <div className="grid grid-cols-2 gap-4">
+        <Select
+          label="Match Type"
+          options={MATCH_TYPE_OPTIONS.map((o) => ({ label: o.label, value: o.value }))}
+          {...form.register('matchType')}
+        />
+        <PriorityField form={form} />
+      </div>
+    </>
+  );
+}
+
+function TagsAndActive({ form }: { form: UseFormReturn<RuleFormValues> }) {
+  return (
+    <>
+      <div className="space-y-2">
+        <Label>Tags</Label>
+        <Controller
+          control={form.control}
+          name="tags"
+          render={({ field }) => (
+            <ChipInput
+              placeholder="Type and press Enter..."
+              value={field.value}
+              onChange={field.onChange}
+            />
+          )}
+        />
+      </div>
+      <Controller
+        control={form.control}
+        name="isActive"
+        render={({ field }) => (
+          <CheckboxInput
+            label="Active"
+            description="Inactive rules are skipped by the matcher."
+            checked={field.value}
+            onCheckedChange={(checked) => field.onChange(Boolean(checked))}
+          />
+        )}
+      />
+    </>
+  );
+}
+
+function DialogActions({
+  editingRule,
+  isSubmitting,
+  onCancel,
+}: {
+  editingRule: Correction | null;
+  isSubmitting: boolean;
+  onCancel: () => void;
+}) {
+  return (
+    <DialogFooter>
+      <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+        Cancel
+      </Button>
+      <Button type="submit" disabled={isSubmitting}>
+        {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        {editingRule ? 'Update' : 'Create'}
+      </Button>
+    </DialogFooter>
+  );
+}
+
+export function RuleFormDialog(props: RuleFormDialogProps) {
+  const { open, onOpenChange, editingRule, form, isSubmitting, onSubmit, preview } = props;
+  return (
+    <Dialog open={open} onOpenChange={(v) => !isSubmitting && onOpenChange(v)}>
+      <DialogContent className="sm:max-w-4xl">
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <DialogHeader>
+            <DialogTitle>{editingRule ? 'Edit Rule' : 'New Rule'}</DialogTitle>
+          </DialogHeader>
+          <div className="grid gap-6 py-4 md:grid-cols-2">
+            <div className="grid gap-4 min-w-0">
+              <PatternAndType form={form} />
+              <TagsAndActive form={form} />
+            </div>
+            <RulePreviewPanel preview={preview} />
+          </div>
+          <DialogActions
+            editingRule={editingRule}
+            isSubmitting={isSubmitting}
+            onCancel={() => onOpenChange(false)}
+          />
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app-ai/src/pages/rules-browser/rule-form/RulePreviewPanel.tsx
+++ b/packages/app-ai/src/pages/rules-browser/rule-form/RulePreviewPanel.tsx
@@ -1,0 +1,140 @@
+/**
+ * Side panel rendered inside `RuleFormDialog` showing the live transactions
+ * a candidate (pattern, matchType) would match against (#2187).
+ */
+import { Loader2, Search } from 'lucide-react';
+
+import { Badge, Button, formatDate } from '@pops/ui';
+
+import type { MatchType } from '../types';
+import type { RulePreviewResult } from './types';
+
+export interface RulePreviewPanelProps {
+  preview: {
+    data: RulePreviewResult | undefined;
+    isFetching: boolean;
+    error: { message: string } | null;
+    refetch: () => Promise<unknown>;
+    inputPattern: string;
+    inputMatchType: MatchType;
+    isIdle: boolean;
+  };
+}
+
+function MatchRow({ match }: { match: RulePreviewResult['matches'][number] }) {
+  return (
+    <li className="p-2 text-sm" data-testid="preview-match-row">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-mono">{match.description}</span>
+        <span className="text-muted-foreground tabular-nums">{formatDate(match.date)}</span>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
+        <span>{match.account}</span>
+        {match.entityName && <span>• {match.entityName}</span>}
+        {match.tags.length > 0 && (
+          <span className="flex gap-1">
+            {match.tags.map((tag) => (
+              <Badge key={tag} variant="outline" className="text-[10px]">
+                {tag}
+              </Badge>
+            ))}
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function PreviewBody({ preview }: RulePreviewPanelProps) {
+  const { data, isFetching, error, isIdle } = preview;
+
+  if (isIdle) {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="preview-empty">
+        Enter a pattern to preview matches.
+      </p>
+    );
+  }
+  if (error) {
+    return <p className="text-sm text-destructive">{error.message}</p>;
+  }
+  if (!data && isFetching) {
+    return (
+      <p className="text-sm text-muted-foreground inline-flex items-center gap-2">
+        <Loader2 className="h-4 w-4 animate-spin" /> Running preview…
+      </p>
+    );
+  }
+  if (!data) return null;
+
+  if (data.matches.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="preview-no-matches">
+        No transactions match this rule.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-border rounded-md border" data-testid="preview-matches">
+      {data.matches.map((match) => (
+        <MatchRow key={match.id} match={match} />
+      ))}
+    </ul>
+  );
+}
+
+function PreviewHeader({ preview }: RulePreviewPanelProps) {
+  const { isFetching, refetch, inputPattern, inputMatchType, isIdle } = preview;
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div>
+        <h3 className="text-sm font-semibold">Preview matches</h3>
+        {!isIdle && (
+          <p className="text-xs text-muted-foreground">
+            Pattern <code className="font-mono">{inputPattern}</code> · {inputMatchType}
+          </p>
+        )}
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => void refetch()}
+        disabled={isIdle || isFetching}
+        data-testid="rule-preview-run"
+      >
+        {isFetching ? (
+          <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Search className="mr-2 h-3.5 w-3.5" />
+        )}
+        Run preview
+      </Button>
+    </div>
+  );
+}
+
+function PreviewSummary({ preview }: RulePreviewPanelProps) {
+  const { data, isIdle } = preview;
+  if (isIdle) return null;
+  const total = data?.total ?? 0;
+  const truncated = data?.truncated ?? false;
+  const shownCount = data?.matches.length ?? 0;
+  return (
+    <p className="text-xs text-muted-foreground" data-testid="rule-preview-count">
+      {total} match{total === 1 ? '' : 'es'}
+      {truncated ? ` (showing first ${shownCount})` : ''}
+    </p>
+  );
+}
+
+export function RulePreviewPanel({ preview }: RulePreviewPanelProps) {
+  return (
+    <div className="flex flex-col gap-3 min-w-0" data-testid="rule-preview-panel">
+      <PreviewHeader preview={preview} />
+      <PreviewSummary preview={preview} />
+      <PreviewBody preview={preview} />
+    </div>
+  );
+}

--- a/packages/app-ai/src/pages/rules-browser/rule-form/types.ts
+++ b/packages/app-ai/src/pages/rules-browser/rule-form/types.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+import type { MatchType } from '../types';
+
+/**
+ * Shape used by the manual create/edit dialog form (#2187). Mirrors the
+ * subset of the `transactionCorrections` row that a human editor cares
+ * about: the pattern + match type that drive matching, the tags applied
+ * on a hit, the active toggle, and the priority used for ordering.
+ *
+ * Confidence is intentionally NOT exposed here — that field is governed
+ * by the AI feedback loop (see `ConfidenceSlider` in the table). New
+ * rules created manually rely on the API's createOrUpdate default of
+ * 0.5 and edits to existing rules leave confidence untouched.
+ */
+export const RuleFormSchema = z.object({
+  descriptionPattern: z.string().min(1, 'Pattern is required'),
+  matchType: z.enum(['exact', 'contains', 'regex']),
+  tags: z.array(z.string()),
+  priority: z.number().int().nonnegative(),
+  isActive: z.boolean(),
+});
+
+export type RuleFormValues = z.infer<typeof RuleFormSchema>;
+
+export const DEFAULT_RULE_FORM_VALUES: RuleFormValues = {
+  descriptionPattern: '',
+  matchType: 'contains',
+  tags: [],
+  priority: 0,
+  isActive: true,
+};
+
+export const MATCH_TYPE_OPTIONS: ReadonlyArray<{ label: string; value: MatchType }> = [
+  { label: 'Contains', value: 'contains' },
+  { label: 'Exact', value: 'exact' },
+  { label: 'Regex', value: 'regex' },
+];
+
+export interface RulePreviewMatch {
+  id: string;
+  description: string;
+  account: string;
+  amount: number;
+  date: string;
+  entityName: string | null;
+  tags: string[];
+}
+
+export interface RulePreviewResult {
+  matches: RulePreviewMatch[];
+  total: number;
+  scanned: number;
+  truncated: boolean;
+}

--- a/packages/app-ai/src/pages/rules-browser/rule-form/useRuleFormState.ts
+++ b/packages/app-ai/src/pages/rules-browser/rule-form/useRuleFormState.ts
@@ -1,0 +1,117 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCallback, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+
+import { trpc } from '@pops/api-client';
+
+import { DEFAULT_RULE_FORM_VALUES, type RuleFormValues, RuleFormSchema } from './types';
+
+import type { Correction } from '../types';
+
+interface UseRuleFormStateOptions {
+  onClose: () => void;
+}
+
+function useRuleMutations(onClose: () => void) {
+  const utils = trpc.useUtils();
+  const createMutation = trpc.core.corrections.createOrUpdate.useMutation({
+    onSuccess: () => {
+      toast.success('Rule saved');
+      void utils.core.corrections.list.invalidate();
+      onClose();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+  const updateMutation = trpc.core.corrections.update.useMutation({
+    onSuccess: () => {
+      toast.success('Rule updated');
+      void utils.core.corrections.list.invalidate();
+      onClose();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+  return { createMutation, updateMutation };
+}
+
+function buildSubmit(
+  editingRule: Correction | null,
+  createMutation: ReturnType<typeof useRuleMutations>['createMutation'],
+  updateMutation: ReturnType<typeof useRuleMutations>['updateMutation']
+) {
+  return (values: RuleFormValues) => {
+    if (editingRule) {
+      updateMutation.mutate({
+        id: editingRule.id,
+        data: {
+          descriptionPattern: values.descriptionPattern,
+          matchType: values.matchType,
+          tags: values.tags,
+          priority: values.priority,
+          isActive: values.isActive,
+        },
+      });
+      return;
+    }
+    createMutation.mutate({
+      descriptionPattern: values.descriptionPattern,
+      matchType: values.matchType,
+      tags: values.tags,
+      priority: values.priority,
+    });
+  };
+}
+
+/**
+ * Hook owning the manual rule create/edit dialog form state (#2187).
+ *
+ * Mirrors `useEntitiesPage`:
+ *   - `useForm` + `zodResolver` + `DEFAULT_RULE_FORM_VALUES`
+ *   - `form.reset(...)` on edit so prefilled values land in `register`d
+ *     inputs (the #2155 TextInput safety pattern relies on uncontrolled
+ *     inputs whose value is rewritten via the ref).
+ *   - boolean `isActive` is managed via Controller in the dialog (#2175).
+ *
+ * The dialog supports both:
+ *   - Create — `core.corrections.createOrUpdate`
+ *   - Edit — `core.corrections.update`
+ *
+ * Pattern + matchType updates rely on the schema/handler additions in
+ * `correction-schemas.ts` and `query-helpers.ts`.
+ */
+export function useRuleFormState({ onClose }: UseRuleFormStateOptions) {
+  const [editingRule, setEditingRule] = useState<Correction | null>(null);
+  const form = useForm<RuleFormValues>({
+    resolver: zodResolver(RuleFormSchema),
+    defaultValues: DEFAULT_RULE_FORM_VALUES,
+  });
+  const { createMutation, updateMutation } = useRuleMutations(onClose);
+
+  const handleAdd = useCallback(() => {
+    setEditingRule(null);
+    form.reset(DEFAULT_RULE_FORM_VALUES);
+  }, [form]);
+
+  const handleEdit = useCallback(
+    (rule: Correction) => {
+      setEditingRule(rule);
+      form.reset({
+        descriptionPattern: rule.descriptionPattern,
+        matchType: rule.matchType,
+        tags: rule.tags,
+        priority: rule.priority,
+        isActive: rule.isActive,
+      });
+    },
+    [form]
+  );
+
+  return {
+    form,
+    editingRule,
+    handleAdd,
+    handleEdit,
+    onSubmit: buildSubmit(editingRule, createMutation, updateMutation),
+    isSubmitting: createMutation.isPending || updateMutation.isPending,
+  };
+}

--- a/packages/app-ai/src/pages/rules-browser/rule-form/useRulePreview.ts
+++ b/packages/app-ai/src/pages/rules-browser/rule-form/useRulePreview.ts
@@ -1,0 +1,79 @@
+import { trpc } from '@pops/api-client';
+import { useDebouncedValue } from '@pops/ui';
+
+import type { MatchType } from '../types';
+import type { RulePreviewResult } from './types';
+
+interface UseRulePreviewArgs {
+  pattern: string;
+  matchType: MatchType;
+  /**
+   * When true, the preview query is paused (useful while the dialog
+   * is closed). The query also pauses automatically when the pattern
+   * is empty.
+   */
+  enabled: boolean;
+}
+
+function isMatchType(value: string): value is MatchType {
+  return value === 'exact' || value === 'contains' || value === 'regex';
+}
+
+function asMatchType(value: string, fallback: MatchType): MatchType {
+  return isMatchType(value) ? value : fallback;
+}
+
+interface UseRulePreviewResult {
+  /** Latest debounced preview, or `undefined` while we're still loading. */
+  data: RulePreviewResult | undefined;
+  isFetching: boolean;
+  error: { message: string } | null;
+  /** Forces an immediate refetch — surfaces a "Run preview" button. */
+  refetch: () => Promise<unknown>;
+  /** Mirrors the input pattern so callers can show the active query. */
+  inputPattern: string;
+  /** Mirrors the input matchType so callers can render context. */
+  inputMatchType: MatchType;
+  /** True before the user has typed anything (avoid showing zero-state). */
+  isIdle: boolean;
+}
+
+/**
+ * Live preview hook backing the manual rule create/edit dialog (#2187).
+ *
+ * Behaviour:
+ *   - Debounces the (pattern, matchType) tuple by 300ms so per-keystroke
+ *     network calls stay quiet.
+ *   - Disabled while `enabled` is false OR the pattern is empty.
+ *   - Returns the matched transactions (capped at 25 by the API), the
+ *     full match count, and a truncated flag for UI signalling.
+ */
+export function useRulePreview({
+  pattern,
+  matchType,
+  enabled,
+}: UseRulePreviewArgs): UseRulePreviewResult {
+  const debouncedPattern = useDebouncedValue(pattern, 300);
+  const debouncedMatchTypeRaw = useDebouncedValue(matchType, 300);
+  const debouncedMatchType = asMatchType(debouncedMatchTypeRaw, matchType);
+  const trimmed = debouncedPattern.trim();
+  const isIdle = trimmed.length === 0;
+
+  const query = trpc.core.corrections.previewMatches.useQuery(
+    { descriptionPattern: trimmed, matchType: debouncedMatchType },
+    {
+      enabled: enabled && !isIdle,
+      staleTime: 5_000,
+    }
+  );
+
+  return {
+    data: query.data?.data,
+    isFetching: query.isFetching,
+    error: query.error ? { message: query.error.message } : null,
+    refetch: () => query.refetch(),
+    inputPattern: trimmed,
+    inputMatchType: debouncedMatchType,
+    isIdle,
+  };
+}

--- a/packages/app-ai/src/pages/rules-browser/sections/RulesTable.tsx
+++ b/packages/app-ai/src/pages/rules-browser/sections/RulesTable.tsx
@@ -11,21 +11,28 @@ type RulesTableProps = {
   corrections: Correction[];
   onAutoDelete: (id: string) => void;
   onDeleteClick: (id: string) => void;
+  onEditClick: (rule: Correction) => void;
 };
 
-export function RulesTable({ corrections, onAutoDelete, onDeleteClick }: RulesTableProps) {
+export function RulesTable({
+  corrections,
+  onAutoDelete,
+  onDeleteClick,
+  onEditClick,
+}: RulesTableProps) {
   if (corrections.length === 0) {
     return (
       <Card className="p-12 text-center">
         <BookOpen className="h-12 w-12 mx-auto text-muted-foreground/40 mb-4" />
         <p className="text-muted-foreground">No categorisation rules found.</p>
         <p className="text-sm text-muted-foreground mt-1">
-          Rules are created automatically when AI categorises transactions.
+          Use the Add Rule button to author one manually, or let AI categorisation create one for
+          you.
         </p>
       </Card>
     );
   }
 
-  const columns = buildRulesColumns({ onAutoDelete, onDeleteClick });
+  const columns = buildRulesColumns({ onAutoDelete, onDeleteClick, onEditClick });
   return <DataTable columns={columns} data={corrections} paginated defaultPageSize={PAGE_SIZE} />;
 }

--- a/packages/app-ai/src/pages/rules-browser/types.ts
+++ b/packages/app-ai/src/pages/rules-browser/types.ts
@@ -9,6 +9,8 @@ export interface Correction {
   location: string | null;
   tags: string[];
   transactionType: 'purchase' | 'transfer' | 'income' | null;
+  isActive: boolean;
+  priority: number;
   confidence: number;
   timesApplied: number;
   createdAt: string;

--- a/packages/app-ai/src/pages/rules-browser/useRulesBrowserModel.ts
+++ b/packages/app-ai/src/pages/rules-browser/useRulesBrowserModel.ts
@@ -2,6 +2,8 @@ import { useCallback, useState } from 'react';
 
 import { trpc } from '@pops/api-client';
 
+import { useRuleFormState } from './rule-form/useRuleFormState';
+
 import type { Correction, MatchType } from './types';
 
 export const PAGE_SIZE = 50;
@@ -10,23 +12,29 @@ function parseMatchType(value: string): MatchType | undefined {
   return value === 'exact' || value === 'contains' || value === 'regex' ? value : undefined;
 }
 
-export function useRulesBrowserModel() {
+interface FilterState {
+  matchType: string;
+  setMatchType: (v: string) => void;
+  minConfidence: string;
+  setMinConfidence: (v: string) => void;
+  offset: number;
+  setOffset: (next: number | ((prev: number) => number)) => void;
+}
+
+function useFilterState(): FilterState {
   const [matchType, setMatchType] = useState('');
   const [minConfidence, setMinConfidence] = useState('');
-  const [offset, setOffset] = useState(0);
+  const [offset, setOffsetState] = useState(0);
+  const setOffset = useCallback((next: number | ((prev: number) => number)) => {
+    setOffsetState((prev) => (typeof next === 'function' ? next(prev) : next));
+  }, []);
+  return { matchType, setMatchType, minConfidence, setMinConfidence, offset, setOffset };
+}
+
+function useDeleteFlow() {
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [removedIds, setRemovedIds] = useState<Set<string>>(new Set());
-
-  const queryInput = {
-    minConfidence: minConfidence ? parseFloat(minConfidence) : undefined,
-    matchType: parseMatchType(matchType),
-    limit: PAGE_SIZE,
-    offset,
-  };
-
-  const { data, isLoading, isError, refetch } = trpc.core.corrections.list.useQuery(queryInput);
   const utils = trpc.useUtils();
-
   const deleteMutation = trpc.core.corrections.delete.useMutation({
     onSuccess: () => {
       void utils.core.corrections.list.invalidate();
@@ -34,37 +42,64 @@ export function useRulesBrowserModel() {
       setRemovedIds(new Set());
     },
   });
-
   const handleDelete = useCallback(() => {
     if (!deleteId) return;
     deleteMutation.mutate({ id: deleteId });
   }, [deleteId, deleteMutation]);
-
   const handleAutoDelete = useCallback((id: string) => {
     setRemovedIds((prev) => new Set(prev).add(id));
   }, []);
+  return { deleteId, setDeleteId, removedIds, deleteMutation, handleDelete, handleAutoDelete };
+}
+
+export function useRulesBrowserModel() {
+  const filters = useFilterState();
+  const del = useDeleteFlow();
+  const [isFormOpen, setIsFormOpen] = useState(false);
+
+  const ruleForm = useRuleFormState({ onClose: () => setIsFormOpen(false) });
+
+  const queryInput = {
+    minConfidence: filters.minConfidence ? parseFloat(filters.minConfidence) : undefined,
+    matchType: parseMatchType(filters.matchType),
+    limit: PAGE_SIZE,
+    offset: filters.offset,
+  };
+
+  const { data, isLoading, isError, refetch } = trpc.core.corrections.list.useQuery(queryInput);
 
   const corrections: Correction[] = (data?.data ?? []).filter(
-    (c: Correction) => !removedIds.has(c.id)
+    (c: Correction) => !del.removedIds.has(c.id)
   );
   const pagination = data?.pagination;
   const totalPages = pagination ? Math.ceil(pagination.total / PAGE_SIZE) : 1;
-  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+  const currentPage = Math.floor(filters.offset / PAGE_SIZE) + 1;
 
-  const resetPage = useCallback(() => {
-    setOffset(0);
-  }, []);
+  const resetPage = useCallback(() => filters.setOffset(0), [filters]);
+
+  const handleAddRule = useCallback(() => {
+    ruleForm.handleAdd();
+    setIsFormOpen(true);
+  }, [ruleForm]);
+
+  const handleEditRule = useCallback(
+    (rule: Correction) => {
+      ruleForm.handleEdit(rule);
+      setIsFormOpen(true);
+    },
+    [ruleForm]
+  );
 
   return {
-    matchType,
-    setMatchType,
-    minConfidence,
-    setMinConfidence,
-    offset,
-    setOffset,
+    matchType: filters.matchType,
+    setMatchType: filters.setMatchType,
+    minConfidence: filters.minConfidence,
+    setMinConfidence: filters.setMinConfidence,
+    offset: filters.offset,
+    setOffset: filters.setOffset,
     resetPage,
-    deleteId,
-    setDeleteId,
+    deleteId: del.deleteId,
+    setDeleteId: del.setDeleteId,
     isLoading,
     isError,
     refetch,
@@ -72,8 +107,13 @@ export function useRulesBrowserModel() {
     pagination,
     totalPages,
     currentPage,
-    deleteMutation,
-    handleDelete,
-    handleAutoDelete,
+    deleteMutation: del.deleteMutation,
+    handleDelete: del.handleDelete,
+    handleAutoDelete: del.handleAutoDelete,
+    isFormOpen,
+    setIsFormOpen,
+    ruleForm,
+    handleAddRule,
+    handleEditRule,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
 
   packages/app-ai:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.73.1(react@19.2.5))
       '@pops/api-client':
         specifier: workspace:*
         version: link:../api-client
@@ -351,6 +354,9 @@ importers:
       react:
         specifier: ^19.2.5
         version: 19.2.5
+      react-hook-form:
+        specifier: ^7.73.1
+        version: 7.73.1(react@19.2.5)
       react-router:
         specifier: ^7.14.2
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -360,6 +366,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1


### PR DESCRIPTION
## Summary

- Adds a manual rule create/edit dialog (`RuleFormDialog`) on `/ai/rules`,
  opened from a new "Add Rule" page-header button and from a row-level
  Edit action. Mirrors `EntityFormDialog` (TextInput register, Controller
  for ChipInput tags + Active toggle per #2175, Select for matchType,
  NumberInput for priority, `form.reset(...)` on edit).
- Backend: new `core.corrections.previewMatches` query that runs a
  candidate `(pattern, matchType)` against the live transactions table
  using `patternMatchesDescription` so semantics match the production
  matcher. Pattern + matchType are now editable on existing corrections
  via the `update` procedure.
- Side preview pane lists matched rows in the dialog with a manual
  "Run preview" action and live debounced refresh as the form changes.
- Two e2e flows under `apps/pops-shell/e2e/ai-rules-create-edit.spec.ts`
  cover the create + preview path (#2119) and the edit-then-persist
  path (#2135) against the seeded `e2e` SQLite env.

## Test plan

- [x] `pnpm typecheck` — all 16 packages pass
- [x] `pnpm lint` — 0 errors
- [x] `pnpm format:check`
- [x] `pnpm test` — all unit/component suites pass; new
      `previewMatches.test.ts` adds 7 cases (contains / exact / regex /
      truncation / invalid-regex / empty); new corrections update test
      for pattern + matchType edits
- [ ] Playwright e2e flows run in CI against the seeded `e2e` env
      (`fe-test-e2e.yml`)

Closes #2187
Closes #2119
Closes #2135
