### PR TITLE
fix(i18n): add inventory.connections key to navigation catalog

### DIFF
--- a/apps/pops-shell/src/i18n/index.test.ts
+++ b/apps/pops-shell/src/i18n/index.test.ts
@@ -214,6 +214,7 @@ describe('translation lookups', () => {
     expect(i18n.t('navigation:finance')).toBe('Finance');
     expect(i18n.t('navigation:media.library')).toBe('Library');
     expect(i18n.t('navigation:cerebrum.admin.usage')).toBe('AI Usage');
+    expect(i18n.t('navigation:inventory.connections')).toBe('Connections');
   });
 
   it('resolves finance namespace keys', () => {

--- a/apps/pops-shell/src/i18n/locales/en-AU/navigation.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/navigation.json
@@ -20,6 +20,7 @@
   "inventory.warranties": "Warranties",
   "inventory.locations": "Locations",
   "inventory.reports": "Reports",
+  "inventory.connections": "Connections",
   "cerebrum": "Cerebrum",
   "cerebrum.ingest": "Ingest",
   "cerebrum.chat": "Chat",

--- a/apps/pops-shell/src/i18n/locales/pt-BR/navigation.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/navigation.json
@@ -20,6 +20,7 @@
   "inventory.warranties": "Garantias",
   "inventory.locations": "Localizações",
   "inventory.reports": "Relatórios",
+  "inventory.connections": "Conexões",
   "cerebrum": "Cerebrum",
   "cerebrum.ingest": "Ingerir",
   "cerebrum.chat": "Chat",


### PR DESCRIPTION
## Summary
- Adds the missing \`inventory.connections\` key to en-AU and pt-BR \`navigation.json\`. The Inventory navConfig has been declaring a Connections nav item with this labelKey since the recent ConnectionsPage stub landed, but the navigation namespace catalog was never updated, so the sidebar rendered the raw key.
- Extends the i18n test to assert the new lookup so future drift is caught.

## Test plan
- [x] \`pnpm vitest run src/i18n/index.test.ts\` (50 passed, including the new assertion)
- [x] \`pnpm typecheck\`
- [x] \`pnpm oxlint\` (0 errors)

Closes #2461