### PR TITLE
fix(finance/transactions): align type select to use 'purchase' value with 'Expense' display label

### DIFF
--- a/docs/themes/02-finance/prds/019-transactions/README.md
+++ b/docs/themes/02-finance/prds/019-transactions/README.md
@@ -18,7 +18,7 @@ Build the transaction ledger — the core of the finance app. Every financial tr
 | account                | TEXT | NOT NULL                    | Account identifier (e.g., "ANZ Everyday", "Amex")         |
 | amount                 | REAL | NOT NULL                    | Transaction amount. Negative = expense, positive = income |
 | date                   | TEXT | NOT NULL                    | YYYY-MM-DD format                                         |
-| type                   | TEXT | NOT NULL                    | "purchase", "transfer", or "income"                       |
+| type                   | TEXT | NOT NULL                    | "Expense", "Income", or "Transfer"                        |
 | tags                   | TEXT | DEFAULT '[]'                | JSON array of tag strings                                 |
 | entity_id              | TEXT | FK → entities(id), nullable | Linked entity                                             |
 | entity_name            | TEXT | nullable                    | Denormalized entity name (survives entity deletion)       |
@@ -46,7 +46,7 @@ Build the transaction ledger — the core of the finance app. Every financial tr
 
 ## Business Rules
 
-- `type` must be one of: "purchase", "transfer", "income"
+- `type` must be one of: "Expense", "Income", "Transfer" (capitalized). The import pipeline uses a lowercase internal representation (`purchase`, `transfer`, `income`) that is converted to the canonical capitalized form before DB write.
 - `amount` can be positive (income) or negative (expense) — no sign convention enforcement at the API level. Zero is not a valid transaction amount; the form validates `amount !== 0` and surfaces "Amount must be non-zero" rather than the generic "required" message
 - `tags` stored as JSON array; API parses and validates
 - `entity_name` is denormalized — survives entity deletion. If entity is deleted, `entity_id` becomes null but `entity_name` remains
@@ -109,4 +109,4 @@ US-02 and US-03 can parallelise after US-01. US-04 can parallelise with US-02.
 
 ## Drift Check
 
-last checked: 2026-04-17
+last checked: 2026-04-29

--- a/packages/app-finance/src/components/imports/EditableTransactionCard.tsx
+++ b/packages/app-finance/src/components/imports/EditableTransactionCard.tsx
@@ -48,7 +48,7 @@ function TransactionTypeSelect({
         value={value}
         onChange={(e) => onChange(e.target.value as TransactionType)}
         options={[
-          { label: 'Purchase (requires entity)', value: 'purchase' },
+          { label: 'Expense (requires entity)', value: 'purchase' },
           { label: 'Transfer (between accounts, no entity)', value: 'transfer' },
           { label: 'Income (salary, refund, etc.)', value: 'income' },
         ]}
@@ -57,7 +57,7 @@ function TransactionTypeSelect({
         {value === 'transfer' &&
           "Transfers don't need an entity - they move money between accounts"}
         {value === 'income' && 'Income transactions: salary, interest, refunds, etc.'}
-        {value === 'purchase' && 'Purchases require an entity (merchant/payee)'}
+        {value === 'purchase' && 'Expenses require an entity (merchant/payee)'}
       </p>
     </div>
   );

--- a/packages/app-finance/src/components/imports/correction-proposal/detail-panel/TypeOptions.ts
+++ b/packages/app-finance/src/components/imports/correction-proposal/detail-panel/TypeOptions.ts
@@ -1,6 +1,6 @@
 export const TYPE_OPTIONS = [
   { value: '', label: '— none —' },
-  { value: 'purchase', label: 'Purchase' },
+  { value: 'purchase', label: 'Expense' },
   { value: 'transfer', label: 'Transfer' },
   { value: 'income', label: 'Income' },
 ];


### PR DESCRIPTION
## Summary

- The import wizard showed **"Purchase"** as the transaction type label in the editable card and correction proposal detail panel, while the transactions list and new-transaction form showed **"Expense"**
- This label mismatch was confusing: users categorised a transaction as "Purchase" during import review but then saw it labelled "Expense" in the ledger
- The internal `transactionType` value (`purchase`) and the DB canonical value (`Expense`) are unchanged — only the UI display labels are updated

## Changes

- `EditableTransactionCard.tsx`: dropdown option label changed from `"Purchase (requires entity)"` → `"Expense (requires entity)"` and helper text updated accordingly
- `correction-proposal/detail-panel/TypeOptions.ts`: `TYPE_OPTIONS` label for `purchase` changed from `"Purchase"` → `"Expense"`
- `docs/themes/02-finance/prds/019-transactions/README.md`: corrected stale data model and business rules to reflect actual DB values (`Expense/Income/Transfer`) and clarified the two-domain type representation

## How it works

The import pipeline uses a lowercase internal enum (`purchase | transfer | income`) stored in the corrections table and as the intermediate `transactionType` on `ProcessedTransaction`. The `execute-service` and `transaction-persistence` layers convert these to `Expense | Income | Transfer` before writing to the transactions table. The filter and form on the transactions page already use the capitalized values correctly.

## Test plan

- [ ] Open Import Wizard, upload a CSV — verify the type dropdown in the editable card shows "Expense", "Transfer", "Income" (no "Purchase")
- [ ] Open a correction proposal — verify the type options show "Expense", "Transfer", "Income"
- [ ] Filter transactions by "Expense" on the transactions page — verify results match imported transactions
- [ ] Create a new transaction with type "Expense" — verify it is saved and displayed correctly
- [ ] `pnpm typecheck` passes on `app-finance`
- [ ] `oxfmt --check` passes on changed files

Closes #2310

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_