### PR TITLE
feat(features): feature toggles framework (PRD-094)

### DIFF
--- a/apps/pops-api/src/db/drizzle-migrations/0043_user_settings.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0043_user_settings.sql
@@ -1,0 +1,9 @@
+-- Per-user preferences (PRD-094 US-05).
+CREATE TABLE `user_settings` (
+	`user_email` text NOT NULL,
+	`key` text NOT NULL,
+	`value` text NOT NULL,
+	PRIMARY KEY(`user_email`, `key`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_user_settings_user` ON `user_settings` (`user_email`);

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1777547400000,
       "tag": "0042_strip_quoted_movie_titles",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "6",
+      "when": 1777629600000,
+      "tag": "0043_user_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -528,6 +528,14 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
       value TEXT NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS user_settings (
+      user_email TEXT NOT NULL,
+      key        TEXT NOT NULL,
+      value      TEXT NOT NULL,
+      PRIMARY KEY (user_email, key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_user_settings_user ON user_settings(user_email);
+
     CREATE TABLE IF NOT EXISTS sync_logs (
       id            INTEGER PRIMARY KEY AUTOINCREMENT,
       synced_at     TEXT NOT NULL,

--- a/apps/pops-api/src/modules/core/features/credentials.ts
+++ b/apps/pops-api/src/modules/core/features/credentials.ts
@@ -1,0 +1,63 @@
+import { getEnv } from '../../../env.js';
+import { settingsRegistry } from '../settings/registry.js';
+import { getSettingOrNull } from '../settings/service.js';
+
+import type { FeatureCredentialStatus, FeatureDefinition, SettingsField } from '@pops/types';
+
+/** Find the SettingsField (across all settings manifests) for a given key. */
+function findSettingsField(key: string): SettingsField | null {
+  for (const manifest of settingsRegistry.getAll()) {
+    for (const group of manifest.groups) {
+      const field = group.fields.find((f) => f.key === key);
+      if (field) return field;
+    }
+  }
+  return null;
+}
+
+/** Resolve a setting key's value via DB then envFallback. */
+function resolveSettingCredential(key: string): FeatureCredentialStatus {
+  const dbRow = getSettingOrNull(key);
+  if (dbRow && dbRow.value !== '') {
+    return { key, source: 'database' };
+  }
+
+  const field = findSettingsField(key);
+  const envVar = field?.envFallback;
+  if (envVar) {
+    const envValue = getEnv(envVar);
+    if (envValue && envValue !== '') {
+      return { key, source: 'environment', envVar };
+    }
+    return { key, source: 'missing', envVar };
+  }
+
+  return { key, source: 'missing' };
+}
+
+/** Resolve an env-only credential. */
+function resolveEnvCredential(envVar: string): FeatureCredentialStatus {
+  const envValue = getEnv(envVar);
+  if (envValue && envValue !== '') {
+    return { key: envVar, source: 'environment', envVar };
+  }
+  return { key: envVar, source: 'missing', envVar };
+}
+
+export interface ResolvedCredentials {
+  credentials: FeatureCredentialStatus[];
+  allConfigured: boolean;
+}
+
+/** Resolve all `requires` and `requiresEnv` for a feature. */
+export function resolveCredentials(feature: FeatureDefinition): ResolvedCredentials {
+  const credentials: FeatureCredentialStatus[] = [];
+  for (const key of feature.requires ?? []) {
+    credentials.push(resolveSettingCredential(key));
+  }
+  for (const envVar of feature.requiresEnv ?? []) {
+    credentials.push(resolveEnvCredential(envVar));
+  }
+  const allConfigured = credentials.every((c) => c.source !== 'missing');
+  return { credentials, allConfigured };
+}

--- a/apps/pops-api/src/modules/core/features/errors.ts
+++ b/apps/pops-api/src/modules/core/features/errors.ts
@@ -1,0 +1,29 @@
+import type { FeatureCredentialStatus } from '@pops/types';
+
+export class FeatureNotFoundError extends Error {
+  constructor(key: string) {
+    super(`Unknown feature "${key}"`);
+    this.name = 'FeatureNotFoundError';
+  }
+}
+
+export class FeatureGateError extends Error {
+  constructor(
+    public readonly key: string,
+    public readonly missing: FeatureCredentialStatus[]
+  ) {
+    super(
+      `Feature "${key}" cannot be enabled — missing: ${missing
+        .map((m) => m.envVar ?? m.key)
+        .join(', ')}`
+    );
+    this.name = 'FeatureGateError';
+  }
+}
+
+export class FeatureScopeError extends Error {
+  constructor(key: string, expected: string, actual: string) {
+    super(`Feature "${key}" has scope "${actual}", expected "${expected}"`);
+    this.name = 'FeatureScopeError';
+  }
+}

--- a/apps/pops-api/src/modules/core/features/index.ts
+++ b/apps/pops-api/src/modules/core/features/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Feature toggles module (PRD-094).
+ */
+export { featuresRegistry, FeaturesRegistry } from './registry.js';
+export {
+  clearUserPreference,
+  FeatureGateError,
+  FeatureNotFoundError,
+  FeatureScopeError,
+  isEnabled,
+  listFeatures,
+  setFeatureEnabled,
+  setUserPreference,
+} from './service.js';
+export { featuresRouter } from './router.js';

--- a/apps/pops-api/src/modules/core/features/manifest.ts
+++ b/apps/pops-api/src/modules/core/features/manifest.ts
@@ -1,0 +1,36 @@
+import { isVecAvailable } from '../../../db.js';
+import { getRedisStatus } from '../../../redis.js';
+
+import type { FeatureManifest } from '@pops/types';
+
+/**
+ * Core feature manifest — capability-only flags for runtime infra (Redis,
+ * sqlite-vec). These are not user-toggleable; they reflect runtime probes.
+ */
+export const coreFeaturesManifest: FeatureManifest = {
+  id: 'core',
+  title: 'Core',
+  icon: 'Cpu',
+  order: 100,
+  features: [
+    {
+      key: 'core.redis',
+      label: 'Redis',
+      description:
+        'Job queues and request cache. When unavailable, the API runs in degraded mode (queues + cache disabled).',
+      default: true,
+      scope: 'capability',
+      capabilityCheck: () => getRedisStatus() === 'ready',
+      requiresEnv: ['REDIS_HOST'],
+    },
+    {
+      key: 'cerebrum.vectorSearch',
+      label: 'Vector search (sqlite-vec)',
+      description:
+        'Semantic and hybrid retrieval. Disabled when the sqlite-vec extension fails to load at startup.',
+      default: true,
+      scope: 'capability',
+      capabilityCheck: () => isVecAvailable(),
+    },
+  ],
+};

--- a/apps/pops-api/src/modules/core/features/registry.test.ts
+++ b/apps/pops-api/src/modules/core/features/registry.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { FeaturesRegistry } from './registry.js';
+
+import type { FeatureManifest } from '@pops/types';
+
+function makeManifest(id: string, order: number, keys: string[]): FeatureManifest {
+  return {
+    id,
+    title: id,
+    order,
+    features: keys.map((key) => ({
+      key,
+      label: key,
+      default: false,
+      scope: 'system',
+    })),
+  };
+}
+
+describe('FeaturesRegistry', () => {
+  it('returns manifests sorted by order', () => {
+    const registry = new FeaturesRegistry();
+    registry.register(makeManifest('beta', 200, ['beta.x']));
+    registry.register(makeManifest('alpha', 100, ['alpha.x']));
+    expect(registry.getAll().map((m) => m.id)).toEqual(['alpha', 'beta']);
+  });
+
+  it('rejects duplicate manifest IDs', () => {
+    const registry = new FeaturesRegistry();
+    registry.register(makeManifest('alpha', 100, ['alpha.x']));
+    expect(() => registry.register(makeManifest('alpha', 200, ['alpha.y']))).toThrow(
+      /alpha.*already registered/
+    );
+  });
+
+  it('rejects duplicate feature keys across manifests', () => {
+    const registry = new FeaturesRegistry();
+    registry.register(makeManifest('first', 100, ['shared.key', 'a']));
+    expect(() => registry.register(makeManifest('second', 200, ['b', 'shared.key']))).toThrow(
+      /(?=.*shared\.key)(?=.*first)(?=.*second)/
+    );
+  });
+
+  it('rejects duplicate feature keys within a manifest', () => {
+    const registry = new FeaturesRegistry();
+    expect(() => registry.register(makeManifest('m', 1, ['x', 'x']))).toThrow(/more than once/);
+  });
+
+  it('getFeature returns the manifest + feature pair', () => {
+    const registry = new FeaturesRegistry();
+    const manifest = makeManifest('alpha', 100, ['alpha.x']);
+    registry.register(manifest);
+    const found = registry.getFeature('alpha.x');
+    expect(found?.feature.key).toBe('alpha.x');
+    expect(found?.manifest.id).toBe('alpha');
+  });
+
+  it('getFeature returns null for unknown keys', () => {
+    const registry = new FeaturesRegistry();
+    expect(registry.getFeature('nope')).toBeNull();
+  });
+
+  it('clear removes all manifests', () => {
+    const registry = new FeaturesRegistry();
+    registry.register(makeManifest('m', 1, ['x']));
+    registry.clear();
+    expect(registry.getAll()).toEqual([]);
+  });
+});

--- a/apps/pops-api/src/modules/core/features/registry.ts
+++ b/apps/pops-api/src/modules/core/features/registry.ts
@@ -1,0 +1,65 @@
+import type { FeatureManifest } from '@pops/types';
+
+/**
+ * Process-wide registry of feature manifests. Each module registers its
+ * manifest at startup; duplicates (manifest IDs or feature keys) are rejected
+ * with a descriptive error so that conflicts surface immediately.
+ *
+ * Mirrors the SettingsRegistry contract from PRD-093.
+ */
+export class FeaturesRegistry {
+  private manifests = new Map<string, FeatureManifest>();
+
+  register(manifest: FeatureManifest): void {
+    if (this.manifests.has(manifest.id)) {
+      throw new Error(
+        `Feature manifest "${manifest.id}" is already registered — duplicate registration is not allowed`
+      );
+    }
+
+    const occupiedKeys = new Map<string, string>();
+    for (const [existingId, m] of this.manifests) {
+      for (const feature of m.features) {
+        occupiedKeys.set(feature.key, existingId);
+      }
+    }
+
+    const seenInManifest = new Set<string>();
+    for (const feature of manifest.features) {
+      if (seenInManifest.has(feature.key)) {
+        throw new Error(
+          `Feature key "${feature.key}" appears more than once within manifest "${manifest.id}"`
+        );
+      }
+      seenInManifest.add(feature.key);
+      const claimant = occupiedKeys.get(feature.key);
+      if (claimant) {
+        throw new Error(
+          `Feature key "${feature.key}" already registered by "${claimant}" — cannot register again in "${manifest.id}"`
+        );
+      }
+    }
+
+    this.manifests.set(manifest.id, manifest);
+  }
+
+  getAll(): FeatureManifest[] {
+    return [...this.manifests.values()].toSorted((a, b) => a.order - b.order);
+  }
+
+  getFeature(
+    key: string
+  ): { manifest: FeatureManifest; feature: FeatureManifest['features'][number] } | null {
+    for (const manifest of this.manifests.values()) {
+      const feature = manifest.features.find((f) => f.key === key);
+      if (feature) return { manifest, feature };
+    }
+    return null;
+  }
+
+  clear(): void {
+    this.manifests.clear();
+  }
+}
+
+export const featuresRegistry = new FeaturesRegistry();

--- a/apps/pops-api/src/modules/core/features/router.ts
+++ b/apps/pops-api/src/modules/core/features/router.ts
@@ -1,0 +1,87 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+/**
+ * Feature toggles tRPC router (PRD-094).
+ *
+ * Exposes manifest discovery, current feature status, and write paths for
+ * system-level and per-user toggles.
+ */
+import { protectedProcedure, router } from '../../../trpc.js';
+import { featuresRegistry } from './registry.js';
+import * as service from './service.js';
+import { FeatureGateError, FeatureNotFoundError, FeatureScopeError } from './service.js';
+import { FeatureManifestSchema, FeatureStatusSchema } from './types.js';
+
+function mapServiceError(err: unknown): never {
+  if (err instanceof FeatureNotFoundError) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+  }
+  if (err instanceof FeatureGateError) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: err.message });
+  }
+  if (err instanceof FeatureScopeError) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: err.message });
+  }
+  throw err;
+}
+
+export const featuresRouter = router({
+  /** Return all registered feature manifests sorted by order. */
+  getManifests: protectedProcedure
+    .output(z.object({ manifests: z.array(FeatureManifestSchema) }))
+    .query(() => ({ manifests: featuresRegistry.getAll() })),
+
+  /** Return runtime status for every feature, including credential resolution. */
+  list: protectedProcedure
+    .output(z.object({ features: z.array(FeatureStatusSchema) }))
+    .query(({ ctx }) => ({
+      features: service.listFeatures({ email: ctx.user.email }),
+    })),
+
+  /** Boolean check for a single feature in the current request's user context. */
+  isEnabled: protectedProcedure
+    .input(z.object({ key: z.string() }))
+    .output(z.object({ enabled: z.boolean() }))
+    .query(({ input, ctx }) => ({
+      enabled: service.isEnabled(input.key, { user: { email: ctx.user.email } }),
+    })),
+
+  /** Set the system-level enabled state. Rejects if credentials/capability gate is failing. */
+  setEnabled: protectedProcedure
+    .input(z.object({ key: z.string(), enabled: z.boolean() }))
+    .output(z.object({ enabled: z.boolean() }))
+    .mutation(({ input }) => {
+      try {
+        return { enabled: service.setFeatureEnabled(input.key, input.enabled) };
+      } catch (err) {
+        mapServiceError(err);
+      }
+    }),
+
+  /** Set a per-user override (404 when feature is not user-scoped). */
+  setUserPreference: protectedProcedure
+    .input(z.object({ key: z.string(), enabled: z.boolean() }))
+    .output(z.object({ enabled: z.boolean() }))
+    .mutation(({ input, ctx }) => {
+      try {
+        return {
+          enabled: service.setUserPreference(input.key, { email: ctx.user.email }, input.enabled),
+        };
+      } catch (err) {
+        mapServiceError(err);
+      }
+    }),
+
+  /** Remove a per-user override; resolution falls back to the system default. */
+  clearUserPreference: protectedProcedure
+    .input(z.object({ key: z.string() }))
+    .output(z.object({ cleared: z.boolean() }))
+    .mutation(({ input, ctx }) => {
+      try {
+        return { cleared: service.clearUserPreference(input.key, { email: ctx.user.email }) };
+      } catch (err) {
+        mapServiceError(err);
+      }
+    }),
+});

--- a/apps/pops-api/src/modules/core/features/service.test.ts
+++ b/apps/pops-api/src/modules/core/features/service.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { seedSetting, setupTestContext } from '../../../shared/test-utils.js';
+import { settingsRegistry } from '../settings/registry.js';
+import { featuresRegistry } from './registry.js';
+import {
+  clearUserPreference,
+  FeatureGateError,
+  FeatureNotFoundError,
+  FeatureScopeError,
+  isEnabled,
+  listFeatures,
+  setFeatureEnabled,
+  setUserPreference,
+} from './service.js';
+import { setUserSetting } from './user-settings.js';
+
+import type { Database } from 'better-sqlite3';
+
+import type { FeatureManifest, SettingsManifest } from '@pops/types';
+
+const ctx = setupTestContext();
+let db: Database;
+
+beforeEach(() => {
+  ({ db } = ctx.setup());
+  settingsRegistry.clear();
+  featuresRegistry.clear();
+});
+
+afterEach(() => {
+  settingsRegistry.clear();
+  featuresRegistry.clear();
+  ctx.teardown();
+  vi.unstubAllEnvs();
+});
+
+function registerSimpleFeature(overrides: Partial<FeatureManifest['features'][number]> = {}) {
+  const manifest: FeatureManifest = {
+    id: 'test',
+    title: 'Test',
+    order: 1,
+    features: [
+      {
+        key: 'test.simple',
+        label: 'Simple',
+        default: false,
+        scope: 'system',
+        ...overrides,
+      },
+    ],
+  };
+  featuresRegistry.register(manifest);
+}
+
+function registerSettingsManifest(fieldKeys: { key: string; envFallback?: string }[]) {
+  const manifest: SettingsManifest = {
+    id: 'test.settings',
+    title: 'Test settings',
+    order: 1,
+    groups: [
+      {
+        id: 'g',
+        title: 'g',
+        fields: fieldKeys.map(({ key, envFallback }) => ({
+          key,
+          label: key,
+          type: 'text' as const,
+          ...(envFallback ? { envFallback } : {}),
+        })),
+      },
+    ],
+  };
+  settingsRegistry.register(manifest);
+}
+
+describe('isEnabled', () => {
+  it('returns false for unknown features', () => {
+    expect(isEnabled('does.not.exist')).toBe(false);
+  });
+
+  it('returns the feature default when no overrides', () => {
+    registerSimpleFeature({ default: true });
+    expect(isEnabled('test.simple')).toBe(true);
+  });
+
+  it('reads system override from settings', () => {
+    registerSimpleFeature({ default: false });
+    seedSetting(db, { key: 'test.simple', value: 'true' });
+    expect(isEnabled('test.simple')).toBe(true);
+  });
+
+  it('uses settingKey when provided', () => {
+    registerSimpleFeature({ default: false, settingKey: 'legacy_key' });
+    seedSetting(db, { key: 'legacy_key', value: 'true' });
+    expect(isEnabled('test.simple')).toBe(true);
+  });
+
+  it('returns false when capabilityCheck returns false', () => {
+    registerSimpleFeature({ default: true, capabilityCheck: () => false });
+    expect(isEnabled('test.simple')).toBe(false);
+  });
+
+  it('returns false when a required setting is missing', () => {
+    registerSettingsManifest([{ key: 'cred.a' }, { key: 'cred.b' }]);
+    registerSimpleFeature({ default: true, requires: ['cred.a', 'cred.b'] });
+    seedSetting(db, { key: 'cred.a', value: 'value' });
+    expect(isEnabled('test.simple')).toBe(false);
+  });
+
+  it('returns true when all required credentials are present', () => {
+    registerSettingsManifest([{ key: 'cred.a' }, { key: 'cred.b' }]);
+    registerSimpleFeature({ default: true, requires: ['cred.a', 'cred.b'] });
+    seedSetting(db, { key: 'cred.a', value: 'value' });
+    seedSetting(db, { key: 'cred.b', value: 'value' });
+    expect(isEnabled('test.simple')).toBe(true);
+  });
+
+  it('falls back to envFallback for required settings', () => {
+    registerSettingsManifest([{ key: 'cred.a', envFallback: 'CRED_A' }]);
+    registerSimpleFeature({ default: true, requires: ['cred.a'] });
+    vi.stubEnv('CRED_A', 'from-env');
+    expect(isEnabled('test.simple')).toBe(true);
+  });
+
+  it('returns false when requiresEnv is missing', () => {
+    registerSimpleFeature({ default: true, requiresEnv: ['SOME_ENV'] });
+    expect(isEnabled('test.simple')).toBe(false);
+  });
+
+  it('returns true when requiresEnv is set', () => {
+    registerSimpleFeature({ default: true, requiresEnv: ['SOME_ENV'] });
+    vi.stubEnv('SOME_ENV', 'value');
+    expect(isEnabled('test.simple')).toBe(true);
+  });
+
+  it('user override takes precedence over system value for user-scoped features', () => {
+    registerSimpleFeature({ default: false, scope: 'user' });
+    seedSetting(db, { key: 'test.simple', value: 'true' });
+    setUserSetting('alice@example.com', 'feature.test.simple', 'false');
+    expect(isEnabled('test.simple', { user: { email: 'alice@example.com' } })).toBe(false);
+  });
+
+  it('falls back to system value when no user override exists', () => {
+    registerSimpleFeature({ default: false, scope: 'user' });
+    seedSetting(db, { key: 'test.simple', value: 'true' });
+    expect(isEnabled('test.simple', { user: { email: 'alice@example.com' } })).toBe(true);
+  });
+
+  it('ignores user override for system-scoped features', () => {
+    registerSimpleFeature({ default: false, scope: 'system' });
+    seedSetting(db, { key: 'test.simple', value: 'true' });
+    setUserSetting('alice@example.com', 'feature.test.simple', 'false');
+    expect(isEnabled('test.simple', { user: { email: 'alice@example.com' } })).toBe(true);
+  });
+});
+
+describe('listFeatures', () => {
+  it('exposes credential resolution per feature', () => {
+    registerSettingsManifest([{ key: 'cred.a', envFallback: 'CRED_A' }]);
+    registerSimpleFeature({ requires: ['cred.a'] });
+    seedSetting(db, { key: 'cred.a', value: 'from-db' });
+    const [feature] = listFeatures();
+    expect(feature?.credentials).toEqual([{ key: 'cred.a', source: 'database' }]);
+  });
+
+  it('marks features unavailable when capability is missing', () => {
+    registerSimpleFeature({ default: true, capabilityCheck: () => false });
+    const [feature] = listFeatures();
+    expect(feature?.state).toBe('unavailable');
+    expect(feature?.capabilityMissing).toBe(true);
+    expect(feature?.enabled).toBe(false);
+  });
+
+  it('marks user override correctly', () => {
+    registerSimpleFeature({ default: false, scope: 'user' });
+    setUserSetting('alice@example.com', 'feature.test.simple', 'true');
+    const [feature] = listFeatures({ email: 'alice@example.com' });
+    expect(feature?.userOverride).toBe(true);
+    expect(feature?.enabled).toBe(true);
+  });
+});
+
+describe('setFeatureEnabled', () => {
+  it('throws FeatureNotFoundError for unknown features', () => {
+    expect(() => setFeatureEnabled('nope', true)).toThrow(FeatureNotFoundError);
+  });
+
+  it('rejects capability-scoped features', () => {
+    registerSimpleFeature({ scope: 'capability', capabilityCheck: () => true });
+    expect(() => setFeatureEnabled('test.simple', true)).toThrow(FeatureScopeError);
+  });
+
+  it('rejects when required credentials are missing', () => {
+    registerSettingsManifest([{ key: 'cred.a' }]);
+    registerSimpleFeature({ requires: ['cred.a'] });
+    expect(() => setFeatureEnabled('test.simple', true)).toThrow(FeatureGateError);
+  });
+
+  it('rejects when capability check fails on enable', () => {
+    registerSimpleFeature({ scope: 'system', capabilityCheck: () => false });
+    expect(() => setFeatureEnabled('test.simple', true)).toThrow(FeatureGateError);
+  });
+
+  it('persists the value via the underlying setting key', () => {
+    registerSimpleFeature({ settingKey: 'legacy_flag' });
+    expect(setFeatureEnabled('test.simple', true)).toBe(true);
+    const row = db.prepare('SELECT value FROM settings WHERE key = ?').get('legacy_flag') as {
+      value: string;
+    };
+    expect(row.value).toBe('true');
+  });
+
+  it('allows disabling a feature even when credentials are missing', () => {
+    registerSettingsManifest([{ key: 'cred.a' }]);
+    registerSimpleFeature({ requires: ['cred.a'] });
+    expect(setFeatureEnabled('test.simple', false)).toBe(false);
+  });
+});
+
+describe('setUserPreference / clearUserPreference', () => {
+  it('rejects when feature is not user-scoped', () => {
+    registerSimpleFeature({ scope: 'system' });
+    expect(() => setUserPreference('test.simple', { email: 'a@b' }, true)).toThrow(
+      FeatureScopeError
+    );
+  });
+
+  it('writes per-user override and resolves to that value', () => {
+    registerSimpleFeature({ scope: 'user', default: false });
+    setUserPreference('test.simple', { email: 'a@b' }, true);
+    expect(isEnabled('test.simple', { user: { email: 'a@b' } })).toBe(true);
+  });
+
+  it('clearUserPreference removes the override and falls back to system default', () => {
+    registerSimpleFeature({ scope: 'user', default: true });
+    setUserPreference('test.simple', { email: 'a@b' }, false);
+    expect(isEnabled('test.simple', { user: { email: 'a@b' } })).toBe(false);
+    expect(clearUserPreference('test.simple', { email: 'a@b' })).toBe(true);
+    expect(isEnabled('test.simple', { user: { email: 'a@b' } })).toBe(true);
+  });
+});

--- a/apps/pops-api/src/modules/core/features/service.ts
+++ b/apps/pops-api/src/modules/core/features/service.ts
@@ -1,0 +1,189 @@
+import { setRawSetting, getSettingOrNull } from '../settings/service.js';
+import { resolveCredentials } from './credentials.js';
+import { FeatureGateError, FeatureNotFoundError, FeatureScopeError } from './errors.js';
+import { featuresRegistry } from './registry.js';
+import { deleteUserSetting, getUserSetting, setUserSetting } from './user-settings.js';
+
+import type { FeatureDefinition, FeatureStatus } from '@pops/types';
+
+export { FeatureGateError, FeatureNotFoundError, FeatureScopeError } from './errors.js';
+
+const USER_SETTING_PREFIX = 'feature.';
+
+interface UserContext {
+  email: string;
+}
+
+interface IsEnabledOptions {
+  user?: UserContext | null;
+}
+
+function userSettingKey(featureKey: string): string {
+  return `${USER_SETTING_PREFIX}${featureKey}`;
+}
+
+function parseBoolean(raw: string | null | undefined, fallback: boolean): boolean {
+  if (raw === null || raw === undefined) return fallback;
+  return raw === 'true' || raw === '1';
+}
+
+function readSystemValue(feature: FeatureDefinition): boolean | null {
+  const key = feature.settingKey ?? feature.key;
+  const row = getSettingOrNull(key);
+  if (!row) return null;
+  return parseBoolean(row.value, feature.default);
+}
+
+function writeSystemValue(feature: FeatureDefinition, enabled: boolean): void {
+  setRawSetting(feature.settingKey ?? feature.key, enabled ? 'true' : 'false');
+}
+
+function readUserOverride(feature: FeatureDefinition, user: UserContext): boolean | null {
+  if (feature.scope !== 'user') return null;
+  const raw = getUserSetting(user.email, userSettingKey(feature.key));
+  if (raw === null) return null;
+  return parseBoolean(raw, feature.default);
+}
+
+interface ResolvedState {
+  enabled: boolean;
+  userOverride: boolean;
+}
+
+function resolveEnabledState(
+  feature: FeatureDefinition,
+  gateOk: boolean,
+  user: UserContext | null
+): ResolvedState {
+  if (!gateOk) return { enabled: false, userOverride: false };
+
+  if (feature.scope === 'user' && user) {
+    const userValue = readUserOverride(feature, user);
+    if (userValue !== null) return { enabled: userValue, userOverride: true };
+  }
+
+  const systemValue = readSystemValue(feature);
+  return { enabled: systemValue ?? feature.default, userOverride: false };
+}
+
+function deriveState(gateOk: boolean, enabled: boolean): FeatureStatus['state'] {
+  if (!gateOk) return 'unavailable';
+  return enabled ? 'enabled' : 'disabled';
+}
+
+function buildFeatureStatus(
+  manifestId: string,
+  feature: FeatureDefinition,
+  user: UserContext | null
+): FeatureStatus {
+  const capabilityMissing = feature.capabilityCheck ? !feature.capabilityCheck() : false;
+  const { credentials, allConfigured } = resolveCredentials(feature);
+  const gateOk = !capabilityMissing && allConfigured;
+  const { enabled, userOverride } = resolveEnabledState(feature, gateOk, user);
+
+  return {
+    key: feature.key,
+    manifestId,
+    label: feature.label,
+    description: feature.description,
+    scope: feature.scope,
+    enabled,
+    default: feature.default,
+    state: deriveState(gateOk, enabled),
+    credentials,
+    capabilityMissing: capabilityMissing || undefined,
+    preview: feature.preview,
+    deprecated: feature.deprecated,
+    configureLink: feature.configureLink,
+    userOverride: feature.scope === 'user' ? userOverride : undefined,
+  };
+}
+
+/**
+ * The single read path for runtime feature gating. Resolves in order:
+ * capability check → required credentials → user override → system value → default.
+ */
+export function isEnabled(key: string, options: IsEnabledOptions = {}): boolean {
+  const entry = featuresRegistry.getFeature(key);
+  if (!entry) {
+    if (process.env['NODE_ENV'] !== 'production') {
+      console.warn(`[features] isEnabled called for unknown feature "${key}"`);
+    }
+    return false;
+  }
+
+  const { feature } = entry;
+  if (feature.capabilityCheck && !feature.capabilityCheck()) return false;
+
+  const { allConfigured } = resolveCredentials(feature);
+  if (!allConfigured) return false;
+
+  if (feature.scope === 'user' && options.user) {
+    const userValue = readUserOverride(feature, options.user);
+    if (userValue !== null) return userValue;
+  }
+
+  const systemValue = readSystemValue(feature);
+  return systemValue ?? feature.default;
+}
+
+/** Build the FeatureStatus list for the admin Features page. */
+export function listFeatures(user: UserContext | null = null): FeatureStatus[] {
+  const out: FeatureStatus[] = [];
+  for (const manifest of featuresRegistry.getAll()) {
+    for (const feature of manifest.features) {
+      out.push(buildFeatureStatus(manifest.id, feature, user));
+    }
+  }
+  return out;
+}
+
+function ensureCanEnable(feature: FeatureDefinition): void {
+  if (feature.capabilityCheck && !feature.capabilityCheck()) {
+    throw new FeatureGateError(feature.key, [{ key: feature.key, source: 'missing' }]);
+  }
+  const { credentials, allConfigured } = resolveCredentials(feature);
+  if (!allConfigured) {
+    throw new FeatureGateError(
+      feature.key,
+      credentials.filter((c) => c.source === 'missing')
+    );
+  }
+}
+
+/** Set the system-level enabled state. Rejects when gating is failing. */
+export function setFeatureEnabled(key: string, enabled: boolean): boolean {
+  const entry = featuresRegistry.getFeature(key);
+  if (!entry) throw new FeatureNotFoundError(key);
+  const { feature } = entry;
+
+  if (feature.scope === 'capability') {
+    throw new FeatureScopeError(key, 'system|user', feature.scope);
+  }
+  if (enabled) ensureCanEnable(feature);
+
+  writeSystemValue(feature, enabled);
+  return enabled;
+}
+
+function requireUserScopedFeature(key: string): FeatureDefinition {
+  const entry = featuresRegistry.getFeature(key);
+  if (!entry) throw new FeatureNotFoundError(key);
+  if (entry.feature.scope !== 'user') {
+    throw new FeatureScopeError(key, 'user', entry.feature.scope);
+  }
+  return entry.feature;
+}
+
+/** Set a per-user override. Rejects when the feature is not user-scoped. */
+export function setUserPreference(key: string, user: UserContext, enabled: boolean): boolean {
+  const feature = requireUserScopedFeature(key);
+  setUserSetting(user.email, userSettingKey(feature.key), enabled ? 'true' : 'false');
+  return enabled;
+}
+
+/** Remove a per-user override; resolution falls back to the system default. */
+export function clearUserPreference(key: string, user: UserContext): boolean {
+  const feature = requireUserScopedFeature(key);
+  return deleteUserSetting(user.email, userSettingKey(feature.key));
+}

--- a/apps/pops-api/src/modules/core/features/types.ts
+++ b/apps/pops-api/src/modules/core/features/types.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+/** Zod schemas mirroring the FeatureManifest types from @pops/types. */
+export const FeatureScopeSchema = z.enum(['system', 'user', 'capability']);
+
+export const FeatureDefinitionSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  default: z.boolean(),
+  scope: FeatureScopeSchema,
+  requires: z.array(z.string()).optional(),
+  requiresEnv: z.array(z.string()).optional(),
+  preview: z.boolean().optional(),
+  deprecated: z.boolean().optional(),
+  settingKey: z.string().optional(),
+  configureLink: z.string().optional(),
+});
+
+export const FeatureManifestSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  icon: z.string().optional(),
+  order: z.number(),
+  features: z.array(FeatureDefinitionSchema),
+});
+
+export const FeatureCredentialStatusSchema = z.object({
+  key: z.string(),
+  source: z.enum(['database', 'environment', 'missing']),
+  envVar: z.string().optional(),
+});
+
+export const FeatureStatusSchema = z.object({
+  key: z.string(),
+  manifestId: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  scope: FeatureScopeSchema,
+  enabled: z.boolean(),
+  default: z.boolean(),
+  state: z.enum(['enabled', 'disabled', 'unavailable']),
+  credentials: z.array(FeatureCredentialStatusSchema),
+  capabilityMissing: z.boolean().optional(),
+  preview: z.boolean().optional(),
+  deprecated: z.boolean().optional(),
+  configureLink: z.string().optional(),
+  userOverride: z.boolean().optional(),
+});

--- a/apps/pops-api/src/modules/core/features/user-settings.ts
+++ b/apps/pops-api/src/modules/core/features/user-settings.ts
@@ -1,0 +1,40 @@
+import { and, eq } from 'drizzle-orm';
+
+import { userSettings } from '@pops/db-types/schema';
+
+import { getDrizzle } from '../../../db.js';
+
+/**
+ * Per-user settings storage helpers. Backs `scope: 'user'` features and any
+ * future per-user UI preferences. Keyed by `(user_email, key)`.
+ */
+
+export function getUserSetting(userEmail: string, key: string): string | null {
+  const db = getDrizzle();
+  const row = db
+    .select()
+    .from(userSettings)
+    .where(and(eq(userSettings.userEmail, userEmail), eq(userSettings.key, key)))
+    .get();
+  return row?.value ?? null;
+}
+
+export function setUserSetting(userEmail: string, key: string, value: string): void {
+  const db = getDrizzle();
+  db.insert(userSettings)
+    .values({ userEmail, key, value })
+    .onConflictDoUpdate({
+      target: [userSettings.userEmail, userSettings.key],
+      set: { value },
+    })
+    .run();
+}
+
+export function deleteUserSetting(userEmail: string, key: string): boolean {
+  const db = getDrizzle();
+  const result = db
+    .delete(userSettings)
+    .where(and(eq(userSettings.userEmail, userEmail), eq(userSettings.key, key)))
+    .run();
+  return result.changes > 0;
+}

--- a/apps/pops-api/src/modules/core/index.ts
+++ b/apps/pops-api/src/modules/core/index.ts
@@ -14,6 +14,11 @@ import { settingsRegistry } from './settings/registry.js';
 settingsRegistry.register(aiConfigManifest);
 settingsRegistry.register(coreOperationalManifest);
 
+import { coreFeaturesManifest } from './features/manifest.js';
+import { featuresRegistry } from './features/registry.js';
+
+featuresRegistry.register(coreFeaturesManifest);
+
 import { router } from '../../trpc.js';
 import { aiBudgetsRouter } from './ai-budgets/router.js';
 import { aiObservabilityRouter } from './ai-observability/router.js';
@@ -22,6 +27,7 @@ import { aiUsageRouter } from './ai-usage/router.js';
 import { correctionsRouter } from './corrections/router.js';
 import { embeddingsRouter } from './embeddings/router.js';
 import { entitiesRouter } from './entities/router.js';
+import { featuresRouter } from './features/router.js';
 import { jobsRouter } from './jobs/router.js';
 import { searchRouter } from './search/router.js';
 import { settingsRouter } from './settings/router.js';
@@ -38,5 +44,6 @@ export const coreRouter = router({
   embeddings: embeddingsRouter,
   tagRules: tagRulesRouter,
   settings: settingsRouter,
+  features: featuresRouter,
   search: searchRouter,
 });

--- a/apps/pops-api/src/modules/core/settings/service.ts
+++ b/apps/pops-api/src/modules/core/settings/service.ts
@@ -24,7 +24,7 @@ export function getSetting(key: SettingsKey): SettingRow {
 }
 
 /** Get a single setting by key, returning null if not found */
-export function getSettingOrNull(key: SettingsKey): SettingRow | null {
+export function getSettingOrNull(key: SettingsKey | string): SettingRow | null {
   const db = getDrizzle();
   const [row] = db.select().from(settings).where(eq(settings.key, key)).all();
   return row ?? null;
@@ -56,17 +56,31 @@ export function listSettings(
 
 /** Set a setting value (upsert — creates or updates) */
 export function setSetting(input: SetSettingInput): SettingRow {
+  return setRawSetting(input.key, input.value);
+}
+
+/**
+ * Untyped upsert into the settings table — used by callers that own their own
+ * key namespace (e.g. the feature-toggle framework, which manages keys via the
+ * features registry rather than `SETTINGS_KEYS`). Prefer `setSetting` whenever
+ * the key is one of the typed `SettingsKey` values.
+ */
+export function setRawSetting(key: string, value: string): SettingRow {
   const db = getDrizzle();
 
   db.insert(settings)
-    .values({ key: input.key, value: input.value })
+    .values({ key, value })
     .onConflictDoUpdate({
       target: settings.key,
-      set: { value: input.value },
+      set: { value },
     })
     .run();
 
-  return getSetting(input.key);
+  const [row] = db.select().from(settings).where(eq(settings.key, key)).all();
+  if (!row) {
+    throw new NotFoundError('Setting', key);
+  }
+  return row;
 }
 
 /** Get multiple settings by key — missing keys are omitted from the result */

--- a/apps/pops-api/src/modules/inventory/features.ts
+++ b/apps/pops-api/src/modules/inventory/features.ts
@@ -1,0 +1,35 @@
+import type { FeatureManifest } from '@pops/types';
+
+/**
+ * Inventory features (PRD-094).
+ *
+ * - `inventory.paperless` is gated on env-only credentials (Docker secrets in
+ *   prod, dotenv in dev). When the env is missing the integration is unavailable.
+ * - `inventory.show_connected_status` is the first user-scoped feature — each
+ *   user can hide the linked-document badges on inventory items.
+ */
+export const inventoryFeaturesManifest: FeatureManifest = {
+  id: 'inventory',
+  title: 'Inventory',
+  icon: 'Package',
+  order: 300,
+  features: [
+    {
+      key: 'inventory.paperless',
+      label: 'Paperless integration',
+      description:
+        'Surface receipts and warranty docs from Paperless-ngx alongside inventory items.',
+      default: true,
+      scope: 'system',
+      requiresEnv: ['PAPERLESS_BASE_URL', 'PAPERLESS_API_TOKEN'],
+    },
+    {
+      key: 'inventory.show_connected_status',
+      label: 'Show connected status',
+      description:
+        'Display the connected-status badge on inventory items linked to documents or photos.',
+      default: true,
+      scope: 'user',
+    },
+  ],
+};

--- a/apps/pops-api/src/modules/inventory/index.ts
+++ b/apps/pops-api/src/modules/inventory/index.ts
@@ -4,10 +4,13 @@
 // Side-effect: register search adapters
 import './items/search-adapter.js';
 
+import { featuresRegistry } from '../core/features/index.js';
 import { settingsRegistry } from '../core/settings/index.js';
+import { inventoryFeaturesManifest } from './features.js';
 import { inventoryManifest } from './settings-manifest.js';
 
 settingsRegistry.register(inventoryManifest);
+featuresRegistry.register(inventoryFeaturesManifest);
 
 import { router } from '../../trpc.js';
 import { connectionsRouter } from './connections/index.js';

--- a/apps/pops-api/src/modules/inventory/paperless/index.ts
+++ b/apps/pops-api/src/modules/inventory/paperless/index.ts
@@ -2,6 +2,7 @@
  * Paperless-ngx API client — re-exports and factory.
  */
 import { getEnv } from '../../../env.js';
+import { isEnabled } from '../../core/features/index.js';
 import { PaperlessClient } from './client.js';
 
 export { PaperlessClient } from './client.js';
@@ -16,9 +17,13 @@ export {
 
 /**
  * Shared Paperless client factory.
- * Returns null if PAPERLESS_BASE_URL or PAPERLESS_API_TOKEN are not set.
+ *
+ * Returns `null` when the `inventory.paperless` feature is disabled — gating
+ * goes through the feature toggle framework (PRD-094) so credentials, env-var
+ * presence, and admin overrides resolve consistently with every other module.
  */
 export function getPaperlessClient(): PaperlessClient | null {
+  if (!isEnabled('inventory.paperless')) return null;
   const url = getEnv('PAPERLESS_BASE_URL');
   const token = getEnv('PAPERLESS_API_TOKEN');
   if (!url || !token) return null;

--- a/apps/pops-api/src/modules/media/features.ts
+++ b/apps/pops-api/src/modules/media/features.ts
@@ -1,0 +1,57 @@
+import type { FeatureManifest } from '@pops/types';
+
+/**
+ * Media features (PRD-094).
+ *
+ * - `media.plex.scheduler` reuses the legacy `plex_scheduler_enabled` settings
+ *   key so behaviour is preserved across the migration.
+ * - `media.rotation` reuses `rotation_enabled` for the same reason.
+ * - `media.radarr` / `media.sonarr` are credential-only — when both URL and
+ *   API key are set they are considered enabled (default `true`).
+ */
+export const mediaFeaturesManifest: FeatureManifest = {
+  id: 'media',
+  title: 'Media',
+  icon: 'Film',
+  order: 200,
+  features: [
+    {
+      key: 'media.plex.scheduler',
+      label: 'Plex auto-sync',
+      description:
+        'Background scheduler that syncs the Plex library and watch history on a fixed interval.',
+      default: false,
+      scope: 'system',
+      requires: ['plex_url', 'plex_token'],
+      settingKey: 'plex_scheduler_enabled',
+      configureLink: '/settings#media.plex',
+    },
+    {
+      key: 'media.rotation',
+      label: 'Library rotation',
+      description: 'Daily rotation cycle that swaps stale movies for fresh candidates.',
+      default: false,
+      scope: 'system',
+      settingKey: 'rotation_enabled',
+      configureLink: '/settings#media.rotation',
+    },
+    {
+      key: 'media.radarr',
+      label: 'Radarr',
+      description: 'Request movie downloads for watchlist items.',
+      default: true,
+      scope: 'system',
+      requires: ['radarr_url', 'radarr_api_key'],
+      configureLink: '/settings#media.arr',
+    },
+    {
+      key: 'media.sonarr',
+      label: 'Sonarr',
+      description: 'Request TV downloads for watchlist items.',
+      default: true,
+      scope: 'system',
+      requires: ['sonarr_url', 'sonarr_api_key'],
+      configureLink: '/settings#media.arr',
+    },
+  ],
+};

--- a/apps/pops-api/src/modules/media/index.ts
+++ b/apps/pops-api/src/modules/media/index.ts
@@ -7,7 +7,9 @@ import './search/tv-shows-adapter.js';
 // Side-effect: register rotation source adapters
 import './rotation/register-sources.js';
 
+import { featuresRegistry } from '../core/features/index.js';
 import { settingsRegistry } from '../core/settings/index.js';
+import { mediaFeaturesManifest } from './features.js';
 import { arrManifest, plexManifest, rotationManifest } from './settings/manifests.js';
 import { mediaOperationalManifest } from './settings/operational-manifest.js';
 
@@ -15,6 +17,8 @@ settingsRegistry.register(plexManifest);
 settingsRegistry.register(arrManifest);
 settingsRegistry.register(rotationManifest);
 settingsRegistry.register(mediaOperationalManifest);
+
+featuresRegistry.register(mediaFeaturesManifest);
 
 import { router } from '../../trpc.js';
 import { arrRouter } from './arr/index.js';

--- a/apps/pops-api/src/modules/media/plex/scheduler.test.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler.test.ts
@@ -88,6 +88,19 @@ vi.mock('@pops/db-types', () => ({
   syncLogs: { syncedAt: 'synced_at', id: 'id', errors: 'errors' },
 }));
 
+// The scheduler reads enable state via the features framework; in this isolated
+// test the registry is empty and we don't exercise feature registration. Mock
+// `isEnabled` so that it mirrors the in-test settings store behaviour for the
+// `media.plex.scheduler` key (legacy `plex_scheduler_enabled`).
+vi.mock('../../core/features/index.js', () => ({
+  isEnabled: vi.fn((key: string) => {
+    if (key === 'media.plex.scheduler') {
+      return settingsStore.get('plex_scheduler_enabled') === 'true';
+    }
+    return false;
+  }),
+}));
+
 import {
   _resetScheduler,
   getPersistedSchedulerState,

--- a/apps/pops-api/src/modules/media/plex/scheduler.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler.ts
@@ -14,9 +14,14 @@ import { settings } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
 import { getSyncQueue } from '../../../jobs/queues.js';
+import { isEnabled } from '../../core/features/index.js';
 import { SETTINGS_KEYS } from '../../core/settings/keys.js';
 import { getLastSyncAt, getLastSyncCounts, getLastSyncError } from './scheduler-sync-logs.js';
 import { getPlexSectionIds } from './service.js';
+
+function isPlexSchedulerEnabled(): boolean {
+  return isEnabled('media.plex.scheduler');
+}
 
 export {
   getSyncLogs,
@@ -161,8 +166,7 @@ export function getSchedulerStatus(): SchedulerStatus {
 }
 
 export function getPersistedSchedulerState(): { enabled: boolean; intervalMs: number } | null {
-  const enabled = getSetting(SCHEDULER_KEYS.enabled);
-  if (enabled !== 'true') return null;
+  if (!isPlexSchedulerEnabled()) return null;
   const interval = getSetting(SCHEDULER_KEYS.intervalMs);
   return { enabled: true, intervalMs: interval ? Number(interval) : DEFAULT_INTERVAL_MS };
 }

--- a/apps/pops-api/src/modules/media/rotation/scheduler.ts
+++ b/apps/pops-api/src/modules/media/rotation/scheduler.ts
@@ -13,6 +13,7 @@ import cron, { type ScheduledTask } from 'node-cron';
 import { settings } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { isEnabled } from '../../core/features/index.js';
 import { emptyResult } from './rotation-cycle-types.js';
 import { executeRotationCycle } from './rotation-cycle.js';
 import { writeRotationLog } from './rotation-log.js';
@@ -128,8 +129,7 @@ export function getRotationSchedulerStatus(): RotationSchedulerStatus {
 }
 
 export function resumeRotationSchedulerIfEnabled(): RotationSchedulerStatus | null {
-  const enabled = getSetting(SETTINGS_KEYS.enabled);
-  if (enabled !== 'true') return null;
+  if (!isEnabled('media.rotation')) return null;
   const savedCron = getSetting(SETTINGS_KEYS.cronExpression) ?? DEFAULT_CRON;
   console.warn(`[Rotation] Auto-resuming scheduler (cron: ${savedCron})`);
   return startRotationScheduler({ cronExpression: savedCron });

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -492,6 +492,13 @@ export function createTestDb(): Database {
       value TEXT NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS user_settings (
+      user_email TEXT NOT NULL,
+      key        TEXT NOT NULL,
+      value      TEXT NOT NULL,
+      PRIMARY KEY (user_email, key)
+    );
+
     CREATE TABLE IF NOT EXISTS dismissed_discover (
       tmdb_id INTEGER PRIMARY KEY,
       dismissed_at TEXT NOT NULL DEFAULT (datetime('now'))

--- a/apps/pops-shell/src/app/pages/features-page/CredentialChip.tsx
+++ b/apps/pops-shell/src/app/pages/features-page/CredentialChip.tsx
@@ -1,0 +1,55 @@
+import { CheckCircle2, Database, ServerCog, XCircle } from 'lucide-react';
+
+import { cn } from '@pops/ui';
+
+import type { FeatureCredentialStatus } from '@pops/types';
+
+interface CredentialChipProps {
+  credential: FeatureCredentialStatus;
+}
+
+/**
+ * Per-credential status pill rendered next to a feature toggle. Communicates
+ * three resolution outcomes:
+ *  - configured (DB) — green
+ *  - configured via env — blue
+ *  - missing — red
+ */
+export function CredentialChip({ credential }: CredentialChipProps) {
+  if (credential.source === 'database') {
+    return (
+      <span className={chipClass('ok')}>
+        <CheckCircle2 className="h-3 w-3" />
+        <Database className="h-3 w-3 opacity-70" />
+        {credential.key}
+      </span>
+    );
+  }
+
+  if (credential.source === 'environment') {
+    return (
+      <span className={chipClass('env')}>
+        <CheckCircle2 className="h-3 w-3" />
+        <ServerCog className="h-3 w-3 opacity-70" />
+        {credential.envVar ?? credential.key}
+      </span>
+    );
+  }
+
+  return (
+    <span className={chipClass('missing')}>
+      <XCircle className="h-3 w-3" />
+      {credential.envVar ?? credential.key}
+    </span>
+  );
+}
+
+function chipClass(state: 'ok' | 'env' | 'missing'): string {
+  return cn(
+    'inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-full border font-medium',
+    state === 'ok' &&
+      'bg-emerald-500/10 text-emerald-600 border-emerald-500/20 dark:text-emerald-400',
+    state === 'env' && 'bg-sky-500/10 text-sky-600 border-sky-500/20 dark:text-sky-400',
+    state === 'missing' && 'bg-rose-500/10 text-rose-600 border-rose-500/20 dark:text-rose-400'
+  );
+}

--- a/apps/pops-shell/src/app/pages/features-page/FeatureCard.tsx
+++ b/apps/pops-shell/src/app/pages/features-page/FeatureCard.tsx
@@ -1,0 +1,65 @@
+import { Link } from 'react-router';
+
+import { Switch } from '@pops/ui';
+
+import { CredentialChip } from './CredentialChip';
+import { FeatureCardHeader } from './FeatureCardHeader';
+import { useFeatureMutations } from './use-feature-mutations';
+
+import type { FeatureStatus } from '@pops/types';
+
+export function FeatureCard({ feature }: { feature: FeatureStatus }) {
+  const { toggle, resetUserOverride, errorMessage, pending } = useFeatureMutations(feature);
+
+  const credentialMissing = feature.credentials.some((c) => c.source === 'missing');
+  const isCapability = feature.scope === 'capability';
+  const isUserScoped = feature.scope === 'user';
+  const toggleDisabled =
+    isCapability || credentialMissing || feature.capabilityMissing === true || pending;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <div className="flex items-start justify-between gap-4">
+        <FeatureCardHeader feature={feature} />
+        {!isCapability && (
+          <Switch
+            checked={feature.enabled}
+            disabled={toggleDisabled}
+            onCheckedChange={toggle}
+            aria-label={`Toggle ${feature.label}`}
+          />
+        )}
+      </div>
+
+      {feature.credentials.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {feature.credentials.map((credential) => (
+            <CredentialChip key={credential.key} credential={credential} />
+          ))}
+        </div>
+      )}
+
+      {credentialMissing && feature.configureLink && (
+        <p className="text-xs text-muted-foreground">
+          Missing credentials —{' '}
+          <Link to={feature.configureLink} className="text-app-accent underline">
+            configure them in Settings
+          </Link>
+          .
+        </p>
+      )}
+
+      {isUserScoped && feature.userOverride && (
+        <button
+          type="button"
+          className="text-[11px] text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          onClick={resetUserOverride}
+        >
+          Reset to default
+        </button>
+      )}
+
+      {errorMessage && <p className="text-xs text-destructive">{errorMessage}</p>}
+    </div>
+  );
+}

--- a/apps/pops-shell/src/app/pages/features-page/FeatureCardHeader.tsx
+++ b/apps/pops-shell/src/app/pages/features-page/FeatureCardHeader.tsx
@@ -1,0 +1,26 @@
+import { FeatureStatePill } from './FeatureStatePill';
+
+import type { FeatureStatus } from '@pops/types';
+
+export function FeatureCardHeader({ feature }: { feature: FeatureStatus }) {
+  return (
+    <div className="space-y-1 min-w-0">
+      <div className="flex items-center gap-2 flex-wrap">
+        <h3 className="font-semibold text-sm">{feature.label}</h3>
+        <FeatureStatePill state={feature.state} />
+        {feature.preview && (
+          <span className="text-[11px] uppercase tracking-wide text-violet-500">Preview</span>
+        )}
+        {feature.deprecated && (
+          <span className="text-[11px] uppercase tracking-wide text-amber-500">Deprecated</span>
+        )}
+        {feature.scope === 'user' && feature.userOverride && (
+          <span className="text-[11px] uppercase tracking-wide text-sky-500">Custom</span>
+        )}
+      </div>
+      {feature.description && (
+        <p className="text-xs text-muted-foreground">{feature.description}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/pops-shell/src/app/pages/features-page/FeatureStatePill.tsx
+++ b/apps/pops-shell/src/app/pages/features-page/FeatureStatePill.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@pops/ui';
+
+import type { FeatureStatus } from '@pops/types';
+
+const PILL_BASE =
+  'inline-flex items-center gap-1 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide rounded-full border';
+
+const STATE_CLASS: Record<FeatureStatus['state'], string> = {
+  enabled: 'bg-emerald-500/10 text-emerald-600 border-emerald-500/20 dark:text-emerald-400',
+  disabled: 'bg-muted text-muted-foreground border-border',
+  unavailable: 'bg-amber-500/10 text-amber-600 border-amber-500/20 dark:text-amber-400',
+};
+
+const STATE_LABEL: Record<FeatureStatus['state'], string> = {
+  enabled: 'Enabled',
+  disabled: 'Disabled',
+  unavailable: 'Unavailable',
+};
+
+export function FeatureStatePill({ state }: { state: FeatureStatus['state'] }) {
+  return <span className={cn(PILL_BASE, STATE_CLASS[state])}>{STATE_LABEL[state]}</span>;
+}

--- a/apps/pops-shell/src/app/pages/features-page/FeaturesPage.tsx
+++ b/apps/pops-shell/src/app/pages/features-page/FeaturesPage.tsx
@@ -1,0 +1,75 @@
+import { trpc } from '@/lib/trpc';
+import { useMemo } from 'react';
+
+import { Skeleton } from '@pops/ui';
+
+import { FeatureCard } from './FeatureCard';
+
+import type { FeatureManifest, FeatureStatus } from '@pops/types';
+
+import type { FeaturesByManifest } from './types';
+
+function groupByManifest(
+  manifests: FeatureManifest[],
+  statuses: FeatureStatus[]
+): FeaturesByManifest[] {
+  const byId = new Map<string, FeatureStatus[]>();
+  for (const status of statuses) {
+    const list = byId.get(status.manifestId) ?? [];
+    list.push(status);
+    byId.set(status.manifestId, list);
+  }
+  return manifests
+    .map((manifest) => ({ manifest, statuses: byId.get(manifest.id) ?? [] }))
+    .filter((entry) => entry.statuses.length > 0);
+}
+
+export function FeaturesPage() {
+  const manifestsQuery = trpc.core.features.getManifests.useQuery();
+  const listQuery = trpc.core.features.list.useQuery();
+
+  const grouped = useMemo<FeaturesByManifest[]>(
+    () => groupByManifest(manifestsQuery.data?.manifests ?? [], listQuery.data?.features ?? []),
+    [manifestsQuery.data?.manifests, listQuery.data?.features]
+  );
+
+  if (manifestsQuery.isLoading || listQuery.isLoading) {
+    return (
+      <div className="p-6 max-w-3xl mx-auto space-y-3">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (grouped.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground text-sm">
+        No features registered.
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto space-y-10">
+      <header className="space-y-1">
+        <h1 className="text-xl font-semibold">Features</h1>
+        <p className="text-sm text-muted-foreground">
+          Toggle integrations and runtime capabilities. Credentials are configured separately on the
+          Settings page.
+        </p>
+      </header>
+
+      {grouped.map(({ manifest, statuses }) => (
+        <section key={manifest.id} id={manifest.id} className="space-y-3 scroll-mt-20">
+          <h2 className="text-base font-semibold">{manifest.title}</h2>
+          <div className="space-y-3">
+            {statuses.map((feature) => (
+              <FeatureCard key={feature.key} feature={feature} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/pops-shell/src/app/pages/features-page/types.ts
+++ b/apps/pops-shell/src/app/pages/features-page/types.ts
@@ -1,0 +1,7 @@
+import type { FeatureManifest, FeatureStatus } from '@pops/types';
+
+/** Feature statuses grouped by their manifest, used by the Features page renderer. */
+export interface FeaturesByManifest {
+  manifest: FeatureManifest;
+  statuses: FeatureStatus[];
+}

--- a/apps/pops-shell/src/app/pages/features-page/use-feature-mutations.ts
+++ b/apps/pops-shell/src/app/pages/features-page/use-feature-mutations.ts
@@ -1,0 +1,42 @@
+import { trpc } from '@/lib/trpc';
+
+import type { FeatureStatus } from '@pops/types';
+
+interface FeatureToggleHandlers {
+  toggle: (checked: boolean) => void;
+  resetUserOverride: () => void;
+  errorMessage: string | undefined;
+  pending: boolean;
+}
+
+/**
+ * Bundles the trpc mutations a feature card needs (system enable, per-user
+ * override, user override clear) so the card stays small.
+ */
+export function useFeatureMutations(feature: FeatureStatus): FeatureToggleHandlers {
+  const utils = trpc.useUtils();
+  const onSuccess = () => utils.core.features.list.invalidate();
+
+  const setEnabled = trpc.core.features.setEnabled.useMutation({ onSuccess });
+  const setUserPreference = trpc.core.features.setUserPreference.useMutation({ onSuccess });
+  const clearUserPreference = trpc.core.features.clearUserPreference.useMutation({ onSuccess });
+
+  const toggle = (checked: boolean) => {
+    if (feature.scope === 'user') {
+      setUserPreference.mutate({ key: feature.key, enabled: checked });
+    } else {
+      setEnabled.mutate({ key: feature.key, enabled: checked });
+    }
+  };
+
+  const resetUserOverride = () => {
+    clearUserPreference.mutate({ key: feature.key });
+  };
+
+  return {
+    toggle,
+    resetUserOverride,
+    errorMessage: setEnabled.error?.message ?? setUserPreference.error?.message,
+    pending: setEnabled.isPending || setUserPreference.isPending || clearUserPreference.isPending,
+  };
+}

--- a/apps/pops-shell/src/app/router.tsx
+++ b/apps/pops-shell/src/app/router.tsx
@@ -14,6 +14,7 @@ import { routes as inventoryRoutes } from '@pops/app-inventory';
 import { routes as mediaRoutes } from '@pops/app-media';
 
 import { RootLayout } from './layout/RootLayout';
+import { FeaturesPage } from './pages/features-page/FeaturesPage';
 import { NotFoundPage } from './pages/NotFoundPage';
 import { SettingsPage } from './pages/SettingsPage';
 
@@ -76,6 +77,7 @@ export const router = createBrowserRouter([
         children: withSuspense(cerebrumRoutes),
       },
       { path: 'settings', element: <SettingsPage /> },
+      { path: 'features', element: <FeaturesPage /> },
       { path: '*', element: <NotFoundPage /> },
     ],
   },

--- a/apps/pops-shell/src/lib/use-feature-enabled.ts
+++ b/apps/pops-shell/src/lib/use-feature-enabled.ts
@@ -1,0 +1,13 @@
+import { trpc } from '@/lib/trpc';
+
+/**
+ * Single read path for runtime feature gating from the frontend.
+ *
+ * Backed by `core.features.isEnabled` — the same resolver the API uses, so the
+ * answer the UI sees is the answer the server enforces. Falls back to the
+ * caller-provided default while the query loads.
+ */
+export function useFeatureEnabled(key: string, fallback = false): boolean {
+  const { data } = trpc.core.features.isEnabled.useQuery({ key });
+  return data?.enabled ?? fallback;
+}

--- a/docs/themes/01-foundation/README.md
+++ b/docs/themes/01-foundation/README.md
@@ -30,8 +30,9 @@ Build a multi-app platform from a shared foundation: one monorepo, one shell, on
 | 6   | [Drizzle ORM](epics/06-drizzle-orm.md)                     | Type-safe queries and schema-as-code, replacing raw SQL                                                           | Done    |
 | 7   | [Search](epics/07-search.md)                               | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | Done    |
 | 8   | [Settings System](epics/08-settings-system.md)             | Unified, self-registering settings page — modular sections per app, replaces scattered settings UIs               | Done    |
+| 9   | [Feature Toggles](epics/09-feature-toggles.md)             | FeatureManifest + `isEnabled()` helper, admin Features page, credential gating, per-user preferences              | Partial |
 
-Epic 0 is prerequisite to everything. Epics 1-5 can be built incrementally. Epic 6 is independent. Epic 8 depends on Epic 4 (settings table) and Epic 2 (shell routing).
+Epic 0 is prerequisite to everything. Epics 1-5 can be built incrementally. Epic 6 is independent. Epic 8 depends on Epic 4 (settings table) and Epic 2 (shell routing). Epic 9 depends on Epic 8 (manifest pattern) and Epic 4 (`user_settings` table).
 
 ## Key Decisions
 

--- a/docs/themes/01-foundation/epics/09-feature-toggles.md
+++ b/docs/themes/01-foundation/epics/09-feature-toggles.md
@@ -1,0 +1,27 @@
+# Epic 09: Feature Toggles Framework
+
+> Theme: [Foundation](../README.md)
+
+## Scope
+
+Build a unified runtime feature-toggle layer on top of the existing settings system (Epic 08). Each module declares a `FeatureManifest` of its toggleable features; a single `features.isEnabled()` helper resolves the answer at runtime by combining capability detection, credential presence, system-level state, and per-user overrides. Replaces the scattered ad-hoc env-var and settings checks currently present across modules (Plex, Rotation, Paperless, Arr, Redis, sqlite-vec).
+
+Implements the recommendations from [docs/ideas/feature-toggles-spike.md](../../../ideas/feature-toggles-spike.md).
+
+## PRDs
+
+| #   | PRD                                                                          | Summary                                                                                             | Status      |
+| --- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------- |
+| 094 | [Feature Toggles Framework](../prds/094-feature-toggles-framework/README.md) | FeatureManifest, registry, `isEnabled()` helper, admin Features page, credential gating, user scope | In progress |
+
+## Dependencies
+
+- **Requires:** Epic 08 (Settings System — manifest pattern and `getSettingValue` helper), Epic 04 (DB Schema Patterns — `user_settings` table)
+- **Unlocks:** A consistent toggle UX across all modules; install-time vs runtime distinction; per-user UI preferences; sunset/deprecation tracking surface
+
+## Out of Scope
+
+- "Whole module" install-time gates (covered by the modular-apps spike, separate effort)
+- Compose profile management (moltbot, tools containers)
+- Multi-user authorisation
+- A/B experiments or percentage rollouts

--- a/docs/themes/01-foundation/prds/094-feature-toggles-framework/README.md
+++ b/docs/themes/01-foundation/prds/094-feature-toggles-framework/README.md
@@ -1,0 +1,182 @@
+# PRD-094: Feature Toggles Framework
+
+> Epic: [09 — Feature Toggles](../../epics/09-feature-toggles.md)
+> Status: In progress
+
+## Overview
+
+A unified runtime feature-toggle layer built on top of the existing settings system (PRD-093). Each module declares a `FeatureManifest` of toggleable features. A single `features.isEnabled(featureKey, { user? })` helper resolves the runtime answer by combining: capability detection, required credential presence, system-level enable/disable state, and per-user overrides. The Admin Features page renders the union of all registered manifests, showing each feature's state and credential status — replacing scattered ad-hoc env-var checks and hand-rolled toggle reads.
+
+This is the layer **above** PRD-093 (which provides settings storage, manifests, and the Settings page). Feature toggles are a different concept: a setting is a configuration value, a feature is an on/off capability that may depend on settings, environment, and runtime probes.
+
+## Data Model
+
+### FeatureManifest (TypeScript, not DB)
+
+```ts
+type FeatureScope = 'system' | 'user' | 'capability';
+
+interface FeatureDefinition {
+  /** Globally unique feature key, namespaced by module: 'media.plex'. */
+  key: string;
+  label: string;
+  description?: string;
+  /** Default state when no override exists. */
+  default: boolean;
+  scope: FeatureScope;
+  /**
+   * Settings keys whose resolved value (DB or env fallback) must be non-empty
+   * for the feature to be activatable. Empty list = no credential gating.
+   */
+  requires?: string[];
+  /**
+   * Environment variables required when the feature is gated by env-only secrets
+   * (e.g. Paperless). Treated identically to `requires` but consulted via env.
+   */
+  requiresEnv?: string[];
+  /** Tag experimental features so the UI can group them separately. */
+  preview?: boolean;
+  /** Mark for sunset planning — surfaces in audit reports. */
+  deprecated?: boolean;
+  /**
+   * Capability detector — returns true when the underlying runtime supports
+   * this feature (Redis available, sqlite-vec loaded). When defined, a false
+   * return makes the feature 'unavailable' regardless of settings or requires.
+   */
+  capabilityCheck?: () => boolean;
+  /** Anchor link to the relevant settings section: '/settings#media.plex'. */
+  configureLink?: string;
+  /**
+   * Settings key that backs the system-level enabled state. Defaults to the
+   * feature's own `key`. Some features back onto pre-existing keys
+   * (e.g. `media.plex.scheduler` reads `plex_scheduler_enabled`).
+   */
+  settingKey?: string;
+}
+
+interface FeatureManifest {
+  /** Module ID, matches the SettingsManifest convention: 'media', 'core'. */
+  id: string;
+  title: string;
+  icon?: string;
+  order: number;
+  features: FeatureDefinition[];
+}
+```
+
+### `user_settings` table (per-user preferences)
+
+```sql
+CREATE TABLE user_settings (
+  user_email TEXT NOT NULL,
+  key        TEXT NOT NULL,
+  value      TEXT NOT NULL,
+  PRIMARY KEY (user_email, key)
+);
+CREATE INDEX idx_user_settings_user ON user_settings(user_email);
+```
+
+User-scoped feature state lives here, keyed by the authenticated user's email (single-user system today, designed for multi-user). The system-scoped settings continue to live in the existing `settings` table.
+
+## API Surface
+
+| Procedure                           | Input              | Output                             | Notes                                                              |
+| ----------------------------------- | ------------------ | ---------------------------------- | ------------------------------------------------------------------ |
+| `core.features.list`                | —                  | `{ features: FeatureStatus[] }`    | All features with resolved state, credential status, manifest meta |
+| `core.features.getManifests`        | —                  | `{ manifests: FeatureManifest[] }` | Raw manifests grouped by module, sorted by `order`                 |
+| `core.features.isEnabled`           | `{ key }`          | `{ enabled: boolean }`             | Runtime check with current request user context                    |
+| `core.features.setEnabled`          | `{ key, enabled }` | `{ enabled: boolean }`             | Writes system-level state (rejects when credentials are missing)   |
+| `core.features.setUserPreference`   | `{ key, enabled }` | `{ enabled: boolean }`             | Writes per-user override (404 when feature is not user-scoped)     |
+| `core.features.clearUserPreference` | `{ key }`          | `{ cleared: boolean }`             | Removes the user override (falls back to system default)           |
+
+Where `FeatureStatus` is:
+
+```ts
+interface FeatureStatus {
+  key: string;
+  manifestId: string;
+  label: string;
+  description?: string;
+  scope: 'system' | 'user' | 'capability';
+  enabled: boolean;
+  default: boolean;
+  /** 'enabled' | 'disabled' | 'unavailable' (capability/credentials missing). */
+  state: 'enabled' | 'disabled' | 'unavailable';
+  /** Per-required-key configured / missing, with env-vs-db source. */
+  credentials: Array<{
+    key: string;
+    source: 'database' | 'environment' | 'missing';
+    envVar?: string;
+  }>;
+  preview?: boolean;
+  deprecated?: boolean;
+  configureLink?: string;
+  /** True when capability check returned false. */
+  capabilityMissing?: boolean;
+  /** When user-scoped: whether the user has set a personal override. */
+  userOverride?: boolean;
+}
+```
+
+## Business Rules
+
+- Each module owns its FeatureManifest. Manifests are registered at API startup via `featuresRegistry.register(manifest)` — exactly mirroring the SettingsRegistry pattern.
+- Duplicate feature keys across manifests cause a startup error. The same feature key cannot be claimed twice.
+- `features.isEnabled(key, { user? })` is the single read path. Modules MUST NOT implement their own toggle reads.
+- Resolution order in `isEnabled`:
+  1. `capabilityCheck()` → if defined and returns `false` → feature is **unavailable**, returns `false`.
+  2. `requires[]` settings → resolve each via DB then `envFallback`. Any missing → unavailable, returns `false`.
+  3. `requiresEnv[]` env vars → resolved via `getEnv()`. Any missing → unavailable, returns `false`.
+  4. `scope: 'user'` and a `user` was passed → return user override if set.
+  5. System-level state from `settingKey ?? key` → returns the boolean if set.
+  6. Otherwise → return `feature.default`.
+- Setting a feature's enabled state is rejected when its credentials/capability gate is missing — UI must show the gate before allowing the toggle.
+- The Admin Features page is rendered from the union of all registered manifests, grouped by `manifestId`, sorted by `order`.
+- Per-user preferences are keyed by the authenticated email (`ctx.user.email`). Anonymous contexts cannot read or write user-scoped state.
+- Capability features (Redis, sqlite-vec) cannot be toggled by the user — they reflect runtime probes, not configuration.
+- The `requires[]` keys reuse the same registry semantics from PRD-093 (env fallback, sensitive masking) — feature-toggle credential rendering links back to the relevant settings section.
+
+## Edge Cases
+
+| Case                                                          | Behaviour                                                                                       |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Feature has no `requires`, no `capabilityCheck`               | Toggle is freely flippable; resolves from system setting then default                           |
+| `requires` lists a key that no settings manifest declares     | Treated as missing (always); operator gets a startup warning                                    |
+| Capability feature is toggled in admin                        | UI does not render a toggle — only a status badge                                               |
+| User-scoped feature read without a user context               | Falls back to system state (warning logged in dev)                                              |
+| Feature's `settingKey` differs from `key`                     | System read uses `settingKey`; admin save also writes `settingKey`                              |
+| Existing setting value is `'true'`/`'false'`                  | Parsed as boolean; any other string is treated as `false`                                       |
+| Per-user override set, then `clearUserPreference` is called   | Resolution falls back to system default                                                         |
+| Feature requires env var that's set in dev but absent in prod | `requiresEnv` evaluation uses `getEnv()` so Docker secrets work the same as env vars            |
+| Two manifests register the same key                           | Startup throws an explicit error (mirrors SettingsRegistry behaviour)                           |
+| Module is not loaded (modular apps, future)                   | Its manifest never registers; the feature does not exist; `isEnabled` returns `false` and warns |
+
+## User Stories
+
+| #   | Story                                                                     | Summary                                                                                      | Status      | Parallelisable   |
+| --- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------- | ---------------- |
+| 01  | [us-01-feature-manifest-and-helper](us-01-feature-manifest-and-helper.md) | Define FeatureManifest, registry, `features.isEnabled()` with capability + credential gating | In progress | No (first)       |
+| 02  | [us-02-migrate-existing-toggles](us-02-migrate-existing-toggles.md)       | Migrate plex/rotation/paperless/radarr/sonarr/redis/sqlite-vec toggles to manifests          | In progress | Blocked by us-01 |
+| 03  | [us-03-admin-features-page](us-03-admin-features-page.md)                 | `/features` admin page rendering manifests with state and toggle controls                    | In progress | Blocked by us-01 |
+| 04  | [us-04-credential-gating](us-04-credential-gating.md)                     | UI: configured/missing chips, disable toggle when credentials missing, link to settings      | In progress | Blocked by us-03 |
+| 05  | [us-05-per-user-preferences](us-05-per-user-preferences.md)               | `user_settings` table, scope: 'user' resolution, `setUserPreference` procedure               | In progress | Blocked by us-01 |
+
+## Verification
+
+- `features.isEnabled('media.plex.scheduler')` returns `false` until both `plex_url` and `plex_token` are set; flipping the admin toggle to `true` then enables it.
+- Disconnecting Redis flips the `core.redis` capability badge to "Unavailable" without changing any setting.
+- `features.isEnabled('inventory.show_connected_status', { user })` returns the user override when one is set, the system default otherwise.
+- The Admin Features page lists every registered feature; capability-only features render a status pill (not a switch).
+- Removing `PAPERLESS_BASE_URL` from env makes `inventory.paperless` unavailable on next request.
+
+## Out of Scope
+
+- Module-level "whole app" gates (modular apps spike — separate effort).
+- Compose-profile toggles (moltbot, tools containers — already covered by Docker profiles).
+- Multi-user authorisation, role-based feature exposure.
+- Sunset/deprecation reporting UI (the field is captured; the report is future work).
+- A/B experiments, percentage rollouts, multi-variant flags.
+
+## Drift Check
+
+last checked: 2026-04-29

--- a/docs/themes/01-foundation/prds/094-feature-toggles-framework/us-01-feature-manifest-and-helper.md
+++ b/docs/themes/01-foundation/prds/094-feature-toggles-framework/us-01-feature-manifest-and-helper.md
@@ -1,0 +1,42 @@
+# US-01: FeatureManifest type + `features.isEnabled()` helper
+
+> Parent PRD: [PRD-094 Feature Toggles Framework](README.md)
+> GitHub issue: #2299
+> Status: In progress
+
+## Goal
+
+Introduce the `FeatureManifest` type, a process-wide `featuresRegistry`, and a single read-path helper `features.isEnabled(key, { user? })` that resolves a feature's runtime state by combining capability detection, credential presence (DB + env fallback), per-user overrides, and the system-level setting.
+
+## Deliverables
+
+- `packages/types/src/feature-manifest.ts` — `FeatureManifest`, `FeatureDefinition`, `FeatureScope` types, exported from `@pops/types`.
+- `apps/pops-api/src/modules/core/features/` module:
+  - `registry.ts` — `FeaturesRegistry` (mirrors `SettingsRegistry`: register, getAll, clear, key collision detection)
+  - `service.ts` — `isEnabled(key, { user? })`, `listFeatures()`, `setFeatureEnabled()`, `setUserPreference()`, `clearUserPreference()`
+  - `router.ts` — tRPC router exposing `list`, `getManifests`, `isEnabled`, `setEnabled`, `setUserPreference`, `clearUserPreference`
+  - `types.ts` — `FeatureStatus` shape used by API and admin UI
+- `core.features` mounted under the existing `coreRouter`.
+
+## Acceptance Criteria
+
+- [x] `@pops/types` exports `FeatureManifest`, `FeatureDefinition`, `FeatureScope`, `FeatureStatus`.
+- [x] `featuresRegistry.register(manifest)` enforces unique feature keys across all manifests; duplicates throw with both manifest IDs in the message.
+- [x] `features.isEnabled(key)` returns `feature.default` when no overrides and no requirements are present.
+- [x] `requires: ['x', 'y']` resolves each key via the settings DB **and** `envFallback` (matches PRD-093 semantics) — any empty value yields `false`.
+- [x] `requiresEnv: ['Z']` resolves via `getEnv()` (Docker secret + `process.env`); any missing value yields `false`.
+- [x] `capabilityCheck()` returning `false` short-circuits the resolution to `false`.
+- [x] `scope: 'user'` features prefer the user override over the system value when a user context is supplied.
+- [x] Unit tests cover: defaults, capability gate, credential gate, env-only credential gate, user override precedence, missing user context, key collisions.
+
+## Out of Scope
+
+- The Admin Features page (US-03).
+- Migrating existing toggles (US-02).
+- The `user_settings` schema migration (delivered alongside US-05; the helper code reads/writes the table, the schema arrives in US-05).
+
+## Notes
+
+- Follows the SettingsRegistry pattern from PRD-093 — same shape for `register/getAll/clear`.
+- The helper is synchronous for parity with `getSettingValue` (already used in hot paths). Caching can be added later if profiling justifies it.
+- A feature's system state lives in the `settings` table (key = `feature.settingKey ?? feature.key`) so existing keys like `plex_scheduler_enabled` continue to work.

--- a/docs/themes/01-foundation/prds/094-feature-toggles-framework/us-02-migrate-existing-toggles.md
+++ b/docs/themes/01-foundation/prds/094-feature-toggles-framework/us-02-migrate-existing-toggles.md
@@ -1,0 +1,36 @@
+# US-02: Migrate existing ad-hoc toggles to FeatureManifest
+
+> Parent PRD: [PRD-094 Feature Toggles Framework](README.md)
+> GitHub issue: #2300
+> Status: In progress
+
+## Goal
+
+Move every existing ad-hoc toggle behind the FeatureManifest pattern so all modules read state through the same `features.isEnabled()` helper. Behaviour is preserved — this is a centralisation of reads, not a behaviour change.
+
+## Toggles to Migrate
+
+| Existing check                                                   | Feature key             | Scope      | Required credentials                             |
+| ---------------------------------------------------------------- | ----------------------- | ---------- | ------------------------------------------------ |
+| `plex_scheduler_enabled` setting                                 | `media.plex.scheduler`  | system     | `plex_url`, `plex_token`                         |
+| `rotation_enabled` setting                                       | `media.rotation`        | system     | (none)                                           |
+| `getEnv('PAPERLESS_BASE_URL')` + `getEnv('PAPERLESS_API_TOKEN')` | `inventory.paperless`   | system     | env: `PAPERLESS_BASE_URL`, `PAPERLESS_API_TOKEN` |
+| Radarr URL + API key probe                                       | `media.radarr`          | system     | `radarr_url`, `radarr_api_key`                   |
+| Sonarr URL + API key probe                                       | `media.sonarr`          | system     | `sonarr_url`, `sonarr_api_key`                   |
+| Redis client status                                              | `core.redis`            | capability | env: `REDIS_HOST`                                |
+| `isVecAvailable()`                                               | `cerebrum.vectorSearch` | capability | (capability probe)                               |
+
+## Acceptance Criteria
+
+- [x] Each module declares its FeatureManifest and registers it on startup (same lifecycle as SettingsManifest registration).
+- [x] `media.plex.scheduler` reads/writes `plex_scheduler_enabled` (preserves existing setting key).
+- [x] `media.rotation` reads/writes `rotation_enabled`.
+- [x] `getPaperlessClient()` uses `features.isEnabled('inventory.paperless')` and returns `null` when disabled — same observable behaviour as before.
+- [x] `core.redis` and `cerebrum.vectorSearch` register `capabilityCheck` callbacks; their `state` is always `unavailable` or `enabled` based on the runtime probe (no toggle).
+- [x] No module continues to call `getEnv()` directly for credential gating purposes — gating goes through the helper.
+- [x] Existing tests continue to pass; new tests assert that disabling a feature short-circuits the relevant code path.
+
+## Out of Scope
+
+- Reworking the underlying credentials (Plex remains in settings; Paperless remains in env).
+- Sunset / deprecation tracking — mark `deprecated: true` is fine but no automated report yet.

--- a/docs/themes/01-foundation/prds/094-feature-toggles-framework/us-03-admin-features-page.md
+++ b/docs/themes/01-foundation/prds/094-feature-toggles-framework/us-03-admin-features-page.md
@@ -1,0 +1,31 @@
+# US-03: Admin Features page
+
+> Parent PRD: [PRD-094 Feature Toggles Framework](README.md)
+> GitHub issue: #2301
+> Status: In progress
+
+## Goal
+
+Build a dedicated `/features` admin page in `pops-shell` (distinct from `/settings`) that lists every registered feature, grouped by module, with its current state and a toggle control where applicable.
+
+## Deliverables
+
+- `apps/pops-shell/src/app/pages/FeaturesPage.tsx` — page component reading from `core.features.list` and `core.features.getManifests`.
+- Section per module (`manifest.title`), feature cards inside each section.
+- Each card shows: label, description, current state pill (`Enabled` / `Disabled` / `Unavailable`), toggle (when scope is `system` or `user`), credential chip(s) for `requires`.
+- Sidebar nav identical to the SettingsPage sidebar (sections sorted by `order`).
+- Route `/features` registered in `apps/pops-shell/src/app/router.tsx`.
+- Top nav entry under "Settings" cluster — labelled "Features".
+
+## Acceptance Criteria
+
+- [x] `/features` route renders the feature list grouped by module.
+- [x] Toggling a feature calls `core.features.setEnabled` and updates the local state on success.
+- [x] Capability features show a status pill with no toggle.
+- [x] Loading state and empty state are handled gracefully.
+- [x] Sidebar nav scrolls to the selected section (mirrors SettingsPage UX).
+
+## Out of Scope
+
+- Credential-gating chips and disabled-toggle behaviour with hint text — that's US-04.
+- Per-user toggle UI — that's US-05.

--- a/docs/themes/01-foundation/prds/094-feature-toggles-framework/us-04-credential-gating.md
+++ b/docs/themes/01-foundation/prds/094-feature-toggles-framework/us-04-credential-gating.md
@@ -1,0 +1,29 @@
+# US-04: Credential-gating `requires` pattern
+
+> Parent PRD: [PRD-094 Feature Toggles Framework](README.md)
+> GitHub issue: #2302
+> Status: In progress
+
+## Goal
+
+When a feature has `requires: [...]` or `requiresEnv: [...]`, the Features admin page must communicate the credential state and prevent the user from enabling a feature whose dependencies are missing.
+
+## Deliverables
+
+- Per-credential chip in the feature card: `Configured` (DB), `Configured via env` (env fallback), or `Missing` with the setting/env-var name.
+- The toggle is disabled when any required credential is missing; hover/aria-disabled exposes a hint.
+- A "Configure credentials" link points to the relevant Settings section anchor (e.g. `/settings#media.plex`).
+- Server-side, `core.features.setEnabled` rejects with `BAD_REQUEST` when credentials are missing — even if the request bypasses the UI.
+
+## Acceptance Criteria
+
+- [x] Each `requires` key renders a chip with one of: `Configured`, `Configured via env`, `Missing`.
+- [x] Each `requiresEnv` env var renders a chip with `Configured via env` or `Missing`.
+- [x] When at least one chip is `Missing`, the toggle is disabled and the card shows a "Configure credentials first" hint linking to `feature.configureLink`.
+- [x] The server rejects `setEnabled({ enabled: true })` for a feature whose credentials are missing.
+- [x] Setting a credential value (via the Settings page) and revisiting Features shows the chip as `Configured`.
+
+## Out of Scope
+
+- Inline credential editing in the Features page (requires the Settings page).
+- Live cross-tab sync (the Settings page already requires a refresh).

--- a/docs/themes/01-foundation/prds/094-feature-toggles-framework/us-05-per-user-preferences.md
+++ b/docs/themes/01-foundation/prds/094-feature-toggles-framework/us-05-per-user-preferences.md
@@ -1,0 +1,33 @@
+# US-05: Per-user feature preferences
+
+> Parent PRD: [PRD-094 Feature Toggles Framework](README.md)
+> GitHub issue: #2303
+> Status: In progress
+
+## Goal
+
+Support per-user feature preferences — features declared with `scope: 'user'` resolve to a per-user override when set, and fall back to the system default otherwise. The first concrete user-scoped feature is `inventory.show_connected_status` (default: `true`).
+
+## Deliverables
+
+- `user_settings` table created via Drizzle migration (`apps/pops-api/src/db/drizzle-migrations/`).
+- `packages/db-types/src/schema/user-settings.ts` exporting the table definition.
+- `apps/pops-api/src/modules/core/features/user-settings.ts` — getter / upsert / delete keyed by `(user_email, key)`.
+- `features.isEnabled('x.y', { user })` checks the user override before the system value when the feature is user-scoped.
+- `core.features.setUserPreference` and `core.features.clearUserPreference` tRPC procedures.
+- One concrete user-scoped feature: `inventory.show_connected_status` (default `true`) registered by the inventory module.
+- Admin Features page renders user-scoped features with a per-user switch (uses the current authenticated email).
+
+## Acceptance Criteria
+
+- [x] `user_settings(user_email, key, value)` schema migration ships and is included in the fresh-DB initialiser.
+- [x] `features.isEnabled('inventory.show_connected_status', { user })` returns the user override when set, otherwise the system default.
+- [x] `setUserPreference` rejects when the feature is not user-scoped.
+- [x] `clearUserPreference` removes the row and resolution falls back to the system default.
+- [x] The Features admin page shows the user-scoped switch separately from the system switch (when the feature has both scopes — currently none, but the UI handles it).
+- [x] Existing inventory components reading "show connected status" go through `features.isEnabled` (or a thin client hook backed by `core.features.isEnabled`).
+
+## Out of Scope
+
+- Multi-user invitation flow — single-user system today, but the schema supports multi-user for the future.
+- Migrating other UI affordances to user-scoped features — only `inventory.show_connected_status` ships in this US.

--- a/packages/db-types/src/schema/index.ts
+++ b/packages/db-types/src/schema/index.ts
@@ -37,6 +37,7 @@ export { rotationLog } from './rotation-log.js';
 export { rotationSources } from './rotation-sources.js';
 export { seasons } from './seasons.js';
 export { settings } from './settings.js';
+export { userSettings } from './user-settings.js';
 export { shelfImpressions } from './shelf-impressions.js';
 export { syncJobResults } from './sync-job-results.js';
 export { syncLogs } from './sync-logs.js';

--- a/packages/db-types/src/schema/user-settings.ts
+++ b/packages/db-types/src/schema/user-settings.ts
@@ -1,0 +1,27 @@
+import { index, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
+
+/**
+ * Per-user preferences. Used by the feature toggle framework when a feature
+ * declares `scope: 'user'` so the user override resolves before the
+ * system-level default.
+ *
+ * Keyed by the authenticated email (single-user system today, but the schema
+ * supports multi-user without further migrations).
+ */
+export const userSettings = sqliteTable(
+  'user_settings',
+  {
+    userEmail: text('user_email').notNull(),
+    key: text('key').notNull(),
+    value: text('value').notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.userEmail, table.key] }),
+    userIdx: index('idx_user_settings_user').on(table.userEmail),
+  })
+);
+
+export type UserSettingRow = InferSelectModel<typeof userSettings>;
+export type UserSettingInsert = InferInsertModel<typeof userSettings>;

