### PR TITLE
fix(ui/data-table): show 'Page 0 of 0' instead of 'Page 1 of 0' when empty

### DIFF
--- a/packages/ui/src/components/DataTable.pagination.tsx
+++ b/packages/ui/src/components/DataTable.pagination.tsx
@@ -64,12 +64,14 @@ function PageSizeSelect<TData>({
 
 function PageNav<TData>({ table }: { table: TanStackTable<TData> }) {
   const { t } = useTranslation('ui');
+  const pageCount = table.getPageCount();
+  const current = pageCount === 0 ? 0 : table.getState().pagination.pageIndex + 1;
   return (
     <div className="flex items-center gap-2">
       <div className="text-sm font-medium">
         {t('dataTable.page', {
-          current: table.getState().pagination.pageIndex + 1,
-          total: table.getPageCount(),
+          current,
+          total: pageCount,
         })}
       </div>
       <div className="flex gap-2">


### PR DESCRIPTION
## Summary

Closes #2307 (and the duplicate #2306).

When a `DataTable` has zero results, `getPageCount()` returns `0` but `pageIndex` stays at `0`, so the pagination footer rendered the mathematically nonsense **"Page 1 of 0"**. Clamp the displayed current page to `0` when there are no pages so the empty state reads **"Page 0 of 0"**.

The change is in the shared `DataTablePagination` component, so the fix benefits every table in the app (Transactions, Budgets, Wish List, Inventory, Media, AI, etc.) — not just `/finance/transactions` where the bug was reported.

## Changes

- `packages/ui/src/components/DataTable.pagination.tsx` — clamp `current` to `0` when `pageCount === 0`.

## Test plan

- [ ] Visit `/finance/transactions` with filters that produce zero rows → footer reads "Page 0 of 0", Previous/Next remain disabled
- [ ] Visit a populated table → footer still reads "Page X of Y" as before
- [ ] Confirm the same on at least one non-finance table (Inventory, Wish List)

https://claude.ai/code/session_014ARNc4h5mPf74oNu5QYd4j

---
_Generated by [Claude Code](https://claude.ai/code/session_014ARNc4h5mPf74oNu5QYd4j)_