### PR TITLE
fix(finance/dashboard): exclude Transfer transactions from income/expense stat cards

### DIFF
--- a/packages/app-finance/src/pages/dashboard/StatsGrid.test.ts
+++ b/packages/app-finance/src/pages/dashboard/StatsGrid.test.ts
@@ -66,4 +66,30 @@ describe('computeStats', () => {
     const stats = computeStats([makeTx(10)], 999);
     expect(stats?.totalTransactions).toBe(999);
   });
+
+  it('excludes Transfer type from income and expense totals', () => {
+    const stats = computeStats(
+      [
+        makeTx(100),
+        makeTx(-30),
+        makeTx(500, { type: 'Transfer' }),
+        makeTx(-500, { type: 'Transfer' }),
+      ],
+      4
+    );
+    expect(stats).toEqual({
+      totalTransactions: 4,
+      totalIncome: 100,
+      totalExpenses: 30,
+    });
+  });
+
+  it('excludes lowercase transfer type too', () => {
+    const stats = computeStats([makeTx(200, { type: 'transfer' }), makeTx(50)], 2);
+    expect(stats).toEqual({
+      totalTransactions: 2,
+      totalIncome: 50,
+      totalExpenses: 0,
+    });
+  });
 });

--- a/packages/app-finance/src/pages/dashboard/StatsGrid.tsx
+++ b/packages/app-finance/src/pages/dashboard/StatsGrid.tsx
@@ -15,10 +15,11 @@ export function computeStats(
   total: number | undefined
 ): Stats | null {
   if (!transactions) return null;
+  const nonTransfers = transactions.filter((t) => t.type.toLowerCase() !== 'transfer');
   return {
     totalTransactions: total ?? 0,
-    totalIncome: transactions.filter((t) => t.amount > 0).reduce((sum, t) => sum + t.amount, 0),
-    totalExpenses: transactions
+    totalIncome: nonTransfers.filter((t) => t.amount > 0).reduce((sum, t) => sum + t.amount, 0),
+    totalExpenses: nonTransfers
       .filter((t) => t.amount < 0)
       .reduce((sum, t) => sum + Math.abs(t.amount), 0),
   };


### PR DESCRIPTION
## Summary

Fixes #2405.

The Finance Dashboard's **Recent Income** and **Recent Expenses** stat cards were aggregating by amount sign only, causing Transfer-type transactions to inflate both totals (e.g. a $500 transfer pair added $500 to income _and_ $500 to expenses).

- `computeStats()` in `StatsGrid.tsx` now filters out `type === 'Transfer'` (case-insensitive) before summing income and expenses
- The fix matches the existing correct pattern in the budget service, which already excludes transfers via `type != 'Transfer'`

## Test plan

- [x] 2 new unit tests added: one covering the canonical `'Transfer'` DB value, one covering lowercase `'transfer'`
- [x] All 9 `StatsGrid.test.ts` tests pass
- [x] Full monorepo typecheck passes (17/17 tasks via turbo pre-commit hook)
- [x] oxlint passes with 0 errors

https://claude.ai/code/session_01Pyuaip53KcrAee6ynVuy2z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pyuaip53KcrAee6ynVuy2z)_