### PR TITLE
fix(a11y): make 3 interactive-role wrappers focusable (unblocks #2490)

### DIFF
--- a/packages/app-inventory/src/components/ConnectionTracePanel.tsx
+++ b/packages/app-inventory/src/components/ConnectionTracePanel.tsx
@@ -72,7 +72,14 @@ function TraceNodeRow({ node, depth, currentItemId }: TraceNodeRowProps) {
         onClick={() => {
           if (!isCurrent) void navigate(`/inventory/items/${node.id}`);
         }}
+        onKeyDown={(e) => {
+          if (!isCurrent && (e.key === 'Enter' || e.key === ' ')) {
+            e.preventDefault();
+            void navigate(`/inventory/items/${node.id}`);
+          }
+        }}
         role="treeitem"
+        tabIndex={isCurrent ? -1 : 0}
         aria-expanded={hasChildren ? open : undefined}
       >
         {hasChildren ? <ExpandToggle open={open} /> : <span className="w-4.5" />}

--- a/packages/app-inventory/src/pages/location-tree-page/sections/location-node/NodeRow.tsx
+++ b/packages/app-inventory/src/pages/location-tree-page/sections/location-node/NodeRow.tsx
@@ -129,7 +129,14 @@ export function NodeRow(props: NodeRowProps) {
         e.stopPropagation();
         props.setRenaming(true);
       }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          props.onSelect(node.id);
+        }
+      }}
       role="treeitem"
+      tabIndex={isSelected ? 0 : -1}
       aria-selected={isSelected}
       aria-expanded={hasChildren ? open : undefined}
     >

--- a/packages/app-media/src/pages/watchlist/WatchlistFilterTabs.tsx
+++ b/packages/app-media/src/pages/watchlist/WatchlistFilterTabs.tsx
@@ -18,6 +18,7 @@ export function WatchlistFilterTabs({ filter, onFilterChange }: WatchlistFilterT
           variant={filter === opt.value ? 'default' : 'secondary'}
           size="sm"
           role="tab"
+          tabIndex={filter === opt.value ? 0 : -1}
           aria-selected={filter === opt.value}
           onClick={() => onFilterChange(opt.value)}
           shape="pill"


### PR DESCRIPTION
## Why

Dependabot #2490 bumps `oxlint` from 1.62.0 → 1.63.0 in the workspace-minor-patch group. The new `jsx-a11y/interactive-supports-focus` rule flags 3 elements in this repo that have an interactive ARIA role on a wrapper the parser can't see is inherently focusable. Those errors are blocking #2490's CI.

Rather than disable the rule (it's a real a11y win — keyboard users can't focus those elements with default browser focus order), this PR fixes the three call sites so #2490 can rebase clean.

## Changes

| File | Element | Fix |
|---|---|---|
| `packages/app-inventory/src/pages/location-tree-page/sections/location-node/NodeRow.tsx:124` | `<div role="treeitem">` | `tabIndex={isSelected ? 0 : -1}` (roving) + `onKeyDown` Enter/Space → `onSelect` (matches existing `onClick`) |
| `packages/app-inventory/src/components/ConnectionTracePanel.tsx:63` | `<div role="treeitem">` | `tabIndex={isCurrent ? -1 : 0}` (current node is the destination, not focusable) + `onKeyDown` Enter/Space → navigate |
| `packages/app-media/src/pages/watchlist/WatchlistFilterTabs.tsx:16` | `<Button role="tab">` (the `@pops/ui` `Button` component) | `tabIndex={filter === opt.value ? 0 : -1}` — underlying `<button>` is already focusable, but the rule can't see through the component wrapper. Standard tablist roving pattern. |

## Not touched

The other two `role="tab"` elements in this repo are on raw lowercase `<button>` and the linter already treats them as focusable, so they don't need changes:

- `packages/app-media/src/pages/RankingsPage.tsx:34`
- `packages/app-media/src/pages/tier-list/DimensionChips.tsx:21`

## Test plan

- [x] `pnpm dlx oxlint@1.63.0 --type-aware` reports `Found 130 warnings and 0 errors` (was 132 / 3 on main with the new oxlint)
- [x] `pnpm format:check` clean
- [x] `pnpm typecheck` passes
- [ ] After merge, dependabot rebases #2490 and its `Lint` check goes green
