### PR TITLE
refactor(nav): merge AI rail entry into Cerebrum

### DIFF
--- a/apps/pops-shell/e2e/ai-cache-clear-stale.spec.ts
+++ b/apps/pops-shell/e2e/ai-cache-clear-stale.spec.ts
@@ -175,7 +175,7 @@ test.describe('AI — cache management: view stats and clear stale entries', () 
     await useRealApi(page);
     cacheMocks = await installCacheMocks(page);
 
-    await page.goto('/ai/cache');
+    await page.goto('/cerebrum/admin/cache');
   });
 
   test.afterEach(async ({ page }) => {

--- a/apps/pops-shell/e2e/ai-rules-create-edit.spec.ts
+++ b/apps/pops-shell/e2e/ai-rules-create-edit.spec.ts
@@ -106,7 +106,7 @@ test.describe('AI rules — manual create/edit + preview', () => {
     page.on('console', (msg) => {
       if (msg.type() === 'error') consoleErrors.push(msg.text());
     });
-    await page.goto('/ai/rules');
+    await page.goto('/cerebrum/admin/rules');
     await expect(page.getByRole('heading', { name: 'Categorisation Rules' })).toBeVisible({
       timeout: 10_000,
     });

--- a/apps/pops-shell/e2e/ai-usage-stats.spec.ts
+++ b/apps/pops-shell/e2e/ai-usage-stats.spec.ts
@@ -38,7 +38,7 @@ test.describe('AI — usage stats page smoke test', () => {
     page.on('console', (msg) => {
       if (msg.type() === 'error') consoleErrors.push(msg.text());
     });
-    await page.goto('/ai');
+    await page.goto('/cerebrum/admin');
   });
 
   test.afterEach(async ({ page }) => {

--- a/apps/pops-shell/e2e/shell-navigation.spec.ts
+++ b/apps/pops-shell/e2e/shell-navigation.spec.ts
@@ -76,10 +76,12 @@ test.describe('Shell — app-rail navigation smoke test', () => {
     await expect(page.getByRole('heading', { name: 'Inventory' })).toBeVisible();
   });
 
-  test('navigates to AI — updates URL, active indicator, and shows a heading', async ({ page }) => {
-    await page.getByRole('button', { name: 'AI', exact: true }).click();
-    await expect(page).toHaveURL(/\/ai/);
-    await expect(page.getByRole('button', { name: 'AI', exact: true })).toHaveAttribute(
+  test('navigates to Cerebrum — updates URL, active indicator, and shows a heading', async ({
+    page,
+  }) => {
+    await page.getByRole('button', { name: 'Cerebrum', exact: true }).click();
+    await expect(page).toHaveURL(/\/cerebrum/);
+    await expect(page.getByRole('button', { name: 'Cerebrum', exact: true })).toHaveAttribute(
       'aria-current',
       'page'
     );

--- a/apps/pops-shell/src/app/nav/registry.ts
+++ b/apps/pops-shell/src/app/nav/registry.ts
@@ -7,7 +7,6 @@
  * 3. Import it here and add to the registeredApps array
  * 4. Add its routes to the shell router (app/router.tsx)
  */
-import { navConfig as aiNavConfig } from '@pops/app-ai';
 import { navConfig as cerebrumNavConfig } from '@pops/app-cerebrum';
 import { navConfig as financeNavConfig } from '@pops/app-finance';
 import { navConfig as inventoryNavConfig } from '@pops/app-inventory';
@@ -20,7 +19,6 @@ export const registeredApps: AppNavConfig[] = [
   financeNavConfig,
   mediaNavConfig,
   inventoryNavConfig,
-  aiNavConfig,
   cerebrumNavConfig,
 ];
 

--- a/apps/pops-shell/src/app/router.tsx
+++ b/apps/pops-shell/src/app/router.tsx
@@ -6,8 +6,10 @@ import { createBrowserRouter, Link, Navigate } from 'react-router';
  *
  * RootLayout provides the top bar + sidebar chrome.
  * Finance routes are lazily loaded from @pops/app-finance.
+ *
+ * The former /ai top-level route has been merged into /cerebrum/admin/*
+ * (see issue #2333). Legacy /ai/* URLs redirect to /cerebrum/admin/*.
  */
-import { routes as aiRoutes } from '@pops/app-ai';
 import { routes as cerebrumRoutes } from '@pops/app-cerebrum';
 import { routes as financeRoutes } from '@pops/app-finance';
 import { routes as inventoryRoutes } from '@pops/app-inventory';
@@ -69,13 +71,15 @@ export const router = createBrowserRouter([
         children: withSuspense(inventoryRoutes),
       },
       {
-        path: 'ai',
-        children: withSuspense(aiRoutes),
-      },
-      {
         path: 'cerebrum',
         children: withSuspense(cerebrumRoutes),
       },
+      // Legacy /ai/* redirects — keep bookmarks and deep-links working.
+      { path: 'ai', element: <Navigate to="/cerebrum" replace /> },
+      { path: 'ai/prompts', element: <Navigate to="/cerebrum/admin/prompts" replace /> },
+      { path: 'ai/config', element: <Navigate to="/settings#ai.config" replace /> },
+      { path: 'ai/rules', element: <Navigate to="/cerebrum/admin/rules" replace /> },
+      { path: 'ai/cache', element: <Navigate to="/cerebrum/admin/cache" replace /> },
       { path: 'settings', element: <SettingsPage /> },
       { path: 'features', element: <FeaturesPage /> },
       { path: '*', element: <NotFoundPage /> },

--- a/apps/pops-shell/src/i18n/index.test.ts
+++ b/apps/pops-shell/src/i18n/index.test.ts
@@ -213,7 +213,7 @@ describe('translation lookups', () => {
   it('resolves navigation namespace keys', () => {
     expect(i18n.t('navigation:finance')).toBe('Finance');
     expect(i18n.t('navigation:media.library')).toBe('Library');
-    expect(i18n.t('navigation:ai.usage')).toBe('AI Usage');
+    expect(i18n.t('navigation:cerebrum.admin.usage')).toBe('AI Usage');
   });
 
   it('resolves finance namespace keys', () => {

--- a/apps/pops-shell/src/i18n/locales/en-AU/navigation.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/navigation.json
@@ -20,14 +20,13 @@
   "inventory.warranties": "Warranties",
   "inventory.locations": "Locations",
   "inventory.reports": "Reports",
-  "ai": "AI",
-  "ai.usage": "AI Usage",
-  "ai.promptTemplates": "Prompt Templates",
-  "ai.rules": "Rules",
-  "ai.cache": "Cache",
   "cerebrum": "Cerebrum",
   "cerebrum.ingest": "Ingest",
   "cerebrum.chat": "Chat",
   "cerebrum.nudges": "Nudges",
-  "cerebrum.proposals": "Proposals"
+  "cerebrum.proposals": "Proposals",
+  "cerebrum.admin.usage": "AI Usage",
+  "cerebrum.admin.promptTemplates": "Prompt Templates",
+  "cerebrum.admin.rules": "Rules",
+  "cerebrum.admin.cache": "Cache"
 }

--- a/apps/pops-shell/src/i18n/locales/pt-BR/navigation.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/navigation.json
@@ -20,14 +20,13 @@
   "inventory.warranties": "Garantias",
   "inventory.locations": "Localizações",
   "inventory.reports": "Relatórios",
-  "ai": "IA",
-  "ai.usage": "Uso de IA",
-  "ai.promptTemplates": "Modelos de Prompt",
-  "ai.rules": "Regras",
-  "ai.cache": "Cache",
   "cerebrum": "Cerebrum",
   "cerebrum.ingest": "Ingerir",
   "cerebrum.chat": "Chat",
   "cerebrum.nudges": "Nudges",
-  "cerebrum.proposals": "Propostas"
+  "cerebrum.proposals": "Propostas",
+  "cerebrum.admin.usage": "Uso de IA",
+  "cerebrum.admin.promptTemplates": "Modelos de Prompt",
+  "cerebrum.admin.rules": "Regras",
+  "cerebrum.admin.cache": "Cache"
 }

--- a/packages/app-cerebrum/package.json
+++ b/packages/app-cerebrum/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@pops/api-client": "workspace:*",
+    "@pops/app-ai": "workspace:*",
     "@pops/navigation": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.100.6",

--- a/packages/app-cerebrum/src/routes.tsx
+++ b/packages/app-cerebrum/src/routes.tsx
@@ -7,7 +7,8 @@
  * AI admin pages (usage, prompts, rules, cache) are mounted under
  * /cerebrum/admin/* — imported from @pops/app-ai.
  */
-import { lazy } from 'react';
+import { lazy, Suspense } from 'react';
+import { Outlet } from 'react-router';
 
 import { routes as aiAdminRoutes } from '@pops/app-ai';
 
@@ -71,5 +72,19 @@ export const routes: RouteObject[] = [
   { path: 'chat', element: <ChatPage /> },
   { path: 'nudges', element: <NudgesPage /> },
   { path: 'proposals', element: <ProposalQueuePage /> },
-  { path: 'admin', children: aiAdminRoutes },
+  {
+    path: 'admin',
+    element: (
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center h-64 text-muted-foreground">
+            Loading…
+          </div>
+        }
+      >
+        <Outlet />
+      </Suspense>
+    ),
+    children: aiAdminRoutes,
+  },
 ];

--- a/packages/app-cerebrum/src/routes.tsx
+++ b/packages/app-cerebrum/src/routes.tsx
@@ -9,9 +9,9 @@
  */
 import { lazy } from 'react';
 
-import type { RouteObject } from 'react-router';
-
 import { routes as aiAdminRoutes } from '@pops/app-ai';
+
+import type { RouteObject } from 'react-router';
 
 import type { IconName } from '@pops/navigation';
 

--- a/packages/app-cerebrum/src/routes.tsx
+++ b/packages/app-cerebrum/src/routes.tsx
@@ -3,10 +3,15 @@
  *
  * Routes are lazy-loaded for code splitting. The shell imports
  * these via @pops/app-cerebrum and mounts them under /cerebrum/*.
+ *
+ * AI admin pages (usage, prompts, rules, cache) are mounted under
+ * /cerebrum/admin/* — imported from @pops/app-ai.
  */
 import { lazy } from 'react';
 
 import type { RouteObject } from 'react-router';
+
+import { routes as aiAdminRoutes } from '@pops/app-ai';
 
 import type { IconName } from '@pops/navigation';
 
@@ -49,6 +54,15 @@ export const navConfig = {
       labelKey: 'cerebrum.proposals',
       icon: 'GitPullRequest',
     },
+    { path: '/admin', label: 'AI Usage', labelKey: 'cerebrum.admin.usage', icon: 'BarChart3' },
+    {
+      path: '/admin/prompts',
+      label: 'Prompt Templates',
+      labelKey: 'cerebrum.admin.promptTemplates',
+      icon: 'FileText',
+    },
+    { path: '/admin/rules', label: 'Rules', labelKey: 'cerebrum.admin.rules', icon: 'BookOpen' },
+    { path: '/admin/cache', label: 'Cache', labelKey: 'cerebrum.admin.cache', icon: 'Database' },
   ],
 } satisfies AppNavConfigShape;
 
@@ -57,4 +71,5 @@ export const routes: RouteObject[] = [
   { path: 'chat', element: <ChatPage /> },
   { path: 'nudges', element: <NudgesPage /> },
   { path: 'proposals', element: <ProposalQueuePage /> },
+  { path: 'admin', children: aiAdminRoutes },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,9 @@ importers:
       '@pops/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@pops/app-ai':
+        specifier: workspace:*
+        version: link:../app-ai
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation


### PR DESCRIPTION
## Summary

- Removes the standalone **AI** entry from the app rail — the `/ai` app was "admin plumbing" (Usage, Prompt Templates, Rules, Cache) that didn't warrant its own top-level nav slot alongside Cerebrum
- Mounts those four AI admin pages under `/cerebrum/admin/*` by importing routes from `@pops/app-ai` into `@pops/app-cerebrum`
- Adds the four admin items to Cerebrum's `navConfig.items` so they appear in the page nav sidebar under Cerebrum
- Keeps `@pops/app-ai` package intact — only its rail registration is removed
- Adds legacy redirects for all `/ai/*` paths so existing bookmarks continue to work:
  - `/ai` → `/cerebrum`
  - `/ai/prompts` → `/cerebrum/admin/prompts`
  - `/ai/config` → `/settings#ai.config`
  - `/ai/rules` → `/cerebrum/admin/rules`
  - `/ai/cache` → `/cerebrum/admin/cache`
- Adds `cerebrum.admin.*` i18n keys to `en-AU` and `pt-BR` navigation locales

## Files changed

- `packages/app-cerebrum/src/routes.tsx` — nested admin routes + updated navConfig
- `packages/app-cerebrum/package.json` — added `@pops/app-ai` workspace dep
- `apps/pops-shell/src/app/nav/registry.ts` — removed `aiNavConfig` from registeredApps
- `apps/pops-shell/src/app/router.tsx` — removed `/ai` route, added redirect routes
- `apps/pops-shell/src/i18n/locales/en-AU/navigation.json` — added cerebrum.admin.* keys
- `apps/pops-shell/src/i18n/locales/pt-BR/navigation.json` — added cerebrum.admin.* keys

## Test plan

- [ ] App rail shows 4 entries: Finance, Media, Inventory, Cerebrum (no AI)
- [ ] Navigating to Cerebrum shows all 8 sidebar items (Ingest, Chat, Nudges, Proposals, AI Usage, Prompt Templates, Rules, Cache)
- [ ] `/cerebrum/admin` loads AI Usage page
- [ ] `/cerebrum/admin/prompts`, `/cerebrum/admin/rules`, `/cerebrum/admin/cache` each load their respective pages
- [ ] Legacy redirect: `/ai` → `/cerebrum`
- [ ] Legacy redirect: `/ai/prompts` → `/cerebrum/admin/prompts`
- [ ] Legacy redirect: `/ai/rules` → `/cerebrum/admin/rules`
- [ ] Legacy redirect: `/ai/cache` → `/cerebrum/admin/cache`
- [ ] Legacy redirect: `/ai/config` → `/settings#ai.config`
- [ ] `pnpm typecheck` passes (no regressions in changed files)
- [ ] `pnpm lint` passes (no regressions in changed files)

Closes #2333

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_