### PR TITLE
fix(settings): listen for hashchange to update active group post-mount

### DIFF
--- a/apps/pops-shell/src/app/pages/SettingsPage.test.tsx
+++ b/apps/pops-shell/src/app/pages/SettingsPage.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * SettingsPage tests — hash-based deep linking and post-mount navigation.
+ *
+ * Issue: #2464 — hash changes after initial mount must update the active group
+ * (back/forward, address-bar edits, programmatic `window.location.hash = '...'`).
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getManifests: vi.fn(),
+  setBulkMutate: vi.fn(),
+}));
+
+vi.mock('@/lib/trpc', () => ({
+  trpc: {
+    useUtils: () => ({}),
+    core: {
+      settings: {
+        getManifests: { useQuery: () => mocks.getManifests() },
+        getBulk: { useQuery: () => ({ data: { settings: {} }, isLoading: false }) },
+        setBulk: { useMutation: () => ({ mutate: mocks.setBulkMutate }) },
+      },
+    },
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/components/settings/SectionRenderer', () => ({
+  SectionRenderer: ({ manifest }: { manifest: { id: string } }) => (
+    <div data-testid="section-renderer">section:{manifest.id}</div>
+  ),
+}));
+
+import { SettingsPage } from './SettingsPage';
+
+const MANIFESTS = [
+  { id: 'finance', title: 'Finance', order: 0, groups: [] },
+  { id: 'media.plex', title: 'Plex', order: 1, groups: [] },
+  { id: 'cerebrum', title: 'Cerebrum', order: 2, groups: [] },
+];
+
+function setHash(hash: string) {
+  window.history.replaceState(null, '', `#${hash}`);
+  fireEvent(window, new HashChangeEvent('hashchange'));
+}
+
+describe('SettingsPage hash-based deep linking', () => {
+  beforeEach(() => {
+    mocks.getManifests.mockReturnValue({
+      data: { manifests: MANIFESTS },
+      isLoading: false,
+    });
+    window.history.replaceState(null, '', '/settings');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState(null, '', '/settings');
+  });
+
+  it('uses the initial hash to pick the active group on mount', async () => {
+    window.history.replaceState(null, '', '/settings#cerebrum');
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:cerebrum')
+    );
+  });
+
+  it('falls back to the first manifest when the hash is empty', async () => {
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:finance')
+    );
+  });
+
+  it('falls back to the first manifest when the hash is unknown', async () => {
+    window.history.replaceState(null, '', '/settings#does-not-exist');
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:finance')
+    );
+  });
+
+  it('updates the active group when the hash changes after mount', async () => {
+    window.history.replaceState(null, '', '/settings#finance');
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:finance')
+    );
+
+    act(() => setHash('media.plex'));
+    await waitFor(() =>
+      expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:media.plex')
+    );
+
+    act(() => setHash('cerebrum'));
+    await waitFor(() =>
+      expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:cerebrum')
+    );
+  });
+
+  it('ignores hashchange events that point to unknown manifests', async () => {
+    window.history.replaceState(null, '', '/settings#cerebrum');
+    render(<SettingsPage />);
+    await waitFor(() =>
+      expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:cerebrum')
+    );
+
+    act(() => setHash('not-a-real-section'));
+    await waitFor(() =>
+      expect(screen.getAllByTestId('section-renderer')[0]).toHaveTextContent('section:finance')
+    );
+  });
+
+  it('removes the hashchange listener on unmount', async () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = render(<SettingsPage />);
+    await waitFor(() => expect(screen.getAllByTestId('section-renderer')[0]).toBeInTheDocument());
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('hashchange', expect.any(Function));
+  });
+});

