### PR TITLE
fix(cerebrum/ingest): remove duplicate 'capture' entry from Type dropdown

### DIFF
--- a/packages/app-cerebrum/src/pages/ingest-page/useTemplateAndScopeData.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useTemplateAndScopeData.ts
@@ -23,11 +23,13 @@ export function useTemplateAndScopeData() {
   const knownScopes = scopesRef.current;
 
   const typeOptions = useMemo(() => {
-    const opts = templates.map((t) => ({
-      value: t.name,
-      label: t.name,
-      description: t.description,
-    }));
+    const opts = templates
+      .filter((t) => t.name !== 'capture')
+      .map((t) => ({
+        value: t.name,
+        label: t.name,
+        description: t.description,
+      }));
     opts.unshift({
       value: 'capture',
       label: 'capture',


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes #2359 — `capture` appeared twice in the Cerebrum Ingest Type dropdown
- Root cause: `capture` is a registered server-side template (returned in the templates list) AND was also hardcoded via `opts.unshift()` in `useTemplateAndScopeData.ts`
- Fix: filter `capture` out of the mapped template options before unshifting it, so it only appears once as the pinned first entry with the "Freeform capture — no template" description

## Test plan

- [ ] Navigate to `/cerebrum`, open the Type dropdown — `capture` appears exactly once, at the top
- [ ] All other types (decision, idea, journal, meeting, note, research) still appear
- [ ] 36 unit tests pass (`pnpm test` in `packages/app-cerebrum`)
- [ ] Lint: 0 errors, typecheck: 17/17 packages green

https://claude.ai/code/session_01LMF6Lubympc3zMWeYs1mxX
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMF6Lubympc3zMWeYs1mxX)_