### PR TITLE
feat(search): index wish list items in global cmd-K search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,9 @@ dist/
 *.sqlite3
 *.sqlite3-wal
 *.sqlite3-shm
-*-shm
+# SQLite WAL-mode auxiliary files for extensionless databases
 *-wal
+*-shm
 *.csv
 !apps/pops-api/src/modules/finance/imports/test-data/amex-sample.csv
 entity_lookup.json

--- a/apps/pops-api/src/modules/core/search/domain-app-mapping.ts
+++ b/apps/pops-api/src/modules/core/search/domain-app-mapping.ts
@@ -12,6 +12,7 @@ const DOMAIN_APP_MAP: Record<string, string> = {
   transactions: 'finance',
   entities: 'finance',
   budgets: 'finance',
+  wishlist: 'finance',
   'inventory-items': 'inventory',
 };
 

--- a/apps/pops-api/src/modules/finance/index.ts
+++ b/apps/pops-api/src/modules/finance/index.ts
@@ -4,6 +4,7 @@
 // Side-effect: register search adapters
 import './transactions/search-adapter.js';
 import './budgets/search-adapter.js';
+import './wishlist/search-adapter.js';
 
 import { settingsRegistry } from '../core/settings/index.js';
 import { financeManifest } from './settings-manifest.js';

--- a/apps/pops-api/src/modules/finance/wishlist/search-adapter.test.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/search-adapter.test.ts
@@ -63,13 +63,21 @@ describe('wishlist search adapter', () => {
     });
   });
 
