### PR TITLE
fix(media): guard TMDB/TheTVDB mappers against surrounding-quote titles

### DIFF
--- a/apps/pops-api/src/db/drizzle-migrations/0051_strip_quoted_tv_show_titles.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0051_strip_quoted_tv_show_titles.sql
@@ -1,0 +1,23 @@
+-- Mirror of `0042_strip_quoted_movie_titles.sql` for the tv_shows table.
+-- Fixes any tv_shows rows whose `name` or `original_name` was persisted with
+-- surrounding double-quote characters via TheTVDB (drift-check #2403; the
+-- upstream guard lives in apps/pops-api/src/modules/media/thetvdb/types-mappers.ts
+-- and apps/pops-api/src/modules/media/lib/strip-surrounding-quotes.ts).
+--
+-- Scope, per column:
+--   - column LIKE '"%"'        → must start AND end with `"` (one-sided untouched)
+--   - length(column) > 2       → excludes bare `""`
+--   - TRIM(column, '"') != ''  → excludes all-quote strings like `"""`
+-- SQLite TRIM(X, Y) removes all Y chars from both ends of X.
+
+UPDATE tv_shows
+SET name = TRIM(name, '"')
+WHERE name LIKE '"%"'
+  AND length(name) > 2
+  AND TRIM(name, '"') != '';
+
+UPDATE tv_shows
+SET original_name = TRIM(original_name, '"')
+WHERE original_name LIKE '"%"'
+  AND length(original_name) > 2
+  AND TRIM(original_name, '"') != '';

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1746058200000,
       "tag": "0050_ai_model_setting_alias",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "6",
+      "when": 1746144600000,
+      "tag": "0051_strip_quoted_tv_show_titles",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/pops-api/src/db/migration-safety.test.ts
+++ b/apps/pops-api/src/db/migration-safety.test.ts
@@ -416,4 +416,147 @@ describe('migration safety', () => {
       db.close();
     });
   });
