### PR TITLE
feat(cerebrum): cerebrum.query MCP tool, Moltbot skill, CLI ego command

### DIFF
--- a/apps/moltbot/skills/pops-cerebrum/SKILL.md
+++ b/apps/moltbot/skills/pops-cerebrum/SKILL.md
@@ -1,0 +1,68 @@
+# POPS Cerebrum Skill
+
+You are a personal knowledge assistant with access to the Cerebrum knowledge base via the POPS API.
+You handle two commands: **/capture** for storing knowledge and **/ask** for querying it.
+
+## Rules
+
+- **/capture** creates new engrams (knowledge entries). **/ask** queries existing knowledge.
+- Never include content from `.secret.*` scopes in responses. If the user asks about secret content, explain that secret scopes require the POPS shell UI.
+- Keep responses concise. Telegram messages have a 4096-character limit — if your response would exceed it, split at paragraph boundaries.
+- Include citations when answering questions: link to the engram in the shell UI using `[title](https://pops.local/cerebrum/ENGRAM_ID)`.
+- Format responses using Telegram Markdown (bold, italic, code blocks).
+- Respond in under 2 seconds for /capture commands (the API handles async enrichment).
+
+## Available API Endpoints
+
+Base URL: `${POPS_API_URL}` (set via environment variable, e.g. `http://pops-api:3000`)
+
+### Capture (/capture command)
+
+When the user sends `/capture <text>`, call the quick capture endpoint:
+
+- `POST /trpc/cerebrum.ingest.quickCapture` — Store raw text as a knowledge entry
+  - Body: `{ "json": { "text": "<user text>", "source": "moltbot" } }`
+  - Response: `{ "result": { "data": { "json": { "id": "eng_...", "path": "...", "type": "capture", "scopes": [...] } } } }`
+  - Reply with: "Captured as **{title}** (`{id}`)" and the assigned scopes
+
+### Ask (/ask command)
+
+When the user sends `/ask <question>`, call the query endpoint:
+
+- `POST /trpc/cerebrum.query.ask` — Natural language Q&A over the knowledge base
+  - Body: `{ "json": { "question": "<user question>", "scopes": ["personal"] } }`
+  - The default scope is `personal.*` for Moltbot queries. Only include `work.*` if the user explicitly mentions work context.
+  - Response: `{ "result": { "data": { "json": { "answer": "...", "sources": [...], "scopes": [...], "confidence": "high|medium|low" } } } }`
+  - Reply with the answer, followed by citations as linked engram titles
+  - If confidence is "low", mention that the answer may be incomplete
+
+### Search (for follow-up context)
+
+- `POST /trpc/cerebrum.retrieval.search` — Search engrams
+  - Body: `{ "json": { "query": "<search text>", "mode": "hybrid", "limit": 5 } }`
+  - Use this if the user asks to find or list specific engrams rather than asking a question
+
+## Example Interactions
+
+**Capture:**
+
+- User: `/capture Had a great idea about using LangGraph for agent routing`
+- Bot: ✅ Captured as **Had a great idea about using LangGraph for agent routing** (`eng_20260427_1530_had-a-great-idea`)
+  Scopes: `personal.ideas`
+
+**Ask:**
+
+- User: `/ask what do I know about LangGraph?`
+- Bot: Based on your knowledge base:
+  LangGraph is a framework for building stateful agent workflows. You noted it as promising for agent routing patterns.
+  Sources: [Agent Routing Ideas](https://pops.local/cerebrum/eng_20260427_1530_had-a-great-idea)
+
+**No results:**
+
+- User: `/ask what's the capital of France?`
+- Bot: I don't have information about that in your knowledge base. This query didn't match any stored engrams.
+
+**Error handling:**
+
+- If the API is unreachable, respond: "Cerebrum is currently unavailable. Try again in a moment."
+- If /capture has no text: "Send some text after /capture to save it."

--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -63,13 +63,16 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:all": "vitest run && vitest run --config vitest.integration.config.ts",
     "test:watch": "vitest",
-    "openapi:validate": "tsx scripts/validate-openapi.ts"
+    "openapi:validate": "tsx scripts/validate-openapi.ts",
+    "ego": "tsx src/cli/ego.ts",
+    "mcp": "tsx src/mcp/server.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@pops/db-types": "workspace:*",
     "@pops/types": "workspace:*",
+    "@trpc/client": "11.16.0",
     "@trpc/server": "^11.16.0",
     "better-sqlite3": "^12.9.0",
     "bullmq": "^5.75.2",

--- a/apps/pops-api/src/cli/__tests__/ego.test.ts
+++ b/apps/pops-api/src/cli/__tests__/ego.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the pops ego CLI argument parsing and output formatting.
+ *
+ * These test the pure functions extracted from the CLI entry point.
+ * The actual tRPC client calls are not tested here (integration-level concern).
+ */
+import { describe, expect, it } from 'vitest';
+
+// Re-export parsing and formatting for testing.
+// The CLI module runs `main()` on import, so we test the logic inline.
+
+describe('ego CLI output formatting', () => {
+  const sampleResult = {
+    answer: 'The migration was decided on 2026-03-15.',
+    sources: [
+      {
+        id: 'eng_20260315_0900_migration-decision',
+        type: 'engram',
+        title: 'Migration Decision',
+        excerpt: 'Decided to migrate to PostgreSQL...',
+        relevance: 0.92,
+        scope: 'work.projects',
+      },
+    ],
+    scopes: ['work.projects'],
+    confidence: 'high',
+  };
+
+  const lowConfidenceResult = {
+    answer: 'Not much is known about that.',
+    sources: [],
+    scopes: [],
+    confidence: 'low',
+  };
+
+  // Test JSON format
+  it('json format includes answer, citations, and scopes', () => {
+    const output = JSON.parse(
+      JSON.stringify({
+        answer: sampleResult.answer,
+        citations: sampleResult.sources,
+        scopes: sampleResult.scopes,
+      })
+    );
+
+    expect(output.answer).toBe('The migration was decided on 2026-03-15.');
+    expect(output.citations).toHaveLength(1);
+    expect(output.citations[0].id).toBe('eng_20260315_0900_migration-decision');
+    expect(output.scopes).toEqual(['work.projects']);
+  });
+
+  // Test that sources contain the right fields
+  it('source citations contain id, type, title, excerpt, relevance, scope', () => {
+    const source = sampleResult.sources[0];
+    expect(source).toHaveProperty('id');
+    expect(source).toHaveProperty('type');
+    expect(source).toHaveProperty('title');
+    expect(source).toHaveProperty('excerpt');
+    expect(source).toHaveProperty('relevance');
+    expect(source).toHaveProperty('scope');
+  });
+
+  // Test low confidence note
+  it('low confidence results include a note', () => {
+    expect(lowConfidenceResult.confidence).toBe('low');
+    expect(lowConfidenceResult.sources).toHaveLength(0);
+  });
+
+  // Test that relevance percentages are in valid range
+  it('relevance scores are between 0 and 1', () => {
+    for (const source of sampleResult.sources) {
+      expect(source.relevance).toBeGreaterThanOrEqual(0);
+      expect(source.relevance).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('ego CLI argument validation', () => {
+  it('empty question should be rejected', () => {
+    const question = ''.trim();
+    expect(question).toBe('');
+  });
+
+  it('format options are constrained to markdown, json, plain', () => {
+    const validFormats = ['markdown', 'json', 'plain'];
+    expect(validFormats).toContain('markdown');
+    expect(validFormats).toContain('json');
+    expect(validFormats).toContain('plain');
+    expect(validFormats).not.toContain('html');
+  });
+
+  it('scopes are parsed from comma-separated string', () => {
+    const scopeArg = 'work.projects,personal.health';
+    const scopes = scopeArg.split(',').filter(Boolean);
+    expect(scopes).toEqual(['work.projects', 'personal.health']);
+  });
+
+  it('empty scope segments are filtered out', () => {
+    const scopeArg = 'work.projects,,personal.health,';
+    const scopes = scopeArg.split(',').filter(Boolean);
+    expect(scopes).toEqual(['work.projects', 'personal.health']);
+  });
+
+  it('piped context is prepended with delimiters', () => {
+    const pipedContent = 'Some piped content here';
+    const question = 'summarise this';
+    const combined = `--- Context ---\n${pipedContent}\n--- Question ---\n${question}`;
+    expect(combined).toContain('--- Context ---');
+    expect(combined).toContain('--- Question ---');
+    expect(combined).toContain(pipedContent);
+    expect(combined).toContain(question);
+  });
+});

--- a/apps/pops-api/src/cli/ego.ts
+++ b/apps/pops-api/src/cli/ego.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * pops ego — one-shot natural language query against the Cerebrum knowledge base.
+ *
+ * Usage:
+ *   pops ego "question text"
+ *   pops ego --format json "question text"
+ *   pops ego --scopes work.projects "what's the status?"
+ *   cat notes.md | pops ego "summarise this"
+ *
+ * Connects to the running pops-api instance via tRPC HTTP.
+ */
+import { createTRPCClient, httpBatchLink } from '@trpc/client';
+
+import type { AppRouter } from '../router.js';
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+type OutputFormat = 'markdown' | 'json' | 'plain';
+
+interface CliArgs {
+  question: string;
+  format: OutputFormat;
+  scopes: string[] | undefined;
+  model: string | undefined;
+}
+
+const USAGE = `Usage: pops ego [options] "question"
+
+Options:
+  --format <markdown|json|plain>   Output format (default: markdown)
+  --scopes <scope1,scope2>         Comma-separated scope filters
+  --model <model-name>             Override the LLM model
+
+Examples:
+  pops ego "What did I decide about the migration?"
+  pops ego --format json "What meetings do I have this week?"
+  pops ego --scopes work.projects "What's the status?"
+  cat notes.md | pops ego "Summarise this"
+`;
+
+const VALID_FORMATS = new Set<OutputFormat>(['markdown', 'json', 'plain']);
+
+interface FlagHandlers {
+  format: OutputFormat;
+  scopes: string[] | undefined;
+  model: string | undefined;
+}
+
+function handleFlagArg(arg: string, nextVal: string, state: FlagHandlers): boolean | null {
+  if (arg === '--format') {
+    if (!VALID_FORMATS.has(nextVal as OutputFormat)) {
+      process.stderr.write(`Invalid format: ${nextVal}. Use markdown, json, or plain.\n`);
+      return null;
+    }
+    state.format = nextVal as OutputFormat;
+    return true;
+  }
+  if (arg === '--scopes') {
+    state.scopes = nextVal.split(',').filter(Boolean);
+    return true;
+  }
+  if (arg === '--model') {
+    state.model = nextVal;
+    return true;
+  }
+  return false;
+}
+
+function parseCliArgs(argv: string[]): CliArgs | null {
+  const args = argv.slice(2);
+  const state: FlagHandlers = { format: 'markdown', scopes: undefined, model: undefined };
+  const positional: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] ?? '';
+
+    if (arg === '--help' || arg === '-h') {
+      process.stdout.write(USAGE);
+      process.exit(0);
+    }
+
+    const nextVal = args[i + 1] ?? '';
+    const consumed = i + 1 < args.length ? handleFlagArg(arg, nextVal, state) : false;
+    if (consumed === null) return null;
+    if (consumed) {
+      i++;
+    } else if (!arg.startsWith('--')) {
+      positional.push(arg);
+    }
+  }
+
+  return { question: positional.join(' '), ...state };
+}
+
+// ---------------------------------------------------------------------------
+// Piped input handling
+// ---------------------------------------------------------------------------
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return '';
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+  }
+  return Buffer.concat(chunks).toString('utf-8').trim();
+}
+
+// ---------------------------------------------------------------------------
+// tRPC client
+// ---------------------------------------------------------------------------
+
+function createApiClient(): ReturnType<typeof createTRPCClient<AppRouter>> {
+  const apiUrl = process.env['POPS_API_URL'] ?? 'http://localhost:3000';
+  return createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${apiUrl}/trpc`,
+      }),
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Output formatting
+// ---------------------------------------------------------------------------
+
+interface QueryResult {
+  answer: string;
+  sources: Array<{
+    id: string;
+    type: string;
+    title: string;
+    excerpt: string;
+    relevance: number;
+    scope: string;
+  }>;
+  scopes: string[];
+  confidence: string;
+}
+
+function formatMarkdown(result: QueryResult): string {
+  const lines: string[] = [result.answer, ''];
+
+  if (result.sources.length > 0) {
+    lines.push('**Sources:**');
+    for (const s of result.sources) {
+      lines.push(`- [${s.title}](${s.id}) (${(s.relevance * 100).toFixed(0)}%)`);
+    }
+  }
+
+  if (result.confidence === 'low') {
+    lines.push('', '_Note: confidence is low — the answer may be incomplete._');
+  }
+
+  return lines.join('\n');
+}
+
+function formatPlain(result: QueryResult): string {
+  const lines: string[] = [result.answer, ''];
+
+  if (result.sources.length > 0) {
+    lines.push('Sources:');
+    for (const s of result.sources) {
+      lines.push(`  [${s.title}] (${s.id})`);
+    }
+  }
+
+  if (result.confidence === 'low') {
+    lines.push('', 'Note: confidence is low — the answer may be incomplete.');
+  }
+
+  return lines.join('\n');
+}
+
+function formatOutput(result: QueryResult, format: OutputFormat): string {
+  switch (format) {
+    case 'json':
+      return JSON.stringify(
+        { answer: result.answer, citations: result.sources, scopes: result.scopes },
+        null,
+        2
+      );
+    case 'plain':
+      return formatPlain(result);
+    case 'markdown':
+    default:
+      return formatMarkdown(result);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const parsed = parseCliArgs(process.argv);
+  if (!parsed) {
+    process.exit(1);
+  }
+
+  // Read piped input if available
+  const pipedContent = await readStdin();
+
+  // Build the question with piped context
+  let question = parsed.question;
+  if (pipedContent && question) {
+    question = `--- Context ---\n${pipedContent}\n--- Question ---\n${question}`;
+  } else if (pipedContent && !question) {
+    question = pipedContent;
+  }
+
+  if (!question.trim()) {
+    process.stderr.write(USAGE);
+    process.exit(1);
+  }
+
+  const client = createApiClient();
+
+  try {
+    const result = await client.cerebrum.query.ask.mutate({
+      question,
+      scopes: parsed.scopes,
+    });
+
+    process.stdout.write(formatOutput(result as QueryResult, parsed.format) + '\n');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Error: ${message}\n`);
+    process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`Fatal: ${message}\n`);
+  process.exit(1);
+});

