### PR TITLE
fix(cerebrum/nav): add leading slash to nav item paths

### DIFF
--- a/packages/app-cerebrum/src/routes.tsx
+++ b/packages/app-cerebrum/src/routes.tsx
@@ -41,10 +41,10 @@ export const navConfig = {
   basePath: '/cerebrum',
   items: [
     { path: '', label: 'Ingest', labelKey: 'cerebrum.ingest', icon: 'FileText' },
-    { path: 'chat', label: 'Chat', labelKey: 'cerebrum.chat', icon: 'MessageSquare' },
-    { path: 'nudges', label: 'Nudges', labelKey: 'cerebrum.nudges', icon: 'Bell' },
+    { path: '/chat', label: 'Chat', labelKey: 'cerebrum.chat', icon: 'MessageSquare' },
+    { path: '/nudges', label: 'Nudges', labelKey: 'cerebrum.nudges', icon: 'Bell' },
     {
-      path: 'proposals',
+      path: '/proposals',
       label: 'Proposals',
       labelKey: 'cerebrum.proposals',
       icon: 'GitPullRequest',


### PR DESCRIPTION
## Summary

Fixes #2324. The Cerebrum sidebar links rendered as `/cerebrumchat`, `/cerebrumnudges`, `/cerebrumproposals` because the `navConfig.items[].path` values omitted the leading slash. The shell's URL builder concatenates `${app.basePath}${item.path}` (see `apps/pops-shell/src/app/layout/sidebar/SidebarNavLink.tsx:17`), so without the slash the segments fuse together.

All four other apps (finance, media, inventory, ai) already use leading slashes on their nav item paths. This change brings cerebrum into line with that convention.

After: `/cerebrum/chat`, `/cerebrum/nudges`, `/cerebrum/proposals` — which match the actual routes mounted in `apps/pops-shell/src/app/router.tsx:75`.

## Test plan

- [x] `pnpm typecheck` passes (all 17 packages)
- [x] `pnpm lint` passes (0 errors)
- [x] `@pops/app-cerebrum` tests pass (36/36)
- [x] `@pops/shell` tests pass (161/161)
- [ ] Manually verify sidebar links resolve to `/cerebrum/chat`, `/cerebrum/nudges`, `/cerebrum/proposals` and the URL bar shows the same

Closes #2324

---
_Generated by [Claude Code](https://claude.ai/code/session_01P47TezP2Xmyub9mP7sDMbd)_