### PR TITLE
feat(ego): SSE streaming for chat endpoint

### DIFF
--- a/apps/pops-api/src/app.ts
+++ b/apps/pops-api/src/app.ts
@@ -10,6 +10,7 @@ import { rateLimiter } from './middleware/rate-limit.js';
 import { envRouter } from './modules/core/envs/router.js';
 import { openApiDocument } from './openapi.js';
 import { appRouter } from './router.js';
+import egoChatStreamRouter from './routes/ego/chat-stream.js';
 import healthRouter from './routes/health.js';
 import inventoryDocumentFilesRouter from './routes/inventory/document-files.js';
 import documentThumbnailRouter from './routes/inventory/documents.js';
@@ -72,6 +73,10 @@ export function createApp(): express.Express {
   // Env context middleware — reads ?env=NAME, validates the env, and scopes
   // the DB connection for all downstream handlers (tRPC, webhooks, etc.).
   app.use(envContextMiddleware);
+
+  // Ego SSE streaming — POST /api/ego/chat/stream
+  // Placed after auth + env context so the user is authenticated and the DB is scoped.
+  app.use(egoChatStreamRouter);
 
   // OpenAPI spec endpoint
   app.get('/api/openapi.json', (_req, res) => {

--- a/apps/pops-api/src/modules/ego/chat-helpers.ts
+++ b/apps/pops-api/src/modules/ego/chat-helpers.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared chat orchestration helpers used by both the tRPC ego.chat mutation
+ * and the SSE streaming endpoint.
+ *
+ * Extracted to avoid duplicating persistence, conversation resolution,
+ * and app context comparison logic across the two code paths.
+ */
+import { getDrizzle } from '../../db.js';
+import { ConversationEngine } from './engine.js';
+import { PersistenceStoreAdapter } from './persistence-store.js';
+import { ConversationPersistence } from './persistence.js';
+import { autoTitle } from './types.js';
+
+import type { AppContext, ChatResult, Conversation, Message, ScopeNegotiation } from './types.js';
+
+const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+
+/** Lazily instantiated persistence service (uses the global Drizzle instance). */
+export function getPersistence(): ConversationPersistence {
+  return new ConversationPersistence({ db: getDrizzle() });
+}
+
+export function getStore(): PersistenceStoreAdapter {
+  return new PersistenceStoreAdapter(getPersistence());
+}
+
+export function getEngine(): ConversationEngine {
+  return new ConversationEngine();
+}
+
+/**
+ * Check whether two AppContext values differ (by value, not reference).
+ * Returns true if the incoming context is meaningfully different from stored.
+ */
+export function appContextChanged(
+  stored: AppContext | undefined | null,
+  incoming: AppContext | undefined
+): boolean {
+  if (!stored && !incoming) return false;
+  if (!stored || !incoming) return true;
+  return (
+    stored.app !== incoming.app ||
+    stored.route !== incoming.route ||
+    stored.entityId !== incoming.entityId ||
+    stored.entityType !== incoming.entityType
+  );
+}
+
+export interface PersistChatParams {
+  persistence: ConversationPersistence;
+  conversationId: string;
+  userMessage: string;
+  result: ChatResult;
+  storedAppContext?: AppContext | null;
+  incomingAppContext?: AppContext;
+}
+
+/** Persist chat results: scope changes, app context changes, messages, and engram context. */
+export function persistChatResults(params: PersistChatParams): Message {
+  const { persistence, conversationId, userMessage, result } = params;
+
+  if (result.scopeNegotiation?.changed) {
+    persistence.updateScopes(conversationId, result.scopeNegotiation.scopes);
+  }
+
+  if (appContextChanged(params.storedAppContext, params.incomingAppContext)) {
+    persistence.updateAppContext(conversationId, params.incomingAppContext ?? null);
+  }
+
+  persistence.appendMessage(conversationId, { role: 'user', content: userMessage });
+
+  const assistantMsg = persistence.appendMessage(conversationId, {
+    role: 'assistant',
+    content: result.response.content,
+    citations: result.response.citations,
+    tokensIn: result.response.tokensIn,
+    tokensOut: result.response.tokensOut,
+  });
+
+  for (const { engramId, relevanceScore } of result.retrievedEngrams) {
+    persistence.upsertContext(conversationId, engramId, relevanceScore);
+  }
+
+  return assistantMsg;
+}
+
+export interface ResolveConversationParams {
+  store: PersistenceStoreAdapter;
+  persistence: ConversationPersistence;
+  conversationId: string | undefined;
+  message: string;
+  scopes: string[];
+  appContext: AppContext | undefined;
+}
+
+/** Load an existing conversation or create a new one. */
+export async function resolveConversation(
+  params: ResolveConversationParams
+): Promise<Conversation> {
+  const { store, persistence, conversationId, message, scopes, appContext } = params;
+  if (conversationId) {
+    const existing = await store.getConversation(conversationId);
+    if (existing) return existing;
+  }
+  return persistence.createConversation({
+    title: autoTitle(message),
+    scopes,
+    appContext,
+    model: DEFAULT_MODEL,
+  });
+}
+
+/** Persist streaming chat results after the stream completes. */
+export interface PersistStreamParams {
+  persistence: ConversationPersistence;
+  conversationId: string;
+  userMessage: string;
+  content: string;
+  citations: string[];
+  tokensIn: number;
+  tokensOut: number;
+  retrievedEngrams: Array<{ engramId: string; relevanceScore: number }>;
+  scopeNegotiation: ScopeNegotiation;
+  storedAppContext?: AppContext | null;
+  incomingAppContext?: AppContext;
+}
+
+/** Persist results after a streaming chat completes. */
+export function persistStreamResults(params: PersistStreamParams): Message {
+  return persistChatResults({
+    persistence: params.persistence,
+    conversationId: params.conversationId,
+    userMessage: params.userMessage,
+    result: {
+      response: {
+        content: params.content,
+        citations: params.citations,
+        tokensIn: params.tokensIn,
+        tokensOut: params.tokensOut,
+      },
+      retrievedEngrams: params.retrievedEngrams,
+      scopeNegotiation: params.scopeNegotiation,
+    },
+    storedAppContext: params.storedAppContext,
+    incomingAppContext: params.incomingAppContext,
+  });
+}

--- a/apps/pops-api/src/modules/ego/engine-helpers.ts
+++ b/apps/pops-api/src/modules/ego/engine-helpers.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure helper functions for the ConversationEngine.
+ *
+ * Extracted to keep engine.ts within the max-lines lint rule.
+ */
+import type { RetrievalFilters } from '../cerebrum/retrieval/types.js';
+import type { EngineConfig, Message } from './types.js';
+
+const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+const DEFAULT_MAX_HISTORY = 20;
+const DEFAULT_MAX_RETRIEVAL = 5;
+const DEFAULT_TOKEN_BUDGET = 4096;
+const DEFAULT_RELEVANCE_THRESHOLD = 0.3;
+
+function isSecretScope(scope: string): boolean {
+  return scope.split('.').includes('secret');
+}
+
+export function buildRetrievalFilters(scopes: string[]): RetrievalFilters {
+  const filters: RetrievalFilters = {};
+  if (scopes.length > 0) {
+    filters.scopes = scopes;
+  }
+  if (scopes.some(isSecretScope)) {
+    filters.includeSecret = true;
+  }
+  return filters;
+}
+
+function roleLabel(role: string): string {
+  if (role === 'user') return 'User';
+  if (role === 'assistant') return 'Assistant';
+  return 'System';
+}
+
+export function formatHistoryForContext(messages: Message[]): string {
+  return messages.map((m) => `${roleLabel(m.role)}: ${m.content}`).join('\n\n');
+}
+
+export function buildDefaultConfig(config?: Partial<EngineConfig>): EngineConfig {
+  return {
+    model: config?.model ?? DEFAULT_MODEL,
+    maxHistoryMessages: config?.maxHistoryMessages ?? DEFAULT_MAX_HISTORY,
+    maxRetrievalResults: config?.maxRetrievalResults ?? DEFAULT_MAX_RETRIEVAL,
+    tokenBudget: config?.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
+    relevanceThreshold: config?.relevanceThreshold ?? DEFAULT_RELEVANCE_THRESHOLD,
+  };
+}

--- a/apps/pops-api/src/modules/ego/engine-stream.test.ts
+++ b/apps/pops-api/src/modules/ego/engine-stream.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the engine streaming generator (PRD-087 US-01 AC #6).
+ *
+ * Tests that generateStreamEvents correctly:
+ * - Yields scope notices as the first token
+ * - Passes through text deltas from the LLM
+ * - Parses citations from the completed text
+ * - Yields a done event with final metadata
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the LLM client.
+vi.mock('./llm-client.js', () => ({
+  streamChatLlm: vi.fn(),
+}));
+
+// Mock the citation parser — must use a class so `new` works.
+const mockCitationParse = vi.fn((text: string) => ({
+  cleanedAnswer: text,
+  citations: [] as Array<{ id: string }>,
+}));
+vi.mock('../cerebrum/query/citation-parser.js', () => ({
+  CitationParser: class MockCitationParser {
+    parse = mockCitationParse;
+  },
+}));
+
+import { generateStreamEvents } from './engine-stream.js';
+import { streamChatLlm } from './llm-client.js';
+
+import type { StreamEvent } from './llm-client.js';
+import type { ChatStreamEvent } from './types.js';
+
+const mockedStreamChatLlm = vi.mocked(streamChatLlm);
+
+/** Collect all events from an async generator. */
+async function collect(gen: AsyncGenerator<ChatStreamEvent>): Promise<ChatStreamEvent[]> {
+  const events: ChatStreamEvent[] = [];
+  for await (const event of gen) {
+    events.push(event);
+  }
+  return events;
+}
+
+/** Create a mock async generator from an array of events. */
+async function* mockLlmStream(events: StreamEvent[]): AsyncGenerator<StreamEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+describe('generateStreamEvents', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('yields scope notice as first token when scopes changed', async () => {
+    mockedStreamChatLlm.mockReturnValue(
+      mockLlmStream([
+        { type: 'token', text: 'Response' },
+        { type: 'done', fullText: 'Response', tokensIn: 10, tokensOut: 5 },
+      ])
+    );
+
+    const events = await collect(
+      generateStreamEvents({
+        model: 'test-model',
+        systemPrompt: 'system',
+        llmMessages: [{ role: 'user', content: 'hi' }],
+        scopeNotice: '*Scope changed to finance*',
+        allResults: [],
+      })
+    );
+
+    expect(events[0]).toEqual({ type: 'token', text: '*Scope changed to finance*\n\n' });
+    expect(events[1]).toEqual({ type: 'token', text: 'Response' });
+    expect(events[2]).toMatchObject({ type: 'done', tokensIn: 10, tokensOut: 5 });
+  });
+
+  it('yields tokens without scope notice when no scope change', async () => {
+    mockedStreamChatLlm.mockReturnValue(
+      mockLlmStream([
+        { type: 'token', text: 'Hello' },
+        { type: 'token', text: ' world' },
+        { type: 'done', fullText: 'Hello world', tokensIn: 20, tokensOut: 10 },
+      ])
+    );
+
+    const events = await collect(
+      generateStreamEvents({
+        model: 'test-model',
+        systemPrompt: 'system',
+        llmMessages: [{ role: 'user', content: 'hi' }],
+        scopeNotice: null,
+        allResults: [],
+      })
+    );
+
+    expect(events).toHaveLength(3);
+    expect(events[0]).toEqual({ type: 'token', text: 'Hello' });
+    expect(events[1]).toEqual({ type: 'token', text: ' world' });
+    expect(events[2]).toMatchObject({
+      type: 'done',
+      content: 'Hello world',
+      tokensIn: 20,
+      tokensOut: 10,
+    });
+  });
+
+  it('includes citation IDs in the done event', async () => {
+    // Override the parse mock to return citations for this test.
+    mockCitationParse.mockReturnValueOnce({
+      cleanedAnswer: 'Answer with citation',
+      citations: [{ id: 'eng_20260101_0000_test' }],
+    });
+
+    mockedStreamChatLlm.mockReturnValue(
+      mockLlmStream([
+        { type: 'token', text: 'Answer [eng_20260101_0000_test]' },
+        { type: 'done', fullText: 'Answer [eng_20260101_0000_test]', tokensIn: 15, tokensOut: 8 },
+      ])
+    );
+
+    const events = await collect(
+      generateStreamEvents({
+        model: 'test-model',
+        systemPrompt: 'system',
+        llmMessages: [{ role: 'user', content: 'hi' }],
+        scopeNotice: null,
+        allResults: [],
+      })
+    );
+
+    const doneEvent = events.find((e) => e.type === 'done');
+    expect(doneEvent).toBeDefined();
+    if (doneEvent?.type === 'done') {
+      expect(doneEvent.citations).toEqual(['eng_20260101_0000_test']);
+    }
+  });
+
+  it('passes model and system prompt to the LLM stream', async () => {
+    mockedStreamChatLlm.mockReturnValue(
+      mockLlmStream([{ type: 'done', fullText: '', tokensIn: 0, tokensOut: 0 }])
+    );
+
+    await collect(
+      generateStreamEvents({
+        model: 'claude-sonnet-4-20250514',
+        systemPrompt: 'You are Ego',
+        llmMessages: [{ role: 'user', content: 'test' }],
+        scopeNotice: null,
+        allResults: [],
+      })
+    );
+
+    expect(mockedStreamChatLlm).toHaveBeenCalledWith('claude-sonnet-4-20250514', 'You are Ego', [
+      { role: 'user', content: 'test' },
+    ]);
+  });
+});

--- a/apps/pops-api/src/modules/ego/engine-stream.ts
+++ b/apps/pops-api/src/modules/ego/engine-stream.ts
@@ -1,0 +1,53 @@
+/**
+ * Streaming generator for the Ego conversation engine (PRD-087 US-01 AC #6).
+ *
+ * Extracted from engine.ts to keep file sizes within the max-lines rule
+ * and avoid `no-this-alias` issues with inner generator functions.
+ */
+import { CitationParser } from '../cerebrum/query/citation-parser.js';
+import { streamChatLlm } from './llm-client.js';
+
+import type { RetrievalResult } from '../cerebrum/retrieval/types.js';
+import type { ChatStreamEvent } from './types.js';
+
+interface StreamGeneratorParams {
+  model: string;
+  systemPrompt: string;
+  llmMessages: Array<{ role: 'user' | 'assistant'; content: string }>;
+  scopeNotice: string | null;
+  allResults: RetrievalResult[];
+}
+
+/**
+ * Create an async generator that streams LLM tokens and emits a final
+ * done event with parsed citations and token counts.
+ */
+export async function* generateStreamEvents(
+  params: StreamGeneratorParams
+): AsyncGenerator<ChatStreamEvent> {
+  const { model, systemPrompt, llmMessages, scopeNotice, allResults } = params;
+  const citationParser = new CitationParser();
+
+  if (scopeNotice) {
+    yield { type: 'token', text: `${scopeNotice}\n\n` };
+  }
+
+  const llmStream = streamChatLlm(model, systemPrompt, llmMessages);
+
+  for await (const event of llmStream) {
+    if (event.type === 'token') {
+      yield { type: 'token', text: event.text };
+    } else {
+      const { cleanedAnswer, citations } = citationParser.parse(event.fullText, allResults);
+      const responseContent = scopeNotice ? `${scopeNotice}\n\n${cleanedAnswer}` : cleanedAnswer;
+
+      yield {
+        type: 'done',
+        content: responseContent,
+        citations: citations.map((c) => c.id),
+        tokensIn: event.tokensIn,
+        tokensOut: event.tokensOut,
+      };
+    }
+  }
+}

--- a/apps/pops-api/src/modules/ego/engine.ts
+++ b/apps/pops-api/src/modules/ego/engine.ts
@@ -10,53 +10,25 @@ import { CitationParser } from '../cerebrum/query/citation-parser.js';
 import { ContextAssemblyService } from '../cerebrum/retrieval/context-assembly.js';
 import { HybridSearchService } from '../cerebrum/retrieval/hybrid-search.js';
 import { biasScopes, loadViewedEngram } from './context-helpers.js';
+import {
+  buildDefaultConfig,
+  buildRetrievalFilters,
+  formatHistoryForContext,
+} from './engine-helpers.js';
+import { generateStreamEvents } from './engine-stream.js';
 import { callChatLlm, callSummariseLlm } from './llm-client.js';
 import { buildEgoSystemPrompt, buildSummarisationPrompt } from './prompts.js';
 import { ConversationScopeNegotiator } from './scope-negotiator.js';
 
-import type { RetrievalFilters, RetrievalResult } from '../cerebrum/retrieval/types.js';
-import type { ChatParams, ChatResult, EngineConfig, Message, ScopeNegotiation } from './types.js';
-
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
-const DEFAULT_MAX_HISTORY = 20;
-const DEFAULT_MAX_RETRIEVAL = 5;
-const DEFAULT_TOKEN_BUDGET = 4096;
-const DEFAULT_RELEVANCE_THRESHOLD = 0.3;
-
-function isSecretScope(scope: string): boolean {
-  return scope.split('.').includes('secret');
-}
-
-function buildRetrievalFilters(scopes: string[]): RetrievalFilters {
-  const filters: RetrievalFilters = {};
-  if (scopes.length > 0) {
-    filters.scopes = scopes;
-  }
-  if (scopes.some(isSecretScope)) {
-    filters.includeSecret = true;
-  }
-  return filters;
-}
-
-function roleLabel(role: string): string {
-  if (role === 'user') return 'User';
-  if (role === 'assistant') return 'Assistant';
-  return 'System';
-}
-
-function formatHistoryForContext(messages: Message[]): string {
-  return messages.map((m) => `${roleLabel(m.role)}: ${m.content}`).join('\n\n');
-}
-
-function buildDefaultConfig(config?: Partial<EngineConfig>): EngineConfig {
-  return {
-    model: config?.model ?? DEFAULT_MODEL,
-    maxHistoryMessages: config?.maxHistoryMessages ?? DEFAULT_MAX_HISTORY,
-    maxRetrievalResults: config?.maxRetrievalResults ?? DEFAULT_MAX_RETRIEVAL,
-    tokenBudget: config?.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
-    relevanceThreshold: config?.relevanceThreshold ?? DEFAULT_RELEVANCE_THRESHOLD,
-  };
-}
+import type { RetrievalResult } from '../cerebrum/retrieval/types.js';
+import type {
+  ChatParams,
+  ChatResult,
+  ChatStreamPreparation,
+  EngineConfig,
+  Message,
+  ScopeNegotiation,
+} from './types.js';
 
 export class ConversationEngine {
   private readonly config: EngineConfig;
@@ -70,36 +42,15 @@ export class ConversationEngine {
 
   /** Process a user message and generate a response. */
   async chat(params: ChatParams): Promise<ChatResult> {
-    const { message, history, appContext } = params;
-
-    // Run scope negotiation to potentially adjust scopes.
-    const negotiation = this.negotiateScopes(params);
-    const effectiveScopes = negotiation.scopes;
-
-    // US-03: Bias scopes towards the active app context (additive).
-    const biasedScopes = biasScopes(effectiveScopes, appContext);
-
-    // US-03: Auto-load viewed engram when user is viewing one in Cerebrum.
-    const viewedEngram = loadViewedEngram(appContext);
-
-    const retrievalResults = await this.retrieveEngrams(message, biasedScopes);
-
-    // Prepend the viewed engram if it wasn't already retrieved.
-    const allResults = this.mergeViewedEngram(viewedEngram, retrievalResults);
-
-    const { systemPrompt, contextBlock } = this.buildContextWindow(
-      allResults,
-      effectiveScopes,
-      appContext
+    const ctx = await this.assembleContext(params);
+    const llmResponse = await callChatLlm(this.config.model, ctx.systemPrompt, ctx.llmMessages);
+    const { cleanedAnswer, citations } = this.citationParser.parse(
+      llmResponse.content,
+      ctx.allResults
     );
-
-    // If scopes changed or there's a secret notice, prepend info to response.
-    const scopeNotice = this.buildScopeNotice(negotiation);
-    const llmMessages = this.buildLlmMessages(history, message, contextBlock);
-    const llmResponse = await callChatLlm(this.config.model, systemPrompt, llmMessages);
-    const { cleanedAnswer, citations } = this.citationParser.parse(llmResponse.content, allResults);
-
-    const responseContent = scopeNotice ? `${scopeNotice}\n\n${cleanedAnswer}` : cleanedAnswer;
+    const responseContent = ctx.scopeNotice
+      ? `${ctx.scopeNotice}\n\n${cleanedAnswer}`
+      : cleanedAnswer;
 
     return {
       response: {
@@ -108,12 +59,55 @@ export class ConversationEngine {
         tokensIn: llmResponse.tokensIn,
         tokensOut: llmResponse.tokensOut,
       },
-      retrievedEngrams: allResults.map((r) => ({
+      retrievedEngrams: ctx.allResults.map((r) => ({
         engramId: r.sourceId,
         relevanceScore: r.score,
       })),
-      scopeNegotiation: negotiation,
+      scopeNegotiation: ctx.negotiation,
     };
+  }
+
+  /** Prepare a streaming chat response. Returns metadata + an async event generator. */
+  async prepareStream(params: ChatParams): Promise<ChatStreamPreparation> {
+    const ctx = await this.assembleContext(params);
+    return {
+      stream: generateStreamEvents({
+        model: this.config.model,
+        systemPrompt: ctx.systemPrompt,
+        llmMessages: ctx.llmMessages,
+        scopeNotice: ctx.scopeNotice,
+        allResults: ctx.allResults,
+      }),
+      retrievedEngrams: ctx.allResults.map((r) => ({
+        engramId: r.sourceId,
+        relevanceScore: r.score,
+      })),
+      scopeNegotiation: ctx.negotiation,
+    };
+  }
+
+  /** Shared context assembly: scope negotiation, retrieval, context window, LLM messages. */
+  private async assembleContext(params: ChatParams): Promise<{
+    negotiation: ScopeNegotiation;
+    allResults: RetrievalResult[];
+    systemPrompt: string;
+    scopeNotice: string | null;
+    llmMessages: Array<{ role: 'user' | 'assistant'; content: string }>;
+  }> {
+    const { message, history, appContext } = params;
+    const negotiation = this.negotiateScopes(params);
+    const biasedScopes = biasScopes(negotiation.scopes, appContext);
+    const viewedEngram = loadViewedEngram(appContext);
+    const retrievalResults = await this.retrieveEngrams(message, biasedScopes);
+    const allResults = this.mergeViewedEngram(viewedEngram, retrievalResults);
+    const { systemPrompt, contextBlock } = this.buildContextWindow(
+      allResults,
+      negotiation.scopes,
+      appContext
+    );
+    const scopeNotice = this.buildScopeNotice(negotiation);
+    const llmMessages = this.buildLlmMessages(history, message, contextBlock);
+    return { negotiation, allResults, systemPrompt, scopeNotice, llmMessages };
   }
 
   /** Summarise older conversation messages into a condensed block. */

--- a/apps/pops-api/src/modules/ego/llm-client-stream.test.ts
+++ b/apps/pops-api/src/modules/ego/llm-client-stream.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the streaming LLM client (PRD-087 US-01 AC #6).
+ *
+ * Mocks the Anthropic SDK to verify token-by-token streaming behavior,
+ * fallback when the API key is missing, and error recovery.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Mock env before importing the module under test.
+vi.mock('../../env.js', () => ({
+  getEnv: vi.fn(),
+}));
+
+// Mock inference tracking (no DB in unit tests).
+vi.mock('../../lib/inference-middleware.js', () => ({
+  trackInference: vi.fn((_params, fn) => fn()),
+}));
+
+// Mock logger.
+vi.mock('../../lib/logger.js', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+// Mock the Anthropic SDK — must use a class so `new` works.
+const mockMessagesStream = vi.fn();
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    default: class MockAnthropic {
+      messages = { stream: mockMessagesStream };
+    },
+  };
+});
+
+import { getEnv } from '../../env.js';
+import { streamChatLlm } from './llm-client.js';
+
+import type { StreamEvent } from './llm-client.js';
+
+const mockedGetEnv = vi.mocked(getEnv);
+
+/** Collect all events from an async generator into an array. */
+async function collectEvents(gen: AsyncGenerator<StreamEvent>): Promise<StreamEvent[]> {
+  const events: StreamEvent[] = [];
+  for await (const event of gen) {
+    events.push(event);
+  }
+  return events;
+}
+
+/** Create a mock async iterable that yields the given stream events. */
+function createMockStream(
+  events: Array<{ type: string; delta?: { type: string; text: string }; index?: number }>,
+  finalMessage: { usage: { input_tokens: number; output_tokens: number } }
+): { [Symbol.asyncIterator]: () => AsyncIterator<unknown>; finalMessage: () => Promise<unknown> } {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const event of events) {
+        yield event;
+      }
+    },
+    finalMessage: () => Promise.resolve(finalMessage),
+  };
+}
+
+describe('streamChatLlm', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('yields unavailable message when API key is not set', async () => {
+    mockedGetEnv.mockReturnValue(undefined);
+
+    const events = await collectEvents(
+      streamChatLlm('claude-sonnet-4-20250514', 'system', [{ role: 'user', content: 'hi' }])
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({ type: 'token', text: expect.stringContaining('unavailable') });
+    expect(events[1]).toMatchObject({ type: 'done', tokensIn: 0, tokensOut: 0 });
+  });
+
+  it('yields text deltas from the stream followed by a done event', async () => {
+    mockedGetEnv.mockReturnValue('test-api-key');
+
+    const mockStream = createMockStream(
+      [
+        { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hello' }, index: 0 },
+        { type: 'content_block_delta', delta: { type: 'text_delta', text: ' world' }, index: 0 },
+        { type: 'content_block_stop', index: 0 },
+      ],
+      { usage: { input_tokens: 100, output_tokens: 50 } }
+    );
+
+    mockMessagesStream.mockReturnValue(mockStream);
+
+    const events = await collectEvents(
+      streamChatLlm('claude-sonnet-4-20250514', 'system', [{ role: 'user', content: 'hi' }])
+    );
+
+    expect(events).toHaveLength(3);
+    expect(events[0]).toEqual({ type: 'token', text: 'Hello' });
+    expect(events[1]).toEqual({ type: 'token', text: ' world' });
+    expect(events[2]).toEqual({
+      type: 'done',
+      fullText: 'Hello world',
+      tokensIn: 100,
+      tokensOut: 50,
+    });
+  });
+
+  it('yields error fallback when stream iteration throws', async () => {
+    mockedGetEnv.mockReturnValue('test-api-key');
+
+    const failingStream = {
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'partial' },
+          index: 0,
+        };
+        throw new Error('Connection lost');
+      },
+      finalMessage: () => Promise.reject(new Error('no message')),
+    };
+
+    mockMessagesStream.mockReturnValue(failingStream);
+
+    const events = await collectEvents(
+      streamChatLlm('claude-sonnet-4-20250514', 'system', [{ role: 'user', content: 'hi' }])
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({ type: 'token', text: 'partial' });
+    // Done event with partial text and zero tokens.
+    expect(events[1]).toMatchObject({
+      type: 'done',
+      fullText: 'partial',
+      tokensIn: 0,
+      tokensOut: 0,
+    });
+  });
+
+  it('yields error message when stream fails with no text produced', async () => {
+    mockedGetEnv.mockReturnValue('test-api-key');
+
+    const failingStream = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: () => Promise.reject(new Error('Immediate failure')),
+        };
+      },
+      finalMessage: () => Promise.reject(new Error('no message')),
+    };
+
+    mockMessagesStream.mockReturnValue(failingStream);
+
+    const events = await collectEvents(
+      streamChatLlm('claude-sonnet-4-20250514', 'system', [{ role: 'user', content: 'hi' }])
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({ type: 'token', text: expect.stringContaining('error') });
+    expect(events[1]).toMatchObject({ type: 'done', tokensIn: 0, tokensOut: 0 });
+  });
+
+  it('ignores non-text-delta events from the stream', async () => {
+    mockedGetEnv.mockReturnValue('test-api-key');
+
+    const mockStream = createMockStream(
+      [
+        { type: 'message_start' },
+        { type: 'content_block_start', index: 0 },
+        { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Only text' }, index: 0 },
+        { type: 'content_block_stop', index: 0 },
+        { type: 'message_stop' },
+      ],
+      { usage: { input_tokens: 10, output_tokens: 5 } }
+    );
+
+    mockMessagesStream.mockReturnValue(mockStream);
+
+    const events = await collectEvents(
+      streamChatLlm('claude-sonnet-4-20250514', 'system', [{ role: 'user', content: 'hi' }])
+    );
+
+    // Only the text_delta token + done event.
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({ type: 'token', text: 'Only text' });
+    expect(events[1]).toMatchObject({ type: 'done', fullText: 'Only text' });
+  });
+});

--- a/apps/pops-api/src/modules/ego/llm-client.ts
+++ b/apps/pops-api/src/modules/ego/llm-client.ts
@@ -1,7 +1,8 @@
 /**
  * LLM client for the Ego conversation engine (PRD-087 US-01).
  *
- * Handles all Anthropic API calls: chat generation and history summarisation.
+ * Handles all Anthropic API calls: chat generation, history summarisation,
+ * and streaming chat generation (US-01 AC #6).
  * Encapsulates rate limiting, inference tracking, and error handling.
  */
 import Anthropic from '@anthropic-ai/sdk';
@@ -10,6 +11,8 @@ import { getEnv } from '../../env.js';
 import { withRateLimitRetry } from '../../lib/ai-retry.js';
 import { trackInference } from '../../lib/inference-middleware.js';
 import { logger } from '../../lib/logger.js';
+
+import type { MessageStream } from '@anthropic-ai/sdk/lib/MessageStream';
 
 const LLM_UNAVAILABLE_MSG =
   'I can help with that, but the LLM is currently unavailable. Please try again later.';
@@ -66,6 +69,110 @@ export async function callChatLlm(
       '[Ego] LLM call failed'
     );
     return { content: LLM_ERROR_MSG, tokensIn: 0, tokensOut: 0 };
+  }
+}
+
+/** Token and text chunk yielded by the streaming LLM client. */
+export interface StreamChunk {
+  type: 'token';
+  text: string;
+}
+
+/** Final metadata yielded when the stream completes. */
+export interface StreamDone {
+  type: 'done';
+  fullText: string;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/** Union type for all events yielded by streamChatLlm. */
+export type StreamEvent = StreamChunk | StreamDone;
+
+/** Track streaming inference after the stream completes. */
+function trackStreamInference(model: string, tokensIn: number, tokensOut: number): void {
+  trackInference({ provider: 'claude', model, operation: 'ego.chat.stream', domain: 'ego' }, () =>
+    Promise.resolve({ usage: { input_tokens: tokensIn, output_tokens: tokensOut } })
+  ).catch((err) => {
+    logger.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[Ego] Failed to track streaming inference'
+    );
+  });
+}
+
+/** Yield fallback events for when the LLM is unavailable or errored. */
+function* fallbackEvents(text: string): Generator<StreamEvent> {
+  yield { type: 'token', text };
+  yield { type: 'done', fullText: text, tokensIn: 0, tokensOut: 0 };
+}
+
+/**
+ * Stream an LLM chat response token-by-token.
+ *
+ * Yields `StreamChunk` events as text deltas arrive, then a final
+ * `StreamDone` event with the complete text and token counts.
+ */
+export async function* streamChatLlm(
+  model: string,
+  systemPrompt: string,
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>
+): AsyncGenerator<StreamEvent> {
+  const apiKey = getEnv('ANTHROPIC_API_KEY');
+  if (!apiKey) {
+    logger.warn('[Ego] ANTHROPIC_API_KEY not set — returning unavailable message');
+    yield* fallbackEvents(LLM_UNAVAILABLE_MSG);
+    return;
+  }
+
+  const client = new Anthropic({ apiKey, maxRetries: 0 });
+  let stream: MessageStream;
+
+  try {
+    stream = client.messages.stream({
+      model,
+      max_tokens: 2048,
+      temperature: 0.3,
+      system: systemPrompt,
+      messages,
+    });
+  } catch (err) {
+    logger.error(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[Ego] Stream creation failed'
+    );
+    yield* fallbackEvents(LLM_ERROR_MSG);
+    return;
+  }
+
+  let fullText = '';
+
+  try {
+    for await (const event of stream) {
+      if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+        fullText += event.delta.text;
+        yield { type: 'token', text: event.delta.text };
+      }
+    }
+
+    const finalMessage = await stream.finalMessage();
+    trackStreamInference(model, finalMessage.usage.input_tokens, finalMessage.usage.output_tokens);
+    yield {
+      type: 'done',
+      fullText,
+      tokensIn: finalMessage.usage.input_tokens,
+      tokensOut: finalMessage.usage.output_tokens,
+    };
+  } catch (err) {
+    logger.error(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[Ego] Stream processing failed'
+    );
+    if (fullText.length === 0) {
+      yield { type: 'token', text: LLM_ERROR_MSG };
+      fullText = LLM_ERROR_MSG;
+    }
+    yield { type: 'done', fullText, tokensIn: 0, tokensOut: 0 };
   }
 }
 

--- a/apps/pops-api/src/modules/ego/router.ts
+++ b/apps/pops-api/src/modules/ego/router.ts
@@ -7,110 +7,16 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-import { getDrizzle } from '../../db.js';
 import { protectedProcedure, router } from '../../trpc.js';
-import { ConversationEngine } from './engine.js';
-import { PersistenceStoreAdapter } from './persistence-store.js';
-import { ConversationPersistence } from './persistence.js';
-import { autoTitle } from './types.js';
+import {
+  getEngine,
+  getPersistence,
+  getStore,
+  persistChatResults,
+  resolveConversation,
+} from './chat-helpers.js';
 
-import type { AppContext, ChatResult, Conversation, Message } from './types.js';
-
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
-
-/** Lazily instantiated persistence service (uses the global Drizzle instance). */
-function getPersistence(): ConversationPersistence {
-  return new ConversationPersistence({ db: getDrizzle() });
-}
-
-function getStore(): PersistenceStoreAdapter {
-  return new PersistenceStoreAdapter(getPersistence());
-}
-
-function getEngine(): ConversationEngine {
-  return new ConversationEngine();
-}
-
-/**
- * Check whether two AppContext values differ (by value, not reference).
- * Returns true if the incoming context is meaningfully different from stored.
- */
-function appContextChanged(
-  stored: AppContext | undefined | null,
-  incoming: AppContext | undefined
-): boolean {
-  if (!stored && !incoming) return false;
-  if (!stored || !incoming) return true;
-  return (
-    stored.app !== incoming.app ||
-    stored.route !== incoming.route ||
-    stored.entityId !== incoming.entityId ||
-    stored.entityType !== incoming.entityType
-  );
-}
-
-interface PersistChatParams {
-  persistence: ConversationPersistence;
-  conversationId: string;
-  userMessage: string;
-  result: ChatResult;
-  storedAppContext?: AppContext | null;
-  incomingAppContext?: AppContext;
-}
-
-/** Persist chat results: scope changes, app context changes, messages, and engram context. */
-function persistChatResults(params: PersistChatParams): Message {
-  const { persistence, conversationId, userMessage, result } = params;
-
-  if (result.scopeNegotiation?.changed) {
-    persistence.updateScopes(conversationId, result.scopeNegotiation.scopes);
-  }
-
-  // US-03: Detect app context change and persist it.
-  if (appContextChanged(params.storedAppContext, params.incomingAppContext)) {
-    persistence.updateAppContext(conversationId, params.incomingAppContext ?? null);
-  }
-
-  persistence.appendMessage(conversationId, { role: 'user', content: userMessage });
-
-  const assistantMsg = persistence.appendMessage(conversationId, {
-    role: 'assistant',
-    content: result.response.content,
-    citations: result.response.citations,
-    tokensIn: result.response.tokensIn,
-    tokensOut: result.response.tokensOut,
-  });
-
-  for (const { engramId, relevanceScore } of result.retrievedEngrams) {
-    persistence.upsertContext(conversationId, engramId, relevanceScore);
-  }
-
-  return assistantMsg;
-}
-
-interface ResolveConversationParams {
-  store: PersistenceStoreAdapter;
-  persistence: ConversationPersistence;
-  conversationId: string | undefined;
-  message: string;
-  scopes: string[];
-  appContext: AppContext | undefined;
-}
-
-/** Load an existing conversation or create a new one. */
-async function resolveConversation(params: ResolveConversationParams): Promise<Conversation> {
-  const { store, persistence, conversationId, message, scopes, appContext } = params;
-  if (conversationId) {
-    const existing = await store.getConversation(conversationId);
-    if (existing) return existing;
-  }
-  return persistence.createConversation({
-    title: autoTitle(message),
-    scopes,
-    appContext,
-    model: DEFAULT_MODEL,
-  });
-}
+import type { AppContext, ChatResult } from './types.js';
 
 const createSchema = z.object({
   title: z.string().min(1).optional(),

--- a/apps/pops-api/src/modules/ego/types.ts
+++ b/apps/pops-api/src/modules/ego/types.ts
@@ -142,6 +142,38 @@ export interface ChatResult {
   scopeNegotiation?: ScopeNegotiation;
 }
 
+// ---------------------------------------------------------------------------
+// Streaming types (PRD-087 US-01 AC #6)
+// ---------------------------------------------------------------------------
+
+/** A partial text token yielded during streaming. */
+export interface ChatStreamToken {
+  type: 'token';
+  text: string;
+}
+
+/** Final metadata yielded when the stream completes. */
+export interface ChatStreamDone {
+  type: 'done';
+  content: string;
+  citations: string[];
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/** Union of events yielded by the engine's streaming generator. */
+export type ChatStreamEvent = ChatStreamToken | ChatStreamDone;
+
+/** Preparation result from ConversationEngine.prepareStream(). */
+export interface ChatStreamPreparation {
+  /** Async generator that yields token chunks and a final done event. */
+  stream: AsyncGenerator<ChatStreamEvent>;
+  /** Engrams retrieved during context assembly. */
+  retrievedEngrams: Array<{ engramId: string; relevanceScore: number }>;
+  /** Scope negotiation outcome. */
+  scopeNegotiation: ScopeNegotiation;
+}
+
 /** Parameters for ConversationEngine.chat(). */
 export interface ChatParams {
   conversationId: string;

--- a/apps/pops-api/src/routes/ego/chat-stream.ts
+++ b/apps/pops-api/src/routes/ego/chat-stream.ts
@@ -1,0 +1,164 @@
+/**
+ * SSE endpoint for streaming ego chat responses (PRD-087 US-01 AC #6).
+ *
+ * POST /api/ego/chat/stream
+ *
+ * Accepts the same body as ego.chat, but returns an SSE stream:
+ *   data: {"type":"token","text":"..."}
+ *   data: {"type":"done","conversationId":"...","citations":[...],"tokensIn":N,"tokensOut":N}
+ *
+ * Persists messages after the stream completes (same as ego.chat).
+ */
+import { type Router as ExpressRouter, Router } from 'express';
+import { z } from 'zod';
+
+import { logger } from '../../lib/logger.js';
+import {
+  getEngine,
+  getPersistence,
+  getStore,
+  persistStreamResults,
+  resolveConversation,
+} from '../../modules/ego/chat-helpers.js';
+
+import type { Request, Response } from 'express';
+
+import type { AppContext, ChatStreamPreparation, Conversation } from '../../modules/ego/types.js';
+
+const router: ExpressRouter = Router();
+
+const bodySchema = z.object({
+  conversationId: z.string().min(1).optional(),
+  message: z.string().min(1),
+  scopes: z.array(z.string().min(1)).optional(),
+  appContext: z
+    .object({
+      app: z.string(),
+      route: z.string().optional(),
+      entityId: z.string().optional(),
+      entityType: z.string().optional(),
+    })
+    .optional(),
+  channel: z.enum(['shell', 'moltbot', 'mcp', 'cli']).optional(),
+  knownScopes: z.array(z.string().min(1)).optional(),
+});
+
+type ValidatedInput = z.infer<typeof bodySchema>;
+
+/** Set standard SSE response headers. */
+function setSseHeaders(res: Response): void {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+}
+
+/** Write a single SSE data event. */
+function writeSseEvent(res: Response, data: Record<string, unknown>): void {
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+interface PipeStreamParams {
+  req: Request;
+  res: Response;
+  preparation: ChatStreamPreparation;
+  conversation: Conversation;
+  input: ValidatedInput;
+  appContext: AppContext | undefined;
+}
+
+/** Stream events to the SSE client and persist after completion. */
+async function pipeStreamEvents(params: PipeStreamParams): Promise<void> {
+  const { req, res, preparation, conversation, input, appContext } = params;
+  const persistence = getPersistence();
+  let clientDisconnected = false;
+  req.on('close', () => {
+    clientDisconnected = true;
+  });
+
+  for await (const event of preparation.stream) {
+    if (clientDisconnected) break;
+
+    if (event.type === 'token') {
+      writeSseEvent(res, { type: 'token', text: event.text });
+    } else {
+      const assistantMsg = persistStreamResults({
+        persistence,
+        conversationId: conversation.id,
+        userMessage: input.message,
+        content: event.content,
+        citations: event.citations,
+        tokensIn: event.tokensIn,
+        tokensOut: event.tokensOut,
+        retrievedEngrams: preparation.retrievedEngrams,
+        scopeNegotiation: preparation.scopeNegotiation,
+        storedAppContext: conversation.appContext as AppContext | undefined | null,
+        incomingAppContext: appContext,
+      });
+
+      writeSseEvent(res, {
+        type: 'done',
+        conversationId: conversation.id,
+        messageId: assistantMsg.id,
+        citations: event.citations,
+        tokensIn: event.tokensIn,
+        tokensOut: event.tokensOut,
+        retrievedEngrams: preparation.retrievedEngrams,
+        scopeNegotiation: preparation.scopeNegotiation,
+      });
+    }
+  }
+}
+
+router.post('/api/ego/chat/stream', async (req, res) => {
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid request body', details: parsed.error.issues });
+    return;
+  }
+
+  const input = parsed.data;
+  setSseHeaders(res);
+
+  const scopes = input.scopes ?? [];
+  const appContext: AppContext | undefined = input.appContext ?? undefined;
+
+  try {
+    const store = getStore();
+    const conversation = await resolveConversation({
+      store,
+      persistence: getPersistence(),
+      conversationId: input.conversationId,
+      message: input.message,
+      scopes,
+      appContext,
+    });
+
+    const history = await store.getMessages(conversation.id);
+    const preparation = await getEngine().prepareStream({
+      conversationId: conversation.id,
+      message: input.message,
+      history,
+      activeScopes: conversation.activeScopes,
+      appContext: conversation.appContext as AppContext | undefined,
+      channel: input.channel ?? 'shell',
+      knownScopes: input.knownScopes,
+    });
+
+    await pipeStreamEvents({ req, res, preparation, conversation, input, appContext });
+  } catch (err) {
+    logger.error(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[Ego] SSE stream error'
+    );
+    writeSseEvent(res, {
+      type: 'error',
+      message: err instanceof Error ? err.message : 'Internal server error',
+    });
+  }
+
+  res.end();
+});
+
+export default router;

--- a/apps/pops-shell/vite.config.ts
+++ b/apps/pops-shell/vite.config.ts
@@ -47,6 +47,10 @@ export default defineConfig({
         target: 'http://localhost:3000',
         changeOrigin: true,
       },
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
     },
   },
 });

--- a/packages/app-cerebrum/src/components/chat/ChatPanel.tsx
+++ b/packages/app-cerebrum/src/components/chat/ChatPanel.tsx
@@ -41,6 +41,7 @@ function ThreadArea({ model }: { model: ChatPageModel }) {
           messages={model.messages}
           isLoading={model.messagesLoading}
           isSending={model.isSending}
+          streamingContent={model.streamingContent}
         />
       )}
 

--- a/packages/app-cerebrum/src/components/chat/MessageThread.tsx
+++ b/packages/app-cerebrum/src/components/chat/MessageThread.tsx
@@ -21,6 +21,8 @@ export interface MessageThreadProps {
   isLoading: boolean;
   /** Whether a new message is being sent (shows typing indicator). */
   isSending: boolean;
+  /** Partial streaming content from the assistant (null when not streaming). */
+  streamingContent?: string | null;
   /** Additional CSS classes for the outer wrapper. */
   className?: string;
 }
@@ -65,7 +67,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
   );
 }
 