--- a/apps/pops-shell/src/app/pages/SettingsPage.tsx
+++ b/apps/pops-shell/src/app/pages/SettingsPage.tsx
@@ -1,12 +1,13 @@
 import { SectionRenderer } from '@/components/settings/SectionRenderer';
 import { trpc } from '@/lib/trpc';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Select } from '@pops/ui';
 
 import { SectionNav } from './settings-page/SectionNav';
 import { SettingsEmpty, SettingsLoading } from './settings-page/SettingsLoading';
+import { useHashSelectedId } from './settings-page/useHashSelectedId';
 import { useTestActionHandler } from './settings-page/useTestActionHandler';
 
 import type { SettingsManifest } from '@pops/types';
@@ -32,20 +33,15 @@ export function SettingsPage() {
   const manifests = useMemo(() => (data?.manifests ?? []) as SettingsManifest[], [data?.manifests]);
   const handleTestAction = useTestActionHandler();
 
-  const [selectedId, setSelectedId] = useState<string>(() => window.location.hash.slice(1));
+  const [selectedId, setSelectedId] = useHashSelectedId(manifests);
 
-  // Once manifests load, resolve the selection against valid manifest ids.
-  useEffect(() => {
-    if (!manifests.length) return;
-    const hash = window.location.hash.slice(1);
-    const hasValidHash = hash !== '' && manifests.some((m) => m.id === hash);
-    setSelectedId(hasValidHash ? hash : (manifests[0]?.id ?? ''));
-  }, [manifests]);
-
-  const handleSelect = useCallback((id: string) => {
-    setSelectedId(id);
-    window.history.replaceState(null, '', `#${id}`);
-  }, []);
+  const handleSelect = useCallback(
+    (id: string) => {
+      setSelectedId(id);
+      window.history.replaceState(null, '', `#${id}`);
+    },
+    [setSelectedId]
+  );
 
   const selectedManifest = useMemo(
     () => manifests.find((m) => m.id === selectedId) ?? manifests[0],

--- a/apps/pops-shell/src/app/pages/settings-page/useHashSelectedId.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useHashSelectedId.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+import type { SettingsManifest } from '@pops/types';
+
+/**
+ * Resolves the active settings group from `window.location.hash`. Re-runs when
+ * manifests load and on every subsequent `hashchange` (back/forward navigation,
+ * address-bar edits, programmatic `window.location.hash = '...'`).
+ *
+ * Falls back to the first manifest id when the hash is empty or doesn't match
+ * any known manifest.
+ */
+export function useHashSelectedId(manifests: SettingsManifest[]): [string, (id: string) => void] {
+  const [selectedId, setSelectedId] = useState<string>(() => window.location.hash.slice(1));
+
+  useEffect(() => {
+    if (!manifests.length) return;
+    const resolveFromHash = () => {
+      const hash = window.location.hash.slice(1);
+      const hasValidHash = hash !== '' && manifests.some((m) => m.id === hash);
+      setSelectedId(hasValidHash ? hash : (manifests[0]?.id ?? ''));
+    };
+    resolveFromHash();
+    window.addEventListener('hashchange', resolveFromHash);
+    return () => window.removeEventListener('hashchange', resolveFromHash);
+  }, [manifests]);
+
+  return [selectedId, setSelectedId];
+}


### PR DESCRIPTION
## Summary
- Adds a `hashchange` window listener so back/forward navigation, address-bar edits, and programmatic `window.location.hash = '...'` update the active settings group.
- Extracts the resolution logic into `useHashSelectedId` to keep `SettingsPage` under the per-function line cap and to make the behavior testable in isolation.
- Adds 6 RTL tests covering initial-mount resolution, fallback to the first manifest on empty/unknown hashes, post-mount hash updates, ignored-on-unknown updates, and listener cleanup on unmount.

## Test plan
- [x] `pnpm vitest run src/app/pages/SettingsPage.test.tsx` (6 passed)
- [x] `pnpm test` (173 passed, no regressions)
- [x] `pnpm typecheck`
- [x] `pnpm oxlint` (0 errors; 7 pre-existing warnings unchanged)

Closes #2464