### PR TITLE
feat(cerebrum/chat): make chat a global overlay accessible from all pages

### DIFF
--- a/apps/pops-shell/src/app/layout/ChatFab.tsx
+++ b/apps/pops-shell/src/app/layout/ChatFab.tsx
@@ -1,0 +1,26 @@
+import { useUIStore } from '@/store/uiStore';
+import { Sparkles } from 'lucide-react';
+
+import { Button, cn } from '@pops/ui';
+
+export function ChatFab() {
+  const open = useUIStore((state) => state.chatOverlayOpen);
+  const toggleChatOverlay = useUIStore((state) => state.toggleChatOverlay);
+
+  return (
+    <Button
+      onClick={toggleChatOverlay}
+      size="icon"
+      shape="circle"
+      className={cn(
+        'fixed bottom-6 right-6 z-50 h-14 w-14 shadow-lg',
+        'bg-sky-600 hover:bg-sky-500 text-white',
+        'transition-transform duration-200',
+        open && 'scale-90'
+      )}
+      aria-label={open ? 'Close chat' : 'Open chat'}
+    >
+      <Sparkles className="h-6 w-6" />
+    </Button>
+  );
+}

--- a/apps/pops-shell/src/app/layout/ChatOverlay.tsx
+++ b/apps/pops-shell/src/app/layout/ChatOverlay.tsx
@@ -62,7 +62,8 @@ export function ChatOverlay() {
           open ? 'translate-x-0' : 'translate-x-full'
         )}
         aria-label="Chat overlay"
-        aria-modal="true"
+        aria-hidden={!open}
+        aria-modal={open}
         role="dialog"
       >
         {open && <ChatOverlayPanel onClose={onClose} />}

--- a/apps/pops-shell/src/app/layout/ChatOverlay.tsx
+++ b/apps/pops-shell/src/app/layout/ChatOverlay.tsx
@@ -1,0 +1,72 @@
+import { useUIStore } from '@/store/uiStore';
+import { X } from 'lucide-react';
+import { useEffect } from 'react';
+
+import { ChatPanel, useChatPageModel } from '@pops/app-cerebrum';
+import { Button, cn } from '@pops/ui';
+
+function useOverlayKeyboard(open: boolean, onClose: () => void): void {
+  useEffect(() => {
+    if (!open) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onClose]);
+}
+
+function ChatOverlayPanel({ onClose }: { onClose: () => void }) {
+  const model = useChatPageModel();
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-border/50 px-4 py-3 shrink-0">
+        <span className="text-sm font-semibold">Ego</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          className="min-h-[44px] min-w-[44px]"
+          aria-label="Close chat"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+      <ChatPanel model={model} className="flex-1 rounded-none border-0" />
+    </div>
+  );
+}
+
+export function ChatOverlay() {
+  const open = useUIStore((state) => state.chatOverlayOpen);
+  const setChatOverlayOpen = useUIStore((state) => state.setChatOverlayOpen);
+  const onClose = () => setChatOverlayOpen(false);
+
+  useOverlayKeyboard(open, onClose);
+
+  return (
+    <>
+      {open && (
+        <div className="fixed inset-0 z-40 bg-black/40" aria-hidden="true" onClick={onClose} />
+      )}
+      <aside
+        className={cn(
+          'fixed right-0 top-0 bottom-0 z-50 flex w-full max-w-2xl flex-col bg-background shadow-2xl',
+          'transition-transform duration-300 ease-in-out',
+          open ? 'translate-x-0' : 'translate-x-full'
+        )}
+        aria-label="Chat overlay"
+        aria-modal="true"
+        role="dialog"
+      >
+        {open && <ChatOverlayPanel onClose={onClose} />}
+      </aside>
+    </>
+  );
+}

--- a/apps/pops-shell/src/app/layout/RootLayout.tsx
+++ b/apps/pops-shell/src/app/layout/RootLayout.tsx
@@ -13,6 +13,8 @@ import { Outlet, useLocation } from 'react-router';
 import { AppContextProvider } from '@pops/navigation';
 import { cn, ErrorBoundary } from '@pops/ui';
 
+import { ChatFab } from './ChatFab';
+import { ChatOverlay } from './ChatOverlay';
 import { AmbientBackground } from './root-layout/AmbientBackground';
 import { NavRegion } from './root-layout/NavRegion';
 import { usePageNavAutoClose } from './root-layout/usePageNavAutoClose';
