### PR TITLE
fix(media/watch-history): fix FK constraint on Undo Mark-as-Watched

### DIFF
--- a/apps/pops-api/src/modules/media/watch-history/handlers/query-helpers.ts
+++ b/apps/pops-api/src/modules/media/watch-history/handlers/query-helpers.ts
@@ -1,6 +1,6 @@
-import { and, count, desc, eq, type SQL } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, type SQL } from 'drizzle-orm';
 
-import { watchHistory } from '@pops/db-types';
+import { debriefResults, debriefSessions, watchHistory } from '@pops/db-types';
 
 import { getDrizzle } from '../../../../db.js';
 import { NotFoundError } from '../../../../shared/errors.js';
@@ -48,7 +48,27 @@ export function getWatchHistoryEntry(id: number): WatchHistoryRow {
 }
 
 export function deleteWatchHistoryEntry(id: number): void {
+  // Verify the entry exists before attempting deletion (throws NotFoundError if missing).
   getWatchHistoryEntry(id);
-  const result = getDrizzle().delete(watchHistory).where(eq(watchHistory.id, id)).run();
-  if (result.changes === 0) throw new NotFoundError('WatchHistoryEntry', String(id));
+
+  getDrizzle().transaction((tx) => {
+    // Cascade: delete debrief_results rows that belong to sessions referencing this entry.
+    const sessionIds = tx
+      .select({ id: debriefSessions.id })
+      .from(debriefSessions)
+      .where(eq(debriefSessions.watchHistoryId, id))
+      .all()
+      .map((r) => r.id);
+
+    if (sessionIds.length > 0) {
+      tx.delete(debriefResults).where(inArray(debriefResults.sessionId, sessionIds)).run();
+    }
+
+    // Cascade: delete debrief_sessions rows referencing this watch_history entry.
+    tx.delete(debriefSessions).where(eq(debriefSessions.watchHistoryId, id)).run();
+
+    // Now safe to delete the watch_history row.
+    const result = tx.delete(watchHistory).where(eq(watchHistory.id, id)).run();
+    if (result.changes === 0) throw new NotFoundError('WatchHistoryEntry', String(id));
+  });
 }

--- a/apps/pops-api/src/modules/media/watch-history/service.test.ts
+++ b/apps/pops-api/src/modules/media/watch-history/service.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  seedDebriefResult,
+  seedDebriefSession,
   seedEpisode,
   seedMovie,
   seedSeason,
@@ -367,6 +369,52 @@ describe('deleteWatchHistoryEntry', () => {
     expect(() => {
       service.deleteWatchHistoryEntry(999);
     }).toThrow('WatchHistoryEntry');
+  });
+
+  it('cascade-deletes debrief_sessions before deleting watch_history (bug #2373 — Undo FK fix)', () => {
+    // Simulate the Mark-as-Watched flow: watch history entry + debrief session created.
+    const watchId = seedWatchHistoryEntry(db, { media_type: 'movie', media_id: 1 });
+    seedDebriefSession(db, { watch_history_id: watchId, status: 'pending' });
+
+    // Undo (delete) must not throw a FK constraint error.
+    expect(() => service.deleteWatchHistoryEntry(watchId)).not.toThrow();
+
+    // The watch history entry should be gone.
+    expect(() => service.getWatchHistoryEntry(watchId)).toThrow('WatchHistoryEntry');
+
+    // The debrief session should also have been removed.
+    const remaining = db
+      .prepare('SELECT id FROM debrief_sessions WHERE watch_history_id = ?')
+      .all(watchId);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('cascade-deletes debrief_results when debrief session has results', () => {
+    const watchId = seedWatchHistoryEntry(db, { media_type: 'movie', media_id: 2 });
+    const sessionId = seedDebriefSession(db, { watch_history_id: watchId, status: 'active' });
+    // Seed a dimension so the FK for debrief_results is valid.
+    const dimId = Number(
+      db
+        .prepare(
+          "INSERT INTO comparison_dimensions (name, active, sort_order) VALUES ('Overall', 1, 0)"
+        )
+        .run().lastInsertRowid
+    );
+    seedDebriefResult(db, { session_id: sessionId, dimension_id: dimId });
+
+    // Undo must cascade through debrief_results → debrief_sessions → watch_history.
+    expect(() => service.deleteWatchHistoryEntry(watchId)).not.toThrow();
+    expect(() => service.getWatchHistoryEntry(watchId)).toThrow('WatchHistoryEntry');
+
+    const sessions = db
+      .prepare('SELECT id FROM debrief_sessions WHERE watch_history_id = ?')
+      .all(watchId);
+    expect(sessions).toHaveLength(0);
+
+    const results = db
+      .prepare('SELECT id FROM debrief_results WHERE session_id = ?')
+      .all(sessionId);
+    expect(results).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Bug**: Clicking Undo after Mark-as-Watched threw `FOREIGN KEY constraint failed` because `logWatch` creates a `debrief_sessions` row (and potentially `debrief_results` rows) that reference the `watch_history` row via a non-cascading FK.
- **Fix**: Wrapped `deleteWatchHistoryEntry` in a Drizzle transaction that first deletes `debrief_results` for any linked sessions, then deletes `debrief_sessions`, then deletes the `watch_history` row — in the correct FK deletion order.
- **Tests**: Added two regression tests covering the session-only case and sessions that have results.

## Root cause

`debrief_sessions.watch_history_id` is a non-cascading FK → `watch_history.id`. When Undo fires `watch_history.delete`, SQLite rejects the delete because at least one `debrief_sessions` row still references it. The bug manifested only when a completed watch was logged (which always triggers `createDebriefSession`).

## Test plan

- [ ] Run `pnpm test` in `apps/pops-api` — all 66 watch-history tests pass (including 2 new cascade tests)
- [ ] Manually reproduce: navigate to `/media/movies/1`, click Mark as Watched, then click Undo — no error toast
- [ ] Confirm both `debrief_sessions` and `watch_history` rows are deleted after Undo

Closes #2373

## Gaps (tracked)

None.

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_