### PR TITLE
fix(search/wishlist): exclude already-purchased items from search results

### DIFF
--- a/apps/pops-api/src/modules/finance/wishlist/search-adapter.test.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/search-adapter.test.ts
@@ -156,4 +156,51 @@ describe('wishlist search adapter', () => {
     const hits = search('Gadget', 3);
     expect(hits).toHaveLength(3);
   });
+
+  describe('purchased-item exclusion (#2391)', () => {
+    it('excludes items where saved >= target_amount', () => {
+      seedWishListItem(db, { item: 'Bought Gadget', target_amount: 100, saved: 100 });
+
+      expect(search('Bought Gadget')).toEqual([]);
+    });
+
+    it('excludes items where saved exceeds target_amount', () => {
+      seedWishListItem(db, { item: 'Overshoot Gadget', target_amount: 50, saved: 75 });
+
+      expect(search('Overshoot Gadget')).toEqual([]);
+    });
+
+    it('includes items where saved < target_amount', () => {
+      seedWishListItem(db, { item: 'Saving Gadget', target_amount: 100, saved: 60 });
+
+      const hits = search('Saving Gadget');
+      expect(hits).toHaveLength(1);
+      expect(hits[0]!.data.item).toBe('Saving Gadget');
+    });
+
+    it('includes items with NULL target_amount (no completion threshold)', () => {
+      seedWishListItem(db, { item: 'Open Gadget', target_amount: null, saved: 9999 });
+
+      const hits = search('Open Gadget');
+      expect(hits).toHaveLength(1);
+      expect(hits[0]!.data.targetAmount).toBeNull();
+    });
+
+    it('treats NULL saved as zero — items with a target but no saved progress are included', () => {
+      seedWishListItem(db, { item: 'Untouched Gadget', target_amount: 200, saved: null });
+
+      const hits = search('Untouched Gadget');
+      expect(hits).toHaveLength(1);
+      expect(hits[0]!.data.item).toBe('Untouched Gadget');
+    });
+
+    it('does not affect overall ordering of remaining items', () => {
+      seedWishListItem(db, { item: 'Camera', target_amount: 500, saved: 100 });
+      seedWishListItem(db, { item: 'Camera Mount', target_amount: 500, saved: 500 }); // purchased
+      seedWishListItem(db, { item: 'Camera Bag', target_amount: 100, saved: 0 });
+
+      const hits = search('Camera');
+      expect(hits.map((h) => h.data.item)).toEqual(['Camera', 'Camera Bag']);
+    });
+  });
 });

--- a/apps/pops-api/src/modules/finance/wishlist/search-adapter.ts
+++ b/apps/pops-api/src/modules/finance/wishlist/search-adapter.ts
@@ -1,4 +1,4 @@
-import { like, sql } from 'drizzle-orm';
+import { and, like, sql } from 'drizzle-orm';
 
 import { wishList } from '@pops/db-types';
 
@@ -43,10 +43,20 @@ export const wishlistSearchAdapter: SearchAdapter<WishlistHitData> = {
     const db = getDrizzle();
     const lowerText = text.toLowerCase();
 
+    // Exclude already-purchased items (saved >= target_amount). Items with no
+    // target_amount stay searchable since there is no completion threshold to
+    // compare against. NULL `saved` is treated as 0 via COALESCE so a row with
+    // a target but no recorded savings still counts as not-yet-purchased
+    // (#2391).
     const rows = db
       .select()
       .from(wishList)
-      .where(like(sql`lower(${wishList.item})`, `%${lowerText}%`))
+      .where(
+        and(
+          like(sql`lower(${wishList.item})`, `%${lowerText}%`),
+          sql`(${wishList.targetAmount} IS NULL OR coalesce(${wishList.saved}, 0) < ${wishList.targetAmount})`
+        )
+      )
       .all();
 
     const hits: SearchHit<WishlistHitData>[] = [];


### PR DESCRIPTION
## Summary

Wishlist search adapter previously returned every matching row, including items where \`saved >= target_amount\`. Those items are effectively purchased and rarely what someone is searching for from the global search bar.

Per #2391 the implementation goes with **Option 1 (exclude)** rather than Option 2 (deprioritise) — it matches the wishlist page behaviour where purchased items are typically archived or removed, and avoids dragging completion-state into the relevance scoring path.

## SQL filter

\`\`\`
target_amount IS NULL
OR coalesce(saved, 0) < target_amount
\`\`\`

- NULL \`target_amount\` keeps the row searchable (no completion threshold to compare against).
- NULL \`saved\` is treated as zero so a row with a target but no recorded savings still counts as not-yet-purchased.

## Test plan
- [x] \`apps/pops-api\`: search-adapter.test.ts (19 passed; 6 new covering purchased/in-progress/NULL cases and ordering preservation)
- [x] turbo \`typecheck\` (17/17)
- [x] pre-commit hook (lint + typecheck) clean

Closes #2391