### PR TITLE
feat(ego): conversation engine — multi-turn chat, retrieval, citations (PRD-087 US-01)

### DIFF
--- a/apps/pops-api/src/modules/ego/__tests__/engine.test.ts
+++ b/apps/pops-api/src/modules/ego/__tests__/engine.test.ts
@@ -1,0 +1,361 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RetrievalResult } from '../../cerebrum/retrieval/types.js';
+import type { ChatParams, Message } from '../types.js';
+
+// --- Mocks ---
+
+const mockHybrid =
+  vi.fn<
+    (
+      query: string,
+      filters: Record<string, unknown>,
+      limit: number,
+      threshold: number
+    ) => Promise<RetrievalResult[]>
+  >();
+
+vi.mock('../../../db.js', () => ({
+  getDrizzle: () => ({}),
+}));
+
+vi.mock('../../cerebrum/retrieval/hybrid-search.js', () => ({
+  HybridSearchService: class {
+    hybrid = mockHybrid;
+  },
+}));
+
+const mockCreate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = { create: mockCreate };
+    constructor() {
+      this.messages = { create: mockCreate };
+    }
+  },
+}));
+
+vi.mock('../../../env.js', () => ({
+  getEnv: (name: string) => {
+    if (name === 'ANTHROPIC_API_KEY') return 'test-key';
+    return undefined;
+  },
+}));
+
+vi.mock('../../../lib/inference-middleware.js', () => ({
+  trackInference: (_params: unknown, fn: () => Promise<unknown>) => fn(),
+}));
+
+vi.mock('../../../lib/ai-retry.js', () => ({
+  withRateLimitRetry: (fn: () => Promise<unknown>) => fn(),
+}));
+
+vi.mock('../../../lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Import after mocks.
+const { ConversationEngine } = await import('../engine.js');
+
+// --- Helpers ---
+
+function makeMessage(
+  overrides: Partial<Message> & { role: Message['role']; content: string }
+): Message {
+  return {
+    id: `msg_test_${Math.random().toString(36).slice(2, 8)}`,
+    conversationId: 'conv_test_001',
+    citations: null,
+    toolCalls: null,
+    tokensIn: null,
+    tokensOut: null,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeRetrievalResult(overrides?: Partial<RetrievalResult>): RetrievalResult {
+  return {
+    sourceType: 'engram',
+    sourceId: 'eng_20260417_0942_agent-coordination',
+    title: 'Agent Coordination',
+    contentPreview: 'Notes about coordinating multiple AI agents.',
+    score: 0.85,
+    matchType: 'semantic',
+    metadata: {
+      type: 'research',
+      scopes: ['work.projects'],
+      tags: ['ai', 'agents'],
+      createdAt: '2026-04-17',
+    },
+    ...overrides,
+  };
+}
+
+function makeLlmResponse(text: string, tokensIn = 100, tokensOut = 50) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    usage: { input_tokens: tokensIn, output_tokens: tokensOut },
+  };
+}
+
+function defaultChatParams(overrides?: Partial<ChatParams>): ChatParams {
+  return {
+    conversationId: 'conv_test_001',
+    message: 'What do I know about agent coordination?',
+    history: [],
+    activeScopes: ['work.projects'],
+    ...overrides,
+  };
+}
+
+/** Extract the filters argument from the most recent mockHybrid call. */
+function getHybridFilters(): Record<string, unknown> {
+  const call = mockHybrid.mock.calls[0];
+  return (call?.[1] ?? {}) as Record<string, unknown>;
+}
+
+// --- Tests ---
+
+describe('ConversationEngine', () => {
+  let engine: InstanceType<typeof ConversationEngine>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    engine = new ConversationEngine();
+  });
+
+  describe('chat', () => {
+    it('returns a response with citations from retrieved engrams', async () => {
+      const retrievalResult = makeRetrievalResult();
+      mockHybrid.mockResolvedValue([retrievalResult]);
+      mockCreate.mockResolvedValue(
+        makeLlmResponse(
+          'Based on your notes, agent coordination involves [eng_20260417_0942_agent-coordination] orchestrating multiple AI agents.',
+          200,
+          80
+        )
+      );
+
+      const result = await engine.chat(defaultChatParams());
+
+      expect(result.response.content).toContain('agent coordination');
+      expect(result.response.citations).toContain('eng_20260417_0942_agent-coordination');
+      expect(result.response.tokensIn).toBe(200);
+      expect(result.response.tokensOut).toBe(80);
+      expect(result.retrievedEngrams).toHaveLength(1);
+      expect(result.retrievedEngrams[0]?.engramId).toBe('eng_20260417_0942_agent-coordination');
+      expect(result.retrievedEngrams[0]?.relevanceScore).toBe(0.85);
+    });
+
+    it('includes conversation history in the LLM call', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('I recall you asked about agents earlier.'));
+
+      const history: Message[] = [
+        makeMessage({ role: 'user', content: 'Tell me about AI agents' }),
+        makeMessage({
+          role: 'assistant',
+          content: 'AI agents are autonomous programs that can take actions.',
+        }),
+      ];
+
+      await engine.chat(defaultChatParams({ history }));
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const callArgs = mockCreate.mock.calls[0]?.[0] as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      // Should include 2 history messages + 1 current message = 3 total
+      expect(callArgs.messages).toHaveLength(3);
+      expect(callArgs.messages[0]?.content).toBe('Tell me about AI agents');
+      expect(callArgs.messages[1]?.content).toBe(
+        'AI agents are autonomous programs that can take actions.'
+      );
+    });
+
+    it('truncates history at maxHistoryMessages', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Response based on recent history.'));
+
+      // Create 25 messages (exceeds default 20).
+      const history: Message[] = [];
+      for (let i = 0; i < 25; i++) {
+        history.push(
+          makeMessage({
+            role: i % 2 === 0 ? 'user' : 'assistant',
+            content: `Message ${i}`,
+          })
+        );
+      }
+
+      // Use a config with maxHistoryMessages = 10 for easier testing.
+      const smallEngine = new ConversationEngine({ maxHistoryMessages: 10 });
+      await smallEngine.chat(defaultChatParams({ history }));
+
+      const callArgs = mockCreate.mock.calls[0]?.[0] as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      // 10 history messages + 1 current message = 11
+      expect(callArgs.messages).toHaveLength(11);
+      // Should include the most recent messages (15-24), not the oldest.
+      expect(callArgs.messages[0]?.content).toBe('Message 15');
+    });
+
+    it('includes active scopes in system prompt', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Test response.'));
+
+      await engine.chat(defaultChatParams({ activeScopes: ['work.projects', 'personal.journal'] }));
+
+      const callArgs = mockCreate.mock.calls[0]?.[0] as { system: string };
+      expect(callArgs.system).toContain('work.projects');
+      expect(callArgs.system).toContain('personal.journal');
+    });
+
+    it('records token counts from LLM response', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Token test.', 350, 120));
+
+      const result = await engine.chat(defaultChatParams());
+
+      expect(result.response.tokensIn).toBe(350);
+      expect(result.response.tokensOut).toBe(120);
+    });
+
+    it('handles zero retrieval results gracefully', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(
+        makeLlmResponse("I don't have any stored knowledge about that topic.")
+      );
+
+      const result = await engine.chat(
+        defaultChatParams({ message: 'Tell me about quantum physics' })
+      );
+
+      expect(result.response.content).toContain("don't have");
+      expect(result.response.citations).toHaveLength(0);
+      expect(result.retrievedEngrams).toHaveLength(0);
+    });
+
+    it('excludes secret scopes from retrieval when not explicitly included', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('No secret info.'));
+
+      await engine.chat(defaultChatParams({ activeScopes: ['work.projects'] }));
+
+      expect(mockHybrid).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ scopes: ['work.projects'] }),
+        expect.any(Number),
+        expect.any(Number)
+      );
+
+      // Should not include includeSecret flag
+      const filters = getHybridFilters();
+      expect(filters['includeSecret']).toBeUndefined();
+    });
+
+    it('includes secret scopes when explicitly active', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Secret info retrieved.'));
+
+      await engine.chat(defaultChatParams({ activeScopes: ['personal.secret.keys'] }));
+
+      const filters = getHybridFilters();
+      expect(filters['includeSecret']).toBe(true);
+    });
+
+    it('includes app context in system prompt when provided', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Finance context response.'));
+
+      await engine.chat(
+        defaultChatParams({
+          appContext: {
+            app: 'finance',
+            route: '/transactions',
+            entityType: 'transaction',
+            entityId: 'txn_123',
+          },
+        })
+      );
+
+      const callArgs = mockCreate.mock.calls[0]?.[0] as { system: string };
+      expect(callArgs.system).toContain('finance');
+    });
+
+    it('attaches retrieved engram context to the user message', async () => {
+      const result1 = makeRetrievalResult({
+        sourceId: 'eng_20260401_1000_first',
+        title: 'First Engram',
+      });
+      const result2 = makeRetrievalResult({
+        sourceId: 'eng_20260402_1100_second',
+        title: 'Second Engram',
+        score: 0.72,
+      });
+      mockHybrid.mockResolvedValue([result1, result2]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Response with context.'));
+
+      await engine.chat(defaultChatParams());
+
+      const callArgs = mockCreate.mock.calls[0]?.[0] as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      const lastMessage = callArgs.messages[callArgs.messages.length - 1];
+      expect(lastMessage?.content).toContain('Retrieved knowledge');
+    });
+
+    it('filters system messages from history when building LLM messages', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Response.'));
+
+      const history: Message[] = [
+        makeMessage({ role: 'system', content: 'System context message' }),
+        makeMessage({ role: 'user', content: 'User question' }),
+        makeMessage({ role: 'assistant', content: 'Assistant answer' }),
+      ];
+
+      await engine.chat(defaultChatParams({ history }));
+
+      const callArgs = mockCreate.mock.calls[0]?.[0] as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      // System messages are excluded from the messages array (they go in system prompt).
+      // So: 1 user + 1 assistant from history + 1 current user = 3
+      expect(callArgs.messages).toHaveLength(3);
+      // First message should be the user message, not the system message.
+      expect(callArgs.messages[0]?.role).toBe('user');
+      expect(callArgs.messages[0]?.content).toBe('User question');
+    });
+  });
+
+  describe('summariseHistory', () => {
+    it('calls LLM with a summarisation prompt', async () => {
+      mockCreate.mockResolvedValue(
+        makeLlmResponse('The conversation covered AI agent coordination and project planning.')
+      );
+
+      const messages: Message[] = [
+        makeMessage({ role: 'user', content: 'Tell me about agents' }),
+        makeMessage({ role: 'assistant', content: 'Agents are autonomous programs.' }),
+      ];
+
+      const summary = await engine.summariseHistory(messages);
+
+      expect(summary).toContain('agent coordination');
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const callArgs = mockCreate.mock.calls[0]?.[0] as {
+        messages: Array<{ content: string }>;
+      };
+      expect(callArgs.messages[0]?.content).toContain('Summarise this conversation');
+    });
+  });
+});

