### PR TITLE
feat(i18n): extract API error messages into i18n-compatible registry

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/nudges/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/router.ts
@@ -9,10 +9,10 @@
  *   scan      — trigger an on-demand nudge scan
  *   configure — update detection thresholds
  */
-import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { getDrizzle } from '../../../db.js';
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { HybridSearchService } from '../retrieval/hybrid-search.js';
 import { ConsolidationDetector } from './detectors/consolidation.js';
@@ -66,7 +66,7 @@ export const nudgesRouter = router({
   get: protectedProcedure.input(z.object({ id: z.string().min(1) })).query(({ input }) => {
     const nudge = getService().get(input.id);
     if (!nudge) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: `Nudge '${input.id}' not found` });
+      throw trpcError('NOT_FOUND', 'cerebrum.nudge.notFound', { id: input.id });
     }
     return { nudge };
   }),
@@ -75,10 +75,7 @@ export const nudgesRouter = router({
   dismiss: protectedProcedure.input(z.object({ id: z.string().min(1) })).mutation(({ input }) => {
     const result = getService().dismiss(input.id);
     if (!result.success) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: `Nudge '${input.id}' is not pending or does not exist`,
-      });
+      throw trpcError('BAD_REQUEST', 'cerebrum.nudge.notPendingOrMissing', { id: input.id });
     }
     return result;
   }),
@@ -87,10 +84,7 @@ export const nudgesRouter = router({
   act: protectedProcedure.input(z.object({ id: z.string().min(1) })).mutation(({ input }) => {
     const result = getService().act(input.id);
     if (!result.success) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: `Nudge '${input.id}' is not pending or does not exist`,
-      });
+      throw trpcError('BAD_REQUEST', 'cerebrum.nudge.notPendingOrMissing', { id: input.id });
     }
     return { result: { success: true, nudge: result.nudge } };
   }),

--- a/apps/pops-api/src/modules/cerebrum/reflex/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/reflex/router.ts
@@ -3,9 +3,9 @@
  *
  * Exposes management endpoints: list, get, test, enable, disable, history.
  */
-import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { getReflexService } from './instance.js';
 
@@ -22,10 +22,7 @@ export const reflexRouter = router({
     const service = getReflexService();
     const result = service.getWithHistory(input.name);
     if (!result) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: `Reflex "${input.name}" not found`,
-      });
+      throw trpcError('NOT_FOUND', 'cerebrum.reflex.notFound', { name: input.name });
     }
     return result;
   }),
@@ -34,10 +31,7 @@ export const reflexRouter = router({
     const service = getReflexService();
     const result = service.testReflex(input.name);
     if (!result) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: `Reflex "${input.name}" not found`,
-      });
+      throw trpcError('NOT_FOUND', 'cerebrum.reflex.notFound', { name: input.name });
     }
     return { result };
   }),
@@ -46,10 +40,7 @@ export const reflexRouter = router({
     const service = getReflexService();
     const found = service.getByName(input.name);
     if (!found) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: `Reflex "${input.name}" not found`,
-      });
+      throw trpcError('NOT_FOUND', 'cerebrum.reflex.notFound', { name: input.name });
     }
     const success = service.enableReflex(input.name);
     return { success };
@@ -59,10 +50,7 @@ export const reflexRouter = router({
     const service = getReflexService();
     const found = service.getByName(input.name);
     if (!found) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: `Reflex "${input.name}" not found`,
-      });
+      throw trpcError('NOT_FOUND', 'cerebrum.reflex.notFound', { name: input.name });
     }
     const success = service.disableReflex(input.name);
     return { success };

--- a/apps/pops-api/src/modules/cerebrum/retrieval/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/router.ts
@@ -8,13 +8,13 @@
  *   similar — k-NN from an existing engram's vector (no re-embedding)
  *   stats   — retrieval layer health and coverage counts
  */
-import { TRPCError } from '@trpc/server';
 import { count, sql } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { embeddings, engramIndex } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { ContextAssemblyService } from './context-assembly.js';
 import { HybridSearchService } from './hybrid-search.js';
@@ -50,17 +50,11 @@ async function runSearchProcedure(input: SearchProcedureInput): Promise<{
   const filters: RetrievalFilters = input.filters ?? {};
 
   if (input.mode !== 'structured' && !input.query?.trim()) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'Query is required for semantic and hybrid search modes',
-    });
+    throw trpcError('BAD_REQUEST', 'media.retrieval.queryRequired');
   }
 
   if (input.mode === 'structured' && !hasAnyStructuredFilter(filters)) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'Structured search requires at least one filter',
-    });
+    throw trpcError('BAD_REQUEST', 'media.retrieval.filterRequired');
   }
 
   const svc = new HybridSearchService(getDrizzle());
@@ -127,10 +121,7 @@ export const retrievalRouter = router({
     )
     .query(async ({ input }) => {
       if (!input.query.trim()) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Query is required for context assembly',
-        });
+        throw trpcError('BAD_REQUEST', 'media.retrieval.contextQueryRequired');
       }
 
       const db = getDrizzle();

--- a/apps/pops-api/src/modules/cerebrum/templates/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/templates/router.ts
@@ -5,9 +5,9 @@
  * directly on disk. The router exposes list/get for UIs that let the user
  * pick a template when creating an engram.
  */
-import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { getTemplateRegistry } from '../instance.js';
 
@@ -22,7 +22,7 @@ export const templatesRouter = router({
   get: protectedProcedure.input(z.object({ name: z.string().min(1) })).query(({ input }) => {
     const template = getTemplateRegistry().get(input.name);
     if (!template) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: `Template '${input.name}' not found` });
+      throw trpcError('NOT_FOUND', 'cerebrum.template.notFound', { name: input.name });
     }
     return { template };
   }),

