### PR TITLE
fix(finance/import): add bank picker to upload step

### DIFF
--- a/docs/themes/02-finance/prds/020-import-wizard-ui/README.md
+++ b/docs/themes/02-finance/prds/020-import-wizard-ui/README.md
@@ -25,6 +25,7 @@ Step 1: Upload CSV
 
 ### Step 1: Upload
 
+- User selects their bank (ANZ, Amex, ING, Up) via radio picker — selection stored in Zustand; help card updates with bank-specific CSV export instructions
 - User selects CSV file (max 25 MB)
 - Parse CSV rows client-side
 - Validates: file required, CSV not empty, headers present

--- a/docs/themes/02-finance/prds/020-import-wizard-ui/us-02-upload-step.md
+++ b/docs/themes/02-finance/prds/020-import-wizard-ui/us-02-upload-step.md
@@ -16,6 +16,9 @@ As a user, I want to upload a bank CSV file so that I can begin importing transa
 - [x] Error messaging for invalid files
 - [x] On success: stores headers/rows and advances to Step 2
 - [x] Loading state while parsing large files
+- [x] Bank picker (radio group) displayed before file upload — options: ANZ, Amex, ING, Up
+- [x] Selected bank stored in Zustand (`bankType`)
+- [x] Help card updates to show bank-specific export instructions based on selection
 
 ## Notes
 

--- a/packages/app-finance/src/components/imports/UploadStep.tsx
+++ b/packages/app-finance/src/components/imports/UploadStep.tsx
@@ -1,11 +1,11 @@
-import Papa from 'papaparse';
-import { useCallback, useState } from 'react';
+import Papa from "papaparse";
+import { useCallback, useState } from "react";
 
-import { Button, RadioInput } from '@pops/ui';
+import { Button, RadioInput } from "@pops/ui";
 
-import { useImportStore } from '../../store/importStore';
-import type { BankType } from '../../store/import-store-types';
-import { FileUpload } from './FileUpload';
+import { useImportStore } from "../../store/importStore";
+import type { BankType } from "../../store/import-store-types";
+import { FileUpload } from "./FileUpload";
 
 interface ParseResult {
   ok: boolean;
@@ -23,22 +23,23 @@ function parseCsvFile(file: File): Promise<ParseResult> {
         if (results.errors.length > 0) {
           resolve({
             ok: false,
-            error: `CSV parsing error: ${results.errors[0]?.message ?? 'Unknown error'}`,
+            error: `CSV parsing error: ${results.errors[0]?.message ?? "Unknown error"}`,
           });
           return;
         }
         if (results.data.length === 0) {
-          resolve({ ok: false, error: 'CSV file is empty' });
+          resolve({ ok: false, error: "CSV file is empty" });
           return;
         }
         const headers = results.meta.fields ?? [];
         if (headers.length === 0) {
-          resolve({ ok: false, error: 'CSV file has no headers' });
+          resolve({ ok: false, error: "CSV file has no headers" });
           return;
         }
         resolve({ ok: true, headers, rows: results.data });
       },
-      error: (error) => resolve({ ok: false, error: `Failed to parse CSV: ${error.message}` }),
+      error: (error) =>
+        resolve({ ok: false, error: `Failed to parse CSV: ${error.message}` }),
     });
   });
 }
