### PR TITLE
feat(inventory): document upload section on item form (#2189)

### DIFF
--- a/apps/pops-api/src/app.ts
+++ b/apps/pops-api/src/app.ts
@@ -11,6 +11,7 @@ import { envRouter } from './modules/core/envs/router.js';
 import { openApiDocument } from './openapi.js';
 import { appRouter } from './router.js';
 import healthRouter from './routes/health.js';
+import inventoryDocumentFilesRouter from './routes/inventory/document-files.js';
 import documentThumbnailRouter from './routes/inventory/documents.js';
 import inventoryPhotosRouter from './routes/inventory/photos.js';
 import mediaImagesRouter from './routes/media/images.js';
@@ -54,6 +55,10 @@ export function createApp(): express.Express {
   // Inventory photo serving — static files from INVENTORY_IMAGES_DIR.
   // Placed before authMiddleware so <img> tags can render without JWT cookies.
   app.use(inventoryPhotosRouter);
+
+  // Inventory document upload serving — static files from INVENTORY_DOCUMENTS_DIR.
+  // Placed before authMiddleware so download links open without JWT cookies.
+  app.use(inventoryDocumentFilesRouter);
 
   // Cloudflare Access JWT auth — validates cf-access-jwt-assertion header.
   // Placed after health/webhook/media routes (those skip auth or use their own).

--- a/apps/pops-api/src/db/drizzle-migrations/0037_item_uploaded_files.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0037_item_uploaded_files.sql
@@ -1,0 +1,20 @@
+-- Add `item_uploaded_files` table for direct (non-Paperless) file uploads
+-- attached to inventory items. Lives alongside the existing `item_documents`
+-- table, which is reserved for Paperless-ngx links and keeps a mandatory
+-- `paperless_document_id` column. Direct uploads need their own filesystem
+-- columns (file_name / file_path / mime_type / file_size), so a parallel
+-- table avoids retrofitting nullable columns onto the Paperless schema.
+
+CREATE TABLE `item_uploaded_files` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `item_id` text NOT NULL,
+  `file_name` text NOT NULL,
+  `file_path` text NOT NULL,
+  `mime_type` text NOT NULL,
+  `file_size` integer NOT NULL,
+  `uploaded_at` text DEFAULT (datetime('now')) NOT NULL,
+  `created_at` text DEFAULT (datetime('now')) NOT NULL,
+  FOREIGN KEY (`item_id`) REFERENCES `home_inventory`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_item_uploaded_files_item` ON `item_uploaded_files` (`item_id`);

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1745193600000,
       "tag": "0036_body_hash_engram_index",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "6",
+      "when": 1777456800000,
+      "tag": "0037_item_uploaded_files",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -195,6 +195,20 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
     CREATE INDEX IF NOT EXISTS idx_item_documents_item ON item_documents(item_id);
     CREATE INDEX IF NOT EXISTS idx_item_documents_doc ON item_documents(paperless_document_id);
 
+    CREATE TABLE IF NOT EXISTS item_uploaded_files (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      item_id     TEXT NOT NULL,
+      file_name   TEXT NOT NULL,
+      file_path   TEXT NOT NULL,
+      mime_type   TEXT NOT NULL,
+      file_size   INTEGER NOT NULL,
+      uploaded_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (item_id) REFERENCES home_inventory(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_item_uploaded_files_item ON item_uploaded_files(item_id);
+
     CREATE TABLE IF NOT EXISTS wish_list (
       id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
       notion_id TEXT UNIQUE,

--- a/apps/pops-api/src/modules/inventory/document-files/document-files.test.ts
+++ b/apps/pops-api/src/modules/inventory/document-files/document-files.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Item uploaded-files (direct, non-Paperless) tRPC router tests.
+ */
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { TRPCError } from '@trpc/server';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createCaller,
+  seedInventoryItem,
+  seedItemUploadedFile,
+  setupTestContext,
+} from '../../../shared/test-utils.js';
+
+import type { Database } from 'better-sqlite3';
+
+const ctx = setupTestContext();
+let caller: ReturnType<typeof createCaller>;
+let db: Database;
+
+beforeEach(() => {
+  ({ caller, db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+interface SandboxedEnv {
+  tempDir: string;
+  restore: () => void;
+}
+
+/** Set INVENTORY_DOCUMENTS_DIR to a fresh temp dir for the duration of a test. */
+function withDocumentsDir(label: string): SandboxedEnv {
+  const tempDir = join(
+    tmpdir(),
+    `pops-docs-${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(tempDir, { recursive: true });
+  const original = process.env.INVENTORY_DOCUMENTS_DIR;
+  process.env.INVENTORY_DOCUMENTS_DIR = tempDir;
+  return {
+    tempDir,
+    restore: () => {
+      if (original === undefined) {
+        delete process.env.INVENTORY_DOCUMENTS_DIR;
+      } else {
+        process.env.INVENTORY_DOCUMENTS_DIR = original;
+      }
+      rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe('inventory.documentFiles.upload', () => {
+  it('writes the file to INVENTORY_DOCUMENTS_DIR with a sequential filename', async () => {
+    const env = withDocumentsDir('upload-happy');
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'Camera' });
+      const buffer = Buffer.from('%PDF-1.4 fake receipt body');
+
+      const result = await caller.inventory.documentFiles.upload({
+        itemId,
+        fileName: 'receipt.pdf',
+        mimeType: 'application/pdf',
+        fileBase64: buffer.toString('base64'),
+      });
+
+      expect(result.message).toBe('Document uploaded');
+      expect(result.data.itemId).toBe(itemId);
+      expect(result.data.fileName).toBe('receipt.pdf');
+      expect(result.data.mimeType).toBe('application/pdf');
+      expect(result.data.fileSize).toBe(buffer.byteLength);
+      expect(result.data.filePath).toMatch(/^items\/.+\/file_001\.pdf$/);
+
+      // File written to disk under the env-configured base dir.
+      const fullPath = join(env.tempDir, result.data.filePath);
+      expect(existsSync(fullPath)).toBe(true);
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('uses sequential filenames for repeated uploads on the same item', async () => {
+    const env = withDocumentsDir('upload-seq');
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'Camera' });
+      const buffer = Buffer.from('hello world');
+      const base64 = buffer.toString('base64');
+
+      const r1 = await caller.inventory.documentFiles.upload({
+        itemId,
+        fileName: 'first.txt',
+        mimeType: 'text/plain',
+        fileBase64: base64,
+      });
+      const r2 = await caller.inventory.documentFiles.upload({
+        itemId,
+        fileName: 'second.txt',
+        mimeType: 'text/plain',
+        fileBase64: base64,
+      });
+      const r3 = await caller.inventory.documentFiles.upload({
+        itemId,
+        fileName: 'third.txt',
+        mimeType: 'text/plain',
+        fileBase64: base64,
+      });
+
+      expect(r1.data.filePath).toMatch(/file_001\.txt$/);
+      expect(r2.data.filePath).toMatch(/file_002\.txt$/);
+      expect(r3.data.filePath).toMatch(/file_003\.txt$/);
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('persists a row to item_uploaded_files with the recorded metadata', async () => {
+    const env = withDocumentsDir('upload-db');
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'Camera' });
+      const buffer = Buffer.from('plain receipt');
+
+      const result = await caller.inventory.documentFiles.upload({
+        itemId,
+        fileName: 'receipt.txt',
+        mimeType: 'text/plain',
+        fileBase64: buffer.toString('base64'),
+      });
+
+      const row = db
+        .prepare('SELECT * FROM item_uploaded_files WHERE id = ?')
+        .get(result.data.id) as
+        | {
+            item_id: string;
+            file_name: string;
+            file_path: string;
+            mime_type: string;
+            file_size: number;
+          }
+        | undefined;
+
+      expect(row).toBeDefined();
+      expect(row!.item_id).toBe(itemId);
+      expect(row!.file_name).toBe('receipt.txt');
+      expect(row!.file_path).toMatch(/^items\/.+\/file_001\.txt$/);
+      expect(row!.mime_type).toBe('text/plain');
+      expect(row!.file_size).toBe(buffer.byteLength);
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('throws NOT_FOUND when item does not exist', async () => {
+    const env = withDocumentsDir('upload-notfound');
+    try {
+      await expect(
+        caller.inventory.documentFiles.upload({
+          itemId: 'does-not-exist',
+          fileName: 'x.pdf',
+          mimeType: 'application/pdf',
+          fileBase64: Buffer.from('hi').toString('base64'),
+        })
+      ).rejects.toThrow(TRPCError);
+
+      try {
+        await caller.inventory.documentFiles.upload({
+          itemId: 'does-not-exist',
+          fileName: 'x.pdf',
+          mimeType: 'application/pdf',
+          fileBase64: Buffer.from('hi').toString('base64'),
+        });
+      } catch (err) {
+        expect((err as TRPCError).code).toBe('NOT_FOUND');
+      }
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('rejects unsupported MIME types as BAD_REQUEST', async () => {
+    const env = withDocumentsDir('upload-mime');
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'Camera' });
+
+      await expect(
+        caller.inventory.documentFiles.upload({
+          itemId,
+          fileName: 'evil.exe',
+          mimeType: 'application/x-msdownload',
+          fileBase64: Buffer.from('MZ').toString('base64'),
+        })
+      ).rejects.toThrow(TRPCError);
+
+      try {
+        await caller.inventory.documentFiles.upload({
+          itemId,
+          fileName: 'evil.exe',
+          mimeType: 'application/x-msdownload',
+          fileBase64: Buffer.from('MZ').toString('base64'),
+        });
+      } catch (err) {
+        expect((err as TRPCError).code).toBe('BAD_REQUEST');
+      }
+    } finally {
+      env.restore();
+    }
+  });
+
+  it("rejects path traversal in user-supplied file names ('..')", async () => {
+    const env = withDocumentsDir('upload-traversal');
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'Camera' });
+
+      await expect(
+        caller.inventory.documentFiles.upload({
+          itemId,
+          fileName: '..',
+          mimeType: 'application/pdf',
+          fileBase64: Buffer.from('x').toString('base64'),
+        })
+      ).rejects.toThrow(TRPCError);
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('strips path components from a malicious file name (writes inside item dir)', async () => {
+    const env = withDocumentsDir('upload-strip');
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'Camera' });
+
+      // The service runs basename() on the supplied name then renames the
+      // on-disk file to `file_NNN.{ext}`, so a path-laden input cannot escape.
+      const result = await caller.inventory.documentFiles.upload({
+        itemId,
+        fileName: '../../etc/passwd',
+        mimeType: 'text/plain',
+        fileBase64: Buffer.from('x').toString('base64'),
+      });
+
+      // Output path must live under items/{itemId}/, not anywhere parent.
+      expect(result.data.filePath.startsWith(`items/${itemId}/`)).toBe(true);
+      expect(result.data.filePath).not.toContain('..');
+      // Stored file_name preserves the basename (no traversal segments).
+      expect(result.data.fileName).toBe('passwd');
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('throws UNAUTHORIZED without auth', async () => {
+    const env = withDocumentsDir('upload-auth');
+    try {
+      const unauth = createCaller(false);
+      await expect(
+        unauth.inventory.documentFiles.upload({
+          itemId: 'a',
+          fileName: 'x.pdf',
+          mimeType: 'application/pdf',
+          fileBase64: 'dGVzdA==',
+        })
+      ).rejects.toThrow(TRPCError);
+    } finally {
+      env.restore();
+    }
+  });
+});
+
+describe('inventory.documentFiles.listForItem', () => {
+  it('returns empty list when no files exist for the item', async () => {
+    const itemId = seedInventoryItem(db, { item_name: 'TV' });
+
+    const result = await caller.inventory.documentFiles.listForItem({ itemId });
+
+    expect(result.data).toEqual([]);
+    expect(result.pagination.total).toBe(0);
+  });
+
+  it('lists files newest-first and filters by item', async () => {
+    const itemA = seedInventoryItem(db, { item_name: 'TV' });
+    const itemB = seedInventoryItem(db, { item_name: 'Radio' });
+    const oldId = seedItemUploadedFile(db, {
+      item_id: itemA,
+      file_name: 'old.pdf',
+      file_path: `items/${itemA}/file_001.pdf`,
+    });
+    // Backdate the older row so ORDER BY uploaded_at DESC has something to do.
+    db.prepare(
+      "UPDATE item_uploaded_files SET uploaded_at = '2024-01-01 00:00:00' WHERE id = ?"
+    ).run(oldId);
+    seedItemUploadedFile(db, {
+      item_id: itemA,
+      file_name: 'new.pdf',
+      file_path: `items/${itemA}/file_002.pdf`,
+    });
+    seedItemUploadedFile(db, {
+      item_id: itemB,
+      file_name: 'other.pdf',
+      file_path: `items/${itemB}/file_001.pdf`,
+    });
+
+    const result = await caller.inventory.documentFiles.listForItem({ itemId: itemA });
+
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0]!.fileName).toBe('new.pdf');
+    expect(result.data[1]!.fileName).toBe('old.pdf');
+    expect(result.pagination.total).toBe(2);
+  });
+
+  it('paginates results', async () => {
+    const itemId = seedInventoryItem(db, { item_name: 'TV' });
+    for (let i = 0; i < 5; i++) {
+      seedItemUploadedFile(db, {
+        item_id: itemId,
+        file_name: `f${i}.pdf`,
+        file_path: `items/${itemId}/file_00${i + 1}.pdf`,
+      });
+    }
+
+    const page = await caller.inventory.documentFiles.listForItem({
+      itemId,
+      limit: 2,
+      offset: 0,
+    });
+
+    expect(page.data).toHaveLength(2);
+    expect(page.pagination.total).toBe(5);
+    expect(page.pagination.hasMore).toBe(true);
+  });
+});
+
+describe('inventory.documentFiles.removeUpload', () => {
+  it('removes the DB row and the on-disk file', async () => {
+    const env = withDocumentsDir('remove-disk');
+    try {
+      const itemId = seedInventoryItem(db, { item_name: 'TV' });
+      const filePath = `items/${itemId}/file_001.pdf`;
+      const fullPath = join(env.tempDir, filePath);
+      mkdirSync(join(env.tempDir, 'items', itemId), { recursive: true });
+      writeFileSync(fullPath, 'fake-pdf');
+
+      const id = seedItemUploadedFile(db, {
+        item_id: itemId,
+        file_name: 'receipt.pdf',
+        file_path: filePath,
+      });
+
+      expect(existsSync(fullPath)).toBe(true);
+
+      const result = await caller.inventory.documentFiles.removeUpload({ id });
+      expect(result.message).toBe('Document removed');
+
+      expect(existsSync(fullPath)).toBe(false);
+      const row = db.prepare('SELECT * FROM item_uploaded_files WHERE id = ?').get(id);
+      expect(row).toBeUndefined();
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('throws NOT_FOUND for a missing id', async () => {
+    await expect(caller.inventory.documentFiles.removeUpload({ id: 99999 })).rejects.toThrow(
+      TRPCError
+    );
+
+    try {
+      await caller.inventory.documentFiles.removeUpload({ id: 99999 });
+    } catch (err) {
+      expect((err as TRPCError).code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('does not error when the on-disk file is already missing', async () => {
+    const itemId = seedInventoryItem(db, { item_name: 'TV' });
+    const id = seedItemUploadedFile(db, {
+      item_id: itemId,
+      file_name: 'gone.pdf',
+      file_path: `items/${itemId}/file_999.pdf`,
+    });
+
+    const result = await caller.inventory.documentFiles.removeUpload({ id });
+    expect(result.message).toBe('Document removed');
+  });
+});
+
+describe('inventory item cascade — uploaded files', () => {
+  it('cascades deletes when the parent inventory item is removed', async () => {
+    const itemId = seedInventoryItem(db, { item_name: 'TV' });
+    seedItemUploadedFile(db, {
+      item_id: itemId,
+      file_name: 'a.pdf',
+      file_path: `items/${itemId}/file_001.pdf`,
+    });
+    seedItemUploadedFile(db, {
+      item_id: itemId,
+      file_name: 'b.pdf',
+      file_path: `items/${itemId}/file_002.pdf`,
+    });
+
+    db.prepare('DELETE FROM home_inventory WHERE id = ?').run(itemId);
+
+    const remaining = db
+      .prepare('SELECT COUNT(*) AS c FROM item_uploaded_files WHERE item_id = ?')
+      .get(itemId) as { c: number };
+    expect(remaining.c).toBe(0);
+  });
+});
+
+describe('inventory.documentFiles auth', () => {
+  it('throws UNAUTHORIZED on listForItem without auth', async () => {
+    const unauth = createCaller(false);
+    await expect(unauth.inventory.documentFiles.listForItem({ itemId: 'a' })).rejects.toThrow(
+      TRPCError
+    );
+  });
+
+  it('throws UNAUTHORIZED on removeUpload without auth', async () => {
+    const unauth = createCaller(false);
+    await expect(unauth.inventory.documentFiles.removeUpload({ id: 1 })).rejects.toThrow(TRPCError);
+  });
+});

--- a/apps/pops-api/src/modules/inventory/document-files/index.ts
+++ b/apps/pops-api/src/modules/inventory/document-files/index.ts
@@ -1,0 +1,1 @@
+export { documentFilesRouter } from './router.js';

--- a/apps/pops-api/src/modules/inventory/document-files/paths.ts
+++ b/apps/pops-api/src/modules/inventory/document-files/paths.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared filesystem path helpers for inventory direct-upload documents.
+ *
+ * Used by both the upload service (writes files) and the static file route
+ * (reads files), so the env var resolution and default fallback live in one
+ * place to avoid drift.
+ *
+ * Mirrors the photos module's `paths.ts` but reads `INVENTORY_DOCUMENTS_DIR`
+ * so document blobs can live on a separate disk/volume from photos if desired.
+ */
+import { resolve } from 'node:path';
+
+const DEFAULT_INVENTORY_DOCUMENTS_DIR = './data/inventory/documents';
+
+/**
+ * Resolve the absolute base directory for inventory item document uploads.
+ *
+ * Reads `INVENTORY_DOCUMENTS_DIR` from the environment, falling back to
+ * `./data/inventory/documents` (relative to the API process cwd).
+ */
+export function getInventoryDocumentsDir(): string {
+  const dir = process.env.INVENTORY_DOCUMENTS_DIR ?? DEFAULT_INVENTORY_DOCUMENTS_DIR;
+  return resolve(dir);
+}

--- a/apps/pops-api/src/modules/inventory/document-files/router.ts
+++ b/apps/pops-api/src/modules/inventory/document-files/router.ts
@@ -1,0 +1,75 @@
+/**
+ * Item uploaded files tRPC router — direct (non-Paperless) document uploads
+ * attached to an inventory item. Mirrors `inventory.photos.*` but for
+ * arbitrary file types (PDF, images, text).
+ */
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { NotFoundError, ValidationError } from '../../../shared/errors.js';
+import { paginationMeta } from '../../../shared/pagination.js';
+import { protectedProcedure, router } from '../../../trpc.js';
+import * as service from './service.js';
+import { DocumentFileQuerySchema, toUploadedFile, UploadDocumentSchema } from './types.js';
+
+const DEFAULT_LIMIT = 50;
+const DEFAULT_OFFSET = 0;
+
+export const documentFilesRouter = router({
+  /**
+   * Upload a document for an inventory item. Accepts base64-encoded file bytes,
+   * writes to `{INVENTORY_DOCUMENTS_DIR}/items/{itemId}/file_NNN.{ext}`, and
+   * creates a DB record with file metadata.
+   */
+  upload: protectedProcedure.input(UploadDocumentSchema).mutation(({ input }) => {
+    try {
+      const buffer = Buffer.from(input.fileBase64, 'base64');
+      const row = service.uploadDocument({
+        itemId: input.itemId,
+        fileName: input.fileName,
+        mimeType: input.mimeType,
+        buffer,
+      });
+      return {
+        data: toUploadedFile(row),
+        message: 'Document uploaded',
+      };
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+      }
+      if (err instanceof ValidationError) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: err.message });
+      }
+      throw err;
+    }
+  }),
+
+  /** Remove an uploaded document by ID. */
+  removeUpload: protectedProcedure
+    .input(z.object({ id: z.number().int().positive() }))
+    .mutation(({ input }) => {
+      try {
+        service.removeUpload(input.id);
+        return { message: 'Document removed' };
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+        }
+        throw err;
+      }
+    }),
+
+  /** List uploaded documents for an item, newest first. */
+  listForItem: protectedProcedure.input(DocumentFileQuerySchema).query(({ input }) => {
+    const limit = input.limit ?? DEFAULT_LIMIT;
+    const offset = input.offset ?? DEFAULT_OFFSET;
+
+    const { rows, total } = service.listUploadsForItem(input.itemId, limit, offset);
+
+    return {
+      data: rows.map(toUploadedFile),
+      pagination: paginationMeta(total, limit, offset),
+    };
+  }),
+});

--- a/apps/pops-api/src/modules/inventory/document-files/service.ts
+++ b/apps/pops-api/src/modules/inventory/document-files/service.ts
@@ -1,0 +1,172 @@
+/**
+ * Item uploaded files service — direct (non-Paperless) uploads attached to an
+ * inventory item. Mirrors the photos service: writes the bytes to disk under
+ * `INVENTORY_DOCUMENTS_DIR/items/{itemId}/`, then records a DB row.
+ */
+import { existsSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+
+import { desc, count, eq } from 'drizzle-orm';
+
+import { homeInventory, itemUploadedFiles } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
+import { NotFoundError, ValidationError } from '../../../shared/errors.js';
+import { getInventoryDocumentsDir } from './paths.js';
+import {
+  ALLOWED_MIME_PREFIXES,
+  MAX_FILE_SIZE_BYTES,
+  type ItemUploadedFileRow,
+  type UploadDocumentInput,
+} from './types.js';
+
+/** Count + rows for a paginated list. */
+export interface UploadedFileListResult {
+  rows: ItemUploadedFileRow[];
+  total: number;
+}
+
+/** Validate that an inventory item exists. */
+function assertItemExists(itemId: string): void {
+  const db = getDrizzle();
+  const [item] = db
+    .select({ id: homeInventory.id })
+    .from(homeInventory)
+    .where(eq(homeInventory.id, itemId))
+    .all();
+  if (!item) throw new NotFoundError('Inventory item', itemId);
+}
+
+/** Get a single uploaded file by ID. Throws NotFoundError if missing. */
+function getUploadedFile(id: number): ItemUploadedFileRow {
+  const db = getDrizzle();
+  const [row] = db.select().from(itemUploadedFiles).where(eq(itemUploadedFiles.id, id)).all();
+  if (!row) throw new NotFoundError('Item uploaded file', String(id));
+  return row;
+}
+
+/**
+ * Reject path-traversal attempts and disallowed characters in a user-supplied
+ * file name. We strip the directory portion (basename) and check the result
+ * is non-empty and free of slashes / `..`.
+ */
+function sanitiseUploadFileName(rawName: string): string {
+  const trimmed = rawName.trim();
+  if (!trimmed) throw new ValidationError('File name is required');
+  // basename() handles both `/` and Windows-style `\` separators on POSIX.
+  const last = trimmed.split(/[\\/]/).pop() ?? '';
+  if (!last || last === '.' || last === '..' || last.includes('/') || last.includes('\\')) {
+    throw new ValidationError('Invalid file name');
+  }
+  return last;
+}
+
+function assertAllowedMime(mimeType: string): void {
+  const ok = ALLOWED_MIME_PREFIXES.some((prefix) =>
+    prefix.endsWith('/') ? mimeType.startsWith(prefix) : mimeType === prefix
+  );
+  if (!ok) {
+    throw new ValidationError(
+      `Unsupported MIME type: ${mimeType}. Allowed: PDF, images, plain text.`
+    );
+  }
+}
+
+function assertWithinSizeLimit(buffer: Buffer): void {
+  if (buffer.byteLength > MAX_FILE_SIZE_BYTES) {
+    throw new ValidationError(
+      `File too large: ${buffer.byteLength} bytes (max ${MAX_FILE_SIZE_BYTES})`
+    );
+  }
+}
+
+/**
+ * Determine the next sequential file path within an item's directory.
+ * Returns a path like `items/{itemId}/file_001.pdf`. Sequence is shared
+ * across all extensions so two uploads on the same item never collide.
+ */
+function nextFilenameForItem(baseDir: string, itemId: string, originalName: string): string {
+  const itemDir = join(baseDir, 'items', itemId);
+  mkdirSync(itemDir, { recursive: true });
+
+  const existing = existsSync(itemDir)
+    ? readdirSync(itemDir).filter((f) => /^file_\d+\./.test(f))
+    : [];
+
+  const nextNum = existing.length + 1;
+  const seq = String(nextNum).padStart(3, '0');
+  // Preserve the original extension (lower-cased) so MIME type detection works
+  // for the static-file route. Default to `.bin` if extension missing.
+  const ext = extname(originalName).toLowerCase() || '.bin';
+  return join('items', itemId, `file_${seq}${ext}`);
+}
+
+/** Upload a document and attach it to an inventory item. */
+export function uploadDocument(input: UploadDocumentInput): ItemUploadedFileRow {
+  const db = getDrizzle();
+
+  assertItemExists(input.itemId);
+  const safeName = sanitiseUploadFileName(input.fileName);
+  assertAllowedMime(input.mimeType);
+  assertWithinSizeLimit(input.buffer);
+
+  const baseDir = getInventoryDocumentsDir();
+  const relPath = nextFilenameForItem(baseDir, input.itemId, safeName);
+  const fullPath = resolve(baseDir, relPath);
+  writeFileSync(fullPath, input.buffer);
+
+  const result = db
+    .insert(itemUploadedFiles)
+    .values({
+      itemId: input.itemId,
+      fileName: safeName,
+      filePath: relPath,
+      mimeType: input.mimeType,
+      fileSize: input.buffer.byteLength,
+    })
+    .run();
+
+  const id = Number(result.lastInsertRowid);
+  return getUploadedFile(id);
+}
+
+/** Remove an uploaded file by ID. Deletes both the DB record and the disk file. */
+export function removeUpload(id: number): void {
+  const file = getUploadedFile(id); // Validates existence
+
+  // Delete file from disk (best-effort — missing file is not an error)
+  const baseDir = getInventoryDocumentsDir();
+  const fullPath = resolve(baseDir, file.filePath);
+  if (existsSync(fullPath)) {
+    unlinkSync(fullPath);
+  }
+
+  const db = getDrizzle();
+  db.delete(itemUploadedFiles).where(eq(itemUploadedFiles.id, id)).run();
+}
+
+/** List uploaded files for an item, newest first. */
+export function listUploadsForItem(
+  itemId: string,
+  limit: number,
+  offset: number
+): UploadedFileListResult {
+  const db = getDrizzle();
+
+  const rows = db
+    .select()
+    .from(itemUploadedFiles)
+    .where(eq(itemUploadedFiles.itemId, itemId))
+    .orderBy(desc(itemUploadedFiles.uploadedAt), desc(itemUploadedFiles.id))
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [countResult] = db
+    .select({ total: count() })
+    .from(itemUploadedFiles)
+    .where(eq(itemUploadedFiles.itemId, itemId))
+    .all();
+
+  return { rows, total: countResult?.total ?? 0 };
+}

--- a/apps/pops-api/src/modules/inventory/document-files/types.ts
+++ b/apps/pops-api/src/modules/inventory/document-files/types.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+
+import type { ItemUploadedFileRow } from '@pops/db-types';
+
+export type { ItemUploadedFileRow };
+
+/** API response shape for an item uploaded file. */
+export interface ItemUploadedFile {
+  id: number;
+  itemId: string;
+  fileName: string;
+  filePath: string;
+  mimeType: string;
+  fileSize: number;
+  uploadedAt: string;
+  createdAt: string;
+}
+
+/** Map a SQLite row to the API response shape. */
+export function toUploadedFile(row: ItemUploadedFileRow): ItemUploadedFile {
+  return {
+    id: row.id,
+    itemId: row.itemId,
+    fileName: row.fileName,
+    filePath: row.filePath,
+    mimeType: row.mimeType,
+    fileSize: row.fileSize,
+    uploadedAt: row.uploadedAt,
+    createdAt: row.createdAt,
+  };
+}
+
+/** Allow PDFs, images, and plain text — same as the UI file picker. */
+export const ALLOWED_MIME_PREFIXES = ['application/pdf', 'image/', 'text/'] as const;
+
+/**
+ * Hard cap on accepted upload bytes (10 MiB). Direct uploads are stored on
+ * the API filesystem; we do not want to ship multi-hundred-MB blobs through
+ * a tRPC base64 payload.
+ */
+export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Server-side input for {@link uploadDocument}. The router decodes
+ * `fileBase64` to a Buffer before calling.
+ */
+export interface UploadDocumentInput {
+  itemId: string;
+  fileName: string;
+  mimeType: string;
+  buffer: Buffer;
+}
+
+/** Zod schema for the upload procedure (used by the tRPC router). */
+export const UploadDocumentSchema = z.object({
+  itemId: z.string().min(1, 'Item ID is required'),
+  fileName: z.string().min(1, 'File name is required').max(255, 'File name too long'),
+  mimeType: z.string().min(1, 'MIME type is required'),
+  /** Base64-encoded file bytes. The router decodes this to a Buffer. */
+  fileBase64: z.string().min(1, 'File content is required'),
+});
+export type UploadDocumentSchemaInput = z.infer<typeof UploadDocumentSchema>;
+
+/** Zod schema for listing uploaded files for an item. */
+export const DocumentFileQuerySchema = z.object({
+  itemId: z.string().min(1, 'Item ID is required'),
+  limit: z.coerce.number().positive().max(500).optional(),
+  offset: z.coerce.number().nonnegative().optional(),
+});
+export type DocumentFileQuery = z.infer<typeof DocumentFileQuerySchema>;

--- a/apps/pops-api/src/modules/inventory/index.ts
+++ b/apps/pops-api/src/modules/inventory/index.ts
@@ -6,6 +6,7 @@ import './items/search-adapter.js';
 
 import { router } from '../../trpc.js';
 import { connectionsRouter } from './connections/index.js';
+import { documentFilesRouter } from './document-files/index.js';
 import { documentsRouter } from './documents/index.js';
 import { inventoryRouter as itemsRouter } from './items/router.js';
 import { locationsRouter } from './locations/router.js';
@@ -20,5 +21,6 @@ export const inventoryRouter = router({
   photos: photosRouter,
   reports: reportsRouter,
   documents: documentsRouter,
+  documentFiles: documentFilesRouter,
   paperless: paperlessRouter,
 });

--- a/apps/pops-api/src/routes/inventory/document-files.test.ts
+++ b/apps/pops-api/src/routes/inventory/document-files.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the inventory direct-upload document static-file route.
+ *
+ * The route is filesystem-only (no DB), so we exercise it with real fixture
+ * files in a temp dir set as INVENTORY_DOCUMENTS_DIR.
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import documentFilesRouter from './document-files.js';
+
+let tempDir: string;
+let originalEnv: string | undefined;
+
+function createTestApp(): express.Express {
+  const app = express();
+  app.use(documentFilesRouter);
+  return app;
+}
+
+const ITEM_ID = 'abc123def456789012345678901234ab';
+
+beforeEach(() => {
+  tempDir = join(
+    tmpdir(),
+    `pops-doc-files-route-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(tempDir, { recursive: true });
+  originalEnv = process.env.INVENTORY_DOCUMENTS_DIR;
+  process.env.INVENTORY_DOCUMENTS_DIR = tempDir;
+});
+
+afterEach(() => {
+  if (originalEnv === undefined) {
+    delete process.env.INVENTORY_DOCUMENTS_DIR;
+  } else {
+    process.env.INVENTORY_DOCUMENTS_DIR = originalEnv;
+  }
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('GET /api/inventory/documents/items/:itemId/:filename', () => {
+  describe('successful serving', () => {
+    it('serves an existing PDF with content-type application/pdf and cache headers', async () => {
+      const itemDir = join(tempDir, 'items', ITEM_ID);
+      mkdirSync(itemDir, { recursive: true });
+      const fileBytes = Buffer.from('%PDF-1.4 minimal');
+      writeFileSync(join(itemDir, 'file_001.pdf'), fileBytes);
+
+      const app = createTestApp();
+      const res = await request(app).get(`/api/inventory/documents/items/${ITEM_ID}/file_001.pdf`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('application/pdf');
+      expect(res.headers['cache-control']).toBe('private, max-age=3600');
+      expect(res.headers['etag']).toBeDefined();
+      expect(res.body).toEqual(fileBytes);
+    });
+
+    it('serves a plain-text upload with text/plain content-type', async () => {
+      const itemDir = join(tempDir, 'items', ITEM_ID);
+      mkdirSync(itemDir, { recursive: true });
+      const text = Buffer.from('hello world\n');
+      writeFileSync(join(itemDir, 'file_002.txt'), text);
+
+      const app = createTestApp();
+      const res = await request(app).get(`/api/inventory/documents/items/${ITEM_ID}/file_002.txt`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/plain');
+      expect(res.text).toBe('hello world\n');
+    });
+  });
+
+  describe('not found', () => {
+    it('returns 404 when the item directory does not exist', async () => {
+      const app = createTestApp();
+      const res = await request(app).get(`/api/inventory/documents/items/${ITEM_ID}/file_001.pdf`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Document not found');
+    });
+
+    it('returns 404 when the file is missing inside an existing item dir', async () => {
+      mkdirSync(join(tempDir, 'items', ITEM_ID), { recursive: true });
+      const app = createTestApp();
+
+      const res = await request(app).get(`/api/inventory/documents/items/${ITEM_ID}/file_999.pdf`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Document not found');
+    });
+  });
+
+  describe('parameter validation', () => {
+    it('returns 400 for an itemId containing path traversal segments', async () => {
+      const app = createTestApp();
+      const res = await request(app).get(
+        '/api/inventory/documents/items/..%2Fetc%2Fpasswd/file_001.pdf'
+      );
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid item id');
+    });
+
+    it('returns 400 for filename without sequence number', async () => {
+      const app = createTestApp();
+      const res = await request(app).get(`/api/inventory/documents/items/${ITEM_ID}/file_.pdf`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid filename');
+    });
+
+    it('returns 400 for filename without an extension', async () => {
+      const app = createTestApp();
+      const res = await request(app).get(`/api/inventory/documents/items/${ITEM_ID}/file_001`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid filename');
+    });
+  });
+});

--- a/apps/pops-api/src/routes/inventory/document-files.ts
+++ b/apps/pops-api/src/routes/inventory/document-files.ts
@@ -1,0 +1,89 @@
+/**
+ * Express route for serving uploaded inventory item documents (direct uploads,
+ * not Paperless-linked).
+ *
+ * GET /api/inventory/documents/items/:itemId/:filename
+ *
+ * Static file serving from `INVENTORY_DOCUMENTS_DIR`
+ * (default: `./data/inventory/documents`). Mounted before auth middleware
+ * — these are user-uploaded blobs that the frontend pulls via plain
+ * `<a href>` download links, so cookie/JWT auth would block downloads.
+ *
+ * Path resolution is sandboxed: the resolved file path must live inside the
+ * configured base dir, and `itemId` / `filename` are validated against strict
+ * patterns to reject path traversal attempts.
+ *
+ * Mirrors `routes/inventory/photos.ts` (the #2178 fix for photo serving), but
+ * with a wider allowlist of file extensions because direct uploads accept
+ * PDFs, images, and plain text.
+ */
+import { resolve } from 'node:path';
+
+import { type Router as ExpressRouter, type Request, Router } from 'express';
+
+import { getInventoryDocumentsDir } from '../../modules/inventory/document-files/paths.js';
+import { tryServeFile } from '../media/images-helpers.js';
+
+/** Cache for one hour — uploaded documents can change on re-upload. */
+const CACHE_CONTROL = 'private, max-age=3600';
+
+/** Item IDs are 32-char hex blobs in prod; e2e seeds use simple `inv-NNN` ids. */
+const ITEM_ID_RE = /^[a-z0-9-]+$/i;
+
+/** Document filenames follow `file_NNN.{ext}` written by `service.ts`. */
+const FILENAME_RE = /^file_\d+\.[a-z0-9]+$/i;
+
+interface ValidationFailure {
+  status: number;
+  body: { error: string };
+}
+
+interface ValidatedParams {
+  itemId: string;
+  filename: string;
+}
+
+function validateParams(req: Request): ValidatedParams | ValidationFailure {
+  const itemId = String(req.params['itemId'] ?? '');
+  const filename = String(req.params['filename'] ?? '');
+
+  if (!itemId || itemId.includes('..') || itemId.includes('/') || !ITEM_ID_RE.test(itemId)) {
+    return { status: 400, body: { error: `Invalid item id: ${itemId}` } };
+  }
+  if (!FILENAME_RE.test(filename)) {
+    return { status: 400, body: { error: `Invalid filename: ${filename}` } };
+  }
+  return { itemId, filename };
+}
+
+function isValidationFailure(
+  value: ValidatedParams | ValidationFailure
+): value is ValidationFailure {
+  return 'status' in value;
+}
+
+const router: ExpressRouter = Router();
+
+router.get('/api/inventory/documents/items/:itemId/:filename', async (req, res): Promise<void> => {
+  const params = validateParams(req);
+  if (isValidationFailure(params)) {
+    res.status(params.status).json(params.body);
+    return;
+  }
+
+  const baseDir = getInventoryDocumentsDir();
+  const filePath = resolve(baseDir, 'items', params.itemId, params.filename);
+
+  // Sandbox check: the resolved path must live inside the base dir.
+  if (!filePath.startsWith(baseDir + '/') && filePath !== baseDir) {
+    res.status(400).json({ error: 'Invalid path' });
+    return;
+  }
+
+  const served = await tryServeFile(filePath, res, CACHE_CONTROL);
+  if (served) return;
+
+  res.status(404).json({ error: 'Document not found' });
+});
+
+export default router;

--- a/apps/pops-api/src/routes/media/images-helpers.ts
+++ b/apps/pops-api/src/routes/media/images-helpers.ts
@@ -6,7 +6,16 @@ import type { Response } from 'express';
 
 const CONTENT_TYPES: Record<string, string> = {
   '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
   '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.heic': 'image/heic',
+  '.heif': 'image/heif',
+  '.pdf': 'application/pdf',
+  '.txt': 'text/plain; charset=utf-8',
+  '.md': 'text/markdown; charset=utf-8',
+  '.csv': 'text/csv; charset=utf-8',
 };
 
 /** Cache for 7 days, revalidate via ETag after that. */

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -412,6 +412,19 @@ export function createTestDb(): Database {
     CREATE INDEX IF NOT EXISTS idx_item_documents_item ON item_documents(item_id);
     CREATE INDEX IF NOT EXISTS idx_item_documents_doc ON item_documents(paperless_document_id);
 
+    CREATE TABLE IF NOT EXISTS item_uploaded_files (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      item_id     TEXT NOT NULL,
+      file_name   TEXT NOT NULL,
+      file_path   TEXT NOT NULL,
+      mime_type   TEXT NOT NULL,
+      file_size   INTEGER NOT NULL,
+      uploaded_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (item_id) REFERENCES home_inventory(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_item_uploaded_files_item ON item_uploaded_files(item_id);
+
     CREATE TABLE IF NOT EXISTS ai_inference_log (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       provider TEXT NOT NULL DEFAULT 'claude',
@@ -949,6 +962,35 @@ export function seedItemDocument(
       title: overrides.title ?? null,
     });
 
+  return Number(result.lastInsertRowid);
+}
+
+/**
+ * Seed a single uploaded-file row (direct, non-Paperless) into the test DB.
+ * Returns the auto-generated id.
+ */
+export function seedItemUploadedFile(
+  db: Database,
+  overrides: {
+    item_id: string;
+    file_name?: string;
+    file_path?: string;
+    mime_type?: string;
+    file_size?: number;
+  }
+): number {
+  const result = db
+    .prepare(
+      `INSERT INTO item_uploaded_files (item_id, file_name, file_path, mime_type, file_size)
+       VALUES (@item_id, @file_name, @file_path, @mime_type, @file_size)`
+    )
+    .run({
+      item_id: overrides.item_id,
+      file_name: overrides.file_name ?? 'receipt.pdf',
+      file_path: overrides.file_path ?? `items/${overrides.item_id}/file_001.pdf`,
+      mime_type: overrides.mime_type ?? 'application/pdf',
+      file_size: overrides.file_size ?? 1024,
+    });
   return Number(result.lastInsertRowid);
 }
 

--- a/apps/pops-shell/e2e/inventory-document-upload.spec.ts
+++ b/apps/pops-shell/e2e/inventory-document-upload.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Tier 3 — Inventory: document upload, download link, and delete on item (#2126)
+ *
+ * Flow:
+ *   1. Pre-clean: remove any uploaded documents previously attached to the
+ *      test item so the test is idempotent against the long-lived `e2e`
+ *      SQLite environment.
+ *   2. Navigate to the item edit page (the only place the document upload
+ *      surface is exposed).
+ *   3. Upload a small text fixture via the hidden Documents `<input
+ *      type="file">`. The form's document section uploads immediately on
+ *      file select, mirroring the photo flow.
+ *   4. Wait for the new row to appear in the documents list and assert the
+ *      download link is non-empty.
+ *   5. Click the row's trash button, confirm the inline prompt, and assert
+ *      the row is removed.
+ *
+ * Idempotency: a beforeEach + afterEach pair drains all uploaded documents
+ * for the test item via `inventory.documentFiles.removeUpload`.
+ */
+import { expect, test, type APIRequestContext } from '@playwright/test';
+
+import { useRealApi } from './helpers/use-real-api';
+
+const TEST_ITEM_ID = 'inv-006'; // HDMI Cable — no seeded uploaded files.
+const E2E_ENV = 'e2e';
+const DOCUMENT_ROW = '[data-testid="document-row"]';
+
+interface DocumentListResponse {
+  result: { data: { data: { id: number; fileName: string; filePath: string }[] } };
+}
+
+/** List all uploaded documents for the test item via the real API. */
+async function listDocuments(
+  req: APIRequestContext
+): Promise<{ id: number; fileName: string; filePath: string }[]> {
+  const input = encodeURIComponent(JSON.stringify({ itemId: TEST_ITEM_ID }));
+  const res = await req.get(
+    `http://localhost:3000/trpc/inventory.documentFiles.listForItem?env=${E2E_ENV}&input=${input}`
+  );
+  if (!res.ok()) throw new Error(`listDocuments failed: ${res.status()}`);
+  const body = (await res.json()) as DocumentListResponse;
+  return body.result.data.data;
+}
+
+/** Delete every uploaded document currently attached to the test item. */
+async function purgeDocuments(req: APIRequestContext): Promise<void> {
+  const documents = await listDocuments(req);
+  for (const doc of documents) {
+    const res = await req.post(
+      `http://localhost:3000/trpc/inventory.documentFiles.removeUpload?env=${E2E_ENV}`,
+      { data: { id: doc.id } }
+    );
+    if (!res.ok()) throw new Error(`purgeDocuments failed for ${doc.id}: ${res.status()}`);
+  }
+}
+
+test.describe('Inventory — document upload, download, delete (#2126)', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await purgeDocuments(request);
+    await useRealApi(page);
+  });
+
+  test.afterEach(async ({ page, request }) => {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    await purgeDocuments(request);
+  });
+
+  test('uploads a document, exposes a download link, then deletes it', async ({ page }) => {
+    // ---------------------------------------------------------------------
+    // 1. Open the item edit page and locate the Documents section.
+    // ---------------------------------------------------------------------
+    await page.goto(`/inventory/items/${TEST_ITEM_ID}/edit`);
+    await expect(page.getByRole('heading', { name: 'Documents' })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // The empty-state placeholder is shown when no documents exist.
+    await expect(page.getByTestId('document-list-empty')).toBeVisible();
+
+    // ---------------------------------------------------------------------
+    // 2. Upload a small text fixture via the hidden <input type="file">
+    //    inside the document upload section.
+    // ---------------------------------------------------------------------
+    const fileInput = page.locator('[data-testid="document-upload-input"]');
+    const fixtureName = `e2e-receipt-${Date.now()}.txt`;
+    await fileInput.setInputFiles({
+      name: fixtureName,
+      mimeType: 'text/plain',
+      buffer: Buffer.from('e2e document upload fixture body\n'),
+    });
+
+    // ---------------------------------------------------------------------
+    // 3. Row appears in the list with the original filename and a working
+    //    download link.
+    // ---------------------------------------------------------------------
+    await expect(page.locator(DOCUMENT_ROW)).toHaveCount(1, { timeout: 15_000 });
+    const row = page.locator(DOCUMENT_ROW).first();
+    await expect(row).toContainText(fixtureName);
+
+    const downloadLink = row.locator('[data-testid="document-download-link"]');
+    const href = await downloadLink.getAttribute('href');
+    expect(href).toBeTruthy();
+    expect(href).not.toBe('');
+    expect(href).toMatch(/\/api\/inventory\/documents\/items\//);
+
+    // ---------------------------------------------------------------------
+    // 4. Delete via the per-row trash button + inline confirmation strip.
+    // ---------------------------------------------------------------------
+    await row.locator('[data-testid="document-delete-button"]').click();
+    await expect(page.getByText(/Delete this document\? This cannot be undone\./)).toBeVisible();
+    await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+    await expect(page.locator(DOCUMENT_ROW)).toHaveCount(0, { timeout: 15_000 });
+    await expect(page.getByTestId('document-list-empty')).toBeVisible();
+  });
+});

--- a/apps/pops-shell/e2e/inventory-photo-upload-reorder.spec.ts
+++ b/apps/pops-shell/e2e/inventory-photo-upload-reorder.spec.ts
@@ -132,7 +132,7 @@ test.describe('Inventory — photo upload, reorder, delete (#2125)', () => {
     await page.goto(`/inventory/items/${TEST_ITEM_ID}/edit`);
     await expect(page.getByRole('heading', { name: 'Photos' })).toBeVisible({ timeout: 15_000 });
 
-    const fileInput = page.locator('input[type="file"][multiple]');
+    const fileInput = page.getByTestId('photo-upload-input');
     await fileInput.setInputFiles([loadFixture(FIXTURE_RED), loadFixture(FIXTURE_BLUE)]);
 
     // SortablePhotoGrid renders one cell per existing photo. Wait for both.

--- a/packages/app-inventory/src/components/DocumentList.tsx
+++ b/packages/app-inventory/src/components/DocumentList.tsx
@@ -1,0 +1,118 @@
+import { Download, FileText, Trash2 } from 'lucide-react';
+
+import { Button, formatBytes, formatDate } from '@pops/ui';
+
+export interface DocumentItem {
+  id: number;
+  itemId: string;
+  fileName: string;
+  filePath: string;
+  mimeType: string;
+  fileSize: number;
+  uploadedAt: string;
+}
+
+interface DocumentListProps {
+  documents: DocumentItem[];
+  onDelete?: (id: number) => void;
+  /** Base URL prefix for download links (default: "/api/inventory/documents"). */
+  baseUrl?: string;
+}
+
+/**
+ * Encode each path segment individually so slashes survive the URL —
+ * `encodeURIComponent(filePath)` would turn `items/{id}/file_001.pdf` into
+ * `items%2F{id}%2Ffile_001.pdf`, which Express routes as a single segment.
+ */
+function buildDownloadHref(baseUrl: string, filePath: string): string {
+  return `${baseUrl}/${filePath.split('/').map(encodeURIComponent).join('/')}`;
+}
+
+function EmptyState() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center py-8 text-muted-foreground"
+      data-testid="document-list-empty"
+    >
+      <FileText className="h-12 w-12 mb-2 opacity-30" />
+      <p className="text-sm">No documents yet</p>
+    </div>
+  );
+}
+
+function DocumentRow({
+  doc,
+  href,
+  onDelete,
+}: {
+  doc: DocumentItem;
+  href: string;
+  onDelete?: (id: number) => void;
+}) {
+  return (
+    <li
+      role="listitem"
+      aria-label={`Document ${doc.fileName}`}
+      className="flex items-center gap-3 rounded-md border border-border p-3"
+      data-testid="document-row"
+      data-document-id={doc.id}
+    >
+      <div className="h-10 w-10 shrink-0 rounded bg-muted flex items-center justify-center">
+        <FileText className="h-5 w-5 text-muted-foreground" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium truncate" title={doc.fileName}>
+          {doc.fileName}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {formatDate(doc.uploadedAt, 'medium')} · {formatBytes(doc.fileSize)}
+        </p>
+      </div>
+      <Button asChild variant="outline" size="sm">
+        <a
+          href={href}
+          download={doc.fileName}
+          aria-label={`Download ${doc.fileName}`}
+          data-testid="document-download-link"
+        >
+          <Download className="h-4 w-4 mr-1.5" />
+          Download
+        </a>
+      </Button>
+      {onDelete && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => onDelete(doc.id)}
+          aria-label={`Delete document ${doc.fileName}`}
+          data-testid="document-delete-button"
+        >
+          <Trash2 className="h-4 w-4 text-destructive" />
+        </Button>
+      )}
+    </li>
+  );
+}
+
+export function DocumentList({
+  documents,
+  onDelete,
+  baseUrl = '/api/inventory/documents',
+}: DocumentListProps) {
+  if (documents.length === 0) return <EmptyState />;
+
+  return (
+    <ul className="space-y-2" data-testid="document-list">
+      {documents.map((doc) => (
+        <DocumentRow
+          key={doc.id}
+          doc={doc}
+          href={buildDownloadHref(baseUrl, doc.filePath)}
+          onDelete={onDelete}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/packages/app-inventory/src/components/DocumentUpload.tsx
+++ b/packages/app-inventory/src/components/DocumentUpload.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useRef, useState } from 'react';
+
+import { cn } from '../lib/utils';
+import { PendingDocumentRow } from './document-upload/PendingDocumentRow';
+import { DropZone } from './photo-upload/DropZone';
+
+/**
+ * Pending in-flight upload entry tracked client-side. Distinct from
+ * `UploadedFile` (used by `PhotoUpload`) because document uploads have no
+ * thumbnail preview / pre-compression sizes — just the raw File and its
+ * progress.
+ */
+export interface PendingDocumentFile {
+  /** Client-side identifier for tracking. */
+  localId: string;
+  file: File;
+  status: 'pending' | 'uploading' | 'done' | 'error';
+  /** Upload progress 0–100. */
+  progress?: number;
+  /** Error message if `status === 'error'`. */
+  error?: string;
+}
+
+interface DocumentUploadProps {
+  /** Called when files are selected. Parent handles the actual upload. */
+  onFilesSelected: (files: File[]) => void;
+  /** Currently tracked files with their upload status. */
+  files?: PendingDocumentFile[];
+  /** Remove a file from the queue. */
+  onRemove?: (localId: string) => void;
+  /** Max file size in MB (default: 10). */
+  maxSizeMb?: number;
+  /** Accepted file types (default: PDF + image + plain text). */
+  accept?: string;
+  /** Whether uploads are currently in progress. */
+  disabled?: boolean;
+  className?: string;
+}
+
+const DEFAULT_MAX_SIZE_MB = 10;
+const DEFAULT_ACCEPT =
+  'application/pdf,image/jpeg,image/png,image/webp,image/heic,image/heif,text/plain,text/markdown,text/csv,.pdf,.txt,.md,.csv';
+
+const ALLOWED_PREFIXES = ['application/pdf', 'image/', 'text/'];
+const ALLOWED_EXTENSIONS = /\.(pdf|jpe?g|png|webp|heic|heif|gif|txt|md|csv)$/i;
+
+function isAllowedType(file: File): boolean {
+  if (
+    file.type &&
+    ALLOWED_PREFIXES.some((p) => (p.endsWith('/') ? file.type.startsWith(p) : file.type === p))
+  ) {
+    return true;
+  }
+  // Some browsers report empty `type` for text uploads; fall back to extension.
+  return ALLOWED_EXTENSIONS.test(file.name);
+}
+
+function validateFiles(fileList: File[], maxSizeMb: number): { valid: File[]; errors: string[] } {
+  const maxBytes = maxSizeMb * 1024 * 1024;
+  const valid: File[] = [];
+  const errors: string[] = [];
+
+  for (const file of fileList) {
+    if (!isAllowedType(file)) {
+      errors.push(`${file.name}: unsupported file type`);
+      continue;
+    }
+    if (file.size > maxBytes) {
+      errors.push(`${file.name}: exceeds ${maxSizeMb}MB limit`);
+      continue;
+    }
+    valid.push(file);
+  }
+  return { valid, errors };
+}
+
+function useFileHandling(maxSizeMb: number, onFilesSelected: (files: File[]) => void) {
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleFiles = useCallback(
+    (fileList: FileList | null) => {
+      if (!fileList || fileList.length === 0) return;
+      const { valid, errors } = validateFiles(Array.from(fileList), maxSizeMb);
+      setValidationError(errors.length > 0 ? errors.join(', ') : null);
+      if (valid.length > 0) onFilesSelected(valid);
+    },
+    [maxSizeMb, onFilesSelected]
+  );
+
+  return { handleFiles, validationError };
+}
+
+export function DocumentUpload({
+  onFilesSelected,
+  files = [],
+  onRemove,
+  maxSizeMb = DEFAULT_MAX_SIZE_MB,
+  accept = DEFAULT_ACCEPT,
+  disabled = false,
+  className,
+}: DocumentUploadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { handleFiles, validationError } = useFileHandling(maxSizeMb, onFilesSelected);
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      <DropZone
+        disabled={disabled}
+        maxSizeMb={maxSizeMb}
+        onClick={() => !disabled && inputRef.current?.click()}
+        onFiles={handleFiles}
+        ariaLabel="Upload documents"
+        helperText={`PDF, images, or text up to ${maxSizeMb}MB`}
+      />
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        multiple
+        data-testid="document-upload-input"
+        onChange={(e) => {
+          handleFiles(e.target.files);
+          if (inputRef.current) inputRef.current.value = '';
+        }}
+        className="hidden"
+      />
+      {validationError && <p className="text-sm text-destructive">{validationError}</p>}
+      {files.length > 0 && (
+        <div className="space-y-2">
+          {files.map((f) => (
+            <PendingDocumentRow key={f.localId} f={f} onRemove={onRemove} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/app-inventory/src/components/PhotoUpload.tsx
+++ b/packages/app-inventory/src/components/PhotoUpload.tsx
@@ -128,6 +128,7 @@ export function PhotoUpload({
         type="file"
         accept={accept}
         multiple
+        data-testid="photo-upload-input"
         onChange={(e) => {
           handleFiles(e.target.files);
           if (inputRef.current) inputRef.current.value = '';

--- a/packages/app-inventory/src/components/document-upload/PendingDocumentRow.tsx
+++ b/packages/app-inventory/src/components/document-upload/PendingDocumentRow.tsx
@@ -1,0 +1,57 @@
+import { FileText, X } from 'lucide-react';
+
+import { Button, formatBytes, Progress } from '@pops/ui';
+
+import type { PendingDocumentFile } from '../DocumentUpload';
+
+function FileStatus({ f }: { f: PendingDocumentFile }) {
+  if (f.status === 'uploading') {
+    return (
+      <div className="mt-1 space-y-1">
+        <Progress value={f.progress ?? 0} className="h-1.5" />
+        <span className="text-xs text-muted-foreground">{f.progress ?? 0}%</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2">
+      {f.status === 'done' && <span className="text-xs text-success">Uploaded</span>}
+      {f.status === 'error' && (
+        <span className="text-xs text-destructive">{f.error ?? 'Upload failed'}</span>
+      )}
+      {f.status === 'pending' && <span className="text-xs text-muted-foreground">Ready</span>}
+      <span className="text-xs text-muted-foreground">{formatBytes(f.file.size)}</span>
+    </div>
+  );
+}
+
+export function PendingDocumentRow({
+  f,
+  onRemove,
+}: {
+  f: PendingDocumentFile;
+  onRemove?: (id: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-md border border-border p-2">
+      <div className="h-10 w-10 shrink-0 rounded bg-muted flex items-center justify-center">
+        <FileText className="h-5 w-5 text-muted-foreground" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm truncate">{f.file.name}</p>
+        <FileStatus f={f} />
+      </div>
+      {onRemove && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          onClick={() => onRemove(f.localId)}
+          aria-label={`Remove ${f.file.name}`}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/packages/app-inventory/src/components/photo-upload/DropZone.tsx
+++ b/packages/app-inventory/src/components/photo-upload/DropZone.tsx
@@ -8,9 +8,23 @@ interface DropZoneProps {
   maxSizeMb: number;
   onClick: () => void;
   onFiles: (files: FileList) => void;
+  /** Accessible button label. Defaults to "Upload photos" for back-compat. */
+  ariaLabel?: string;
+  /**
+   * Helper text rendered below the prompt. Defaults to
+   * `Images up to {maxSizeMb}MB`. Override for non-image dropzones.
+   */
+  helperText?: string;
 }
 
-export function DropZone({ disabled, maxSizeMb, onClick, onFiles }: DropZoneProps) {
+export function DropZone({
+  disabled,
+  maxSizeMb,
+  onClick,
+  onFiles,
+  ariaLabel = 'Upload photos',
+  helperText,
+}: DropZoneProps) {
   const [isDragOver, setIsDragOver] = useState(false);
 
   const handleDrop = useCallback(
@@ -40,7 +54,7 @@ export function DropZone({ disabled, maxSizeMb, onClick, onFiles }: DropZoneProp
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') onClick();
       }}
-      aria-label="Upload photos"
+      aria-label={ariaLabel}
       className={cn(
         'flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-6 cursor-pointer transition-colors',
         isDragOver
@@ -53,7 +67,7 @@ export function DropZone({ disabled, maxSizeMb, onClick, onFiles }: DropZoneProp
       <p className="text-sm text-muted-foreground text-center">
         <span className="font-medium text-foreground">Click to browse</span> or drag and drop
       </p>
-      <p className="text-xs text-muted-foreground">Images up to {maxSizeMb}MB</p>
+      <p className="text-xs text-muted-foreground">{helperText ?? `Images up to ${maxSizeMb}MB`}</p>
     </div>
   );
 }

--- a/packages/app-inventory/src/pages/ItemFormPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.test.tsx
@@ -161,6 +161,17 @@ vi.mock('@pops/api-client', () => ({
           useMutation: () => ({ mutate: mockReorderMutate, isPending: false }),
         },
       },
+      documentFiles: {
+        listForItem: {
+          useQuery: () => ({ data: { data: [] }, refetch: vi.fn() }),
+        },
+        upload: {
+          useMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+        },
+        removeUpload: {
+          useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+        },
+      },
     },
     useUtils: () => ({
       inventory: {

--- a/packages/app-inventory/src/pages/ItemFormPage.tsx
+++ b/packages/app-inventory/src/pages/ItemFormPage.tsx
@@ -2,11 +2,14 @@ import { Link } from 'react-router';
 
 import { Alert, AlertDescription, AlertTitle, PageHeader, Skeleton } from '@pops/ui';
 
-import { ConnectionsSection } from './item-form-page/sections/ConnectionsSection';
-import { CoreFieldsSection } from './item-form-page/sections/CoreFieldsSection';
 import { FormFooter } from './item-form-page/sections/FormFooter';
 import { NotesSection } from './item-form-page/sections/NotesSection';
-import { PhotoUploadSection } from './item-form-page/sections/PhotoUploadSection';
+import {
+  ConnectionsBlock,
+  CoreSection,
+  DocumentsSection,
+  PhotosSection,
+} from './item-form-page/sections/section-adapters';
 import { useItemFormPageModel } from './item-form-page/useItemFormPageModel';
 
 export { extractPrefix } from './item-form-page/useItemFormPageModel';
@@ -61,110 +64,13 @@ function buildBreadcrumbs(
   return [{ label: 'Inventory', href: '/inventory' }, { label: 'New Item' }];
 }
 
-function CoreSection({ model }: { model: Model }) {
-  const {
-    form: {
-      register,
-      control,
-      watch,
-      setValue,
-      formState: { errors },
-    },
-    assetIdError,
-    assetIdChecking,
-    generating,
-    locationTree,
-    createLocationMutation,
-    handleAutoGenerate,
-    validateAssetIdUniqueness,
-  } = model;
-  return (
-    <CoreFieldsSection
-      register={register}
-      control={control}
-      watch={watch}
-      setValue={setValue}
-      errors={errors}
-      assetIdError={assetIdError}
-      assetIdChecking={assetIdChecking}
-      generating={generating}
-      locationTree={locationTree}
-      onAutoGenerate={() => void handleAutoGenerate()}
-      onValidateAssetId={(v) => void validateAssetIdUniqueness(v)}
-      onCreateLocation={(name, parentId) => createLocationMutation.mutate({ name, parentId })}
-    />
-  );
-}
-
-function PhotosSection({ model }: { model: Model }) {
-  const {
-    id,
-    isEditMode,
-    existingPhotos,
-    uploadFiles,
-    imageProcessing,
-    reorderMutation,
-    deleteConfirmId,
-    setDeleteConfirmId,
-    photoDeleteMutation,
-    handleFilesSelected,
-    handleRemoveUpload,
-    handleDeletePhoto,
-    confirmDeletePhoto,
-  } = model;
-  return (
-    <PhotoUploadSection
-      isEditMode={isEditMode}
-      existingPhotos={existingPhotos}
-      uploadFiles={uploadFiles}
-      imageProcessing={imageProcessing}
-      isReordering={reorderMutation.isPending}
-      deleteConfirmId={deleteConfirmId}
-      isDeleting={photoDeleteMutation.isPending}
-      onFilesSelected={handleFilesSelected}
-      onRemoveUpload={handleRemoveUpload}
-      onDeletePhoto={handleDeletePhoto}
-      onConfirmDelete={confirmDeletePhoto}
-      onCancelDelete={() => setDeleteConfirmId(null)}
-      onReorder={(orderedIds) => {
-        if (id) reorderMutation.mutate({ itemId: id, orderedIds });
-      }}
-    />
-  );
-}
-
-function ConnectionsBlock({ model }: { model: Model }) {
-  const {
-    isEditMode,
-    pendingConnections,
-    setPendingConnections,
-    connectionSearch,
-    setConnectionSearch,
-    searchResults,
-    searchLoading,
-  } = model;
-  if (isEditMode) return null;
-  return (
-    <ConnectionsSection
-      pendingConnections={pendingConnections}
-      connectionSearch={connectionSearch}
-      searchResults={searchResults}
-      searchLoading={searchLoading}
-      onSearchChange={setConnectionSearch}
-      onAdd={(item) =>
-        setPendingConnections((prev) => [...prev, { id: item.id, itemName: item.itemName }])
-      }
-      onRemove={(itemId) => setPendingConnections((prev) => prev.filter((c) => c.id !== itemId))}
-    />
-  );
-}
-
 function FormBody({ model }: { model: Model }) {
   const { form, isEditMode, isMutating, notesPreview, setNotesPreview, onSubmit } = model;
   return (
     <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
       <CoreSection model={model} />
       <PhotosSection model={model} />
+      <DocumentsSection model={model} />
       <NotesSection
         register={form.register}
         watch={form.watch}

--- a/packages/app-inventory/src/pages/item-form-page/document-upload-helpers.ts
+++ b/packages/app-inventory/src/pages/item-form-page/document-upload-helpers.ts
@@ -1,0 +1,85 @@
+import { toast } from 'sonner';
+
+import { blobToBase64 } from './upload-helpers';
+
+import type { trpc } from '@pops/api-client';
+
+import type { PendingDocumentFile } from '../../components/DocumentUpload';
+
+/** Patch a single tracked file by `localId`. */
+export function patchDocumentFile(
+  prev: PendingDocumentFile[],
+  localId: string,
+  patch: Partial<PendingDocumentFile>
+): PendingDocumentFile[] {
+  return prev.map((f) => (f.localId === localId ? { ...f, ...patch } : f));
+}
+
+interface UploadOneDocumentArgs {
+  pendingEntry: PendingDocumentFile;
+  isEditMode: boolean;
+  id: string | undefined;
+  uploadMutation: ReturnType<typeof trpc.inventory.documentFiles.upload.useMutation>;
+  setUploadFiles: React.Dispatch<React.SetStateAction<PendingDocumentFile[]>>;
+}
+
+/** Upload one document via the tRPC mutation, updating local progress as it goes. */
+export async function uploadOneDocument(args: UploadOneDocumentArgs): Promise<void> {
+  const { pendingEntry, isEditMode, id, uploadMutation, setUploadFiles } = args;
+  const { localId, file } = pendingEntry;
+
+  setUploadFiles((prev) => patchDocumentFile(prev, localId, { status: 'uploading', progress: 25 }));
+
+  try {
+    if (!isEditMode || !id) {
+      // On create mode the parent has no item ID yet; we just leave the entry
+      // as 'pending' and rely on the parent re-running uploads after save.
+      setUploadFiles((prev) => patchDocumentFile(prev, localId, { status: 'pending' }));
+      return;
+    }
+
+    const fileBase64 = await blobToBase64(file);
+    setUploadFiles((prev) => patchDocumentFile(prev, localId, { progress: 60 }));
+
+    await uploadMutation.mutateAsync({
+      itemId: id,
+      fileName: file.name,
+      mimeType: file.type || 'application/octet-stream',
+      fileBase64,
+    });
+
+    setUploadFiles((prev) => patchDocumentFile(prev, localId, { status: 'done', progress: 100 }));
+  } catch (err: unknown) {
+    setUploadFiles((prev) =>
+      patchDocumentFile(prev, localId, {
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Upload failed',
+      })
+    );
+    toast.error(`Failed to upload ${file.name}`);
+  }
+}
+
+interface ProcessAndUploadDocumentsArgs {
+  pending: PendingDocumentFile[];
+  setUploadFiles: React.Dispatch<React.SetStateAction<PendingDocumentFile[]>>;
+  isEditMode: boolean;
+  id: string | undefined;
+  uploadMutation: ReturnType<typeof trpc.inventory.documentFiles.upload.useMutation>;
+}
+
+/** Sequentially upload each pending document. */
+export async function processAndUploadDocuments(
+  args: ProcessAndUploadDocumentsArgs
+): Promise<void> {
+  const { pending, setUploadFiles, isEditMode, id, uploadMutation } = args;
+  for (const entry of pending) {
+    await uploadOneDocument({
+      pendingEntry: entry,
+      isEditMode,
+      id,
+      uploadMutation,
+      setUploadFiles,
+    });
+  }
+}

--- a/packages/app-inventory/src/pages/item-form-page/photo-upload-helpers.ts
+++ b/packages/app-inventory/src/pages/item-form-page/photo-upload-helpers.ts
@@ -1,18 +1,13 @@
 import { toast } from 'sonner';
 
+import { blobToBase64 } from './upload-helpers';
+
 import type { trpc } from '@pops/api-client';
 
 import type { UploadedFile } from '../../components/PhotoUpload';
 import type { ProcessedFile } from '../../hooks/useImageProcessor';
 
-export async function blobToBase64(blob: Blob): Promise<string> {
-  const bytes = new Uint8Array(await blob.arrayBuffer());
-  let binary = '';
-  for (let i = 0; i < bytes.length; i += 8192) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
-  }
-  return btoa(binary);
-}
+export { blobToBase64 };
 
 export function patchFile(
   prev: UploadedFile[],

--- a/packages/app-inventory/src/pages/item-form-page/sections/DocumentUploadSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/DocumentUploadSection.tsx
@@ -1,0 +1,82 @@
+import { FileText } from 'lucide-react';
+
+import { Button } from '@pops/ui';
+
+import { DocumentList, type DocumentItem } from '../../../components/DocumentList';
+import { DocumentUpload, type PendingDocumentFile } from '../../../components/DocumentUpload';
+
+interface DocumentUploadSectionProps {
+  isEditMode: boolean;
+  existingDocuments: DocumentItem[];
+  uploadFiles: PendingDocumentFile[];
+  deleteConfirmId: number | null;
+  isDeleting: boolean;
+  isUploading: boolean;
+  onFilesSelected: (files: File[]) => Promise<void>;
+  onRemoveUpload: (localId: string) => void;
+  onDeleteDocument: (id: number) => void;
+  onConfirmDelete: () => void;
+  onCancelDelete: () => void;
+}
+
+export function DocumentUploadSection({
+  isEditMode,
+  existingDocuments,
+  uploadFiles,
+  deleteConfirmId,
+  isDeleting,
+  isUploading,
+  onFilesSelected,
+  onRemoveUpload,
+  onDeleteDocument,
+  onConfirmDelete,
+  onCancelDelete,
+}: DocumentUploadSectionProps) {
+  return (
+    <section
+      className="space-y-4 p-6 rounded-2xl border-2 border-app-accent/10 bg-card/50 shadow-sm shadow-app-accent/5"
+      data-testid="document-upload-section"
+    >
+      <h2 className="text-lg font-bold flex items-center gap-2 text-foreground">
+        <FileText className="h-5 w-5 text-app-accent" />
+        Documents
+      </h2>
+
+      {!isEditMode && (
+        <p className="text-sm text-muted-foreground">
+          Save the item first to start attaching documents.
+        </p>
+      )}
+
+      {isEditMode && <DocumentList documents={existingDocuments} onDelete={onDeleteDocument} />}
+
+      {deleteConfirmId !== null && (
+        <div className="flex items-center gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
+          <p className="text-sm flex-1">Delete this document? This cannot be undone.</p>
+          <Button type="button" variant="outline" size="sm" onClick={onCancelDelete}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            className="bg-destructive text-white hover:bg-destructive/80"
+            onClick={onConfirmDelete}
+            loading={isDeleting}
+            loadingText="Deleting..."
+          >
+            Delete
+          </Button>
+        </div>
+      )}
+
+      {isEditMode && (
+        <DocumentUpload
+          onFilesSelected={(files) => void onFilesSelected(files)}
+          files={uploadFiles}
+          onRemove={onRemoveUpload}
+          disabled={isUploading}
+        />
+      )}
+    </section>
+  );
+}

--- a/packages/app-inventory/src/pages/item-form-page/sections/section-adapters.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/section-adapters.tsx
@@ -1,0 +1,146 @@
+import { ConnectionsSection } from './ConnectionsSection';
+import { CoreFieldsSection } from './CoreFieldsSection';
+import { DocumentUploadSection } from './DocumentUploadSection';
+import { PhotoUploadSection } from './PhotoUploadSection';
+
+import type { useItemFormPageModel } from '../useItemFormPageModel';
+
+/**
+ * Thin presentational adapters that take the full form model and pass only
+ * the slice each section needs. They live next to the section components so
+ * `ItemFormPage.tsx` can stay under the file-length lint cap and so the
+ * model wiring is co-located with the sections it feeds.
+ */
+
+type Model = ReturnType<typeof useItemFormPageModel>;
+
+export function CoreSection({ model }: { model: Model }) {
+  const {
+    form: {
+      register,
+      control,
+      watch,
+      setValue,
+      formState: { errors },
+    },
+    assetIdError,
+    assetIdChecking,
+    generating,
+    locationTree,
+    createLocationMutation,
+    handleAutoGenerate,
+    validateAssetIdUniqueness,
+  } = model;
+  return (
+    <CoreFieldsSection
+      register={register}
+      control={control}
+      watch={watch}
+      setValue={setValue}
+      errors={errors}
+      assetIdError={assetIdError}
+      assetIdChecking={assetIdChecking}
+      generating={generating}
+      locationTree={locationTree}
+      onAutoGenerate={() => void handleAutoGenerate()}
+      onValidateAssetId={(v) => void validateAssetIdUniqueness(v)}
+      onCreateLocation={(name, parentId) => createLocationMutation.mutate({ name, parentId })}
+    />
+  );
+}
+
+export function PhotosSection({ model }: { model: Model }) {
+  const {
+    id,
+    isEditMode,
+    existingPhotos,
+    uploadFiles,
+    imageProcessing,
+    reorderMutation,
+    deleteConfirmId,
+    setDeleteConfirmId,
+    photoDeleteMutation,
+    handleFilesSelected,
+    handleRemoveUpload,
+    handleDeletePhoto,
+    confirmDeletePhoto,
+  } = model;
+  return (
+    <PhotoUploadSection
+      isEditMode={isEditMode}
+      existingPhotos={existingPhotos}
+      uploadFiles={uploadFiles}
+      imageProcessing={imageProcessing}
+      isReordering={reorderMutation.isPending}
+      deleteConfirmId={deleteConfirmId}
+      isDeleting={photoDeleteMutation.isPending}
+      onFilesSelected={handleFilesSelected}
+      onRemoveUpload={handleRemoveUpload}
+      onDeletePhoto={handleDeletePhoto}
+      onConfirmDelete={confirmDeletePhoto}
+      onCancelDelete={() => setDeleteConfirmId(null)}
+      onReorder={(orderedIds) => {
+        if (id) reorderMutation.mutate({ itemId: id, orderedIds });
+      }}
+    />
+  );
+}
+
+export function DocumentsSection({ model }: { model: Model }) {
+  const {
+    isEditMode,
+    existingDocuments,
+    documentUploadFiles,
+    documentDeleteConfirmId,
+    setDocumentDeleteConfirmId,
+    documentRemoveMutation,
+    handleDocumentFilesSelected,
+    handleDocumentRemoveUpload,
+    handleDeleteDocument,
+    confirmDeleteDocument,
+  } = model;
+  // Disable the upload widget while any pending entry is mid-flight to avoid
+  // racy double-submits when the user clicks the picker repeatedly.
+  const isUploading = documentUploadFiles.some((f) => f.status === 'uploading');
+  return (
+    <DocumentUploadSection
+      isEditMode={isEditMode}
+      existingDocuments={existingDocuments}
+      uploadFiles={documentUploadFiles}
+      deleteConfirmId={documentDeleteConfirmId}
+      isDeleting={documentRemoveMutation.isPending}
+      isUploading={isUploading}
+      onFilesSelected={handleDocumentFilesSelected}
+      onRemoveUpload={handleDocumentRemoveUpload}
+      onDeleteDocument={handleDeleteDocument}
+      onConfirmDelete={confirmDeleteDocument}
+      onCancelDelete={() => setDocumentDeleteConfirmId(null)}
+    />
+  );
+}
+
+export function ConnectionsBlock({ model }: { model: Model }) {
+  const {
+    isEditMode,
+    pendingConnections,
+    setPendingConnections,
+    connectionSearch,
+    setConnectionSearch,
+    searchResults,
+    searchLoading,
+  } = model;
+  if (isEditMode) return null;
+  return (
+    <ConnectionsSection
+      pendingConnections={pendingConnections}
+      connectionSearch={connectionSearch}
+      searchResults={searchResults}
+      searchLoading={searchLoading}
+      onSearchChange={setConnectionSearch}
+      onAdd={(item) =>
+        setPendingConnections((prev) => [...prev, { id: item.id, itemName: item.itemName }])
+      }
+      onRemove={(itemId) => setPendingConnections((prev) => prev.filter((c) => c.id !== itemId))}
+    />
+  );
+}

--- a/packages/app-inventory/src/pages/item-form-page/upload-helpers.ts
+++ b/packages/app-inventory/src/pages/item-form-page/upload-helpers.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared upload helpers used by both photo and document upload flows.
+ *
+ * The browser's `FileReader.readAsDataURL` is convenient but appends a
+ * `data:...;base64,` prefix that has to be stripped, so we hand-encode the
+ * raw bytes ourselves.
+ */
+
+/**
+ * Encode the contents of a Blob (or File) as a base64 string suitable for
+ * sending through the tRPC `fileBase64` field. Chunks the conversion to
+ * avoid blowing the call-stack on large files.
+ */
+export async function blobToBase64(blob: Blob): Promise<string> {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 8192) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
+  }
+  return btoa(binary);
+}

--- a/packages/app-inventory/src/pages/item-form-page/useDocumentUpload.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useDocumentUpload.ts
@@ -1,0 +1,91 @@
+import { useCallback, useState } from 'react';
+
+import { trpc } from '@pops/api-client';
+
+import { processAndUploadDocuments } from './document-upload-helpers';
+
+import type { DocumentItem } from '../../components/DocumentList';
+import type { PendingDocumentFile } from '../../components/DocumentUpload';
+
+function useDocumentMutations(
+  id: string | undefined,
+  isEditMode: boolean,
+  setDeleteConfirmId: (v: number | null) => void
+) {
+  const { data: documentsData, refetch: refetchDocuments } =
+    trpc.inventory.documentFiles.listForItem.useQuery(
+      { itemId: id ?? '' },
+      { enabled: isEditMode }
+    );
+  const existingDocuments: DocumentItem[] = documentsData?.data ?? [];
+  const uploadMutation = trpc.inventory.documentFiles.upload.useMutation({
+    onSuccess: () => void refetchDocuments(),
+  });
+  const removeMutation = trpc.inventory.documentFiles.removeUpload.useMutation({
+    onSuccess: () => {
+      void refetchDocuments();
+      setDeleteConfirmId(null);
+    },
+  });
+  return { existingDocuments, uploadMutation, removeMutation };
+}
+
+/**
+ * Item-form-page state hook for direct document uploads. Mirrors
+ * {@link usePhotoUploadState} but talks to `inventory.documentFiles.*`
+ * and uses {@link PendingDocumentFile} for pending entries.
+ *
+ * On create mode (no `id`) the upload mutation is skipped — pending entries
+ * stay as 'pending' and the parent is expected to re-trigger uploads after
+ * the item is saved. Today the form does not yet wire that follow-up step
+ * because the backend requires the item to exist; this matches the photo
+ * upload behaviour for create mode.
+ */
+export function useDocumentUploadState(id: string | undefined, isEditMode: boolean) {
+  const [uploadFiles, setUploadFiles] = useState<PendingDocumentFile[]>([]);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null);
+  const { existingDocuments, uploadMutation, removeMutation } = useDocumentMutations(
+    id,
+    isEditMode,
+    setDeleteConfirmId
+  );
+
+  const handleFilesSelected = useCallback(
+    async (files: File[]) => {
+      const pending: PendingDocumentFile[] = files.map((file, i) => ({
+        localId: `${Date.now()}-${i}`,
+        file,
+        status: 'pending' as const,
+      }));
+      setUploadFiles((prev) => [...prev, ...pending]);
+      await processAndUploadDocuments({
+        pending,
+        setUploadFiles,
+        isEditMode,
+        id,
+        uploadMutation,
+      });
+    },
+    [isEditMode, id, uploadMutation]
+  );
+
+  const handleRemoveUpload = useCallback((localId: string) => {
+    setUploadFiles((prev) => prev.filter((f) => f.localId !== localId));
+  }, []);
+
+  const confirmDeleteDocument = useCallback(() => {
+    if (deleteConfirmId !== null) removeMutation.mutate({ id: deleteConfirmId });
+  }, [deleteConfirmId, removeMutation]);
+
+  return {
+    documentUploadFiles: uploadFiles,
+    documentDeleteConfirmId: deleteConfirmId,
+    setDocumentDeleteConfirmId: setDeleteConfirmId,
+    existingDocuments,
+    documentRemoveMutation: removeMutation,
+    handleDocumentFilesSelected: handleFilesSelected,
+    handleDocumentRemoveUpload: handleRemoveUpload,
+    handleDeleteDocument: setDeleteConfirmId,
+    confirmDeleteDocument,
+  };
+}

--- a/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
@@ -7,6 +7,7 @@ import { trpc } from '@pops/api-client';
 
 import { defaultValues, type ItemFormValues, type PendingConnection } from './types';
 import { useAssetIdValidation } from './useAssetIdValidation';
+import { useDocumentUploadState } from './useDocumentUpload';
 import { useItemMutations } from './useItemMutations';
 import { usePhotoUploadState } from './usePhotoUpload';
 
@@ -119,6 +120,7 @@ export function useItemFormPageModel() {
   const [connectionSearch, setConnectionSearch] = useState('');
 
   const photoState = usePhotoUploadState(id, isEditMode);
+  const documentState = useDocumentUploadState(id, isEditMode);
   const assetId = useAssetIdValidation({ id, typeValue, setValue });
   const mutations = useItemMutations({ id, isEditMode, pendingConnections });
 
@@ -156,6 +158,7 @@ export function useItemFormPageModel() {
     isLoading,
     error,
     ...photoState,
+    ...documentState,
     ...assetId,
     ...mutations,
   };

--- a/packages/db-types/src/index.ts
+++ b/packages/db-types/src/index.ts
@@ -31,6 +31,7 @@ import type { homeInventory } from './schema/inventory.js';
 import type { itemConnections } from './schema/item-connections.js';
 import type { itemDocuments } from './schema/item-documents.js';
 import type { itemPhotos } from './schema/item-photos.js';
+import type { itemUploadedFiles } from './schema/item-uploaded-files.js';
 import type { locations } from './schema/locations.js';
 import type { mediaScores } from './schema/media-scores.js';
 import type { mediaWatchlist } from './schema/media-watchlist.js';
@@ -80,6 +81,7 @@ export {
   itemConnections,
   itemDocuments,
   itemPhotos,
+  itemUploadedFiles,
   locations,
   mediaScores,
   mediaWatchlist,
@@ -136,6 +138,7 @@ export type MediaScoreRow = InferSelectModel<typeof mediaScores>;
 export type LocationRow = InferSelectModel<typeof locations>;
 export type ItemConnectionRow = InferSelectModel<typeof itemConnections>;
 export type ItemPhotoRow = InferSelectModel<typeof itemPhotos>;
+export type ItemUploadedFileRow = InferSelectModel<typeof itemUploadedFiles>;
 export type ItemDocumentRow = InferSelectModel<typeof itemDocuments>;
 export type SettingRow = InferSelectModel<typeof settings>;
 
@@ -160,6 +163,7 @@ export type MediaScoreInsert = InferInsertModel<typeof mediaScores>;
 export type LocationInsert = InferInsertModel<typeof locations>;
 export type ItemConnectionInsert = InferInsertModel<typeof itemConnections>;
 export type ItemPhotoInsert = InferInsertModel<typeof itemPhotos>;
+export type ItemUploadedFileInsert = InferInsertModel<typeof itemUploadedFiles>;
 export type ItemDocumentInsert = InferInsertModel<typeof itemDocuments>;
 export type SettingInsert = InferInsertModel<typeof settings>;
 export type SyncLogRow = InferSelectModel<typeof syncLogs>;

--- a/packages/db-types/src/schema/index.ts
+++ b/packages/db-types/src/schema/index.ts
@@ -22,6 +22,7 @@ export { homeInventory } from './inventory.js';
 export { itemConnections } from './item-connections.js';
 export { itemDocuments } from './item-documents.js';
 export { itemPhotos } from './item-photos.js';
+export { itemUploadedFiles } from './item-uploaded-files.js';
 export { locations } from './locations.js';
 export { mediaScores } from './media-scores.js';
 export { mediaWatchlist } from './media-watchlist.js';

--- a/packages/db-types/src/schema/item-uploaded-files.ts
+++ b/packages/db-types/src/schema/item-uploaded-files.ts
@@ -1,0 +1,35 @@
+import { sql } from 'drizzle-orm';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+import { homeInventory } from './inventory.js';
+
+/**
+ * Per-item directly-uploaded files (PDFs, images, plain-text receipts, etc.).
+ *
+ * This is a parallel sibling to `item_documents`, which is reserved for
+ * Paperless-ngx links (`paperless_document_id` mandatory there). Direct uploads
+ * have no Paperless ID and need their own filesystem-backed columns
+ * (`file_path`, `file_name`, `mime_type`, `file_size`), so a dedicated table
+ * keeps the two integrations independent and avoids retrofitting nullable
+ * columns onto the existing schema.
+ */
+export const itemUploadedFiles = sqliteTable(
+  'item_uploaded_files',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    itemId: text('item_id')
+      .notNull()
+      .references(() => homeInventory.id, { onDelete: 'cascade' }),
+    fileName: text('file_name').notNull(),
+    filePath: text('file_path').notNull(),
+    mimeType: text('mime_type').notNull(),
+    fileSize: integer('file_size').notNull(),
+    uploadedAt: text('uploaded_at')
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [index('idx_item_uploaded_files_item').on(table.itemId)]
+);


### PR DESCRIPTION
## Summary

- Adds direct (non-Paperless) document uploads on the inventory item form. Picker accepts PDFs, images, and plain text; uploads fire on file select via a new `inventory.documentFiles.upload` tRPC procedure, list rows show filename + upload date + size + Download link + per-row delete with inline confirm.
- New parallel `item_uploaded_files` table (`id`, `item_id`, `file_name`, `file_path`, `mime_type`, `file_size`, `uploaded_at`, `created_at`). The existing Paperless-only `item_documents` table is **not** touched, so the Paperless link/unlink flow keeps working unchanged. Two distinct attachment surfaces, two clean schemas.
- New Express download route at `/api/inventory/documents/items/:itemId/:filename` mirroring the photo serving route from #2178 (mounted before auth so download links work without JWT cookies). Path traversal is sandboxed with the same regex+resolve dance as the photos route.
- Shared bits factored: `blobToBase64` extracted to `upload-helpers.ts`, `DropZone` aria-label / helper text parameterised so the `PhotoUpload` and `DocumentUpload` components reuse it, item form section adapters extracted to keep `ItemFormPage.tsx` under the file-length lint cap.
- e2e spec mirrors `inventory-photo-upload-reorder.spec.ts`: upload a small text fixture, assert the download link href is non-empty, delete via the trash button + inline confirm, assert the empty state returns. Runs against the seeded `e2e` SQLite env with idempotent before/after purge.

Closes #2189
Closes #2126

## Test plan

- [x] `pnpm lint` — 0 errors (74 pre-existing warnings)
- [x] `pnpm format:check` — clean
- [x] `pnpm typecheck` for `@pops/api`, `@pops/db-types`, `@pops/api-client`, `@pops/app-inventory`, `@pops/shell`
- [x] `pnpm test` for `@pops/api` (167 files, 2944 tests) including 17 new `documentFiles` router tests + 7 new download-route tests
- [x] `pnpm test:integration` for `@pops/api` (3 files, 34 tests)
- [x] `pnpm test` for `@pops/app-inventory` (18 files, 365 tests) and `@pops/shell` (11 files, 111 tests)
- [x] `pnpm openapi:validate` and `pnpm build` for `@pops/api`
- [ ] CI: run `inventory-quality.yml`, `api-quality.yml`, `db-types-quality.yml`, `fe-test-e2e.yml`
- [ ] Manual smoke: upload a PDF, refresh, click Download link, then delete

## Notes for reviewers

The new schema deliberately lives next to the existing `item_documents` table rather than extending it:

- `item_documents` requires a non-null `paperless_document_id`. Direct uploads have no such ID and need their own `file_path` / `mime_type` / `file_size` columns.
- Adding nullable `file_*` columns and making `paperless_document_id` nullable would muddy every existing service-layer query and the Paperless backfill.
- A second table makes the "is this a Paperless link or a direct upload?" question trivial in code (different tables, different routers).

The inventory tRPC namespace exposes both: `inventory.documents.*` (Paperless link/unlink, unchanged) and `inventory.documentFiles.*` (new direct upload).
