### PR TITLE
fix(finance/import): auto-classify negative-amount transfers / income (#2448)

### DIFF
--- a/apps/pops-api/src/modules/finance/imports/lib/process-transaction-helpers.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/process-transaction-helpers.ts
@@ -31,6 +31,31 @@ export function buildMatchedFromEntity(args: MatchedFromEntityArgs): ProcessedTr
   };
 }
 
+/**
+ * Build a `matched` ProcessedTransaction for a row auto-classified as a
+ * transfer (#2448). No entity is assigned — transfers are inter-account
+ * movements, not merchant purchases. The Review UI surfaces them in their
+ * own bucket via `transactionType: 'transfer'`.
+ */
+export function buildMatchedTransfer(
+  transaction: ParsedTransaction,
+  knownTags: string[]
+): ProcessedTransaction {
+  return {
+    ...transaction,
+    entity: { matchType: 'none' },
+    status: 'matched',
+    transactionType: 'transfer',
+    suggestedTags: buildSuggestedTags({
+      description: transaction.description,
+      entityId: null,
+      correctionTags: [],
+      aiCategory: null,
+      knownTags,
+    }),
+  };
+}
+
 export function buildUncertainFromAi(
   transaction: ParsedTransaction,
   entityName: string,

--- a/apps/pops-api/src/modules/finance/imports/lib/process-transaction.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/process-transaction.ts
@@ -8,9 +8,11 @@ import { matchEntity } from './entity-matcher.js';
 import {
   buildFailure,
   buildMatchedFromEntity,
+  buildMatchedTransfer,
   buildUncertainFromAi,
   buildUncertainNoMatch,
 } from './process-transaction-helpers.js';
+import { isTransferOrIncomeRow } from './transfer-classifier.js';
 
 import type { ParsedTransaction, ProcessedTransaction } from '../types.js';
 import type { AliasMap, EntityLookupMap } from './entity-matcher.js';
@@ -144,6 +146,26 @@ async function classifyTransaction(
       [correctionApplied.bucket]: correctionApplied.processed,
       batchStatus: 'success',
     } as TransactionProcessResult;
+  }
+
+  // Auto-classify inbound transfers / income before the entity-matcher and AI
+  // cascade — these rows are not merchants and surfacing them in the
+  // Review/uncertain bucket asks the user a question that has no good answer
+  // (#2448).
+  if (isTransferOrIncomeRow(transaction)) {
+    logger.debug(
+      {
+        index,
+        total,
+        description: transaction.description.slice(0, 50),
+        amount: transaction.amount,
+      },
+      '[Import] Auto-classified as transfer'
+    );
+    return {
+      matched: buildMatchedTransfer(transaction, context.knownTags),
+      batchStatus: 'success',
+    };
   }
 
   const entityMatched = tryEntityMatch(transaction, context);