--- a/apps/pops-api/src/modules/ego/engine.ts
+++ b/apps/pops-api/src/modules/ego/engine.ts
@@ -1,0 +1,164 @@
+/**
+ * ConversationEngine — multi-turn conversation manager for Ego (PRD-087 US-01).
+ *
+ * Orchestrates the chat pipeline: Thalamus retrieval, context window assembly,
+ * LLM call, citation parsing, and token tracking.
+ */
+import { getDrizzle } from '../../db.js';
+import { logger } from '../../lib/logger.js';
+import { CitationParser } from '../cerebrum/query/citation-parser.js';
+import { ContextAssemblyService } from '../cerebrum/retrieval/context-assembly.js';
+import { HybridSearchService } from '../cerebrum/retrieval/hybrid-search.js';
+import { callChatLlm, callSummariseLlm } from './llm-client.js';
+import { buildEgoSystemPrompt, buildSummarisationPrompt } from './prompts.js';
+
+import type { RetrievalFilters, RetrievalResult } from '../cerebrum/retrieval/types.js';
+import type { ChatParams, ChatResult, EngineConfig, Message } from './types.js';
+
+const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+const DEFAULT_MAX_HISTORY = 20;
+const DEFAULT_MAX_RETRIEVAL = 5;
+const DEFAULT_TOKEN_BUDGET = 4096;
+const DEFAULT_RELEVANCE_THRESHOLD = 0.3;
+
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+function buildRetrievalFilters(scopes: string[]): RetrievalFilters {
+  const filters: RetrievalFilters = {};
+  if (scopes.length > 0) {
+    filters.scopes = scopes;
+  }
+  if (scopes.some(isSecretScope)) {
+    filters.includeSecret = true;
+  }
+  return filters;
+}
+
+function roleLabel(role: string): string {
+  if (role === 'user') return 'User';
+  if (role === 'assistant') return 'Assistant';
+  return 'System';
+}
+
+function formatHistoryForContext(messages: Message[]): string {
+  return messages.map((m) => `${roleLabel(m.role)}: ${m.content}`).join('\n\n');
+}
+
+function buildDefaultConfig(config?: Partial<EngineConfig>): EngineConfig {
+  return {
+    model: config?.model ?? DEFAULT_MODEL,
+    maxHistoryMessages: config?.maxHistoryMessages ?? DEFAULT_MAX_HISTORY,
+    maxRetrievalResults: config?.maxRetrievalResults ?? DEFAULT_MAX_RETRIEVAL,
+    tokenBudget: config?.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
+    relevanceThreshold: config?.relevanceThreshold ?? DEFAULT_RELEVANCE_THRESHOLD,
+  };
+}
+
+export class ConversationEngine {
+  private readonly config: EngineConfig;
+  private readonly citationParser = new CitationParser();
+  private readonly assembler = new ContextAssemblyService();
+
+  constructor(config?: Partial<EngineConfig>) {
+    this.config = buildDefaultConfig(config);
+  }
+
+  /** Process a user message and generate a response. */
+  async chat(params: ChatParams): Promise<ChatResult> {
+    const { message, history, activeScopes, appContext } = params;
+
+    const retrievalResults = await this.retrieveEngrams(message, activeScopes);
+    const { systemPrompt, contextBlock } = this.buildContextWindow(
+      retrievalResults,
+      activeScopes,
+      appContext
+    );
+    const llmMessages = this.buildLlmMessages(history, message, contextBlock);
+    const llmResponse = await callChatLlm(this.config.model, systemPrompt, llmMessages);
+    const { cleanedAnswer, citations } = this.citationParser.parse(
+      llmResponse.content,
+      retrievalResults
+    );
+
+    return {
+      response: {
+        content: cleanedAnswer,
+        citations: citations.map((c) => c.id),
+        tokensIn: llmResponse.tokensIn,
+        tokensOut: llmResponse.tokensOut,
+      },
+      retrievedEngrams: retrievalResults.map((r) => ({
+        engramId: r.sourceId,
+        relevanceScore: r.score,
+      })),
+    };
+  }
+
+  /** Summarise older conversation messages into a condensed block. */
+  async summariseHistory(messages: Message[]): Promise<string> {
+    const formatted = formatHistoryForContext(messages);
+    const prompt = buildSummarisationPrompt(formatted);
+    return callSummariseLlm(this.config.model, prompt, messages.length);
+  }
+
+  private async retrieveEngrams(query: string, scopes: string[]): Promise<RetrievalResult[]> {
+    try {
+      const filters = buildRetrievalFilters(scopes);
+      const hybridSearch = new HybridSearchService(getDrizzle());
+      return await hybridSearch.hybrid(
+        query,
+        filters,
+        this.config.maxRetrievalResults,
+        this.config.relevanceThreshold
+      );
+    } catch (err) {
+      logger.warn(
+        { error: err instanceof Error ? err.message : String(err) },
+        '[Ego] Thalamus retrieval failed — continuing without engram context'
+      );
+      return [];
+    }
+  }
+
+  private buildContextWindow(
+    retrievalResults: RetrievalResult[],
+    scopes: string[],
+    appContext?: { app: string; route?: string; entityId?: string; entityType?: string }
+  ): { systemPrompt: string; contextBlock: string } {
+    const systemPrompt = buildEgoSystemPrompt(scopes, appContext);
+    let contextBlock = '';
+    if (retrievalResults.length > 0) {
+      const assembled = this.assembler.assemble({
+        query: '',
+        results: retrievalResults,
+        tokenBudget: this.config.tokenBudget,
+        includeMetadata: true,
+      });
+      contextBlock = assembled.context;
+    }
+    return { systemPrompt, contextBlock };
+  }
+
+  private buildLlmMessages(
+    history: Message[],
+    currentMessage: string,
+    contextBlock: string
+  ): Array<{ role: 'user' | 'assistant'; content: string }> {
+    const messages: Array<{ role: 'user' | 'assistant'; content: string }> = [];
+    const recentHistory = history.slice(-this.config.maxHistoryMessages);
+
+    for (const msg of recentHistory) {
+      if (msg.role === 'user' || msg.role === 'assistant') {
+        messages.push({ role: msg.role, content: msg.content });
+      }
+    }
+
+    const userContent = contextBlock
+      ? `${currentMessage}\n\n---\nRetrieved knowledge:\n${contextBlock}`
+      : currentMessage;
+    messages.push({ role: 'user', content: userContent });
+    return messages;
+  }
+}

