### PR TITLE
feat(ego): context awareness — app context, scope biasing, viewed engram (PRD-087 US-03)

### DIFF
--- a/apps/pops-api/src/modules/ego/__tests__/context-awareness.test.ts
+++ b/apps/pops-api/src/modules/ego/__tests__/context-awareness.test.ts
@@ -1,0 +1,569 @@
+/**
+ * Tests for Ego context awareness (PRD-087 US-03).
+ *
+ * Covers:
+ * - System prompt includes human-readable app context description
+ * - Viewed engram auto-loaded into context with score 1.0
+ * - Scope biasing adds app-relevant scopes to retrieval
+ * - Context state endpoint returns correct data
+ * - App context update when it changes between turns
+ */
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createTestDb } from '../../../shared/test-utils.js';
+import { buildEgoSystemPrompt, formatAppContextDescription } from '../prompts.js';
+
+import type { Database } from 'better-sqlite3';
+
+import type { RetrievalResult } from '../../cerebrum/retrieval/types.js';
+import type { ChatParams } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks (must precede dynamic imports)
+// ---------------------------------------------------------------------------
+
+const mockHybrid =
+  vi.fn<
+    (
+      query: string,
+      filters: Record<string, unknown>,
+      limit: number,
+      threshold: number
+    ) => Promise<RetrievalResult[]>
+  >();
+
+vi.mock('../../../db.js', () => ({
+  getDrizzle: () => ({}),
+}));
+
+vi.mock('../../cerebrum/retrieval/hybrid-search.js', () => ({
+  HybridSearchService: class {
+    hybrid = mockHybrid;
+  },
+}));
+
+const mockEngramRead = vi.fn();
+
+vi.mock('../../cerebrum/instance.js', () => ({
+  getEngramService: () => ({
+    read: mockEngramRead,
+  }),
+}));
+
+const mockCreate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = { create: mockCreate };
+    constructor() {
+      this.messages = { create: mockCreate };
+    }
+  },
+}));
+
+vi.mock('../../../env.js', () => ({
+  getEnv: (name: string) => {
+    if (name === 'ANTHROPIC_API_KEY') return 'test-key';
+    return undefined;
+  },
+}));
+
+vi.mock('../../../lib/inference-middleware.js', () => ({
+  trackInference: (_params: unknown, fn: () => Promise<unknown>) => fn(),
+}));
+
+vi.mock('../../../lib/ai-retry.js', () => ({
+  withRateLimitRetry: (fn: () => Promise<unknown>) => fn(),
+}));
+
+vi.mock('../../../lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Import after mocks.
+const { ConversationEngine } = await import('../engine.js');
+const { ConversationPersistence } = await import('../persistence.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeLlmResponse(text: string, tokensIn = 100, tokensOut = 50) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    usage: { input_tokens: tokensIn, output_tokens: tokensOut },
+  };
+}
+
+function defaultChatParams(overrides?: Partial<ChatParams>): ChatParams {
+  return {
+    conversationId: 'conv_test_001',
+    message: 'What do I know about this?',
+    history: [],
+    activeScopes: ['work.projects'],
+    ...overrides,
+  };
+}
+
+function getHybridFilters(): Record<string, unknown> {
+  const call = mockHybrid.mock.calls[0];
+  return (call?.[1] ?? {}) as Record<string, unknown>;
+}
+
+function makeClock(start = new Date('2026-04-27T10:00:00Z')): () => Date {
+  let t = start.getTime();
+  return () => {
+    const d = new Date(t);
+    t += 1_000;
+    return d;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: formatAppContextDescription (pure function)
+// ---------------------------------------------------------------------------
+
+describe('formatAppContextDescription', () => {
+  it('describes viewing an engram in Cerebrum', () => {
+    const result = formatAppContextDescription({
+      app: 'cerebrum',
+      entityType: 'engram',
+      entityId: 'eng_20260427_1500_test',
+    });
+    expect(result).toBe('The user is viewing engram eng_20260427_1500_test in Cerebrum');
+  });
+
+  it('describes viewing a transaction in finance', () => {
+    const result = formatAppContextDescription({
+      app: 'finance',
+      entityType: 'transaction',
+      entityId: 'txn_1234',
+    });
+    expect(result).toBe('The user is looking at transaction #txn_1234 in the finance app');
+  });
+
+  it('describes viewing a movie in media', () => {
+    const result = formatAppContextDescription({
+      app: 'media',
+      entityType: 'movie',
+      entityId: '42',
+    });
+    expect(result).toBe('The user is looking at movie #42 in the media app');
+  });
+
+  it('describes a route without entity', () => {
+    const result = formatAppContextDescription({
+      app: 'media',
+      route: '/watchlist',
+    });
+    expect(result).toBe('The user is currently on /watchlist in the media app');
+  });
+
+  it('describes just the app when no route or entity', () => {
+    const result = formatAppContextDescription({ app: 'inventory' });
+    expect(result).toBe('The user is currently in the inventory app');
+  });
+
+  it('handles unknown app names gracefully', () => {
+    const result = formatAppContextDescription({ app: 'custom-app' });
+    expect(result).toBe('The user is currently in the custom-app app');
+  });
+
+  it('handles unknown entity types gracefully', () => {
+    const result = formatAppContextDescription({
+      app: 'finance',
+      entityType: 'budget',
+      entityId: 'bgt_001',
+    });
+    expect(result).toBe('The user is looking at budget #bgt_001 in the finance app');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: buildEgoSystemPrompt with app context
+// ---------------------------------------------------------------------------
+
+describe('buildEgoSystemPrompt with app context', () => {
+  it('includes app context description in the system prompt', () => {
+    const prompt = buildEgoSystemPrompt(['personal.finance'], {
+      app: 'finance',
+      route: '/transactions',
+      entityType: 'transaction',
+      entityId: 'txn_123',
+    });
+
+    expect(prompt).toContain('The user is looking at transaction #txn_123 in the finance app');
+    expect(prompt).toContain('personal.finance');
+  });
+
+  it('omits context line when no app context provided', () => {
+    const prompt = buildEgoSystemPrompt(['work.projects']);
+    expect(prompt).not.toContain('The user is');
+    expect(prompt).toContain('work.projects');
+  });
+
+  it('includes engram context for Cerebrum', () => {
+    const prompt = buildEgoSystemPrompt([], {
+      app: 'cerebrum',
+      entityType: 'engram',
+      entityId: 'eng_20260427_1500_test',
+    });
+    expect(prompt).toContain('The user is viewing engram eng_20260427_1500_test in Cerebrum');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: ConversationEngine — engram auto-loading
+// ---------------------------------------------------------------------------
+
+describe('ConversationEngine — engram auto-loading', () => {
+  let engine: InstanceType<typeof ConversationEngine>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    engine = new ConversationEngine();
+  });
+
+  it('auto-loads viewed engram with score 1.0 when viewing an engram', async () => {
+    mockHybrid.mockResolvedValue([]);
+    mockEngramRead.mockReturnValue({
+      engram: {
+        id: 'eng_20260427_1500_test',
+        title: 'Test Engram',
+        type: 'note',
+        scopes: ['personal.cerebrum'],
+        tags: ['test'],
+        created: '2026-04-27',
+      },
+      body: 'This is the engram body content.',
+    });
+    mockCreate.mockResolvedValue(makeLlmResponse('Response about the engram.'));
+
+    const result = await engine.chat(
+      defaultChatParams({
+        appContext: {
+          app: 'cerebrum',
+          entityType: 'engram',
+          entityId: 'eng_20260427_1500_test',
+        },
+      })
+    );
+
+    expect(mockEngramRead).toHaveBeenCalledWith('eng_20260427_1500_test');
+    expect(result.retrievedEngrams).toContainEqual({
+      engramId: 'eng_20260427_1500_test',
+      relevanceScore: 1.0,
+    });
+    // Verify it's prepended (first in the list).
+    expect(result.retrievedEngrams[0]?.engramId).toBe('eng_20260427_1500_test');
+    expect(result.retrievedEngrams[0]?.relevanceScore).toBe(1.0);
+  });
+
+  it('does not auto-load when entityType is not engram', async () => {
+    mockHybrid.mockResolvedValue([]);
+    mockCreate.mockResolvedValue(makeLlmResponse('Response.'));
+
+    await engine.chat(
+      defaultChatParams({
+        appContext: {
+          app: 'finance',
+          entityType: 'transaction',
+          entityId: 'txn_123',
+        },
+      })
+    );
+
+    expect(mockEngramRead).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-load when entityId is missing', async () => {
+    mockHybrid.mockResolvedValue([]);
+    mockCreate.mockResolvedValue(makeLlmResponse('Response.'));
+
+    await engine.chat(
+      defaultChatParams({
+        appContext: {
+          app: 'cerebrum',
+          entityType: 'engram',
+        },
+      })
+    );
+
+    expect(mockEngramRead).not.toHaveBeenCalled();
+  });
+
+  it('continues gracefully when engram read fails', async () => {
+    mockHybrid.mockResolvedValue([]);
+    mockEngramRead.mockImplementation(() => {
+      throw new Error('Engram not found');
+    });
+    mockCreate.mockResolvedValue(makeLlmResponse('Response without engram.'));
+
+    const result = await engine.chat(
+      defaultChatParams({
+        appContext: {
+          app: 'cerebrum',
+          entityType: 'engram',
+          entityId: 'eng_nonexistent',
+        },
+      })
+    );
+
+    // Should still produce a valid response without the engram.
+    expect(result.response.content).toBe('Response without engram.');
+    expect(result.retrievedEngrams).toHaveLength(0);
+  });
+
+  it('prepends auto-loaded engram before Thalamus results', async () => {
+    const thalamusResult: RetrievalResult = {
+      sourceType: 'engram',
+      sourceId: 'eng_20260401_0000_other',
+      title: 'Other Engram',
+      contentPreview: 'Other content.',
+      score: 0.75,
+      matchType: 'semantic',
+      metadata: {},
+    };
+    mockHybrid.mockResolvedValue([thalamusResult]);
+    mockEngramRead.mockReturnValue({
+      engram: {
+        id: 'eng_20260427_1500_viewed',
+        title: 'Viewed Engram',
+        type: 'note',
+        scopes: ['personal'],
+        tags: [],
+        created: '2026-04-27',
+      },
+      body: 'Viewed engram body.',
+    });
+    mockCreate.mockResolvedValue(makeLlmResponse('Combined response.'));
+
+    const result = await engine.chat(
+      defaultChatParams({
+        appContext: {
+          app: 'cerebrum',
+          entityType: 'engram',
+          entityId: 'eng_20260427_1500_viewed',
+        },
+      })
+    );
+
+    expect(result.retrievedEngrams).toHaveLength(2);
+    expect(result.retrievedEngrams[0]?.engramId).toBe('eng_20260427_1500_viewed');
+    expect(result.retrievedEngrams[0]?.relevanceScore).toBe(1.0);
+    expect(result.retrievedEngrams[1]?.engramId).toBe('eng_20260401_0000_other');
+    expect(result.retrievedEngrams[1]?.relevanceScore).toBe(0.75);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Scope biasing from app context
+// ---------------------------------------------------------------------------
+
+describe('ConversationEngine — scope biasing', () => {
+  let engine: InstanceType<typeof ConversationEngine>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    engine = new ConversationEngine();
+  });
+
+  it('adds personal.finance scope when app is finance', async () => {
+    mockHybrid.mockResolvedValue([]);
+    mockCreate.mockResolvedValue(makeLlmResponse('Response.'));
+
+    await engine.chat(
+      defaultChatParams({
+        activeScopes: ['work.projects'],
+        appContext: { app: 'finance' },
+      })
+    );
+
+    const filters = getHybridFilters();
+    const scopes = filters['scopes'] as string[];
+    expect(scopes).toContain('work.projects');
+    expect(scopes).toContain('personal.finance');
+  });
+
+  it('adds personal.media scope when app is media', async () => {
+    mockHybrid.mockResolvedValue([]);
+    mockCreate.mockResolvedValue(makeLlmResponse('Response.'));
+
+    await engine.chat(
+      defaultChatParams({
+        activeScopes: [],
+        appContext: { app: 'media' },
+      })
+    );
+
+    const filters = getHybridFilters();
+    const scopes = filters['scopes'] as string[];
+    expect(scopes).toContain('personal.media');
+  });
+
+  it('adds personal.inventory scope when app is inventory', async () => {
+    mockHybrid.mockResolvedValue([]);
+    mockCreate.mockResolvedValue(makeLlmResponse('Response.'));
+
+    await engine.chat(
+      defaultChatParams({
+        activeScopes: ['personal.journal'],
+        appContext: { app: 'inventory' },
+      })
+    );
+
+    const filters = getHybridFilters();
+    const scopes = filters['scopes'] as string[];
+    expect(scopes).toContain('personal.journal');
+    expect(scopes).toContain('personal.inventory');
+  });
+
+  it('does not duplicate scope if already present', async () => {
+    mockHybrid.mockResolvedValue([]);
+    mockCreate.mockResolvedValue(makeLlmResponse('Response.'));
+
+    await engine.chat(
+      defaultChatParams({
+        activeScopes: ['personal.finance'],
+        appContext: { app: 'finance' },
+      })
+    );
+
+    const filters = getHybridFilters();
+    const scopes = filters['scopes'] as string[];
+    const financeCount = scopes.filter((s: string) => s === 'personal.finance').length;
+    expect(financeCount).toBe(1);
+  });
+
+  it('does not add scope for unknown app', async () => {
+    mockHybrid.mockResolvedValue([]);
+    mockCreate.mockResolvedValue(makeLlmResponse('Response.'));
+
+    await engine.chat(
+      defaultChatParams({
+        activeScopes: ['work.projects'],
+        appContext: { app: 'cerebrum' },
+      })
+    );
+
+    const filters = getHybridFilters();
+    const scopes = filters['scopes'] as string[];
+    expect(scopes).toEqual(['work.projects']);
+  });
+
+  it('merges scope biasing additively — does not replace existing scopes', async () => {
+    mockHybrid.mockResolvedValue([]);
+    mockCreate.mockResolvedValue(makeLlmResponse('Response.'));
+
+    await engine.chat(
+      defaultChatParams({
+        activeScopes: ['work.projects', 'personal.journal'],
+        appContext: { app: 'finance' },
+      })
+    );
+
+    const filters = getHybridFilters();
+    const scopes = filters['scopes'] as string[];
+    expect(scopes).toContain('work.projects');
+    expect(scopes).toContain('personal.journal');
+    expect(scopes).toContain('personal.finance');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Context state endpoint (ego.context.getActive)
+// ---------------------------------------------------------------------------
+
+describe('ConversationPersistence — context state', () => {
+  let db: Database;
+  let svc: InstanceType<typeof ConversationPersistence>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    svc = new ConversationPersistence({
+      db: drizzle(db),
+      now: makeClock(),
+    });
+  });
+
+  it('getContextEntries returns all engram associations for a conversation', () => {
+    const conv = svc.createConversation({ model: 'm' });
+    svc.upsertContext(conv.id, 'eng_20260101_0000_alpha', 0.9);
+    svc.upsertContext(conv.id, 'eng_20260102_0000_beta', 0.75);
+
+    const entries = svc.getContextEntries(conv.id);
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((e) => e.engramId)).toContain('eng_20260101_0000_alpha');
+    expect(entries.map((e) => e.engramId)).toContain('eng_20260102_0000_beta');
+
+    const alpha = entries.find((e) => e.engramId === 'eng_20260101_0000_alpha');
+    expect(alpha?.relevanceScore).toBe(0.9);
+    expect(alpha?.loadedAt).toBeTruthy();
+  });
+
+  it('getContextEntries returns empty array when no entries exist', () => {
+    const conv = svc.createConversation({ model: 'm' });
+    const entries = svc.getContextEntries(conv.id);
+    expect(entries).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: App context update between turns
+// ---------------------------------------------------------------------------
+
+describe('ConversationPersistence — updateAppContext', () => {
+  let db: Database;
+  let svc: InstanceType<typeof ConversationPersistence>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    svc = new ConversationPersistence({
+      db: drizzle(db),
+      now: makeClock(),
+    });
+  });
+
+  it('updates app context on the conversation', () => {
+    const conv = svc.createConversation({
+      model: 'm',
+      appContext: { app: 'finance', route: '/transactions' },
+    });
+    expect(conv.appContext).toEqual({ app: 'finance', route: '/transactions' });
+
+    svc.updateAppContext(conv.id, { app: 'media', route: '/watchlist' });
+
+    const refreshed = svc.getConversation(conv.id);
+    expect(refreshed!.conversation.appContext).toEqual({ app: 'media', route: '/watchlist' });
+    expect(refreshed!.conversation.updatedAt).not.toBe(conv.updatedAt);
+  });
+
+  it('sets app context to null when passed null', () => {
+    const conv = svc.createConversation({
+      model: 'm',
+      appContext: { app: 'finance' },
+    });
+
+    svc.updateAppContext(conv.id, null);
+
+    const refreshed = svc.getConversation(conv.id);
+    expect(refreshed!.conversation.appContext).toBeNull();
+  });
+
+  it('sets app context from null to a value', () => {
+    const conv = svc.createConversation({ model: 'm' });
+    expect(conv.appContext).toBeNull();
+
+    svc.updateAppContext(conv.id, { app: 'inventory' });
+
+    const refreshed = svc.getConversation(conv.id);
+    expect(refreshed!.conversation.appContext).toEqual({ app: 'inventory' });
+  });
+});

--- a/apps/pops-api/src/modules/ego/engine.ts
+++ b/apps/pops-api/src/modules/ego/engine.ts
@@ -1,11 +1,13 @@
 /**
- * ConversationEngine — multi-turn conversation manager for Ego (PRD-087 US-01).
+ * ConversationEngine — multi-turn conversation manager for Ego (PRD-087 US-01, US-03).
  *
  * Orchestrates the chat pipeline: Thalamus retrieval, context window assembly,
- * LLM call, citation parsing, and token tracking.
+ * LLM call, citation parsing, and token tracking. Supports app-context-aware
+ * scope biasing and automatic engram loading (US-03).
  */
 import { getDrizzle } from '../../db.js';
 import { logger } from '../../lib/logger.js';
+import { getEngramService } from '../cerebrum/instance.js';
 import { CitationParser } from '../cerebrum/query/citation-parser.js';
 import { ContextAssemblyService } from '../cerebrum/retrieval/context-assembly.js';
 import { HybridSearchService } from '../cerebrum/retrieval/hybrid-search.js';
@@ -13,7 +15,7 @@ import { callChatLlm, callSummariseLlm } from './llm-client.js';
 import { buildEgoSystemPrompt, buildSummarisationPrompt } from './prompts.js';
 
 import type { RetrievalFilters, RetrievalResult } from '../cerebrum/retrieval/types.js';
-import type { ChatParams, ChatResult, EngineConfig, Message } from './types.js';
+import type { AppContext, ChatParams, ChatResult, EngineConfig, Message } from './types.js';
 
 const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
 const DEFAULT_MAX_HISTORY = 20;
@@ -21,16 +23,41 @@ const DEFAULT_MAX_RETRIEVAL = 5;
 const DEFAULT_TOKEN_BUDGET = 4096;
 const DEFAULT_RELEVANCE_THRESHOLD = 0.3;
 
+/**
+ * Maps pops app names to their corresponding scope prefixes for retrieval biasing.
+ * When the user is in a specific app, these scopes are additively merged into
+ * the retrieval filters to improve relevance.
+ */
+const APP_SCOPE_MAP: Record<string, string> = {
+  finance: 'personal.finance',
+  media: 'personal.media',
+  inventory: 'personal.inventory',
+};
+
 function isSecretScope(scope: string): boolean {
   return scope.split('.').includes('secret');
 }
 
-function buildRetrievalFilters(scopes: string[]): RetrievalFilters {
+/**
+ * Build retrieval filters from active scopes, optionally biasing toward
+ * app-context-relevant scopes (additive, not replacing existing scopes).
+ */
+function buildRetrievalFilters(scopes: string[], appContext?: AppContext): RetrievalFilters {
   const filters: RetrievalFilters = {};
-  if (scopes.length > 0) {
-    filters.scopes = scopes;
+
+  const mergedScopes = [...scopes];
+
+  if (appContext?.app) {
+    const appScope = APP_SCOPE_MAP[appContext.app];
+    if (appScope && !mergedScopes.includes(appScope)) {
+      mergedScopes.push(appScope);
+    }
   }
-  if (scopes.some(isSecretScope)) {
+
+  if (mergedScopes.length > 0) {
+    filters.scopes = mergedScopes;
+  }
+  if (mergedScopes.some(isSecretScope)) {
     filters.includeSecret = true;
   }
   return filters;
@@ -69,18 +96,22 @@ export class ConversationEngine {
   async chat(params: ChatParams): Promise<ChatResult> {
     const { message, history, activeScopes, appContext } = params;
 
-    const retrievalResults = await this.retrieveEngrams(message, activeScopes);
+    const retrievalResults = await this.retrieveEngrams(message, activeScopes, appContext);
+
+    // Auto-load viewed engram when the user is viewing one in Cerebrum (US-03).
+    const viewedEngramResult = await this.loadViewedEngram(appContext);
+    const allResults = viewedEngramResult
+      ? [viewedEngramResult, ...retrievalResults]
+      : retrievalResults;
+
     const { systemPrompt, contextBlock } = this.buildContextWindow(
-      retrievalResults,
+      allResults,
       activeScopes,
       appContext
     );
     const llmMessages = this.buildLlmMessages(history, message, contextBlock);
     const llmResponse = await callChatLlm(this.config.model, systemPrompt, llmMessages);
-    const { cleanedAnswer, citations } = this.citationParser.parse(
-      llmResponse.content,
-      retrievalResults
-    );
+    const { cleanedAnswer, citations } = this.citationParser.parse(llmResponse.content, allResults);
 
     return {
       response: {
@@ -89,7 +120,7 @@ export class ConversationEngine {
         tokensIn: llmResponse.tokensIn,
         tokensOut: llmResponse.tokensOut,
       },
-      retrievedEngrams: retrievalResults.map((r) => ({
+      retrievedEngrams: allResults.map((r) => ({
         engramId: r.sourceId,
         relevanceScore: r.score,
       })),
@@ -103,9 +134,13 @@ export class ConversationEngine {
     return callSummariseLlm(this.config.model, prompt, messages.length);
   }
 
-  private async retrieveEngrams(query: string, scopes: string[]): Promise<RetrievalResult[]> {
+  private async retrieveEngrams(
+    query: string,
+    scopes: string[],
+    appContext?: AppContext
+  ): Promise<RetrievalResult[]> {
     try {
-      const filters = buildRetrievalFilters(scopes);
+      const filters = buildRetrievalFilters(scopes, appContext);
       const hybridSearch = new HybridSearchService(getDrizzle());
       return await hybridSearch.hybrid(
         query,
@@ -119,6 +154,41 @@ export class ConversationEngine {
         '[Ego] Thalamus retrieval failed — continuing without engram context'
       );
       return [];
+    }
+  }
+
+  /**
+   * When the user is viewing an engram (appContext.entityType === 'engram'),
+   * auto-load it as a synthetic RetrievalResult with maximum relevance (1.0).
+   * Returns null if not viewing an engram or if the read fails.
+   */
+  private async loadViewedEngram(appContext?: AppContext): Promise<RetrievalResult | null> {
+    if (appContext?.entityType !== 'engram' || !appContext.entityId) {
+      return null;
+    }
+
+    try {
+      const { engram, body } = getEngramService().read(appContext.entityId);
+      return {
+        sourceType: 'engram',
+        sourceId: engram.id,
+        title: engram.title,
+        contentPreview: body,
+        score: 1.0,
+        matchType: 'semantic',
+        metadata: {
+          type: engram.type,
+          scopes: engram.scopes,
+          tags: engram.tags,
+          createdAt: engram.created,
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        { engramId: appContext.entityId, error: err instanceof Error ? err.message : String(err) },
+        '[Ego] Failed to auto-load viewed engram — continuing without it'
+      );
+      return null;
     }
   }
 

--- a/apps/pops-api/src/modules/ego/index.ts
+++ b/apps/pops-api/src/modules/ego/index.ts
@@ -4,13 +4,15 @@
  * Procedures:
  *   ego.conversations.create/list/get/delete — CRUD (US-05)
  *   ego.chat                                 — multi-turn conversation (US-01)
+ *   ego.context.getActive                    — context state query (US-03)
  */
 import { mergeRouters, router } from '../../trpc.js';
-import { chatRouter, conversationsRouter } from './router.js';
+import { chatRouter, contextRouter, conversationsRouter } from './router.js';
 
 export const egoRouter = mergeRouters(
   chatRouter,
   router({
     conversations: conversationsRouter,
+    context: contextRouter,
   })
 );

--- a/apps/pops-api/src/modules/ego/persistence.ts
+++ b/apps/pops-api/src/modules/ego/persistence.ts
@@ -175,6 +175,33 @@ export class ConversationPersistence {
       .run();
   }
 
+  /** Update the conversation's app context JSON. */
+  updateAppContext(conversationId: string, appContext: unknown): void {
+    this.db
+      .update(conversations)
+      .set({
+        appContext: appContext != null ? JSON.stringify(appContext) : null,
+        updatedAt: this.now().toISOString(),
+      })
+      .where(eq(conversations.id, conversationId))
+      .run();
+  }
+
+  /** Get all context entries (engram associations) for a conversation. */
+  getContextEntries(
+    conversationId: string
+  ): Array<{ engramId: string; relevanceScore: number | null; loadedAt: string }> {
+    return this.db
+      .select({
+        engramId: conversationContext.engramId,
+        relevanceScore: conversationContext.relevanceScore,
+        loadedAt: conversationContext.loadedAt,
+      })
+      .from(conversationContext)
+      .where(eq(conversationContext.conversationId, conversationId))
+      .all();
+  }
+
   /** Auto-generate title from first user message when no title is set. */
   private maybeAutoTitle(conversationId: string, input: AppendMessageInput): void {
     if (input.role !== 'user') return;

--- a/apps/pops-api/src/modules/ego/prompts.ts
+++ b/apps/pops-api/src/modules/ego/prompts.ts
@@ -1,11 +1,57 @@
 /**
- * LLM system prompt templates for the Ego conversation engine (PRD-087 US-01).
+ * LLM system prompt templates for the Ego conversation engine (PRD-087 US-01, US-03).
  *
  * Prompts are exported as pure functions so they can be tested and overridden
  * without coupling to the engine class.
  */
 
 import type { AppContext } from './types.js';
+
+/** Human-readable labels for pops app names used in context descriptions. */
+const APP_LABELS: Record<string, string> = {
+  finance: 'finance',
+  media: 'media',
+  inventory: 'inventory',
+  cerebrum: 'Cerebrum',
+  ai: 'AI Ops',
+};
+
+/** Human-readable labels for entity types used in context descriptions. */
+const ENTITY_LABELS: Record<string, string> = {
+  engram: 'engram',
+  transaction: 'transaction',
+  movie: 'movie',
+  tv_show: 'TV show',
+  item: 'inventory item',
+};
+
+/**
+ * Format app context into a human-readable description for the system prompt.
+ *
+ * Examples:
+ * - "The user is currently viewing their movie collection in the media app"
+ * - "The user is looking at transaction #1234 in the finance app"
+ * - "The user is viewing engram eng_20260427_1500_test in Cerebrum"
+ */
+export function formatAppContextDescription(appContext: AppContext): string {
+  const appLabel = APP_LABELS[appContext.app] ?? appContext.app;
+  const entityLabel = appContext.entityType
+    ? (ENTITY_LABELS[appContext.entityType] ?? appContext.entityType)
+    : null;
+
+  if (appContext.entityId && entityLabel) {
+    if (appContext.entityType === 'engram') {
+      return `The user is viewing ${entityLabel} ${appContext.entityId} in ${appLabel}`;
+    }
+    return `The user is looking at ${entityLabel} #${appContext.entityId} in the ${appLabel} app`;
+  }
+
+  if (appContext.route) {
+    return `The user is currently on ${appContext.route} in the ${appLabel} app`;
+  }
+
+  return `The user is currently in the ${appLabel} app`;
+}
 
 /**
  * Build the Ego system prompt for a conversation turn.
@@ -16,12 +62,7 @@ import type { AppContext } from './types.js';
 export function buildEgoSystemPrompt(scopes: string[], appContext?: AppContext): string {
   const scopeList = scopes.length > 0 ? scopes.join(', ') : '(all non-secret scopes)';
 
-  const appLine = appContext ? `\nThe user is currently in: ${appContext.app}` : '';
-  const routeLine = appContext?.route ? ` (route: ${appContext.route})` : '';
-  const entityLine =
-    appContext?.entityId && appContext.entityType
-      ? ` viewing ${appContext.entityType}: ${appContext.entityId}`
-      : '';
+  const contextLine = appContext ? `\n${formatAppContextDescription(appContext)}` : '';
 
   return `You are Ego, the conversational interface to Cerebrum \u2014 a personal knowledge management system.
 
@@ -30,7 +71,7 @@ Your capabilities:
 - Answer questions grounded in stored engrams
 - Help the user explore connections between their stored knowledge
 
-Active scopes for this conversation: ${scopeList}${appLine}${routeLine}${entityLine}
+Active scopes for this conversation: ${scopeList}${contextLine}
 
 When referencing engrams, always cite them by ID in square brackets: [eng_YYYYMMDD_HHmm_slug]
 If the available context doesn't contain enough information, say so explicitly rather than guessing.`;

--- a/apps/pops-api/src/modules/ego/router.ts
+++ b/apps/pops-api/src/modules/ego/router.ts
@@ -70,6 +70,20 @@ const chatInputSchema = z.object({
   appContext: appContextSchema,
 });
 
+/**
+ * Detect whether the incoming appContext differs from the stored one.
+ * Uses JSON serialisation for deep equality since AppContext is a simple object.
+ */
+function appContextChanged(stored: unknown | null, incoming: AppContext | undefined): boolean {
+  if (!stored && !incoming) return false;
+  if (!stored || !incoming) return true;
+  return JSON.stringify(stored) !== JSON.stringify(incoming);
+}
+
+const contextGetActiveSchema = z.object({
+  conversationId: z.string().min(1),
+});
+
 export const chatRouter = router({
   chat: protectedProcedure.input(chatInputSchema).mutation(async ({ input }) => {
     const store = getStore();
@@ -93,10 +107,17 @@ export const chatRouter = router({
       conversationId = conversation.id;
     }
 
+    // Update app context if it changed between turns (US-03).
+    if (appContext && appContextChanged(conversation.appContext, appContext)) {
+      persistence.updateAppContext(conversation.id, appContext);
+      conversation = { ...conversation, appContext };
+    }
+
     // Load message history.
     const history = await store.getMessages(conversation.id);
 
-    // Run the conversation engine.
+    // Run the conversation engine — use incoming appContext for current turn.
+    const effectiveAppContext = (appContext ?? conversation.appContext) as AppContext | undefined;
     let result;
     try {
       result = await engine.chat({
@@ -104,7 +125,7 @@ export const chatRouter = router({
         message: input.message,
         history,
         activeScopes: conversation.activeScopes,
-        appContext: conversation.appContext as AppContext | undefined,
+        appContext: effectiveAppContext,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -135,6 +156,31 @@ export const chatRouter = router({
       conversationId: conversation.id,
       response: assistantMsg,
       retrievedEngrams: result.retrievedEngrams,
+    };
+  }),
+});
+
+export const contextRouter = router({
+  getActive: protectedProcedure.input(contextGetActiveSchema).query(({ input }) => {
+    const persistence = getPersistence();
+    const result = persistence.getConversation(input.conversationId);
+
+    if (!result) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: `Conversation '${input.conversationId}' not found`,
+      });
+    }
+
+    const contextEntries = persistence.getContextEntries(input.conversationId);
+
+    return {
+      scopes: result.conversation.activeScopes,
+      appContext: result.conversation.appContext,
+      engrams: contextEntries.map((entry) => ({
+        id: entry.engramId,
+        relevanceScore: entry.relevanceScore ?? 0,
+      })),
     };
   }),
 });

--- a/docs/themes/06-cerebrum/prds/087-ego-core/README.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/README.md
@@ -93,7 +93,7 @@ Build the conversational agent core — the "I" of the system. Ego manages multi
 | --- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------- | ---------------- |
 | 01  | [us-01-conversation-engine](us-01-conversation-engine.md)           | Multi-turn conversation management: history, context window, system prompt             | Not started | No (first)       |
 | 02  | [us-02-shell-chat-panel](us-02-shell-chat-panel.md)                 | React component in pops-shell: streaming responses, message history, conversation list | Not started | Blocked by us-01 |
-| 03  | [us-03-context-awareness](us-03-context-awareness.md)               | App-aware context: current pops app, recent actions, active engram context             | Not started | Blocked by us-01 |
+| 03  | [us-03-context-awareness](us-03-context-awareness.md)               | App-aware context: current pops app, recent actions, active engram context             | Partial     | Blocked by us-01 |
 | 04  | [us-04-scope-negotiation](us-04-scope-negotiation.md)               | Infer scopes from conversation: explicit mentions, topic inference, channel defaults   | Not started | Blocked by us-01 |
 | 05  | [us-05-conversation-persistence](us-05-conversation-persistence.md) | SQLite persistence: conversations, messages, context metadata                          | Not started | Yes              |
 

--- a/docs/themes/06-cerebrum/prds/087-ego-core/us-03-context-awareness.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/us-03-context-awareness.md
@@ -8,14 +8,14 @@ As the Ego system, I need to know which pops app the user is currently in, what 
 
 ## Acceptance Criteria
 
-- [ ] The conversation engine receives app context on each message: the active pops app (e.g., `media`, `finance`, `inventory`, `cerebrum`), the current route or view, and optionally the entity being viewed (e.g., a specific movie, transaction, or engram)
-- [ ] App context is included in the system prompt augmentation — the LLM knows "the user is currently viewing their movie collection" or "the user is looking at transaction #1234"
-- [ ] When the user is viewing an engram in Cerebrum, that engram is automatically loaded into the conversation context with maximum relevance score, regardless of whether Thalamus retrieval would have found it
+- [x] The conversation engine receives app context on each message: the active pops app (e.g., `media`, `finance`, `inventory`, `cerebrum`), the current route or view, and optionally the entity being viewed (e.g., a specific movie, transaction, or engram)
+- [x] App context is included in the system prompt augmentation — the LLM knows "the user is currently viewing their movie collection" or "the user is looking at transaction #1234"
+- [x] When the user is viewing an engram in Cerebrum, that engram is automatically loaded into the conversation context with maximum relevance score, regardless of whether Thalamus retrieval would have found it
 - [ ] Recent user actions (last 5, configurable) from the active pops app are summarised in the context — e.g., "user recently searched for 'sci-fi movies', viewed 'Blade Runner 2049', added a tag to 'Arrival'"
-- [ ] Context updates propagate to subsequent Thalamus queries — retrieval is biased toward engrams relevant to the active app context (e.g., querying in the finance app biases toward `personal.finance.*` scopes)
-- [ ] If the user switches pops apps mid-conversation (detected on the next message), the app context is updated and the system prompt is regenerated for the next turn
-- [ ] The `ego.context.getActive` procedure returns the current context state: active scopes, app context, and the list of engrams loaded in context with their relevance scores
-- [ ] App context is stored on the `conversations` row as JSON and persists across page refreshes
+- [x] Context updates propagate to subsequent Thalamus queries — retrieval is biased toward engrams relevant to the active app context (e.g., querying in the finance app biases toward `personal.finance.*` scopes)
+- [x] If the user switches pops apps mid-conversation (detected on the next message), the app context is updated and the system prompt is regenerated for the next turn
+- [x] The `ego.context.getActive` procedure returns the current context state: active scopes, app context, and the list of engrams loaded in context with their relevance scores
+- [x] App context is stored on the `conversations` row as JSON and persists across page refreshes
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Rich app context in system prompt ("The user is viewing engram X in Cerebrum")
- Auto-load viewed engram into context with max relevance (1.0)
- Scope biasing from active app (finance → personal.finance.*, etc.)
- ego.context.getActive query endpoint
- App context update detection between turns
- 30 unit tests across 6 describe blocks

## Test plan

- [x] `pnpm typecheck` passes (17/17)
- [x] `pnpm test` passes (3207 tests, 184 files)
- [x] Pre-commit hooks pass

Closes #2224