--- a/apps/pops-api/src/modules/finance/imports/lib/transfer-classifier.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/transfer-classifier.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for transfer-classifier (#2448) — the pre-AI gate that
+ * auto-classifies inbound transfers / income rows so they don't reach the
+ * entity matcher or AI categorizer.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { isTransferOrIncomeRow } from './transfer-classifier.js';
+
+import type { ParsedTransaction } from '../types.js';
+
+function tx(overrides: Partial<ParsedTransaction> = {}): ParsedTransaction {
+  return {
+    date: '2026-04-30',
+    description: 'PURCHASE AT MERCHANT',
+    amount: 50,
+    account: 'amex',
+    rawRow: 'raw',
+    checksum: 'sha',
+    ...overrides,
+  };
+}
+
+describe('isTransferOrIncomeRow', () => {
+  describe('classifies as transfer when amount < 0 AND keyword present', () => {
+    it('detects PayID payment received (negative amount)', () => {
+      expect(
+        isTransferOrIncomeRow(
+          tx({ description: 'PayID Payment Received, Thank you', amount: -2300 })
+        )
+      ).toBe(true);
+    });
+
+    it('detects "Payment - Thank You" credit-card credit', () => {
+      expect(isTransferOrIncomeRow(tx({ description: 'PAYMENT - THANK YOU', amount: -500 }))).toBe(
+        true
+      );
+    });
+
+    it('detects refund row', () => {
+      expect(isTransferOrIncomeRow(tx({ description: 'Refund from vendor', amount: -120 }))).toBe(
+        true
+      );
+    });
+
+    it('detects salary deposit', () => {
+      expect(isTransferOrIncomeRow(tx({ description: 'Salary March', amount: -5000 }))).toBe(true);
+    });
+
+    it('detects "transfer" keyword', () => {
+      expect(
+        isTransferOrIncomeRow(tx({ description: 'Inter-account Transfer', amount: -100 }))
+      ).toBe(true);
+    });
+
+    it('detects "reimbursement"', () => {
+      expect(
+        isTransferOrIncomeRow(tx({ description: 'Reimbursement from Acme', amount: -75 }))
+      ).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+      expect(isTransferOrIncomeRow(tx({ description: 'payid received', amount: -1 }))).toBe(true);
+      expect(isTransferOrIncomeRow(tx({ description: 'PAYID RECEIVED', amount: -1 }))).toBe(true);
+    });
+  });
+
+  describe('does not classify when amount >= 0', () => {
+    it('positive-amount row with transfer keyword (e.g. outgoing payment as a purchase)', () => {
+      expect(isTransferOrIncomeRow(tx({ description: 'Payment to vendor', amount: 100 }))).toBe(
+        false
+      );
+    });
+
+    it('zero-amount row', () => {
+      expect(isTransferOrIncomeRow(tx({ description: 'Refund pending', amount: 0 }))).toBe(false);
+    });
+  });
+
+  describe('does not classify when keyword absent', () => {
+    it('negative-amount row without a transfer keyword (e.g. credit card credit from chargeback)', () => {
+      expect(
+        isTransferOrIncomeRow(tx({ description: 'Adjustment - statement correction', amount: -50 }))
+      ).toBe(false);
+    });
+
+    it('regular merchant purchase (positive amount, no keyword)', () => {
+      expect(
+        isTransferOrIncomeRow(tx({ description: 'Woolworths 1234 Bondi', amount: 75.5 }))
+      ).toBe(false);
+    });
+
+    it('keyword as substring without word boundary does NOT match', () => {
+      // "transferable" should not match "transfer" — keep specific to the
+      // discrete words listed in TRANSFER_KEYWORD_PATTERN.
+      expect(isTransferOrIncomeRow(tx({ description: 'Transferable Bond Co', amount: -100 }))).toBe(
+        false
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles description with surrounding whitespace', () => {
+      expect(isTransferOrIncomeRow(tx({ description: '  PayID Payment  ', amount: -10 }))).toBe(
+        true
+      );
+    });
+
+    it('matches keyword anywhere in the description', () => {
+      expect(
+        isTransferOrIncomeRow(
+          tx({ description: 'monthly recurring transfer to savings', amount: -200 })
+        )
+      ).toBe(true);
+    });
+  });
+});

--- a/apps/pops-api/src/modules/finance/imports/lib/transfer-classifier.ts
+++ b/apps/pops-api/src/modules/finance/imports/lib/transfer-classifier.ts
@@ -1,0 +1,46 @@
+/**
+ * Pre-AI classifier that auto-tags inbound transfer / income rows so they
+ * skip the entity matcher and AI categorizer entirely (#2448).
+ *
+ * Issue context: in an Amex import, a row like
+ * `description: "PayID Payment Received, Thank you", amount: -2300.00`
+ * (negative amount = inbound payment to clear the credit card balance) was
+ * sent to the AI categorizer, which surfaced "PayID Payment" as a suggested
+ * entity in the Review step. That row is a transfer, not a merchant — the
+ * user should not be asked to assign it to an entity at all.
+ *
+ * Rule (per issue): when amount < 0 AND the description contains a
+ * transfer/income keyword, classify as transfer (no entity required).
+ *
+ * Sign convention: in this codebase, credit-card statements use `amount < 0`
+ * for inbound payments (money coming IN to the card). Bank-account
+ * statements use the same sign convention for outgoing transfers. Either
+ * way, a negative-amount row paired with a transfer keyword is reliably an
+ * inter-account movement, not a merchant transaction.
+ */
+import type { ParsedTransaction } from '../types.js';
+
+/**
+ * Keywords that indicate the row is an inter-account transfer or
+ * income/refund event rather than a merchant purchase.
+ *
+ * The list is intentionally conservative: only words whose presence in a
+ * negative-amount row is a strong signal of non-merchant intent. Adding
+ * generic words like "fee" here would mis-classify real merchant fees
+ * (e.g. "Annual Membership Fee" charged by a gym).
+ */
+const TRANSFER_KEYWORD_PATTERN = /\b(payment|transfer|refund|payid|salary|reimbursement)\b/i;
+
+/**
+ * Returns true when the transaction should be auto-classified as a transfer
+ * and bypass both the entity matcher and AI categorizer.
+ *
+ * Both conditions must hold:
+ *   1. amount < 0 (inbound on credit cards / outbound on bank accounts —
+ *      either way, an inter-account movement)
+ *   2. description matches one of the transfer keywords
+ */
+export function isTransferOrIncomeRow(transaction: ParsedTransaction): boolean {
+  if (transaction.amount >= 0) return false;
+  return TRANSFER_KEYWORD_PATTERN.test(transaction.description);
+}


### PR DESCRIPTION
## Summary

Inbound transfers (e.g. \`PayID Payment Received\`) and refunds were flowing through the entity matcher and AI categorizer cascade, surfacing as suggested entities in the Review step (\"PayID Payment\"). The user shouldn't be asked to assign these to an entity at all — they're inter-account movements, not merchants.

## Rule

A new \`transfer-classifier.ts\` runs **before** the entity-match cascade in \`classifyTransaction\`:

\`\`\`
amount < 0 AND description matches /
  payment | transfer | refund | payid | salary | reimbursement /
\`\`\`

When both hold, the row lands in \`matched\` with \`transactionType: 'transfer'\` and no entity assigned, skipping both entity match and the AI categorizer entirely.

## Why these specific keywords

The list is intentionally conservative — generic words like \"fee\" would mis-classify real merchant fees (e.g. \"Annual Membership Fee\" charged by a gym). Word-boundary anchors stop false positives like \"Transferable Bond Co\".

## Sign convention note

In this codebase, credit-card statements use \`amount < 0\` for inbound payments. Bank-account statements use the same sign for outgoing transfers. Either way, a negative-amount row paired with a transfer keyword is reliably an inter-account movement, not a merchant transaction.

## Test plan
- [x] 14 new tests covering positive (all 6 keywords, casing, mid-sentence) and negative cases (positive/zero amounts, missing keyword, substring without word boundary)
- [x] All 418 import-module tests pass
- [x] Turbo \`typecheck\` (17/17)

Closes #2448