### PR TITLE
fix(media): hydrate tier-list placements from tier_overrides on load (#2195)

### DIFF
--- a/apps/pops-api/src/modules/media/comparisons/router-debrief-tier.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router-debrief-tier.ts
@@ -42,6 +42,22 @@ export const debriefAndTierProcedures = {
     }
   }),
 
+  /**
+   * Get persisted tier-list placements for a dimension.
+   *
+   * Hydrates the board with previously-submitted placements so the UI can
+   * round-trip a tier list across reloads (see #2195). Returns the joined
+   * movie metadata so the placed cards can render without a separate fetch.
+   */
+  getTierListPlacements: protectedProcedure.input(GetTierListMoviesSchema).query(({ input }) => {
+    try {
+      const placements = service.getTierListPlacementsForDimension(input.dimensionId);
+      return { data: placements };
+    } catch (err) {
+      rethrowKnownErrors(err);
+    }
+  }),
+
   /** Submit a tier list: converts placements to pairwise comparisons + tier overrides. */
   submitTierList: protectedProcedure.input(SubmitTierListSchema).mutation(({ input }) => {
     try {

--- a/apps/pops-api/src/modules/media/comparisons/service.ts
+++ b/apps/pops-api/src/modules/media/comparisons/service.ts
@@ -46,6 +46,7 @@ export {
 } from './lib/score-management.js';
 export { isPairOnCooloff, recordSkip } from './lib/skip-cooloff.js';
 export { batchRecordComparisons, getTierListMovies, submitTierList } from './lib/tier-list.js';
+export { getTierListPlacementsForDimension, type TierListPlacement } from './tier-overrides.js';
 export { getRandomPair } from './pairs/random-pair.js';
 export { getSmartPair } from './pairs/smart-pair.js';
 export { getRankings, type RankingsResult, resolvePosterUrl } from './rankings.service.js';

--- a/apps/pops-api/src/modules/media/comparisons/tier-overrides.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/tier-overrides.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { seedDimension, setupTestContext } from '../../../shared/test-utils.js';
+import { seedDimension, seedMovie, setupTestContext } from '../../../shared/test-utils.js';
 import {
+  getTierListPlacementsForDimension,
   getTierOverrideForMedia,
   getTierOverrides,
   removeTierOverride,
@@ -9,6 +10,20 @@ import {
 } from './tier-overrides.js';
 
 import type { Database } from 'better-sqlite3';
+
+function seedMediaScore(
+  db: Database,
+  mediaId: number,
+  dimensionId: number,
+  score: number,
+  comparisonCount = 1
+): void {
+  db.prepare(
+    `INSERT INTO media_scores
+       (media_type, media_id, dimension_id, score, comparison_count, updated_at)
+     VALUES ('movie', ?, ?, ?, ?, datetime('now'))`
+  ).run(mediaId, dimensionId, score, comparisonCount);
+}
 
 const ctx = setupTestContext();
 let db: Database;
@@ -127,5 +142,74 @@ describe('getTierOverrideForMedia', () => {
   it('returns null when no override exists', () => {
     const dimId = seedDimension(db, { name: 'Overall' });
     expect(getTierOverrideForMedia('movie', 999, dimId)).toBeNull();
+  });
+});
+
+describe('getTierListPlacementsForDimension', () => {
+  it('returns placements joined with movie metadata', () => {
+    const dimId = seedDimension(db, { name: 'Overall' });
+    const movieA = seedMovie(db, { tmdb_id: 100, title: 'Alpha' });
+    const movieB = seedMovie(db, { tmdb_id: 200, title: 'Bravo' });
+    seedMediaScore(db, movieA, dimId, 1620, 4);
+    seedMediaScore(db, movieB, dimId, 1480, 3);
+    setTierOverride('movie', movieA, dimId, 'S');
+    setTierOverride('movie', movieB, dimId, 'B');
+
+    const placements = getTierListPlacementsForDimension(dimId);
+
+    expect(placements).toHaveLength(2);
+    const byTier = Object.fromEntries(placements.map((p) => [p.tier, p]));
+    expect(byTier.S).toMatchObject({
+      mediaId: movieA,
+      mediaType: 'movie',
+      title: 'Alpha',
+      score: 1620,
+      comparisonCount: 4,
+      posterUrl: '/media/images/movie/100/poster.jpg',
+    });
+    expect(byTier.B).toMatchObject({
+      mediaId: movieB,
+      title: 'Bravo',
+      score: 1480,
+      comparisonCount: 3,
+    });
+  });
+
+  it('falls back to default score when no media_scores row exists', () => {
+    const dimId = seedDimension(db, { name: 'Overall' });
+    const movieA = seedMovie(db, { tmdb_id: 100, title: 'Alpha' });
+    setTierOverride('movie', movieA, dimId, 'S');
+
+    const placements = getTierListPlacementsForDimension(dimId);
+
+    expect(placements).toHaveLength(1);
+    expect(placements[0]).toMatchObject({ score: 1500, comparisonCount: 0 });
+  });
+
+  it('prefers poster_override_path over the tmdb-derived URL', () => {
+    const dimId = seedDimension(db, { name: 'Overall' });
+    const movieA = seedMovie(db, {
+      tmdb_id: 100,
+      title: 'Alpha',
+      poster_override_path: '/custom/poster.jpg',
+    });
+    setTierOverride('movie', movieA, dimId, 'A');
+
+    const [placement] = getTierListPlacementsForDimension(dimId);
+    expect(placement?.posterUrl).toBe('/custom/poster.jpg');
+  });
+
+  it('does not return placements from other dimensions', () => {
+    const dim1 = seedDimension(db, { name: 'Overall' });
+    const dim2 = seedDimension(db, { name: 'Acting' });
+    const movieA = seedMovie(db, { tmdb_id: 100, title: 'Alpha' });
+    setTierOverride('movie', movieA, dim1, 'S');
+
+    expect(getTierListPlacementsForDimension(dim2)).toEqual([]);
+  });
+
+  it('returns an empty array when no placements exist', () => {
+    const dimId = seedDimension(db, { name: 'Overall' });
+    expect(getTierListPlacementsForDimension(dimId)).toEqual([]);
   });
 });

--- a/apps/pops-api/src/modules/media/comparisons/tier-overrides.ts
+++ b/apps/pops-api/src/modules/media/comparisons/tier-overrides.ts
@@ -83,6 +83,82 @@ export function getTierOverrides(dimensionId: number): TierOverride[] {
 }
 
 /**
+ * A tier override joined with the placed movie's metadata, ready to render
+ * directly on the tier-list board.
+ */
+export interface TierListPlacement {
+  mediaId: number;
+  mediaType: 'movie';
+  tier: string;
+  title: string;
+  posterUrl: string | null;
+  score: number;
+  comparisonCount: number;
+}
+
+/**
+ * Get all tier-list placements for a dimension, joined with the movie's
+ * display metadata (title, poster, current score, comparison count).
+ *
+ * Used by the tier-list page on mount to hydrate the board with previously-
+ * submitted placements. Movies that lack a `media_scores` row for the
+ * dimension default to score 1500 / 0 comparisons — this can happen when an
+ * override is set before any comparison has been recorded for that pair.
+ */
+export function getTierListPlacementsForDimension(dimensionId: number): TierListPlacement[] {
+  const db = getDb();
+
+  return db
+    .prepare(
+      `SELECT
+         tov.media_id        AS mediaId,
+         tov.tier            AS tier,
+         m.title             AS title,
+         m.tmdb_id           AS movieTmdbId,
+         m.poster_override_path AS moviePosterOverride,
+         COALESCE(ms.score, 1500.0)        AS score,
+         COALESCE(ms.comparison_count, 0)  AS comparisonCount
+       FROM tier_overrides tov
+       JOIN movies m
+         ON tov.media_type = 'movie' AND m.id = tov.media_id
+       LEFT JOIN media_scores ms
+         ON ms.media_type = 'movie'
+        AND ms.media_id = tov.media_id
+        AND ms.dimension_id = tov.dimension_id
+       WHERE tov.dimension_id = ?
+         AND tov.media_type = 'movie'
+       ORDER BY tov.tier, m.title`
+    )
+    .all(dimensionId)
+    .map((row) => {
+      const r = row as {
+        mediaId: number;
+        tier: string;
+        title: string;
+        movieTmdbId: number | null;
+        moviePosterOverride: string | null;
+        score: number;
+        comparisonCount: number;
+      };
+      return {
+        mediaId: r.mediaId,
+        mediaType: 'movie' as const,
+        tier: r.tier,
+        title: r.title,
+        posterUrl: resolvePosterUrl(r.moviePosterOverride, r.movieTmdbId),
+        score: Math.round(r.score * 10) / 10,
+        comparisonCount: r.comparisonCount,
+      };
+    });
+}
+
+function resolvePosterUrl(override: string | null, tmdbId: number | null): string | null {
+  if (override) return override;
+  if (tmdbId) return `/media/images/movie/${tmdbId}/poster.jpg`;
+  return null;
+}
+
+/**
  * Get the tier override for a specific media item in a dimension, or null.
  */
 export function getTierOverrideForMedia(

--- a/apps/pops-shell/e2e/media-tier-list.spec.ts
+++ b/apps/pops-shell/e2e/media-tier-list.spec.ts
@@ -1,34 +1,36 @@
 /**
- * E2E — Media tier list: create dimension, drag movies into tiers, save, reload (#2131 + #2190)
+ * E2E — Media tier list (#2131, #2190, #2195)
  *
- * Tier 3 flow: navigate to `/media/tier-list`, create a fresh comparison
- * dimension via the page's empty-state CTA (or the header "+ New" button),
- * confirm the unranked pool populates from the seeded library, drag two
- * movies into tiers via dnd-kit's pointer sensor, submit the tier list,
- * reload, and assert the tier assignments persist.
+ * Two scenarios live in this file:
  *
- * Why we create the dimension here rather than relying on a seeded one:
- *   The seeded `e2e` env may have shared dimensions with comparisons recorded
- *   by other tests, leading to flaky pool selection. Creating a dimension
- *   under a unique timestamped name guarantees a clean tier-list state with
- *   no prior placements or comparisons.
+ * 1. **Create dimension from empty-state CTA** (#2131 + #2190).
+ *    Creates a fresh, timestamped dimension via the page's CTA, confirms
+ *    the chip activates, and verifies the dimension survives a reload.
+ *    Stops short of the full drag flow because a brand-new dimension has
+ *    no `media_scores` rows yet, so `fetchEligibleRows` returns nothing.
  *
- * Cleanup:
- *   The seeded `e2e` SQLite is long-lived. We deactivate the dimension we
- *   created in `afterEach` via `media.comparisons.updateDimension` so it no
- *   longer surfaces in the chips. The underlying row stays — the dimension
- *   API does not currently expose a hard delete, but `active: false` is the
- *   established cleanup path mirrored by the dimension manager UI.
+ * 2. **Persisted placements survive reload** (#2195).
+ *    Uses the seeded `Cinematography` dimension (which has 4 scored movies)
+ *    to exercise the full drag → submit → reload → assert flow. After
+ *    submitting, the page is reloaded and the test asserts that the same
+ *    movies are still rendered inside their assigned tier rows. This is
+ *    the gap closed by #2195 — `tier_overrides` is now read back into the
+ *    board on hydration.
  *
  * Drag-drop technique:
  *   The board uses dnd-kit's PointerSensor with a 5px activation distance.
- *   Playwright's mouse APIs (`mouse.move` / `mouse.down` / `mouse.up`) drive
- *   real pointer events with arbitrary intermediate steps, which dnd-kit
- *   relays through its synthetic drag pipeline. We move the mouse onto the
- *   movie card, press, drift past the activation distance, hover over the
- *   target tier row, and release — mirroring a real user drag.
+ *   Playwright's `mouse.move` / `mouse.down` / `mouse.up` drive real pointer
+ *   events with arbitrary intermediate steps, which dnd-kit relays through
+ *   its synthetic drag pipeline.
+ *
+ * Cleanup:
+ *   The seeded `e2e` SQLite is long-lived. The first test deactivates the
+ *   dimension it created in `afterEach`. The second test relies on
+ *   `tier_overrides`'s upsert semantics — a re-run replaces prior placements
+ *   for the same (mediaId, dimensionId), so leaving overrides behind is
+ *   self-healing across runs.
  */
-import { expect, test, type APIRequestContext } from '@playwright/test';
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
 
 import { useRealApi } from './helpers/use-real-api';
 
@@ -194,5 +196,134 @@ test.describe('Media — tier list create, drag, save, reload (#2131, #2190)', (
       await reloadedChip.click();
       await expect(reloadedChip).toHaveAttribute('aria-selected', 'true');
     }
+  });
+});
+
+/**
+ * Drive a dnd-kit PointerSensor drag from the source movie card to the named
+ * target drop zone. The 5px activation constraint requires at least one
+ * intermediate move past 5px before the drop element starts tracking.
+ */
+async function dragMovieToTier(
+  page: Page,
+  movieTitle: string,
+  tier: 'S' | 'A' | 'B' | 'C' | 'D'
+): Promise<void> {
+  const card = page.locator(`[aria-label="${movieTitle}"]`).first();
+  const target = page.locator(`[aria-label="Tier ${tier}"]`).first();
+
+  await card.scrollIntoViewIfNeeded();
+  const cardBox = await card.boundingBox();
+  if (!cardBox) throw new Error(`bounding box missing for movie card "${movieTitle}"`);
+  const targetBox = await target.boundingBox();
+  if (!targetBox) throw new Error(`bounding box missing for tier "${tier}"`);
+
+  const startX = cardBox.x + cardBox.width / 2;
+  const startY = cardBox.y + cardBox.height / 2;
+  const endX = targetBox.x + targetBox.width / 2;
+  const endY = targetBox.y + targetBox.height / 2;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  // dnd-kit PointerSensor activates after 5px — 10px nudge is comfortably past it.
+  await page.mouse.move(startX + 10, startY + 10, { steps: 5 });
+  await page.mouse.move(endX, endY, { steps: 15 });
+  await page.mouse.up();
+}
+
+test.describe('Media — tier list placements survive reload (#2195)', () => {
+  // The seeded Cinematography dimension has 4 movies with media_scores rows
+  // (Shawshank, Godfather, Dark Knight, Interstellar) so the unranked pool is
+  // populated immediately — no need to seed scores ourselves.
+  const DIMENSION_NAME = 'Cinematography';
+  const MOVIE_S = 'The Shawshank Redemption';
+  const MOVIE_B = 'The Dark Knight';
+
+  let pageErrors: string[] = [];
+  let consoleErrors: string[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    pageErrors = [];
+    consoleErrors = [];
+    await useRealApi(page);
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    const realConsoleErrors = consoleErrors.filter(
+      (e) =>
+        !e.includes('React Router') &&
+        !e.includes('Download the React DevTools') &&
+        !e.includes('Failed to load resource')
+    );
+    expect(pageErrors).toHaveLength(0);
+    expect(realConsoleErrors).toHaveLength(0);
+  });
+
+  test('places movies in S/B, submits, then reload shows them still in S/B', async ({ page }) => {
+    // ----- Step 1: navigate and select Cinematography ----------------------
+    await page.goto('/media/tier-list');
+    await expect(page.getByRole('heading', { name: 'Tier List', level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const dimensionChip = page.getByRole('tab', { name: DIMENSION_NAME });
+    await expect(dimensionChip).toBeVisible({ timeout: 10_000 });
+    if ((await dimensionChip.getAttribute('aria-selected')) !== 'true') {
+      await dimensionChip.click();
+      await expect(dimensionChip).toHaveAttribute('aria-selected', 'true');
+    }
+
+    // The board should render at least the two movies we want to place. They
+    // may already be in S / B from a prior run (tier_overrides is upserted),
+    // which is fine — the reload assertion checks final state, not that the
+    // drag itself moved anything.
+    await expect(page.getByRole('button', { name: /^Submit Tier List/i })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // ----- Step 2: drag both movies into their tiers -----------------------
+    // If the movie is already inside the target tier from a prior run, the
+    // mouse move ends inside that tier and dnd-kit treats it as a no-op.
+    await dragMovieToTier(page, MOVIE_S, 'S');
+    await dragMovieToTier(page, MOVIE_B, 'B');
+
+    // ----- Step 3: submit ---------------------------------------------------
+    const submitBtn = page.getByRole('button', { name: /^Submit Tier List/i });
+    await expect(submitBtn).toBeEnabled({ timeout: 5_000 });
+    const submitResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('/trpc/media.comparisons.submitTierList') &&
+        res.request().method() === 'POST'
+    );
+    await submitBtn.click();
+    const submitRes = await submitResponse;
+    expect(submitRes.ok()).toBe(true);
+
+    // After submit the page switches to the TierListSummary view.
+    await expect(page.getByText(/comparisons/i).first()).toBeVisible({ timeout: 10_000 });
+
+    // ----- Step 4: reload and re-select the dimension ----------------------
+    await page.goto('/media/tier-list');
+    await expect(page.getByRole('heading', { name: 'Tier List', level: 1 })).toBeVisible({
+      timeout: 10_000,
+    });
+    const reloadedChip = page.getByRole('tab', { name: DIMENSION_NAME });
+    await expect(reloadedChip).toBeVisible({ timeout: 10_000 });
+    if ((await reloadedChip.getAttribute('aria-selected')) !== 'true') {
+      await reloadedChip.click();
+      await expect(reloadedChip).toHaveAttribute('aria-selected', 'true');
+    }
+
+    // ----- Step 5: assert placements survived ------------------------------
+    const tierS = page.locator('[aria-label="Tier S"]').first();
+    const tierB = page.locator('[aria-label="Tier B"]').first();
+
+    await expect(tierS.locator(`[aria-label="${MOVIE_S}"]`)).toBeVisible({ timeout: 10_000 });
+    await expect(tierB.locator(`[aria-label="${MOVIE_B}"]`)).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/packages/app-media/src/components/TierListBoard.test.tsx
+++ b/packages/app-media/src/components/TierListBoard.test.tsx
@@ -201,4 +201,20 @@ describe('TierListBoard', () => {
     });
     expect(screen.getByText('Unranked (4)')).toBeTruthy();
   });
+
+  it('hydrates from initialPlacements so persisted tiers survive reload', () => {
+    render(
+      <TierListBoard
+        movies={sampleMovies}
+        onSubmit={vi.fn()}
+        initialPlacements={{ S: [1], A: [], B: [2], C: [], D: [] }}
+      />
+    );
+
+    // Two of the four sample movies are pre-placed → unranked has the
+    // remaining two. The submit button is enabled because >=2 are placed.
+    expect(screen.getByText('Unranked (2)')).toBeTruthy();
+    const submitBtn = screen.getByRole('button', { name: /submit tier list/i });
+    expect(submitBtn.hasAttribute('disabled')).toBe(false);
+  });
 });

--- a/packages/app-media/src/components/TierListBoard.tsx
+++ b/packages/app-media/src/components/TierListBoard.tsx
@@ -19,6 +19,12 @@ export type { Tier, TierMovie, TierPlacements };
 interface TierListBoardProps {
   movies: TierMovie[];
   onSubmit: (placements: Array<{ movieId: number; tier: Tier }>) => void;
+  /**
+   * Hydrate the board with persisted placements (see #2195). When omitted,
+   * the board starts empty — used by callers that don't round-trip through
+   * `tier_overrides` (e.g. unit tests, isolated component stories).
+   */
+  initialPlacements?: TierPlacements;
   submitPending?: boolean;
   onNotWatched?: (movieId: number) => void;
   onMarkStale?: (movieId: number) => void;

--- a/packages/app-media/src/components/tier-list-board/useHydratedPlacements.ts
+++ b/packages/app-media/src/components/tier-list-board/useHydratedPlacements.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
+
+import { TIERS, type TierPlacements } from './types';
+
+/**
+ * Stable equality check for two `TierPlacements` records — compares each
+ * tier's id list as a set so re-fetched data with the same content but a
+ * different array reference does not blow away in-flight user edits.
+ */
+function placementsEqual(a: TierPlacements, b: TierPlacements): boolean {
+  for (const tier of TIERS) {
+    if (a[tier].length !== b[tier].length) return false;
+    const set = new Set(a[tier]);
+    for (const id of b[tier]) {
+      if (!set.has(id)) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Re-sync local board state when the hydrated payload changes (#2195) —
+ * dimension switch, post-submit invalidation refetch, etc. The set-based
+ * equality check means a reference-only change with identical contents is
+ * a no-op, so a mid-drag user edit isn't clobbered by a refetch.
+ */
+export function useHydratedPlacements(
+  initialPlacements: TierPlacements | undefined,
+  setPlacements: Dispatch<SetStateAction<TierPlacements>>
+): void {
+  const lastHydratedRef = useRef<TierPlacements | null>(null);
+  useEffect(() => {
+    if (!initialPlacements) return;
+    if (lastHydratedRef.current && placementsEqual(lastHydratedRef.current, initialPlacements)) {
+      return;
+    }
+    lastHydratedRef.current = initialPlacements;
+    setPlacements(initialPlacements);
+  }, [initialPlacements, setPlacements]);
+}

--- a/packages/app-media/src/components/tier-list-board/useTierBoardModel.ts
+++ b/packages/app-media/src/components/tier-list-board/useTierBoardModel.ts
@@ -9,16 +9,26 @@ import {
   type TierMovie,
   type TierPlacements,
 } from './types';
+import { useHydratedPlacements } from './useHydratedPlacements';
 
 import type { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core';
 
 interface UseTierBoardArgs {
   movies: TierMovie[];
   onSubmit: (placements: Array<{ movieId: number; tier: Tier }>) => void;
+  /**
+   * Initial board state — used by the tier-list page to hydrate placements
+   * from the persisted `tier_overrides` table on mount, so that reloading
+   * the page after a submit shows movies still in their assigned tiers
+   * (#2195). Defaults to all-empty when no persisted state exists.
+   */
+  initialPlacements?: TierPlacements;
   onNotWatched?: (movieId: number) => void;
   onMarkStale?: (movieId: number) => void;
   onNA?: (movieId: number) => void;
 }
+
+const EMPTY_PLACEMENTS: TierPlacements = { S: [], A: [], B: [], C: [], D: [] };
 
 function findTierContaining(placements: TierPlacements, movieId: number): Tier | 'unranked' {
   for (const tier of TIERS) {
@@ -154,18 +164,17 @@ function useDragHandlers(args: DragHandlerArgs) {
 export function useTierBoardModel({
   movies,
   onSubmit,
+  initialPlacements,
   onNotWatched,
   onMarkStale,
   onNA,
 }: UseTierBoardArgs) {
-  const [placements, setPlacements] = useState<TierPlacements>({
-    S: [],
-    A: [],
-    B: [],
-    C: [],
-    D: [],
-  });
+  const [placements, setPlacements] = useState<TierPlacements>(
+    () => initialPlacements ?? EMPTY_PLACEMENTS
+  );
   const [activeId, setActiveId] = useState<number | null>(null);
+
+  useHydratedPlacements(initialPlacements, setPlacements);
 
   const movieMap = useMemo(() => new Map(movies.map((m) => [m.mediaId, m])), [movies]);
   const placedIds = useMemo(() => new Set(Object.values(placements).flat()), [placements]);

--- a/packages/app-media/src/hooks/useTierListSubmit.ts
+++ b/packages/app-media/src/hooks/useTierListSubmit.ts
@@ -48,6 +48,7 @@ export function useTierListSubmit({ movieTitles, onSuccess }: UseTierListSubmitO
       };
       setResult(enriched);
       void utils.media.comparisons.getTierListMovies.invalidate();
+      void utils.media.comparisons.getTierListPlacements.invalidate();
       void utils.media.comparisons.listAll.invalidate();
       void utils.media.comparisons.scores.invalidate();
       onSuccess?.(enriched);

--- a/packages/app-media/src/pages/TierListPage.test.tsx
+++ b/packages/app-media/src/pages/TierListPage.test.tsx
@@ -67,6 +67,7 @@ vi.mock('@pops/api-client', () => ({
       media: {
         comparisons: {
           getTierListMovies: { invalidate: vi.fn() },
+          getTierListPlacements: { invalidate: vi.fn() },
           getSmartPair: { invalidate: vi.fn() },
           listDimensions: { invalidate: vi.fn() },
         },
@@ -82,6 +83,9 @@ vi.mock('@pops/api-client', () => ({
             const result = mockTierListQuery(...args);
             return { ...result, refetch: mockRefetch, isFetching: false };
           },
+        },
+        getTierListPlacements: {
+          useQuery: () => ({ data: { data: [] }, isLoading: false, isFetching: false }),
         },
         submitTierList: {
           useMutation: () => ({

--- a/packages/app-media/src/pages/TierListPage.tsx
+++ b/packages/app-media/src/pages/TierListPage.tsx
@@ -40,6 +40,7 @@ function TierListBody({ m }: { m: ReturnType<typeof useTierListPageModel> }) {
   return (
     <TierBoardSection
       movies={m.movies}
+      initialPlacements={m.initialPlacements}
       moviesLoading={m.tierMoviesQuery.isLoading}
       moviesError={m.tierMoviesQuery.error ? { message: m.tierMoviesQuery.error.message } : null}
       isPending={m.submitState.isPending}

--- a/packages/app-media/src/pages/tier-list/TierBoardSection.tsx
+++ b/packages/app-media/src/pages/tier-list/TierBoardSection.tsx
@@ -2,13 +2,24 @@ import { LayoutGrid, RefreshCw } from 'lucide-react';
 
 import { Alert, AlertDescription, AlertTitle, cn } from '@pops/ui';
 
-import { type Tier, TierListBoard, type TierMovie } from '../../components/TierListBoard';
+import {
+  type Tier,
+  TierListBoard,
+  type TierMovie,
+  type TierPlacements,
+} from '../../components/TierListBoard';
 import { PoolSkeleton } from './PoolSkeleton';
 
 interface TierBoardSectionProps {
   movies: TierMovie[];
   moviesLoading: boolean;
   moviesError: { message: string } | null;
+  /**
+   * Persisted placements (see #2195) hydrated from `tier_overrides` so that
+   * a reload after a submit shows movies in their last-saved tiers rather
+   * than dumping everything back into the unranked pool.
+   */
+  initialPlacements?: TierPlacements;
   isPending: boolean;
   isFetching: boolean;
   refetch: () => void;
@@ -63,6 +74,7 @@ export function TierBoardSection(props: TierBoardSectionProps) {
     return (
       <TierListBoard
         movies={movies}
+        initialPlacements={props.initialPlacements}
         onSubmit={props.handleSubmit}
         submitPending={props.isPending}
         onNotWatched={props.handleNotWatched}

--- a/packages/app-media/src/pages/tier-list/useTierListPageModel.ts
+++ b/packages/app-media/src/pages/tier-list/useTierListPageModel.ts
@@ -4,13 +4,51 @@ import { toast } from 'sonner';
 
 import { trpc } from '@pops/api-client';
 
-import { type Tier, type TierMovie } from '../../components/TierListBoard';
+import { TIERS } from '../../components/tier-list-board/types';
+import { type Tier, type TierMovie, type TierPlacements } from '../../components/TierListBoard';
 import { useTierListSubmit } from '../../hooks/useTierListSubmit';
 import { useTierListMutations } from './useTierListMutations';
+
+interface TierPlacementResponse {
+  mediaId: number;
+  mediaType: 'movie';
+  tier: string;
+  title: string;
+  posterUrl: string | null;
+  score: number;
+  comparisonCount: number;
+}
+
+function buildInitialPlacements(rows: TierPlacementResponse[]): TierPlacements {
+  const placements: TierPlacements = { S: [], A: [], B: [], C: [], D: [] };
+  for (const row of rows) {
+    if (TIERS.includes(row.tier as Tier)) {
+      placements[row.tier as Tier].push(row.mediaId);
+    }
+  }
+  return placements;
+}
 
 interface CreateDimensionInput {
   name: string;
   description: string | null;
+}
+
+/**
+ * Merge placed movies with the unranked pool. A movie can be in both sets
+ * when the next round picked it again before it was placed; dedupe by
+ * mediaId, preferring the placed copy so we keep its persisted score.
+ */
+function mergeMovieLists(placed: TierMovie[], unranked: TierMovie[]): TierMovie[] {
+  const seen = new Set<number>();
+  const merged: TierMovie[] = [];
+  for (const m of [...placed, ...unranked]) {
+    if (!seen.has(m.mediaId)) {
+      merged.push(m);
+      seen.add(m.mediaId);
+    }
+  }
+  return merged;
 }
 
 function useDimensionsAndMovies() {
@@ -31,17 +69,39 @@ function useDimensionsAndMovies() {
     { enabled: effectiveDimension != null, staleTime: Infinity }
   );
 
-  const movies: TierMovie[] = useMemo(
+  const placementsQuery = trpc.media.comparisons.getTierListPlacements.useQuery(
+    { dimensionId: effectiveDimension ?? 0 },
+    { enabled: effectiveDimension != null, staleTime: Infinity }
+  );
+
+  const placedMovies: TierMovie[] = useMemo(
     () =>
-      (tierMoviesQuery.data?.data ?? []).map((m) => ({
-        mediaType: 'movie' as const,
-        mediaId: m.id,
-        title: m.title,
-        posterUrl: m.posterUrl,
-        score: m.score,
-        comparisonCount: m.comparisonCount,
+      (placementsQuery.data?.data ?? []).map((p: TierPlacementResponse) => ({
+        mediaType: p.mediaType,
+        mediaId: p.mediaId,
+        title: p.title,
+        posterUrl: p.posterUrl,
+        score: p.score,
+        comparisonCount: p.comparisonCount,
       })),
-    [tierMoviesQuery.data]
+    [placementsQuery.data]
+  );
+
+  const movies: TierMovie[] = useMemo(() => {
+    const unranked = (tierMoviesQuery.data?.data ?? []).map((m) => ({
+      mediaType: 'movie' as const,
+      mediaId: m.id,
+      title: m.title,
+      posterUrl: m.posterUrl,
+      score: m.score,
+      comparisonCount: m.comparisonCount,
+    }));
+    return mergeMovieLists(placedMovies, unranked);
+  }, [placedMovies, tierMoviesQuery.data]);
+
+  const initialPlacements = useMemo(
+    () => buildInitialPlacements((placementsQuery.data?.data ?? []) as TierPlacementResponse[]),
+    [placementsQuery.data]
   );
 
   return {
@@ -51,7 +111,9 @@ function useDimensionsAndMovies() {
     activeDimensions,
     effectiveDimension,
     tierMoviesQuery,
+    placementsQuery,
     movies,
+    initialPlacements,
   };
 }
 


### PR DESCRIPTION
## Summary

`tier_overrides` was effectively write-only from the tier-list page's perspective. `submitTierList` writes one row per placement, but the page model didn't read those rows back, so reloading `/media/tier-list` after a submit dropped every placed movie back into the unranked pool.

This PR closes the round-trip:

- **Backend**: new `getTierListPlacementsForDimension` service function that joins `tier_overrides` with `movies` and `media_scores` for board rendering (title, poster URL, score, comparison count). Exposed via the `getTierListPlacements` tRPC query. Five unit tests cover join shape, default-score fallback for orphan overrides, `poster_override_path` precedence, per-dimension scoping, and empty result.
- **Frontend**: `useTierBoardModel` accepts an `initialPlacements` prop and re-syncs when the hydrated payload changes. The set-based equality check makes a refetch with identical content a no-op, so a mid-drag user edit isn't clobbered. The hydration helper lives in `useHydratedPlacements.ts` to keep the model under the project's `max-lines` limit. `useTierListPageModel` queries placements alongside the unranked pool and merges placed movies into the board's movie list. `useTierListSubmit` invalidates the new query so the board re-syncs without a hard reload.
- **E2E**: a second scenario in `media-tier-list.spec.ts` uses the seeded Cinematography dimension (4 scored movies) to drive the full drag → submit → reload → assert flow. The post-reload assertion is the one #2195 explicitly upgraded from "page is interactive" to "movies remain in S / B tiers".

Closes #2195.

## Test plan

- [ ] CI Backend Tests pass (covers the 5 new service tests)
- [ ] CI Quality Checks pass (lint/format/typecheck across the touched packages)
- [ ] CI Playwright E2E Tests pass — the existing `creates a new dimension` scenario still passes, and the new `places movies in S/B, submits, then reload shows them still in S/B` scenario passes against the seeded Cinematography dimension
