### PR TITLE
fix(inventory): add persistent + Add Item button to Items list page header

### DIFF
--- a/docs/themes/04-inventory/prds/044-items-list-page/README.md
+++ b/docs/themes/04-inventory/prds/044-items-list-page/README.md
@@ -15,6 +15,13 @@ Build the inventory items list — a dual-mode view (table and grid) of all inve
 
 ## UI Components
 
+### Page Header
+
+| Element               | Detail                                              |
+| --------------------- | --------------------------------------------------- |
+| Title                 | "Inventory" (translated)                            |
+| **+ Add Item** button | Always visible; navigates to `/inventory/items/new` |
+
 ### Table View
 
 | Element          | Detail                                                                                                  |
@@ -58,7 +65,7 @@ Build the inventory items list — a dual-mode view (table and grid) of all inve
 - View toggle state (table/grid) is persisted in localStorage
 - Type select is dynamically populated from the distinct types present in the items table
 - All filter and sort state is persisted in URL query parameters
-- Empty library shows a call-to-action: "No items yet — Add your first item" with a link to the create form
+- Empty library shows a "No inventory items yet." message; the persistent **+ Add Item** header button is the primary CTA
 
 ## Edge Cases
 

--- a/docs/themes/04-inventory/prds/044-items-list-page/us-03-filters-search.md
+++ b/docs/themes/04-inventory/prds/044-items-list-page/us-03-filters-search.md
@@ -18,7 +18,8 @@ As a user, I want to filter inventory items by type, location, and condition, se
 - [x] All filter values are persisted as URL query parameters (`?q=`, `?type=`, `?locationId=`, `?condition=`)
 - [x] Changing any filter re-fetches the items list and resets pagination to page 1
 - [x] "Clear filters" button appears when any filter is active; clicking it resets all filters
-- [x] Empty state (no items in database): "No items yet — Add your first item" with link to `/inventory/items/new`
+- [x] Persistent **+ Add Item** button in the page header, always visible (navigates to `/inventory/items/new`)
+- [x] Empty state (no items in database): "No inventory items yet." message; the header Add Item button is the primary CTA
 - [x] No-results state (filters active but no matches): "No items match your filters" with "Clear filters" button
 - [x] Tests cover: search debounce, asset ID redirect on Enter, type/location/condition filter application, query parameter persistence, clear filters reset, empty state rendering, no-results state rendering
 

