### PR TITLE
docs: sync PRD 085-091 status with implementation

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -130,22 +130,22 @@ Live status of every theme and epic. Updated as work completes.
 | ----------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------- |
 | Engram Storage (format, CRUD) | Done        | PRD-077 (format, templates, index schema, CRUD, tRPC, provisioning) + PRD-078 (scope model) complete          |
 | Thalamus (indexing/retrieval) | Done        | PRD-079 (indexing/sync) + PRD-080 (retrieval engine: semantic, structured, hybrid, context assembly) complete |
-| Ingest (input pipeline)       | Not started | Manual, agent, capture channels + classification + scope inference                                            |
+| Ingest (input pipeline)       | In progress | PRD-081 in progress — normaliser, classifier, entity extraction, scope inference implemented                  |
 | Emit (output production)      | Partial     | PRD-082 (Query Engine) done. Document generation and proactive nudges not started                             |
 
 ### Cerebrum — Phase 2 (Curation & Interface)
 
-| Epic                    | Status      | Notes                                                                               |
-| ----------------------- | ----------- | ----------------------------------------------------------------------------------- |
-| Glia (curation workers) | Not started | Pruner, consolidator, linker, auditor + trust graduation                            |
-| Ego (chat agent)        | Partial     | PRD-088 (Ego Channels) done. PRD-087 (Ego Core) partial — SSE streaming gap remains |
+| Epic                    | Status  | Notes                                                                                |
+| ----------------------- | ------- | ------------------------------------------------------------------------------------ |
+| Glia (curation workers) | Partial | PRD-085 (workers) done. PRD-086 (trust graduation) partial — review UI + reverts gap |
+| Ego (chat agent)        | Partial | PRD-088 (Ego Channels) done. PRD-087 (Ego Core) partial — SSE streaming gap remains |
 
 ### Cerebrum — Phase 3 (Automation & Ecosystem)
 
-| Epic                   | Status      | Notes                                                            |
-| ---------------------- | ----------- | ---------------------------------------------------------------- |
-| Reflex (automation)    | Not started | reflexes.toml, event/threshold/scheduled triggers                |
-| Plexus (plugin system) | Partial     | PRD-090 (architecture) done; PRD-091 (core adapters) not started |
+| Epic                   | Status | Notes                                                                    |
+| ---------------------- | ------ | ------------------------------------------------------------------------ |
+| Reflex (automation)    | Done   | PRD-089 complete — definitions, event/threshold/scheduled triggers, mgmt |
+| Plexus (plugin system) | Done   | PRD-090 (architecture) + PRD-091 (email, calendar, GitHub adapters) done |
 
 ### Phase 1 — Foundation (continued)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,7 +138,7 @@ Live status of every theme and epic. Updated as work completes.
 | Epic                    | Status  | Notes                                                                                |
 | ----------------------- | ------- | ------------------------------------------------------------------------------------ |
 | Glia (curation workers) | Partial | PRD-085 (workers) done. PRD-086 (trust graduation) partial — review UI + reverts gap |
-| Ego (chat agent)        | Partial | PRD-088 (Ego Channels) done. PRD-087 (Ego Core) partial — SSE streaming gap remains |
+| Ego (chat agent)        | Partial | PRD-088 (Ego Channels) done. PRD-087 (Ego Core) partial — SSE streaming gap remains  |
 
 ### Cerebrum — Phase 3 (Automation & Ecosystem)
 

--- a/docs/themes/06-cerebrum/README.md
+++ b/docs/themes/06-cerebrum/README.md
@@ -41,12 +41,12 @@ Cerebrum is a subsystem umbrella containing multiple named components:
 | --- | -------------------------------------------- | ------------------------------------------------------------------------------ | ----------- |
 | 0   | [Engram Storage](epics/00-engram-storage.md) | File format, templates, directory structure, scope model, CRUD operations      | Partial     |
 | 1   | [Thalamus](epics/01-thalamus.md)             | File watcher, frontmatter indexing, embedding sync, cross-source retrieval     | Partial     |
-| 2   | [Ingest](epics/02-ingest.md)                 | Manual/agent/capture input, classification, entity extraction, scope inference | Not started |
+| 2   | [Ingest](epics/02-ingest.md)                 | Manual/agent/capture input, classification, entity extraction, scope inference | In progress |
 | 3   | [Emit](epics/03-emit.md)                     | Query engine, document generation, proactive nudges                            | Partial     |
