### PR TITLE
fix(a11y): skip-to-content link, html-lang sync, DataTable filter aria-labels

### DIFF
--- a/apps/pops-shell/src/app/layout/RootLayout.tsx
+++ b/apps/pops-shell/src/app/layout/RootLayout.tsx
@@ -19,6 +19,7 @@ import { AmbientBackground } from './root-layout/AmbientBackground';
 import { NavRegion } from './root-layout/NavRegion';
 import { usePageNavAutoClose } from './root-layout/usePageNavAutoClose';
 import { Sidebar } from './Sidebar';
+import { SkipLink } from './SkipLink';
 import { TopBar } from './TopBar';
 
 export function RootLayout() {
@@ -34,6 +35,7 @@ export function RootLayout() {
   return (
     <AppContextProvider>
       <div className={cn('min-h-screen bg-background relative', appColorClass)}>
+        <SkipLink />
         <AmbientBackground />
 
         <div className="relative z-10 pt-14 md:pt-16">
@@ -44,7 +46,11 @@ export function RootLayout() {
             {/* Mobile: overlay sidebar */}
             <Sidebar open={sidebarOpen} />
 
-            <main className="flex-1 min-w-0 overflow-x-clip p-4 md:p-6 lg:p-8 max-w-screen-2xl mx-auto transition-all duration-200">
+            <main
+              id="main-content"
+              tabIndex={-1}
+              className="flex-1 min-w-0 overflow-x-clip p-4 md:p-6 lg:p-8 max-w-screen-2xl mx-auto transition-all duration-200 focus:outline-none"
+            >
               <ErrorBoundary>
                 <Outlet />
               </ErrorBoundary>

--- a/apps/pops-shell/src/app/layout/SkipLink.tsx
+++ b/apps/pops-shell/src/app/layout/SkipLink.tsx
@@ -1,0 +1,22 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Visually-hidden skip-to-content link that becomes visible on focus.
+ *
+ * Lets keyboard-only and screen-reader users bypass the topbar / app rail /
+ * page nav (~30+ tabstops) and jump straight to the page's `<main>` content.
+ * Targets `id="main-content"` set on the shell's `<main>` element. Renders
+ * as the very first focusable element of the document so it's reached on the
+ * first Tab keypress (WCAG 2.4.1 Bypass Blocks).
+ */
+export function SkipLink() {
+  const { t } = useTranslation('shell');
+  return (
+    <a
+      href="#main-content"
+      className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-foreground focus:shadow-lg focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-ring"
+    >
+      {t('skipToContent')}
+    </a>
+  );
+}

--- a/apps/pops-shell/src/i18n/index.test.ts
+++ b/apps/pops-shell/src/i18n/index.test.ts
@@ -135,6 +135,15 @@ describe('locale switching', () => {
     await i18n.changeLanguage('pt-BR');
     expect(i18n.t('common:save')).toBe('Salvar');
   });
+
+  it('mirrors the active language onto <html lang> (#2469)', async () => {
+    await i18n.changeLanguage('en-AU');
+    expect(document.documentElement.getAttribute('lang')).toBe('en-AU');
+    await i18n.changeLanguage('pt-BR');
+    expect(document.documentElement.getAttribute('lang')).toBe('pt-BR');
+    await i18n.changeLanguage('en-AU');
+    expect(document.documentElement.getAttribute('lang')).toBe('en-AU');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/pops-shell/src/i18n/index.ts
+++ b/apps/pops-shell/src/i18n/index.ts
@@ -48,6 +48,18 @@ function getStoredLocale(): SupportedLocale {
 
 const i18n = createInstance();
 
+/**
+ * Mirror the active language onto `<html lang>` so screen readers pick up
+ * pronunciation rules for the rendered content (WCAG 3.1.1 / 3.1.2).
+ */
+function syncHtmlLang(lng: string): void {
+  if (typeof document !== 'undefined') {
+    document.documentElement.setAttribute('lang', lng);
+  }
+}
+
+i18n.on('languageChanged', syncHtmlLang);
+
 void i18n.use(initReactI18next).init({
   lng: getStoredLocale(),
   fallbackLng: DEFAULT_LOCALE,
@@ -79,5 +91,9 @@ void i18n.use(initReactI18next).init({
     },
   },
 });
+
+// `init` does not fire `languageChanged` for the initial language, so set it
+// explicitly here to cover first-paint screen-reader behaviour.
+syncHtmlLang(i18n.language || DEFAULT_LOCALE);
 
 export default i18n;

--- a/apps/pops-shell/src/i18n/locales/en-AU/shell.json
+++ b/apps/pops-shell/src/i18n/locales/en-AU/shell.json
@@ -15,5 +15,6 @@
   "appPages": "{{app}} pages",
   "locale": "Language",
   "localeEnAU": "English (Australia)",
-  "localePtBR": "Portuguese (Brazil)"
+  "localePtBR": "Portuguese (Brazil)",
+  "skipToContent": "Skip to content"
 }

--- a/apps/pops-shell/src/i18n/locales/pt-BR/shell.json
+++ b/apps/pops-shell/src/i18n/locales/pt-BR/shell.json
@@ -15,5 +15,6 @@
   "appPages": "Páginas de {{app}}",
   "locale": "Idioma",
   "localeEnAU": "English (Australia)",
-  "localePtBR": "Português (Brasil)"
+  "localePtBR": "Português (Brasil)",
+  "skipToContent": "Pular para o conteúdo"
 }

--- a/packages/ui/src/components/DataTableFilters.fields.tsx
+++ b/packages/ui/src/components/DataTableFilters.fields.tsx
@@ -8,9 +8,10 @@ import type { Column } from '@tanstack/react-table';
 interface TextFilterProps {
   column: Column<unknown>;
   placeholder?: string;
+  ariaLabel?: string;
 }
 
-export function TextFilter({ column, placeholder }: TextFilterProps) {
+export function TextFilter({ column, placeholder, ariaLabel }: TextFilterProps) {
   return (
     <TextInput
       placeholder={placeholder ?? 'Filter...'}
@@ -19,6 +20,7 @@ export function TextFilter({ column, placeholder }: TextFilterProps) {
       clearable
       onClear={() => column.setFilterValue('')}
       className="w-full"
+      aria-label={ariaLabel}
     />
   );
 }
@@ -27,9 +29,10 @@ interface SelectFilterProps {
   column: Column<unknown>;
   options: SelectOption[];
   placeholder?: string;
+  ariaLabel?: string;
 }
 
-export function SelectFilter({ column, options, placeholder }: SelectFilterProps) {
+export function SelectFilter({ column, options, placeholder, ariaLabel }: SelectFilterProps) {
   return (
     <Select
       value={(column.getFilterValue() as string) ?? ''}
@@ -37,6 +40,7 @@ export function SelectFilter({ column, options, placeholder }: SelectFilterProps
       options={options}
       placeholder={placeholder}
       className="w-full"
+      aria-label={ariaLabel}
     />
   );
 }
@@ -45,9 +49,15 @@ interface MultiSelectFilterProps {
   column: Column<unknown>;
   options: SelectOption[];
   placeholder?: string;
+  ariaLabel?: string;
 }
 
-export function MultiSelectFilter({ column, options, placeholder }: MultiSelectFilterProps) {
+export function MultiSelectFilter({
+  column,
+  options,
+  placeholder,
+  ariaLabel,
+}: MultiSelectFilterProps) {
   const filterValue = (column.getFilterValue() as string[]) ?? [];
 
   return (
@@ -60,16 +70,20 @@ export function MultiSelectFilter({ column, options, placeholder }: MultiSelectF
       multiple
       placeholder={placeholder ?? 'Select...'}
       className="w-full"
+      aria-label={ariaLabel}
     />
   );
 }
 
 interface DateRangeFilterProps {
   column: Column<unknown>;
+  ariaLabel?: string;
 }
 
-export function DateRangeFilter({ column }: DateRangeFilterProps) {
+export function DateRangeFilter({ column, ariaLabel }: DateRangeFilterProps) {
   const filterValue = (column.getFilterValue() as [string, string]) ?? ['', ''];
+  const fromLabel = ariaLabel ? `${ariaLabel} (from)` : 'From';
+  const toLabel = ariaLabel ? `${ariaLabel} (to)` : 'To';
 
   return (
     <div className="flex min-w-0 flex-col gap-2 overflow-hidden sm:flex-row sm:items-center">
@@ -79,6 +93,7 @@ export function DateRangeFilter({ column }: DateRangeFilterProps) {
         onChange={(e) => column.setFilterValue([e.target.value, filterValue[1]])}
         placeholder="From"
         className="min-w-0 flex-1"
+        aria-label={fromLabel}
       />
       <span className="hidden text-muted-foreground sm:block">to</span>
       <TextInput
@@ -87,6 +102,7 @@ export function DateRangeFilter({ column }: DateRangeFilterProps) {
         onChange={(e) => column.setFilterValue([filterValue[0], e.target.value])}
         placeholder="To"
         className="min-w-0 flex-1"
+        aria-label={toLabel}
       />
     </div>
   );
@@ -96,14 +112,18 @@ interface NumberRangeFilterProps {
   column: Column<unknown>;
   minPlaceholder?: string;
   maxPlaceholder?: string;
+  ariaLabel?: string;
 }
 
 export function NumberRangeFilter({
   column,
   minPlaceholder = 'Min',
   maxPlaceholder = 'Max',
+  ariaLabel,
 }: NumberRangeFilterProps) {
   const filterValue = (column.getFilterValue() as [number, number]) ?? [undefined, undefined];
+  const minLabel = ariaLabel ? `${ariaLabel} (min)` : minPlaceholder;
+  const maxLabel = ariaLabel ? `${ariaLabel} (max)` : maxPlaceholder;
 
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -112,6 +132,7 @@ export function NumberRangeFilter({
         onChange={(value) => column.setFilterValue([value, filterValue[1]])}
         placeholder={minPlaceholder}
         className="w-full sm:w-25"
+        aria-label={minLabel}
       />
       <span className="hidden text-muted-foreground sm:block">to</span>
       <NumberInput
@@ -119,6 +140,7 @@ export function NumberRangeFilter({
         onChange={(value) => column.setFilterValue([filterValue[0], value])}
         placeholder={maxPlaceholder}
         className="w-full sm:w-25"
+        aria-label={maxLabel}
       />
     </div>
   );

--- a/packages/ui/src/components/DataTableFilters.tsx
+++ b/packages/ui/src/components/DataTableFilters.tsx
@@ -75,10 +75,15 @@ function FilterControl({
   column: NonNullable<ReturnType<Table<unknown>['getColumn']>>;
 }) {
   if (filter.type === 'text')
-    return <TextFilter column={column} placeholder={filter.placeholder} />;
+    return <TextFilter column={column} placeholder={filter.placeholder} ariaLabel={filter.label} />;
   if (filter.type === 'select' && filter.options)
     return (
-      <SelectFilter column={column} options={filter.options} placeholder={filter.placeholder} />
+      <SelectFilter
+        column={column}
+        options={filter.options}
+        placeholder={filter.placeholder}
+        ariaLabel={filter.label}
+      />
     );
   if (filter.type === 'multiselect' && filter.options)
     return (
@@ -86,10 +91,13 @@ function FilterControl({
         column={column}
         options={filter.options}
         placeholder={filter.placeholder}
+        ariaLabel={filter.label}
       />
     );
-  if (filter.type === 'daterange') return <DateRangeFilter column={column} />;
-  if (filter.type === 'numberrange') return <NumberRangeFilter column={column} />;
+  if (filter.type === 'daterange')
+    return <DateRangeFilter column={column} ariaLabel={filter.label} />;
+  if (filter.type === 'numberrange')
+    return <NumberRangeFilter column={column} ariaLabel={filter.label} />;
   return null;
 }
 


### PR DESCRIPTION
## Summary

Three concrete WCAG fixes from #2469:

### 1. Skip link (WCAG 2.4.1 — Bypass Blocks)
New \`<SkipLink>\` component renders as the first focusable element of the shell and jumps to \`id=\"main-content\"\` set on \`<main>\`. Visually hidden until focused, then becomes a styled pill at top-left. Saves keyboard-only users 30+ tabstops past the topbar / app rail / page nav.

### 2. \`<html lang>\` sync (WCAG 3.1.1 — Language of Page)
i18n now subscribes to \`languageChanged\` and mirrors the active locale onto \`document.documentElement.lang\`. Also runs once at init since i18next does not fire the event for the initial language.

### 3. DataTable filter aria-labels (WCAG 1.3.1 / 3.3.2 — Labels and Instructions)
Threads an \`ariaLabel\` prop from \`FilterControl\` through to the underlying field components (Text/Select/MultiSelect/DateRange/NumberRange) so the per-filter \`<label>\` in the FilterGrid is now exposed to assistive tech via \`aria-label\` on the actual input. Date-range and number-range fields disambiguate their two halves with \`(from)\` / \`(to)\` / \`(min)\` / \`(max)\` suffixes.

## Test plan
- [x] New i18n test asserts \`<html lang>\` updates on locale switch (51 passed)
- [x] All shell tests pass (168)
- [x] All UI tests pass (35)
- [x] turbo \`typecheck\` (17/17 pass)
- [x] \`pnpm lint\` (0 errors)

Closes #2469