### PR TITLE
fix(a11y): add DialogDescription to dialogs missing aria-describedby

### DIFF
--- a/packages/app-ai/src/pages/rules-browser/rule-form/RuleFormDialog.tsx
+++ b/packages/app-ai/src/pages/rules-browser/rule-form/RuleFormDialog.tsx
@@ -16,6 +16,7 @@ import {
   ChipInput,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -147,6 +148,9 @@ export function RuleFormDialog(props: RuleFormDialogProps) {
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <DialogHeader>
             <DialogTitle>{editingRule ? 'Edit Rule' : 'New Rule'}</DialogTitle>
+            <DialogDescription className="sr-only">
+              Define the pattern and settings for this categorisation rule
+            </DialogDescription>
           </DialogHeader>
           <div className="grid gap-6 py-4 md:grid-cols-2">
             <div className="grid gap-4 min-w-0">

--- a/packages/app-cerebrum/src/components/ScopeConfirmDialog.tsx
+++ b/packages/app-cerebrum/src/components/ScopeConfirmDialog.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -31,6 +32,9 @@ export function ScopeConfirmDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Inferred Scopes</DialogTitle>
+          <DialogDescription className="sr-only">
+            Review and confirm the scopes inferred from your content
+          </DialogDescription>
         </DialogHeader>
         <p className="text-sm text-muted-foreground">
           No scopes were provided. The following scopes were inferred from the content:

--- a/packages/app-cerebrum/src/components/ScopeConfirmDialog.tsx
+++ b/packages/app-cerebrum/src/components/ScopeConfirmDialog.tsx
@@ -32,13 +32,10 @@ export function ScopeConfirmDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Inferred Scopes</DialogTitle>
-          <DialogDescription className="sr-only">
-            Review and confirm the scopes inferred from your content
-          </DialogDescription>
         </DialogHeader>
-        <p className="text-sm text-muted-foreground">
+        <DialogDescription className="text-sm text-muted-foreground">
           No scopes were provided. The following scopes were inferred from the content:
-        </p>
+        </DialogDescription>
         <div className="flex flex-wrap gap-2 py-2">
           {scopes.map((scope) => (
             <Badge key={scope} variant="secondary">

--- a/packages/app-finance/src/pages/budgets/BudgetFormDialog.tsx
+++ b/packages/app-finance/src/pages/budgets/BudgetFormDialog.tsx
@@ -7,6 +7,7 @@ import {
   CheckboxInput,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -84,6 +85,9 @@ export function BudgetFormDialog(props: BudgetFormDialogProps) {
             <DialogTitle>
               {editingBudget ? t('budgets.editBudget') : t('budgets.newBudget')}
             </DialogTitle>
+            <DialogDescription className="sr-only">
+              Enter the details for your budget
+            </DialogDescription>
           </DialogHeader>
           <FormFields form={form} />
           <DialogFooter>

--- a/packages/app-finance/src/pages/entities/EntityFormDialog.tsx
+++ b/packages/app-finance/src/pages/entities/EntityFormDialog.tsx
@@ -6,6 +6,7 @@ import {
   ChipInput,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -102,6 +103,9 @@ export function EntityFormDialog(props: EntityFormDialogProps) {
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <DialogHeader>
             <DialogTitle>{editingEntity ? 'Edit Entity' : 'New Entity'}</DialogTitle>
+            <DialogDescription className="sr-only">
+              Enter the details for this entity
+            </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
             <NameAndType form={form} />

--- a/packages/app-finance/src/pages/transactions/TransactionFormDialog.tsx
+++ b/packages/app-finance/src/pages/transactions/TransactionFormDialog.tsx
@@ -6,6 +6,7 @@ import {
   ChipInput,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -162,6 +163,9 @@ export function TransactionFormDialog(props: DialogProps) {
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <DialogHeader>
             <DialogTitle>{editingTransaction ? 'Edit Transaction' : 'New Transaction'}</DialogTitle>
+            <DialogDescription className="sr-only">
+              Enter the details for this transaction
+            </DialogDescription>
           </DialogHeader>
           <FormFields form={form} entities={entities} />
           <DialogFooter>

--- a/packages/app-finance/src/pages/wishlist/WishlistFormDialog.tsx
+++ b/packages/app-finance/src/pages/wishlist/WishlistFormDialog.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -88,6 +89,9 @@ export function WishlistFormDialog(props: DialogProps) {
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <DialogHeader>
             <DialogTitle>{editingItem ? 'Edit Item' : 'New Wishlist Item'}</DialogTitle>
+            <DialogDescription className="sr-only">
+              Enter the details for your wishlist item
+            </DialogDescription>
           </DialogHeader>
           <FormFields form={form} />
           <DialogFooter>

--- a/packages/app-media/src/components/DimensionManager.tsx
+++ b/packages/app-media/src/components/DimensionManager.tsx
@@ -127,7 +127,9 @@ export function DimensionManager() {
       <DialogContent className="max-w-md p-0">
         <DialogHeader className="sr-only">
           <DialogTitle>Comparison Dimensions</DialogTitle>
-          <DialogDescription>Manage the dimensions used for comparing media</DialogDescription>
+          <DialogDescription className="sr-only">
+            Manage the dimensions used for comparing media
+          </DialogDescription>
         </DialogHeader>
         <CRUDManagementSection
           title="Comparison Dimensions"

--- a/packages/app-media/src/components/DimensionManager.tsx
+++ b/packages/app-media/src/components/DimensionManager.tsx
@@ -11,6 +11,7 @@ import {
   CRUDManagementSection,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -126,6 +127,7 @@ export function DimensionManager() {
       <DialogContent className="max-w-md p-0">
         <DialogHeader className="sr-only">
           <DialogTitle>Comparison Dimensions</DialogTitle>
+          <DialogDescription>Manage the dimensions used for comparing media</DialogDescription>
         </DialogHeader>
         <CRUDManagementSection
           title="Comparison Dimensions"

--- a/packages/app-media/src/components/QuickPickDialog.tsx
+++ b/packages/app-media/src/components/QuickPickDialog.tsx
@@ -13,6 +13,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -169,6 +170,9 @@ export function QuickPickDialog() {
             <Sparkles className="h-5 w-5 text-app-accent" />
             What Should I Watch?
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Get a random movie recommendation from your watchlist
+          </DialogDescription>
         </DialogHeader>
         <div className="px-6 pb-6 pt-4">
           <PickContent

--- a/packages/ui/src/components/DataTableFilters.tsx
+++ b/packages/ui/src/components/DataTableFilters.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -158,6 +159,9 @@ export function FilterBar({ filters, table, onClearAll }: FilterBarProps) {
         <DialogContent className="md:hidden max-h-[85vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Filters</DialogTitle>
+            <DialogDescription className="sr-only">
+              Apply filters to narrow down table results
+            </DialogDescription>
           </DialogHeader>
           <FilterGrid filters={filters} table={table} />
           <DialogFooter className="flex-row gap-2">


### PR DESCRIPTION
## Summary

- Fixes #2314 — Radix `DialogContent` was missing `aria-describedby` on 9 dialogs, causing a console warning on every dialog open
- Each dialog now includes a `DialogDescription` (visible or `sr-only`) that satisfies Radix's accessibility contract
- No visual changes — `sr-only` descriptions are for screen readers only

## Dialogs fixed

| File | Description added |
|------|-------------------|
| `packages/ui/src/components/DataTableFilters.tsx` | "Apply filters to narrow down table results" |
| `packages/app-cerebrum/src/components/ScopeConfirmDialog.tsx` | "Review and confirm the scopes inferred from your content" |
| `packages/app-finance/src/pages/wishlist/WishlistFormDialog.tsx` | "Enter the details for your wishlist item" |
| `packages/app-finance/src/pages/budgets/BudgetFormDialog.tsx` | "Enter the details for your budget" |
| `packages/app-finance/src/pages/entities/EntityFormDialog.tsx` | "Enter the details for this entity" |
| `packages/app-finance/src/pages/transactions/TransactionFormDialog.tsx` | "Enter the details for this transaction" |
| `packages/app-ai/src/pages/rules-browser/rule-form/RuleFormDialog.tsx` | "Define the pattern and settings for this categorisation rule" |
| `packages/app-media/src/components/DimensionManager.tsx` | "Manage the dimensions used for comparing media" |
| `packages/app-media/src/components/QuickPickDialog.tsx` | "Get a random movie recommendation from your watchlist" |

## Test plan

- [ ] Open each dialog type and confirm the console warning is gone
- [ ] Verify no visible UI changes in any dialog
- [ ] Screen reader test: each dialog announces its description

https://claude.ai/code/session_01D8VjxQT17qNCNgoAYiQLxP

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8VjxQT17qNCNgoAYiQLxP)_