### PR TITLE
feat(cerebrum): MCP server with search, ingest, engram.read, engram.write tools

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@pops/db-types": "workspace:*",
     "@pops/types": "workspace:*",
     "@trpc/server": "^11.16.0",

--- a/apps/pops-api/src/mcp/__tests__/cerebrum-engram-read.test.ts
+++ b/apps/pops-api/src/mcp/__tests__/cerebrum-engram-read.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { NotFoundError } from '../../shared/errors.js';
+import { parseResult } from './test-helpers.js';
+
+import type { Engram } from '../../modules/cerebrum/engrams/types.js';
+
+const mockRead = vi.fn();
+
+vi.mock('../../modules/cerebrum/instance.js', () => ({
+  getEngramService: () => ({
+    read: mockRead,
+  }),
+}));
+
+const { handleEngramRead } = await import('../tools/cerebrum-engram-read.js');
+
+function makeEngram(overrides: Partial<Engram> = {}): Engram {
+  return {
+    id: 'eng_20260427_1200_test',
+    type: 'note',
+    scopes: ['personal'],
+    tags: ['test'],
+    links: [],
+    created: '2026-04-27T12:00:00Z',
+    modified: '2026-04-27T12:00:00Z',
+    source: 'manual',
+    status: 'active',
+    template: null,
+    title: 'Test Engram',
+    filePath: 'personal/note/eng_20260427_1200_test.md',
+    contentHash: 'abc123',
+    wordCount: 42,
+    customFields: {},
+    ...overrides,
+  };
+}
+
+describe('handleEngramRead', () => {
+  it('returns VALIDATION_ERROR for empty id', async () => {
+    const result = await handleEngramRead({ id: '  ' });
+    const parsed = parseResult(result);
+    expect(parsed).toEqual({ error: 'id is required', code: 'VALIDATION_ERROR' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns VALIDATION_ERROR for missing id', async () => {
+    const result = await handleEngramRead({});
+    const parsed = parseResult(result);
+    expect(parsed).toEqual(expect.objectContaining({ code: 'VALIDATION_ERROR' }));
+  });
+
+  it('returns engram metadata and body for a valid read', async () => {
+    const engram = makeEngram();
+    mockRead.mockReturnValueOnce({ engram, body: '# Test\n\nSome content here.' });
+
+    const result = await handleEngramRead({ id: 'eng_20260427_1200_test' });
+    const parsed = parseResult(result) as { engram: Record<string, unknown>; body: string };
+
+    expect(parsed.engram.id).toBe('eng_20260427_1200_test');
+    expect(parsed.engram.title).toBe('Test Engram');
+    expect(parsed.engram.type).toBe('note');
+    expect(parsed.engram.scopes).toEqual(['personal']);
+    expect(parsed.engram.tags).toEqual(['test']);
+    expect(parsed.engram.status).toBe('active');
+    expect(parsed.body).toBe('# Test\n\nSome content here.');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('blocks access when all scopes are secret', async () => {
+    const engram = makeEngram({ scopes: ['personal.secret.passwords'] });
+    mockRead.mockReturnValueOnce({ engram, body: 'secret stuff' });
+
+    const result = await handleEngramRead({ id: 'eng_20260427_1200_test' });
+    const parsed = parseResult(result) as { code: string };
+    expect(parsed.code).toBe('SCOPE_BLOCKED');
+    expect(result.isError).toBe(true);
+  });
+
+  it('allows access when at least one scope is not secret', async () => {
+    const engram = makeEngram({ scopes: ['personal.secret.passwords', 'personal.notes'] });
+    mockRead.mockReturnValueOnce({ engram, body: 'mixed scope content' });
+
+    const result = await handleEngramRead({ id: 'eng_20260427_1200_test' });
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('maps NotFoundError from service', async () => {
+    mockRead.mockImplementationOnce(() => {
+      throw new NotFoundError('Engram', 'eng_nonexistent');
+    });
+
+    const result = await handleEngramRead({ id: 'eng_nonexistent' });
+    const parsed = parseResult(result) as { code: string };
+    expect(parsed.code).toBe('NOT_FOUND');
+    expect(result.isError).toBe(true);
+  });
+
+  it('does not include filePath, contentHash, wordCount, or customFields in response', async () => {
+    const engram = makeEngram();
+    mockRead.mockReturnValueOnce({ engram, body: 'content' });
+
+    const result = await handleEngramRead({ id: 'eng_20260427_1200_test' });
+    const parsed = parseResult(result) as { engram: Record<string, unknown> };
+    expect(parsed.engram).not.toHaveProperty('filePath');
+    expect(parsed.engram).not.toHaveProperty('contentHash');
+    expect(parsed.engram).not.toHaveProperty('wordCount');
+    expect(parsed.engram).not.toHaveProperty('customFields');
+  });
+});

--- a/apps/pops-api/src/mcp/__tests__/cerebrum-engram-write.test.ts
+++ b/apps/pops-api/src/mcp/__tests__/cerebrum-engram-write.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { NotFoundError, ValidationError } from '../../shared/errors.js';
+import { parseResult } from './test-helpers.js';
+
+import type { Engram } from '../../modules/cerebrum/engrams/types.js';
+
+const mockUpdate = vi.fn();
+
+vi.mock('../../modules/cerebrum/instance.js', () => ({
+  getEngramService: () => ({
+    update: mockUpdate,
+  }),
+}));
+
+const { handleEngramWrite } = await import('../tools/cerebrum-engram-write.js');
+
+function makeEngram(overrides: Partial<Engram> = {}): Engram {
+  return {
+    id: 'eng_20260427_1200_test',
+    type: 'note',
+    scopes: ['personal'],
+    tags: ['test'],
+    links: [],
+    created: '2026-04-27T12:00:00Z',
+    modified: '2026-04-27T13:00:00Z',
+    source: 'manual',
+    status: 'active',
+    template: null,
+    title: 'Updated Engram',
+    filePath: 'personal/note/eng_20260427_1200_test.md',
+    contentHash: 'def456',
+    wordCount: 50,
+    customFields: {},
+    ...overrides,
+  };
+}
+
+describe('handleEngramWrite', () => {
+  it('returns VALIDATION_ERROR for empty id', async () => {
+    const result = await handleEngramWrite({ id: '', body: 'content' });
+    const parsed = parseResult(result);
+    expect(parsed).toEqual({ error: 'id is required', code: 'VALIDATION_ERROR' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns VALIDATION_ERROR when no changes are provided', async () => {
+    const result = await handleEngramWrite({ id: 'eng_20260427_1200_test' });
+    const parsed = parseResult(result);
+    expect(parsed).toEqual({
+      error: 'at least one field to update must be provided',
+      code: 'VALIDATION_ERROR',
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('updates body only', async () => {
+    const engram = makeEngram();
+    mockUpdate.mockReturnValueOnce(engram);
+
+    const result = await handleEngramWrite({
+      id: 'eng_20260427_1200_test',
+      body: 'New body content',
+    });
+    const parsed = parseResult(result) as { engram: Record<string, unknown> };
+
+    expect(parsed.engram.id).toBe('eng_20260427_1200_test');
+    expect(parsed.engram.modified).toBe('2026-04-27T13:00:00Z');
+    expect(result.isError).toBeUndefined();
+
+    expect(mockUpdate).toHaveBeenCalledWith('eng_20260427_1200_test', { body: 'New body content' });
+  });
+
+  it('updates title only', async () => {
+    mockUpdate.mockReturnValueOnce(makeEngram({ title: 'New Title' }));
+
+    await handleEngramWrite({
+      id: 'eng_20260427_1200_test',
+      title: 'New Title',
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith('eng_20260427_1200_test', { title: 'New Title' });
+  });
+
+  it('updates scopes and tags together', async () => {
+    mockUpdate.mockReturnValueOnce(
+      makeEngram({ scopes: ['work'], tags: ['meeting', 'important'] })
+    );
+
+    await handleEngramWrite({
+      id: 'eng_20260427_1200_test',
+      scopes: ['work'],
+      tags: ['meeting', 'important'],
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith('eng_20260427_1200_test', {
+      scopes: ['work'],
+      tags: ['meeting', 'important'],
+    });
+  });
+
+  it('returns only id, title, type, scopes, modified in response', async () => {
+    mockUpdate.mockReturnValueOnce(makeEngram());
+
+    const result = await handleEngramWrite({
+      id: 'eng_20260427_1200_test',
+      body: 'content',
+    });
+    const parsed = parseResult(result) as { engram: Record<string, unknown> };
+
+    expect(Object.keys(parsed.engram).toSorted()).toEqual(
+      ['id', 'modified', 'scopes', 'title', 'type'].toSorted()
+    );
+  });
+
+  it('maps NotFoundError from service', async () => {
+    mockUpdate.mockImplementationOnce(() => {
+      throw new NotFoundError('Engram', 'eng_nonexistent');
+    });
+
+    const result = await handleEngramWrite({
+      id: 'eng_nonexistent',
+      body: 'content',
+    });
+    const parsed = parseResult(result) as { code: string };
+    expect(parsed.code).toBe('NOT_FOUND');
+    expect(result.isError).toBe(true);
+  });
+
+  it('maps ValidationError from service', async () => {
+    mockUpdate.mockImplementationOnce(() => {
+      throw new ValidationError({ message: 'invalid status transition' });
+    });
+
+    const result = await handleEngramWrite({
+      id: 'eng_20260427_1200_test',
+      body: 'content',
+    });
+    const parsed = parseResult(result) as { code: string };
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(result.isError).toBe(true);
+  });
+
+  it('filters non-string values from scopes and tags', async () => {
+    mockUpdate.mockReturnValueOnce(makeEngram());
+
+    await handleEngramWrite({
+      id: 'eng_20260427_1200_test',
+      scopes: ['valid', 123, null] as unknown as string[],
+      tags: ['tag1', false, 'tag2'] as unknown as string[],
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith('eng_20260427_1200_test', {
+      scopes: ['valid'],
+      tags: ['tag1', 'tag2'],
+    });
+  });
+});

--- a/apps/pops-api/src/mcp/__tests__/cerebrum-ingest.test.ts
+++ b/apps/pops-api/src/mcp/__tests__/cerebrum-ingest.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleJsonBody } from '../tools/cerebrum-ingest.js';
+import { parseResult } from './test-helpers.js';
+
+// Mock the IngestService to avoid DB dependency in unit tests
+vi.mock('../../modules/cerebrum/ingest/pipeline.js', () => ({
+  IngestService: class MockIngestService {
+    async submit(input: Record<string, unknown>) {
+      return {
+        engram: {
+          id: 'eng_20260427_1200_test',
+          title: input['title'] ?? 'Derived Title',
+          type: input['type'] ?? 'note',
+          scopes: input['scopes'] ?? ['personal'],
+          filePath: 'personal/note/eng_20260427_1200_test.md',
+        },
+        classification: null,
+        entities: [],
+        scopeInference: { scopes: ['personal'], source: 'rules', confidence: 0.9 },
+      };
+    }
+  },
+}));
+
+// Dynamic import of handler AFTER mock is set up
+const { handleCerebrumIngest } = await import('../tools/cerebrum-ingest.js');
+
+describe('handleJsonBody', () => {
+  it('returns the original body for non-JSON content', () => {
+    const result = handleJsonBody('Hello world');
+    expect(result.body).toBe('Hello world');
+    expect(result.derivedTitle).toBeNull();
+  });
+
+  it('wraps valid JSON object in a fenced code block', () => {
+    const json = '{"name": "test", "value": 42}';
+    const result = handleJsonBody(json);
+    expect(result.body).toBe('```json\n{"name": "test", "value": 42}\n```');
+  });
+
+  it('wraps valid JSON array in a fenced code block', () => {
+    const json = '[1, 2, 3]';
+    const result = handleJsonBody(json);
+    expect(result.body).toBe('```json\n[1, 2, 3]\n```');
+    expect(result.derivedTitle).toBeNull();
+  });
+
+  it('derives title from "title" key', () => {
+    const json = '{"title": "My Document", "body": "content"}';
+    const result = handleJsonBody(json);
+    expect(result.derivedTitle).toBe('My Document');
+  });
+
+  it('derives title from "name" key when title is absent', () => {
+    const json = '{"name": "Project Alpha", "status": "active"}';
+    const result = handleJsonBody(json);
+    expect(result.derivedTitle).toBe('Project Alpha');
+  });
+
+  it('derives title from "subject" key', () => {
+    const json = '{"subject": "Meeting Notes", "date": "2026-01-01"}';
+    const result = handleJsonBody(json);
+    expect(result.derivedTitle).toBe('Meeting Notes');
+  });
+
+  it('falls back to key summary when no title-like keys exist', () => {
+    const json = '{"alpha": 1, "beta": 2, "gamma": 3}';
+    const result = handleJsonBody(json);
+    expect(result.derivedTitle).toBe('JSON: alpha, beta, gamma');
+  });
+
+  it('truncates key summary for objects with many keys', () => {
+    const obj: Record<string, number> = {};
+    for (let i = 0; i < 10; i++) obj[`key${i}`] = i;
+    const json = JSON.stringify(obj);
+    const result = handleJsonBody(json);
+    expect(result.derivedTitle).toContain('…');
+    expect(result.derivedTitle?.split(',').length).toBeLessThanOrEqual(5);
+  });
+
+  it('truncates derived title to 120 characters', () => {
+    const longTitle = 'A'.repeat(200);
+    const json = JSON.stringify({ title: longTitle });
+    const result = handleJsonBody(json);
+    expect(result.derivedTitle).toHaveLength(120);
+  });
+
+  it('returns original body for invalid JSON starting with {', () => {
+    const body = '{not valid json';
+    const result = handleJsonBody(body);
+    expect(result.body).toBe(body);
+    expect(result.derivedTitle).toBeNull();
+  });
+
+  it('handles whitespace around JSON', () => {
+    const json = '  \n  {"title": "Trimmed"}  \n  ';
+    const result = handleJsonBody(json);
+    expect(result.body).toBe('```json\n{"title": "Trimmed"}\n```');
+    expect(result.derivedTitle).toBe('Trimmed');
+  });
+
+  it('skips empty-string title keys', () => {
+    const json = '{"title": "  ", "name": "Fallback"}';
+    const result = handleJsonBody(json);
+    expect(result.derivedTitle).toBe('Fallback');
+  });
+});
+
+describe('handleCerebrumIngest', () => {
+  it('returns VALIDATION_ERROR for empty body', async () => {
+    const result = await handleCerebrumIngest({ body: '   ' });
+    const parsed = parseResult(result);
+    expect(parsed).toEqual({
+      error: 'body is required and must be non-empty',
+      code: 'VALIDATION_ERROR',
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns VALIDATION_ERROR for missing body', async () => {
+    const result = await handleCerebrumIngest({});
+    const parsed = parseResult(result);
+    expect(parsed).toEqual(expect.objectContaining({ code: 'VALIDATION_ERROR' }));
+  });
+
+  it('ingests plain text content', async () => {
+    const result = await handleCerebrumIngest({
+      body: 'Hello world',
+      title: 'Test Note',
+      type: 'note',
+      scopes: ['personal'],
+      tags: ['test'],
+    });
+    const parsed = parseResult(result) as { engram: { id: string } };
+    expect(parsed.engram).toBeDefined();
+    expect(parsed.engram.id).toBe('eng_20260427_1200_test');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('auto-derives title from JSON body when no title provided', async () => {
+    const result = await handleCerebrumIngest({
+      body: '{"title": "Auto Title", "data": 42}',
+    });
+    const parsed = parseResult(result) as { engram: { title: string } };
+    // The mock returns the title passed to submit
+    expect(parsed.engram).toBeDefined();
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('filters non-string values from scopes array', async () => {
+    const result = await handleCerebrumIngest({
+      body: 'content',
+      scopes: ['valid', 42, null, 'also-valid'] as unknown as string[],
+    });
+    expect(result.isError).toBeUndefined();
+  });
+});

--- a/apps/pops-api/src/mcp/__tests__/cerebrum-search.test.ts
+++ b/apps/pops-api/src/mcp/__tests__/cerebrum-search.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { parseResult } from './test-helpers.js';
+
+import type { RetrievalResult } from '../../modules/cerebrum/retrieval/types.js';
+
+// Mock the DB and HybridSearchService
+vi.mock('../../db.js', () => ({
+  getDrizzle: () => ({}),
+}));
+
+const mockHybridResults: RetrievalResult[] = [
+  {
+    sourceType: 'engram',
+    sourceId: 'eng_20260101_0900_finance-note',
+    title: 'Finance planning for Q1',
+    contentPreview: 'This is a note about Q1 finance planning with detailed budget allocations.',
+    score: 0.92,
+    matchType: 'both',
+    metadata: { scopes: ['personal.finance'] },
+  },
+  {
+    sourceType: 'engram',
+    sourceId: 'eng_20260102_1000_meeting-notes',
+    title: 'Meeting notes from Jan 2',
+    contentPreview: 'A'.repeat(300),
+    score: 0.85,
+    matchType: 'semantic',
+    metadata: { scopes: ['work.projects'] },
+  },
+];
+
+const mockHybrid = vi.fn().mockResolvedValue(mockHybridResults);
+
+vi.mock('../../modules/cerebrum/retrieval/hybrid-search.js', () => ({
+  HybridSearchService: class MockHybridSearchService {
+    hybrid = mockHybrid;
+  },
+}));
+
+const { handleCerebrumSearch } = await import('../tools/cerebrum-search.js');
+
+describe('handleCerebrumSearch', () => {
+  it('returns VALIDATION_ERROR for empty query', async () => {
+    const result = await handleCerebrumSearch({ query: '   ' });
+    const parsed = parseResult(result);
+    expect(parsed).toEqual({
+      error: 'query is required and must be non-empty',
+      code: 'VALIDATION_ERROR',
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns VALIDATION_ERROR for missing query', async () => {
+    const result = await handleCerebrumSearch({});
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns mapped results with id, title, score, scopes, snippet', async () => {
+    const result = await handleCerebrumSearch({ query: 'finance planning' });
+    const parsed = parseResult(result) as { results: Array<{ id: string; snippet: string }> };
+    expect(parsed.results).toHaveLength(2);
+
+    const first = parsed.results[0];
+    expect(first?.id).toBe('eng_20260101_0900_finance-note');
+    expect(first?.snippet).toContain('Q1 finance planning');
+  });
+
+  it('truncates snippets longer than 200 characters', async () => {
+    const result = await handleCerebrumSearch({ query: 'meeting' });
+    const parsed = parseResult(result) as { results: Array<{ snippet: string }> };
+    const second = parsed.results[1];
+    expect(second?.snippet.length).toBeLessThanOrEqual(201); // 200 + ellipsis char
+    expect(second?.snippet).toContain('…');
+  });
+
+  it('passes scopes and limit to the search service', async () => {
+    mockHybrid.mockClear();
+    await handleCerebrumSearch({
+      query: 'test',
+      scopes: ['personal.finance'],
+      limit: 5,
+    });
+
+    expect(mockHybrid).toHaveBeenCalledWith(
+      'test',
+      expect.objectContaining({ scopes: ['personal.finance'] }),
+      5,
+      0.8
+    );
+  });
+
+  it('sets includeSecret when scopes contain a secret scope', async () => {
+    mockHybrid.mockClear();
+    await handleCerebrumSearch({
+      query: 'secrets',
+      scopes: ['personal.secret.passwords'],
+    });
+
+    expect(mockHybrid).toHaveBeenCalledWith(
+      'secrets',
+      expect.objectContaining({ includeSecret: true }),
+      20,
+      0.8
+    );
+  });
+
+  it('does not set includeSecret for non-secret scopes', async () => {
+    mockHybrid.mockClear();
+    await handleCerebrumSearch({
+      query: 'normal',
+      scopes: ['personal.finance'],
+    });
+
+    expect(mockHybrid).toHaveBeenCalledWith(
+      'normal',
+      expect.objectContaining({ includeSecret: false }),
+      20,
+      0.8
+    );
+  });
+
+  it('handles search service errors gracefully', async () => {
+    mockHybrid.mockRejectedValueOnce(new Error('DB connection failed'));
+    const result = await handleCerebrumSearch({ query: 'test' });
+    const parsed = parseResult(result) as { error: string; code: string };
+    expect(parsed.code).toBe('INTERNAL_ERROR');
+    expect(parsed.error).toBe('DB connection failed');
+    expect(result.isError).toBe(true);
+  });
+});

--- a/apps/pops-api/src/mcp/__tests__/errors.test.ts
+++ b/apps/pops-api/src/mcp/__tests__/errors.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { NotFoundError, ValidationError } from '../../shared/errors.js';
+import { mapServiceError, mcpError, mcpSuccess } from '../errors.js';
+import { extractText, parseResult } from './test-helpers.js';
+
+describe('mcpSuccess', () => {
+  it('wraps a payload in a text content block', () => {
+    const result = mcpSuccess({ count: 42 });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: '{"count":42}' }],
+    });
+  });
+
+  it('serialises null', () => {
+    const result = mcpSuccess(null);
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'null' }],
+    });
+  });
+
+  it('does not set isError', () => {
+    const result = mcpSuccess({ ok: true });
+    expect(result).not.toHaveProperty('isError');
+  });
+});
+
+describe('mcpError', () => {
+  it('wraps an error message and code in a text content block', () => {
+    const result = mcpError('not found', 'NOT_FOUND');
+    const parsed = parseResult(result);
+    expect(parsed).toEqual({ error: 'not found', code: 'NOT_FOUND' });
+  });
+
+  it('sets isError to true', () => {
+    const result = mcpError('oops', 'INTERNAL_ERROR');
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe('mapServiceError', () => {
+  it('maps NotFoundError to NOT_FOUND', () => {
+    const err = new NotFoundError('Engram', 'eng_123');
+    const result = mapServiceError(err);
+    const parsed = parseResult(result) as { code: string; error: string };
+    expect(parsed.code).toBe('NOT_FOUND');
+    expect(parsed.error).toContain('eng_123');
+    expect(result.isError).toBe(true);
+  });
+
+  it('maps ValidationError to VALIDATION_ERROR', () => {
+    const err = new ValidationError({ field: 'bad' });
+    const result = mapServiceError(err);
+    const parsed = parseResult(result) as { code: string };
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(result.isError).toBe(true);
+  });
+
+  it('maps generic Error to INTERNAL_ERROR', () => {
+    const err = new Error('something broke');
+    const result = mapServiceError(err);
+    const parsed = parseResult(result) as { code: string; error: string };
+    expect(parsed.code).toBe('INTERNAL_ERROR');
+    expect(parsed.error).toBe('something broke');
+  });
+
+  it('maps non-Error values to INTERNAL_ERROR with stringified message', () => {
+    const result = mapServiceError('raw string error');
+    const parsed = parseResult(result) as { code: string; error: string };
+    expect(parsed.code).toBe('INTERNAL_ERROR');
+    expect(parsed.error).toBe('raw string error');
+  });
+
+  it('extractText returns {} for non-text content', () => {
+    // Ensure the helper is safe
+    const text = extractText({ content: [] });
+    expect(text).toBe('{}');
+  });
+});

--- a/apps/pops-api/src/mcp/__tests__/test-helpers.ts
+++ b/apps/pops-api/src/mcp/__tests__/test-helpers.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared test helpers for MCP tool tests.
+ */
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Extract the text content from the first item in a CallToolResult.
+ * Assumes the first content item is a text block (which all our tools produce).
+ */
+export function extractText(result: CallToolResult): string {
+  const first = result.content[0];
+  if (first && 'text' in first && typeof first.text === 'string') {
+    return first.text;
+  }
+  return '{}';
+}
+
+/** Parse the JSON text content from a CallToolResult. */
+export function parseResult(result: CallToolResult): unknown {
+  return JSON.parse(extractText(result));
+}

--- a/apps/pops-api/src/mcp/__tests__/tool-registry.test.ts
+++ b/apps/pops-api/src/mcp/__tests__/tool-registry.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock all service dependencies so we can test registry dispatch in isolation
+vi.mock('../../db.js', () => ({ getDrizzle: () => ({}) }));
+vi.mock('../../modules/cerebrum/retrieval/hybrid-search.js', () => ({
+  HybridSearchService: class {
+    async hybrid() {
+      return [];
+    }
+  },
+}));
+vi.mock('../../modules/cerebrum/ingest/pipeline.js', () => ({
+  IngestService: class {
+    async submit() {
+      return {
+        engram: { id: 'eng_test', title: 't', type: 'note', scopes: [], filePath: '' },
+        classification: null,
+        entities: [],
+        scopeInference: { scopes: [], source: 'fallback', confidence: 0 },
+      };
+    }
+  },
+}));
+vi.mock('../../modules/cerebrum/instance.js', () => ({
+  getEngramService: () => ({
+    read: () => ({
+      engram: {
+        id: 'eng_test',
+        title: 't',
+        type: 'note',
+        scopes: ['personal'],
+        tags: [],
+        status: 'active',
+        created: '2026-01-01T00:00:00Z',
+        modified: '2026-01-01T00:00:00Z',
+      },
+      body: 'content',
+    }),
+    update: () => ({
+      id: 'eng_test',
+      title: 't',
+      type: 'note',
+      scopes: ['personal'],
+      modified: '2026-01-01T00:00:00Z',
+    }),
+  }),
+}));
+
+const { dispatchTool, toolDefinitions } = await import('../tools/index.js');
+
+describe('toolDefinitions', () => {
+  it('registers exactly 4 tools', () => {
+    expect(toolDefinitions).toHaveLength(4);
+  });
+
+  it('includes cerebrum.search', () => {
+    expect(toolDefinitions.some((t) => t.name === 'cerebrum.search')).toBe(true);
+  });
+
+  it('includes cerebrum.ingest', () => {
+    expect(toolDefinitions.some((t) => t.name === 'cerebrum.ingest')).toBe(true);
+  });
+
+  it('includes cerebrum.engram.read', () => {
+    expect(toolDefinitions.some((t) => t.name === 'cerebrum.engram.read')).toBe(true);
+  });
+
+  it('includes cerebrum.engram.write', () => {
+    expect(toolDefinitions.some((t) => t.name === 'cerebrum.engram.write')).toBe(true);
+  });
+
+  it('all tools have a description and inputSchema', () => {
+    for (const tool of toolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema['type']).toBe('object');
+    }
+  });
+});
+
+describe('dispatchTool', () => {
+  it('returns null for unknown tool names', () => {
+    const result = dispatchTool('cerebrum.nonexistent', {});
+    expect(result).toBeNull();
+  });
+
+  it('dispatches cerebrum.search and returns a promise', () => {
+    const result = dispatchTool('cerebrum.search', { query: 'test' });
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it('dispatches cerebrum.ingest', () => {
+    const result = dispatchTool('cerebrum.ingest', { body: 'content' });
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it('dispatches cerebrum.engram.read', () => {
+    const result = dispatchTool('cerebrum.engram.read', { id: 'eng_test' });
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it('dispatches cerebrum.engram.write', () => {
+    const result = dispatchTool('cerebrum.engram.write', { id: 'eng_test', body: 'new' });
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it('cerebrum.search resolves to a valid MCP response', async () => {
+    const result = await dispatchTool('cerebrum.search', { query: 'test' });
+    expect(result).toBeDefined();
+    expect(result?.content).toBeDefined();
+    expect(result?.content[0]?.type).toBe('text');
+  });
+});

--- a/apps/pops-api/src/mcp/errors.ts
+++ b/apps/pops-api/src/mcp/errors.ts
@@ -1,0 +1,35 @@
+/**
+ * MCP error formatting — maps service-layer errors to MCP tool responses.
+ */
+import { NotFoundError, ValidationError } from '../shared/errors.js';
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import type { McpErrorCode } from './types.js';
+
+/** Build a successful MCP tool response from a JSON-serialisable payload. */
+export function mcpSuccess(payload: unknown): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+  };
+}
+
+/** Build an MCP error response. */
+export function mcpError(message: string, code: McpErrorCode): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: message, code }) }],
+    isError: true,
+  };
+}
+
+/** Map a thrown error to an MCP tool error response. */
+export function mapServiceError(err: unknown): CallToolResult {
+  if (err instanceof NotFoundError) {
+    return mcpError(err.message, 'NOT_FOUND');
+  }
+  if (err instanceof ValidationError) {
+    return mcpError(err.message, 'VALIDATION_ERROR');
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return mcpError(message, 'INTERNAL_ERROR');
+}

--- a/apps/pops-api/src/mcp/server.ts
+++ b/apps/pops-api/src/mcp/server.ts
@@ -1,0 +1,50 @@
+/**
+ * Cerebrum MCP server — standalone entry point for Claude Code stdio transport.
+ *
+ * Spawn with: `npx tsx apps/pops-api/src/mcp/server.ts`
+ *
+ * Bootstraps the database connection, registers all tools, and connects
+ * via stdio. Each tool call delegates to existing cerebrum services.
+ */
+import { config } from 'dotenv';
+
+// Load environment variables using the same pattern as the main API entry point.
+// CWD is typically the repo root when spawned by Claude Code.
+config(); // loads .env in CWD if present
+config({ path: 'apps/pops-api/.env', override: false });
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+import { mcpError } from './errors.js';
+import { dispatchTool, toolDefinitions } from './tools/index.js';
+
+const server = new Server({ name: 'cerebrum', version: '1.0.0' }, { capabilities: { tools: {} } });
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: toolDefinitions,
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  const safeArgs = (args ?? {}) as Record<string, unknown>;
+
+  const result = dispatchTool(name, safeArgs);
+  if (!result) {
+    return mcpError(`Unknown tool: ${name}`, 'VALIDATION_ERROR');
+  }
+
+  return result;
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`[cerebrum-mcp] Fatal: ${message}\n`);
+  process.exit(1);
+});

--- a/apps/pops-api/src/mcp/tools/cerebrum-engram-read.ts
+++ b/apps/pops-api/src/mcp/tools/cerebrum-engram-read.ts
@@ -1,0 +1,71 @@
+/**
+ * cerebrum.engram.read — read an engram by ID.
+ *
+ * Delegates to EngramService.read() and returns engram metadata + body.
+ * Blocks access if all scopes are secret.
+ */
+import { getEngramService } from '../../modules/cerebrum/instance.js';
+import { mapServiceError, mcpError, mcpSuccess } from '../errors.js';
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+function allScopesSecret(scopes: string[]): boolean {
+  return scopes.length > 0 && scopes.every(isSecretScope);
+}
+
+function parseArgs(raw: Record<string, unknown>): { id: string } {
+  const id = typeof raw['id'] === 'string' ? raw['id'] : '';
+  return { id };
+}
+
+export async function handleEngramRead(raw: Record<string, unknown>): Promise<CallToolResult> {
+  const { id } = parseArgs(raw);
+
+  if (!id.trim()) {
+    return mcpError('id is required', 'VALIDATION_ERROR');
+  }
+
+  try {
+    const svc = getEngramService();
+    const { engram, body } = svc.read(id);
+
+    if (allScopesSecret(engram.scopes)) {
+      return mcpError(
+        `Engram '${id}' is fully secret-scoped and cannot be read via MCP`,
+        'SCOPE_BLOCKED'
+      );
+    }
+
+    return mcpSuccess({
+      engram: {
+        id: engram.id,
+        title: engram.title,
+        type: engram.type,
+        scopes: engram.scopes,
+        tags: engram.tags,
+        status: engram.status,
+        created: engram.created,
+        modified: engram.modified,
+      },
+      body,
+    });
+  } catch (err) {
+    return mapServiceError(err);
+  }
+}
+
+/** JSON Schema for the cerebrum.engram.read tool input. */
+export const engramReadSchema = {
+  type: 'object' as const,
+  properties: {
+    id: {
+      type: 'string' as const,
+      description: 'Engram ID (e.g. "eng_20260427_1430_my-note")',
+    },
+  },
+  required: ['id'] as const,
+};

--- a/apps/pops-api/src/mcp/tools/cerebrum-engram-write.ts
+++ b/apps/pops-api/src/mcp/tools/cerebrum-engram-write.ts
@@ -1,0 +1,103 @@
+/**
+ * cerebrum.engram.write — update an existing engram.
+ *
+ * Delegates to EngramService.update() and returns updated metadata.
+ */
+import { getEngramService } from '../../modules/cerebrum/instance.js';
+import { mapServiceError, mcpError, mcpSuccess } from '../errors.js';
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import type { UpdateEngramInput } from '../../modules/cerebrum/engrams/service.js';
+
+interface WriteArgs {
+  id: string;
+  body?: string;
+  title?: string;
+  scopes?: string[];
+  tags?: string[];
+}
+
+function parseArgs(raw: Record<string, unknown>): WriteArgs {
+  const id = typeof raw['id'] === 'string' ? raw['id'] : '';
+  const body = typeof raw['body'] === 'string' ? raw['body'] : undefined;
+  const title = typeof raw['title'] === 'string' ? raw['title'] : undefined;
+  const scopes = Array.isArray(raw['scopes'])
+    ? (raw['scopes'] as unknown[]).filter((s): s is string => typeof s === 'string')
+    : undefined;
+  const tags = Array.isArray(raw['tags'])
+    ? (raw['tags'] as unknown[]).filter((s): s is string => typeof s === 'string')
+    : undefined;
+  return { id, body, title, scopes, tags };
+}
+
+export async function handleEngramWrite(raw: Record<string, unknown>): Promise<CallToolResult> {
+  const args = parseArgs(raw);
+
+  if (!args.id.trim()) {
+    return mcpError('id is required', 'VALIDATION_ERROR');
+  }
+
+  const hasChanges =
+    args.body !== undefined ||
+    args.title !== undefined ||
+    args.scopes !== undefined ||
+    args.tags !== undefined;
+
+  if (!hasChanges) {
+    return mcpError('at least one field to update must be provided', 'VALIDATION_ERROR');
+  }
+
+  try {
+    const svc = getEngramService();
+    const changes: UpdateEngramInput = {};
+    if (args.body !== undefined) changes.body = args.body;
+    if (args.title !== undefined) changes.title = args.title;
+    if (args.scopes !== undefined) changes.scopes = args.scopes;
+    if (args.tags !== undefined) changes.tags = args.tags;
+
+    const engram = svc.update(args.id, changes);
+
+    return mcpSuccess({
+      engram: {
+        id: engram.id,
+        title: engram.title,
+        type: engram.type,
+        scopes: engram.scopes,
+        modified: engram.modified,
+      },
+    });
+  } catch (err) {
+    return mapServiceError(err);
+  }
+}
+
+/** JSON Schema for the cerebrum.engram.write tool input. */
+export const engramWriteSchema = {
+  type: 'object' as const,
+  properties: {
+    id: {
+      type: 'string' as const,
+      description: 'Engram ID to update',
+    },
+    body: {
+      type: 'string' as const,
+      description: 'New body content',
+    },
+    title: {
+      type: 'string' as const,
+      description: 'New title',
+    },
+    scopes: {
+      type: 'array' as const,
+      items: { type: 'string' as const },
+      description: 'Replacement scopes',
+    },
+    tags: {
+      type: 'array' as const,
+      items: { type: 'string' as const },
+      description: 'Replacement tags',
+    },
+  },
+  required: ['id'] as const,
+};

--- a/apps/pops-api/src/mcp/tools/cerebrum-ingest.ts
+++ b/apps/pops-api/src/mcp/tools/cerebrum-ingest.ts
@@ -1,0 +1,145 @@
+/**
+ * cerebrum.ingest — ingest content into the engram knowledge base.
+ *
+ * Delegates to IngestService. Also handles structured JSON detection:
+ * if the body starts with `{` or `[` and parses as valid JSON, it is
+ * converted to Markdown with the JSON in a fenced code block.
+ */
+import { IngestService } from '../../modules/cerebrum/ingest/pipeline.js';
+import { mapServiceError, mcpError, mcpSuccess } from '../errors.js';
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+interface IngestArgs {
+  body: string;
+  title?: string;
+  type?: string;
+  scopes?: string[];
+  tags?: string[];
+}
+
+const TITLE_KEYS = ['title', 'name', 'subject', 'label'] as const;
+
+/** Try to extract a title from a JSON object's well-known keys, falling back to a key summary. */
+function deriveTitleFromObject(obj: Record<string, unknown>): string | null {
+  for (const key of TITLE_KEYS) {
+    const val = obj[key];
+    if (typeof val === 'string' && val.trim().length > 0) {
+      return val.trim().slice(0, 120);
+    }
+  }
+
+  const keys = Object.keys(obj);
+  if (keys.length > 0) {
+    return `JSON: ${keys.slice(0, 5).join(', ')}${keys.length > 5 ? '…' : ''}`;
+  }
+
+  return null;
+}
+
+/**
+ * Detect structured JSON and convert to Markdown.
+ * Returns a new body and optional derived title.
+ */
+function handleJsonBody(body: string): { body: string; derivedTitle: string | null } {
+  const trimmed = body.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+    return { body, derivedTitle: null };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return { body, derivedTitle: null };
+  }
+
+  const isPlainObject = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed);
+  const derivedTitle = isPlainObject
+    ? deriveTitleFromObject(parsed as Record<string, unknown>)
+    : null;
+
+  const mdBody = `\`\`\`json\n${trimmed}\n\`\`\``;
+  return { body: mdBody, derivedTitle };
+}
+
+function parseArgs(raw: Record<string, unknown>): IngestArgs {
+  const body = typeof raw['body'] === 'string' ? raw['body'] : '';
+  const title = typeof raw['title'] === 'string' ? raw['title'] : undefined;
+  const type = typeof raw['type'] === 'string' ? raw['type'] : undefined;
+  const scopes = Array.isArray(raw['scopes'])
+    ? (raw['scopes'] as unknown[]).filter((s): s is string => typeof s === 'string')
+    : undefined;
+  const tags = Array.isArray(raw['tags'])
+    ? (raw['tags'] as unknown[]).filter((s): s is string => typeof s === 'string')
+    : undefined;
+  return { body, title, type, scopes, tags };
+}
+
+export async function handleCerebrumIngest(raw: Record<string, unknown>): Promise<CallToolResult> {
+  const args = parseArgs(raw);
+
+  if (!args.body.trim()) {
+    return mcpError('body is required and must be non-empty', 'VALIDATION_ERROR');
+  }
+
+  try {
+    const { body: processedBody, derivedTitle } = handleJsonBody(args.body);
+    const title = args.title ?? derivedTitle ?? undefined;
+
+    const svc = new IngestService();
+    const result = await svc.submit({
+      body: processedBody,
+      title,
+      type: args.type,
+      scopes: args.scopes,
+      tags: args.tags,
+      source: 'agent',
+    });
+
+    return mcpSuccess({
+      engram: {
+        id: result.engram.id,
+        title: result.engram.title,
+        type: result.engram.type,
+        scopes: result.engram.scopes,
+        filePath: result.engram.filePath,
+      },
+    });
+  } catch (err) {
+    return mapServiceError(err);
+  }
+}
+
+/** JSON Schema for the cerebrum.ingest tool input. */
+export const cerebrumIngestSchema = {
+  type: 'object' as const,
+  properties: {
+    body: {
+      type: 'string' as const,
+      description: 'The content body to ingest. Plain text, Markdown, or JSON.',
+    },
+    title: {
+      type: 'string' as const,
+      description: 'Optional title. Auto-derived if omitted.',
+    },
+    type: {
+      type: 'string' as const,
+      description: 'Content type (e.g. "note", "reference", "log"). Auto-classified if omitted.',
+    },
+    scopes: {
+      type: 'array' as const,
+      items: { type: 'string' as const },
+      description: 'Scopes for the engram (e.g. ["personal.finance"]). Auto-inferred if omitted.',
+    },
+    tags: {
+      type: 'array' as const,
+      items: { type: 'string' as const },
+      description: 'Tags for the engram.',
+    },
+  },
+  required: ['body'] as const,
+};
+
+// Exported for testing
+export { handleJsonBody };

--- a/apps/pops-api/src/mcp/tools/cerebrum-search.ts
+++ b/apps/pops-api/src/mcp/tools/cerebrum-search.ts
@@ -1,0 +1,106 @@
+/**
+ * cerebrum.search — hybrid search over the engram knowledge base.
+ *
+ * Delegates to HybridSearchService and maps results to the MCP output format.
+ */
+import { getDrizzle } from '../../db.js';
+import { HybridSearchService } from '../../modules/cerebrum/retrieval/hybrid-search.js';
+import { mapServiceError, mcpError, mcpSuccess } from '../errors.js';
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import type { RetrievalResult } from '../../modules/cerebrum/retrieval/types.js';
+
+const MAX_SNIPPET_LENGTH = 200;
+const DEFAULT_LIMIT = 20;
+
+interface SearchArgs {
+  query: string;
+  scopes?: string[];
+  limit?: number;
+}
+
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+function hasExplicitSecretScope(scopes: string[] | undefined): boolean {
+  return scopes?.some(isSecretScope) ?? false;
+}
+
+function truncateSnippet(text: string): string {
+  if (text.length <= MAX_SNIPPET_LENGTH) return text;
+  return text.slice(0, MAX_SNIPPET_LENGTH) + '…';
+}
+
+function mapResult(result: RetrievalResult): {
+  id: string;
+  title: string;
+  score: number;
+  scopes: string[];
+  snippet: string;
+} {
+  const scopes = (result.metadata['scopes'] as string[] | undefined) ?? [];
+  return {
+    id: result.sourceId,
+    title: result.title,
+    score: result.score,
+    scopes,
+    snippet: truncateSnippet(result.contentPreview),
+  };
+}
+
+function parseArgs(raw: Record<string, unknown>): SearchArgs {
+  const query = typeof raw['query'] === 'string' ? raw['query'] : '';
+  const scopes = Array.isArray(raw['scopes'])
+    ? (raw['scopes'] as unknown[]).filter((s): s is string => typeof s === 'string')
+    : undefined;
+  const limit =
+    typeof raw['limit'] === 'number' && Number.isInteger(raw['limit']) && raw['limit'] > 0
+      ? raw['limit']
+      : undefined;
+  return { query, scopes, limit };
+}
+
+export async function handleCerebrumSearch(raw: Record<string, unknown>): Promise<CallToolResult> {
+  const args = parseArgs(raw);
+
+  if (!args.query.trim()) {
+    return mcpError('query is required and must be non-empty', 'VALIDATION_ERROR');
+  }
+
+  try {
+    const db = getDrizzle();
+    const svc = new HybridSearchService(db);
+
+    const includeSecret = hasExplicitSecretScope(args.scopes);
+    const filters = {
+      ...(args.scopes ? { scopes: args.scopes } : {}),
+      includeSecret,
+    };
+
+    const results = await svc.hybrid(args.query, filters, args.limit ?? DEFAULT_LIMIT, 0.8);
+
+    return mcpSuccess({ results: results.map(mapResult) });
+  } catch (err) {
+    return mapServiceError(err);
+  }
+}
+
+/** JSON Schema for the cerebrum.search tool input. */
+export const cerebrumSearchSchema = {
+  type: 'object' as const,
+  properties: {
+    query: { type: 'string' as const, description: 'Natural language search query' },
+    scopes: {
+      type: 'array' as const,
+      items: { type: 'string' as const },
+      description: 'Optional scope filters (e.g. ["personal.finance", "work.projects"])',
+    },
+    limit: {
+      type: 'number' as const,
+      description: 'Maximum number of results (default 20, max 100)',
+    },
+  },
+  required: ['query'] as const,
+};

--- a/apps/pops-api/src/mcp/tools/index.ts
+++ b/apps/pops-api/src/mcp/tools/index.ts
@@ -1,0 +1,64 @@
+import { engramReadSchema, handleEngramRead } from './cerebrum-engram-read.js';
+import { engramWriteSchema, handleEngramWrite } from './cerebrum-engram-write.js';
+/**
+ * Tool registry — central catalogue of all MCP tools and their dispatch logic.
+ */
+import { cerebrumIngestSchema, handleCerebrumIngest } from './cerebrum-ingest.js';
+import { cerebrumSearchSchema, handleCerebrumSearch } from './cerebrum-search.js';
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import type { ToolHandler } from '../types.js';
+
+/** MCP tool definition as returned by ListTools. */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+/** All registered tools. */
+export const toolDefinitions: ToolDefinition[] = [
+  {
+    name: 'cerebrum.search',
+    description:
+      'Search the Cerebrum knowledge base using hybrid semantic + structured search. Returns ranked results with titles, scores, scopes, and content snippets.',
+    inputSchema: cerebrumSearchSchema,
+  },
+  {
+    name: 'cerebrum.ingest',
+    description:
+      'Ingest new content into the Cerebrum knowledge base. Accepts plain text, Markdown, or JSON. Runs classification, entity extraction, and scope inference automatically.',
+    inputSchema: cerebrumIngestSchema,
+  },
+  {
+    name: 'cerebrum.engram.read',
+    description:
+      'Read an engram by ID. Returns full metadata (title, type, scopes, tags, status, timestamps) and the body content.',
+    inputSchema: engramReadSchema,
+  },
+  {
+    name: 'cerebrum.engram.write',
+    description:
+      'Update an existing engram. Can modify body, title, scopes, and/or tags. Returns updated metadata.',
+    inputSchema: engramWriteSchema,
+  },
+];
+
+/** Map of tool name → handler function. */
+const handlers: Record<string, ToolHandler> = {
+  'cerebrum.search': handleCerebrumSearch,
+  'cerebrum.ingest': handleCerebrumIngest,
+  'cerebrum.engram.read': handleEngramRead,
+  'cerebrum.engram.write': handleEngramWrite,
+};
+
+/** Dispatch a tool call by name. Returns null if the tool is not registered. */
+export function dispatchTool(
+  name: string,
+  args: Record<string, unknown>
+): Promise<CallToolResult> | null {
+  const handler = handlers[name];
+  if (!handler) return null;
+  return handler(args);
+}

--- a/apps/pops-api/src/mcp/types.ts
+++ b/apps/pops-api/src/mcp/types.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared MCP types for the Cerebrum MCP server.
+ */
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+export type { CallToolResult };
+
+/** Canonical error codes returned by MCP tools. */
+export type McpErrorCode = 'NOT_FOUND' | 'VALIDATION_ERROR' | 'SCOPE_BLOCKED' | 'INTERNAL_ERROR';
+
+/** Shape of an MCP error payload (serialised as JSON in the text content). */
+export interface McpErrorPayload {
+  error: string;
+  code: McpErrorCode;
+}
+
+/** Tool handler function signature. */
+export type ToolHandler = (args: Record<string, unknown>) => Promise<CallToolResult>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.90.0
         version: 0.90.0(zod@4.3.6)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@pops/db-types':
         specifier: workspace:*
         version: link:../../packages/db-types
@@ -7534,6 +7537,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.14
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -12105,6 +12130,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

- Adds a standalone MCP server (`apps/pops-api/src/mcp/`) that Claude Code can spawn via stdio transport
- Registers 4 tools: `cerebrum.search`, `cerebrum.ingest`, `cerebrum.engram.read`, `cerebrum.engram.write`
- Each tool is a thin adapter over existing cerebrum services (no new business logic)
- Structured JSON detection in ingest tool (auto-converts JSON bodies to Markdown)
- Comprehensive error handling with typed error codes (`NOT_FOUND`, `VALIDATION_ERROR`, `SCOPE_BLOCKED`)
- 51 unit tests across 7 test files

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 new errors)
- [x] `pnpm test` passes (3027 tests, 174 files)
- [ ] Manual: spawn `npx tsx apps/pops-api/src/mcp/server.ts` and verify stdio transport connects

Closes #2201 #2202 #2203 #2204