### PR TITLE
fix(media/discover): resolve /media/calendar 404 with upcoming-releases shelf

### DIFF
--- a/apps/pops-api/src/modules/media/discovery/shelf/tmdb-shelves.test.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/tmdb-shelves.test.ts
@@ -85,10 +85,11 @@ function mockDecade(decade: number) {
 }
 
 describe('tmdb-shelves registration', () => {
-  it('registers all 5 shelves at module load', () => {
-    expect(mockRegisterShelf).toHaveBeenCalledTimes(5);
+  it('registers all 6 shelves at module load', () => {
+    expect(mockRegisterShelf).toHaveBeenCalledTimes(6);
     const ids = mockRegisterShelf.mock.calls.map((c) => c[0]?.id);
     expect(ids).toContain('new-releases');
+    expect(ids).toContain('upcoming-releases');
     expect(ids).toContain('hidden-gems');
     expect(ids).toContain('critics-vs-audiences');
     expect(ids).toContain('award-winners');
@@ -150,6 +151,45 @@ describe('new-releases shelf', () => {
 
     const callArg = vi.mocked(client.discoverMovies).mock.calls[0]?.[0];
     expect(callArg?.genreIds).toBeUndefined();
+  });
+});
+
+describe('upcoming-releases shelf', () => {
+  it('generate() returns 1 instance with shelfId=upcoming-releases', () => {
+    const [call] = mockRegisterShelf.mock.calls.filter((c) => c[0]?.id === 'upcoming-releases');
+    const def = call?.[0];
+    expect(def).toBeDefined();
+    const instances = def!.generate(profile);
+    expect(instances).toHaveLength(1);
+    expect(instances[0]!.shelfId).toBe('upcoming-releases');
+  });
+
+  it('query() calls discoverMovies with future releaseDateGte and releaseDateLte', async () => {
+    const client = makeMockClient();
+    mockGetTmdbClient.mockReturnValue(client);
+
+    const [call] = mockRegisterShelf.mock.calls.filter((c) => c[0]?.id === 'upcoming-releases');
+    const instances = call![0].generate(profile);
+    await instances[0]!.query({ limit: 10, offset: 0 });
+
+    const callArg = vi.mocked(client.discoverMovies).mock.calls[0]?.[0];
+    expect(callArg?.releaseDateGte).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(callArg?.releaseDateLte).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // releaseDateLte must be after releaseDateGte (90-day window)
+    expect(callArg!.releaseDateLte! > callArg!.releaseDateGte!).toBe(true);
+  });
+
+  it('query() calls discoverMovies sorted by release_date.asc', async () => {
+    const client = makeMockClient();
+    mockGetTmdbClient.mockReturnValue(client);
+
+    const [call] = mockRegisterShelf.mock.calls.filter((c) => c[0]?.id === 'upcoming-releases');
+    const instances = call![0].generate(profile);
+    await instances[0]!.query({ limit: 10, offset: 0 });
+
+    expect(client.discoverMovies).toHaveBeenCalledWith(
+      expect.objectContaining({ sortBy: 'release_date.asc' })
+    );
   });
 });
 

--- a/apps/pops-api/src/modules/media/discovery/shelf/tmdb-shelves.ts
+++ b/apps/pops-api/src/modules/media/discovery/shelf/tmdb-shelves.ts
@@ -1,13 +1,14 @@
 import { registerShelf } from './registry.js';
 /**
- * TMDB-powered discovery shelves — 5 static (template=false) shelves
+ * TMDB-powered discovery shelves — 6 static (template=false) shelves
  * that each query TMDB /discover/movie with different filters:
  *
- *  1. new-releases      — Last 30 days, filtered by top genre affinities
- *  2. hidden-gems       — Vote count 50-500, avg ≥7.0, top genres
- *  3. critics-vs-audiences — High avg (≥8.0) + low popularity (ascending sort)
- *  4. award-winners     — TMDB keyword IDs for academy-award / golden-globe + top genres
- *  5. decade-picks      — Year range of the decade with most watches in watch_history
+ *  1. new-releases        — Last 30 days, filtered by top genre affinities
+ *  2. upcoming-releases   — Next 90 days, sorted by release date ascending
+ *  3. hidden-gems         — Vote count 50-500, avg ≥7.0, top genres
+ *  4. critics-vs-audiences — High avg (≥8.0) + low popularity (ascending sort)
+ *  5. award-winners       — TMDB keyword IDs for academy-award / golden-globe + top genres
+ *  6. decade-picks        — Year range of the decade with most watches in watch_history
  */
 import {
   ACADEMY_AWARD_KEYWORD_ID,
@@ -39,6 +40,32 @@ const newReleasesShelf: ShelfDefinition = {
           releaseDateGte: cutoff,
           genreIds: genreIds.length > 0 ? genreIds : undefined,
           sortBy: 'popularity.desc',
+          page,
+        }),
+      }),
+    ];
+  },
+};
+
+const upcomingReleasesShelf: ShelfDefinition = {
+  id: 'upcoming-releases',
+  template: false,
+  category: 'tmdb',
+  generate(profile: PreferenceProfile): ShelfInstance[] {
+    const today = new Date().toISOString().slice(0, 10);
+    const cutoff = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    return [
+      buildTmdbInstance({
+        shelfId: 'upcoming-releases',
+        title: 'Upcoming Releases',
+        subtitle: 'Coming to cinemas in the next 90 days',
+        emoji: '🎬',
+        score: 0.6,
+        profile,
+        discoverOpts: (page) => ({
+          releaseDateGte: today,
+          releaseDateLte: cutoff,
+          sortBy: 'release_date.asc',
           page,
         }),
       }),
@@ -150,6 +177,7 @@ const decadePicksShelf: ShelfDefinition = {
 };
 
 registerShelf(newReleasesShelf);
+registerShelf(upcomingReleasesShelf);
 registerShelf(hiddenGemsShelf);
 registerShelf(criticsVsAudiencesShelf);
 registerShelf(awardWinnersShelf);

--- a/docs/themes/03-media/prds/065-shelf-discovery/README.md
+++ b/docs/themes/03-media/prds/065-shelf-discovery/README.md
@@ -52,7 +52,7 @@ interface ShelfInstance {
 | `trending-tmdb`         | "Trending"                      | TMDB             | `/trending/movie/{week\|day}`                               |
 | `trending-plex`         | "Trending on Plex"              | Plex Discover    | Cloud trending, hidden if disconnected                      |
 | `new-releases`          | "New Releases"                  | TMDB             | Released in last 30 days, filtered by genre affinity        |
-| `upcoming-releases`     | "Upcoming Releases"             | TMDB             | Release date today → +90 days, sorted by release date asc  |
+| `upcoming-releases`     | "Upcoming Releases"             | TMDB             | Release date today → +90 days, sorted by release date asc   |
 | `hidden-gems`           | "Hidden Gems"                   | TMDB             | Vote count 50-500, vote average > 7.0, in top genres        |
 | `critics-vs-audiences`  | "Critics Love, Audiences Split" | TMDB             | High vote average + low popularity (proxy for polarizing)   |
 | `short-watch`           | "Quick Watch"                   | Local            | Runtime < 100min, unwatched, scored                         |

--- a/docs/themes/03-media/prds/065-shelf-discovery/README.md
+++ b/docs/themes/03-media/prds/065-shelf-discovery/README.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-A dynamic shelf pool system for the discover page. Instead of showing the same 9 hardcoded sections in the same order every time, the page is assembled per session from a pool of 27 shelf definitions. Each session selects 10-15 shelves, orders them by relevance and variety, and jitters item positions within each shelf. The result: a Netflix-like experience where the page feels different every time you open it.
+A dynamic shelf pool system for the discover page. Instead of showing the same 9 hardcoded sections in the same order every time, the page is assembled per session from a pool of 28 shelf definitions. Each session selects 10-15 shelves, orders them by relevance and variety, and jitters item positions within each shelf. The result: a Netflix-like experience where the page feels different every time you open it.
 
 ## Shelf System Architecture
 
@@ -30,7 +30,7 @@ interface ShelfInstance {
 }
 ```
 
-### Shelf pool (27 definitions)
+### Shelf pool (28 definitions)
 
 #### Seed-based templates (8 — each generates multiple instances)
 
@@ -45,13 +45,14 @@ interface ShelfInstance {
 | `dimension-inspired`  | "You loved {Movie}'s {Dimension}" | High-scoring movie + dimension                              | `/movie/{id}/recommendations` filtered by dimension affinity |
 | `context`             | "{Context Title}"                 | Time/date/season triggers                                   | `/discover/movie?with_genres={ids}&with_keywords={ids}`      |
 
-#### Static shelves (19)
+#### Static shelves (20)
 
 | ID                      | Title                           | Source           | Query logic                                                 |
 | ----------------------- | ------------------------------- | ---------------- | ----------------------------------------------------------- |
 | `trending-tmdb`         | "Trending"                      | TMDB             | `/trending/movie/{week\|day}`                               |
 | `trending-plex`         | "Trending on Plex"              | Plex Discover    | Cloud trending, hidden if disconnected                      |
 | `new-releases`          | "New Releases"                  | TMDB             | Released in last 30 days, filtered by genre affinity        |
+| `upcoming-releases`     | "Upcoming Releases"             | TMDB             | Release date today → +90 days, sorted by release date asc  |
 | `hidden-gems`           | "Hidden Gems"                   | TMDB             | Vote count 50-500, vote average > 7.0, in top genres        |
 | `critics-vs-audiences`  | "Critics Love, Audiences Split" | TMDB             | High vote average + low popularity (proxy for polarizing)   |
 | `short-watch`           | "Quick Watch"                   | Local            | Runtime < 100min, unwatched, scored                         |
@@ -73,7 +74,7 @@ interface ShelfInstance {
 
 Each page load runs the assembly:
 
-1. **Generate instances**: call `generate()` on all 27 shelf definitions → ~50-100 shelf instances
+1. **Generate instances**: call `generate()` on all 28 shelf definitions → ~50-100 shelf instances
 2. **Filter empty**: discard instances where `query()` would return 0 results (fast pre-check)
 3. **Score each instance**:
    - Relevance: user affinity score (0-1)

--- a/docs/themes/03-media/prds/065-shelf-discovery/us-07-tmdb-discovery-shelves.md
+++ b/docs/themes/03-media/prds/065-shelf-discovery/us-07-tmdb-discovery-shelves.md
@@ -5,11 +5,12 @@
 
 ## Description
 
-As a user, I want discovery shelves sourced from TMDB's broader catalog — new releases, hidden gems, critically acclaimed, award winners, and decade picks.
+As a user, I want discovery shelves sourced from TMDB's broader catalog — new releases, upcoming releases, hidden gems, critically acclaimed, award winners, and decade picks.
 
 ## Acceptance Criteria
 
 - [x] `new-releases` shelf: TMDB discover, released in last 30 days, filtered by top genre affinities
+- [x] `upcoming-releases` shelf: TMDB discover, release date between today and +90 days, sorted by release date ascending; surfaces upcoming content on the Discover page (resolves the `/media/calendar` 404)
 - [x] `hidden-gems` shelf: TMDB discover, vote count 50-500, vote average > 7.0, top genres
 - [x] `critics-vs-audiences` shelf: TMDB discover, high vote average + low popularity as polarization proxy
 - [x] `award-winners` shelf: TMDB discover with keywords (academy award, golden globe), filtered by genre
@@ -17,3 +18,4 @@ As a user, I want discovery shelves sourced from TMDB's broader catalog — new 
 - [x] All shelves: static (not template), category tmdb
 - [x] All results scored by preference profile, dismissed filtered, library-owned flagged
 - [x] Tests: each shelf produces results, filters work, scoring applied
+- [x] `/media/calendar` route redirects to `/media/discover` (no more 404)

--- a/packages/app-media/src/routes.tsx
+++ b/packages/app-media/src/routes.tsx
@@ -147,6 +147,7 @@ export const routes: RouteObject[] = [
   { path: 'rotation/log', element: <RotationLogPage /> },
   { path: 'rotation/candidates', element: <CandidateQueuePage /> },
   { path: 'arr/calendar', element: <CalendarPage /> },
+  { path: 'calendar', element: <Navigate to="/media/discover" replace /> },
   { path: 'tier-list', element: <TierListPage /> },
   { path: 'debrief/:movieId', element: <DebriefPage /> },
   { path: 'debrief/:movieId/results', element: <DebriefResultsPage /> },


### PR DESCRIPTION
## Summary

- Adds an `upcoming-releases` TMDB discovery shelf to the Discover page session pool, querying movies releasing today → +90 days sorted by release date ascending. This surfaces the PRD-038 "calendar of upcoming releases" intent directly on the existing `/media/discover` page via the dynamic shelf engine.
- Adds a `{ path: 'calendar', element: <Navigate to="/media/discover" replace /> }` route so `/media/calendar` redirects to Discover instead of 404ing.
- Updates `tmdb-shelves.test.ts`: registration count 5 → 6, plus 3 new test cases covering the `upcoming-releases` shelf (instance shape, date window, sort order).
- Updates PRD-065 shelf pool table (27 → 28 definitions, new `upcoming-releases` row) and US-07 acceptance criteria.

Closes #2397

## Test plan

- [x] `pnpm typecheck` clean on both `packages/app-media` and `apps/pops-api`
- [x] `apps/pops-api` — all 18 tests in `tmdb-shelves.test.ts` pass (including 3 new upcoming-releases tests)
- [x] `packages/app-media` — 702 tests pass (including routes.tsx typecheck)
- [x] `/media/calendar` no longer 404s — redirects to `/media/discover`
- [x] `upcoming-releases` shelf appears in the Discover page session when the TMDB call returns results

## Gaps (tracked)

None — the `upcoming-releases` shelf uses the existing `buildTmdbInstance` / `discoverMovies` path; no new DB schema or tRPC procedures required.

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_