### PR TITLE
fix(cerebrum/ingest): Accept & Submit button now submits engram after accepting scope

### DIFF
--- a/packages/app-cerebrum/src/pages/IngestPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/IngestPage.test.tsx
@@ -204,6 +204,8 @@ vi.mock('@pops/ui', async () => {
       React.createElement('div', null, children),
     DialogTitle: ({ children }: { children: React.ReactNode }) =>
       React.createElement('h3', null, children),
+    DialogDescription: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('p', null, children),
     DialogFooter: ({ children }: { children: React.ReactNode }) =>
       React.createElement('div', null, children),
     Skeleton: ({ className }: { className?: string }) =>
@@ -438,5 +440,70 @@ describe('IngestPage', () => {
 
     // Scope inference should be triggered
     expect(refetchFn).toHaveBeenCalled();
+  });
+
+  it('shows inferred scopes in dialog after submit with no scopes', async () => {
+    const refetchFn = vi.fn().mockResolvedValue({
+      data: { scopes: ['personal.captures'], source: 'llm', confidence: 0.8 },
+    });
+    mockInferScopesQuery.mockReturnValue({
+      data: undefined,
+      isFetching: false,
+      error: null,
+      refetch: refetchFn,
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    const body = screen.getByLabelText('Body');
+    await user.type(body, 'A note without scopes');
+
+    const submit = screen.getByRole('button', { name: /submit/i });
+    await user.click(submit);
+
+    // Dialog opens with inferred scope badge
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('personal.captures')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /accept/i })).toBeInTheDocument();
+  });
+
+  it('Accept & Submit fires the submit mutation with inferred scopes', async () => {
+    const refetchFn = vi.fn().mockResolvedValue({
+      data: { scopes: ['personal.captures'], source: 'llm', confidence: 0.8 },
+    });
+    mockInferScopesQuery.mockReturnValue({
+      data: undefined,
+      isFetching: false,
+      error: null,
+      refetch: refetchFn,
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    const titleInput = screen.getByLabelText('Title');
+    await user.type(titleInput, 'Test');
+
+    const body = screen.getByLabelText('Body');
+    await user.type(body, 'Test body');
+
+    // Submit without scopes — triggers inference dialog
+    const submit = screen.getByRole('button', { name: /submit/i });
+    await user.click(submit);
+
+    // Click "Accept & Submit" in the dialog
+    const acceptBtn = screen.getByRole('button', { name: /accept/i });
+    await user.click(acceptBtn);
+
+    // Submit mutation should be called with the inferred scope
+    expect(mockSubmitMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'Test body',
+        title: 'Test',
+        source: 'manual',
+        scopes: ['personal.captures'],
+      })
+    );
   });
 });

--- a/packages/app-cerebrum/src/pages/ingest-page/useSubmission.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useSubmission.ts
@@ -25,9 +25,21 @@ export function useSubmission(formState: FormState, inference: Inference) {
 
   const confirmInferredScopes = useCallback(() => {
     inference.confirm((scopes) => {
-      formState.updateField('scopes', [...new Set([...formState.form.scopes, ...scopes])]);
+      const mergedScopes = [...new Set([...formState.form.scopes, ...scopes])];
+      formState.updateField('scopes', mergedScopes);
+      const { form } = formState;
+      submitMutation.mutate({
+        body: form.body,
+        title: form.title || undefined,
+        type: form.type || undefined,
+        scopes: mergedScopes.length > 0 ? mergedScopes : undefined,
+        tags: form.tags.length > 0 ? form.tags : undefined,
+        template: form.template || undefined,
+        source: 'manual',
+        customFields: Object.keys(form.customFields).length > 0 ? form.customFields : undefined,
+      });
     });
-  }, [inference, formState]);
+  }, [inference, formState, submitMutation]);
 
   const handleSubmit = useCallback(async () => {
     const { form } = formState;


### PR DESCRIPTION
## Summary

- **Bug**: Clicking "Accept & Submit" in the Inferred Scopes dialog only applied the scope to the form field — it did not fire the engram-create mutation. The user had to click "Submit Engram" a second time.
- **Fix (Option A)**: `confirmInferredScopes` now builds the merged scope list synchronously and immediately calls `submitMutation.mutate` with the full payload, bypassing the async React state update cycle.
- **Tests**: Added `DialogDescription` to the `@pops/ui` test mock (was missing, causing all 13 IngestPage tests to fail on the branch), plus two new tests covering the dialog display and the "Accept & Submit" end-to-end path.

## Files changed

- `packages/app-cerebrum/src/pages/ingest-page/useSubmission.ts` — core fix in `confirmInferredScopes`
- `packages/app-cerebrum/src/pages/IngestPage.test.tsx` — mock fix + 2 new tests

## Test plan

- [ ] Navigate to `/cerebrum`, fill Type → `note`, Title → "Test", Body → "Test", leave SCOPES empty
- [ ] Click "Submit Engram" — Inferred Scopes dialog opens with suggested scope
- [ ] Click "Accept & Submit" — dialog closes, form disappears, "Engram Created" success view appears (single click, no second submit needed)
- [ ] Verify the scope chip appears in the success view or on the following form reset
- [ ] `pnpm test --run` passes (38 tests, all green)

Closes #2361

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_