@@ -49,6 +51,9 @@ export function RootLayout() {
             </main>
           </div>
         </div>
+
+        <ChatFab />
+        <ChatOverlay />
       </div>
     </AppContextProvider>
   );

--- a/apps/pops-shell/src/store/uiStore.ts
+++ b/apps/pops-shell/src/store/uiStore.ts
@@ -9,6 +9,7 @@ interface UIState {
   sidebarOpen: boolean;
   railOpen: boolean;
   pageNavOpen: boolean;
+  chatOverlayOpen: boolean;
   /**
    * When true, the next location-change close of the PageNav overlay is
    * suppressed. Used by AppRail to prevent the navigation it triggers from
@@ -22,6 +23,8 @@ interface UIState {
   togglePageNav: () => void;
   setPageNavOpen: (open: boolean) => void;
   setSkipNextPageNavClose: (skip: boolean) => void;
+  toggleChatOverlay: () => void;
+  setChatOverlayOpen: (open: boolean) => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -30,6 +33,7 @@ export const useUIStore = create<UIState>()(
       sidebarOpen: true,
       railOpen: true,
       pageNavOpen: false,
+      chatOverlayOpen: false,
       skipNextPageNavClose: false,
       toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
       setSidebarOpen: (open) => set({ sidebarOpen: open }),
@@ -38,6 +42,8 @@ export const useUIStore = create<UIState>()(
       togglePageNav: () => set((state) => ({ pageNavOpen: !state.pageNavOpen })),
       setPageNavOpen: (open) => set({ pageNavOpen: open }),
       setSkipNextPageNavClose: (skip) => set({ skipNextPageNavClose: skip }),
+      toggleChatOverlay: () => set((state) => ({ chatOverlayOpen: !state.chatOverlayOpen })),
+      setChatOverlayOpen: (open) => set({ chatOverlayOpen: open }),
     }),
     {
       name: 'pops-ui-storage',

--- a/packages/app-cerebrum/src/index.ts
+++ b/packages/app-cerebrum/src/index.ts
@@ -5,3 +5,5 @@
  * to lazily load cerebrum pages under /cerebrum/*.
  */
 export { navConfig, routes } from './routes';
+export { ChatPanel } from './components/chat/ChatPanel';
+export { useChatPageModel } from './pages/chat-page/useChatPageModel';

--- a/packages/app-cerebrum/src/routes.tsx
+++ b/packages/app-cerebrum/src/routes.tsx
@@ -47,7 +47,6 @@ export const navConfig = {
   basePath: '/cerebrum',
   items: [
     { path: '', label: 'Ingest', labelKey: 'cerebrum.ingest', icon: 'FileText' },
-    { path: '/chat', label: 'Chat', labelKey: 'cerebrum.chat', icon: 'MessageSquare' },
     { path: '/nudges', label: 'Nudges', labelKey: 'cerebrum.nudges', icon: 'Bell' },
     {
       path: '/proposals',


### PR DESCRIPTION
## Summary

- Adds a floating action button (Sparkles icon, sky-600, bottom-right corner) rendered in `RootLayout` so it appears on every authenticated route
- Adds `ChatOverlay` — a full-height sliding panel (max-w-2xl, from the right) that mounts the existing `ChatPanel`/`useChatPageModel` intact; conversation state persists across open/close within a session
- Dismissible via Esc key, backdrop click, or close button inside the panel
- Removes the "Chat" item from the Cerebrum sidebar nav (`navConfig.items`); the `/cerebrum/chat` deep-link route is retained
- Adds `chatOverlayOpen` / `toggleChatOverlay` / `setChatOverlayOpen` to `uiStore`
- Exports `ChatPanel` and `useChatPageModel` from `@pops/app-cerebrum` so the shell overlay can import them without duplication

## Test plan

- [ ] FAB is visible on all authenticated routes (finance, media, inventory, cerebrum, settings)
- [ ] Clicking FAB opens the overlay; clicking again closes it
- [ ] Esc key closes the overlay
- [ ] Clicking the backdrop closes the overlay
- [ ] Close button (X) in the panel header closes the overlay
- [ ] Chat conversation state (selected conversation, message input) is preserved across open/close
- [ ] `/cerebrum/chat` deep-link still renders the full `ChatPage`
- [ ] "Chat" no longer appears in the Cerebrum sidebar

## Gaps (tracked)

None — all acceptance criteria from the issue are met.

Closes #2332

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_