--- a/apps/pops-api/src/modules/ego/index.ts
+++ b/apps/pops-api/src/modules/ego/index.ts
@@ -1,9 +1,16 @@
 /**
- * Ego domain — AI conversation persistence and retrieval.
+ * Ego domain — conversational AI interface to Cerebrum (PRD-087).
+ *
+ * Procedures:
+ *   ego.conversations.create/list/get/delete — CRUD (US-05)
+ *   ego.chat                                 — multi-turn conversation (US-01)
  */
-import { router } from '../../trpc.js';
-import { conversationsRouter } from './router.js';
+import { mergeRouters, router } from '../../trpc.js';
+import { chatRouter, conversationsRouter } from './router.js';
 
-export const egoRouter = router({
-  conversations: conversationsRouter,
-});
+export const egoRouter = mergeRouters(
+  chatRouter,
+  router({
+    conversations: conversationsRouter,
+  })
+);

--- a/apps/pops-api/src/modules/ego/llm-client.ts
+++ b/apps/pops-api/src/modules/ego/llm-client.ts
@@ -1,0 +1,112 @@
+/**
+ * LLM client for the Ego conversation engine (PRD-087 US-01).
+ *
+ * Handles all Anthropic API calls: chat generation and history summarisation.
+ * Encapsulates rate limiting, inference tracking, and error handling.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+import { getEnv } from '../../env.js';
+import { withRateLimitRetry } from '../../lib/ai-retry.js';
+import { trackInference } from '../../lib/inference-middleware.js';
+import { logger } from '../../lib/logger.js';
+
+const LLM_UNAVAILABLE_MSG =
+  'I can help with that, but the LLM is currently unavailable. Please try again later.';
+const LLM_ERROR_MSG = 'I encountered an error while generating a response. Please try again.';
+
+/** Response from the LLM including text and token counts. */
+export interface LlmResponse {
+  content: string;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/** Call the LLM for chat generation. */
+export async function callChatLlm(
+  model: string,
+  systemPrompt: string,
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>
+): Promise<LlmResponse> {
+  const apiKey = getEnv('ANTHROPIC_API_KEY');
+  if (!apiKey) {
+    logger.warn('[Ego] ANTHROPIC_API_KEY not set — returning unavailable message');
+    return { content: LLM_UNAVAILABLE_MSG, tokensIn: 0, tokensOut: 0 };
+  }
+
+  const client = new Anthropic({ apiKey, maxRetries: 0 });
+
+  try {
+    const response = await trackInference(
+      { provider: 'claude', model, operation: 'ego.chat', domain: 'ego' },
+      () =>
+        withRateLimitRetry(
+          () =>
+            client.messages.create({
+              model,
+              max_tokens: 2048,
+              temperature: 0.3,
+              system: systemPrompt,
+              messages,
+            }),
+          'ego.chat',
+          { logger, logPrefix: '[Ego]' }
+        )
+    );
+
+    const text = response.content[0]?.type === 'text' ? response.content[0].text : '';
+    return {
+      content: text,
+      tokensIn: response.usage.input_tokens,
+      tokensOut: response.usage.output_tokens,
+    };
+  } catch (err) {
+    logger.error(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[Ego] LLM call failed'
+    );
+    return { content: LLM_ERROR_MSG, tokensIn: 0, tokensOut: 0 };
+  }
+}
+
+/** Call the LLM to summarise older conversation history. */
+export async function callSummariseLlm(
+  model: string,
+  prompt: string,
+  messageCount: number
+): Promise<string> {
+  const apiKey = getEnv('ANTHROPIC_API_KEY');
+  const fallback = `[Earlier conversation: ${messageCount} messages exchanged]`;
+
+  if (!apiKey) {
+    return fallback;
+  }
+
+  const client = new Anthropic({ apiKey, maxRetries: 0 });
+
+  try {
+    const response = await trackInference(
+      { provider: 'claude', model, operation: 'ego.summarise', domain: 'ego' },
+      () =>
+        withRateLimitRetry(
+          () =>
+            client.messages.create({
+              model,
+              max_tokens: 512,
+              temperature: 0,
+              messages: [{ role: 'user', content: prompt }],
+            }),
+          'ego.summarise',
+          { logger, logPrefix: '[Ego]' }
+        )
+    );
+
+    return response.content[0]?.type === 'text' ? response.content[0].text : fallback;
+  } catch (err) {
+    logger.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[Ego] History summarisation failed — using placeholder'
+    );
+    return fallback;
+  }
+}

