### PR TITLE
fix(cerebrum/ingest): TYPE select only shows capture — add all engram types (#2326)

### DIFF
--- a/packages/app-cerebrum/src/pages/ingest-page/types.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/types.ts
@@ -1,5 +1,33 @@
 /** Shared types for the ingest page model. */
 
+/**
+ * Canonical engram types supported by the ingest pipeline.
+ * Must stay in sync with KNOWN_TYPES in apps/pops-api/src/modules/cerebrum/ingest/classifier.ts
+ * and the default template files under apps/pops-api/src/modules/cerebrum/templates/defaults/.
+ */
+export const ENGRAM_TYPES = [
+  'capture',
+  'note',
+  'idea',
+  'decision',
+  'meeting',
+  'journal',
+  'research',
+] as const;
+
+export type EngramType = (typeof ENGRAM_TYPES)[number];
+
+/** Human-readable Title Case labels for each engram type. */
+export const ENGRAM_TYPE_LABELS: Record<EngramType, string> = {
+  capture: 'Capture',
+  note: 'Note',
+  idea: 'Idea',
+  decision: 'Decision',
+  meeting: 'Meeting',
+  journal: 'Journal',
+  research: 'Research',
+};
+
 /** A template summary returned by cerebrum.templates.list (body excluded). */
 export interface TemplateSummary {
   name: string;
@@ -33,7 +61,7 @@ export interface SubmitResult {
 }
 
 export const INITIAL_FORM: IngestFormValues = {
-  type: '',
+  type: 'capture',
   template: '',
   title: '',
   body: '',

--- a/packages/app-cerebrum/src/pages/ingest-page/useTemplateAndScopeData.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useTemplateAndScopeData.ts
@@ -6,6 +6,8 @@ import { useMemo, useRef } from 'react';
 
 import { trpc } from '@pops/api-client';
 
+import { ENGRAM_TYPE_LABELS, ENGRAM_TYPES } from './types';
+
 import type { ScopeEntry, TemplateSummary } from './types';
 
 export function useTemplateAndScopeData() {
@@ -23,19 +25,17 @@ export function useTemplateAndScopeData() {
   const knownScopes = scopesRef.current;
 
   const typeOptions = useMemo(() => {
-    const opts = templates
-      .filter((t) => t.name !== 'capture')
-      .map((t) => ({
-        value: t.name,
-        label: t.name,
-        description: t.description,
-      }));
-    opts.unshift({
-      value: 'capture',
-      label: 'capture',
-      description: 'Freeform capture — no template',
+    const templatesByName = new Map<string, TemplateSummary>(
+      templates.map((t: TemplateSummary) => [t.name, t])
+    );
+    return ENGRAM_TYPES.map((typeName) => {
+      const tpl = templatesByName.get(typeName);
+      return {
+        value: typeName,
+        label: ENGRAM_TYPE_LABELS[typeName],
+        description: tpl?.description ?? '',
+      };
     });
-    return opts;
   }, [templates]);
 
   const scopeSuggestions = useMemo(


### PR DESCRIPTION
## Summary

- The TYPE dropdown on the Ingest page only showed `capture` because `typeOptions` was built entirely from the API's template list response, which could return only a subset of types.
- Added `ENGRAM_TYPES` (canonical list) and `ENGRAM_TYPE_LABELS` (Title Case labels) to `packages/app-cerebrum/src/pages/ingest-page/types.ts`.
- Rewrote `typeOptions` in `useTemplateAndScopeData.ts` to iterate over `ENGRAM_TYPES` and use `ENGRAM_TYPE_LABELS`, enriching each entry with the template description if the API happens to return it.
- Set `capture` as the default selected value in `INITIAL_FORM`.

All seven types now always appear: Capture, Note, Idea, Decision, Meeting, Journal, Research — matching the canonical list in the classifier and default template files.

## Test plan

- [ ] Navigate to `/cerebrum` (Ingest page)
- [ ] Confirm the TYPE dropdown shows: Capture, Note, Idea, Decision, Meeting, Journal, Research
- [ ] Confirm `Capture` is selected by default
- [ ] Select a different type (e.g. Meeting) and confirm the form still submits correctly
- [ ] `pnpm typecheck` in `packages/app-cerebrum` passes with no new errors

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_