+
+  describe('0051_strip_quoted_tv_show_titles migration (#2403)', () => {
+    const migrationSql = `
+      UPDATE tv_shows
+      SET name = TRIM(name, '"')
+      WHERE name LIKE '"%"'
+        AND length(name) > 2
+        AND TRIM(name, '"') != '';
+
+      UPDATE tv_shows
+      SET original_name = TRIM(original_name, '"')
+      WHERE original_name LIKE '"%"'
+        AND length(original_name) > 2
+        AND TRIM(original_name, '"') != '';
+    `;
+    const byName = 'SELECT name, original_name FROM tv_shows WHERE name = ?';
+
+    function insertShow(
+      db: BetterSqlite3.Database,
+      name: string,
+      originalName: string | null = null
+    ): void {
+      db.prepare('INSERT INTO tv_shows (tvdb_id, name, original_name) VALUES (?, ?, ?)').run(
+        1,
+        name,
+        originalName
+      );
+    }
+
+    it('strips surrounding quotes from a wrapped name', () => {
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('foreign_keys = ON');
+      initializeSchema(db);
+      insertShow(db, '"The Wire"');
+      db.exec(migrationSql);
+      expect(db.prepare(byName).get('The Wire')).toBeDefined();
+      db.close();
+    });
+
+    it('strips surrounding quotes from original_name independently of name', () => {
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('foreign_keys = ON');
+      initializeSchema(db);
+      insertShow(db, 'The Wire', '"The Wire"');
+      db.exec(migrationSql);
+      const row = db.prepare(byName).get('The Wire') as {
+        name: string;
+        original_name: string;
+      };
+      expect(row.original_name).toBe('The Wire');
+      db.close();
+    });
+
+    it('does not touch a name with only a leading quote', () => {
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('foreign_keys = ON');
+      initializeSchema(db);
+      insertShow(db, '"Something');
+      db.exec(migrationSql);
+      expect(db.prepare(byName).get('"Something')).toBeDefined();
+      db.close();
+    });
+
+    it('does not touch a name with only a trailing quote', () => {
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('foreign_keys = ON');
+      initializeSchema(db);
+      insertShow(db, 'Something"');
+      db.exec(migrationSql);
+      expect(db.prepare(byName).get('Something"')).toBeDefined();
+      db.close();
+    });
+
+    it('does not touch a name with internal quotes', () => {
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('foreign_keys = ON');
+      initializeSchema(db);
+      insertShow(db, 'Show "Title" Format');
+      db.exec(migrationSql);
+      expect(db.prepare(byName).get('Show "Title" Format')).toBeDefined();
+      db.close();
+    });
+
+    it('does not produce an empty name from bare ""', () => {
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('foreign_keys = ON');
+      initializeSchema(db);
+      insertShow(db, '""');
+      db.exec(migrationSql);
+      expect(db.prepare(byName).get('""')).toBeDefined();
+      db.close();
+    });
+
+    it('does not produce an empty name from all-quote string """', () => {
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('foreign_keys = ON');
+      initializeSchema(db);
+      insertShow(db, '"""');
+      db.exec(migrationSql);
+      expect(db.prepare(byName).get('"""')).toBeDefined();
+      db.close();
+    });
+
+    it('does not affect a clean name', () => {
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('foreign_keys = ON');
+      initializeSchema(db);
+      insertShow(db, 'Breaking Bad');
+      db.exec(migrationSql);
+      expect(db.prepare(byName).get('Breaking Bad')).toBeDefined();
+      db.close();
+    });
+
+    it('leaves NULL original_name untouched', () => {
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('foreign_keys = ON');
+      initializeSchema(db);
+      insertShow(db, 'The Sopranos', null);
+      db.exec(migrationSql);
+      const row = db.prepare(byName).get('The Sopranos') as {
+        name: string;
+        original_name: string | null;
+      };
+      expect(row.original_name).toBeNull();
+      db.close();
+    });
+
+    it('is idempotent — running twice gives the same result', () => {
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('foreign_keys = ON');
+      initializeSchema(db);
+      insertShow(db, '"The Wire"', '"The Wire"');
+      db.exec(migrationSql);
+      db.exec(migrationSql);
+      const row = db.prepare(byName).get('The Wire') as {
+        name: string;
+        original_name: string;
+      };
+      expect(row.name).toBe('The Wire');
+      expect(row.original_name).toBe('The Wire');
+      db.close();
+    });
+  });
 });

--- a/apps/pops-api/src/modules/media/lib/strip-surrounding-quotes.test.ts
+++ b/apps/pops-api/src/modules/media/lib/strip-surrounding-quotes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripSurroundingQuotes } from './strip-surrounding-quotes.js';
+
+describe('stripSurroundingQuotes', () => {
+  it('strips balanced surrounding quotes', () => {
+    expect(stripSurroundingQuotes('"Wuthering Heights"')).toBe('Wuthering Heights');
+  });
+
+  it('strips multiple leading/trailing quote chars (mirrors SQLite TRIM)', () => {
+    expect(stripSurroundingQuotes('""Wuthering""')).toBe('Wuthering');
+  });
+
+  it('leaves an unwrapped title alone', () => {
+    expect(stripSurroundingQuotes('The Dark Knight')).toBe('The Dark Knight');
+  });
+
+  it('leaves a title with only a leading quote alone', () => {
+    expect(stripSurroundingQuotes('"Something')).toBe('"Something');
+  });
+
+  it('leaves a title with only a trailing quote alone', () => {
+    expect(stripSurroundingQuotes('Something"')).toBe('Something"');
+  });
+
+  it('preserves internal quotes when the wrapping pair is absent', () => {
+    expect(stripSurroundingQuotes('Film "Noir" Style')).toBe('Film "Noir" Style');
+  });
+
+  it('strips wrapping but preserves internal quotes', () => {
+    expect(stripSurroundingQuotes('"Film "Noir" Style"')).toBe('Film "Noir" Style');
+  });
+
+  it('does not produce an empty string from bare ""', () => {
+    expect(stripSurroundingQuotes('""')).toBe('""');
+  });
+
+  it('does not produce an empty string from all-quote """', () => {
+    expect(stripSurroundingQuotes('"""')).toBe('"""');
+  });
+
+  it('handles empty string', () => {
+    expect(stripSurroundingQuotes('')).toBe('');
+  });
+
+  it('is idempotent', () => {
+    const once = stripSurroundingQuotes('"Wuthering Heights"');
+    const twice = stripSurroundingQuotes(once);
+    expect(twice).toBe('Wuthering Heights');
+  });
+});

