### PR TITLE
fix(ui): use Button prefix slot for icon buttons; strip redundant mr-2 from DropdownMenuItems

### DIFF
--- a/packages/app-ai/src/pages/RulesBrowserPage.tsx
+++ b/packages/app-ai/src/pages/RulesBrowserPage.tsx
@@ -77,8 +77,8 @@ function RulesBrowserBody({ model }: { model: Model }) {
         title={t('rules.title')}
         description={t('rules.description')}
         actions={
-          <Button onClick={model.handleAddRule}>
-            <Plus className="mr-2 h-4 w-4" /> {t('rules.addRule')}
+          <Button onClick={model.handleAddRule} prefix={<Plus className="h-4 w-4" />}>
+            {t('rules.addRule')}
           </Button>
         }
       />

--- a/packages/app-finance/src/pages/BudgetsPage.tsx
+++ b/packages/app-finance/src/pages/BudgetsPage.tsx
@@ -46,8 +46,8 @@ export function BudgetsPage() {
             : t('budgets.manageTargets')
         }
         actions={
-          <Button onClick={state.handleAdd}>
-            <Plus className="mr-2 h-4 w-4" /> {t('budgets.addBudget')}
+          <Button onClick={state.handleAdd} prefix={<Plus className="h-4 w-4" />}>
+            {t('budgets.addBudget')}
           </Button>
         }
       />

--- a/packages/app-finance/src/pages/EntitiesPage.tsx
+++ b/packages/app-finance/src/pages/EntitiesPage.tsx
@@ -108,8 +108,8 @@ export function EntitiesPage() {
         title={t('entities')}
         description={getDescription(t, query.data, state.showOrphanedOnly)}
         actions={
-          <Button onClick={state.handleAdd}>
-            <Plus className="mr-2 h-4 w-4" /> {t('entities.addEntity')}
+          <Button onClick={state.handleAdd} prefix={<Plus className="h-4 w-4" />}>
+            {t('entities.addEntity')}
           </Button>
         }
       />

--- a/packages/app-finance/src/pages/TransactionsPage.tsx
+++ b/packages/app-finance/src/pages/TransactionsPage.tsx
@@ -114,8 +114,8 @@ export function TransactionsPage() {
             : undefined
         }
         actions={
-          <Button onClick={state.handleAdd}>
-            <Plus className="mr-2 h-4 w-4" /> {t('transactions.addTransaction')}
+          <Button onClick={state.handleAdd} prefix={<Plus className="h-4 w-4" />}>
+            {t('transactions.addTransaction')}
           </Button>
         }
       />

--- a/packages/app-finance/src/pages/WishlistPage.tsx
+++ b/packages/app-finance/src/pages/WishlistPage.tsx
@@ -29,8 +29,8 @@ function PageHeader({ totalText, onAdd }: { totalText: string; onAdd: () => void
         <h1 className="text-2xl md:text-3xl font-bold">Wish List</h1>
         <p className="text-muted-foreground text-sm">{totalText}</p>
       </div>
-      <Button onClick={onAdd}>
-        <Plus className="mr-2 h-4 w-4" /> Add Item
+      <Button onClick={onAdd} prefix={<Plus className="h-4 w-4" />}>
+        Add Item
       </Button>
     </div>
   );

--- a/packages/app-finance/src/pages/budgets/columns.tsx
+++ b/packages/app-finance/src/pages/budgets/columns.tsx
@@ -152,14 +152,14 @@ function buildActionsColumn(args: {
           align="end"
         >
           <DropdownMenuItem onClick={() => args.onEdit(row.original)}>
-            <Pencil className="mr-2 h-4 w-4" /> Edit
+            <Pencil /> Edit
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="text-destructive focus:text-destructive"
             onClick={() => args.onDelete(row.original.id)}
           >
-            <Trash2 className="mr-2 h-4 w-4" /> Delete
+            <Trash2 /> Delete
           </DropdownMenuItem>
         </DropdownMenu>
       </div>

--- a/packages/app-finance/src/pages/entities/columns.tsx
+++ b/packages/app-finance/src/pages/entities/columns.tsx
@@ -137,14 +137,14 @@ function buildActionsColumn(args: {
           align="end"
         >
           <DropdownMenuItem onClick={() => args.onEdit(row.original)}>
-            <Pencil className="mr-2 h-4 w-4" /> Edit
+            <Pencil /> Edit
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="text-destructive focus:text-destructive"
             onClick={() => args.onDelete(row.original.id)}
           >
-            <Trash2 className="mr-2 h-4 w-4" /> Delete
+            <Trash2 /> Delete
           </DropdownMenuItem>
         </DropdownMenu>
       </div>

--- a/packages/app-finance/src/pages/transactions/columns.tsx
+++ b/packages/app-finance/src/pages/transactions/columns.tsx
@@ -140,14 +140,14 @@ function buildActionsColumn(args: BuildColumnsArgs): ColumnDef<Transaction> {
           align="end"
         >
           <DropdownMenuItem onClick={() => args.onEdit(row.original)}>
-            <Pencil className="mr-2 h-4 w-4" /> Edit
+            <Pencil /> Edit
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="text-destructive focus:text-destructive"
             onClick={() => args.onDelete(row.original.id)}
           >
-            <Trash2 className="mr-2 h-4 w-4" /> Delete
+            <Trash2 /> Delete
           </DropdownMenuItem>
         </DropdownMenu>
       </div>

--- a/packages/app-finance/src/pages/wishlist/columns.tsx
+++ b/packages/app-finance/src/pages/wishlist/columns.tsx
@@ -114,14 +114,14 @@ function buildActionsColumn(args: {
           align="end"
         >
           <DropdownMenuItem onClick={() => args.onEdit(row.original)}>
-            <Pencil className="mr-2 h-4 w-4" /> Edit
+            <Pencil /> Edit
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="text-destructive focus:text-destructive"
             onClick={() => args.onDelete(row.original.id)}
           >
-            <Trash2 className="mr-2 h-4 w-4" /> Delete
+            <Trash2 /> Delete
           </DropdownMenuItem>
         </DropdownMenu>
       </div>


### PR DESCRIPTION
## Summary

Fixes #2308 — `+ Add Transaction` button (and all similar buttons) had the leading icon placed as a raw child with `mr-2 h-4 w-4`, bypassing the `prefix` slot on the shared `Button` component. This caused:

- **Double spacing**: `gap-2` from the button + `mr-2` from the icon
- **Missing wrapper**: skipped the `inline-flex shrink-0` wrapper that ensures proper optical alignment

Also cleaned up the same anti-pattern in `DropdownMenuItem` action menus (Edit / Delete) — those primitives already provide `flex items-center gap-2` and auto-size SVGs via `[&_svg:not([class*='size-'])]:size-4`, so the `className="mr-2 h-4 w-4"` was redundant.

## Files changed

**Button prefix slot fix (5 files):**
- `packages/app-finance/src/pages/TransactionsPage.tsx`
- `packages/app-finance/src/pages/BudgetsPage.tsx`
- `packages/app-finance/src/pages/EntitiesPage.tsx`
- `packages/app-finance/src/pages/WishlistPage.tsx`
- `packages/app-ai/src/pages/RulesBrowserPage.tsx`

**DropdownMenuItem icon className removal (4 files):**
- `packages/app-finance/src/pages/transactions/columns.tsx`
- `packages/app-finance/src/pages/budgets/columns.tsx`
- `packages/app-finance/src/pages/entities/columns.tsx`
- `packages/app-finance/src/pages/wishlist/columns.tsx`

## Test plan

- [ ] Visit `/finance/transactions` — "+ Add Transaction" button icon is properly aligned with no extra gap
- [ ] Visit `/finance/budgets`, `/finance/entities`, `/finance/wishlist` — same check on "Add" buttons
- [ ] Visit `/ai/rules` — "+ Add Rule" button icon aligned
- [ ] Open row action dropdowns (Edit / Delete) in each table — icons render at correct size with correct spacing

https://claude.ai/code/session_01ShTuMyH9aP2W16C7r9jJSc

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShTuMyH9aP2W16C7r9jJSc)_