### PR TITLE
ux(finance/dashboard): add CTAs to empty Recent Transactions and Active Budgets states

### DIFF
--- a/docs/themes/02-finance/prds/019-transactions/us-04-dashboard.md
+++ b/docs/themes/02-finance/prds/019-transactions/us-04-dashboard.md
@@ -15,7 +15,8 @@ As a user, I want a dashboard page showing key financial stats and recent transa
 - [x] Active budgets section (first 3) — links to budgets page
 - [x] Loading skeletons for stats and transaction rows
 - [x] Error state with expandable technical details
-- [x] Empty state when no transactions exist
+- [x] Empty state when no transactions exist — shows "No transactions yet." with "Import" (→ `/finance/import`) and "Add Transaction" (→ `/finance/transactions`) CTAs
+- [x] Empty state when no active budgets exist — shows "No active budgets found." with "Manage Budgets" CTA (→ `/finance/budgets`)
 - [x] Read-only — no CRUD operations from dashboard
 - [x] Transaction rows have hover effect and link to transactions page with filter applied
 

--- a/packages/app-finance/src/pages/dashboard/ActiveBudgets.tsx
+++ b/packages/app-finance/src/pages/dashboard/ActiveBudgets.tsx
@@ -1,4 +1,6 @@
-import { Badge, Card, SkeletonGrid } from '@pops/ui';
+import { Link } from 'react-router';
+
+import { Badge, Button, Card, SkeletonGrid } from '@pops/ui';
 
 import type { Budget } from '@pops/api/modules/finance/budgets/types';
 
@@ -36,7 +38,14 @@ export function ActiveBudgets({
     return <SkeletonGrid count={3} itemHeight="h-32" cols="md:grid-cols-3" />;
   }
   if (!budgets || budgets.length === 0) {
-    return <p className="text-sm text-muted-foreground">No active budgets found</p>;
+    return (
+      <Card className="p-12 text-center border-dashed">
+        <p className="text-muted-foreground mb-4">No active budgets found.</p>
+        <Button asChild size="sm">
+          <Link to="/finance/budgets">Manage Budgets</Link>
+        </Button>
+      </Card>
+    );
   }
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/packages/app-finance/src/pages/dashboard/RecentTransactions.tsx
+++ b/packages/app-finance/src/pages/dashboard/RecentTransactions.tsx
@@ -1,4 +1,6 @@
-import { Badge, Card, SkeletonGrid } from '@pops/ui';
+import { Link } from 'react-router';
+
+import { Badge, Button, Card, SkeletonGrid } from '@pops/ui';
 
 import type { Transaction } from '@pops/api/modules/finance/transactions/types';
 
@@ -59,8 +61,16 @@ export function RecentTransactions({ transactions, isLoading }: RecentTransactio
   }
   if (!transactions || transactions.length === 0) {
     return (
-      <Card className="p-12 text-center text-muted-foreground border-dashed">
-        No transactions found
+      <Card className="p-12 text-center border-dashed">
+        <p className="text-muted-foreground mb-4">No transactions yet.</p>
+        <div className="flex items-center justify-center gap-3">
+          <Button asChild size="sm">
+            <Link to="/finance/import">Import</Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/finance/transactions">Add Transaction</Link>
+          </Button>
+        </div>
       </Card>
     );
   }


### PR DESCRIPTION
## Summary

- Adds "No transactions yet." empty state to Recent Transactions panel with two CTAs: **Import** (→ `/finance/import`) and **Add Transaction** (→ `/finance/transactions`)
- Adds "No active budgets found." empty state to Active Budgets panel with a **Manage Budgets** CTA (→ `/finance/budgets`)
- Both empty states use a dashed-border Card for visual consistency with the rest of the dashboard
- Dashboard remains read-only — CTAs navigate to other pages, no CRUD forms added

Closes #2317

## Test plan

- [ ] With no transactions in the DB: confirm "No transactions yet." message and both CTA buttons render
- [ ] Click **Import** — navigates to `/finance/import`
- [ ] Click **Add Transaction** — navigates to `/finance/transactions`
- [ ] With no budgets in the DB: confirm "No active budgets found." message and "Manage Budgets" button render
- [ ] Click **Manage Budgets** — navigates to `/finance/budgets`
- [ ] With data present: confirm normal transaction list and budget cards render (no regression)
- [ ] `pnpm typecheck` passes in `packages/app-finance`
- [ ] All 344 tests pass in `packages/app-finance`
- [ ] oxfmt check passes

## Gaps (tracked)

None.

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_