### PR TITLE
feat(cerebrum): Plexus plugin architecture (PRD-090)

### DIFF
--- a/apps/pops-api/src/db/drizzle-migrations/0041_plexus_adapters.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0041_plexus_adapters.sql
@@ -1,0 +1,27 @@
+-- Plexus adapter registry and ingestion filters (PRD-090).
+CREATE TABLE `plexus_adapters` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`status` text DEFAULT 'registered' NOT NULL,
+	`config` text,
+	`last_health` text,
+	`last_error` text,
+	`ingested_count` integer DEFAULT 0 NOT NULL,
+	`emitted_count` integer DEFAULT 0 NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_plexus_adapters_name` ON `plexus_adapters` (`name`);--> statement-breakpoint
+CREATE INDEX `idx_plexus_adapters_status` ON `plexus_adapters` (`status`);--> statement-breakpoint
+CREATE TABLE `plexus_filters` (
+	`id` text PRIMARY KEY NOT NULL,
+	`adapter_id` text NOT NULL,
+	`filter_type` text NOT NULL,
+	`field` text NOT NULL,
+	`pattern` text NOT NULL,
+	`enabled` integer DEFAULT 1 NOT NULL,
+	FOREIGN KEY (`adapter_id`) REFERENCES `plexus_adapters`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_plexus_filters_adapter_id` ON `plexus_filters` (`adapter_id`);

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1714200000000,
       "tag": "0040_bumpy_namorita",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "6",
+      "when": 1777543200000,
+      "tag": "0041_plexus_adapters",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -798,6 +798,33 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
       ON embeddings(source_type, source_id, chunk_index);
     CREATE INDEX IF NOT EXISTS idx_embeddings_source_type ON embeddings(source_type);
     CREATE INDEX IF NOT EXISTS idx_embeddings_content_hash ON embeddings(content_hash);