-/** Typing indicator shown while waiting for assistant response. */
+/** Typing indicator shown while waiting for assistant response (before tokens arrive). */
 function TypingIndicator() {
   return (
     <div className="flex gap-3">
@@ -81,15 +83,38 @@ function TypingIndicator() {
   );
 }
 
-export function MessageThread({ messages, isLoading, isSending, className }: MessageThreadProps) {
-  const bottomRef = useRef<HTMLDivElement>(null);
+/** Streaming message bubble — renders partial assistant content as it arrives. */
+function StreamingBubble({ content }: { content: string }) {
+  return (
+    <div className="flex gap-3">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-app-accent/10 text-app-accent">
+        <Bot className="h-4 w-4" />
+      </div>
+      <div className="max-w-[80%] rounded-lg bg-muted/50 px-4 py-3 text-foreground">
+        <div className="prose prose-sm prose-invert max-w-none text-sm [&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1 [&_pre]:my-2 [&_code]:text-xs">
+          <Markdown>{content}</Markdown>
+        </div>
+      </div>
+    </div>
+  );
+}
 
-  // Auto-scroll to bottom when messages change or sending state changes.
+export function MessageThread({
+  messages,
+  isLoading,
+  isSending,
+  streamingContent,
+  className,
+}: MessageThreadProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const isStreaming = streamingContent !== null && streamingContent !== undefined;
+
+  // Auto-scroll to bottom when messages change, sending state changes, or streaming content updates.
   useEffect(() => {
     if (typeof bottomRef.current?.scrollIntoView === 'function') {
       bottomRef.current.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [messages, isSending]);
+  }, [messages, isSending, streamingContent]);
 
   if (isLoading) {
     return (
@@ -106,7 +131,8 @@ export function MessageThread({ messages, isLoading, isSending, className }: Mes
       {messages.map((msg) => (
         <MessageBubble key={msg.id} message={msg} />
       ))}
-      {isSending && <TypingIndicator />}
+      {isStreaming && streamingContent.length > 0 && <StreamingBubble content={streamingContent} />}
+      {isSending && !isStreaming && <TypingIndicator />}
       <div ref={bottomRef} />
     </div>
   );

--- a/packages/app-cerebrum/src/pages/chat-page/types.ts
+++ b/packages/app-cerebrum/src/pages/chat-page/types.ts
@@ -63,4 +63,6 @@ export interface ChatPageModel {
   activeScopes: string[];
   /** Retrieved engrams for the current conversation context. */
   retrievedEngrams: RetrievedEngram[];
+  /** Partial streaming content being received (null when not streaming). */
+  streamingContent: string | null;
 }

--- a/packages/app-cerebrum/src/pages/chat-page/useChatMutations.ts
+++ b/packages/app-cerebrum/src/pages/chat-page/useChatMutations.ts
@@ -1,20 +1,17 @@
 /**
- * Sub-hook: chat and delete mutations.
+ * Sub-hook: chat mutations (SSE streaming) and delete.
+ *
+ * The streaming path uses the SSE endpoint for token-by-token rendering.
+ * The non-streaming tRPC ego.chat mutation remains for MCP/CLI channels.
  */
 import { useCallback, useState } from 'react';
 
 import { trpc } from '@pops/api-client';
 
-import type { ChatMessage, RetrievedEngram } from './types';
+import { useStreamingChat } from './useStreamingChat';
 
-/** Shape returned by the ego.chat mutation. */
-interface ChatResponse {
-  conversationId: string;
-  response: ChatMessage;
-  retrievedEngrams: RetrievedEngram[];
-}
+import type { RetrievedEngram } from './types';
 
-/** Shape of the ego.conversations.delete mutation input. */
 interface DeleteInput {
   id: string;
 }
@@ -35,24 +32,32 @@ export function useChatMutations({
   const [retrievedEngrams, setRetrievedEngrams] = useState<RetrievedEngram[]>([]);
   const utils = trpc.useUtils();
 
-  const chatMutation = trpc.ego.chat.useMutation({
-    onSuccess: (data: ChatResponse) => {
-      setSelectedConversationId(data.conversationId);
-      setRetrievedEngrams(data.retrievedEngrams);
-      void utils.ego.conversations.list.invalidate();
-      void utils.ego.conversations.get.invalidate({ id: data.conversationId });
-    },
-  });
+  const streaming = useStreamingChat();
 
   const sendMessage = useCallback(() => {
     const trimmed = inputValue.trim();
-    if (!trimmed) return;
+    if (!trimmed || streaming.isStreaming) return;
+
     setInputValue('');
-    chatMutation.mutate({
-      conversationId: selectedConversationId ?? undefined,
-      message: trimmed,
-    });
-  }, [inputValue, selectedConversationId, chatMutation, setInputValue]);
+    streaming.stream(
+      { conversationId: selectedConversationId, message: trimmed },
+      {
+        onConversation: setSelectedConversationId,
+        onEngrams: setRetrievedEngrams,
+        onInvalidate: (conversationId) => {
+          void utils.ego.conversations.list.invalidate();
+          void utils.ego.conversations.get.invalidate({ id: conversationId });
+        },
+      }
+    );
+  }, [
+    inputValue,
+    selectedConversationId,
+    streaming,
+    setInputValue,
+    setSelectedConversationId,
+    utils,
+  ]);
 
   const deleteMutation = trpc.ego.conversations.delete.useMutation({
     onSuccess: (_data: { success: boolean }, variables: DeleteInput) => {
@@ -73,11 +78,12 @@ export function useChatMutations({
 
   return {
     sendMessage,
-    isSending: chatMutation.isPending,
-    sendError: chatMutation.error?.message ?? null,
+    isSending: streaming.isStreaming,
+    sendError: streaming.error,
     deleteConversation,
     isDeleting: deleteMutation.isPending,
     retrievedEngrams,
     clearEngrams,
+    streamingContent: streaming.streamingContent,
   };
 }

--- a/packages/app-cerebrum/src/pages/chat-page/useChatPageModel.ts
+++ b/packages/app-cerebrum/src/pages/chat-page/useChatPageModel.ts
@@ -57,5 +57,6 @@ export function useChatPageModel(): ChatPageModel {
     setSearchQuery: list.setSearchQuery,
     activeScopes: detail.activeScopes,
     retrievedEngrams: mutations.retrievedEngrams,
+    streamingContent: mutations.streamingContent,
   };
 }

--- a/packages/app-cerebrum/src/pages/chat-page/useStreamingChat.ts
+++ b/packages/app-cerebrum/src/pages/chat-page/useStreamingChat.ts
@@ -1,0 +1,158 @@
+/**
+ * Low-level SSE streaming hook for ego chat (PRD-087 US-01 AC #6).
+ *
+ * Fetches from the /api/ego/chat/stream SSE endpoint and processes
+ * the event stream, updating state as tokens arrive.
+ */
+import { useCallback, useRef, useState } from 'react';
+
+import type { RetrievedEngram } from './types';
+
+/** SSE token event from /api/ego/chat/stream. */
+interface SseTokenEvent {
+  type: 'token';
+  text: string;
+}
+
+/** SSE done event from /api/ego/chat/stream. */
+interface SseDoneEvent {
+  type: 'done';
+  conversationId: string;
+  messageId: string;
+  citations: string[];
+  tokensIn: number;
+  tokensOut: number;
+  retrievedEngrams: RetrievedEngram[];
+}
+
+/** SSE error event from /api/ego/chat/stream. */
+interface SseErrorEvent {
+  type: 'error';
+  message: string;
+}
+
+type SseEvent = SseTokenEvent | SseDoneEvent | SseErrorEvent;
+
+/** Parse an SSE data line into a typed event object. */
+function parseSseEvent(line: string): SseEvent | null {
+  if (!line.startsWith('data: ')) return null;
+  try {
+    return JSON.parse(line.slice(6)) as SseEvent;
+  } catch {
+    return null;
+  }
+}
+
+interface StreamChatParams {
+  conversationId: string | null;
+  message: string;
+}
+
+interface StreamCallbacks {
+  onConversation: (id: string) => void;
+  onEngrams: (engrams: RetrievedEngram[]) => void;
+  onInvalidate: (conversationId: string) => void;
+}
+
+/** Process the SSE response body, dispatching events to state setters. */
+async function processStream(
+  body: ReadableStream<Uint8Array>,
+  setContent: React.Dispatch<React.SetStateAction<string | null>>,
+  setError: React.Dispatch<React.SetStateAction<string | null>>,
+  callbacks: StreamCallbacks
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      const event = parseSseEvent(trimmed);
+      if (!event) continue;
+
+      if (event.type === 'token') {
+        setContent((prev) => (prev ?? '') + event.text);
+      } else if (event.type === 'done') {
+        callbacks.onConversation(event.conversationId);
+        callbacks.onEngrams(event.retrievedEngrams);
+        setContent(null);
+        callbacks.onInvalidate(event.conversationId);
+      } else if (event.type === 'error') {
+        setError(event.message);
+        setContent(null);
+      }
+    }
+  }
+}
+
+export interface UseStreamingChatReturn {
+  /** Start streaming a message to the SSE endpoint. */
+  stream: (params: StreamChatParams, callbacks: StreamCallbacks) => void;
+  /** Whether a stream is currently active. */
+  isStreaming: boolean;
+  /** Error from the last stream attempt. */
+  error: string | null;
+  /** Partial streaming content (null when not streaming). */
+  streamingContent: string | null;
+  /** Clear the error state. */
+  clearError: () => void;
+}
+
+export function useStreamingChat(): UseStreamingChatReturn {
+  const [streamingContent, setStreamingContent] = useState<string | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const stream = useCallback(
+    (params: StreamChatParams, callbacks: StreamCallbacks) => {
+      if (isStreaming) return;
+
+      setIsStreaming(true);
+      setError(null);
+      setStreamingContent('');
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      fetch('/api/ego/chat/stream', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          conversationId: params.conversationId ?? undefined,
+          message: params.message,
+        }),
+        signal: controller.signal,
+      })
+        .then(async (response) => {
+          if (!response.ok) throw new Error(`Stream request failed: ${response.status}`);
+          if (!response.body) throw new Error('Response body is null');
+          await processStream(response.body, setStreamingContent, setError, callbacks);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof Error && err.name === 'AbortError') return;
+          setError(err instanceof Error ? err.message : 'Stream failed');
+          setStreamingContent(null);
+        })
+        .finally(() => {
+          setIsStreaming(false);
+          abortRef.current = null;
+        });
+    },
+    [isStreaming]
+  );
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return { stream, isStreaming, error, streamingContent, clearError };
+}


### PR DESCRIPTION
## Summary
- Add token-by-token SSE streaming for the ego chat panel via `POST /api/ego/chat/stream`
- Existing tRPC `ego.chat` mutation remains unchanged for MCP/CLI channels
- Frontend chat panel renders partial assistant responses as tokens arrive, replacing the typing indicator

## Changes

### Backend
- **`llm-client.ts`**: Added `streamChatLlm()` async generator using `client.messages.stream()` from the Anthropic SDK
- **`engine-stream.ts`**: Stream event generator with scope notice injection and citation parsing on completion
- **`engine.ts`**: New `prepareStream()` method with shared context assembly via `assembleContext()`
- **`chat-helpers.ts`**: Extracted shared persistence/conversation resolution from the tRPC router for reuse
- **`engine-helpers.ts`**: Extracted pure helper functions to keep engine.ts within lint limits
- **`routes/ego/chat-stream.ts`**: Express SSE route at `/api/ego/chat/stream` with Zod validation, stream piping, and post-stream persistence
- **`types.ts`**: New `ChatStreamEvent`, `ChatStreamPreparation` types
- **`app.ts`**: Registered the SSE route after auth + env context middleware

### Frontend
- **`useStreamingChat.ts`**: fetch-based SSE consumer with abort support and progressive state updates
- **`useChatMutations.ts`**: Wired to use streaming for `sendMessage`
- **`MessageThread.tsx`**: New `StreamingBubble` component renders partial Markdown as tokens arrive
- **`types.ts`** / **`useChatPageModel.ts`** / **`ChatPanel.tsx`**: Piped `streamingContent` through the view model

### SSE Protocol
```
data: {"type":"token","text":"..."}     # partial text delta
data: {"type":"done","conversationId":"...","messageId":"...","citations":[...],"tokensIn":N,"tokensOut":N}
data: {"type":"error","message":"..."}  # on failure
```

## Test plan
- [x] `llm-client-stream.test.ts`: 5 unit tests (streaming, fallback, error recovery, event filtering)
- [x] `engine-stream.test.ts`: 4 unit tests (scope notices, token passthrough, citations, param forwarding)
- [x] Lint: 0 errors, 75 warnings (unchanged from main)
- [x] Typecheck: passes across all 17 packages
- [x] All 3336 existing tests pass (one pre-existing flaky watcher test)
- [ ] Manual: send a message in the chat panel and verify tokens stream in real-time
- [ ] Manual: verify MCP/CLI channels still work via the tRPC mutation