### PR TITLE
fix(db): add safety migrations for ai_inference_log, body_hash, glia_actions, conversations (#2329 #2330 #2331 #2341)

### DIFF
--- a/apps/pops-api/src/db/drizzle-migrations/0045_ai_inference_log.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0045_ai_inference_log.sql
@@ -1,0 +1,31 @@
+-- Safety migration: create ai_inference_log if it was missed during
+-- fresh-database initialisation (issue #2341). The table should have been
+-- created by migration 0034_ai_observability (via renaming ai_usage) but
+-- databases bootstrapped before that migration ran, or bootstrapped from an
+-- old schema snapshot, may be missing it entirely.
+-- Uses CREATE TABLE IF NOT EXISTS so it is safe to run against databases
+-- that already have the table.
+CREATE TABLE IF NOT EXISTS `ai_inference_log` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`provider` text NOT NULL,
+	`model` text NOT NULL,
+	`operation` text NOT NULL,
+	`domain` text,
+	`input_tokens` integer NOT NULL DEFAULT 0,
+	`output_tokens` integer NOT NULL DEFAULT 0,
+	`cost_usd` real NOT NULL DEFAULT 0,
+	`latency_ms` integer NOT NULL DEFAULT 0,
+	`status` text NOT NULL DEFAULT 'success',
+	`cached` integer NOT NULL DEFAULT 0,
+	`context_id` text,
+	`error_message` text,
+	`metadata` text,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_ai_inference_log_created_at` ON `ai_inference_log` (`created_at`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_ai_inference_log_provider_model` ON `ai_inference_log` (`provider`,`model`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_ai_inference_log_operation` ON `ai_inference_log` (`operation`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_ai_inference_log_domain` ON `ai_inference_log` (`domain`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_ai_inference_log_context_id` ON `ai_inference_log` (`context_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_ai_inference_log_status` ON `ai_inference_log` (`status`);

--- a/apps/pops-api/src/db/drizzle-migrations/0046_engrams_body_hash.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0046_engrams_body_hash.sql
@@ -1,0 +1,9 @@
+-- Safety migration: add body_hash column to engram_index if it was missed
+-- during fresh-database initialisation (issue #2329). The column should have
+-- been added by migration 0036_body_hash_engram_index but databases
+-- bootstrapped before that migration ran may be missing it.
+-- Drizzle's migration runner skips already-applied migrations (tracked in
+-- __drizzle_migrations), so this will not double-run on up-to-date databases.
+ALTER TABLE `engram_index` ADD COLUMN `body_hash` text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_engram_index_body_hash` ON `engram_index` (`body_hash`);

--- a/apps/pops-api/src/db/drizzle-migrations/0047_glia_actions.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0047_glia_actions.sql
@@ -1,0 +1,35 @@
+-- Safety migration: create glia_actions and glia_trust_state tables if they
+-- were missed during fresh-database initialisation (issue #2330).
+-- Uses CREATE TABLE IF NOT EXISTS so it is safe to run against databases
+-- that already have the tables.
+CREATE TABLE IF NOT EXISTS `glia_actions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`action_type` text NOT NULL,
+	`affected_ids` text NOT NULL,
+	`rationale` text NOT NULL,
+	`payload` text,
+	`phase` text NOT NULL,
+	`status` text NOT NULL,
+	`user_decision` text,
+	`user_note` text,
+	`executed_at` text,
+	`decided_at` text,
+	`reverted_at` text,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_glia_actions_action_type` ON `glia_actions` (`action_type`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_glia_actions_status` ON `glia_actions` (`status`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_glia_actions_phase` ON `glia_actions` (`phase`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_glia_actions_created_at` ON `glia_actions` (`created_at`);--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `glia_trust_state` (
+	`action_type` text PRIMARY KEY NOT NULL,
+	`current_phase` text NOT NULL,
+	`approved_count` integer NOT NULL DEFAULT 0,
+	`rejected_count` integer NOT NULL DEFAULT 0,
+	`reverted_count` integer NOT NULL DEFAULT 0,
+	`autonomous_since` text,
+	`last_revert_at` text,
+	`graduated_at` text,
+	`updated_at` text NOT NULL
+);

--- a/apps/pops-api/src/db/drizzle-migrations/0048_conversations.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0048_conversations.sql
@@ -1,0 +1,39 @@
+-- Safety migration: create conversations, messages, and conversation_context
+-- tables if they were missed during fresh-database initialisation (issue #2331).
+-- Uses CREATE TABLE IF NOT EXISTS so it is safe to run against databases
+-- that already have the tables.
+CREATE TABLE IF NOT EXISTS `conversations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`title` text,
+	`active_scopes` text NOT NULL,
+	`app_context` text,
+	`model` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_conversations_created_at` ON `conversations` (`created_at`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_conversations_updated_at` ON `conversations` (`updated_at`);--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `messages` (
+	`id` text PRIMARY KEY NOT NULL,
+	`conversation_id` text NOT NULL REFERENCES conversations(`id`) ON DELETE CASCADE,
+	`role` text NOT NULL,
+	`content` text NOT NULL,
+	`citations` text,
+	`tool_calls` text,
+	`tokens_in` integer,
+	`tokens_out` integer,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_messages_conversation_created` ON `messages` (`conversation_id`,`created_at`);--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `conversation_context` (
+	`conversation_id` text NOT NULL REFERENCES conversations(`id`) ON DELETE CASCADE,
+	`engram_id` text NOT NULL,
+	`relevance_score` real,
+	`loaded_at` text NOT NULL,
+	PRIMARY KEY (`conversation_id`, `engram_id`)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_conversation_context_conversation` ON `conversation_context` (`conversation_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_conversation_context_engram` ON `conversation_context` (`engram_id`);

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -316,6 +316,34 @@
       "when": 1777633800000,
       "tag": "0044_nudge_log",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "6",
+      "when": 1777634400000,
+      "tag": "0045_ai_inference_log",
+      "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "6",
+      "when": 1777634401000,
+      "tag": "0046_engrams_body_hash",
+      "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "6",
+      "when": 1777634402000,
+      "tag": "0047_glia_actions",
+      "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "6",
+      "when": 1777634403000,
+      "tag": "0048_conversations",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -688,6 +688,7 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
       modified_at   TEXT NOT NULL,
       title         TEXT NOT NULL,
       content_hash  TEXT NOT NULL,
+      body_hash     TEXT,
       word_count    INTEGER NOT NULL,
       custom_fields TEXT
     );
@@ -696,6 +697,7 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
     CREATE INDEX IF NOT EXISTS idx_engram_index_status ON engram_index(status);
     CREATE INDEX IF NOT EXISTS idx_engram_index_created_at ON engram_index(created_at);
     CREATE INDEX IF NOT EXISTS idx_engram_index_content_hash ON engram_index(content_hash);
+    CREATE INDEX IF NOT EXISTS idx_engram_index_body_hash ON engram_index(body_hash);
 
     CREATE TABLE IF NOT EXISTS engram_scopes (
       engram_id TEXT NOT NULL REFERENCES engram_index(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary

- **0045**: `CREATE TABLE IF NOT EXISTS ai_inference_log` — fixes 500 errors on the AI Observability page (`/cerebrum/admin`) where `no such table: ai_inference_log` was thrown on deployed databases that missed the original migration (#2341)
- **0046**: `ALTER TABLE engram_index ADD COLUMN body_hash` — fixes `no such column: body_hash` errors from `cerebrum.engrams.list` (#2329)
- **0047**: `CREATE TABLE IF NOT EXISTS glia_actions` (+ `glia_trust_state`) — fixes `no such table: glia_actions` from `cerebrum.glia.actions.list` (#2330)
- **0048**: `CREATE TABLE IF NOT EXISTS conversations` (+ `messages`, `conversation_context`) — fixes `no such table: conversations` from `ego.conversations.list` (#2331)

All four tables/columns exist in the Drizzle schema (`packages/db-types/src/schema/`) and in `initializeSchema()` but were never migrated on existing deployed databases. All migrations use `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` to be idempotent. The `ALTER TABLE ADD COLUMN` for `body_hash` is safe because Drizzle's migration runner tracks applied migrations in `__drizzle_migrations` and will not re-run this on databases that already have the column.

`initializeSchema()` in `apps/pops-api/src/db/schema.ts` was also updated to include `body_hash` in the `engram_index` CREATE TABLE statement (and its index), so fresh databases get the column too.

## Test plan

- [ ] Verify `pnpm typecheck` passes (all 14 packages — confirmed clean in pre-commit hook)
- [ ] Deploy to a staging database that was initialised before migrations 0034–0040 ran and confirm the four tRPC procedures no longer 500
- [ ] Confirm the migration runner skips all four new migrations on a fresh database (seeded by `initializeSchema()`)

Closes #2341 Closes #2329 Closes #2330 Closes #2331

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_