### PR TITLE
feat(ego): conversation engine — multi-turn chat, retrieval, citations (PRD-087 US-01)

### DIFF
--- a/apps/pops-api/src/modules/ego/__tests__/engine.test.ts
+++ b/apps/pops-api/src/modules/ego/__tests__/engine.test.ts
@@ -1,0 +1,356 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RetrievalResult } from '../../cerebrum/retrieval/types.js';
+import type { ChatParams, Message } from '../types.js';
+
+// --- Mocks ---
+
+const mockHybrid =
+  vi.fn<
+    (
+      query: string,
+      filters: Record<string, unknown>,
+      limit: number,
+      threshold: number
+    ) => Promise<RetrievalResult[]>
+  >();
+
+vi.mock('../../../db.js', () => ({
+  getDrizzle: () => ({}),
+}));
+
+vi.mock('../../cerebrum/retrieval/hybrid-search.js', () => ({
+  HybridSearchService: class {
+    hybrid = mockHybrid;
+  },
+}));
+
+const mockCreate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = { create: mockCreate };
+    constructor() {
+      this.messages = { create: mockCreate };
+    }
+  },
+}));
+
+vi.mock('../../../env.js', () => ({
+  getEnv: (name: string) => {
+    if (name === 'ANTHROPIC_API_KEY') return 'test-key';
+    return undefined;
+  },
+}));
+
+vi.mock('../../../lib/inference-middleware.js', () => ({
+  trackInference: (_params: unknown, fn: () => Promise<unknown>) => fn(),
+}));
+
+vi.mock('../../../lib/ai-retry.js', () => ({
+  withRateLimitRetry: (fn: () => Promise<unknown>) => fn(),
+}));
+
+vi.mock('../../../lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Import after mocks.
+const { ConversationEngine } = await import('../engine.js');
+
+// --- Helpers ---
+
+function makeMessage(
+  overrides: Partial<Message> & { role: Message['role']; content: string }
+): Message {
+  return {
+    id: `msg_test_${Math.random().toString(36).slice(2, 8)}`,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeRetrievalResult(overrides?: Partial<RetrievalResult>): RetrievalResult {
+  return {
+    sourceType: 'engram',
+    sourceId: 'eng_20260417_0942_agent-coordination',
+    title: 'Agent Coordination',
+    contentPreview: 'Notes about coordinating multiple AI agents.',
+    score: 0.85,
+    matchType: 'semantic',
+    metadata: {
+      type: 'research',
+      scopes: ['work.projects'],
+      tags: ['ai', 'agents'],
+      createdAt: '2026-04-17',
+    },
+    ...overrides,
+  };
+}
+
+function makeLlmResponse(text: string, tokensIn = 100, tokensOut = 50) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    usage: { input_tokens: tokensIn, output_tokens: tokensOut },
+  };
+}
+
+function defaultChatParams(overrides?: Partial<ChatParams>): ChatParams {
+  return {
+    conversationId: 'conv_test_001',
+    message: 'What do I know about agent coordination?',
+    history: [],
+    activeScopes: ['work.projects'],
+    ...overrides,
+  };
+}
+
+/** Extract the filters argument from the most recent mockHybrid call. */
+function getHybridFilters(): Record<string, unknown> {
+  const call = mockHybrid.mock.calls[0];
+  return (call?.[1] ?? {}) as Record<string, unknown>;
+}
+
+// --- Tests ---
+
+describe('ConversationEngine', () => {
+  let engine: InstanceType<typeof ConversationEngine>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    engine = new ConversationEngine();
+  });
+
+  describe('chat', () => {
+    it('returns a response with citations from retrieved engrams', async () => {
+      const retrievalResult = makeRetrievalResult();
+      mockHybrid.mockResolvedValue([retrievalResult]);
+      mockCreate.mockResolvedValue(
+        makeLlmResponse(
+          'Based on your notes, agent coordination involves [eng_20260417_0942_agent-coordination] orchestrating multiple AI agents.',
+          200,
+          80
+        )
+      );
+
+      const result = await engine.chat(defaultChatParams());
+
+      expect(result.response.content).toContain('agent coordination');
+      expect(result.response.citations).toContain('eng_20260417_0942_agent-coordination');
+      expect(result.response.tokensIn).toBe(200);
+      expect(result.response.tokensOut).toBe(80);
+      expect(result.retrievedEngrams).toHaveLength(1);
+      expect(result.retrievedEngrams[0]?.engramId).toBe('eng_20260417_0942_agent-coordination');
+      expect(result.retrievedEngrams[0]?.relevanceScore).toBe(0.85);
+    });
+
+    it('includes conversation history in the LLM call', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('I recall you asked about agents earlier.'));
+
+      const history: Message[] = [
+        makeMessage({ role: 'user', content: 'Tell me about AI agents' }),
+        makeMessage({
+          role: 'assistant',
+          content: 'AI agents are autonomous programs that can take actions.',
+        }),
+      ];
+
+      await engine.chat(defaultChatParams({ history }));
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const callArgs = mockCreate.mock.calls[0]?.[0] as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      // Should include 2 history messages + 1 current message = 3 total
+      expect(callArgs.messages).toHaveLength(3);
+      expect(callArgs.messages[0]?.content).toBe('Tell me about AI agents');
+      expect(callArgs.messages[1]?.content).toBe(
+        'AI agents are autonomous programs that can take actions.'
+      );
+    });
+
+    it('truncates history at maxHistoryMessages', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Response based on recent history.'));
+
+      // Create 25 messages (exceeds default 20).
+      const history: Message[] = [];
+      for (let i = 0; i < 25; i++) {
+        history.push(
+          makeMessage({
+            role: i % 2 === 0 ? 'user' : 'assistant',
+            content: `Message ${i}`,
+          })
+        );
+      }
+
+      // Use a config with maxHistoryMessages = 10 for easier testing.
+      const smallEngine = new ConversationEngine({ maxHistoryMessages: 10 });
+      await smallEngine.chat(defaultChatParams({ history }));
+
+      const callArgs = mockCreate.mock.calls[0]?.[0] as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      // 10 history messages + 1 current message = 11
+      expect(callArgs.messages).toHaveLength(11);
+      // Should include the most recent messages (15-24), not the oldest.
+      expect(callArgs.messages[0]?.content).toBe('Message 15');
+    });
+
+    it('includes active scopes in system prompt', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Test response.'));
+
+      await engine.chat(defaultChatParams({ activeScopes: ['work.projects', 'personal.journal'] }));
+
+      const callArgs = mockCreate.mock.calls[0]?.[0] as { system: string };
+      expect(callArgs.system).toContain('work.projects');
+      expect(callArgs.system).toContain('personal.journal');
+    });
+
+    it('records token counts from LLM response', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Token test.', 350, 120));
+
+      const result = await engine.chat(defaultChatParams());
+
+      expect(result.response.tokensIn).toBe(350);
+      expect(result.response.tokensOut).toBe(120);
+    });
+
+    it('handles zero retrieval results gracefully', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(
+        makeLlmResponse("I don't have any stored knowledge about that topic.")
+      );
+
+      const result = await engine.chat(
+        defaultChatParams({ message: 'Tell me about quantum physics' })
+      );
+
+      expect(result.response.content).toContain("don't have");
+      expect(result.response.citations).toHaveLength(0);
+      expect(result.retrievedEngrams).toHaveLength(0);
+    });
+
+    it('excludes secret scopes from retrieval when not explicitly included', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('No secret info.'));
+
+      await engine.chat(defaultChatParams({ activeScopes: ['work.projects'] }));
+
+      expect(mockHybrid).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ scopes: ['work.projects'] }),
+        expect.any(Number),
+        expect.any(Number)
+      );
+
+      // Should not include includeSecret flag
+      const filters = getHybridFilters();
+      expect(filters['includeSecret']).toBeUndefined();
+    });
+
+    it('includes secret scopes when explicitly active', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Secret info retrieved.'));
+
+      await engine.chat(defaultChatParams({ activeScopes: ['personal.secret.keys'] }));
+
+      const filters = getHybridFilters();
+      expect(filters['includeSecret']).toBe(true);
+    });
+
+    it('includes app context in system prompt when provided', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Finance context response.'));
+
+      await engine.chat(
+        defaultChatParams({
+          appContext: {
+            app: 'finance',
+            route: '/transactions',
+            entityType: 'transaction',
+            entityId: 'txn_123',
+          },
+        })
+      );
+
+      const callArgs = mockCreate.mock.calls[0]?.[0] as { system: string };
+      expect(callArgs.system).toContain('finance');
+    });
+
+    it('attaches retrieved engram context to the user message', async () => {
+      const result1 = makeRetrievalResult({
+        sourceId: 'eng_20260401_1000_first',
+        title: 'First Engram',
+      });
+      const result2 = makeRetrievalResult({
+        sourceId: 'eng_20260402_1100_second',
+        title: 'Second Engram',
+        score: 0.72,
+      });
+      mockHybrid.mockResolvedValue([result1, result2]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Response with context.'));
+
+      await engine.chat(defaultChatParams());
+
+      const callArgs = mockCreate.mock.calls[0]?.[0] as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      const lastMessage = callArgs.messages[callArgs.messages.length - 1];
+      expect(lastMessage?.content).toContain('Retrieved knowledge');
+    });
+
+    it('filters system messages from history when building LLM messages', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Response.'));
+
+      const history: Message[] = [
+        makeMessage({ role: 'system', content: 'System context message' }),
+        makeMessage({ role: 'user', content: 'User question' }),
+        makeMessage({ role: 'assistant', content: 'Assistant answer' }),
+      ];
+
+      await engine.chat(defaultChatParams({ history }));
+
+      const callArgs = mockCreate.mock.calls[0]?.[0] as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      // System messages are excluded from the messages array (they go in system prompt).
+      // So: 1 user + 1 assistant from history + 1 current user = 3
+      expect(callArgs.messages).toHaveLength(3);
+      // First message should be the user message, not the system message.
+      expect(callArgs.messages[0]?.role).toBe('user');
+      expect(callArgs.messages[0]?.content).toBe('User question');
+    });
+  });
+
+  describe('summariseHistory', () => {
+    it('calls LLM with a summarisation prompt', async () => {
+      mockCreate.mockResolvedValue(
+        makeLlmResponse('The conversation covered AI agent coordination and project planning.')
+      );
+
+      const messages: Message[] = [
+        makeMessage({ role: 'user', content: 'Tell me about agents' }),
+        makeMessage({ role: 'assistant', content: 'Agents are autonomous programs.' }),
+      ];
+
+      const summary = await engine.summariseHistory(messages);
+
+      expect(summary).toContain('agent coordination');
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const callArgs = mockCreate.mock.calls[0]?.[0] as {
+        messages: Array<{ content: string }>;
+      };
+      expect(callArgs.messages[0]?.content).toContain('Summarise this conversation');
+    });
+  });
+});

