### PR TITLE
fix(cerebrum): hybrid search degrades to BM25-only on semantic failure (#2439)

### DIFF
--- a/apps/pops-api/.env.example
+++ b/apps/pops-api/.env.example
@@ -31,6 +31,16 @@ THETVDB_API_KEY=your_thetvdb_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 # CLAUDE_API_KEY=  # deprecated, use ANTHROPIC_API_KEY
 
+# Embedding API (used by Cerebrum semantic search / Ego chat context retrieval).
+# Defaults to OpenAI's text-embedding-3-small at https://api.openai.com/v1.
+# Set EMBEDDING_API_URL + EMBEDDING_MODEL to point at a different provider
+# (e.g. Voyage). Without EMBEDDING_API_KEY, semantic search short-circuits
+# to an empty result set and Ego falls back to BM25-only retrieval — the
+# app still works, just without embedding-driven context (#2439).
+EMBEDDING_API_KEY=
+# EMBEDDING_API_URL=https://api.openai.com/v1
+# EMBEDDING_MODEL=text-embedding-3-small
+
 # Redis (optional for local dev — required for job queue and cache features)
 # Run `mise redis:start` to start a local Redis container.
 # In production this is set to redis://redis:6379 (Docker network).

--- a/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for HybridSearchService graceful-degrade behaviour (#2439).
+ *
+ * The hybrid call must keep returning structured (BM25) results even when
+ * semantic search throws — embedding API failures (config missing, network,
+ * provider 4xx, rate limits) are best-effort and must not break Ego chat.
+ */
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createTestDb } from '../../../shared/test-utils.js';
+import { HybridSearchService } from './hybrid-search.js';
+
+import type { Database } from 'better-sqlite3';
+
+import type { SemanticSearchService } from './semantic-search.js';
+import type { RetrievalResult } from './types.js';
+
+describe('HybridSearchService — graceful degrade on semantic failure (#2439)', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function makeService(): HybridSearchService {
+    return new HybridSearchService(drizzle(db));
+  }
+
+  function stubSemanticToReject(svc: HybridSearchService, error: Error): void {
+    // Spy on the private semantic service through the prototype so we don't
+    // depend on internal field names.
+    const semantic = (svc as unknown as { semanticSvc: SemanticSearchService }).semanticSvc;
+    vi.spyOn(semantic, 'search').mockRejectedValue(error);
+  }
+
+  it('returns empty array (no throw) when semantic and structured both yield no results', async () => {
+    const svc = makeService();
+    stubSemanticToReject(svc, new Error('EMBEDDING_API_KEY is not configured'));
+
+    const results = await svc.hybrid('any query');
+    expect(results).toEqual([]);
+  });
+
+  it('still returns structured results when semantic throws config error', async () => {
+    // Seed one engram so structured query has something to find.
+    db.prepare(
+      `INSERT INTO engram_index (id, file_path, type, source, status, created_at, modified_at, title, content_hash, word_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      'eng_1',
+      'note/eng_1.md',
+      'note',
+      'manual',
+      'active',
+      '2026-01-01T00:00:00Z',
+      '2026-01-01T00:00:00Z',
+      'Test Engram',
+      'hash_1',
+      10
+    );
+
+    const svc = makeService();
+    stubSemanticToReject(svc, new Error('EMBEDDING_API_KEY is not configured'));
+
+    const results = await svc.hybrid('any query', { types: ['note'] });
+    // Structured query returns the seeded engram even though semantic failed.
+    expect(results.length).toBe(1);
+    expect(results[0]?.sourceId).toBe('eng_1');
+  });
+
+  it('does not throw when semantic rejects with a network error', async () => {
+    const svc = makeService();
+    stubSemanticToReject(svc, Object.assign(new Error('fetch failed'), { code: 'ECONNREFUSED' }));
+
+    await expect(svc.hybrid('any query')).resolves.toEqual([]);
+  });
+
+  it('does not throw when semantic rejects with a 400 (e.g. Voyage rejecting unknown arg)', async () => {
+    const svc = makeService();
+    stubSemanticToReject(svc, Object.assign(new Error('400 Bad Request'), { status: 400 }));
+
+    await expect(svc.hybrid('any query')).resolves.toEqual([]);
+  });
+
+  it('logs a warn (not an error) when semantic fails so the fallback is observable', async () => {
+    const svc = makeService();
+    const sentinel = new Error('EMBEDDING_API_KEY is not configured');
+    stubSemanticToReject(svc, sentinel);
+
+    // The catch block calls logger.warn — we can't easily assert on logger
+    // output here without importing it, but at least confirm hybrid resolves
+    // rather than rejecting (which is the behavioral contract we care about).
+    const results: RetrievalResult[] = await svc.hybrid('q');
+    expect(Array.isArray(results)).toBe(true);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/hybrid-search.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../lib/logger.js';
 import { getSettingValue } from '../../core/settings/service.js';
 import { SemanticSearchService } from './semantic-search.js';
 import { StructuredQueryService } from './structured-query.js';
@@ -97,8 +98,22 @@ export class HybridSearchService {
 
     // Pass `limit` (not fetchLimit) to semantic search — it over-fetches 3x internally.
     // Structured query gets fetchLimit since it doesn't over-fetch.
+    //
+    // Semantic search is best-effort: an embedding-API failure (network,
+    // Voyage 400, rate-limit) must not break hybrid retrieval, since the
+    // structured (BM25) leg is independent and still useful. Falling back to
+    // BM25-only mirrors the existing graceful-degrade path for the
+    // `isEmbeddingConfigured()` check inside SemanticSearchService.search and
+    // the `Thalamus retrieval failed` catch upstream in the chat engine
+    // (#2439).
     const [semanticResults, structuredResults] = await Promise.all([
-      this.semanticSvc.search(query, filters, limit, threshold),
+      this.semanticSvc.search(query, filters, limit, threshold).catch((error: unknown) => {
+        logger.warn(
+          { error: error instanceof Error ? error.message : String(error) },
+          '[HybridSearch] Semantic search failed — falling back to BM25-only'
+        );
+        return [] as RetrievalResult[];
+      }),
       this.structuredSvc.query(filters, fetchLimit),
     ]);
 


### PR DESCRIPTION
## Summary

The earlier graceful-degrade fix (#2443) only covered the config-missing path — \`SemanticSearchService.search\` returns \`[]\` when \`isEmbeddingConfigured()\` is false. **Runtime** embedding failures — network errors, provider 4xx (e.g. Voyage rejecting an unknown \`dimensions\` arg per #2457), rate-limit 429s — would still bubble out of \`Promise.all\` in \`HybridSearchService.hybrid\` and crash the chat-stream handler.

This PR closes the remaining gap.

## Changes

### \`hybrid-search.ts\`

The semantic leg of the \`Promise.all\` is now wrapped in \`.catch\` that:
1. Logs a \`warn\` so degraded retrieval is observable.
2. Returns \`[]\` so the structured (BM25) leg's results are preserved.

### \`apps/pops-api/.env.example\`

Adds \`EMBEDDING_API_KEY\` (and commented-out \`EMBEDDING_API_URL\` / \`EMBEDDING_MODEL\` overrides) with a note that the absence of a key is a **supported degraded mode** rather than a fatal misconfiguration.

### \`chat-stream.ts\`

Already wraps the entire \`prepareStream\` chain in \`try/catch\` and streams an SSE \`error\` event to the client. Confirmed no change needed there.

## Test plan
- [x] 5 new tests in \`hybrid-search.test.ts\`: empty result on config-missing, structured result preserved when semantic throws, network error tolerated, 4xx tolerated, hybrid resolves rather than rejects
- [x] Pre-existing pops-api tests pass (one flaky timing test in watcher.test.ts that passes in isolation; unrelated)
- [x] Turbo \`typecheck\` (17/17)

Closes #2439