-  it('exact match is case-insensitive', () => {
+  it('exact match is case-insensitive for ASCII', () => {
     seedWishListItem(db, { item: 'Japan Trip' });
 
     const hits = search('japan trip');
     expect(hits).toHaveLength(1);
     expect(hits[0]!.score).toBe(1.0);
     expect(hits[0]!.matchType).toBe('exact');
+  });
+
+  it('match is case-insensitive for non-ASCII characters', () => {
+    seedWishListItem(db, { item: 'Café au Lait Machine' });
+
+    const hits = search('café');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.matchType).toBe('prefix');
   });
 
   it('returns prefix match with score 0.8', () => {

--- a/apps/pops-api/src/modules/finance/wishlist/search-adapter.test.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/search-adapter.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Database } from 'better-sqlite3';
+
+// Prevent side-effect registration from throwing on import
+vi.mock('../../core/search/registry.js', () => ({
+  registerSearchAdapter: vi.fn(),
+  getAdapters: vi.fn(),
+  resetRegistry: vi.fn(),
+}));
+
+import { seedWishListItem, setupTestContext } from '../../../shared/test-utils.js';
+import { registerSearchAdapter } from '../../core/search/registry.js';
+import { type WishlistHitData, wishlistSearchAdapter } from './search-adapter.js';
+
+import type { SearchHit } from '../../core/search/index.js';
+
+const ctx = setupTestContext();
+let db: Database;
+
+beforeEach(() => {
+  ({ db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+function search(query: string, limit?: number): SearchHit<WishlistHitData>[] {
+  return wishlistSearchAdapter.search(
+    { text: query },
+    { app: 'finance', page: 'wishlist' },
+    limit ? { limit } : undefined
+  ) as SearchHit<WishlistHitData>[];
+}
+
+describe('wishlist search adapter', () => {
+  it('registers with correct metadata', () => {
+    expect(wishlistSearchAdapter.domain).toBe('wishlist');
+    expect(wishlistSearchAdapter.icon).toBe('Star');
+    expect(wishlistSearchAdapter.color).toBe('yellow');
+    expect(registerSearchAdapter).toHaveBeenCalledWith(wishlistSearchAdapter);
+  });
+
+  it('returns empty results for empty query', () => {
+    seedWishListItem(db, { item: 'Japan Trip' });
+    expect(search('')).toEqual([]);
+    expect(search('  ')).toEqual([]);
+  });
+
+  it('returns exact match with score 1.0', () => {
+    seedWishListItem(db, { item: 'Japan Trip', priority: 'high', target_amount: 5000 });
+
+    const hits = search('Japan Trip');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(1.0);
+    expect(hits[0]!.matchType).toBe('exact');
+    expect(hits[0]!.matchField).toBe('item');
+    expect(hits[0]!.data).toEqual({
+      item: 'Japan Trip',
+      priority: 'high',
+      targetAmount: 5000,
+    });
+  });
+
+  it('exact match is case-insensitive', () => {
+    seedWishListItem(db, { item: 'Japan Trip' });
+
+    const hits = search('japan trip');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(1.0);
+    expect(hits[0]!.matchType).toBe('exact');
+  });
+
+  it('returns prefix match with score 0.8', () => {
+    seedWishListItem(db, { item: 'Gaming PC', priority: 'medium', target_amount: 2000 });
+
+    const hits = search('Gaming');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(0.8);
+    expect(hits[0]!.matchType).toBe('prefix');
+    expect(hits[0]!.data.item).toBe('Gaming PC');
+  });
+
+  it('returns contains match with score 0.5', () => {
+    seedWishListItem(db, { item: 'Standing Desk' });
+
+    const hits = search('anding');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.score).toBe(0.5);
+    expect(hits[0]!.matchType).toBe('contains');
+  });
+
+  it('sorts results by score descending', () => {
+    seedWishListItem(db, { item: 'Camera' });
+    seedWishListItem(db, { item: 'Camera Bag' });
+    seedWishListItem(db, { item: 'Action Camera Mount' });
+
+    const hits = search('Camera');
+    expect(hits.length).toBeGreaterThanOrEqual(2);
+
+    expect(hits[0]!.score).toBe(1.0);
+    expect(hits[0]!.data.item).toBe('Camera');
+    expect(hits[1]!.score).toBe(0.8);
+    expect(hits[1]!.data.item).toBe('Camera Bag');
+    expect(hits[2]!.score).toBe(0.5);
+    expect(hits[2]!.data.item).toBe('Action Camera Mount');
+  });
+
+  it('uri points to wishlist page', () => {
+    seedWishListItem(db, { item: 'Japan Trip' });
+
+    const hits = search('japan');
+    expect(hits[0]!.uri).toBe('/finance/wishlist');
+  });
+
+  it('includes hit data with item, priority, and targetAmount', () => {
+    seedWishListItem(db, { item: 'New Camera', priority: 'low', target_amount: 1200 });
+
+    const hits = search('New Camera');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.data).toEqual({
+      item: 'New Camera',
+      priority: 'low',
+      targetAmount: 1200,
+    });
+  });
+
+  it('handles null priority and targetAmount', () => {
+    seedWishListItem(db, { item: 'Standing Desk', priority: null, target_amount: null });
+
+    const hits = search('Standing Desk');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.data.priority).toBeNull();
+    expect(hits[0]!.data.targetAmount).toBeNull();
+  });
+
+  it('returns no results when nothing matches', () => {
+    seedWishListItem(db, { item: 'Japan Trip' });
+    expect(search('zzz-no-match')).toEqual([]);
+  });
+
+  it('respects limit option', () => {
+    for (let i = 0; i < 5; i++) {
+      seedWishListItem(db, { item: `Gadget ${i}` });
+    }
+
+    const hits = search('Gadget', 3);
+    expect(hits).toHaveLength(3);
+  });
+});

--- a/apps/pops-api/src/modules/finance/wishlist/search-adapter.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/search-adapter.ts
@@ -1,0 +1,75 @@
+import { like } from 'drizzle-orm';
+
+import { wishList } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
+import { registerSearchAdapter } from '../../core/search/index.js';
+
+import type { Query, SearchAdapter, SearchContext, SearchHit } from '../../core/search/index.js';
+
+export interface WishlistHitData {
+  item: string;
+  priority: string | null;
+  targetAmount: number | null;
+}
+
+function scoreHit(
+  item: string,
+  query: string
+): { score: number; matchType: 'exact' | 'prefix' | 'contains' } | null {
+  const lower = item.toLowerCase();
+  const q = query.toLowerCase();
+
+  if (lower === q) return { score: 1.0, matchType: 'exact' };
+  if (lower.startsWith(q)) return { score: 0.8, matchType: 'prefix' };
+  if (lower.includes(q)) return { score: 0.5, matchType: 'contains' };
+  return null;
+}
+
+export const wishlistSearchAdapter: SearchAdapter<WishlistHitData> = {
+  domain: 'wishlist',
+  icon: 'Star',
+  color: 'yellow',
+
+  search(
+    query: Query,
+    _context: SearchContext,
+    options?: { limit?: number }
+  ): SearchHit<WishlistHitData>[] {
+    const text = query.text.trim();
+    if (!text) return [];
+
+    const db = getDrizzle();
+    const limit = options?.limit ?? 20;
+
+    const rows = db
+      .select()
+      .from(wishList)
+      .where(like(wishList.item, `%${text}%`))
+      .limit(limit)
+      .all();
+
+    const hits: SearchHit<WishlistHitData>[] = [];
+
+    for (const row of rows) {
+      const match = scoreHit(row.item, text);
+      if (!match) continue;
+
+      hits.push({
+        uri: `/finance/wishlist`,
+        score: match.score,
+        matchField: 'item',
+        matchType: match.matchType,
+        data: {
+          item: row.item,
+          priority: row.priority,
+          targetAmount: row.targetAmount,
+        },
+      });
+    }
+
+    return hits.toSorted((a, b) => b.score - a.score);
+  },
+};
+
+registerSearchAdapter(wishlistSearchAdapter);

--- a/apps/pops-api/src/modules/finance/wishlist/search-adapter.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/search-adapter.ts
@@ -1,4 +1,4 @@
-import { like } from 'drizzle-orm';
+import { like, sql } from 'drizzle-orm';
 
 import { wishList } from '@pops/db-types';
 
@@ -9,6 +9,7 @@ import type { Query, SearchAdapter, SearchContext, SearchHit } from '../../core/
 
 export interface WishlistHitData {
   item: string;
+  // Free-text in the DB; renderer handles low/medium/high and surfaces others as-is
   priority: string | null;
   targetAmount: number | null;
 }
@@ -40,13 +41,12 @@ export const wishlistSearchAdapter: SearchAdapter<WishlistHitData> = {
     if (!text) return [];
 
     const db = getDrizzle();
-    const limit = options?.limit ?? 20;
+    const lowerText = text.toLowerCase();
 
     const rows = db
       .select()
       .from(wishList)
-      .where(like(wishList.item, `%${text}%`))
-      .limit(limit)
+      .where(like(sql`lower(${wishList.item})`, `%${lowerText}%`))
       .all();
 
     const hits: SearchHit<WishlistHitData>[] = [];
@@ -68,7 +68,13 @@ export const wishlistSearchAdapter: SearchAdapter<WishlistHitData> = {
       });
     }
 
-    return hits.toSorted((a, b) => b.score - a.score);
+    hits.sort((a, b) => b.score - a.score);
+
+    if (options?.limit && options.limit > 0) {
+      return hits.slice(0, options.limit);
+    }
+
+    return hits;
   },
 };
 