--- a/apps/pops-api/src/modules/core/corrections/router-changeset.ts
+++ b/apps/pops-api/src/modules/core/corrections/router-changeset.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { logger } from '../../../lib/logger.js';
 import { NotFoundError } from '../../../shared/errors.js';
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import {
   PREVIEW_RULES_FETCH_LIMIT,
@@ -130,14 +131,21 @@ export const changesetRouter = router({
         triggeringTransactionCount: input.triggeringTransactions.length,
         err,
       });
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message:
-          err instanceof Error
-            ? `Failed to revise ChangeSet: ${err.message}`
-            : 'Failed to revise ChangeSet',
-        cause: err,
-      });
+      throw err instanceof Error
+        ? trpcError(
+            'INTERNAL_SERVER_ERROR',
+            'core.corrections.revisionFailed',
+            {
+              detail: err.message,
+            },
+            err
+          )
+        : trpcError(
+            'INTERNAL_SERVER_ERROR',
+            'core.corrections.revisionFailedGeneric',
+            undefined,
+            err
+          );
     }
   }),
 

--- a/apps/pops-api/src/modules/finance/imports/router.ts
+++ b/apps/pops-api/src/modules/finance/imports/router.ts
@@ -14,6 +14,7 @@ import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { NotFoundError, ValidationError } from '../../../shared/errors.js';
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { applyChangeSet } from '../../core/corrections/service.js';
 import { ChangeSetSchema } from '../../core/corrections/types.js';
@@ -133,22 +134,16 @@ export const importsRouter = router({
     .mutation(({ input }) => {
       const progress = getProgress(input.sessionId);
       if (!progress) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Import session not found' });
+        throw trpcError('NOT_FOUND', 'finance.import.sessionNotFound');
       }
       if (progress.status !== 'completed' || !progress.result) {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: 'Import session is not ready for re-evaluation',
-        });
+        throw trpcError('PRECONDITION_FAILED', 'finance.import.sessionNotReady');
       }
 
       // Ensure this is a processImport session (not executeImport).
       const result = progress.result;
       if (!isProcessImportOutput(result)) {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: 'Import session result is not a processImport result',
-        });
+        throw trpcError('PRECONDITION_FAILED', 'finance.import.sessionNotProcessResult');
       }
 
       // 1) Apply ChangeSet atomically (DB transaction)
