### PR TITLE
fix(cerebrum/chat): messages don't appear after sending — add post-send invalidation (#2388)

### DIFF
--- a/packages/app-cerebrum/src/pages/chat-page/useChatMutations.ts
+++ b/packages/app-cerebrum/src/pages/chat-page/useChatMutations.ts
@@ -39,6 +39,26 @@ export function useChatMutations({
     if (!trimmed || streaming.isStreaming) return;
 
     setInputValue('');
+
+    if (selectedConversationId) {
+      utils.ego.conversations.get.setData({ id: selectedConversationId }, (prev) => {
+        if (!prev) return prev;
+        const now = new Date().toISOString();
+        const optimisticMessage = {
+          id: `optimistic_${Date.now()}`,
+          conversationId: selectedConversationId,
+          role: 'user',
+          content: trimmed,
+          citations: null,
+          toolCalls: null,
+          tokensIn: null,
+          tokensOut: null,
+          createdAt: now,
+        };
+        return { ...prev, messages: [...prev.messages, optimisticMessage] };
+      });
+    }
+
     streaming.stream(
       { conversationId: selectedConversationId, message: trimmed },
       {

--- a/packages/app-cerebrum/src/pages/chat-page/useChatMutations.ts
+++ b/packages/app-cerebrum/src/pages/chat-page/useChatMutations.ts
@@ -12,15 +12,44 @@ import { useStreamingChat } from './useStreamingChat';
 
 import type { RetrievedEngram } from './types';
 
-interface DeleteInput {
-  id: string;
-}
-
 interface UseChatMutationsParams {
   selectedConversationId: string | null;
   setSelectedConversationId: (id: string | null) => void;
   inputValue: string;
   setInputValue: (value: string) => void;
+}
+
+function buildOptimisticMessage(conversationId: string, content: string) {
+  return {
+    id: `optimistic_${Date.now()}`,
+    conversationId,
+    role: 'user',
+    content,
+    citations: null,
+    toolCalls: null,
+    tokensIn: null,
+    tokensOut: null,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function useDeleteConversation(
+  selectedConversationId: string | null,
+  setSelectedConversationId: (id: string | null) => void,
+  setRetrievedEngrams: (e: RetrievedEngram[]) => void,
+  utils: ReturnType<typeof trpc.useUtils>
+) {
+  const mutation = trpc.ego.conversations.delete.useMutation({
+    onSuccess: (_data: { success: boolean }, variables: { id: string }) => {
+      if (selectedConversationId === variables.id) {
+        setSelectedConversationId(null);
+        setRetrievedEngrams([]);
+      }
+      void utils.ego.conversations.list.invalidate();
+    },
+  });
+  const deleteConversation = useCallback((id: string) => mutation.mutate({ id }), [mutation]);
+  return { deleteConversation, isDeleting: mutation.isPending };
 }
 
 export function useChatMutations({
@@ -31,34 +60,25 @@ export function useChatMutations({
 }: UseChatMutationsParams) {
   const [retrievedEngrams, setRetrievedEngrams] = useState<RetrievedEngram[]>([]);
   const utils = trpc.useUtils();
-
   const streaming = useStreamingChat();
+  const { deleteConversation, isDeleting } = useDeleteConversation(
+    selectedConversationId,
+    setSelectedConversationId,
+    setRetrievedEngrams,
+    utils
+  );
 
   const sendMessage = useCallback(() => {
     const trimmed = inputValue.trim();
     if (!trimmed || streaming.isStreaming) return;
-
     setInputValue('');
-
     if (selectedConversationId) {
-      utils.ego.conversations.get.setData({ id: selectedConversationId }, (prev) => {
-        if (!prev) return prev;
-        const now = new Date().toISOString();
-        const optimisticMessage = {
-          id: `optimistic_${Date.now()}`,
-          conversationId: selectedConversationId,
-          role: 'user',
-          content: trimmed,
-          citations: null,
-          toolCalls: null,
-          tokensIn: null,
-          tokensOut: null,
-          createdAt: now,
-        };
-        return { ...prev, messages: [...prev.messages, optimisticMessage] };
-      });
+      const msg = buildOptimisticMessage(selectedConversationId, trimmed);
+      utils.ego.conversations.get.setData(
+        { id: selectedConversationId },
+        (prev) => (prev ? { ...prev, messages: [...prev.messages, msg] } : prev),
+      );
     }
-
     streaming.stream(
       { conversationId: selectedConversationId, message: trimmed },
       {
@@ -68,31 +88,9 @@ export function useChatMutations({
           void utils.ego.conversations.list.invalidate();
           void utils.ego.conversations.get.invalidate({ id: conversationId });
         },
-      }
+      },
     );
-  }, [
-    inputValue,
-    selectedConversationId,
-    streaming,
-    setInputValue,
-    setSelectedConversationId,
-    utils,
-  ]);
-
-  const deleteMutation = trpc.ego.conversations.delete.useMutation({
-    onSuccess: (_data: { success: boolean }, variables: DeleteInput) => {
-      if (selectedConversationId === variables.id) {
-        setSelectedConversationId(null);
-        setRetrievedEngrams([]);
-      }
-      void utils.ego.conversations.list.invalidate();
-    },
-  });
-
-  const deleteConversation = useCallback(
-    (id: string) => deleteMutation.mutate({ id }),
-    [deleteMutation]
-  );
+  }, [inputValue, selectedConversationId, streaming, setInputValue, setSelectedConversationId, utils]); // prettier-ignore
 
   const clearEngrams = useCallback(() => setRetrievedEngrams([]), []);
 
@@ -101,7 +99,7 @@ export function useChatMutations({
     isSending: streaming.isStreaming,
     sendError: streaming.error,
     deleteConversation,
-    isDeleting: deleteMutation.isPending,
+    isDeleting,
     retrievedEngrams,
     clearEngrams,
     streamingContent: streaming.streamingContent,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- After sending a message on `/cerebrum/chat`, the user's bubble now appears immediately via optimistic cache update (no waiting for the SSE stream to complete)
- The `ego.conversations.get` query cache is patched synchronously with the optimistic user message before streaming begins
- On stream completion, `onInvalidate` fires and refetches both `ego.conversations.get` (replacing the optimistic message with the real one) and `ego.conversations.list` (updating the sidebar timestamp)

## Test plan

- [ ] Send a message in an existing conversation — the user bubble should appear immediately, not only after the server responds
- [ ] The assistant response streams in normally after the user bubble appears
- [ ] Reloading the page should show all messages (server state is correct)
- [ ] Starting a new conversation (no `selectedConversationId`) still works — no optimistic update is attempted for a null conversation ID
- [ ] Deleting a conversation from the list still invalidates `ego.conversations.list` correctly

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_