### PR TITLE
fix(cerebrum/embeddings): provider-aware request body + non-fatal call sites

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search.ts
+++ b/apps/pops-api/src/modules/cerebrum/retrieval/semantic-search.ts
@@ -5,6 +5,7 @@
 import { createHash } from 'node:crypto';
 
 import { getDb, isVecAvailable } from '../../../db.js';
+import { logger } from '../../../lib/logger.js';
 import {
   getEmbedding,
   getEmbeddingConfig,
@@ -44,21 +45,30 @@ export interface SearchByVectorOptions {
   threshold?: number;
 }
 
-async function embedQuery(query: string): Promise<number[]> {
+async function embedQuery(query: string): Promise<number[] | null> {
   const config = getEmbeddingConfig();
   const queryHash = createHash('sha256').update(query.trim()).digest('hex');
   const cacheKey = redisKey('query_vec', queryHash);
 
   const redis = getRedis();
-  if (isRedisAvailable() && redis) {
-    const cached = await redis.get(cacheKey);
-    if (cached) return JSON.parse(cached) as number[];
-    const vector = await getEmbedding(query, config);
-    await redis.set(cacheKey, JSON.stringify(vector), 'EX', getSemanticQueryCacheTtl());
-    return vector;
+  try {
+    if (isRedisAvailable() && redis) {
+      const cached = await redis.get(cacheKey);
+      if (cached) return JSON.parse(cached) as number[];
+      const vector = await getEmbedding(query, config, { inputType: 'query' });
+      await redis.set(cacheKey, JSON.stringify(vector), 'EX', getSemanticQueryCacheTtl());
+      return vector;
+    }
+    return await getEmbedding(query, config, { inputType: 'query' });
+  } catch (err) {
+    // A provider error must not crash the API. Degrade to "no semantic results"
+    // so the chat / retrieval surfaces stay up while the operator investigates.
+    logger.warn(
+      { error: err instanceof Error ? err.message : String(err), provider: config.provider },
+      '[SemanticSearch] embedQuery failed; returning no semantic results'
+    );
+    return null;
   }
-
-  return getEmbedding(query, config);
 }
 
 export class SemanticSearchService {
@@ -79,6 +89,7 @@ export class SemanticSearchService {
     if (!isVecAvailable()) throw vecUnavailableError();
 
     const queryVector = await embedQuery(query);
+    if (!queryVector) return [];
     const vectorBlob = Float32Array.from(queryVector);
     const rows = knnQuery(vectorBlob, limit * 3).filter((r) => r.distance <= threshold);
     const seen = dedupeBySource(rows);

--- a/apps/pops-api/src/modules/core/embeddings/service.ts
+++ b/apps/pops-api/src/modules/core/embeddings/service.ts
@@ -6,6 +6,7 @@ import { embeddings } from '@pops/db-types';
 
 import { getDrizzle, getDb, isVecAvailable } from '../../../db.js';
 import { embedContent } from '../../../jobs/embed-content.js';
+import { logger } from '../../../lib/logger.js';
 import { getEmbeddingConfig, getEmbedding } from '../../../shared/embedding-client.js';
 import { getRedis, isRedisAvailable, redisKey } from '../../../shared/redis-client.js';
 
@@ -19,20 +20,29 @@ function vecUnavailableError(): Error {
   });
 }
 
-async function embedQueryWithCache(query: string): Promise<number[]> {
+async function embedQueryWithCache(query: string): Promise<number[] | null> {
   const config = getEmbeddingConfig();
   const queryHash = createHash('sha256').update(query.trim()).digest('hex');
   const cacheKey = redisKey('query_vec', queryHash);
 
   const redis = getRedis();
-  if (isRedisAvailable() && redis) {
-    const cached = await redis.get(cacheKey);
-    if (cached) return JSON.parse(cached) as number[];
-    const vector = await getEmbedding(query, config);
-    await redis.set(cacheKey, JSON.stringify(vector), 'EX', QUERY_CACHE_TTL_SECONDS);
-    return vector;
+  try {
+    if (isRedisAvailable() && redis) {
+      const cached = await redis.get(cacheKey);
+      if (cached) return JSON.parse(cached) as number[];
+      const vector = await getEmbedding(query, config, { inputType: 'query' });
+      await redis.set(cacheKey, JSON.stringify(vector), 'EX', QUERY_CACHE_TTL_SECONDS);
+      return vector;
+    }
+    return await getEmbedding(query, config, { inputType: 'query' });
+  } catch (err) {
+    // A provider error must not crash the API. Degrade to "no semantic results".
+    logger.warn(
+      { error: err instanceof Error ? err.message : String(err), provider: config.provider },
+      '[Embeddings] embedQueryWithCache failed; returning no semantic results'
+    );
+    return null;
   }
-  return getEmbedding(query, config);
 }
 
 interface VecRow {
@@ -87,6 +97,7 @@ export async function semanticSearch(
 
   const { sourceTypes, limit = 10, threshold = 1.0 } = options;
   const queryVector = await embedQueryWithCache(query);
+  if (!queryVector) return [];
   const rows = runKnnQuery(Float32Array.from(queryVector), limit, sourceTypes);
 
   return rows

--- a/apps/pops-api/src/shared/embedding-client.test.ts
+++ b/apps/pops-api/src/shared/embedding-client.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Provider-aware behavior of the embedding client.
+ *
+ * The OpenAI body shape (`dimensions`) and the Voyage body shape
+ * (`output_dimension` + `input_type`) are not interchangeable; sending the
+ * wrong one to either provider produces a 4xx. These tests pin the per-provider
+ * request shape and the pricing fallbacks.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  detectProvider,
+  estimateEmbeddingCost,
+  getEmbedding,
+  getEmbeddingConfig,
+} from './embedding-client.js';
+
+import type { EmbeddingConfig } from './embedding-client.js';
+
+const ORIGINAL_FETCH = global.fetch;
+
+function makeOkResponse(vector: number[]): Response {
+  return new Response(
+    JSON.stringify({ data: [{ embedding: vector }], usage: { total_tokens: 5 } }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe('detectProvider', () => {
+  it('returns "voyage" for any voyageai.com URL', () => {
+    expect(detectProvider('https://api.voyageai.com/v1')).toBe('voyage');
+  });
+
+  it('returns "openai" for any other URL', () => {
+    expect(detectProvider('https://api.openai.com/v1')).toBe('openai');
+    expect(detectProvider('https://example.com/v1')).toBe('openai');
+  });
+});
+
+describe('getEmbeddingConfig', () => {
+  it('inherits provider from URL', () => {
+    vi.stubEnv('EMBEDDING_API_URL', 'https://api.voyageai.com/v1');
+    vi.stubEnv('EMBEDDING_API_KEY', 'test');
+    vi.stubEnv('EMBEDDING_MODEL', 'voyage-4-lite');
+    vi.stubEnv('EMBEDDING_DIMENSIONS', '1024');
+
+    const cfg = getEmbeddingConfig();
+    expect(cfg.provider).toBe('voyage');
+    expect(cfg.model).toBe('voyage-4-lite');
+    expect(cfg.dimensions).toBe(1024);
+  });
+
+  it('defaults to OpenAI provider', () => {
+    vi.stubEnv('EMBEDDING_API_KEY', 'test');
+    expect(getEmbeddingConfig().provider).toBe('openai');
+  });
+});
+
+describe('getEmbedding request shape', () => {
+  function captureFetch(): ReturnType<typeof vi.fn> {
+    const fetchMock = vi.fn(async () => makeOkResponse([0.1, 0.2, 0.3]));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    return fetchMock;
+  }
+
+  it('sends OpenAI-shaped body for the openai provider', async () => {
+    const fetchMock = captureFetch();
+    const config: EmbeddingConfig = {
+      apiUrl: 'https://api.openai.com/v1',
+      apiKey: 'sk-test',
+      model: 'text-embedding-3-small',
+      dimensions: 1536,
+      provider: 'openai',
+    };
+
+    await getEmbedding('hello', config, { inputType: 'query' });
+
+    const [, init] = fetchMock.mock.calls[0] as [unknown, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ input: 'hello', model: 'text-embedding-3-small', dimensions: 1536 });
+  });
+
+  it('sends Voyage-shaped body (output_dimension + input_type) for the voyage provider', async () => {
+    const fetchMock = captureFetch();
+    const config: EmbeddingConfig = {
+      apiUrl: 'https://api.voyageai.com/v1',
+      apiKey: 'pa-test',
+      model: 'voyage-4-lite',
+      dimensions: 1024,
+      provider: 'voyage',
+    };
+
+    await getEmbedding('hello', config, { inputType: 'query' });
+
+    const [, init] = fetchMock.mock.calls[0] as [unknown, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({
+      input: 'hello',
+      model: 'voyage-4-lite',
+      output_dimension: 1024,
+      input_type: 'query',
+    });
+    // Voyage rejects the OpenAI-only `dimensions` field with a 400.
+    expect(body).not.toHaveProperty('dimensions');
+  });
+
+  it('defaults inputType to "document" when not provided', async () => {
+    const fetchMock = captureFetch();
+    const config: EmbeddingConfig = {
+      apiUrl: 'https://api.voyageai.com/v1',
+      apiKey: 'pa-test',
+      model: 'voyage-4-lite',
+      dimensions: 1024,
+      provider: 'voyage',
+    };
+
+    await getEmbedding('hello', config);
+
+    const [, init] = fetchMock.mock.calls[0] as [unknown, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toMatchObject({ input_type: 'document' });
+  });
+
+  it('throws on non-OK provider response (callers must catch)', async () => {
+    global.fetch = vi.fn(
+      async () => new Response('{"detail":"bad"}', { status: 400 })
+    ) as unknown as typeof fetch;
+
+    const config: EmbeddingConfig = {
+      apiUrl: 'https://api.voyageai.com/v1',
+      apiKey: 'pa-test',
+      model: 'voyage-4-lite',
+      dimensions: 1024,
+      provider: 'voyage',
+    };
+
+    await expect(getEmbedding('hello', config)).rejects.toThrow(/Embedding API error 400/);
+  });
+});
+
+describe('estimateEmbeddingCost', () => {
+  it('prices known OpenAI models', () => {
+    expect(estimateEmbeddingCost(1_000_000, 'text-embedding-3-small')).toBeCloseTo(0.02);
+    expect(estimateEmbeddingCost(1_000_000, 'text-embedding-3-large')).toBeCloseTo(0.13);
+  });
+
+  it('prices known Voyage models', () => {
+    expect(estimateEmbeddingCost(1_000_000, 'voyage-4-lite')).toBeCloseTo(0.02);
+    expect(estimateEmbeddingCost(1_000_000, 'voyage-3-large')).toBeCloseTo(0.18);
+    expect(estimateEmbeddingCost(1_000_000, 'voyage-finance-2')).toBeCloseTo(0.12);
+  });
+
+  it('falls back to small-model pricing for unknown models', () => {
+    expect(estimateEmbeddingCost(1_000_000, 'mystery-model')).toBeCloseTo(0.02);
+  });
+});

--- a/apps/pops-api/src/shared/embedding-client.ts
+++ b/apps/pops-api/src/shared/embedding-client.ts
@@ -1,5 +1,5 @@
 /**
- * OpenAI-compatible embeddings API client.
+ * Embeddings API client supporting OpenAI- and Voyage-compatible providers.
  *
  * Configured entirely via environment variables so model choice is not baked into code:
  *   EMBEDDING_API_URL  — base URL (default: https://api.openai.com/v1)
@@ -8,19 +8,31 @@
  *   EMBEDDING_DIMENSIONS — vector dimensions (default: 1536)
  */
 
+export type EmbeddingProvider = 'openai' | 'voyage';
+
+export type EmbeddingInputType = 'query' | 'document';
+
 export interface EmbeddingConfig {
   apiUrl: string;
   apiKey: string;
   model: string;
   dimensions: number;
+  provider: EmbeddingProvider;
+}
+
+/** Detect provider from the configured base URL. Defaults to openai. */
+export function detectProvider(apiUrl: string): EmbeddingProvider {
+  return apiUrl.includes('voyageai.com') ? 'voyage' : 'openai';
 }
 
 export function getEmbeddingConfig(): EmbeddingConfig {
+  const apiUrl = process.env['EMBEDDING_API_URL'] ?? 'https://api.openai.com/v1';
   return {
-    apiUrl: process.env['EMBEDDING_API_URL'] ?? 'https://api.openai.com/v1',
+    apiUrl,
     apiKey: process.env['EMBEDDING_API_KEY'] ?? '',
     model: process.env['EMBEDDING_MODEL'] ?? 'text-embedding-3-small',
     dimensions: parseInt(process.env['EMBEDDING_DIMENSIONS'] ?? '1536', 10),
+    provider: detectProvider(apiUrl),
   };
 }
 
@@ -29,7 +41,41 @@ export function isEmbeddingConfigured(): boolean {
   return Boolean(process.env['EMBEDDING_API_KEY']);
 }
 
-export async function getEmbedding(text: string, config: EmbeddingConfig): Promise<number[]> {
+/** Build the provider-specific request body. */
+function buildRequestBody(
+  text: string,
+  config: EmbeddingConfig,
+  inputType: EmbeddingInputType
+): Record<string, unknown> {
+  if (config.provider === 'voyage') {
+    return {
+      input: text,
+      model: config.model,
+      output_dimension: config.dimensions,
+      input_type: inputType,
+    };
+  }
+  return {
+    input: text,
+    model: config.model,
+    dimensions: config.dimensions,
+  };
+}
+
+export interface GetEmbeddingOptions {
+  /**
+   * Whether the text is a retrieval query or a document being indexed.
+   * Voyage uses this to pick the appropriate embedding head; OpenAI ignores it.
+   * Defaults to 'document' to match OpenAI's symmetric behavior.
+   */
+  inputType?: EmbeddingInputType;
+}
+
+export async function getEmbedding(
+  text: string,
+  config: EmbeddingConfig,
+  options: GetEmbeddingOptions = {}
+): Promise<number[]> {
   if (!text.trim()) {
     throw new Error('Cannot embed empty text');
   }
@@ -37,17 +83,14 @@ export async function getEmbedding(text: string, config: EmbeddingConfig): Promi
     throw new Error('EMBEDDING_API_KEY is not configured');
   }
 
+  const inputType = options.inputType ?? 'document';
   const response = await fetch(`${config.apiUrl}/embeddings`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${config.apiKey}`,
     },
-    body: JSON.stringify({
-      input: text,
-      model: config.model,
-      dimensions: config.dimensions,
-    }),
+    body: JSON.stringify(buildRequestBody(text, config, inputType)),
   });
 
   if (!response.ok) {
@@ -57,7 +100,7 @@ export async function getEmbedding(text: string, config: EmbeddingConfig): Promi
 
   const data = (await response.json()) as {
     data: { embedding: number[] }[];
-    usage: { total_tokens: number };
+    usage?: { total_tokens?: number };
   };
   const vector = data.data[0]?.embedding;
   if (!vector) {
@@ -71,11 +114,31 @@ export interface EmbeddingUsage {
   costUsd: number;
 }
 
-/** Estimate cost from token usage (OpenAI text-embedding-3-small pricing). */
+interface PricingEntry {
+  match: (model: string) => boolean;
+  pricePerMillion: number;
+}
+
+// Per-provider pricing in USD per 1M input tokens.
+// OpenAI: https://openai.com/pricing
+// Voyage:  https://docs.voyageai.com/docs/pricing
+const PRICING: PricingEntry[] = [
+  { match: (m) => m.includes('text-embedding-3-large'), pricePerMillion: 0.13 },
+  { match: (m) => m.includes('text-embedding-3-small'), pricePerMillion: 0.02 },
+  { match: (m) => m === 'voyage-3-large', pricePerMillion: 0.18 },
+  { match: (m) => m === 'voyage-code-3', pricePerMillion: 0.18 },
+  { match: (m) => m === 'voyage-finance-2', pricePerMillion: 0.12 },
+  { match: (m) => m === 'voyage-law-2', pricePerMillion: 0.12 },
+  { match: (m) => m === 'voyage-3.5', pricePerMillion: 0.06 },
+  { match: (m) => m === 'voyage-3.5-lite', pricePerMillion: 0.02 },
+  { match: (m) => m === 'voyage-4', pricePerMillion: 0.06 },
+  { match: (m) => m === 'voyage-4-lite', pricePerMillion: 0.02 },
+];
+
+/** Estimate cost from token usage based on the model name. */
 export function estimateEmbeddingCost(totalTokens: number, model: string): number {
-  // text-embedding-3-small: $0.02 / 1M tokens
-  // text-embedding-3-large: $0.13 / 1M tokens
-  // Fallback to small pricing for unknown models
-  const pricePerMillion = model.includes('large') ? 0.13 : 0.02;
+  const entry = PRICING.find((p) => p.match(model));
+  // Fallback to OpenAI text-embedding-3-small pricing for unknown models.
+  const pricePerMillion = entry?.pricePerMillion ?? 0.02;
   return (totalTokens / 1_000_000) * pricePerMillion;
 }


### PR DESCRIPTION
Closes #2457.

## Problem

`embedding-client.ts` hardcoded the OpenAI request shape (`dimensions`). With `EMBEDDING_API_URL` pointed at Voyage, the API returned 400 (`Argument 'dimensions' is not supported by our API`). That error propagated unhandled out of `embedQuery()` in both `semantic-search.ts` and `core/embeddings/service.ts`, crashing the Node process on the first chat or retrieval call.

## Changes

- **Provider abstraction.** Detect the provider from `EMBEDDING_API_URL` (`openai` | `voyage`). Voyage requests use `output_dimension` and `input_type`; OpenAI keeps `dimensions`.
- **Don't crash the API on a provider failure.** Wrap `embedQuery` / `embedQueryWithCache` in try/catch in both callers; on failure, log and return ``null`` so the search degrades to "no semantic results". `HybridSearchService` already handles this signal by falling back to BM25.
- **Pricing.** Extend `estimateEmbeddingCost` to cover the Voyage models (`voyage-3.5`, `voyage-4`, `voyage-4-lite`, `voyage-3-large`, `voyage-code-3`, `voyage-finance-2`, `voyage-law-2`). Unknown models still fall back to OpenAI small pricing.

## Test plan

- [x] `pnpm vitest run src/shared/embedding-client.test.ts` — new tests pin the per-provider body shape and the pricing fallbacks.
- [x] `pnpm vitest run src/modules/cerebrum/retrieval src/modules/core/embeddings src/jobs/handlers/embeddings.test.ts` — downstream tests still pass.
- [x] `pnpm typecheck` clean.
- [x] `pnpm -w lint` clean.