### PR TITLE
fix(infra): set DOCKER_API_VERSION on watchtower (Docker 24+ compat)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,16 @@ ENGRAM_ROOT=./data/engrams
 # (shares the api image), and pops-shell. Default is `main` (latest from main).
 POPS_IMAGE_TAG=main
 
-# Watchtower (host docker config dir, used to pull from private GHCR if images are private)
+# Watchtower
+# Docker API version Watchtower negotiates with the host daemon. 1.45 works for
+# any Docker ≥ 24 (the default daemon is fine). Drop to 1.40 if your host runs
+# something older — Watchtower 1.7.1's built-in default of 1.24 is too old for
+# modern daemons (they reject anything below 1.40).
+DOCKER_API_VERSION=1.45
+
+# Host docker config dir, used by Watchtower to pull from private GHCR if your
+# images are private. Pops's published images are public, so the default value
+# is fine unless you're hosting a private fork.
 DOCKER_CONFIG_DIR=/root/.docker
+
 TZ=Australia/Melbourne

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  workflow_dispatch:
 
 permissions:
   packages: write

--- a/docs/themes/00-platform/prds/096-application-packaging/README.md
+++ b/docs/themes/00-platform/prds/096-application-packaging/README.md
@@ -70,6 +70,15 @@ The compose file ships a Watchtower service. Default behavior:
 - Rolling restart, cleans up old image layers
 - Reads docker auth from `${DOCKER_CONFIG_DIR:-/root/.docker}/config.json`
 
+### Deployer env knobs
+
+| Variable             | Default         | When to override                                                                                                                                                            |
+| -------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POPS_IMAGE_TAG`     | `main`          | Pin to a specific build (e.g. `sha-abc1234` or `vN`) to disable auto-update for that container. See `.env.example`.                                                         |
+| `DOCKER_CONFIG_DIR`  | `/root/.docker` | Path on the host where docker login credentials live; only relevant if you've forked pops and made your GHCR packages private (knoxio's are public — no auth needed).       |
+| `DOCKER_API_VERSION` | `1.45`          | Docker API version Watchtower negotiates. 1.45 works on any Docker ≥ 24. Drop to 1.40 only if your host runs an older daemon — Watchtower 1.7.1's built-in 1.24 is too old. |
+| `TZ`                 | `UTC`           | Timezone passed to Watchtower for log timestamps + scheduled poll display.                                                                                                  |
+
 Disable Watchtower entirely by removing the service from a deployer-local compose override, or by stopping/removing the container. Pin a specific tag to disable auto-updates while keeping Watchtower running:
 
 ```bash

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -212,7 +212,7 @@ services:
       # Watchtower 1.7.1 negotiates an old Docker API by default, which
       # daemons ≥ 24 reject. 1.45 is a safe minimum for modern hosts;
       # override via .env if you're on something older.
-      DOCKER_API_VERSION: ${DOCKER_API_VERSION:-1.45}
+      DOCKER_API_VERSION: '${DOCKER_API_VERSION:-1.45}'
       WATCHTOWER_LABEL_ENABLE: 'true'
       WATCHTOWER_CLEANUP: 'true'
       WATCHTOWER_INCLUDE_RESTARTING: 'true'

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -209,6 +209,10 @@ services:
       - ${DOCKER_CONFIG_DIR:-/root/.docker}:/config:ro
     environment:
       DOCKER_CONFIG: /config
+      # Watchtower 1.7.1 negotiates an old Docker API by default, which
+      # daemons ≥ 24 reject. 1.45 is a safe minimum for modern hosts;
+      # override via .env if you're on something older.
+      DOCKER_API_VERSION: ${DOCKER_API_VERSION:-1.45}
       WATCHTOWER_LABEL_ENABLE: 'true'
       WATCHTOWER_CLEANUP: 'true'
       WATCHTOWER_INCLUDE_RESTARTING: 'true'


### PR DESCRIPTION
## Summary

Watchtower 1.7.1 negotiates Docker API v1.24 by default. Daemons from Docker 24+ reject anything below v1.40, so the container crashloops on modern hosts:

```
Error response from daemon: client version 1.25 is too old.
Minimum supported API version is 1.40
```

Caught immediately on the live deploy after PR #2485 merged — the host runs Docker 29.3 (API 1.54).

## Fix

Set \`DOCKER_API_VERSION: \${DOCKER_API_VERSION:-1.45}\`. 1.45 is a safe minimum for any Docker ≥ 24; deployers on older daemons can override via \`.env\`.

## Test plan

- [x] Verified live: live patch in place on the home server, watchtower stable, polling every 60s, label-scoping confirmed (\`Only checking containers using enable label\`)
- [x] \`docker compose -f infra/docker-compose.yml config\` validates
- [ ] CI compose-validate job (will run on this PR)