--- a/packages/types/src/feature-manifest.ts
+++ b/packages/types/src/feature-manifest.ts
@@ -1,0 +1,103 @@
+/**
+ * Feature manifest types — shared between API (registry / service) and frontend
+ * (admin Features page renderer).
+ *
+ * Sits on top of the settings system (PRD-093). A feature is an on/off
+ * capability; its credential dependencies are settings keys. The runtime
+ * `features.isEnabled()` helper is the single read path for runtime gating.
+ */
+
+/**
+ * Runtime scope of a feature.
+ * - `system`     — admin-only, single value across the deployment
+ * - `user`       — per-user override on top of the system default
+ * - `capability` — read-only runtime probe (Redis, sqlite-vec)
+ */
+export type FeatureScope = 'system' | 'user' | 'capability';
+
+export interface FeatureDefinition {
+  /** Globally unique key, namespaced by module: `media.plex.scheduler`. */
+  key: string;
+  label: string;
+  description?: string;
+  /** Default state when no override is set and no gating is failing. */
+  default: boolean;
+  scope: FeatureScope;
+  /**
+   * Settings keys whose resolved value (DB or `envFallback`) must be non-empty
+   * for the feature to be activatable. Mirrors PRD-093 semantics — empty list
+   * means no credential gating.
+   */
+  requires?: string[];
+  /**
+   * Environment variables required when the credential is env-only (Docker
+   * secret / dotenv). Treated identically to `requires`, resolved via
+   * `getEnv()` rather than the settings table.
+   */
+  requiresEnv?: string[];
+  /** Tag the feature as preview/experimental for grouping purposes. */
+  preview?: boolean;
+  /** Mark for sunset planning. Surfaces in audit reports. */
+  deprecated?: boolean;
+  /**
+   * Setting key that backs the system-level enabled state. Defaults to
+   * `feature.key`. Lets a feature reuse a pre-existing setting key
+   * (e.g. `media.plex.scheduler` reads `plex_scheduler_enabled`).
+   */
+  settingKey?: string;
+  /** Anchor link to the relevant Settings section: `/settings#media.plex`. */
+  configureLink?: string;
+  /**
+   * Capability detector — returns `true` when the underlying runtime supports
+   * this feature (Redis available, sqlite-vec loaded). When defined, a `false`
+   * return makes the feature `unavailable` regardless of settings or requires.
+   *
+   * Stripped before serialisation by the API; never reaches the frontend.
+   */
+  capabilityCheck?: () => boolean;
+}
+
+export interface FeatureManifest {
+  /** Module ID: `media`, `inventory`, `core`. Matches SettingsManifest convention. */
+  id: string;
+  title: string;
+  icon?: string;
+  order: number;
+  features: FeatureDefinition[];
+}
+
+/** Runtime status of a feature — what the API returns to the admin page. */
+export interface FeatureStatus {
+  key: string;
+  manifestId: string;
+  label: string;
+  description?: string;
+  scope: FeatureScope;
+  /** Resolved enabled state (after capability + credentials + override + default). */
+  enabled: boolean;
+  default: boolean;
+  /**
+   * Coarse status for the UI:
+   * - `enabled`: the feature is currently on
+   * - `disabled`: gating passes but the toggle is off
+   * - `unavailable`: capability or required credentials missing
+   */
+  state: 'enabled' | 'disabled' | 'unavailable';
+  /** Per-required-credential resolution. */
+  credentials: FeatureCredentialStatus[];
+  /** True when the capability check returned false. */
+  capabilityMissing?: boolean;
+  preview?: boolean;
+  deprecated?: boolean;
+  configureLink?: string;
+  /** True when a per-user override is set (only meaningful for `scope: 'user'`). */
+  userOverride?: boolean;
+}
+
+export interface FeatureCredentialStatus {
+  key: string;
+  /** Where the value comes from. `missing` means neither DB nor env. */
+  source: 'database' | 'environment' | 'missing';
+  /** Set when the resolution involved an env var (fallback or `requiresEnv`). */
+  envVar?: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,3 +17,10 @@ export type {
   SettingsGroup,
   SettingsManifest,
 } from './settings-manifest.js';
+export type {
+  FeatureCredentialStatus,
+  FeatureDefinition,
+  FeatureManifest,
+  FeatureScope,
+  FeatureStatus,
+} from './feature-manifest.js';


### PR DESCRIPTION
## Summary

Implements the feature toggles framework recommended in [docs/ideas/feature-toggles-spike.md](../tree/main/docs/ideas/feature-toggles-spike.md). Delivers PRD-094 end-to-end and migrates existing ad-hoc toggles to the new pattern.

- New `FeatureManifest` + `featuresRegistry` + `features.isEnabled()` helper as the single read path for runtime gating (capability → required credentials → user override → system value → default).
- Per-user preferences via a new `user_settings` table — first user-scoped feature: `inventory.show_connected_status`.
- Admin Features page at `/features` with credential chips, missing-credential hints linking back to Settings, and a status pill for capability-only flags.
- Migrated: `media.plex.scheduler`, `media.rotation`, `inventory.paperless`, `media.radarr`, `media.sonarr`, `core.redis`, `cerebrum.vectorSearch`.

## Closes

- Closes #2298 — Epic: Feature toggles framework
- Closes #2299 — FeatureManifest type + features.isEnabled() helper
- Closes #2300 — Migrate existing ad-hoc toggles
- Closes #2301 — Admin Features page with credential status
- Closes #2302 — Credential-gating requires pattern
- Closes #2303 — Per-user feature preferences

## Docs

- New: [PRD-094 Feature Toggles Framework](docs/themes/01-foundation/prds/094-feature-toggles-framework/README.md) + 5 user stories
- New: [Epic 09 Feature Toggles](docs/themes/01-foundation/epics/09-feature-toggles.md)
- Updated: foundation theme README to reference the new epic

## Test plan

- [x] `pnpm test` — 220 files, 3807 tests passing (32 new tests in `core/features/`)
- [x] `mise typecheck` — all 17 packages pass
- [x] `mise lint` — 0 errors (144 pre-existing warnings)
- [x] `pnpm format:check` — clean
- [ ] Browser smoke: open `/features`, toggle Plex auto-sync (with creds), confirm credential chip changes when a setting is removed.
- [ ] Verify `/features` user-scoped switch toggles `inventory.show_connected_status` and survives reload.
- [ ] Confirm Redis disconnect flips `core.redis` status pill to "Unavailable".

## Notes

- Behaviour preserved across migrations: legacy setting keys (`plex_scheduler_enabled`, `rotation_enabled`) are reused via `feature.settingKey` so existing prod data continues to work.
- `core.features.setEnabled` rejects with `BAD_REQUEST` when credentials/capability are missing — the UI gate is enforced server-side, not just client-side.
- `user_settings(user_email, key, value)` migration ships at `0042_user_settings.sql`; fresh DBs get the table via `initializeSchema`.