### PR TITLE
fix(media/watchlist): show '—' placeholder when year metadata is missing

### DIFF
--- a/docs/themes/03-media/prds/036-watchlist/us-01-watchlist-page.md
+++ b/docs/themes/03-media/prds/036-watchlist/us-01-watchlist-page.md
@@ -21,6 +21,7 @@ As a user, I want a prioritised watchlist page that shows movies and TV shows I 
 - [x] Empty state: "Your watchlist is empty" with links to the library page and search page
 - [x] Loading state: skeleton matching the active layout (grid for desktop, list for mobile)
 - [x] Filter-specific empty state: "No movies on your watchlist" or "No TV shows on your watchlist"
+- [x] Each card shows a year line below the title; cards with no year data show `—` instead of empty space, so all cards have consistent height
 - [x] Tests cover: grid layout renders on desktop viewport, list layout renders on mobile viewport, filter tabs switch content, priority badges show correct numbers, notes display and truncation, empty state renders
 
 ## Notes

--- a/packages/app-media/src/components/WatchlistCard.tsx
+++ b/packages/app-media/src/components/WatchlistCard.tsx
@@ -160,7 +160,7 @@ export function WatchlistCard(props: WatchlistCardProps) {
         <Link to={href} className="hover:underline">
           <h3 className="text-sm font-medium leading-tight line-clamp-2">{title}</h3>
         </Link>
-        {year && <p className="text-xs text-muted-foreground">{year}</p>}
+        <p className="text-xs text-muted-foreground">{year ?? '—'}</p>
         {rotationStatus === 'leaving' && rotationExpiresAt && (
           <LeavingBadge rotationExpiresAt={rotationExpiresAt} />
         )}


### PR DESCRIPTION
## Summary

- Watchlist cards with missing year metadata (e.g. La luna, Green Book, The Exorcist, The Green Mile) showed empty space below the title, causing inconsistent card heights across the grid
- Changed `{year && <p>{year}</p>}` to `<p>{year ?? '—'}</p>` so all cards always render a year line, using an em dash as a placeholder when data is absent
- Updated US-01 acceptance criteria to document the year consistency requirement

## Changes

- `packages/app-media/src/components/WatchlistCard.tsx` — render `—` instead of nothing when `year` is null/undefined
- `docs/themes/03-media/prds/036-watchlist/us-01-watchlist-page.md` — added acceptance criterion for year placeholder

## Test plan

- [x] All 702 existing tests pass (`pnpm test` in `packages/app-media`)
- [x] TypeScript typecheck passes (`pnpm typecheck`)
- [x] oxfmt formatting check passes

Closes #2336

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_