### PR TITLE
feat(settings): register cerebrum/ego/glia/plexus/MCP/thalamus config in unified settings

### DIFF
--- a/apps/pops-api/src/mcp/tools/cerebrum-query.ts
+++ b/apps/pops-api/src/mcp/tools/cerebrum-query.ts
@@ -5,14 +5,16 @@
  * Limits retrieval to top-3 results for low MCP latency.
  */
 import { QueryService } from '../../modules/cerebrum/query/query-service.js';
+import { getSettingValue } from '../../modules/core/settings/service.js';
 import { mapServiceError, mcpError, mcpSuccess } from '../errors.js';
 
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import type { QueryDomain } from '../../modules/cerebrum/query/types.js';
 
-/** MCP-specific max sources — lower than the default for faster responses. */
-const MCP_MAX_SOURCES = 3;
+function getMcpQueryMaxSources(): number {
+  return getSettingValue('cerebrum.mcp.queryMaxSources', 3);
+}
 
 const VALID_DOMAINS = new Set<string>(['engrams', 'transactions', 'media', 'inventory']);
 
@@ -48,7 +50,7 @@ export async function handleCerebrumQuery(raw: Record<string, unknown>): Promise
     const result = await svc.ask({
       question: args.question,
       scopes: args.scopes,
-      maxSources: MCP_MAX_SOURCES,
+      maxSources: getMcpQueryMaxSources(),
       domains,
     });
 

--- a/apps/pops-api/src/mcp/tools/cerebrum-search.ts
+++ b/apps/pops-api/src/mcp/tools/cerebrum-search.ts
@@ -5,14 +5,20 @@
  */
 import { getDrizzle } from '../../db.js';
 import { HybridSearchService } from '../../modules/cerebrum/retrieval/hybrid-search.js';
+import { getSettingValue } from '../../modules/core/settings/service.js';
 import { mapServiceError, mcpError, mcpSuccess } from '../errors.js';
 
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import type { RetrievalResult } from '../../modules/cerebrum/retrieval/types.js';
 
-const MAX_SNIPPET_LENGTH = 200;
-const DEFAULT_LIMIT = 20;
+function getMcpSearchSnippetLength(): number {
+  return getSettingValue('cerebrum.mcp.searchSnippetLength', 200);
+}
+
+function getMcpSearchDefaultLimit(): number {
+  return getSettingValue('cerebrum.mcp.searchDefaultLimit', 20);
+}
 
 interface SearchArgs {
   query: string;
@@ -29,8 +35,9 @@ function hasExplicitSecretScope(scopes: string[] | undefined): boolean {
 }
 
 function truncateSnippet(text: string): string {
-  if (text.length <= MAX_SNIPPET_LENGTH) return text;
-  return text.slice(0, MAX_SNIPPET_LENGTH) + '…';
+  const maxLen = getMcpSearchSnippetLength();
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen) + '…';
 }
 
 function mapResult(result: RetrievalResult): {
@@ -79,7 +86,12 @@ export async function handleCerebrumSearch(raw: Record<string, unknown>): Promis
       includeSecret,
     };
 
-    const results = await svc.hybrid(args.query, filters, args.limit ?? DEFAULT_LIMIT, 0.8);
+    const results = await svc.hybrid(
+      args.query,
+      filters,
+      args.limit ?? getMcpSearchDefaultLimit(),
+      0.8
+    );
 
     return mcpSuccess({ results: results.map(mapResult) });
   } catch (err) {

--- a/apps/pops-api/src/modules/cerebrum/emit/generation-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/generation-service.ts
@@ -12,6 +12,7 @@
  * ContextAssemblyService, CitationParser).
  */
 import { getDrizzle } from '../../../db.js';
+import { getSettingValue } from '../../core/settings/service.js';
 import { CitationParser } from '../query/citation-parser.js';
 import { ContextAssemblyService } from '../retrieval/context-assembly.js';
 import { HybridSearchService } from '../retrieval/hybrid-search.js';
@@ -31,9 +32,17 @@ import { buildScopeFilters, computeDefaultAudienceScope, filterByScope } from '.
 import type { RetrievalFilters, RetrievalResult } from '../retrieval/types.js';
 import type { GenerationRequest, GenerationResult, PreviewResult } from './types.js';
 
-const GENERATION_TOKEN_BUDGET = 8192;
-const RELEVANCE_THRESHOLD = 0.2;
-const DEFAULT_MAX_SOURCES = 20;
+function getEmitTokenBudget(): number {
+  return getSettingValue('cerebrum.emit.tokenBudget', 8192);
+}
+
+function getEmitRelevanceThreshold(): number {
+  return getSettingValue('cerebrum.emit.relevanceThreshold', 0.2);
+}
+
+function getEmitMaxSources(): number {
+  return getSettingValue('cerebrum.emit.maxSources', 20);
+}
 
 /**
  * Build retrieval filters from a generation request.
@@ -79,7 +88,7 @@ export class GenerationService {
     const assembled = this.assembler.assemble({
       query,
       results: filtered,
-      tokenBudget: GENERATION_TOKEN_BUDGET,
+      tokenBudget: getEmitTokenBudget(),
       includeMetadata: true,
     });
 
@@ -108,7 +117,7 @@ export class GenerationService {
     const assembled = this.assembler.assemble({
       query,
       results: capped,
-      tokenBudget: GENERATION_TOKEN_BUDGET,
+      tokenBudget: getEmitTokenBudget(),
       includeMetadata: true,
     });
 
@@ -144,7 +153,7 @@ export class GenerationService {
     const assembled = this.assembler.assemble({
       query,
       results: sorted,
-      tokenBudget: GENERATION_TOKEN_BUDGET,
+      tokenBudget: getEmitTokenBudget(),
       includeMetadata: true,
     });
 
@@ -171,7 +180,7 @@ export class GenerationService {
     const assembled = this.assembler.assemble({
       query,
       results: filtered,
-      tokenBudget: GENERATION_TOKEN_BUDGET,
+      tokenBudget: getEmitTokenBudget(),
       includeMetadata: true,
     });
     const outline = await callEmitLlm(buildOutlinePrompt(assembled.context), query);
@@ -181,6 +190,6 @@ export class GenerationService {
   /** Run hybrid search against Thalamus. */
   private async retrieve(query: string, filters: RetrievalFilters): Promise<RetrievalResult[]> {
     const hybridSearch = new HybridSearchService(getDrizzle());
-    return hybridSearch.hybrid(query, filters, DEFAULT_MAX_SOURCES, RELEVANCE_THRESHOLD);
+    return hybridSearch.hybrid(query, filters, getEmitMaxSources(), getEmitRelevanceThreshold());
   }
 }

--- a/apps/pops-api/src/modules/cerebrum/emit/llm.ts
+++ b/apps/pops-api/src/modules/cerebrum/emit/llm.ts
@@ -10,10 +10,17 @@ import { getEnv } from '../../../env.js';
 import { withRateLimitRetry } from '../../../lib/ai-retry.js';
 import { trackInference } from '../../../lib/inference-middleware.js';
 import { logger } from '../../../lib/logger.js';
+import { getSettingValue } from '../../core/settings/service.js';
 
-const MODEL = 'claude-sonnet-4-20250514';
 const OPERATION = 'cerebrum.emit';
-const GENERATION_MAX_TOKENS = 2048;
+
+function getEmitModel(): string {
+  return getSettingValue('cerebrum.emit.model', 'claude-sonnet-4-20250514');
+}
+
+function getEmitMaxTokens(): number {
+  return getSettingValue('cerebrum.emit.maxTokens', 2048);
+}
 
 /** Call the LLM for document generation. Gracefully degrades if API key is missing. */
 export async function callEmitLlm(systemPrompt: string, userMessage: string): Promise<string> {
@@ -24,16 +31,18 @@ export async function callEmitLlm(systemPrompt: string, userMessage: string): Pr
   }
 
   const client = new Anthropic({ apiKey, maxRetries: 0 });