--- a/apps/pops-api/src/modules/media/lib/strip-surrounding-quotes.ts
+++ b/apps/pops-api/src/modules/media/lib/strip-surrounding-quotes.ts
@@ -1,0 +1,30 @@
+/**
+ * Strip balanced surrounding double-quote characters from a media title.
+ *
+ * Mirrors the semantics of migration `0042_strip_quoted_movie_titles.sql`
+ * (and its TV-shows companion `0051`), which uses SQLite
+ * `TRIM(title, '"')` gated by `title LIKE '"%"'` and
+ * `TRIM(title, '"') != ''`.
+ *
+ * Use at upstream client mappers (TMDB / TheTVDB) so that titles returned
+ * by the source API with surrounding quotes never reach the database in
+ * that form (issues #2402 / #2403; root cause of #2343 — *Wuthering
+ * Heights* 2026 returned by TMDB as `"Wuthering Heights"`).
+ *
+ * Rules:
+ * - Must start AND end with `"` — one-sided quotes are preserved.
+ * - All leading and all trailing `"` chars are removed (matches `TRIM`).
+ * - If the trimmed result would be empty, the original is preserved
+ *   (so `""` and `"""` are left alone rather than blanked).
+ * - Internal quotes are preserved (e.g. `Film "Noir" Style` is untouched).
+ */
+export function stripSurroundingQuotes(value: string): string {
+  if (!value.startsWith('"') || !value.endsWith('"')) return value;
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '"') start++;
+  while (end > start && value[end - 1] === '"') end--;
+  if (start === 0 && end === value.length) return value;
+  const trimmed = value.slice(start, end);
+  return trimmed.length > 0 ? trimmed : value;
+}

