### PR TITLE
fix(finance/transactions): date-range filter overlaps Account select (#2305)

### DIFF
--- a/packages/ui/src/components/DataTableFilters.fields.tsx
+++ b/packages/ui/src/components/DataTableFilters.fields.tsx
@@ -72,13 +72,13 @@ export function DateRangeFilter({ column }: DateRangeFilterProps) {
   const filterValue = (column.getFilterValue() as [string, string]) ?? ['', ''];
 
   return (
-    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+    <div className="flex min-w-0 flex-col gap-2 overflow-hidden sm:flex-row sm:items-center">
       <TextInput
         type="date"
         value={filterValue[0]}
         onChange={(e) => column.setFilterValue([e.target.value, filterValue[1]])}
         placeholder="From"
-        className="flex-1"
+        className="min-w-0 flex-1"
       />
       <span className="hidden text-muted-foreground sm:block">to</span>
       <TextInput
@@ -86,7 +86,7 @@ export function DateRangeFilter({ column }: DateRangeFilterProps) {
         value={filterValue[1]}
         onChange={(e) => column.setFilterValue([filterValue[0], e.target.value])}
         placeholder="To"
-        className="flex-1"
+        className="min-w-0 flex-1"
       />
     </div>
   );

--- a/packages/ui/src/components/DataTableFilters.tsx
+++ b/packages/ui/src/components/DataTableFilters.tsx
@@ -55,7 +55,7 @@ function FilterGrid({ filters, table }: { filters: ColumnFilter[]; table: Table<
         const column = table.getColumn(filter.id);
         if (!column) return null;
         return (
-          <div key={filter.id} className="space-y-1.5">
+          <div key={filter.id} className="min-w-0 space-y-1.5">
             <label className="text-2xs font-semibold uppercase tracking-wider text-muted-foreground px-0.5">
               {filter.label}
             </label>


### PR DESCRIPTION
## Summary

- On `/finance/transactions`, the Date Range filter's "To" date input was overflowing its grid column and sitting behind the Account dropdown, making it unusable.
- Root cause: the `DateRangeFilter` flex container and its inner inputs lacked `min-w-0`, allowing them to expand beyond their assigned grid cell; the grid cell itself also lacked `min-w-0`.
- Fix applies two targeted changes in `packages/ui/src/components/`:
  - `DataTableFilters.fields.tsx`: added `min-w-0 overflow-hidden` to the `DateRangeFilter` wrapper div and `min-w-0` to each date `TextInput`.
  - `DataTableFilters.tsx`: added `min-w-0` to the `FilterGrid` item wrapper div so the grid cell constrains its content.

## Test plan

- [ ] Navigate to `/finance/transactions` and confirm the Date Range and Account filters sit in separate columns without overlap.
- [ ] Confirm the "From" and "To" date inputs are fully usable within the Date Range column.
- [ ] Verify layout at `sm` (2-col) and `lg` (3-col) breakpoints.
- [ ] `pnpm typecheck` passes in `packages/app-finance` (no new errors introduced).

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_