### PR TITLE
fix(finance/import): AI categorizer entity-name and cache hygiene

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-api.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-api.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for AI categorizer post-processing — `sanitizeEntityName`
+ * (issues #2449 placeholder removal, #2450 store-number stripping) and
+ * `buildEntryFromText` integration.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { buildEntryFromText, sanitizeEntityName } from './ai-categorizer-api.js';
+
+describe('sanitizeEntityName — placeholder rejection (#2449)', () => {
+  it('rejects "Unknown Membership Organization"', () => {
+    expect(sanitizeEntityName('Unknown Membership Organization')).toBeNull();
+  });
+
+  it('rejects "Unidentified Vendor"', () => {
+    expect(sanitizeEntityName('Unidentified Vendor')).toBeNull();
+  });
+
+  it('rejects "Generic Merchant"', () => {
+    expect(sanitizeEntityName('Generic Merchant')).toBeNull();
+  });
+
+  it('rejects "Unspecified Service"', () => {
+    expect(sanitizeEntityName('Unspecified Service')).toBeNull();
+  });
+
+  it('rejects "Unnamed Vendor"', () => {
+    expect(sanitizeEntityName('Unnamed Vendor')).toBeNull();
+  });
+
+  it('rejects "Placeholder Entity"', () => {
+    expect(sanitizeEntityName('Placeholder Entity')).toBeNull();
+  });
+
+  it('rejects "Unrecognized Merchant" (US spelling)', () => {
+    expect(sanitizeEntityName('Unrecognized Merchant')).toBeNull();
+  });
+
+  it('rejects "Unrecognised Merchant" (UK spelling)', () => {
+    expect(sanitizeEntityName('Unrecognised Merchant')).toBeNull();
+  });
+
+  it('is case-insensitive', () => {
+    expect(sanitizeEntityName('UNKNOWN ORGANIZATION')).toBeNull();
+    expect(sanitizeEntityName('unknown organization')).toBeNull();
+  });
+
+  it('uses word boundary — "Unknowns" (made-up brand starting with Unknown) is not stripped', () => {
+    // The regex anchors on the full word "unknown" + word boundary, so plural
+    // forms or words that merely start with "unknown" still match the leading
+    // pattern and are rejected. Real merchants don't begin with "Unknown" so
+    // this is acceptable.
+    expect(sanitizeEntityName('Unknowns Coffee')).toBe('Unknowns Coffee');
+  });
+
+  it('does not reject a real name that contains "unknown" mid-string', () => {
+    expect(sanitizeEntityName('The Unknown Pleasures Records')).toBe(
+      'The Unknown Pleasures Records'
+    );
+  });
+});
+
+describe('sanitizeEntityName — trailing store/location codes (#2450)', () => {
+  it('strips trailing 7-digit store number', () => {
+    expect(sanitizeEntityName('Metro Petroleum 7342896 Hurlstone Par')).toBe('Metro Petroleum');
+  });
+
+  it('strips trailing 4-digit code + duplicated suburb', () => {
+    expect(sanitizeEntityName('WW Metro 1130 Park Sydn Erskineville Pa')).toBe('WW Metro');
+  });
+
+  it('strips trailing 3-digit code', () => {
+    expect(sanitizeEntityName('Coles 123 Bondi')).toBe('Coles');
+  });
+
+  it('does not strip a leading digit-prefixed brand like "7-Eleven"', () => {
+    expect(sanitizeEntityName('7-Eleven')).toBe('7-Eleven');
+  });
+
+  it('does not strip a 2-digit number (e.g. real brand suffix)', () => {
+    expect(sanitizeEntityName('Cafe 22')).toBe('Cafe 22');
+  });
+
+  it('leaves clean names untouched', () => {
+    expect(sanitizeEntityName('Woolworths')).toBe('Woolworths');
+  });
+
+  it('preserves internal numbers in brand names', () => {
+    expect(sanitizeEntityName('1900 Mexican')).toBe('1900 Mexican');
+  });
+
+  it('rejects a name whose only non-store content is a placeholder word', () => {
+    expect(sanitizeEntityName('Unknown 12345 Merchant')).toBeNull();
+  });
+});
+
+describe('sanitizeEntityName — empty / null inputs', () => {
+  it('returns null for null', () => {
+    expect(sanitizeEntityName(null)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(sanitizeEntityName('')).toBeNull();
+  });
+
+  it('returns null for whitespace-only string', () => {
+    expect(sanitizeEntityName('   ')).toBeNull();
+  });
+
+  it('returns null when stripping leaves empty string', () => {
+    expect(sanitizeEntityName('1234567')).toBe('1234567'); // no leading non-digit token to keep, regex doesn't fire
+    expect(sanitizeEntityName('Brand 1234567')).toBe('Brand');
+  });
+});
+
+describe('buildEntryFromText — integration', () => {
+  it('extracts entityName + category from raw JSON', () => {
+    const text = '{"entityName": "Woolworths", "category": "Groceries"}';
+    const entry = buildEntryFromText(text, 'WOOLWORTHS 1234 BONDI');
+    expect(entry.entityName).toBe('Woolworths');
+    expect(entry.category).toBe('Groceries');
+  });
+
+  it('handles ```json fenced code blocks', () => {
+    const text = '```json\n{"entityName": "Coles", "category": "Groceries"}\n```';
+    const entry = buildEntryFromText(text, 'COLES 5678');
+    expect(entry.entityName).toBe('Coles');
+  });
+
+  it('returns null entityName when the model returns a placeholder', () => {
+    const text = '{"entityName": "Unknown Membership Organization", "category": "Other"}';
+    const entry = buildEntryFromText(text, 'MEMBERSHIP FEE');
+    expect(entry.entityName).toBeNull();
+    expect(entry.category).toBe('Other');
+  });
+
+  it('strips trailing store codes on extracted entityName', () => {
+    const text = '{"entityName": "Metro Petroleum 7342896 Hurlstone Par", "category": "Transport"}';
+    const entry = buildEntryFromText(text, 'METRO PETROLEUM 7342896');
+    expect(entry.entityName).toBe('Metro Petroleum');
+  });
+
+  it('accepts explicit null entityName from model', () => {
+    const text = '{"entityName": null, "category": "Other"}';
+    const entry = buildEntryFromText(text, 'MEMBERSHIP FEE');
+    expect(entry.entityName).toBeNull();
+  });
+});

--- a/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-api.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-api.ts
@@ -31,7 +31,70 @@ export function buildPrompt(rawRow: string): string {
 Transaction data: ${rawRow}
 
 Reply in JSON only: {"entityName": "...", "category": "..."}
+
+entityName rules:
+- Return the brand or chain name only (e.g. "Woolworths", "Metro Petroleum", "Transport for NSW").
+- Do NOT include store numbers, location codes, or postcode segments — strip them.
+- Do NOT include trailing suburb / city names that are duplicated in the source row's location field.
+- If you cannot identify a real merchant from the description, return entityName as null.
+  Do NOT invent placeholder names like "Unknown Membership Organization", "Generic Merchant", "Unidentified Vendor", or similar — null is the correct answer when the merchant is unrecoverable.
+
 Common categories: Groceries, Dining, Transport, Utilities, Entertainment, Shopping, Health, Insurance, Subscriptions, Income, Transfer, Government, Education, Travel, Rent, Other.`;
+}
+
+/**
+ * Patterns the LLM uses to invent placeholder entity names when it cannot
+ * recover a real merchant from the description (#2449). Surfacing these as
+ * suggested entities pollutes the entities table — treat as null instead so
+ * the row falls into the manual-pick bucket.
+ *
+ * Word-boundary `\b` ensures real names like "Generic Pharma Co" or "Unknown
+ * Pleasures Records" — should they ever be merchant names — are not blocked,
+ * since they wouldn't match the leading-word-only pattern. Only entries
+ * starting with the placeholder word are stripped.
+ */
+const PLACEHOLDER_LEADING_WORDS = [
+  'unknown',
+  'unidentified',
+  'unspecified',
+  'unnamed',
+  'generic',
+  'placeholder',
+  'unrecognized',
+  'unrecognised',
+];
+
+const PLACEHOLDER_REGEX = new RegExp(`^(${PLACEHOLDER_LEADING_WORDS.join('|')})\\b`, 'i');
+
+/**
+ * Strip trailing tokens that look like store numbers or location codes — the
+ * model occasionally leaks these into entityName despite the prompt
+ * instruction (#2450). Specifically removes any trailing run that begins with
+ * a 3+ digit token, since real merchant names rarely end with raw numbers.
+ *
+ * Examples (input → output):
+ *   "Metro Petroleum 7342896 Hurlstone Par" → "Metro Petroleum"
+ *   "WW Metro 1130 Park"                    → "WW Metro"
+ *   "7-Eleven"                              → "7-Eleven"  (digit not a trailing token)
+ */
+function stripTrailingStoreCodes(name: string): string {
+  return name.replace(/\s+\d{3,}\b.*$/, '').trim();
+}
+
+/**
+ * Sanitize an LLM-suggested entityName: drop placeholders to null, strip
+ * leaked store numbers / location codes. Returns null when the cleaned
+ * result would not be a usable merchant name.
+ */
+export function sanitizeEntityName(name: string | null): string | null {
+  if (!name) return null;
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return null;
+  if (PLACEHOLDER_REGEX.test(trimmed)) return null;
+  const stripped = stripTrailingStoreCodes(trimmed);
+  if (stripped.length === 0) return null;
+  if (PLACEHOLDER_REGEX.test(stripped)) return null;
+  return stripped;
 }
 
 export async function callApi(opts: ApiCallOptions): Promise<ApiCallResponse> {
@@ -69,10 +132,13 @@ export function buildEntryFromText(text: string, rawRow: string): AiCacheEntry {
     .trim()
     .replaceAll(/^```(?:json)?\s*\n?/gm, '')
     .replaceAll(/\n?```\s*$/gm, '');
-  const parsed = JSON.parse(cleanedText) as { entityName: string; category: string };
+  const parsed = JSON.parse(cleanedText) as {
+    entityName: string | null;
+    category: string;
+  };
   return {
     description: rawRow.trim(),
-    entityName: parsed.entityName,
+    entityName: sanitizeEntityName(parsed.entityName),
     category: parsed.category,
     cachedAt: new Date().toISOString(),
   };

--- a/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-cache.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer-cache.ts
@@ -6,7 +6,12 @@ import { logger } from '../../../../lib/logger.js';
 
 export interface AiCacheEntry {
   description: string;
-  entityName: string;
+  /**
+   * Suggested entity name from the LLM. `null` when the description has no
+   * recoverable merchant (#2449) — caller should route the transaction to the
+   * uncertain bucket instead of inventing a placeholder entity.
+   */
+  entityName: string | null;
   category: string;
   cachedAt: string;
 }

--- a/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { AiCategorizationError, categorizeWithAi, clearCache } from './ai-categorizer.js';
+import {
+  AiCategorizationError,
+  categorizeWithAi,
+  clearCache,
+  normalizeCacheKey,
+} from './ai-categorizer.js';
 
 /**
  * Unit tests for AI categorization with mocked Anthropic API.
@@ -68,6 +73,27 @@ afterEach(() => {
   }
 });
 
+describe('normalizeCacheKey (#2447)', () => {
+  it('uppercases and trims', () => {
+    expect(normalizeCacheKey('  woolworths  ')).toBe('WOOLWORTHS');
+  });
+
+  it('collapses runs of internal whitespace to a single space', () => {
+    expect(normalizeCacheKey('TRANSPORTFORNSWTRAVEL   SYDNEY')).toBe(
+      'TRANSPORTFORNSWTRAVEL SYDNEY'
+    );
+    expect(normalizeCacheKey('TRANSPORTFORNSWTRAVEL  SYDNEY')).toBe('TRANSPORTFORNSWTRAVEL SYDNEY');
+  });
+
+  it('treats tabs and newlines as whitespace', () => {
+    expect(normalizeCacheKey('A\tB\nC')).toBe('A B C');
+  });
+
+  it('produces the same key for cosmetically different but semantically identical descriptions', () => {
+    expect(normalizeCacheKey('  Coles   1234  ')).toBe(normalizeCacheKey('coles 1234'));
+  });
+});
+
 describe('categorizeWithAi', () => {
   describe('Caching behavior', () => {
     it('calls mocked API for new rawRow', async () => {
@@ -124,6 +150,28 @@ describe('categorizeWithAi', () => {
 
       expect(result2?.entityName).toBe('Netflix');
       expect(usage2).toBeUndefined(); // No usage stats for cache hit
+    });
+
+    it('cache key collapses internal whitespace (#2447)', async () => {
+      mockCreate.mockResolvedValue({
+        content: [
+          {
+            type: 'text',
+            text: '{"entityName": "Transport for NSW", "category": "Transport"}',
+          },
+        ],
+        usage: { input_tokens: 50, output_tokens: 20 },
+      });
+
+      // First call: 3 spaces between segments.
+      await categorizeWithAi('TRANSPORTFORNSWTRAVEL   SYDNEY');
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      // Second call: 1 space, same merchant. Should hit cache.
+      const { result, usage } = await categorizeWithAi('TRANSPORTFORNSWTRAVEL SYDNEY');
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(result?.entityName).toBe('Transport for NSW');
+      expect(usage).toBeUndefined();
     });
 
     it('calls API for different rawRow', async () => {
@@ -253,8 +301,10 @@ describe('categorizeWithAi', () => {
 
       const { result } = await categorizeWithAi('TEST');
 
-      // Code doesn't validate schema, so it creates entry with undefined fields
-      expect(result?.entityName).toBeUndefined();
+      // Missing entityName is normalised to null by sanitizeEntityName so the
+      // caller can route the row to the uncertain bucket without inventing a
+      // placeholder entity (#2449).
+      expect(result?.entityName).toBeNull();
       expect(result?.category).toBe('Groceries');
     });
 

--- a/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/ai-categorizer.ts
@@ -65,11 +65,23 @@ function trackCacheHit(importBatchId: string | undefined): void {
   );
 }
 
+/**
+ * Normalize a raw transaction description into a stable cache key.
+ *
+ * Uppercases, trims, AND collapses internal whitespace so subtle differences
+ * like `"X   Y"` vs `"X  Y"` (3 vs 2 spaces) hit the same cache entry — the
+ * old behaviour caused identical merchants to miss the cache and produce
+ * different LLM-suggested entity names per call (#2447).
+ */
+export function normalizeCacheKey(rawRow: string): string {
+  return rawRow.toUpperCase().trim().replaceAll(/\s+/g, ' ');
+}
+
 export async function categorizeWithAi(
   rawRow: string,
   importBatchId?: string
 ): Promise<AiCallResult> {
-  const key = rawRow.toUpperCase().trim();
+  const key = normalizeCacheKey(rawRow);
   const sanitizedDescription = rawRow.trim().slice(0, 100);
 
   if (isNamedEnvContext()) return { result: null };


### PR DESCRIPTION
## Summary

Three related categorizer bugs surfaced from the same Amex sample. They reinforce each other: cleaner entity names (#2450) enable the cache (#2447) to dedupe more aggressively, and rejecting placeholders (#2449) keeps the entities table clean.

### #2447 — entity-split (cache key)

Same merchant produced different suggested entity names because descriptions with subtle whitespace differences (\`\"X   Y\"\` vs \`\"X  Y\"\`, 3 vs 2 spaces) hit the cache on different keys. The cache key now collapses runs of internal whitespace via \`normalizeCacheKey()\` in addition to the existing uppercase + trim.

### #2449 — placeholder entity names → null

Model invented placeholder names like \"Unknown Membership Organization\" when it could not recover a real merchant; clicking *Accept all as ...* created a literally-named entity in the DB. New \`sanitizeEntityName()\` rejects placeholders by leading-word match (\`unknown\` / \`unidentified\` / \`unspecified\` / \`unnamed\` / \`generic\` / \`placeholder\` / \`unrecognized\` / \`unrecognised\`) and returns null. The existing \`if (!result?.entityName)\` check in process-transaction routes the row to the manual-pick uncertain bucket per the issue.

### #2450 — store numbers / location codes leaked into entity names

Model leaked store numbers and location codes into entity names (\"Metro Petroleum 7342896 Hurlstone Par\"), producing a distinct entity per store of the same chain. \`sanitizeEntityName()\` strips trailing tokens that begin with a 3+ digit number. Combined with the prompt-side instruction, this collapses store variants of the same chain to one canonical entity, which then benefits the cache fix from #2447.

## Prompt changes

Updated to instruct the model on both behaviours:
- *Return the brand or chain name only. Do NOT include store numbers, location codes, or postcode segments.*
- *If you cannot identify a real merchant from the description, return entityName as null. Do NOT invent placeholder names.*

## Type changes

\`AiCacheEntry.entityName\` widened from \`string\` to \`string | null\`. The existing null check in \`process-transaction.ts:tryAiCategorization\` already handled the null path.

## Test plan
- [x] 31 new tests across \`ai-categorizer-api.test.ts\` (sanitizer + buildEntryFromText) and \`ai-categorizer.test.ts\` (\`normalizeCacheKey\` + whitespace-collapse cache-hit assertion)
- [x] Full pops-api suite: 3929/3929 pass
- [x] Turbo \`typecheck\` (17/17)

Closes #2447
Closes #2449
Closes #2450