### PR TITLE
fix(ai/rules): add Entity selector to Edit and Add Rule dialogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ dist/
 *.sqlite3
 *.sqlite3-wal
 *.sqlite3-shm
+*-shm
+*-wal
 *.csv
 !apps/pops-api/src/modules/finance/imports/test-data/amex-sample.csv
 entity_lookup.json

--- a/packages/app-ai/src/pages/RulesBrowserPage.test.tsx
+++ b/packages/app-ai/src/pages/RulesBrowserPage.test.tsx
@@ -19,6 +19,14 @@ const mockPreviewQuery = vi.fn((..._args: unknown[]) => ({
 vi.mock('@pops/api-client', () => ({
   trpc: {
     core: {
+      entities: {
+        list: {
+          useQuery: () => ({
+            data: { data: [], pagination: { total: 0, limit: 500, offset: 0 } },
+            isLoading: false,
+          }),
+        },
+      },
       corrections: {
         list: { useQuery: (...args: unknown[]) => mockListQuery(...args) },
         previewMatches: { useQuery: (...args: unknown[]) => mockPreviewQuery(...args) },

--- a/packages/app-ai/src/pages/RulesBrowserPage.tsx
+++ b/packages/app-ai/src/pages/RulesBrowserPage.tsx
@@ -111,6 +111,7 @@ function RulesBrowserBody({ model }: { model: Model }) {
         isSubmitting={model.ruleForm.isSubmitting}
         onSubmit={model.ruleForm.onSubmit}
         preview={preview}
+        entities={model.ruleForm.entities}
       />
     </div>
   );

--- a/packages/app-ai/src/pages/rules-browser/rule-form/RuleFormDialog.tsx
+++ b/packages/app-ai/src/pages/rules-browser/rule-form/RuleFormDialog.tsx
@@ -20,6 +20,8 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  EntitySelect,
+  type EntityOption,
   Label,
   NumberInput,
   Select,
@@ -39,6 +41,7 @@ interface RuleFormDialogProps {
   isSubmitting: boolean;
   onSubmit: (values: RuleFormValues) => void;
   preview: RulePreviewPanelProps['preview'];
+  entities: EntityOption[];
 }
 
 function PriorityField({ form }: { form: UseFormReturn<RuleFormValues> }) {
@@ -64,7 +67,39 @@ function PriorityField({ form }: { form: UseFormReturn<RuleFormValues> }) {
   );
 }
 
-function PatternAndType({ form }: { form: UseFormReturn<RuleFormValues> }) {
+function EntityField({
+  form,
+  entities,
+}: {
+  form: UseFormReturn<RuleFormValues>;
+  entities: EntityOption[];
+}) {
+  return (
+    <Controller
+      control={form.control}
+      name="entityId"
+      render={({ field }) => (
+        <div className="flex flex-col gap-1.5 w-full">
+          <Label>Entity</Label>
+          <EntitySelect
+            entities={entities}
+            value={field.value ?? undefined}
+            onChange={(id) => field.onChange(id)}
+            placeholder="Choose entity..."
+          />
+        </div>
+      )}
+    />
+  );
+}
+
+function PatternAndType({
+  form,
+  entities,
+}: {
+  form: UseFormReturn<RuleFormValues>;
+  entities: EntityOption[];
+}) {
   return (
     <>
       <TextInput
@@ -81,6 +116,7 @@ function PatternAndType({ form }: { form: UseFormReturn<RuleFormValues> }) {
         />
         <PriorityField form={form} />
       </div>
+      <EntityField form={form} entities={entities} />
     </>
   );
 }
@@ -141,7 +177,7 @@ function DialogActions({
 }
 
 export function RuleFormDialog(props: RuleFormDialogProps) {
-  const { open, onOpenChange, editingRule, form, isSubmitting, onSubmit, preview } = props;
+  const { open, onOpenChange, editingRule, form, isSubmitting, onSubmit, preview, entities } = props;
   return (
     <Dialog open={open} onOpenChange={(v) => !isSubmitting && onOpenChange(v)}>
       <DialogContent className="sm:max-w-4xl">
@@ -154,7 +190,7 @@ export function RuleFormDialog(props: RuleFormDialogProps) {
           </DialogHeader>
           <div className="grid gap-6 py-4 md:grid-cols-2">
             <div className="grid gap-4 min-w-0">
-              <PatternAndType form={form} />
+              <PatternAndType form={form} entities={entities} />
               <TagsAndActive form={form} />
             </div>
             <RulePreviewPanel preview={preview} />

--- a/packages/app-ai/src/pages/rules-browser/rule-form/RuleFormDialog.tsx
+++ b/packages/app-ai/src/pages/rules-browser/rule-form/RuleFormDialog.tsx
@@ -177,7 +177,8 @@ function DialogActions({
 }
 
 export function RuleFormDialog(props: RuleFormDialogProps) {
-  const { open, onOpenChange, editingRule, form, isSubmitting, onSubmit, preview, entities } = props;
+  const { open, onOpenChange, editingRule, form, isSubmitting, onSubmit, preview, entities } =
+    props;
   return (
     <Dialog open={open} onOpenChange={(v) => !isSubmitting && onOpenChange(v)}>
       <DialogContent className="sm:max-w-4xl">

--- a/packages/app-ai/src/pages/rules-browser/rule-form/types.ts
+++ b/packages/app-ai/src/pages/rules-browser/rule-form/types.ts
@@ -16,6 +16,7 @@ import type { MatchType } from '../types';
 export const RuleFormSchema = z.object({
   descriptionPattern: z.string().min(1, 'Pattern is required'),
   matchType: z.enum(['exact', 'contains', 'regex']),
+  entityId: z.string().nullable().optional(),
   tags: z.array(z.string()),
   priority: z.number().int().nonnegative(),
   isActive: z.boolean(),
@@ -26,6 +27,7 @@ export type RuleFormValues = z.infer<typeof RuleFormSchema>;
 export const DEFAULT_RULE_FORM_VALUES: RuleFormValues = {
   descriptionPattern: '',
   matchType: 'contains',
+  entityId: null,
   tags: [],
   priority: 0,
   isActive: true,

--- a/packages/app-ai/src/pages/rules-browser/rule-form/useRuleFormState.ts
+++ b/packages/app-ai/src/pages/rules-browser/rule-form/useRuleFormState.ts
@@ -46,6 +46,7 @@ function buildSubmit(
         data: {
           descriptionPattern: values.descriptionPattern,
           matchType: values.matchType,
+          entityId: values.entityId ?? null,
           tags: values.tags,
           priority: values.priority,
           isActive: values.isActive,
@@ -56,6 +57,7 @@ function buildSubmit(
     createMutation.mutate({
       descriptionPattern: values.descriptionPattern,
       matchType: values.matchType,
+      entityId: values.entityId ?? null,
       tags: values.tags,
       priority: values.priority,
     });
@@ -86,6 +88,8 @@ export function useRuleFormState({ onClose }: UseRuleFormStateOptions) {
     defaultValues: DEFAULT_RULE_FORM_VALUES,
   });
   const { createMutation, updateMutation } = useRuleMutations(onClose);
+  const entitiesQuery = trpc.core.entities.list.useQuery({ limit: 500 });
+  const entities = (entitiesQuery.data?.data ?? []).map((e) => ({ id: e.id, name: e.name }));
 
   const handleAdd = useCallback(() => {
     setEditingRule(null);
@@ -98,6 +102,7 @@ export function useRuleFormState({ onClose }: UseRuleFormStateOptions) {
       form.reset({
         descriptionPattern: rule.descriptionPattern,
         matchType: rule.matchType,
+        entityId: rule.entityId ?? null,
         tags: rule.tags,
         priority: rule.priority,
         isActive: rule.isActive,
@@ -109,6 +114,7 @@ export function useRuleFormState({ onClose }: UseRuleFormStateOptions) {
   return {
     form,
     editingRule,
+    entities,
     handleAdd,
     handleEdit,
     onSubmit: buildSubmit(editingRule, createMutation, updateMutation),


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #2396 — the Edit Rule (and Add Rule) dialogs were missing an Entity selector, making it impossible to change or set a rule's entity association via the UI.

- Added `EntitySelect` combobox to the rule form (below Match Type / Priority) in both Edit and Add modes
- Fetches the entity list via `trpc.core.entities.list` (limit 500) inside `useRuleFormState`
- Populates the entity field when editing an existing rule (`rule.entityId`)
- Passes `entityId` through both `createOrUpdate` and `update` mutations — the backend `UpdateCorrectionSchema` already supported this field

## Changes

- `rule-form/types.ts` — added `entityId: z.string().nullable().optional()` to `RuleFormSchema` and `DEFAULT_RULE_FORM_VALUES`
- `rule-form/useRuleFormState.ts` — fetch entities, populate `entityId` on edit, pass through on submit
- `rule-form/RuleFormDialog.tsx` — new `EntityField` sub-component using `@pops/ui`'s `EntitySelect`, wired via `Controller`
- `RulesBrowserPage.tsx` — pass `model.ruleForm.entities` to `RuleFormDialog`

## Test plan

- [ ] Open `/ai/rules`, click pencil on an existing rule — Entity dropdown appears pre-populated with the rule's current entity
- [ ] Change the entity and save — rule's entity association updates in the list
- [ ] Click "Add Rule" — Entity dropdown is present (defaults to no selection)
- [ ] Create a new rule with an entity — entity appears in the ENTITY column after save

https://claude.ai/code/session_01WjpzwYYpdzAW6SjiZuHHGM
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjpzwYYpdzAW6SjiZuHHGM)_