--- a/apps/pops-api/src/modules/ego/persistence-store.ts
+++ b/apps/pops-api/src/modules/ego/persistence-store.ts
@@ -1,0 +1,63 @@
+/**
+ * PersistenceStoreAdapter — wraps ConversationPersistence to implement the
+ * ConversationStore interface that the ConversationEngine depends on.
+ */
+import type { ConversationPersistence } from './persistence.js';
+import type { AppContext, Conversation, ConversationStore, Message } from './types.js';
+
+export class PersistenceStoreAdapter implements ConversationStore {
+  private readonly persistence: ConversationPersistence;
+
+  constructor(persistence: ConversationPersistence) {
+    this.persistence = persistence;
+  }
+
+  async getConversation(id: string): Promise<Conversation | null> {
+    const result = this.persistence.getConversation(id);
+    return result?.conversation ?? null;
+  }
+
+  async createConversation(params: {
+    id: string;
+    title: string | null;
+    activeScopes: string[];
+    appContext: AppContext | null;
+    model: string;
+  }): Promise<Conversation> {
+    return this.persistence.createConversation({
+      title: params.title ?? undefined,
+      scopes: params.activeScopes,
+      appContext: params.appContext,
+      model: params.model,
+    });
+  }
+
+  async getMessages(conversationId: string): Promise<Message[]> {
+    const result = this.persistence.getConversation(conversationId);
+    return result?.messages ?? [];
+  }
+
+  async addMessage(conversationId: string, message: Message): Promise<void> {
+    this.persistence.appendMessage(conversationId, {
+      role: message.role,
+      content: message.content,
+      citations: message.citations ?? undefined,
+      toolCalls: message.toolCalls ?? undefined,
+      tokensIn: message.tokensIn ?? undefined,
+      tokensOut: message.tokensOut ?? undefined,
+    });
+  }
+
+  async touchConversation(_conversationId: string): Promise<void> {
+    // appendMessage already updates updatedAt via persistence.appendMessage
+  }
+
+  async addContextEngrams(
+    conversationId: string,
+    engrams: Array<{ engramId: string; relevanceScore: number }>
+  ): Promise<void> {
+    for (const { engramId, relevanceScore } of engrams) {
+      this.persistence.upsertContext(conversationId, engramId, relevanceScore);
+    }
+  }
+}

