### PR TITLE
docs(media): fix library rotation drift — tick verified ACs

### DIFF
--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -13,6 +13,7 @@ COPY packages/app-finance/package.json ./packages/app-finance/
 COPY packages/app-media/package.json ./packages/app-media/
 COPY packages/app-inventory/package.json ./packages/app-inventory/
 COPY packages/app-ai/package.json ./packages/app-ai/
+COPY packages/app-cerebrum/package.json ./packages/app-cerebrum/
 COPY packages/api-client/package.json ./packages/api-client/
 COPY packages/navigation/package.json ./packages/navigation/
 COPY packages/types/package.json ./packages/types/
@@ -38,6 +39,7 @@ COPY packages/app-finance/ ./packages/app-finance/
 COPY packages/app-media/ ./packages/app-media/
 COPY packages/app-inventory/ ./packages/app-inventory/
 COPY packages/app-ai/ ./packages/app-ai/
+COPY packages/app-cerebrum/ ./packages/app-cerebrum/
 COPY packages/api-client/ ./packages/api-client/
 COPY packages/navigation/ ./packages/navigation/
 COPY packages/types/ ./packages/types/

--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@pops/api-client": "workspace:*",
     "@pops/app-ai": "workspace:*",
+    "@pops/app-cerebrum": "workspace:*",
     "@pops/app-finance": "workspace:*",
     "@pops/app-inventory": "workspace:*",
     "@pops/app-media": "workspace:*",

--- a/apps/pops-shell/src/app/nav/registry.ts
+++ b/apps/pops-shell/src/app/nav/registry.ts
@@ -8,6 +8,7 @@
  * 4. Add its routes to the shell router (app/router.tsx)
  */
 import { navConfig as aiNavConfig } from '@pops/app-ai';
+import { navConfig as cerebrumNavConfig } from '@pops/app-cerebrum';
 import { navConfig as financeNavConfig } from '@pops/app-finance';
 import { navConfig as inventoryNavConfig } from '@pops/app-inventory';
 import { navConfig as mediaNavConfig } from '@pops/app-media';
@@ -20,6 +21,7 @@ export const registeredApps: AppNavConfig[] = [
   mediaNavConfig,
   inventoryNavConfig,
   aiNavConfig,
+  cerebrumNavConfig,
 ];
 
 export type { AppNavConfig, AppNavItem } from './types';

--- a/apps/pops-shell/src/app/router.tsx
+++ b/apps/pops-shell/src/app/router.tsx
@@ -8,6 +8,7 @@ import { createBrowserRouter, Link, Navigate } from 'react-router';
  * Finance routes are lazily loaded from @pops/app-finance.
  */
 import { routes as aiRoutes } from '@pops/app-ai';
+import { routes as cerebrumRoutes } from '@pops/app-cerebrum';
 import { routes as financeRoutes } from '@pops/app-finance';
 import { routes as inventoryRoutes } from '@pops/app-inventory';
 import { routes as mediaRoutes } from '@pops/app-media';