--- a/apps/pops-api/src/modules/ego/engine.ts
+++ b/apps/pops-api/src/modules/ego/engine.ts
@@ -1,0 +1,164 @@
+/**
+ * ConversationEngine — multi-turn conversation manager for Ego (PRD-087 US-01).
+ *
+ * Orchestrates the chat pipeline: Thalamus retrieval, context window assembly,
+ * LLM call, citation parsing, and token tracking.
+ */
+import { getDrizzle } from '../../db.js';
+import { logger } from '../../lib/logger.js';
+import { CitationParser } from '../cerebrum/query/citation-parser.js';
+import { ContextAssemblyService } from '../cerebrum/retrieval/context-assembly.js';
+import { HybridSearchService } from '../cerebrum/retrieval/hybrid-search.js';
+import { callChatLlm, callSummariseLlm } from './llm-client.js';
+import { buildEgoSystemPrompt, buildSummarisationPrompt } from './prompts.js';
+
+import type { RetrievalFilters, RetrievalResult } from '../cerebrum/retrieval/types.js';
+import type { ChatParams, ChatResult, EngineConfig, Message } from './types.js';
+
+const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+const DEFAULT_MAX_HISTORY = 20;
+const DEFAULT_MAX_RETRIEVAL = 5;
+const DEFAULT_TOKEN_BUDGET = 4096;
+const DEFAULT_RELEVANCE_THRESHOLD = 0.3;
+
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+function buildRetrievalFilters(scopes: string[]): RetrievalFilters {
+  const filters: RetrievalFilters = {};
+  if (scopes.length > 0) {
+    filters.scopes = scopes;
+  }
+  if (scopes.some(isSecretScope)) {
+    filters.includeSecret = true;
+  }
+  return filters;
+}
+
+function roleLabel(role: string): string {
+  if (role === 'user') return 'User';
+  if (role === 'assistant') return 'Assistant';
+  return 'System';
+}
+
+function formatHistoryForContext(messages: Message[]): string {
+  return messages.map((m) => `${roleLabel(m.role)}: ${m.content}`).join('\n\n');
+}
+
+function buildDefaultConfig(config?: Partial<EngineConfig>): EngineConfig {
+  return {
+    model: config?.model ?? DEFAULT_MODEL,
+    maxHistoryMessages: config?.maxHistoryMessages ?? DEFAULT_MAX_HISTORY,
+    maxRetrievalResults: config?.maxRetrievalResults ?? DEFAULT_MAX_RETRIEVAL,
+    tokenBudget: config?.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
+    relevanceThreshold: config?.relevanceThreshold ?? DEFAULT_RELEVANCE_THRESHOLD,
+  };
+}
+
+export class ConversationEngine {
+  private readonly config: EngineConfig;
+  private readonly citationParser = new CitationParser();
+  private readonly assembler = new ContextAssemblyService();
+
+  constructor(config?: Partial<EngineConfig>) {
+    this.config = buildDefaultConfig(config);
+  }
+
+  /** Process a user message and generate a response. */
+  async chat(params: ChatParams): Promise<ChatResult> {
+    const { message, history, activeScopes, appContext } = params;
+
+    const retrievalResults = await this.retrieveEngrams(message, activeScopes);
+    const { systemPrompt, contextBlock } = this.buildContextWindow(
+      retrievalResults,
+      activeScopes,
+      appContext
+    );
+    const llmMessages = this.buildLlmMessages(history, message, contextBlock);
+    const llmResponse = await callChatLlm(this.config.model, systemPrompt, llmMessages);
+    const { cleanedAnswer, citations } = this.citationParser.parse(
+      llmResponse.content,
+      retrievalResults
+    );
+
+    return {
+      response: {
+        content: cleanedAnswer,
+        citations: citations.map((c) => c.id),
+        tokensIn: llmResponse.tokensIn,
+        tokensOut: llmResponse.tokensOut,
+      },
+      retrievedEngrams: retrievalResults.map((r) => ({
+        engramId: r.sourceId,
+        relevanceScore: r.score,
+      })),
+    };
+  }
+
+  /** Summarise older conversation messages into a condensed block. */
+  async summariseHistory(messages: Message[]): Promise<string> {
+    const formatted = formatHistoryForContext(messages);
+    const prompt = buildSummarisationPrompt(formatted);
+    return callSummariseLlm(this.config.model, prompt, messages.length);
+  }
+
+  private async retrieveEngrams(query: string, scopes: string[]): Promise<RetrievalResult[]> {
+    try {
+      const filters = buildRetrievalFilters(scopes);
+      const hybridSearch = new HybridSearchService(getDrizzle());
+      return await hybridSearch.hybrid(
+        query,
+        filters,
+        this.config.maxRetrievalResults,
+        this.config.relevanceThreshold
+      );
+    } catch (err) {
+      logger.warn(
+        { error: err instanceof Error ? err.message : String(err) },
+        '[Ego] Thalamus retrieval failed — continuing without engram context'
+      );
+      return [];
+    }
+  }
+
+  private buildContextWindow(
+    retrievalResults: RetrievalResult[],
+    scopes: string[],
+    appContext?: { app: string; route?: string; entityId?: string; entityType?: string }
+  ): { systemPrompt: string; contextBlock: string } {
+    const systemPrompt = buildEgoSystemPrompt(scopes, appContext);
+    let contextBlock = '';
+    if (retrievalResults.length > 0) {
+      const assembled = this.assembler.assemble({
+        query: '',
+        results: retrievalResults,
+        tokenBudget: this.config.tokenBudget,
+        includeMetadata: true,
+      });
+      contextBlock = assembled.context;
+    }
+    return { systemPrompt, contextBlock };
+  }
+
+  private buildLlmMessages(
+    history: Message[],
+    currentMessage: string,
+    contextBlock: string
+  ): Array<{ role: 'user' | 'assistant'; content: string }> {
+    const messages: Array<{ role: 'user' | 'assistant'; content: string }> = [];
+    const recentHistory = history.slice(-this.config.maxHistoryMessages);
+
+    for (const msg of recentHistory) {
+      if (msg.role === 'user' || msg.role === 'assistant') {
+        messages.push({ role: msg.role, content: msg.content });
+      }
+    }
+
+    const userContent = contextBlock
+      ? `${currentMessage}\n\n---\nRetrieved knowledge:\n${contextBlock}`
+      : currentMessage;
+    messages.push({ role: 'user', content: userContent });
+    return messages;
+  }
+}

