### PR TITLE
fix(infra/db): replace [REDACTED] SQLITE_PATH fallback with sane default + startup guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ test-results/
 # Temporary files
 tmp/
 
+# Junk DB files from SQLITE_PATH=[REDACTED] placeholder (legacy)
+apps/pops-api/\[REDACTED\]*
+
 .room-sandbox/
 .room-agent.json
 data/

--- a/apps/pops-api/.env.example
+++ b/apps/pops-api/.env.example
@@ -6,8 +6,9 @@ CLOUDFLARE_ACCESS_AUD=your-application-aud
 PORT=3000
 
 # Database
-# SQLite database will be created at this path
-DB_PATH=./data/pops.db
+# Absolute path to the SQLite database file. Relative paths resolve from apps/pops-api/.
+# An absolute path is strongly recommended in production (e.g. /opt/pops/data/pops.db).
+SQLITE_PATH=./data/pops.db
 
 # Media Images
 # Directory for locally cached posters and backdrops

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { existsSync, unlinkSync } from 'node:fs';
+import { unlinkSync } from 'node:fs';
 
 import BetterSqlite3 from 'better-sqlite3';
 import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3';
@@ -16,6 +16,7 @@ import {
   runMigrations,
 } from './db/migrations-runner.js';
 import { initializeSchema } from './db/schema.js';
+import { resolveSqlitePath } from './db/sqlite-path.js';
 import { isVecAvailable, tryLoadVecExtension } from './db/vec-loader.js';
 
 let prodDb: BetterSqlite3.Database | null = null;
