### PR TITLE
feat(cerebrum): document generation (PRD-083)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/emit/__tests__/generation-service.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/__tests__/generation-service.test.ts
@@ -1,0 +1,433 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RetrievalResult } from '../../retrieval/types.js';
+import type { GenerationService as GenerationServiceType } from '../generation-service.js';
+
+// Mock external dependencies before importing the service.
+vi.mock('../../../../db.js', () => ({
+  getDrizzle: vi.fn(),
+}));
+
+vi.mock('../../../../env.js', () => ({
+  getEnv: vi.fn((key: string) => {
+    if (key === 'ANTHROPIC_API_KEY') return 'test-key';
+    return undefined;
+  }),
+}));
+
+vi.mock('../../../../lib/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../lib/inference-middleware.js', () => ({
+  trackInference: vi.fn((_meta: unknown, fn: () => unknown) => fn()),
+}));
+
+vi.mock('../../../../lib/ai-retry.js', () => ({
+  withRateLimitRetry: vi.fn((fn: () => unknown) => fn()),
+}));
+
+// Mock the LLM caller.
+const mockCallLlm = vi.fn<(systemPrompt: string, userMessage: string) => Promise<string>>();
+vi.mock('../llm.js', () => ({
+  callEmitLlm: (...args: unknown[]) => mockCallLlm(args[0] as string, args[1] as string),
+}));
+
+// Mock the HybridSearchService.
+const mockHybrid = vi.fn<() => Promise<RetrievalResult[]>>();
+vi.mock('../../retrieval/hybrid-search.js', () => {
+  return {
+    HybridSearchService: class MockHybridSearchService {
+      hybrid = mockHybrid;
+    },
+  };
+});
+
+// Mock the ContextAssemblyService (depends on retrieval/types only, no @pops/db-types).
+vi.mock('../../retrieval/context-assembly.js', () => {
+  return {
+    ContextAssemblyService: class MockContextAssemblyService {
+      assemble = vi.fn((input: { query: string; results: RetrievalResult[] }) => ({
+        context: `Query: ${input.query}\n\n${input.results.map((r) => `[${r.sourceType}:${r.sourceId}] ${r.title}\n${r.contentPreview}`).join('\n---\n')}`,
+        sources: input.results.map((r) => ({
+          sourceType: r.sourceType,
+          sourceId: r.sourceId,
+          title: r.title,
+          relevanceScore: r.score,
+        })),
+        truncated: false,
+        tokenEstimate: 100,
+      }));
+    },
+  };
+});
+
+// Dynamic import after mocks are set up.
+const { GenerationService } = await import('../generation-service.js');
+
+function makeResult(sourceId: string, metadata: Record<string, unknown> = {}): RetrievalResult {
+  return {
+    sourceType: 'engram',
+    sourceId,
+    title: `Engram ${sourceId}`,
+    contentPreview: `Content for ${sourceId}. This is some substantive text about the topic.`,
+    score: 0.8,
+    matchType: 'semantic',
+    metadata: {
+      scopes: ['work.projects'],
+      createdAt: '2026-04-15T10:00:00Z',
+      type: 'note',
+      ...metadata,
+    },
+  };
+}
+
+describe('GenerationService', () => {
+  let service: GenerationServiceType;
+
+  beforeEach(() => {
+    service = new GenerationService();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ---------- Report generation ----------
+
+  describe('generateReport', () => {
+    it('generates a report with sections and citations', async () => {
+      const results = [
+        makeResult('eng_20260415_1000_agent-coordination', {
+          type: 'decision',
+          scopes: ['work.projects.karbon'],
+        }),
+        makeResult('eng_20260416_0900_architecture-review', {
+          type: 'meeting',
+          scopes: ['work.projects.karbon'],
+        }),
+        makeResult('eng_20260417_1400_implementation-plan', {
+          type: 'research',
+          scopes: ['work.projects.karbon'],
+        }),
+      ];
+      mockHybrid.mockResolvedValueOnce(results);
+
+      mockCallLlm.mockResolvedValueOnce(
+        '# Agent Coordination Report\n\n' +
+          'Introduction about agent coordination.\n\n' +
+          '## Architecture Decisions\n\n' +
+          'The team decided on a modular approach [eng_20260415_1000_agent-coordination].\n\n' +
+          '## Implementation\n\n' +
+          'The implementation plan covers [eng_20260417_1400_implementation-plan].\n\n' +
+          '## Conclusion\n\n' +
+          'Summary of findings.'
+      );
+
+      const result = await service.generateReport({
+        mode: 'report',
+        query: 'agent coordination decisions',
+      });
+
+      expect(result.document).not.toBeNull();
+      expect(result.document?.title).toBe('Agent Coordination Report');
+      expect(result.document?.mode).toBe('report');
+      expect(result.document?.body).toContain('## Architecture Decisions');
+      expect(result.document?.body).toContain('## Implementation');
+      expect(result.document?.sources.length).toBeGreaterThan(0);
+    });
+
+    it('returns notice for zero results', async () => {
+      mockHybrid.mockResolvedValueOnce([]);
+
+      const result = await service.generateReport({
+        mode: 'report',
+        query: 'nonexistent topic',
+      });
+
+      expect(result.document).toBeNull();
+      expect(result.notice).toBe('No relevant engrams found for this query');
+    });
+
+    it('returns notice for insufficient sources (< 2)', async () => {
+      mockHybrid.mockResolvedValueOnce([makeResult('eng_1')]);
+
+      const result = await service.generateReport({
+        mode: 'report',
+        query: 'sparse topic',
+      });
+
+      expect(result.document).toBeNull();
+      expect(result.notice).toBe('Insufficient data to generate a meaningful report');
+    });
+
+    it('applies audience scope filtering', async () => {
+      const results = [
+        makeResult('eng_1', { scopes: ['work.projects'] }),
+        makeResult('eng_2', { scopes: ['personal.journal'] }),
+        makeResult('eng_3', { scopes: ['work.meetings'] }),
+      ];
+      mockHybrid.mockResolvedValueOnce(results);
+
+      mockCallLlm.mockResolvedValueOnce('# Report\n\nFiltered content [eng_1].');
+
+      const result = await service.generateReport({
+        mode: 'report',
+        query: 'work status',
+        audienceScope: 'work.*',
+      });
+
+      expect(result.document).not.toBeNull();
+      expect(result.document?.audienceScope).toBe('work.*');
+    });
+
+    it('excludes secret scopes by default', async () => {
+      const results = [
+        makeResult('eng_1', { scopes: ['work.projects'] }),
+        makeResult('eng_2', { scopes: ['work.secret.salary'] }),
+        makeResult('eng_3', { scopes: ['work.meetings'] }),
+      ];
+      mockHybrid.mockResolvedValueOnce(results);
+
+      mockCallLlm.mockResolvedValueOnce('# Report\n\nContent [eng_1] [eng_3].');
+
+      const result = await service.generateReport({
+        mode: 'report',
+        query: 'work overview',
+      });
+
+      // eng_2 (secret) should be excluded from sources
+      expect(result.document).not.toBeNull();
+      const sourceIds = result.document?.sources.map((s) => s.id) ?? [];
+      expect(sourceIds).not.toContain('eng_2');
+    });
+  });
+
+  // ---------- Summary generation ----------
+
+  describe('generateSummary', () => {
+    it('generates a summary with date range', async () => {
+      const results = [
+        makeResult('eng_1', { createdAt: '2026-04-01T10:00:00Z', type: 'decision' }),
+        makeResult('eng_2', { createdAt: '2026-04-03T10:00:00Z', type: 'meeting' }),
+        makeResult('eng_3', { createdAt: '2026-04-05T10:00:00Z', type: 'research' }),
+      ];
+      mockHybrid.mockResolvedValueOnce(results);
+
+      mockCallLlm.mockResolvedValueOnce(
+        '# Weekly Summary: 2026-04-01 to 2026-04-07\n\n' +
+          '## Highlights\n\n- Key decision [eng_1]\n\n' +
+          '## Decisions\n\n- Decision item [eng_1]\n\n' +
+          '## Meetings\n\n- Meeting notes [eng_2]\n\n' +
+          '## Research\n\n- Research findings [eng_3]'
+      );
+
+      const result = await service.generateSummary({
+        mode: 'summary',
+        dateRange: { from: '2026-04-01', to: '2026-04-07' },
+      });
+
+      expect(result.document).not.toBeNull();
+      expect(result.document?.mode).toBe('summary');
+      expect(result.document?.body).toContain('## Highlights');
+      expect(result.document?.sources).toHaveLength(3);
+    });
+
+    it('returns empty summary for zero engrams in date range', async () => {
+      mockHybrid.mockResolvedValueOnce([]);
+
+      const result = await service.generateSummary({
+        mode: 'summary',
+        dateRange: { from: '2026-04-01', to: '2026-04-07' },
+      });
+
+      expect(result.document).not.toBeNull();
+      expect(result.document?.body).toContain('No engrams found between 2026-04-01 and 2026-04-07');
+      expect(result.document?.sources).toHaveLength(0);
+    });
+
+    it('groups by type when no topic filter', async () => {
+      const results = [
+        makeResult('eng_1', { type: 'decision' }),
+        makeResult('eng_2', { type: 'meeting' }),
+      ];
+      mockHybrid.mockResolvedValueOnce(results);
+
+      mockCallLlm.mockResolvedValueOnce(
+        '# Summary\n\n## Decisions\n\n- Item [eng_1]\n\n## Meetings\n\n- Item [eng_2]'
+      );
+
+      const result = await service.generateSummary({
+        mode: 'summary',
+        dateRange: { from: '2026-04-01', to: '2026-04-07' },
+      });
+
+      expect(result.document).not.toBeNull();
+      expect(result.document?.body).toContain('## Decisions');
+      expect(result.document?.body).toContain('## Meetings');
+    });
+  });
+
+  // ---------- Timeline generation ----------
+
+  describe('generateTimeline', () => {
+    it('generates a chronological timeline', async () => {
+      const results = [
+        makeResult('eng_1', { createdAt: '2026-01-15T10:00:00Z', type: 'decision' }),
+        makeResult('eng_2', { createdAt: '2026-03-20T10:00:00Z', type: 'meeting' }),
+        makeResult('eng_3', { createdAt: '2026-06-10T10:00:00Z', type: 'research' }),
+      ];
+      mockHybrid.mockResolvedValueOnce(results);
+
+      mockCallLlm.mockResolvedValueOnce(
+        '# Decision Timeline\n\n' +
+          '**2026-01-15** — [decision] **Architecture Decision** — Chose microservices [eng_1]\n\n' +
+          '**2026-03-20** — [meeting] **Review Meeting** — Quarterly review [eng_2]\n\n' +
+          '**2026-06-10** — [research] **Performance Study** — Benchmark results [eng_3]'
+      );
+
+      const result = await service.generateTimeline({
+        mode: 'timeline',
+        query: 'decisions over time',
+      });
+
+      expect(result.document).not.toBeNull();
+      expect(result.document?.mode).toBe('timeline');
+      expect(result.document?.title).toBe('Decision Timeline');
+      expect(result.document?.dateRange).toEqual({
+        from: '2026-01-15T10:00:00Z',
+        to: '2026-06-10T10:00:00Z',
+      });
+    });
+
+    it('returns notice for zero results', async () => {
+      mockHybrid.mockResolvedValueOnce([]);
+
+      const result = await service.generateTimeline({
+        mode: 'timeline',
+      });
+
+      expect(result.document).toBeNull();
+      expect(result.notice).toBe('No relevant engrams found for this timeline');
+    });
+
+    it('handles single entry timeline', async () => {
+      const results = [
+        makeResult('eng_1', { createdAt: '2026-04-15T10:00:00Z', type: 'decision' }),
+      ];
+      mockHybrid.mockResolvedValueOnce(results);
+
+      mockCallLlm.mockResolvedValueOnce(
+        '# Timeline\n\n**2026-04-15** — [decision] **Single Decision** — The only entry [eng_1]'
+      );
+
+      const result = await service.generateTimeline({
+        mode: 'timeline',
+      });
+
+      expect(result.document).not.toBeNull();
+      expect(result.document?.body).toContain('single point in time');
+      expect(result.document?.sources).toHaveLength(1);
+    });
+
+    it('applies date range filtering', async () => {
+      const results = [
+        makeResult('eng_1', { createdAt: '2026-04-01T10:00:00Z' }),
+        makeResult('eng_2', { createdAt: '2026-04-15T10:00:00Z' }),
+      ];
+      mockHybrid.mockResolvedValueOnce(results);
+
+      mockCallLlm.mockResolvedValueOnce('# Timeline\n\nEntries [eng_1] [eng_2].');
+
+      const result = await service.generateTimeline({
+        mode: 'timeline',
+        dateRange: { from: '2026-04-01', to: '2026-04-30' },
+      });
+
+      expect(result.document).not.toBeNull();
+      // Verify mockHybrid was called (retrieval happened)
+      expect(mockHybrid).toHaveBeenCalled();
+    });
+  });
+
+  // ---------- Preview ----------
+
+  describe('preview', () => {
+    it('returns sources and outline without full generation', async () => {
+      const results = [
+        makeResult('eng_1', { type: 'decision' }),
+        makeResult('eng_2', { type: 'meeting' }),
+      ];
+      mockHybrid.mockResolvedValueOnce(results);
+
+      mockCallLlm.mockResolvedValueOnce(
+        '# Report Outline\n\n- ## Architecture [eng_1]\n- ## Process [eng_2]'
+      );
+
+      const preview = await service.preview({
+        mode: 'report',
+        query: 'agent coordination',
+      });
+
+      expect(preview.sources).toHaveLength(2);
+      expect(preview.outline).toContain('Architecture');
+      expect(preview.outline).toContain('Process');
+    });
+
+    it('returns empty outline for zero sources', async () => {
+      mockHybrid.mockResolvedValueOnce([]);
+
+      const preview = await service.preview({
+        mode: 'report',
+        query: 'nonexistent topic',
+      });
+
+      expect(preview.sources).toHaveLength(0);
+      expect(preview.outline).toContain('No sources found');
+    });
+  });
+
+  // ---------- generate() dispatcher ----------
+
+  describe('generate', () => {
+    it('dispatches to generateReport for report mode', async () => {
+      const results = [makeResult('eng_1'), makeResult('eng_2')];
+      mockHybrid.mockResolvedValueOnce(results);
+      mockCallLlm.mockResolvedValueOnce('# Report\n\nContent [eng_1].');
+
+      const result = await service.generate({
+        mode: 'report',
+        query: 'test topic',
+      });
+
+      expect(result.document?.mode).toBe('report');
+    });
+
+    it('dispatches to generateSummary for summary mode', async () => {
+      mockHybrid.mockResolvedValueOnce([]);
+
+      const result = await service.generate({
+        mode: 'summary',
+        dateRange: { from: '2026-04-01', to: '2026-04-07' },
+      });
+
+      expect(result.document?.mode).toBe('summary');
+    });
+
+    it('dispatches to generateTimeline for timeline mode', async () => {
+      mockHybrid.mockResolvedValueOnce([]);
+
+      const result = await service.generate({
+        mode: 'timeline',
+      });
+
+      expect(result.document).toBeNull();
+    });
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/emit/__tests__/modes.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/__tests__/modes.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from 'vitest';
+
+import { toSourceCitations, extractDateRange } from '../helpers.js';
+import { checkReportSources, buildReportDocument } from '../modes/report.js';
+import {
+  buildEmptySummary,
+  capSummaryResults,
+  sortByTypeImportance,
+  buildSummaryDocument,
+} from '../modes/summary.js';
+import {
+  sortChronologically,
+  buildSingleEntryNotice,
+  buildTimelineDocument,
+} from '../modes/timeline.js';
+
+import type { RetrievalResult } from '../../retrieval/types.js';
+
+/** Helper that properly handles metadata merging. */
+function makeResult(
+  sourceId: string,
+  metadata: Record<string, unknown> = {},
+  overrides: Partial<Omit<RetrievalResult, 'metadata'>> = {}
+): RetrievalResult {
+  return {
+    sourceType: 'engram',
+    sourceId,
+    title: `Engram ${sourceId}`,
+    contentPreview: `Content for ${sourceId}`,
+    score: 0.8,
+    matchType: 'semantic',
+    metadata: {
+      scopes: ['work.projects'],
+      createdAt: '2026-04-15T10:00:00Z',
+      type: 'note',
+      ...metadata,
+    },
+    ...overrides,
+  };
+}
+
+// ---------- Report mode ----------
+
+describe('checkReportSources', () => {
+  it('returns null (no issue) when >= 2 sources exist', () => {
+    const results = [makeResult('eng_1'), makeResult('eng_2')];
+    expect(checkReportSources(results)).toBeNull();
+  });
+
+  it('returns notice for zero results', () => {
+    const result = checkReportSources([]);
+    expect(result).not.toBeNull();
+    expect(result?.document).toBeNull();
+    expect(result?.notice).toBe('No relevant engrams found for this query');
+  });
+
+  it('returns notice for insufficient sources (1 result)', () => {
+    const result = checkReportSources([makeResult('eng_1')]);
+    expect(result).not.toBeNull();
+    expect(result?.document).toBeNull();
+    expect(result?.notice).toBe('Insufficient data to generate a meaningful report');
+  });
+});
+
+describe('buildReportDocument', () => {
+  it('extracts title from LLM output H1', () => {
+    const llmOutput = '# Agent Coordination Report\n\nIntroduction here.';
+    const sources = toSourceCitations([makeResult('eng_1'), makeResult('eng_2')]);
+    const doc = buildReportDocument(llmOutput, sources, 'work.*', [
+      makeResult('eng_1'),
+      makeResult('eng_2'),
+    ]);
+
+    expect(doc.title).toBe('Agent Coordination Report');
+    expect(doc.mode).toBe('report');
+    expect(doc.audienceScope).toBe('work.*');
+    expect(doc.sources).toHaveLength(2);
+  });
+
+  it('falls back to generic title when no H1 found', () => {
+    const llmOutput = 'Some content without a heading.';
+    const sources = toSourceCitations([makeResult('eng_1')]);
+    const doc = buildReportDocument(llmOutput, sources, 'work.*', [makeResult('eng_1')]);
+
+    expect(doc.title).toBe('Generated Report');
+  });
+
+  it('includes metadata with source count and scope coverage', () => {
+    const results = [
+      makeResult('eng_1', { scopes: ['work.projects'] }),
+      makeResult('eng_2', { scopes: ['work.meetings'] }),
+    ];
+    const sources = toSourceCitations(results);
+    const doc = buildReportDocument('# Title\nBody', sources, 'work.*', results);
+
+    expect(doc.metadata.sourceCount).toBe(2);
+    expect(doc.metadata.scopeCoverage).toContain('work.projects');
+    expect(doc.metadata.scopeCoverage).toContain('work.meetings');
+    expect(doc.metadata.mode).toBe('report');
+  });
+});
+
+describe('toSourceCitations', () => {
+  it('maps retrieval results to source citations', () => {
+    const results = [makeResult('eng_1')];
+    const citations = toSourceCitations(results);
+
+    expect(citations).toHaveLength(1);
+    expect(citations[0]?.id).toBe('eng_1');
+    expect(citations[0]?.type).toBe('engram');
+    expect(citations[0]?.title).toBe('Engram eng_1');
+    expect(citations[0]?.relevance).toBe(0.8);
+  });
+
+  it('truncates long excerpts', () => {
+    const longContent = 'a'.repeat(300);
+    const results: RetrievalResult[] = [
+      {
+        sourceType: 'engram',
+        sourceId: 'eng_1',
+        title: 'Test',
+        contentPreview: longContent,
+        score: 0.8,
+        matchType: 'semantic',
+        metadata: { scopes: ['work'] },
+      },
+    ];
+    const citations = toSourceCitations(results);
+    expect(citations[0]!.excerpt.length).toBeLessThanOrEqual(203); // 200 + '...'
+  });
+});
+
+// ---------- Summary mode ----------
+
+describe('buildEmptySummary', () => {
+  it('returns a document with empty-range notice', () => {
+    const doc = buildEmptySummary({ from: '2026-04-01', to: '2026-04-07' }, 'work.*');
+
+    expect(doc.mode).toBe('summary');
+    expect(doc.sources).toHaveLength(0);
+    expect(doc.body).toContain('No engrams found between 2026-04-01 and 2026-04-07');
+    expect(doc.dateRange).toEqual({ from: '2026-04-01', to: '2026-04-07' });
+    expect(doc.metadata.sourceCount).toBe(0);
+  });
+});
+
+describe('capSummaryResults', () => {
+  it('returns results unchanged when under the cap', () => {
+    const results = [makeResult('eng_1'), makeResult('eng_2')];
+    const { capped, truncated } = capSummaryResults(results);
+    expect(capped).toHaveLength(2);
+    expect(truncated).toBe(false);
+  });
+
+  it('caps results at 50 and marks as truncated', () => {
+    const results = Array.from({ length: 60 }, (_, i) =>
+      makeResult(`eng_${i}`, {}, { score: 60 - i })
+    );
+    const { capped, truncated } = capSummaryResults(results);
+    expect(capped).toHaveLength(50);
+    expect(truncated).toBe(true);
+    // Should keep highest-scored items
+    expect(capped[0]?.score).toBeGreaterThanOrEqual(capped[49]!.score);
+  });
+});
+
+describe('extractDateRange', () => {
+  it('computes range from createdAt metadata', () => {
+    const results = [
+      makeResult('eng_1', { createdAt: '2026-04-10T10:00:00Z' }),
+      makeResult('eng_2', { createdAt: '2026-04-01T10:00:00Z' }),
+      makeResult('eng_3', { createdAt: '2026-04-20T10:00:00Z' }),
+    ];
+
+    const range = extractDateRange(results);
+    expect(range).toEqual({
+      from: '2026-04-01T10:00:00Z',
+      to: '2026-04-20T10:00:00Z',
+    });
+  });
+
+  it('returns null when no dates available', () => {
+    const results = [makeResult('eng_1', { createdAt: undefined })];
+    expect(extractDateRange(results)).toBeNull();
+  });
+});
+
+describe('sortByTypeImportance', () => {
+  it('sorts by type importance descending (decisions first)', () => {
+    const sources = [
+      { id: '1', type: 'note', title: '', excerpt: '', relevance: 0.8, scope: '' },
+      { id: '2', type: 'decision', title: '', excerpt: '', relevance: 0.8, scope: '' },
+      { id: '3', type: 'meeting', title: '', excerpt: '', relevance: 0.8, scope: '' },
+      { id: '4', type: 'research', title: '', excerpt: '', relevance: 0.8, scope: '' },
+    ];
+
+    const sorted = sortByTypeImportance(sources);
+    expect(sorted.map((s) => s.type)).toEqual(['decision', 'research', 'meeting', 'note']);
+  });
+});
+
+describe('buildSummaryDocument', () => {
+  it('builds a summary with correct metadata', () => {
+    const results = [
+      makeResult('eng_1', { createdAt: '2026-04-01T10:00:00Z' }),
+      makeResult('eng_2', { createdAt: '2026-04-07T10:00:00Z' }),
+    ];
+    const dateRange = { from: '2026-04-01', to: '2026-04-07' };
+
+    const doc = buildSummaryDocument({
+      llmOutput: '# Weekly Summary\n\nContent here.',
+      results,
+      dateRange,
+      audienceScope: 'work.*',
+      truncated: false,
+    });
+
+    expect(doc.title).toBe('Weekly Summary');
+    expect(doc.mode).toBe('summary');
+    expect(doc.audienceScope).toBe('work.*');
+    expect(doc.sources).toHaveLength(2);
+    expect(doc.metadata.truncated).toBe(false);
+  });
+
+  it('marks truncated when capped', () => {
+    const doc = buildSummaryDocument({
+      llmOutput: '# Summary\nTruncated content.',
+      results: [makeResult('eng_1')],
+      dateRange: { from: '2026-04-01', to: '2026-04-30' },
+      audienceScope: 'all',
+      truncated: true,
+    });
+
+    expect(doc.metadata.truncated).toBe(true);
+  });
+});
+
+// ---------- Timeline mode ----------
+
+describe('sortChronologically', () => {
+  it('sorts results by createdAt date (oldest first)', () => {
+    const results = [
+      makeResult('eng_3', { createdAt: '2026-04-20T10:00:00Z' }),
+      makeResult('eng_1', { createdAt: '2026-04-01T10:00:00Z' }),
+      makeResult('eng_2', { createdAt: '2026-04-10T10:00:00Z' }),
+    ];
+
+    const sorted = sortChronologically(results);
+    expect(sorted.map((r) => r.sourceId)).toEqual(['eng_1', 'eng_2', 'eng_3']);
+  });
+
+  it('handles missing dates (pushed to beginning)', () => {
+    const results = [
+      makeResult('eng_2', { createdAt: '2026-04-10T10:00:00Z' }),
+      makeResult('eng_1', { createdAt: undefined }),
+    ];
+
+    const sorted = sortChronologically(results);
+    expect(sorted[0]?.sourceId).toBe('eng_1'); // no date -> empty string -> sorts first
+  });
+});
+
+describe('buildSingleEntryNotice', () => {
+  it('returns a notice about single point in time', () => {
+    const notice = buildSingleEntryNotice();
+    expect(notice).toContain('single point in time');
+  });
+});
+
+describe('buildTimelineDocument', () => {
+  it('builds a timeline with correct structure', () => {
+    const results = [
+      makeResult('eng_1', { createdAt: '2026-01-15T10:00:00Z' }),
+      makeResult('eng_2', { createdAt: '2026-06-20T10:00:00Z' }),
+    ];
+
+    const doc = buildTimelineDocument('# Decision Timeline\n\nEntries here.', results, 'work.*');
+
+    expect(doc.title).toBe('Decision Timeline');
+    expect(doc.mode).toBe('timeline');
+    expect(doc.audienceScope).toBe('work.*');
+    expect(doc.sources).toHaveLength(2);
+    expect(doc.dateRange).toEqual({
+      from: '2026-01-15T10:00:00Z',
+      to: '2026-06-20T10:00:00Z',
+    });
+  });
+
+  it('appends single-entry notice for single result', () => {
+    const results = [makeResult('eng_1', { createdAt: '2026-04-15T10:00:00Z' })];
+
+    const doc = buildTimelineDocument('# Timeline\nOne entry.', results, 'all');
+
+    expect(doc.body).toContain('single point in time');
+  });
+
+  it('does not append notice for multiple results', () => {
+    const results = [
+      makeResult('eng_1', { createdAt: '2026-04-01T10:00:00Z' }),
+      makeResult('eng_2', { createdAt: '2026-04-15T10:00:00Z' }),
+    ];
+
+    const doc = buildTimelineDocument('# Timeline\nEntries.', results, 'all');
+
+    expect(doc.body).not.toContain('single point in time');
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/emit/__tests__/scope-filter.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/__tests__/scope-filter.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isSecretScope,
+  matchesAudienceScope,
+  shouldIncludeEngram,
+  filterByScope,
+  computeDefaultAudienceScope,
+} from '../scope-filter.js';
+
+import type { RetrievalResult } from '../../retrieval/types.js';
+
+function makeResult(sourceId: string, scopes: string[], score = 0.8): RetrievalResult {
+  return {
+    sourceType: 'engram',
+    sourceId,
+    title: `Engram ${sourceId}`,
+    contentPreview: 'Some content',
+    score,
+    matchType: 'semantic',
+    metadata: { scopes },
+  };
+}
+
+describe('isSecretScope', () => {
+  it('returns true for scopes containing a "secret" segment', () => {
+    expect(isSecretScope('personal.secret.therapy')).toBe(true);
+    expect(isSecretScope('work.secret.jobsearch')).toBe(true);
+    expect(isSecretScope('secret.data')).toBe(true);
+  });
+
+  it('returns false for non-secret scopes', () => {
+    expect(isSecretScope('work.projects.karbon')).toBe(false);
+    expect(isSecretScope('personal.journal')).toBe(false);
+    expect(isSecretScope('secretive.notes')).toBe(false);
+  });
+});
+
+describe('matchesAudienceScope', () => {
+  it('matches exact scope against audience without wildcard', () => {
+    expect(matchesAudienceScope('work', 'work')).toBe(true);
+  });
+
+  it('matches child scopes against wildcard audience', () => {
+    expect(matchesAudienceScope('work.projects.karbon', 'work.*')).toBe(true);
+    expect(matchesAudienceScope('work.meetings', 'work.*')).toBe(true);
+  });
+
+  it('does not match unrelated scopes', () => {
+    expect(matchesAudienceScope('personal.journal', 'work.*')).toBe(false);
+    expect(matchesAudienceScope('work.projects', 'personal.*')).toBe(false);
+  });
+
+  it('matches deeper audience scope prefixes', () => {
+    expect(matchesAudienceScope('work.projects.karbon.tasks', 'work.projects.*')).toBe(true);
+    expect(matchesAudienceScope('work.meetings', 'work.projects.*')).toBe(false);
+  });
+
+  it('does not match partial segment matches', () => {
+    // "workaholic.stuff" should NOT match "work.*"
+    expect(matchesAudienceScope('workaholic.stuff', 'work.*')).toBe(false);
+  });
+});
+
+describe('shouldIncludeEngram', () => {
+  it('excludes engrams with secret scopes when includeSecret is false', () => {
+    expect(shouldIncludeEngram(['work.secret.jobsearch'], 'work.*', false)).toBe(false);
+  });
+
+  it('includes engrams with secret scopes when includeSecret is true and audience matches', () => {
+    expect(shouldIncludeEngram(['work.secret.jobsearch'], 'work.*', true)).toBe(true);
+  });
+
+  it('excludes secret engrams outside audience scope even with includeSecret', () => {
+    expect(shouldIncludeEngram(['personal.secret.therapy'], 'work.*', true)).toBe(false);
+  });
+
+  it('excludes engrams with mixed secret and non-secret scopes when includeSecret is false', () => {
+    // An engram with both secret + non-secret scopes is treated as secret
+    expect(
+      shouldIncludeEngram(['work.projects.karbon', 'work.secret.jobsearch'], 'work.*', false)
+    ).toBe(false);
+  });
+
+  it('includes non-secret engrams matching audience scope', () => {
+    expect(shouldIncludeEngram(['work.projects.karbon'], 'work.*', false)).toBe(true);
+  });
+
+  it('excludes non-secret engrams outside audience scope', () => {
+    expect(shouldIncludeEngram(['personal.journal'], 'work.*', false)).toBe(false);
+  });
+
+  it('includes all non-secret engrams when no audience scope', () => {
+    expect(shouldIncludeEngram(['work.projects.karbon'], undefined, false)).toBe(true);
+    expect(shouldIncludeEngram(['personal.journal'], undefined, false)).toBe(true);
+  });
+
+  it('excludes secret engrams even when no audience scope', () => {
+    expect(shouldIncludeEngram(['personal.secret.therapy'], undefined, false)).toBe(false);
+  });
+
+  it('includes mixed-scope engram with includeSecret when secret scope matches audience', () => {
+    expect(
+      shouldIncludeEngram(['work.projects.karbon', 'work.secret.jobsearch'], 'work.*', true)
+    ).toBe(true);
+  });
+});
+
+describe('filterByScope', () => {
+  it('filters out secret engrams', () => {
+    const results = [
+      makeResult('eng_1', ['work.projects']),
+      makeResult('eng_2', ['work.secret.data']),
+      makeResult('eng_3', ['personal.journal']),
+    ];
+
+    const filtered = filterByScope(results, undefined, false);
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((r) => r.sourceId)).toEqual(['eng_1', 'eng_3']);
+  });
+
+  it('filters by audience scope', () => {
+    const results = [
+      makeResult('eng_1', ['work.projects']),
+      makeResult('eng_2', ['personal.journal']),
+      makeResult('eng_3', ['work.meetings']),
+    ];
+
+    const filtered = filterByScope(results, 'work.*', false);
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((r) => r.sourceId)).toEqual(['eng_1', 'eng_3']);
+  });
+
+  it('allows secret engrams when includeSecret is true within audience', () => {
+    const results = [
+      makeResult('eng_1', ['work.projects']),
+      makeResult('eng_2', ['work.secret.salary']),
+      makeResult('eng_3', ['personal.secret.therapy']),
+    ];
+
+    const filtered = filterByScope(results, 'work.*', true);
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((r) => r.sourceId)).toEqual(['eng_1', 'eng_2']);
+  });
+});
+
+describe('computeDefaultAudienceScope', () => {
+  it('returns the broadest common prefix among non-secret scopes', () => {
+    const results = [
+      makeResult('eng_1', ['work.projects.karbon']),
+      makeResult('eng_2', ['work.meetings']),
+      makeResult('eng_3', ['work.projects.atlas']),
+    ];
+
+    expect(computeDefaultAudienceScope(results)).toBe('work.*');
+  });
+
+  it('returns "all" when there are no scopes', () => {
+    const results = [makeResult('eng_1', [])];
+    expect(computeDefaultAudienceScope(results)).toBe('all');
+  });
+
+  it('returns "all" when scopes span different top-level domains', () => {
+    const results = [
+      makeResult('eng_1', ['work.projects']),
+      makeResult('eng_2', ['personal.journal']),
+    ];
+
+    expect(computeDefaultAudienceScope(results)).toBe('all');
+  });
+
+  it('excludes secret scopes from the computation', () => {
+    const results = [
+      makeResult('eng_1', ['work.projects']),
+      makeResult('eng_2', ['work.secret.salary']),
+      makeResult('eng_3', ['work.meetings']),
+    ];
+
+    expect(computeDefaultAudienceScope(results)).toBe('work.*');
+  });
+
+  it('handles single scope correctly', () => {
+    const results = [makeResult('eng_1', ['work.projects.karbon'])];
+    expect(computeDefaultAudienceScope(results)).toBe('work.projects.karbon.*');
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/emit/generation-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/generation-service.ts
@@ -1,0 +1,186 @@
+/**
+ * GenerationService — pipeline orchestrator for document generation (PRD-083).
+ *
+ * Methods:
+ *   generate         — full generation pipeline for any mode
+ *   generateReport   — shorthand for report mode
+ *   generateSummary  — shorthand for summary mode
+ *   generateTimeline — shorthand for timeline mode
+ *   preview          — dry run returning sources + outline
+ *
+ * Reuses retrieval infrastructure from PRD-082 (HybridSearchService,
+ * ContextAssemblyService, CitationParser).
+ */
+import { getDrizzle } from '../../../db.js';
+import { CitationParser } from '../query/citation-parser.js';
+import { ContextAssemblyService } from '../retrieval/context-assembly.js';
+import { HybridSearchService } from '../retrieval/hybrid-search.js';
+import { toSourceCitations } from './helpers.js';
+import { callEmitLlm } from './llm.js';
+import { checkReportSources, buildReportDocument } from './modes/report.js';
+import { buildEmptySummary, capSummaryResults, buildSummaryDocument } from './modes/summary.js';
+import { sortChronologically, buildTimelineDocument } from './modes/timeline.js';
+import {
+  buildReportPrompt,
+  buildOutlinePrompt,
+  buildSummaryPrompt,
+  buildTimelinePrompt,
+} from './prompts.js';
+import { buildScopeFilters, computeDefaultAudienceScope, filterByScope } from './scope-filter.js';
+
+import type { RetrievalFilters, RetrievalResult } from '../retrieval/types.js';
+import type { GenerationRequest, GenerationResult, PreviewResult } from './types.js';
+
+const GENERATION_TOKEN_BUDGET = 8192;
+const RELEVANCE_THRESHOLD = 0.2;
+const DEFAULT_MAX_SOURCES = 20;
+
+/**
+ * Build retrieval filters from a generation request.
+ */
+function buildFiltersFromRequest(request: GenerationRequest): RetrievalFilters {
+  const base: RetrievalFilters = { sourceTypes: ['engram'] };
+  if (request.types?.length) base.types = request.types;
+  if (request.tags?.length) base.tags = request.tags;
+  if (request.dateRange)
+    base.dateRange = { from: request.dateRange.from, to: request.dateRange.to };
+  if (request.scopes?.length) base.scopes = request.scopes;
+  return buildScopeFilters(base, request.audienceScope, request.includeSecret ?? false);
+}
+
+export class GenerationService {
+  private readonly citationParser = new CitationParser();
+  private readonly assembler = new ContextAssemblyService();
+
+  /** Full generation pipeline: retrieve -> scope filter -> synthesise -> format. */
+  async generate(request: GenerationRequest): Promise<GenerationResult> {
+    switch (request.mode) {
+      case 'report':
+        return this.generateReport(request);
+      case 'summary':
+        return this.generateSummary(request);
+      case 'timeline':
+        return this.generateTimeline(request);
+    }
+  }
+
+  /** Generate a structured report from a query. */
+  async generateReport(request: GenerationRequest): Promise<GenerationResult> {
+    const query = request.query ?? '';
+    const includeSecret = request.includeSecret ?? false;
+    const filters = buildFiltersFromRequest(request);
+    const results = await this.retrieve(query, filters);
+    const filtered = filterByScope(results, request.audienceScope, includeSecret);
+
+    const insufficientCheck = checkReportSources(filtered);
+    if (insufficientCheck) return insufficientCheck;
+
+    const audienceScope = request.audienceScope ?? computeDefaultAudienceScope(filtered);
+    const assembled = this.assembler.assemble({
+      query,
+      results: filtered,
+      tokenBudget: GENERATION_TOKEN_BUDGET,
+      includeMetadata: true,
+    });
+
+    const prompt = buildReportPrompt(assembled.context, audienceScope);
+    const llmOutput = await callEmitLlm(prompt, query);
+    const { cleanedAnswer, citations } = this.citationParser.parse(llmOutput, filtered);
+
+    return { document: buildReportDocument(cleanedAnswer, citations, audienceScope, filtered) };
+  }
+
+  /** Generate a summary digest over a date range. */
+  async generateSummary(request: GenerationRequest): Promise<GenerationResult> {
+    const includeSecret = request.includeSecret ?? false;
+    const query = request.query ?? 'summary of all content';
+    const filters = buildFiltersFromRequest(request);
+    const results = await this.retrieve(query, filters);
+    const filtered = filterByScope(results, request.audienceScope, includeSecret);
+    const audienceScope = request.audienceScope ?? computeDefaultAudienceScope(filtered);
+    const effectiveDateRange = request.dateRange ?? { from: 'unknown', to: 'unknown' };
+
+    if (filtered.length === 0) {
+      return { document: buildEmptySummary(effectiveDateRange, audienceScope) };
+    }
+
+    const { capped, truncated } = capSummaryResults(filtered);
+    const assembled = this.assembler.assemble({
+      query,
+      results: capped,
+      tokenBudget: GENERATION_TOKEN_BUDGET,
+      includeMetadata: true,
+    });
+
+    const prompt = buildSummaryPrompt(assembled.context, effectiveDateRange, audienceScope);
+    const llmOutput = await callEmitLlm(prompt, query);
+    const { cleanedAnswer } = this.citationParser.parse(llmOutput, capped);
+
+    return {
+      document: buildSummaryDocument({
+        llmOutput: cleanedAnswer,
+        results: capped,
+        dateRange: effectiveDateRange,
+        audienceScope,
+        truncated,
+      }),
+    };
+  }
+
+  /** Generate a chronological timeline from dated engrams. */
+  async generateTimeline(request: GenerationRequest): Promise<GenerationResult> {
+    const includeSecret = request.includeSecret ?? false;
+    const query = request.query ?? 'timeline of all events';
+    const filters = buildFiltersFromRequest(request);
+    const results = await this.retrieve(query, filters);
+    const filtered = filterByScope(results, request.audienceScope, includeSecret);
+    const audienceScope = request.audienceScope ?? computeDefaultAudienceScope(filtered);
+
+    if (filtered.length === 0) {
+      return { document: null, notice: 'No relevant engrams found for this timeline' };
+    }
+
+    const sorted = sortChronologically(filtered);
+    const assembled = this.assembler.assemble({
+      query,
+      results: sorted,
+      tokenBudget: GENERATION_TOKEN_BUDGET,
+      includeMetadata: true,
+    });
+
+    const prompt = buildTimelinePrompt(assembled.context, audienceScope, request.groupBy);
+    const llmOutput = await callEmitLlm(prompt, query);
+    const { cleanedAnswer } = this.citationParser.parse(llmOutput, sorted);
+
+    return { document: buildTimelineDocument(cleanedAnswer, sorted, audienceScope) };
+  }
+
+  /** Preview: returns sources and a generated outline without full document generation. */
+  async preview(request: GenerationRequest): Promise<PreviewResult> {
+    const query = request.query ?? 'preview';
+    const includeSecret = request.includeSecret ?? false;
+    const filters = buildFiltersFromRequest(request);
+    const results = await this.retrieve(query, filters);
+    const filtered = filterByScope(results, request.audienceScope, includeSecret);
+    const sources = toSourceCitations(filtered);
+
+    if (filtered.length === 0) {
+      return { sources, outline: 'No sources found — cannot generate outline.' };
+    }
+
+    const assembled = this.assembler.assemble({
+      query,
+      results: filtered,
+      tokenBudget: GENERATION_TOKEN_BUDGET,
+      includeMetadata: true,
+    });
+    const outline = await callEmitLlm(buildOutlinePrompt(assembled.context), query);
+    return { sources, outline };
+  }
+
+  /** Run hybrid search against Thalamus. */
+  private async retrieve(query: string, filters: RetrievalFilters): Promise<RetrievalResult[]> {
+    const hybridSearch = new HybridSearchService(getDrizzle());
+    return hybridSearch.hybrid(query, filters, DEFAULT_MAX_SOURCES, RELEVANCE_THRESHOLD);
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/emit/helpers.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/helpers.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared helpers for document generation modes (PRD-083).
+ *
+ * Reduces duplication across report, summary, and timeline modes.
+ */
+
+import type { SourceCitation } from '../query/types.js';
+import type { RetrievalResult } from '../retrieval/types.js';
+import type { DateRange } from './types.js';
+
+const EXCERPT_MAX_LENGTH = 200;
+
+/** Extract the actual date range covered by retrieved results. */
+export function extractDateRange(results: RetrievalResult[]): DateRange | null {
+  const dates: string[] = [];
+  for (const r of results) {
+    const createdAt = r.metadata['createdAt'] as string | undefined;
+    if (createdAt) dates.push(createdAt);
+  }
+  if (dates.length === 0) return null;
+  const sorted = dates.toSorted();
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  if (!first || !last) return null;
+  return { from: first, to: last };
+}
+
+/** Truncate to 200 chars at word boundary with ellipsis. */
+export function truncateExcerpt(text: string): string {
+  if (text.length <= EXCERPT_MAX_LENGTH) return text;
+  const truncated = text.slice(0, EXCERPT_MAX_LENGTH);
+  const lastSpace = truncated.lastIndexOf(' ');
+  const cutPoint = lastSpace > 0 ? lastSpace : EXCERPT_MAX_LENGTH;
+  return text.slice(0, cutPoint) + '...';
+}
+
+/** Extract primary scope from retrieval result metadata. */
+export function extractPrimaryScope(result: RetrievalResult): string {
+  const scopes = result.metadata['scopes'] as string[] | undefined;
+  return scopes?.[0] ?? 'unknown';
+}
+
+/** Map retrieval results to source citations. */
+export function toSourceCitations(results: RetrievalResult[]): SourceCitation[] {
+  return results.map((r) => ({
+    id: r.sourceId,
+    type: r.sourceType,
+    title: r.title,
+    excerpt: truncateExcerpt(r.contentPreview ?? ''),
+    relevance: r.score,
+    scope: extractPrimaryScope(r),
+  }));
+}
+
+/** Extract title from LLM output (first H1 line) or return fallback. */
+export function extractTitle(llmOutput: string, fallback: string): string {
+  const titleMatch = llmOutput.match(/^#\s+(.+)$/m);
+  return titleMatch?.[1] ?? fallback;
+}
+
+/** Collect unique scope prefixes from results. */
+export function collectScopeCoverage(results: RetrievalResult[]): string[] {
+  const scopes = new Set<string>();
+  for (const r of results) {
+    const s = (r.metadata['scopes'] as string[] | undefined) ?? [];
+    for (const scope of s) scopes.add(scope);
+  }
+  return [...scopes];
+}

--- a/apps/pops-api/src/modules/cerebrum/emit/llm.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/llm.ts
@@ -1,0 +1,58 @@
+/**
+ * LLM call helper for document generation (PRD-083).
+ *
+ * Extracted to keep GenerationService under the line limit and
+ * to centralise LLM interaction patterns for the emit module.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+import { getEnv } from '../../../env.js';
+import { withRateLimitRetry } from '../../../lib/ai-retry.js';
+import { trackInference } from '../../../lib/inference-middleware.js';
+import { logger } from '../../../lib/logger.js';
+
+const MODEL = 'claude-sonnet-4-20250514';
+const OPERATION = 'cerebrum.emit';
+const GENERATION_MAX_TOKENS = 2048;
+
+/** Call the LLM for document generation. Gracefully degrades if API key is missing. */
+export async function callEmitLlm(systemPrompt: string, userMessage: string): Promise<string> {
+  const apiKey = getEnv('ANTHROPIC_API_KEY');
+  if (!apiKey) {
+    logger.warn('[EmitService] ANTHROPIC_API_KEY not set — cannot generate document');
+    return '(Document generation unavailable — LLM API key not configured)';
+  }
+
+  const client = new Anthropic({ apiKey, maxRetries: 0 });
+
+  try {
+    const response = await trackInference(
+      { provider: 'claude', model: MODEL, operation: OPERATION, domain: 'cerebrum' },
+      () =>
+        withRateLimitRetry(
+          () =>
+            client.messages.create({
+              model: MODEL,
+              max_tokens: GENERATION_MAX_TOKENS,
+              temperature: 0,
+              system: systemPrompt,
+              messages: [{ role: 'user', content: userMessage }],
+            }),
+          OPERATION,
+          { logger, logPrefix: '[EmitService]' }
+        )
+    );
+
+    const text = response.content[0]?.type === 'text' ? response.content[0].text : '';
+    return text;
+  } catch (err) {
+    logger.error(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[EmitService] LLM call failed'
+    );
+    throw new Error(
+      `Document generation failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err }
+    );
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/emit/modes/report.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/modes/report.ts
@@ -1,0 +1,66 @@
+/**
+ * Report generation mode (PRD-083 US-01).
+ *
+ * Pipeline: retrieve relevant engrams -> group by subtopic -> synthesise
+ * sections -> format with citations. Requires a query and minimum 2 sources.
+ */
+
+import { collectScopeCoverage, extractDateRange, extractTitle } from '../helpers.js';
+
+import type { SourceCitation } from '../../query/types.js';
+import type { RetrievalResult } from '../../retrieval/types.js';
+import type { GeneratedDocument, GenerationResult } from '../types.js';
+
+const MIN_SOURCES_FOR_REPORT = 2;
+
+/**
+ * Check if enough sources exist for a meaningful report.
+ * Returns an insufficient-data notice if fewer than 2 sources.
+ */
+export function checkReportSources(results: RetrievalResult[]): GenerationResult | null {
+  if (results.length === 0) {
+    return {
+      document: null,
+      notice: 'No relevant engrams found for this query',
+    };
+  }
+
+  if (results.length < MIN_SOURCES_FOR_REPORT) {
+    return {
+      document: null,
+      notice: 'Insufficient data to generate a meaningful report',
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Build the final report document from LLM output and source data.
+ */
+export function buildReportDocument(
+  llmOutput: string,
+  sources: SourceCitation[],
+  audienceScope: string,
+  results: RetrievalResult[]
+): GeneratedDocument {
+  const title = extractTitle(llmOutput, 'Generated Report');
+  const dateRange = extractDateRange(results);
+  const scopeCoverage = collectScopeCoverage(results);
+
+  return {
+    title,
+    body: llmOutput,
+    mode: 'report',
+    sources,
+    audienceScope,
+    dateRange,
+    metadata: {
+      sourceCount: sources.length,
+      dateRange,
+      scopeCoverage,
+      mode: 'report',
+      truncated: false,
+    },
+  };
+}

--- a/apps/pops-api/src/modules/cerebrum/emit/modes/summary.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/modes/summary.ts
@@ -1,0 +1,105 @@
+/**
+ * Summary generation mode (PRD-083 US-02).
+ *
+ * Retrieves engrams within a date range, groups by type/topic,
+ * and produces a digestible overview (weekly digest, monthly review).
+ */
+
+import {
+  collectScopeCoverage,
+  extractDateRange,
+  extractTitle,
+  toSourceCitations,
+} from '../helpers.js';
+import { TYPE_IMPORTANCE } from '../types.js';
+
+import type { SourceCitation } from '../../query/types.js';
+import type { RetrievalResult } from '../../retrieval/types.js';
+import type { DateRange, GeneratedDocument } from '../types.js';
+
+/** Maximum number of sources for a single summary to avoid context overflow. */
+const MAX_SUMMARY_SOURCES = 50;
+
+/**
+ * Build an empty summary document for date ranges with zero engrams.
+ */
+export function buildEmptySummary(dateRange: DateRange, audienceScope: string): GeneratedDocument {
+  return {
+    title: `Summary: ${dateRange.from} to ${dateRange.to}`,
+    body: `# Summary: ${dateRange.from} to ${dateRange.to}\n\nNo engrams found between ${dateRange.from} and ${dateRange.to}.`,
+    mode: 'summary',
+    sources: [],
+    audienceScope,
+    dateRange,
+    metadata: {
+      sourceCount: 0,
+      dateRange,
+      scopeCoverage: [],
+      mode: 'summary',
+      truncated: false,
+    },
+  };
+}
+
+/**
+ * Cap results at MAX_SUMMARY_SOURCES, sorted by relevance.
+ * Returns the capped list and whether truncation occurred.
+ */
+export function capSummaryResults(results: RetrievalResult[]): {
+  capped: RetrievalResult[];
+  truncated: boolean;
+} {
+  if (results.length <= MAX_SUMMARY_SOURCES) {
+    return { capped: results, truncated: false };
+  }
+  const sorted = [...results].toSorted((a, b) => b.score - a.score);
+  return { capped: sorted.slice(0, MAX_SUMMARY_SOURCES), truncated: true };
+}
+
+/**
+ * Sort sources by type importance for highlights extraction.
+ * Returns sources ordered by TYPE_IMPORTANCE descending.
+ */
+export function sortByTypeImportance(sources: SourceCitation[]): SourceCitation[] {
+  return [...sources].toSorted((a, b) => {
+    const aImportance = TYPE_IMPORTANCE[a.type] ?? 0;
+    const bImportance = TYPE_IMPORTANCE[b.type] ?? 0;
+    return bImportance - aImportance;
+  });
+}
+
+/** Parameters for building a summary document. */
+interface BuildSummaryParams {
+  llmOutput: string;
+  results: RetrievalResult[];
+  dateRange: DateRange;
+  audienceScope: string;
+  truncated: boolean;
+}
+
+/**
+ * Build the final summary document from LLM output and source data.
+ */
+export function buildSummaryDocument(params: BuildSummaryParams): GeneratedDocument {
+  const { llmOutput, results, dateRange, audienceScope, truncated } = params;
+  const sources = toSourceCitations(results);
+  const actualDateRange = extractDateRange(results) ?? dateRange;
+  const scopeCoverage = collectScopeCoverage(results);
+  const title = extractTitle(llmOutput, `Summary: ${dateRange.from} to ${dateRange.to}`);
+
+  return {
+    title,
+    body: llmOutput,
+    mode: 'summary',
+    sources,
+    audienceScope,
+    dateRange: actualDateRange,
+    metadata: {
+      sourceCount: sources.length,
+      dateRange: actualDateRange,
+      scopeCoverage,
+      mode: 'summary',
+      truncated,
+    },
+  };
+}

--- a/apps/pops-api/src/modules/cerebrum/emit/modes/timeline.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/modes/timeline.ts
@@ -1,0 +1,67 @@
+/**
+ * Timeline generation mode (PRD-083 US-03).
+ *
+ * Retrieves dated engrams, produces chronological sequences.
+ * Each entry: date, title, type badge, one-line summary.
+ */
+
+import {
+  collectScopeCoverage,
+  extractDateRange,
+  extractTitle,
+  toSourceCitations,
+} from '../helpers.js';
+
+import type { RetrievalResult } from '../../retrieval/types.js';
+import type { GeneratedDocument } from '../types.js';
+
+/**
+ * Sort retrieval results chronologically by createdAt date (oldest first).
+ */
+export function sortChronologically(results: RetrievalResult[]): RetrievalResult[] {
+  return [...results].toSorted((a, b) => {
+    const dateA = (a.metadata['createdAt'] as string | undefined) ?? '';
+    const dateB = (b.metadata['createdAt'] as string | undefined) ?? '';
+    return dateA.localeCompare(dateB);
+  });
+}
+
+/**
+ * Build a single-entry timeline notice.
+ */
+export function buildSingleEntryNotice(): string {
+  return '\n\n*This timeline represents a single point in time.*';
+}
+
+/**
+ * Build the final timeline document from LLM output and source data.
+ */
+export function buildTimelineDocument(
+  llmOutput: string,
+  results: RetrievalResult[],
+  audienceScope: string
+): GeneratedDocument {
+  const sources = toSourceCitations(results);
+  const dateRange = extractDateRange(results);
+  const scopeCoverage = collectScopeCoverage(results);
+  const title = extractTitle(llmOutput, 'Timeline');
+
+  // Add single-entry notice if applicable.
+  const body = results.length === 1 ? llmOutput + buildSingleEntryNotice() : llmOutput;
+
+  return {
+    title,
+    body,
+    mode: 'timeline',
+    sources,
+    audienceScope,
+    dateRange,
+    metadata: {
+      sourceCount: sources.length,
+      dateRange,
+      scopeCoverage,
+      mode: 'timeline',
+      truncated: false,
+    },
+  };
+}

--- a/apps/pops-api/src/modules/cerebrum/emit/prompts.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/prompts.ts
@@ -1,0 +1,109 @@
+/**
+ * LLM prompt templates for document generation (PRD-083).
+ *
+ * Each mode has a dedicated prompt builder that accepts the assembled context
+ * and mode-specific parameters. Prompts instruct the model to synthesise
+ * (not copy), cite sources by ID, and never introduce external information.
+ */
+
+import type { DateRange, TimelineGroupBy } from './types.js';
+
+/**
+ * Build the system prompt for report generation.
+ * Produces structured Markdown with introduction, body sections, and conclusion.
+ */
+export function buildReportPrompt(context: string, audienceScope: string): string {
+  return `You are Cerebrum, a document generation engine for a personal knowledge system.
+Generate a structured report on the topic described in the user query.
+Use ONLY the provided sources. Follow these rules strictly:
+
+1. Structure the report as: a short title (H1), an introduction paragraph, body sections (H2) grouped by subtopic, and a brief conclusion.
+2. Synthesise information — do NOT copy source text verbatim. Rephrase and integrate.
+3. Cite every claim by including the source ID in square brackets, e.g. [eng_20260417_0942_agent-coordination].
+4. Never introduce information not present in the sources.
+5. Maintain a tone appropriate for the audience scope: ${audienceScope}.
+6. If sources are contradictory, note the disagreement and cite both sides.
+7. Keep sections focused — each section should cover one coherent subtopic.
+
+Sources:
+${context}`;
+}
+
+/**
+ * Build the system prompt for generating a report outline (preview mode).
+ * Returns section headings and which sources map to each, without full synthesis.
+ */
+export function buildOutlinePrompt(context: string): string {
+  return `You are Cerebrum, a document generation engine for a personal knowledge system.
+Given the sources below, produce ONLY an outline for a structured report.
+Format: an H1 title, then a bulleted list of H2 section headings.
+Under each heading, list the source IDs (in brackets) that would be used for that section.
+Do NOT generate full prose — only the outline structure.
+
+Sources:
+${context}`;
+}
+
+/**
+ * Build the system prompt for summary generation.
+ * Produces a digest grouped by type or topic with highlights.
+ */
+export function buildSummaryPrompt(
+  context: string,
+  dateRange: DateRange,
+  audienceScope: string
+): string {
+  return `You are Cerebrum, a document generation engine for a personal knowledge system.
+Generate a summary digest covering the period from ${dateRange.from} to ${dateRange.to}.
+Use ONLY the provided sources. Follow these rules strictly:
+
+1. Start with a short title (H1) including the date range.
+2. Add a "Highlights" section (H2) with the 3-5 most significant items ranked by importance (decisions > research > meetings > ideas > journal > notes > captures).
+3. Group remaining content by type (H2 sections: Decisions, Research, Meetings, Ideas, Journal, Notes, Captures). Only include sections that have content.
+4. Under each type section, produce a bulleted list: each item has title, date, and a one-sentence summary synthesised from the body.
+5. Cite every referenced engram by ID in brackets: [engram_id].
+6. Never introduce information not present in the sources.
+7. Maintain a tone appropriate for the audience scope: ${audienceScope}.
+8. If covering a subset of a larger result set, note this at the end.
+
+Sources:
+${context}`;
+}
+
+/**
+ * Build the system prompt for timeline generation.
+ * Produces a chronological list of dated entries.
+ */
+export function buildTimelinePrompt(
+  context: string,
+  audienceScope: string,
+  groupBy?: TimelineGroupBy
+): string {
+  const groupInstructionMap: Record<string, string> = {
+    type: 'Group entries by type (H2 sections), with each group in chronological order.',
+    month:
+      'Group entries by month (H2 sections with "YYYY-MM" headers), chronological within each month.',
+    quarter:
+      'Group entries by quarter (H2 sections with "YYYY QN" headers), chronological within each quarter.',
+  };
+  const groupInstruction =
+    (groupBy && groupInstructionMap[groupBy]) ??
+    'Present all entries in a single chronological list (oldest first).';
+
+  return `You are Cerebrum, a document generation engine for a personal knowledge system.
+Generate a chronological timeline from the provided dated entries.
+Use ONLY the provided sources. Follow these rules strictly:
+
+1. Start with a short title (H1) describing the timeline scope.
+2. ${groupInstruction}
+3. Each entry format: **YYYY-MM-DD** — [type_badge] **Title** — one-line summary [engram_id]
+   Where type_badge is one of: [decision], [meeting], [research], [idea], [journal], [note], [capture].
+4. For entries with empty bodies, write "metadata only" instead of a summary.
+5. Order entries chronologically (oldest first) within each group.
+6. Cite every entry by its engram ID in brackets.
+7. Never introduce information not present in the sources.
+8. Maintain a tone appropriate for the audience scope: ${audienceScope}.
+
+Sources:
+${context}`;
+}

--- a/apps/pops-api/src/modules/cerebrum/emit/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/router.ts
@@ -1,0 +1,216 @@
+/**
+ * tRPC router for cerebrum.emit — document generation (PRD-083).
+ *
+ * Procedures:
+ *   generate         — full generation pipeline (any mode)
+ *   generateReport   — shorthand for report mode
+ *   generateSummary  — shorthand for summary mode
+ *   generateTimeline — shorthand for timeline mode
+ *   preview          — dry run: sources + outline without full generation
+ */
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { HttpError, NotFoundError, ValidationError } from '../../../shared/errors.js';
+import { protectedProcedure, router } from '../../../trpc.js';
+import { GenerationService } from './generation-service.js';
+
+import type { GenerationMode, TimelineGroupBy } from './types.js';
+
+function toTrpcError(err: unknown): never {
+  if (err instanceof NotFoundError) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+  }
+  if (err instanceof ValidationError) {
+    const details = err.details;
+    let message: string;
+    if (typeof details === 'string') {
+      message = details;
+    } else if (
+      typeof details === 'object' &&
+      details !== null &&
+      typeof (details as { message?: unknown }).message === 'string'
+    ) {
+      message = (details as { message: string }).message;
+    } else {
+      message = err.message;
+    }
+    throw new TRPCError({ code: 'BAD_REQUEST', message, cause: err });
+  }
+  if (err instanceof HttpError) {
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: err.message });
+  }
+  throw err;
+}
+
+function getService(): GenerationService {
+  return new GenerationService();
+}
+
+const dateRangeSchema = z.object({
+  from: z.string().min(1),
+  to: z.string().min(1),
+});
+
+const modeEnum = z.enum(['report', 'summary', 'timeline']);
+const groupByEnum = z.enum(['type', 'month', 'quarter']);
+
+const generationRequestSchema = z.object({
+  mode: modeEnum,
+  query: z.string().min(1).optional(),
+  dateRange: dateRangeSchema.optional(),
+  scopes: z.array(z.string().min(1)).optional(),
+  audienceScope: z.string().min(1).optional(),
+  includeSecret: z.boolean().optional(),
+  types: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+  format: z.enum(['markdown', 'plain']).optional(),
+  groupBy: groupByEnum.optional(),
+});
+
+const reportInputSchema = z.object({
+  query: z.string().min(1),
+  scopes: z.array(z.string().min(1)).optional(),
+  audienceScope: z.string().min(1).optional(),
+  includeSecret: z.boolean().optional(),
+  types: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+});
+
+const summaryInputSchema = z.object({
+  dateRange: dateRangeSchema,
+  query: z.string().min(1).optional(),
+  scopes: z.array(z.string().min(1)).optional(),
+  audienceScope: z.string().min(1).optional(),
+  includeSecret: z.boolean().optional(),
+  types: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+});
+
+const timelineInputSchema = z.object({
+  query: z.string().min(1).optional(),
+  scopes: z.array(z.string().min(1)).optional(),
+  dateRange: dateRangeSchema.optional(),
+  audienceScope: z.string().min(1).optional(),
+  includeSecret: z.boolean().optional(),
+  types: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+  groupBy: groupByEnum.optional(),
+});
+
+/**
+ * Validate date range: from must be before or equal to to.
+ */
+function validateDateRange(dateRange?: { from: string; to: string }): void {
+  if (!dateRange) return;
+  if (dateRange.from > dateRange.to) {
+    throw new ValidationError('Invalid date range: from must be before or equal to to');
+  }
+}
+
+export const emitRouter = router({
+  /** Full generation pipeline: any mode. */
+  generate: protectedProcedure.input(generationRequestSchema).mutation(async ({ input }) => {
+    try {
+      // Validate mode-specific requirements.
+      if (input.mode === 'report' && !input.query) {
+        throw new ValidationError('Query is required for report mode');
+      }
+      if (input.mode === 'summary' && !input.dateRange) {
+        throw new ValidationError('Date range is required for summary mode');
+      }
+      validateDateRange(input.dateRange);
+
+      return await getService().generate({
+        mode: input.mode as GenerationMode,
+        query: input.query,
+        dateRange: input.dateRange,
+        scopes: input.scopes,
+        audienceScope: input.audienceScope,
+        includeSecret: input.includeSecret,
+        types: input.types,
+        tags: input.tags,
+        format: input.format === 'plain' ? 'plain' : 'markdown',
+        groupBy: input.groupBy as TimelineGroupBy | undefined,
+      });
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+
+  /** Report generation shorthand. */
+  generateReport: protectedProcedure.input(reportInputSchema).mutation(async ({ input }) => {
+    try {
+      return await getService().generateReport({
+        mode: 'report',
+        query: input.query,
+        scopes: input.scopes,
+        audienceScope: input.audienceScope,
+        includeSecret: input.includeSecret,
+        types: input.types,
+        tags: input.tags,
+      });
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+
+  /** Summary generation shorthand. */
+  generateSummary: protectedProcedure.input(summaryInputSchema).mutation(async ({ input }) => {
+    try {
+      validateDateRange(input.dateRange);
+      return await getService().generateSummary({
+        mode: 'summary',
+        query: input.query,
+        dateRange: input.dateRange,
+        scopes: input.scopes,
+        audienceScope: input.audienceScope,
+        includeSecret: input.includeSecret,
+        types: input.types,
+        tags: input.tags,
+      });
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+
+  /** Timeline generation shorthand. */
+  generateTimeline: protectedProcedure.input(timelineInputSchema).mutation(async ({ input }) => {
+    try {
+      validateDateRange(input.dateRange);
+      return await getService().generateTimeline({
+        mode: 'timeline',
+        query: input.query,
+        dateRange: input.dateRange,
+        scopes: input.scopes,
+        audienceScope: input.audienceScope,
+        includeSecret: input.includeSecret,
+        types: input.types,
+        tags: input.tags,
+        groupBy: input.groupBy as TimelineGroupBy | undefined,
+      });
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+
+  /** Preview: returns sources and outline without full generation. */
+  preview: protectedProcedure.input(generationRequestSchema).query(async ({ input }) => {
+    try {
+      validateDateRange(input.dateRange);
+      return await getService().preview({
+        mode: input.mode as GenerationMode,
+        query: input.query,
+        dateRange: input.dateRange,
+        scopes: input.scopes,
+        audienceScope: input.audienceScope,
+        includeSecret: input.includeSecret,
+        types: input.types,
+        tags: input.tags,
+        groupBy: input.groupBy as TimelineGroupBy | undefined,
+      });
+    } catch (err) {
+      toTrpcError(err);
+    }
+  }),
+});

--- a/apps/pops-api/src/modules/cerebrum/emit/scope-filter.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/scope-filter.ts
@@ -1,0 +1,147 @@
+/**
+ * Scope filtering for document generation (PRD-083 US-04).
+ *
+ * Applied at retrieval time to enforce audience scope boundaries and
+ * hard-block *.secret.* content. Secret content never enters the LLM
+ * context window — this is a security requirement, not a convenience filter.
+ */
+
+import type { RetrievalFilters } from '../retrieval/types.js';
+import type { RetrievalResult } from '../retrieval/types.js';
+
+/**
+ * Check whether a scope path contains a "secret" segment.
+ * E.g. "personal.secret.therapy" -> true, "work.projects.karbon" -> false.
+ */
+export function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+/**
+ * Check whether a scope matches an audience scope prefix.
+ * E.g. scope "work.projects.karbon" matches audience "work.*" or "work.projects.*".
+ * An exact match (scope === audience without wildcard) also passes.
+ */
+export function matchesAudienceScope(scope: string, audienceScope: string): boolean {
+  // Strip trailing wildcard for prefix matching.
+  const prefix = audienceScope.endsWith('.*') ? audienceScope.slice(0, -2) : audienceScope;
+
+  return scope === prefix || scope.startsWith(prefix + '.');
+}
+
+/**
+ * Determine whether an engram should be included based on its scopes,
+ * the audience scope filter, and the includeSecret flag.
+ *
+ * An engram with ANY secret scope is treated as secret (most restrictive wins).
+ * When includeSecret is true with an audienceScope, only secret content within
+ * that audience scope is included (e.g., work.secret.* but not personal.secret.*).
+ */
+export function shouldIncludeEngram(
+  engramScopes: string[],
+  audienceScope: string | undefined,
+  includeSecret: boolean
+): boolean {
+  const hasSecretScope = engramScopes.some(isSecretScope);
+
+  // Hard-block secret content unless opted in.
+  if (hasSecretScope && !includeSecret) {
+    return false;
+  }
+
+  // No audience filter -> include (secret check already passed).
+  if (!audienceScope) {
+    return true;
+  }
+
+  // Check if any of the engram's scopes match the audience scope.
+  const matchesAudience = engramScopes.some((s) => matchesAudienceScope(s, audienceScope));
+
+  if (!matchesAudience) {
+    return false;
+  }
+
+  // If the engram has secret scopes and includeSecret is true,
+  // only include if the secret scope is within the audience scope.
+  if (hasSecretScope && includeSecret) {
+    const secretScopes = engramScopes.filter(isSecretScope);
+    return secretScopes.some((s) => matchesAudienceScope(s, audienceScope));
+  }
+
+  return true;
+}
+
+/**
+ * Filter retrieval results by audience scope and secret rules.
+ * Applied post-retrieval as a safety net (retrieval filters are the primary gate).
+ */
+export function filterByScope(
+  results: RetrievalResult[],
+  audienceScope: string | undefined,
+  includeSecret: boolean
+): RetrievalResult[] {
+  return results.filter((r) => {
+    const scopes = (r.metadata['scopes'] as string[] | undefined) ?? [];
+    return shouldIncludeEngram(scopes, audienceScope, includeSecret);
+  });
+}
+
+/**
+ * Build retrieval filters incorporating audience scope and secret rules.
+ * These are applied at query time so secret content never enters the pipeline.
+ */
+export function buildScopeFilters(
+  baseFilters: RetrievalFilters,
+  audienceScope: string | undefined,
+  includeSecret: boolean
+): RetrievalFilters {
+  const filters: RetrievalFilters = { ...baseFilters };
+
+  if (audienceScope) {
+    // Set scopes to the audience scope prefix for retrieval-time filtering.
+    const prefix = audienceScope.endsWith('.*') ? audienceScope.slice(0, -2) : audienceScope;
+    filters.scopes = [...(filters.scopes ?? []), prefix];
+  }
+
+  if (includeSecret) {
+    filters.includeSecret = true;
+  }
+
+  return filters;
+}
+
+/**
+ * Compute the default audience scope from retrieved sources.
+ * Returns the broadest (shortest) non-secret scope prefix among all sources.
+ * Returns 'all' if no scopes are found.
+ */
+export function computeDefaultAudienceScope(results: RetrievalResult[]): string {
+  const allScopes = new Set<string>();
+
+  for (const r of results) {
+    const scopes = (r.metadata['scopes'] as string[] | undefined) ?? [];
+    for (const s of scopes) {
+      if (!isSecretScope(s)) {
+        allScopes.add(s);
+      }
+    }
+  }
+
+  if (allScopes.size === 0) return 'all';
+
+  // Find the shortest common prefix among all non-secret scopes.
+  const scopeList = [...allScopes].toSorted((a, b) => a.length - b.length);
+  const shortest = scopeList[0];
+  if (!shortest) return 'all';
+
+  // Find the top-level segment that all scopes share.
+  const segments = shortest.split('.');
+  for (let i = segments.length; i > 0; i--) {
+    const candidate = segments.slice(0, i).join('.');
+    if (scopeList.every((s) => s === candidate || s.startsWith(candidate + '.'))) {
+      return candidate + '.*';
+    }
+  }
+
+  return 'all';
+}

--- a/apps/pops-api/src/modules/cerebrum/emit/types.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Types for the Cerebrum Document Generation system (PRD-083).
+ *
+ * Covers: GenerationRequest, GeneratedDocument, GenerationMode,
+ * and the preview/generation pipeline interfaces.
+ */
+
+import type { SourceCitation } from '../query/types.js';
+
+/** Supported document generation modes. */
+export type GenerationMode = 'report' | 'summary' | 'timeline';
+
+/** Supported output formats. */
+export type OutputFormat = 'markdown' | 'plain';
+
+/** Date range filter with ISO 8601 strings. */
+export interface DateRange {
+  from: string;
+  to: string;
+}
+
+/** Optional grouping strategies for timelines. */
+export type TimelineGroupBy = 'type' | 'month' | 'quarter';
+
+/**
+ * Generation request — the input to the document generation pipeline.
+ * Corresponds to the PRD-083 GenerationRequest data model.
+ */
+export interface GenerationRequest {
+  /** Output mode: report, summary, or timeline. */
+  mode: GenerationMode;
+  /** Topic or question — required for report mode. */
+  query?: string;
+  /** Date range filter — required for summary mode. */
+  dateRange?: DateRange;
+  /** Explicit scope filter for retrieval. */
+  scopes?: string[];
+  /** Intended audience scope (e.g., 'work.*'). Controls content inclusion. */
+  audienceScope?: string;
+  /** Opt-in for *.secret.* content (default: false). */
+  includeSecret?: boolean;
+  /** Filter engrams by type (e.g., 'decision', 'meeting'). */
+  types?: string[];
+  /** Filter engrams by tags. */
+  tags?: string[];
+  /** Output format (default: 'markdown'). */
+  format?: OutputFormat;
+  /** Grouping strategy for timeline mode. */
+  groupBy?: TimelineGroupBy;
+}
+
+/** Metadata about the generation process. */
+export interface GenerationMetadata {
+  sourceCount: number;
+  dateRange: DateRange | null;
+  scopeCoverage: string[];
+  mode: GenerationMode;
+  truncated: boolean;
+}
+
+/**
+ * Generated document — the output of the document generation pipeline.
+ * Corresponds to the PRD-083 GeneratedDocument data model.
+ */
+export interface GeneratedDocument {
+  title: string;
+  body: string;
+  mode: GenerationMode;
+  sources: SourceCitation[];
+  audienceScope: string;
+  dateRange: DateRange | null;
+  metadata: GenerationMetadata;
+}
+
+/** Result of a generate call — document or notice on insufficient data. */
+export interface GenerationResult {
+  document: GeneratedDocument | null;
+  notice?: string;
+}
+
+/** Result of a preview call — sources and outline without full generation. */
+export interface PreviewResult {
+  sources: SourceCitation[];
+  outline: string;
+}
+
+/** Type importance ranking for summary highlights (higher = more important). */
+export const TYPE_IMPORTANCE: Record<string, number> = {
+  decision: 7,
+  research: 6,
+  meeting: 5,
+  idea: 4,
+  journal: 3,
+  note: 2,
+  capture: 1,
+};

--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -3,6 +3,7 @@
  * See docs/themes/06-cerebrum for the full spec.
  */
 import { router } from '../../trpc.js';
+import { emitRouter } from './emit/router.js';
 import { engramsRouter } from './engrams/router.js';
 import { scopesRouter } from './engrams/scopes-router.js';
 import { ingestRouter } from './ingest/router.js';
@@ -19,4 +20,5 @@ export const cerebrumRouter = router({
   retrieval: retrievalRouter,
   ingest: ingestRouter,
   query: queryRouter,
+  emit: emitRouter,
 });

--- a/docs/themes/06-cerebrum/epics/03-emit.md
+++ b/docs/themes/06-cerebrum/epics/03-emit.md
@@ -11,7 +11,7 @@ Build the output layer that transforms stored knowledge into usable artifacts. E
 | #   | PRD                                                              | Summary                                                                               | Status      |
 | --- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ----------- |
 | 082 | [Query Engine](../prds/082-query-engine/README.md)               | Natural language Q&A, scope-aware retrieval, source attribution, multi-domain queries | Done        |
-| 083 | [Document Generation](../prds/083-document-generation/README.md) | Reports, summaries, timelines — scope-filtered, audience-aware output documents       | Not started |
+| 083 | [Document Generation](../prds/083-document-generation/README.md) | Reports, summaries, timelines — scope-filtered, audience-aware output documents       | Done        |
 | 084 | [Proactive Nudges](../prds/084-proactive-nudges/README.md)       | Consolidation proposals, staleness alerts, pattern detection, notification delivery   | Not started |
 
 PRD-082 (Query Engine) is the foundation — PRDs 083 and 084 depend on the retrieval and grounding patterns it establishes. PRD-083 and PRD-084 can parallelise after PRD-082.

--- a/docs/themes/06-cerebrum/prds/083-document-generation/README.md
+++ b/docs/themes/06-cerebrum/prds/083-document-generation/README.md
@@ -1,7 +1,7 @@
 # PRD-083: Document Generation
 
 > Epic: [03 — Emit](../../epics/03-emit.md)
-> Status: Not started
+> Status: Done
 
 ## Overview
 
@@ -75,12 +75,12 @@ Define the document generation system that produces structured output documents 
 
 ## User Stories
 
-| #   | Story                                                         | Summary                                                                       | Status      | Parallelisable   |
-| --- | ------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------- | ---------------- |
-| 01  | [us-01-report-generation](us-01-report-generation.md)         | Generate structured reports from a query or topic with sections and citations | Not started | No (first)       |
-| 02  | [us-02-summary-generation](us-02-summary-generation.md)       | Generate summaries over time ranges or topics: weekly digest, monthly review  | Not started | Blocked by us-01 |
-| 03  | [us-03-timeline-generation](us-03-timeline-generation.md)     | Generate chronological timelines from dated engrams with optional grouping    | Not started | Blocked by us-01 |
-| 04  | [us-04-scope-filtered-output](us-04-scope-filtered-output.md) | All generated documents respect audience scope and hard-block secret content  | Not started | Yes              |
+| #   | Story                                                         | Summary                                                                       | Status | Parallelisable   |
+| --- | ------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------ | ---------------- |
+| 01  | [us-01-report-generation](us-01-report-generation.md)         | Generate structured reports from a query or topic with sections and citations | Done   | No (first)       |
+| 02  | [us-02-summary-generation](us-02-summary-generation.md)       | Generate summaries over time ranges or topics: weekly digest, monthly review  | Done   | Blocked by us-01 |
+| 03  | [us-03-timeline-generation](us-03-timeline-generation.md)     | Generate chronological timelines from dated engrams with optional grouping    | Done   | Blocked by us-01 |
+| 04  | [us-04-scope-filtered-output](us-04-scope-filtered-output.md) | All generated documents respect audience scope and hard-block secret content  | Done   | Yes              |
 
 US-01 establishes the core generation pipeline (retrieval, synthesis, formatting) that US-02 and US-03 extend with mode-specific behaviour. US-04 is the scope filtering layer and can parallelise with US-01 since it is a cross-cutting concern applied to all modes.
 

--- a/docs/themes/06-cerebrum/prds/083-document-generation/us-01-report-generation.md
+++ b/docs/themes/06-cerebrum/prds/083-document-generation/us-01-report-generation.md
@@ -1,7 +1,7 @@
 # US-01: Report Generation
 
 > PRD: [PRD-083: Document Generation](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a user, I want to generate a structured report from a query or topic by retri
 
 ## Acceptance Criteria
 
-- [ ] The `cerebrum.emit.generateReport` procedure accepts a query string plus optional filters (scopes, audienceScope, includeSecret, types, tags) and returns a `GeneratedDocument`
-- [ ] The generation pipeline: (1) retrieve relevant engrams via Thalamus using the query, (2) cluster retrieved sources by subtopic, (3) generate an outline with section headings, (4) synthesise each section from its source cluster, (5) generate an introduction and conclusion
-- [ ] The generated report is structured Markdown with an H1 title, introduction paragraph, H2 section headings for each subtopic, and a conclusion
-- [ ] Every section cites the engrams it drew from using inline citation IDs (same format as PRD-082: `[engram_id]`)
-- [ ] The `sources` array in the response contains all cited engrams with ID, title, excerpt, and relevance score
-- [ ] If retrieval returns fewer than 2 relevant sources, the system returns `{ document: null, notice: "Insufficient data to generate a meaningful report" }` instead of producing a thin document
-- [ ] The `cerebrum.emit.preview` endpoint returns the retrieved sources and a generated outline without producing the full document — useful for user confirmation before generation
-- [ ] The LLM prompt instructs the model to synthesise information (not copy verbatim), maintain a tone appropriate to the audience scope, and never introduce facts not present in the source material
+- [x] The `cerebrum.emit.generateReport` procedure accepts a query string plus optional filters (scopes, audienceScope, includeSecret, types, tags) and returns a `GeneratedDocument`
+- [x] The generation pipeline: (1) retrieve relevant engrams via Thalamus using the query, (2) cluster retrieved sources by subtopic, (3) generate an outline with section headings, (4) synthesise each section from its source cluster, (5) generate an introduction and conclusion
+- [x] The generated report is structured Markdown with an H1 title, introduction paragraph, H2 section headings for each subtopic, and a conclusion
+- [x] Every section cites the engrams it drew from using inline citation IDs (same format as PRD-082: `[engram_id]`)
+- [x] The `sources` array in the response contains all cited engrams with ID, title, excerpt, and relevance score
+- [x] If retrieval returns fewer than 2 relevant sources, the system returns `{ document: null, notice: "Insufficient data to generate a meaningful report" }` instead of producing a thin document
+- [x] The `cerebrum.emit.preview` endpoint returns the retrieved sources and a generated outline without producing the full document — useful for user confirmation before generation
+- [x] The LLM prompt instructs the model to synthesise information (not copy verbatim), maintain a tone appropriate to the audience scope, and never introduce facts not present in the source material
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/083-document-generation/us-02-summary-generation.md
+++ b/docs/themes/06-cerebrum/prds/083-document-generation/us-02-summary-generation.md
@@ -1,7 +1,7 @@
 # US-02: Summary Generation
 
 > PRD: [PRD-083: Document Generation](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a user, I want to generate summaries over time ranges or topics — weekly di
 
 ## Acceptance Criteria
 
-- [ ] The `cerebrum.emit.generateSummary` procedure accepts a `dateRange` (required: `{ from, to }` in ISO 8601) plus optional filters (scopes, audienceScope, includeSecret, types, tags) and returns a `GeneratedDocument`
-- [ ] Summaries group engrams by type (decisions, meetings, journal entries, research, ideas, notes, captures) and produce a section for each type that has content in the date range
-- [ ] Each type section contains a bulleted list of engrams with their title, date, and a one-sentence summary synthesised from the body
-- [ ] If a topic filter is provided instead of (or in addition to) a date range, the summary groups by subtopic instead of by type
-- [ ] Summaries for empty date ranges (no engrams found) return a document with a note: "No engrams found between {from} and {to}"
-- [ ] The summary includes a "Highlights" section at the top with the 3-5 most significant engrams (by type importance: decisions > research > meetings > ideas > journal > notes > captures)
-- [ ] Source citations are included for every referenced engram — the summary acts as a navigable index into the knowledge base
-- [ ] The generated document's `dateRange` field in the response reflects the actual date range covered (which may differ from the requested range if the earliest/latest engrams fall within a subset)
+- [x] The `cerebrum.emit.generateSummary` procedure accepts a `dateRange` (required: `{ from, to }` in ISO 8601) plus optional filters (scopes, audienceScope, includeSecret, types, tags) and returns a `GeneratedDocument`
+- [x] Summaries group engrams by type (decisions, meetings, journal entries, research, ideas, notes, captures) and produce a section for each type that has content in the date range
+- [x] Each type section contains a bulleted list of engrams with their title, date, and a one-sentence summary synthesised from the body
+- [x] If a topic filter is provided instead of (or in addition to) a date range, the summary groups by subtopic instead of by type
+- [x] Summaries for empty date ranges (no engrams found) return a document with a note: "No engrams found between {from} and {to}"
+- [x] The summary includes a "Highlights" section at the top with the 3-5 most significant engrams (by type importance: decisions > research > meetings > ideas > journal > notes > captures)
+- [x] Source citations are included for every referenced engram — the summary acts as a navigable index into the knowledge base
+- [x] The generated document's `dateRange` field in the response reflects the actual date range covered (which may differ from the requested range if the earliest/latest engrams fall within a subset)
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/083-document-generation/us-03-timeline-generation.md
+++ b/docs/themes/06-cerebrum/prds/083-document-generation/us-03-timeline-generation.md
@@ -1,7 +1,7 @@
 # US-03: Timeline Generation
 
 > PRD: [PRD-083: Document Generation](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a user, I want to generate chronological timelines from dated engrams — dec
 
 ## Acceptance Criteria
 
-- [ ] The `cerebrum.emit.generateTimeline` procedure accepts optional filters (scopes, dateRange, audienceScope, includeSecret, types, tags) and returns a `GeneratedDocument` formatted as a timeline
-- [ ] The timeline is a chronological list of entries ordered by engram creation date (oldest first), each containing: date (formatted as `YYYY-MM-DD`), title, type badge (e.g., `[decision]`, `[meeting]`), and a one-line summary
-- [ ] Optional grouping by type produces parallel timelines (one per type) within the same document, each with its own chronological sequence
-- [ ] Optional grouping by month/quarter produces section headers that break the timeline into time periods
-- [ ] A timeline with a single entry is valid — returned with a note that it represents a single point in time
-- [ ] Metadata-only engrams (empty body) are included in the timeline with their title and date but marked as "metadata only" in place of a summary
-- [ ] The timeline's `dateRange` in the response reflects the actual span from the earliest to latest included engram
-- [ ] Source citations reference every engram included in the timeline
+- [x] The `cerebrum.emit.generateTimeline` procedure accepts optional filters (scopes, dateRange, audienceScope, includeSecret, types, tags) and returns a `GeneratedDocument` formatted as a timeline
+- [x] The timeline is a chronological list of entries ordered by engram creation date (oldest first), each containing: date (formatted as `YYYY-MM-DD`), title, type badge (e.g., `[decision]`, `[meeting]`), and a one-line summary
+- [x] Optional grouping by type produces parallel timelines (one per type) within the same document, each with its own chronological sequence
+- [x] Optional grouping by month/quarter produces section headers that break the timeline into time periods
+- [x] A timeline with a single entry is valid — returned with a note that it represents a single point in time
+- [x] Metadata-only engrams (empty body) are included in the timeline with their title and date but marked as "metadata only" in place of a summary
+- [x] The timeline's `dateRange` in the response reflects the actual span from the earliest to latest included engram
+- [x] Source citations reference every engram included in the timeline
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/083-document-generation/us-04-scope-filtered-output.md
+++ b/docs/themes/06-cerebrum/prds/083-document-generation/us-04-scope-filtered-output.md
@@ -1,7 +1,7 @@
 # US-04: Scope-Filtered Output
 
 > PRD: [PRD-083: Document Generation](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a user generating documents for a specific audience (e.g., a work report, a p
 
 ## Acceptance Criteria
 
-- [ ] Every generation request accepts an `audienceScope` parameter that defines the intended audience (e.g., `work.*`, `personal.*`, `work.projects.karbon`)
-- [ ] When `audienceScope` is provided, retrieval is filtered to only include engrams whose scopes match the audience scope prefix — engrams outside the audience scope are excluded at query time, not post-generation
-- [ ] When `audienceScope` is omitted, it defaults to the broadest non-secret scope among the retrieved sources
-- [ ] The `*.secret.*` hard-block excludes all engrams with any `*.secret.*` scope from retrieval and document content unless `includeSecret: true` is explicitly passed
-- [ ] An engram with both a matching audience scope and a secret scope (e.g., `[work.projects.karbon, work.secret.jobsearch]`) is excluded unless `includeSecret: true` is passed — the most restrictive scope wins
-- [ ] `includeSecret: true` combined with an `audienceScope` only includes secret content within that audience scope — e.g., `audienceScope: work.*, includeSecret: true` includes `work.secret.*` but not `personal.secret.*`
-- [ ] The generated document's metadata includes the `audienceScope` that was applied, so the user can verify what filtering was active
-- [ ] Scope filtering is implemented as a retrieval-time filter (Thalamus query parameter), not a post-generation content scrub — secret content never enters the LLM context window
+- [x] Every generation request accepts an `audienceScope` parameter that defines the intended audience (e.g., `work.*`, `personal.*`, `work.projects.karbon`)
+- [x] When `audienceScope` is provided, retrieval is filtered to only include engrams whose scopes match the audience scope prefix — engrams outside the audience scope are excluded at query time, not post-generation
+- [x] When `audienceScope` is omitted, it defaults to the broadest non-secret scope among the retrieved sources
+- [x] The `*.secret.*` hard-block excludes all engrams with any `*.secret.*` scope from retrieval and document content unless `includeSecret: true` is explicitly passed
+- [x] An engram with both a matching audience scope and a secret scope (e.g., `[work.projects.karbon, work.secret.jobsearch]`) is excluded unless `includeSecret: true` is passed — the most restrictive scope wins
+- [x] `includeSecret: true` combined with an `audienceScope` only includes secret content within that audience scope — e.g., `audienceScope: work.*, includeSecret: true` includes `work.secret.*` but not `personal.secret.*`
+- [x] The generated document's metadata includes the `audienceScope` that was applied, so the user can verify what filtering was active
+- [x] Scope filtering is implemented as a retrieval-time filter (Thalamus query parameter), not a post-generation content scrub — secret content never enters the LLM context window
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Implement all 4 user stories for PRD-083 Document Generation
- Add `cerebrum.emit` module with report, summary, and timeline generation modes
- All output is scope-filtered with secret content hard-blocked at retrieval time (never enters LLM context)
- Reuses existing retrieval, context assembly, and citation parsing infrastructure from PRD-082

## What's included

**US-01 Report Generation**: `cerebrum.emit.generateReport` — structured sections with citations, min 2 sources required, preview endpoint for dry runs

**US-02 Summary Generation**: `cerebrum.emit.generateSummary` — date-range digests grouped by type with highlights, empty range handling, result capping at 50

**US-03 Timeline Generation**: `cerebrum.emit.generateTimeline` — chronological entries with type badges, optional grouping by type/month/quarter, single-entry notice

**US-04 Scope-Filtered Output**: Audience scope enforcement on all modes, secret hard-block at retrieval time, mixed-scope engrams treated as secret, default scope inference

## Files

```
apps/pops-api/src/modules/cerebrum/emit/
  types.ts              — GenerationRequest, GeneratedDocument, etc.
  generation-service.ts — Pipeline orchestrator
  llm.ts                — LLM call helper (extracted for line limit)
  helpers.ts            — Shared helpers (DRY across modes)
  prompts.ts            — LLM prompt templates per mode
  scope-filter.ts       — Audience scope + secret filtering
  router.ts             — tRPC procedures
  modes/
    report.ts           — Report-specific logic
    summary.ts          — Summary-specific logic
    timeline.ts         — Timeline-specific logic
  __tests__/
    generation-service.test.ts — 17 tests
    modes.test.ts              — 22 tests
    scope-filter.test.ts       — 24 tests
```

## Test plan

- [x] 63 unit tests pass covering all modes, scope filtering, and pipeline
- [x] Zero lint errors (oxlint)
- [x] Zero format issues (oxfmt)
- [x] Zero type errors in emit module (tsc)
- [x] Full monorepo typecheck passes (turbo typecheck)
- [x] Pre-commit hooks pass (lint-staged + typecheck)

Closes #1837