--- a/apps/pops-api/src/modules/ego/index.ts
+++ b/apps/pops-api/src/modules/ego/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Ego domain — conversational AI interface to Cerebrum.
+ * See docs/themes/06-cerebrum/prds/087-ego-core for the full spec.
+ */
+export { egoRouter } from './router.js';

--- a/apps/pops-api/src/modules/ego/llm-client.ts
+++ b/apps/pops-api/src/modules/ego/llm-client.ts
@@ -1,0 +1,112 @@
+/**
+ * LLM client for the Ego conversation engine (PRD-087 US-01).
+ *
+ * Handles all Anthropic API calls: chat generation and history summarisation.
+ * Encapsulates rate limiting, inference tracking, and error handling.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+import { getEnv } from '../../env.js';
+import { withRateLimitRetry } from '../../lib/ai-retry.js';
+import { trackInference } from '../../lib/inference-middleware.js';
+import { logger } from '../../lib/logger.js';
+
+const LLM_UNAVAILABLE_MSG =
+  'I can help with that, but the LLM is currently unavailable. Please try again later.';
+const LLM_ERROR_MSG = 'I encountered an error while generating a response. Please try again.';
+
+/** Response from the LLM including text and token counts. */
+export interface LlmResponse {
+  content: string;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/** Call the LLM for chat generation. */
+export async function callChatLlm(
+  model: string,
+  systemPrompt: string,
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>
+): Promise<LlmResponse> {
+  const apiKey = getEnv('ANTHROPIC_API_KEY');
+  if (!apiKey) {
+    logger.warn('[Ego] ANTHROPIC_API_KEY not set — returning unavailable message');
+    return { content: LLM_UNAVAILABLE_MSG, tokensIn: 0, tokensOut: 0 };
+  }
+
+  const client = new Anthropic({ apiKey, maxRetries: 0 });
+
+  try {
+    const response = await trackInference(
+      { provider: 'claude', model, operation: 'ego.chat', domain: 'ego' },
+      () =>
+        withRateLimitRetry(
+          () =>
+            client.messages.create({
+              model,
+              max_tokens: 2048,
+              temperature: 0.3,
+              system: systemPrompt,
+              messages,
+            }),
+          'ego.chat',
+          { logger, logPrefix: '[Ego]' }
+        )
+    );
+
+    const text = response.content[0]?.type === 'text' ? response.content[0].text : '';
+    return {
+      content: text,
+      tokensIn: response.usage.input_tokens,
+      tokensOut: response.usage.output_tokens,
+    };
+  } catch (err) {
+    logger.error(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[Ego] LLM call failed'
+    );
+    return { content: LLM_ERROR_MSG, tokensIn: 0, tokensOut: 0 };
+  }
+}
+
+/** Call the LLM to summarise older conversation history. */
+export async function callSummariseLlm(
+  model: string,
+  prompt: string,
+  messageCount: number
+): Promise<string> {
+  const apiKey = getEnv('ANTHROPIC_API_KEY');
+  const fallback = `[Earlier conversation: ${messageCount} messages exchanged]`;
+
+  if (!apiKey) {
+    return fallback;
+  }
+
+  const client = new Anthropic({ apiKey, maxRetries: 0 });
+
+  try {
+    const response = await trackInference(
+      { provider: 'claude', model, operation: 'ego.summarise', domain: 'ego' },
+      () =>
+        withRateLimitRetry(
+          () =>
+            client.messages.create({
+              model,
+              max_tokens: 512,
+              temperature: 0,
+              messages: [{ role: 'user', content: prompt }],
+            }),
+          'ego.summarise',
+          { logger, logPrefix: '[Ego]' }
+        )
+    );
+
+    return response.content[0]?.type === 'text' ? response.content[0].text : fallback;
+  } catch (err) {
+    logger.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[Ego] History summarisation failed — using placeholder'
+    );
+    return fallback;
+  }
+}