--- a/apps/pops-api/src/modules/media/thetvdb/types-mappers.test.ts
+++ b/apps/pops-api/src/modules/media/thetvdb/types-mappers.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for TheTVDB raw → domain mappers — title quote guard (#2403).
+ *
+ * Mirror of the TMDB-side guard added for #2402. TheTVDB titles travel
+ * through `name` (search + extended) and `name_translated.eng` /
+ * `originalName`. All four are scrubbed of balanced surrounding quotes.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { mapSearchResult, mapShowDetail } from './types-mappers.js';
+
+import type { RawTvdbSearchResult, RawTvdbSeriesExtended } from './types-raw.js';
+
+function rawSearch(overrides: Partial<RawTvdbSearchResult> = {}): RawTvdbSearchResult {
+  return {
+    tvdb_id: '1',
+    name: 'Default',
+    overview: '',
+    first_air_time: '2026-01-01',
+    status: 'Continuing',
+    image_url: null,
+    thumbnail: null,
+    genres: [],
+    primary_language: 'en',
+    year: '2026',
+    ...overrides,
+  };
+}
+
+function rawSeries(overrides: Partial<RawTvdbSeriesExtended> = {}): RawTvdbSeriesExtended {
+  return {
+    id: 1,
+    name: 'Default',
+    originalName: null,
+    overview: '',
+    firstAired: '2026-01-01',
+    lastAired: null,
+    status: { id: 1, name: 'Continuing' },
+    originalLanguage: 'en',
+    averageRuntime: 60,
+    genres: [],
+    networks: [],
+    seasons: [],
+    artworks: [],
+    ...overrides,
+  };
+}
+
+describe('mapSearchResult — title quote guard (#2403)', () => {
+  it('strips surrounding quotes from name', () => {
+    const result = mapSearchResult(rawSearch({ name: '"The Wire"' }));
+    expect(result.name).toBe('The Wire');
+  });
+
+  it('strips surrounding quotes from name_translated.eng (originalName)', () => {
+    const result = mapSearchResult(rawSearch({ name_translated: { eng: '"Breaking Bad"' } }));
+    expect(result.originalName).toBe('Breaking Bad');
+  });
+
+  it('leaves originalName null when no translation is provided', () => {
+    const result = mapSearchResult(rawSearch({ name_translated: null }));
+    expect(result.originalName).toBeNull();
+  });
+
+  it('leaves clean names alone', () => {
+    const result = mapSearchResult(rawSearch({ name: 'Breaking Bad' }));
+    expect(result.name).toBe('Breaking Bad');
+  });
+
+  it('does not strip one-sided quotes', () => {
+    const result = mapSearchResult(rawSearch({ name: 'Lopsided"' }));
+    expect(result.name).toBe('Lopsided"');
+  });
+});
+
+describe('mapShowDetail — title quote guard (#2403)', () => {
+  it('strips surrounding quotes from name', () => {
+    const detail = mapShowDetail(rawSeries({ name: '"The Sopranos"' }));
+    expect(detail.name).toBe('The Sopranos');
+  });
+
+  it('strips surrounding quotes from originalName', () => {
+    const detail = mapShowDetail(rawSeries({ originalName: '"Los Soprano"' }));
+    expect(detail.originalName).toBe('Los Soprano');
+  });
+
+  it('preserves null originalName', () => {
+    const detail = mapShowDetail(rawSeries({ originalName: null }));
+    expect(detail.originalName).toBeNull();
+  });
+
+  it('leaves clean names alone', () => {
+    const detail = mapShowDetail(rawSeries({ name: 'Mad Men' }));
+    expect(detail.name).toBe('Mad Men');
+  });
+});

--- a/apps/pops-api/src/modules/media/thetvdb/types-mappers.ts
+++ b/apps/pops-api/src/modules/media/thetvdb/types-mappers.ts
@@ -1,4 +1,6 @@
 /** Mapping functions: Raw TheTVDB API → Domain. */
+import { stripSurroundingQuotes } from '../lib/strip-surrounding-quotes.js';
+
 import type {
   TvdbArtwork,
   TvdbEpisode,
@@ -28,8 +30,8 @@ function pickFirst<T>(...values: Array<T | null | undefined>): T | null {
 export function mapSearchResult(raw: RawTvdbSearchResult): TvdbSearchResult {
   return {
     tvdbId: Number(pickFirst(raw.tvdb_id, raw.objectID) ?? 0),
-    name: raw.name,
-    originalName: raw.name_translated?.eng ?? null,
+    name: stripSurroundingQuotes(raw.name),
+    originalName: raw.name_translated?.eng ? stripSurroundingQuotes(raw.name_translated.eng) : null,
     overview: pickFirst(raw.overview, raw.overviews?.eng),
     firstAirDate: raw.first_air_time ?? null,
     status: raw.status ?? null,
@@ -77,7 +79,7 @@ interface ShowDetailScalars {
 
 function mapShowDetailScalars(raw: RawTvdbSeriesExtended): ShowDetailScalars {
   return {
-    originalName: raw.originalName ?? null,
+    originalName: raw.originalName ? stripSurroundingQuotes(raw.originalName) : null,
     overview: raw.overview ?? null,
     firstAirDate: raw.firstAired ?? null,
     lastAirDate: raw.lastAired ?? null,
@@ -92,7 +94,7 @@ export function mapShowDetail(raw: RawTvdbSeriesExtended): TvdbShowDetail {
   const rawSeasons = (raw.seasons ?? []).filter(isDefaultOrOfficialSeason);
   return {
     tvdbId: raw.id,
-    name: raw.name,
+    name: stripSurroundingQuotes(raw.name),
     ...mapShowDetailScalars(raw),
     genres: (raw.genres ?? []).map((g) => ({ id: g.id, name: g.name })),
     networks: (raw.networks ?? []).map((n) => ({ id: n.id, name: n.name })),

--- a/apps/pops-api/src/modules/media/tmdb/client-mappers.test.ts
+++ b/apps/pops-api/src/modules/media/tmdb/client-mappers.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for TMDB raw → domain mappers.
+ *
+ * Issue #2402 — guard at the mapper layer so titles returned by TMDB with
+ * surrounding double-quote characters never reach the database in that
+ * form (root cause of #2343, the *Wuthering Heights* 2026 record).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { mapMovieDetail, mapMovieResult } from './client-mappers.js';
+
+import type { RawTmdbMovieDetail, RawTmdbSearchResponse } from './types.js';
+
+type RawMovieResult = RawTmdbSearchResponse['results'][number];
+
+function rawSearchResult(overrides: Partial<RawMovieResult> = {}): RawMovieResult {
+  return {
+    id: 1,
+    title: 'Default Title',
+    original_title: 'Default Original',
+    overview: '',
+    release_date: '2026-01-01',
+    poster_path: null,
+    backdrop_path: null,
+    vote_average: 0,
+    vote_count: 0,
+    genre_ids: [],
+    original_language: 'en',
+    popularity: 0,
+    ...overrides,
+  };
+}
+
+function rawMovieDetail(overrides: Partial<RawTmdbMovieDetail> = {}): RawTmdbMovieDetail {
+  return {
+    id: 1,
+    imdb_id: null,
+    title: 'Default Title',
+    original_title: 'Default Original',
+    overview: '',
+    tagline: '',
+    release_date: '2026-01-01',
+    runtime: 0,
+    status: '',
+    original_language: 'en',
+    budget: 0,
+    revenue: 0,
+    poster_path: null,
+    backdrop_path: null,
+    vote_average: 0,
+    vote_count: 0,
+    genres: [],
+    production_companies: [],
+    spoken_languages: [],
+    ...overrides,
+  };
+}
+
+describe('mapMovieResult — title quote guard (#2402)', () => {
+  it('strips surrounding quotes from title', () => {
+    const result = mapMovieResult(rawSearchResult({ title: '"Wuthering Heights"' }));
+    expect(result.title).toBe('Wuthering Heights');
+  });
+
+  it('strips surrounding quotes from originalTitle', () => {
+    const result = mapMovieResult(rawSearchResult({ original_title: '"Cumbres Borrascosas"' }));
+    expect(result.originalTitle).toBe('Cumbres Borrascosas');
+  });
+
+  it('leaves clean titles alone', () => {
+    const result = mapMovieResult(rawSearchResult({ title: 'The Dark Knight' }));
+    expect(result.title).toBe('The Dark Knight');
+  });
+
+  it('preserves titles with internal quotes', () => {
+    const result = mapMovieResult(rawSearchResult({ title: 'Film "Noir" Style' }));
+    expect(result.title).toBe('Film "Noir" Style');
+  });
+
+  it('does not strip one-sided quotes', () => {
+    const result = mapMovieResult(rawSearchResult({ title: '"Lopsided' }));
+    expect(result.title).toBe('"Lopsided');
+  });
+});
+
+describe('mapMovieDetail — title quote guard (#2402)', () => {
+  it('strips surrounding quotes from title', () => {
+    const detail = mapMovieDetail(rawMovieDetail({ title: '"Wuthering Heights"' }));
+    expect(detail.title).toBe('Wuthering Heights');
+  });
+
+  it('strips surrounding quotes from originalTitle', () => {
+    const detail = mapMovieDetail(rawMovieDetail({ original_title: '"Cumbres Borrascosas"' }));
+    expect(detail.originalTitle).toBe('Cumbres Borrascosas');
+  });
+
+  it('leaves clean titles alone', () => {
+    const detail = mapMovieDetail(rawMovieDetail({ title: 'Inception' }));
+    expect(detail.title).toBe('Inception');
+  });
+});

--- a/apps/pops-api/src/modules/media/tmdb/client-mappers.ts
+++ b/apps/pops-api/src/modules/media/tmdb/client-mappers.ts
@@ -1,3 +1,5 @@
+import { stripSurroundingQuotes } from '../lib/strip-surrounding-quotes.js';
+
 import type {
   RawTmdbImageResponse,
   RawTmdbMovieDetail,
@@ -13,8 +15,8 @@ type RawMovieResult = RawTmdbSearchResponse['results'][number];
 export function mapMovieResult(r: RawMovieResult): TmdbSearchResponse['results'][number] {
   return {
     tmdbId: r.id,
-    title: r.title,
-    originalTitle: r.original_title,
+    title: stripSurroundingQuotes(r.title),
+    originalTitle: stripSurroundingQuotes(r.original_title),
     overview: r.overview,
     releaseDate: r.release_date,
     posterPath: r.poster_path,
@@ -40,8 +42,8 @@ export function mapMovieDetail(raw: RawTmdbMovieDetail): TmdbMovieDetail {
   return {
     tmdbId: raw.id,
     imdbId: raw.imdb_id,
-    title: raw.title,
-    originalTitle: raw.original_title,
+    title: stripSurroundingQuotes(raw.title),
+    originalTitle: stripSurroundingQuotes(raw.original_title),
     overview: raw.overview,
     tagline: raw.tagline,
     releaseDate: raw.release_date,


### PR DESCRIPTION
## Summary

Adds an upstream guard at the TMDB and TheTVDB client-mapper layer so titles returned with balanced surrounding double-quote characters are stripped before they reach the database. Mirrors the semantics of migration `0042_strip_quoted_movie_titles.sql` (which fixed the *Wuthering Heights* 2026 movie record from #2343), extending the same protection to the TV-shows path.

## Changes

- **New helper** `apps/pops-api/src/modules/media/lib/strip-surrounding-quotes.ts` — pure function with the exact `TRIM(x, '\"')` semantics of migration 0042: must start AND end with `\"`, both leading and trailing `\"` chars stripped, no-op when the trimmed result would be empty (`\"\"`, `\"\"\"`), internal quotes preserved. 11 unit tests.
- **TMDB** `client-mappers.ts` — `mapMovieResult` and `mapMovieDetail` apply the guard to `title` and `originalTitle` (closes #2402). 8 focused mapper tests.
- **TheTVDB** `types-mappers.ts` — `mapSearchResult` and `mapShowDetail` apply the guard to `name` and `originalName` (closes #2403). 9 focused mapper tests.
- **Migration 0051** `0051_strip_quoted_tv_show_titles.sql` — strips quotes from any pre-existing `tv_shows.name` / `tv_shows.original_name` rows. Same scope guards as 0042 (`LIKE '\"%\"' AND length > 2 AND TRIM != ''`). 10 new migration-safety tests covering balanced/lopsided/internal/all-quote/null/idempotency cases.

## Test plan
- [x] \`apps/pops-api\`: full test suite (3890 passed)
- [x] turbo \`typecheck\` (17/17 pass)
- [x] \`pnpm lint\` (no new warnings; 142 pre-existing unchanged)

## Why bundle 2402 + 2403

The two issues share the same root cause and remediation pattern. Splitting them would force the helper to live in a shared location regardless, the TMDB and TVDB tests to reference identical fixtures, and the migration to land separately from the upstream guard it pairs with. One PR makes the fix easier to review and revert.

Closes #2402
Closes #2403