### PR TITLE
feat: context awareness, tier-list hydration fix, PRD-087 doc sync

### DIFF
--- a/apps/pops-api/src/modules/ego/__tests__/context-awareness.test.ts
+++ b/apps/pops-api/src/modules/ego/__tests__/context-awareness.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Tests for PRD-087 US-03: Context Awareness.
+ *
+ * Covers: rich app context in system prompt, auto-load viewed engram,
+ * scope biasing, context.getActive endpoint, app context update detection,
+ * persistence additions (updateAppContext, getContextEntries).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RetrievalResult } from '../../cerebrum/retrieval/types.js';
+import type { AppContext, ChatParams } from '../types.js';
+
+// --- Mocks ---
+
+const mockHybrid =
+  vi.fn<
+    (
+      query: string,
+      filters: Record<string, unknown>,
+      limit: number,
+      threshold: number
+    ) => Promise<RetrievalResult[]>
+  >();
+
+vi.mock('../../../db.js', () => ({
+  getDrizzle: () => ({}),
+}));
+
+vi.mock('../../cerebrum/retrieval/hybrid-search.js', () => ({
+  HybridSearchService: class {
+    hybrid = mockHybrid;
+  },
+}));
+
+const mockEngramRead = vi.fn();
+
+vi.mock('../../cerebrum/instance.js', () => ({
+  getEngramService: () => ({
+    read: mockEngramRead,
+  }),
+}));
+
+const mockCreate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = { create: mockCreate };
+    constructor() {
+      this.messages = { create: mockCreate };
+    }
+  },
+}));
+
+vi.mock('../../../env.js', () => ({
+  getEnv: (name: string) => {
+    if (name === 'ANTHROPIC_API_KEY') return 'test-key';
+    return undefined;
+  },
+}));
+
+vi.mock('../../../lib/inference-middleware.js', () => ({
+  trackInference: (_params: unknown, fn: () => Promise<unknown>) => fn(),
+}));
+
+vi.mock('../../../lib/ai-retry.js', () => ({
+  withRateLimitRetry: (fn: () => Promise<unknown>) => fn(),
+}));
+
+vi.mock('../../../lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Import after mocks
+const { ConversationEngine } = await import('../engine.js');
+const { biasScopes, loadViewedEngram } = await import('../context-helpers.js');
+const { buildEgoSystemPrompt, formatAppContextBlock } = await import('../prompts.js');
+
+// --- Helpers ---
+
+function makeRetrievalResult(overrides?: Partial<RetrievalResult>): RetrievalResult {
+  return {
+    sourceType: 'engram',
+    sourceId: 'eng_20260417_0942_agent-coordination',
+    title: 'Agent Coordination',
+    contentPreview: 'Notes about coordinating multiple AI agents.',
+    score: 0.85,
+    matchType: 'semantic',
+    metadata: {
+      type: 'research',
+      scopes: ['work.projects'],
+      tags: ['ai', 'agents'],
+      createdAt: '2026-04-17',
+    },
+    ...overrides,
+  };
+}
+
+function makeLlmResponse(text: string, tokensIn = 100, tokensOut = 50) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    usage: { input_tokens: tokensIn, output_tokens: tokensOut },
+  };
+}
+
+function defaultChatParams(overrides?: Partial<ChatParams>): ChatParams {
+  return {
+    conversationId: 'conv_test_001',
+    message: 'What do I know about budgets?',
+    history: [],
+    activeScopes: ['personal.finance'],
+    ...overrides,
+  };
+}
+
+function getHybridFilters(): Record<string, unknown> {
+  const call = mockHybrid.mock.calls[0];
+  return (call?.[1] ?? {}) as Record<string, unknown>;
+}
+
+// --- Tests ---
+
+describe('US-03: Context Awareness', () => {
+  let engine: InstanceType<typeof ConversationEngine>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    engine = new ConversationEngine();
+  });
+
+  // ---- 1. Rich app context in system prompt (prompts.ts) ----
+
+  describe('formatAppContextBlock', () => {
+    it('returns empty string when no app context is provided', () => {
+      expect(formatAppContextBlock()).toBe('');
+      expect(formatAppContextBlock(undefined)).toBe('');
+    });
+
+    it('returns human-readable description for known apps', () => {
+      const ctx: AppContext = { app: 'finance' };
+      const block = formatAppContextBlock(ctx);
+      expect(block).toContain('Finance app');
+      expect(block).toContain('transactions, budgets');
+    });
+
+    it('includes route when provided', () => {
+      const ctx: AppContext = { app: 'media', route: '/media/watchlist' };
+      const block = formatAppContextBlock(ctx);
+      expect(block).toContain('Media app');
+      expect(block).toContain('/media/watchlist');
+    });
+
+    it('includes entity details when both entityId and entityType are set', () => {
+      const ctx: AppContext = {
+        app: 'cerebrum',
+        entityType: 'engram',
+        entityId: 'eng_20260417_0942_budget',
+      };
+      const block = formatAppContextBlock(ctx);
+      expect(block).toContain('engram');
+      expect(block).toContain('eng_20260417_0942_budget');
+    });
+
+    it('falls back to generic description for unknown apps', () => {
+      const ctx: AppContext = { app: 'custom' };
+      const block = formatAppContextBlock(ctx);
+      expect(block).toContain('the custom app');
+    });
+  });
+
+  describe('buildEgoSystemPrompt with appContext', () => {
+    it('includes app context block in system prompt', () => {
+      const prompt = buildEgoSystemPrompt(['personal.finance'], {
+        app: 'finance',
+        route: '/transactions',
+      });
+      expect(prompt).toContain('Finance app');
+      expect(prompt).toContain('/transactions');
+      expect(prompt).toContain('Active scopes');
+    });
+
+    it('omits app context block when no context given', () => {
+      const prompt = buildEgoSystemPrompt(['personal.finance']);
+      expect(prompt).not.toContain('Current app context');
+    });
+  });
+
+  // ---- 2. Auto-load viewed engram (engine.ts) ----
+
+  describe('loadViewedEngram', () => {
+    it('returns null when no app context', () => {
+      expect(loadViewedEngram()).toBeNull();
+      expect(loadViewedEngram(undefined)).toBeNull();
+    });
+
+    it('returns null when entityType is not "engram"', () => {
+      expect(
+        loadViewedEngram({ app: 'finance', entityType: 'transaction', entityId: 'txn_123' })
+      ).toBeNull();
+    });
+
+    it('returns null when entityId is missing', () => {
+      expect(loadViewedEngram({ app: 'cerebrum', entityType: 'engram' })).toBeNull();
+    });
+
+    it('returns a synthetic RetrievalResult with score 1.0 for a viewed engram', () => {
+      mockEngramRead.mockReturnValue({
+        engram: {
+          id: 'eng_20260417_0942_budget',
+          title: 'Budget Planning',
+          type: 'note',
+          scopes: ['personal.finance'],
+          tags: ['budget'],
+          created: '2026-04-17',
+        },
+        body: 'Detailed notes about budgeting strategies and tips for saving.',
+      });
+
+      const result = loadViewedEngram({
+        app: 'cerebrum',
+        entityType: 'engram',
+        entityId: 'eng_20260417_0942_budget',
+      });
+
+      expect(result).not.toBeNull();
+      expect(result?.score).toBe(1.0);
+      expect(result?.sourceId).toBe('eng_20260417_0942_budget');
+      expect(result?.title).toBe('Budget Planning');
+      expect(result?.matchType).toBe('structured');
+      expect(result?.metadata).toMatchObject({ autoLoaded: true });
+    });
+
+    it('returns null and logs warning when engram read fails', () => {
+      mockEngramRead.mockImplementation(() => {
+        throw new Error('Engram not found');
+      });
+
+      const result = loadViewedEngram({
+        app: 'cerebrum',
+        entityType: 'engram',
+        entityId: 'eng_nonexistent',
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('engine auto-loads viewed engram during chat', () => {
+    it('prepends the viewed engram to retrieval results', async () => {
+      mockEngramRead.mockReturnValue({
+        engram: {
+          id: 'eng_20260417_0942_budget',
+          title: 'Budget Planning',
+          type: 'note',
+          scopes: ['personal.finance'],
+          tags: ['budget'],
+          created: '2026-04-17',
+        },
+        body: 'Budget strategies.',
+      });
+      mockHybrid.mockResolvedValue([makeRetrievalResult()]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Here is what I found.'));
+
+      const result = await engine.chat(
+        defaultChatParams({
+          appContext: {
+            app: 'cerebrum',
+            entityType: 'engram',
+            entityId: 'eng_20260417_0942_budget',
+          },
+        })
+      );
+
+      // Should have both the auto-loaded engram and the retrieved one
+      expect(result.retrievedEngrams).toHaveLength(2);
+      expect(result.retrievedEngrams[0]?.engramId).toBe('eng_20260417_0942_budget');
+      expect(result.retrievedEngrams[0]?.relevanceScore).toBe(1.0);
+    });
+
+    it('avoids duplicating engram already in retrieval results', async () => {
+      mockEngramRead.mockReturnValue({
+        engram: {
+          id: 'eng_20260417_0942_agent-coordination',
+          title: 'Agent Coordination',
+          type: 'note',
+          scopes: ['work.projects'],
+          tags: [],
+          created: '2026-04-17',
+        },
+        body: 'Agent notes.',
+      });
+      const retrievedResult = makeRetrievalResult({
+        sourceId: 'eng_20260417_0942_agent-coordination',
+      });
+      mockHybrid.mockResolvedValue([retrievedResult]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Found it.'));
+
+      const result = await engine.chat(
+        defaultChatParams({
+          appContext: {
+            app: 'cerebrum',
+            entityType: 'engram',
+            entityId: 'eng_20260417_0942_agent-coordination',
+          },
+        })
+      );
+
+      // Should not duplicate — only 1 result
+      expect(result.retrievedEngrams).toHaveLength(1);
+    });
+  });
+
+  // ---- 3. Scope biasing (engine.ts) ----
+
+  describe('biasScopes', () => {
+    it('returns original scopes when no app context', () => {
+      const scopes = ['work.projects', 'personal.journal'];
+      expect(biasScopes(scopes)).toEqual(scopes);
+    });
+
+    it('adds finance scope prefix when in finance app', () => {
+      const scopes = ['work.projects'];
+      const biased = biasScopes(scopes, { app: 'finance' });
+      expect(biased).toContain('work.projects');
+      expect(biased).toContain('personal.finance');
+    });
+
+    it('adds media scope prefix when in media app', () => {
+      const biased = biasScopes([], { app: 'media' });
+      expect(biased).toContain('personal.media');
+    });
+
+    it('adds multiple prefixes for ai app', () => {
+      const biased = biasScopes([], { app: 'ai' });
+      expect(biased).toContain('personal.ai');
+      expect(biased).toContain('work.ai');
+    });
+
+    it('does not duplicate existing scopes', () => {
+      const scopes = ['personal.finance'];
+      const biased = biasScopes(scopes, { app: 'finance' });
+      const financeCount = biased.filter((s) => s === 'personal.finance').length;
+      expect(financeCount).toBe(1);
+    });
+
+    it('returns original scopes for cerebrum app (no bias needed)', () => {
+      const scopes = ['work.projects'];
+      const biased = biasScopes(scopes, { app: 'cerebrum' });
+      expect(biased).toEqual(scopes);
+    });
+
+    it('returns original scopes for unknown apps', () => {
+      const scopes = ['work.projects'];
+      const biased = biasScopes(scopes, { app: 'unknown_app' });
+      expect(biased).toEqual(scopes);
+    });
+  });
+
+  describe('engine applies scope biasing during retrieval', () => {
+    it('passes biased scopes to hybrid search when app context is set', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Test.'));
+
+      await engine.chat(
+        defaultChatParams({
+          activeScopes: ['work.projects'],
+          appContext: { app: 'finance' },
+        })
+      );
+
+      const filters = getHybridFilters();
+      const scopes = filters['scopes'] as string[];
+      expect(scopes).toContain('work.projects');
+      expect(scopes).toContain('personal.finance');
+    });
+  });
+
+  // ---- 4. App context update detection (router.ts helpers) ----
+
+  // These are tested in the integration sense via the router, but we can
+  // also test the detection logic. Since appContextChanged is not exported
+  // from router, we test it via the full chat flow. We verify the prompt
+  // correctly includes app context which proves it was passed through.
+
+  describe('system prompt reflects app context changes', () => {
+    it('includes new app context in the system prompt', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Media response.'));
+
+      await engine.chat(
+        defaultChatParams({
+          appContext: {
+            app: 'media',
+            route: '/media/watchlist',
+          },
+        })
+      );
+
+      const callArgs = mockCreate.mock.calls[0]?.[0] as { system: string };
+      expect(callArgs.system).toContain('Media app');
+      expect(callArgs.system).toContain('/media/watchlist');
+    });
+
+    it('handles switching from finance to media app context', async () => {
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Response after switch.'));
+
+      // First call with finance context
+      await engine.chat(
+        defaultChatParams({
+          appContext: { app: 'finance', route: '/transactions' },
+        })
+      );
+
+      const firstCall = mockCreate.mock.calls[0]?.[0] as { system: string };
+      expect(firstCall.system).toContain('Finance app');
+
+      vi.clearAllMocks();
+      mockHybrid.mockResolvedValue([]);
+      mockCreate.mockResolvedValue(makeLlmResponse('Now in media.'));
+
+      // Second call with media context
+      await engine.chat(
+        defaultChatParams({
+          appContext: { app: 'media', route: '/watchlist' },
+        })
+      );
+
+      const secondCall = mockCreate.mock.calls[0]?.[0] as { system: string };
+      expect(secondCall.system).toContain('Media app');
+      expect(secondCall.system).not.toContain('Finance app');
+    });
+  });
+});

--- a/apps/pops-api/src/modules/ego/__tests__/engine.test.ts
+++ b/apps/pops-api/src/modules/ego/__tests__/engine.test.ts
@@ -25,6 +25,14 @@ vi.mock('../../cerebrum/retrieval/hybrid-search.js', () => ({
   },
 }));
 
+vi.mock('../../cerebrum/instance.js', () => ({
+  getEngramService: () => ({
+    read: () => {
+      throw new Error('No engram in test context');
+    },
+  }),
+}));
+
 const mockCreate = vi.fn();
 
 vi.mock('@anthropic-ai/sdk', () => ({
@@ -288,7 +296,7 @@ describe('ConversationEngine', () => {
       );
 
       const callArgs = mockCreate.mock.calls[0]?.[0] as { system: string };
-      expect(callArgs.system).toContain('finance');
+      expect(callArgs.system).toContain('Finance app');
     });
 
     it('attaches retrieved engram context to the user message', async () => {

--- a/apps/pops-api/src/modules/ego/context-helpers.ts
+++ b/apps/pops-api/src/modules/ego/context-helpers.ts
@@ -1,0 +1,74 @@
+/**
+ * Context awareness helpers for the Ego conversation engine (PRD-087 US-03).
+ *
+ * Extracted from engine.ts to keep file sizes manageable:
+ *  - biasScopes: additive scope biasing based on active app context
+ *  - loadViewedEngram: auto-load viewed engram as a synthetic RetrievalResult
+ */
+import { logger } from '../../lib/logger.js';
+import { getEngramService } from '../cerebrum/instance.js';
+
+import type { RetrievalResult } from '../cerebrum/retrieval/types.js';
+import type { AppContext } from './types.js';
+
+/**
+ * Mapping from pops app names to scope prefixes used for retrieval biasing.
+ * When the user is in a specific app, these prefixes are added (additively)
+ * to the retrieval filter scopes so that app-relevant engrams rank higher.
+ */
+const APP_SCOPE_PREFIXES: Record<string, string[]> = {
+  finance: ['personal.finance'],
+  media: ['personal.media'],
+  inventory: ['personal.inventory'],
+  cerebrum: [],
+  ai: ['personal.ai', 'work.ai'],
+};
+
+/**
+ * Bias retrieval scopes towards the active app. Adds app-relevant scope
+ * prefixes to the existing scopes (additive, not exclusive). Deduplicates.
+ */
+export function biasScopes(scopes: string[], appContext?: AppContext): string[] {
+  if (!appContext) return scopes;
+  const prefixes = APP_SCOPE_PREFIXES[appContext.app];
+  if (!prefixes || prefixes.length === 0) return scopes;
+
+  const biased = new Set(scopes);
+  for (const prefix of prefixes) {
+    biased.add(prefix);
+  }
+  return [...biased];
+}
+
+/**
+ * Auto-load the viewed engram as a synthetic RetrievalResult with score 1.0.
+ * Only triggers when `appContext.entityType === 'engram'` and entityId is set.
+ */
+export function loadViewedEngram(appContext?: AppContext): RetrievalResult | null {
+  if (!appContext?.entityId || appContext.entityType !== 'engram') return null;
+
+  try {
+    const { engram, body } = getEngramService().read(appContext.entityId);
+    return {
+      sourceType: 'engram',
+      sourceId: engram.id,
+      title: engram.title,
+      contentPreview: body.slice(0, 500),
+      score: 1.0,
+      matchType: 'structured',
+      metadata: {
+        type: engram.type,
+        scopes: engram.scopes,
+        tags: engram.tags,
+        createdAt: engram.created,
+        autoLoaded: true,
+      },
+    };
+  } catch (err) {
+    logger.warn(
+      { error: err instanceof Error ? err.message : String(err), engramId: appContext.entityId },
+      '[Ego] Failed to auto-load viewed engram — continuing without it'
+    );
+    return null;
+  }
+}

--- a/apps/pops-api/src/modules/ego/engine.ts
+++ b/apps/pops-api/src/modules/ego/engine.ts
@@ -1,5 +1,5 @@
 /**
- * ConversationEngine — multi-turn conversation manager for Ego (PRD-087 US-01).
+ * ConversationEngine — multi-turn conversation manager for Ego (PRD-087 US-01, US-03).
  *
  * Orchestrates the chat pipeline: scope negotiation, Thalamus retrieval,
  * context window assembly, LLM call, citation parsing, and token tracking.
@@ -9,6 +9,7 @@ import { logger } from '../../lib/logger.js';
 import { CitationParser } from '../cerebrum/query/citation-parser.js';
 import { ContextAssemblyService } from '../cerebrum/retrieval/context-assembly.js';
 import { HybridSearchService } from '../cerebrum/retrieval/hybrid-search.js';
+import { biasScopes, loadViewedEngram } from './context-helpers.js';
 import { callChatLlm, callSummariseLlm } from './llm-client.js';
 import { buildEgoSystemPrompt, buildSummarisationPrompt } from './prompts.js';
 import { ConversationScopeNegotiator } from './scope-negotiator.js';
@@ -75,9 +76,19 @@ export class ConversationEngine {
     const negotiation = this.negotiateScopes(params);
     const effectiveScopes = negotiation.scopes;
 
-    const retrievalResults = await this.retrieveEngrams(message, effectiveScopes);
+    // US-03: Bias scopes towards the active app context (additive).
+    const biasedScopes = biasScopes(effectiveScopes, appContext);
+
+    // US-03: Auto-load viewed engram when user is viewing one in Cerebrum.
+    const viewedEngram = loadViewedEngram(appContext);
+
+    const retrievalResults = await this.retrieveEngrams(message, biasedScopes);
+
+    // Prepend the viewed engram if it wasn't already retrieved.
+    const allResults = this.mergeViewedEngram(viewedEngram, retrievalResults);
+
     const { systemPrompt, contextBlock } = this.buildContextWindow(
-      retrievalResults,
+      allResults,
       effectiveScopes,
       appContext
     );
@@ -86,10 +97,7 @@ export class ConversationEngine {
     const scopeNotice = this.buildScopeNotice(negotiation);
     const llmMessages = this.buildLlmMessages(history, message, contextBlock);
     const llmResponse = await callChatLlm(this.config.model, systemPrompt, llmMessages);
-    const { cleanedAnswer, citations } = this.citationParser.parse(
-      llmResponse.content,
-      retrievalResults
-    );
+    const { cleanedAnswer, citations } = this.citationParser.parse(llmResponse.content, allResults);
 
     const responseContent = scopeNotice ? `${scopeNotice}\n\n${cleanedAnswer}` : cleanedAnswer;
 
@@ -100,7 +108,7 @@ export class ConversationEngine {
         tokensIn: llmResponse.tokensIn,
         tokensOut: llmResponse.tokensOut,
       },
-      retrievedEngrams: retrievalResults.map((r) => ({
+      retrievedEngrams: allResults.map((r) => ({
         engramId: r.sourceId,
         relevanceScore: r.score,
       })),
@@ -149,6 +157,20 @@ export class ConversationEngine {
       parts.push(negotiation.secretNotice);
     }
     return parts.length > 0 ? parts.join('\n\n') : null;
+  }
+
+  /**
+   * Merge the auto-loaded viewed engram with retrieval results.
+   * Prepends it if not already present (avoids duplicates).
+   */
+  private mergeViewedEngram(
+    viewedEngram: RetrievalResult | null,
+    retrievalResults: RetrievalResult[]
+  ): RetrievalResult[] {
+    if (!viewedEngram) return retrievalResults;
+    const alreadyRetrieved = retrievalResults.some((r) => r.sourceId === viewedEngram.sourceId);
+    if (alreadyRetrieved) return retrievalResults;
+    return [viewedEngram, ...retrievalResults];
   }
 
   private async retrieveEngrams(query: string, scopes: string[]): Promise<RetrievalResult[]> {

--- a/apps/pops-api/src/modules/ego/index.ts
+++ b/apps/pops-api/src/modules/ego/index.ts
@@ -5,9 +5,11 @@
  *   ego.conversations.create/list/get/delete — CRUD (US-05)
  *   ego.chat                                 — multi-turn conversation (US-01)
  *   ego.context.setScopes                    — explicit scope override (US-04)
+ *   ego.context.getActive                    — current context state (US-03)
  */
 import { mergeRouters, router } from '../../trpc.js';
-import { chatRouter, contextRouter, conversationsRouter } from './router.js';
+import { contextRouter } from './router-context.js';
+import { chatRouter, conversationsRouter } from './router.js';
 
 export const egoRouter = mergeRouters(
   chatRouter,

--- a/apps/pops-api/src/modules/ego/persistence.ts
+++ b/apps/pops-api/src/modules/ego/persistence.ts
@@ -175,6 +175,34 @@ export class ConversationPersistence {
       .run();
   }
 
+  /** Update the conversation's app context (US-03). */
+  updateAppContext(conversationId: string, appContext: unknown): void {
+    this.db
+      .update(conversations)
+      .set({
+        appContext: appContext != null ? JSON.stringify(appContext) : null,
+        updatedAt: this.now().toISOString(),
+      })
+      .where(eq(conversations.id, conversationId))
+      .run();
+  }
+
+  /** Get all context entries (engram associations) for a conversation (US-03). */
+  getContextEntries(
+    conversationId: string
+  ): Array<{ engramId: string; relevanceScore: number | null; loadedAt: string }> {
+    return this.db
+      .select({
+        engramId: conversationContext.engramId,
+        relevanceScore: conversationContext.relevanceScore,
+        loadedAt: conversationContext.loadedAt,
+      })
+      .from(conversationContext)
+      .where(eq(conversationContext.conversationId, conversationId))
+      .orderBy(desc(conversationContext.loadedAt))
+      .all();
+  }
+
   /** Auto-generate title from first user message when no title is set. */
   private maybeAutoTitle(conversationId: string, input: AppendMessageInput): void {
     if (input.role !== 'user') return;

--- a/apps/pops-api/src/modules/ego/prompts.ts
+++ b/apps/pops-api/src/modules/ego/prompts.ts
@@ -1,11 +1,41 @@
 /**
- * LLM system prompt templates for the Ego conversation engine (PRD-087 US-01).
+ * LLM system prompt templates for the Ego conversation engine (PRD-087 US-01, US-03).
  *
  * Prompts are exported as pure functions so they can be tested and overridden
  * without coupling to the engine class.
  */
 
 import type { AppContext } from './types.js';
+
+/** Human-readable descriptions for each pops app. */
+const APP_DESCRIPTIONS: Record<string, string> = {
+  finance: 'the Finance app (transactions, budgets, entities, imports)',
+  media: 'the Media app (movies, TV shows, watchlist, watch history, rankings)',
+  inventory: 'the Inventory app (items, locations, warranties, insurance)',
+  cerebrum: 'the Cerebrum knowledge base (engrams, scopes, retrieval)',
+  ai: 'the AI Ops app (usage tracking, model config, rules)',
+};
+
+/**
+ * Format an AppContext into a human-readable context description block.
+ *
+ * Returns an empty string when no app context is provided.
+ */
+export function formatAppContextBlock(appContext?: AppContext): string {
+  if (!appContext) return '';
+
+  const appDesc = APP_DESCRIPTIONS[appContext.app] ?? `the ${appContext.app} app`;
+  const parts: string[] = [`The user is currently in ${appDesc}.`];
+
+  if (appContext.route) {
+    parts.push(`Current route: ${appContext.route}`);
+  }
+  if (appContext.entityId && appContext.entityType) {
+    parts.push(`Viewing ${appContext.entityType}: ${appContext.entityId}`);
+  }
+
+  return `\n\nCurrent app context:\n${parts.join('\n')}`;
+}
 
 /**
  * Build the Ego system prompt for a conversation turn.
@@ -15,13 +45,7 @@ import type { AppContext } from './types.js';
  */
 export function buildEgoSystemPrompt(scopes: string[], appContext?: AppContext): string {
   const scopeList = scopes.length > 0 ? scopes.join(', ') : '(all non-secret scopes)';
-
-  const appLine = appContext ? `\nThe user is currently in: ${appContext.app}` : '';
-  const routeLine = appContext?.route ? ` (route: ${appContext.route})` : '';
-  const entityLine =
-    appContext?.entityId && appContext.entityType
-      ? ` viewing ${appContext.entityType}: ${appContext.entityId}`
-      : '';
+  const contextBlock = formatAppContextBlock(appContext);
 
   return `You are Ego, the conversational interface to Cerebrum \u2014 a personal knowledge management system.
 
@@ -30,7 +54,7 @@ Your capabilities:
 - Answer questions grounded in stored engrams
 - Help the user explore connections between their stored knowledge
 
-Active scopes for this conversation: ${scopeList}${appLine}${routeLine}${entityLine}
+Active scopes for this conversation: ${scopeList}${contextBlock}
 
 When referencing engrams, always cite them by ID in square brackets: [eng_YYYYMMDD_HHmm_slug]
 If the available context doesn't contain enough information, say so explicitly rather than guessing.`;

--- a/apps/pops-api/src/modules/ego/router-context.ts
+++ b/apps/pops-api/src/modules/ego/router-context.ts
@@ -1,0 +1,62 @@
+/**
+ * Context sub-router for ego — scope management + context state (PRD-087 US-03, US-04).
+ */
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { getDrizzle } from '../../db.js';
+import { protectedProcedure, router } from '../../trpc.js';
+import { ConversationPersistence } from './persistence.js';
+
+import type { AppContext } from './types.js';
+
+function getPersistence(): ConversationPersistence {
+  return new ConversationPersistence({ db: getDrizzle() });
+}
+
+const setScopesSchema = z.object({
+  conversationId: z.string().min(1),
+  scopes: z.array(z.string()),
+});
+
+const getActiveSchema = z.object({
+  conversationId: z.string().min(1),
+});
+
+/** Context sub-router: scope management + context state (PRD-087 US-03, US-04). */
+export const contextRouter = router({
+  setScopes: protectedProcedure.input(setScopesSchema).mutation(({ input }) => {
+    const persistence = getPersistence();
+    const existing = persistence.getConversation(input.conversationId);
+    if (!existing) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: `Conversation '${input.conversationId}' not found`,
+      });
+    }
+    persistence.updateScopes(input.conversationId, input.scopes);
+    return { scopes: input.scopes };
+  }),
+
+  /** US-03: Return the current context state for a conversation. */
+  getActive: protectedProcedure.input(getActiveSchema).query(({ input }) => {
+    const persistence = getPersistence();
+    const existing = persistence.getConversation(input.conversationId);
+    if (!existing) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: `Conversation '${input.conversationId}' not found`,
+      });
+    }
+    const contextEntries = persistence.getContextEntries(input.conversationId);
+    return {
+      scopes: existing.conversation.activeScopes,
+      appContext: existing.conversation.appContext as AppContext | null,
+      engrams: contextEntries.map((entry) => ({
+        engramId: entry.engramId,
+        relevanceScore: entry.relevanceScore,
+        loadedAt: entry.loadedAt,
+      })),
+    };
+  }),
+});

--- a/apps/pops-api/src/modules/ego/router.ts
+++ b/apps/pops-api/src/modules/ego/router.ts
@@ -31,15 +31,44 @@ function getEngine(): ConversationEngine {
   return new ConversationEngine();
 }
 
-/** Persist chat results: scope changes, messages, and engram context. */
-function persistChatResults(
-  persistence: ConversationPersistence,
-  conversationId: string,
-  userMessage: string,
-  result: ChatResult
-): Message {
+/**
+ * Check whether two AppContext values differ (by value, not reference).
+ * Returns true if the incoming context is meaningfully different from stored.
+ */
+function appContextChanged(
+  stored: AppContext | undefined | null,
+  incoming: AppContext | undefined
+): boolean {
+  if (!stored && !incoming) return false;
+  if (!stored || !incoming) return true;
+  return (
+    stored.app !== incoming.app ||
+    stored.route !== incoming.route ||
+    stored.entityId !== incoming.entityId ||
+    stored.entityType !== incoming.entityType
+  );
+}
+
+interface PersistChatParams {
+  persistence: ConversationPersistence;
+  conversationId: string;
+  userMessage: string;
+  result: ChatResult;
+  storedAppContext?: AppContext | null;
+  incomingAppContext?: AppContext;
+}
+
+/** Persist chat results: scope changes, app context changes, messages, and engram context. */
+function persistChatResults(params: PersistChatParams): Message {
+  const { persistence, conversationId, userMessage, result } = params;
+
   if (result.scopeNegotiation?.changed) {
     persistence.updateScopes(conversationId, result.scopeNegotiation.scopes);
+  }
+
+  // US-03: Detect app context change and persist it.
+  if (appContextChanged(params.storedAppContext, params.incomingAppContext)) {
+    persistence.updateAppContext(conversationId, params.incomingAppContext ?? null);
   }
 
   persistence.appendMessage(conversationId, { role: 'user', content: userMessage });
@@ -126,11 +155,6 @@ const chatInputSchema = z.object({
   knownScopes: z.array(z.string().min(1)).optional(),
 });
 
-const setScopesSchema = z.object({
-  conversationId: z.string().min(1),
-  scopes: z.array(z.string()),
-});
-
 export const chatRouter = router({
   chat: protectedProcedure.input(chatInputSchema).mutation(async ({ input }) => {
     const store = getStore();
@@ -166,7 +190,14 @@ export const chatRouter = router({
       throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message });
     }
 
-    const assistantMsg = persistChatResults(persistence, conversation.id, input.message, result);
+    const assistantMsg = persistChatResults({
+      persistence,
+      conversationId: conversation.id,
+      userMessage: input.message,
+      result,
+      storedAppContext: conversation.appContext as AppContext | undefined | null,
+      incomingAppContext: appContext,
+    });
 
     return {
       conversationId: conversation.id,
@@ -201,21 +232,5 @@ export const conversationsRouter = router({
   delete: protectedProcedure.input(deleteSchema).mutation(({ input }) => {
     getPersistence().deleteConversation(input.id);
     return { success: true };
-  }),
-});
-
-/** Context sub-router: explicit scope management (PRD-087 US-04). */
-export const contextRouter = router({
-  setScopes: protectedProcedure.input(setScopesSchema).mutation(({ input }) => {
-    const persistence = getPersistence();
-    const existing = persistence.getConversation(input.conversationId);
-    if (!existing) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: `Conversation '${input.conversationId}' not found`,
-      });
-    }
-    persistence.updateScopes(input.conversationId, input.scopes);
-    return { scopes: input.scopes };
   }),
 });

--- a/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
+++ b/apps/pops-api/src/modules/media/comparisons/comparisons.test.ts
@@ -2209,6 +2209,39 @@ describe('getTierListMovies', () => {
     expect(result.data[0]!.title).toBe('API Movie');
     expect(result.data[0]!.score).toBe(1500);
   });
+
+  it('includes tierOverride when override exists', () => {
+    const dimId = seedDimension(db, { name: 'Override Dim' });
+    const m1 = seedMovie(db, { title: 'Overridden Movie', tmdb_id: 961 });
+    const m2 = seedMovie(db, { title: 'No Override Movie', tmdb_id: 962 });
+
+    seedScore(db, m1, dimId, 1500, 5);
+    seedScore(db, m2, dimId, 1400, 3);
+
+    // Set a tier override for m1
+    db.prepare(
+      "INSERT INTO tier_overrides (media_type, media_id, dimension_id, tier) VALUES ('movie', ?, ?, 'S')"
+    ).run(m1, dimId);
+
+    const results = getTierListMovies(dimId);
+    expect(results).toHaveLength(2);
+
+    const overridden = results.find((r) => r.id === m1);
+    const unranked = results.find((r) => r.id === m2);
+
+    expect(overridden?.tierOverride).toBe('S');
+    expect(unranked?.tierOverride).toBeNull();
+  });
+
+  it('returns null tierOverride when no override exists', () => {
+    const dimId = seedDimension(db, { name: 'No Override Dim' });
+    const m1 = seedMovie(db, { title: 'Plain Movie', tmdb_id: 963 });
+    seedScore(db, m1, dimId, 1500, 5);
+
+    const results = getTierListMovies(dimId);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.tierOverride).toBeNull();
+  });
 });
 
 describe('batchRecordComparisons', () => {

--- a/apps/pops-api/src/modules/media/comparisons/lib/tier-list-selection.ts
+++ b/apps/pops-api/src/modules/media/comparisons/lib/tier-list-selection.ts
@@ -1,7 +1,9 @@
 import { getDb } from '../../../../db.js';
 import { getDimension } from '../dimensions.service.js';
+import { getTierOverrides } from '../tier-overrides.js';
 import { normalizePairOrder } from './comparison-queries.js';
 
+import type { TierOverride } from '../tier-overrides.js';
 import type { TierListMovie } from '../types.js';
 
 const MAX_TIER_LIST_MOVIES = 8;
@@ -23,13 +25,23 @@ function getMoviePosterUrl(override: string | null, tmdbId: number | null): stri
   return null;
 }
 
-function toTierListMovie(row: ScoreRow): TierListMovie {
+/** Build a map of mediaId → tier from tier overrides for fast lookup. */
+function buildTierOverrideMap(overrides: TierOverride[]): Map<number, string> {
+  const map = new Map<number, string>();
+  for (const o of overrides) {
+    map.set(o.mediaId, o.tier);
+  }
+  return map;
+}
+
+function toTierListMovie(row: ScoreRow, tierOverrideMap: Map<number, string>): TierListMovie {
   return {
     id: row.mediaId,
     title: row.title,
     posterUrl: getMoviePosterUrl(row.moviePosterOverride, row.movieTmdbId),
     score: Math.round(row.score * 10) / 10,
     comparisonCount: row.comparisonCount,
+    tierOverride: tierOverrideMap.get(row.mediaId) ?? null,
   };
 }
 
@@ -154,12 +166,19 @@ function greedySelect(rows: ScoreRow[], existingPairs: Set<string>): ScoreRow[] 
  *  3. Tie-break by lowest comparison count (highest uncertainty)
  *  - Exclude: blacklisted, excluded-for-dimension, staleness < 0.3
  *  - Returns fewer than 8 if not enough eligible (min 0)
+ *  - Includes persisted tier overrides so the client can hydrate placements.
  */
 export function getTierListMovies(dimensionId: number): TierListMovie[] {
   getDimension(dimensionId);
   const rows = fetchEligibleRows(dimensionId);
   if (rows.length === 0) return [];
-  if (rows.length <= MAX_TIER_LIST_MOVIES) return rows.map(toTierListMovie);
+
+  const overrides = getTierOverrides(dimensionId);
+  const tierOverrideMap = buildTierOverrideMap(overrides);
+
+  if (rows.length <= MAX_TIER_LIST_MOVIES) {
+    return rows.map((r) => toTierListMovie(r, tierOverrideMap));
+  }
   const existingPairs = fetchExistingPairKeys(dimensionId);
-  return greedySelect(rows, existingPairs).map(toTierListMovie);
+  return greedySelect(rows, existingPairs).map((r) => toTierListMovie(r, tierOverrideMap));
 }

--- a/apps/pops-api/src/modules/media/comparisons/types-domain.ts
+++ b/apps/pops-api/src/modules/media/comparisons/types-domain.ts
@@ -184,6 +184,8 @@ export interface TierListMovie {
   posterUrl: string | null;
   score: number;
   comparisonCount: number;
+  /** Persisted tier override from a previous submission, or null if unranked. */
+  tierOverride: string | null;
 }
 
 const TIER_RANKS = ['S', 'A', 'B', 'C', 'D'] as const;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -135,10 +135,10 @@ Live status of every theme and epic. Updated as work completes.
 
 ### Cerebrum — Phase 2 (Curation & Interface)
 
-| Epic                    | Status      | Notes                                                       |
-| ----------------------- | ----------- | ----------------------------------------------------------- |
-| Glia (curation workers) | Not started | Pruner, consolidator, linker, auditor + trust graduation    |
-| Ego (chat agent)        | Partial     | PRD-088 (Ego Channels) done. PRD-087 (Ego Core) not started |
+| Epic                    | Status      | Notes                                                                               |
+| ----------------------- | ----------- | ----------------------------------------------------------------------------------- |
+| Glia (curation workers) | Not started | Pruner, consolidator, linker, auditor + trust graduation                            |
+| Ego (chat agent)        | Partial     | PRD-088 (Ego Channels) done. PRD-087 (Ego Core) partial — SSE streaming gap remains |
 
 ### Cerebrum — Phase 3 (Automation & Ecosystem)
 

--- a/docs/themes/06-cerebrum/epics/05-ego.md
+++ b/docs/themes/06-cerebrum/epics/05-ego.md
@@ -8,10 +8,10 @@ Build the conversational agent that serves as the "I" of the system. Ego is a to
 
 ## PRDs
 
-| #   | PRD                                                | Summary                                                                              | Status      |
-| --- | -------------------------------------------------- | ------------------------------------------------------------------------------------ | ----------- |
-| 087 | [Ego Core](../prds/087-ego-core/README.md)         | Conversation engine, context management, scope negotiation, conversation persistence | Not started |
-| 088 | [Ego Channels](../prds/088-ego-channels/README.md) | Shell chat panel, MCP tools for Claude Code, Moltbot integration, CLI interface      | Done        |
+| #   | PRD                                                | Summary                                                                              | Status  |
+| --- | -------------------------------------------------- | ------------------------------------------------------------------------------------ | ------- |
+| 087 | [Ego Core](../prds/087-ego-core/README.md)         | Conversation engine, context management, scope negotiation, conversation persistence | Partial |
+| 088 | [Ego Channels](../prds/088-ego-channels/README.md) | Shell chat panel, MCP tools for Claude Code, Moltbot integration, CLI interface      | Done    |
 
 PRD-087 (Core) must complete before PRD-088 (Channels) — the channels are thin adapters over the core conversation engine.
 

--- a/docs/themes/06-cerebrum/prds/087-ego-core/README.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/README.md
@@ -1,7 +1,7 @@
 # PRD-087: Ego Core
 
 > Epic: [05 — Ego](../../epics/05-ego.md)
-> Status: In progress
+> Status: Partial
 > Supersedes: PRD-054 (AI Overlay)
 
 ## Overview
@@ -89,13 +89,13 @@ Build the conversational agent core — the "I" of the system. Ego manages multi
 
 ## User Stories
 
-| #   | Story                                                               | Summary                                                                                | Status      | Parallelisable   |
-| --- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------- | ---------------- |
-| 01  | [us-01-conversation-engine](us-01-conversation-engine.md)           | Multi-turn conversation management: history, context window, system prompt             | Not started | No (first)       |
-| 02  | [us-02-shell-chat-panel](us-02-shell-chat-panel.md)                 | React component in pops-shell: streaming responses, message history, conversation list | Partial     | Blocked by us-01 |
-| 03  | [us-03-context-awareness](us-03-context-awareness.md)               | App-aware context: current pops app, recent actions, active engram context             | Not started | Blocked by us-01 |
-| 04  | [us-04-scope-negotiation](us-04-scope-negotiation.md)               | Infer scopes from conversation: explicit mentions, topic inference, channel defaults   | Done        | Blocked by us-01 |
-| 05  | [us-05-conversation-persistence](us-05-conversation-persistence.md) | SQLite persistence: conversations, messages, context metadata                          | Not started | Yes              |
+| #   | Story                                                               | Summary                                                                                | Status  | Parallelisable   |
+| --- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ------- | ---------------- |
+| 01  | [us-01-conversation-engine](us-01-conversation-engine.md)           | Multi-turn conversation management: history, context window, system prompt             | Partial | No (first)       |
+| 02  | [us-02-shell-chat-panel](us-02-shell-chat-panel.md)                 | React component in pops-shell: streaming responses, message history, conversation list | Partial | Blocked by us-01 |
+| 03  | [us-03-context-awareness](us-03-context-awareness.md)               | App-aware context: current pops app, recent actions, active engram context             | Partial | Blocked by us-01 |
+| 04  | [us-04-scope-negotiation](us-04-scope-negotiation.md)               | Infer scopes from conversation: explicit mentions, topic inference, channel defaults   | Done    | Blocked by us-01 |
+| 05  | [us-05-conversation-persistence](us-05-conversation-persistence.md) | SQLite persistence: conversations, messages, context metadata                          | Done    | Yes              |
 
 US-01 (conversation engine) is the foundation. US-02, US-03, and US-04 depend on it. US-05 (persistence) can be built in parallel since it defines the storage schema independently.
 

--- a/docs/themes/06-cerebrum/prds/087-ego-core/us-01-conversation-engine.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/us-01-conversation-engine.md
@@ -8,14 +8,14 @@ As the Ego system, I need a multi-turn conversation engine that manages message 
 
 ## Acceptance Criteria
 
-- [ ] A `ConversationEngine` class manages conversation lifecycle: create conversation, append user message, generate assistant response, retrieve conversation history
-- [ ] On each user message, the engine queries Thalamus (`cerebrum.retrieval.search`) with the message content scoped to the conversation's `active_scopes`, retrieves the top-K engrams (configurable, default 5), and injects their content into the context window as grounded references with engram IDs
-- [ ] Context window assembly follows priority order: (1) system prompt with Cerebrum capabilities and active scopes, (2) conversation history (most recent N messages, configurable, default 20), (3) engrams already loaded in the conversation context, (4) newly retrieved engrams for the current query — truncated by lowest relevance score when total tokens exceed the model limit
-- [ ] When conversation history exceeds the message window (N messages), older messages are summarised into a condensed block by the LLM and stored as a system message, freeing token budget for retrieval context
-- [ ] The system prompt describes: what Cerebrum is, what engrams are, the user's active scopes, available tools (search, ingest, link), and instructions to cite engram IDs when referencing stored knowledge
+- [x] A `ConversationEngine` class manages conversation lifecycle: create conversation, append user message, generate assistant response, retrieve conversation history
+- [x] On each user message, the engine queries Thalamus (`cerebrum.retrieval.search`) with the message content scoped to the conversation's `active_scopes`, retrieves the top-K engrams (configurable, default 5), and injects their content into the context window as grounded references with engram IDs
+- [x] Context window assembly follows priority order: (1) system prompt with Cerebrum capabilities and active scopes, (2) conversation history (most recent N messages, configurable, default 20), (3) engrams already loaded in the conversation context, (4) newly retrieved engrams for the current query — truncated by lowest relevance score when total tokens exceed the model limit
+- [x] When conversation history exceeds the message window (N messages), older messages are summarised into a condensed block by the LLM and stored as a system message, freeing token budget for retrieval context
+- [x] The system prompt describes: what Cerebrum is, what engrams are, the user's active scopes, available tools (search, ingest, link), and instructions to cite engram IDs when referencing stored knowledge
 - [ ] Responses are streamed via server-sent events — partial tokens are delivered to the client as they arrive from the LLM
-- [ ] After the response completes, the engine extracts cited engram IDs from the response content, stores them in the message's `citations` array, and logs `tool_calls` if any tools were invoked during the turn
-- [ ] Token counts (`tokens_in`, `tokens_out`) are recorded per message from the LLM response metadata
+- [x] After the response completes, the engine extracts cited engram IDs from the response content, stores them in the message's `citations` array, and logs `tool_calls` if any tools were invoked during the turn
+- [x] Token counts (`tokens_in`, `tokens_out`) are recorded per message from the LLM response metadata
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/087-ego-core/us-03-context-awareness.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/us-03-context-awareness.md
@@ -8,14 +8,14 @@ As the Ego system, I need to know which pops app the user is currently in, what 
 
 ## Acceptance Criteria
 
-- [ ] The conversation engine receives app context on each message: the active pops app (e.g., `media`, `finance`, `inventory`, `cerebrum`), the current route or view, and optionally the entity being viewed (e.g., a specific movie, transaction, or engram)
-- [ ] App context is included in the system prompt augmentation — the LLM knows "the user is currently viewing their movie collection" or "the user is looking at transaction #1234"
-- [ ] When the user is viewing an engram in Cerebrum, that engram is automatically loaded into the conversation context with maximum relevance score, regardless of whether Thalamus retrieval would have found it
+- [x] The conversation engine receives app context on each message: the active pops app (e.g., `media`, `finance`, `inventory`, `cerebrum`), the current route or view, and optionally the entity being viewed (e.g., a specific movie, transaction, or engram)
+- [x] App context is included in the system prompt augmentation — the LLM knows "the user is currently viewing their movie collection" or "the user is looking at transaction #1234"
+- [x] When the user is viewing an engram in Cerebrum, that engram is automatically loaded into the conversation context with maximum relevance score, regardless of whether Thalamus retrieval would have found it
 - [ ] Recent user actions (last 5, configurable) from the active pops app are summarised in the context — e.g., "user recently searched for 'sci-fi movies', viewed 'Blade Runner 2049', added a tag to 'Arrival'"
-- [ ] Context updates propagate to subsequent Thalamus queries — retrieval is biased toward engrams relevant to the active app context (e.g., querying in the finance app biases toward `personal.finance.*` scopes)
-- [ ] If the user switches pops apps mid-conversation (detected on the next message), the app context is updated and the system prompt is regenerated for the next turn
-- [ ] The `ego.context.getActive` procedure returns the current context state: active scopes, app context, and the list of engrams loaded in context with their relevance scores
-- [ ] App context is stored on the `conversations` row as JSON and persists across page refreshes
+- [x] Context updates propagate to subsequent Thalamus queries — retrieval is biased toward engrams relevant to the active app context (e.g., querying in the finance app biases toward `personal.finance.*` scopes)
+- [x] If the user switches pops apps mid-conversation (detected on the next message), the app context is updated and the system prompt is regenerated for the next turn
+- [x] The `ego.context.getActive` procedure returns the current context state: active scopes, app context, and the list of engrams loaded in context with their relevance scores
+- [x] App context is stored on the `conversations` row as JSON and persists across page refreshes
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/087-ego-core/us-05-conversation-persistence.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/us-05-conversation-persistence.md
@@ -8,15 +8,15 @@ As a user, I want my conversations with Ego to be saved and resumable so that I 
 
 ## Acceptance Criteria
 
-- [ ] A Drizzle schema defines the `conversations` table with columns: `id` (TEXT PK), `title` (TEXT), `active_scopes` (TEXT, JSON array), `app_context` (TEXT, JSON), `model` (TEXT NOT NULL), `created_at` (TEXT NOT NULL), `updated_at` (TEXT NOT NULL)
-- [ ] A Drizzle schema defines the `messages` table with columns: `id` (TEXT PK), `conversation_id` (TEXT FK NOT NULL), `role` (TEXT NOT NULL), `content` (TEXT NOT NULL), `citations` (TEXT, JSON array), `tool_calls` (TEXT, JSON array), `tokens_in` (INTEGER), `tokens_out` (INTEGER), `created_at` (TEXT NOT NULL)
-- [ ] A Drizzle schema defines the `conversation_context` table with columns: `conversation_id` (TEXT FK NOT NULL), `engram_id` (TEXT NOT NULL), `relevance_score` (REAL), `loaded_at` (TEXT NOT NULL) — composite PK on `(conversation_id, engram_id)`
-- [ ] `ego.conversations.create` inserts a new conversation row and returns it — title defaults to null (set on first message)
-- [ ] `ego.conversations.list` returns conversations sorted by `updated_at` descending with pagination — supports text search on `title`
-- [ ] `ego.conversations.get` returns the conversation with all associated messages ordered by `created_at` ascending
-- [ ] `ego.conversations.delete` deletes the conversation, all associated messages, and all context entries in a single transaction
-- [ ] Each `ego.chat` call appends the user message and assistant response to the `messages` table, updates `conversation.updated_at`, and upserts `conversation_context` entries for any newly retrieved engrams
-- [ ] Conversation title is auto-generated from the first user message: first 80 characters cleaned of Markdown formatting, truncated at the nearest word boundary
+- [x] A Drizzle schema defines the `conversations` table with columns: `id` (TEXT PK), `title` (TEXT), `active_scopes` (TEXT, JSON array), `app_context` (TEXT, JSON), `model` (TEXT NOT NULL), `created_at` (TEXT NOT NULL), `updated_at` (TEXT NOT NULL)
+- [x] A Drizzle schema defines the `messages` table with columns: `id` (TEXT PK), `conversation_id` (TEXT FK NOT NULL), `role` (TEXT NOT NULL), `content` (TEXT NOT NULL), `citations` (TEXT, JSON array), `tool_calls` (TEXT, JSON array), `tokens_in` (INTEGER), `tokens_out` (INTEGER), `created_at` (TEXT NOT NULL)
+- [x] A Drizzle schema defines the `conversation_context` table with columns: `conversation_id` (TEXT FK NOT NULL), `engram_id` (TEXT NOT NULL), `relevance_score` (REAL), `loaded_at` (TEXT NOT NULL) — composite PK on `(conversation_id, engram_id)`
+- [x] `ego.conversations.create` inserts a new conversation row and returns it — title defaults to null (set on first message)
+- [x] `ego.conversations.list` returns conversations sorted by `updated_at` descending with pagination — supports text search on `title`
+- [x] `ego.conversations.get` returns the conversation with all associated messages ordered by `created_at` ascending
+- [x] `ego.conversations.delete` deletes the conversation, all associated messages, and all context entries in a single transaction
+- [x] Each `ego.chat` call appends the user message and assistant response to the `messages` table, updates `conversation.updated_at`, and upserts `conversation_context` entries for any newly retrieved engrams
+- [x] Conversation title is auto-generated from the first user message: first 80 characters cleaned of Markdown formatting, truncated at the nearest word boundary
 
 ## Notes
 

--- a/packages/app-media/src/components/TierListBoard.test.tsx
+++ b/packages/app-media/src/components/TierListBoard.test.tsx
@@ -66,6 +66,7 @@ const sampleMovies: TierMovie[] = [
     posterUrl: null,
     score: 1600,
     comparisonCount: 5,
+    tierOverride: null,
   },
   {
     mediaType: 'movie',
@@ -74,6 +75,7 @@ const sampleMovies: TierMovie[] = [
     posterUrl: null,
     score: 1500,
     comparisonCount: 3,
+    tierOverride: null,
   },
   {
     mediaType: 'movie',
@@ -82,6 +84,7 @@ const sampleMovies: TierMovie[] = [
     posterUrl: null,
     score: 1400,
     comparisonCount: 8,
+    tierOverride: null,
   },
   {
     mediaType: 'movie',
@@ -90,6 +93,7 @@ const sampleMovies: TierMovie[] = [
     posterUrl: null,
     score: 1300,
     comparisonCount: 2,
+    tierOverride: null,
   },
 ];
 
@@ -200,5 +204,42 @@ describe('TierListBoard', () => {
       dndHandlers.onDragEnd?.({ active: { id: '1' }, over: { id: 'unranked' } });
     });
     expect(screen.getByText('Unranked (4)')).toBeTruthy();
+  });
+
+  it('hydrates placements from tier overrides on mount', () => {
+    const moviesWithOverrides: TierMovie[] = [
+      {
+        mediaType: 'movie',
+        mediaId: 1,
+        title: 'The Matrix',
+        posterUrl: null,
+        score: 1600,
+        comparisonCount: 5,
+        tierOverride: 'S',
+      },
+      {
+        mediaType: 'movie',
+        mediaId: 2,
+        title: 'Inception',
+        posterUrl: null,
+        score: 1500,
+        comparisonCount: 3,
+        tierOverride: 'B',
+      },
+      {
+        mediaType: 'movie',
+        mediaId: 3,
+        title: 'Interstellar',
+        posterUrl: null,
+        score: 1400,
+        comparisonCount: 8,
+        tierOverride: null,
+      },
+    ];
+
+    render(<TierListBoard movies={moviesWithOverrides} onSubmit={vi.fn()} />);
+
+    // 2 movies placed (S + B), 1 unranked
+    expect(screen.getByText('Unranked (1)')).toBeTruthy();
   });
 });

--- a/packages/app-media/src/components/tier-list-board/types.ts
+++ b/packages/app-media/src/components/tier-list-board/types.ts
@@ -26,6 +26,8 @@ export interface TierMovie {
   posterUrl: string | null;
   score: number;
   comparisonCount: number;
+  /** Persisted tier override from a previous submission, or null if unranked. */
+  tierOverride: Tier | null;
 }
 
 export type TierPlacements = Record<Tier, number[]>;

--- a/packages/app-media/src/components/tier-list-board/useTierBoardModel.ts
+++ b/packages/app-media/src/components/tier-list-board/useTierBoardModel.ts
@@ -1,5 +1,5 @@
 import { PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import {
   DISMISS_ZONES,
@@ -151,6 +151,20 @@ function useDragHandlers(args: DragHandlerArgs) {
   return { handleDragStart, handleDragOver, handleDragEnd };
 }
 
+/**
+ * Build initial placements from movies that have a persisted tierOverride.
+ * Movies without an override stay in the unranked pool.
+ */
+function hydrateFromOverrides(movies: TierMovie[]): TierPlacements {
+  const placements: TierPlacements = { S: [], A: [], B: [], C: [], D: [] };
+  for (const movie of movies) {
+    if (movie.tierOverride && TIERS.includes(movie.tierOverride)) {
+      placements[movie.tierOverride].push(movie.mediaId);
+    }
+  }
+  return placements;
+}
+
 export function useTierBoardModel({
   movies,
   onSubmit,
@@ -158,13 +172,18 @@ export function useTierBoardModel({
   onMarkStale,
   onNA,
 }: UseTierBoardArgs) {
-  const [placements, setPlacements] = useState<TierPlacements>({
-    S: [],
-    A: [],
-    B: [],
-    C: [],
-    D: [],
-  });
+  // Hydrate placements from tier overrides on initial render.
+  // The ref tracks which movies array was used for hydration so we
+  // re-hydrate when the movie set changes (e.g. dimension switch).
+  const hydratedRef = useRef<TierMovie[]>([]);
+  const [placements, setPlacements] = useState<TierPlacements>(() => hydrateFromOverrides(movies));
+
+  // Re-hydrate when movies array identity changes (dimension switch or refetch).
+  if (movies !== hydratedRef.current && movies.length > 0) {
+    hydratedRef.current = movies;
+    setPlacements(hydrateFromOverrides(movies));
+  }
+
   const [activeId, setActiveId] = useState<number | null>(null);
 
   const movieMap = useMemo(() => new Map(movies.map((m) => [m.mediaId, m])), [movies]);

--- a/packages/app-media/src/pages/TierListPage.test.tsx
+++ b/packages/app-media/src/pages/TierListPage.test.tsx
@@ -126,9 +126,30 @@ const dim1 = { id: 1, name: 'Cinematography', active: true, description: null, s
 const dim2 = { id: 2, name: 'Entertainment', active: true, description: null, sortOrder: 1 };
 
 const movies = [
-  { id: 10, title: 'The Matrix', posterUrl: null, score: 1500, comparisonCount: 5 },
-  { id: 20, title: 'Inception', posterUrl: null, score: 1480, comparisonCount: 3 },
-  { id: 30, title: 'Interstellar', posterUrl: null, score: 1520, comparisonCount: 8 },
+  {
+    id: 10,
+    title: 'The Matrix',
+    posterUrl: null,
+    score: 1500,
+    comparisonCount: 5,
+    tierOverride: null,
+  },
+  {
+    id: 20,
+    title: 'Inception',
+    posterUrl: null,
+    score: 1480,
+    comparisonCount: 3,
+    tierOverride: null,
+  },
+  {
+    id: 30,
+    title: 'Interstellar',
+    posterUrl: null,
+    score: 1520,
+    comparisonCount: 8,
+    tierOverride: null,
+  },
 ];
 
 function renderPage() {

--- a/packages/app-media/src/pages/tier-list/useTierListPageModel.ts
+++ b/packages/app-media/src/pages/tier-list/useTierListPageModel.ts
@@ -40,6 +40,7 @@ function useDimensionsAndMovies() {
         posterUrl: m.posterUrl,
         score: m.score,
         comparisonCount: m.comparisonCount,
+        tierOverride: (m.tierOverride as TierMovie['tierOverride']) ?? null,
       })),
     [tierMoviesQuery.data]
   );


### PR DESCRIPTION
## Summary

- **PRD-087 US-03 Context Awareness**: Re-implement cleanly on current main after merge conflicts in #2232. Rich app context in system prompt, auto-load viewed engram, scope biasing, `ego.context.getActive` endpoint, app context persistence, 24 new tests.
- **Tier-List Hydration Fix (#2195)**: `tier_overrides` were written on submit but never read back on load. Now `getTierListMovies` includes the `tierOverride` field and the frontend hydrates placements from overrides on mount.
- **PRD-087 Doc Sync**: Tick acceptance criteria across US-01/03/05, update status tables in PRD, Epic, Theme, and roadmap.

## Test plan

- [x] `pnpm typecheck` passes (all 17 packages)
- [x] `pnpm test` passes (185 files, 3264 tests)
- [x] `pnpm lint` passes (0 errors)
- [x] Context awareness tests: 24 new tests in `context-awareness.test.ts`
- [x] Tier override hydration: 2 new backend tests + 1 new frontend test
- [x] Existing engine tests updated and passing (124 ego tests total)

Closes #2224 #2195