### PR TITLE
fix(db/migrations): make manual migrations runner idempotent on restart (#2375)

### DIFF
--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -104,8 +104,15 @@ function openDatabase(path: string): BetterSqlite3.Database {
     return db;
   }
 
-  applyManualMigrations(db, path);
+  // Drizzle migrations must run before manual migrations so that the base
+  // tables they depend on (e.g. `entities`, `transactions`) exist when the
+  // manual runner tries to apply migrations that reference them.
+  // Previously this order was reversed, causing a "no such table" crash on
+  // tsx hot-reload when a manual migration (e.g. 007_transaction_corrections)
+  // had not yet been applied and the referenced table was only created by
+  // Drizzle. (#2375)
   applyDrizzleMigrations(db, vecLoaded);
+  applyManualMigrations(db, path);
   return db;
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes a crash on `tsx` hot-reload where the API throws `SqliteError: no such table` when the manual migrations runner tries to apply migrations (e.g. `007_transaction_corrections`, `008_add_tags_to_transactions`) that reference tables (`entities`, `transactions`) before those tables exist.
- Root cause: `openDatabase()` ran manual migrations **before** Drizzle migrations — but the base tables those manual migrations reference are created by Drizzle's `0000_naive_chameleon.sql`. On a database that hadn't yet applied migration 007+, the runner would crash because `entities`/`transactions` didn't exist yet.
- Fix: swap the call order in `openDatabase()` so `applyDrizzleMigrations` runs first, ensuring all base tables exist before manual migrations reference them.

## Test plan

- [ ] `pnpm --filter @pops/api typecheck` passes (verified: all 17 packages clean)
- [ ] On a dev database that has not yet had migration 007 applied: restart API with tsx — should apply 007 cleanly without crash
- [ ] On a database with all migrations already applied: restart should be a no-op (existing `schema_migrations` tracking still prevents re-runs)

Closes #2375

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_