### PR TITLE
fix(settings/ai): family-aliased AI model dropdown + migration

### DIFF
--- a/apps/pops-api/src/db/drizzle-migrations/0050_ai_model_setting_alias.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0050_ai_model_setting_alias.sql
@@ -1,0 +1,7 @@
+-- Migrate the global ai.model setting from the deprecated Haiku snapshot id
+-- to the family alias (issue #2463 / matches the family-aliasing in #2440 / #2442).
+-- Idempotent: only updates when the legacy snapshot value is present.
+UPDATE `settings`
+   SET `value` = 'claude-haiku-4-5'
+ WHERE `key` = 'ai.model'
+   AND `value` = 'claude-haiku-4-5-20251001';

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1746057600000,
       "tag": "0049_sonnet_4_6_model_pricing",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "6",
+      "when": 1746058200000,
+      "tag": "0050_ai_model_setting_alias",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/pops-api/src/modules/core/settings/ai-manifest.test.ts
+++ b/apps/pops-api/src/modules/core/settings/ai-manifest.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for the AI Configuration settings manifest.
+ *
+ * Issue #2463 — the global ai.model dropdown previously offered a single
+ * snapshot-id option, leaking the deprecated `claude-haiku-4-5-20251001`
+ * id and giving users no choice. These tests guard against regression.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { aiConfigManifest } from './ai-manifest.js';
+
+import type { SettingsField, SettingsGroup } from '@pops/types';
+
+describe('aiConfigManifest', () => {
+  function findField(key: string): SettingsField | undefined {
+    return aiConfigManifest.groups
+      .flatMap((g: SettingsGroup) => g.fields)
+      .find((f: SettingsField) => f.key === key);
+  }
+
+  it('exposes the model field with family-aliased options', () => {
+    const field = findField('ai.model');
+    expect(field).toBeDefined();
+    expect(field?.type).toBe('select');
+    expect(field?.options).toEqual([
+      { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+      { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+      { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
+    ]);
+  });
+
+  it('uses the haiku family alias as the default (not the snapshot id)', () => {
+    const field = findField('ai.model');
+    expect(field?.default).toBe('claude-haiku-4-5');
+  });
+
+  it('does not expose any deprecated snapshot ids in the option list', () => {
+    const field = findField('ai.model');
+    const values = (field?.options ?? []).map((o: { value: string }) => o.value);
+    for (const value of values) {
+      expect(value, `option value ${value} should not be a snapshot id`).not.toMatch(/-\d{8}$/);
+    }
+  });
+});

--- a/apps/pops-api/src/modules/core/settings/ai-manifest.ts
+++ b/apps/pops-api/src/modules/core/settings/ai-manifest.ts
@@ -14,12 +14,13 @@ export const aiConfigManifest: SettingsManifest = {
           key: 'ai.model',
           label: 'AI Model',
           type: 'select',
-          default: 'claude-haiku-4-5-20251001',
+          description:
+            'Default model for AI operations that do not specify their own. Per-module overrides (e.g. cerebrum.classifier.model) still take precedence.',
+          default: 'claude-haiku-4-5',
           options: [
-            {
-              value: 'claude-haiku-4-5-20251001',
-              label: 'Claude Haiku (claude-haiku-4-5-20251001)',
-            },
+            { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+            { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+            { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
           ],
         },
       ],


### PR DESCRIPTION
## Summary
- The Settings → AI Configuration model dropdown previously offered a single \`Claude Haiku\` option whose label and value leaked the deprecated full snapshot id \`claude-haiku-4-5-20251001\` (same family-aliasing oversight as #2440 / #2442 — that sweep missed this surface).
- Replaces the option list with the three family-aliased models — \`claude-haiku-4-5\`, \`claude-sonnet-4-6\`, \`claude-opus-4-7\` — with friendly labels (\"Claude Haiku 4.5\" etc.) and switches the default to \`claude-haiku-4-5\`.
- Adds migration 0050 to rewrite any existing \`settings\` row with key \`ai.model\` and value \`claude-haiku-4-5-20251001\` to the new family alias, so users with prior selections see the dropdown render the right option.
- Adds focused tests on the manifest asserting the option list, default, and that no snapshot ids leak in.

## Test plan
- [x] \`apps/pops-api\`: new ai-manifest.test.ts (3 passed)
- [x] \`apps/pops-api\`: settings.test.ts + migration-safety.test.ts pass
- [x] turbo \`typecheck\` (17/17 pass)

## Out of scope
The cerebrum manifests under \`packages-api/src/modules/cerebrum/settings/retrieval-ingest-manifest.ts\` and the \`getSettingValue\` defaults in \`scope-inference.ts\` / \`entity-extractor.ts\` / \`classifier.ts\` still hard-code the haiku snapshot id. They're not surfaced through the AI Configuration UI and are intentionally left for a follow-up sweep.

Closes #2463