### PR TITLE
fix(finance/dashboard): zero-amount stat cards render in neutral colour

### DIFF
--- a/docs/themes/02-finance/prds/019-transactions/us-04-dashboard.md
+++ b/docs/themes/02-finance/prds/019-transactions/us-04-dashboard.md
@@ -10,6 +10,7 @@ As a user, I want a dashboard page showing key financial stats and recent transa
 ## Acceptance Criteria
 
 - [x] Stats cards: total transaction count, recent income (last 10), recent expenses (last 10), net balance
+- [x] Stats card amounts are colour-coded by sign: positive → success (green), negative → destructive (red), zero → neutral foreground. Zero values never render in red or green.
 - [x] Recent transactions list (last 10) with date, description, amount (colour-coded), entity name, account badge
 - [x] Active budgets section (first 3) — links to budgets page
 - [x] Loading skeletons for stats and transaction rows

--- a/packages/app-finance/src/pages/dashboard/StatsGrid.test.ts
+++ b/packages/app-finance/src/pages/dashboard/StatsGrid.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeStats, signedColor } from './StatsGrid';
+
+import type { Transaction } from '@pops/api/modules/finance/transactions/types';
+
+function makeTx(amount: number, overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: `tx-${amount}`,
+    date: '2026-04-29',
+    description: 'Test',
+    amount,
+    accountId: 'acc-1',
+    accountName: 'Test',
+    type: amount >= 0 ? 'income' : 'purchase',
+    entityId: null,
+    entityName: null,
+    tags: [],
+    location: null,
+    createdAt: '2026-04-29T00:00:00Z',
+    updatedAt: '2026-04-29T00:00:00Z',
+    ...overrides,
+  } as Transaction;
+}
+
+describe('signedColor', () => {
+  it('maps positive amounts to emerald', () => {
+    expect(signedColor(0.01)).toBe('emerald');
+    expect(signedColor(1234.56)).toBe('emerald');
+  });
+
+  it('maps negative amounts to rose', () => {
+    expect(signedColor(-0.01)).toBe('rose');
+    expect(signedColor(-1234.56)).toBe('rose');
+  });
+
+  it('maps zero to slate (neutral)', () => {
+    expect(signedColor(0)).toBe('slate');
+    expect(signedColor(-0)).toBe('slate');
+  });
+});
+
+describe('computeStats', () => {
+  it('returns null when transactions are undefined', () => {
+    expect(computeStats(undefined, 0)).toBeNull();
+  });
+
+  it('returns zeroed stats for an empty transaction list', () => {
+    expect(computeStats([], 0)).toEqual({
+      totalTransactions: 0,
+      totalIncome: 0,
+      totalExpenses: 0,
+    });
+  });
+
+  it('sums income (positive) and expenses (abs of negative) separately', () => {
+    const stats = computeStats([makeTx(100), makeTx(-30), makeTx(50), makeTx(-20)], 4);
+    expect(stats).toEqual({
+      totalTransactions: 4,
+      totalIncome: 150,
+      totalExpenses: 50,
+    });
+  });
+
+  it('uses the provided total count rather than the array length', () => {
+    const stats = computeStats([makeTx(10)], 999);
+    expect(stats?.totalTransactions).toBe(999);
+  });
+});

--- a/packages/app-finance/src/pages/dashboard/StatsGrid.tsx
+++ b/packages/app-finance/src/pages/dashboard/StatsGrid.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-import { SkeletonGrid, StatCard } from '@pops/ui';
+import { SkeletonGrid, StatCard, type StatCardColor } from '@pops/ui';
 
 import type { Transaction } from '@pops/api/modules/finance/transactions/types';
 
@@ -24,12 +24,19 @@ export function computeStats(
   };
 }
 