--- a/docs/themes/01-foundation/prds/057-search-engine/README.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/README.md
@@ -85,6 +85,8 @@ v1 is plain text only. Structured syntax added as v2 USs.
 | 08  | [us-08-fan-out-ranking](us-08-fan-out-ranking.md)                                     | Query fan-out to all adapters, section collection, context ordering             | Done                      | —              |
 | 08b | [us-08b-show-more-pagination](us-08b-show-more-pagination.md)                         | Show more pagination within a single domain section                             | Done                      | —              |
 | 09  | [us-09-structured-syntax](us-09-structured-syntax.md)                                 | Parse structured query syntax (type:, domain:, year:, value:) and apply filters | Not started (deferred v2) | —              |
+| 10  | [us-10-wishlist-adapter](us-10-wishlist-adapter.md)                                   | Wishlist backend adapter: search by item name                                   | Done                      | —              |
+| 10b | [us-10b-wishlist-result-component](us-10b-wishlist-result-component.md)               | Wishlist ResultComponent: item name + priority + target amount                  | Done                      | —              |
 
 All 6 backend adapters (us-02 through us-07) can parallelise. All 6 frontend components (us-02b through us-07b) can parallelise once their backend counterpart is done.
 
@@ -98,7 +100,7 @@ All 6 backend adapters (us-02 through us-07) can parallelise. All 6 frontend com
 - Each adapter receives `SearchContext` and may use it to boost results (e.g. inventory adapter boosts items in the current location). Adapters may also ignore context entirely
 - Adapter registry location: `apps/pops-api/src/modules/core/search/`. Each domain adapter calls `registerSearchAdapter()` at startup
 - `ResultComponent` is registered alongside the search function — the engine passes `hit` and `query` string, the component owns layout and match highlighting
