### PR TITLE
fix(ui/DataTable): show proper column labels in Columns dropdown

### DIFF
--- a/packages/ui/src/components/DataTable.toolbar.test.ts
+++ b/packages/ui/src/components/DataTable.toolbar.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { getColumnLabel } from './DataTable.toolbar';
+
+describe('getColumnLabel', () => {
+  it('returns the string header verbatim when present', () => {
+    expect(getColumnLabel('description', 'Description')).toBe('Description');
+    expect(getColumnLabel('amount', 'Amount')).toBe('Amount');
+  });
+
+  it('converts camelCase id to Title Case when header is a function', () => {
+    expect(getColumnLabel('createdAt', () => null)).toBe('Created At');
+    expect(getColumnLabel('lastEditedBy', () => null)).toBe('Last Edited By');
+  });
+
+  it('converts snake_case id to Title Case when header is undefined', () => {
+    expect(getColumnLabel('last_edited_time', undefined)).toBe('Last Edited Time');
+    expect(getColumnLabel('created_at', undefined)).toBe('Created At');
+  });
+
+  it('capitalizes simple lowercase ids', () => {
+    expect(getColumnLabel('actions', undefined)).toBe('Actions');
+    expect(getColumnLabel('date', undefined)).toBe('Date');
+  });
+
+  it('handles mixed snake_and_camelCase', () => {
+    expect(getColumnLabel('item_createdAt', undefined)).toBe('Item Created At');
+  });
+});

--- a/packages/ui/src/components/DataTable.toolbar.tsx
+++ b/packages/ui/src/components/DataTable.toolbar.tsx
@@ -12,6 +12,14 @@ import { TextInput } from './TextInput';
 
 import type { Table as TanStackTable } from '@tanstack/react-table';
 
+export function getColumnLabel(id: string, header: unknown): string {
+  if (typeof header === 'string') return header;
+  return id
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 export interface DataTableToolbarProps<TData> {
   table: TanStackTable<TData>;
   searchable: boolean;
@@ -66,9 +74,7 @@ function ColumnVisibilityMenu<TData>({ table }: { table: TanStackTable<TData> })
               checked={column.getIsVisible()}
               onCheckedChange={(value) => column.toggleVisibility(!!value)}
             >
-              {typeof column.columnDef.header === 'string'
-                ? column.columnDef.header
-                : column.id.charAt(0).toUpperCase() + column.id.slice(1)}
+              {getColumnLabel(column.id, column.columnDef.header)}
             </DropdownMenuCheckboxItem>
           ))}
       </DropdownMenuContent>

--- a/packages/ui/src/components/DataTable.toolbar.tsx
+++ b/packages/ui/src/components/DataTable.toolbar.tsx
@@ -66,7 +66,9 @@ function ColumnVisibilityMenu<TData>({ table }: { table: TanStackTable<TData> })
               checked={column.getIsVisible()}
               onCheckedChange={(value) => column.toggleVisibility(!!value)}
             >
-              {column.id}
+              {typeof column.columnDef.header === 'string'
+                ? column.columnDef.header
+                : column.id.charAt(0).toUpperCase() + column.id.slice(1)}
             </DropdownMenuCheckboxItem>
           ))}
       </DropdownMenuContent>


### PR DESCRIPTION
## Summary

- Fixes the Columns visibility dropdown showing raw lowercase column IDs (e.g. `description`, `date`) instead of proper display names (e.g. `Description`, `Date`)
- In `DataTable.toolbar.tsx`, the `ColumnVisibilityMenu` now uses `column.columnDef.header` when it's a plain string, and falls back to capitalizing the column ID for function-based headers — no column definition changes required

## Detail

The fix is a one-liner in the shared `ColumnVisibilityMenu` component:

```tsx
// Before
{column.id}

// After
{typeof column.columnDef.header === 'string'
  ? column.columnDef.header
  : column.id.charAt(0).toUpperCase() + column.id.slice(1)}
```

This covers all cases:
| Column | Before | After |
|--------|--------|-------|
| `header: 'Description'` | `description` | `Description` |
| `header: 'Account'` | `account` | `Account` |
| `header: ({ column }) => <SortableHeader>Date</SortableHeader>` | `date` | `Date` |
| `id: 'actions'` (no header) | `actions` | `Actions` |

The fix applies to all DataTable usages across the codebase (Transactions, Entities, Budgets, Wishlist).

Closes #2315

https://claude.ai/code/session_01K8yMjbPgdyPSseW4ECCkuv

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8yMjbPgdyPSseW4ECCkuv)_