### PR TITLE
fix(settings): test connection buttons show toast and correctly detect failures

### DIFF
--- a/apps/pops-shell/src/app/pages/settings-page/useTestActionHandler.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useTestActionHandler.ts
@@ -9,6 +9,18 @@ import { useCallback } from 'react';
  * comes from settings manifest data at runtime. The tRPC client tree is typed
  * as a deeply nested object but we need to walk it with arbitrary string keys.
  */
+
+/** Throws if the procedure response signals a failed connection without throwing. */
+function assertConnected(result: unknown): void {
+  if (!result || typeof result !== 'object') return;
+  const data = (result as Record<string, unknown>).data;
+  if (!data || typeof data !== 'object') return;
+  const typed = data as { connected?: boolean; error?: string };
+  if (typed.connected === false) {
+    throw new Error(typed.error ?? 'Connection failed');
+  }
+}
+
 export function useTestActionHandler() {
   const utils = trpc.useUtils();
 
@@ -26,9 +38,13 @@ export function useTestActionHandler() {
       if (current !== null && typeof current === 'object') {
         const node = current as Record<string, unknown>;
         if (typeof node.query === 'function') {
-          await (node.query as () => Promise<unknown>)();
+          const result = await (node.query as () => Promise<unknown>)();
+          assertConnected(result);
         } else if (typeof node.mutate === 'function') {
-          await (node.mutate as (input: Record<string, never>) => Promise<unknown>)({});
+          const result = await (node.mutate as (input: Record<string, never>) => Promise<unknown>)(
+            {}
+          );
+          assertConnected(result);
         } else {
           throw new Error(`Cannot call procedure: ${procedure}`);
         }

--- a/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   setBulkMutate: vi.fn(),
   toastError: vi.fn(),
   toastInfo: vi.fn(),
+  toastSuccess: vi.fn(),
 }));
 
 vi.mock('@/lib/trpc', () => ({
@@ -27,7 +28,9 @@ vi.mock('@/lib/trpc', () => ({
   },
 }));
 
-vi.mock('sonner', () => ({ toast: { error: mocks.toastError, info: mocks.toastInfo } }));
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError, info: mocks.toastInfo, success: mocks.toastSuccess },
+}));
 
 import { SectionRenderer } from './SectionRenderer';
 
