### PR TITLE
fix(cerebrum/nav): add missing i18n keys for Nudges and Proposals

### DIFF
--- a/apps/pops-shell/src/i18n/locales/en-AU/navigation.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/navigation.json
@@ -27,5 +27,7 @@
   "ai.cache": "Cache",
   "cerebrum": "Cerebrum",
   "cerebrum.ingest": "Ingest",
-  "cerebrum.chat": "Chat"
+  "cerebrum.chat": "Chat",
+  "cerebrum.nudges": "Nudges",
+  "cerebrum.proposals": "Proposals"
 }

--- a/apps/pops-shell/src/i18n/locales/pt-BR/navigation.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/navigation.json
@@ -27,5 +27,7 @@
   "ai.cache": "Cache",
   "cerebrum": "Cerebrum",
   "cerebrum.ingest": "Ingerir",
-  "cerebrum.chat": "Chat"
+  "cerebrum.chat": "Chat",
+  "cerebrum.nudges": "Nudges",
+  "cerebrum.proposals": "Propostas"
 }


### PR DESCRIPTION
## Summary

- `cerebrum.nudges` and `cerebrum.proposals` were missing from both `en-AU` and `pt-BR` navigation locale files
- The sidebar was falling back to the raw key string (e.g. `cerebrum.nudges`) instead of the human-readable label
- Added `"cerebrum.nudges": "Nudges"` / `"cerebrum.proposals": "Proposals"` to `en-AU/navigation.json`
- Added `"cerebrum.nudges": "Nudges"` / `"cerebrum.proposals": "Propostas"` to `pt-BR/navigation.json`

Closes #2325

## Test plan

- [ ] Navigate to `/cerebrum` and confirm the sidebar shows **Nudges** and **Proposals** (not `cerebrum.nudges` / `cerebrum.proposals`)
- [ ] Switch language to Portuguese and confirm **Nudges** / **Propostas** appear correctly

https://claude.ai/code/session_01GLxPjFdJXuSHRQgonS6hGd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLxPjFdJXuSHRQgonS6hGd)_