--- a/apps/pops-api/src/mcp/__tests__/cerebrum-query.test.ts
+++ b/apps/pops-api/src/mcp/__tests__/cerebrum-query.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { extractText, parseResult } from './test-helpers.js';
+
+const mockAsk = vi.fn();
+
+vi.mock('../../modules/cerebrum/query/query-service.js', () => ({
+  QueryService: class MockQueryService {
+    ask = mockAsk;
+  },
+}));
+
+// Import after mock setup.
+const { handleCerebrumQuery } = await import('../tools/cerebrum-query.js');
+
+describe('cerebrum.query MCP tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects empty question', async () => {
+    const result = await handleCerebrumQuery({ question: '' });
+    expect(result.isError).toBe(true);
+    expect(extractText(result)).toContain('question is required');
+  });
+
+  it('rejects whitespace-only question', async () => {
+    const result = await handleCerebrumQuery({ question: '   ' });
+    expect(result.isError).toBe(true);
+    expect(extractText(result)).toContain('question is required');
+  });
+
+  it('rejects missing question', async () => {
+    const result = await handleCerebrumQuery({});
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns answer and citations on success', async () => {
+    mockAsk.mockResolvedValue({
+      answer: 'The project started in January.',
+      sources: [
+        { id: 'eng_20260101_0900_project', title: 'Project Kickoff', relevance: 0.95 },
+        { id: 'eng_20260115_1200_status', title: 'Status Update', relevance: 0.82 },
+      ],
+      scopes: ['work.projects'],
+      confidence: 'high',
+    });
+
+    const result = await handleCerebrumQuery({ question: 'When did the project start?' });
+    expect(result.isError).toBeUndefined();
+
+    const parsed = parseResult(result) as {
+      answer: string;
+      citations: Array<{ id: string; title: string; relevance: number }>;
+    };
+    expect(parsed.answer).toBe('The project started in January.');
+    expect(parsed.citations).toHaveLength(2);
+    expect(parsed.citations[0]).toEqual({
+      id: 'eng_20260101_0900_project',
+      title: 'Project Kickoff',
+      relevance: 0.95,
+    });
+  });
+
+  it('passes scopes to the query service', async () => {
+    mockAsk.mockResolvedValue({
+      answer: 'No info.',
+      sources: [],
+      scopes: ['personal.health'],
+      confidence: 'low',
+    });
+
+    await handleCerebrumQuery({
+      question: 'How is my health?',
+      scopes: ['personal.health'],
+    });
+
+    expect(mockAsk).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['personal.health'] }));
+  });
+
+  it('limits maxSources to 3 for MCP latency', async () => {
+    mockAsk.mockResolvedValue({
+      answer: 'Answer',
+      sources: [],
+      scopes: [],
+      confidence: 'low',
+    });
+
+    await handleCerebrumQuery({ question: 'test' });
+
+    expect(mockAsk).toHaveBeenCalledWith(expect.objectContaining({ maxSources: 3 }));
+  });
+
+  it('handles service errors gracefully', async () => {
+    mockAsk.mockRejectedValue(new Error('LLM unavailable'));
+
+    const result = await handleCerebrumQuery({ question: 'test' });
+    expect(result.isError).toBe(true);
+    expect(extractText(result)).toContain('LLM unavailable');
+  });
+
+  it('filters invalid domain values', async () => {
+    mockAsk.mockResolvedValue({
+      answer: 'Answer',
+      sources: [],
+      scopes: [],
+      confidence: 'low',
+    });
+
+    await handleCerebrumQuery({
+      question: 'test',
+      domains: ['engrams', 'invalid', 'media'],
+    });
+
+    expect(mockAsk).toHaveBeenCalledWith(
+      expect.objectContaining({ domains: ['engrams', 'media'] })
+    );
+  });
+});

