### PR TITLE
fix(ui): standardize rows-per-page options to [10, 25, 50, 100]

### DIFF
--- a/packages/app-finance/src/pages/BudgetsPage.tsx
+++ b/packages/app-finance/src/pages/BudgetsPage.tsx
@@ -65,7 +65,6 @@ export function BudgetsPage() {
           searchPlaceholder={t('budgets.searchPlaceholder')}
           paginated
           defaultPageSize={50}
-          pageSizeOptions={[25, 50, 100]}
           filters={BUDGET_TABLE_FILTERS}
         />
       )}

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -75,7 +75,6 @@ function TableSection({
         searchPlaceholder={t('entities.searchPlaceholder')}
         paginated
         defaultPageSize={50}
-        pageSizeOptions={[25, 50, 100]}
         filters={ENTITY_TABLE_FILTERS}
       />
     </>

--- a/packages/app-finance/src/pages/TransactionsPage.tsx
+++ b/packages/app-finance/src/pages/TransactionsPage.tsx
@@ -55,7 +55,6 @@ function TableContent({
       searchPlaceholder={t('transactions.searchPlaceholder')}
       paginated
       defaultPageSize={50}
-      pageSizeOptions={[25, 50, 100]}
       filters={TRANSACTION_TABLE_FILTERS}
     />
   );

--- a/packages/ui/src/components/DataTable.tsx
+++ b/packages/ui/src/components/DataTable.tsx
@@ -44,7 +44,7 @@ export function DataTable<TData, TValue>({
   searchPlaceholder = 'Search...',
   searchColumn,
   paginated = true,
-  pageSizeOptions = [10, 20, 50, 100],
+  pageSizeOptions = [10, 25, 50, 100],
   defaultPageSize = 10,
   columnVisibility = true,
   emptyState,


### PR DESCRIPTION
## Summary

- Standardize `DataTable` default `pageSizeOptions` from `[10, 20, 50, 100]` to `[10, 25, 50, 100]`
- Remove explicit `pageSizeOptions={[25, 50, 100]}` overrides from Transactions, Budgets, and Entities pages so they inherit the shared default
- All tables (Transactions, Budgets, Entities, Wish List) now present identical rows-per-page options

Fixes #2321

## Test plan

- [ ] Navigate to `/finance/transactions` — rows-per-page dropdown shows `10, 25, 50, 100`
- [ ] Navigate to `/finance/budgets` — same options
- [ ] Navigate to `/finance/entities` — same options
- [ ] Navigate to `/finance/wishlist` — same options (was already using the default)

https://claude.ai/code/session_01FmrLjr5SLPKuB8iA386TXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmrLjr5SLPKuB8iA386TXF)_