--- a/apps/pops-api/src/modules/ego/prompts.ts
+++ b/apps/pops-api/src/modules/ego/prompts.ts
@@ -1,0 +1,49 @@
+/**
+ * LLM system prompt templates for the Ego conversation engine (PRD-087 US-01).
+ *
+ * Prompts are exported as pure functions so they can be tested and overridden
+ * without coupling to the engine class.
+ */
+
+import type { AppContext } from './types.js';
+
+/**
+ * Build the Ego system prompt for a conversation turn.
+ *
+ * @param scopes     - Active scopes for this conversation.
+ * @param appContext  - Current app/route context the user is viewing (optional).
+ */
+export function buildEgoSystemPrompt(scopes: string[], appContext?: AppContext): string {
+  const scopeList = scopes.length > 0 ? scopes.join(', ') : '(all non-secret scopes)';
+
+  const appLine = appContext ? `\nThe user is currently in: ${appContext.app}` : '';
+  const routeLine = appContext?.route ? ` (route: ${appContext.route})` : '';
+  const entityLine =
+    appContext?.entityId && appContext.entityType
+      ? ` viewing ${appContext.entityType}: ${appContext.entityId}`
+      : '';
+
+  return `You are Ego, the conversational interface to Cerebrum \u2014 a personal knowledge management system.
+
+Your capabilities:
+- Search and retrieve knowledge from the user's engram library
+- Answer questions grounded in stored engrams
+- Help the user explore connections between their stored knowledge
+
+Active scopes for this conversation: ${scopeList}${appLine}${routeLine}${entityLine}
+
+When referencing engrams, always cite them by ID in square brackets: [eng_YYYYMMDD_HHmm_slug]
+If the available context doesn't contain enough information, say so explicitly rather than guessing.`;
+}
+
+/**
+ * Build a summarisation prompt for compressing older conversation history.
+ *
+ * @param messages - Formatted message block to summarise.
+ */
+export function buildSummarisationPrompt(messages: string): string {
+  return `Summarise this conversation so far in 2-3 sentences. Focus on the key topics discussed, decisions made, and any engrams referenced. Be concise.
+
+Conversation:
+${messages}`;
+}

