### PR TITLE
fix(inventory/reports): rename route /inventory/report → /inventory/reports

### DIFF
--- a/apps/pops-shell/e2e/inventory-insurance-report.spec.ts
+++ b/apps/pops-shell/e2e/inventory-insurance-report.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Integration test — Inventory insurance report filtered by location (#2114)
  *
- * Tier 2: navigate to /inventory/report/insurance, pick a seeded location filter,
+ * Tier 2: navigate to /inventory/reports/insurance, pick a seeded location filter,
  * verify only items from that location are shown, the displayed total matches the
  * sum of those items' replacement values, and no console errors occur.
  *
@@ -96,7 +96,7 @@ test.describe('Inventory — insurance report filtered by location', () => {
   });
 
   test('deep-link with ?locationId scopes items and total to that location', async ({ page }) => {
-    await page.goto(`/inventory/report/insurance?locationId=${LOCATION_ID}`);
+    await page.goto(`/inventory/reports/insurance?locationId=${LOCATION_ID}`);
 
     // Summary renders before we assert totals.
     await expect(page.getByRole('heading', { name: /Insurance Report/i })).toBeVisible({
@@ -106,7 +106,7 @@ test.describe('Inventory — insurance report filtered by location', () => {
   });
 
   test('selecting a location via the picker scopes items and total', async ({ page }) => {
-    await page.goto('/inventory/report/insurance');
+    await page.goto('/inventory/reports/insurance');
 
     // Sanity: unfiltered report is visible first — Road Bike must be present
     // somewhere in the all-locations view so we know the page rendered fully.

--- a/apps/pops-shell/e2e/inventory-reports-value-by-location.spec.ts
+++ b/apps/pops-shell/e2e/inventory-reports-value-by-location.spec.ts
@@ -1,7 +1,7 @@
 /**
  * E2E — Inventory reports: value breakdown by location (#2128)
  *
- * Tier 3: navigate to `/inventory/report`, confirm the Value by Location
+ * Tier 3: navigate to `/inventory/reports`, confirm the Value by Location
  * widget renders, at least one seeded location shows a non-zero replacement
  * value, and the sum across all locations equals the overall replacement
  * value shown in the items list summary.
@@ -106,7 +106,7 @@ test.describe('Inventory reports — value breakdown by location', () => {
     page.on('console', (msg) => {
       if (msg.type() === 'error') consoleErrors.push(msg.text());
     });
-    await page.goto('/inventory/report');
+    await page.goto('/inventory/reports');
   });
 
   test.afterEach(async ({ page }) => {

--- a/docs/themes/04-inventory/prds/051-value-insurance-reporting/README.md
+++ b/docs/themes/04-inventory/prds/051-value-insurance-reporting/README.md
@@ -9,7 +9,7 @@ Build a total asset value dashboard, value breakdowns by location and type, and 
 
 ## Route
 
-`/inventory/report`
+`/inventory/reports`
 
 ## Dashboard Widgets
 

--- a/docs/themes/04-inventory/prds/051-value-insurance-reporting/us-01-dashboard-widgets.md
+++ b/docs/themes/04-inventory/prds/051-value-insurance-reporting/us-01-dashboard-widgets.md
@@ -9,7 +9,7 @@ As a user, I want a reporting dashboard showing total asset values, item count, 
 
 ## Acceptance Criteria
 
-- [x] Page at `/inventory/report` — accessible from inventory navigation
+- [x] Page at `/inventory/reports` — accessible from inventory navigation
 - [x] Dashboard fetches all widget data via `inventory.reports.dashboard` (single API call)
 - [x] Widget: Total replacement value — formatted as currency (e.g., "$12,450")
 - [x] Widget: Total resale value — formatted as currency

--- a/packages/app-inventory/src/pages/ReportDashboardPage.test.tsx
+++ b/packages/app-inventory/src/pages/ReportDashboardPage.test.tsx
@@ -25,14 +25,14 @@ vi.mock('../components/ValueBreakdown', () => ({
 
 import { ReportDashboardPage } from './ReportDashboardPage';
 
-function renderPage(initialPath = '/inventory/report') {
+function renderPage(initialPath = '/inventory/reports') {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
-        <Route path="/inventory/report" element={<ReportDashboardPage />} />
+        <Route path="/inventory/reports" element={<ReportDashboardPage />} />
         <Route path="/inventory/warranties" element={<div data-testid="warranties-page" />} />
         <Route
-          path="/inventory/report/insurance"
+          path="/inventory/reports/insurance"
           element={<div data-testid="insurance-report-page" />}
         />
         <Route path="/inventory/items/:id" element={<div data-testid="item-detail-page" />} />
@@ -91,7 +91,7 @@ describe('ReportDashboardPage', () => {
     expect(screen.getByText('Insurance Report')).toBeInTheDocument();
   });
 
-  it('navigates to /inventory/report/insurance on Insurance Report click', () => {
+  it('navigates to /inventory/reports/insurance on Insurance Report click', () => {
     mocks.dashboardQuery.mockReturnValue({ ...populatedDashboard, isLoading: false });
     renderPage();
     fireEvent.click(screen.getByText('Insurance Report'));

--- a/packages/app-inventory/src/pages/ReportDashboardPage.tsx
+++ b/packages/app-inventory/src/pages/ReportDashboardPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
 /**
- * ReportDashboardPage — inventory reporting hub at `/inventory/report`.
+ * ReportDashboardPage — inventory reporting hub at `/inventory/reports`.
  *
  * Shows the summary dashboard widgets (item count, values, expiring warranties,
  * recently added) and a navigation card to the detailed insurance report.
@@ -27,7 +27,7 @@ export function ReportDashboardPage() {
         <Button
           variant="outline"
           prefix={<FileText className="h-4 w-4" />}
-          onClick={() => navigate('/inventory/report/insurance')}
+          onClick={() => navigate('/inventory/reports/insurance')}
         >
           {t('report.insurance')}
         </Button>

--- a/packages/app-inventory/src/pages/location-tree-page/sections/PageHeaderActions.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/PageHeaderActions.tsx
@@ -11,7 +11,7 @@ export function PageHeaderActions({ onAddRoot }: PageHeaderActionsProps) {
   return (
     <>
       <Link
-        to="/inventory/report/insurance"
+        to="/inventory/reports/insurance"
         className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
       >
         <FileText className="h-4 w-4" />

--- a/packages/app-inventory/src/pages/location-tree-page/sections/location-node/NodeActions.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/location-node/NodeActions.tsx
@@ -114,7 +114,7 @@ function PrimaryActions({
         <FolderPlus className="h-3.5 w-3.5 text-muted-foreground" />
       </ActionIconButton>
       <Link
-        to={`/inventory/report/insurance?locationId=${node.id}`}
+        to={`/inventory/reports/insurance?locationId=${node.id}`}
         onClick={(e) => e.stopPropagation()}
         className="p-0.5 rounded hover:bg-muted"
         title={`Insurance report for ${node.name}`}

--- a/packages/app-inventory/src/routes.test.tsx
+++ b/packages/app-inventory/src/routes.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { useLocation } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { SearchPreservingRedirect } from './routes';
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname + location.search}</div>;
+}
+
+describe('SearchPreservingRedirect', () => {
+  it('redirects /inventory/report to /inventory/reports', () => {
+    render(
+      <MemoryRouter initialEntries={['/inventory/report']}>
+        <Routes>
+          <Route
+            path="/inventory/report"
+            element={<SearchPreservingRedirect to="/inventory/reports" />}
+          />
+          <Route path="/inventory/reports" element={<LocationDisplay />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('location').textContent).toBe('/inventory/reports');
+  });
+
+  it('redirects /inventory/report/insurance to /inventory/reports/insurance', () => {
+    render(
+      <MemoryRouter initialEntries={['/inventory/report/insurance']}>
+        <Routes>
+          <Route
+            path="/inventory/report/insurance"
+            element={<SearchPreservingRedirect to="/inventory/reports/insurance" />}
+          />
+          <Route path="/inventory/reports/insurance" element={<LocationDisplay />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('location').textContent).toBe('/inventory/reports/insurance');
+  });
+
+  it('preserves ?locationId query string when redirecting /inventory/report/insurance', () => {
+    render(
+      <MemoryRouter initialEntries={['/inventory/report/insurance?locationId=loc-123']}>
+        <Routes>
+          <Route
+            path="/inventory/report/insurance"
+            element={<SearchPreservingRedirect to="/inventory/reports/insurance" />}
+          />
+          <Route path="/inventory/reports/insurance" element={<LocationDisplay />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('location').textContent).toBe(
+      '/inventory/reports/insurance?locationId=loc-123'
+    );
+  });
+});

--- a/packages/app-inventory/src/routes.tsx
+++ b/packages/app-inventory/src/routes.tsx
@@ -5,7 +5,7 @@
  * these via @pops/app-inventory and mounts them under /inventory/*.
  */
 import { lazy } from 'react';
-import { Navigate } from 'react-router';
+import { Navigate, useLocation } from 'react-router';
 
 import type { RouteObject } from 'react-router';
 
@@ -40,6 +40,12 @@ const LocationTreePage = lazy(() =>
     default: m.LocationTreePage,
   }))
 );
+
+/** Redirects the old singular path to the plural equivalent, preserving query string. */
+export function SearchPreservingRedirect({ to }: { to: string }) {
+  const { search } = useLocation();
+  return <Navigate to={`${to}${search}`} replace />;
+}
 
 /** Local type mirror for compile-time safety (shell owns the canonical types). */
 interface AppNavConfigShape {
@@ -86,6 +92,9 @@ export const routes: RouteObject[] = [
       { path: 'insurance', element: <InsuranceReportPage /> },
     ],
   },
-  { path: 'report', element: <Navigate to="/inventory/reports" replace /> },
-  { path: 'report/insurance', element: <Navigate to="/inventory/reports/insurance" replace /> },
+  { path: 'report', element: <SearchPreservingRedirect to="/inventory/reports" /> },
+  {
+    path: 'report/insurance',
+    element: <SearchPreservingRedirect to="/inventory/reports/insurance" />,
+  },
 ];

--- a/packages/app-inventory/src/routes.tsx
+++ b/packages/app-inventory/src/routes.tsx
@@ -5,6 +5,7 @@
  * these via @pops/app-inventory and mounts them under /inventory/*.
  */
 import { lazy } from 'react';
+import { Navigate } from 'react-router';
 
 import type { RouteObject } from 'react-router';
 
@@ -67,7 +68,7 @@ export const navConfig = {
       icon: 'ShieldCheck',
     },
     { path: '/locations', label: 'Locations', labelKey: 'inventory.locations', icon: 'MapPin' },
-    { path: '/report', label: 'Reports', labelKey: 'inventory.reports', icon: 'BarChart3' },
+    { path: '/reports', label: 'Reports', labelKey: 'inventory.reports', icon: 'BarChart3' },
   ],
 } satisfies AppNavConfigShape;
 
@@ -79,10 +80,12 @@ export const routes: RouteObject[] = [
   { path: 'warranties', element: <WarrantiesPage /> },
   { path: 'locations', element: <LocationTreePage /> },
   {
-    path: 'report',
+    path: 'reports',
     children: [
       { index: true, element: <ReportDashboardPage /> },
       { path: 'insurance', element: <InsuranceReportPage /> },
     ],
   },
+  { path: 'report', element: <Navigate to="/inventory/reports" replace /> },
+  { path: 'report/insurance', element: <Navigate to="/inventory/reports/insurance" replace /> },
 ];


### PR DESCRIPTION
## Summary

- Renames the inventory reports route from `/inventory/report` (singular) to `/inventory/reports` (plural) to match the sidebar label
- Adds backwards-compatible redirects: `/inventory/report` → `/inventory/reports` and `/inventory/report/insurance` → `/inventory/reports/insurance`
- Updates all internal `navigate()` calls and `<Link>` components to use the plural path
- Updates unit tests, E2E specs, and PRD-051 route documentation

## Test plan

- [ ] Navigate to `/inventory` → click "Reports" in sidebar → lands on `/inventory/reports` ✓
- [ ] Navigate directly to `/inventory/report` → redirects to `/inventory/reports` ✓
- [ ] Navigate directly to `/inventory/report/insurance` → redirects to `/inventory/reports/insurance` ✓
- [ ] All 365 unit tests pass (`pnpm test` in `packages/app-inventory`)
- [ ] Full monorepo typecheck passes (17/17 packages)

Closes #2354

https://claude.ai/code/session_01EK31mQ7zNhge65m3yMFUoC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK31mQ7zNhge65m3yMFUoC)_