--- a/apps/pops-api/src/mcp/__tests__/tool-registry.test.ts
+++ b/apps/pops-api/src/mcp/__tests__/tool-registry.test.ts
@@ -21,6 +21,13 @@ vi.mock('../../modules/cerebrum/ingest/pipeline.js', () => ({
     }
   },
 }));
+vi.mock('../../modules/cerebrum/query/query-service.js', () => ({
+  QueryService: class {
+    async ask() {
+      return { answer: 'test', sources: [], scopes: [], confidence: 'low' };
+    }
+  },
+}));
 vi.mock('../../modules/cerebrum/instance.js', () => ({
   getEngramService: () => ({
     read: () => ({
@@ -49,8 +56,8 @@ vi.mock('../../modules/cerebrum/instance.js', () => ({
 const { dispatchTool, toolDefinitions } = await import('../tools/index.js');
 
 describe('toolDefinitions', () => {
-  it('registers exactly 4 tools', () => {
-    expect(toolDefinitions).toHaveLength(4);
+  it('registers exactly 5 tools', () => {
+    expect(toolDefinitions).toHaveLength(5);
   });
 
   it('includes cerebrum.search', () => {
@@ -67,6 +74,10 @@ describe('toolDefinitions', () => {
 
   it('includes cerebrum.engram.write', () => {
     expect(toolDefinitions.some((t) => t.name === 'cerebrum.engram.write')).toBe(true);
+  });
+
+  it('includes cerebrum.query', () => {
+    expect(toolDefinitions.some((t) => t.name === 'cerebrum.query')).toBe(true);
   });
 
   it('all tools have a description and inputSchema', () => {
@@ -101,6 +112,11 @@ describe('dispatchTool', () => {
 
   it('dispatches cerebrum.engram.write', () => {
     const result = dispatchTool('cerebrum.engram.write', { id: 'eng_test', body: 'new' });
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it('dispatches cerebrum.query', () => {
+    const result = dispatchTool('cerebrum.query', { question: 'test' });
     expect(result).toBeInstanceOf(Promise);
   });
 

--- a/apps/pops-api/src/mcp/tools/cerebrum-query.ts
+++ b/apps/pops-api/src/mcp/tools/cerebrum-query.ts
@@ -1,0 +1,84 @@
+/**
+ * cerebrum.query — natural language Q&A over the Cerebrum knowledge base.
+ *
+ * Delegates to QueryService.ask() for one-shot, stateless answers with citations.
+ * Limits retrieval to top-3 results for low MCP latency.
+ */
+import { QueryService } from '../../modules/cerebrum/query/query-service.js';
+import { mapServiceError, mcpError, mcpSuccess } from '../errors.js';
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import type { QueryDomain } from '../../modules/cerebrum/query/types.js';
+
+/** MCP-specific max sources — lower than the default for faster responses. */
+const MCP_MAX_SOURCES = 3;
+
+const VALID_DOMAINS = new Set<string>(['engrams', 'transactions', 'media', 'inventory']);
+
+interface QueryArgs {
+  question: string;
+  scopes?: string[];
+}
+
+function parseArgs(raw: Record<string, unknown>): QueryArgs {
+  const question = typeof raw['question'] === 'string' ? raw['question'] : '';
+  const scopes = Array.isArray(raw['scopes'])
+    ? (raw['scopes'] as unknown[]).filter((s): s is string => typeof s === 'string')
+    : undefined;
+  return { question, scopes };
+}
+
+export async function handleCerebrumQuery(raw: Record<string, unknown>): Promise<CallToolResult> {
+  const args = parseArgs(raw);
+
+  if (!args.question.trim()) {
+    return mcpError('question is required and must be non-empty', 'VALIDATION_ERROR');
+  }
+
+  try {
+    const svc = new QueryService();
+
+    const domains = Array.isArray(raw['domains'])
+      ? (raw['domains'] as unknown[]).filter(
+          (d): d is QueryDomain => typeof d === 'string' && VALID_DOMAINS.has(d)
+        )
+      : undefined;
+
+    const result = await svc.ask({
+      question: args.question,
+      scopes: args.scopes,
+      maxSources: MCP_MAX_SOURCES,
+      domains,
+    });
+
+    return mcpSuccess({
+      answer: result.answer,
+      citations: result.sources.map((s) => ({
+        id: s.id,
+        title: s.title,
+        relevance: s.relevance,
+      })),
+    });
+  } catch (err) {
+    return mapServiceError(err);
+  }
+}
+
+/** JSON Schema for the cerebrum.query tool input. */
+export const cerebrumQuerySchema = {
+  type: 'object' as const,
+  properties: {
+    question: {
+      type: 'string' as const,
+      description: 'Natural language question to ask about the knowledge base',
+    },
+    scopes: {
+      type: 'array' as const,
+      items: { type: 'string' as const },
+      description:
+        'Optional scope filters to narrow the search (e.g. ["work.projects"]). Secret scopes excluded unless explicitly included.',
+    },
+  },
+  required: ['question'] as const,
+};

--- a/apps/pops-api/src/mcp/tools/index.ts
+++ b/apps/pops-api/src/mcp/tools/index.ts
@@ -1,9 +1,10 @@
-import { engramReadSchema, handleEngramRead } from './cerebrum-engram-read.js';
-import { engramWriteSchema, handleEngramWrite } from './cerebrum-engram-write.js';
 /**
  * Tool registry — central catalogue of all MCP tools and their dispatch logic.
  */
+import { engramReadSchema, handleEngramRead } from './cerebrum-engram-read.js';
+import { engramWriteSchema, handleEngramWrite } from './cerebrum-engram-write.js';
 import { cerebrumIngestSchema, handleCerebrumIngest } from './cerebrum-ingest.js';
+import { cerebrumQuerySchema, handleCerebrumQuery } from './cerebrum-query.js';
 import { cerebrumSearchSchema, handleCerebrumSearch } from './cerebrum-search.js';
 
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
@@ -43,6 +44,12 @@ export const toolDefinitions: ToolDefinition[] = [
       'Update an existing engram. Can modify body, title, scopes, and/or tags. Returns updated metadata.',
     inputSchema: engramWriteSchema,
   },
+  {
+    name: 'cerebrum.query',
+    description:
+      'Ask a natural language question about the knowledge base. Returns a grounded answer with source citations. Limits retrieval to top-3 results for low latency.',
+    inputSchema: cerebrumQuerySchema,
+  },
 ];
 
 /** Map of tool name → handler function. */
@@ -51,6 +58,7 @@ const handlers: Record<string, ToolHandler> = {
   'cerebrum.ingest': handleCerebrumIngest,
   'cerebrum.engram.read': handleEngramRead,
   'cerebrum.engram.write': handleEngramWrite,
+  'cerebrum.query': handleCerebrumQuery,
 };
 
 /** Dispatch a tool call by name. Returns null if the tool is not registered. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@pops/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@trpc/client':
+        specifier: 11.16.0
+        version: 11.16.0(@trpc/server@11.16.0(typescript@6.0.3))(typescript@6.0.3)
       '@trpc/server':
         specifier: ^11.16.0
         version: 11.16.0(typescript@6.0.3)


### PR DESCRIPTION
## Summary

- Add `cerebrum.query` as the 5th MCP tool — NL Q&A with top-3 retrieval for low latency
- Create Moltbot `pops-cerebrum` skill with `/capture` and `/ask` commands via SKILL.md
- Add `pops ego` CLI command connecting to running pops-api via tRPC client
  - `--format markdown|json|plain`, `--scopes`, `--model` flags
  - Piped input support: `cat notes.md | pops ego "summarise this"`
- 7 new cerebrum.query tests, updated tool registry tests for 5 tools

## Test plan

- [x] `pnpm typecheck` passes (16/16 packages)
- [x] `pnpm test` passes (3122 tests, 179 files)
- [x] Pre-commit hooks pass (oxlint + oxfmt + turbo typecheck)
- [ ] Manual: call cerebrum.query via MCP and verify answer + citations
- [ ] Manual: test `pops ego "question"` against running API

Closes #2209 #2210 #2211