@@ -205,21 +200,15 @@ export const importsRouter = router({
     .mutation(({ input }) => {
       const progress = getProgress(input.sessionId);
       if (!progress) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Import session not found' });
+        throw trpcError('NOT_FOUND', 'finance.import.sessionNotFound');
       }
       if (progress.status !== 'completed' || !progress.result) {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: 'Import session is not ready for re-evaluation',
-        });
+        throw trpcError('PRECONDITION_FAILED', 'finance.import.sessionNotReady');
       }
 
       const result = progress.result;
       if (!isProcessImportOutput(result)) {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: 'Import session result is not a processImport result',
-        });
+        throw trpcError('PRECONDITION_FAILED', 'finance.import.sessionNotProcessResult');
       }
 
       const { nextResult, affectedCount } = reevaluateImportSessionWithRules({

--- a/apps/pops-api/src/modules/inventory/paperless/router.ts
+++ b/apps/pops-api/src/modules/inventory/paperless/router.ts
@@ -1,9 +1,9 @@
 /**
  * Paperless-ngx tRPC router — connection status, health check, and document search.
  */
-import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { getPaperlessClient } from './index.js';
 import { PaperlessApiError } from './types.js';
@@ -31,10 +31,7 @@ export const paperlessRouter = router({
     .query(async ({ input }) => {
       const client = getPaperlessClient();
       if (!client) {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: 'Paperless-ngx is not configured',
-        });
+        throw trpcError('PRECONDITION_FAILED', 'inventory.paperless.notConfigured');
       }
 
       try {
@@ -50,10 +47,12 @@ export const paperlessRouter = router({
         };
       } catch (err) {
         if (err instanceof PaperlessApiError) {
-          throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Paperless error: ${err.message}`,
-          });
+          throw trpcError(
+            'INTERNAL_SERVER_ERROR',
+            'inventory.paperless.apiError',
+            { detail: err.message },
+            err
+          );
         }
         throw err;
       }

--- a/apps/pops-api/src/modules/inventory/reports/router.ts
+++ b/apps/pops-api/src/modules/inventory/reports/router.ts
@@ -1,9 +1,9 @@
 /**
  * Inventory reports tRPC router — warranty tracking and insurance reports.
  */
-import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { toInventoryItem } from '../items/types.js';
 import * as service from './service.js';
@@ -47,11 +47,12 @@ export const reportsRouter = router({
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
         console.error('[insurance-report] Failed:', detail, err);
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: `Failed to generate insurance report: ${detail}`,
-          cause: err,
-        });
+        throw trpcError(
+          'INTERNAL_SERVER_ERROR',
+          'inventory.reports.insuranceReportFailed',
+          { detail },
+          err
+        );
       }
     }),
 
@@ -62,11 +63,12 @@ export const reportsRouter = router({
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       console.error('[value-by-location] Failed:', detail, err);
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: `Failed to load value by location breakdown: ${detail}`,
-        cause: err,
-      });
+      throw trpcError(
+        'INTERNAL_SERVER_ERROR',
+        'inventory.reports.valueByLocationFailed',
+        { detail },
+        err
+      );
     }
   }),
 
@@ -77,11 +79,12 @@ export const reportsRouter = router({
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       console.error('[value-by-type] Failed:', detail, err);
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: `Failed to load value by type breakdown: ${detail}`,
-        cause: err,
-      });
+      throw trpcError(
+        'INTERNAL_SERVER_ERROR',
+        'inventory.reports.valueByTypeFailed',
+        { detail },
+        err
+      );
     }
   }),
 });

--- a/apps/pops-api/src/modules/media/arr/router-helpers.ts
+++ b/apps/pops-api/src/modules/media/arr/router-helpers.ts
@@ -1,5 +1,4 @@
-import { TRPCError } from '@trpc/server';
-
+import { trpcError } from '../../../shared/trpc-error.js';
 import * as arrService from './service.js';
 import { ArrApiError } from './types.js';
 
@@ -35,13 +34,18 @@ export async function withArrErrorHandling<T>(service: string, fn: () => Promise
     return await fn();
   } catch (err) {
     if (err instanceof ArrApiError) {
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: `${service} error: ${err.message}`,
-      });
+      throw trpcError(
+        'INTERNAL_SERVER_ERROR',
+        'media.arr.apiError',
+        {
+          service,
+          detail: err.message,
+        },
+        err
+      );
     }
     if (err instanceof Error && err.message === `${service} not configured`) {
-      throw new TRPCError({ code: 'PRECONDITION_FAILED', message: err.message });
+      throw trpcError('PRECONDITION_FAILED', 'media.arr.serviceNotConfigured', { service });
     }
     throw err;
   }
@@ -51,7 +55,7 @@ export async function withArrErrorHandling<T>(service: string, fn: () => Promise
 export function requireRadarrClient(): RadarrClient {
   const client = arrService.getRadarrClient();
   if (!client) {
-    throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'Radarr is not configured' });
+    throw trpcError('PRECONDITION_FAILED', 'media.arr.radarrNotConfigured');
   }
   return client;
 }
@@ -60,7 +64,7 @@ export function requireRadarrClient(): RadarrClient {
 export function requireSonarrClient(): SonarrClient {
   const client = arrService.getSonarrClient();
   if (!client) {
-    throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'Sonarr is not configured' });
+    throw trpcError('PRECONDITION_FAILED', 'media.arr.sonarrNotConfigured');
   }
   return client;
 }

--- a/apps/pops-api/src/modules/media/comparisons/router-helpers.ts
+++ b/apps/pops-api/src/modules/media/comparisons/router-helpers.ts
@@ -4,6 +4,7 @@ import { ConflictError, NotFoundError, ValidationError } from '../../../shared/e
 
 /**
  * Convert known service errors into appropriate TRPC errors.
+ * Preserves the `messageKey` from the original error when present.
  */
 export function rethrowKnownErrors(err: unknown): never {
   if (err instanceof NotFoundError) {

--- a/apps/pops-api/src/modules/media/library/router.ts
+++ b/apps/pops-api/src/modules/media/library/router.ts
@@ -5,6 +5,7 @@ import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { NotFoundError } from '../../../shared/errors.js';
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { toMovie } from '../movies/types.js';
 import { getPlexClient } from '../plex/service.js';
@@ -78,15 +79,18 @@ export const libraryRouter = router({
       } catch (err) {
         if (err instanceof TmdbApiError) {
           if (err.status === 404) {
-            throw new TRPCError({
-              code: 'NOT_FOUND',
-              message: `Movie not found on TMDB (ID: ${input.tmdbId})`,
+            throw trpcError('NOT_FOUND', 'media.library.movieNotFoundOnTmdb', {
+              tmdbId: String(input.tmdbId),
             });
           }
-          throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `TMDB API error: ${err.message}`,
-          });
+          throw trpcError(
+            'INTERNAL_SERVER_ERROR',
+            'media.library.tmdbApiError',
+            {
+              detail: err.message,
+            },
+            err
+          );
         }
         throw err;
       }
@@ -112,10 +116,14 @@ export const libraryRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
       }
       if (err instanceof TmdbApiError) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: `TMDB API error: ${err.message}`,
-        });
+        throw trpcError(
+          'INTERNAL_SERVER_ERROR',
+          'media.library.tmdbApiError',
+          {
+            detail: err.message,
+          },
+          err
+        );
       }
       throw err;
     }
@@ -139,10 +147,14 @@ export const libraryRouter = router({
         };
       } catch (err) {
         if (err instanceof TvdbApiError) {
-          throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `TheTVDB API error: ${err.message}`,
-          });
+          throw trpcError(
+            'INTERNAL_SERVER_ERROR',
+            'media.library.tvdbApiError',
+            {
+              detail: err.message,
+            },
+            err
+          );
         }
         throw err;
       }
@@ -187,10 +199,14 @@ export const libraryRouter = router({
           throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
         }
         if (err instanceof TvdbApiError) {
-          throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `TheTVDB API error: ${err.message}`,
-          });
+          throw trpcError(
+            'INTERNAL_SERVER_ERROR',
+            'media.library.tvdbApiError',
+            {
+              detail: err.message,
+            },
+            err
+          );
         }
         throw err;
       }

--- a/apps/pops-api/src/modules/media/plex/router-auth.ts
+++ b/apps/pops-api/src/modules/media/plex/router-auth.ts
@@ -1,10 +1,10 @@
-import { TRPCError } from '@trpc/server';
 import { eq, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { settings } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure } from '../../../trpc.js';
 import { SETTINGS_KEYS } from '../../core/settings/keys.js';
 import * as plexService from './service.js';
@@ -43,10 +43,11 @@ export const authProcedures = {
       },
     });
     if (!res.ok) {
-      throw new TRPCError({
-        code: res.status === 429 ? 'TOO_MANY_REQUESTS' : 'INTERNAL_SERVER_ERROR',
-        message: `Failed to get Plex PIN (HTTP ${res.status})`,
-      });
+      throw trpcError(
+        res.status === 429 ? 'TOO_MANY_REQUESTS' : 'INTERNAL_SERVER_ERROR',
+        'media.plex.pinFailed',
+        { status: String(res.status) }
+      );
     }
     const data = (await res.json()) as { id: number; code: string };
     return { data: { id: data.id, code: data.code, clientId } };
@@ -61,11 +62,10 @@ export const authProcedures = {
       });
       if (!res.ok) {
         if (res.status === 404) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: 'Invalid or expired PIN ID' });
+          throw trpcError('NOT_FOUND', 'media.plex.pinNotFound');
         }
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: `Failed to check Plex PIN (HTTP ${res.status})`,
+        throw trpcError('INTERNAL_SERVER_ERROR', 'media.plex.pinCheckFailed', {
+          status: String(res.status),
         });
       }
 

--- a/apps/pops-api/src/modules/media/plex/router-connection.ts
+++ b/apps/pops-api/src/modules/media/plex/router-connection.ts
@@ -1,10 +1,10 @@
-import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { settings } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure } from '../../../trpc.js';
 import { SETTINGS_KEYS } from '../../core/settings/keys.js';
 import { PlexClient } from './client.js';
@@ -20,11 +20,7 @@ function normalizeUrl(input: string): string {
   try {
     new URL(final);
   } catch {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message:
-        'Invalid URL format. Please provide a valid address (e.g., http://192.168.1.100:32400)',
-    });
+    throw trpcError('BAD_REQUEST', 'media.plex.invalidUrl');
   }
   return final;
 }
@@ -57,10 +53,7 @@ async function validateConnection(url: string, token: string | undefined): Promi
     }
   } catch (err) {
     console.error(`[Plex] Connection validation failed for ${url}:`, err);
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: `Could not connect to Plex server at ${url}. Verify the address is correct and the server is reachable.`,
-    });
+    throw trpcError('BAD_REQUEST', 'media.plex.connectionFailed', { url });
   }
 }
 
@@ -94,10 +87,12 @@ export const connectionProcedures = {
       return { data: await client.getLibraries() };
     } catch (err) {
       if (err instanceof PlexApiError) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: `Plex API error: ${err.message}`,
-        });
+        throw trpcError(
+          'INTERNAL_SERVER_ERROR',
+          'media.plex.apiError',
+          { detail: err.message },
+          err
+        );
       }
       throw err;
     }

--- a/apps/pops-api/src/modules/media/plex/router-helpers.ts
+++ b/apps/pops-api/src/modules/media/plex/router-helpers.ts
@@ -1,5 +1,4 @@
-import { TRPCError } from '@trpc/server';
-
+import { trpcError } from '../../../shared/trpc-error.js';
 import * as plexService from './service.js';
 
 import type { Job } from 'bullmq';
@@ -39,10 +38,7 @@ export interface SyncJob {
 export function requirePlexClient(): PlexClient {
   const client = plexService.getPlexClient();
   if (!client) {
-    throw new TRPCError({
-      code: 'PRECONDITION_FAILED',
-      message: 'Plex is not configured. Connect to Plex in settings first.',
-    });
+    throw trpcError('PRECONDITION_FAILED', 'media.plex.notConfigured');
   }
   return client;
 }

--- a/apps/pops-api/src/modules/media/rotation/download-candidate.ts
+++ b/apps/pops-api/src/modules/media/rotation/download-candidate.ts
@@ -1,9 +1,9 @@
-import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
 
 import { movies, rotationCandidates, settings } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { trpcError } from '../../../shared/trpc-error.js';
 import { getRadarrClient } from '../arr/service.js';
 import { addMovie as addMovieToLibrary } from '../library/service.js';
 import { getImageCache, getTmdbClient } from '../tmdb/index.js';
@@ -21,12 +21,11 @@ function loadCandidate(candidateId: number): typeof rotationCandidates.$inferSel
     .where(eq(rotationCandidates.id, candidateId))
     .get();
   if (!candidate) {
-    throw new TRPCError({ code: 'NOT_FOUND', message: 'Candidate not found' });
+    throw trpcError('NOT_FOUND', 'media.rotation.candidateNotFound');
   }
   if (candidate.status !== 'pending') {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: `Candidate is already ${candidate.status}`,
+    throw trpcError('BAD_REQUEST', 'media.rotation.candidateAlreadyProcessed', {
+      status: candidate.status,
     });
   }
   return candidate;
@@ -45,10 +44,7 @@ function loadRadarrConfig(): RadarrConfig {
     .where(eq(settings.key, 'rotation_root_folder_path'))
     .get()?.value;
   if (!qualityProfileId || !rootFolderPath) {
-    throw new TRPCError({
-      code: 'PRECONDITION_FAILED',
-      message: 'Radarr quality profile or root folder not configured',
-    });
+    throw trpcError('PRECONDITION_FAILED', 'media.rotation.radarrConfigMissing');
   }
   return { qualityProfileId: Number(qualityProfileId), rootFolderPath };
 }
@@ -61,7 +57,7 @@ export async function downloadCandidateImpl(
 
   const client = getRadarrClient();
   if (!client) {
-    throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'Radarr not configured' });
+    throw trpcError('PRECONDITION_FAILED', 'media.rotation.radarrNotConfigured');
   }
 
   const config = loadRadarrConfig();

--- a/apps/pops-api/src/modules/media/rotation/rotation-candidates-router.ts
+++ b/apps/pops-api/src/modules/media/rotation/rotation-candidates-router.ts
@@ -1,10 +1,10 @@
-import { TRPCError } from '@trpc/server';
 import { and, count, desc, eq, like, sql } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { rotationCandidates, rotationExclusions, rotationSources } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure } from '../../../trpc.js';
 import { downloadCandidateImpl } from './download-candidate.js';
 import { rotationExclusionsProcedures } from './rotation-exclusions-router.js';
@@ -34,10 +34,7 @@ export const rotationCandidatesProcedures = {
           .get();
 
         if (excluded) {
-          throw new TRPCError({
-            code: 'CONFLICT',
-            message: 'Movie is excluded from rotation',
-          });
+          throw trpcError('CONFLICT', 'media.rotation.movieExcludedFromRotation');
         }
 
         let manualSource = tx

--- a/apps/pops-api/src/modules/media/rotation/rotation-sources-router.ts
+++ b/apps/pops-api/src/modules/media/rotation/rotation-sources-router.ts
@@ -1,10 +1,10 @@
-import { TRPCError } from '@trpc/server';
 import { count, desc, eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { rotationCandidates, rotationSources } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure } from '../../../trpc.js';
 import { fetchPlexFriends } from '../plex/friends.js';
 import { getPlexToken } from '../plex/service.js';
@@ -115,7 +115,7 @@ export const rotationSourcesProcedures = {
         updates.syncIntervalHours = input.syncIntervalHours;
 
       if (Object.keys(updates).length === 0) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No fields to update' });
+        throw trpcError('BAD_REQUEST', 'common.noFieldsToUpdate');
       }
 
       const result = db
@@ -140,10 +140,10 @@ export const rotationSourcesProcedures = {
         .get();
 
       if (!source) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Source not found' });
+        throw trpcError('NOT_FOUND', 'media.rotation.sourceNotFound');
       }
       if (source.type === 'manual') {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot delete the manual source' });
+        throw trpcError('FORBIDDEN', 'media.rotation.cannotDeleteManualSource');
       }
 
       db.transaction((tx) => {

--- a/apps/pops-api/src/shared/error-messages.test.ts
+++ b/apps/pops-api/src/shared/error-messages.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { ERROR_MESSAGES, errorMessage } from './error-messages.js';
+
+describe('errorMessage()', () => {
+  it('returns the template verbatim when there are no placeholders', () => {
+    expect(errorMessage('finance.import.sessionNotFound')).toBe('Import session not found');
+  });
+
+  it('interpolates a single placeholder', () => {
+    expect(errorMessage('media.library.movieNotFoundOnTmdb', { tmdbId: '550' })).toBe(
+      'Movie not found on TMDB (ID: 550)'
+    );
+  });
+
+  it('interpolates multiple placeholders', () => {
+    expect(errorMessage('common.notFound', { resource: 'Budget', id: '42' })).toBe(
+      "Budget '42' not found"
+    );
+  });
+
+  it('replaces missing param placeholders with empty string', () => {
+    const result = errorMessage('media.arr.apiError', { service: 'Radarr' });
+    expect(result).toBe('Radarr error: ');
+  });
+
+  it('handles templates with escaped single quotes', () => {
+    expect(errorMessage('cerebrum.nudge.notFound', { id: 'abc-123' })).toBe(
+      "Nudge 'abc-123' not found"
+    );
+  });
+
+  it('returns unmodified template when params is undefined', () => {
+    expect(errorMessage('common.validationFailed')).toBe('Validation failed');
+  });
+});
+
+describe('ERROR_MESSAGES registry', () => {
+  it('contains at least 30 keys', () => {
+    expect(Object.keys(ERROR_MESSAGES).length).toBeGreaterThanOrEqual(30);
+  });
+
+  it('every value is a non-empty string', () => {
+    for (const [key, value] of Object.entries(ERROR_MESSAGES)) {
+      expect(typeof value).toBe('string');
+      expect(value.length, `key "${key}" has empty message`).toBeGreaterThan(0);
+    }
+  });
+
+  it('keys follow dotted namespace convention', () => {
+    for (const key of Object.keys(ERROR_MESSAGES)) {
+      expect(key).toMatch(/^[a-z]+(\.[a-zA-Z]+)+$/);
+    }
+  });
+});

--- a/apps/pops-api/src/shared/error-messages.ts
+++ b/apps/pops-api/src/shared/error-messages.ts
@@ -1,0 +1,115 @@
+/**
+ * i18n-compatible error message registry.
+ *
+ * Each key maps to an EN-AU message template. Interpolation placeholders use
+ * `{{name}}` syntax so both server-side and client-side formatters can resolve
+ * them consistently.
+ *
+ * The server always returns the EN-AU string in the `message` field and the
+ * error key in a `messageKey` field. The frontend translates using the key.
+ */
+
+/** All valid error message keys. */
+export type ErrorMessageKey = keyof typeof ERROR_MESSAGES;
+
+/**
+ * Registry of error keys → EN-AU message templates.
+ *
+ * Organised by domain: common, finance, media, inventory, cerebrum, core.
+ */
+export const ERROR_MESSAGES = {
+  // ── Common / generic ────────────────────────────────────────────────
+  'common.notFound': "{{resource}} '{{id}}' not found",
+  'common.conflict': '{{resource}} already exists',
+  'common.validationFailed': 'Validation failed',
+  'common.noFieldsToUpdate': 'No fields to update',
+  'common.internalError': 'An unexpected error occurred',
+
+  // ── Finance ─────────────────────────────────────────────────────────
+  'finance.import.sessionNotFound': 'Import session not found',
+  'finance.import.sessionNotReady': 'Import session is not ready for re-evaluation',
+  'finance.import.sessionNotProcessResult': 'Import session result is not a processImport result',
+  'finance.import.commitValidationFailed': 'Import commit validation failed: {{detail}}',
+
+  // ── Media — Library ─────────────────────────────────────────────────
+  'media.library.movieNotFoundOnTmdb': 'Movie not found on TMDB (ID: {{tmdbId}})',
+  'media.library.tmdbApiError': 'TMDB API error: {{detail}}',
+  'media.library.tvdbApiError': 'TheTVDB API error: {{detail}}',
+
+  // ── Media — Plex ────────────────────────────────────────────────────
+  'media.plex.notConfigured': 'Plex is not configured. Connect to Plex in settings first.',
+  'media.plex.invalidUrl':
+    'Invalid URL format. Please provide a valid address (e.g., http://192.168.1.100:32400)',
+  'media.plex.connectionFailed':
+    'Could not connect to Plex server at {{url}}. Verify the address is correct and the server is reachable.',
+  'media.plex.apiError': 'Plex API error: {{detail}}',
+  'media.plex.pinFailed': 'Failed to get Plex PIN (HTTP {{status}})',
+  'media.plex.pinCheckFailed': 'Failed to check Plex PIN (HTTP {{status}})',
+  'media.plex.pinNotFound': 'Invalid or expired PIN ID',
+
+  // ── Media — Arr (Radarr/Sonarr) ────────────────────────────────────
+  'media.arr.radarrNotConfigured': 'Radarr is not configured',
+  'media.arr.sonarrNotConfigured': 'Sonarr is not configured',
+  'media.arr.apiError': '{{service}} error: {{detail}}',
+  'media.arr.serviceNotConfigured': '{{service}} not configured',
+
+  // ── Media — Rotation ────────────────────────────────────────────────
+  'media.rotation.candidateNotFound': 'Candidate not found',
+  'media.rotation.candidateAlreadyProcessed': 'Candidate is already {{status}}',
+  'media.rotation.radarrConfigMissing': 'Radarr quality profile or root folder not configured',
+  'media.rotation.radarrNotConfigured': 'Radarr not configured',
+  'media.rotation.sourceNotFound': 'Source not found',
+  'media.rotation.cannotDeleteManualSource': 'Cannot delete the manual source',
+  'media.rotation.movieExcludedFromRotation': 'Movie is excluded from rotation',
+
+  // ── Media — Retrieval / Search ──────────────────────────────────────
+  'media.retrieval.queryRequired': 'Query is required for semantic and hybrid search modes',
+  'media.retrieval.filterRequired': 'Structured search requires at least one filter',
+  'media.retrieval.contextQueryRequired': 'Query is required for context assembly',
+
+  // ── Inventory ───────────────────────────────────────────────────────
+  'inventory.reports.insuranceReportFailed': 'Failed to generate insurance report: {{detail}}',
+  'inventory.reports.valueByLocationFailed':
+    'Failed to load value by location breakdown: {{detail}}',
+  'inventory.reports.valueByTypeFailed': 'Failed to load value by type breakdown: {{detail}}',
+  'inventory.paperless.notConfigured': 'Paperless-ngx is not configured',
+  'inventory.paperless.apiError': 'Paperless error: {{detail}}',
+
+  // ── Cerebrum — Nudges ───────────────────────────────────────────────
+  'cerebrum.nudge.notFound': "Nudge '{{id}}' not found",
+  'cerebrum.nudge.notPendingOrMissing': "Nudge '{{id}}' is not pending or does not exist",
+
+  // ── Cerebrum — Templates ────────────────────────────────────────────
+  'cerebrum.template.notFound': "Template '{{name}}' not found",
+
+  // ── Cerebrum — Reflex ───────────────────────────────────────────────
+  'cerebrum.reflex.notFound': 'Reflex "{{name}}" not found',
+
+  // ── Cerebrum — Emit ─────────────────────────────────────────────────
+  'cerebrum.emit.invalidDateRange': 'Invalid date range: from must be before or equal to to',
+  'cerebrum.emit.queryRequiredForReport': 'Query is required for report mode',
+  'cerebrum.emit.dateRangeRequiredForSummary': 'Date range is required for summary mode',
+
+  // ── Core — Corrections ──────────────────────────────────────────────
+  'core.corrections.revisionFailed': 'Failed to revise ChangeSet: {{detail}}',
+  'core.corrections.revisionFailedGeneric': 'Failed to revise ChangeSet',
+} as const;
+
+/** Interpolation params — a simple string record. */
+export type ErrorMessageParams = Record<string, string>;
+
+/**
+ * Resolve an error message key to its EN-AU string, interpolating any
+ * `{{placeholder}}` tokens with the given params.
+ *
+ * @example
+ * ```ts
+ * errorMessage('common.notFound', { resource: 'Budget', id: '42' });
+ * // → "Budget '42' not found"
+ * ```
+ */
+export function errorMessage(key: ErrorMessageKey, params?: ErrorMessageParams): string {
+  const template: string = ERROR_MESSAGES[key];
+  if (!params) return template;
+  return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) => params[name] ?? '');
+}

--- a/apps/pops-api/src/shared/errors.ts
+++ b/apps/pops-api/src/shared/errors.ts
@@ -1,36 +1,46 @@
 /**
  * Custom HTTP error classes.
  * Thrown from service/route layers, caught by the global error handler.
+ *
+ * Each error carries an optional `messageKey` so the frontend can look up the
+ * translated string while the EN-AU fallback lives in `message`.
  */
 
+import type { ErrorMessageKey } from './error-messages.js';
+
 export class HttpError extends Error {
+  /** i18n key the frontend uses to resolve a localised message. */
+  public readonly messageKey?: ErrorMessageKey;
+
   constructor(
     public readonly statusCode: number,
     message: string,
-    public readonly details?: unknown
+    public readonly details?: unknown,
+    messageKey?: ErrorMessageKey
   ) {
     super(message);
     this.name = 'HttpError';
+    this.messageKey = messageKey;
   }
 }
 
 export class NotFoundError extends HttpError {
   constructor(resource: string, id: string) {
-    super(404, `${resource} '${id}' not found`);
+    super(404, `${resource} '${id}' not found`, undefined, 'common.notFound');
     this.name = 'NotFoundError';
   }
 }
 
 export class ValidationError extends HttpError {
   constructor(details: unknown) {
-    super(400, 'Validation failed', details);
+    super(400, 'Validation failed', details, 'common.validationFailed');
     this.name = 'ValidationError';
   }
 }
 
 export class ConflictError extends HttpError {
   constructor(message: string) {
-    super(409, message);
+    super(409, message, undefined, 'common.conflict');
     this.name = 'ConflictError';
   }
 }

--- a/apps/pops-api/src/shared/index.ts
+++ b/apps/pops-api/src/shared/index.ts
@@ -1,5 +1,7 @@
+export * from './error-messages.js';
 export * from './errors.js';
 export * from './pagination.js';
+export * from './trpc-error.js';
 export * from './params.js';
 export * from './types.js';
 export * from './validate.js';

--- a/apps/pops-api/src/shared/trpc-error.test.ts
+++ b/apps/pops-api/src/shared/trpc-error.test.ts
@@ -1,0 +1,32 @@
+import { TRPCError } from '@trpc/server';
+import { describe, expect, it } from 'vitest';
+
+import { trpcError } from './trpc-error.js';
+
+describe('trpcError()', () => {
+  it('creates a TRPCError with the correct code and resolved message', () => {
+    const err = trpcError('NOT_FOUND', 'common.notFound', { resource: 'Budget', id: '42' });
+    expect(err).toBeInstanceOf(TRPCError);
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.message).toBe("Budget '42' not found");
+  });
+
+  it('attaches messageKey on the cause', () => {
+    const err = trpcError('BAD_REQUEST', 'common.validationFailed');
+    expect(err.cause).toBeDefined();
+    expect(err.cause).toBeInstanceOf(Error);
+    expect(err.cause).toHaveProperty('messageKey', 'common.validationFailed');
+  });
+
+  it('works without params for parameterless messages', () => {
+    const err = trpcError('NOT_FOUND', 'finance.import.sessionNotFound');
+    expect(err.message).toBe('Import session not found');
+  });
+
+  it('passes through an original cause', () => {
+    const original = new Error('db failure');
+    const err = trpcError('INTERNAL_SERVER_ERROR', 'common.internalError', undefined, original);
+    expect(err.cause).toBeInstanceOf(Error);
+    expect(err.cause).toHaveProperty('cause', original);
+  });
+});

--- a/apps/pops-api/src/shared/trpc-error.ts
+++ b/apps/pops-api/src/shared/trpc-error.ts
@@ -1,0 +1,43 @@
+/**
+ * Helper to create a TRPCError with an i18n `messageKey` attached.
+ *
+ * The `messageKey` travels through TRPCError.cause and is surfaced by the
+ * custom `errorFormatter` in `trpc.ts` so the frontend can look it up in
+ * its translation files.
+ */
+import { TRPCError } from '@trpc/server';
+
+import { errorMessage } from './error-messages.js';
+
+import type { ErrorMessageKey, ErrorMessageParams } from './error-messages.js';
+
+/** Lightweight carrier so the errorFormatter can read `messageKey`. */
+class MessageKeyCause extends Error {
+  constructor(
+    public readonly messageKey: ErrorMessageKey,
+    originalCause?: unknown
+  ) {
+    super(messageKey);
+    this.name = 'MessageKeyCause';
+    if (originalCause !== undefined) {
+      this.cause = originalCause;
+    }
+  }
+}
+
+/**
+ * Build a `TRPCError` whose `message` is the resolved EN-AU string and whose
+ * `cause` carries the `messageKey` for the frontend i18n layer.
+ */
+export function trpcError(
+  code: ConstructorParameters<typeof TRPCError>[0]['code'],
+  key: ErrorMessageKey,
+  params?: ErrorMessageParams,
+  cause?: unknown
+): TRPCError {
+  return new TRPCError({
+    code,
+    message: errorMessage(key, params),
+    cause: new MessageKeyCause(key, cause),
+  });
+}

--- a/apps/pops-api/src/trpc.ts
+++ b/apps/pops-api/src/trpc.ts
@@ -66,7 +66,24 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
 
 export type ContextType = Awaited<ReturnType<typeof createContext>>;
 
-const t = initTRPC.context<Context>().meta<OpenApiMeta>().create();
+const t = initTRPC
+  .context<Context>()
+  .meta<OpenApiMeta>()
+  .create({
+    errorFormatter({ shape, error }) {
+      return {
+        ...shape,
+        data: {
+          ...shape.data,
+          /** i18n key for frontend translation lookup. */
+          messageKey:
+            error.cause instanceof Error && 'messageKey' in error.cause
+              ? (error.cause as { messageKey: string }).messageKey
+              : undefined,
+        },
+      };
+    },
+  });
 
 /** Base router for composing routers. */
 export const router = t.router;

--- a/apps/pops-shell/src/i18n/locales/en-AU/errors.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/errors.json
@@ -1,0 +1,61 @@
+{
+  "common.notFound": "{{resource}} '{{id}}' not found",
+  "common.conflict": "{{resource}} already exists",
+  "common.validationFailed": "Validation failed",
+  "common.noFieldsToUpdate": "No fields to update",
+  "common.internalError": "An unexpected error occurred",
+
+  "finance.import.sessionNotFound": "Import session not found",
+  "finance.import.sessionNotReady": "Import session is not ready for re-evaluation",
+  "finance.import.sessionNotProcessResult": "Import session result is not a processImport result",
+  "finance.import.commitValidationFailed": "Import commit validation failed: {{detail}}",
+
+  "media.library.movieNotFoundOnTmdb": "Movie not found on TMDB (ID: {{tmdbId}})",
+  "media.library.tmdbApiError": "TMDB API error: {{detail}}",
+  "media.library.tvdbApiError": "TheTVDB API error: {{detail}}",
+
+  "media.plex.notConfigured": "Plex is not configured. Connect to Plex in settings first.",
+  "media.plex.invalidUrl": "Invalid URL format. Please provide a valid address (e.g., http://192.168.1.100:32400)",
+  "media.plex.connectionFailed": "Could not connect to Plex server at {{url}}. Verify the address is correct and the server is reachable.",
+  "media.plex.apiError": "Plex API error: {{detail}}",
+  "media.plex.pinFailed": "Failed to get Plex PIN (HTTP {{status}})",
+  "media.plex.pinCheckFailed": "Failed to check Plex PIN (HTTP {{status}})",
+  "media.plex.pinNotFound": "Invalid or expired PIN ID",
+
+  "media.arr.radarrNotConfigured": "Radarr is not configured",
+  "media.arr.sonarrNotConfigured": "Sonarr is not configured",
+  "media.arr.apiError": "{{service}} error: {{detail}}",
+  "media.arr.serviceNotConfigured": "{{service}} not configured",
+
+  "media.rotation.candidateNotFound": "Candidate not found",
+  "media.rotation.candidateAlreadyProcessed": "Candidate is already {{status}}",
+  "media.rotation.radarrConfigMissing": "Radarr quality profile or root folder not configured",
+  "media.rotation.radarrNotConfigured": "Radarr not configured",
+  "media.rotation.sourceNotFound": "Source not found",
+  "media.rotation.cannotDeleteManualSource": "Cannot delete the manual source",
+  "media.rotation.movieExcludedFromRotation": "Movie is excluded from rotation",
+
+  "media.retrieval.queryRequired": "Query is required for semantic and hybrid search modes",
+  "media.retrieval.filterRequired": "Structured search requires at least one filter",
+  "media.retrieval.contextQueryRequired": "Query is required for context assembly",
+
+  "inventory.reports.insuranceReportFailed": "Failed to generate insurance report: {{detail}}",
+  "inventory.reports.valueByLocationFailed": "Failed to load value by location breakdown: {{detail}}",
+  "inventory.reports.valueByTypeFailed": "Failed to load value by type breakdown: {{detail}}",
+  "inventory.paperless.notConfigured": "Paperless-ngx is not configured",
+  "inventory.paperless.apiError": "Paperless error: {{detail}}",
+
+  "cerebrum.nudge.notFound": "Nudge '{{id}}' not found",
+  "cerebrum.nudge.notPendingOrMissing": "Nudge '{{id}}' is not pending or does not exist",
+
+  "cerebrum.template.notFound": "Template '{{name}}' not found",
+
+  "cerebrum.reflex.notFound": "Reflex \"{{name}}\" not found",
+
+  "cerebrum.emit.invalidDateRange": "Invalid date range: from must be before or equal to to",
+  "cerebrum.emit.queryRequiredForReport": "Query is required for report mode",
+  "cerebrum.emit.dateRangeRequiredForSummary": "Date range is required for summary mode",
+
+  "core.corrections.revisionFailed": "Failed to revise ChangeSet: {{detail}}",
+  "core.corrections.revisionFailedGeneric": "Failed to revise ChangeSet"
+}

--- a/apps/pops-shell/src/i18n/locales/pt-BR/errors.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/errors.json
@@ -1,0 +1,61 @@
+{
+  "common.notFound": "{{resource}} '{{id}}' não encontrado(a)",
+  "common.conflict": "{{resource}} já existe",
+  "common.validationFailed": "Falha na validação",
+  "common.noFieldsToUpdate": "Nenhum campo para atualizar",
+  "common.internalError": "Ocorreu um erro inesperado",
+
+  "finance.import.sessionNotFound": "Sessão de importação não encontrada",
+  "finance.import.sessionNotReady": "A sessão de importação não está pronta para reavaliação",
+  "finance.import.sessionNotProcessResult": "O resultado da sessão de importação não é um resultado de processImport",
+  "finance.import.commitValidationFailed": "Falha na validação do commit da importação: {{detail}}",
+
+  "media.library.movieNotFoundOnTmdb": "Filme não encontrado no TMDB (ID: {{tmdbId}})",
+  "media.library.tmdbApiError": "Erro na API do TMDB: {{detail}}",
+  "media.library.tvdbApiError": "Erro na API do TheTVDB: {{detail}}",
+
+  "media.plex.notConfigured": "O Plex não está configurado. Conecte-se ao Plex nas configurações primeiro.",
+  "media.plex.invalidUrl": "Formato de URL inválido. Forneça um endereço válido (ex: http://192.168.1.100:32400)",
+  "media.plex.connectionFailed": "Não foi possível conectar ao servidor Plex em {{url}}. Verifique se o endereço está correto e o servidor está acessível.",
+  "media.plex.apiError": "Erro na API do Plex: {{detail}}",
+  "media.plex.pinFailed": "Falha ao obter PIN do Plex (HTTP {{status}})",
+  "media.plex.pinCheckFailed": "Falha ao verificar PIN do Plex (HTTP {{status}})",
+  "media.plex.pinNotFound": "PIN inválido ou expirado",
+
+  "media.arr.radarrNotConfigured": "O Radarr não está configurado",
+  "media.arr.sonarrNotConfigured": "O Sonarr não está configurado",
+  "media.arr.apiError": "Erro do {{service}}: {{detail}}",
+  "media.arr.serviceNotConfigured": "{{service}} não configurado",
+
+  "media.rotation.candidateNotFound": "Candidato não encontrado",
+  "media.rotation.candidateAlreadyProcessed": "O candidato já está com status {{status}}",
+  "media.rotation.radarrConfigMissing": "Perfil de qualidade ou pasta raiz do Radarr não configurados",
+  "media.rotation.radarrNotConfigured": "Radarr não configurado",
+  "media.rotation.sourceNotFound": "Fonte não encontrada",
+  "media.rotation.cannotDeleteManualSource": "Não é possível excluir a fonte manual",
+  "media.rotation.movieExcludedFromRotation": "Filme excluído da rotação",
+
+  "media.retrieval.queryRequired": "A consulta é obrigatória para os modos de busca semântica e híbrida",
+  "media.retrieval.filterRequired": "A busca estruturada requer pelo menos um filtro",
+  "media.retrieval.contextQueryRequired": "A consulta é obrigatória para montagem de contexto",
+
+  "inventory.reports.insuranceReportFailed": "Falha ao gerar relatório de seguro: {{detail}}",
+  "inventory.reports.valueByLocationFailed": "Falha ao carregar detalhamento de valor por localização: {{detail}}",
+  "inventory.reports.valueByTypeFailed": "Falha ao carregar detalhamento de valor por tipo: {{detail}}",
+  "inventory.paperless.notConfigured": "O Paperless-ngx não está configurado",
+  "inventory.paperless.apiError": "Erro do Paperless: {{detail}}",
+
+  "cerebrum.nudge.notFound": "Nudge '{{id}}' não encontrado",
+  "cerebrum.nudge.notPendingOrMissing": "Nudge '{{id}}' não está pendente ou não existe",
+
+  "cerebrum.template.notFound": "Template '{{name}}' não encontrado",
+
+  "cerebrum.reflex.notFound": "Reflexo \"{{name}}\" não encontrado",
+
+  "cerebrum.emit.invalidDateRange": "Intervalo de datas inválido: a data inicial deve ser anterior ou igual à final",
+  "cerebrum.emit.queryRequiredForReport": "A consulta é obrigatória para o modo relatório",
+  "cerebrum.emit.dateRangeRequiredForSummary": "O intervalo de datas é obrigatório para o modo resumo",
+
+  "core.corrections.revisionFailed": "Falha ao revisar ChangeSet: {{detail}}",
+  "core.corrections.revisionFailedGeneric": "Falha ao revisar ChangeSet"
+}


### PR DESCRIPTION
## Summary

- Create an error message registry (`apps/pops-api/src/shared/error-messages.ts`) with 46 keyed EN-AU message templates organised by domain (common, finance, media, inventory, cerebrum, core)
- Create `trpcError()` helper that resolves the EN-AU message and attaches a `messageKey` via `TRPCError.cause` for frontend i18n lookup
- Add custom `errorFormatter` to tRPC init that surfaces `messageKey` in the error shape sent to the frontend
- Add `messageKey` field to `HttpError` base class for service-layer errors (e.g. `NotFoundError` carries `common.notFound`)
- Replace hardcoded error strings with error keys across 17 router/helper files spanning finance, media, inventory, cerebrum, and core modules
- Create `en-AU` and `pt-BR` locale JSON files for the frontend translation layer at `apps/pops-shell/src/i18n/locales/`
- Add comprehensive tests for `errorMessage()` and `trpcError()` (13 test cases)

Closes #2263

## Test plan

- [x] `errorMessage()` unit tests: template interpolation, missing params, no-placeholder messages
- [x] `trpcError()` unit tests: correct code, resolved message, messageKey propagation, cause chaining
- [x] All 1998 existing test cases pass (no regressions)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — all 17 packages pass
- [x] `pnpm format:check` — clean
- [ ] Verify `messageKey` appears in tRPC error responses by calling an endpoint that triggers an error
- [ ] Verify frontend can read `error.data.messageKey` from tRPC client errors