-| 4   | [Glia](epics/04-glia.md)                     | Curation workers (pruner, consolidator, linker, auditor), trust graduation     | Not started |
+| 4   | [Glia](epics/04-glia.md)                     | Curation workers (pruner, consolidator, linker, auditor), trust graduation     | Partial     |
 | 5   | [Ego](epics/05-ego.md)                       | Chat agent — shell panel, MCP tools, Moltbot, CLI. Supersedes PRD-054          | Partial     |
 | 6   | [Reflex](epics/06-reflex.md)                 | Automation triggers — event, threshold, scheduled. reflexes.toml               | Done        |
-| 7   | [Plexus](epics/07-plexus.md)                 | Plugin system — adapter interface, core integrations (email, calendar, GitHub) | Partial     |
+| 7   | [Plexus](epics/07-plexus.md)                 | Plugin system — adapter interface, core integrations (email, calendar, GitHub) | Done        |
 
 Epics 0-3 form Phase 1 (MVP): store, index, ingest, retrieve. Epics 4-5 form Phase 2: curation and chat interface. Epics 6-7 form Phase 3: automation and ecosystem. Within each phase, epics are sequential on their dependencies (0 before 1 before 2, etc.) but later phases can begin individual epics as their dependencies are met.
 

--- a/docs/themes/06-cerebrum/prds/085-curation-workers/README.md
+++ b/docs/themes/06-cerebrum/prds/085-curation-workers/README.md
@@ -120,4 +120,4 @@ All four workers are independent and can be built in parallel. Each worker depen
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-28