-- Domain→app mapping for context ordering: `movies` and `tv-shows` → media app, `transactions`, `entities`, `budgets` → finance app, `inventory-items` → inventory app. All domains belonging to the current app are context sections
+- Domain→app mapping for context ordering: `movies` and `tv-shows` → media app, `transactions`, `entities`, `budgets`, `wishlist` → finance app, `inventory-items` → inventory app. All domains belonging to the current app are context sections
 
 ## Out of Scope
 

--- a/docs/themes/01-foundation/prds/057-search-engine/us-10-wishlist-adapter.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-10-wishlist-adapter.md
@@ -1,0 +1,23 @@
+# US-10: Wishlist search adapter (backend)
+
+> PRD: [057 — Search Engine](README.md)
+> Status: Done
+
+## Description
+
+As the system, I search wish list items by name and return typed `SearchHit` results with priority and target amount.
+
+## Acceptance Criteria
+
+- [x] Adapter registered with `domain: "wishlist"`, icon: `"Star"`, color: `"yellow"`
+- [x] Searches `wish_list` table by `item` column (case-insensitive LIKE)
+- [x] Relevance scoring: exact match (1.0) > prefix (0.8) > contains (0.5)
+- [x] `matchField: "item"` and `matchType` set correctly per hit
+- [x] Hit data shape: `{ item, priority, targetAmount }`
+- [x] URI navigates to `/finance/wishlist` (no per-item detail page exists)
+- [x] Respects `options.limit` parameter
+- [x] Tests: search returns correct hits, scoring correct
+
+## Notes
+
+Only `item` is searched. `priority` and `targetAmount` are included in hit data for display only.

--- a/docs/themes/01-foundation/prds/057-search-engine/us-10b-wishlist-result-component.md
+++ b/docs/themes/01-foundation/prds/057-search-engine/us-10b-wishlist-result-component.md
@@ -1,0 +1,19 @@
+# US-10b: Wishlist result component (frontend)
+
+> PRD: [057 — Search Engine](README.md)
+> Status: Done
+
+## Description
+
+As a user, I want wish list search results to show the item name, priority, and target amount so I can find the right item.
+
+## Acceptance Criteria
+
+- [x] `WishlistResult` registered in frontend registry for domain `"wishlist"`
+- [x] Renders: item name + priority (if set) + formatted target amount (if set)
+- [x] Highlights matched portion of item name using `query` prop + `matchField`/`matchType`
+- [x] Tests: renders correctly, highlighting works
+
+## Notes
+
+Component lives in `packages/app-finance/`. Depends on US-10 for hit data shape.

--- a/packages/app-finance/src/components/search/WishlistResult.test.tsx
+++ b/packages/app-finance/src/components/search/WishlistResult.test.tsx
@@ -32,7 +32,7 @@ describe('WishlistResult', () => {
     expect(screen.getByText('$5,000.00')).toBeInTheDocument();
   });
 