@@ -124,20 +125,7 @@ export function isNamedEnvContext(): boolean {
 
 function getProdDb(): BetterSqlite3.Database {
   if (!prodDb) {
-    const envPath = process.env['SQLITE_PATH'];
-    if (!envPath) {
-      const fallback = './data/pops.db';
-      if (!existsSync(fallback)) {
-        throw new Error(
-          `[db] SQLITE_PATH is not set and fallback path '${fallback}' does not exist. ` +
-            `Copy apps/pops-api/.env.example to .env and set SQLITE_PATH to an absolute path.`
-        );
-      }
-      console.warn(`[db] SQLITE_PATH not set — using fallback: ${fallback}`);
-      prodDb = openDatabase(fallback);
-    } else {
-      prodDb = openDatabase(envPath);
-    }
+    prodDb = openDatabase(resolveSqlitePath());
   }
   return prodDb;
 }

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { unlinkSync } from 'node:fs';
+import { existsSync, unlinkSync } from 'node:fs';
 
 import BetterSqlite3 from 'better-sqlite3';
 import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3';
@@ -124,8 +124,20 @@ export function isNamedEnvContext(): boolean {
 
 function getProdDb(): BetterSqlite3.Database {
   if (!prodDb) {
-    const sqlitePath = process.env['SQLITE_PATH'] ?? '[REDACTED]';
-    prodDb = openDatabase(sqlitePath);
+    const envPath = process.env['SQLITE_PATH'];
+    if (!envPath) {
+      const fallback = './data/pops.db';
+      if (!existsSync(fallback)) {
+        throw new Error(
+          `[db] SQLITE_PATH is not set and fallback path '${fallback}' does not exist. ` +
+            `Copy apps/pops-api/.env.example to .env and set SQLITE_PATH to an absolute path.`
+        );
+      }
+      console.warn(`[db] SQLITE_PATH not set — using fallback: ${fallback}`);
+      prodDb = openDatabase(fallback);
+    } else {
+      prodDb = openDatabase(envPath);
+    }
   }
   return prodDb;
 }

--- a/apps/pops-api/src/db/sqlite-path.test.ts
+++ b/apps/pops-api/src/db/sqlite-path.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, existsSync: vi.fn() };
+});
+
+import { existsSync } from 'node:fs';
+
+import { DEFAULT_SQLITE_PATH, resolveSqlitePath } from './sqlite-path.js';
+
+const mockExistsSync = vi.mocked(existsSync);
+
+describe('resolveSqlitePath', () => {
+  afterEach(() => {
+    delete process.env['SQLITE_PATH'];
+    vi.clearAllMocks();
+  });
+
+  it('returns SQLITE_PATH when env var is set', () => {
+    process.env['SQLITE_PATH'] = '/custom/path/pops.db';
+    expect(resolveSqlitePath()).toBe('/custom/path/pops.db');
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+
+  it('returns fallback and logs warning when env unset and fallback path exists', () => {
+    mockExistsSync.mockReturnValue(true);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = resolveSqlitePath();
+
+    expect(result).toBe(DEFAULT_SQLITE_PATH);
+    expect(mockExistsSync).toHaveBeenCalledWith(DEFAULT_SQLITE_PATH);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('SQLITE_PATH not set'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(DEFAULT_SQLITE_PATH));
+  });
+
+  it('throws with actionable message when env unset and fallback path missing', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    expect(() => resolveSqlitePath()).toThrow('SQLITE_PATH is not set');
+    expect(() => resolveSqlitePath()).toThrow(DEFAULT_SQLITE_PATH);
+    expect(() => resolveSqlitePath()).toThrow('Copy apps/pops-api/.env.example');
+  });
+});

--- a/apps/pops-api/src/db/sqlite-path.ts
+++ b/apps/pops-api/src/db/sqlite-path.ts
@@ -1,0 +1,18 @@
+import { existsSync } from 'node:fs';
+
+// Relative to CWD — valid when the server is started from apps/pops-api/ (e.g. `pnpm dev`).
+// Production deployments always set SQLITE_PATH explicitly, so this fallback is local-dev-only.
+export const DEFAULT_SQLITE_PATH = './data/pops.db';
+
+export function resolveSqlitePath(): string {
+  const envPath = process.env['SQLITE_PATH'];
+  if (envPath) return envPath;
+  if (!existsSync(DEFAULT_SQLITE_PATH)) {
+    throw new Error(
+      `[db] SQLITE_PATH is not set and fallback path '${DEFAULT_SQLITE_PATH}' does not exist. ` +
+        `Copy apps/pops-api/.env.example to .env and set SQLITE_PATH to an absolute path.`
+    );
+  }
+  console.warn(`[db] SQLITE_PATH not set — using fallback: ${DEFAULT_SQLITE_PATH}`);
+  return DEFAULT_SQLITE_PATH;
+}

--- a/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-cache.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-cache.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
+import { DEFAULT_SQLITE_PATH } from '../../../../db/sqlite-path.js';
 import { logger } from '../../../../lib/logger.js';
 
 export interface AiCacheEntry {
@@ -16,7 +17,7 @@ let diskLoaded = false;
 function getCachePath(): string {
   return (
     process.env['AI_CACHE_PATH'] ??
-    join(dirname(process.env['SQLITE_PATH'] ?? './data/pops.db'), 'ai_entity_cache.json')
+    join(dirname(process.env['SQLITE_PATH'] ?? DEFAULT_SQLITE_PATH), 'ai_entity_cache.json')
   );
 }
 

--- a/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-cache.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-cache.ts
@@ -16,7 +16,7 @@ let diskLoaded = false;
 function getCachePath(): string {
   return (
     process.env['AI_CACHE_PATH'] ??
-    join(dirname(process.env['SQLITE_PATH'] ?? '[REDACTED]'), 'ai_entity_cache.json')
+    join(dirname(process.env['SQLITE_PATH'] ?? './data/pops.db'), 'ai_entity_cache.json')
   );
 }
 

--- a/docs/themes/00-infrastructure/prds/060-database-operations/README.md
+++ b/docs/themes/00-infrastructure/prds/060-database-operations/README.md
@@ -72,6 +72,7 @@ Running any of these against a production database destroys real data with no wa
 | 03  | [us-03-pre-migration-backup](us-03-pre-migration-backup.md)     | Automatic SQLite file backup before any pending migration runs, with auto-restore on failure    | Done   | Yes              |
 | 04  | [us-04-migration-safety-tests](us-04-migration-safety-tests.md) | CI test that applies migrations to a seeded DB and verifies data integrity                      | Done   | Blocked by us-01 |
 | 05  | [us-05-go-live-runbook](us-05-go-live-runbook.md)               | Document the procedure for transitioning from dev database to production data                   | Done   | Yes              |
+| 06  | [us-06-sqlite-path-fallback](us-06-sqlite-path-fallback.md)     | Replace [REDACTED] placeholder with sane default and startup assertion for missing SQLITE_PATH  | Done   | Yes              |
 
 US-02, US-03, and US-05 can all parallelise. US-04 depends on US-01 (needs the unified migration system to test against).
 

--- a/docs/themes/00-infrastructure/prds/060-database-operations/us-06-sqlite-path-fallback.md
+++ b/docs/themes/00-infrastructure/prds/060-database-operations/us-06-sqlite-path-fallback.md
@@ -1,0 +1,20 @@
+# US-06: Fix SQLITE_PATH fallback — replace [REDACTED] placeholder with sane default
+
+> PRD: [060 — Database Operations](README.md)
+> Status: Done
+
+## Description
+
+As a developer, I want the API to use a safe fallback database path so that a missing `SQLITE_PATH` env var produces a clear error rather than silently creating a junk database at a literal `[REDACTED]` path.
+
+## Acceptance Criteria
+
+- [x] `db.ts` `getProdDb()` uses `'./data/pops.db'` as the fallback instead of `'[REDACTED]'`
+- [x] When `SQLITE_PATH` is not set and `./data/pops.db` does not exist, the server throws a clear error message telling the operator to set `SQLITE_PATH`
+- [x] `ai-categorizer-cache.ts` `getCachePath()` uses `'./data/pops.db'` as the fallback instead of `'[REDACTED]'`
+- [x] Root `.gitignore` ignores `[REDACTED]*` files in `apps/pops-api/` to prevent junk files from accumulating
+- [x] `apps/pops-api/.env.example` documents `SQLITE_PATH` (replacing the stale `DB_PATH` key) with a note that an absolute path is recommended
+
+## Related
+
+GitHub issue: [#2381](https://github.com/knoxio/pops/issues/2381)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces the literal `'[REDACTED]'` placeholder in `db.ts` and `ai-categorizer-cache.ts` with `'./data/pops.db'`
- `getProdDb()` now throws a clear, actionable error if `SQLITE_PATH` is unset _and_ the fallback path doesn't exist — preventing the silent junk-database creation described in #2381
- Fixes `DB_PATH` → `SQLITE_PATH` in `apps/pops-api/.env.example` (was stale/wrong key)
- Adds `.gitignore` pattern for `apps/pops-api/[REDACTED]*` to guard against legacy placeholder files accumulating
- Adds US-06 to PRD-060 (Database Operations) covering this fix

## Test plan

- [ ] `cd apps/pops-api && pnpm dev` with no `.env` and no `./data/pops.db` → server throws `[db] SQLITE_PATH is not set and fallback path './data/pops.db' does not exist. Copy apps/pops-api/.env.example to .env and set SQLITE_PATH to an absolute path.`
- [ ] `cd apps/pops-api && pnpm dev` with `SQLITE_PATH` set correctly → server starts normally
- [ ] `cd apps/pops-api && pnpm dev` with no `SQLITE_PATH` but `./data/pops.db` present → server starts with a warning log

## Gaps (tracked)

None — this fully resolves #2381. Issue #2375 (migration re-application crash) was caused by the same root issue per the original report and should be verified/closed separately.

https://claude.ai/code/session_01Fs9qPZBPPf3RQaZaP78aNC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs9qPZBPPf3RQaZaP78aNC)_