--- a/docs/themes/06-cerebrum/prds/085-curation-workers/us-01-pruner.md
+++ b/docs/themes/06-cerebrum/prds/085-curation-workers/us-01-pruner.md
@@ -1,6 +1,7 @@
 # US-01: Pruner Worker
 
 > PRD: [PRD-085: Curation Workers](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/085-curation-workers/us-02-consolidator.md
+++ b/docs/themes/06-cerebrum/prds/085-curation-workers/us-02-consolidator.md
@@ -1,6 +1,7 @@
 # US-02: Consolidator Worker
 
 > PRD: [PRD-085: Curation Workers](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/085-curation-workers/us-03-linker.md
+++ b/docs/themes/06-cerebrum/prds/085-curation-workers/us-03-linker.md
@@ -1,6 +1,7 @@
 # US-03: Linker Worker
 
 > PRD: [PRD-085: Curation Workers](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/085-curation-workers/us-04-auditor.md
+++ b/docs/themes/06-cerebrum/prds/085-curation-workers/us-04-auditor.md
@@ -1,6 +1,7 @@
 # US-04: Auditor Worker
 
 > PRD: [PRD-085: Curation Workers](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/086-trust-graduation/README.md
+++ b/docs/themes/06-cerebrum/prds/086-trust-graduation/README.md
@@ -116,4 +116,4 @@ US-01 and US-02 can be built in parallel. US-03 and US-04 both depend on the `gl
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-28

--- a/docs/themes/06-cerebrum/prds/086-trust-graduation/us-01-proposal-queue.md
+++ b/docs/themes/06-cerebrum/prds/086-trust-graduation/us-01-proposal-queue.md
@@ -1,6 +1,7 @@
 # US-01: Proposal Review Queue
 
 > PRD: [PRD-086: Trust Graduation](README.md)
+> Status: Partial
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/086-trust-graduation/us-02-approval-tracking.md
+++ b/docs/themes/06-cerebrum/prds/086-trust-graduation/us-02-approval-tracking.md
@@ -1,6 +1,7 @@
 # US-02: Approval Tracking
 
 > PRD: [PRD-086: Trust Graduation](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/086-trust-graduation/us-03-graduation-logic.md
+++ b/docs/themes/06-cerebrum/prds/086-trust-graduation/us-03-graduation-logic.md
@@ -1,6 +1,7 @@
 # US-03: Graduation Logic
 
 > PRD: [PRD-086: Trust Graduation](README.md)
+> Status: Partial
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/086-trust-graduation/us-04-audit-trail.md
+++ b/docs/themes/06-cerebrum/prds/086-trust-graduation/us-04-audit-trail.md
@@ -1,6 +1,7 @@
 # US-04: Audit Trail
 
 > PRD: [PRD-086: Trust Graduation](README.md)
+> Status: Partial
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/087-ego-core/README.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/README.md
@@ -121,4 +121,4 @@ US-01 (conversation engine) is the foundation. US-02, US-03, and US-04 depend on
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-28

--- a/docs/themes/06-cerebrum/prds/087-ego-core/us-01-conversation-engine.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/us-01-conversation-engine.md
@@ -1,6 +1,7 @@
 # US-01: Conversation Engine
 
 > PRD: [PRD-087: Ego Core](README.md)
+> Status: Partial
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/087-ego-core/us-02-shell-chat-panel.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/us-02-shell-chat-panel.md
@@ -1,6 +1,7 @@
 # US-02: Shell Chat Panel
 
 > PRD: [PRD-087: Ego Core](README.md)
+> Status: Partial
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/087-ego-core/us-03-context-awareness.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/us-03-context-awareness.md
@@ -1,6 +1,7 @@
 # US-03: Context Awareness
 
 > PRD: [PRD-087: Ego Core](README.md)
+> Status: Partial
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/087-ego-core/us-04-scope-negotiation.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/us-04-scope-negotiation.md
@@ -1,6 +1,7 @@
 # US-04: Scope Negotiation
 
 > PRD: [PRD-087: Ego Core](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/087-ego-core/us-05-conversation-persistence.md
+++ b/docs/themes/06-cerebrum/prds/087-ego-core/us-05-conversation-persistence.md
@@ -1,6 +1,7 @@
 # US-05: Conversation Persistence
 
 > PRD: [PRD-087: Ego Core](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/088-ego-channels/README.md
+++ b/docs/themes/06-cerebrum/prds/088-ego-channels/README.md
@@ -76,4 +76,4 @@ All three channels are independent adapters and can be built in parallel. Each d
 
 ## Drift Check
 
-last checked: 2026-04-27
+last checked: 2026-04-28

--- a/docs/themes/06-cerebrum/prds/088-ego-channels/us-01-mcp-tools.md
+++ b/docs/themes/06-cerebrum/prds/088-ego-channels/us-01-mcp-tools.md
@@ -1,6 +1,7 @@
 # US-01: MCP Tools for Claude Code
 
 > PRD: [PRD-088: Ego Channels](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/088-ego-channels/us-02-moltbot-channel.md
+++ b/docs/themes/06-cerebrum/prds/088-ego-channels/us-02-moltbot-channel.md
@@ -1,6 +1,7 @@
 # US-02: Moltbot Channel
 
 > PRD: [PRD-088: Ego Channels](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/088-ego-channels/us-03-cli-interface.md
+++ b/docs/themes/06-cerebrum/prds/088-ego-channels/us-03-cli-interface.md
@@ -1,6 +1,7 @@
 # US-03: CLI Interface
 
 > PRD: [PRD-088: Ego Channels](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/089-reflex-system/us-01-reflex-definitions.md
+++ b/docs/themes/06-cerebrum/prds/089-reflex-system/us-01-reflex-definitions.md
@@ -1,6 +1,7 @@
 # US-01: Reflex Definitions
 
 > PRD: [PRD-089: Reflex System](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/089-reflex-system/us-02-event-triggers.md
+++ b/docs/themes/06-cerebrum/prds/089-reflex-system/us-02-event-triggers.md
@@ -1,6 +1,7 @@
 # US-02: Event Triggers
 
 > PRD: [PRD-089: Reflex System](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/089-reflex-system/us-03-threshold-triggers.md
+++ b/docs/themes/06-cerebrum/prds/089-reflex-system/us-03-threshold-triggers.md
@@ -1,6 +1,7 @@
 # US-03: Threshold Triggers
 
 > PRD: [PRD-089: Reflex System](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/089-reflex-system/us-04-scheduled-triggers.md
+++ b/docs/themes/06-cerebrum/prds/089-reflex-system/us-04-scheduled-triggers.md
@@ -1,6 +1,7 @@
 # US-04: Scheduled Triggers
 
 > PRD: [PRD-089: Reflex System](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/089-reflex-system/us-05-reflex-management.md
+++ b/docs/themes/06-cerebrum/prds/089-reflex-system/us-05-reflex-management.md
@@ -1,6 +1,7 @@
 # US-05: Reflex Management
 
 > PRD: [PRD-089: Reflex System](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/090-plugin-architecture/README.md
+++ b/docs/themes/06-cerebrum/prds/090-plugin-architecture/README.md
@@ -110,4 +110,4 @@ US-01 defines the interface that US-02 and US-03 depend on. US-04 (ingestion fil
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-28

--- a/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-01-adapter-interface.md
+++ b/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-01-adapter-interface.md
@@ -1,6 +1,7 @@
 # US-01: Adapter Interface
 
 > PRD: [PRD-090: Plugin Architecture](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-02-plugin-lifecycle.md
+++ b/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-02-plugin-lifecycle.md
@@ -1,6 +1,7 @@
 # US-02: Plugin Lifecycle
 
 > PRD: [PRD-090: Plugin Architecture](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-03-plugin-registry.md
+++ b/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-03-plugin-registry.md
@@ -1,6 +1,7 @@
 # US-03: Plugin Registry
 
 > PRD: [PRD-090: Plugin Architecture](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-04-ingestion-filters.md
+++ b/docs/themes/06-cerebrum/prds/090-plugin-architecture/us-04-ingestion-filters.md
@@ -1,6 +1,7 @@
 # US-04: Ingestion Filters
 
 > PRD: [PRD-090: Plugin Architecture](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/091-core-adapters/README.md
+++ b/docs/themes/06-cerebrum/prds/091-core-adapters/README.md
@@ -96,4 +96,4 @@ All three adapters are independent implementations of the same interface and can
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-28

--- a/docs/themes/06-cerebrum/prds/091-core-adapters/us-01-email-adapter.md
+++ b/docs/themes/06-cerebrum/prds/091-core-adapters/us-01-email-adapter.md
@@ -1,6 +1,7 @@
 # US-01: Email Adapter
 
 > PRD: [PRD-091: Core Integration Adapters](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/091-core-adapters/us-02-calendar-adapter.md
+++ b/docs/themes/06-cerebrum/prds/091-core-adapters/us-02-calendar-adapter.md
@@ -1,6 +1,7 @@
 # US-02: Calendar Adapter
 
 > PRD: [PRD-091: Core Integration Adapters](README.md)
+> Status: Done
 
 ## Description
 

--- a/docs/themes/06-cerebrum/prds/091-core-adapters/us-03-github-adapter.md
+++ b/docs/themes/06-cerebrum/prds/091-core-adapters/us-03-github-adapter.md
@@ -1,6 +1,7 @@
 # US-03: GitHub Adapter
 
 > PRD: [PRD-091: Core Integration Adapters](README.md)
+> Status: Done
 
 ## Description
 


### PR DESCRIPTION
## Summary

- Added `> Status:` headers to all 28 user story files across PRDs 085-091 (none had them)
- Updated drift check dates to `2026-04-28` for PRDs 085, 086, 087, 088, 090, 091
- Corrected Cerebrum theme README epic statuses: Glia (Not started -> Partial), Ingest (Not started -> In progress), Plexus (Partial -> Done)
- Corrected roadmap implementation tracker: Glia (Not started -> Partial), Reflex (Not started -> Done), Plexus (Partial -> Done), Ingest (Not started -> In progress)

### Per-PRD status summary

| PRD | Status | Detail |
|-----|--------|--------|
| 085 (Curation Workers) | Done | All 4 US files: Done |
| 086 (Trust Graduation) | Partial | US-01 Partial (React UI gaps), US-02 Done, US-03 Partial (TOML reading gap), US-04 Partial (revert + digest gaps) |
| 087 (Ego Core) | Partial | US-01 Partial (SSE gap), US-02 Partial (SSE gap), US-03 Partial (recent actions gap), US-04 Done, US-05 Done |
| 088 (Ego Channels) | Done | All 3 US files: Done |
| 089 (Reflex System) | Done | All 5 US files: Done |
| 090 (Plugin Architecture) | Done | All 4 US files: Done |
| 091 (Core Adapters) | Done | All 3 US files: Done |

## Test plan

- [ ] Verify each US file has a `> Status:` line matching its AC checkbox state
- [ ] Verify drift check dates are `2026-04-28`
- [ ] Verify theme README epic table matches PRD statuses
- [ ] Verify roadmap tracker matches epic statuses

Closes #2274