### PR TITLE
fix(settings): restore sticky sidebar and scrollIntoView (#2349)

### DIFF
--- a/apps/pops-shell/src/app/layout/RootLayout.tsx
+++ b/apps/pops-shell/src/app/layout/RootLayout.tsx
@@ -42,7 +42,7 @@ export function RootLayout() {
             {/* Mobile: overlay sidebar */}
             <Sidebar open={sidebarOpen} />
 
-            <main className="flex-1 min-w-0 overflow-x-hidden p-4 md:p-6 lg:p-8 max-w-screen-2xl mx-auto transition-all duration-200">
+            <main className="flex-1 min-w-0 overflow-x-clip p-4 md:p-6 lg:p-8 max-w-screen-2xl mx-auto transition-all duration-200">
               <ErrorBoundary>
                 <Outlet />
               </ErrorBoundary>


### PR DESCRIPTION
## Summary

- Fixes two related UX bugs in the `/settings` page (issue #2349)
- `overflow-x: hidden` on `<main>` forces `overflow-y: auto` per CSS spec, making `<main>` a scroll container with unbounded height — sticky positioning inside it never triggered, and `scrollIntoView` targeted `<main>` instead of the window
- Changed to `overflow-x: clip`, which clips horizontal overflow without creating a scroll container

## Root cause

CSS spec: `overflow-x: hidden` + `overflow-y: visible` → browser computes `overflow-y` as `auto`, promoting the element to a scroll container. The settings sidebar's `position: sticky` was then relative to `<main>` (which has no bounded height and never actually scrolls), so it never stuck. Likewise, `el.scrollIntoView()` targeted `<main>` as the nearest scroll ancestor and found the element was already "in view" within `<main>`'s layout, leaving the window position unchanged.

`overflow-x: clip` has identical visual behaviour (clips content) but does **not** create a scroll container, so:
- Window scroll drives sticky positioning correctly
- `scrollIntoView` scrolls the window
- `window.addEventListener('scroll', ...)` in `useSectionObserver` fires as expected

## Test plan

- [ ] Navigate to `/settings`, scroll down — confirm left sidebar stays fixed in view
- [ ] Click a sidebar entry (e.g. "Arr") — confirm viewport scrolls to that section and hash updates
- [ ] Scroll through settings — confirm active sidebar entry highlights the current section
- [ ] Confirm no horizontal scrollbar appears on any page (clip still applies)

## Gaps (tracked)

None.

https://claude.ai/code/session_01L1ZN7Cf8d7ZX1nUTVQJjk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1ZN7Cf8d7ZX1nUTVQJjk9)_