-  it('renders dash when targetAmount is null', () => {
+  it('does not render trailing amount when targetAmount is null', () => {
     render(
       <WishlistResult
         data={{
@@ -44,7 +44,7 @@ describe('WishlistResult', () => {
     );
 
     expect(screen.getByText('Standing Desk')).toBeInTheDocument();
-    expect(screen.queryByText('—')).not.toBeInTheDocument();
+    expect(screen.queryByText('$0.00')).not.toBeInTheDocument();
   });
 
   it('hides priority when null', () => {

--- a/packages/app-finance/src/components/search/WishlistResult.test.tsx
+++ b/packages/app-finance/src/components/search/WishlistResult.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { _clearRegistry, getResultComponent, registerResultComponent } from '@pops/navigation';
+
+import { WishlistResult } from './WishlistResult';
+
+beforeEach(() => {
+  _clearRegistry();
+});
+
+describe('WishlistResult', () => {
+  it('registers for the wishlist domain', () => {
+    registerResultComponent('wishlist', WishlistResult);
+    const Component = getResultComponent('wishlist');
+    expect(Component).toBe(WishlistResult);
+  });
+
+  it('renders item name, priority, and formatted target amount', () => {
+    render(
+      <WishlistResult
+        data={{
+          item: 'Japan Trip',
+          priority: 'high',
+          targetAmount: 5000,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Japan Trip')).toBeInTheDocument();
+    expect(screen.getByText('High')).toBeInTheDocument();
+    expect(screen.getByText('$5,000.00')).toBeInTheDocument();
+  });
+
+  it('renders dash when targetAmount is null', () => {
+    render(
+      <WishlistResult
+        data={{
+          item: 'Standing Desk',
+          priority: null,
+          targetAmount: null,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Standing Desk')).toBeInTheDocument();
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
+  });
+
+  it('hides priority when null', () => {
+    render(
+      <WishlistResult
+        data={{
+          item: 'Gaming PC',
+          priority: null,
+          targetAmount: 2000,
+        }}
+      />
+    );
+
+    expect(screen.queryByText('High')).not.toBeInTheDocument();
+    expect(screen.queryByText('Medium')).not.toBeInTheDocument();
+    expect(screen.queryByText('Low')).not.toBeInTheDocument();
+    expect(screen.getByText('$2,000.00')).toBeInTheDocument();
+  });
+
+  it('capitalises priority', () => {
+    render(
+      <WishlistResult
+        data={{
+          item: 'New Camera',
+          priority: 'medium',
+          targetAmount: null,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+  });
+
+  it('highlights matched item name for exact match', () => {
+    const { container } = render(
+      <WishlistResult
+        data={{
+          item: 'Japan Trip',
+          priority: null,
+          targetAmount: null,
+          _query: 'Japan Trip',
+          _matchField: 'item',
+          _matchType: 'exact',
+        }}
+      />
+    );
+
+    const mark = container.querySelector('mark');
+    expect(mark).toBeInTheDocument();
+    expect(mark!.textContent).toBe('Japan Trip');
+  });
+
+  it('highlights matched item name for prefix match', () => {
+    const { container } = render(
+      <WishlistResult
+        data={{
+          item: 'Gaming PC',
+          priority: null,
+          targetAmount: null,
+          _query: 'Gaming',
+          _matchField: 'item',
+          _matchType: 'prefix',
+        }}
+      />
+    );
+
+    const mark = container.querySelector('mark');
+    expect(mark).toBeInTheDocument();
+    expect(mark!.textContent).toBe('Gaming');
+  });
+
+  it('highlights matched item name for contains match', () => {
+    const { container } = render(
+      <WishlistResult
+        data={{
+          item: 'Standing Desk',
+          priority: null,
+          targetAmount: null,
+          _query: 'anding',
+          _matchField: 'item',
+          _matchType: 'contains',
+        }}
+      />
+    );
+
+    const mark = container.querySelector('mark');
+    expect(mark).toBeInTheDocument();
+    expect(mark!.textContent).toBe('anding');
+  });
+
+  it('does not highlight when matchField is not item', () => {
+    const { container } = render(
+      <WishlistResult
+        data={{
+          item: 'Japan Trip',
+          priority: null,
+          targetAmount: null,
+          _query: 'Japan',
+          _matchField: 'notes',
+          _matchType: 'exact',
+        }}
+      />
+    );
+
+    expect(container.querySelector('mark')).not.toBeInTheDocument();
+  });
+
+  it('does not highlight when no query provided', () => {
+    const { container } = render(
+      <WishlistResult
+        data={{
+          item: 'Japan Trip',
+          priority: null,
+          targetAmount: null,
+        }}
+      />
+    );
+
+    expect(container.querySelector('mark')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-finance/src/components/search/WishlistResult.tsx
+++ b/packages/app-finance/src/components/search/WishlistResult.tsx
@@ -1,8 +1,7 @@
 import { registerResultComponent, type ResultComponentProps } from '@pops/navigation';
 import { formatCurrency, highlightMatch, SearchResultItem } from '@pops/ui';
 
-function formatAmount(amount: number | null | undefined): string {
-  if (amount == null) return '—';
+function formatAmount(amount: number): string {
   return formatCurrency(amount, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 

--- a/packages/app-finance/src/components/search/WishlistResult.tsx
+++ b/packages/app-finance/src/components/search/WishlistResult.tsx
@@ -1,0 +1,39 @@
+import { registerResultComponent, type ResultComponentProps } from '@pops/navigation';
+import { formatCurrency, highlightMatch, SearchResultItem } from '@pops/ui';
+
+function formatAmount(amount: number | null | undefined): string {
+  if (amount == null) return '—';
+  return formatCurrency(amount, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function formatPriority(priority: string | null | undefined): string {
+  if (!priority) return '';
+  return priority.charAt(0).toUpperCase() + priority.slice(1);
+}
+
+export function WishlistResult({ data }: ResultComponentProps) {
+  const item = (data.item as string) ?? '';
+  const priority = data.priority as string | null | undefined;
+  const targetAmount = data.targetAmount as number | null | undefined;
+  const query = (data._query as string) ?? '';
+  const matchField = (data._matchField as string) ?? '';
+  const matchType = (data._matchType as string) ?? '';
+
+  const shouldHighlight = matchField === 'item' && query;
+
+  return (
+    <SearchResultItem
+      title={shouldHighlight ? highlightMatch(item, query, matchType) : item}
+      meta={priority ? [<span key="priority">{formatPriority(priority)}</span>] : undefined}
+      trailing={
+        targetAmount != null ? (
+          <div className="text-muted-foreground shrink-0 text-sm font-medium">
+            {formatAmount(targetAmount)}
+          </div>
+        ) : undefined
+      }
+    />
+  );
+}
+
+registerResultComponent('wishlist', WishlistResult);

--- a/packages/app-finance/src/index.ts
+++ b/packages/app-finance/src/index.ts
@@ -10,3 +10,4 @@ export { navConfig, routes } from './routes';
 import './components/search/EntitiesResultComponent';
 import './components/search/TransactionsResultComponent';
 import './components/search/BudgetResult';
+import './components/search/WishlistResult';

--- a/packages/navigation/src/search-input/useSearchInputData.tsx
+++ b/packages/navigation/src/search-input/useSearchInputData.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightLeft, Box, Building2, Film, PiggyBank, Search, Tv } from 'lucide-react';
+import { ArrowRightLeft, Box, Building2, Film, PiggyBank, Search, Star, Tv } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { trpc } from '@pops/api-client';
@@ -17,6 +17,7 @@ const ICON_MAP: Record<string, ReactNode> = {
   ArrowRightLeft: <ArrowRightLeft className="h-3.5 w-3.5" />,
   PiggyBank: <PiggyBank className="h-3.5 w-3.5" />,
   Building2: <Building2 className="h-3.5 w-3.5" />,
+  Star: <Star className="h-3.5 w-3.5" />,
 };
 
 function domainToLabel(domain: string): string {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a `wishlistSearchAdapter` (backend) that searches `wish_list.item` with exact/prefix/contains scoring (1.0/0.8/0.5), registered under domain `wishlist` with icon `Star` and color `yellow`
- Maps `wishlist → finance` in `domain-app-mapping.ts` so wish list results appear first when searching from the Finance app
- Adds `WishlistResult` frontend component (item name with match highlighting, priority, target amount) and registers it in the `@pops/navigation` result component registry
- Adds `Star` to the icon map in `useSearchInputData`
- Adds US-10 + US-10b to PRD-057, updates business rules to include `wishlist` in the domain→app mapping

## Test plan

- [ ] `pnpm test` in `apps/pops-api` — 12 new `wishlist search adapter` tests all pass
- [ ] `pnpm test` in `packages/app-finance` — 9 new `WishlistResult` tests all pass
- [ ] Full turbo typecheck passes (verified by pre-commit hook)
- [ ] Manual: seed DB (`mise db:seed`), open cmd-K, type `japan` → "Japan Trip" appears under a "Wishlist" section
- [ ] Manual: clicking a wishlist result navigates to `/finance/wishlist`

## Gaps (tracked)

Closes #2353

https://claude.ai/code/session_01KKEVCQrzkCcpbdssPw4niM
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKEVCQrzkCcpbdssPw4niM)_