### PR TITLE
feat(inventory): add per-row actions menu (Edit/Delete) to items table

### DIFF
--- a/docs/themes/04-inventory/prds/044-items-list-page/README.md
+++ b/docs/themes/04-inventory/prds/044-items-list-page/README.md
@@ -22,6 +22,7 @@ Build the inventory items list — a dual-mode view (table and grid) of all inve
 | Columns          | Name, Asset ID, Type, Location (breadcrumb), Condition (badge), Purchase Date, Replacement Value |
 | Sortable columns | Name, Type, Replacement Value, Purchase Date                                                     |
 | Row click        | Navigates to `/inventory/items/:id`                                                              |
+| Actions menu     | Per-row `⋯` button opens a dropdown: Edit (→ `/inventory/items/:id/edit`), Delete (confirmation dialog) |
 
 ### Grid View
 
@@ -47,6 +48,7 @@ Build the inventory items list — a dual-mode view (table and grid) of all inve
 | --------------------------------- | -------------------------------------------------------------------- |
 | `inventory.items.list`            | Fetch paginated items with search, type, location, condition filters |
 | `inventory.items.searchByAssetId` | Check for exact asset ID match on search submit                      |
+| `inventory.items.delete`          | Delete an item from the per-row actions menu                         |
 
 ## Business Rules
 

--- a/docs/themes/04-inventory/prds/044-items-list-page/README.md
+++ b/docs/themes/04-inventory/prds/044-items-list-page/README.md
@@ -17,11 +17,11 @@ Build the inventory items list — a dual-mode view (table and grid) of all inve
 
 ### Table View
 
-| Element          | Detail                                                                                           |
-| ---------------- | ------------------------------------------------------------------------------------------------ |
-| Columns          | Name, Asset ID, Type, Location (breadcrumb), Condition (badge), Purchase Date, Replacement Value |
-| Sortable columns | Name, Type, Replacement Value, Purchase Date                                                     |
-| Row click        | Navigates to `/inventory/items/:id`                                                              |
+| Element          | Detail                                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------------------------- |
+| Columns          | Name, Asset ID, Type, Location (breadcrumb), Condition (badge), Purchase Date, Replacement Value        |
+| Sortable columns | Name, Type, Replacement Value, Purchase Date                                                            |
+| Row click        | Navigates to `/inventory/items/:id`                                                                     |
 | Actions menu     | Per-row `⋯` button opens a dropdown: Edit (→ `/inventory/items/:id/edit`), Delete (confirmation dialog) |
 
 ### Grid View

--- a/docs/themes/04-inventory/prds/044-items-list-page/us-01-table-view.md
+++ b/docs/themes/04-inventory/prds/044-items-list-page/us-01-table-view.md
@@ -14,6 +14,7 @@ As a user, I want a table view of my inventory items with sortable columns so th
 - [x] Default sort is Name ASC
 - [x] Clicking a column header toggles sort direction; active sort column is visually indicated
 - [x] Clicking a row navigates to `/inventory/items/:id`
+- [x] Each row has a `⋯` actions button that opens a dropdown with: Edit (navigates to `/inventory/items/:id/edit`) and Delete (shows confirmation dialog; on confirm calls `inventory.items.delete` and refreshes the list)
 - [x] Condition column renders badges: "new" (blue), "good" (green), "fair" (yellow), "poor" (orange), "broken" (red)
 - [x] Location column shows breadcrumb path (e.g., "Home > Living Room > TV Unit"); full path in tooltip
 - [x] Asset ID column shows the ID or a dash if null

