### PR TITLE
fix(cerebrum/ingest): populate Type dropdown with all engram types

### DIFF
--- a/packages/app-cerebrum/src/pages/ingest-page/types.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/types.ts
@@ -1,5 +1,33 @@
 /** Shared types for the ingest page model. */
 
+/**
+ * Canonical engram types supported by the ingest pipeline.
+ * Must stay in sync with KNOWN_TYPES in apps/pops-api/src/modules/cerebrum/ingest/classifier.ts
+ * and the default template files under apps/pops-api/src/modules/cerebrum/templates/defaults/.
+ */
+export const ENGRAM_TYPES = [
+  'capture',
+  'note',
+  'idea',
+  'decision',
+  'meeting',
+  'journal',
+  'research',
+] as const;
+
+export type EngramType = (typeof ENGRAM_TYPES)[number];
+
+/** Human-readable Title Case labels for each engram type. */
+export const ENGRAM_TYPE_LABELS: Record<EngramType, string> = {
+  capture: 'Capture',
+  note: 'Note',
+  idea: 'Idea',
+  decision: 'Decision',
+  meeting: 'Meeting',
+  journal: 'Journal',
+  research: 'Research',
+};
+
 /** A template summary returned by cerebrum.templates.list (body excluded). */
 export interface TemplateSummary {
   name: string;
@@ -33,7 +61,7 @@ export interface SubmitResult {
 }
 
 export const INITIAL_FORM: IngestFormValues = {
-  type: '',
+  type: 'capture',
   template: '',
   title: '',
   body: '',

--- a/packages/app-cerebrum/src/pages/ingest-page/useTemplateAndScopeData.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useTemplateAndScopeData.ts
@@ -6,6 +6,8 @@ import { useMemo, useRef } from 'react';
 
 import { trpc } from '@pops/api-client';
 
+import { ENGRAM_TYPE_LABELS, ENGRAM_TYPES } from './types';
+
 import type { ScopeEntry, TemplateSummary } from './types';
 
 export function useTemplateAndScopeData() {
@@ -23,19 +25,17 @@ export function useTemplateAndScopeData() {
   const knownScopes = scopesRef.current;
 
   const typeOptions = useMemo(() => {
-    const opts = templates
-      .filter((t) => t.name !== 'capture')
-      .map((t) => ({
-        value: t.name,
-        label: t.name,
-        description: t.description,
-      }));
-    opts.unshift({
-      value: 'capture',
-      label: 'capture',
-      description: 'Freeform capture — no template',
+    const templatesByName = new Map<string, TemplateSummary>(
+      templates.map((t: TemplateSummary) => [t.name, t])
+    );
+    return ENGRAM_TYPES.map((typeName) => {
+      const tpl = templatesByName.get(typeName);
+      return {
+        value: typeName,
+        label: ENGRAM_TYPE_LABELS[typeName],
+        description: tpl?.description ?? '',
+      };
     });
-    return opts;
   }, [templates]);
 
   const scopeSuggestions = useMemo(


### PR DESCRIPTION
## Summary

- Add `ENGRAM_TYPES` and `ENGRAM_TYPE_LABELS` constants to `packages/app-cerebrum/src/pages/ingest-page/types.ts` as the canonical frontend list of all seven engram types
- Rebuild `typeOptions` in `useTemplateAndScopeData.ts` to always emit all types from `ENGRAM_TYPES` with Title Case labels from `ENGRAM_TYPE_LABELS`, rather than deriving only from the async template API response
- Set `'capture'` as the default value in `INITIAL_FORM` so the dropdown starts at a valid selection

Previously the dropdown only showed one option ("capture") because the `typeOptions` memo built from the API template list and used the raw template name as the label. Now all seven types (Capture, Note, Idea, Decision, Meeting, Journal, Research) are always present with proper Title Case labels. Template metadata (description, custom fields) is still pulled from the API response when available.

## Test plan

- [ ] Open `/cerebrum/ingest` — the TYPE dropdown should show: Capture, Note, Idea, Decision, Meeting, Journal, Research
- [ ] Each option should display Title Case (not lowercase)
- [ ] While templates are still loading, all options are still available (from the static `ENGRAM_TYPES` list)
- [ ] Selecting a type that has a matching template (Note, Idea, Decision, Meeting, Journal, Research) should reveal template custom fields
- [ ] Selecting Capture should show no template fields (freeform)
- [ ] Form submission with any type works as expected

Closes #2326

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_