### PR TITLE
refactor(search): type result-component registry with generics

### DIFF
--- a/packages/app-finance/src/components/search/BudgetResult.test.tsx
+++ b/packages/app-finance/src/components/search/BudgetResult.test.tsx
@@ -95,14 +95,10 @@ describe('BudgetResult', () => {
   it('highlights matched category for exact match', () => {
     const { container } = render(
       <BudgetResult
-        data={{
-          category: 'Groceries',
-          period: 'monthly',
-          amount: 500,
-          _query: 'Groceries',
-          _matchField: 'category',
-          _matchType: 'exact',
-        }}
+        data={{ category: 'Groceries', period: 'monthly', amount: 500 }}
+        query="Groceries"
+        matchField="category"
+        matchType="exact"
       />
     );
 
@@ -114,14 +110,10 @@ describe('BudgetResult', () => {
   it('highlights matched category for prefix match', () => {
     const { container } = render(
       <BudgetResult
-        data={{
-          category: 'Entertainment',
-          period: 'monthly',
-          amount: 200,
-          _query: 'Enter',
-          _matchField: 'category',
-          _matchType: 'prefix',
-        }}
+        data={{ category: 'Entertainment', period: 'monthly', amount: 200 }}
+        query="Enter"
+        matchField="category"
+        matchType="prefix"
       />
     );
 
@@ -133,14 +125,10 @@ describe('BudgetResult', () => {
   it('highlights matched category for contains match', () => {
     const { container } = render(
       <BudgetResult
-        data={{
-          category: 'Entertainment',
-          period: 'monthly',
-          amount: 200,
-          _query: 'tain',
-          _matchField: 'category',
-          _matchType: 'contains',
-        }}
+        data={{ category: 'Entertainment', period: 'monthly', amount: 200 }}
+        query="tain"
+        matchField="category"
+        matchType="contains"
       />
     );
 
@@ -152,14 +140,10 @@ describe('BudgetResult', () => {
   it('does not highlight when matchField is not category', () => {
     const { container } = render(
       <BudgetResult
-        data={{
-          category: 'Groceries',
-          period: 'monthly',
-          amount: 500,
-          _query: 'Groceries',
-          _matchField: 'notes',
-          _matchType: 'exact',
-        }}
+        data={{ category: 'Groceries', period: 'monthly', amount: 500 }}
+        query="Groceries"
+        matchField="notes"
+        matchType="exact"
       />
     );
 

--- a/packages/app-finance/src/components/search/BudgetResult.tsx
+++ b/packages/app-finance/src/components/search/BudgetResult.tsx
@@ -1,6 +1,12 @@
 import { registerResultComponent, type ResultComponentProps } from '@pops/navigation';
 import { formatCurrency, highlightMatch, SearchResultItem } from '@pops/ui';
 
+interface BudgetHitData extends Record<string, unknown> {
+  category: string;
+  period: string | null;
+  amount: number | null;
+}
+
 function formatAmount(amount: number | null | undefined): string {
   if (amount == null) return '—';
   return formatCurrency(amount, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
@@ -14,14 +20,13 @@ function formatPeriod(period: string | null | undefined): string {
   return period;
 }
 
-export function BudgetResult({ data }: ResultComponentProps) {
-  const category = (data.category as string) ?? '';
-  const period = data.period as string | null | undefined;
-  const amount = data.amount as number | null | undefined;
-  const query = (data._query as string) ?? '';
-  const matchField = (data._matchField as string) ?? '';
-  const matchType = (data._matchType as string) ?? '';
-
+export function BudgetResult({
+  data,
+  query = '',
+  matchField = '',
+  matchType,
+}: ResultComponentProps<BudgetHitData>) {
+  const { category, period, amount } = data;
   const shouldHighlight = matchField === 'category' && query;
 
   return (

--- a/packages/app-finance/src/components/search/EntitiesResultComponent.test.tsx
+++ b/packages/app-finance/src/components/search/EntitiesResultComponent.test.tsx
@@ -38,12 +38,8 @@ describe('EntitiesResultComponent', () => {
   it('highlights matched portion of name', () => {
     render(
       <EntitiesResultComponent
-        data={{
-          name: 'Woolworths',
-          type: 'company',
-          aliases: [],
-          query: 'wool',
-        }}
+        data={{ name: 'Woolworths', type: 'company', aliases: [] }}
+        query="wool"
       />
     );
 

--- a/packages/app-finance/src/components/search/EntitiesResultComponent.tsx
+++ b/packages/app-finance/src/components/search/EntitiesResultComponent.tsx
@@ -3,13 +3,10 @@ import { Badge, highlightMatch, SearchResultItem } from '@pops/ui';
 
 import type { ResultComponentProps } from '@pops/navigation';
 
-interface EntityHitData {
+interface EntityHitData extends Record<string, unknown> {
   name: string;
   type: string;
   aliases: string[];
-  query?: string;
-  matchField?: string;
-  matchType?: 'exact' | 'prefix' | 'contains';
 }
 
 const entityTypeStyles: Record<string, string> = {
@@ -20,8 +17,8 @@ const entityTypeStyles: Record<string, string> = {
   organisation: 'bg-emerald-500/10 text-emerald-700 border-emerald-500/20 dark:text-emerald-400',
 };
 
-export function EntitiesResultComponent({ data }: ResultComponentProps) {
-  const { name, type, aliases, query } = data as unknown as EntityHitData;
+export function EntitiesResultComponent({ data, query }: ResultComponentProps<EntityHitData>) {
+  const { name, type, aliases } = data;
 
   const style = entityTypeStyles[type] ?? 'bg-muted text-muted-foreground border-transparent';
 

--- a/packages/app-finance/src/components/search/TransactionsResultComponent.tsx
+++ b/packages/app-finance/src/components/search/TransactionsResultComponent.tsx
@@ -5,6 +5,14 @@ import type { ResultComponentProps } from '@pops/navigation';
 
 type TxType = 'income' | 'expense' | 'transfer';
 
+interface TransactionHitData extends Record<string, unknown> {
+  description: string;
+  amount: number;
+  date: string;
+  entityName: string | null;
+  type: string;
+}
+
 interface TransactionData {
   description: string;
   amount: number;
@@ -15,14 +23,13 @@ interface TransactionData {
 
 const VALID_TYPES = new Set<string>(['income', 'expense', 'transfer']);
 
-function parseTransactionData(data: Record<string, unknown>): TransactionData {
-  const rawType = String(data['type'] ?? '');
+function parseTransactionData(data: TransactionHitData): TransactionData {
   return {
-    description: String(data['description'] ?? ''),
-    amount: Number(data['amount'] ?? 0),
-    date: String(data['date'] ?? ''),
-    entityName: data['entityName'] != null ? String(data['entityName']) : null,
-    type: VALID_TYPES.has(rawType) ? (rawType as TxType) : 'expense',
+    description: data.description,
+    amount: data.amount,
+    date: data.date,
+    entityName: data.entityName,
+    type: VALID_TYPES.has(data.type) ? (data.type as TxType) : 'expense',
   };
 }
 
@@ -37,7 +44,11 @@ function amountColorClass(type: TxType): string {
   }
 }
 
-export function TransactionsResultComponent({ data, query, matchField }: ResultComponentProps) {
+export function TransactionsResultComponent({
+  data,
+  query,
+  matchField,
+}: ResultComponentProps<TransactionHitData>) {
   const tx = parseTransactionData(data);
   const shouldHighlight = matchField === 'description' && query;
 

--- a/packages/app-finance/src/components/search/WishlistResult.test.tsx
+++ b/packages/app-finance/src/components/search/WishlistResult.test.tsx
@@ -81,14 +81,10 @@ describe('WishlistResult', () => {
   it('highlights matched item name for exact match', () => {
     const { container } = render(
       <WishlistResult
-        data={{
-          item: 'Japan Trip',
-          priority: null,
-          targetAmount: null,
-          _query: 'Japan Trip',
-          _matchField: 'item',
-          _matchType: 'exact',
-        }}
+        data={{ item: 'Japan Trip', priority: null, targetAmount: null }}
+        query="Japan Trip"
+        matchField="item"
+        matchType="exact"
       />
     );
 
@@ -100,14 +96,10 @@ describe('WishlistResult', () => {
   it('highlights matched item name for prefix match', () => {
     const { container } = render(
       <WishlistResult
-        data={{
-          item: 'Gaming PC',
-          priority: null,
-          targetAmount: null,
-          _query: 'Gaming',
-          _matchField: 'item',
-          _matchType: 'prefix',
-        }}
+        data={{ item: 'Gaming PC', priority: null, targetAmount: null }}
+        query="Gaming"
+        matchField="item"
+        matchType="prefix"
       />
     );
 
@@ -119,14 +111,10 @@ describe('WishlistResult', () => {
   it('highlights matched item name for contains match', () => {
     const { container } = render(
       <WishlistResult
-        data={{
-          item: 'Standing Desk',
-          priority: null,
-          targetAmount: null,
-          _query: 'anding',
-          _matchField: 'item',
-          _matchType: 'contains',
-        }}
+        data={{ item: 'Standing Desk', priority: null, targetAmount: null }}
+        query="anding"
+        matchField="item"
+        matchType="contains"
       />
     );
 
@@ -138,14 +126,10 @@ describe('WishlistResult', () => {
   it('does not highlight when matchField is not item', () => {
     const { container } = render(
       <WishlistResult
-        data={{
-          item: 'Japan Trip',
-          priority: null,
-          targetAmount: null,
-          _query: 'Japan',
-          _matchField: 'notes',
-          _matchType: 'exact',
-        }}
+        data={{ item: 'Japan Trip', priority: null, targetAmount: null }}
+        query="Japan"
+        matchField="notes"
+        matchType="exact"
       />
     );
 

--- a/packages/app-finance/src/components/search/WishlistResult.tsx
+++ b/packages/app-finance/src/components/search/WishlistResult.tsx
@@ -1,6 +1,12 @@
 import { registerResultComponent, type ResultComponentProps } from '@pops/navigation';
 import { formatCurrency, highlightMatch, SearchResultItem } from '@pops/ui';
 
+interface WishlistHitData extends Record<string, unknown> {
+  item: string;
+  priority: string | null;
+  targetAmount: number | null;
+}
+
 function formatAmount(amount: number): string {
   return formatCurrency(amount, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
@@ -10,14 +16,13 @@ function formatPriority(priority: string | null | undefined): string {
   return priority.charAt(0).toUpperCase() + priority.slice(1);
 }
 
-export function WishlistResult({ data }: ResultComponentProps) {
-  const item = (data.item as string) ?? '';
-  const priority = data.priority as string | null | undefined;
-  const targetAmount = data.targetAmount as number | null | undefined;
-  const query = (data._query as string) ?? '';
-  const matchField = (data._matchField as string) ?? '';
-  const matchType = (data._matchType as string) ?? '';
-
+export function WishlistResult({
+  data,
+  query = '',
+  matchField = '',
+  matchType,
+}: ResultComponentProps<WishlistHitData>) {
+  const { item, priority, targetAmount } = data;
   const shouldHighlight = matchField === 'item' && query;
 
   return (

--- a/packages/app-inventory/src/components/search/InventoryItemSearchResult.test.tsx
+++ b/packages/app-inventory/src/components/search/InventoryItemSearchResult.test.tsx
@@ -16,58 +16,62 @@ const baseItem = {
   room: 'Office',
   replacementValue: 4299,
   brand: 'Apple',
-  _query: 'macbook',
-  _matchType: 'prefix',
 };
+
+const matchProps = { query: 'macbook', matchType: 'prefix' as const };
 
 describe('InventoryItemSearchResult', () => {
   it('renders name, brand, and location', () => {
-    render(<InventoryItemSearchResult data={baseItem as unknown as Record<string, unknown>} />);
+    render(<InventoryItemSearchResult data={baseItem} {...matchProps} />);
     expect(screen.getByText(/MacBook/)).toBeInTheDocument();
     expect(screen.getByText('Apple')).toBeInTheDocument();
     expect(screen.getByText('Office · Desk')).toBeInTheDocument();
   });
 
   it('renders formatted replacement value', () => {
-    render(<InventoryItemSearchResult data={baseItem as unknown as Record<string, unknown>} />);
+    render(<InventoryItemSearchResult data={baseItem} {...matchProps} />);
     expect(screen.getByTestId('value')).toHaveTextContent('$4,299');
   });
 
   it('hides value when null', () => {
-    const data = { ...baseItem, replacementValue: null };
-    render(<InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(
+      <InventoryItemSearchResult data={{ ...baseItem, replacementValue: null }} {...matchProps} />
+    );
     expect(screen.queryByTestId('value')).not.toBeInTheDocument();
   });
 
   it('hides brand when null', () => {
-    const data = { ...baseItem, brand: null };
-    render(<InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<InventoryItemSearchResult data={{ ...baseItem, brand: null }} {...matchProps} />);
     expect(screen.queryByText('Apple')).not.toBeInTheDocument();
   });
 
   it('renders location only when room is null', () => {
-    const data = { ...baseItem, room: null };
-    render(<InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<InventoryItemSearchResult data={{ ...baseItem, room: null }} {...matchProps} />);
     expect(screen.getByText('Desk')).toBeInTheDocument();
   });
 
   it('renders room only when location is null', () => {
-    const data = { ...baseItem, location: null };
-    render(<InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<InventoryItemSearchResult data={{ ...baseItem, location: null }} {...matchProps} />);
     expect(screen.getByText('Office')).toBeInTheDocument();
   });
 
   it('hides location text when both room and location are null', () => {
-    const data = { ...baseItem, room: null, location: null };
-    render(<InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(
+      <InventoryItemSearchResult
+        data={{ ...baseItem, room: null, location: null }}
+        {...matchProps}
+      />
+    );
     expect(screen.queryByText('Office')).not.toBeInTheDocument();
     expect(screen.queryByText('Desk')).not.toBeInTheDocument();
   });
 
   it('hides separator between brand and location when location is empty', () => {
-    const data = { ...baseItem, room: null, location: null };
     const { container } = render(
-      <InventoryItemSearchResult data={data as unknown as Record<string, unknown>} />
+      <InventoryItemSearchResult
+        data={{ ...baseItem, room: null, location: null }}
+        {...matchProps}
+      />
     );
     const dots = container.querySelectorAll('span');
     const dotTexts = Array.from(dots).map((el) => el.textContent);

--- a/packages/app-inventory/src/components/search/InventoryItemSearchResult.tsx
+++ b/packages/app-inventory/src/components/search/InventoryItemSearchResult.tsx
@@ -10,7 +10,7 @@ import { formatAUD, highlightMatch, SearchResultItem } from '@pops/ui';
  */
 import type { ResultComponentProps } from '@pops/navigation';
 
-interface InventoryItemHitData {
+interface InventoryItemHitData extends Record<string, unknown> {
   itemName: string;
   location: string | null;
   room: string | null;
@@ -18,14 +18,12 @@ interface InventoryItemHitData {
   brand: string | null;
 }
 
-export function InventoryItemSearchResult({ data }: ResultComponentProps) {
-  const hit = data as unknown as InventoryItemHitData & {
-    _query?: string;
-    _matchType?: string;
-  };
-  const { itemName, location, room, replacementValue, brand } = hit;
-  const query = hit._query ?? '';
-  const matchType = hit._matchType ?? 'contains';
+export function InventoryItemSearchResult({
+  data,
+  query = '',
+  matchType = 'contains',
+}: ResultComponentProps<InventoryItemHitData>) {
+  const { itemName, location, room, replacementValue, brand } = data;
 
   const locationText = [room, location].filter(Boolean).join(' · ');
 

--- a/packages/app-media/src/components/search/MovieSearchResult.test.tsx
+++ b/packages/app-media/src/components/search/MovieSearchResult.test.tsx
@@ -15,76 +15,69 @@ const baseMovie = {
   year: '2008',
   posterUrl: '/media/images/movie/155/poster.jpg',
   voteAverage: 9.0,
-  _query: 'dark',
-  _matchType: 'contains',
+  runtime: null,
 };
+
+const matchProps = { query: 'dark', matchType: 'contains' as const };
 
 describe('MovieSearchResult', () => {
   it('renders title, year, and rating', () => {
-    render(<MovieSearchResult data={baseMovie as unknown as Record<string, unknown>} />);
+    render(<MovieSearchResult data={baseMovie} {...matchProps} />);
     expect(screen.getByText(/Dark/)).toBeInTheDocument();
     expect(screen.getByText('2008')).toBeInTheDocument();
     expect(screen.getByText('9.0')).toBeInTheDocument();
   });
 
   it('renders poster image', () => {
-    render(<MovieSearchResult data={baseMovie as unknown as Record<string, unknown>} />);
+    render(<MovieSearchResult data={baseMovie} {...matchProps} />);
     const img = screen.getByAltText('The Dark Knight poster');
     expect(img).toBeInTheDocument();
     expect(img).toHaveAttribute('src', '/media/images/movie/155/poster.jpg');
   });
 
   it('renders placeholder when no posterUrl', () => {
-    const data = { ...baseMovie, posterUrl: null };
-    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<MovieSearchResult data={{ ...baseMovie, posterUrl: null }} {...matchProps} />);
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 
   it('renders rating with star icon', () => {
-    render(<MovieSearchResult data={baseMovie as unknown as Record<string, unknown>} />);
+    render(<MovieSearchResult data={baseMovie} {...matchProps} />);
     expect(screen.getByTestId('rating')).toBeInTheDocument();
     expect(screen.getByText('9.0')).toBeInTheDocument();
   });
 
   it('hides rating when null', () => {
-    const data = { ...baseMovie, voteAverage: null };
-    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<MovieSearchResult data={{ ...baseMovie, voteAverage: null }} {...matchProps} />);
     expect(screen.queryByTestId('rating')).not.toBeInTheDocument();
   });
 
   it('hides year when null', () => {
-    const data = { ...baseMovie, year: null };
-    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<MovieSearchResult data={{ ...baseMovie, year: null }} {...matchProps} />);
     expect(screen.queryByText('2008')).not.toBeInTheDocument();
   });
 
   it('hides separator when year is null', () => {
-    const data = { ...baseMovie, year: null };
-    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<MovieSearchResult data={{ ...baseMovie, year: null }} {...matchProps} />);
     expect(screen.queryByText('·')).not.toBeInTheDocument();
   });
 
   it('hides separator when rating is null', () => {
-    const data = { ...baseMovie, voteAverage: null };
-    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<MovieSearchResult data={{ ...baseMovie, voteAverage: null }} {...matchProps} />);
     expect(screen.queryByText('·')).not.toBeInTheDocument();
   });
 
   it('renders runtime when present', () => {
-    const data = { ...baseMovie, runtime: 152 };
-    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<MovieSearchResult data={{ ...baseMovie, runtime: 152 }} {...matchProps} />);
     expect(screen.getByTestId('runtime')).toHaveTextContent('2h 32m');
   });
 
   it('renders runtime as minutes-only when under one hour', () => {
-    const data = { ...baseMovie, runtime: 45 };
-    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<MovieSearchResult data={{ ...baseMovie, runtime: 45 }} {...matchProps} />);
     expect(screen.getByTestId('runtime')).toHaveTextContent('45m');
   });
 
   it('hides runtime when null', () => {
-    const data = { ...baseMovie, runtime: null };
-    render(<MovieSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<MovieSearchResult data={{ ...baseMovie, runtime: null }} {...matchProps} />);
     expect(screen.queryByTestId('runtime')).not.toBeInTheDocument();
   });
 

--- a/packages/app-media/src/components/search/MovieSearchResult.tsx
+++ b/packages/app-media/src/components/search/MovieSearchResult.tsx
@@ -12,7 +12,7 @@ import { formatRuntime } from '../../lib/format';
  */
 import type { ResultComponentProps } from '@pops/navigation';
 
-interface MovieHitData {
+interface MovieHitData extends Record<string, unknown> {
   title: string;
   year: string | null;
   posterUrl: string | null;
@@ -36,14 +36,12 @@ function formatRuntimeOrNull(minutes: number | null): string | null {
   return formatRuntime(minutes);
 }
 
-export function MovieSearchResult({ data }: ResultComponentProps) {
-  const hit = data as unknown as MovieHitData & {
-    _query?: string;
-    _matchType?: string;
-  };
-  const { title, year, posterUrl, voteAverage, runtime } = hit;
-  const query = hit._query ?? '';
-  const matchType = hit._matchType ?? 'contains';
+export function MovieSearchResult({
+  data,
+  query = '',
+  matchType = 'contains',
+}: ResultComponentProps<MovieHitData>) {
+  const { title, year, posterUrl, voteAverage, runtime } = data;
   const runtimeLabel = formatRuntimeOrNull(runtime ?? null);
 
   return (

--- a/packages/app-media/src/components/search/TvShowSearchResult.test.tsx
+++ b/packages/app-media/src/components/search/TvShowSearchResult.test.tsx
@@ -17,73 +17,67 @@ const baseTvShow = {
   status: 'Ended',
   numberOfSeasons: 5,
   voteAverage: 9.5,
-  _query: 'breaking',
-  _matchType: 'prefix',
 };
+
+const matchProps = { query: 'breaking', matchType: 'prefix' as const };
 
 describe('TvShowSearchResult', () => {
   it('renders name, year, and season count', () => {
-    render(<TvShowSearchResult data={baseTvShow as unknown as Record<string, unknown>} />);
+    render(<TvShowSearchResult data={baseTvShow} {...matchProps} />);
     expect(screen.getByText(/Breaking/)).toBeInTheDocument();
     expect(screen.getByText('2008')).toBeInTheDocument();
     expect(screen.getByText('5 seasons')).toBeInTheDocument();
   });
 
   it('renders poster image', () => {
-    render(<TvShowSearchResult data={baseTvShow as unknown as Record<string, unknown>} />);
+    render(<TvShowSearchResult data={baseTvShow} {...matchProps} />);
     const img = screen.getByAltText('Breaking Bad poster');
     expect(img).toBeInTheDocument();
     expect(img).toHaveAttribute('src', '/media/images/tv/81189/poster.jpg');
   });
 
   it('renders placeholder when no posterUrl', () => {
-    const data = { ...baseTvShow, posterUrl: null };
-    render(<TvShowSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<TvShowSearchResult data={{ ...baseTvShow, posterUrl: null }} {...matchProps} />);
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 
   it("renders singular 'season' for 1 season", () => {
-    const data = { ...baseTvShow, numberOfSeasons: 1 };
-    render(<TvShowSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<TvShowSearchResult data={{ ...baseTvShow, numberOfSeasons: 1 }} {...matchProps} />);
     expect(screen.getByText('1 season')).toBeInTheDocument();
   });
 
   it('hides season count when null', () => {
-    const data = { ...baseTvShow, numberOfSeasons: null };
-    render(<TvShowSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<TvShowSearchResult data={{ ...baseTvShow, numberOfSeasons: null }} {...matchProps} />);
     expect(screen.queryByText(/season/)).not.toBeInTheDocument();
   });
 
   it('hides year when null', () => {
-    const data = { ...baseTvShow, year: null };
-    render(<TvShowSearchResult data={data as unknown as Record<string, unknown>} />);
+    render(<TvShowSearchResult data={{ ...baseTvShow, year: null }} {...matchProps} />);
     expect(screen.queryByText('2008')).not.toBeInTheDocument();
   });
 
   describe('status badge', () => {
     it('renders status badge for Ended', () => {
-      render(<TvShowSearchResult data={baseTvShow as unknown as Record<string, unknown>} />);
+      render(<TvShowSearchResult data={baseTvShow} {...matchProps} />);
       const badge = screen.getByTestId('status-badge');
       expect(badge).toHaveTextContent('Ended');
     });
 
     it('renders status badge for Continuing with blue style', () => {
-      const data = { ...baseTvShow, status: 'Continuing' };
-      render(<TvShowSearchResult data={data as unknown as Record<string, unknown>} />);
+      render(<TvShowSearchResult data={{ ...baseTvShow, status: 'Continuing' }} {...matchProps} />);
       const badge = screen.getByTestId('status-badge');
       expect(badge).toHaveTextContent('Continuing');
       expect(badge.className).toContain('bg-info');
     });
 
     it('renders Ended badge without blue style', () => {
-      render(<TvShowSearchResult data={baseTvShow as unknown as Record<string, unknown>} />);
+      render(<TvShowSearchResult data={baseTvShow} {...matchProps} />);
       const badge = screen.getByTestId('status-badge');
       expect(badge.className).not.toContain('bg-info');
     });
 
     it('hides status badge when null', () => {
-      const data = { ...baseTvShow, status: null };
-      render(<TvShowSearchResult data={data as unknown as Record<string, unknown>} />);
+      render(<TvShowSearchResult data={{ ...baseTvShow, status: null }} {...matchProps} />);
       expect(screen.queryByTestId('status-badge')).not.toBeInTheDocument();
     });
   });

--- a/packages/app-media/src/components/search/TvShowSearchResult.tsx
+++ b/packages/app-media/src/components/search/TvShowSearchResult.tsx
@@ -10,7 +10,7 @@ import { Badge, cn, highlightMatch, SearchResultItem } from '@pops/ui';
  */
 import type { ResultComponentProps } from '@pops/navigation';
 
-interface TvShowHitData {
+interface TvShowHitData extends Record<string, unknown> {
   name: string;
   year: string | null;
   posterUrl: string | null;
@@ -34,14 +34,12 @@ export function TvShowStatusBadge({ status }: { status: string | null }) {
   );
 }
 
-export function TvShowSearchResult({ data }: ResultComponentProps) {
-  const hit = data as unknown as TvShowHitData & {
-    _query?: string;
-    _matchType?: string;
-  };
-  const { name, year, posterUrl, status, numberOfSeasons } = hit;
-  const query = hit._query ?? '';
-  const matchType = hit._matchType ?? 'contains';
+export function TvShowSearchResult({
+  data,
+  query = '',
+  matchType = 'contains',
+}: ResultComponentProps<TvShowHitData>) {
+  const { name, year, posterUrl, status, numberOfSeasons } = data;
 
   return (
     <SearchResultItem

--- a/packages/navigation/src/result-component-registry.tsx
+++ b/packages/navigation/src/result-component-registry.tsx
@@ -1,8 +1,15 @@
 import type { ComponentType } from 'react';
 
-/** Props passed to every result component by the search panel. */
-export interface ResultComponentProps {
-  data: Record<string, unknown>;
+/**
+ * Props passed to every result component by the search panel.
+ *
+ * `T` is the per-domain hit-data shape produced by the SearchAdapter that
+ * registered this component. Defaulting to `Record<string, unknown>` keeps
+ * the call site (the search panel) generic — it can dispatch by domain
+ * without knowing the concrete shape.
+ */
+export interface ResultComponentProps<T = Record<string, unknown>> {
+  data: T;
   /** Raw query string for match highlighting. */
   query?: string;
   /** Which field matched (e.g. "description", "name"). */
@@ -11,8 +18,8 @@ export interface ResultComponentProps {
   matchType?: string;
 }
 
-/** A React component that renders a single search result. */
-export type ResultComponent = ComponentType<ResultComponentProps>;
+/** A React component that renders a single search result for a given hit shape. */
+export type ResultComponent<T = Record<string, unknown>> = ComponentType<ResultComponentProps<T>>;
 
 /** Generic fallback — renders the first string field found in `data`. */
 export function GenericResultComponent({ data }: ResultComponentProps) {
@@ -23,11 +30,22 @@ export function GenericResultComponent({ data }: ResultComponentProps) {
 const registry = new Map<string, ResultComponent>();
 
 /**
- * Register a ResultComponent for a given domain.
- * Each app package calls this at load time as a side effect.
+ * Register a typed `ResultComponent<T>` for a given domain.
+ *
+ * Each app package calls this at load time as a side effect. `T` lets a
+ * component declare the exact `HitData` shape it expects — inside the
+ * component, `data` is typed as `T` instead of an opaque record, so no
+ * per-field casts are needed.
+ *
+ * The registry storage erases `T` (the search panel does not — and should
+ * not — know each domain's shape), so a single narrowing assignment crosses
+ * the boundary here. Runtime safety relies on the contract that the
+ * SearchAdapter for `domain` produces hits matching `T`.
  */
-export function registerResultComponent(domain: string, component: ResultComponent): void {
-  registry.set(domain, component);
+export function registerResultComponent<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(domain: string, component: ResultComponent<T>): void {
+  registry.set(domain, component as ResultComponent);
 }
 
 /**

--- a/packages/navigation/src/search-results/SectionView.tsx
+++ b/packages/navigation/src/search-results/SectionView.tsx
@@ -63,12 +63,10 @@ function ResultButton({
         data-result-index={index}
       >
         <ResultComponent
-          data={{
-            ...hit.data,
-            _query: query,
-            _matchField: hit.matchField,
-            _matchType: hit.matchType,
-          }}
+          data={hit.data}
+          query={query}
+          matchField={hit.matchField}
+          matchType={hit.matchType}
         />
       </button>
     </li>


### PR DESCRIPTION
## Summary

Replaces per-component data casts with a typed registry contract, per #2389. Components registered via:

\`\`\`ts
registerResultComponent<WishlistHitData>('wishlist', WishlistResult);
\`\`\`

now receive \`ResultComponentProps<WishlistHitData>\` directly — \`data\` is the per-domain shape, no \`as\` reach-ins, no \`as unknown as HitData\` anywhere.

The registry storage still erases \`T\` (the search panel must dispatch by domain without knowing each shape), so the contract narrows in exactly one place: a single \`as ResultComponent\` inside \`registerResultComponent\` itself. Runtime safety relies on the contract that each SearchAdapter produces hits matching its component's \`T\`.

## Bonus cleanup

The previous code had a long-standing inconsistency: \`SectionView\` injected \`_query\` / \`_matchField\` / \`_matchType\` into the data record, while \`ResultComponentProps\` already declared them as proper props (only \`TransactionsResultComponent\` actually consumed them via props). \`SectionView\` now passes them as props (matching the contract); every consumer reads them from props instead of \`data._query\` etc. This was what made the typed \`data: T\` shape land cleanly — components no longer have to reach into \`data\` for engine-side metadata.

## Files

- \`packages/navigation/src/result-component-registry.tsx\` — typed \`ResultComponent<T>\`, generic register
- \`packages/navigation/src/search-results/SectionView.tsx\` — pass meta via props, drop \`_*\` injection
- 6 result components + their tests across app-finance, app-inventory, app-media — drop casts, type their \`HitData\`, read meta from props

## Test plan
- [x] 199 search-related tests pass (navigation 113 + finance 39 + inventory 14 + media 33)
- [x] Full workspace turbo \`typecheck\` (17/17)
- [x] \`pnpm lint\` — warnings dropped from 142 → 130 (12 fewer due to removed casts), 0 errors

Closes #2389