### PR TITLE
fix(inventory): drop narrow max-width on Warranties / Locations / Connections pages

### DIFF
--- a/packages/app-inventory/src/pages/ConnectionsPage.tsx
+++ b/packages/app-inventory/src/pages/ConnectionsPage.tsx
@@ -7,7 +7,7 @@ export function ConnectionsPage() {
   const { t } = useTranslation('inventory');
 
   return (
-    <div className="space-y-6 max-w-3xl">
+    <div className="space-y-6">
       <PageHeader
         title={t('connections')}
         icon={

--- a/packages/app-inventory/src/pages/LocationTreePage.tsx
+++ b/packages/app-inventory/src/pages/LocationTreePage.tsx
@@ -25,7 +25,7 @@ function EmptyState() {
 
 function ErrorState() {
   return (
-    <div className="space-y-6 max-w-4xl">
+    <div className="space-y-6">
       <PageHeader title="Locations" icon={<MapPin className="h-6 w-6 text-muted-foreground" />} />
       <p className="text-destructive">Failed to load locations.</p>
     </div>
@@ -71,7 +71,7 @@ export function LocationTreePage() {
   const movingNode = model.movingId ? model.nodeMap.get(model.movingId) : null;
 
   return (
-    <div className="space-y-6 max-w-4xl">
+    <div className="space-y-6">
       <PageHeader
         title="Locations"
         icon={<MapPin className="h-6 w-6 text-muted-foreground" />}

--- a/packages/app-inventory/src/pages/WarrantiesPage.tsx
+++ b/packages/app-inventory/src/pages/WarrantiesPage.tsx
@@ -114,7 +114,7 @@ export function WarrantiesPage() {
   const tiers = useMemo(() => categorizeWarranties(data?.data ?? []), [data]);
 
   return (
-    <div className="space-y-6 max-w-3xl">
+    <div className="space-y-6">
       <PageHeader
         title={t('section.warrantyTracking')}
         icon={


### PR DESCRIPTION
## Summary
- The Warranties, Locations, and Connections pages capped their inner container at \`max-w-3xl\` (768px) or \`max-w-4xl\` (896px), leaving 40-60% empty horizontal space on a typical 1372px viewport.
- The shell layout already constrains main content to \`max-w-screen-2xl\` (1536px), so per-page caps were redundant and inconsistent with sibling routes (ItemsPage, ReportDashboardPage) that fill available width.
- Drops the per-page max-width on the three pages.

## Test plan
- [x] \`apps/pops-api\` + workspace turbo \`typecheck\` (17/17 pass)
- [x] \`packages/app-inventory\`: 371 tests pass
- [x] \`pnpm lint\` (0 errors)

Closes #2460