### PR TITLE
feat(cerebrum): query engine for NL Q&A (PRD-082)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -6,6 +6,7 @@ import { router } from '../../trpc.js';
 import { engramsRouter } from './engrams/router.js';
 import { scopesRouter } from './engrams/scopes-router.js';
 import { ingestRouter } from './ingest/router.js';
+import { queryRouter } from './query/router.js';
 import { retrievalRouter } from './retrieval/router.js';
 import { templatesRouter } from './templates/router.js';
 import { indexRouter } from './thalamus/router.js';
@@ -17,4 +18,5 @@ export const cerebrumRouter = router({
   index: indexRouter,
   retrieval: retrievalRouter,
   ingest: ingestRouter,
+  query: queryRouter,
 });

--- a/apps/pops-api/src/modules/cerebrum/query/__tests__/citation-parser.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/__tests__/citation-parser.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CitationParser } from '../citation-parser.js';
+
+import type { RetrievalResult } from '../../retrieval/types.js';
+
+// Suppress logger.warn in tests.
+vi.mock('../../../../lib/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function makeResult(overrides: Partial<RetrievalResult> = {}): RetrievalResult {
+  return {
+    sourceType: overrides.sourceType ?? 'engram',
+    sourceId: overrides.sourceId ?? 'eng_20260417_0942_agent-coordination',
+    title: overrides.title ?? 'Agent Coordination Notes',
+    contentPreview:
+      overrides.contentPreview ?? 'These are notes about coordinating agents across the platform.',
+    score: overrides.score ?? 0.85,
+    matchType: overrides.matchType ?? 'semantic',
+    metadata: overrides.metadata ?? { scopes: ['work.engineering'] },
+  };
+}
+
+describe('CitationParser', () => {
+  let parser: CitationParser;
+
+  beforeEach(() => {
+    parser = new CitationParser();
+  });
+
+  describe('valid citation mapping', () => {
+    it('extracts a single bracketed engram ID', () => {
+      const sources = [makeResult()];
+      const llmOutput =
+        'The agents coordinate via message passing [eng_20260417_0942_agent-coordination].';
+
+      const result = parser.parse(llmOutput, sources);
+
+      expect(result.citations).toHaveLength(1);
+      expect(result.citations[0]!.id).toBe('eng_20260417_0942_agent-coordination');
+      expect(result.citations[0]!.type).toBe('engram');
+      expect(result.citations[0]!.title).toBe('Agent Coordination Notes');
+      expect(result.citations[0]!.scope).toBe('work.engineering');
+    });
+
+    it('extracts multiple distinct citations', () => {
+      const sources = [
+        makeResult({ sourceId: 'eng_20260417_0942_agent-coordination', score: 0.9 }),
+        makeResult({
+          sourceId: 'eng_20260418_1030_pipeline-design',
+          title: 'Pipeline Design',
+          score: 0.7,
+        }),
+      ];
+      const llmOutput =
+        'Agents coordinate [eng_20260417_0942_agent-coordination] and pipelines are designed [eng_20260418_1030_pipeline-design].';
+
+      const result = parser.parse(llmOutput, sources);
+
+      expect(result.citations).toHaveLength(2);
+      // Ordered by relevance (highest first).
+      expect(result.citations[0]!.id).toBe('eng_20260417_0942_agent-coordination');
+      expect(result.citations[1]!.id).toBe('eng_20260418_1030_pipeline-design');
+    });
+
+    it('deduplicates same citation referenced multiple times', () => {
+      const sources = [makeResult()];
+      const llmOutput =
+        'First mention [eng_20260417_0942_agent-coordination] and again [eng_20260417_0942_agent-coordination].';
+
+      const result = parser.parse(llmOutput, sources);
+      expect(result.citations).toHaveLength(1);
+    });
+  });
+
+  describe('hallucinated citation stripping', () => {
+    it('strips citations not in the retrieved set', () => {
+      const sources = [makeResult()];
+      const llmOutput =
+        'Real [eng_20260417_0942_agent-coordination] and fake [eng_20260501_1111_nonexistent].';
+
+      const result = parser.parse(llmOutput, sources);
+
+      expect(result.citations).toHaveLength(1);
+      expect(result.citations[0]!.id).toBe('eng_20260417_0942_agent-coordination');
+      // Hallucinated citation is removed from the cleaned answer.
+      expect(result.cleanedAnswer).not.toContain('[eng_20260501_1111_nonexistent]');
+    });
+
+    it('cleans up double spaces after stripping', () => {
+      const sources = [makeResult()];
+      const llmOutput = 'Before [eng_20260501_1111_nonexistent] after the fake citation.';
+
+      const result = parser.parse(llmOutput, sources);
+      expect(result.cleanedAnswer).not.toMatch(/  /);
+    });
+  });
+
+  describe('typed citations [sourceType:sourceId]', () => {
+    it('extracts typed citation references', () => {
+      const sources = [
+        makeResult({
+          sourceType: 'transaction',
+          sourceId: 'txn_001',
+          title: 'Coffee Purchase',
+          metadata: {
+            scopes: ['personal.finance'],
+            amount: -4.5,
+            date: '2026-04-15',
+            category: 'Food',
+          },
+        }),
+      ];
+      const llmOutput = 'You bought coffee [transaction:txn_001] on April 15th.';
+
+      const result = parser.parse(llmOutput, sources);
+      expect(result.citations).toHaveLength(1);
+      expect(result.citations[0]!.id).toBe('txn_001');
+      expect(result.citations[0]!.type).toBe('transaction');
+    });
+
+    it('strips hallucinated typed citations', () => {
+      const sources = [makeResult()];
+      const llmOutput = 'Fake typed [media:mov_999] reference.';
+
+      const result = parser.parse(llmOutput, sources);
+      expect(result.citations).toHaveLength(0);
+      expect(result.cleanedAnswer).not.toContain('[media:mov_999]');
+    });
+  });
+
+  describe('excerpt truncation', () => {
+    it('returns full content preview when under 200 chars', () => {
+      const sources = [makeResult({ contentPreview: 'Short content.' })];
+      const llmOutput = 'Answer [eng_20260417_0942_agent-coordination].';
+
+      const result = parser.parse(llmOutput, sources);
+      expect(result.citations[0]!.excerpt).toBe('Short content.');
+    });
+
+    it('truncates at word boundary with ellipsis when over 200 chars', () => {
+      const longContent = 'word '.repeat(50); // 250 chars
+      const sources = [makeResult({ contentPreview: longContent })];
+      const llmOutput = 'Answer [eng_20260417_0942_agent-coordination].';
+
+      const result = parser.parse(llmOutput, sources);
+      const excerpt = result.citations[0]!.excerpt;
+      expect(excerpt.length).toBeLessThanOrEqual(201); // 200 + ellipsis char
+      expect(excerpt.endsWith('…')).toBe(true);
+    });
+  });
+
+  describe('domain-specific formatting', () => {
+    it('includes amount, date, category for transactions', () => {
+      const sources = [
+        makeResult({
+          sourceType: 'transaction',
+          sourceId: 'eng_20260417_0942_txn-coffee',
+          title: 'Coffee',
+          contentPreview: 'Bought coffee at the corner cafe.',
+          metadata: {
+            scopes: ['personal.finance'],
+            amount: -4.5,
+            date: '2026-04-15',
+            category: 'Food',
+          },
+        }),
+      ];
+      const llmOutput = 'You bought coffee [eng_20260417_0942_txn-coffee].';
+
+      const result = parser.parse(llmOutput, sources);
+      const excerpt = result.citations[0]!.excerpt;
+      expect(excerpt).toContain('Amount: -4.5');
+      expect(excerpt).toContain('Date: 2026-04-15');
+      expect(excerpt).toContain('Category: Food');
+    });
+
+    it('includes type and rating for media', () => {
+      const sources = [
+        makeResult({
+          sourceType: 'media',
+          sourceId: 'eng_20260417_0942_media-inception',
+          title: 'Inception',
+          contentPreview: 'A mind-bending thriller about dreams.',
+          metadata: {
+            scopes: ['personal.media'],
+            type: 'movie',
+            rating: 8.8,
+          },
+        }),
+      ];
+      const llmOutput = 'You watched Inception [eng_20260417_0942_media-inception].';
+
+      const result = parser.parse(llmOutput, sources);
+      const excerpt = result.citations[0]!.excerpt;
+      expect(excerpt).toContain('Type: movie');
+      expect(excerpt).toContain('Rating: 8.8');
+    });
+
+    it('includes location for inventory', () => {
+      const sources = [
+        makeResult({
+          sourceType: 'inventory',
+          sourceId: 'eng_20260417_0942_inv-macbook',
+          title: 'MacBook Pro',
+          contentPreview: 'M3 MacBook Pro 14 inch.',
+          metadata: {
+            scopes: ['personal.inventory'],
+            location: 'Home Office',
+          },
+        }),
+      ];
+      const llmOutput = 'Your MacBook [eng_20260417_0942_inv-macbook] is in the office.';
+
+      const result = parser.parse(llmOutput, sources);
+      const excerpt = result.citations[0]!.excerpt;
+      expect(excerpt).toContain('Location: Home Office');
+    });
+  });
+
+  describe('ordering', () => {
+    it('orders citations by relevance score (highest first)', () => {
+      const sources = [
+        makeResult({ sourceId: 'eng_20260417_0942_low-relevance', score: 0.3 }),
+        makeResult({ sourceId: 'eng_20260418_1030_high-relevance', score: 0.95, title: 'High' }),
+        makeResult({ sourceId: 'eng_20260419_0800_mid-relevance', score: 0.6, title: 'Mid' }),
+      ];
+      const llmOutput =
+        'Low [eng_20260417_0942_low-relevance], high [eng_20260418_1030_high-relevance], mid [eng_20260419_0800_mid-relevance].';
+
+      const result = parser.parse(llmOutput, sources);
+      expect(result.citations[0]!.relevance).toBe(0.95);
+      expect(result.citations[1]!.relevance).toBe(0.6);
+      expect(result.citations[2]!.relevance).toBe(0.3);
+    });
+  });
+
+  describe('zero valid citations', () => {
+    it('returns empty citations when all are hallucinated', () => {
+      const sources = [makeResult()];
+      const llmOutput = 'All fake [eng_20260501_1111_nonexistent] citations.';
+
+      const result = parser.parse(llmOutput, sources);
+      expect(result.citations).toHaveLength(0);
+    });
+
+    it('returns empty citations when LLM output has no citations', () => {
+      const sources = [makeResult()];
+      const llmOutput = 'A plain answer without any citations.';
+
+      const result = parser.parse(llmOutput, sources);
+      expect(result.citations).toHaveLength(0);
+    });
+  });
+
+  describe('mixed valid/invalid citations', () => {
+    it('keeps valid and strips invalid citations', () => {
+      const sources = [
+        makeResult({ sourceId: 'eng_20260417_0942_agent-coordination', score: 0.8 }),
+      ];
+      const llmOutput =
+        'Valid [eng_20260417_0942_agent-coordination] and invalid [eng_20260501_1111_fake].';
+
+      const result = parser.parse(llmOutput, sources);
+      expect(result.citations).toHaveLength(1);
+      expect(result.citations[0]!.id).toBe('eng_20260417_0942_agent-coordination');
+      expect(result.cleanedAnswer).toContain('[eng_20260417_0942_agent-coordination]');
+      expect(result.cleanedAnswer).not.toContain('[eng_20260501_1111_fake]');
+    });
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/query/__tests__/query-service.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/__tests__/query-service.test.ts
@@ -1,0 +1,355 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RetrievalResult } from '../../retrieval/types.js';
+
+// --- Mocks must be defined before imports that use them ---
+
+vi.mock('../../../../db.js', () => ({
+  getDrizzle: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../env.js', () => ({
+  getEnv: vi.fn(() => 'test-api-key'),
+}));
+
+vi.mock('../../../../lib/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../lib/inference-middleware.js', () => ({
+  trackInference: vi.fn((_params: Record<string, unknown>, fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../../../lib/ai-retry.js', () => ({
+  withRateLimitRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+const mockHybrid = vi.fn();
+
+vi.mock('../../retrieval/hybrid-search.js', () => {
+  return {
+    HybridSearchService: class {
+      hybrid = mockHybrid;
+    },
+  };
+});
+
+const mockAssemble = vi.fn();
+
+vi.mock('../../retrieval/context-assembly.js', () => {
+  return {
+    ContextAssemblyService: class {
+      assemble = mockAssemble;
+    },
+  };
+});
+
+const mockCreate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    default: class {
+      messages = { create: mockCreate };
+    },
+  };
+});
+
+// Now import the module under test.
+import { QueryService } from '../query-service.js';
+
+function makeRetrievalResult(overrides: Partial<RetrievalResult> = {}): RetrievalResult {
+  return {
+    sourceType: overrides.sourceType ?? 'engram',
+    sourceId: overrides.sourceId ?? 'eng_20260417_0942_agent-coordination',
+    title: overrides.title ?? 'Agent Coordination Notes',
+    contentPreview:
+      overrides.contentPreview ?? 'Notes about coordinating multiple agents in the platform.',
+    score: overrides.score ?? 0.85,
+    matchType: overrides.matchType ?? 'semantic',
+    metadata: overrides.metadata ?? { scopes: ['work.engineering'] },
+  };
+}
+
+function makeLlmResponse(text: string) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    usage: { input_tokens: 100, output_tokens: 50 },
+  };
+}
+
+describe('QueryService', () => {
+  let service: QueryService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new QueryService();
+
+    // Default mocks: return some results and a basic LLM response.
+    mockHybrid.mockResolvedValue([makeRetrievalResult()]);
+    mockAssemble.mockReturnValue({
+      context: 'Assembled context here',
+      sources: [
+        {
+          sourceType: 'engram',
+          sourceId: 'eng_20260417_0942_agent-coordination',
+          title: 'Agent Coordination Notes',
+          relevanceScore: 0.85,
+        },
+      ],
+      truncated: false,
+      tokenEstimate: 200,
+    });
+    mockCreate.mockResolvedValue(
+      makeLlmResponse(
+        'Agents coordinate via message passing [eng_20260417_0942_agent-coordination].'
+      )
+    );
+  });
+
+  describe('ask', () => {
+    it('returns a complete QueryResponse for a valid question', async () => {
+      const response = await service.ask({ question: 'How do agents coordinate?' });
+
+      expect(response.answer).toContain('Agents coordinate');
+      expect(response.sources).toHaveLength(1);
+      expect(response.sources[0]!.id).toBe('eng_20260417_0942_agent-coordination');
+      expect(response.scopes).toBeDefined();
+      expect(response.confidence).toBeDefined();
+    });
+
+    it('returns low confidence with canned answer when zero results', async () => {
+      mockHybrid.mockResolvedValue([]);
+
+      const response = await service.ask({ question: 'Something completely unknown' });
+
+      expect(response.answer).toBe("I don't have information about that.");
+      expect(response.sources).toHaveLength(0);
+      expect(response.confidence).toBe('low');
+    });
+
+    it('computes high confidence when top score > 0.8', async () => {
+      mockHybrid.mockResolvedValue([makeRetrievalResult({ score: 0.9 })]);
+
+      const response = await service.ask({ question: 'High confidence query' });
+
+      expect(response.confidence).toBe('high');
+    });
+
+    it('computes medium confidence when top score is 0.5–0.8', async () => {
+      mockHybrid.mockResolvedValue([makeRetrievalResult({ score: 0.65 })]);
+
+      const response = await service.ask({ question: 'Medium confidence query' });
+
+      expect(response.confidence).toBe('medium');
+    });
+
+    it('computes low confidence when top score < 0.5', async () => {
+      mockHybrid.mockResolvedValue([makeRetrievalResult({ score: 0.35 })]);
+
+      const response = await service.ask({ question: 'Low confidence query' });
+
+      expect(response.confidence).toBe('low');
+    });
+
+    it('downgrades to low confidence when zero valid citations', async () => {
+      // LLM returns text without any citations.
+      mockCreate.mockResolvedValue(makeLlmResponse('A plain answer without citations.'));
+
+      const response = await service.ask({ question: 'No citations answer' });
+
+      expect(response.confidence).toBe('low');
+    });
+
+    it('trims whitespace from question', async () => {
+      await service.ask({ question: '  How do agents coordinate?  ' });
+
+      // Verify hybrid search received trimmed query.
+      expect(mockHybrid).toHaveBeenCalledWith(
+        'How do agents coordinate?',
+        expect.objectContaining({}),
+        10,
+        0.3
+      );
+    });
+
+    it('passes explicit scopes to retrieval filters', async () => {
+      await service.ask({
+        question: 'My question',
+        scopes: ['work.engineering'],
+      });
+
+      expect(mockHybrid).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ scopes: ['work.engineering'] }),
+        expect.any(Number),
+        expect.any(Number)
+      );
+    });
+
+    it('passes includeSecret to retrieval filters', async () => {
+      await service.ask({
+        question: 'My question',
+        includeSecret: true,
+      });
+
+      expect(mockHybrid).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ includeSecret: true }),
+        expect.any(Number),
+        expect.any(Number)
+      );
+    });
+
+    it('respects maxSources parameter', async () => {
+      await service.ask({
+        question: 'My question',
+        maxSources: 5,
+      });
+
+      expect(mockHybrid).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({}),
+        5,
+        expect.any(Number)
+      );
+    });
+  });
+
+  describe('ask — domain filtering', () => {
+    it('maps domain names to sourceTypes in filters', async () => {
+      await service.ask({
+        question: 'How much did I spend?',
+        domains: ['transactions'],
+      });
+
+      expect(mockHybrid).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ sourceTypes: ['transaction'] }),
+        expect.any(Number),
+        expect.any(Number)
+      );
+    });
+
+    it('maps multiple domains correctly', async () => {
+      await service.ask({
+        question: 'Show everything',
+        domains: ['engrams', 'media', 'inventory'],
+      });
+
+      expect(mockHybrid).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ sourceTypes: ['engram', 'media', 'inventory'] }),
+        expect.any(Number),
+        expect.any(Number)
+      );
+    });
+
+    it('omits sourceTypes filter when no domains specified', async () => {
+      await service.ask({ question: 'Everything' });
+
+      const filters = mockHybrid.mock.calls[0]![1];
+      expect(filters).not.toHaveProperty('sourceTypes');
+    });
+  });
+
+  describe('ask — LLM graceful degradation', () => {
+    it('returns fallback answer when ANTHROPIC_API_KEY is missing', async () => {
+      const { getEnv } = await import('../../../../env.js');
+      vi.mocked(getEnv).mockReturnValueOnce(undefined);
+
+      const response = await service.ask({ question: 'Any question' });
+
+      expect(response.answer).toContain('LLM unavailable');
+    });
+
+    it('returns fallback answer when LLM call throws', async () => {
+      mockCreate.mockRejectedValueOnce(new Error('API down'));
+
+      const response = await service.ask({ question: 'Any question' });
+
+      expect(response.answer).toContain('LLM error');
+    });
+  });
+
+  describe('retrieve', () => {
+    it('returns sources without calling the LLM', async () => {
+      const result = await service.retrieve('How do agents work?');
+
+      expect(result.sources).toHaveLength(1);
+      expect(result.sources[0]!.id).toBe('eng_20260417_0942_agent-coordination');
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('returns empty sources when no results', async () => {
+      mockHybrid.mockResolvedValue([]);
+
+      const result = await service.retrieve('Unknown topic');
+
+      expect(result.sources).toHaveLength(0);
+    });
+
+    it('respects maxSources parameter', async () => {
+      await service.retrieve('Query', undefined, undefined, 3);
+
+      expect(mockHybrid).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({}),
+        3,
+        expect.any(Number)
+      );
+    });
+  });
+
+  describe('explain', () => {
+    it('returns scope inference and retrieval plan', () => {
+      const result = service.explain('How do agents work?');
+
+      expect(result.scopeInference).toBeDefined();
+      expect(result.scopeInference.source).toBeDefined();
+      expect(result.retrievalPlan).toBeDefined();
+      expect(result.retrievalPlan.maxSources).toBe(10);
+      expect(result.retrievalPlan.threshold).toBe(0.3);
+    });
+
+    it('detects secret mentions', () => {
+      const result = service.explain('Where is my password stored?');
+
+      expect(result.secretNotice).toBeTruthy();
+      expect(result.secretNotice).toContain('sensitive data');
+    });
+
+    it('returns null secretNotice for normal questions', () => {
+      const result = service.explain('What happened yesterday?');
+
+      expect(result.secretNotice).toBeNull();
+    });
+
+    it('does not call hybrid search or LLM', () => {
+      service.explain('Any question');
+
+      expect(mockHybrid).not.toHaveBeenCalled();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('secret scope exclusion', () => {
+    it('does not include secret scopes by default', async () => {
+      await service.ask({ question: 'work notes' });
+
+      const filters = mockHybrid.mock.calls[0]![1];
+      expect(filters).not.toHaveProperty('includeSecret');
+    });
+
+    it('includes secret scopes when explicitly requested', async () => {
+      await service.ask({ question: 'work notes', includeSecret: true });
+
+      const filters = mockHybrid.mock.calls[0]![1];
+      expect(filters).toHaveProperty('includeSecret', true);
+    });
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/query/__tests__/scope-inferencer.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/__tests__/scope-inferencer.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+
+import { QueryScopeInferencer } from '../scope-inferencer.js';
+
+const KNOWN_SCOPES = [
+  'work.engineering',
+  'work.meetings',
+  'work.secret.credentials',
+  'personal.journal',
+  'personal.health',
+  'personal.secret.keys',
+  'general.notes',
+];
+
+function makeInferencer(): QueryScopeInferencer {
+  return new QueryScopeInferencer();
+}
+
+describe('QueryScopeInferencer', () => {
+  describe('explicit scopes', () => {
+    it('returns explicit scopes unchanged when provided', () => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer('anything', KNOWN_SCOPES, ['custom.scope']);
+      expect(result.scopes).toEqual(['custom.scope']);
+      expect(result.source).toBe('explicit');
+    });
+
+    it('skips inference entirely with explicit scopes', () => {
+      const inferencer = makeInferencer();
+      // Even though question contains "work", explicit scopes win.
+      const result = inferencer.infer('work meeting notes', KNOWN_SCOPES, ['personal.journal']);
+      expect(result.scopes).toEqual(['personal.journal']);
+      expect(result.source).toBe('explicit');
+    });
+
+    it('filters secret scopes from explicit when includeSecret is false', () => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer(
+        'anything',
+        KNOWN_SCOPES,
+        ['work.engineering', 'work.secret.credentials'],
+        false
+      );
+      expect(result.scopes).toEqual(['work.engineering']);
+      expect(result.source).toBe('explicit');
+    });
+
+    it('includes secret scopes from explicit when includeSecret is true', () => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer(
+        'anything',
+        KNOWN_SCOPES,
+        ['work.engineering', 'work.secret.credentials'],
+        true
+      );
+      expect(result.scopes).toEqual(['work.engineering', 'work.secret.credentials']);
+      expect(result.source).toBe('explicit');
+    });
+  });
+
+  describe('work keyword inference', () => {
+    it.each([
+      'What did I discuss in the meeting yesterday?',
+      'Show my recent work notes',
+      'What was discussed at the standup?',
+      'Find my office notes',
+      'What are the project deadlines?',
+      'Which PRs did I review?',
+      'When did we deploy the feature?',
+      'Sprint retrospective notes',
+    ])('infers work scopes for: "%s"', (question) => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer(question, KNOWN_SCOPES);
+      expect(result.source).toBe('inferred');
+      expect(result.scopes.every((s) => s.startsWith('work.'))).toBe(true);
+    });
+
+    it('excludes work.secret.* scopes by default', () => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer('work credentials', KNOWN_SCOPES);
+      expect(result.scopes).not.toContain('work.secret.credentials');
+    });
+
+    it('includes work.secret.* scopes when includeSecret is true', () => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer('work notes', KNOWN_SCOPES, undefined, true);
+      expect(result.scopes).toContain('work.secret.credentials');
+    });
+  });
+
+  describe('personal keyword inference', () => {
+    it.each([
+      'What did I write in my journal last week?',
+      'Show my diary entries',
+      'therapy session notes',
+      'family plans for the weekend',
+      'personal goals this month',
+      'health checkup results',
+      'exercise routine',
+      'hobby projects I started',
+    ])('infers personal scopes for: "%s"', (question) => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer(question, KNOWN_SCOPES);
+      expect(result.source).toBe('inferred');
+      expect(result.scopes.every((s) => s.startsWith('personal.'))).toBe(true);
+    });
+
+    it('excludes personal.secret.* scopes by default', () => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer('personal notes', KNOWN_SCOPES);
+      expect(result.scopes).not.toContain('personal.secret.keys');
+    });
+  });
+
+  describe('ambiguous / default fallback', () => {
+    it('returns all non-secret scopes for ambiguous questions', () => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer('What happened last Tuesday?', KNOWN_SCOPES);
+      expect(result.source).toBe('default');
+      expect(result.scopes).toContain('work.engineering');
+      expect(result.scopes).toContain('personal.journal');
+      expect(result.scopes).toContain('general.notes');
+      expect(result.scopes).not.toContain('work.secret.credentials');
+      expect(result.scopes).not.toContain('personal.secret.keys');
+    });
+
+    it('returns empty scopes when knownScopes is empty', () => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer('What happened?', []);
+      expect(result.scopes).toEqual([]);
+      expect(result.source).toBe('default');
+    });
+
+    it('returns empty scopes when knownScopes is undefined', () => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer('What happened?');
+      expect(result.scopes).toEqual([]);
+      expect(result.source).toBe('default');
+    });
+  });
+
+  describe('secret hard-block', () => {
+    it('never includes secret scopes unless includeSecret=true', () => {
+      const inferencer = makeInferencer();
+      // All three paths: explicit, inferred, default.
+      const explicit = inferencer.infer('x', KNOWN_SCOPES, ['work.secret.credentials']);
+      expect(explicit.scopes).not.toContain('work.secret.credentials');
+
+      const inferred = inferencer.infer('work notes', KNOWN_SCOPES);
+      expect(inferred.scopes).not.toContain('work.secret.credentials');
+
+      const defaultResult = inferencer.infer('anything', KNOWN_SCOPES);
+      expect(defaultResult.scopes).not.toContain('work.secret.credentials');
+      expect(defaultResult.scopes).not.toContain('personal.secret.keys');
+    });
+
+    it('includes secret scopes across all paths when includeSecret=true', () => {
+      const inferencer = makeInferencer();
+      const defaultResult = inferencer.infer('anything', KNOWN_SCOPES, undefined, true);
+      expect(defaultResult.scopes).toContain('work.secret.credentials');
+      expect(defaultResult.scopes).toContain('personal.secret.keys');
+    });
+  });
+
+  describe('secret detection', () => {
+    it.each(['Show me the secret notes', 'What is my password?', 'Find the credential for AWS'])(
+      'detects secret mention in: "%s"',
+      (question) => {
+        const inferencer = makeInferencer();
+        const notice = inferencer.detectSecretMention(question);
+        expect(notice).toBeTruthy();
+        expect(notice).toContain('sensitive data');
+      }
+    );
+
+    it('returns null for non-secret questions', () => {
+      const inferencer = makeInferencer();
+      expect(inferencer.detectSecretMention('What did I eat yesterday?')).toBeNull();
+    });
+
+    it('detects "private key" multi-word keyword', () => {
+      const inferencer = makeInferencer();
+      const notice = inferencer.detectSecretMention('Where is my private key stored?');
+      expect(notice).toBeTruthy();
+    });
+  });
+
+  describe('keyword matching edge cases', () => {
+    it('matches keywords case-insensitively', () => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer('WORK MEETING NOTES', KNOWN_SCOPES);
+      expect(result.source).toBe('inferred');
+    });
+
+    it('matches keywords at word boundaries (no partial match)', () => {
+      const inferencer = makeInferencer();
+      // "network" contains "work" as a substring, but word boundary prevents match.
+      const result = inferencer.infer('Network configuration details', KNOWN_SCOPES);
+      expect(result.source).toBe('default');
+    });
+
+    it('falls back to default when work keywords match but no work scopes exist', () => {
+      const inferencer = makeInferencer();
+      const result = inferencer.infer('work meeting', ['personal.journal', 'general.notes']);
+      // No work.* scopes available, so falls through to personal check, then default.
+      expect(result.source).toBe('default');
+    });
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/query/citation-parser.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/citation-parser.ts
@@ -1,0 +1,156 @@
+/**
+ * CitationParser — extracts and validates inline source citations from LLM
+ * output against the retrieved source set (PRD-082 US-03).
+ *
+ * Handles:
+ *  - Bracketed engram IDs: [eng_20260417_0942_agent-coordination]
+ *  - Bracketed sourceType:sourceId references: [engram:eng_20260417_0942_...]
+ *  - Strips hallucinated citations (IDs not in retrieved set), logging them.
+ *  - Truncates excerpts to 200 chars at word boundary with ellipsis.
+ *  - Orders output citations by relevance (highest first).
+ */
+import { logger } from '../../../lib/logger.js';
+
+import type { RetrievalResult } from '../retrieval/types.js';
+import type { CitationParseResult, SourceCitation } from './types.js';
+
+/** Matches bracketed engram IDs like [eng_20260417_0942_agent-coordination]. */
+const ENGRAM_CITATION_RE = /\[eng_\d{8}_\d{4}_[a-z0-9-]+\]/g;
+
+/**
+ * Matches bracketed sourceType:sourceId references like [engram:eng_...].
+ * Captures sourceType and sourceId in groups.
+ */
+const TYPED_CITATION_RE = /\[(engram|transaction|media|inventory):([^\]]+)\]/g;
+
+const EXCERPT_MAX_LENGTH = 200;
+
+/**
+ * Truncate text to a maximum length at a word boundary, appending ellipsis.
+ */
+function truncateExcerpt(text: string): string {
+  if (text.length <= EXCERPT_MAX_LENGTH) return text;
+
+  // Find last space within budget.
+  const truncated = text.slice(0, EXCERPT_MAX_LENGTH);
+  const lastSpace = truncated.lastIndexOf(' ');
+  const cutPoint = lastSpace > 0 ? lastSpace : EXCERPT_MAX_LENGTH;
+  return text.slice(0, cutPoint) + '…';
+}
+
+/**
+ * Determine the primary scope from RetrievalResult metadata.
+ */
+function extractPrimaryScope(result: RetrievalResult): string {
+  const scopes = result.metadata['scopes'] as string[] | undefined;
+  return scopes?.[0] ?? 'unknown';
+}
+
+/** Push a labelled metadata field into parts if the value is defined. */
+function pushIfDefined(parts: string[], label: string, value: unknown): void {
+  if (value !== undefined) parts.push(`${label}: ${String(value)}`);
+}
+
+/** Extract domain-specific metadata parts for enriching excerpts. */
+function extractDomainMetaParts(metadata: Record<string, unknown>, sourceType: string): string[] {
+  const parts: string[] = [];
+  switch (sourceType) {
+    case 'transaction':
+      pushIfDefined(parts, 'Amount', metadata['amount']);
+      pushIfDefined(parts, 'Date', metadata['date'] ?? metadata['createdAt']);
+      pushIfDefined(parts, 'Category', metadata['category']);
+      break;
+    case 'media':
+      pushIfDefined(parts, 'Type', metadata['type'] ?? metadata['mediaType']);
+      pushIfDefined(parts, 'Rating', metadata['rating']);
+      break;
+    case 'inventory':
+      pushIfDefined(parts, 'Location', metadata['location']);
+      break;
+  }
+  return parts;
+}
+
+/**
+ * Format a domain-specific excerpt with additional metadata when available.
+ */
+function formatExcerpt(result: RetrievalResult): string {
+  const parts = extractDomainMetaParts(result.metadata, result.sourceType);
+  const metaPrefix = parts.length > 0 ? parts.join(' | ') + ' — ' : '';
+  return truncateExcerpt(metaPrefix + (result.contentPreview ?? ''));
+}
+
+export class CitationParser {
+  /**
+   * Parse citations from LLM output, mapping them to retrieved sources.
+   *
+   * @param llmOutput        - Raw text from the LLM response.
+   * @param retrievedSources - The source set from HybridSearchService.
+   */
+  parse(llmOutput: string, retrievedSources: RetrievalResult[]): CitationParseResult {
+    // Build lookup maps for fast matching.
+    const bySourceId = new Map<string, RetrievalResult>();
+    const byCompositeKey = new Map<string, RetrievalResult>();
+    for (const r of retrievedSources) {
+      bySourceId.set(r.sourceId, r);
+      byCompositeKey.set(`${r.sourceType}:${r.sourceId}`, r);
+    }
+
+    const matchedIds = new Set<string>();
+    let cleanedAnswer = llmOutput;
+
+    // Extract bracketed engram IDs.
+    for (const match of llmOutput.matchAll(ENGRAM_CITATION_RE)) {
+      const id = match[0].slice(1, -1); // strip brackets
+      if (bySourceId.has(id)) {
+        matchedIds.add(id);
+      } else {
+        logger.warn({ citationId: id }, '[QueryEngine] Stripped hallucinated citation');
+        cleanedAnswer = cleanedAnswer.replace(match[0], '');
+      }
+    }
+
+    // Extract typed citations [sourceType:sourceId].
+    for (const match of llmOutput.matchAll(TYPED_CITATION_RE)) {
+      const fullMatch = match[0];
+      const sourceType = match[1];
+      const sourceId = match[2];
+      if (!sourceType || !sourceId) continue;
+      const key = `${sourceType}:${sourceId}`;
+      const result = byCompositeKey.get(key);
+      if (result) {
+        matchedIds.add(result.sourceId);
+      } else if (bySourceId.has(sourceId)) {
+        matchedIds.add(sourceId);
+      } else {
+        logger.warn(
+          { citationRef: fullMatch },
+          '[QueryEngine] Stripped hallucinated typed citation'
+        );
+        cleanedAnswer = cleanedAnswer.replace(fullMatch, '');
+      }
+    }
+
+    // Build citations from matched sources, ordered by relevance.
+    const citations: SourceCitation[] = [];
+    for (const id of matchedIds) {
+      const result = bySourceId.get(id);
+      if (!result) continue;
+      citations.push({
+        id: result.sourceId,
+        type: result.sourceType,
+        title: result.title,
+        excerpt: formatExcerpt(result),
+        relevance: result.score,
+        scope: extractPrimaryScope(result),
+      });
+    }
+
+    citations.sort((a, b) => b.relevance - a.relevance);
+
+    // Clean up any double spaces left from stripping citations.
+    cleanedAnswer = cleanedAnswer.replace(/  +/g, ' ').trim();
+
+    return { cleanedAnswer, citations };
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/query/prompts.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/prompts.ts
@@ -1,0 +1,26 @@
+/**
+ * LLM system prompt templates for the Cerebrum Query Engine (PRD-082).
+ *
+ * Prompts are exported as template functions so they can be configured or
+ * overridden in tests without hardcoding strings in the service.
+ */
+
+/**
+ * Build the system prompt for the query answering LLM call.
+ *
+ * @param context - Pre-assembled, token-budgeted context window from ContextAssemblyService.
+ */
+export function buildQuerySystemPrompt(context: string): string {
+  return `You are Cerebrum, a personal knowledge retrieval engine. Answer the user's question
+using ONLY the context provided below. Follow these rules strictly:
+
+1. Answer only from the provided context. Do not use external knowledge.
+2. Cite every claim by including the source ID in square brackets, e.g. [eng_20260417_0942_agent-coordination].
+3. If the context does not contain enough information to answer, say: "I don't have enough information to answer that fully." and cite what you can.
+4. Keep answers concise and direct.
+5. When citing transactions, include the amount and date.
+6. When citing media, include the title and type.
+
+Context:
+${context}`;
+}

--- a/apps/pops-api/src/modules/cerebrum/query/query-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/query-service.ts
@@ -1,0 +1,245 @@
+/**
+ * QueryService — pipeline orchestrator for the Cerebrum Query Engine (PRD-082).
+ *
+ * Methods:
+ *   ask      — full NL Q&A pipeline: scope inference → retrieval → LLM → citation parsing
+ *   retrieve — retrieval-only (no LLM), returns sources
+ *   explain  — debug: shows what the pipeline would do without executing
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+import { getDrizzle } from '../../../db.js';
+import { getEnv } from '../../../env.js';
+import { withRateLimitRetry } from '../../../lib/ai-retry.js';
+import { trackInference } from '../../../lib/inference-middleware.js';
+import { logger } from '../../../lib/logger.js';
+import { ContextAssemblyService } from '../retrieval/context-assembly.js';
+import { HybridSearchService } from '../retrieval/hybrid-search.js';
+import { CitationParser } from './citation-parser.js';
+import { buildQuerySystemPrompt } from './prompts.js';
+import { QueryScopeInferencer } from './scope-inferencer.js';
+
+import type { RetrievalFilters } from '../retrieval/types.js';
+import type {
+  ConfidenceLevel,
+  QueryDomain,
+  QueryRequest,
+  QueryResponse,
+  ScopeInferenceResult,
+  SourceCitation,
+} from './types.js';
+
+const MODEL = 'claude-sonnet-4-20250514';
+const OPERATION = 'cerebrum.query';
+const DEFAULT_MAX_SOURCES = 10;
+const RELEVANCE_THRESHOLD = 0.3;
+const TOKEN_BUDGET = 4096;
+
+const NO_INFO_ANSWER = "I don't have information about that.";
+
+/** Map domain names to Thalamus sourceType values. */
+const DOMAIN_MAP: Record<QueryDomain, string> = {
+  engrams: 'engram',
+  transactions: 'transaction',
+  media: 'media',
+  inventory: 'inventory',
+};
+
+function computeConfidence(sources: SourceCitation[]): ConfidenceLevel {
+  if (sources.length === 0) return 'low';
+  const topScore = sources[0]?.relevance ?? 0;
+  if (topScore > 0.8) return 'high';
+  if (topScore >= 0.5) return 'medium';
+  return 'low';
+}
+
+function buildRetrievalFilters(
+  scopes: string[],
+  includeSecret: boolean,
+  domains?: QueryDomain[]
+): RetrievalFilters {
+  const filters: RetrievalFilters = {};
+
+  if (scopes.length > 0) {
+    filters.scopes = scopes;
+  }
+
+  if (includeSecret) {
+    filters.includeSecret = true;
+  }
+
+  if (domains && domains.length > 0) {
+    filters.sourceTypes = domains.map((d) => DOMAIN_MAP[d]);
+  }
+
+  return filters;
+}
+
+export class QueryService {
+  private readonly inferencer = new QueryScopeInferencer();
+  private readonly citationParser = new CitationParser();
+  private readonly assembler = new ContextAssemblyService();
+
+  /**
+   * Full NL Q&A pipeline: infer scopes → retrieve → LLM → parse citations.
+   */
+  async ask(request: QueryRequest): Promise<QueryResponse> {
+    const question = request.question.trim();
+    const maxSources = request.maxSources ?? DEFAULT_MAX_SOURCES;
+    const includeSecret = request.includeSecret ?? false;
+
+    // 1. Scope inference.
+    const scopeResult = this.inferencer.infer(question, undefined, request.scopes, includeSecret);
+
+    // 2. Build filters and retrieve.
+    const filters = buildRetrievalFilters(scopeResult.scopes, includeSecret, request.domains);
+    const hybridSearch = new HybridSearchService(getDrizzle());
+    const results = await hybridSearch.hybrid(question, filters, maxSources, RELEVANCE_THRESHOLD);
+
+    // 3. Zero results → short-circuit.
+    if (results.length === 0) {
+      return {
+        answer: NO_INFO_ANSWER,
+        sources: [],
+        scopes: scopeResult.scopes,
+        confidence: 'low',
+      };
+    }
+
+    // 4. Assemble context for LLM.
+    const assembled = this.assembler.assemble({
+      query: question,
+      results,
+      tokenBudget: TOKEN_BUDGET,
+      includeMetadata: true,
+    });
+
+    // 5. Generate answer via LLM.
+    const systemPrompt = buildQuerySystemPrompt(assembled.context);
+    const llmAnswer = await this.callLlm(systemPrompt, question);
+
+    // 6. Parse citations.
+    const { cleanedAnswer, citations } = this.citationParser.parse(llmAnswer, results);
+
+    // 7. Compute confidence — downgrade if zero valid citations.
+    let confidence = computeConfidence(citations);
+    if (citations.length === 0) {
+      confidence = 'low';
+    }
+
+    return {
+      answer: cleanedAnswer,
+      sources: citations,
+      scopes: scopeResult.scopes,
+      confidence,
+    };
+  }
+
+  /**
+   * Retrieval-only: returns sources without calling the LLM.
+   */
+  async retrieve(
+    question: string,
+    scopes?: string[],
+    includeSecret?: boolean,
+    maxSources?: number
+  ): Promise<{ sources: SourceCitation[] }> {
+    const trimmed = question.trim();
+    const limit = maxSources ?? DEFAULT_MAX_SOURCES;
+    const secret = includeSecret ?? false;
+
+    const scopeResult = this.inferencer.infer(trimmed, undefined, scopes, secret);
+    const filters = buildRetrievalFilters(scopeResult.scopes, secret);
+    const hybridSearch = new HybridSearchService(getDrizzle());
+    const results = await hybridSearch.hybrid(trimmed, filters, limit, RELEVANCE_THRESHOLD);
+
+    const sources: SourceCitation[] = results.map((r) => ({
+      id: r.sourceId,
+      type: r.sourceType,
+      title: r.title,
+      excerpt: truncateExcerpt(r.contentPreview ?? ''),
+      relevance: r.score,
+      scope: extractPrimaryScope(r),
+    }));
+
+    return { sources };
+  }
+
+  /**
+   * Debug endpoint: shows scope inference and retrieval plan without executing.
+   */
+  explain(question: string): {
+    scopeInference: ScopeInferenceResult;
+    retrievalPlan: { filters: RetrievalFilters; maxSources: number; threshold: number };
+    secretNotice: string | null;
+  } {
+    const trimmed = question.trim();
+    const scopeResult = this.inferencer.infer(trimmed);
+    const filters = buildRetrievalFilters(scopeResult.scopes, false);
+    const secretNotice = this.inferencer.detectSecretMention(trimmed);
+
+    return {
+      scopeInference: scopeResult,
+      retrievalPlan: {
+        filters,
+        maxSources: DEFAULT_MAX_SOURCES,
+        threshold: RELEVANCE_THRESHOLD,
+      },
+      secretNotice,
+    };
+  }
+
+  /** Call the LLM for answer generation. Gracefully degrades if API key is missing. */
+  private async callLlm(systemPrompt: string, question: string): Promise<string> {
+    const apiKey = getEnv('ANTHROPIC_API_KEY');
+    if (!apiKey) {
+      logger.warn('[QueryEngine] ANTHROPIC_API_KEY not set — returning retrieval-only answer');
+      return "I don't have enough information to answer that fully. (LLM unavailable)";
+    }
+
+    const client = new Anthropic({ apiKey, maxRetries: 0 });
+
+    try {
+      const response = await trackInference(
+        { provider: 'claude', model: MODEL, operation: OPERATION, domain: 'cerebrum' },
+        () =>
+          withRateLimitRetry(
+            () =>
+              client.messages.create({
+                model: MODEL,
+                max_tokens: 1024,
+                temperature: 0,
+                system: systemPrompt,
+                messages: [{ role: 'user', content: question }],
+              }),
+            OPERATION,
+            { logger, logPrefix: '[QueryEngine]' }
+          )
+      );
+
+      const text = response.content[0]?.type === 'text' ? response.content[0].text : '';
+      return text;
+    } catch (err) {
+      logger.error(
+        { error: err instanceof Error ? err.message : String(err) },
+        '[QueryEngine] LLM call failed'
+      );
+      return "I don't have enough information to answer that fully. (LLM error)";
+    }
+  }
+}
+
+/** Truncate to 200 chars at word boundary with ellipsis. */
+function truncateExcerpt(text: string): string {
+  if (text.length <= 200) return text;
+  const truncated = text.slice(0, 200);
+  const lastSpace = truncated.lastIndexOf(' ');
+  const cutPoint = lastSpace > 0 ? lastSpace : 200;
+  return text.slice(0, cutPoint) + '…';
+}
+
+/** Extract primary scope from retrieval result metadata. */
+function extractPrimaryScope(result: { metadata: Record<string, unknown> }): string {
+  const scopes = result.metadata['scopes'] as string[] | undefined;
+  return scopes?.[0] ?? 'unknown';
+}

--- a/apps/pops-api/src/modules/cerebrum/query/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/router.ts
@@ -1,0 +1,107 @@
+/**
+ * tRPC router for cerebrum.query (PRD-082).
+ *
+ * Procedures:
+ *   ask      — full NL Q&A pipeline (mutation — calls LLM, has side effects)
+ *   retrieve — retrieval-only, no LLM (query)
+ *   explain  — debug: show scope inference + retrieval plan (query)
+ */
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { HttpError, NotFoundError, ValidationError } from '../../../shared/errors.js';
+import { protectedProcedure, router } from '../../../trpc.js';
+import { QueryService } from './query-service.js';
+
+import type { QueryDomain } from './types.js';
+
+function toTrpcError(err: unknown): never {
+  if (err instanceof NotFoundError) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+  }
+  if (err instanceof ValidationError) {
+    const details = err.details;
+    let message: string;
+    if (typeof details === 'string') {
+      message = details;
+    } else if (
+      typeof details === 'object' &&
+      details !== null &&
+      typeof (details as { message?: unknown }).message === 'string'
+    ) {
+      message = (details as { message: string }).message;
+    } else {
+      message = err.message;
+    }
+    throw new TRPCError({ code: 'BAD_REQUEST', message, cause: err });
+  }
+  if (err instanceof HttpError) {
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: err.message });
+  }
+  throw err;
+}
+
+function getService(): QueryService {
+  return new QueryService();
+}
+
+const domainEnum = z.enum(['engrams', 'transactions', 'media', 'inventory']);
+
+const queryRequestSchema = z.object({
+  question: z.string().min(1),
+  scopes: z.array(z.string().min(1)).optional(),
+  includeSecret: z.boolean().optional(),
+  maxSources: z.number().int().positive().max(50).optional(),
+  domains: z.array(domainEnum).optional(),
+});
+
+const retrieveSchema = z.object({
+  question: z.string().min(1),
+  scopes: z.array(z.string().min(1)).optional(),
+  includeSecret: z.boolean().optional(),
+  maxSources: z.number().int().positive().max(50).optional(),
+});
+
+const explainSchema = z.object({
+  question: z.string().min(1),
+});
+
+export const queryRouter = router({
+  /** Full NL Q&A pipeline: scope inference → retrieval → LLM → citation parsing. */
+  ask: protectedProcedure.input(queryRequestSchema).mutation(async ({ input }) => {
+    try {
+      return await getService().ask({
+        question: input.question,
+        scopes: input.scopes,
+        includeSecret: input.includeSecret,
+        maxSources: input.maxSources,
+        domains: input.domains as QueryDomain[] | undefined,
+      });
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+
+  /** Retrieval-only — returns sources without calling the LLM. */
+  retrieve: protectedProcedure.input(retrieveSchema).query(async ({ input }) => {
+    try {
+      return await getService().retrieve(
+        input.question,
+        input.scopes,
+        input.includeSecret,
+        input.maxSources
+      );
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+
+  /** Debug: show scope inference and retrieval plan without executing. */
+  explain: protectedProcedure.input(explainSchema).query(({ input }) => {
+    try {
+      return getService().explain(input.question);
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+});

--- a/apps/pops-api/src/modules/cerebrum/query/scope-inferencer.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/scope-inferencer.ts
@@ -1,0 +1,114 @@
+/**
+ * QueryScopeInferencer — keyword-based scope inference for the Query Engine
+ * (PRD-082 US-02).
+ *
+ * Matches question text against work/personal keyword lists to narrow retrieval
+ * scopes. Falls back to all non-secret scopes when ambiguous.
+ */
+
+import type { ScopeInferenceResult } from './types.js';
+
+const WORK_KEYWORDS = [
+  'work',
+  'office',
+  'meeting',
+  'project',
+  'client',
+  'deadline',
+  'sprint',
+  'standup',
+  'pr',
+  'prs',
+  'deploy',
+];
+
+const PERSONAL_KEYWORDS = [
+  'journal',
+  'diary',
+  'therapy',
+  'family',
+  'personal',
+  'health',
+  'exercise',
+  'hobby',
+];
+
+const SECRET_KEYWORDS = ['secret', 'password', 'private key', 'credential'];
+
+/**
+ * Check whether a scope path contains a "secret" segment.
+ * E.g. "personal.secret.keys" → true, "work.notes" → false.
+ */
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+/**
+ * Test whether any keyword appears as a standalone word in the question.
+ * Uses a word-boundary regex to avoid partial matches (e.g. "therapy" should
+ * not match "the").
+ */
+function matchesKeywords(question: string, keywords: readonly string[]): boolean {
+  const lower = question.toLowerCase();
+  return keywords.some((kw) => new RegExp(`\\b${kw}\\b`, 'i').test(lower));
+}
+
+export class QueryScopeInferencer {
+  /**
+   * Infer retrieval scopes from the question text.
+   *
+   * @param question    - The user's natural language question.
+   * @param knownScopes - All scopes available in the system (optional).
+   * @param explicit    - Explicit scopes from QueryRequest (skip inference).
+   * @param includeSecret - If true, allow secret scopes through.
+   */
+  infer(
+    question: string,
+    knownScopes?: string[],
+    explicit?: string[],
+    includeSecret?: boolean
+  ): ScopeInferenceResult {
+    // Explicit scopes → skip inference entirely.
+    if (explicit && explicit.length > 0) {
+      const scopes = includeSecret ? explicit : explicit.filter((s) => !isSecretScope(s));
+      return { scopes, source: 'explicit' };
+    }
+
+    const pool = knownScopes ?? [];
+
+    // Work keywords → filter to work.* scopes.
+    if (matchesKeywords(question, WORK_KEYWORDS)) {
+      const workScopes = pool.filter(
+        (s) => s.startsWith('work.') && (includeSecret === true || !isSecretScope(s))
+      );
+      if (workScopes.length > 0) {
+        return { scopes: workScopes, source: 'inferred' };
+      }
+    }
+
+    // Personal keywords → filter to personal.* scopes.
+    if (matchesKeywords(question, PERSONAL_KEYWORDS)) {
+      const personalScopes = pool.filter(
+        (s) => s.startsWith('personal.') && (includeSecret === true || !isSecretScope(s))
+      );
+      if (personalScopes.length > 0) {
+        return { scopes: personalScopes, source: 'inferred' };
+      }
+    }
+
+    // Ambiguous → all non-secret scopes.
+    const defaultScopes = includeSecret ? pool : pool.filter((s) => !isSecretScope(s));
+    return { scopes: defaultScopes, source: 'default' };
+  }
+
+  /**
+   * Detect whether the question mentions secret/sensitive concepts.
+   * Returns a notice string if detected, null otherwise.
+   */
+  detectSecretMention(question: string): string | null {
+    if (matchesKeywords(question, SECRET_KEYWORDS)) {
+      return 'Your question may reference sensitive data. Secret scopes are excluded unless explicitly enabled.';
+    }
+    return null;
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/query/types.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Types for the Cerebrum Query Engine (PRD-082).
+ *
+ * Covers: QueryRequest, QueryResponse, SourceCitation, ScopeInferenceResult,
+ * and domain-to-sourceType mappings.
+ */
+
+/** Supported query domains mapped to Thalamus sourceType values. */
+export const DOMAIN_SOURCE_TYPE_MAP: Record<QueryDomain, string> = {
+  engrams: 'engram',
+  transactions: 'transaction',
+  media: 'media',
+  inventory: 'inventory',
+};
+
+export type QueryDomain = 'engrams' | 'transactions' | 'media' | 'inventory';
+
+export const ALL_QUERY_DOMAINS: QueryDomain[] = ['engrams', 'transactions', 'media', 'inventory'];
+
+export type ConfidenceLevel = 'high' | 'medium' | 'low';
+
+export interface QueryRequest {
+  question: string;
+  scopes?: string[];
+  includeSecret?: boolean;
+  /** Maximum number of sources to retrieve (default 10). */
+  maxSources?: number;
+  /** Filter by domain. Omit or empty to search all. */
+  domains?: QueryDomain[];
+}
+
+export interface QueryResponse {
+  answer: string;
+  sources: SourceCitation[];
+  /** Scopes used for retrieval (explicit or inferred). */
+  scopes: string[];
+  confidence: ConfidenceLevel;
+}
+
+export interface SourceCitation {
+  id: string;
+  type: string;
+  title: string;
+  /** Max 200 chars, truncated at word boundary with ellipsis. */
+  excerpt: string;
+  /** Relevance score 0–1. */
+  relevance: number;
+  /** Primary scope of the source. */
+  scope: string;
+}
+
+export type ScopeInferenceSource = 'explicit' | 'inferred' | 'default';
+
+export interface ScopeInferenceResult {
+  scopes: string[];
+  source: ScopeInferenceSource;
+}
+
+/** Internal result from the citation parser. */
+export interface CitationParseResult {
+  cleanedAnswer: string;
+  citations: SourceCitation[];
+}


### PR DESCRIPTION
## Summary

- Adds the Cerebrum Query Engine (`apps/pops-api/src/modules/cerebrum/query/`)
- `cerebrum.query.ask` — full NL Q&A pipeline: scope inference -> retrieval -> LLM -> citation parsing
- `cerebrum.query.retrieve` — retrieval-only (no LLM call)
- `cerebrum.query.explain` — debug endpoint showing scope inference and retrieval plan
- `QueryScopeInferencer` — keyword-based work/personal scope detection with secret hard-blocking
- `CitationParser` — extracts inline citations, strips hallucinated IDs, formats domain-specific excerpts
- Configurable LLM prompt template stored separately from service logic
- 76 unit tests across 3 test files

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 new errors)
- [x] `pnpm test` passes
- [ ] Manual: call `cerebrum.query.explain` with test questions to verify scope inference

Closes #2205 #2206 #2207 #2208