### PR TITLE
fix(inventory): align condition filter with form values via shared constant

### DIFF
--- a/packages/app-inventory/package.json
+++ b/packages/app-inventory/package.json
@@ -15,6 +15,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@pops/api": "workspace:*",
     "@pops/api-client": "workspace:*",
+    "@pops/db-types": "workspace:*",
     "@pops/navigation": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.100.6",

--- a/packages/app-inventory/src/pages/ItemsPage.test.tsx
+++ b/packages/app-inventory/src/pages/ItemsPage.test.tsx
@@ -121,10 +121,12 @@ describe('ItemsPage', () => {
       renderPage();
 
       const selects = screen.getAllByRole('combobox');
-      // Condition select: All Conditions + New + Good + Fair + Poor + Broken = 6
+      // All Conditions + Excellent + New + Good + Fair + Poor + Broken = 7
       const conditionSelect = selects[1]!; // second select
       const options = conditionSelect.querySelectorAll('option');
-      expect(options.length).toBe(6);
+      expect(options.length).toBe(7);
+      const values = Array.from(options).map((o) => o.getAttribute('value'));
+      expect(values).toEqual(['', 'Excellent', 'New', 'Good', 'Fair', 'Poor', 'Broken']);
     });
 
     it('shows Clear filters button when a filter is active', () => {
@@ -156,11 +158,19 @@ describe('ItemsPage', () => {
     });
 
     it('reads condition filter from URL params', () => {
-      renderPage('/inventory?condition=good');
+      renderPage('/inventory?condition=Good');
 
       const selects = screen.getAllByRole('combobox');
       const conditionSelect = selects[1];
-      expect(conditionSelect).toHaveValue('good');
+      expect(conditionSelect).toHaveValue('Good');
+    });
+
+    it('reads Excellent condition filter from URL params', () => {
+      renderPage('/inventory?condition=Excellent');
+
+      const selects = screen.getAllByRole('combobox');
+      const conditionSelect = selects[1];
+      expect(conditionSelect).toHaveValue('Excellent');
     });
 
     it('debounces the search query — API receives the term only after 300ms', async () => {

--- a/packages/app-inventory/src/pages/item-form-page/sections/core-fields/ClassificationSection.tsx
+++ b/packages/app-inventory/src/pages/item-form-page/sections/core-fields/ClassificationSection.tsx
@@ -1,5 +1,6 @@
 import { Controller } from 'react-hook-form';
 
+import { INVENTORY_CONDITIONS } from '@pops/db-types';
 import { CheckboxInput, Select } from '@pops/ui';
 
 import { LocationPicker } from '../../../../components/LocationPicker';
@@ -28,14 +29,7 @@ const ITEM_TYPES = [
   'Office',
   'Other',
 ];
-const CONDITIONS = [
-  { value: 'Excellent', label: 'Excellent' },
-  { value: 'New', label: 'New' },
-  { value: 'Good', label: 'Good' },
-  { value: 'Fair', label: 'Fair' },
-  { value: 'Poor', label: 'Poor' },
-  { value: 'Broken', label: 'Broken' },
-];
+const CONDITIONS = INVENTORY_CONDITIONS.map((c) => ({ value: c, label: c }));
 
 /**
  * Restricts the field path to only those whose value type is a boolean. The

--- a/packages/app-inventory/src/pages/items-page/FiltersBar.tsx
+++ b/packages/app-inventory/src/pages/items-page/FiltersBar.tsx
@@ -1,14 +1,11 @@
 import { Search } from 'lucide-react';
 
+import { INVENTORY_CONDITIONS } from '@pops/db-types';
 import { Button, Select, type SelectOption, TextInput } from '@pops/ui';
 
 const CONDITION_OPTIONS: SelectOption[] = [
   { value: '', label: 'All Conditions' },
-  { value: 'new', label: 'New' },
-  { value: 'good', label: 'Good' },
-  { value: 'fair', label: 'Fair' },
-  { value: 'poor', label: 'Poor' },
-  { value: 'broken', label: 'Broken' },
+  ...INVENTORY_CONDITIONS.map((c) => ({ value: c, label: c })),
 ];
 
 const IN_USE_OPTIONS: SelectOption[] = [

--- a/packages/db-types/src/constants.ts
+++ b/packages/db-types/src/constants.ts
@@ -15,3 +15,12 @@ export type WishListPriority = (typeof WISH_LIST_PRIORITIES)[number];
 
 export const MEDIA_TYPES = ['movie', 'tv_show'] as const;
 export type MediaType = (typeof MEDIA_TYPES)[number];
+
+/**
+ * Allowed values for `home_inventory.condition`. Stored title-case in the DB
+ * but matched case-insensitively in the items list filter, so the values can
+ * be used directly in both the edit form and the filter dropdown without
+ * casing transforms.
+ */
+export const INVENTORY_CONDITIONS = ['Excellent', 'New', 'Good', 'Fair', 'Poor', 'Broken'] as const;
+export type InventoryCondition = (typeof INVENTORY_CONDITIONS)[number];

--- a/packages/db-types/src/index.ts
+++ b/packages/db-types/src/index.ts
@@ -212,10 +212,4 @@ export type NudgeLogRow = InferSelectModel<typeof nudgeLog>;
 export type NudgeLogInsert = InferInsertModel<typeof nudgeLog>;
 
 // Constants
-export {
-  ENTITY_TYPES,
-  WISH_LIST_PRIORITIES,
-  MEDIA_TYPES,
-  INVENTORY_CONDITIONS,
-} from './constants.js';
-export type { EntityType, WishListPriority, MediaType, InventoryCondition } from './constants.js';
+export * from './constants.js';

--- a/packages/db-types/src/index.ts
+++ b/packages/db-types/src/index.ts
@@ -212,5 +212,10 @@ export type NudgeLogRow = InferSelectModel<typeof nudgeLog>;
 export type NudgeLogInsert = InferInsertModel<typeof nudgeLog>;
 
 // Constants
-export { ENTITY_TYPES, WISH_LIST_PRIORITIES, MEDIA_TYPES } from './constants.js';
-export type { EntityType, WishListPriority, MediaType } from './constants.js';
+export {
+  ENTITY_TYPES,
+  WISH_LIST_PRIORITIES,
+  MEDIA_TYPES,
+  INVENTORY_CONDITIONS,
+} from './constants.js';
+export type { EntityType, WishListPriority, MediaType, InventoryCondition } from './constants.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -612,6 +612,9 @@ importers:
       '@pops/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@pops/db-types':
+        specifier: workspace:*
+        version: link:../db-types
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation


### PR DESCRIPTION
## Summary
- The inventory items list condition filter was missing \`Excellent\` (so MacBook items seeded with that condition could not be filtered) and used lowercase URL-param values that diverged from the title-case values written to the DB by the edit form.
- Adds \`INVENTORY_CONDITIONS\` to \`@pops/db-types\` as the single source of truth (\`Excellent | New | Good | Fair | Poor | Broken\`) and drives both the form options and the filter dropdown from it.
- Adds \`@pops/db-types\` as a workspace dep of \`@pops/app-inventory\` (was missing) and updates the existing ItemsPage tests to assert the new option set and casing.

The SQL filter was already case-insensitive (\`lower(condition) = lower(?)\`) so existing rows match correctly; old bookmarks like \`?condition=good\` will still filter the rows server-side, just without the dropdown showing the value as selected.

## Test plan
- [x] \`packages/app-inventory\`: 372 passed
- [x] \`apps/pops-shell\`: 167 passed
- [x] turbo \`typecheck\` across all 17 tasks

Closes #2459