--- a/packages/app-inventory/src/components/InventoryTable.tsx
+++ b/packages/app-inventory/src/components/InventoryTable.tsx
@@ -1,4 +1,4 @@
-import { Check, X } from 'lucide-react';
+import { Check, MoreHorizontal, Pencil, Trash2, X } from 'lucide-react';
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 
@@ -13,9 +13,13 @@ import { useNavigate } from 'react-router';
  */
 import {
   AssetIdBadge,
+  Button,
   type Condition,
   ConditionBadge,
   DataTable,
+  DropdownMenu,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
   formatAUD,
   LocationBreadcrumb,
   type LocationSegment,
@@ -79,6 +83,38 @@ function conditionCell(condition: string | null): React.ReactNode {
 function purchaseDateCell(date: string | null): React.ReactNode {
   if (!date) return <span className="text-muted-foreground">—</span>;
   return <span className="text-sm tabular-nums">{new Date(date).toLocaleDateString()}</span>;
+}
+
+function buildActionsColumn(args: {
+  onEdit: (id: string) => void;
+  onDeleteRequest: (id: string) => void;
+}): ColumnDef<InventoryTableItem> {
+  return {
+    id: 'actions',
+    cell: ({ row }) => (
+      <div className="text-right">
+        <DropdownMenu
+          trigger={
+            <Button variant="ghost" size="icon" aria-label="Actions">
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          }
+          align="end"
+        >
+          <DropdownMenuItem onClick={() => args.onEdit(row.original.id)}>
+            <Pencil className="mr-2 h-4 w-4" /> Edit
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => args.onDeleteRequest(row.original.id)}
+          >
+            <Trash2 className="mr-2 h-4 w-4" /> Delete
+          </DropdownMenuItem>
+        </DropdownMenu>
+      </div>
+    ),
+  };
 }
 
 function createColumns(
@@ -151,6 +187,8 @@ export interface InventoryTableProps {
   loading?: boolean;
   /** Show the built-in search bar (default false — parent page handles search). */
   searchable?: boolean;
+  onEdit?: (id: string) => void;
+  onDeleteRequest?: (id: string) => void;
 }
 
 const EMPTY_LOCATION_MAP: ReadonlyMap<string, LocationSegment[]> = new Map();
@@ -160,9 +198,17 @@ export function InventoryTable({
   locationPathMap = EMPTY_LOCATION_MAP,
   loading,
   searchable = false,
+  onEdit,
+  onDeleteRequest,
 }: InventoryTableProps) {
   const navigate = useNavigate();
-  const columns = useMemo(() => createColumns(locationPathMap), [locationPathMap]);
+  const columns = useMemo(() => {
+    const cols = createColumns(locationPathMap);
+    if (onEdit && onDeleteRequest) {
+      cols.push(buildActionsColumn({ onEdit, onDeleteRequest }));
+    }
+    return cols;
+  }, [locationPathMap, onEdit, onDeleteRequest]);
 
   return (
     <DataTable

--- a/packages/app-inventory/src/pages/ItemsPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.test.tsx
@@ -7,6 +7,8 @@ const mocks = vi.hoisted(() => ({
   typesQuery: vi.fn(),
   treeQuery: vi.fn(),
   searchByAssetId: vi.fn(),
+  deleteItem: vi.fn(),
+  invalidateList: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@pops/api-client', () => ({
@@ -16,6 +18,15 @@ vi.mock('@pops/api-client', () => ({
         list: { useQuery: (input: unknown) => mocks.itemsQuery(input) },
         distinctTypes: { useQuery: () => mocks.typesQuery() },
         searchByAssetId: { fetch: mocks.searchByAssetId },
+        delete: {
+          useMutation: (opts?: { onSuccess?: () => void }) => ({
+            mutate: (input: { id: string }) => {
+              mocks.deleteItem(input);
+              opts?.onSuccess?.();
+            },
+            isPending: false,
+          }),
+        },
       },
       locations: {
         tree: { useQuery: () => mocks.treeQuery() },
@@ -23,7 +34,10 @@ vi.mock('@pops/api-client', () => ({
     },
     useUtils: () => ({
       inventory: {
-        items: { searchByAssetId: { fetch: mocks.searchByAssetId } },
+        items: {
+          list: { invalidate: mocks.invalidateList },
+          searchByAssetId: { fetch: mocks.searchByAssetId },
+        },
       },
     }),
   },

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -19,6 +19,42 @@ import { ItemsContent } from './items-page/ItemsContent';
 import { SummaryAndView } from './items-page/SummaryAndView';
 import { useItemsPageModel, VIEW_STORAGE } from './items-page/useItemsPageModel';
 
+function DeleteItemDialog({
+  isOpen,
+  isPending,
+  onConfirm,
+  onClose,
+}: {
+  isOpen: boolean;
+  isPending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete item?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete the item and all associated photos and connections.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="ghost"
+            className="text-destructive hover:text-destructive"
+            disabled={isPending}
+            onClick={onConfirm}
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
 export function ItemsPage() {
   const { t } = useTranslation('inventory');
   const model = useItemsPageModel();
@@ -71,26 +107,12 @@ export function ItemsPage() {
         onEdit={(id) => navigate(`/inventory/items/${id}/edit`)}
         onDeleteRequest={setDeletingItemId}
       />
-      <AlertDialog open={deletingItemId !== null} onOpenChange={(open) => !open && setDeletingItemId(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete item?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently delete the item and all associated photos and connections.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              variant="ghost"
-              className="text-destructive hover:text-destructive"
-              onClick={() => deletingItemId && deleteMutation.mutate({ id: deletingItemId })}
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DeleteItemDialog
+        isOpen={deletingItemId !== null}
+        isPending={deleteMutation.isPending}
+        onConfirm={() => deletingItemId && deleteMutation.mutate({ id: deletingItemId })}
+        onClose={() => setDeletingItemId(null)}
+      />
     </div>
   );
 }

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -1,6 +1,18 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { PageHeader } from '@pops/ui';
+import { trpc } from '@pops/api-client';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  PageHeader,
+} from '@pops/ui';
 
 import { FiltersBar } from './items-page/FiltersBar';
 import { ItemsContent } from './items-page/ItemsContent';
@@ -12,6 +24,15 @@ export function ItemsPage() {
   const model = useItemsPageModel();
   const { filters, navigate } = model;
   const hasSearchOrFilters = !!filters.search || model.hasActiveFilters;
+
+  const [deletingItemId, setDeletingItemId] = useState<string | null>(null);
+  const utils = trpc.useUtils();
+  const deleteMutation = trpc.inventory.items.delete.useMutation({
+    onSuccess: () => {
+      void utils.inventory.items.list.invalidate();
+      setDeletingItemId(null);
+    },
+  });
 
   return (
     <div className="space-y-6">
@@ -47,7 +68,29 @@ export function ItemsPage() {
         locationPathMap={model.locationPathMap}
         onAdd={() => navigate('/inventory/items/new')}
         onOpen={(id) => navigate(`/inventory/items/${id}`)}
+        onEdit={(id) => navigate(`/inventory/items/${id}/edit`)}
+        onDeleteRequest={setDeletingItemId}
       />
+      <AlertDialog open={deletingItemId !== null} onOpenChange={(open) => !open && setDeletingItemId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete item?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the item and all associated photos and connections.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="ghost"
+              className="text-destructive hover:text-destructive"
+              onClick={() => deletingItemId && deleteMutation.mutate({ id: deletingItemId })}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/packages/app-inventory/src/pages/items-page/ItemsContent.tsx
+++ b/packages/app-inventory/src/pages/items-page/ItemsContent.tsx
@@ -79,6 +79,8 @@ interface ItemsContentProps {
   locationPathMap: ReadonlyMap<string, LocationSegment[]>;
   onAdd: () => void;
   onOpen: (id: string) => void;
+  onEdit: (id: string) => void;
+  onDeleteRequest: (id: string) => void;
 }
 
 export function ItemsContent({
@@ -89,12 +91,21 @@ export function ItemsContent({
   locationPathMap,
   onAdd,
   onOpen,
+  onEdit,
+  onDeleteRequest,
 }: ItemsContentProps) {
   if (isLoading) return <ItemsPageSkeleton />;
   if (items.length === 0)
     return <EmptyState hasSearchOrFilters={hasSearchOrFilters} onAdd={onAdd} />;
   if (viewMode === 'table') {
-    return <InventoryTable items={items} locationPathMap={locationPathMap} />;
+    return (
+      <InventoryTable
+        items={items}
+        locationPathMap={locationPathMap}
+        onEdit={onEdit}
+        onDeleteRequest={onDeleteRequest}
+      />
+    );
   }
   return <GridView items={items} onOpen={onOpen} />;
 }


### PR DESCRIPTION
## Summary

Fixes #2362 — inventory item rows had no Edit/Delete affordance; the list was effectively read-only from the table view.

- Adds a per-row `⋯` actions button to `InventoryTable` with **Edit** (navigates to `/inventory/items/:id/edit`) and **Delete** (confirmation `AlertDialog` → `inventory.items.delete` mutation + list invalidation)
- Threads `onEdit` / `onDeleteRequest` through `ItemsContent` to `InventoryTable`
- `ItemsPage` owns the delete state, mutation, and confirmation dialog — keeps the table component dumb
- Row-click navigation to the detail page was already wired; this PR adds the missing explicit actions column for parity with Entities and Transactions tables
- Updates PRD-044 table-view spec and US-01 acceptance criteria to document the new actions column

## Test plan

- [ ] Navigate to `/inventory` — each row has a `⋯` button on the right
- [ ] Click `⋯` → Edit — navigates to `/inventory/items/:id/edit`
- [ ] Click `⋯` → Delete — confirmation dialog appears; Cancel dismisses, Delete removes the item and refreshes the list
- [ ] Clicking the row itself still navigates to `/inventory/items/:id` (detail page)
- [ ] Grid view is unaffected (no actions column there)

https://claude.ai/code/session_01KREGfn8XeEWRFhnJn42ZHW

---
_Generated by [Claude Code](https://claude.ai/code/session_01KREGfn8XeEWRFhnJn42ZHW)_