### PR TITLE
feat(deploy): add GHCR image publish workflow for pops-api + pops-shell

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,66 @@
+name: Publish Images
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  publish:
+    name: Build and push Docker images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate metadata for pops-api
+        id: meta-api
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/knoxio/pops-api
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+
+      - name: Build and push pops-api
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/pops-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta-api.outputs.tags }}
+          labels: ${{ steps.meta-api.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}
+
+      - name: Generate metadata for pops-shell
+        id: meta-shell
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/knoxio/pops-shell
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+
+      - name: Build and push pops-shell
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/pops-shell/Dockerfile
+          push: true
+          tags: ${{ steps.meta-shell.outputs.tags }}
+          labels: ${{ steps.meta-shell.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-images.yml` that builds and pushes `pops-api` and `pops-shell` Docker images to `ghcr.io/knoxio/` on every merge to `main` and on `v*` release tags
- Tags each image with `main` (on default branch), `sha-<short-sha>` (per-commit traceability), and `v<x.y.z>` (semver on release tags)
- Passes `BUILD_VERSION=${{ github.sha }}` as a build arg to both Dockerfiles (both already declare `ARG BUILD_VERSION=dev`)
- Uses `docker/login-action@v3`, `docker/metadata-action@v5`, and `docker/build-push-action@v6`
- Scoped `permissions: packages: write, contents: read` — no other existing workflows are modified

## Test plan

- [ ] Merge to `main` — confirm `ghcr.io/knoxio/pops-api:main`, `ghcr.io/knoxio/pops-api:sha-<sha>`, and equivalent `pops-shell` images are pushed to GHCR
- [ ] Push a `v*` tag — confirm semver-tagged images (e.g. `pops-api:v1.0.0`) appear in GHCR
- [ ] Confirm no other workflow files were modified
- [ ] Confirm `workflows-quality.yml` YAML lint passes on this PR

Closes #2291

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_