### PR TITLE
fix(filters): remove duplicate empty-value option from select filters

### DIFF
--- a/packages/app-ai/src/pages/RulesBrowserPage.test.tsx
+++ b/packages/app-ai/src/pages/RulesBrowserPage.test.tsx
@@ -512,7 +512,7 @@ describe('RulesBrowserPage', () => {
   it('passes matchType to server query when filter selected', async () => {
     const user = userEvent.setup();
     renderPage();
-    const select = screen.getByRole('combobox', { name: /all match types/i });
+    const select = screen.getByRole('combobox');
     await user.selectOptions(select, 'exact');
     // Verify the query was called with matchType param (server-side filter)
     const lastCall = mockListQuery.mock.calls.at(-1);
@@ -523,7 +523,7 @@ describe('RulesBrowserPage', () => {
     const user = userEvent.setup();
     renderPage();
     expect(screen.queryByText('Clear filters')).not.toBeInTheDocument();
-    const select = screen.getByRole('combobox', { name: /all match types/i });
+    const select = screen.getByRole('combobox');
     await user.selectOptions(select, 'exact');
     expect(screen.getByText('Clear filters')).toBeInTheDocument();
   });

--- a/packages/app-ai/src/pages/rules-browser/sections/RulesFilters.tsx
+++ b/packages/app-ai/src/pages/rules-browser/sections/RulesFilters.tsx
@@ -30,7 +30,6 @@ export function RulesFilters({
           onMatchTypeChange(e.target.value);
         }}
         options={MATCH_TYPE_OPTIONS}
-        placeholder="All Match Types"
         className="w-44"
       />
       <TextInput

--- a/packages/app-inventory/src/pages/ItemsPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.test.tsx
@@ -77,9 +77,9 @@ describe('ItemsPage', () => {
 
       const typeSelect = screen.getAllByRole('combobox')[0]!;
       expect(typeSelect).toBeInTheDocument();
-      // Options include: placeholder + "All Types" + 3 dynamic types = 5
+      // Options include: "All Types" + 3 dynamic types = 4
       const options = typeSelect.querySelectorAll('option');
-      expect(options.length).toBe(5);
+      expect(options.length).toBe(4);
     });
 
     it('renders Location select dropdown with hierarchical options', () => {
@@ -107,10 +107,10 @@ describe('ItemsPage', () => {
       renderPage();
 
       const selects = screen.getAllByRole('combobox');
-      // Condition select: placeholder + All Conditions + New + Good + Fair + Poor + Broken = 7
+      // Condition select: All Conditions + New + Good + Fair + Poor + Broken = 6
       const conditionSelect = selects[1]!; // second select
       const options = conditionSelect.querySelectorAll('option');
-      expect(options.length).toBe(7);
+      expect(options.length).toBe(6);
     });
 
     it('shows Clear filters button when a filter is active', () => {

--- a/packages/app-inventory/src/pages/items-page/FiltersBar.tsx
+++ b/packages/app-inventory/src/pages/items-page/FiltersBar.tsx
@@ -78,28 +78,24 @@ export function FiltersBar({
         value={typeFilter}
         onChange={(e) => onParamChange('type', e.target.value)}
         options={typeOptions}
-        placeholder="All Types"
         className="w-36"
       />
       <Select
         value={conditionFilter}
         onChange={(e) => onParamChange('condition', e.target.value)}
         options={CONDITION_OPTIONS}
-        placeholder="All Conditions"
         className="w-40"
       />
       <Select
         value={inUseFilter}
         onChange={(e) => onParamChange('inUse', e.target.value)}
         options={IN_USE_OPTIONS}
-        placeholder="All"
         className="w-28"
       />
       <Select
         value={locationFilter}
         onChange={(e) => onParamChange('locationId', e.target.value)}
         options={locationOptions}
-        placeholder="All Locations"
         className="w-40"
       />
       {hasActiveFilters && (

--- a/packages/ui/src/components/DataTableFilters.fields.tsx
+++ b/packages/ui/src/components/DataTableFilters.fields.tsx
@@ -35,7 +35,7 @@ export function SelectFilter({ column, options, placeholder }: SelectFilterProps
       value={(column.getFilterValue() as string) ?? ''}
       onChange={(e) => column.setFilterValue(e.target.value || undefined)}
       options={options}
-      placeholder={placeholder ?? 'Select...'}
+      placeholder={placeholder}
       className="w-full sm:w-45"
     />
   );


### PR DESCRIPTION
## Summary

Fixes #2311

Filter `<select>` dropdowns that already include an "All X" option with `value=""` were also receiving a second `<option value="" disabled>Select…</option>` from the `Select` component's `placeholder` prop. This violated the `<select>` contract — two options with the same `value=""` make form state non-deterministic and cause browsers to silently swap the visible label on reload.

**Root cause:** `SelectFilter` (in `DataTableFilters.fields.tsx`) defaulted `placeholder` to `'Select...'`, which the `Select` component rendered as a disabled placeholder option in addition to the "All X" entry already in each filter's options array.

**Fix (Option A from the issue):** Drop the default placeholder from `SelectFilter` so the "All X" option is the sole empty-value entry. Applied the same fix to inventory `FiltersBar` and the AI rules browser `RulesFilters`, which had the identical pattern.

## Changes

- `packages/ui/src/components/DataTableFilters.fields.tsx` — `SelectFilter` no longer defaults `placeholder` to `'Select...'`; it passes `placeholder` through only when explicitly provided
- `packages/app-inventory/src/pages/items-page/FiltersBar.tsx` — removed redundant `placeholder` props from Type, Condition, In Use, and Location selects (all already have "All X" entries)
- `packages/app-ai/src/pages/rules-browser/sections/RulesFilters.tsx` — removed redundant `placeholder` from match type select
- `packages/app-inventory/src/pages/ItemsPage.test.tsx` — updated option counts (Type: 5→4, Condition: 7→6)
- `packages/app-ai/src/pages/RulesBrowserPage.test.tsx` — updated combobox query to not rely on placeholder-derived aria-label

## Test plan

- [ ] Navigate to `/finance/transactions` — Account and Type selects each show exactly one "All X" entry with no duplicate placeholder
- [ ] Navigate to `/inventory` — Type, Condition, In Use, Location selects each have a single "All X" entry
- [ ] Navigate to `/ai/rules` — Match Type select shows one "All Match Types" entry
- [ ] All unit tests pass (`pnpm test` across app-finance, app-inventory, app-ai, ui)
- [ ] Lint and typecheck pass

https://claude.ai/code/session_013JBQSYeLhkSunoJkm7rg3N

---
_Generated by [Claude Code](https://claude.ai/code/session_013JBQSYeLhkSunoJkm7rg3N)_