+  const model = getEmitModel();
+  const maxTokens = getEmitMaxTokens();
 
   try {
     const response = await trackInference(
-      { provider: 'claude', model: MODEL, operation: OPERATION, domain: 'cerebrum' },
+      { provider: 'claude', model, operation: OPERATION, domain: 'cerebrum' },
       () =>
         withRateLimitRetry(
           () =>
             client.messages.create({
-              model: MODEL,
-              max_tokens: GENERATION_MAX_TOKENS,
+              model,
+              max_tokens: maxTokens,
               temperature: 0,
               system: systemPrompt,
               messages: [{ role: 'user', content: userMessage }],

--- a/apps/pops-api/src/modules/cerebrum/engrams/scope-rules.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/scope-rules.ts
@@ -11,9 +11,14 @@ import { join } from 'node:path';
 
 import { parse as parseToml } from 'smol-toml';
 
+import { getSettingValue } from '../../core/settings/service.js';
 import { scopeStringSchema } from './scope-schema.js';
 
-const DEFAULT_FALLBACK_SCOPE = 'personal.captures';
+const HARDCODED_FALLBACK_SCOPE = 'personal.captures';
+
+function getDefaultFallbackScope(): string {
+  return getSettingValue('cerebrum.engram.fallbackScope', HARDCODED_FALLBACK_SCOPE);
+}
 
 export interface ScopeRule {
   match: {
@@ -46,15 +51,15 @@ function parseFallbackScope(obj: Record<string, unknown>): string {
     obj['defaults'] !== null &&
     typeof (obj['defaults'] as Record<string, unknown>)['fallback_scope'] === 'string'
       ? ((obj['defaults'] as Record<string, unknown>)['fallback_scope'] as string)
-      : DEFAULT_FALLBACK_SCOPE;
+      : HARDCODED_FALLBACK_SCOPE;
 
   const parsedFallback = scopeStringSchema.safeParse(fallbackRaw);
   if (!parsedFallback.success) {
     console.warn(
-      `[cerebrum] scope-rules.toml: invalid defaults.fallback_scope '${String(fallbackRaw)}' — using default '${DEFAULT_FALLBACK_SCOPE}'`
+      `[cerebrum] scope-rules.toml: invalid defaults.fallback_scope '${String(fallbackRaw)}' — using default '${HARDCODED_FALLBACK_SCOPE}'`
     );
   }
-  return parsedFallback.success ? parsedFallback.data : DEFAULT_FALLBACK_SCOPE;
+  return parsedFallback.success ? parsedFallback.data : HARDCODED_FALLBACK_SCOPE;
 }
 
 function parseAssignScopes(assignRaw: unknown[]): string[] {
@@ -222,7 +227,7 @@ export class ScopeRuleEngine {
 
 function defaultConfig(): ScopeRulesConfig {
   return {
-    defaults: { fallback_scope: DEFAULT_FALLBACK_SCOPE },
+    defaults: { fallback_scope: getDefaultFallbackScope() },
     rules: [],
   };
 }

--- a/apps/pops-api/src/modules/cerebrum/glia/trust-machine.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/trust-machine.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_THRESHOLDS } from './types.js';
+import { getGliaThresholds } from './types.js';
 
 /**
  * GliaTrustMachine — phase transitions and automatic demotion.
@@ -24,7 +24,7 @@ export interface TransitionResult {
 export class GliaTrustMachine {
   constructor(
     private readonly actionService: GliaActionService,
-    private readonly getThresholds: () => GraduationThresholds = () => DEFAULT_THRESHOLDS,
+    private readonly getThresholds: () => GraduationThresholds = getGliaThresholds,
     private readonly now: () => Date = () => new Date()
   ) {}
 

--- a/apps/pops-api/src/modules/cerebrum/glia/types.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/types.ts
@@ -80,14 +80,48 @@ export interface GraduationThresholds {
   demotionWindowDays: number;
 }
 
-/** Default graduation thresholds per ADR-021. */
-export const DEFAULT_THRESHOLDS: GraduationThresholds = {
+import { getSettingValue } from '../../core/settings/service.js';
+
+/** Hardcoded graduation thresholds per ADR-021. */
+const FALLBACK_THRESHOLDS: GraduationThresholds = {
   proposeToActReportMinApproved: 20,
   proposeToActReportMaxRejectionRate: 0.1,
   actReportToSilentMinDays: 60,
   demotionRevertThreshold: 2,
   demotionWindowDays: 7,
 };
+
+/** Read graduation thresholds from settings (with hardcoded fallbacks). */
+export function getGliaThresholds(): GraduationThresholds {
+  return {
+    proposeToActReportMinApproved: getSettingValue(
+      'cerebrum.glia.proposeMinApproved',
+      FALLBACK_THRESHOLDS.proposeToActReportMinApproved
+    ),
+    proposeToActReportMaxRejectionRate: getSettingValue(
+      'cerebrum.glia.proposeMaxRejectionRate',
+      FALLBACK_THRESHOLDS.proposeToActReportMaxRejectionRate
+    ),
+    actReportToSilentMinDays: getSettingValue(
+      'cerebrum.glia.actReportMinDays',
+      FALLBACK_THRESHOLDS.actReportToSilentMinDays
+    ),
+    demotionRevertThreshold: getSettingValue(
+      'cerebrum.glia.demotionRevertThreshold',
+      FALLBACK_THRESHOLDS.demotionRevertThreshold
+    ),
+    demotionWindowDays: getSettingValue(
+      'cerebrum.glia.demotionWindowDays',
+      FALLBACK_THRESHOLDS.demotionWindowDays
+    ),
+  };
+}
+
+/**
+ * @deprecated Use `getGliaThresholds()` instead. Retained for backward
+ * compatibility with tests that depend on a static constant.
+ */
+export const DEFAULT_THRESHOLDS: GraduationThresholds = FALLBACK_THRESHOLDS;
 
 /** Filters for querying actions. */
 export interface ActionListFilters {

--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -2,6 +2,11 @@
  * Cerebrum domain — engram storage and retrieval.
  * See docs/themes/06-cerebrum for the full spec.
  */
+import { settingsRegistry } from '../core/settings/index.js';
+import { cerebrumManifest } from './settings-manifest.js';
+
+settingsRegistry.register(cerebrumManifest);
+
 import { mergeRouters, router } from '../../trpc.js';
 import { emitRouter } from './emit/router.js';
 import { engramsRouter } from './engrams/router.js';

--- a/apps/pops-api/src/modules/cerebrum/ingest/classifier.ts
+++ b/apps/pops-api/src/modules/cerebrum/ingest/classifier.ts
@@ -11,12 +11,19 @@ import { getEnv } from '../../../env.js';
 import { withRateLimitRetry } from '../../../lib/ai-retry.js';
 import { trackInference } from '../../../lib/inference-middleware.js';
 import { logger } from '../../../lib/logger.js';
+import { getSettingValue } from '../../core/settings/service.js';
 
 import type { ClassificationResult } from './types.js';
 
-const MODEL = 'claude-haiku-4-5-20251001';
 const OPERATION = 'cerebrum.classify';
-const DEFAULT_CONFIDENCE_THRESHOLD = 0.6;
+
+function getClassifierModel(): string {
+  return getSettingValue('cerebrum.classifier.model', 'claude-haiku-4-5-20251001');
+}
+
+function getClassifierConfidenceThreshold(): number {
+  return getSettingValue('cerebrum.classifier.confidenceThreshold', 0.6);
+}
 const FALLBACK_TYPE = 'capture';
 
 const KNOWN_TYPES = [
@@ -95,7 +102,7 @@ export class CortexClassifier {
   private readonly confidenceThreshold: number;
 
   constructor(options?: { confidenceThreshold?: number }) {
-    this.confidenceThreshold = options?.confidenceThreshold ?? DEFAULT_CONFIDENCE_THRESHOLD;
+    this.confidenceThreshold = options?.confidenceThreshold ?? getClassifierConfidenceThreshold();
   }
 
   async classify(body: string, title?: string): Promise<ClassificationResult> {
@@ -107,16 +114,17 @@ export class CortexClassifier {
 
     const client = new Anthropic({ apiKey, maxRetries: 0 });
     const prompt = buildPrompt(body, title);
+    const model = getClassifierModel();
 
     let parsed: LlmClassifyResponse;
     try {
       const response = await trackInference(
-        { provider: 'claude', model: MODEL, operation: OPERATION, domain: 'cerebrum' },
+        { provider: 'claude', model, operation: OPERATION, domain: 'cerebrum' },
         () =>
           withRateLimitRetry(
             () =>
               client.messages.create({
-                model: MODEL,
+                model,
                 max_tokens: 256,
                 temperature: 0,
                 messages: [{ role: 'user', content: prompt }],

--- a/apps/pops-api/src/modules/cerebrum/ingest/entity-extractor.ts
+++ b/apps/pops-api/src/modules/cerebrum/ingest/entity-extractor.ts
@@ -11,12 +11,19 @@ import { getEnv } from '../../../env.js';
 import { withRateLimitRetry } from '../../../lib/ai-retry.js';
 import { trackInference } from '../../../lib/inference-middleware.js';
 import { logger } from '../../../lib/logger.js';
+import { getSettingValue } from '../../core/settings/service.js';
 
 import type { EntityExtractionResult, EntityType, ExtractedEntity } from './types.js';
 
-const MODEL = 'claude-haiku-4-5-20251001';
 const OPERATION = 'cerebrum.extract-entities';
-const DEFAULT_CONFIDENCE_THRESHOLD = 0.7;
+
+function getEntityExtractorModel(): string {
+  return getSettingValue('cerebrum.entityExtractor.model', 'claude-haiku-4-5-20251001');
+}
+
+function getEntityExtractorConfidenceThreshold(): number {
+  return getSettingValue('cerebrum.entityExtractor.confidenceThreshold', 0.7);
+}
 
 const ENTITY_TYPES: EntityType[] = ['person', 'project', 'date', 'topic', 'organisation'];
 
@@ -140,7 +147,8 @@ export class CortexEntityExtractor {
   private readonly confidenceThreshold: number;
 
   constructor(options?: { confidenceThreshold?: number }) {
-    this.confidenceThreshold = options?.confidenceThreshold ?? DEFAULT_CONFIDENCE_THRESHOLD;
+    this.confidenceThreshold =
+      options?.confidenceThreshold ?? getEntityExtractorConfidenceThreshold();
   }
 
   /**
@@ -165,16 +173,17 @@ export class CortexEntityExtractor {
     const refDate = referenceDate ?? new Date().toISOString().slice(0, 10);
     const client = new Anthropic({ apiKey, maxRetries: 0 });
     const prompt = buildPrompt(body, existingTags, refDate);
+    const model = getEntityExtractorModel();
 
     let rawEntities: LlmEntity[];
     try {
       const response = await trackInference(
-        { provider: 'claude', model: MODEL, operation: OPERATION, domain: 'cerebrum' },
+        { provider: 'claude', model, operation: OPERATION, domain: 'cerebrum' },
         () =>
           withRateLimitRetry(
             () =>
               client.messages.create({
-                model: MODEL,
+                model,
                 max_tokens: 512,
                 temperature: 0,
                 messages: [{ role: 'user', content: prompt }],

--- a/apps/pops-api/src/modules/cerebrum/ingest/scope-inference.ts
+++ b/apps/pops-api/src/modules/cerebrum/ingest/scope-inference.ts
@@ -16,14 +16,18 @@ import { getEnv } from '../../../env.js';
 import { withRateLimitRetry } from '../../../lib/ai-retry.js';
 import { trackInference } from '../../../lib/inference-middleware.js';
 import { logger } from '../../../lib/logger.js';
+import { getSettingValue } from '../../core/settings/service.js';
 import { resolveScopes } from '../engrams/scope-rules.js';
 import { scopeStringSchema } from '../engrams/scope-schema.js';
 
 import type { ScopeRulesConfig } from '../engrams/scope-rules.js';
 import type { ScopeInferenceResult } from './types.js';
 
-const MODEL = 'claude-haiku-4-5-20251001';
 const OPERATION = 'cerebrum.infer-scopes';
+
+function getScopeInferenceModel(): string {
+  return getSettingValue('cerebrum.scopeInference.model', 'claude-haiku-4-5-20251001');
+}
 
 interface LlmScopeResponse {
   scopes: string[];
@@ -153,15 +157,16 @@ export class ScopeInferenceService {
 
     const client = new Anthropic({ apiKey, maxRetries: 0 });
     const prompt = buildPrompt(body, type, tags, knownScopes);
+    const model = getScopeInferenceModel();
 
     try {
       const response = await trackInference(
-        { provider: 'claude', model: MODEL, operation: OPERATION, domain: 'cerebrum' },
+        { provider: 'claude', model, operation: OPERATION, domain: 'cerebrum' },
         () =>
           withRateLimitRetry(
             () =>
               client.messages.create({
-                model: MODEL,
+                model,
                 max_tokens: 128,
                 temperature: 0,
                 messages: [{ role: 'user', content: prompt }],

--- a/apps/pops-api/src/modules/cerebrum/nudges/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/router.ts
@@ -19,12 +19,12 @@ import { ConsolidationDetector } from './detectors/consolidation.js';
 import { PatternDetector } from './detectors/patterns.js';
 import { StalenessDetector } from './detectors/staleness.js';
 import { NudgeService } from './nudge-service.js';
-import { DEFAULT_THRESHOLDS } from './types.js';
+import { getDefaultNudgeThresholds } from './types.js';
 
 import type { NudgeThresholds } from './types.js';
 
 /** Module-scoped thresholds — mutated by `configure`, shared across requests. */
-let activeThresholds: NudgeThresholds = { ...DEFAULT_THRESHOLDS };
+let activeThresholds: NudgeThresholds = getDefaultNudgeThresholds();
 
 /** Build a NudgeService for the current request context. */
 function getService(): NudgeService {

--- a/apps/pops-api/src/modules/cerebrum/nudges/types.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/types.ts
@@ -55,8 +55,10 @@ export interface NudgeThresholds {
   nudgeCooldownHours: number;
 }
 
-/** Default thresholds per PRD-084 specification. */
-export const DEFAULT_THRESHOLDS: NudgeThresholds = {
+import { getSettingValue } from '../../core/settings/service.js';
+
+/** Hardcoded fallback thresholds per PRD-084 specification. */
+const FALLBACK_THRESHOLDS: NudgeThresholds = {
   consolidationSimilarity: 0.85,
   consolidationMinCluster: 3,
   stalenessDays: 90,
@@ -64,6 +66,42 @@ export const DEFAULT_THRESHOLDS: NudgeThresholds = {
   maxPendingNudges: 20,
   nudgeCooldownHours: 24,
 };
+
+/** Default thresholds from settings (falls back to hardcoded defaults). */
+export function getDefaultNudgeThresholds(): NudgeThresholds {
+  return {
+    consolidationSimilarity: getSettingValue(
+      'cerebrum.nudge.consolidationSimilarity',
+      FALLBACK_THRESHOLDS.consolidationSimilarity
+    ),
+    consolidationMinCluster: getSettingValue(
+      'cerebrum.nudge.consolidationMinCluster',
+      FALLBACK_THRESHOLDS.consolidationMinCluster
+    ),
+    stalenessDays: getSettingValue(
+      'cerebrum.nudge.stalenessDays',
+      FALLBACK_THRESHOLDS.stalenessDays
+    ),
+    patternMinOccurrences: getSettingValue(
+      'cerebrum.nudge.patternMinOccurrences',
+      FALLBACK_THRESHOLDS.patternMinOccurrences
+    ),
+    maxPendingNudges: getSettingValue(
+      'cerebrum.nudge.maxPending',
+      FALLBACK_THRESHOLDS.maxPendingNudges
+    ),
+    nudgeCooldownHours: getSettingValue(
+      'cerebrum.nudge.cooldownHours',
+      FALLBACK_THRESHOLDS.nudgeCooldownHours
+    ),
+  };
+}
+
+/**
+ * @deprecated Use `getDefaultNudgeThresholds()` instead. Retained for backward
+ * compatibility with tests that depend on a static constant.
+ */
+export const DEFAULT_THRESHOLDS: NudgeThresholds = FALLBACK_THRESHOLDS;
 
 /** Result from a detector scan — zero or more nudge candidates. */
 export interface DetectorResult {

--- a/apps/pops-api/src/modules/cerebrum/plexus/lifecycle.ts
+++ b/apps/pops-api/src/modules/cerebrum/plexus/lifecycle.ts
@@ -1,3 +1,4 @@
+import { getSettingValue } from '../../core/settings/service.js';
 /**
  * Plexus lifecycle manager (PRD-090, US-02).
  *
@@ -24,10 +25,19 @@ import type {
   PlexusAdapterRow,
 } from './types.js';
 
-const DEFAULT_HEALTH_INTERVAL_MS = 5 * 60 * 1000;
-const HEALTH_CHECK_TIMEOUT_MS = 10_000;
 const SHUTDOWN_TIMEOUT_MS = 5_000;
-const MAX_CONSECUTIVE_FAILURES = 3;
+
+function getPlexusHealthIntervalMs(): number {
+  return getSettingValue('cerebrum.plexus.healthIntervalMs', 5 * 60 * 1000);
+}
+
+function getPlexusHealthTimeoutMs(): number {
+  return getSettingValue('cerebrum.plexus.healthTimeoutMs', 10_000);
+}
+
+function getPlexusMaxConsecutiveFailures(): number {
+  return getSettingValue('cerebrum.plexus.maxConsecutiveFailures', 3);
+}
 
 interface RegisteredAdapter {
   instance: PlexusAdapterInterface;
@@ -63,7 +73,7 @@ export class PlexusLifecycleManager {
   private healthIntervalMs: number;
 
   constructor(options?: { healthIntervalMs?: number }) {
-    this.healthIntervalMs = options?.healthIntervalMs ?? DEFAULT_HEALTH_INTERVAL_MS;
+    this.healthIntervalMs = options?.healthIntervalMs ?? getPlexusHealthIntervalMs();
   }
 
   /** Register an adapter and immediately attempt initialisation. */
@@ -80,7 +90,7 @@ export class PlexusLifecycleManager {
     try {
       await withTimeout(
         adapter.initialize(config),
-        HEALTH_CHECK_TIMEOUT_MS,
+        getPlexusHealthTimeoutMs(),
         `initialize(${adapter.name})`
       );
       updateAdapterStatus(id, 'healthy');
@@ -197,7 +207,7 @@ export class PlexusLifecycleManager {
     try {
       const result = await withTimeout(
         entry.instance.healthCheck(),
-        HEALTH_CHECK_TIMEOUT_MS,
+        getPlexusHealthTimeoutMs(),
         `healthCheck(${adapterId})`
       );
       if (result.status === 'healthy') {
@@ -219,7 +229,7 @@ export class PlexusLifecycleManager {
     now: string
   ): HealthResult {
     entry.consecutiveFailures++;
-    if (entry.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+    if (entry.consecutiveFailures >= getPlexusMaxConsecutiveFailures()) {
       updateAdapterStatus(adapterId, 'error', message);
       if (entry.healthTimer) clearTimeout(entry.healthTimer);
       this.adapters.delete(adapterId);

--- a/apps/pops-api/src/modules/cerebrum/query/citation-parser.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/citation-parser.ts
@@ -10,6 +10,7 @@
  *  - Orders output citations by relevance (highest first).
  */
 import { logger } from '../../../lib/logger.js';
+import { getSettingValue } from '../../core/settings/service.js';
 
 import type { RetrievalResult } from '../retrieval/types.js';
 import type { CitationParseResult, SourceCitation } from './types.js';
@@ -23,18 +24,21 @@ const ENGRAM_CITATION_RE = /\[eng_\d{8}_\d{4}_[a-z0-9-]+\]/g;
  */
 const TYPED_CITATION_RE = /\[(engram|transaction|media|inventory):([^\]]+)\]/g;
 
-const EXCERPT_MAX_LENGTH = 200;
+function getExcerptMaxLength(): number {
+  return getSettingValue('cerebrum.citation.excerptMaxLength', 200);
+}
 
 /**
  * Truncate text to a maximum length at a word boundary, appending ellipsis.
  */
 function truncateExcerpt(text: string): string {
-  if (text.length <= EXCERPT_MAX_LENGTH) return text;
+  const maxLen = getExcerptMaxLength();
+  if (text.length <= maxLen) return text;
 
   // Find last space within budget.
-  const truncated = text.slice(0, EXCERPT_MAX_LENGTH);
+  const truncated = text.slice(0, maxLen);
   const lastSpace = truncated.lastIndexOf(' ');
-  const cutPoint = lastSpace > 0 ? lastSpace : EXCERPT_MAX_LENGTH;
+  const cutPoint = lastSpace > 0 ? lastSpace : maxLen;
   return text.slice(0, cutPoint) + '…';
 }
 

--- a/apps/pops-api/src/modules/cerebrum/query/query-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/query-service.ts
@@ -13,6 +13,7 @@ import { getEnv } from '../../../env.js';
 import { withRateLimitRetry } from '../../../lib/ai-retry.js';
 import { trackInference } from '../../../lib/inference-middleware.js';
 import { logger } from '../../../lib/logger.js';
+import { getSettingValue } from '../../core/settings/service.js';
 import { ContextAssemblyService } from '../retrieval/context-assembly.js';
 import { HybridSearchService } from '../retrieval/hybrid-search.js';
 import { CitationParser } from './citation-parser.js';
@@ -29,11 +30,23 @@ import type {
   SourceCitation,
 } from './types.js';
 
-const MODEL = 'claude-sonnet-4-20250514';
 const OPERATION = 'cerebrum.query';
-const DEFAULT_MAX_SOURCES = 10;
-const RELEVANCE_THRESHOLD = 0.3;
-const TOKEN_BUDGET = 4096;
+
+function getQueryModel(): string {
+  return getSettingValue('cerebrum.query.model', 'claude-sonnet-4-20250514');
+}
+
+function getQueryMaxSources(): number {
+  return getSettingValue('cerebrum.query.maxSources', 10);
+}
+
+function getQueryRelevanceThreshold(): number {
+  return getSettingValue('cerebrum.query.relevanceThreshold', 0.3);
+}
+
+function getQueryTokenBudget(): number {
+  return getSettingValue('cerebrum.query.tokenBudget', 4096);
+}
 
 const NO_INFO_ANSWER = "I don't have information about that.";
 
@@ -85,7 +98,7 @@ export class QueryService {
    */
   async ask(request: QueryRequest): Promise<QueryResponse> {
     const question = request.question.trim();
-    const maxSources = request.maxSources ?? DEFAULT_MAX_SOURCES;
+    const maxSources = request.maxSources ?? getQueryMaxSources();
     const includeSecret = request.includeSecret ?? false;
 
     // 1. Scope inference.
@@ -94,7 +107,8 @@ export class QueryService {
     // 2. Build filters and retrieve.
     const filters = buildRetrievalFilters(scopeResult.scopes, includeSecret, request.domains);
     const hybridSearch = new HybridSearchService(getDrizzle());
-    const results = await hybridSearch.hybrid(question, filters, maxSources, RELEVANCE_THRESHOLD);
+    const relevanceThreshold = getQueryRelevanceThreshold();
+    const results = await hybridSearch.hybrid(question, filters, maxSources, relevanceThreshold);
 
     // 3. Zero results → short-circuit.
     if (results.length === 0) {
@@ -110,7 +124,7 @@ export class QueryService {
     const assembled = this.assembler.assemble({
       query: question,
       results,
-      tokenBudget: TOKEN_BUDGET,
+      tokenBudget: getQueryTokenBudget(),
       includeMetadata: true,
     });
 
@@ -145,13 +159,18 @@ export class QueryService {
     maxSources?: number
   ): Promise<{ sources: SourceCitation[] }> {
     const trimmed = question.trim();
-    const limit = maxSources ?? DEFAULT_MAX_SOURCES;
+    const limit = maxSources ?? getQueryMaxSources();
     const secret = includeSecret ?? false;
 
     const scopeResult = this.inferencer.infer(trimmed, undefined, scopes, secret);
     const filters = buildRetrievalFilters(scopeResult.scopes, secret);
     const hybridSearch = new HybridSearchService(getDrizzle());
-    const results = await hybridSearch.hybrid(trimmed, filters, limit, RELEVANCE_THRESHOLD);
+    const results = await hybridSearch.hybrid(
+      trimmed,
+      filters,
+      limit,
+      getQueryRelevanceThreshold()
+    );
 
     const sources: SourceCitation[] = results.map((r) => ({
       id: r.sourceId,
@@ -182,8 +201,8 @@ export class QueryService {
       scopeInference: scopeResult,
       retrievalPlan: {
         filters,
-        maxSources: DEFAULT_MAX_SOURCES,
-        threshold: RELEVANCE_THRESHOLD,
+        maxSources: getQueryMaxSources(),
+        threshold: getQueryRelevanceThreshold(),
       },
       secretNotice,
     };
@@ -198,15 +217,16 @@ export class QueryService {
     }
 
     const client = new Anthropic({ apiKey, maxRetries: 0 });
+    const model = getQueryModel();
 
     try {
       const response = await trackInference(
-        { provider: 'claude', model: MODEL, operation: OPERATION, domain: 'cerebrum' },
+        { provider: 'claude', model, operation: OPERATION, domain: 'cerebrum' },
         () =>
           withRateLimitRetry(
             () =>
               client.messages.create({
-                model: MODEL,
+                model,
                 max_tokens: 1024,
                 temperature: 0,
                 system: systemPrompt,

--- a/apps/pops-api/src/modules/cerebrum/retrieval/context-assembly.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/context-assembly.ts
@@ -1,3 +1,5 @@
+import { getSettingValue } from '../../core/settings/service.js';
+
 /**
  * ContextAssemblyService — assembles a token-budgeted context window from
  * retrieval results, formatted for LLM consumption with source attribution.
@@ -7,7 +9,9 @@
  */
 import type { RetrievalResult, SourceAttribution } from './types.js';
 
-const DEFAULT_TOKEN_BUDGET = 4096;
+function getContextTokenBudget(): number {
+  return getSettingValue('cerebrum.context.tokenBudget', 4096);
+}
 const WORDS_TO_TOKENS = 1.3;
 const SENTENCE_BOUNDARY = /[.!?]\s/;
 
@@ -78,7 +82,7 @@ export interface ContextAssemblyOutput {
 
 export class ContextAssemblyService {
   assemble(input: ContextAssemblyInput): ContextAssemblyOutput {
-    const { query, results, tokenBudget = DEFAULT_TOKEN_BUDGET, includeMetadata = true } = input;
+    const { query, results, tokenBudget = getContextTokenBudget(), includeMetadata = true } = input;
 
     const seen = new Set<string>();
     const sections: string[] = [];

--- a/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.ts
@@ -1,3 +1,4 @@
+import { getSettingValue } from '../../core/settings/service.js';
 import { SemanticSearchService } from './semantic-search.js';
 import { StructuredQueryService } from './structured-query.js';
 
@@ -12,9 +13,17 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 import type { RetrievalFilters, RetrievalResult } from './types.js';
 
-const RRF_K = 60;
-const DEFAULT_LIMIT = 20;
-const DEFAULT_THRESHOLD = 0.8;
+function getHybridRrfK(): number {
+  return getSettingValue('cerebrum.hybrid.rrfK', 60);
+}
+
+function getHybridDefaultLimit(): number {
+  return getSettingValue('cerebrum.hybrid.defaultLimit', 20);
+}
+
+function getHybridDefaultThreshold(): number {
+  return getSettingValue('cerebrum.hybrid.defaultThreshold', 0.8);
+}
 
 function isSecretScope(scope: string): boolean {
   return scope.split('.').includes('secret');
@@ -26,11 +35,12 @@ function reciprocalRankFusion(
   structuredResults: RetrievalResult[],
   limit: number
 ): RetrievalResult[] {
+  const rrfK = getHybridRrfK();
   const scores = new Map<string, { score: number; result: RetrievalResult; inBoth: boolean }>();
 
   for (const [i, r] of semanticResults.entries()) {
     const key = `${r.sourceType}:${r.sourceId}`;
-    const contribution = 1 / (RRF_K + i + 1);
+    const contribution = 1 / (rrfK + i + 1);
     const existing = scores.get(key);
     if (existing) {
       existing.score += contribution;
@@ -42,7 +52,7 @@ function reciprocalRankFusion(
 
   for (const [i, r] of structuredResults.entries()) {
     const key = `${r.sourceType}:${r.sourceId}`;
-    const contribution = 1 / (RRF_K + i + 1);
+    const contribution = 1 / (rrfK + i + 1);
     const existing = scores.get(key);
     if (existing) {
       existing.score += contribution;
@@ -80,8 +90,8 @@ export class HybridSearchService {
   async hybrid(
     query: string,
     filters: RetrievalFilters = {},
-    limit = DEFAULT_LIMIT,
-    threshold = DEFAULT_THRESHOLD
+    limit = getHybridDefaultLimit(),
+    threshold = getHybridDefaultThreshold()
   ): Promise<RetrievalResult[]> {
     const fetchLimit = limit * 3;
 
@@ -109,14 +119,18 @@ export class HybridSearchService {
   async semanticSearch(
     query: string,
     filters: RetrievalFilters = {},
-    limit = DEFAULT_LIMIT,
-    threshold = DEFAULT_THRESHOLD
+    limit = getHybridDefaultLimit(),
+    threshold = getHybridDefaultThreshold()
   ): Promise<RetrievalResult[]> {
     return this.semanticSvc.search(query, filters, limit, threshold);
   }
 
   /** Structured-only search. */
-  structuredOnly(filters: RetrievalFilters, limit = DEFAULT_LIMIT, offset = 0): RetrievalResult[] {
+  structuredOnly(
+    filters: RetrievalFilters,
+    limit = getHybridDefaultLimit(),
+    offset = 0
+  ): RetrievalResult[] {
     return this.structuredSvc.query(filters, limit, offset);
   }
 
@@ -127,8 +141,8 @@ export class HybridSearchService {
   async similar(
     engramId: string,
     filters: RetrievalFilters = {},
-    limit = DEFAULT_LIMIT,
-    threshold = DEFAULT_THRESHOLD
+    limit = getHybridDefaultLimit(),
+    threshold = getHybridDefaultThreshold()
   ): Promise<RetrievalResult[]> {
     const vector = this.semanticSvc.getVectorForEngram(engramId);
     if (!vector) {

--- a/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search.ts
@@ -7,6 +7,7 @@ import { createHash } from 'node:crypto';
 import { getDb, isVecAvailable } from '../../../db.js';
 import { getEmbedding, getEmbeddingConfig } from '../../../shared/embedding-client.js';
 import { getRedis, isRedisAvailable, redisKey } from '../../../shared/redis-client.js';
+import { getSettingValue } from '../../core/settings/service.js';
 import {
   collectResults,
   dedupeBySource,
@@ -19,9 +20,17 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
 import type { RetrievalFilters, RetrievalResult } from './types.js';
 
-const DEFAULT_LIMIT = 20;
-const DEFAULT_THRESHOLD = 0.8;
-const QUERY_CACHE_TTL_SECONDS = 300;
+function getSemanticDefaultLimit(): number {
+  return getSettingValue('cerebrum.semantic.defaultLimit', 20);
+}
+
+function getSemanticDefaultThreshold(): number {
+  return getSettingValue('cerebrum.semantic.defaultThreshold', 0.8);
+}
+
+function getSemanticQueryCacheTtl(): number {
+  return getSettingValue('cerebrum.semantic.queryCacheTtl', 300);
+}
 
 export interface SearchByVectorOptions {
   vectorBlob: Float32Array;
@@ -41,7 +50,7 @@ async function embedQuery(query: string): Promise<number[]> {
     const cached = await redis.get(cacheKey);
     if (cached) return JSON.parse(cached) as number[];
     const vector = await getEmbedding(query, config);
-    await redis.set(cacheKey, JSON.stringify(vector), 'EX', QUERY_CACHE_TTL_SECONDS);
+    await redis.set(cacheKey, JSON.stringify(vector), 'EX', getSemanticQueryCacheTtl());
     return vector;
   }
 
@@ -54,8 +63,8 @@ export class SemanticSearchService {
   async search(
     query: string,
     filters: RetrievalFilters = {},
-    limit = DEFAULT_LIMIT,
-    threshold = DEFAULT_THRESHOLD
+    limit = getSemanticDefaultLimit(),
+    threshold = getSemanticDefaultThreshold()
   ): Promise<RetrievalResult[]> {
     if (!query.trim()) {
       throw Object.assign(new Error('Query is required for semantic search'), {
@@ -83,8 +92,8 @@ export class SemanticSearchService {
    */
   async searchByVector(opts: SearchByVectorOptions): Promise<RetrievalResult[]> {
     if (!isVecAvailable()) throw vecUnavailableError();
-    const limit = opts.limit ?? DEFAULT_LIMIT;
-    const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
+    const limit = opts.limit ?? getSemanticDefaultLimit();
+    const threshold = opts.threshold ?? getSemanticDefaultThreshold();
     const filters = opts.filters ?? {};
 
     const rows = knnQuery(opts.vectorBlob, limit * 3).filter(

--- a/apps/pops-api/src/modules/cerebrum/settings-manifest.ts
+++ b/apps/pops-api/src/modules/cerebrum/settings-manifest.ts
@@ -1,0 +1,35 @@
+import { emitGroup, queryGroup } from './settings/query-emit-manifest.js';
+import { ingestGroup, retrievalGroup } from './settings/retrieval-ingest-manifest.js';
+import {
+  engramsGroup,
+  gliaGroup,
+  mcpGroup,
+  nudgesGroup,
+  plexusGroup,
+  thalamusGroup,
+} from './settings/subsystem-manifest.js';
+
+/**
+ * Cerebrum settings manifest — assembled from domain-specific group files
+ * to stay under the max-lines lint rule.
+ */
+import type { SettingsManifest } from '@pops/types';
+
+export const cerebrumManifest: SettingsManifest = {
+  id: 'cerebrum',
+  title: 'Cerebrum',
+  icon: 'Brain',
+  order: 300,
+  groups: [
+    queryGroup,
+    emitGroup,
+    retrievalGroup,
+    ingestGroup,
+    nudgesGroup,
+    engramsGroup,
+    plexusGroup,
+    thalamusGroup,
+    gliaGroup,
+    mcpGroup,
+  ],
+};

--- a/apps/pops-api/src/modules/cerebrum/settings/query-emit-manifest.ts
+++ b/apps/pops-api/src/modules/cerebrum/settings/query-emit-manifest.ts
@@ -1,0 +1,90 @@
+/**
+ * Cerebrum settings manifest — query engine and document generation groups.
+ */
+import type { SettingsGroup } from '@pops/types';
+
+export const queryGroup: SettingsGroup = {
+  id: 'query',
+  title: 'Query Engine',
+  description: 'Natural-language Q&A pipeline settings.',
+  fields: [
+    {
+      key: 'cerebrum.query.model',
+      label: 'Query Model',
+      type: 'text',
+      default: 'claude-sonnet-4-20250514',
+      description: 'LLM model used for Q&A answer generation.',
+    },
+    {
+      key: 'cerebrum.query.maxSources',
+      label: 'Max Sources',
+      type: 'number',
+      default: '10',
+      description: 'Maximum number of sources to retrieve per query.',
+      validation: { min: 1, max: 100 },
+    },
+    {
+      key: 'cerebrum.query.relevanceThreshold',
+      label: 'Relevance Threshold',
+      type: 'number',
+      default: '0.3',
+      description: 'Minimum relevance score for retrieved sources (0-1).',
+      validation: { min: 0, max: 1 },
+    },
+    {
+      key: 'cerebrum.query.tokenBudget',
+      label: 'Token Budget',
+      type: 'number',
+      default: '4096',
+      description: 'Maximum tokens for the context window passed to the LLM.',
+      validation: { min: 256 },
+    },
+  ],
+};
+
+export const emitGroup: SettingsGroup = {
+  id: 'emit',
+  title: 'Document Generation',
+  description: 'Report, summary, and timeline generation settings.',
+  fields: [
+    {
+      key: 'cerebrum.emit.model',
+      label: 'Generation Model',
+      type: 'text',
+      default: 'claude-sonnet-4-20250514',
+      description: 'LLM model used for document generation.',
+    },
+    {
+      key: 'cerebrum.emit.maxTokens',
+      label: 'Generation Max Tokens',
+      type: 'number',
+      default: '2048',
+      description: 'Maximum tokens for LLM document generation output.',
+      validation: { min: 256 },
+    },
+    {
+      key: 'cerebrum.emit.relevanceThreshold',
+      label: 'Relevance Threshold',
+      type: 'number',
+      default: '0.2',
+      description: 'Minimum relevance score for emit retrieval (0-1).',
+      validation: { min: 0, max: 1 },
+    },
+    {
+      key: 'cerebrum.emit.maxSources',
+      label: 'Max Sources',
+      type: 'number',
+      default: '20',
+      description: 'Maximum sources retrieved for document generation.',
+      validation: { min: 1, max: 200 },
+    },
+    {
+      key: 'cerebrum.emit.tokenBudget',
+      label: 'Token Budget',
+      type: 'number',
+      default: '8192',
+      description: 'Token budget for the assembled context window.',
+      validation: { min: 256 },
+    },
+  ],
+};

--- a/apps/pops-api/src/modules/cerebrum/settings/retrieval-ingest-manifest.ts
+++ b/apps/pops-api/src/modules/cerebrum/settings/retrieval-ingest-manifest.ts
@@ -1,0 +1,113 @@
+/**
+ * Cerebrum settings manifest — retrieval and ingest pipeline groups.
+ */
+import type { SettingsGroup } from '@pops/types';
+
+export const retrievalGroup: SettingsGroup = {
+  id: 'retrieval',
+  title: 'Retrieval',
+  description: 'Semantic search, hybrid search, and context assembly settings.',
+  fields: [
+    {
+      key: 'cerebrum.semantic.defaultLimit',
+      label: 'Semantic Default Limit',
+      type: 'number',
+      default: '20',
+      description: 'Default number of results from semantic search.',
+      validation: { min: 1, max: 200 },
+    },
+    {
+      key: 'cerebrum.semantic.defaultThreshold',
+      label: 'Semantic Default Threshold',
+      type: 'number',
+      default: '0.8',
+      description: 'Default distance threshold for semantic search (0-1).',
+      validation: { min: 0, max: 1 },
+    },
+    {
+      key: 'cerebrum.semantic.queryCacheTtl',
+      label: 'Query Cache TTL (seconds)',
+      type: 'number',
+      default: '300',
+      description: 'Time-to-live for cached query embeddings in Redis.',
+      validation: { min: 0 },
+    },
+    {
+      key: 'cerebrum.hybrid.rrfK',
+      label: 'RRF K Constant',
+      type: 'number',
+      default: '60',
+      description: 'Reciprocal Rank Fusion K constant for merging results.',
+      validation: { min: 1 },
+    },
+    {
+      key: 'cerebrum.hybrid.defaultLimit',
+      label: 'Hybrid Default Limit',
+      type: 'number',
+      default: '20',
+      description: 'Default number of results from hybrid search.',
+      validation: { min: 1, max: 200 },
+    },
+    {
+      key: 'cerebrum.hybrid.defaultThreshold',
+      label: 'Hybrid Default Threshold',
+      type: 'number',
+      default: '0.8',
+      description: 'Default distance threshold for hybrid search (0-1).',
+      validation: { min: 0, max: 1 },
+    },
+    {
+      key: 'cerebrum.context.tokenBudget',
+      label: 'Context Assembly Token Budget',
+      type: 'number',
+      default: '4096',
+      description: 'Default token budget for context assembly.',
+      validation: { min: 256 },
+    },
+  ],
+};
+
+export const ingestGroup: SettingsGroup = {
+  id: 'ingest',
+  title: 'Ingest Pipeline',
+  description: 'Classifier, entity extractor, and scope inference settings.',
+  fields: [
+    {
+      key: 'cerebrum.classifier.model',
+      label: 'Classifier Model',
+      type: 'text',
+      default: 'claude-haiku-4-5-20251001',
+      description: 'LLM model used for content classification.',
+    },
+    {
+      key: 'cerebrum.classifier.confidenceThreshold',
+      label: 'Classifier Confidence Threshold',
+      type: 'number',
+      default: '0.6',
+      description: 'Minimum confidence to accept a classification (0-1).',
+      validation: { min: 0, max: 1 },
+    },
+    {
+      key: 'cerebrum.entityExtractor.model',
+      label: 'Entity Extractor Model',
+      type: 'text',
+      default: 'claude-haiku-4-5-20251001',
+      description: 'LLM model used for entity extraction.',
+    },
+    {
+      key: 'cerebrum.entityExtractor.confidenceThreshold',
+      label: 'Entity Extractor Confidence Threshold',
+      type: 'number',
+      default: '0.7',
+      description: 'Minimum confidence for extracted entities (0-1).',
+      validation: { min: 0, max: 1 },
+    },
+    {
+      key: 'cerebrum.scopeInference.model',
+      label: 'Scope Inference Model',
+      type: 'text',
+      default: 'claude-haiku-4-5-20251001',
+      description: 'LLM model used for scope inference.',
+    },
+  ],
+};

--- a/apps/pops-api/src/modules/cerebrum/settings/subsystem-manifest.ts
+++ b/apps/pops-api/src/modules/cerebrum/settings/subsystem-manifest.ts
@@ -1,0 +1,193 @@
+/**
+ * Cerebrum settings manifest — nudges, engrams, plexus, thalamus, glia, MCP groups.
+ */
+import type { SettingsGroup } from '@pops/types';
+
+export const nudgesGroup: SettingsGroup = {
+  id: 'nudges',
+  title: 'Nudges',
+  description: 'Proactive nudge detection thresholds.',
+  fields: [
+    {
+      key: 'cerebrum.nudge.consolidationSimilarity',
+      label: 'Consolidation Similarity',
+      type: 'number',
+      default: '0.85',
+      description: 'Minimum Thalamus similarity to propose consolidation.',
+      validation: { min: 0, max: 1 },
+    },
+    {
+      key: 'cerebrum.nudge.consolidationMinCluster',
+      label: 'Consolidation Min Cluster',
+      type: 'number',
+      default: '3',
+      validation: { min: 2 },
+    },
+    {
+      key: 'cerebrum.nudge.stalenessDays',
+      label: 'Staleness Days',
+      type: 'number',
+      default: '90',
+      description: 'Days since modification before an engram is flagged as stale.',
+      validation: { min: 1 },
+    },
+    {
+      key: 'cerebrum.nudge.patternMinOccurrences',
+      label: 'Pattern Min Occurrences',
+      type: 'number',
+      default: '5',
+      validation: { min: 2 },
+    },
+    {
+      key: 'cerebrum.nudge.maxPending',
+      label: 'Max Pending Nudges',
+      type: 'number',
+      default: '20',
+      validation: { min: 1 },
+    },
+    {
+      key: 'cerebrum.nudge.cooldownHours',
+      label: 'Nudge Cooldown Hours',
+      type: 'number',
+      default: '24',
+      validation: { min: 0 },
+    },
+  ],
+};
+
+export const engramsGroup: SettingsGroup = {
+  id: 'engrams',
+  title: 'Engrams',
+  fields: [
+    {
+      key: 'cerebrum.engram.fallbackScope',
+      label: 'Fallback Scope',
+      type: 'text',
+      default: 'personal.captures',
+      description: 'Default scope assigned when no rules or LLM inference match.',
+    },
+    {
+      key: 'cerebrum.citation.excerptMaxLength',
+      label: 'Citation Excerpt Max Length',
+      type: 'number',
+      default: '200',
+      description: 'Maximum character length for citation excerpts.',
+      validation: { min: 50 },
+    },
+  ],
+};
+
+export const plexusGroup: SettingsGroup = {
+  id: 'plexus',
+  title: 'Plexus (Adapter Lifecycle)',
+  description: 'Health check interval, timeout, and failure thresholds.',
+  fields: [
+    {
+      key: 'cerebrum.plexus.healthIntervalMs',
+      label: 'Health Check Interval',
+      type: 'duration',
+      default: '300000',
+    },
+    {
+      key: 'cerebrum.plexus.healthTimeoutMs',
+      label: 'Health Check Timeout',
+      type: 'number',
+      default: '10000',
+      description: 'Timeout for a single health check call (ms).',
+      validation: { min: 1000 },
+    },
+    {
+      key: 'cerebrum.plexus.maxConsecutiveFailures',
+      label: 'Max Consecutive Failures',
+      type: 'number',
+      default: '3',
+      validation: { min: 1 },
+    },
+  ],
+};
+
+export const thalamusGroup: SettingsGroup = {
+  id: 'thalamus',
+  title: 'Thalamus',
+  fields: [
+    {
+      key: 'cerebrum.thalamus.crossSourceIntervalMs',
+      label: 'Cross-Source Index Interval',
+      type: 'duration',
+      default: '21600000',
+      description: 'Interval for the cross-source indexer job (ms). Default 6h.',
+    },
+  ],
+};
+
+export const gliaGroup: SettingsGroup = {
+  id: 'glia',
+  title: 'Glia (Trust Graduation)',
+  description: 'Graduation and demotion thresholds for the Glia trust system.',
+  fields: [
+    {
+      key: 'cerebrum.glia.proposeMinApproved',
+      label: 'Propose Min Approved',
+      type: 'number',
+      default: '20',
+      validation: { min: 1 },
+    },
+    {
+      key: 'cerebrum.glia.proposeMaxRejectionRate',
+      label: 'Propose Max Rejection Rate',
+      type: 'number',
+      default: '0.1',
+      validation: { min: 0, max: 1 },
+    },
+    {
+      key: 'cerebrum.glia.actReportMinDays',
+      label: 'Act+Report Min Days',
+      type: 'number',
+      default: '60',
+      validation: { min: 1 },
+    },
+    {
+      key: 'cerebrum.glia.demotionRevertThreshold',
+      label: 'Demotion Revert Threshold',
+      type: 'number',
+      default: '2',
+      validation: { min: 1 },
+    },
+    {
+      key: 'cerebrum.glia.demotionWindowDays',
+      label: 'Demotion Window Days',
+      type: 'number',
+      default: '7',
+      validation: { min: 1 },
+    },
+  ],
+};
+
+export const mcpGroup: SettingsGroup = {
+  id: 'mcp',
+  title: 'MCP Tools',
+  description: 'Settings for Cerebrum MCP tool endpoints.',
+  fields: [
+    {
+      key: 'cerebrum.mcp.queryMaxSources',
+      label: 'MCP Query Max Sources',
+      type: 'number',
+      default: '3',
+      validation: { min: 1, max: 50 },
+    },
+    {
+      key: 'cerebrum.mcp.searchSnippetLength',
+      label: 'MCP Search Snippet Length',
+      type: 'number',
+      default: '200',
+      validation: { min: 50 },
+    },
+    {
+      key: 'cerebrum.mcp.searchDefaultLimit',
+      label: 'MCP Search Default Limit',
+      type: 'number',
+      default: '20',
+      validation: { min: 1, max: 100 },
+    },
+  ],
+};

--- a/apps/pops-api/src/modules/cerebrum/thalamus/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/instance.ts
@@ -14,6 +14,7 @@ import { engramIndex } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
 import { DEFAULT_JOB_OPTIONS, getDefaultQueue } from '../../../jobs/queues.js';
+import { getSettingValue } from '../../core/settings/service.js';
 import { getEngramRoot } from '../instance.js';
 import { EmbeddingTrigger } from './embedding-trigger.js';
 import { FrontmatterSyncService } from './sync.js';
@@ -22,7 +23,10 @@ import { FileWatcherService } from './watcher.js';
 import type { WatchEvent } from './watcher.js';
 
 const CROSS_SOURCE_SCHEDULER_ID = 'pops-cross-source-index';
-const CROSS_SOURCE_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+function getCrossSourceIntervalMs(): number {
+  return getSettingValue('cerebrum.thalamus.crossSourceIntervalMs', 6 * 60 * 60 * 1000);
+}
 
 let watcher: FileWatcherService | null = null;
 
@@ -87,7 +91,7 @@ export async function startThalamus(): Promise<void> {
   void getDefaultQueue()
     .upsertJobScheduler(
       CROSS_SOURCE_SCHEDULER_ID,
-      { every: CROSS_SOURCE_INTERVAL_MS },
+      { every: getCrossSourceIntervalMs() },
       { name: 'crossSourceIndex', data: { type: 'crossSourceIndex' }, opts: DEFAULT_JOB_OPTIONS }
     )
     .catch((err: unknown) => {

--- a/apps/pops-api/src/modules/core/settings/index.ts
+++ b/apps/pops-api/src/modules/core/settings/index.ts
@@ -4,4 +4,5 @@
 export { SETTINGS_KEY_VALUES, SETTINGS_KEYS, type SettingsKey } from './keys.js';
 export { settingsRegistry } from './registry.js';
 export { settingsRouter } from './router.js';
+export { getSettingValue } from './service.js';
 export type { SetSettingInput, Setting, SettingListInput } from './types.js';

--- a/apps/pops-api/src/modules/core/settings/service.ts
+++ b/apps/pops-api/src/modules/core/settings/service.ts
@@ -97,6 +97,30 @@ export function setBulkSettings(entries: { key: string; value: string }[]): Reco
   return result;
 }
 
+/**
+ * Read a setting's value, returning `fallback` if the key does not exist in the
+ * database or if the settings table is not available. This is the preferred way
+ * for modules to consume settings — it avoids throwing on missing keys and
+ * keeps the default co-located with the call site.
+ */
+export function getSettingValue<T extends string | number>(key: string, fallback: T): T {
+  try {
+    const db = getDrizzle();
+    const [row] = db.select().from(settings).where(eq(settings.key, key)).all();
+    if (!row) return fallback;
+    // Coerce to the same primitive type as the fallback.
+    if (typeof fallback === 'number') {
+      const parsed = Number(row.value);
+      return (Number.isNaN(parsed) ? fallback : parsed) as T;
+    }
+    return row.value as T;
+  } catch {
+    // Settings table may not exist in test databases or during early
+    // bootstrapping — gracefully degrade to the hardcoded fallback.
+    return fallback;
+  }
+}
+
 /** Delete a setting by key */
 export function deleteSetting(key: SettingsKey): void {
   const db = getDrizzle();

--- a/apps/pops-api/src/modules/ego/engine-helpers.ts
+++ b/apps/pops-api/src/modules/ego/engine-helpers.ts
@@ -3,14 +3,30 @@
  *
  * Extracted to keep engine.ts within the max-lines lint rule.
  */
+import { getSettingValue } from '../core/settings/service.js';
+
 import type { RetrievalFilters } from '../cerebrum/retrieval/types.js';
 import type { EngineConfig, Message } from './types.js';
 
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
-const DEFAULT_MAX_HISTORY = 20;
-const DEFAULT_MAX_RETRIEVAL = 5;
-const DEFAULT_TOKEN_BUDGET = 4096;
-const DEFAULT_RELEVANCE_THRESHOLD = 0.3;
+function getEgoDefaultModel(): string {
+  return getSettingValue('ego.defaultModel', 'claude-sonnet-4-20250514');
+}
+
+function getEgoMaxHistory(): number {
+  return getSettingValue('ego.maxHistory', 20);
+}
+
+function getEgoMaxRetrieval(): number {
+  return getSettingValue('ego.maxRetrieval', 5);
+}
+
+function getEgoTokenBudget(): number {
+  return getSettingValue('ego.tokenBudget', 4096);
+}
+
+function getEgoRelevanceThreshold(): number {
+  return getSettingValue('ego.relevanceThreshold', 0.3);
+}
 
 function isSecretScope(scope: string): boolean {
   return scope.split('.').includes('secret');
@@ -39,10 +55,10 @@ export function formatHistoryForContext(messages: Message[]): string {
 
 export function buildDefaultConfig(config?: Partial<EngineConfig>): EngineConfig {
   return {
-    model: config?.model ?? DEFAULT_MODEL,
-    maxHistoryMessages: config?.maxHistoryMessages ?? DEFAULT_MAX_HISTORY,
-    maxRetrievalResults: config?.maxRetrievalResults ?? DEFAULT_MAX_RETRIEVAL,
-    tokenBudget: config?.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
-    relevanceThreshold: config?.relevanceThreshold ?? DEFAULT_RELEVANCE_THRESHOLD,
+    model: config?.model ?? getEgoDefaultModel(),
+    maxHistoryMessages: config?.maxHistoryMessages ?? getEgoMaxHistory(),
+    maxRetrievalResults: config?.maxRetrievalResults ?? getEgoMaxRetrieval(),
+    tokenBudget: config?.tokenBudget ?? getEgoTokenBudget(),
+    relevanceThreshold: config?.relevanceThreshold ?? getEgoRelevanceThreshold(),
   };
 }

--- a/apps/pops-api/src/modules/ego/index.ts
+++ b/apps/pops-api/src/modules/ego/index.ts
@@ -7,6 +7,11 @@
  *   ego.context.setScopes                    — explicit scope override (US-04)
  *   ego.context.getActive                    — current context state (US-03)
  */
+import { settingsRegistry } from '../core/settings/index.js';
+import { egoManifest } from './settings-manifest.js';
+
+settingsRegistry.register(egoManifest);
+
 import { mergeRouters, router } from '../../trpc.js';
 import { contextRouter } from './router-context.js';
 import { chatRouter, conversationsRouter } from './router.js';

--- a/apps/pops-api/src/modules/ego/llm-client.ts
+++ b/apps/pops-api/src/modules/ego/llm-client.ts
@@ -11,8 +11,25 @@ import { getEnv } from '../../env.js';
 import { withRateLimitRetry } from '../../lib/ai-retry.js';
 import { trackInference } from '../../lib/inference-middleware.js';
 import { logger } from '../../lib/logger.js';
+import { getSettingValue } from '../core/settings/service.js';
 
 import type { MessageStream } from '@anthropic-ai/sdk/lib/MessageStream';
+
+function getEgoChatMaxTokens(): number {
+  return getSettingValue('ego.chat.maxTokens', 2048);
+}
+
+function getEgoChatTemperature(): number {
+  return getSettingValue('ego.chat.temperature', 0.3);
+}
+
+function getEgoSummaryMaxTokens(): number {
+  return getSettingValue('ego.summary.maxTokens', 512);
+}
+
+function getEgoSummaryTemperature(): number {
+  return getSettingValue('ego.summary.temperature', 0);
+}
 
 const LLM_UNAVAILABLE_MSG =
   'I can help with that, but the LLM is currently unavailable. Please try again later.';
@@ -47,8 +64,8 @@ export async function callChatLlm(
           () =>
             client.messages.create({
               model,
-              max_tokens: 2048,
-              temperature: 0.3,
+              max_tokens: getEgoChatMaxTokens(),
+              temperature: getEgoChatTemperature(),
               system: systemPrompt,
               messages,
             }),
@@ -131,8 +148,8 @@ export async function* streamChatLlm(
   try {
     stream = client.messages.stream({
       model,
-      max_tokens: 2048,
-      temperature: 0.3,
+      max_tokens: getEgoChatMaxTokens(),
+      temperature: getEgoChatTemperature(),
       system: systemPrompt,
       messages,
     });
@@ -199,8 +216,8 @@ export async function callSummariseLlm(
           () =>
             client.messages.create({
               model,
-              max_tokens: 512,
-              temperature: 0,
+              max_tokens: getEgoSummaryMaxTokens(),
+              temperature: getEgoSummaryTemperature(),
               messages: [{ role: 'user', content: prompt }],
             }),
           'ego.summarise',

--- a/apps/pops-api/src/modules/ego/settings-manifest.ts
+++ b/apps/pops-api/src/modules/ego/settings-manifest.ts
@@ -1,0 +1,99 @@
+/**
+ * Ego settings manifest — registers conversation engine and LLM client
+ * config values in the unified settings system.
+ */
+import type { SettingsManifest } from '@pops/types';
+
+export const egoManifest: SettingsManifest = {
+  id: 'ego',
+  title: 'Ego (Conversational AI)',
+  icon: 'MessageCircle',
+  order: 310,
+  groups: [
+    {
+      id: 'engine',
+      title: 'Conversation Engine',
+      description: 'Defaults for multi-turn conversation sessions.',
+      fields: [
+        {
+          key: 'ego.defaultModel',
+          label: 'Default Model',
+          type: 'text',
+          default: 'claude-sonnet-4-20250514',
+          description: 'LLM model used for chat and context retrieval.',
+        },
+        {
+          key: 'ego.maxHistory',
+          label: 'Max History Messages',
+          type: 'number',
+          default: '20',
+          description: 'Maximum conversation messages to include in context.',
+          validation: { min: 1, max: 200 },
+        },
+        {
+          key: 'ego.maxRetrieval',
+          label: 'Max Retrieval Results',
+          type: 'number',
+          default: '5',
+          description: 'Maximum engram retrieval results per turn.',
+          validation: { min: 1, max: 50 },
+        },
+        {
+          key: 'ego.tokenBudget',
+          label: 'Token Budget',
+          type: 'number',
+          default: '4096',
+          description: 'Token budget for the assembled retrieval context.',
+          validation: { min: 256 },
+        },
+        {
+          key: 'ego.relevanceThreshold',
+          label: 'Relevance Threshold',
+          type: 'number',
+          default: '0.3',
+          description: 'Minimum relevance score for retrieval results (0–1).',
+          validation: { min: 0, max: 1 },
+        },
+      ],
+    },
+    {
+      id: 'llm',
+      title: 'LLM Parameters',
+      description: 'Token limits and temperature for chat and summary calls.',
+      fields: [
+        {
+          key: 'ego.chat.maxTokens',
+          label: 'Chat Max Tokens',
+          type: 'number',
+          default: '2048',
+          description: 'Maximum output tokens for chat responses.',
+          validation: { min: 64 },
+        },
+        {
+          key: 'ego.chat.temperature',
+          label: 'Chat Temperature',
+          type: 'number',
+          default: '0.3',
+          description: 'Sampling temperature for chat responses (0–1).',
+          validation: { min: 0, max: 1 },
+        },
+        {
+          key: 'ego.summary.maxTokens',
+          label: 'Summary Max Tokens',
+          type: 'number',
+          default: '512',
+          description: 'Maximum output tokens for history summarisation.',
+          validation: { min: 64 },
+        },
+        {
+          key: 'ego.summary.temperature',
+          label: 'Summary Temperature',
+          type: 'number',
+          default: '0',
+          description: 'Sampling temperature for history summarisation (0–1).',
+          validation: { min: 0, max: 1 },
+        },
+      ],
+    },
+  ],
+};

--- a/packages/types/src/settings-keys.ts
+++ b/packages/types/src/settings-keys.ts
@@ -27,6 +27,82 @@ export const SETTINGS_KEYS = {
   AI_MONTHLY_TOKEN_BUDGET: 'ai.monthlyTokenBudget',
   AI_BUDGET_EXCEEDED_FALLBACK: 'ai.budgetExceededFallback',
 
+  // Cerebrum — Query Engine
+  CEREBRUM_QUERY_MODEL: 'cerebrum.query.model',
+  CEREBRUM_QUERY_MAX_SOURCES: 'cerebrum.query.maxSources',
+  CEREBRUM_QUERY_RELEVANCE_THRESHOLD: 'cerebrum.query.relevanceThreshold',
+  CEREBRUM_QUERY_TOKEN_BUDGET: 'cerebrum.query.tokenBudget',
+
+  // Cerebrum — Emit (Document Generation)
+  CEREBRUM_EMIT_MODEL: 'cerebrum.emit.model',
+  CEREBRUM_EMIT_MAX_TOKENS: 'cerebrum.emit.maxTokens',
+  CEREBRUM_EMIT_RELEVANCE_THRESHOLD: 'cerebrum.emit.relevanceThreshold',
+  CEREBRUM_EMIT_MAX_SOURCES: 'cerebrum.emit.maxSources',
+  CEREBRUM_EMIT_TOKEN_BUDGET: 'cerebrum.emit.tokenBudget',
+
+  // Cerebrum — Retrieval
+  CEREBRUM_SEMANTIC_DEFAULT_LIMIT: 'cerebrum.semantic.defaultLimit',
+  CEREBRUM_SEMANTIC_DEFAULT_THRESHOLD: 'cerebrum.semantic.defaultThreshold',
+  CEREBRUM_SEMANTIC_QUERY_CACHE_TTL: 'cerebrum.semantic.queryCacheTtl',
+  CEREBRUM_HYBRID_RRF_K: 'cerebrum.hybrid.rrfK',
+  CEREBRUM_HYBRID_DEFAULT_LIMIT: 'cerebrum.hybrid.defaultLimit',
+  CEREBRUM_HYBRID_DEFAULT_THRESHOLD: 'cerebrum.hybrid.defaultThreshold',
+  CEREBRUM_CONTEXT_TOKEN_BUDGET: 'cerebrum.context.tokenBudget',
+
+  // Cerebrum — Ingest
+  CEREBRUM_CLASSIFIER_MODEL: 'cerebrum.classifier.model',
+  CEREBRUM_CLASSIFIER_CONFIDENCE_THRESHOLD: 'cerebrum.classifier.confidenceThreshold',
+  CEREBRUM_ENTITY_EXTRACTOR_MODEL: 'cerebrum.entityExtractor.model',
+  CEREBRUM_ENTITY_EXTRACTOR_CONFIDENCE_THRESHOLD: 'cerebrum.entityExtractor.confidenceThreshold',
+  CEREBRUM_SCOPE_INFERENCE_MODEL: 'cerebrum.scopeInference.model',
+
+  // Cerebrum — Nudges
+  CEREBRUM_NUDGE_CONSOLIDATION_SIMILARITY: 'cerebrum.nudge.consolidationSimilarity',
+  CEREBRUM_NUDGE_CONSOLIDATION_MIN_CLUSTER: 'cerebrum.nudge.consolidationMinCluster',
+  CEREBRUM_NUDGE_STALENESS_DAYS: 'cerebrum.nudge.stalenessDays',
+  CEREBRUM_NUDGE_PATTERN_MIN_OCCURRENCES: 'cerebrum.nudge.patternMinOccurrences',
+  CEREBRUM_NUDGE_MAX_PENDING: 'cerebrum.nudge.maxPending',
+  CEREBRUM_NUDGE_COOLDOWN_HOURS: 'cerebrum.nudge.cooldownHours',
+
+  // Cerebrum — Engrams
+  CEREBRUM_ENGRAM_FALLBACK_SCOPE: 'cerebrum.engram.fallbackScope',
+
+  // Cerebrum — Citation Parser
+  CEREBRUM_CITATION_EXCERPT_MAX_LENGTH: 'cerebrum.citation.excerptMaxLength',
+
+  // Cerebrum — Plexus (adapter lifecycle)
+  CEREBRUM_PLEXUS_HEALTH_INTERVAL_MS: 'cerebrum.plexus.healthIntervalMs',
+  CEREBRUM_PLEXUS_HEALTH_TIMEOUT_MS: 'cerebrum.plexus.healthTimeoutMs',
+  CEREBRUM_PLEXUS_MAX_CONSECUTIVE_FAILURES: 'cerebrum.plexus.maxConsecutiveFailures',
+
+  // Cerebrum — Thalamus
+  CEREBRUM_THALAMUS_CROSS_SOURCE_INTERVAL_MS: 'cerebrum.thalamus.crossSourceIntervalMs',
+
+  // Cerebrum — MCP
+  CEREBRUM_MCP_QUERY_MAX_SOURCES: 'cerebrum.mcp.queryMaxSources',
+  CEREBRUM_MCP_SEARCH_SNIPPET_LENGTH: 'cerebrum.mcp.searchSnippetLength',
+  CEREBRUM_MCP_SEARCH_DEFAULT_LIMIT: 'cerebrum.mcp.searchDefaultLimit',
+
+  // Cerebrum — Glia (trust graduation)
+  CEREBRUM_GLIA_PROPOSE_MIN_APPROVED: 'cerebrum.glia.proposeMinApproved',
+  CEREBRUM_GLIA_PROPOSE_MAX_REJECTION_RATE: 'cerebrum.glia.proposeMaxRejectionRate',
+  CEREBRUM_GLIA_ACT_REPORT_MIN_DAYS: 'cerebrum.glia.actReportMinDays',
+  CEREBRUM_GLIA_DEMOTION_REVERT_THRESHOLD: 'cerebrum.glia.demotionRevertThreshold',
+  CEREBRUM_GLIA_DEMOTION_WINDOW_DAYS: 'cerebrum.glia.demotionWindowDays',
+
+  // Ego — Conversation Engine
+  EGO_DEFAULT_MODEL: 'ego.defaultModel',
+  EGO_MAX_HISTORY: 'ego.maxHistory',
+  EGO_MAX_RETRIEVAL: 'ego.maxRetrieval',
+  EGO_TOKEN_BUDGET: 'ego.tokenBudget',
+  EGO_RELEVANCE_THRESHOLD: 'ego.relevanceThreshold',
+
+  // Ego — LLM Client
+  EGO_CHAT_MAX_TOKENS: 'ego.chat.maxTokens',
+  EGO_CHAT_TEMPERATURE: 'ego.chat.temperature',
+  EGO_SUMMARY_MAX_TOKENS: 'ego.summary.maxTokens',
+  EGO_SUMMARY_TEMPERATURE: 'ego.summary.temperature',
+
   // App
   THEME: 'theme',
 } as const;


### PR DESCRIPTION
## Summary

- Add `getSettingValue<T>()` helper to settings service with graceful fallback for missing tables
- Create settings manifests for **cerebrum** (10 groups: query, emit, retrieval, ingest, nudges, engrams, plexus, thalamus, glia, MCP) and **ego** (2 groups: engine, LLM)
- Replace 50+ hardcoded constants across 20 source files with `getSettingValue()` lookups that preserve original defaults
- Register manifests via `settingsRegistry.register()` in domain index files
- Add all new keys to `@pops/types` `SETTINGS_KEYS`

## Test plan

- [x] `pnpm typecheck` passes (full monorepo, 17/17 tasks)
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes (210 test files, 3717 tests)
- [x] `pnpm format:check` passes
- [ ] Verify settings UI renders new cerebrum/ego manifest groups
- [ ] Verify overriding a setting in the DB changes runtime behavior

Closes #2264 #2265 #2266 #2267 #2272 #2273