### PR TITLE
fix(finance/entities): add government and bank to entity type list

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/types.ts
+++ b/apps/pops-api/src/modules/finance/imports/types.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { ENTITY_TYPES } from '@pops/db-types';
+
 import { ChangeSetSchema } from '../../core/corrections/types.js';
 import { TagRuleChangeSetSchema } from '../../core/tag-rules/types.js';
 
@@ -241,7 +243,7 @@ export type ApplyChangeSetAndReevaluateOutput = z.infer<
 export const pendingEntitySchema = z.object({
   tempId: z.string().regex(/^temp:entity:[0-9a-f-]{36}$/, 'Temp ID must match temp:entity:{uuid}'),
   name: z.string().min(1),
-  type: z.enum(['company', 'person', 'government', 'bank']).default('company'),
+  type: z.enum(ENTITY_TYPES).default('company'),
 });
 
 export type PendingEntity = z.infer<typeof pendingEntitySchema>;

--- a/docs/themes/02-finance/prds/023-entities/README.md
+++ b/docs/themes/02-finance/prds/023-entities/README.md
@@ -11,17 +11,17 @@ Build the entity registry — the merchant/payee database that transactions and 
 
 ### entities
 
-| Column                   | Type | Constraints                       | Description                                            |
-| ------------------------ | ---- | --------------------------------- | ------------------------------------------------------ |
-| id                       | TEXT | PK, UUID                          | `crypto.randomUUID()`                                  |
-| name                     | TEXT | NOT NULL, unique (case-sensitive) | Entity display name                                    |
-| type                     | TEXT | NOT NULL, DEFAULT 'company'       | "company", "person", "government", "bank"              |
-| abn                      | TEXT | nullable                          | Australian Business Number                             |
-| aliases                  | TEXT | nullable                          | Comma-separated alternate names for matching           |
-| default_transaction_type | TEXT | nullable                          | Suggested type when matched (purchase/transfer/income) |
-| default_tags             | TEXT | DEFAULT '[]'                      | JSON array of tags to apply by default                 |
-| notes                    | TEXT | nullable                          | Free-form notes                                        |
-| last_edited_time         | TEXT | NOT NULL                          | ISO 8601                                               |
+| Column                   | Type | Constraints                       | Description                                                                 |
+| ------------------------ | ---- | --------------------------------- | --------------------------------------------------------------------------- |
+| id                       | TEXT | PK, UUID                          | `crypto.randomUUID()`                                                       |
+| name                     | TEXT | NOT NULL, unique (case-sensitive) | Entity display name                                                         |
+| type                     | TEXT | NOT NULL, DEFAULT 'company'       | "company", "person", "government", "bank", "place", "brand", "organisation" |
+| abn                      | TEXT | nullable                          | Australian Business Number                                                  |
+| aliases                  | TEXT | nullable                          | Comma-separated alternate names for matching                                |
+| default_transaction_type | TEXT | nullable                          | Suggested type when matched (purchase/transfer/income)                      |
+| default_tags             | TEXT | DEFAULT '[]'                      | JSON array of tags to apply by default                                      |
+| notes                    | TEXT | nullable                          | Free-form notes                                                             |
+| last_edited_time         | TEXT | NOT NULL                          | ISO 8601                                                                    |
 
 ## API Surface
 
@@ -39,7 +39,7 @@ Build the entity registry — the merchant/payee database that transactions and 
 - Aliases stored as comma-separated string; API accepts/returns arrays
 - Default tags stored as JSON array; API accepts/returns arrays
 - Deletion doesn't cascade — transactions retain `entity_name` (denormalized) but `entity_id` becomes null
-- Type defaults to "company" if not provided
+- Type defaults to "company" if not provided. Valid types: `company`, `person`, `government`, `bank`, `place`, `brand`, `organisation`
 - Entities are shared across all domains (finance, inventory, etc.)
 
 ## UI: Entities Page

--- a/packages/app-finance/package.json
+++ b/packages/app-finance/package.json
@@ -16,6 +16,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@pops/api": "workspace:*",
     "@pops/api-client": "workspace:*",
+    "@pops/db-types": "workspace:*",
     "@pops/navigation": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.100.6",

--- a/packages/app-finance/src/pages/entities/types.ts
+++ b/packages/app-finance/src/pages/entities/types.ts
@@ -13,7 +13,15 @@ export interface Entity {
   transactionCount?: number;
 }
 
-export const ENTITY_TYPES = ['company', 'person', 'place', 'brand', 'organisation'] as const;
+export const ENTITY_TYPES = [
+  'company',
+  'person',
+  'government',
+  'bank',
+  'place',
+  'brand',
+  'organisation',
+] as const;
 
 export const TRANSACTION_TYPES = [
   { label: 'None', value: '' },

--- a/packages/app-finance/src/pages/entities/types.ts
+++ b/packages/app-finance/src/pages/entities/types.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+export { ENTITY_TYPES } from '@pops/db-types';
+
 export interface Entity {
   id: string;
   name: string;
@@ -12,16 +14,6 @@ export interface Entity {
   lastEditedTime: string;
   transactionCount?: number;
 }
-
-export const ENTITY_TYPES = [
-  'company',
-  'person',
-  'government',
-  'bank',
-  'place',
-  'brand',
-  'organisation',
-] as const;
 
 export const TRANSACTION_TYPES = [
   { label: 'None', value: '' },

--- a/packages/db-types/src/constants.ts
+++ b/packages/db-types/src/constants.ts
@@ -1,5 +1,13 @@
 /** Shared domain constants derived from the database schema. */
-export const ENTITY_TYPES = ['company', 'person', 'place', 'brand', 'organisation'] as const;
+export const ENTITY_TYPES = [
+  'company',
+  'person',
+  'government',
+  'bank',
+  'place',
+  'brand',
+  'organisation',
+] as const;
 export type EntityType = (typeof ENTITY_TYPES)[number];
 
 export const WISH_LIST_PRIORITIES = ['Needing', 'Soon', 'One Day', 'Dreaming'] as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,6 +503,9 @@ importers:
       '@pops/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@pops/db-types':
+        specifier: workspace:*
+        version: link:../db-types
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation


### PR DESCRIPTION
## Summary

Fixes the drift between the entity type list in code and the PRD-023 spec.

- Adds `government` and `bank` to `ENTITY_TYPES` in both `packages/db-types/src/constants.ts` (canonical) and `packages/app-finance/src/pages/entities/types.ts` (UI)
- The Type filter on `/finance/entities` and the New/Edit Entity form now show all 7 types: Company, Person, Government, Bank, Place, Brand, Organisation
- Updates PRD-023 data model and business rules to document the full canonical type list

No schema migration needed — the DB column has no check constraint, only `DEFAULT 'company'`.

Closes #2318

## Test plan

- [ ] Navigate to `/finance/entities` → open Type filter → confirm Government and Bank appear in the list
- [ ] Click "Add Entity" → confirm Type select includes Government and Bank
- [ ] Edit an existing entity → confirm Type select includes all 7 options
- [ ] Typecheck passes: `pnpm typecheck` (all 17 packages clean)

https://claude.ai/code/session_01E33oXWnhHpecumXMFtMAgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01E33oXWnhHpecumXMFtMAgV)_