### PR TITLE
fix(media/movie-detail): align ArrStatusBadge with action buttons

### DIFF
--- a/packages/app-media/src/pages/movie-detail/MovieHeroActions.tsx
+++ b/packages/app-media/src/pages/movie-detail/MovieHeroActions.tsx
@@ -33,7 +33,7 @@ export function MovieHeroActions({
   pendingDebrief,
 }: MovieHeroActionsProps) {
   return (
-    <div className="flex items-start gap-3 mt-3">
+    <div className="flex items-center gap-3 mt-3">
       <WatchlistToggle mediaType="movie" mediaId={movie.id} />
       <MarkAsWatchedButton mediaId={movie.id} />
       <ArrStatusBadge kind="movie" externalId={movie.tmdbId} />


### PR DESCRIPTION
## Summary

- Change `items-start` → `items-center` on the action row in `MovieHeroActions.tsx` so the smaller `ArrStatusBadge` pill centers vertically with the adjacent action buttons instead of hugging the top of the row.

## Test plan

- [ ] Navigate to any movie detail page
- [ ] Confirm the "Not in Radarr" (or equivalent) badge is vertically centered with the surrounding buttons
- [ ] Confirm no layout regression when the badge is absent

Closes #2338

https://claude.ai/code/session_0157ju752KpjWRrVFM26LuCD

---
_Generated by [Claude Code](https://claude.ai/code/session_0157ju752KpjWRrVFM26LuCD)_