### PR TITLE
fix(ui): correct pagination on empty results + fix filter overflow at lg breakpoint

### DIFF
--- a/packages/ui/src/components/DataTableFilters.fields.tsx
+++ b/packages/ui/src/components/DataTableFilters.fields.tsx
@@ -18,7 +18,7 @@ export function TextFilter({ column, placeholder }: TextFilterProps) {
       onChange={(e) => column.setFilterValue(e.target.value)}
       clearable
       onClear={() => column.setFilterValue('')}
-      className="w-full sm:max-w-sm"
+      className="w-full"
     />
   );
 }
@@ -36,7 +36,7 @@ export function SelectFilter({ column, options, placeholder }: SelectFilterProps
       onChange={(e) => column.setFilterValue(e.target.value || undefined)}
       options={options}
       placeholder={placeholder}
-      className="w-full sm:w-45"
+      className="w-full"
     />
   );
 }
@@ -59,7 +59,7 @@ export function MultiSelectFilter({ column, options, placeholder }: MultiSelectF
       }
       multiple
       placeholder={placeholder ?? 'Select...'}
-      className="w-full sm:min-w-50"
+      className="w-full"
     />
   );
 }
@@ -78,7 +78,7 @@ export function DateRangeFilter({ column }: DateRangeFilterProps) {
         value={filterValue[0]}
         onChange={(e) => column.setFilterValue([e.target.value, filterValue[1]])}
         placeholder="From"
-        className="w-full sm:w-38"
+        className="flex-1"
       />
       <span className="hidden text-muted-foreground sm:block">to</span>
       <TextInput
@@ -86,7 +86,7 @@ export function DateRangeFilter({ column }: DateRangeFilterProps) {
         value={filterValue[1]}
         onChange={(e) => column.setFilterValue([filterValue[0], e.target.value])}
         placeholder="To"
-        className="w-full sm:w-38"
+        className="flex-1"
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- **Bug #2306:** Pagination already shows "Page 0 of 0" when there are no results (fixed in commit `3c4fdf79`). The `currentPage` guard (`pageCount === 0 ? 0 : pageIndex + 1`) is already in place in `DataTable.pagination.tsx`.
- **Bug #2309:** Removed fixed `sm:w-XX` width constraints from filter field components (`TextFilter`, `SelectFilter`, `MultiSelectFilter`) so they expand to `w-full` and fill their responsive grid cell. Changed `DateRangeFilter` date inputs from `w-full sm:w-38` to `flex-1` so both inputs share the cell width equally at all breakpoints.

## Files changed

- `packages/ui/src/components/DataTableFilters.fields.tsx` — drop `sm:max-w-sm`, `sm:w-45`, `sm:min-w-50`, and `sm:w-38` fixed widths; use `w-full` / `flex-1` instead

## Test plan

- [ ] Run `cd packages/ui && pnpm test` — 35 tests pass
- [ ] Run `node_modules/.bin/oxfmt --check packages/ui` — format clean
- [ ] Verify Transactions filter row at ~1024px viewport: inputs no longer overflow their grid cells
- [ ] Verify DateRangeFilter: From/To date inputs each take half the cell width at sm+ breakpoints

Closes #2306
Closes #2309

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_