### PR TITLE
fix(media/library): QuickPickDialog always shows visible response on click

### DIFF
--- a/docs/themes/03-media/prds/037-ratings-comparisons/us-05-quick-pick.md
+++ b/docs/themes/03-media/prds/037-ratings-comparisons/us-05-quick-pick.md
@@ -21,6 +21,7 @@ As a user, I want a "What should I watch?" page that shows random unwatched movi
 - [x] When fewer unwatched movies exist than the requested count, display all available (no error)
 - [x] Poster cards use the same MediaCard component or matching styling
 - [x] Tests cover: correct number of movies displayed, movies are unwatched, "Show me others" refreshes the set, count selector changes count, empty state renders, partial fill when few unwatched movies
+- [x] `QuickPickDialog` (Tonight? header button) always renders a visible panel response — never a silent no-op: loading skeleton while fetching, a pick card when movies are available, an informative empty state with next-step guidance when nothing is available, and an error state when the API call fails
 
 ## Notes
 

--- a/packages/app-media/src/components/QuickPickDialog.tsx
+++ b/packages/app-media/src/components/QuickPickDialog.tsx
@@ -1,14 +1,9 @@
-import { Sparkles } from 'lucide-react';
+import { AlertCircle, Library, Sparkles } from 'lucide-react';
 import { useCallback, useState } from 'react';
+import { Link } from 'react-router';
 import { toast } from 'sonner';
 
 import { trpc } from '@pops/api-client';
-/**
- * QuickPickDialog — "What Should I Watch Tonight?" modal.
- *
- * Shows a single random recommendation at a time.
- * "Not this one" cycles to next, "Watch this!" adds to watchlist.
- */
 import {
   Button,
   Dialog,
@@ -45,10 +40,31 @@ function FinishedView({ onRefresh }: { onRefresh: () => void }) {
 
 function EmptyView() {
   return (
-    <div className="text-center py-8">
-      <p className="text-muted-foreground">
-        No picks available — all movies are watched or on your watchlist.
-      </p>
+    <div className="text-center py-8 space-y-4">
+      <Library className="h-10 w-10 mx-auto text-muted-foreground" />
+      <div className="space-y-1">
+        <p className="font-medium">Nothing to pick from</p>
+        <p className="text-sm text-muted-foreground">
+          All your library movies are watched or already on your watchlist.
+        </p>
+      </div>
+      <Link to="/media/search">
+        <Button variant="outline" size="sm">
+          Find something new
+        </Button>
+      </Link>
+    </div>
+  );
+}
+
+function ErrorView({ message }: { message: string }) {
+  return (
+    <div className="text-center py-8 space-y-3">
+      <AlertCircle className="h-10 w-10 mx-auto text-destructive/70" />
+      <div className="space-y-1">
+        <p className="font-medium">Couldn't load picks</p>
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
     </div>
   );
 }
@@ -58,7 +74,7 @@ function useQuickPickModel() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const utils = trpc.useUtils();
 
-  const { data, isLoading, refetch } = trpc.media.discovery.quickPick.useQuery(
+  const { data, isLoading, error, refetch } = trpc.media.discovery.quickPick.useQuery(
     { count: 5 },
     { enabled: open }
   );
@@ -97,6 +113,7 @@ function useQuickPickModel() {
   return {
     open,
     isLoading,
+    error,
     movies,
     currentMovie,
     currentIndex,
@@ -117,6 +134,7 @@ function useQuickPickModel() {
 
 function PickContent({
   isLoading,
+  error,
   movies,
   isFinished,
   currentMovie,
@@ -127,6 +145,7 @@ function PickContent({
   onRefresh,
 }: {
   isLoading: boolean;
+  error: Error | null;
   movies: unknown[];
   isFinished: boolean;
   currentMovie: ReturnType<typeof useQuickPickModel>['currentMovie'];
@@ -137,6 +156,7 @@ function PickContent({
   onRefresh: () => void;
 }) {
   if (isLoading) return <PickLoading />;
+  if (error) return <ErrorView message={error.message} />;
   if (movies.length === 0) return <EmptyView />;
   if (isFinished) return <FinishedView onRefresh={onRefresh} />;
   if (!currentMovie) return null;
@@ -173,6 +193,7 @@ export function QuickPickDialog() {
         <div className="px-6 pb-6 pt-4">
           <PickContent
             isLoading={model.isLoading}
+            error={model.error}
             movies={model.movies}
             isFinished={model.isFinished}
             currentMovie={model.currentMovie}

--- a/packages/app-media/src/components/QuickPickDialog.tsx
+++ b/packages/app-media/src/components/QuickPickDialog.tsx
@@ -145,7 +145,7 @@ function PickContent({
   onRefresh,
 }: {
   isLoading: boolean;
-  error: Error | null;
+  error: { message: string } | null;
   movies: unknown[];
   isFinished: boolean;
   currentMovie: ReturnType<typeof useQuickPickModel>['currentMovie'];


### PR DESCRIPTION
## Summary

- Fixes #2394 — the "Tonight?" button in the media library header had no visible effect when clicked if all library movies were watched or watchlisted, or if the API call failed
- Exposes `error` from the `quickPick` tRPC query and renders an `ErrorView` with the error message instead of silently falling through to an empty state
- Replaces the sparse, misleading `EmptyView` ("No picks available — all movies are watched or on your watchlist.") with an informative panel that includes a heading, contextual explanation, and a "Find something new" CTA linking to `/media/search`
- Adds `ErrorView` component with `AlertCircle` icon and human-readable error message
- Updates US-05 acceptance criteria to explicitly cover the dialog response contract

## Test plan

- [ ] Click "Tonight?" with unwatched movies in the library → pick card renders as before
- [ ] Click "Tonight?" when all movies are watched/watchlisted → "Nothing to pick from" panel with "Find something new" button appears
- [ ] Simulate an API error (or disconnect API) → "Couldn't load picks" panel with error message appears
- [ ] "Find something new" button navigates to `/media/search` and closes the dialog

https://claude.ai/code/session_01NmR33kHjTVzYjnEsXLN5xW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmR33kHjTVzYjnEsXLN5xW)_