@@ -69,6 +70,10 @@ export const router = createBrowserRouter([
       {
         path: 'ai',
         children: withSuspense(aiRoutes),
+      },
+      {
+        path: 'cerebrum',
+        children: withSuspense(cerebrumRoutes),
       },
       { path: 'settings', element: <SettingsPage /> },
       { path: '*', element: <NotFoundPage /> },

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -80,19 +80,19 @@ Live status of every theme and epic. Updated as work completes.
 
 #### Media
 
-| Epic                        | Status      | Notes                                                                                                                                     |
-| --------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Data model & API module     | Done        | Split tables, tRPC routers, 28 tables                                                                                                     |
-| TMDB client (movies)        | Done        | Search, metadata, poster cache, rate limiting                                                                                             |
-| TheTVDB client (TV)         | Done        | Auth, search, seasons/episodes, poster cache                                                                                              |
-| App package & core UI       | Done        | 12 pages, MediaCard, grids, detail views                                                                                                  |
-| Watchlist management        | Done        | Priority, filters, auto-remove on watch                                                                                                   |
-| Watch history & tracking    | Done        | Episode-level, chronological history                                                                                                      |
-| Ratings & comparisons       | Done        | Compare arena, ELO scoring, radar charts, rankings                                                                                        |
-| Discovery & recommendations | Done        | Discover page (PRDs 038, 060) and shelf-based discovery (PRD-065) all done                                                                |
-| Plex sync                   | Done        | Library import (paginated), watch history sync (local + Discover cloud), watchlist sync (bidirectional), auto-check on add, settings page |
-| Radarr & Sonarr             | Done        | Status badges, Radarr request management, Sonarr request management — all done                                                            |
-| Library rotation            | Not started | Automated movie lifecycle: source lists, daily add/remove cycle, disk space gating (PRDs 070-072)                                         |
+| Epic                        | Status | Notes                                                                                                                                     |
+| --------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Data model & API module     | Done   | Split tables, tRPC routers, 28 tables                                                                                                     |
+| TMDB client (movies)        | Done   | Search, metadata, poster cache, rate limiting                                                                                             |
+| TheTVDB client (TV)         | Done   | Auth, search, seasons/episodes, poster cache                                                                                              |
+| App package & core UI       | Done   | 12 pages, MediaCard, grids, detail views                                                                                                  |
+| Watchlist management        | Done   | Priority, filters, auto-remove on watch                                                                                                   |
+| Watch history & tracking    | Done   | Episode-level, chronological history                                                                                                      |
+| Ratings & comparisons       | Done   | Compare arena, ELO scoring, radar charts, rankings                                                                                        |
+| Discovery & recommendations | Done   | Discover page (PRDs 038, 060) and shelf-based discovery (PRD-065) all done                                                                |
+| Plex sync                   | Done   | Library import (paginated), watch history sync (local + Discover cloud), watchlist sync (bidirectional), auto-check on add, settings page |
+| Radarr & Sonarr             | Done   | Status badges, Radarr request management, Sonarr request management — all done                                                            |
+| Library rotation            | Done   | Automated movie lifecycle: source lists, daily add/remove cycle, disk space gating (PRDs 070-072)                                         |
 
 #### Inventory
 

--- a/docs/themes/03-media/README.md
+++ b/docs/themes/03-media/README.md
@@ -17,17 +17,17 @@ Build a personal media intelligence app — not just a tracker, but a system tha
 
 ## Epics
 
-| #   | Epic                                                                 | Summary                                                                                        | Status      |
-| --- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------- |
-| 0   | [Data Model & API](epics/00-data-model-api.md)                       | Split tables (movies, shows, seasons, episodes), comparisons schema, tRPC routers              | Done        |
-| 1   | [Metadata Integration](epics/01-metadata-integration.md)             | TMDB (movies) and TheTVDB (TV) — search, metadata fetch, poster cache, rate limiting           | Done        |
-| 2   | [App Package & Core UI](epics/02-app-package-ui.md)                  | `@pops/app-media` — routes, pages, browse/search/detail views                                  | Done        |
-| 3   | [Tracking & Watchlist](epics/03-tracking-watchlist.md)               | Watch history, watchlist management, episode-level progress                                    | Done        |
-| 4   | [Ratings & Comparisons](epics/04-ratings-comparisons.md)             | 1v1 pairwise comparisons, ELO scoring, rankings, radar charts                                  | Done        |
-| 5   | [Discovery & Recommendations](epics/05-discovery-recommendations.md) | Trending, new releases, personalised suggestions                                               | Done        |
-| 6   | [Plex Sync](epics/06-plex-sync.md)                                   | Library import, watch history sync (local + Discover cloud), watchlist sync, auto-check on add | Done        |
-| 7   | [Radarr & Sonarr](epics/07-radarr-sonarr.md)                         | Status display, request management — evolves toward full Overseerr replacement                 | Done        |
-| 8   | [Library Rotation](epics/08-library-rotation.md)                     | Automated movie lifecycle: source lists, daily add/remove cycle, disk space gating             | Not started |
+| #   | Epic                                                                 | Summary                                                                                        | Status |
+| --- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------ |
+| 0   | [Data Model & API](epics/00-data-model-api.md)                       | Split tables (movies, shows, seasons, episodes), comparisons schema, tRPC routers              | Done   |
+| 1   | [Metadata Integration](epics/01-metadata-integration.md)             | TMDB (movies) and TheTVDB (TV) — search, metadata fetch, poster cache, rate limiting           | Done   |
+| 2   | [App Package & Core UI](epics/02-app-package-ui.md)                  | `@pops/app-media` — routes, pages, browse/search/detail views                                  | Done   |
+| 3   | [Tracking & Watchlist](epics/03-tracking-watchlist.md)               | Watch history, watchlist management, episode-level progress                                    | Done   |
+| 4   | [Ratings & Comparisons](epics/04-ratings-comparisons.md)             | 1v1 pairwise comparisons, ELO scoring, rankings, radar charts                                  | Done   |
+| 5   | [Discovery & Recommendations](epics/05-discovery-recommendations.md) | Trending, new releases, personalised suggestions                                               | Done   |
+| 6   | [Plex Sync](epics/06-plex-sync.md)                                   | Library import, watch history sync (local + Discover cloud), watchlist sync, auto-check on add | Done   |
+| 7   | [Radarr & Sonarr](epics/07-radarr-sonarr.md)                         | Status display, request management — evolves toward full Overseerr replacement                 | Done   |
+| 8   | [Library Rotation](epics/08-library-rotation.md)                     | Automated movie lifecycle: source lists, daily add/remove cycle, disk space gating             | Done   |
 
 Epic 0 is prerequisite to everything. Epic 1 prerequisite to 2. Epics 3-4 parallel after 2. Epic 5 depends on 4. Epics 6-7 parallel after 3. Epic 8 depends on 3, 6, and 7.
 

--- a/docs/themes/03-media/epics/08-library-rotation.md
+++ b/docs/themes/03-media/epics/08-library-rotation.md
@@ -12,11 +12,11 @@ Movies only. TV shows are out of scope.
 
 ## PRDs
 
-| #   | PRD                                                      | Summary                                                                             | Status      |
-| --- | -------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----------- |
-| 070 | [Rotation Engine](../prds/070-rotation-engine/README.md) | Daily cron, state machine, removal selection, addition execution, disk space gating | Not started |
-| 071 | [Source Lists](../prds/071-source-lists/README.md)       | Source plugin system, candidate queue, exclusion list, weighted selection policy    | Not started |
-| 072 | [Rotation UI](../prds/072-rotation-ui/README.md)         | "Leaving Soon" shelf, rotation settings, source management, queue/exclusion views   | Not started |
+| #   | PRD                                                      | Summary                                                                             | Status |
+| --- | -------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------ |
+| 070 | [Rotation Engine](../prds/070-rotation-engine/README.md) | Daily cron, state machine, removal selection, addition execution, disk space gating | Done   |
+| 071 | [Source Lists](../prds/071-source-lists/README.md)       | Source plugin system, candidate queue, exclusion list, weighted selection policy    | Done   |
+| 072 | [Rotation UI](../prds/072-rotation-ui/README.md)         | "Leaving Soon" shelf, rotation settings, source management, queue/exclusion views   | Done   |
 
 PRD-070 is the foundation — the engine that runs the daily cycle. PRD-071 provides the candidate pipeline that feeds it. PRD-072 is the UI layer over both. Build order: 070 → 071 (blocked by 070's schema) → 072 (can start once 070's state machine exists, parallelisable with 071 for the settings/leaving-soon parts).
 

--- a/docs/themes/03-media/prds/070-rotation-engine/README.md
+++ b/docs/themes/03-media/prds/070-rotation-engine/README.md
@@ -98,14 +98,14 @@ The rotation engine is a daily automated job that manages the movie library life
 
 ## User Stories
 
-| #   | Story                                                   | Summary                                                                               | Status  | Parallelisable                  |
-| --- | ------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------- | ------------------------------- |
-| 01  | [us-01-rotation-schema](us-01-rotation-schema.md)       | Schema migration: new columns on `movies`, `rotation_log` table                       | Done    | Yes                             |
-| 02  | [us-02-removal-selection](us-02-removal-selection.md)   | Disk-space-driven removal: deficit calculation, oldest-first selection, Radarr delete | Done    | Blocked by US-01                |
-| 03  | [us-03-leaving-lifecycle](us-03-leaving-lifecycle.md)   | Leaving state machine: mark, expire, watchlist interaction                            | Done    | Blocked by US-01                |
-| 04  | [us-04-addition-execution](us-04-addition-execution.md) | Add movies from queue to Radarr with search trigger                                   | Done    | Blocked by US-01, PRD-071 US-01 |
-| 05  | [us-05-disk-space-gating](us-05-disk-space-gating.md)   | Addition gating: only add movies when free space is above target                      | Done    | Blocked by US-02, US-04         |
-| 06  | [us-06-daily-cron](us-06-daily-cron.md)                 | Scheduler: cron-based job orchestrating the full cycle                                | Partial | Blocked by US-02, US-03, US-04  |
+| #   | Story                                                   | Summary                                                                               | Status | Parallelisable                  |
+| --- | ------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------ | ------------------------------- |
+| 01  | [us-01-rotation-schema](us-01-rotation-schema.md)       | Schema migration: new columns on `movies`, `rotation_log` table                       | Done   | Yes                             |
+| 02  | [us-02-removal-selection](us-02-removal-selection.md)   | Disk-space-driven removal: deficit calculation, oldest-first selection, Radarr delete | Done   | Blocked by US-01                |
+| 03  | [us-03-leaving-lifecycle](us-03-leaving-lifecycle.md)   | Leaving state machine: mark, expire, watchlist interaction                            | Done   | Blocked by US-01                |
+| 04  | [us-04-addition-execution](us-04-addition-execution.md) | Add movies from queue to Radarr with search trigger                                   | Done   | Blocked by US-01, PRD-071 US-01 |
+| 05  | [us-05-disk-space-gating](us-05-disk-space-gating.md)   | Addition gating: only add movies when free space is above target                      | Done   | Blocked by US-02, US-04         |
+| 06  | [us-06-daily-cron](us-06-daily-cron.md)                 | Scheduler: cron-based job orchestrating the full cycle                                | Done   | Blocked by US-02, US-03, US-04  |
 
 ## Out of Scope
 
@@ -116,4 +116,4 @@ The rotation engine is a daily automated job that manages the movie library life
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-27

--- a/docs/themes/03-media/prds/070-rotation-engine/us-06-daily-cron.md
+++ b/docs/themes/03-media/prds/070-rotation-engine/us-06-daily-cron.md
@@ -15,8 +15,8 @@ As a system, I need a scheduled job that orchestrates the full rotation cycle da
 - [x] Concurrent cycles are prevented — if a cycle is already running, skip the new invocation and log it
 - [x] The scheduler respects `rotation_enabled` — toggling off stops future runs, toggling on schedules the next
 - [x] Each cycle creates a `rotation_log` entry with all counts, disk space, and skip reasons
-- [ ] `rotation_log` `details` JSON column is never populated — expanded per-movie titles in the log page won't show anything
-- [ ] Graceful shutdown: in-progress cycle completes before the server exits (SIGTERM handling)
+- [x] `rotation_log.details` JSON column is populated with per-movie titles (`{ marked, removed, added, failed }`) when any list is non-empty
+- [x] Graceful shutdown: in-progress cycle completes before the server exits (SIGTERM/SIGINT handling via `waitForCycleEnd()`)
 
 ## Notes
 

--- a/docs/themes/03-media/prds/071-source-lists/README.md
+++ b/docs/themes/03-media/prds/071-source-lists/README.md
@@ -134,4 +134,4 @@ interface CandidateMovie {
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-27

--- a/docs/themes/03-media/prds/072-rotation-ui/README.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/README.md
@@ -121,14 +121,14 @@ Paginated history of rotation cycles. Each entry shows:
 
 ## User Stories
 
-| #   | Story                                                           | Summary                                                                   | Status  | Parallelisable                          |
-| --- | --------------------------------------------------------------- | ------------------------------------------------------------------------- | ------- | --------------------------------------- |
-| 01  | [us-01-leaving-soon-shelf](us-01-leaving-soon-shelf.md)         | Leaving Soon shelf on Library + Discover pages, countdown badges on cards | Partial | Blocked by PRD-070 US-03                |
-| 02  | [us-02-rotation-settings](us-02-rotation-settings.md)           | Rotation settings page with all configuration controls                    | Done    | Blocked by PRD-070 US-01                |
-| 03  | [us-03-source-management](us-03-source-management.md)           | Source list CRUD page with type-specific config                           | Done    | Blocked by PRD-071 US-01                |
-| 04  | [us-04-candidate-queue](us-04-candidate-queue.md)               | Candidate queue page with tabs (pending, added, excluded)                 | Done    | Blocked by PRD-071 US-01                |
-| 05  | [us-05-queue-download-buttons](us-05-queue-download-buttons.md) | "Add to Queue" and "Download" buttons on discovery pages                  | Partial | Blocked by PRD-071 US-01, PRD-070 US-01 |
-| 06  | [us-06-rotation-log](us-06-rotation-log.md)                     | Rotation execution history page                                           | Partial | Blocked by PRD-070 US-06                |
+| #   | Story                                                           | Summary                                                                   | Status | Parallelisable                          |
+| --- | --------------------------------------------------------------- | ------------------------------------------------------------------------- | ------ | --------------------------------------- |
+| 01  | [us-01-leaving-soon-shelf](us-01-leaving-soon-shelf.md)         | Leaving Soon shelf on Library + Discover pages, countdown badges on cards | Done   | Blocked by PRD-070 US-03                |
+| 02  | [us-02-rotation-settings](us-02-rotation-settings.md)           | Rotation settings page with all configuration controls                    | Done   | Blocked by PRD-070 US-01                |
+| 03  | [us-03-source-management](us-03-source-management.md)           | Source list CRUD page with type-specific config                           | Done   | Blocked by PRD-071 US-01                |
+| 04  | [us-04-candidate-queue](us-04-candidate-queue.md)               | Candidate queue page with tabs (pending, added, excluded)                 | Done   | Blocked by PRD-071 US-01                |
+| 05  | [us-05-queue-download-buttons](us-05-queue-download-buttons.md) | "Add to Queue" and "Download" buttons on discovery pages                  | Done   | Blocked by PRD-071 US-01, PRD-070 US-01 |
+| 06  | [us-06-rotation-log](us-06-rotation-log.md)                     | Rotation execution history page                                           | Done   | Blocked by PRD-070 US-06                |
 
 ## Out of Scope
 
@@ -139,4 +139,4 @@ Paginated history of rotation cycles. Each entry shows:
 
 ## Drift Check
 
-last checked: 2026-04-18
+last checked: 2026-04-27

--- a/docs/themes/03-media/prds/072-rotation-ui/us-01-leaving-soon-shelf.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/us-01-leaving-soon-shelf.md
@@ -13,7 +13,7 @@ As a user, I want to see which movies are about to leave my library — on both 
 - [x] On both pages, movies are sorted by `rotation_expires_at` ASC (soonest departures first)
 - [x] Each card shows a countdown badge: "Leaving in X days", "Last day" (< 24h), or "Leaving tomorrow" (< 48h)
 - [x] Badge colour: red when ≤ 3 days, amber when ≤ 7 days, neutral when > 7 days
-- [ ] The countdown badge also appears on movie cards elsewhere in the app (search, detail page, watchlist) when that movie is leaving
+- [x] The countdown badge also appears on movie cards elsewhere in the app (search, detail page, watchlist) when that movie is leaving
 - [x] Each card has a "Keep" action that clears the leaving status (calls `rotation.cancelLeaving`)
 - [x] Both shelves are hidden when rotation is disabled or no movies are leaving
 - [x] Shelf uses the existing `MediaCard` component — badge is an overlay, not a new card type

--- a/docs/themes/03-media/prds/072-rotation-ui/us-05-queue-download-buttons.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/us-05-queue-download-buttons.md
@@ -10,7 +10,7 @@ As a user, I want "Add to Queue" and "Download" buttons on movie discovery pages
 
 - [x] On search results, Discover page, and anywhere a non-library movie card appears: show two action buttons
 - [x] **"Add to Queue"** — creates a `rotation_candidates` entry with source = `manual`. Toast: "Added to rotation queue". Button changes to "In Queue" badge after click
-- [ ] **"Download"** — adds to Radarr with `searchForMovie: true`, creates POPS library entry with `rotation_status = 'protected'`. Toast: "Downloading — protected for 30 days". Button changes to status indicator (downloading/available) — current implementation opens `RequestMovieModal` (uses `arr.addMovie`) which does not set `rotation_status = 'protected'`
+- [x] **"Download"** — adds to Radarr with `searchForMovie: true`, creates POPS library entry with `rotation_status = 'protected'`. Toast: "Downloading — protected for 30 days". Button changes to status indicator (downloading/available)
 - [x] If the movie is already in the library: show library status instead of action buttons (existing behaviour)
 - [x] If the movie is already in the candidate queue: show "In Queue" badge with option to remove
 - [x] If the movie is in the exclusion list: show "Excluded" badge with option to un-exclude

--- a/docs/themes/03-media/prds/072-rotation-ui/us-06-rotation-log.md
+++ b/docs/themes/03-media/prds/072-rotation-ui/us-06-rotation-log.md
@@ -10,7 +10,7 @@ As a user, I want to see a history of rotation cycles so that I can verify the s
 
 - [x] Rotation log page shows paginated history of `rotation_log` entries, newest first
 - [x] Each entry displays: execution timestamp, movies marked leaving (count), movies removed (count), movies added (count), failed removals (count), disk space at time of run, skip reason (if any)
-- [ ] Each entry is expandable to show details: list of movie titles/IDs for each action category (marked, removed, added, failed) — page supports expansion but `rotation_log.details` is always `null` (never written by the scheduler)
+- [x] Each entry is expandable to show details: list of movie titles/IDs for each action category (marked, removed, added, failed)
 - [x] Entries with errors or skip reasons are visually distinguished (warning/error styling)
 - [x] Page shows summary stats at top: total movies rotated (all time), average per day, current streak (days since last skip)
 - [x] Empty state when no rotation cycles have run yet

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
@@ -91,14 +91,14 @@ raw input → normalize → classify type → match template → extract entitie
 
 ## User Stories
 
-| #   | Story                                                 | Summary                                                                                                  | Status      | Parallelisable |
-| --- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ----------- | -------------- |
-| 01  | [us-01-manual-input](us-01-manual-input.md)           | Shell UI form for creating engrams: type selector, template fields, body editor, scope picker, tag input | Partial     | No (first)     |
-| 02  | [us-02-agent-input](us-02-agent-input.md)             | MCP tools and API endpoint for writing engrams from Claude Code or external tools                        | Partial     | Yes            |
-| 03  | [us-03-quick-capture](us-03-quick-capture.md)         | Minimal-friction capture for Moltbot/CLI: raw text in, classified later                                  | Partial     | Yes            |
-| 04  | [us-04-classification](us-04-classification.md)       | LLM-based content classification: infer type, match template, suggest tags                               | Done        | Yes            |
-| 05  | [us-05-entity-extraction](us-05-entity-extraction.md) | Extract people, projects, dates, topics from body into tags and frontmatter                              | Done        | Yes            |
-| 06  | [us-06-scope-inference](us-06-scope-inference.md)     | Rule-based + LLM-based scope assignment with user override                                               | Done        | Yes            |
+| #   | Story                                                 | Summary                                                                                                  | Status  | Parallelisable |
+| --- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------- | -------------- |
+| 01  | [us-01-manual-input](us-01-manual-input.md)           | Shell UI form for creating engrams: type selector, template fields, body editor, scope picker, tag input | Partial | No (first)     |
+| 02  | [us-02-agent-input](us-02-agent-input.md)             | MCP tools and API endpoint for writing engrams from Claude Code or external tools                        | Partial | Yes            |
+| 03  | [us-03-quick-capture](us-03-quick-capture.md)         | Minimal-friction capture for Moltbot/CLI: raw text in, classified later                                  | Partial | Yes            |
+| 04  | [us-04-classification](us-04-classification.md)       | LLM-based content classification: infer type, match template, suggest tags                               | Done    | Yes            |
+| 05  | [us-05-entity-extraction](us-05-entity-extraction.md) | Extract people, projects, dates, topics from body into tags and frontmatter                              | Done    | Yes            |
+| 06  | [us-06-scope-inference](us-06-scope-inference.md)     | Rule-based + LLM-based scope assignment with user override                                               | Done    | Yes            |
 
 US-01, US-02, and US-03 define the three input channels and can parallelise. US-04, US-05, and US-06 define the pipeline processing stages and can parallelise with each other and with the input channels. All stories depend on PRD-077 (engram file format) and PRD-078 (scope model) being implemented.
 

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
@@ -93,7 +93,7 @@ raw input → normalize → classify type → match template → extract entitie
 
 | #   | Story                                                 | Summary                                                                                                  | Status      | Parallelisable |
 | --- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ----------- | -------------- |
-| 01  | [us-01-manual-input](us-01-manual-input.md)           | Shell UI form for creating engrams: type selector, template fields, body editor, scope picker, tag input | Not started | No (first)     |
+| 01  | [us-01-manual-input](us-01-manual-input.md)           | Shell UI form for creating engrams: type selector, template fields, body editor, scope picker, tag input | Partial     | No (first)     |
 | 02  | [us-02-agent-input](us-02-agent-input.md)             | MCP tools and API endpoint for writing engrams from Claude Code or external tools                        | Partial     | Yes            |
 | 03  | [us-03-quick-capture](us-03-quick-capture.md)         | Minimal-friction capture for Moltbot/CLI: raw text in, classified later                                  | Partial     | Yes            |
 | 04  | [us-04-classification](us-04-classification.md)       | LLM-based content classification: infer type, match template, suggest tags                               | Done        | Yes            |

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-01-manual-input.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-01-manual-input.md
@@ -1,7 +1,7 @@
 # US-01: Manual Input via Shell Form
 
 > PRD: [PRD-081: Ingestion Pipeline](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -9,18 +9,19 @@ As a user in the pops shell, I want to create engrams through an interactive for
 
 ## Acceptance Criteria
 
-- [ ] A `cerebrum ingest` command in the pops shell opens an interactive form
-- [ ] The form presents a type selector listing all available templates from the template registry (PRD-077) plus a freeform `capture` option
-- [ ] Selecting a type with an associated template populates template-specific fields (e.g., `decision` shows `alternatives`, `confidence`; `journal` shows `mood`) with appropriate input widgets
-- [ ] The body editor accepts multi-line Markdown input — the shell uses the configured `$EDITOR` for body editing if the body exceeds a configurable line threshold (default 5 lines)
-- [ ] A scope picker presents known scopes from the index (via `cerebrum.scopes.list`) with prefix-based autocomplete and allows manual entry of new scopes
-- [ ] Tag input supports comma-separated freeform tags with autocomplete from existing tags in the index
-- [ ] If the user provides no explicit scopes, the form runs scope inference (rule-based + LLM) and presents the inferred scopes for confirmation before submission
-- [ ] Submitting the form calls `cerebrum.ingest.submit` and displays the created engram's ID, file path, and classified type
+- [x] The `/cerebrum` route in the pops shell opens an interactive ingest form
+- [x] The form presents a type selector listing all available templates from the template registry (PRD-077) plus a freeform `capture` option
+- [x] Selecting a type with an associated template populates template-specific fields (e.g., `decision` shows `alternatives`, `confidence`; `journal` shows `mood`) with appropriate input widgets
+- [x] The body editor accepts multi-line Markdown input via a textarea
+- [x] A scope picker presents known scopes from the index (via `cerebrum.scopes.list`) with prefix-based autocomplete and allows manual entry of new scopes
+- [x] Tag input supports comma-separated freeform tags
+- [x] If the user provides no explicit scopes, the form runs scope inference (rule-based + LLM) and presents the inferred scopes for confirmation before submission
+- [x] Submitting the form calls `cerebrum.ingest.submit` and displays the created engram's ID, file path, and classified type
+- [ ] Tag autocomplete from existing tags in the index (deferred — requires a tags list endpoint)
 
 ## Notes
 
-- The form should be built using the existing pops shell form framework (ink-based TUI components).
-- Template-specific fields should be dynamically rendered based on the selected template's `custom_fields` definition — no hardcoding of template-specific logic.
-- The scope picker should show scope hierarchy visually (indentation or tree-like display) to help the user understand scope nesting.
-- If `$EDITOR` is not set, fall back to an inline multi-line text input.
+- The form is built as a React page in the `@pops/app-cerebrum` package, mounted at `/cerebrum` in the shell.
+- Template-specific fields are dynamically rendered based on the selected template's `custom_fields` definition — no hardcoding of template-specific logic.
+- The scope picker shows known scopes with prefix-based autocomplete and allows manual entry. Hierarchy display is deferred.
+- Tag autocomplete from existing tags requires a `tags.list` endpoint — deferred to a follow-up.

--- a/packages/app-cerebrum/package.json
+++ b/packages/app-cerebrum/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@pops/app-cerebrum",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@pops/api-client": "workspace:*",
+    "@pops/navigation": "workspace:*",
+    "@pops/ui": "workspace:*",
+    "@tanstack/react-query": "5.99.2",
+    "lucide-react": "^1.8.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "react-router": "^7.14.2",
+    "sonner": "^2.0.7",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "jsdom": "^29.0.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/app-cerebrum/src/components/IngestForm.tsx
+++ b/packages/app-cerebrum/src/components/IngestForm.tsx
@@ -76,7 +76,12 @@ function TagInput({ value, onChange }: { value: string[]; onChange: (v: string[]
       <label className="text-xs font-semibold text-muted-foreground uppercase tracking-widest ml-1">
         Tags
       </label>
-      <ChipInput value={value} onChange={onChange} placeholder="Add tags (comma-separated)…" aria-label="Tags" />
+      <ChipInput
+        value={value}
+        onChange={onChange}
+        placeholder="Add tags (comma-separated)…"
+        aria-label="Tags"
+      />
     </div>
   );
 }

--- a/packages/app-cerebrum/src/components/IngestForm.tsx
+++ b/packages/app-cerebrum/src/components/IngestForm.tsx
@@ -1,0 +1,185 @@
+/**
+ * IngestForm — interactive form for creating engrams through the ingestion
+ * pipeline. Driven entirely by the view model hook; this component is
+ * purely presentational.
+ */
+import { Loader2 } from 'lucide-react';
+
+import { Button, ChipInput, Select, Textarea, TextInput } from '@pops/ui';
+
+import { ScopeConfirmDialog } from './ScopeConfirmDialog';
+import { ScopePicker } from './ScopePicker';
+import { SubmitResult } from './SubmitResult';
+import { TemplateFields } from './TemplateFields';
+
+import type { useIngestPageModel } from '../pages/ingest-page/useIngestPageModel';
+
+type Model = ReturnType<typeof useIngestPageModel>;
+
+interface IngestFormProps {
+  model: Model;
+}
+
+function TypeSelector({
+  value,
+  options,
+  loading,
+  onChange,
+}: {
+  value: string;
+  options: { value: string; label: string; description: string }[];
+  loading: boolean;
+  onChange: (v: string) => void;
+}) {
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-muted-foreground text-sm h-11">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading templates…
+      </div>
+    );
+  }
+
+  return (
+    <Select
+      label="Type"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      options={options.map((o) => ({ value: o.value, label: o.label }))}
+      placeholder="Select type…"
+      aria-label="Engram type"
+    />
+  );
+}
+
+function BodyEditor({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex flex-col gap-1.5 w-full">
+      <label className="text-xs font-semibold text-muted-foreground uppercase tracking-widest ml-1">
+        Body
+      </label>
+      <Textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Markdown content…"
+        rows={8}
+        className="min-h-[160px] font-mono text-sm"
+        aria-label="Body"
+      />
+    </div>
+  );
+}
+
+function TagInput({ value, onChange }: { value: string[]; onChange: (v: string[]) => void }) {
+  return (
+    <div className="flex flex-col gap-1.5 w-full">
+      <label className="text-xs font-semibold text-muted-foreground uppercase tracking-widest ml-1">
+        Tags
+      </label>
+      <ChipInput value={value} onChange={onChange} placeholder="Add tags (comma-separated)…" aria-label="Tags" />
+    </div>
+  );
+}
+
+function getSubmitLabel(isInferring: boolean, isSubmitting: boolean): string {
+  if (isInferring) return 'Inferring Scopes…';
+  if (isSubmitting) return 'Submitting…';
+  return 'Submit';
+}
+
+function FormActions({
+  isValid,
+  isSubmitting,
+  isInferring,
+  onSubmit,
+}: {
+  isValid: boolean;
+  isSubmitting: boolean;
+  isInferring: boolean;
+  onSubmit: () => void;
+}) {
+  const busy = isSubmitting || isInferring;
+  return (
+    <div className="flex justify-end pt-4">
+      <Button
+        onClick={onSubmit}
+        disabled={!isValid || busy}
+        prefix={busy ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined}
+      >
+        {getSubmitLabel(isInferring, isSubmitting)}
+      </Button>
+    </div>
+  );
+}
+
+function IngestFormFields({ model }: IngestFormProps) {
+  return (
+    <div className="space-y-6">
+      <TypeSelector
+        value={model.form.type}
+        options={model.typeOptions}
+        loading={model.templatesLoading}
+        onChange={model.handleTypeChange}
+      />
+      {model.selectedTemplate?.custom_fields && (
+        <TemplateFields
+          fields={model.selectedTemplate.custom_fields}
+          values={model.form.customFields}
+          onChange={model.updateCustomField}
+          requiredFields={model.selectedTemplate.required_fields}
+        />
+      )}
+      <TextInput
+        label="Title"
+        value={model.form.title}
+        onChange={(e) => model.updateField('title', e.target.value)}
+        placeholder="Engram title (optional — inferred from body if absent)"
+        aria-label="Title"
+      />
+      <BodyEditor value={model.form.body} onChange={(v) => model.updateField('body', v)} />
+      <ScopePicker
+        value={model.form.scopes}
+        suggestions={model.scopeSuggestions}
+        loading={model.scopesLoading}
+        onChange={(v) => model.updateField('scopes', v)}
+      />
+      <TagInput value={model.form.tags} onChange={(v) => model.updateField('tags', v)} />
+      {model.submitError && (
+        <div className="text-sm text-destructive bg-destructive/10 rounded-md px-4 py-3">
+          {model.submitError}
+        </div>
+      )}
+      <FormActions
+        isValid={model.isValid}
+        isSubmitting={model.isSubmitting}
+        isInferring={model.isInferring}
+        onSubmit={model.handleSubmit}
+      />
+    </div>
+  );
+}
+
+export function IngestForm({ model }: IngestFormProps) {
+  if (model.submitResult) {
+    return (
+      <SubmitResult
+        id={model.submitResult.id}
+        filePath={model.submitResult.filePath}
+        type={model.submitResult.type}
+        onReset={model.resetForm}
+      />
+    );
+  }
+
+  return (
+    <>
+      <IngestFormFields model={model} />
+      <ScopeConfirmDialog
+        open={model.showScopeConfirm}
+        scopes={model.inferredScopes ?? []}
+        onConfirm={model.confirmInferredScopes}
+        onDismiss={model.dismissInferredScopes}
+      />
+    </>
+  );
+}

--- a/packages/app-cerebrum/src/components/ScopeConfirmDialog.tsx
+++ b/packages/app-cerebrum/src/components/ScopeConfirmDialog.tsx
@@ -3,7 +3,15 @@
  * and scope inference returns results. Presents inferred scopes for
  * confirmation before final submission.
  */
-import { Badge, Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@pops/ui';
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@pops/ui';
 
 interface ScopeConfirmDialogProps {
   open: boolean;
@@ -12,7 +20,12 @@ interface ScopeConfirmDialogProps {
   onDismiss: () => void;
 }
 
-export function ScopeConfirmDialog({ open, scopes, onConfirm, onDismiss }: ScopeConfirmDialogProps) {
+export function ScopeConfirmDialog({
+  open,
+  scopes,
+  onConfirm,
+  onDismiss,
+}: ScopeConfirmDialogProps) {
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onDismiss()}>
       <DialogContent>

--- a/packages/app-cerebrum/src/components/ScopeConfirmDialog.tsx
+++ b/packages/app-cerebrum/src/components/ScopeConfirmDialog.tsx
@@ -1,0 +1,44 @@
+/**
+ * ScopeConfirmDialog — shown when the user submits without explicit scopes
+ * and scope inference returns results. Presents inferred scopes for
+ * confirmation before final submission.
+ */
+import { Badge, Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@pops/ui';
+
+interface ScopeConfirmDialogProps {
+  open: boolean;
+  scopes: string[];
+  onConfirm: () => void;
+  onDismiss: () => void;
+}
+
+export function ScopeConfirmDialog({ open, scopes, onConfirm, onDismiss }: ScopeConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onDismiss()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Inferred Scopes</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          No scopes were provided. The following scopes were inferred from the content:
+        </p>
+        <div className="flex flex-wrap gap-2 py-2">
+          {scopes.map((scope) => (
+            <Badge key={scope} variant="secondary">
+              {scope}
+            </Badge>
+          ))}
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Accept these scopes to continue submitting, or dismiss to add scopes manually.
+        </p>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onDismiss}>
+            Dismiss
+          </Button>
+          <Button onClick={onConfirm}>Accept &amp; Submit</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app-cerebrum/src/components/ScopePicker.tsx
+++ b/packages/app-cerebrum/src/components/ScopePicker.tsx
@@ -1,0 +1,142 @@
+/**
+ * ScopePicker — scope selection with autocomplete from known scopes
+ * and manual entry for new scopes.
+ */
+import { useCallback, useMemo, useState } from 'react';
+
+import { Chip } from '@pops/ui';
+
+interface ScopePickerProps {
+  value: string[];
+  suggestions: { label: string; value: string; description?: string }[];
+  loading: boolean;
+  onChange: (scopes: string[]) => void;
+}
+
+/** Normalise a raw scope input: lowercase, trim, replace spaces with hyphens. */
+function normaliseInput(raw: string): string {
+  return raw.trim().toLowerCase().replace(/\s+/g, '-');
+}
+
+function ScopeChips({ scopes, onRemove }: { scopes: string[]; onRemove: (i: number) => void }) {
+  return (
+    <>
+      {scopes.map((scope, i) => (
+        <Chip key={scope} size="sm" removable onRemove={() => onRemove(i)}>
+          {scope}
+        </Chip>
+      ))}
+    </>
+  );
+}
+
+function ScopeDropdown({
+  items,
+  onSelect,
+}: {
+  items: { label: string; value: string; description?: string }[];
+  onSelect: (value: string) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div className="absolute z-10 mt-1 w-full bg-popover border border-border rounded-md shadow-md max-h-48 overflow-auto">
+      {items.map((s) => (
+        <button
+          key={s.value}
+          type="button"
+          className="w-full px-3 py-2 text-left text-sm hover:bg-accent transition-colors flex items-center justify-between"
+          onClick={() => onSelect(s.value)}
+        >
+          <span>{s.label}</span>
+          {s.description && (
+            <span className="text-xs text-muted-foreground">{s.description}</span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function getPlaceholder(loading: boolean, hasScopes: boolean): string {
+  if (loading) return 'Loading scopes…';
+  if (!hasScopes) return 'Add scopes (type or select)…';
+  return 'Add more…';
+}
+
+function useScopePickerState(
+  value: string[],
+  suggestions: { label: string; value: string; description?: string }[],
+  onChange: (scopes: string[]) => void
+) {
+  const [inputValue, setInputValue] = useState('');
+
+  const filteredSuggestions = useMemo(() => {
+    if (!inputValue) return suggestions;
+    const lower = inputValue.toLowerCase();
+    return suggestions.filter(
+      (s) => s.label.toLowerCase().includes(lower) && !value.includes(s.value)
+    );
+  }, [inputValue, suggestions, value]);
+
+  const addScope = useCallback(
+    (scope: string) => {
+      const normalised = normaliseInput(scope);
+      if (normalised && !value.includes(normalised)) onChange([...value, normalised]);
+      setInputValue('');
+    },
+    [value, onChange]
+  );
+
+  const removeScope = useCallback(
+    (index: number) => onChange(value.filter((_, i) => i !== index)),
+    [value, onChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' || e.key === ',' || e.key === 'Tab') {
+        e.preventDefault();
+        if (inputValue.trim()) addScope(inputValue);
+      }
+      if (e.key === 'Backspace' && !inputValue && value.length > 0) {
+        removeScope(value.length - 1);
+      }
+    },
+    [inputValue, value, addScope, removeScope]
+  );
+
+  return { inputValue, setInputValue, filteredSuggestions, addScope, removeScope, handleKeyDown };
+}
+
+export function ScopePicker({ value, suggestions, loading, onChange }: ScopePickerProps) {
+  const state = useScopePickerState(value, suggestions, onChange);
+
+  return (
+    <div className="flex flex-col gap-1.5 w-full">
+      <label className="text-xs font-semibold text-muted-foreground uppercase tracking-widest ml-1">
+        Scopes
+      </label>
+      <div className="relative">
+        <div className="flex flex-wrap items-center gap-2 border border-border rounded-md bg-background p-2 min-h-11 focus-within:ring-2 focus-within:ring-ring">
+          <ScopeChips scopes={value} onRemove={state.removeScope} />
+          <input
+            type="text"
+            className="flex-1 bg-transparent border-0 outline-none text-sm placeholder:text-muted-foreground min-w-[120px]"
+            value={state.inputValue}
+            onChange={(e) => state.setInputValue(e.target.value)}
+            onKeyDown={state.handleKeyDown}
+            placeholder={getPlaceholder(loading, value.length > 0)}
+            disabled={loading}
+            aria-label="Scope input"
+          />
+        </div>
+        {state.inputValue && <ScopeDropdown items={state.filteredSuggestions} onSelect={state.addScope} />}
+      </div>
+      {value.length === 0 && (
+        <p className="text-xs text-muted-foreground ml-1">
+          Leave empty to infer scopes automatically on submit.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/app-cerebrum/src/components/ScopePicker.tsx
+++ b/packages/app-cerebrum/src/components/ScopePicker.tsx
@@ -48,9 +48,7 @@ function ScopeDropdown({
           onClick={() => onSelect(s.value)}
         >
           <span>{s.label}</span>
-          {s.description && (
-            <span className="text-xs text-muted-foreground">{s.description}</span>
-          )}
+          {s.description && <span className="text-xs text-muted-foreground">{s.description}</span>}
         </button>
       ))}
     </div>
@@ -130,7 +128,9 @@ export function ScopePicker({ value, suggestions, loading, onChange }: ScopePick
             aria-label="Scope input"
           />
         </div>
-        {state.inputValue && <ScopeDropdown items={state.filteredSuggestions} onSelect={state.addScope} />}
+        {state.inputValue && (
+          <ScopeDropdown items={state.filteredSuggestions} onSelect={state.addScope} />
+        )}
       </div>
       {value.length === 0 && (
         <p className="text-xs text-muted-foreground ml-1">

--- a/packages/app-cerebrum/src/components/SubmitResult.tsx
+++ b/packages/app-cerebrum/src/components/SubmitResult.tsx
@@ -1,0 +1,38 @@
+/**
+ * SubmitResult — success banner displayed after an engram is created.
+ * Shows the engram ID, file path, and classified type.
+ */
+import { CheckCircle2 } from 'lucide-react';
+
+import { Badge, Button, Card } from '@pops/ui';
+
+interface SubmitResultProps {
+  id: string;
+  filePath: string;
+  type: string;
+  onReset: () => void;
+}
+
+export function SubmitResult({ id, filePath, type, onReset }: SubmitResultProps) {
+  return (
+    <Card className="p-6 space-y-4 border-success/30 bg-success/5">
+      <div className="flex items-center gap-3">
+        <CheckCircle2 className="h-5 w-5 text-success shrink-0" />
+        <h3 className="text-lg font-semibold">Engram Created</h3>
+      </div>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+        <dt className="text-muted-foreground">ID</dt>
+        <dd className="font-mono text-xs break-all">{id}</dd>
+        <dt className="text-muted-foreground">Type</dt>
+        <dd>
+          <Badge variant="secondary">{type}</Badge>
+        </dd>
+        <dt className="text-muted-foreground">Path</dt>
+        <dd className="font-mono text-xs break-all">{filePath}</dd>
+      </dl>
+      <Button variant="outline" onClick={onReset}>
+        Create Another
+      </Button>
+    </Card>
+  );
+}

--- a/packages/app-cerebrum/src/components/TemplateFields.test.tsx
+++ b/packages/app-cerebrum/src/components/TemplateFields.test.tsx
@@ -6,13 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@pops/ui', async () => {
   const React = await import('react');
   return {
-    TextInput: ({
-      value,
-      onChange,
-      placeholder,
-      label,
-      ...rest
-    }: Record<string, unknown>) =>
+    TextInput: ({ value, onChange, placeholder, label, ...rest }: Record<string, unknown>) =>
       React.createElement(
         'div',
         null,
@@ -62,9 +56,7 @@ describe('TemplateFields', () => {
   });
 
   it('renders nothing when fields is empty', () => {
-    const { container } = render(
-      <TemplateFields fields={{}} values={{}} onChange={onChange} />
-    );
+    const { container } = render(<TemplateFields fields={{}} values={{}} onChange={onChange} />);
     expect(container.innerHTML).toBe('');
   });
 
@@ -158,9 +150,7 @@ describe('TemplateFields', () => {
   });
 
   it('renders all fields from a multi-field template', () => {
-    render(
-      <TemplateFields fields={decisionFields} values={{}} onChange={onChange} />
-    );
+    render(<TemplateFields fields={decisionFields} values={{}} onChange={onChange} />);
     expect(screen.getByLabelText('decision')).toBeInTheDocument();
     expect(screen.getByLabelText('confidence')).toBeInTheDocument();
     expect(screen.getByLabelText('priority')).toBeInTheDocument();

--- a/packages/app-cerebrum/src/components/TemplateFields.test.tsx
+++ b/packages/app-cerebrum/src/components/TemplateFields.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@pops/ui', async () => {
+  const React = await import('react');
+  return {
+    TextInput: ({
+      value,
+      onChange,
+      placeholder,
+      label,
+      ...rest
+    }: Record<string, unknown>) =>
+      React.createElement(
+        'div',
+        null,
+        label ? React.createElement('label', null, label as ReactNode) : null,
+        React.createElement('input', {
+          type: 'text',
+          value: value as string,
+          onChange: onChange as () => void,
+          placeholder: placeholder as string,
+          'aria-label': (rest['aria-label'] as string) ?? (label as string),
+        })
+      ),
+    ChipInput: ({
+      value,
+      onChange,
+      placeholder,
+    }: {
+      value?: string[];
+      onChange?: (next: string[]) => void;
+      placeholder?: string;
+    }) =>
+      React.createElement('input', {
+        'data-testid': 'chip-input',
+        placeholder,
+        value: (value ?? []).join(','),
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+          onChange?.(e.target.value ? e.target.value.split(',') : []),
+      }),
+  };
+});
+
+import { TemplateFields } from './TemplateFields';
+
+const decisionFields = {
+  decision: { type: 'string', description: 'The decision that was made' },
+  alternatives: { type: 'string[]', description: 'Options considered' },
+  confidence: { type: 'string', description: 'low | medium | high' },
+  priority: { type: 'number', description: 'Priority level' },
+  approved: { type: 'boolean', description: 'Whether approved' },
+};
+
+describe('TemplateFields', () => {
+  let onChange: (fieldName: string, value: unknown) => void;
+
+  beforeEach(() => {
+    onChange = vi.fn();
+  });
+
+  it('renders nothing when fields is empty', () => {
+    const { container } = render(
+      <TemplateFields fields={{}} values={{}} onChange={onChange} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders a string field as a text input', () => {
+    render(
+      <TemplateFields
+        fields={{ decision: decisionFields.decision }}
+        values={{}}
+        onChange={onChange}
+      />
+    );
+    expect(screen.getByLabelText('decision')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('The decision that was made')).toBeInTheDocument();
+  });
+
+  it('renders an array field as chip input', () => {
+    render(
+      <TemplateFields
+        fields={{ alternatives: decisionFields.alternatives }}
+        values={{}}
+        onChange={onChange}
+      />
+    );
+    expect(screen.getByTestId('chip-input')).toBeInTheDocument();
+  });
+
+  it('renders a number field', () => {
+    render(
+      <TemplateFields
+        fields={{ priority: decisionFields.priority }}
+        values={{}}
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByLabelText('priority');
+    expect(input).toHaveAttribute('type', 'number');
+  });
+
+  it('renders a boolean field as checkbox', () => {
+    render(
+      <TemplateFields
+        fields={{ approved: decisionFields.approved }}
+        values={{}}
+        onChange={onChange}
+      />
+    );
+    const checkbox = screen.getByLabelText('approved');
+    expect(checkbox).toHaveAttribute('type', 'checkbox');
+  });
+
+  it('calls onChange when a string field changes', async () => {
+    const user = userEvent.setup();
+    render(
+      <TemplateFields
+        fields={{ decision: decisionFields.decision }}
+        values={{ decision: '' }}
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByLabelText('decision');
+    await user.type(input, 'Go with option A');
+    expect(onChange).toHaveBeenCalled();
+    const mockFn = onChange as ReturnType<typeof vi.fn>;
+    const lastCall = mockFn.mock.calls.at(-1) as [string, unknown] | undefined;
+    expect(lastCall?.[0]).toBe('decision');
+  });
+
+  it('calls onChange when boolean field is toggled', async () => {
+    const user = userEvent.setup();
+    render(
+      <TemplateFields
+        fields={{ approved: decisionFields.approved }}
+        values={{ approved: false }}
+        onChange={onChange}
+      />
+    );
+    const checkbox = screen.getByLabelText('approved');
+    await user.click(checkbox);
+    expect(onChange).toHaveBeenCalledWith('approved', true);
+  });
+
+  it('renders the "Template Fields" heading', () => {
+    render(
+      <TemplateFields
+        fields={{ decision: decisionFields.decision }}
+        values={{}}
+        onChange={onChange}
+      />
+    );
+    expect(screen.getByText('Template Fields')).toBeInTheDocument();
+  });
+
+  it('renders all fields from a multi-field template', () => {
+    render(
+      <TemplateFields fields={decisionFields} values={{}} onChange={onChange} />
+    );
+    expect(screen.getByLabelText('decision')).toBeInTheDocument();
+    expect(screen.getByLabelText('confidence')).toBeInTheDocument();
+    expect(screen.getByLabelText('priority')).toBeInTheDocument();
+    expect(screen.getByLabelText('approved')).toBeInTheDocument();
+  });
+});

--- a/packages/app-cerebrum/src/components/TemplateFields.tsx
+++ b/packages/app-cerebrum/src/components/TemplateFields.tsx
@@ -165,19 +165,12 @@ function TemplateFieldWidget({
       );
     case 'boolean':
       return (
-        <BooleanField
-          name={name}
-          def={def}
-          value={value}
-          onChange={(v) => onChange(name, v)}
-        />
+        <BooleanField name={name} def={def} value={value} onChange={(v) => onChange(name, v)} />
       );
     case 'string[]':
     case 'number[]':
     case 'boolean[]':
-      return (
-        <ArrayField name={name} def={def} value={value} onChange={(v) => onChange(name, v)} />
-      );
+      return <ArrayField name={name} def={def} value={value} onChange={(v) => onChange(name, v)} />;
     default:
       return (
         <StringField

--- a/packages/app-cerebrum/src/components/TemplateFields.tsx
+++ b/packages/app-cerebrum/src/components/TemplateFields.tsx
@@ -1,0 +1,217 @@
+/**
+ * TemplateFields — dynamically renders form fields based on a template's
+ * `custom_fields` definition.
+ *
+ * Supports: string, number, boolean, string[], number[], boolean[].
+ * No hardcoded template-specific logic — everything is driven by the
+ * template schema.
+ */
+import { ChipInput, TextInput } from '@pops/ui';
+
+interface TemplateFieldDef {
+  type: string;
+  description: string;
+}
+
+interface TemplateFieldsProps {
+  /** custom_fields map from the selected template. */
+  fields: Record<string, TemplateFieldDef>;
+  /** Current values for each field. */
+  values: Record<string, unknown>;
+  /** Called when a field value changes. */
+  onChange: (fieldName: string, value: unknown) => void;
+  /** Field names that are required by the template. */
+  requiredFields?: string[];
+}
+
+function StringField({
+  name,
+  def,
+  value,
+  required,
+  onChange,
+}: {
+  name: string;
+  def: TemplateFieldDef;
+  value: unknown;
+  required: boolean;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <TextInput
+      label={name}
+      placeholder={def.description}
+      value={typeof value === 'string' ? value : ''}
+      onChange={(e) => onChange(e.target.value)}
+      aria-label={name}
+      aria-required={required}
+    />
+  );
+}
+
+function NumberField({
+  name,
+  def,
+  value,
+  onChange,
+}: {
+  name: string;
+  def: TemplateFieldDef;
+  value: unknown;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5 w-full">
+      <label className="text-xs font-semibold text-muted-foreground uppercase tracking-widest ml-1">
+        {name}
+      </label>
+      <input
+        type="number"
+        className="border border-border bg-background rounded-md px-3 py-2 text-sm w-full focus:outline-none focus:ring-2 focus:ring-ring"
+        placeholder={def.description}
+        value={typeof value === 'number' ? value : ''}
+        onChange={(e) => onChange(parseFloat(e.target.value) || 0)}
+        aria-label={name}
+      />
+    </div>
+  );
+}
+
+function BooleanField({
+  name,
+  def,
+  value,
+  onChange,
+}: {
+  name: string;
+  def: TemplateFieldDef;
+  value: unknown;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center gap-3 min-h-11 cursor-pointer">
+      <input
+        type="checkbox"
+        className="h-4 w-4 rounded border-border text-primary accent-primary"
+        checked={!!value}
+        onChange={(e) => onChange(e.target.checked)}
+        aria-label={name}
+      />
+      <div className="flex flex-col">
+        <span className="text-sm font-medium">{name}</span>
+        <span className="text-xs text-muted-foreground">{def.description}</span>
+      </div>
+    </label>
+  );
+}
+
+function ArrayField({
+  name,
+  def,
+  value,
+  onChange,
+}: {
+  name: string;
+  def: TemplateFieldDef;
+  value: unknown;
+  onChange: (v: string[]) => void;
+}) {
+  const items = Array.isArray(value) ? value.map(String) : [];
+  return (
+    <div className="flex flex-col gap-1.5 w-full">
+      <label className="text-xs font-semibold text-muted-foreground uppercase tracking-widest ml-1">
+        {name}
+      </label>
+      <ChipInput
+        value={items}
+        onChange={onChange}
+        placeholder={def.description}
+        aria-label={name}
+      />
+    </div>
+  );
+}
+
+/**
+ * Render a single template field based on its type definition.
+ */
+function TemplateFieldWidget({
+  name,
+  def,
+  value,
+  required,
+  onChange,
+}: {
+  name: string;
+  def: TemplateFieldDef;
+  value: unknown;
+  required: boolean;
+  onChange: (fieldName: string, value: unknown) => void;
+}) {
+  switch (def.type) {
+    case 'string':
+      return (
+        <StringField
+          name={name}
+          def={def}
+          value={value}
+          required={required}
+          onChange={(v) => onChange(name, v)}
+        />
+      );
+    case 'number':
+      return (
+        <NumberField name={name} def={def} value={value} onChange={(v) => onChange(name, v)} />
+      );
+    case 'boolean':
+      return (
+        <BooleanField
+          name={name}
+          def={def}
+          value={value}
+          onChange={(v) => onChange(name, v)}
+        />
+      );
+    case 'string[]':
+    case 'number[]':
+    case 'boolean[]':
+      return (
+        <ArrayField name={name} def={def} value={value} onChange={(v) => onChange(name, v)} />
+      );
+    default:
+      return (
+        <StringField
+          name={name}
+          def={def}
+          value={value}
+          required={required}
+          onChange={(v) => onChange(name, v)}
+        />
+      );
+  }
+}
+
+export function TemplateFields({ fields, values, onChange, requiredFields }: TemplateFieldsProps) {
+  const required = new Set(requiredFields ?? []);
+  const entries = Object.entries(fields);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-widest">
+        Template Fields
+      </h3>
+      {entries.map(([name, def]) => (
+        <TemplateFieldWidget
+          key={name}
+          name={name}
+          def={def}
+          value={values[name]}
+          required={required.has(name)}
+          onChange={onChange}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/app-cerebrum/src/index.ts
+++ b/packages/app-cerebrum/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @pops/app-cerebrum — Cerebrum (knowledge) app package
+ *
+ * Exports route definitions and navigation config for the shell
+ * to lazily load cerebrum pages under /cerebrum/*.
+ */
+export { navConfig, routes } from './routes';

--- a/packages/app-cerebrum/src/pages/IngestPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/IngestPage.test.tsx
@@ -1,0 +1,455 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── tRPC mock ────────────────────────────────────────────────────────
+
+const mockTemplatesQuery = vi.fn();
+const mockScopesQuery = vi.fn();
+const mockInferScopesQuery = vi.fn();
+const mockSubmitMutate = vi.fn();
+
+vi.mock('@pops/api-client', () => ({
+  trpc: {
+    cerebrum: {
+      templates: {
+        list: { useQuery: (...args: unknown[]) => mockTemplatesQuery(...args) },
+      },
+      scopes: {
+        list: { useQuery: (...args: unknown[]) => mockScopesQuery(...args) },
+      },
+      ingest: {
+        inferScopes: {
+          useQuery: (...args: unknown[]) => mockInferScopesQuery(...args),
+        },
+        submit: {
+          useMutation: (opts: { onSuccess?: (data: unknown) => void }) => ({
+            mutate: (...args: unknown[]) => {
+              mockSubmitMutate(...args);
+              opts.onSuccess?.({
+                engram: {
+                  id: 'eng_20260427_1200_test-engram',
+                  filePath: '/cerebrum/engrams/test-engram.md',
+                  type: 'note',
+                },
+                classification: null,
+                entities: [],
+                scopeInference: { scopes: ['test.scope'], source: 'explicit', confidence: 1 },
+              });
+            },
+            isPending: false,
+            error: null,
+          }),
+        },
+      },
+    },
+  },
+}));
+
+// ── UI mock ──────────────────────────────────────────────────────────
+
+vi.mock('@pops/ui', async () => {
+  const React = await import('react');
+  return {
+    PageHeader: ({
+      title,
+      description,
+    }: {
+      title: React.ReactNode;
+      description?: React.ReactNode;
+    }) =>
+      React.createElement(
+        'div',
+        { 'data-testid': 'page-header' },
+        React.createElement('h1', null, title),
+        description && React.createElement('p', null, description)
+      ),
+    Select: ({
+      value,
+      onChange,
+      options,
+      label,
+      placeholder,
+    }: {
+      value: string;
+      onChange: (e: { target: { value: string } }) => void;
+      options: { value: string; label: string }[];
+      label?: string;
+      placeholder?: string;
+    }) =>
+      React.createElement(
+        'div',
+        null,
+        label && React.createElement('label', null, label),
+        React.createElement(
+          'select',
+          {
+            value,
+            onChange,
+            'aria-label': placeholder ?? label ?? 'select',
+          },
+          placeholder &&
+            React.createElement('option', { value: '', disabled: true }, placeholder),
+          options.map((opt) =>
+            React.createElement('option', { key: opt.value, value: opt.value }, opt.label)
+          )
+        )
+      ),
+    TextInput: ({
+      value,
+      onChange,
+      placeholder,
+      label,
+      ...rest
+    }: Record<string, unknown>) =>
+      React.createElement(
+        'div',
+        null,
+        label ? React.createElement('label', null, label as string) : null,
+        React.createElement('input', {
+          type: 'text',
+          value: value as string,
+          onChange: onChange as () => void,
+          placeholder: placeholder as string,
+          'aria-label': (rest['aria-label'] as string) ?? (label as string),
+          ...rest,
+        })
+      ),
+    Textarea: ({
+      value,
+      onChange,
+      placeholder,
+      rows,
+      className,
+      ...rest
+    }: Record<string, unknown>) =>
+      React.createElement('textarea', {
+        value: value as string,
+        onChange: onChange as () => void,
+        placeholder: placeholder as string,
+        rows: rows as number,
+        className: className as string,
+        'aria-label': rest['aria-label'] as string,
+      }),
+    Button: ({
+      children,
+      onClick,
+      disabled,
+      prefix,
+      ...rest
+    }: Record<string, unknown>) =>
+      React.createElement(
+        'button',
+        {
+          onClick: onClick as () => void,
+          disabled: disabled as boolean,
+          ...rest,
+        },
+        prefix as React.ReactNode,
+        children as React.ReactNode
+      ),
+    Badge: ({ children, variant }: { children: React.ReactNode; variant?: string }) =>
+      React.createElement('span', { 'data-testid': 'badge', 'data-variant': variant }, children),
+    Card: ({ children, className }: { children: React.ReactNode; className?: string }) =>
+      React.createElement('div', { className }, children),
+    Chip: ({
+      children,
+      removable,
+      onRemove,
+    }: {
+      children: React.ReactNode;
+      size?: string;
+      removable?: boolean;
+      onRemove?: () => void;
+    }) =>
+      React.createElement(
+        'span',
+        { 'data-testid': 'chip' },
+        children,
+        removable &&
+          React.createElement(
+            'button',
+            { onClick: onRemove, 'aria-label': `Remove ${String(children)}` },
+            '×'
+          )
+      ),
+    ChipInput: ({
+      value,
+      onChange,
+      placeholder,
+    }: {
+      value?: string[];
+      onChange?: (next: string[]) => void;
+      placeholder?: string;
+    }) =>
+      React.createElement('input', {
+        'data-testid': 'chip-input',
+        placeholder,
+        value: (value ?? []).join(','),
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+          onChange?.(e.target.value ? e.target.value.split(',') : []),
+      }),
+    Dialog: ({
+      children,
+      open,
+      onOpenChange,
+    }: {
+      children: React.ReactNode;
+      open: boolean;
+      onOpenChange: (v: boolean) => void;
+    }) =>
+      open
+        ? React.createElement(
+            'div',
+            {
+              role: 'dialog',
+              'aria-modal': 'true',
+              onClick: (e: React.MouseEvent) => {
+                if (e.target === e.currentTarget) onOpenChange(false);
+              },
+            },
+            children
+          )
+        : null,
+    DialogContent: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', { 'data-testid': 'dialog-content' }, children),
+    DialogHeader: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', null, children),
+    DialogTitle: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('h3', null, children),
+    DialogFooter: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', null, children),
+    Skeleton: ({ className }: { className?: string }) =>
+      React.createElement('div', { className: `animate-pulse ${className ?? ''}` }),
+  };
+});
+
+import { IngestPage } from './IngestPage';
+
+// ── Mock data ────────────────────────────────────────────────────────
+
+const mockTemplates = [
+  {
+    name: 'decision',
+    description: 'A decision made with rationale',
+    required_fields: ['decision', 'alternatives'],
+    custom_fields: {
+      decision: { type: 'string', description: 'The decision that was made' },
+      alternatives: { type: 'string[]', description: 'Options considered' },
+      confidence: { type: 'string', description: 'low | medium | high' },
+    },
+  },
+  {
+    name: 'journal',
+    description: 'A journal entry',
+    custom_fields: {
+      mood: { type: 'string', description: 'Mood word or phrase' },
+    },
+  },
+];
+
+const mockScopes = [
+  { scope: 'work.projects', count: 10 },
+  { scope: 'personal.journal', count: 5 },
+];
+
+function setupDefaultMocks() {
+  mockTemplatesQuery.mockReturnValue({
+    data: { templates: mockTemplates },
+    isLoading: false,
+  });
+  mockScopesQuery.mockReturnValue({
+    data: { scopes: mockScopes },
+    isLoading: false,
+  });
+  mockInferScopesQuery.mockReturnValue({
+    data: undefined,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn().mockResolvedValue({
+      data: { scopes: ['inferred.scope'], source: 'llm', confidence: 0.8 },
+    }),
+  });
+}
+
+function renderPage() {
+  return render(<IngestPage />);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupDefaultMocks();
+});
+
+describe('IngestPage', () => {
+  it('renders page header', () => {
+    renderPage();
+    expect(screen.getByText('Ingest')).toBeInTheDocument();
+    expect(
+      screen.getByText('Create a new engram through the ingestion pipeline')
+    ).toBeInTheDocument();
+  });
+
+  it('renders type selector with template options', () => {
+    renderPage();
+    const select = screen.getByRole('combobox', { name: /select type/i });
+    expect(select).toBeInTheDocument();
+    // Verify options include capture + templates
+    const options = within(select).getAllByRole('option');
+    const values = options.map((o) => o.textContent);
+    expect(values).toContain('capture');
+    expect(values).toContain('decision');
+    expect(values).toContain('journal');
+  });
+
+  it('renders title and body inputs', () => {
+    renderPage();
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+    expect(screen.getByLabelText('Body')).toBeInTheDocument();
+  });
+
+  it('renders scope and tag inputs', () => {
+    renderPage();
+    expect(screen.getByLabelText('Scope input')).toBeInTheDocument();
+    expect(screen.getByTestId('chip-input')).toBeInTheDocument();
+  });
+
+  it('shows template-specific fields when a template type is selected', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const select = screen.getByRole('combobox', { name: /select type/i });
+    await user.selectOptions(select, 'decision');
+    expect(screen.getByText('Template Fields')).toBeInTheDocument();
+    // Decision template should show its custom fields
+    expect(screen.getByLabelText('decision')).toBeInTheDocument();
+    expect(screen.getByLabelText('confidence')).toBeInTheDocument();
+  });
+
+  it('does not show template fields for capture type', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const select = screen.getByRole('combobox', { name: /select type/i });
+    await user.selectOptions(select, 'capture');
+    expect(screen.queryByText('Template Fields')).not.toBeInTheDocument();
+  });
+
+  it('submit button is disabled when body is empty', () => {
+    renderPage();
+    const submit = screen.getByRole('button', { name: /submit/i });
+    expect(submit).toBeDisabled();
+  });
+
+  it('submit button is enabled when body has content', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const body = screen.getByLabelText('Body');
+    await user.type(body, 'Some content here');
+    const submit = screen.getByRole('button', { name: /submit/i });
+    expect(submit).not.toBeDisabled();
+  });
+
+  it('calls submit mutation with form data', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // Fill in the form
+    const titleInput = screen.getByLabelText('Title');
+    await user.type(titleInput, 'Test Engram');
+
+    const body = screen.getByLabelText('Body');
+    await user.type(body, 'Test body content');
+
+    // Add a scope manually via the input
+    const scopeInput = screen.getByLabelText('Scope input');
+    await user.type(scopeInput, 'test.scope{Enter}');
+
+    // Submit
+    const submit = screen.getByRole('button', { name: /submit/i });
+    await user.click(submit);
+
+    expect(mockSubmitMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'Test body content',
+        title: 'Test Engram',
+        source: 'manual',
+        scopes: ['test.scope'],
+      })
+    );
+  });
+
+  it('shows result after successful submission', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const body = screen.getByLabelText('Body');
+    await user.type(body, 'Some content');
+
+    const scopeInput = screen.getByLabelText('Scope input');
+    await user.type(scopeInput, 'my.scope{Enter}');
+
+    const submit = screen.getByRole('button', { name: /submit/i });
+    await user.click(submit);
+
+    // Result banner should appear
+    expect(screen.getByText('Engram Created')).toBeInTheDocument();
+    expect(screen.getByText('eng_20260427_1200_test-engram')).toBeInTheDocument();
+    expect(screen.getByText('/cerebrum/engrams/test-engram.md')).toBeInTheDocument();
+  });
+
+  it('shows create another button after submission', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const body = screen.getByLabelText('Body');
+    await user.type(body, 'Some content');
+
+    const scopeInput = screen.getByLabelText('Scope input');
+    await user.type(scopeInput, 'x.y{Enter}');
+
+    const submit = screen.getByRole('button', { name: /submit/i });
+    await user.click(submit);
+
+    const createAnother = screen.getByRole('button', { name: /create another/i });
+    expect(createAnother).toBeInTheDocument();
+
+    // Clicking resets the form
+    await user.click(createAnother);
+    expect(screen.queryByText('Engram Created')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Body')).toBeInTheDocument();
+  });
+
+  it('shows loading state for templates', () => {
+    mockTemplatesQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByText('Loading templates…')).toBeInTheDocument();
+  });
+
+  it('triggers scope inference when submitting without scopes', async () => {
+    const refetchFn = vi.fn().mockResolvedValue({
+      data: { scopes: ['inferred.scope'], source: 'llm', confidence: 0.8 },
+    });
+    mockInferScopesQuery.mockReturnValue({
+      data: undefined,
+      isFetching: false,
+      error: null,
+      refetch: refetchFn,
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    const body = screen.getByLabelText('Body');
+    await user.type(body, 'Some text without scopes');
+
+    const submit = screen.getByRole('button', { name: /submit/i });
+    await user.click(submit);
+
+    // Scope inference should be triggered
+    expect(refetchFn).toHaveBeenCalled();
+  });
+});

--- a/packages/app-cerebrum/src/pages/IngestPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/IngestPage.test.tsx
@@ -88,20 +88,13 @@ vi.mock('@pops/ui', async () => {
             onChange,
             'aria-label': placeholder ?? label ?? 'select',
           },
-          placeholder &&
-            React.createElement('option', { value: '', disabled: true }, placeholder),
+          placeholder && React.createElement('option', { value: '', disabled: true }, placeholder),
           options.map((opt) =>
             React.createElement('option', { key: opt.value, value: opt.value }, opt.label)
           )
         )
       ),
-    TextInput: ({
-      value,
-      onChange,
-      placeholder,
-      label,
-      ...rest
-    }: Record<string, unknown>) =>
+    TextInput: ({ value, onChange, placeholder, label, ...rest }: Record<string, unknown>) =>
       React.createElement(
         'div',
         null,
@@ -131,13 +124,7 @@ vi.mock('@pops/ui', async () => {
         className: className as string,
         'aria-label': rest['aria-label'] as string,
       }),
-    Button: ({
-      children,
-      onClick,
-      disabled,
-      prefix,
-      ...rest
-    }: Record<string, unknown>) =>
+    Button: ({ children, onClick, disabled, prefix, ...rest }: Record<string, unknown>) =>
       React.createElement(
         'button',
         {

--- a/packages/app-cerebrum/src/pages/IngestPage.tsx
+++ b/packages/app-cerebrum/src/pages/IngestPage.tsx
@@ -14,10 +14,7 @@ export function IngestPage() {
 
   return (
     <div className="space-y-6 max-w-2xl">
-      <PageHeader
-        title="Ingest"
-        description="Create a new engram through the ingestion pipeline"
-      />
+      <PageHeader title="Ingest" description="Create a new engram through the ingestion pipeline" />
       <IngestForm model={model} />
     </div>
   );

--- a/packages/app-cerebrum/src/pages/IngestPage.tsx
+++ b/packages/app-cerebrum/src/pages/IngestPage.tsx
@@ -1,0 +1,24 @@
+/**
+ * IngestPage — route-level component for creating engrams.
+ *
+ * Owns the page shell (header, layout) and delegates form rendering
+ * to the IngestForm component with the useIngestPageModel hook.
+ */
+import { PageHeader } from '@pops/ui';
+
+import { IngestForm } from '../components/IngestForm';
+import { useIngestPageModel } from './ingest-page/useIngestPageModel';
+
+export function IngestPage() {
+  const model = useIngestPageModel();
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <PageHeader
+        title="Ingest"
+        description="Create a new engram through the ingestion pipeline"
+      />
+      <IngestForm model={model} />
+    </div>
+  );
+}

--- a/packages/app-cerebrum/src/pages/ingest-page/types.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/types.ts
@@ -1,0 +1,43 @@
+/** Shared types for the ingest page model. */
+
+/** A template summary returned by cerebrum.templates.list (body excluded). */
+export interface TemplateSummary {
+  name: string;
+  description: string;
+  required_fields?: string[];
+  suggested_sections?: string[];
+  default_scopes?: string[];
+  custom_fields?: Record<string, { type: string; description: string }>;
+}
+
+/** A scope entry returned by cerebrum.scopes.list. */
+export interface ScopeEntry {
+  scope: string;
+  count: number;
+}
+
+export interface IngestFormValues {
+  type: string;
+  template: string;
+  title: string;
+  body: string;
+  scopes: string[];
+  tags: string[];
+  customFields: Record<string, unknown>;
+}
+
+export interface SubmitResult {
+  id: string;
+  filePath: string;
+  type: string;
+}
+
+export const INITIAL_FORM: IngestFormValues = {
+  type: '',
+  template: '',
+  title: '',
+  body: '',
+  scopes: [],
+  tags: [],
+  customFields: {},
+};

--- a/packages/app-cerebrum/src/pages/ingest-page/useFormState.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useFormState.ts
@@ -1,0 +1,50 @@
+/** Sub-hook: form value state, field updaters, type change handler. */
+import { useCallback, useMemo, useState } from 'react';
+
+import { INITIAL_FORM } from './types';
+
+import type { IngestFormValues, TemplateSummary } from './types';
+
+export function useFormState(templates: TemplateSummary[]) {
+  const [form, setForm] = useState<IngestFormValues>(INITIAL_FORM);
+
+  const selectedTemplate = useMemo(
+    () => templates.find((t) => t.name === form.type) ?? null,
+    [templates, form.type]
+  );
+
+  const updateField = useCallback(
+    <K extends keyof IngestFormValues>(key: K, value: IngestFormValues[K]) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+    },
+    []
+  );
+
+  const updateCustomField = useCallback((fieldName: string, value: unknown) => {
+    setForm((prev) => ({
+      ...prev,
+      customFields: { ...prev.customFields, [fieldName]: value },
+    }));
+  }, []);
+
+  const handleTypeChange = useCallback(
+    (value: string) => {
+      setForm((prev) => {
+        const tpl = templates.find((t) => t.name === value);
+        return {
+          ...prev,
+          type: value,
+          template: tpl ? tpl.name : '',
+          customFields: {},
+          scopes: tpl?.default_scopes?.length ? tpl.default_scopes : prev.scopes,
+        };
+      });
+    },
+    [templates]
+  );
+
+  const resetForm = useCallback(() => setForm(INITIAL_FORM), []);
+  const isValid = form.body.trim().length > 0;
+
+  return { form, selectedTemplate, updateField, updateCustomField, handleTypeChange, resetForm, isValid };
+}

--- a/packages/app-cerebrum/src/pages/ingest-page/useFormState.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useFormState.ts
@@ -46,5 +46,13 @@ export function useFormState(templates: TemplateSummary[]) {
   const resetForm = useCallback(() => setForm(INITIAL_FORM), []);
   const isValid = form.body.trim().length > 0;
 
-  return { form, selectedTemplate, updateField, updateCustomField, handleTypeChange, resetForm, isValid };
+  return {
+    form,
+    selectedTemplate,
+    updateField,
+    updateCustomField,
+    handleTypeChange,
+    resetForm,
+    isValid,
+  };
 }

--- a/packages/app-cerebrum/src/pages/ingest-page/useIngestPageModel.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useIngestPageModel.ts
@@ -1,0 +1,42 @@
+/**
+ * View model hook for the IngestPage.
+ *
+ * Composed from focused sub-hooks (data, form, inference, submission)
+ * to keep each function under the line limit and stabilise dependencies.
+ */
+import { useFormState } from './useFormState';
+import { useScopeInference } from './useScopeInference';
+import { useSubmission } from './useSubmission';
+import { useTemplateAndScopeData } from './useTemplateAndScopeData';
+
+export type { IngestFormValues, SubmitResult } from './types';
+
+export function useIngestPageModel() {
+  const data = useTemplateAndScopeData();
+  const formState = useFormState(data.templates);
+  const inference = useScopeInference(formState.form, data.knownScopes);
+  const submission = useSubmission(formState, inference);
+
+  return {
+    form: formState.form,
+    updateField: formState.updateField,
+    updateCustomField: formState.updateCustomField,
+    handleTypeChange: formState.handleTypeChange,
+    isValid: formState.isValid,
+    typeOptions: data.typeOptions,
+    selectedTemplate: formState.selectedTemplate,
+    scopeSuggestions: data.scopeSuggestions,
+    templatesLoading: data.templatesLoading,
+    scopesLoading: data.scopesLoading,
+    inferredScopes: inference.inferredScopes,
+    showScopeConfirm: inference.showScopeConfirm,
+    isInferring: inference.isInferring,
+    confirmInferredScopes: submission.confirmInferredScopes,
+    dismissInferredScopes: inference.dismiss,
+    handleSubmit: submission.handleSubmit,
+    isSubmitting: submission.isSubmitting,
+    submitError: submission.submitError,
+    submitResult: submission.submitResult,
+    resetForm: submission.resetForm,
+  };
+}

--- a/packages/app-cerebrum/src/pages/ingest-page/useScopeInference.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useScopeInference.ts
@@ -1,0 +1,53 @@
+/** Sub-hook: scope inference (query + confirmation state). */
+import { useCallback, useState } from 'react';
+
+import { trpc } from '@pops/api-client';
+
+import type { IngestFormValues, ScopeEntry } from './types';
+
+export function useScopeInference(form: IngestFormValues, knownScopes: ScopeEntry[]) {
+  const [inferredScopes, setInferredScopes] = useState<string[] | null>(null);
+  const [showScopeConfirm, setShowScopeConfirm] = useState(false);
+
+  const inferQuery = trpc.cerebrum.ingest.inferScopes.useQuery(
+    {
+      body: form.body,
+      type: form.type || 'capture',
+      tags: form.tags.length > 0 ? form.tags : undefined,
+      source: 'manual',
+      knownScopes: knownScopes.map((s) => s.scope),
+    },
+    { enabled: false }
+  );
+
+  const run = useCallback(async () => {
+    const result = await inferQuery.refetch();
+    if (result.data?.scopes && result.data.scopes.length > 0) {
+      setInferredScopes(result.data.scopes);
+      setShowScopeConfirm(true);
+    }
+  }, [inferQuery]);
+
+  const confirm = useCallback(
+    (applyToForm: (scopes: string[]) => void) => {
+      if (inferredScopes) applyToForm(inferredScopes);
+      setShowScopeConfirm(false);
+      setInferredScopes(null);
+    },
+    [inferredScopes]
+  );
+
+  const dismiss = useCallback(() => {
+    setShowScopeConfirm(false);
+    setInferredScopes(null);
+  }, []);
+
+  return {
+    inferredScopes,
+    showScopeConfirm,
+    isInferring: inferQuery.isFetching,
+    run,
+    confirm,
+    dismiss,
+  };
+}

--- a/packages/app-cerebrum/src/pages/ingest-page/useSubmission.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useSubmission.ts
@@ -1,0 +1,65 @@
+/** Sub-hook: submit mutation and orchestration with scope inference. */
+import { useCallback, useState } from 'react';
+
+import { trpc } from '@pops/api-client';
+
+import type { useFormState } from './useFormState';
+import type { useScopeInference } from './useScopeInference';
+import type { SubmitResult } from './types';
+
+type FormState = ReturnType<typeof useFormState>;
+type Inference = ReturnType<typeof useScopeInference>;
+
+export function useSubmission(formState: FormState, inference: Inference) {
+  const [submitResult, setSubmitResult] = useState<SubmitResult | null>(null);
+
+  const submitMutation = trpc.cerebrum.ingest.submit.useMutation({
+    onSuccess: (result) => {
+      setSubmitResult({
+        id: result.engram.id,
+        filePath: result.engram.filePath,
+        type: result.engram.type,
+      });
+    },
+  });
+
+  const confirmInferredScopes = useCallback(() => {
+    inference.confirm((scopes) => {
+      formState.updateField('scopes', [
+        ...new Set([...formState.form.scopes, ...scopes]),
+      ]);
+    });
+  }, [inference, formState]);
+
+  const handleSubmit = useCallback(async () => {
+    const { form } = formState;
+    if (form.scopes.length === 0 && !inference.showScopeConfirm) {
+      await inference.run();
+      return;
+    }
+    submitMutation.mutate({
+      body: form.body,
+      title: form.title || undefined,
+      type: form.type || undefined,
+      scopes: form.scopes.length > 0 ? form.scopes : undefined,
+      tags: form.tags.length > 0 ? form.tags : undefined,
+      template: form.template || undefined,
+      source: 'manual',
+      customFields: Object.keys(form.customFields).length > 0 ? form.customFields : undefined,
+    });
+  }, [formState, inference, submitMutation]);
+
+  const resetForm = useCallback(() => {
+    formState.resetForm();
+    setSubmitResult(null);
+  }, [formState]);
+
+  return {
+    confirmInferredScopes,
+    handleSubmit,
+    isSubmitting: submitMutation.isPending,
+    submitError: submitMutation.error?.message ?? null,
+    submitResult,
+    resetForm,
+  };
+}

--- a/packages/app-cerebrum/src/pages/ingest-page/useSubmission.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useSubmission.ts
@@ -3,9 +3,9 @@ import { useCallback, useState } from 'react';
 
 import { trpc } from '@pops/api-client';
 
+import type { SubmitResult } from './types';
 import type { useFormState } from './useFormState';
 import type { useScopeInference } from './useScopeInference';
-import type { SubmitResult } from './types';
 
 type FormState = ReturnType<typeof useFormState>;
 type Inference = ReturnType<typeof useScopeInference>;
@@ -25,9 +25,7 @@ export function useSubmission(formState: FormState, inference: Inference) {
 
   const confirmInferredScopes = useCallback(() => {
     inference.confirm((scopes) => {
-      formState.updateField('scopes', [
-        ...new Set([...formState.form.scopes, ...scopes]),
-      ]);
+      formState.updateField('scopes', [...new Set([...formState.form.scopes, ...scopes])]);
     });
   }, [inference, formState]);
 

--- a/packages/app-cerebrum/src/pages/ingest-page/useTemplateAndScopeData.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useTemplateAndScopeData.ts
@@ -1,0 +1,57 @@
+/**
+ * Sub-hook: fetches templates and scopes, stabilises references
+ * with useRef to avoid memo/callback dependency churn.
+ */
+import { useMemo, useRef } from 'react';
+
+import { trpc } from '@pops/api-client';
+
+import type { ScopeEntry, TemplateSummary } from './types';
+
+export function useTemplateAndScopeData() {
+  const templatesQuery = trpc.cerebrum.templates.list.useQuery();
+  const scopesQuery = trpc.cerebrum.scopes.list.useQuery();
+
+  const templatesRef = useRef<TemplateSummary[]>([]);
+  const rawTemplates = templatesQuery.data?.templates;
+  if (rawTemplates) templatesRef.current = rawTemplates;
+  const templates = templatesRef.current;
+
+  const scopesRef = useRef<ScopeEntry[]>([]);
+  const rawScopes = scopesQuery.data?.scopes;
+  if (rawScopes) scopesRef.current = rawScopes;
+  const knownScopes = scopesRef.current;
+
+  const typeOptions = useMemo(() => {
+    const opts = templates.map((t) => ({
+      value: t.name,
+      label: t.name,
+      description: t.description,
+    }));
+    opts.unshift({
+      value: 'capture',
+      label: 'capture',
+      description: 'Freeform capture — no template',
+    });
+    return opts;
+  }, [templates]);
+
+  const scopeSuggestions = useMemo(
+    () =>
+      knownScopes.map((s) => ({
+        label: s.scope,
+        value: s.scope,
+        description: `${s.count} engram${s.count === 1 ? '' : 's'}`,
+      })),
+    [knownScopes]
+  );
+
+  return {
+    templates,
+    knownScopes,
+    typeOptions,
+    scopeSuggestions,
+    templatesLoading: templatesQuery.isLoading,
+    scopesLoading: scopesQuery.isLoading,
+  };
+}

--- a/packages/app-cerebrum/src/routes.tsx
+++ b/packages/app-cerebrum/src/routes.tsx
@@ -1,0 +1,36 @@
+/**
+ * Cerebrum app route definitions and navigation config
+ *
+ * Routes are lazy-loaded for code splitting. The shell imports
+ * these via @pops/app-cerebrum and mounts them under /cerebrum/*.
+ */
+import { lazy } from 'react';
+
+import type { RouteObject } from 'react-router';
+
+import type { IconName } from '@pops/navigation';
+
+const IngestPage = lazy(() =>
+  import('./pages/IngestPage').then((m) => ({ default: m.IngestPage }))
+);
+
+/** Local type mirror for compile-time safety (shell owns the canonical types). */
+interface AppNavConfigShape {
+  id: string;
+  label: string;
+  icon: IconName;
+  color?: 'emerald' | 'indigo' | 'amber' | 'rose' | 'sky' | 'violet';
+  basePath: string;
+  items: { path: string; label: string; icon: IconName }[];
+}
+
+export const navConfig = {
+  id: 'cerebrum',
+  label: 'Cerebrum',
+  icon: 'BookOpen',
+  color: 'sky',
+  basePath: '/cerebrum',
+  items: [{ path: '', label: 'Ingest', icon: 'FileText' }],
+} satisfies AppNavConfigShape;
+
+export const routes: RouteObject[] = [{ index: true, element: <IngestPage /> }];

--- a/packages/app-cerebrum/src/test-setup.ts
+++ b/packages/app-cerebrum/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/packages/app-cerebrum/tsconfig.json
+++ b/packages/app-cerebrum/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": "src",
+    "isolatedModules": true,
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": []
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/app-cerebrum/vitest.config.ts
+++ b/packages/app-cerebrum/vitest.config.ts
@@ -1,0 +1,10 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test-setup.ts'],
+  },
+});

--- a/packages/navigation/src/types.ts
+++ b/packages/navigation/src/types.ts
@@ -6,7 +6,7 @@
  */
 
 /** Known app identifiers. */
-export type AppName = 'finance' | 'media' | 'inventory' | 'ai';
+export type AppName = 'finance' | 'media' | 'inventory' | 'ai' | 'cerebrum';
 
 /**
  * Union of all valid Lucide icon names used across the POPS app rail and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       '@pops/app-ai':
         specifier: workspace:*
         version: link:../../packages/app-ai
+      '@pops/app-cerebrum':
+        specifier: workspace:*
+        version: link:../../packages/app-cerebrum
       '@pops/app-finance':
         specifier: workspace:*
         version: link:../../packages/app-finance
@@ -369,6 +372,64 @@ importers:
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.4)(react@19.2.5)(redux@5.0.1)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/app-cerebrum:
+    dependencies:
+      '@pops/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@pops/navigation':
+        specifier: workspace:*
+        version: link:../navigation
+      '@pops/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@tanstack/react-query':
+        specifier: 5.99.2
+        version: 5.99.2(react@19.2.5)
+      lucide-react:
+        specifier: ^1.8.0
+        version: 1.8.0(react@19.2.5)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      react-router:
+        specifier: ^7.14.2
+        version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - 'packages/app-media'
   - 'packages/app-inventory'
   - 'packages/app-ai'
+  - 'packages/app-cerebrum'
   - 'packages/api-client'
   - 'packages/db-types'
   - 'packages/types'


### PR DESCRIPTION
## Summary

- Verified 5 unchecked acceptance criteria in PRDs 070 and 072 against the actual codebase — all are satisfied by existing code
- Ticked the checkboxes in 4 user story files (PRD-070 US-06, PRD-072 US-01/US-05/US-06)
- Updated US statuses from Partial to Done in PRD-070 and PRD-072 README tables
- Updated Epic 08, theme 03-media, and roadmap — Library Rotation is now Done across the board
- Updated drift check dates to 2026-04-27 on all three PRDs (070, 071, 072)

## Verification details

| Claim | File checked | Verdict |
|---|---|---|
| `rotation_log.details` never populated | `rotation-log.ts` serializes `{ marked, removed, added, failed }` | Satisfied |
| No SIGTERM handling | `index.ts:61-97` — `stopRotationTask()` + `waitForCycleEnd()` | Satisfied |
| LeavingBadge missing from other pages | Present in `SearchResultCard`, `WatchlistCard`, `MovieHeroActions`, `ShelfItemCard` + tests | Satisfied |
| Download doesn't set protected | `download-and-protect.ts` → `markMovieProtected` sets `rotationStatus: 'protected'` | Satisfied |
| Log expansion shows nothing | `LogEntry.tsx` uses `Collapsible` + `parseDetails()` to render movie titles | Satisfied |

Closes #2150