@@ -55,28 +56,36 @@ function UploadFooter({
   return (
     <div className="flex justify-end gap-3">
       <Button onClick={onNext} disabled={disabled}>
-        {isProcessing ? 'Processing...' : 'Next'}
+        {isProcessing ? "Processing..." : "Next"}
       </Button>
     </div>
   );
 }
 
 const BANK_OPTIONS = [
-  { value: 'ANZ', label: 'ANZ', description: 'Everyday, Savings' },
-  { value: 'Amex', label: 'Amex', description: 'American Express' },
-  { value: 'ING', label: 'ING', description: 'Savings, Everyday' },
-  { value: 'Up', label: 'Up', description: 'Everyday, Round Up' },
+  { value: "ANZ", label: "ANZ", description: "Everyday, Savings" },
+  { value: "Amex", label: "Amex", description: "American Express" },
+  { value: "ING", label: "ING", description: "Savings, Everyday" },
+  { value: "Up", label: "Up", description: "Everyday, Round Up" },
 ] satisfies Array<{ value: BankType; label: string; description: string }>;
 
 const BANK_HELP: Record<BankType, string> = {
-  ANZ: 'Log in to ANZ Internet Banking, open your account, and export transactions as CSV.',
-  Amex: 'Log in to your Amex online portal and download your transactions as a CSV export.',
-  ING: 'Log in to ING Banking Online, open your account, and export transactions as CSV.',
-  Up: 'In the Up app, go to your account, tap Export, and choose CSV format.',
+  ANZ: "Log in to ANZ Internet Banking, open your account, and export transactions as CSV.",
+  Amex: "Log in to your Amex online portal and download your transactions as a CSV export.",
+  ING: "Log in to ING Banking Online, open your account, and export transactions as CSV.",
+  Up: "In the Up app, go to your account, tap Export, and choose CSV format.",
 };
 
 function useUploadStep() {
-  const { file, bankType, setFile, setBankType, setHeaders, setRows, nextStep } = useImportStore();
+  const {
+    file,
+    bankType,
+    setFile,
+    setBankType,
+    setHeaders,
+    setRows,
+    nextStep,
+  } = useImportStore();
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -85,19 +94,19 @@ function useUploadStep() {
       setFile(selectedFile);
       setError(null);
     },
-    [setFile]
+    [setFile],
   );
 
   const handleBankChange = useCallback(
     (value: string) => {
       setBankType(value as BankType);
     },
-    [setBankType]
+    [setBankType],
   );
 
   const handleNext = useCallback(async () => {
     if (!file) {
-      setError('Please select a file');
+      setError("Please select a file");
       return;
     }
     setIsProcessing(true);
@@ -105,7 +114,7 @@ function useUploadStep() {
     const result = await parseCsvFile(file);
     setIsProcessing(false);
     if (!result.ok) {
-      setError(result.error ?? 'Unknown error');
+      setError(result.error ?? "Unknown error");
       return;
     }
     setHeaders(result.headers ?? []);
@@ -113,12 +122,27 @@ function useUploadStep() {
     nextStep();
   }, [file, setHeaders, setRows, nextStep]);
 
-  return { file, bankType, isProcessing, error, handleFileSelect, handleBankChange, handleNext };
+  return {
+    file,
+    bankType,
+    isProcessing,
+    error,
+    handleFileSelect,
+    handleBankChange,
+    handleNext,
+  };
 }
 
 export function UploadStep() {
-  const { file, bankType, isProcessing, error, handleFileSelect, handleBankChange, handleNext } =
-    useUploadStep();
+  const {
+    file,
+    bankType,
+    isProcessing,
+    error,
+    handleFileSelect,
+    handleBankChange,
+    handleNext,
+  } = useUploadStep();
 
   return (
     <div className="space-y-6">
@@ -146,7 +170,8 @@ export function UploadStep() {
 
       <div className="bg-info/5 border border-info/20 rounded-lg p-4">
         <h3 className="text-sm font-medium text-info mb-2">
-          How to export from {BANK_OPTIONS.find((b) => b.value === bankType)?.label ?? bankType}
+          How to export from{" "}
+          {BANK_OPTIONS.find((b) => b.value === bankType)?.label ?? bankType}
         </h3>
         <p className="text-xs text-info">{BANK_HELP[bankType]}</p>
       </div>

--- a/packages/app-finance/src/components/imports/UploadStep.tsx
+++ b/packages/app-finance/src/components/imports/UploadStep.tsx
@@ -1,9 +1,10 @@
 import Papa from 'papaparse';
 import { useCallback, useState } from 'react';
 
-import { Button } from '@pops/ui';
+import { Button, RadioInput } from '@pops/ui';
 
 import { useImportStore } from '../../store/importStore';
+import type { BankType } from '../../store/import-store-types';
 import { FileUpload } from './FileUpload';
 
 interface ParseResult {
@@ -60,8 +61,22 @@ function UploadFooter({
   );
 }
 
+const BANK_OPTIONS = [
+  { value: 'ANZ', label: 'ANZ', description: 'Everyday, Savings' },
+  { value: 'Amex', label: 'Amex', description: 'American Express' },
+  { value: 'ING', label: 'ING', description: 'Savings, Everyday' },
+  { value: 'Up', label: 'Up', description: 'Everyday, Round Up' },
+] satisfies Array<{ value: BankType; label: string; description: string }>;
+
+const BANK_HELP: Record<BankType, string> = {
+  ANZ: 'Log in to ANZ Internet Banking, open your account, and export transactions as CSV.',
+  Amex: 'Log in to your Amex online portal and download your transactions as a CSV export.',
+  ING: 'Log in to ING Banking Online, open your account, and export transactions as CSV.',
+  Up: 'In the Up app, go to your account, tap Export, and choose CSV format.',
+};
+
 function useUploadStep() {
-  const { file, setFile, setHeaders, setRows, nextStep } = useImportStore();
+  const { file, bankType, setFile, setBankType, setHeaders, setRows, nextStep } = useImportStore();
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -71,6 +86,13 @@ function useUploadStep() {
       setError(null);
     },
     [setFile]
+  );
+
+  const handleBankChange = useCallback(
+    (value: string) => {
+      setBankType(value as BankType);
+    },
+    [setBankType]
   );
 
   const handleNext = useCallback(async () => {
@@ -91,23 +113,29 @@ function useUploadStep() {
     nextStep();
   }, [file, setHeaders, setRows, nextStep]);
 
-  return { file, isProcessing, error, handleFileSelect, handleNext };
+  return { file, bankType, isProcessing, error, handleFileSelect, handleBankChange, handleNext };
 }
 
-/**
- * Step 1: Upload CSV file and parse it
- */
 export function UploadStep() {
-  const { file, isProcessing, error, handleFileSelect, handleNext } = useUploadStep();
+  const { file, bankType, isProcessing, error, handleFileSelect, handleBankChange, handleNext } =
+    useUploadStep();
 
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-2xl font-semibold mb-2">Upload CSV</h2>
         <p className="text-sm text-gray-600 dark:text-gray-400">
-          Select an Amex CSV export file to import transactions.
+          Select your bank and upload a CSV export to import transactions.
         </p>
       </div>
+
+      <RadioInput
+        label="Bank"
+        options={BANK_OPTIONS}
+        value={bankType}
+        onValueChange={handleBankChange}
+        orientation="horizontal"
+      />
 
       <FileUpload
         onFileSelect={handleFileSelect}
@@ -117,10 +145,10 @@ export function UploadStep() {
       />
 
       <div className="bg-info/5 border border-info/20 rounded-lg p-4">
-        <h3 className="text-sm font-medium text-info mb-2">Bank: American Express (Amex)</h3>
-        <p className="text-xs text-info">
-          Download your Amex transactions as CSV from your online banking portal.
-        </p>
+        <h3 className="text-sm font-medium text-info mb-2">
+          How to export from {BANK_OPTIONS.find((b) => b.value === bankType)?.label ?? bankType}
+        </h3>
+        <p className="text-xs text-info">{BANK_HELP[bankType]}</p>
       </div>
 
       {error && (

--- a/packages/app-finance/src/components/imports/UploadStep.tsx
+++ b/packages/app-finance/src/components/imports/UploadStep.tsx
@@ -1,11 +1,12 @@
-import Papa from "papaparse";
-import { useCallback, useState } from "react";
+import Papa from 'papaparse';
+import { useCallback, useState } from 'react';
 
-import { Button, RadioInput } from "@pops/ui";
+import { Button, RadioInput } from '@pops/ui';
 
-import { useImportStore } from "../../store/importStore";
-import type { BankType } from "../../store/import-store-types";
-import { FileUpload } from "./FileUpload";
+import { useImportStore } from '../../store/importStore';
+import { FileUpload } from './FileUpload';
+
+import type { BankType } from '../../store/import-store-types';
 
 interface ParseResult {
   ok: boolean;
@@ -23,23 +24,22 @@ function parseCsvFile(file: File): Promise<ParseResult> {
         if (results.errors.length > 0) {
           resolve({
             ok: false,
-            error: `CSV parsing error: ${results.errors[0]?.message ?? "Unknown error"}`,
+            error: `CSV parsing error: ${results.errors[0]?.message ?? 'Unknown error'}`,
           });
           return;
         }
         if (results.data.length === 0) {
-          resolve({ ok: false, error: "CSV file is empty" });
+          resolve({ ok: false, error: 'CSV file is empty' });
           return;
         }
         const headers = results.meta.fields ?? [];
         if (headers.length === 0) {
-          resolve({ ok: false, error: "CSV file has no headers" });
+          resolve({ ok: false, error: 'CSV file has no headers' });
           return;
         }
         resolve({ ok: true, headers, rows: results.data });
       },
-      error: (error) =>
-        resolve({ ok: false, error: `Failed to parse CSV: ${error.message}` }),
+      error: (error) => resolve({ ok: false, error: `Failed to parse CSV: ${error.message}` }),
     });
   });
 }
@@ -56,36 +56,28 @@ function UploadFooter({
   return (
     <div className="flex justify-end gap-3">
       <Button onClick={onNext} disabled={disabled}>
-        {isProcessing ? "Processing..." : "Next"}
+        {isProcessing ? 'Processing...' : 'Next'}
       </Button>
     </div>
   );
 }
 
 const BANK_OPTIONS = [
-  { value: "ANZ", label: "ANZ", description: "Everyday, Savings" },
-  { value: "Amex", label: "Amex", description: "American Express" },
-  { value: "ING", label: "ING", description: "Savings, Everyday" },
-  { value: "Up", label: "Up", description: "Everyday, Round Up" },
+  { value: 'ANZ', label: 'ANZ', description: 'Everyday, Savings' },
+  { value: 'Amex', label: 'Amex', description: 'American Express' },
+  { value: 'ING', label: 'ING', description: 'Savings, Everyday' },
+  { value: 'Up', label: 'Up', description: 'Everyday, Round Up' },
 ] satisfies Array<{ value: BankType; label: string; description: string }>;
 
 const BANK_HELP: Record<BankType, string> = {
-  ANZ: "Log in to ANZ Internet Banking, open your account, and export transactions as CSV.",
-  Amex: "Log in to your Amex online portal and download your transactions as a CSV export.",
-  ING: "Log in to ING Banking Online, open your account, and export transactions as CSV.",
-  Up: "In the Up app, go to your account, tap Export, and choose CSV format.",
+  ANZ: 'Log in to ANZ Internet Banking, open your account, and export transactions as CSV.',
+  Amex: 'Log in to your Amex online portal and download your transactions as a CSV export.',
+  ING: 'Log in to ING Banking Online, open your account, and export transactions as CSV.',
+  Up: 'In the Up app, go to your account, tap Export, and choose CSV format.',
 };
 
 function useUploadStep() {
-  const {
-    file,
-    bankType,
-    setFile,
-    setBankType,
-    setHeaders,
-    setRows,
-    nextStep,
-  } = useImportStore();
+  const { file, bankType, setFile, setBankType, setHeaders, setRows, nextStep } = useImportStore();
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -94,19 +86,19 @@ function useUploadStep() {
       setFile(selectedFile);
       setError(null);
     },
-    [setFile],
+    [setFile]
   );
 
   const handleBankChange = useCallback(
     (value: string) => {
       setBankType(value as BankType);
     },
-    [setBankType],
+    [setBankType]
   );
 
   const handleNext = useCallback(async () => {
     if (!file) {
-      setError("Please select a file");
+      setError('Please select a file');
       return;
     }
     setIsProcessing(true);
@@ -114,7 +106,7 @@ function useUploadStep() {
     const result = await parseCsvFile(file);
     setIsProcessing(false);
     if (!result.ok) {
-      setError(result.error ?? "Unknown error");
+      setError(result.error ?? 'Unknown error');
       return;
     }
     setHeaders(result.headers ?? []);
@@ -134,15 +126,8 @@ function useUploadStep() {
 }
 
 export function UploadStep() {
-  const {
-    file,
-    bankType,
-    isProcessing,
-    error,
-    handleFileSelect,
-    handleBankChange,
-    handleNext,
-  } = useUploadStep();
+  const { file, bankType, isProcessing, error, handleFileSelect, handleBankChange, handleNext } =
+    useUploadStep();
 
   return (
     <div className="space-y-6">
@@ -170,8 +155,7 @@ export function UploadStep() {
 
       <div className="bg-info/5 border border-info/20 rounded-lg p-4">
         <h3 className="text-sm font-medium text-info mb-2">
-          How to export from{" "}
-          {BANK_OPTIONS.find((b) => b.value === bankType)?.label ?? bankType}
+          How to export from {BANK_OPTIONS.find((b) => b.value === bankType)?.label ?? bankType}
         </h3>
         <p className="text-xs text-info">{BANK_HELP[bankType]}</p>
       </div>

--- a/packages/app-finance/src/store/import-store-types.ts
+++ b/packages/app-finance/src/store/import-store-types.ts
@@ -1,16 +1,16 @@
-import type { ChangeSet } from '@pops/api/modules/core/corrections/types';
-import type { TagRuleChangeSet } from '@pops/api/modules/core/tag-rules/types';
+import type { ChangeSet } from "@pops/api/modules/core/corrections/types";
+import type { TagRuleChangeSet } from "@pops/api/modules/core/tag-rules/types";
 import type {
   ConfirmedTransaction,
   ImportWarning,
   ParsedTransaction,
   ProcessedTransaction as BaseProcessedTransaction,
   CommitResult,
-} from '@pops/api/modules/finance/imports';
+} from "@pops/api/modules/finance/imports";
 
-export type BankType = 'ANZ' | 'Amex' | 'ING' | 'Up';
+export type BankType = "ANZ" | "Amex" | "ING" | "Up";
 export type { ChangeSet };
-export type EntityType = 'company' | 'person' | 'government' | 'bank';
+export type EntityType = "company" | "person" | "government" | "bank";
 
 export interface PendingEntity {
   tempId: string;
@@ -84,10 +84,12 @@ export interface ImportStore {
   setBankType: (bankType: BankType) => void;
   setHeaders: (headers: string[]) => void;
   setRows: (rows: Record<string, string>[]) => void;
-  setColumnMap: (columnMap: ImportStore['columnMap']) => void;
+  setColumnMap: (columnMap: ImportStore["columnMap"]) => void;
   setParsedTransactions: (parsed: ParsedTransaction[]) => void;
   setProcessSessionId: (sessionId: string | null) => void;
-  setProcessedTransactions: (processed: ImportStore['processedTransactions']) => void;
+  setProcessedTransactions: (
+    processed: ImportStore["processedTransactions"],
+  ) => void;
   setConfirmedTransactions: (confirmed: ConfirmedTransaction[]) => void;
   setCommitResult: (result: CommitResult | null) => void;
 
@@ -98,7 +100,7 @@ export interface ImportStore {
 
   addPendingEntity: (
     input: AddPendingEntityInput,
-    dbEntities?: Array<{ name: string }>
+    dbEntities?: Array<{ name: string }>,
   ) => PendingEntity;
   listPendingEntities: () => PendingEntity[];
   removePendingEntity: (tempId: string) => void;
@@ -107,13 +109,15 @@ export interface ImportStore {
   listPendingChangeSets: () => PendingChangeSet[];
   removePendingChangeSet: (tempId: string) => void;
 
-  addPendingTagRuleChangeSet: (input: AddPendingTagRuleChangeSetInput) => PendingTagRuleChangeSet;
+  addPendingTagRuleChangeSet: (
+    input: AddPendingTagRuleChangeSetInput,
+  ) => PendingTagRuleChangeSet;
   listPendingTagRuleChangeSets: () => PendingTagRuleChangeSet[];
   removePendingTagRuleChangeSet: (tempId: string) => void;
 
   updateTransaction: (
     transaction: ProcessedTransaction,
-    updates: Partial<ProcessedTransaction>
+    updates: Partial<ProcessedTransaction>,
   ) => void;
   findSimilar: (transaction: ProcessedTransaction) => ProcessedTransaction[];
 
@@ -123,12 +127,12 @@ export interface ImportStore {
 export const initialState = {
   currentStep: 1,
   file: null,
-  bankType: 'Amex' as BankType,
+  bankType: "Amex" as BankType,
   headers: [],
   rows: [],
-  columnMap: { date: '', description: '', amount: '' },
+  columnMap: { date: "", description: "", amount: "" },
   parsedTransactions: [],
-  parsedTransactionsFingerprint: '',
+  parsedTransactionsFingerprint: "",
   processSessionId: null,
   processedForFingerprint: null,
   processedTransactions: {
@@ -148,25 +152,27 @@ export const initialState = {
 /**
  * Produce a content fingerprint for a list of parsed transactions.
  */
-export function fingerprintParsedTransactions(txns: ParsedTransaction[]): string {
-  if (txns.length === 0) return '';
-  return txns.map((t) => t.checksum).join('|');
+export function fingerprintParsedTransactions(
+  txns: ParsedTransaction[],
+): string {
+  if (txns.length === 0) return "";
+  return txns.map((t) => t.checksum).join("|");
 }
 
 export const downstreamReset: Pick<
   ImportStore,
-  | 'headers'
-  | 'rows'
-  | 'parsedTransactions'
-  | 'parsedTransactionsFingerprint'
-  | 'processSessionId'
-  | 'processedForFingerprint'
-  | 'processedTransactions'
-  | 'confirmedTransactions'
-  | 'commitResult'
-  | 'pendingEntities'
-  | 'pendingChangeSets'
-  | 'pendingTagRuleChangeSets'
+  | "headers"
+  | "rows"
+  | "parsedTransactions"
+  | "parsedTransactionsFingerprint"
+  | "processSessionId"
+  | "processedForFingerprint"
+  | "processedTransactions"
+  | "confirmedTransactions"
+  | "commitResult"
+  | "pendingEntities"
+  | "pendingChangeSets"
+  | "pendingTagRuleChangeSets"
 > = {
   headers: initialState.headers,
   rows: initialState.rows,
@@ -185,5 +191,7 @@ export const downstreamReset: Pick<
 export function isSameFile(a: File | null, b: File | null): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
-  return a.name === b.name && a.size === b.size && a.lastModified === b.lastModified;
+  return (
+    a.name === b.name && a.size === b.size && a.lastModified === b.lastModified
+  );
 }

--- a/packages/app-finance/src/store/import-store-types.ts
+++ b/packages/app-finance/src/store/import-store-types.ts
@@ -1,16 +1,16 @@
-import type { ChangeSet } from "@pops/api/modules/core/corrections/types";
-import type { TagRuleChangeSet } from "@pops/api/modules/core/tag-rules/types";
+import type { ChangeSet } from '@pops/api/modules/core/corrections/types';
+import type { TagRuleChangeSet } from '@pops/api/modules/core/tag-rules/types';
 import type {
   ConfirmedTransaction,
   ImportWarning,
   ParsedTransaction,
   ProcessedTransaction as BaseProcessedTransaction,
   CommitResult,
-} from "@pops/api/modules/finance/imports";
+} from '@pops/api/modules/finance/imports';
 
-export type BankType = "ANZ" | "Amex" | "ING" | "Up";
+export type BankType = 'ANZ' | 'Amex' | 'ING' | 'Up';
 export type { ChangeSet };
-export type EntityType = "company" | "person" | "government" | "bank";
+export type EntityType = 'company' | 'person' | 'government' | 'bank';
 
 export interface PendingEntity {
   tempId: string;
@@ -84,12 +84,10 @@ export interface ImportStore {
   setBankType: (bankType: BankType) => void;
   setHeaders: (headers: string[]) => void;
   setRows: (rows: Record<string, string>[]) => void;
-  setColumnMap: (columnMap: ImportStore["columnMap"]) => void;
+  setColumnMap: (columnMap: ImportStore['columnMap']) => void;
   setParsedTransactions: (parsed: ParsedTransaction[]) => void;
   setProcessSessionId: (sessionId: string | null) => void;
-  setProcessedTransactions: (
-    processed: ImportStore["processedTransactions"],
-  ) => void;
+  setProcessedTransactions: (processed: ImportStore['processedTransactions']) => void;
   setConfirmedTransactions: (confirmed: ConfirmedTransaction[]) => void;
   setCommitResult: (result: CommitResult | null) => void;
 
@@ -100,7 +98,7 @@ export interface ImportStore {
 
   addPendingEntity: (
     input: AddPendingEntityInput,
-    dbEntities?: Array<{ name: string }>,
+    dbEntities?: Array<{ name: string }>
   ) => PendingEntity;
   listPendingEntities: () => PendingEntity[];
   removePendingEntity: (tempId: string) => void;
@@ -109,15 +107,13 @@ export interface ImportStore {
   listPendingChangeSets: () => PendingChangeSet[];
   removePendingChangeSet: (tempId: string) => void;
 
-  addPendingTagRuleChangeSet: (
-    input: AddPendingTagRuleChangeSetInput,
-  ) => PendingTagRuleChangeSet;
+  addPendingTagRuleChangeSet: (input: AddPendingTagRuleChangeSetInput) => PendingTagRuleChangeSet;
   listPendingTagRuleChangeSets: () => PendingTagRuleChangeSet[];
   removePendingTagRuleChangeSet: (tempId: string) => void;
 
   updateTransaction: (
     transaction: ProcessedTransaction,
-    updates: Partial<ProcessedTransaction>,
+    updates: Partial<ProcessedTransaction>
   ) => void;
   findSimilar: (transaction: ProcessedTransaction) => ProcessedTransaction[];
 
@@ -127,12 +123,12 @@ export interface ImportStore {
 export const initialState = {
   currentStep: 1,
   file: null,
-  bankType: "Amex" as BankType,
+  bankType: 'Amex' as BankType,
   headers: [],
   rows: [],
-  columnMap: { date: "", description: "", amount: "" },
+  columnMap: { date: '', description: '', amount: '' },
   parsedTransactions: [],
-  parsedTransactionsFingerprint: "",
+  parsedTransactionsFingerprint: '',
   processSessionId: null,
   processedForFingerprint: null,
   processedTransactions: {
@@ -152,27 +148,25 @@ export const initialState = {
 /**
  * Produce a content fingerprint for a list of parsed transactions.
  */
-export function fingerprintParsedTransactions(
-  txns: ParsedTransaction[],
-): string {
-  if (txns.length === 0) return "";
-  return txns.map((t) => t.checksum).join("|");
+export function fingerprintParsedTransactions(txns: ParsedTransaction[]): string {
+  if (txns.length === 0) return '';
+  return txns.map((t) => t.checksum).join('|');
 }
 
 export const downstreamReset: Pick<
   ImportStore,
-  | "headers"
-  | "rows"
-  | "parsedTransactions"
-  | "parsedTransactionsFingerprint"
-  | "processSessionId"
-  | "processedForFingerprint"
-  | "processedTransactions"
-  | "confirmedTransactions"
-  | "commitResult"
-  | "pendingEntities"
-  | "pendingChangeSets"
-  | "pendingTagRuleChangeSets"
+  | 'headers'
+  | 'rows'
+  | 'parsedTransactions'
+  | 'parsedTransactionsFingerprint'
+  | 'processSessionId'
+  | 'processedForFingerprint'
+  | 'processedTransactions'
+  | 'confirmedTransactions'
+  | 'commitResult'
+  | 'pendingEntities'
+  | 'pendingChangeSets'
+  | 'pendingTagRuleChangeSets'
 > = {
   headers: initialState.headers,
   rows: initialState.rows,
@@ -191,7 +185,5 @@ export const downstreamReset: Pick<
 export function isSameFile(a: File | null, b: File | null): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
-  return (
-    a.name === b.name && a.size === b.size && a.lastModified === b.lastModified
-  );
+  return a.name === b.name && a.size === b.size && a.lastModified === b.lastModified;
 }

--- a/packages/app-finance/src/store/import-store-types.ts
+++ b/packages/app-finance/src/store/import-store-types.ts
@@ -8,7 +8,7 @@ import type {
   CommitResult,
 } from '@pops/api/modules/finance/imports';
 
-export type BankType = 'Amex';
+export type BankType = 'ANZ' | 'Amex' | 'ING' | 'Up';
 export type { ChangeSet };
 export type EntityType = 'company' | 'person' | 'government' | 'bank';
 


### PR DESCRIPTION
## Summary

- Adds a horizontal radio picker (ANZ | Amex | ING | Up) to Step 1 of the import wizard, above the file input
- Help card now shows bank-specific CSV export instructions that update when the selection changes
- Widens `BankType` from `'Amex'` to `'ANZ' | 'Amex' | 'ING' | 'Up'`
- `bankType` is stored in Zustand via the existing `setBankType` action (previously unused)

Closes #2323.

## Test plan

- [ ] Navigate to `/finance/import` — bank picker shows with 4 options (ANZ, Amex, ING, Up), defaulting to Amex
- [ ] Select each bank — help card heading and instructions update accordingly
- [ ] Upload a CSV and advance to Step 2 — wizard proceeds normally regardless of bank selection
- [ ] Subtitle no longer reads "Select an Amex CSV export file"

## Gaps (tracked)

None — `bankType` is stored but not yet used by the column mapping or processing steps. That wiring is out of scope for this fix.

https://claude.ai/code/session_011p9MbZ43gpJ4vYYddofEA5

---
_Generated by [Claude Code](https://claude.ai/code/session_011p9MbZ43gpJ4vYYddofEA5)_