### PR TITLE
fix(shell): remove user@example.com placeholder from TopBar

### DIFF
--- a/apps/pops-shell/src/app/layout/top-bar/TopBarActions.tsx
+++ b/apps/pops-shell/src/app/layout/top-bar/TopBarActions.tsx
@@ -46,8 +46,6 @@ export function TopBarActions({ onOpenMobileSearch }: TopBarActionsProps) {
           <Moon className="h-5 w-5 text-indigo-600 group-hover:text-indigo-500 transition-colors" />
         )}
       </Button>
-
-      <div className="hidden md:block text-sm text-muted-foreground">user@example.com</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Removes the hardcoded `user@example.com` string from the top-right of the TopBar. POPS is a single-user system per `CLAUDE.md` / `AGENTS.md`, and PRD-005 (shell) only specs branding and a theme toggle for the TopBar — there is no spec for an identity label. The placeholder leaked to prod (https://pops.jmiranda.dev) and misled about auth state.

Following the issue's "fail closed" directive: when there is no identity to display, render nothing.

## Change

- `apps/pops-shell/src/app/layout/top-bar/TopBarActions.tsx`: drop the hardcoded `<div>user@example.com</div>`.

If a real identity surface is wanted later (e.g. wiring `Cf-Access-Authenticated-User-Email` through to the shell), that can be its own PRD-backed change — out of scope for this fix.

## Test plan

- [x] `turbo typecheck` passes across all 17 packages (run via pre-commit hook)
- [ ] Manual: load any page, confirm TopBar no longer shows `user@example.com` and layout is unaffected on md+ widths

Closes #2345

---
_Generated by [Claude Code](https://claude.ai/code/session_015HaeEky2uGgGfaw5tbJUH4)_