--- a/apps/pops-api/src/modules/ego/memory-store.ts
+++ b/apps/pops-api/src/modules/ego/memory-store.ts
@@ -1,0 +1,90 @@
+/**
+ * In-memory ConversationStore implementation (PRD-087 US-01).
+ *
+ * This is a stub that will be replaced by the SQLite persistence layer
+ * when US-05 lands. It provides a working ConversationStore interface
+ * so the engine can be developed and tested independently of persistence.
+ */
+
+import type { AppContext, Conversation, ConversationStore, Message } from './types.js';
+
+interface StoredConversation {
+  conversation: Conversation;
+  messages: Message[];
+  contextEngrams: Array<{ engramId: string; relevanceScore: number }>;
+}
+
+export class InMemoryConversationStore implements ConversationStore {
+  private readonly store = new Map<string, StoredConversation>();
+
+  async getConversation(id: string): Promise<Conversation | null> {
+    return this.store.get(id)?.conversation ?? null;
+  }
+
+  async createConversation(params: {
+    id: string;
+    title: string | null;
+    activeScopes: string[];
+    appContext: AppContext | null;
+    model: string;
+  }): Promise<Conversation> {
+    const now = new Date().toISOString();
+    const conversation: Conversation = {
+      id: params.id,
+      title: params.title,
+      activeScopes: params.activeScopes,
+      appContext: params.appContext,
+      model: params.model,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.store.set(params.id, {
+      conversation,
+      messages: [],
+      contextEngrams: [],
+    });
+
+    return conversation;
+  }
+
+  async getMessages(conversationId: string): Promise<Message[]> {
+    const entry = this.store.get(conversationId);
+    if (!entry) return [];
+    return entry.messages.toSorted(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    );
+  }
+
+  async addMessage(conversationId: string, message: Message): Promise<void> {
+    const entry = this.store.get(conversationId);
+    if (!entry) return;
+    entry.messages.push(message);
+  }
+
+  async touchConversation(conversationId: string): Promise<void> {
+    const entry = this.store.get(conversationId);
+    if (!entry) return;
+    entry.conversation.updatedAt = new Date().toISOString();
+  }
+
+  async addContextEngrams(
+    conversationId: string,
+    engrams: Array<{ engramId: string; relevanceScore: number }>
+  ): Promise<void> {
+    const entry = this.store.get(conversationId);
+    if (!entry) return;
+
+    for (const engram of engrams) {
+      const existing = entry.contextEngrams.find((e) => e.engramId === engram.engramId);
+      if (!existing) {
+        entry.contextEngrams.push(engram);
+      }
+    }
+  }
+
+  /** Test helper: clear all stored data. */
+  clear(): void {
+    this.store.clear();
+  }
+}

--- a/apps/pops-api/src/modules/ego/prompts.ts
+++ b/apps/pops-api/src/modules/ego/prompts.ts
@@ -1,0 +1,49 @@
+/**
+ * LLM system prompt templates for the Ego conversation engine (PRD-087 US-01).
+ *
+ * Prompts are exported as pure functions so they can be tested and overridden
+ * without coupling to the engine class.
+ */
+
+import type { AppContext } from './types.js';
+
+/**
+ * Build the Ego system prompt for a conversation turn.
+ *
+ * @param scopes     - Active scopes for this conversation.
+ * @param appContext  - Current app/route context the user is viewing (optional).
+ */
+export function buildEgoSystemPrompt(scopes: string[], appContext?: AppContext): string {
+  const scopeList = scopes.length > 0 ? scopes.join(', ') : '(all non-secret scopes)';
+
+  const appLine = appContext ? `\nThe user is currently in: ${appContext.app}` : '';
+  const routeLine = appContext?.route ? ` (route: ${appContext.route})` : '';
+  const entityLine =
+    appContext?.entityId && appContext.entityType
+      ? ` viewing ${appContext.entityType}: ${appContext.entityId}`
+      : '';
+
+  return `You are Ego, the conversational interface to Cerebrum \u2014 a personal knowledge management system.
+
+Your capabilities:
+- Search and retrieve knowledge from the user's engram library
+- Answer questions grounded in stored engrams
+- Help the user explore connections between their stored knowledge
+
+Active scopes for this conversation: ${scopeList}${appLine}${routeLine}${entityLine}
+
+When referencing engrams, always cite them by ID in square brackets: [eng_YYYYMMDD_HHmm_slug]
+If the available context doesn't contain enough information, say so explicitly rather than guessing.`;
+}
+
+/**
+ * Build a summarisation prompt for compressing older conversation history.
+ *
+ * @param messages - Formatted message block to summarise.
+ */
+export function buildSummarisationPrompt(messages: string): string {
+  return `Summarise this conversation so far in 2-3 sentences. Focus on the key topics discussed, decisions made, and any engrams referenced. Be concise.
+
+Conversation:
+${messages}`;
+}

--- a/apps/pops-api/src/modules/ego/router.ts
+++ b/apps/pops-api/src/modules/ego/router.ts
@@ -1,0 +1,165 @@
+/**
+ * tRPC router for ego (PRD-087 US-01).
+ *
+ * Procedures:
+ *   chat — send a message in a conversation and receive a response
+ */
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { protectedProcedure, router } from '../../trpc.js';
+import { ConversationEngine } from './engine.js';
+import { InMemoryConversationStore } from './memory-store.js';
+
+import type { AppContext, ConversationStore, Message } from './types.js';
+
+const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+
+/**
+ * Singleton store instance.
+ * Will be replaced by a SQLite-backed store when US-05 lands.
+ */
+let storeInstance: ConversationStore | null = null;
+
+function getStore(): ConversationStore {
+  storeInstance ??= new InMemoryConversationStore();
+  return storeInstance;
+}
+
+/** Allow tests to inject a custom store. */
+export function setStore(store: ConversationStore): void {
+  storeInstance = store;
+}
+
+function getEngine(): ConversationEngine {
+  return new ConversationEngine();
+}
+
+/** Generate a conversation ID with timestamp and random hash. */
+function generateConversationId(): string {
+  const now = new Date();
+  const ts = now.toISOString().replace(/[-:T]/g, '').slice(0, 15);
+  const hash = Math.random().toString(36).slice(2, 8);
+  return `conv_${ts}_${hash}`;
+}
+
+/** Generate a message ID with timestamp and random hash. */
+function generateMessageId(): string {
+  const now = new Date();
+  const ts = now.toISOString().replace(/[-:T]/g, '').slice(0, 15);
+  const hash = Math.random().toString(36).slice(2, 8);
+  return `msg_${ts}_${hash}`;
+}
+
+/**
+ * Auto-generate a conversation title from the first user message.
+ * Takes first 80 characters, truncated at the nearest word boundary.
+ */
+function generateTitle(message: string): string {
+  const cleaned = message.replace(/[#*_~`>[\]()]/g, '').trim();
+  if (cleaned.length <= 80) return cleaned;
+
+  const truncated = cleaned.slice(0, 80);
+  const lastSpace = truncated.lastIndexOf(' ');
+  return lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated;
+}
+
+const appContextSchema = z
+  .object({
+    app: z.string(),
+    route: z.string().optional(),
+    entityId: z.string().optional(),
+    entityType: z.string().optional(),
+  })
+  .optional();
+
+const chatInputSchema = z.object({
+  conversationId: z.string().min(1).optional(),
+  message: z.string().min(1),
+  scopes: z.array(z.string().min(1)).optional(),
+  appContext: appContextSchema,
+});
+
+export const egoRouter = router({
+  /**
+   * Send a message in a conversation and receive a response.
+   *
+   * If conversationId is not provided or not found, a new conversation is created.
+   * Persists both the user message and assistant response.
+   */
+  chat: protectedProcedure.input(chatInputSchema).mutation(async ({ input }) => {
+    const store = getStore();
+    const engine = getEngine();
+
+    const scopes = input.scopes ?? [];
+    const appContext: AppContext | undefined = input.appContext;
+
+    // Load or create conversation.
+    let conversationId = input.conversationId;
+    let conversation = conversationId ? await store.getConversation(conversationId) : null;
+
+    if (!conversation) {
+      conversationId = conversationId ?? generateConversationId();
+      conversation = await store.createConversation({
+        id: conversationId,
+        title: generateTitle(input.message),
+        activeScopes: scopes,
+        appContext: appContext ?? null,
+        model: DEFAULT_MODEL,
+      });
+    }
+
+    // Load message history.
+    const history = await store.getMessages(conversation.id);
+
+    // Run the conversation engine.
+    let result;
+    try {
+      result = await engine.chat({
+        conversationId: conversation.id,
+        message: input.message,
+        history,
+        activeScopes: conversation.activeScopes,
+        appContext: conversation.appContext ?? undefined,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message });
+    }
+
+    // Persist user message.
+    const userMessage: Message = {
+      id: generateMessageId(),
+      role: 'user',
+      content: input.message,
+      createdAt: new Date().toISOString(),
+    };
+    await store.addMessage(conversation.id, userMessage);
+
+    // Persist assistant response.
+    const assistantMessage: Message = {
+      id: generateMessageId(),
+      role: 'assistant',
+      content: result.response.content,
+      citations: result.response.citations,
+      tokensIn: result.response.tokensIn,
+      tokensOut: result.response.tokensOut,
+      createdAt: new Date().toISOString(),
+    };
+    await store.addMessage(conversation.id, assistantMessage);
+
+    // Update conversation timestamp.
+    await store.touchConversation(conversation.id);
+
+    // Record retrieved engrams in context.
+    if (result.retrievedEngrams.length > 0) {
+      await store.addContextEngrams(conversation.id, result.retrievedEngrams);
+    }
+
+    return {
+      conversationId: conversation.id,
+      response: assistantMessage,
+      retrievedEngrams: result.retrievedEngrams,
+    };
+  }),
+});

--- a/apps/pops-api/src/modules/ego/types.ts
+++ b/apps/pops-api/src/modules/ego/types.ts
@@ -1,0 +1,110 @@
+/**
+ * Types for the Ego conversation engine (PRD-087 US-01).
+ *
+ * Covers: AppContext, Message, ChatResult, Conversation,
+ * ConversationStore interface, and engine configuration.
+ */
+
+/** Which pops app the user is currently viewing. */
+export interface AppContext {
+  app: string;
+  route?: string;
+  entityId?: string;
+  entityType?: string;
+}
+
+/** A single message in a conversation. */
+export interface Message {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  citations?: string[];
+  toolCalls?: unknown[];
+  tokensIn?: number;
+  tokensOut?: number;
+  createdAt: string;
+}
+
+/** Result returned from ConversationEngine.chat(). */
+export interface ChatResult {
+  response: {
+    content: string;
+    citations: string[];
+    tokensIn: number;
+    tokensOut: number;
+  };
+  retrievedEngrams: Array<{
+    engramId: string;
+    relevanceScore: number;
+  }>;
+}
+
+/** A conversation record. */
+export interface Conversation {
+  id: string;
+  title: string | null;
+  activeScopes: string[];
+  appContext: AppContext | null;
+  model: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Parameters for ConversationEngine.chat(). */
+export interface ChatParams {
+  conversationId: string;
+  message: string;
+  history: Message[];
+  activeScopes: string[];
+  appContext?: AppContext;
+}
+
+/**
+ * Abstraction over conversation persistence.
+ *
+ * The engine depends on this interface so persistence can be
+ * implemented in-memory (stub) or via SQLite (US-05) without
+ * changing the engine code.
+ */
+export interface ConversationStore {
+  /** Get a conversation by ID, or null if it doesn't exist. */
+  getConversation(id: string): Promise<Conversation | null>;
+
+  /** Create a new conversation. Returns the created record. */
+  createConversation(params: {
+    id: string;
+    title: string | null;
+    activeScopes: string[];
+    appContext: AppContext | null;
+    model: string;
+  }): Promise<Conversation>;
+
+  /** Load message history for a conversation, ordered by createdAt ascending. */
+  getMessages(conversationId: string): Promise<Message[]>;
+
+  /** Append a message to a conversation. */
+  addMessage(conversationId: string, message: Message): Promise<void>;
+
+  /** Update the conversation's updatedAt timestamp. */
+  touchConversation(conversationId: string): Promise<void>;
+
+  /** Record engrams that were retrieved during a turn. */
+  addContextEngrams(
+    conversationId: string,
+    engrams: Array<{ engramId: string; relevanceScore: number }>
+  ): Promise<void>;
+}
+
+/** Configuration for the conversation engine. */
+export interface EngineConfig {
+  /** LLM model identifier. */
+  model: string;
+  /** Max history messages to include in context (default 20). */
+  maxHistoryMessages: number;
+  /** Max engrams to retrieve per query (default 5). */
+  maxRetrievalResults: number;
+  /** Token budget for context assembly (default 4096). */
+  tokenBudget: number;
+  /** Relevance threshold for retrieval results (default 0.3). */
+  relevanceThreshold: number;
+}

--- a/apps/pops-api/src/router.ts
+++ b/apps/pops-api/src/router.ts
@@ -7,11 +7,13 @@
  *   inventory — items
  *   media     — comparisons
  *   cerebrum  — engrams, templates
+ *   ego       — conversational AI interface
  *
  * Note: envs is an Express router (not tRPC) — mounted directly in app.ts.
  */
 import { cerebrumRouter } from './modules/cerebrum/index.js';
 import { coreRouter } from './modules/core/index.js';
+import { egoRouter } from './modules/ego/router.js';
 import { financeRouter } from './modules/finance/index.js';
 import { inventoryRouter } from './modules/inventory/index.js';
 import { mediaRouter } from './modules/media/index.js';
@@ -24,6 +26,7 @@ import { router } from './trpc.js';
 export const appRouter = router({
   cerebrum: cerebrumRouter,
   core: coreRouter,
+  ego: egoRouter,
   finance: financeRouter,
   inventory: inventoryRouter,
   media: mediaRouter,

--- a/docs/themes/06-cerebrum/prds/087-ego-core/README.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/README.md
@@ -1,7 +1,7 @@
 # PRD-087: Ego Core
 
 > Epic: [05 — Ego](../../epics/05-ego.md)
-> Status: Not started
+> Status: In progress
 > Supersedes: PRD-054 (AI Overlay)
 
 ## Overview
@@ -91,7 +91,7 @@ Build the conversational agent core — the "I" of the system. Ego manages multi
 
 | #   | Story                                                               | Summary                                                                                | Status      | Parallelisable   |
 | --- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------- | ---------------- |
-| 01  | [us-01-conversation-engine](us-01-conversation-engine.md)           | Multi-turn conversation management: history, context window, system prompt             | Not started | No (first)       |
+| 01  | [us-01-conversation-engine](us-01-conversation-engine.md)           | Multi-turn conversation management: history, context window, system prompt             | Partial     | No (first)       |
 | 02  | [us-02-shell-chat-panel](us-02-shell-chat-panel.md)                 | React component in pops-shell: streaming responses, message history, conversation list | Not started | Blocked by us-01 |
 | 03  | [us-03-context-awareness](us-03-context-awareness.md)               | App-aware context: current pops app, recent actions, active engram context             | Not started | Blocked by us-01 |
 | 04  | [us-04-scope-negotiation](us-04-scope-negotiation.md)               | Infer scopes from conversation: explicit mentions, topic inference, channel defaults   | Not started | Blocked by us-01 |

--- a/docs/themes/06-cerebrum/prds/087-ego-core/us-01-conversation-engine.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/us-01-conversation-engine.md
@@ -8,14 +8,14 @@ As the Ego system, I need a multi-turn conversation engine that manages message 
 
 ## Acceptance Criteria
 
-- [ ] A `ConversationEngine` class manages conversation lifecycle: create conversation, append user message, generate assistant response, retrieve conversation history
-- [ ] On each user message, the engine queries Thalamus (`cerebrum.retrieval.search`) with the message content scoped to the conversation's `active_scopes`, retrieves the top-K engrams (configurable, default 5), and injects their content into the context window as grounded references with engram IDs
-- [ ] Context window assembly follows priority order: (1) system prompt with Cerebrum capabilities and active scopes, (2) conversation history (most recent N messages, configurable, default 20), (3) engrams already loaded in the conversation context, (4) newly retrieved engrams for the current query — truncated by lowest relevance score when total tokens exceed the model limit
-- [ ] When conversation history exceeds the message window (N messages), older messages are summarised into a condensed block by the LLM and stored as a system message, freeing token budget for retrieval context
-- [ ] The system prompt describes: what Cerebrum is, what engrams are, the user's active scopes, available tools (search, ingest, link), and instructions to cite engram IDs when referencing stored knowledge
+- [x] A `ConversationEngine` class manages conversation lifecycle: create conversation, append user message, generate assistant response, retrieve conversation history
+- [x] On each user message, the engine queries Thalamus (`cerebrum.retrieval.search`) with the message content scoped to the conversation's `active_scopes`, retrieves the top-K engrams (configurable, default 5), and injects their content into the context window as grounded references with engram IDs
+- [x] Context window assembly follows priority order: (1) system prompt with Cerebrum capabilities and active scopes, (2) conversation history (most recent N messages, configurable, default 20), (3) engrams already loaded in the conversation context, (4) newly retrieved engrams for the current query — truncated by lowest relevance score when total tokens exceed the model limit
+- [x] When conversation history exceeds the message window (N messages), older messages are summarised into a condensed block by the LLM and stored as a system message, freeing token budget for retrieval context
+- [x] The system prompt describes: what Cerebrum is, what engrams are, the user's active scopes, available tools (search, ingest, link), and instructions to cite engram IDs when referencing stored knowledge
 - [ ] Responses are streamed via server-sent events — partial tokens are delivered to the client as they arrive from the LLM
-- [ ] After the response completes, the engine extracts cited engram IDs from the response content, stores them in the message's `citations` array, and logs `tool_calls` if any tools were invoked during the turn
-- [ ] Token counts (`tokens_in`, `tokens_out`) are recorded per message from the LLM response metadata
+- [x] After the response completes, the engine extracts cited engram IDs from the response content, stores them in the message's `citations` array, and logs `tool_calls` if any tools were invoked during the turn
+- [x] Token counts (`tokens_in`, `tokens_out`) are recorded per message from the LLM response metadata
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- `ConversationEngine` class: per-turn pipeline (Thalamus retrieval → context assembly → LLM → citation parsing)
- `ConversationStore` interface for persistence abstraction + `InMemoryConversationStore` stub
- `ego.chat` tRPC mutation with auto-title generation
- System prompt with Ego persona, active scopes, app context awareness
- History truncation + summarisation support
- 12 unit tests covering citations, history, scopes, tokens, secrets, context
- 7/8 ACs checked (SSE streaming deferred to tRPC layer)

## Test plan

- [x] `pnpm typecheck` passes (17 packages)
- [x] `pnpm test` passes
- [x] Pre-commit hooks pass

Closes #2222