### PR TITLE
fix(multi): batch fixes — media, finance, cerebrum, inventory, UI, Redis/jobs

### DIFF
--- a/apps/pops-api/src/jobs/dead-letter.ts
+++ b/apps/pops-api/src/jobs/dead-letter.ts
@@ -16,7 +16,12 @@ export interface DeadLetterParams {
 
 export function moveToDeadLetter(params: DeadLetterParams): void {
   const { queue, jobId, jobName, data, attemptsMade, err, removeOriginal } = params;
-  void getDeadLetterQueue()
+  const dlq = getDeadLetterQueue();
+  if (!dlq) {
+    logger.warn({ queue, jobId, jobName }, 'Dead-letter queue unavailable — Redis not configured');
+    return;
+  }
+  void dlq
     .add(DEAD_LETTER_QUEUE, {
       originalQueue: queue,
       originalJobId: jobId,

--- a/apps/pops-api/src/jobs/queues.ts
+++ b/apps/pops-api/src/jobs/queues.ts
@@ -1,4 +1,5 @@
 import { Queue } from 'bullmq';
+import pino from 'pino';
 
 import { createRedisConnection } from './redis.js';
 
@@ -11,6 +12,8 @@ import type {
   EmbeddingsQueueJobData,
   SyncQueueJobData,
 } from './types.js';
+
+const logger = pino({ name: 'pops-jobs' });
 
 // ---------------------------------------------------------------------------
 // Queue name constants
@@ -72,71 +75,86 @@ export const DEFAULT_JOB_OPTIONS: DefaultJobOptions = {
 // Lazy queue singletons
 // ---------------------------------------------------------------------------
 
-let _syncQueue: Queue<SyncQueueJobData> | null = null;
-let _embeddingsQueue: Queue<EmbeddingsQueueJobData> | null = null;
-let _curationQueue: Queue<CurationQueueJobData> | null = null;
-let _defaultQueue: Queue<DefaultQueueJobData> | null = null;
-let _deadLetterQueue: Queue<DeadLetterJobData> | null = null;
+let syncQueue: Queue<SyncQueueJobData> | null = null;
+let embeddingsQueue: Queue<EmbeddingsQueueJobData> | null = null;
+let curationQueue: Queue<CurationQueueJobData> | null = null;
+let defaultQueue: Queue<DefaultQueueJobData> | null = null;
+let deadLetterQueue: Queue<DeadLetterJobData> | null = null;
 
-export function getSyncQueue(): Queue<SyncQueueJobData> {
-  _syncQueue ??= new Queue<SyncQueueJobData>(SYNC_QUEUE, {
-    connection: createRedisConnection(),
+function warnNoRedis(queueName: string): null {
+  logger.warn({ queue: queueName }, 'Redis unavailable — queue disabled (REDIS_HOST not set)');
+  return null;
+}
+
+export function getSyncQueue(): Queue<SyncQueueJobData> | null {
+  const connection = createRedisConnection();
+  if (!connection) return warnNoRedis(SYNC_QUEUE);
+  syncQueue ??= new Queue<SyncQueueJobData>(SYNC_QUEUE, {
+    connection,
     defaultJobOptions: SYNC_JOB_OPTIONS,
   });
-  return _syncQueue;
+  return syncQueue;
 }
 
-export function getEmbeddingsQueue(): Queue<EmbeddingsQueueJobData> {
-  _embeddingsQueue ??= new Queue<EmbeddingsQueueJobData>(EMBEDDINGS_QUEUE, {
-    connection: createRedisConnection(),
+export function getEmbeddingsQueue(): Queue<EmbeddingsQueueJobData> | null {
+  const connection = createRedisConnection();
+  if (!connection) return warnNoRedis(EMBEDDINGS_QUEUE);
+  embeddingsQueue ??= new Queue<EmbeddingsQueueJobData>(EMBEDDINGS_QUEUE, {
+    connection,
     defaultJobOptions: EMBEDDINGS_JOB_OPTIONS,
   });
-  return _embeddingsQueue;
+  return embeddingsQueue;
 }
 
-export function getCurationQueue(): Queue<CurationQueueJobData> {
-  _curationQueue ??= new Queue<CurationQueueJobData>(CURATION_QUEUE, {
-    connection: createRedisConnection(),
+export function getCurationQueue(): Queue<CurationQueueJobData> | null {
+  const connection = createRedisConnection();
+  if (!connection) return warnNoRedis(CURATION_QUEUE);
+  curationQueue ??= new Queue<CurationQueueJobData>(CURATION_QUEUE, {
+    connection,
     defaultJobOptions: CURATION_JOB_OPTIONS,
   });
-  return _curationQueue;
+  return curationQueue;
 }
 
-export function getDefaultQueue(): Queue<DefaultQueueJobData> {
-  _defaultQueue ??= new Queue<DefaultQueueJobData>(DEFAULT_QUEUE, {
-    connection: createRedisConnection(),
+export function getDefaultQueue(): Queue<DefaultQueueJobData> | null {
+  const connection = createRedisConnection();
+  if (!connection) return warnNoRedis(DEFAULT_QUEUE);
+  defaultQueue ??= new Queue<DefaultQueueJobData>(DEFAULT_QUEUE, {
+    connection,
     defaultJobOptions: DEFAULT_JOB_OPTIONS,
   });
-  return _defaultQueue;
+  return defaultQueue;
 }
 
-export function getDeadLetterQueue(): Queue<DeadLetterJobData> {
-  _deadLetterQueue ??= new Queue<DeadLetterJobData>(DEAD_LETTER_QUEUE, {
-    connection: createRedisConnection(),
+export function getDeadLetterQueue(): Queue<DeadLetterJobData> | null {
+  const connection = createRedisConnection();
+  if (!connection) return warnNoRedis(DEAD_LETTER_QUEUE);
+  deadLetterQueue ??= new Queue<DeadLetterJobData>(DEAD_LETTER_QUEUE, {
+    connection,
     defaultJobOptions: {
       removeOnComplete: { count: 500 },
       removeOnFail: false,
     },
   });
-  return _deadLetterQueue;
+  return deadLetterQueue;
 }
 
 export async function closeQueues(): Promise<void> {
   await Promise.all([
-    _syncQueue?.close(),
-    _embeddingsQueue?.close(),
-    _curationQueue?.close(),
-    _defaultQueue?.close(),
-    _deadLetterQueue?.close(),
+    syncQueue?.close(),
+    embeddingsQueue?.close(),
+    curationQueue?.close(),
+    defaultQueue?.close(),
+    deadLetterQueue?.close(),
   ]);
-  _syncQueue = null;
-  _embeddingsQueue = null;
-  _curationQueue = null;
-  _defaultQueue = null;
-  _deadLetterQueue = null;
+  syncQueue = null;
+  embeddingsQueue = null;
+  curationQueue = null;
+  defaultQueue = null;
+  deadLetterQueue = null;
 }
 
-/** Return a queue instance by name — null for unknown names. */
+/** Return a queue instance by name — null for unknown names or when Redis is unavailable. */
 export function getQueueByName(name: string): Queue | null {
   switch (name) {
     case SYNC_QUEUE:

--- a/apps/pops-api/src/modules/cerebrum/ingest/pipeline.ts
+++ b/apps/pops-api/src/modules/cerebrum/ingest/pipeline.ts
@@ -187,6 +187,7 @@ export class IngestService {
     // Enqueue async enrichment job (fire-and-forget)
     try {
       const queue = getCurationQueue();
+      if (!queue) throw new Error('Curation queue unavailable — Redis not configured');
       await queue.add('classifyEngram', {
         type: 'classifyEngram',
         engramId: engram.id,

--- a/apps/pops-api/src/modules/cerebrum/thalamus/cross-source.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/cross-source.ts
@@ -165,6 +165,10 @@ export class CrossSourceIndexer {
       const chunk0HashBySourceId = new Map(existing.map((e) => [e.sourceId, e.contentHash]));
 
       const queue = getEmbeddingsQueue();
+      if (!queue) {
+        console.warn(`[thalamus] Embeddings queue unavailable — skipping source ${sourceType}`);
+        continue;
+      }
 
       for (const item of items) {
         if (!item.text.trim()) continue;

--- a/apps/pops-api/src/modules/cerebrum/thalamus/embedding-trigger.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/embedding-trigger.ts
@@ -43,6 +43,14 @@ export class EmbeddingTrigger {
 
       try {
         const queue = getEmbeddingsQueue();
+        if (!queue) {
+          output.push({
+            engramId,
+            action: 'error',
+            reason: 'Embeddings queue unavailable — Redis not configured',
+          });
+          continue;
+        }
         await queue.add(
           EMBEDDINGS_QUEUE,
           { sourceType: 'engram', sourceId: engramId, content: result.bodyText },

--- a/apps/pops-api/src/modules/cerebrum/thalamus/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/instance.ts
@@ -88,24 +88,28 @@ export async function startThalamus(): Promise<void> {
   console.warn(`[thalamus] File watcher started (root: ${root})`);
 
   // Register cross-source index repeatable job (every 6 hours).
-  void getDefaultQueue()
-    .upsertJobScheduler(
-      CROSS_SOURCE_SCHEDULER_ID,
-      { every: getCrossSourceIntervalMs() },
-      { name: 'crossSourceIndex', data: { type: 'crossSourceIndex' }, opts: DEFAULT_JOB_OPTIONS }
-    )
-    .catch((err: unknown) => {
-      console.error('[thalamus] Failed to register cross-source index scheduler:', err);
-    });
+  const defaultQ = getDefaultQueue();
+  if (defaultQ) {
+    void defaultQ
+      .upsertJobScheduler(
+        CROSS_SOURCE_SCHEDULER_ID,
+        { every: getCrossSourceIntervalMs() },
+        { name: 'crossSourceIndex', data: { type: 'crossSourceIndex' }, opts: DEFAULT_JOB_OPTIONS }
+      )
+      .catch((err: unknown) => {
+        console.error('[thalamus] Failed to register cross-source index scheduler:', err);
+      });
+  }
 }
 
 /** Stop the Thalamus file watcher and deregister the cross-source scheduler. */
 export async function stopThalamus(): Promise<void> {
-  void getDefaultQueue()
-    .removeJobScheduler(CROSS_SOURCE_SCHEDULER_ID)
-    .catch((err: unknown) => {
+  const defaultQ = getDefaultQueue();
+  if (defaultQ) {
+    void defaultQ.removeJobScheduler(CROSS_SOURCE_SCHEDULER_ID).catch((err: unknown) => {
       console.error('[thalamus] Failed to remove cross-source index scheduler:', err);
     });
+  }
 
   if (watcher) {
     await watcher.stop();

--- a/apps/pops-api/src/modules/cerebrum/thalamus/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/thalamus/router.ts
@@ -23,9 +23,11 @@ export const indexRouter = router({
     let pendingCount: number | null = null;
     try {
       const queue = getEmbeddingsQueue();
-      pendingCount = await queue
-        .getJobCounts('waiting', 'active', 'delayed')
-        .then((counts) => (counts.waiting ?? 0) + (counts.active ?? 0) + (counts.delayed ?? 0));
+      if (queue) {
+        pendingCount = await queue
+          .getJobCounts('waiting', 'active', 'delayed')
+          .then((counts) => (counts.waiting ?? 0) + (counts.active ?? 0) + (counts.delayed ?? 0));
+      }
     } catch {
       // Queue unavailable — leave null.
     }

--- a/apps/pops-api/src/modules/core/jobs/router-stats.ts
+++ b/apps/pops-api/src/modules/core/jobs/router-stats.ts
@@ -89,7 +89,9 @@ export const statsRouter = router({
     )
     .query(async () => {
       try {
-        const schedulers = await getSyncQueue().getJobSchedulers();
+        const q = getSyncQueue();
+        if (!q) return { schedulers: [] };
+        const schedulers = await q.getJobSchedulers();
         return { schedulers };
       } catch {
         return { schedulers: [] };

--- a/apps/pops-api/src/modules/core/jobs/router.ts
+++ b/apps/pops-api/src/modules/core/jobs/router.ts
@@ -40,6 +40,11 @@ async function listJobsAcrossQueues(
 
 async function retryDeadLetterJob(jobId: string): Promise<void> {
   const dlq = getDeadLetterQueue();
+  if (!dlq)
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Dead-letter queue unavailable — Redis not configured',
+    });
   const job = await dlq.getJob(jobId);
   if (!job) throw new TRPCError({ code: 'NOT_FOUND', message: 'Dead-letter job not found' });
 

--- a/apps/pops-api/src/modules/media/plex/router-sync.ts
+++ b/apps/pops-api/src/modules/media/plex/router-sync.ts
@@ -66,6 +66,7 @@ export const syncProcedures = {
 
       try {
         const queue = getSyncQueue();
+        if (!queue) throw new Error('Sync queue unavailable — Redis not configured');
         const [active, waiting] = await Promise.all([
           queue.getJobs(['active']),
           queue.getJobs(['waiting']),
@@ -89,7 +90,7 @@ export const syncProcedures = {
     .input(z.object({ jobId: z.string().min(1) }))
     .query(async ({ input }) => {
       const queue = getSyncQueue();
-      const bullJob = await queue.getJob(input.jobId);
+      const bullJob = queue ? await queue.getJob(input.jobId) : null;
       if (bullJob) return { data: bullmqJobToSyncJob(bullJob) };
 
       const db = getDrizzle();
@@ -110,6 +111,7 @@ export const syncProcedures = {
   getActiveSyncJobs: protectedProcedure.query(async () => {
     if (getRedisStatus() === 'disconnected') return { data: [] };
     const queue = getSyncQueue();
+    if (!queue) return { data: [] };
     const [active, waiting] = await Promise.all([
       queue.getJobs(['active']),
       queue.getJobs(['waiting']),

--- a/apps/pops-api/src/modules/media/plex/scheduler.ts
+++ b/apps/pops-api/src/modules/media/plex/scheduler.ts
@@ -105,22 +105,25 @@ export function startScheduler(options: SchedulerOptions = {}): SchedulerStatus 
   tvSectionId = options.tvSectionId ?? saved.tvSectionId;
   nextSyncAt = new Date(Date.now() + intervalMs).toISOString();
 
-  void getSyncQueue()
-    .upsertJobScheduler(
-      SCHEDULER_ID,
-      { every: intervalMs },
-      {
-        name: 'plexScheduledSync',
-        data: {
-          type: 'plexScheduledSync',
-          movieSectionId: movieSectionId ?? undefined,
-          tvSectionId: tvSectionId ?? undefined,
-        },
-      }
-    )
-    .catch((err: unknown) => {
-      console.error('[Plex Scheduler] Failed to register BullMQ scheduler:', err);
-    });
+  const syncQ = getSyncQueue();
+  if (syncQ) {
+    void syncQ
+      .upsertJobScheduler(
+        SCHEDULER_ID,
+        { every: intervalMs },
+        {
+          name: 'plexScheduledSync',
+          data: {
+            type: 'plexScheduledSync',
+            movieSectionId: movieSectionId ?? undefined,
+            tvSectionId: tvSectionId ?? undefined,
+          },
+        }
+      )
+      .catch((err: unknown) => {
+        console.error('[Plex Scheduler] Failed to register BullMQ scheduler:', err);
+      });
+  }
 
   isRunning = true;
   persistSchedulerConfig();
@@ -130,11 +133,12 @@ export function startScheduler(options: SchedulerOptions = {}): SchedulerStatus 
 /** Remove the BullMQ repeatable job and stop the scheduler. */
 export function stopScheduler(): SchedulerStatus {
   if (isRunning) {
-    void getSyncQueue()
-      .removeJobScheduler(SCHEDULER_ID)
-      .catch((err: unknown) => {
+    const syncQ = getSyncQueue();
+    if (syncQ) {
+      void syncQ.removeJobScheduler(SCHEDULER_ID).catch((err: unknown) => {
         console.error('[Plex Scheduler] Failed to remove BullMQ scheduler:', err);
       });
+    }
   }
   isRunning = false;
   nextSyncAt = null;

--- a/apps/pops-api/src/modules/media/plex/sync-discover-episode.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-discover-episode.ts
@@ -5,6 +5,7 @@ import { episodes, seasons } from '@pops/db-types';
 import { logWatch } from '../watch-history/service.js';
 import { resolveShow } from './sync-discover-show.js';
 import { pushError, type DiscoverItemResult } from './sync-discover-types.js';
+import { hasNearDuplicateWatch } from './sync-helpers.js';
 
 import type { getDrizzle } from '../../../db.js';
 import type { getTvdbClient } from '../thetvdb/index.js';
@@ -95,6 +96,10 @@ export async function processEpisodeEntry(args: ProcessEpisodeEntryArgs): Promis
     }
 
     result.watched++;
+    if (hasNearDuplicateWatch('episode', episode.id, entry.date)) {
+      result.alreadyLogged++;
+      return;
+    }
     const logResult = logWatch({
       mediaType: 'episode',
       mediaId: episode.id,

--- a/apps/pops-api/src/modules/media/plex/sync-helpers.ts
+++ b/apps/pops-api/src/modules/media/plex/sync-helpers.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, gte, lte } from 'drizzle-orm';
 
 /**
  * Shared helpers for Plex sync operations.
@@ -6,7 +6,7 @@ import { and, eq } from 'drizzle-orm';
  * Extracted from service.ts, sync-movies.ts, and sync-tv.ts to eliminate
  * duplicated watch-history logging and external ID extraction logic.
  */
-import { episodes, seasons } from '@pops/db-types';
+import { episodes, seasons, watchHistory } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
 import { getTvShowByTvdbId } from '../tv-shows/service.js';
@@ -83,19 +83,66 @@ export function extractExternalIdAsNumber(item: PlexMediaItem, source: string): 
   return Number.isNaN(parsed) ? null : parsed;
 }
 
+/** Near-duplicate dedup window for Plex sync: 5 minutes in milliseconds. */
+const NEAR_DUPLICATE_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * Check whether a watch event for the same media already exists within
+ * ±5 minutes of the given timestamp. Used to suppress duplicate entries
+ * that arise when both local Plex sync and Plex Discover cloud sync
+ * process the same playback.
+ *
+ * Returns true if a near-duplicate exists (caller should skip the insert).
+ */
+export function hasNearDuplicateWatch(
+  mediaType: 'movie' | 'episode',
+  mediaId: number,
+  watchedAt: string
+): boolean {
+  try {
+    const db = getDrizzle();
+    const ts = new Date(watchedAt).getTime();
+    const windowStart = new Date(ts - NEAR_DUPLICATE_WINDOW_MS).toISOString();
+    const windowEnd = new Date(ts + NEAR_DUPLICATE_WINDOW_MS).toISOString();
+
+    const existing = db
+      .select({ id: watchHistory.id })
+      .from(watchHistory)
+      .where(
+        and(
+          eq(watchHistory.mediaType, mediaType),
+          eq(watchHistory.mediaId, mediaId),
+          gte(watchHistory.watchedAt, windowStart),
+          lte(watchHistory.watchedAt, windowEnd)
+        )
+      )
+      .get();
+
+    return existing != null;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Log a movie watch event from Plex data.
- * Silently ignores duplicate watch entries.
+ * Silently ignores duplicate watch entries (exact timestamp or within ±5 min).
  * Returns true if a new entry was created, false if duplicate.
  */
 export function logMovieWatch(movieId: number, lastViewedAtUnix: number | null): boolean {
+  const watchedAt = lastViewedAtUnix
+    ? new Date(lastViewedAtUnix * 1000).toISOString()
+    : new Date().toISOString();
+
+  if (hasNearDuplicateWatch('movie', movieId, watchedAt)) {
+    return false;
+  }
+
   try {
     const result = logWatch({
       mediaType: 'movie',
       mediaId: movieId,
-      watchedAt: lastViewedAtUnix
-        ? new Date(lastViewedAtUnix * 1000).toISOString()
-        : new Date().toISOString(),
+      watchedAt,
       completed: 1,
       source: 'plex_sync',
     });
@@ -145,12 +192,19 @@ function processSingleEpisode(plexEp: PlexEpisode, ctx: ProcessEpisodeContext): 
       return;
     }
 
+    const episodeWatchedAt = plexEp.lastViewedAt
+      ? new Date(plexEp.lastViewedAt * 1000).toISOString()
+      : new Date().toISOString();
+
+    if (hasNearDuplicateWatch('episode', episode.id, episodeWatchedAt)) {
+      diagnostics.alreadyLogged++;
+      return;
+    }
+
     const result = logWatch({
       mediaType: 'episode',
       mediaId: episode.id,
-      watchedAt: plexEp.lastViewedAt
-        ? new Date(plexEp.lastViewedAt * 1000).toISOString()
-        : new Date().toISOString(),
+      watchedAt: episodeWatchedAt,
       completed: 1,
       source: 'plex_sync',
     });

--- a/packages/app-finance/src/pages/wishlist/columns.tsx
+++ b/packages/app-finance/src/pages/wishlist/columns.tsx
@@ -25,7 +25,7 @@ const itemColumn: ColumnDef<WishlistItem> = {
   accessorKey: 'item',
   header: ({ column }) => <SortableHeader column={column}>Item</SortableHeader>,
   cell: ({ row }) => (
-    <div className="flex flex-col">
+    <div className="flex flex-col" data-wishlist-id={row.original.id}>
       <span className="font-medium">{row.original.item}</span>
       {row.original.url && (
         <a


### PR DESCRIPTION
## Summary

Batch of fixes across multiple domains, all passing lint + full monorepo typecheck.

- **Media (#2337):** Near-duplicate watch event guard in Plex discover sync — `hasNearDuplicateWatch` helper deduplicates events within ±5 min on both episode and movie sync paths
- **Media (#2335/#2340):** `WatchlistCard` / `WatchlistItem` show `ID {mediaId}` fallback when `year` is null so same-title entries (e.g. two "La luna") remain distinguishable
- **Media (#2337):** `formatWatchTime` helper + time-of-day subtitle on `HistoryCard` so users can tell genuine re-watches from sync duplicates
- **Media:** `warnIfBareMetadata` in watchlist service logs when a movie/show is added without `release_date` or `poster_path`
- **Cerebrum (#2388):** `onDone` callback in `useStreamingChat` / `useChatMutations` writes the assistant message into the tRPC cache immediately after stream completes — eliminates flash of missing message
- **Finance (#2312):** `transactions.availableAccounts` tRPC procedure + `Autocomplete` combobox in `TransactionFormDialog` so Account field is seeded from real account names
- **Finance (#2390):** `data-wishlist-id` attribute on `WishlistPage` table rows for scroll-to-match navigation from search results
- **Inventory (#2413):** Graceful fallback + `console.warn` when `locationId` URL param doesn't resolve to a known location
- **UI (#2305):** `DataTableFilters` layout — removed `grid` wrapper so filters no longer overflow into adjacent columns
- **Redis/jobs (#2446):** Gate all BullMQ queue singletons on `REDIS_HOST` being set; null guards on every caller; rename private singletons to drop `_` prefix (lint)

## Closes

Closes #2305, Closes #2312, Closes #2335, Closes #2337, Closes #2340, Closes #2388, Closes #2390, Closes #2413, Closes #2446

https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A

---
_Generated by [Claude Code](https://claude.ai/code/session_015ED4HqB9ako1R1CwMZqV9A)_