+
+    -- Plexus adapter registry (PRD-090).
+    CREATE TABLE IF NOT EXISTS plexus_adapters (
+      id             TEXT PRIMARY KEY,
+      name           TEXT NOT NULL UNIQUE,
+      status         TEXT NOT NULL DEFAULT 'registered',
+      config         TEXT,
+      last_health    TEXT,
+      last_error     TEXT,
+      ingested_count INTEGER NOT NULL DEFAULT 0,
+      emitted_count  INTEGER NOT NULL DEFAULT 0,
+      created_at     TEXT NOT NULL,
+      updated_at     TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_plexus_adapters_name ON plexus_adapters(name);
+    CREATE INDEX IF NOT EXISTS idx_plexus_adapters_status ON plexus_adapters(status);
+
+    -- Plexus ingestion filters (PRD-090).
+    CREATE TABLE IF NOT EXISTS plexus_filters (
+      id          TEXT PRIMARY KEY,
+      adapter_id  TEXT NOT NULL REFERENCES plexus_adapters(id) ON DELETE CASCADE,
+      filter_type TEXT NOT NULL,
+      field       TEXT NOT NULL,
+      pattern     TEXT NOT NULL,
+      enabled     INTEGER NOT NULL DEFAULT 1
+    );
+    CREATE INDEX IF NOT EXISTS idx_plexus_filters_adapter_id ON plexus_filters(adapter_id);
   `);
 
   // embeddings_vec virtual table (PRD-076). Requires sqlite-vec extension.

--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -9,6 +9,7 @@ import { scopesRouter } from './engrams/scopes-router.js';
 import { gliaRouter } from './glia/router.js';
 import { ingestRouter } from './ingest/router.js';
 import { nudgesRouter } from './nudges/router.js';
+import { plexusRouter } from './plexus/router.js';
 import { queryRouter } from './query/router.js';
 import { retrievalRouter } from './retrieval/router.js';
 import { templatesRouter } from './templates/router.js';
@@ -26,4 +27,5 @@ export const cerebrumRouter = router({
 
   glia: gliaRouter,
   nudges: nudgesRouter,
+  plexus: plexusRouter,
 });

--- a/apps/pops-api/src/modules/cerebrum/plexus/__tests__/filters.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/__tests__/filters.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyFilters,
+  compileFilter,
+  compileFilters,
+  dryRun,
+  evaluateItem,
+  extractField,
+} from '../filters.js';
+
+import type { EngineData, FilterRule } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function item(overrides: Partial<EngineData> = {}): EngineData {
+  return {
+    body: 'test body',
+    source: 'plexus:test',
+    ...overrides,
+  };
+}
+
+function rule(overrides: Partial<FilterRule> = {}): FilterRule {
+  return {
+    filterType: 'include',
+    field: 'body',
+    pattern: '.*',
+    enabled: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// compileFilter
+// ---------------------------------------------------------------------------
+
+describe('compileFilter', () => {
+  it('compiles a valid regex pattern', () => {
+    const result = compileFilter(rule({ pattern: '^hello' }));
+    expect(result).not.toBeNull();
+    expect(result?.regex.source).toBe('^hello');
+  });
+
+  it('returns null for an invalid regex pattern', () => {
+    const result = compileFilter(rule({ pattern: '[invalid' }));
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compileFilters
+// ---------------------------------------------------------------------------
+
+describe('compileFilters', () => {
+  it('separates valid and invalid filters', () => {
+    const rules: FilterRule[] = [
+      rule({ pattern: '^valid' }),
+      rule({ pattern: '[bad' }),
+      rule({ pattern: 'also-valid$' }),
+    ];
+    const { compiled, invalid } = compileFilters(rules);
+    expect(compiled).toHaveLength(2);
+    expect(invalid).toHaveLength(1);
+    expect(invalid[0]?.pattern).toBe('[bad');
+  });
+
+  it('skips disabled filters', () => {
+    const { compiled } = compileFilters([rule({ enabled: false })]);
+    expect(compiled).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractField
+// ---------------------------------------------------------------------------
+
+describe('extractField', () => {
+  it('extracts well-known fields', () => {
+    const e = item({ title: 'Title', type: 'note', source: 'plexus:x', externalId: 'ext-1' });
+    expect(extractField(e, 'body')).toBe('test body');
+    expect(extractField(e, 'title')).toBe('Title');
+    expect(extractField(e, 'type')).toBe('note');
+    expect(extractField(e, 'source')).toBe('plexus:x');
+    expect(extractField(e, 'externalId')).toBe('ext-1');
+  });
+
+  it('joins tags and scopes as comma-separated strings', () => {
+    const e = item({ tags: ['a', 'b'], scopes: ['s1', 's2'] });
+    expect(extractField(e, 'tags')).toBe('a,b');
+    expect(extractField(e, 'scopes')).toBe('s1,s2');
+  });
+
+  it('extracts from customFields', () => {
+    const e = item({ customFields: { subject: 'Re: hello', priority: 3 } });
+    expect(extractField(e, 'subject')).toBe('Re: hello');
+    expect(extractField(e, 'priority')).toBe('3');
+  });
+
+  it('returns undefined for missing fields', () => {
+    expect(extractField(item(), 'nonexistent')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateItem
+// ---------------------------------------------------------------------------
+
+describe('evaluateItem', () => {
+  it('accepts all items when no filters are compiled', () => {
+    expect(evaluateItem(item(), [])).toBe(true);
+  });
+
+  it('accepts items matching an include filter', () => {
+    const { compiled } = compileFilters([
+      rule({ filterType: 'include', field: 'body', pattern: 'test' }),
+    ]);
+    expect(evaluateItem(item(), compiled)).toBe(true);
+  });
+
+  it('rejects items not matching any include filter', () => {
+    const { compiled } = compileFilters([
+      rule({ filterType: 'include', field: 'body', pattern: '^no-match$' }),
+    ]);
+    expect(evaluateItem(item(), compiled)).toBe(false);
+  });
+
+  it('rejects items matching an exclude filter', () => {
+    const { compiled } = compileFilters([
+      rule({ filterType: 'exclude', field: 'body', pattern: 'test' }),
+    ]);
+    expect(evaluateItem(item(), compiled)).toBe(false);
+  });
+
+  it('accepts items not matching any exclude filter', () => {
+    const { compiled } = compileFilters([
+      rule({ filterType: 'exclude', field: 'body', pattern: '^no-match$' }),
+    ]);
+    expect(evaluateItem(item(), compiled)).toBe(true);
+  });
+
+  it('evaluates includes first, then excludes', () => {
+    const { compiled } = compileFilters([
+      // Include anything with "report" in body.
+      rule({ filterType: 'include', field: 'body', pattern: 'report' }),
+      // Exclude items with "draft" in title.
+      rule({ filterType: 'exclude', field: 'title', pattern: 'draft' }),
+    ]);
+
+    // Matches include, does not match exclude → accepted.
+    expect(evaluateItem(item({ body: 'quarterly report', title: 'Final' }), compiled)).toBe(true);
+
+    // Matches include AND matches exclude → rejected.
+    expect(evaluateItem(item({ body: 'quarterly report', title: 'draft v2' }), compiled)).toBe(
+      false
+    );
+
+    // Does not match include → rejected (regardless of exclude).
+    expect(evaluateItem(item({ body: 'meeting notes', title: 'Final' }), compiled)).toBe(false);
+  });
+
+  it('handles exclude-only rules (pass-through minus exclusions)', () => {
+    const { compiled } = compileFilters([
+      rule({ filterType: 'exclude', field: 'type', pattern: '^spam$' }),
+    ]);
+
+    expect(evaluateItem(item({ type: 'email' }), compiled)).toBe(true);
+    expect(evaluateItem(item({ type: 'spam' }), compiled)).toBe(false);
+  });
+
+  it('handles include-only rules (only matching items pass)', () => {
+    const { compiled } = compileFilters([
+      rule({ filterType: 'include', field: 'type', pattern: '^email$' }),
+    ]);
+
+    expect(evaluateItem(item({ type: 'email' }), compiled)).toBe(true);
+    expect(evaluateItem(item({ type: 'notification' }), compiled)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyFilters (batch)
+// ---------------------------------------------------------------------------
+
+describe('applyFilters', () => {
+  it('returns all items when no rules exist', () => {
+    const items = [item({ body: 'a' }), item({ body: 'b' })];
+    const result = applyFilters(items, []);
+    expect(result.accepted).toHaveLength(2);
+    expect(result.filtered).toBe(0);
+  });
+
+  it('filters items according to rules', () => {
+    const items = [
+      item({ body: 'keep this' }),
+      item({ body: 'drop this' }),
+      item({ body: 'keep that too' }),
+    ];
+    const rules: FilterRule[] = [rule({ filterType: 'include', field: 'body', pattern: 'keep' })];
+    const result = applyFilters(items, rules);
+    expect(result.accepted).toHaveLength(2);
+    expect(result.filtered).toBe(1);
+  });
+
+  it('handles custom field filters', () => {
+    const items = [
+      item({ customFields: { from: 'alice@company.com' } }),
+      item({ customFields: { from: 'spam@junk.com' } }),
+    ];
+    const rules: FilterRule[] = [
+      rule({ filterType: 'include', field: 'from', pattern: '.*@company\\.com$' }),
+    ];
+    const result = applyFilters(items, rules);
+    expect(result.accepted).toHaveLength(1);
+    expect(result.filtered).toBe(1);
+  });
+
+  it('skips invalid patterns gracefully', () => {
+    const items = [item({ body: 'a' })];
+    const rules: FilterRule[] = [
+      rule({ filterType: 'exclude', field: 'body', pattern: '[invalid' }),
+    ];
+    // Invalid pattern is skipped, so no filtering happens.
+    const result = applyFilters(items, rules);
+    expect(result.accepted).toHaveLength(1);
+    expect(result.filtered).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dryRun
+// ---------------------------------------------------------------------------
+
+describe('dryRun', () => {
+  it('partitions items into would-ingest and would-filter', () => {
+    const items = [item({ body: 'keep' }), item({ body: 'drop' })];
+    const rules: FilterRule[] = [rule({ filterType: 'include', field: 'body', pattern: 'keep' })];
+    const result = dryRun(items, rules);
+    expect(result.wouldIngest).toHaveLength(1);
+    expect(result.wouldFilter).toHaveLength(1);
+    expect(result.wouldIngest[0]?.body).toBe('keep');
+    expect(result.wouldFilter[0]?.body).toBe('drop');
+  });
+
+  it('returns all items as would-ingest when no rules', () => {
+    const items = [item(), item()];
+    const result = dryRun(items, []);
+    expect(result.wouldIngest).toHaveLength(2);
+    expect(result.wouldFilter).toHaveLength(0);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/plexus/__tests__/lifecycle.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/__tests__/lifecycle.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for PlexusLifecycleManager (PRD-090, US-02).
+ *
+ * Uses an in-memory SQLite database to exercise the full registration,
+ * health-check, and shutdown flows without touching disk.
+ */
+import BetterSqlite3 from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setDb } from '../../../../db.js';
+import { BaseAdapter } from '../adapter.js';
+import { PlexusLifecycleManager } from '../lifecycle.js';
+
+import type { AdapterConfig, AdapterStatus, EngineData, IngestOptions } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal in-memory SQLite DB with the plexus tables. */
+function createTestDb(): BetterSqlite3.Database {
+  const db = new BetterSqlite3(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE plexus_adapters (
+      id             TEXT PRIMARY KEY,
+      name           TEXT NOT NULL UNIQUE,
+      status         TEXT NOT NULL DEFAULT 'registered',
+      config         TEXT,
+      last_health    TEXT,
+      last_error     TEXT,
+      ingested_count INTEGER NOT NULL DEFAULT 0,
+      emitted_count  INTEGER NOT NULL DEFAULT 0,
+      created_at     TEXT NOT NULL,
+      updated_at     TEXT NOT NULL
+    );
+    CREATE TABLE plexus_filters (
+      id          TEXT PRIMARY KEY,
+      adapter_id  TEXT NOT NULL REFERENCES plexus_adapters(id) ON DELETE CASCADE,
+      filter_type TEXT NOT NULL,
+      field       TEXT NOT NULL,
+      pattern     TEXT NOT NULL,
+      enabled     INTEGER NOT NULL DEFAULT 1
+    );
+  `);
+  return db;
+}
+
+/** A mock adapter that succeeds at everything by default. */
+class MockAdapter extends BaseAdapter {
+  declare readonly name: string;
+  readonly version = '1.0.0';
+
+  initializeFn = vi.fn<(config: AdapterConfig) => Promise<void>>().mockResolvedValue(undefined);
+  ingestFn = vi.fn<(options: IngestOptions) => Promise<EngineData[]>>().mockResolvedValue([]);
+  healthCheckFn = vi.fn<() => Promise<AdapterStatus>>().mockResolvedValue({
+    status: 'healthy',
+    lastChecked: new Date().toISOString(),
+  });
+  shutdownFn = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+  constructor(adapterName = 'mock') {
+    super();
+    (this as { name: string }).name = adapterName;
+  }
+
+  override async initialize(config: AdapterConfig): Promise<void> {
+    await super.initialize(config);
+    return this.initializeFn(config);
+  }
+
+  async ingest(options: IngestOptions): Promise<EngineData[]> {
+    return this.ingestFn(options);
+  }
+
+  override async healthCheck(): Promise<AdapterStatus> {
+    return this.healthCheckFn();
+  }
+
+  override async shutdown(): Promise<void> {
+    return this.shutdownFn();
+  }
+}
+
+function defaultConfig(): AdapterConfig {
+  return { name: 'mock', credentials: {}, settings: {} };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PlexusLifecycleManager', () => {
+  let db: BetterSqlite3.Database;
+  let prevDb: BetterSqlite3.Database | null;
+  let lifecycle: PlexusLifecycleManager;
+
+  beforeEach(() => {
+    db = createTestDb();
+    prevDb = setDb(db);
+    // Use a very large interval so scheduled health checks don't fire during tests.
+    lifecycle = new PlexusLifecycleManager({ healthIntervalMs: 999_999_999 });
+  });
+
+  afterEach(() => {
+    if (prevDb) setDb(prevDb);
+    else db.close();
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Registration
+  // -------------------------------------------------------------------------
+
+  describe('register', () => {
+    it('creates a DB row and transitions to healthy on success', async () => {
+      const adapter = new MockAdapter();
+      const row = await lifecycle.register(adapter, defaultConfig());
+
+      expect(row.id).toBe('plx_mock');
+      expect(row.name).toBe('mock');
+      expect(row.status).toBe('healthy');
+      expect(row.last_error).toBeNull();
+      expect(adapter.initializeFn).toHaveBeenCalledOnce();
+    });
+
+    it('transitions to error when initialize() throws', async () => {
+      const adapter = new MockAdapter();
+      adapter.initializeFn.mockRejectedValue(new Error('connection refused'));
+
+      const row = await lifecycle.register(adapter, defaultConfig());
+
+      expect(row.status).toBe('error');
+      expect(row.last_error).toBe('connection refused');
+    });
+
+    it('stores adapter settings in the config column', async () => {
+      const adapter = new MockAdapter();
+      const config: AdapterConfig = {
+        name: 'mock',
+        credentials: {},
+        settings: { host: 'imap.example.com', port: 993 },
+      };
+      const row = await lifecycle.register(adapter, config);
+      expect(JSON.parse(row.config ?? '{}')).toEqual({ host: 'imap.example.com', port: 993 });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unregister
+  // -------------------------------------------------------------------------
+
+  describe('unregister', () => {
+    it('calls shutdown() and removes the DB row', async () => {
+      const adapter = new MockAdapter();
+      await lifecycle.register(adapter, defaultConfig());
+
+      const removed = await lifecycle.unregister('plx_mock');
+
+      expect(removed).toBe(true);
+      expect(adapter.shutdownFn).toHaveBeenCalledOnce();
+
+      const row = db.prepare('SELECT * FROM plexus_adapters WHERE id = ?').get('plx_mock');
+      expect(row).toBeUndefined();
+    });
+
+    it('returns false when the adapter does not exist', async () => {
+      const removed = await lifecycle.unregister('plx_nonexistent');
+      expect(removed).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Health checks
+  // -------------------------------------------------------------------------
+
+  describe('healthCheck', () => {
+    it('returns healthy when the adapter is fine', async () => {
+      const adapter = new MockAdapter();
+      await lifecycle.register(adapter, defaultConfig());
+
+      const result = await lifecycle.healthCheck('plx_mock');
+      expect(result.status).toBe('healthy');
+      expect(result.error).toBeUndefined();
+    });
+
+    it('returns degraded after a single failure', async () => {
+      const adapter = new MockAdapter();
+      await lifecycle.register(adapter, defaultConfig());
+
+      // Make health check fail.
+      adapter.healthCheckFn.mockRejectedValue(new Error('timeout'));
+
+      const result = await lifecycle.healthCheck('plx_mock');
+      expect(result.status).toBe('degraded');
+      expect(result.error).toBe('timeout');
+    });
+
+    it('transitions to error after 3 consecutive failures', async () => {
+      const adapter = new MockAdapter();
+      await lifecycle.register(adapter, defaultConfig());
+
+      adapter.healthCheckFn.mockRejectedValue(new Error('dead'));
+
+      await lifecycle.healthCheck('plx_mock');
+      await lifecycle.healthCheck('plx_mock');
+      const result = await lifecycle.healthCheck('plx_mock');
+
+      expect(result.status).toBe('error');
+
+      // The adapter should be removed from active set.
+      expect(lifecycle.isHealthy('plx_mock')).toBe(false);
+    });
+
+    it('resets failure count on successful health check', async () => {
+      const adapter = new MockAdapter();
+      await lifecycle.register(adapter, defaultConfig());
+
+      // Fail twice.
+      adapter.healthCheckFn.mockRejectedValue(new Error('flaky'));
+      await lifecycle.healthCheck('plx_mock');
+      await lifecycle.healthCheck('plx_mock');
+
+      // Recover.
+      adapter.healthCheckFn.mockResolvedValue({
+        status: 'healthy',
+        lastChecked: new Date().toISOString(),
+      });
+      const result = await lifecycle.healthCheck('plx_mock');
+      expect(result.status).toBe('healthy');
+
+      // Subsequent failure should be degraded, not error.
+      adapter.healthCheckFn.mockRejectedValue(new Error('flaky again'));
+      const after = await lifecycle.healthCheck('plx_mock');
+      expect(after.status).toBe('degraded');
+    });
+
+    it('returns error for an unknown adapter', async () => {
+      const result = await lifecycle.healthCheck('plx_nonexistent');
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('not active');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isHealthy
+  // -------------------------------------------------------------------------
+
+  describe('isHealthy', () => {
+    it('returns true for a healthy registered adapter', async () => {
+      const adapter = new MockAdapter();
+      await lifecycle.register(adapter, defaultConfig());
+      expect(lifecycle.isHealthy('plx_mock')).toBe(true);
+    });
+
+    it('returns false for an unknown adapter', () => {
+      expect(lifecycle.isHealthy('plx_nonexistent')).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error isolation
+  // -------------------------------------------------------------------------
+
+  describe('error isolation', () => {
+    it('one adapter failing does not affect another', async () => {
+      const a = new MockAdapter('alpha');
+      const b = new MockAdapter('beta');
+
+      await lifecycle.register(a, { name: 'alpha', credentials: {}, settings: {} });
+      await lifecycle.register(b, { name: 'beta', credentials: {}, settings: {} });
+
+      // Adapter A fails health checks 3 times → error.
+      a.healthCheckFn.mockRejectedValue(new Error('crash'));
+      await lifecycle.healthCheck('plx_alpha');
+      await lifecycle.healthCheck('plx_alpha');
+      await lifecycle.healthCheck('plx_alpha');
+
+      // Adapter B should still be healthy.
+      expect(lifecycle.isHealthy('plx_alpha')).toBe(false);
+      expect(lifecycle.isHealthy('plx_beta')).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Shutdown
+  // -------------------------------------------------------------------------
+
+  describe('shutdownAll', () => {
+    it('calls shutdown() on all active adapters', async () => {
+      const a = new MockAdapter();
+      const b = new MockAdapter('other');
+
+      await lifecycle.register(a, defaultConfig());
+      await lifecycle.register(b, { name: 'other', credentials: {}, settings: {} });
+
+      await lifecycle.shutdownAll();
+
+      expect(a.shutdownFn).toHaveBeenCalledOnce();
+      expect(b.shutdownFn).toHaveBeenCalledOnce();
+      expect(lifecycle.getActiveAdapterIds()).toHaveLength(0);
+    });
+
+    it('continues shutting down even if one adapter throws', async () => {
+      const a = new MockAdapter();
+      a.shutdownFn.mockRejectedValue(new Error('shutdown error'));
+
+      const b = new MockAdapter('other');
+
+      await lifecycle.register(a, defaultConfig());
+      await lifecycle.register(b, { name: 'other', credentials: {}, settings: {} });
+
+      // Should not throw.
+      await lifecycle.shutdownAll();
+      expect(b.shutdownFn).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Sync
+  // -------------------------------------------------------------------------
+
+  describe('sync', () => {
+    it('calls ingest and returns counts', async () => {
+      const adapter = new MockAdapter();
+      adapter.ingestFn.mockResolvedValue([
+        { body: 'item 1', source: '' },
+        { body: 'item 2', source: '' },
+      ]);
+
+      await lifecycle.register(adapter, defaultConfig());
+      const result = await lifecycle.sync('plx_mock');
+
+      expect(result.ingested).toBe(2);
+      expect(result.filtered).toBe(0);
+
+      // Check the DB counter was updated.
+      const row = db
+        .prepare('SELECT ingested_count FROM plexus_adapters WHERE id = ?')
+        .get('plx_mock') as { ingested_count: number };
+      expect(row.ingested_count).toBe(2);
+    });
+
+    it('stamps source field on ingested items', async () => {
+      const adapter = new MockAdapter();
+      const items: EngineData[] = [{ body: 'test', source: '' }];
+      adapter.ingestFn.mockResolvedValue(items);
+
+      await lifecycle.register(adapter, defaultConfig());
+      await lifecycle.sync('plx_mock');
+
+      expect(items[0]?.source).toBe('plexus:mock');
+    });
+
+    it('throws when adapter is not active', async () => {
+      await expect(lifecycle.sync('plx_nonexistent')).rejects.toThrow('not active');
+    });
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/plexus/__tests__/registry.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/__tests__/registry.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the Plexus registry: TOML parsing, credential resolution,
+ * and manifest building (PRD-090, US-03).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the cerebrum instance module to avoid pulling in @pops/db-types.
+vi.mock('../../instance.js', () => ({
+  getEngramRoot: () => '/tmp/test-engrams',
+}));
+
+const { buildManifests, parsePlexusToml, resolveCredential, resolveCredentials } =
+  await import('../registry.js');
+
+// ---------------------------------------------------------------------------
+// resolveCredential / resolveCredentials
+// ---------------------------------------------------------------------------
+
+describe('resolveCredential', () => {
+  it('resolves env: prefixed values from process.env', () => {
+    vi.stubEnv('TEST_SECRET', 's3cret');
+    expect(resolveCredential('password', 'env:TEST_SECRET')).toBe('s3cret');
+    vi.unstubAllEnvs();
+  });
+
+  it('throws when the referenced env var is not set', () => {
+    // Ensure the variable does not exist.
+    delete process.env['MISSING_VAR'];
+    expect(() => resolveCredential('api_key', 'env:MISSING_VAR')).toThrow(
+      "Environment variable 'MISSING_VAR' not found"
+    );
+  });
+
+  it('returns plain values as-is when not prefixed with env:', () => {
+    expect(resolveCredential('host', 'imap.example.com')).toBe('imap.example.com');
+  });
+});
+
+describe('resolveCredentials', () => {
+  it('resolves all entries in a credentials map', () => {
+    vi.stubEnv('PLX_USER', 'alice');
+    vi.stubEnv('PLX_PASS', 'hunter2');
+    const result = resolveCredentials({ username: 'env:PLX_USER', password: 'env:PLX_PASS' });
+    expect(result).toEqual({ username: 'alice', password: 'hunter2' });
+    vi.unstubAllEnvs();
+  });
+
+  it('returns empty object for undefined credentials', () => {
+    expect(resolveCredentials(undefined)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePlexusToml
+// ---------------------------------------------------------------------------
+
+describe('parsePlexusToml', () => {
+  it('parses a valid plexus.toml with one adapter', () => {
+    const toml = `
+[adapters.email]
+module = "builtin:email"
+enabled = true
+
+[adapters.email.settings]
+protocol = "imap"
+host = "imap.gmail.com"
+port = 993
+
+[adapters.email.credentials]
+username = "env:PLEXUS_EMAIL_USER"
+password = "env:PLEXUS_EMAIL_PASS"
+`;
+    const result = parsePlexusToml(toml);
+    expect(result.adapters).toBeDefined();
+    const email = result.adapters?.['email'];
+    expect(email).toBeDefined();
+    expect(email?.module).toBe('builtin:email');
+    expect(email?.enabled).toBe(true);
+    expect(email?.settings).toEqual({ protocol: 'imap', host: 'imap.gmail.com', port: 993 });
+    expect(email?.credentials).toEqual({
+      username: 'env:PLEXUS_EMAIL_USER',
+      password: 'env:PLEXUS_EMAIL_PASS',
+    });
+  });
+
+  it('parses multiple adapters', () => {
+    const toml = `
+[adapters.email]
+module = "builtin:email"
+enabled = true
+
+[adapters.github]
+module = "builtin:github"
+enabled = false
+`;
+    const result = parsePlexusToml(toml);
+    expect(Object.keys(result.adapters ?? {})).toHaveLength(2);
+    expect(result.adapters?.['github']?.enabled).toBe(false);
+  });
+
+  it('parses filters under an adapter', () => {
+    const toml = `
+[adapters.email]
+module = "builtin:email"
+enabled = true
+
+[[adapters.email.filters]]
+type = "exclude"
+field = "subject"
+pattern = "^\\\\[JIRA\\\\]"
+
+[[adapters.email.filters]]
+type = "include"
+field = "from"
+pattern = ".*@company\\\\.com$"
+`;
+    const result = parsePlexusToml(toml);
+    const filters = result.adapters?.['email']?.filters;
+    expect(filters).toHaveLength(2);
+    expect(filters?.[0]).toEqual({ type: 'exclude', field: 'subject', pattern: '^\\[JIRA\\]' });
+    expect(filters?.[1]).toEqual({ type: 'include', field: 'from', pattern: '.*@company\\.com$' });
+  });
+
+  it('returns empty adapters when no [adapters] section exists', () => {
+    const result = parsePlexusToml('# empty config\n');
+    expect(result.adapters).toEqual({});
+  });
+
+  it('throws on malformed TOML', () => {
+    expect(() => parsePlexusToml('not valid [[')).toThrow();
+  });
+
+  it('defaults module to builtin:{name} when not specified', () => {
+    const toml = `
+[adapters.calendar]
+enabled = true
+`;
+    const result = parsePlexusToml(toml);
+    expect(result.adapters?.['calendar']?.module).toBe('builtin:calendar');
+  });
+
+  it('defaults enabled to true when not specified', () => {
+    const toml = `
+[adapters.rss]
+module = "builtin:rss"
+`;
+    const result = parsePlexusToml(toml);
+    expect(result.adapters?.['rss']?.enabled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildManifests
+// ---------------------------------------------------------------------------
+
+describe('buildManifests', () => {
+  it('builds manifests from parsed TOML', () => {
+    const toml = parsePlexusToml(`
+[adapters.email]
+module = "builtin:email"
+enabled = true
+
+[adapters.email.settings]
+host = "imap.example.com"
+
+[adapters.email.credentials]
+user = "env:EMAIL_USER"
+
+[[adapters.email.filters]]
+type = "exclude"
+field = "subject"
+pattern = "^spam"
+`);
+    const manifests = buildManifests(toml);
+    expect(manifests).toHaveLength(1);
+    const first = manifests[0];
+    expect(first).toBeDefined();
+    expect(first?.name).toBe('email');
+    expect(first?.module).toBe('builtin:email');
+    expect(first?.enabled).toBe(true);
+    expect(first?.settings).toEqual({ host: 'imap.example.com' });
+    expect(first?.credentials).toEqual({ user: 'env:EMAIL_USER' });
+    expect(first?.filters).toHaveLength(1);
+    expect(first?.filters[0]).toEqual({
+      filterType: 'exclude',
+      field: 'subject',
+      pattern: '^spam',
+    });
+  });
+
+  it('returns empty array when no adapters are defined', () => {
+    const manifests = buildManifests({ adapters: undefined });
+    expect(manifests).toEqual([]);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/plexus/adapter.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/adapter.ts
@@ -1,0 +1,111 @@
+/**
+ * Plexus adapter interface and base class (PRD-090, US-01).
+ *
+ * Every adapter implements the `PlexusAdapter` interface. The `BaseAdapter`
+ * abstract class provides sensible defaults so simple adapters only need to
+ * override `ingest()`.
+ */
+import type {
+  AdapterConfig,
+  AdapterStatus,
+  EmitContent,
+  EmitOptions,
+  EngineData,
+  IngestOptions,
+} from './types.js';
+
+/**
+ * Contract that every Plexus adapter must fulfil.
+ *
+ * Four required methods (`initialize`, `ingest`, `healthCheck`, `shutdown`)
+ * and one optional (`emit`). Adapters that do not support output leave `emit`
+ * undefined — calling it throws a descriptive error via the lifecycle manager.
+ */
+export interface PlexusAdapterInterface<TSettings = Record<string, unknown>> {
+  /** Human-readable adapter name (e.g. `email`, `github`). */
+  readonly name: string;
+  /** Semantic version of the adapter implementation. */
+  readonly version: string;
+
+  /**
+   * Initialise the adapter with resolved configuration.
+   * Called once after registration. Should validate credentials and establish
+   * connections. Throw on failure — the lifecycle manager catches it and
+   * transitions the adapter to `error`.
+   */
+  initialize(config: AdapterConfig<TSettings>): Promise<void>;
+
+  /**
+   * Fetch content from the external system.
+   * Returns an array of `EngineData` items that the ingestion pipeline will
+   * process.
+   */
+  ingest(options: IngestOptions): Promise<EngineData[]>;
+
+  /**
+   * Check adapter health: connection alive, credentials valid, rate limits OK.
+   */
+  healthCheck(): Promise<AdapterStatus>;
+
+  /**
+   * Gracefully shut down the adapter: close connections, flush buffers.
+   */
+  shutdown(): Promise<void>;
+
+  /**
+   * Emit content to the external system.
+   * Optional — only adapters that support output (e.g. email) implement this.
+   */
+  emit?(options: EmitOptions, content: EmitContent): Promise<void>;
+}
+
+/**
+ * Abstract base class reducing boilerplate for simple adapters.
+ *
+ * Provides default implementations:
+ * - `initialize`: stores the config for subclass use
+ * - `healthCheck`: returns `healthy`
+ * - `shutdown`: no-op
+ *
+ * Concrete adapters extend this and override `ingest()` at minimum.
+ */
+export abstract class BaseAdapter<
+  TSettings = Record<string, unknown>,
+> implements PlexusAdapterInterface<TSettings> {
+  abstract readonly name: string;
+  abstract readonly version: string;
+
+  protected config: AdapterConfig<TSettings> | null = null;
+
+  async initialize(config: AdapterConfig<TSettings>): Promise<void> {
+    this.config = config;
+  }
+
+  abstract ingest(options: IngestOptions): Promise<EngineData[]>;
+
+  async healthCheck(): Promise<AdapterStatus> {
+    return {
+      status: 'healthy',
+      lastChecked: new Date().toISOString(),
+    };
+  }
+
+  async shutdown(): Promise<void> {
+    // No-op by default.
+  }
+}
+
+/**
+ * Call `emit` on an adapter, throwing a descriptive error if the adapter does
+ * not implement it.
+ */
+export function callEmit(
+  adapter: PlexusAdapterInterface,
+  options: EmitOptions,
+  content: EmitContent
+): Promise<void> {
+  if (!adapter.emit) {
+    return Promise.reject(new Error(`Adapter '${adapter.name}' does not support emit operations`));
+  }
+  return adapter.emit(options, content);
+}

--- a/apps/pops-api/src/modules/cerebrum/plexus/filters.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/filters.ts
@@ -1,0 +1,227 @@
+/**
+ * Plexus ingestion filters (PRD-090, US-04).
+ *
+ * Per-adapter include/exclude rules evaluated before content enters the
+ * ingestion pipeline. Regex patterns are compiled once at evaluation time
+ * (callers should cache compiled patterns for hot paths).
+ */
+import type { EngineData, FilterRule, FilterType } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Pattern compilation
+// ---------------------------------------------------------------------------
+
+interface CompiledFilter {
+  filterType: FilterType;
+  field: string;
+  regex: RegExp;
+}
+
+/**
+ * Compile a filter rule's pattern into a RegExp. Returns `null` if the pattern
+ * is invalid (caller should log a warning and skip).
+ */
+export function compileFilter(rule: FilterRule): CompiledFilter | null {
+  try {
+    return {
+      filterType: rule.filterType,
+      field: rule.field,
+      regex: new RegExp(rule.pattern),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compile all enabled filter rules. Invalid patterns are silently dropped
+ * (caller should log a warning for diagnostics).
+ */
+export function compileFilters(rules: FilterRule[]): {
+  compiled: CompiledFilter[];
+  invalid: FilterRule[];
+} {
+  const compiled: CompiledFilter[] = [];
+  const invalid: FilterRule[] = [];
+
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    const c = compileFilter(rule);
+    if (c) {
+      compiled.push(c);
+    } else {
+      invalid.push(rule);
+    }
+  }
+
+  return { compiled, invalid };
+}
+
+// ---------------------------------------------------------------------------
+// Field extraction
+// ---------------------------------------------------------------------------
+
+/** Well-known scalar fields on EngineData. */
+const SCALAR_FIELDS: ReadonlySet<string> = new Set([
+  'body',
+  'title',
+  'type',
+  'source',
+  'externalId',
+]);
+
+/** Well-known array fields on EngineData (joined as comma-separated strings). */
+const ARRAY_FIELDS: ReadonlySet<string> = new Set(['tags', 'scopes']);
+
+/**
+ * Extract the value of a named field from an `EngineData` item.
+ *
+ * Adapter-specific fields live in `customFields`; well-known fields (`body`,
+ * `title`, `type`, `source`) are checked first.
+ */
+export function extractField(item: EngineData, field: string): string | undefined {
+  if (SCALAR_FIELDS.has(field)) {
+    return item[field as keyof EngineData] as string | undefined;
+  }
+
+  if (ARRAY_FIELDS.has(field)) {
+    const arr = item[field as 'tags' | 'scopes'];
+    return arr ? arr.join(',') : undefined;
+  }
+
+  // Fall back to customFields.
+  const value = item.customFields?.[field];
+  if (value == null) return undefined;
+  return typeof value === 'string' ? value : String(value);
+}
+
+// ---------------------------------------------------------------------------
+// Filter evaluation
+// ---------------------------------------------------------------------------
+
+/**
+ * Test a single item against a list of compiled filters for a given type
+ * (include or exclude).
+ */
+function matchesAny(item: EngineData, filters: CompiledFilter[], type: FilterType): boolean {
+  const subset = filters.filter((f) => f.filterType === type);
+  if (subset.length === 0) return false;
+  return subset.some((f) => {
+    const value = extractField(item, f.field);
+    if (value === undefined) return false;
+    return f.regex.test(value);
+  });
+}
+
+/**
+ * Evaluate whether a single item passes the filter rules.
+ *
+ * Evaluation order (per PRD-090):
+ * 1. If include filters exist: item must match at least one include filter.
+ * 2. If exclude filters exist: item must not match any exclude filter.
+ * 3. Items that survive both checks are accepted.
+ */
+export function evaluateItem(item: EngineData, compiled: CompiledFilter[]): boolean {
+  const hasIncludes = compiled.some((f) => f.filterType === 'include');
+  const hasExcludes = compiled.some((f) => f.filterType === 'exclude');
+
+  // If include filters exist, item must match at least one.
+  if (hasIncludes && !matchesAny(item, compiled, 'include')) {
+    return false;
+  }
+
+  // If exclude filters exist, item must not match any.
+  if (hasExcludes && matchesAny(item, compiled, 'exclude')) {
+    return false;
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Batch evaluation
+// ---------------------------------------------------------------------------
+
+export interface FilterResult {
+  /** Items that passed all filters. */
+  accepted: EngineData[];
+  /** Number of items removed by filters. */
+  filtered: number;
+}
+
+/**
+ * Apply filter rules to a batch of `EngineData` items.
+ *
+ * @param items  - Raw items from the adapter.
+ * @param rules  - Filter rules (from `plexus_filters` table).
+ * @returns Accepted items and the count of filtered items.
+ */
+export function applyFilters(items: EngineData[], rules: FilterRule[]): FilterResult {
+  if (rules.length === 0) {
+    return { accepted: items, filtered: 0 };
+  }
+
+  const { compiled, invalid } = compileFilters(rules);
+  if (invalid.length > 0) {
+    for (const r of invalid) {
+      console.warn(
+        `[plexus] Invalid filter pattern '${r.pattern}' for field '${r.field}' — skipped`
+      );
+    }
+  }
+
+  if (compiled.length === 0) {
+    return { accepted: items, filtered: 0 };
+  }
+
+  const accepted: EngineData[] = [];
+  let filtered = 0;
+
+  for (const item of items) {
+    if (evaluateItem(item, compiled)) {
+      accepted.push(item);
+    } else {
+      filtered++;
+    }
+  }
+
+  return { accepted, filtered };
+}
+
+// ---------------------------------------------------------------------------
+// Dry-run mode
+// ---------------------------------------------------------------------------
+
+export interface DryRunResult {
+  /** Items that would be ingested. */
+  wouldIngest: EngineData[];
+  /** Items that would be filtered out. */
+  wouldFilter: EngineData[];
+}
+
+/**
+ * Dry-run: show what would be ingested vs filtered without writing anything.
+ */
+export function dryRun(items: EngineData[], rules: FilterRule[]): DryRunResult {
+  if (rules.length === 0) {
+    return { wouldIngest: items, wouldFilter: [] };
+  }
+
+  const { compiled } = compileFilters(rules);
+  if (compiled.length === 0) {
+    return { wouldIngest: items, wouldFilter: [] };
+  }
+
+  const wouldIngest: EngineData[] = [];
+  const wouldFilter: EngineData[] = [];
+
+  for (const item of items) {
+    if (evaluateItem(item, compiled)) {
+      wouldIngest.push(item);
+    } else {
+      wouldFilter.push(item);
+    }
+  }
+
+  return { wouldIngest, wouldFilter };
+}

--- a/apps/pops-api/src/modules/cerebrum/plexus/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/instance.ts
@@ -1,0 +1,32 @@
+/**
+ * Plexus process-scoped singletons.
+ *
+ * The lifecycle manager and registry are long-lived — one instance per process.
+ * Drizzle / SQLite access is resolved per-call inside the lifecycle manager
+ * itself so env-scoped DB context is honoured.
+ */
+import { PlexusLifecycleManager } from './lifecycle.js';
+import { PlexusRegistry } from './registry.js';
+
+let cachedLifecycle: PlexusLifecycleManager | null = null;
+let cachedRegistry: PlexusRegistry | null = null;
+
+/** Return the shared lifecycle manager singleton. */
+export function getPlexusLifecycle(): PlexusLifecycleManager {
+  cachedLifecycle ??= new PlexusLifecycleManager();
+  return cachedLifecycle;
+}
+
+/** Return the shared registry singleton. */
+export function getPlexusRegistry(): PlexusRegistry {
+  if (!cachedRegistry) {
+    cachedRegistry = new PlexusRegistry(getPlexusLifecycle());
+  }
+  return cachedRegistry;
+}
+
+/** Test hook — drop cached singletons so tests can rebind. */
+export function resetPlexusCache(): void {
+  cachedLifecycle = null;
+  cachedRegistry = null;
+}

--- a/apps/pops-api/src/modules/cerebrum/plexus/lifecycle-db.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/lifecycle-db.ts
@@ -1,0 +1,114 @@
+/**
+ * Database helpers for the Plexus lifecycle manager (PRD-090).
+ *
+ * Extracted from lifecycle.ts to keep the main class under the line limit.
+ */
+import { getDb } from '../../../db.js';
+
+import type {
+  AdapterStatusValue,
+  FilterDefinition,
+  FilterRule,
+  FilterType,
+  PlexusAdapterRow,
+} from './types.js';
+
+export function upsertAdapterRow(
+  adapterId: string,
+  name: string,
+  settings: Record<string, unknown>,
+  now: string
+): void {
+  const db = getDb();
+  db.prepare(
+    `INSERT INTO plexus_adapters (id, name, status, config, created_at, updated_at)
+     VALUES (?, ?, 'registered', ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       status = 'registered',
+       config = excluded.config,
+       last_error = NULL,
+       updated_at = excluded.updated_at`
+  ).run(adapterId, name, JSON.stringify(settings), now, now);
+}
+
+export function updateAdapterStatus(
+  adapterId: string,
+  status: AdapterStatusValue,
+  error?: string
+): void {
+  const db = getDb();
+  db.prepare(
+    'UPDATE plexus_adapters SET status = ?, last_error = ?, updated_at = ? WHERE id = ?'
+  ).run(status, error ?? null, new Date().toISOString(), adapterId);
+}
+
+export function updateAdapterLastHealth(adapterId: string): void {
+  const now = new Date().toISOString();
+  const db = getDb();
+  db.prepare('UPDATE plexus_adapters SET last_health = ?, updated_at = ? WHERE id = ?').run(
+    now,
+    now,
+    adapterId
+  );
+}
+
+export function getAdapterRow(adapterId: string): PlexusAdapterRow {
+  const db = getDb();
+  const row = db.prepare('SELECT * FROM plexus_adapters WHERE id = ?').get(adapterId) as
+    | PlexusAdapterRow
+    | undefined;
+  if (!row) throw new Error(`Adapter row '${adapterId}' not found`);
+  return row;
+}
+
+export function deleteAdapter(adapterId: string): boolean {
+  const db = getDb();
+  db.prepare('DELETE FROM plexus_filters WHERE adapter_id = ?').run(adapterId);
+  const result = db.prepare('DELETE FROM plexus_adapters WHERE id = ?').run(adapterId);
+  return result.changes > 0;
+}
+
+export function incrementIngestedCount(adapterId: string, count: number): void {
+  const db = getDb();
+  db.prepare(
+    'UPDATE plexus_adapters SET ingested_count = ingested_count + ?, updated_at = ? WHERE id = ?'
+  ).run(count, new Date().toISOString(), adapterId);
+}
+
+export function getEnabledFilterRows(adapterId: string): FilterRule[] {
+  const db = getDb();
+  const rows = db
+    .prepare(
+      'SELECT filter_type, field, pattern, enabled FROM plexus_filters WHERE adapter_id = ? AND enabled = 1'
+    )
+    .all(adapterId) as Array<{
+    filter_type: string;
+    field: string;
+    pattern: string;
+    enabled: number;
+  }>;
+  return rows.map((r) => ({
+    filterType: r.filter_type as FilterType,
+    field: r.field,
+    pattern: r.pattern,
+    enabled: r.enabled === 1,
+  }));
+}
+
+export function syncFilterRows(adapterId: string, filters: FilterDefinition[]): void {
+  const db = getDb();
+  db.prepare('DELETE FROM plexus_filters WHERE adapter_id = ?').run(adapterId);
+  const insert = db.prepare(
+    'INSERT INTO plexus_filters (id, adapter_id, filter_type, field, pattern, enabled) VALUES (?, ?, ?, ?, ?, ?)'
+  );
+  for (const [i, f] of filters.entries()) {
+    insert.run(
+      `pxf_${adapterId}_${i}`,
+      adapterId,
+      f.filterType,
+      f.field,
+      f.pattern,
+      f.enabled !== false ? 1 : 0
+    );
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/plexus/lifecycle.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/lifecycle.ts
@@ -1,0 +1,231 @@
+/**
+ * Plexus lifecycle manager (PRD-090, US-02).
+ *
+ * Manages the full adapter lifecycle: register → initialize → health-check
+ * loop → shutdown. Error isolation ensures one misbehaving adapter never
+ * affects others.
+ */
+import {
+  deleteAdapter,
+  getAdapterRow,
+  getEnabledFilterRows,
+  incrementIngestedCount,
+  syncFilterRows,
+  updateAdapterLastHealth,
+  updateAdapterStatus,
+  upsertAdapterRow,
+} from './lifecycle-db.js';
+
+import type { PlexusAdapterInterface } from './adapter.js';
+import type {
+  AdapterConfig,
+  AdapterStatusValue,
+  FilterDefinition,
+  PlexusAdapterRow,
+} from './types.js';
+
+const DEFAULT_HEALTH_INTERVAL_MS = 5 * 60 * 1000;
+const HEALTH_CHECK_TIMEOUT_MS = 10_000;
+const SHUTDOWN_TIMEOUT_MS = 5_000;
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+interface RegisteredAdapter {
+  instance: PlexusAdapterInterface;
+  consecutiveFailures: number;
+  healthTimer: ReturnType<typeof setTimeout> | null;
+}
+
+type HealthResult = { status: AdapterStatusValue; lastCheck: string; error?: string };
+
+/** Race a promise against a timeout. */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export class PlexusLifecycleManager {
+  private adapters = new Map<string, RegisteredAdapter>();
+  private healthIntervalMs: number;
+
+  constructor(options?: { healthIntervalMs?: number }) {
+    this.healthIntervalMs = options?.healthIntervalMs ?? DEFAULT_HEALTH_INTERVAL_MS;
+  }
+
+  /** Register an adapter and immediately attempt initialisation. */
+  async register(
+    adapter: PlexusAdapterInterface,
+    config: AdapterConfig,
+    filters?: FilterDefinition[]
+  ): Promise<PlexusAdapterRow> {
+    const id = `plx_${adapter.name}`;
+    upsertAdapterRow(id, adapter.name, config.settings, new Date().toISOString());
+    if (filters) syncFilterRows(id, filters);
+
+    updateAdapterStatus(id, 'initializing');
+    try {
+      await withTimeout(
+        adapter.initialize(config),
+        HEALTH_CHECK_TIMEOUT_MS,
+        `initialize(${adapter.name})`
+      );
+      updateAdapterStatus(id, 'healthy');
+      updateAdapterLastHealth(id);
+    } catch (err) {
+      updateAdapterStatus(id, 'error', errMsg(err));
+      return getAdapterRow(id);
+    }
+
+    const entry: RegisteredAdapter = {
+      instance: adapter,
+      consecutiveFailures: 0,
+      healthTimer: null,
+    };
+    this.adapters.set(id, entry);
+    this.scheduleHealthCheck(id, entry);
+    return getAdapterRow(id);
+  }
+
+  /** Shutdown and remove an adapter. */
+  async unregister(adapterId: string): Promise<boolean> {
+    const entry = this.adapters.get(adapterId);
+    if (entry) {
+      if (entry.healthTimer) clearTimeout(entry.healthTimer);
+      try {
+        await withTimeout(entry.instance.shutdown(), SHUTDOWN_TIMEOUT_MS, `shutdown(${adapterId})`);
+      } catch {
+        /* best-effort */
+      }
+      this.adapters.delete(adapterId);
+    }
+    return deleteAdapter(adapterId);
+  }
+
+  /** Run a health check for a specific adapter. */
+  async healthCheck(adapterId: string): Promise<HealthResult> {
+    const entry = this.adapters.get(adapterId);
+    if (!entry) {
+      return {
+        status: 'error',
+        lastCheck: new Date().toISOString(),
+        error: `Adapter '${adapterId}' is not active`,
+      };
+    }
+    return this.runHealthCheck(adapterId, entry);
+  }
+
+  /** Whether an adapter is healthy and available for work dispatch. */
+  isHealthy(adapterId: string): boolean {
+    if (!this.adapters.has(adapterId)) return false;
+    return getAdapterRow(adapterId).status === 'healthy';
+  }
+
+  /** Trigger an immediate ingestion cycle. */
+  async sync(adapterId: string): Promise<{ ingested: number; filtered: number }> {
+    const entry = this.adapters.get(adapterId);
+    if (!entry) throw new Error(`Adapter '${adapterId}' is not active`);
+    const row = getAdapterRow(adapterId);
+    if (row.status === 'error')
+      throw new Error(`Adapter '${adapterId}' is in error state — re-initialize first`);
+
+    const { applyFilters } = await import('./filters.js');
+    let items: import('./types.js').EngineData[];
+    try {
+      items = await entry.instance.ingest({});
+    } catch (err) {
+      updateAdapterStatus(adapterId, 'error', errMsg(err));
+      throw err;
+    }
+
+    for (const item of items) item.source = `plexus:${row.name}`;
+    const { accepted, filtered } = applyFilters(items, getEnabledFilterRows(adapterId));
+    incrementIngestedCount(adapterId, accepted.length);
+    return { ingested: accepted.length, filtered };
+  }
+
+  /** Gracefully shut down all active adapters. */
+  async shutdownAll(): Promise<void> {
+    const shutdowns = [...this.adapters.entries()].map(async ([id, entry]) => {
+      if (entry.healthTimer) clearTimeout(entry.healthTimer);
+      try {
+        await withTimeout(entry.instance.shutdown(), SHUTDOWN_TIMEOUT_MS, `shutdown(${id})`);
+      } catch {
+        /* abandoned */
+      }
+      updateAdapterStatus(id, 'shutdown');
+    });
+    await Promise.allSettled(shutdowns);
+    this.adapters.clear();
+  }
+
+  getActiveAdapterIds(): string[] {
+    return [...this.adapters.keys()];
+  }
+  getAdapterInstance(id: string): PlexusAdapterInterface | undefined {
+    return this.adapters.get(id)?.instance;
+  }
+
+  // -----------------------------------------------------------------------
+  // Private
+  // -----------------------------------------------------------------------
+
+  private scheduleHealthCheck(adapterId: string, entry: RegisteredAdapter): void {
+    const jitter = Math.floor(Math.random() * 30_000);
+    entry.healthTimer = setTimeout(() => {
+      void this.runHealthCheck(adapterId, entry).then(() => {
+        if (this.adapters.has(adapterId)) this.scheduleHealthCheck(adapterId, entry);
+      });
+    }, this.healthIntervalMs + jitter);
+  }
+
+  private async runHealthCheck(adapterId: string, entry: RegisteredAdapter): Promise<HealthResult> {
+    const now = new Date().toISOString();
+    try {
+      const result = await withTimeout(
+        entry.instance.healthCheck(),
+        HEALTH_CHECK_TIMEOUT_MS,
+        `healthCheck(${adapterId})`
+      );
+      if (result.status === 'healthy') {
+        entry.consecutiveFailures = 0;
+        updateAdapterStatus(adapterId, 'healthy');
+        updateAdapterLastHealth(adapterId);
+        return { status: 'healthy', lastCheck: now };
+      }
+      return this.recordFailure(adapterId, entry, result.message ?? 'Unhealthy', now);
+    } catch (err) {
+      return this.recordFailure(adapterId, entry, errMsg(err), now);
+    }
+  }
+
+  private recordFailure(
+    adapterId: string,
+    entry: RegisteredAdapter,
+    message: string,
+    now: string
+  ): HealthResult {
+    entry.consecutiveFailures++;
+    if (entry.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      updateAdapterStatus(adapterId, 'error', message);
+      if (entry.healthTimer) clearTimeout(entry.healthTimer);
+      this.adapters.delete(adapterId);
+      return { status: 'error', lastCheck: now, error: message };
+    }
+    updateAdapterStatus(adapterId, 'degraded', message);
+    return { status: 'degraded', lastCheck: now, error: message };
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/plexus/registry.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/registry.ts
@@ -1,0 +1,183 @@
+/**
+ * Plexus plugin registry (PRD-090, US-03).
+ *
+ * Watches `plexus.toml`, resolves credentials from environment variables,
+ * and reconciles adapter state on file changes.
+ */
+import { existsSync, readFileSync, watch } from 'node:fs';
+import { join } from 'node:path';
+
+import { getEngramRoot } from '../instance.js';
+import { buildManifests, parsePlexusToml } from './toml-parser.js';
+
+import type { PlexusAdapterInterface } from './adapter.js';
+import type { PlexusLifecycleManager } from './lifecycle.js';
+import type { PluginManifest } from './types.js';
+
+/**
+ * Resolve a credential value. Values prefixed with `env:` are looked up in
+ * `process.env`. Throws if the referenced variable is not set.
+ */
+export function resolveCredential(key: string, value: string): string {
+  if (value.startsWith('env:')) {
+    const envVar = value.slice(4);
+    const resolved = process.env[envVar];
+    if (resolved === undefined) {
+      throw new Error(
+        `Environment variable '${envVar}' not found (referenced by credential '${key}')`
+      );
+    }
+    return resolved;
+  }
+  return value;
+}
+
+/**
+ * Resolve all credential entries in a credentials map.
+ */
+export function resolveCredentials(
+  credentials: Record<string, string> | undefined
+): Record<string, string> {
+  if (!credentials) return {};
+  const resolved: Record<string, string> = {};
+  for (const [key, value] of Object.entries(credentials)) {
+    resolved[key] = resolveCredential(key, value);
+  }
+  return resolved;
+}
+
+// Re-export parsing functions so existing imports from registry still work.
+export { buildManifests, parsePlexusToml };
+
+/**
+ * The Plexus registry watches `plexus.toml` and keeps the lifecycle manager
+ * in sync with the declared adapters.
+ */
+export class PlexusRegistry {
+  private tomlPath: string;
+  private watcher: ReturnType<typeof watch> | null = null;
+  private knownManifests = new Map<string, PluginManifest>();
+  private adapterFactories = new Map<string, () => PlexusAdapterInterface>();
+  private reconcileTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private lifecycle: PlexusLifecycleManager,
+    options?: { configDir?: string }
+  ) {
+    const configDir = options?.configDir ?? join(getEngramRoot(), '.config');
+    this.tomlPath = join(configDir, 'plexus.toml');
+  }
+
+  /** Register a built-in adapter factory (PRD-091 provides implementations). */
+  registerFactory(builtinName: string, factory: () => PlexusAdapterInterface): void {
+    this.adapterFactories.set(`builtin:${builtinName}`, factory);
+  }
+
+  /** Load `plexus.toml` and register all enabled adapters. */
+  async loadAndReconcile(): Promise<void> {
+    const manifests = this.readManifests();
+    await this.reconcile(manifests);
+  }
+
+  /** Start watching `plexus.toml` for changes. */
+  startWatching(): void {
+    if (this.watcher || !existsSync(this.tomlPath)) return;
+
+    this.watcher = watch(this.tomlPath, () => {
+      if (this.reconcileTimer) clearTimeout(this.reconcileTimer);
+      this.reconcileTimer = setTimeout(() => {
+        void this.loadAndReconcile().catch((err: unknown) => {
+          console.error(
+            '[plexus] Failed to reconcile after plexus.toml change:',
+            err instanceof Error ? err.message : err
+          );
+        });
+      }, 2_000);
+    });
+  }
+
+  /** Stop watching and clean up timers. */
+  stopWatching(): void {
+    this.watcher?.close();
+    this.watcher = null;
+    if (this.reconcileTimer) clearTimeout(this.reconcileTimer);
+    this.reconcileTimer = null;
+  }
+
+  /** Get the current TOML path (for testing / diagnostics). */
+  getTomlPath(): string {
+    return this.tomlPath;
+  }
+
+  // -----------------------------------------------------------------------
+  // Private
+  // -----------------------------------------------------------------------
+
+  private readManifests(): PluginManifest[] {
+    if (!existsSync(this.tomlPath)) return [];
+    try {
+      const content = readFileSync(this.tomlPath, 'utf-8');
+      return buildManifests(parsePlexusToml(content));
+    } catch (err) {
+      console.error(
+        '[plexus] Failed to parse plexus.toml:',
+        err instanceof Error ? err.message : err
+      );
+      return [];
+    }
+  }
+
+  private async reconcile(manifests: PluginManifest[]): Promise<void> {
+    const desiredNames = new Set(manifests.filter((m) => m.enabled).map((m) => m.name));
+
+    // Remove adapters no longer in config.
+    for (const name of this.knownManifests.keys()) {
+      if (!desiredNames.has(name)) {
+        await this.lifecycle.unregister(`plx_${name}`);
+        this.knownManifests.delete(name);
+      }
+    }
+
+    // Register new or modified adapters.
+    for (const manifest of manifests) {
+      if (!manifest.enabled) continue;
+      await this.reconcileAdapter(manifest);
+    }
+  }
+
+  private async reconcileAdapter(manifest: PluginManifest): Promise<void> {
+    const existing = this.knownManifests.get(manifest.name);
+    if (existing && JSON.stringify(existing) === JSON.stringify(manifest)) return;
+
+    const adapter = this.resolveAdapter(manifest);
+    if (!adapter) {
+      console.error(
+        `[plexus] Could not resolve module '${manifest.module}' for '${manifest.name}'`
+      );
+      return;
+    }
+
+    let credentials: Record<string, string>;
+    try {
+      credentials = resolveCredentials(manifest.credentials);
+    } catch (err) {
+      console.error(
+        `[plexus] Credential resolution failed for '${manifest.name}':`,
+        err instanceof Error ? err.message : err
+      );
+      return;
+    }
+
+    await this.lifecycle.register(
+      adapter,
+      { name: manifest.name, credentials, settings: manifest.settings },
+      manifest.filters
+    );
+    this.knownManifests.set(manifest.name, manifest);
+  }
+
+  private resolveAdapter(manifest: PluginManifest): PlexusAdapterInterface | null {
+    const factory = this.adapterFactories.get(manifest.module);
+    return factory ? factory() : null;
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/plexus/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/router.ts
@@ -1,0 +1,194 @@
+/**
+ * tRPC router for cerebrum.plexus (PRD-090).
+ *
+ * Exposes adapter management and ingestion filter CRUD. The router is a thin
+ * adapter over the lifecycle manager and database — no business logic here.
+ */
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { getDb } from '../../../db.js';
+import { protectedProcedure, router } from '../../../trpc.js';
+
+import type { PlexusAdapter, PlexusAdapterRow, PlexusFilter, PlexusFilterRow } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToAdapter(row: PlexusAdapterRow): PlexusAdapter {
+  let config: Record<string, unknown> | null = null;
+  if (row.config) {
+    try {
+      config = JSON.parse(row.config) as Record<string, unknown>;
+    } catch {
+      config = null;
+    }
+  }
+  return {
+    id: row.id,
+    name: row.name,
+    status: row.status,
+    config,
+    lastHealth: row.last_health,
+    lastError: row.last_error,
+    ingestedCount: row.ingested_count,
+    emittedCount: row.emitted_count,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToFilter(row: PlexusFilterRow): PlexusFilter {
+  return {
+    id: row.id,
+    adapterId: row.adapter_id,
+    filterType: row.filter_type,
+    field: row.field,
+    pattern: row.pattern,
+    enabled: row.enabled === 1,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Input schemas
+// ---------------------------------------------------------------------------
+
+const adapterIdSchema = z.object({ adapterId: z.string().min(1) });
+
+const filterDefinitionSchema = z.object({
+  filterType: z.enum(['include', 'exclude']),
+  field: z.string().min(1),
+  pattern: z.string().min(1),
+  enabled: z.boolean().optional().default(true),
+});
+
+const setFiltersSchema = z.object({
+  adapterId: z.string().min(1),
+  filters: z.array(filterDefinitionSchema),
+});
+
+// ---------------------------------------------------------------------------
+// Sub-routers
+// ---------------------------------------------------------------------------
+
+const adaptersRouter = router({
+  /** List all registered adapters. */
+  list: protectedProcedure.query(() => {
+    const db = getDb();
+    const rows = db
+      .prepare('SELECT * FROM plexus_adapters ORDER BY name')
+      .all() as PlexusAdapterRow[];
+    return { adapters: rows.map(rowToAdapter) };
+  }),
+
+  /** Get a single adapter by ID. */
+  get: protectedProcedure.input(adapterIdSchema).query(({ input }) => {
+    const db = getDb();
+    const row = db.prepare('SELECT * FROM plexus_adapters WHERE id = ?').get(input.adapterId) as
+      | PlexusAdapterRow
+      | undefined;
+    if (!row) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: `Adapter '${input.adapterId}' not found` });
+    }
+    return { adapter: rowToAdapter(row) };
+  }),
+
+  /** Run a health check on a specific adapter. */
+  healthCheck: protectedProcedure.input(adapterIdSchema).mutation(async ({ input }) => {
+    // Lazy-import to avoid circular dependency at module load time.
+    const { getPlexusLifecycle } = await import('./instance.js');
+    const lifecycle = getPlexusLifecycle();
+    const result = await lifecycle.healthCheck(input.adapterId);
+    return result;
+  }),
+
+  /** Trigger a manual sync for an adapter. */
+  sync: protectedProcedure.input(adapterIdSchema).mutation(async ({ input }) => {
+    const { getPlexusLifecycle } = await import('./instance.js');
+    const lifecycle = getPlexusLifecycle();
+    const result = await lifecycle.sync(input.adapterId);
+    return result;
+  }),
+
+  /** Unregister (shutdown + remove) an adapter. */
+  unregister: protectedProcedure.input(adapterIdSchema).mutation(async ({ input }) => {
+    const { getPlexusLifecycle } = await import('./instance.js');
+    const lifecycle = getPlexusLifecycle();
+    const success = await lifecycle.unregister(input.adapterId);
+    return { success };
+  }),
+});
+
+const filtersRouter = router({
+  /** List filters for an adapter. */
+  list: protectedProcedure.input(adapterIdSchema).query(({ input }) => {
+    const db = getDb();
+    const rows = db
+      .prepare('SELECT * FROM plexus_filters WHERE adapter_id = ? ORDER BY id')
+      .all(input.adapterId) as PlexusFilterRow[];
+    return { filters: rows.map(rowToFilter) };
+  }),
+
+  /** Replace all filters for an adapter (atomic). */
+  set: protectedProcedure.input(setFiltersSchema).mutation(({ input }) => {
+    const db = getDb();
+
+    // Verify adapter exists.
+    const adapter = db
+      .prepare('SELECT id FROM plexus_adapters WHERE id = ?')
+      .get(input.adapterId) as { id: string } | undefined;
+    if (!adapter) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: `Adapter '${input.adapterId}' not found`,
+      });
+    }
+
+    // Validate regex patterns.
+    for (const f of input.filters) {
+      try {
+        new RegExp(f.pattern);
+      } catch {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Invalid regex pattern '${f.pattern}' for field '${f.field}'`,
+        });
+      }
+    }
+
+    // Full replace in a transaction.
+    const txn = db.transaction(() => {
+      db.prepare('DELETE FROM plexus_filters WHERE adapter_id = ?').run(input.adapterId);
+      const insert = db.prepare(
+        'INSERT INTO plexus_filters (id, adapter_id, filter_type, field, pattern, enabled) VALUES (?, ?, ?, ?, ?, ?)'
+      );
+      for (const [i, f] of input.filters.entries()) {
+        insert.run(
+          `pxf_${input.adapterId}_${i}`,
+          input.adapterId,
+          f.filterType,
+          f.field,
+          f.pattern,
+          f.enabled ? 1 : 0
+        );
+      }
+    });
+    txn();
+
+    // Return the updated filter list.
+    const rows = db
+      .prepare('SELECT * FROM plexus_filters WHERE adapter_id = ? ORDER BY id')
+      .all(input.adapterId) as PlexusFilterRow[];
+    return { filters: rows.map(rowToFilter) };
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Composed plexus router
+// ---------------------------------------------------------------------------
+
+export const plexusRouter = router({
+  adapters: adaptersRouter,
+  filters: filtersRouter,
+});

--- a/apps/pops-api/src/modules/cerebrum/plexus/toml-parser.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/toml-parser.ts
@@ -1,0 +1,90 @@
+/**
+ * TOML parsing utilities for plexus.toml (PRD-090, US-03).
+ *
+ * Pure functions for parsing adapter configuration from TOML strings.
+ */
+import { parse as parseToml } from 'smol-toml';
+
+import type {
+  FilterDefinition,
+  FilterType,
+  PlexusToml,
+  PluginManifest,
+  TomlAdapterConfig,
+} from './types.js';
+
+/** Parse a single raw filter entry into a typed filter object. */
+function parseRawFilter(f: unknown): { type: FilterType; field: string; pattern: string } | null {
+  if (!f || typeof f !== 'object') return null;
+  const fObj = f as Record<string, unknown>;
+  const fType = fObj['type'];
+  const fField = fObj['field'];
+  const fPattern = fObj['pattern'];
+  if (typeof fType !== 'string' || typeof fField !== 'string' || typeof fPattern !== 'string') {
+    return null;
+  }
+  return { type: fType as FilterType, field: fField, pattern: fPattern };
+}
+
+/** Parse the raw filters array from a TOML adapter entry. */
+function parseRawFilters(rawFilters: unknown): TomlAdapterConfig['filters'] {
+  if (!Array.isArray(rawFilters)) return [];
+  const filters: NonNullable<TomlAdapterConfig['filters']> = [];
+  for (const f of rawFilters) {
+    const parsed = parseRawFilter(f);
+    if (parsed) filters.push(parsed);
+  }
+  return filters;
+}
+
+/**
+ * Parse a `plexus.toml` string into typed config.
+ * Throws on malformed TOML.
+ */
+export function parsePlexusToml(content: string): PlexusToml {
+  const raw = parseToml(content) as Record<string, unknown>;
+  const adapters: Record<string, TomlAdapterConfig> = {};
+
+  const rawAdapters = raw['adapters'] as Record<string, Record<string, unknown>> | undefined;
+  if (!rawAdapters || typeof rawAdapters !== 'object') {
+    return { adapters };
+  }
+
+  for (const [name, entry] of Object.entries(rawAdapters)) {
+    if (!entry || typeof entry !== 'object') continue;
+
+    adapters[name] = {
+      module: typeof entry['module'] === 'string' ? entry['module'] : `builtin:${name}`,
+      enabled: entry['enabled'] !== false,
+      settings: (entry['settings'] as Record<string, unknown>) ?? {},
+      credentials: (entry['credentials'] as Record<string, string>) ?? {},
+      filters: parseRawFilters(entry['filters']),
+    };
+  }
+
+  return { adapters };
+}
+
+/**
+ * Build `PluginManifest` entries from parsed TOML config.
+ */
+export function buildManifests(toml: PlexusToml): PluginManifest[] {
+  if (!toml.adapters) return [];
+
+  return Object.entries(toml.adapters).map(([name, cfg]) => {
+    const filters: FilterDefinition[] = (cfg.filters ?? []).map((f) => ({
+      filterType: f.type,
+      field: f.field,
+      pattern: f.pattern,
+    }));
+
+    return {
+      name,
+      module: cfg.module,
+      enabled: cfg.enabled,
+      settings: cfg.settings ?? {},
+      credentials: cfg.credentials ?? {},
+      filters,
+    };
+  });
+}

--- a/apps/pops-api/src/modules/cerebrum/plexus/types.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/types.ts
@@ -1,0 +1,220 @@
+/**
+ * Plexus type definitions (PRD-090).
+ *
+ * Core types for the plugin architecture: adapter interface, engine data,
+ * health status, configuration, and filter definitions.
+ */
+
+// ---------------------------------------------------------------------------
+// Adapter status
+// ---------------------------------------------------------------------------
+
+export const ADAPTER_STATUSES = [
+  'registered',
+  'initializing',
+  'healthy',
+  'degraded',
+  'error',
+  'shutdown',
+] as const;
+export type AdapterStatusValue = (typeof ADAPTER_STATUSES)[number];
+
+// ---------------------------------------------------------------------------
+// Engine data — pre-engram structure yielded by adapters
+// ---------------------------------------------------------------------------
+
+/**
+ * Content produced by an adapter's `ingest()` method. Passed directly into the
+ * ingestion pipeline (PRD-081). The adapter provides what it knows; the pipeline
+ * fills in classification, entity extraction, and scope inference.
+ */
+export interface EngineData {
+  /** Main content body (Markdown or plain text). */
+  body: string;
+  /** Human-readable title. */
+  title?: string;
+  /** Content type hint (e.g. `email`, `issue`, `event`). */
+  type?: string;
+  /** Explicit scope paths. */
+  scopes?: string[];
+  /** Tag strings. */
+  tags?: string[];
+  /**
+   * Source identifier. Must be `plexus:{adapter_name}` — set automatically by
+   * the lifecycle manager so adapters don't need to hard-code it.
+   */
+  source: string;
+  /** Adapter-specific metadata. */
+  customFields?: Record<string, unknown>;
+  /**
+   * Original ID from the external system. Enables deduplication independent of
+   * content-hash (an email might change formatting on re-fetch but keep the
+   * same external ID).
+   */
+  externalId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter health
+// ---------------------------------------------------------------------------
+
+export interface AdapterStatus {
+  status: 'healthy' | 'degraded' | 'error';
+  /** Human-readable detail. */
+  message?: string;
+  /** ISO 8601 timestamp of the check. */
+  lastChecked: string;
+  /** Adapter-specific metrics (connection pool size, rate-limit remaining, etc.). */
+  metrics?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter config
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration passed to `adapter.initialize()`.
+ * @template TSettings Adapter-specific settings shape.
+ */
+export interface AdapterConfig<TSettings = Record<string, unknown>> {
+  /** Adapter name (matches the key in `plexus.toml`). */
+  name: string;
+  /** Resolved credentials (env var references already replaced with values). */
+  credentials: Record<string, string>;
+  /** Adapter-specific configuration. */
+  settings: TSettings;
+}
+
+// ---------------------------------------------------------------------------
+// Ingest / emit options
+// ---------------------------------------------------------------------------
+
+export interface IngestOptions {
+  /** Only fetch items newer than this timestamp. */
+  since?: Date;
+  /** Max items to return. */
+  limit?: number;
+  /** Pre-resolved filter rules (evaluated by the plugin system). */
+  filters?: FilterRule[];
+}
+
+export interface EmitOptions {
+  /** Adapter-specific destination identifier. */
+  target: string;
+  /** Output format preference. */
+  format?: string;
+}
+
+export interface EmitContent {
+  title: string;
+  /** Markdown body. */
+  body: string;
+  metadata?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Filter definitions
+// ---------------------------------------------------------------------------
+
+export type FilterType = 'include' | 'exclude';
+
+export interface FilterRule {
+  filterType: FilterType;
+  /** Field name to match against (adapter-specific). */
+  field: string;
+  /** Regex pattern (anchored — full match unless `.*` is used). */
+  pattern: string;
+  enabled: boolean;
+}
+
+export interface FilterDefinition {
+  filterType: FilterType;
+  field: string;
+  pattern: string;
+  enabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Database row shapes
+// ---------------------------------------------------------------------------
+
+export interface PlexusAdapterRow {
+  id: string;
+  name: string;
+  status: AdapterStatusValue;
+  config: string | null;
+  last_health: string | null;
+  last_error: string | null;
+  ingested_count: number;
+  emitted_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PlexusFilterRow {
+  id: string;
+  adapter_id: string;
+  filter_type: FilterType;
+  field: string;
+  pattern: string;
+  enabled: number;
+}
+
+// ---------------------------------------------------------------------------
+// API response shapes
+// ---------------------------------------------------------------------------
+
+export interface PlexusAdapter {
+  id: string;
+  name: string;
+  status: AdapterStatusValue;
+  config: Record<string, unknown> | null;
+  lastHealth: string | null;
+  lastError: string | null;
+  ingestedCount: number;
+  emittedCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PlexusFilter {
+  id: string;
+  adapterId: string;
+  filterType: FilterType;
+  field: string;
+  pattern: string;
+  enabled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// TOML config shape
+// ---------------------------------------------------------------------------
+
+export interface TomlAdapterConfig {
+  module: string;
+  enabled: boolean;
+  settings?: Record<string, unknown>;
+  credentials?: Record<string, string>;
+  filters?: Array<{
+    type: FilterType;
+    field: string;
+    pattern: string;
+  }>;
+}
+
+export interface PlexusToml {
+  adapters?: Record<string, TomlAdapterConfig>;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin manifest (used by registry for discovery)
+// ---------------------------------------------------------------------------
+
+export interface PluginManifest {
+  name: string;
+  module: string;
+  enabled: boolean;
+  settings: Record<string, unknown>;
+  credentials: Record<string, string>;
+  filters: FilterDefinition[];
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -142,10 +142,10 @@ Live status of every theme and epic. Updated as work completes.
 
 ### Cerebrum — Phase 3 (Automation & Ecosystem)
 
-| Epic                   | Status      | Notes                                                          |
-| ---------------------- | ----------- | -------------------------------------------------------------- |
-| Reflex (automation)    | Not started | reflexes.toml, event/threshold/scheduled triggers              |
-| Plexus (plugin system) | Not started | Adapter interface, core integrations (email, calendar, GitHub) |
+| Epic                   | Status      | Notes                                                            |
+| ---------------------- | ----------- | ---------------------------------------------------------------- |
+| Reflex (automation)    | Not started | reflexes.toml, event/threshold/scheduled triggers                |
+| Plexus (plugin system) | Partial     | PRD-090 (architecture) done; PRD-091 (core adapters) not started |
 
 ### Phase 1 — Foundation (continued)
 

--- a/docs/themes/06-cerebrum/README.md
+++ b/docs/themes/06-cerebrum/README.md
@@ -46,7 +46,7 @@ Cerebrum is a subsystem umbrella containing multiple named components:
 | 4   | [Glia](epics/04-glia.md)                     | Curation workers (pruner, consolidator, linker, auditor), trust graduation     | Not started |
 | 5   | [Ego](epics/05-ego.md)                       | Chat agent — shell panel, MCP tools, Moltbot, CLI. Supersedes PRD-054          | Partial     |
 | 6   | [Reflex](epics/06-reflex.md)                 | Automation triggers — event, threshold, scheduled. reflexes.toml               | Not started |
-| 7   | [Plexus](epics/07-plexus.md)                 | Plugin system — adapter interface, core integrations (email, calendar, GitHub) | Not started |
+| 7   | [Plexus](epics/07-plexus.md)                 | Plugin system — adapter interface, core integrations (email, calendar, GitHub) | Partial     |
 
 Epics 0-3 form Phase 1 (MVP): store, index, ingest, retrieve. Epics 4-5 form Phase 2: curation and chat interface. Epics 6-7 form Phase 3: automation and ecosystem. Within each phase, epics are sequential on their dependencies (0 before 1 before 2, etc.) but later phases can begin individual epics as their dependencies are met.
 

--- a/docs/themes/06-cerebrum/epics/07-plexus.md
+++ b/docs/themes/06-cerebrum/epics/07-plexus.md
@@ -10,7 +10,7 @@ Build the plugin system that connects Cerebrum to external data sources and serv
 
 | #   | PRD                                                              | Summary                                                                                  | Status      |
 | --- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------- |
-| 090 | [Plugin Architecture](../prds/090-plugin-architecture/README.md) | Adapter interface, lifecycle management, plugin registry, configuration, error isolation | Not started |
+| 090 | [Plugin Architecture](../prds/090-plugin-architecture/README.md) | Adapter interface, lifecycle management, plugin registry, configuration, error isolation | Done        |
 | 091 | [Core Integration Adapters](../prds/091-core-adapters/README.md) | Email, calendar, and GitHub adapters as reference implementations                        | Not started |
 
 PRD-090 (Architecture) must complete before PRD-091 (Core Adapters) — the adapters implement the interface that the architecture defines.

--- a/docs/themes/06-cerebrum/prds/090-plugin-architecture/README.md
+++ b/docs/themes/06-cerebrum/prds/090-plugin-architecture/README.md
@@ -1,7 +1,7 @@
 # PRD-090: Plugin Architecture
 
 > Epic: [07 — Plexus](../../epics/07-plexus.md)
-> Status: Not started
+> Status: Done
 
 ## Overview
 
@@ -80,12 +80,12 @@ Define the Plexus adapter interface, plugin lifecycle system, plugin registry, a
 
 ## User Stories
 
-| #   | Story                                                 | Summary                                                                       | Status      | Parallelisable   |
-| --- | ----------------------------------------------------- | ----------------------------------------------------------------------------- | ----------- | ---------------- |
-| 01  | [us-01-adapter-interface](us-01-adapter-interface.md) | TypeScript interface definition for PlexusAdapter with EngineData return type | Not started | No (first)       |
-| 02  | [us-02-plugin-lifecycle](us-02-plugin-lifecycle.md)   | Register, initialize, health check, shutdown lifecycle with error isolation   | Not started | Blocked by us-01 |
-| 03  | [us-03-plugin-registry](us-03-plugin-registry.md)     | plexus.toml configuration, adapter discovery, credential management           | Not started | Blocked by us-01 |
-| 04  | [us-04-ingestion-filters](us-04-ingestion-filters.md) | Per-adapter include/exclude rules for filtering ingested content              | Not started | Yes              |
+| #   | Story                                                 | Summary                                                                       | Status | Parallelisable   |
+| --- | ----------------------------------------------------- | ----------------------------------------------------------------------------- | ------ | ---------------- |
+| 01  | [us-01-adapter-interface](us-01-adapter-interface.md) | TypeScript interface definition for PlexusAdapter with EngineData return type | Done   | No (first)       |
+| 02  | [us-02-plugin-lifecycle](us-02-plugin-lifecycle.md)   | Register, initialize, health check, shutdown lifecycle with error isolation   | Done   | Blocked by us-01 |
+| 03  | [us-03-plugin-registry](us-03-plugin-registry.md)     | plexus.toml configuration, adapter discovery, credential management           | Done   | Blocked by us-01 |
+| 04  | [us-04-ingestion-filters](us-04-ingestion-filters.md) | Per-adapter include/exclude rules for filtering ingested content              | Done   | Yes              |
 
 US-01 defines the interface that US-02 and US-03 depend on. US-04 (ingestion filters) is independent of the lifecycle and registry and can be built in parallel.
 

--- a/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-01-adapter-interface.md
+++ b/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-01-adapter-interface.md
@@ -8,14 +8,14 @@ As a developer building a Plexus adapter, I need a well-defined TypeScript inter
 
 ## Acceptance Criteria
 
-- [ ] A `PlexusAdapter` TypeScript interface is exported from a shared module with four required methods and one optional: `initialize(config: AdapterConfig): Promise<void>`, `ingest(options: IngestOptions): Promise<EngineData[]>`, `healthCheck(): Promise<AdapterStatus>`, `shutdown(): Promise<void>`, and optionally `emit?(options: EmitOptions, content: EmitContent): Promise<void>`. Calling `emit` on an adapter that does not implement it throws a descriptive error
-- [ ] `AdapterConfig` is a typed object containing: `name` (string), `credentials` (Record<string, string> — resolved from env vars), and an adapter-specific `settings` object (generic type parameter on the interface)
-- [ ] `EngineData` is a typed object containing: `body` (string, required), `title` (string, optional), `type` (string, optional), `scopes` (string array, optional), `tags` (string array, optional), `source` (string, required — must be `plexus:{adapter_name}`), `customFields` (Record<string, unknown>, optional), `externalId` (string, optional — original ID from the external system for deduplication)
-- [ ] `AdapterStatus` is a typed object containing: `status` (`'healthy' | 'degraded' | 'error'`), `message` (string, optional — human-readable status detail), `lastChecked` (ISO 8601 string), `metrics` (optional object with adapter-specific stats like connection pool size, API rate limit remaining)
-- [ ] `IngestOptions` contains: `since` (Date, optional — only fetch items newer than this timestamp), `limit` (number, optional — max items to return), `filters` (array of filter rules, resolved by the plugin system before calling the adapter)
-- [ ] `EmitOptions` contains: `target` (string — adapter-specific destination identifier), `format` (string, optional — output format preference)
-- [ ] `EmitContent` contains: `title` (string), `body` (string — Markdown), `metadata` (Record<string, unknown>, optional)
-- [ ] An abstract `BaseAdapter` class provides default implementations for `initialize` (stores config), `shutdown` (no-op), and `healthCheck` (returns healthy) — concrete adapters extend this and override as needed
+- [x] A `PlexusAdapter` TypeScript interface is exported from a shared module with four required methods and one optional: `initialize(config: AdapterConfig): Promise<void>`, `ingest(options: IngestOptions): Promise<EngineData[]>`, `healthCheck(): Promise<AdapterStatus>`, `shutdown(): Promise<void>`, and optionally `emit?(options: EmitOptions, content: EmitContent): Promise<void>`. Calling `emit` on an adapter that does not implement it throws a descriptive error
+- [x] `AdapterConfig` is a typed object containing: `name` (string), `credentials` (Record<string, string> — resolved from env vars), and an adapter-specific `settings` object (generic type parameter on the interface)
+- [x] `EngineData` is a typed object containing: `body` (string, required), `title` (string, optional), `type` (string, optional), `scopes` (string array, optional), `tags` (string array, optional), `source` (string, required — must be `plexus:{adapter_name}`), `customFields` (Record<string, unknown>, optional), `externalId` (string, optional — original ID from the external system for deduplication)
+- [x] `AdapterStatus` is a typed object containing: `status` (`'healthy' | 'degraded' | 'error'`), `message` (string, optional — human-readable status detail), `lastChecked` (ISO 8601 string), `metrics` (optional object with adapter-specific stats like connection pool size, API rate limit remaining)
+- [x] `IngestOptions` contains: `since` (Date, optional — only fetch items newer than this timestamp), `limit` (number, optional — max items to return), `filters` (array of filter rules, resolved by the plugin system before calling the adapter)
+- [x] `EmitOptions` contains: `target` (string — adapter-specific destination identifier), `format` (string, optional — output format preference)
+- [x] `EmitContent` contains: `title` (string), `body` (string — Markdown), `metadata` (Record<string, unknown>, optional)
+- [x] An abstract `BaseAdapter` class provides default implementations for `initialize` (stores config), `shutdown` (no-op), and `healthCheck` (returns healthy) — concrete adapters extend this and override as needed
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-02-plugin-lifecycle.md
+++ b/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-02-plugin-lifecycle.md
@@ -8,14 +8,14 @@ As the Cerebrum system, I need a plugin lifecycle manager that handles adapter r
 
 ## Acceptance Criteria
 
-- [ ] A `PlexusLifecycleManager` class manages the full adapter lifecycle: register (store config, create DB row) → initialize (call `adapter.initialize()`, transition to `healthy` on success or `error` on failure) → running (periodic health checks) → shutdown (call `adapter.shutdown()`, remove from active adapters)
-- [ ] Registration creates a `plexus_adapters` row with `status: registered` and stores the adapter configuration. The adapter's `initialize()` method is called immediately after registration — successful initialization transitions to `healthy`, failure transitions to `error` with the error message stored in `last_error`
-- [ ] Periodic health checks run every 5 minutes (configurable) for all `healthy` or `degraded` adapters by calling `adapter.healthCheck()`. A healthy response resets error state. A single failure transitions from `healthy` to `degraded`. Three consecutive failures transition to `error`
-- [ ] Error isolation: each adapter runs in its own error boundary — `try/catch` around all adapter method calls. Unhandled exceptions or promise rejections from an adapter are caught, logged with adapter context, and the adapter transitions to `error` status. Other adapters continue operating normally
-- [ ] An `error` status adapter is disabled — no sync operations are attempted. The user must manually re-initialize via `cerebrum.plexus.adapters.register` (or a re-initialize API) to recover
-- [ ] Health check timeout: if `healthCheck()` does not resolve within 10 seconds, it is treated as a failure
-- [ ] On system shutdown, `shutdown()` is called on all active adapters in parallel with a 5-second timeout — adapters that do not shut down within the timeout are abandoned
-- [ ] The lifecycle manager exposes an `isHealthy(adapterId)` method that other components (e.g., Reflex, Emit) can check before dispatching work to an adapter
+- [x] A `PlexusLifecycleManager` class manages the full adapter lifecycle: register (store config, create DB row) → initialize (call `adapter.initialize()`, transition to `healthy` on success or `error` on failure) → running (periodic health checks) → shutdown (call `adapter.shutdown()`, remove from active adapters)
+- [x] Registration creates a `plexus_adapters` row with `status: registered` and stores the adapter configuration. The adapter's `initialize()` method is called immediately after registration — successful initialization transitions to `healthy`, failure transitions to `error` with the error message stored in `last_error`
+- [x] Periodic health checks run every 5 minutes (configurable) for all `healthy` or `degraded` adapters by calling `adapter.healthCheck()`. A healthy response resets error state. A single failure transitions from `healthy` to `degraded`. Three consecutive failures transition to `error`
+- [x] Error isolation: each adapter runs in its own error boundary — `try/catch` around all adapter method calls. Unhandled exceptions or promise rejections from an adapter are caught, logged with adapter context, and the adapter transitions to `error` status. Other adapters continue operating normally
+- [x] An `error` status adapter is disabled — no sync operations are attempted. The user must manually re-initialize via `cerebrum.plexus.adapters.register` (or a re-initialize API) to recover
+- [x] Health check timeout: if `healthCheck()` does not resolve within 10 seconds, it is treated as a failure
+- [x] On system shutdown, `shutdown()` is called on all active adapters in parallel with a 5-second timeout — adapters that do not shut down within the timeout are abandoned
+- [x] The lifecycle manager exposes an `isHealthy(adapterId)` method that other components (e.g., Reflex, Emit) can check before dispatching work to an adapter
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-03-plugin-registry.md
+++ b/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-03-plugin-registry.md
@@ -8,8 +8,8 @@ As a user, I need a plugin registry that discovers and configures adapters from 
 
 ## Acceptance Criteria
 
-- [ ] Adapters are configured in `engrams/.config/plexus.toml` using named sections — each section defines an adapter with `name`, `module` (TypeScript module path or built-in identifier), `enabled` (boolean), `settings` (adapter-specific configuration), and `credentials` (key-value pairs referencing environment variables)
-- [ ] Example `plexus.toml` structure:
+- [x] Adapters are configured in `engrams/.config/plexus.toml` using named sections — each section defines an adapter with `name`, `module` (TypeScript module path or built-in identifier), `enabled` (boolean), `settings` (adapter-specific configuration), and `credentials` (key-value pairs referencing environment variables)
+- [x] Example `plexus.toml` structure:
   ```toml
   [adapters.email]
   module = "builtin:email"
@@ -17,12 +17,12 @@ As a user, I need a plugin registry that discovers and configures adapters from 
   settings = { protocol = "imap", host = "imap.gmail.com", port = 993 }
   credentials = { username = "env:PLEXUS_EMAIL_USER", password = "env:PLEXUS_EMAIL_PASS" }
   ```
-- [ ] Credential values prefixed with `env:` are resolved from environment variables at initialization time — if the referenced variable is not set, initialization fails with a clear error message naming the missing variable
-- [ ] Credentials are never stored in plaintext in the database or logs — the `config` column in `plexus_adapters` stores settings without credentials; credentials are resolved fresh from environment variables on each initialization
-- [ ] On startup, the registry reads `plexus.toml`, loads enabled adapters, resolves credentials, and passes them to the lifecycle manager for initialization
-- [ ] A file watcher on `plexus.toml` detects changes and reconciles: new adapters are registered, removed adapters are shut down, modified adapters are re-initialized. Changes take effect within 10 seconds
-- [ ] The `module` field supports `builtin:{name}` for the three reference adapters (PRD-091) and relative paths for custom adapters — the registry resolves the module, imports it, and validates that it implements the `PlexusAdapter` interface
-- [ ] `cerebrum.plexus.adapters.list` includes configuration details (settings, enabled status) alongside runtime state (health, ingestion counts) for each adapter
+- [x] Credential values prefixed with `env:` are resolved from environment variables at initialization time — if the referenced variable is not set, initialization fails with a clear error message naming the missing variable
+- [x] Credentials are never stored in plaintext in the database or logs — the `config` column in `plexus_adapters` stores settings without credentials; credentials are resolved fresh from environment variables on each initialization
+- [x] On startup, the registry reads `plexus.toml`, loads enabled adapters, resolves credentials, and passes them to the lifecycle manager for initialization
+- [x] A file watcher on `plexus.toml` detects changes and reconciles: new adapters are registered, removed adapters are shut down, modified adapters are re-initialized. Changes take effect within 10 seconds
+- [x] The `module` field supports `builtin:{name}` for the three reference adapters (PRD-091) and relative paths for custom adapters — the registry resolves the module, imports it, and validates that it implements the `PlexusAdapter` interface
+- [x] `cerebrum.plexus.adapters.list` includes configuration details (settings, enabled status) alongside runtime state (health, ingestion counts) for each adapter
 
 ## Notes
 

--- a/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-04-ingestion-filters.md
+++ b/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-04-ingestion-filters.md
@@ -8,8 +8,8 @@ As a user, I need per-adapter ingestion filter rules so that I can control which
 
 ## Acceptance Criteria
 
-- [ ] Each adapter can have zero or more filter rules stored in the `plexus_filters` table, with fields: `filter_type` (`include` or `exclude`), `field` (adapter-specific field name to match against), `pattern` (regex pattern), and `enabled` (boolean)
-- [ ] Filters are also definable in `plexus.toml` under each adapter's section as an array of filter objects — these are synced to the database on load:
+- [x] Each adapter can have zero or more filter rules stored in the `plexus_filters` table, with fields: `filter_type` (`include` or `exclude`), `field` (adapter-specific field name to match against), `pattern` (regex pattern), and `enabled` (boolean)
+- [x] Filters are also definable in `plexus.toml` under each adapter's section as an array of filter objects — these are synced to the database on load:
   ```toml
   [adapters.email]
   # ...
@@ -22,12 +22,12 @@ As a user, I need per-adapter ingestion filter rules so that I can control which
   field = "from"
   pattern = ".*@company\\.com$"
   ```
-- [ ] Filter evaluation order: if both include and exclude filters exist, include filters are evaluated first (only content matching at least one include filter passes), then exclude filters remove matches from the included set. If only exclude filters exist, all content passes except excluded matches. If only include filters exist, only matching content passes
-- [ ] The `field` value is adapter-specific — email adapters filter on `subject`, `from`, `to`; GitHub adapters filter on `event_type`, `repo`, `author`; calendar adapters filter on `calendar_name`, `category`. Each adapter documents its filterable fields
-- [ ] Patterns support regex syntax (anchored — full match unless `.*` is used). Invalid regex patterns are caught at filter load time and the filter is disabled with a warning log
-- [ ] Filter evaluation happens in the plugin system before content is sent to the ingestion pipeline — filtered content is counted (reflected in `filtered` count returned by sync) but not ingested
-- [ ] `cerebrum.plexus.filters.set` replaces all filters for an adapter atomically — this is a full replace, not a merge, to simplify conflict resolution
-- [ ] Filters can be toggled individually via the `enabled` field without removing them — useful for temporarily disabling a filter during debugging
+- [x] Filter evaluation order: if both include and exclude filters exist, include filters are evaluated first (only content matching at least one include filter passes), then exclude filters remove matches from the included set. If only exclude filters exist, all content passes except excluded matches. If only include filters exist, only matching content passes
+- [x] The `field` value is adapter-specific — email adapters filter on `subject`, `from`, `to`; GitHub adapters filter on `event_type`, `repo`, `author`; calendar adapters filter on `calendar_name`, `category`. Each adapter documents its filterable fields
+- [x] Patterns support regex syntax (anchored — full match unless `.*` is used). Invalid regex patterns are caught at filter load time and the filter is disabled with a warning log
+- [x] Filter evaluation happens in the plugin system before content is sent to the ingestion pipeline — filtered content is counted (reflected in `filtered` count returned by sync) but not ingested
+- [x] `cerebrum.plexus.filters.set` replaces all filters for an adapter atomically — this is a full replace, not a merge, to simplify conflict resolution
+- [x] Filters can be toggled individually via the `enabled` field without removing them — useful for temporarily disabling a filter during debugging
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Implement the Plexus adapter interface, lifecycle manager, plugin registry, and ingestion filter framework (PRD-090, all 4 user stories)
- Add tRPC router at `cerebrum.plexus` with adapter management and filter CRUD endpoints
- Add SQLite tables (`plexus_adapters`, `plexus_filters`) with Drizzle migration
- 54 unit tests covering lifecycle (register/init/health/shutdown/error isolation), registry (TOML parsing, credential resolution), and filters (include/exclude rules, dry-run)

## Test plan

- [x] `npx vitest run src/modules/cerebrum/plexus` — 54 tests pass
- [x] `npx tsc --noEmit` — zero type errors in plexus module
- [x] `npx oxlint apps/pops-api/src/modules/cerebrum/plexus/` — zero lint errors
- [x] Pre-commit hooks pass (oxlint + oxfmt + turbo typecheck)

Closes #1833