--- a/packages/app-inventory/src/pages/ItemsPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.test.tsx
@@ -247,17 +247,17 @@ describe('ItemsPage', () => {
   });
 
   describe('Empty state', () => {
-    it('shows empty state with Add button when no items exist', () => {
+    it('shows empty state message and persistent Add Item button when no items exist', () => {
       renderPage();
 
       expect(screen.getByText('No inventory items yet.')).toBeInTheDocument();
-      expect(screen.getByText('Add your first item')).toBeInTheDocument();
+      expect(screen.getByText('Add Item')).toBeInTheDocument();
     });
 
-    it('navigates to new item page when Add button is clicked', () => {
+    it('navigates to new item page when Add Item button is clicked', () => {
       renderPage();
 
-      fireEvent.click(screen.getByText('Add your first item'));
+      fireEvent.click(screen.getByText('Add Item'));
       expect(screen.getByTestId('item-new-page')).toBeInTheDocument();
     });
 

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -1,8 +1,6 @@
 import { Plus } from 'lucide-react';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { trpc } from '@pops/api-client';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -63,15 +61,6 @@ export function ItemsPage() {
   const { filters, navigate } = model;
   const hasSearchOrFilters = !!filters.search || model.hasActiveFilters;
 
-  const [deletingItemId, setDeletingItemId] = useState<string | null>(null);
-  const utils = trpc.useUtils();
-  const deleteMutation = trpc.inventory.items.delete.useMutation({
-    onSuccess: () => {
-      void utils.inventory.items.list.invalidate();
-      setDeletingItemId(null);
-    },
-  });
-
   const addButton = (
     <Button onClick={() => navigate('/inventory/items/new')} prefix={<Plus className="h-4 w-4" />}>
       Add Item
@@ -112,13 +101,15 @@ export function ItemsPage() {
         locationPathMap={model.locationPathMap}
         onOpen={(id) => navigate(`/inventory/items/${id}`)}
         onEdit={(id) => navigate(`/inventory/items/${id}/edit`)}
-        onDeleteRequest={setDeletingItemId}
+        onDeleteRequest={model.setDeletingItemId}
       />
       <DeleteItemDialog
-        isOpen={deletingItemId !== null}
-        isPending={deleteMutation.isPending}
-        onConfirm={() => deletingItemId && deleteMutation.mutate({ id: deletingItemId })}
-        onClose={() => setDeletingItemId(null)}
+        isOpen={model.deletingItemId !== null}
+        isPending={model.deleteMutation.isPending}
+        onConfirm={() =>
+          model.deletingItemId && model.deleteMutation.mutate({ id: model.deletingItemId })
+        }
+        onClose={() => model.setDeletingItemId(null)}
       />
     </div>
   );

--- a/packages/app-inventory/src/pages/ItemsPage.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.tsx
@@ -1,3 +1,4 @@
+import { Plus } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -11,6 +12,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  Button,
   PageHeader,
 } from '@pops/ui';
 
@@ -70,9 +72,15 @@ export function ItemsPage() {
     },
   });
 
+  const addButton = (
+    <Button onClick={() => navigate('/inventory/items/new')} prefix={<Plus className="h-4 w-4" />}>
+      Add Item
+    </Button>
+  );
+
   return (
     <div className="space-y-6">
-      <PageHeader title={t('title')} />
+      <PageHeader title={t('title')} actions={addButton} />
       <FiltersBar
         search={filters.search}
         typeFilter={filters.typeFilter}
@@ -102,7 +110,6 @@ export function ItemsPage() {
         viewMode={model.viewMode}
         hasSearchOrFilters={hasSearchOrFilters}
         locationPathMap={model.locationPathMap}
-        onAdd={() => navigate('/inventory/items/new')}
         onOpen={(id) => navigate(`/inventory/items/${id}`)}
         onEdit={(id) => navigate(`/inventory/items/${id}/edit`)}
         onDeleteRequest={setDeletingItemId}

--- a/packages/app-inventory/src/pages/items-page/ItemsContent.tsx
+++ b/packages/app-inventory/src/pages/items-page/ItemsContent.tsx
@@ -1,6 +1,6 @@
-import { Package, Plus } from 'lucide-react';
+import { Package } from 'lucide-react';
 
-import { Button, type LocationSegment, Skeleton } from '@pops/ui';
+import { type LocationSegment, Skeleton } from '@pops/ui';
 
 import { InventoryCard } from '../../components/InventoryCard';
 import { InventoryTable } from '../../components/InventoryTable';
@@ -27,26 +27,11 @@ function ItemsPageSkeleton() {
   );
 }
 
-function EmptyState({
-  hasSearchOrFilters,
-  onAdd,
-}: {
-  hasSearchOrFilters: boolean;
-  onAdd: () => void;
-}) {
+function EmptyState({ hasSearchOrFilters }: { hasSearchOrFilters: boolean }) {
   return (
     <div className="flex flex-col items-center justify-center h-64 text-muted-foreground gap-4">
       <Package className="h-12 w-12 opacity-40" />
-      {hasSearchOrFilters ? (
-        <p>No items match your filters.</p>
-      ) : (
-        <>
-          <p>No inventory items yet.</p>
-          <Button prefix={<Plus className="h-4 w-4" />} onClick={onAdd}>
-            Add your first item
-          </Button>
-        </>
-      )}
+      {hasSearchOrFilters ? <p>No items match your filters.</p> : <p>No inventory items yet.</p>}
     </div>
   );
 }
@@ -77,7 +62,6 @@ interface ItemsContentProps {
   viewMode: ViewMode;
   hasSearchOrFilters: boolean;
   locationPathMap: ReadonlyMap<string, LocationSegment[]>;
-  onAdd: () => void;
   onOpen: (id: string) => void;
   onEdit: (id: string) => void;
   onDeleteRequest: (id: string) => void;
@@ -89,14 +73,12 @@ export function ItemsContent({
   viewMode,
   hasSearchOrFilters,
   locationPathMap,
-  onAdd,
   onOpen,
   onEdit,
   onDeleteRequest,
 }: ItemsContentProps) {
   if (isLoading) return <ItemsPageSkeleton />;
-  if (items.length === 0)
-    return <EmptyState hasSearchOrFilters={hasSearchOrFilters} onAdd={onAdd} />;
+  if (items.length === 0) return <EmptyState hasSearchOrFilters={hasSearchOrFilters} />;
   if (viewMode === 'table') {
     return (
       <InventoryTable

--- a/packages/app-inventory/src/pages/items-page/useItemsPageModel.ts
+++ b/packages/app-inventory/src/pages/items-page/useItemsPageModel.ts
@@ -188,6 +188,7 @@ export function useItemsPageModel() {
   const navigate = useNavigate();
   const filters = useItemsPageFilters();
   const [viewMode, setViewMode] = useState<ViewMode>(getInitialView);
+  const [deletingItemId, setDeletingItemId] = useState<string | null>(null);
 
   useItemsPageContext(filters);
   const { typeOptions, locationOptions, locationPathMap } = useItemsPageOptions();
@@ -196,6 +197,14 @@ export function useItemsPageModel() {
   const queryInput = useMemo(() => buildQueryInput(filters), [filters]);
   const { data, isLoading } = trpc.inventory.items.list.useQuery(queryInput);
   const summary = summarize(data);
+
+  const utils = trpc.useUtils();
+  const deleteMutation = trpc.inventory.items.delete.useMutation({
+    onSuccess: () => {
+      void utils.inventory.items.list.invalidate();
+      setDeletingItemId(null);
+    },
+  });
 
   return {
     navigate,
@@ -209,5 +218,8 @@ export function useItemsPageModel() {
     ...summary,
     isLoading,
     hasActiveFilters: hasAnyActiveFilter(filters),
+    deletingItemId,
+    setDeletingItemId,
+    deleteMutation,
   };
 }


### PR DESCRIPTION
## Summary

- Adds a persistent **+ Add Item** button to the `PageHeader` on the Inventory Items list (`/inventory`), always visible regardless of whether items exist — matching the pattern used by Transactions, Budgets, and Wishlist pages
- Simplifies the empty state to show only the "No inventory items yet." message (no duplicate button)
- Moves `deletingItemId` state and `deleteMutation` into `useItemsPageModel` to keep `ItemsPage` under the `max-lines-per-function` lint limit (60 lines)
- Updates PRD-044 and US-03 to reflect the correct spec

Closes #2400

## Test plan

- [ ] Navigate to `/inventory` with items present — **+ Add Item** button visible in page header
- [ ] Click **+ Add Item** — navigates to `/inventory/items/new`
- [ ] Navigate to `/inventory` with no items (empty DB) — empty state shows "No inventory items yet." message; header button still present
- [ ] Delete an item via the per-row actions menu — delete dialog appears and works as before
- [ ] `pnpm oxlint` in `packages/app-inventory` — 0 errors
- [ ] `pnpm typecheck` in `packages/app-inventory` — passes

## Gaps (tracked)

None.

https://claude.ai/code/session_014v1tfVaU7NhPSZoH4mSSbC

---
_Generated by [Claude Code](https://claude.ai/code/session_014v1tfVaU7NhPSZoH4mSSbC)_