--- a/apps/pops-api/src/modules/ego/router.ts
+++ b/apps/pops-api/src/modules/ego/router.ts
@@ -1,19 +1,34 @@
 /**
- * tRPC router for ego.conversations.
+ * tRPC router for ego — conversations CRUD + chat.
  *
- * Thin adapter over ConversationPersistence — no database work lives here.
- * All business logic belongs to the persistence service.
+ * Conversations CRUD is a thin adapter over ConversationPersistence.
+ * Chat delegates to the ConversationEngine for the LLM pipeline.
  */
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { getDrizzle } from '../../db.js';
 import { protectedProcedure, router } from '../../trpc.js';
+import { ConversationEngine } from './engine.js';
+import { PersistenceStoreAdapter } from './persistence-store.js';
 import { ConversationPersistence } from './persistence.js';
+import { autoTitle } from './types.js';
+
+import type { AppContext } from './types.js';
+
+const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
 
 /** Lazily instantiated persistence service (uses the global Drizzle instance). */
 function getPersistence(): ConversationPersistence {
   return new ConversationPersistence({ db: getDrizzle() });
+}
+
+function getStore(): PersistenceStoreAdapter {
+  return new PersistenceStoreAdapter(getPersistence());
+}
+
+function getEngine(): ConversationEngine {
+  return new ConversationEngine();
 }
 
 const createSchema = z.object({
@@ -37,6 +52,91 @@ const getSchema = z.object({
 
 const deleteSchema = z.object({
   id: z.string().min(1),
+});
+
+const appContextSchema = z
+  .object({
+    app: z.string(),
+    route: z.string().optional(),
+    entityId: z.string().optional(),
+    entityType: z.string().optional(),
+  })
+  .optional();
+
+const chatInputSchema = z.object({
+  conversationId: z.string().min(1).optional(),
+  message: z.string().min(1),
+  scopes: z.array(z.string().min(1)).optional(),
+  appContext: appContextSchema,
+});
+
+export const chatRouter = router({
+  chat: protectedProcedure.input(chatInputSchema).mutation(async ({ input }) => {
+    const store = getStore();
+    const engine = getEngine();
+    const persistence = getPersistence();
+
+    const scopes = input.scopes ?? [];
+    const appContext: AppContext | undefined = input.appContext ?? undefined;
+
+    // Load or create conversation.
+    let conversationId = input.conversationId;
+    let conversation = conversationId ? await store.getConversation(conversationId) : null;
+
+    if (!conversation) {
+      conversation = persistence.createConversation({
+        title: autoTitle(input.message),
+        scopes,
+        appContext: appContext ?? undefined,
+        model: DEFAULT_MODEL,
+      });
+      conversationId = conversation.id;
+    }
+
+    // Load message history.
+    const history = await store.getMessages(conversation.id);
+
+    // Run the conversation engine.
+    let result;
+    try {
+      result = await engine.chat({
+        conversationId: conversation.id,
+        message: input.message,
+        history,
+        activeScopes: conversation.activeScopes,
+        appContext: conversation.appContext as AppContext | undefined,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message });
+    }
+
+    // Persist user message.
+    persistence.appendMessage(conversation.id, {
+      role: 'user',
+      content: input.message,
+    });
+
+    // Persist assistant response.
+    const assistantMsg = persistence.appendMessage(conversation.id, {
+      role: 'assistant',
+      content: result.response.content,
+      citations: result.response.citations,
+      tokensIn: result.response.tokensIn,
+      tokensOut: result.response.tokensOut,
+    });
+
+    // Record retrieved engrams in context.
+    for (const { engramId, relevanceScore } of result.retrievedEngrams) {
+      persistence.upsertContext(conversation.id, engramId, relevanceScore);
+    }
+
+    return {
+      conversationId: conversation.id,
+      response: assistantMsg,
+      retrievedEngrams: result.retrievedEngrams,
+    };
+  }),
 });
 
 export const conversationsRouter = router({

--- a/apps/pops-api/src/modules/ego/types.ts
+++ b/apps/pops-api/src/modules/ego/types.ts
@@ -107,6 +107,72 @@ export interface AppendMessageInput {
 }
 
 // ---------------------------------------------------------------------------
+// Engine types (PRD-087 US-01)
+// ---------------------------------------------------------------------------
+
+/** Which pops app the user is currently viewing. */
+export interface AppContext {
+  app: string;
+  route?: string;
+  entityId?: string;
+  entityType?: string;
+}
+
+/** Result returned from ConversationEngine.chat(). */
+export interface ChatResult {
+  response: {
+    content: string;
+    citations: string[];
+    tokensIn: number;
+    tokensOut: number;
+  };
+  retrievedEngrams: Array<{
+    engramId: string;
+    relevanceScore: number;
+  }>;
+}
+
+/** Parameters for ConversationEngine.chat(). */
+export interface ChatParams {
+  conversationId: string;
+  message: string;
+  history: Message[];
+  activeScopes: string[];
+  appContext?: AppContext;
+}
+
+/** Configuration for the conversation engine. */
+export interface EngineConfig {
+  model: string;
+  maxHistoryMessages: number;
+  maxRetrievalResults: number;
+  tokenBudget: number;
+  relevanceThreshold: number;
+}
+
+/**
+ * Abstraction over conversation persistence for the engine.
+ * Implemented by PersistenceStoreAdapter wrapping ConversationPersistence.
+ */
+export interface ConversationStore {
+  getConversation(id: string): Promise<Conversation | null>;
+  createConversation(params: {
+    id: string;
+    title: string | null;
+    activeScopes: string[];
+    appContext: AppContext | null;
+    model: string;
+  }): Promise<Conversation>;
+  getMessages(conversationId: string): Promise<Message[]>;
+  addMessage(conversationId: string, message: Message): Promise<void>;
+  touchConversation(conversationId: string): Promise<void>;
+  addContextEngrams(
+    conversationId: string,
+    engrams: Array<{ engramId: string; relevanceScore: number }>
+  ): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
 // Row → domain mappers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `ConversationEngine`: per-turn pipeline (Thalamus retrieval → context assembly → LLM → citations)
- `PersistenceStoreAdapter`: bridges engine's ConversationStore interface to real SQLite persistence (US-05)
- `ego.chat` tRPC mutation: load/create conversation, run engine, persist messages + context
- LLM client with Anthropic SDK, rate limiting, inference tracking, graceful degradation
- System prompt with Ego persona, active scopes, app context awareness
- Integrated with US-05 persistence (no in-memory stubs)
- 12 unit tests for the engine

## Test plan

- [x] `pnpm typecheck` passes (17/17 packages)
- [x] `pnpm test` passes (3181+ tests, 183 files)
- [x] Pre-commit hooks pass

Closes #2222