@@ -406,6 +409,87 @@ describe('SectionRenderer', () => {
 
         expect(onTestAction).toHaveBeenCalledOnce();
         expect(onTestAction).toHaveBeenCalledWith('media.plex.testConnection');
+      } finally {
+        await act(async () => {
+          await vi.runAllTimersAsync();
+        });
+        vi.useRealTimers();
+      }
+    });
+
+    it('shows a success toast when the test action resolves', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const onTestAction = vi.fn().mockResolvedValue(undefined);
+
+        const manifest = makeManifest({
+          groups: [
+            {
+              id: 'g1',
+              title: 'Connection',
+              fields: [
+                {
+                  key: 'plex_url',
+                  label: 'Plex URL',
+                  type: 'url',
+                  default: 'http://plex.local',
+                  testAction: { procedure: 'media.plex.testConnection', label: 'Test Connection' },
+                },
+              ],
+            },
+          ],
+        });
+
+        render(<SectionRenderer manifest={manifest} onTestAction={onTestAction} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /test connection/i }));
+
+        await act(async () => {
+          await Promise.resolve();
+        });
+
+        expect(mocks.toastSuccess).toHaveBeenCalledWith('Connected');
+      } finally {
+        await act(async () => {
+          await vi.runAllTimersAsync();
+        });
+        vi.useRealTimers();
+      }
+    });
+
+    it('shows an error toast when the test action throws', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const onTestAction = vi.fn().mockRejectedValue(new Error('Plex not configured'));
+
+        const manifest = makeManifest({
+          groups: [
+            {
+              id: 'g1',
+              title: 'Connection',
+              fields: [
+                {
+                  key: 'plex_token',
+                  label: 'Plex Token',
+                  type: 'password',
+                  testAction: { procedure: 'media.plex.testConnection', label: 'Test Connection' },
+                },
+              ],
+            },
+          ],
+        });
+
+        render(<SectionRenderer manifest={manifest} onTestAction={onTestAction} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /test connection/i }));
+
+        await act(async () => {
+          await Promise.resolve();
+        });
+
+        expect(mocks.toastError).toHaveBeenCalledWith('Plex not configured');
       } finally {
         await act(async () => {
           await vi.runAllTimersAsync();

--- a/apps/pops-shell/src/components/settings/section-renderer/useTestAction.ts
+++ b/apps/pops-shell/src/components/settings/section-renderer/useTestAction.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { toast } from 'sonner';
 
 import type { TestState } from './types';
 
@@ -12,10 +13,13 @@ export function useTestAction(onTestAction: (procedure: string) => Promise<void>
     try {
       await onTestAction(procedure);
       setTestState('success');
+      toast.success('Connected');
       setTimeout(() => setTestState('idle'), 3000);
     } catch (err) {
+      const message = err instanceof Error ? err.message : 'Connection failed';
       setTestState('error');
-      setTestError(err instanceof Error ? err.message : 'Test failed');
+      setTestError(message);
+      toast.error(message);
     }
   };
 

--- a/docs/themes/01-foundation/prds/093-unified-settings/us-03-section-renderer.md
+++ b/docs/themes/01-foundation/prds/093-unified-settings/us-03-section-renderer.md
@@ -56,6 +56,9 @@ As a user, I want settings fields to render as appropriate input widgets with in
 - [x] Success shows a green checkmark indicator next to the button
 - [x] Failure shows a red X with the error message next to the button
 - [x] The button shows a loading spinner while the procedure is in flight
+- [x] Procedures that return `{ data: { connected: false, error?: string } }` without throwing are treated as failures and show the error state
+- [x] On success, a `toast.success('Connected')` notification is shown
+- [x] On failure, a `toast.error(message)` notification is shown with the error message
 
 ### Async Options Loader for Select Fields
 
@@ -71,6 +74,8 @@ As a user, I want settings fields to render as appropriate input widgets with in
 - [x] Unit test: enter an invalid value in a field with a `pattern` validation rule — verify the error message is displayed and `setBulk` is not called
 - [x] Unit test: render a field with `envFallback` and no database value — verify the "Using environment variable" label is shown
 - [x] Unit test: render a field with `testAction`, click the test button — verify the specified procedure is called
+- [x] Unit test: test action resolves — verify `toast.success('Connected')` is called
+- [x] Unit test: test action throws — verify `toast.error` is called with the error message
 
 ## Notes
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #2386 — Test Connection / Test Radarr / Test Sonarr buttons in Settings gave no visible feedback on failure.

**Two bugs fixed:**

- `useTestActionHandler` treated any non-throwing response as success, so when the backend returned `{ data: { connected: false, error: '...' } }` (the normal failure path for Plex/Radarr/Sonarr), the UI showed a green checkmark instead of an error. A new `assertConnected` helper inspects the response and throws with the error message when `data.connected === false`.
- `useTestAction` updated state (inline icon) but never showed a toast. Users relying on the notification system got no feedback at all. Now emits `toast.success('Connected')` on success and `toast.error(message)` on failure.

**No backend changes** — the existing `{ data: { connected: boolean, error?: string } }` shape is correct; the frontend was just not consuming it.

## Test plan

- [ ] Click Test Connection in Settings → Plex with Plex not configured — red toast + red X + inline error message
- [ ] Click Test Connection with a bad URL/token — red toast + inline error
- [ ] Click Test Connection with valid config — green toast "Connected" + green checkmark
- [ ] Same pattern verified for Test Radarr and Test Sonarr
- [ ] All 167 shell unit tests pass
- [ ] Turbo typecheck passes across all 14 packages

## Gaps (tracked)

None.

https://claude.ai/code/session_015JW83TokpUjHYSvxNXLfvb
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015JW83TokpUjHYSvxNXLfvb)_