### PR TITLE
fix(finance/transactions): 'Amount must be non-zero' for zero amounts

### DIFF
--- a/docs/themes/02-finance/prds/019-transactions/README.md
+++ b/docs/themes/02-finance/prds/019-transactions/README.md
@@ -47,7 +47,7 @@ Build the transaction ledger — the core of the finance app. Every financial tr
 ## Business Rules
 
 - `type` must be one of: "purchase", "transfer", "income"
-- `amount` can be positive (income) or negative (expense) — no sign convention enforcement at the API level
+- `amount` can be positive (income) or negative (expense) — no sign convention enforcement at the API level. Zero is not a valid transaction amount; the form validates `amount !== 0` and surfaces "Amount must be non-zero" rather than the generic "required" message
 - `tags` stored as JSON array; API parses and validates
 - `entity_name` is denormalized — survives entity deletion. If entity is deleted, `entity_id` becomes null but `entity_name` remains
 - `checksum` uniqueness prevents duplicate imports from the same CSV

--- a/packages/app-finance/src/pages/transactions/types.ts
+++ b/packages/app-finance/src/pages/transactions/types.ts
@@ -43,7 +43,8 @@ export const TransactionFormSchema = z.object({
   amount: z
     .string()
     .min(1, 'Amount is required')
-    .refine((v) => Number.isFinite(Number(v)), 'Amount must be a number'),
+    .refine((v) => Number.isFinite(Number(v)), 'Amount must be a valid number')
+    .refine((v) => Number(v) !== 0, 'Amount must be non-zero'),
   description: z.string().min(1, 'Description is required'),
   account: z.string().min(1, 'Account is required'),
   type: z.string().min(1, 'Type is required'),

--- a/packages/app-finance/src/pages/transactions/useTransactionsPage.test.ts
+++ b/packages/app-finance/src/pages/transactions/useTransactionsPage.test.ts
@@ -66,6 +66,7 @@ vi.mock('sonner', () => ({
   },
 }));
 
+import { TransactionFormSchema } from './types';
 // Import after mocks are registered.
 import { buildTransactionPayload, useTransactionsPage } from './useTransactionsPage';
 
@@ -119,6 +120,61 @@ beforeEach(() => {
         { id: 'ent-2', name: 'Coles', type: 'company' },
       ],
     },
+  });
+});
+
+// ---------- TransactionFormSchema — amount validation ----------
+
+describe('TransactionFormSchema — amount', () => {
+  const baseValues = {
+    date: '2026-04-26',
+    description: 'Woolworths',
+    account: 'Credit Card',
+    type: 'Expense',
+    entityId: '',
+    tags: [],
+    notes: '',
+  };
+
+  it('accepts a non-zero amount', () => {
+    const result = TransactionFormSchema.safeParse({ ...baseValues, amount: '-12.50' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty amount with "Amount is required"', () => {
+    const result = TransactionFormSchema.safeParse({ ...baseValues, amount: '' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = result.error.issues.find((i) => i.path[0] === 'amount')?.message;
+      expect(msg).toBe('Amount is required');
+    }
+  });
+
+  it('rejects "0" with "Amount must be non-zero"', () => {
+    const result = TransactionFormSchema.safeParse({ ...baseValues, amount: '0' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = result.error.issues.find((i) => i.path[0] === 'amount')?.message;
+      expect(msg).toBe('Amount must be non-zero');
+    }
+  });
+
+  it('rejects "0.00" with "Amount must be non-zero"', () => {
+    const result = TransactionFormSchema.safeParse({ ...baseValues, amount: '0.00' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = result.error.issues.find((i) => i.path[0] === 'amount')?.message;
+      expect(msg).toBe('Amount must be non-zero');
+    }
+  });
+
+  it('rejects a non-numeric string with "Amount must be a valid number"', () => {
+    const result = TransactionFormSchema.safeParse({ ...baseValues, amount: 'abc' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = result.error.issues.find((i) => i.path[0] === 'amount')?.message;
+      expect(msg).toBe('Amount must be a valid number');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a `.refine((v) => Number(v) !== 0, 'Amount must be non-zero')` check to `TransactionFormSchema` so that submitting `0` or `0.00` surfaces a clear, accurate error instead of the misleading "Amount is required" message
- Adds 5 targeted schema unit tests covering empty, zero (`"0"`), zero (`"0.00"`), non-numeric, and valid non-zero cases
- Updates PRD-019 business rules to document that zero is not a valid transaction amount

## Test plan

- [ ] Open New Transaction form — leave Amount at default (placeholder `0.00`) and submit → see "Amount is required"
- [ ] Type `0` or `0.00` in Amount and submit → see "Amount must be non-zero" (previously showed "Amount is required")
- [ ] Type any non-zero amount and submit → no Amount error
- [ ] `pnpm test -- useTransactionsPage` passes all 21 tests

## Gaps (tracked)

None.

Closes #2313

https://claude.ai/code/session_01DsVy5QjDsNsoUS75eEhoiz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsVy5QjDsNsoUS75eEhoiz)_