+function signedColor(amount: number): StatCardColor {
+  if (amount > 0) return 'emerald';
+  if (amount < 0) return 'rose';
+  return 'slate';
+}
+
 export function StatsGrid({ stats, isLoading }: { stats: Stats | null; isLoading: boolean }) {
   const { t } = useTranslation('finance');
   if (isLoading) {
     return <SkeletonGrid count={4} itemHeight="h-32" cols="sm:grid-cols-2 lg:grid-cols-4" />;
   }
   if (!stats) return null;
+  const netBalance = stats.totalIncome - stats.totalExpenses;
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       <StatCard
@@ -42,19 +49,19 @@ export function StatsGrid({ stats, isLoading }: { stats: Stats | null; isLoading
         title={t('dashboard.recentIncome')}
         value={`$${stats.totalIncome.toFixed(2)}`}
         description={t('dashboard.last10')}
-        color="emerald"
+        color={stats.totalIncome > 0 ? 'emerald' : 'slate'}
       />
       <StatCard
         title={t('dashboard.recentExpenses')}
         value={`$${stats.totalExpenses.toFixed(2)}`}
         description={t('dashboard.last10')}
-        color="rose"
+        color={stats.totalExpenses > 0 ? 'rose' : 'slate'}
       />
       <StatCard
         title={t('dashboard.netBalance')}
-        value={`$${(stats.totalIncome - stats.totalExpenses).toFixed(2)}`}
+        value={`$${netBalance.toFixed(2)}`}
         description={t('dashboard.last10')}
-        color={stats.totalIncome > stats.totalExpenses ? 'emerald' : 'rose'}
+        color={signedColor(netBalance)}
       />
     </div>
   );

--- a/packages/app-finance/src/pages/dashboard/StatsGrid.tsx
+++ b/packages/app-finance/src/pages/dashboard/StatsGrid.tsx
@@ -24,7 +24,7 @@ export function computeStats(
   };
 }
 
-function signedColor(amount: number): StatCardColor {
+export function signedColor(amount: number): StatCardColor {
   if (amount > 0) return 'emerald';
   if (amount < 0) return 'rose';
   return 'slate';
@@ -49,13 +49,13 @@ export function StatsGrid({ stats, isLoading }: { stats: Stats | null; isLoading
         title={t('dashboard.recentIncome')}
         value={`$${stats.totalIncome.toFixed(2)}`}
         description={t('dashboard.last10')}
-        color={stats.totalIncome > 0 ? 'emerald' : 'slate'}
+        color={signedColor(stats.totalIncome)}
       />
       <StatCard
         title={t('dashboard.recentExpenses')}
         value={`$${stats.totalExpenses.toFixed(2)}`}
         description={t('dashboard.last10')}
-        color={stats.totalExpenses > 0 ? 'rose' : 'slate'}
+        color={signedColor(-stats.totalExpenses)}
       />
       <StatCard
         title={t('dashboard.netBalance')}


### PR DESCRIPTION
## Summary

Closes #2316.

The Finance Dashboard's **Recent Expenses** and **Net Balance** cards were rendering `$0.00` in red because the colour was hard-coded to the metric's category, not the value's sign. A zero amount has no sign, so red was misleading — it implied money had been lost or a budget exceeded when nothing had happened.

The fix switches every signed stat card to a tri-state mapping:

| Value          | Colour                  |
| -------------- | ----------------------- |
| `> 0`          | `emerald` (success)     |
| `< 0`          | `rose` (destructive)    |
| `=== 0`        | `slate` (neutral)       |

This also corrects a related off-by-one in **Net Balance**: the previous condition `totalIncome > totalExpenses ? 'emerald' : 'rose'` painted Net Balance rose when income equalled expenses (including the all-zero case). Now `0` falls into the neutral bucket.

The same neutral-when-zero rule is applied to **Recent Income** for consistency, even though the original ticket only called out Recent Expenses and Net Balance — colour should mean direction everywhere on the card row, or it means nothing.

## Changes

- `packages/app-finance/src/pages/dashboard/StatsGrid.tsx` — extract a `signedColor()` helper and pick `slate` when the underlying amount is `0`.
- `docs/themes/02-finance/prds/019-transactions/us-04-dashboard.md` — add an acceptance criterion that codifies the tri-state colour rule for stat cards (PRD-First / Documentation Sync rule).

`StatCard` itself is unchanged: it's a domain-agnostic component used across many apps, so the policy belongs in the dashboard composition layer, not the primitive.

## Test plan

- [ ] Visit `/finance` with no transactions → all four cards render numerically; Recent Expenses, Recent Income, and Net Balance render `$0.00` in neutral foreground (not red, not green).
- [ ] Visit `/finance` with income > expenses → Net Balance reads positive in green.
- [ ] Visit `/finance` with expenses > income → Net Balance reads negative in red.
- [ ] Visit `/finance` with income == expenses (non-zero on both sides) → Net Balance reads `$0.00` in neutral.
- [ ] Confirm Recent Income still reads green when there is income, Recent Expenses still reads red when there are expenses.

https://claude.ai/code/session_01Ar7HwtVtysLqGWZpRrHTmn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar7HwtVtysLqGWZpRrHTmn)_