### PR TITLE
fix(inventory): pre-fill Location from ?locationId param on new item form (#2413)

### DIFF
--- a/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
@@ -98,6 +98,21 @@ function locationExistsInTree(nodes: LocationTreeNode[], id: string): boolean {
   return false;
 }
 
+function useLocationIdPrefill(
+  isEditMode: boolean,
+  locationTree: LocationTreeNode[],
+  setValue: (name: 'locationId', value: string, opts?: { shouldDirty?: boolean }) => void,
+) {
+  const [searchParams] = useSearchParams();
+  useEffect(() => {
+    if (isEditMode || locationTree.length === 0) return;
+    const paramId = searchParams.get('locationId') ?? '';
+    if (paramId && locationExistsInTree(locationTree, paramId)) {
+      setValue('locationId', paramId, { shouldDirty: false });
+    }
+  }, [isEditMode, locationTree, searchParams, setValue]);
+}
+
 function useLocationsAndCreate() {
   const utils = trpc.useUtils();
   const { data: locationsData } = trpc.inventory.locations.tree.useQuery();
@@ -114,7 +129,6 @@ function useLocationsAndCreate() {
 
 export function useItemFormPageModel() {
   const { id } = useParams<{ id: string }>();
-  const [searchParams] = useSearchParams();
   const isEditMode = !!id;
 
   const form = useForm<ItemFormValues>({ defaultValues });
@@ -140,14 +154,7 @@ export function useItemFormPageModel() {
     { enabled: !isEditMode && connectionSearch.length >= 2 }
   );
   const { locationTree, createLocationMutation } = useLocationsAndCreate();
-
-  useEffect(() => {
-    if (isEditMode || locationTree.length === 0) return;
-    const paramId = searchParams.get('locationId') ?? '';
-    if (paramId && locationExistsInTree(locationTree, paramId)) {
-      setValue('locationId', paramId, { shouldDirty: false });
-    }
-  }, [isEditMode, locationTree, searchParams, setValue]);
+  useLocationIdPrefill(isEditMode, locationTree, setValue);
 
   const {
     data: itemData,

--- a/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useParams } from 'react-router';
+import { useParams, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 
 import { trpc } from '@pops/api-client';
@@ -10,6 +10,8 @@ import { useAssetIdValidation } from './useAssetIdValidation';
 import { useDocumentUploadState } from './useDocumentUpload';
 import { useItemMutations } from './useItemMutations';
 import { usePhotoUploadState } from './usePhotoUpload';
+
+import type { LocationTreeNode } from '../location-tree-page/utils';
 
 export type { ItemFormValues, PendingConnection };
 export { extractPrefix } from './types';
@@ -88,6 +90,14 @@ function useUnsavedChangesGuard(isDirty: boolean): void {
   }, [isDirty]);
 }
 
+function locationExistsInTree(nodes: LocationTreeNode[], id: string): boolean {
+  for (const node of nodes) {
+    if (node.id === id) return true;
+    if (locationExistsInTree(node.children, id)) return true;
+  }
+  return false;
+}
+
 function useLocationsAndCreate() {
   const utils = trpc.useUtils();
   const { data: locationsData } = trpc.inventory.locations.tree.useQuery();
@@ -104,6 +114,7 @@ function useLocationsAndCreate() {
 
 export function useItemFormPageModel() {
   const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
   const isEditMode = !!id;
 
   const form = useForm<ItemFormValues>({ defaultValues });
@@ -129,6 +140,14 @@ export function useItemFormPageModel() {
     { enabled: !isEditMode && connectionSearch.length >= 2 }
   );
   const { locationTree, createLocationMutation } = useLocationsAndCreate();
+
+  useEffect(() => {
+    if (isEditMode || locationTree.length === 0) return;
+    const paramId = searchParams.get('locationId') ?? '';
+    if (paramId && locationExistsInTree(locationTree, paramId)) {
+      setValue('locationId', paramId, { shouldDirty: false });
+    }
+  }, [isEditMode, locationTree, searchParams, setValue]);
 
   const {
     data: itemData,

--- a/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
+++ b/packages/app-inventory/src/pages/item-form-page/useItemFormPageModel.ts
@@ -101,7 +101,7 @@ function locationExistsInTree(nodes: LocationTreeNode[], id: string): boolean {
 function useLocationIdPrefill(
   isEditMode: boolean,
   locationTree: LocationTreeNode[],
-  setValue: (name: 'locationId', value: string, opts?: { shouldDirty?: boolean }) => void,
+  setValue: (name: 'locationId', value: string, opts?: { shouldDirty?: boolean }) => void
 ) {
   const [searchParams] = useSearchParams();
   useEffect(() => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Reads `locationId` from the URL search params when the new-item form mounts in create mode
- Validates the param against the fetched location tree before applying (invalid IDs fall back to empty)
- Sets the form value with `shouldDirty: false` so the field is pre-filled without marking the form dirty

## Test plan

- [ ] Navigate to `/inventory/locations`, click a location node, open the detail panel, click "Add Item Here"
- [ ] Confirm URL becomes `/inventory/items/new?locationId=<id>` and the Location field is pre-selected to that location
- [ ] Confirm navigating to `/inventory/items/new` (no param) still shows empty placeholder
- [ ] Confirm navigating to `/inventory/items/new?locationId=invalid-id` falls back to empty (no crash)
- [ ] Confirm editing an existing item (`/inventory/items/:id/edit`) is unaffected — param is ignored in edit mode
- [ ] `pnpm typecheck` passes in `packages/app-inventory` (no errors in changed files)

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_