### PR TITLE
docs(prd-081): mark US-05 entity extraction as done

### DIFF
--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
@@ -97,7 +97,7 @@ raw input → normalize → classify type → match template → extract entitie
 | 02  | [us-02-agent-input](us-02-agent-input.md)             | MCP tools and API endpoint for writing engrams from Claude Code or external tools                        | Partial     | Yes            |
 | 03  | [us-03-quick-capture](us-03-quick-capture.md)         | Minimal-friction capture for Moltbot/CLI: raw text in, classified later                                  | Partial     | Yes            |
 | 04  | [us-04-classification](us-04-classification.md)       | LLM-based content classification: infer type, match template, suggest tags                               | Done        | Yes            |
-| 05  | [us-05-entity-extraction](us-05-entity-extraction.md) | Extract people, projects, dates, topics from body into tags and frontmatter                              | Partial     | Yes            |
+| 05  | [us-05-entity-extraction](us-05-entity-extraction.md) | Extract people, projects, dates, topics from body into tags and frontmatter                              | Done        | Yes            |
 | 06  | [us-06-scope-inference](us-06-scope-inference.md)     | Rule-based + LLM-based scope assignment with user override                                               | Done        | Yes            |
 
 US-01, US-02, and US-03 define the three input channels and can parallelise. US-04, US-05, and US-06 define the pipeline processing stages and can parallelise with each other and with the input channels. All stories depend on PRD-077 (engram file format) and PRD-078 (scope model) being implemented.

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-05-entity-extraction.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-05-entity-extraction.md
@@ -1,7 +1,7 @@
 # US-05: Entity Extraction
 
 > PRD: [PRD-081: Ingestion Pipeline](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -12,7 +12,7 @@ As the Cerebrum system, I need to extract structured entities (people, projects,
 - [x] A `CortexEntityExtractor` service accepts a body string and returns `{ entities: Entity[] }` where each entity has `{ type: string, value: string, confidence: number }`
 - [x] Entity types supported: `person` (names of people), `project` (project or product names), `date` (referenced dates beyond the engram's creation date), `topic` (subject matter keywords), `organisation` (company or team names)
 - [x] Extracted entities with confidence above the threshold (default 0.7) are merged into the engram's `tags` array — entity type is used as a prefix if disambiguation is needed (e.g., `person:Alice`, `project:Karbon`)
-- [ ] Date entities are normalised to ISO 8601 format and stored as a `referenced_dates` custom field in the engram frontmatter
+- [x] Date entities are normalised to ISO 8601 format and stored as a `referenced_dates` custom field in the engram frontmatter
 - [x] Person and organisation entities are stored with consistent capitalisation (title case for names, original case for acronyms)
 - [x] Entity extraction deduplicates against existing tags — if a tag already exists (case-insensitive match), it is not added again
 - [x] The `cerebrum.ingest.extractEntities` API endpoint exposes extraction as a standalone operation


### PR DESCRIPTION
## Summary
- Tick the remaining date normalisation acceptance criterion in US-05
- Update US-05 status from Partial to Done in both the user story file and the PRD-081 README table

Follows merge of PR #2217 which implemented ISO 8601 date entity normalisation and `referenced_dates` frontmatter.

Closes #2154.