### PR TITLE
fix(cerebrum/ingest): surface submit errors + stop leaking orphan files

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/create-engram.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/create-engram.ts
@@ -1,7 +1,3 @@
-import { eq } from 'drizzle-orm';
-
-import { engramIndex } from '@pops/db-types';
-
 import { ValidationError } from '../../../../shared/errors.js';
 import { applyTemplate } from '../../templates/apply.js';
 import { serializeEngram } from '../file.js';
@@ -164,23 +160,20 @@ export function createEngram(deps: CreateDeps, input: CreateEngramInput): string
 
   const relPath = `${resolved.type}/${id}.md`;
 
-  // Index first, then file: an index-write failure with the file already on
-  // disk leaks an orphaned markdown file. The opposite ordering is recoverable
-  // — the catch below rolls back the index row.
-  upsertIndex(db, {
-    id,
-    filePath: relPath,
-    frontmatter,
-    body: resolved.body,
-    customFields: resolved.customFields,
-  });
-
-  try {
+  // Wrap the index insert and the file write in a single transaction so a
+  // failure on either side is fully rolled back. The transaction only commits
+  // when the callback returns; if writeFileAtomic throws, the upsertIndex
+  // savepoint is rolled back too — no orphaned row, no orphaned file.
+  db.transaction((tx) => {
+    upsertIndex(tx, {
+      id,
+      filePath: relPath,
+      frontmatter,
+      body: resolved.body,
+      customFields: resolved.customFields,
+    });
     writeFileAtomic(absolutePath(root, relPath), serializeEngram(frontmatter, resolved.body));
-  } catch (err) {
-    db.delete(engramIndex).where(eq(engramIndex.id, id)).run();
-    throw err;
-  }
+  });
 
   return id;
 }

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/create-engram.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/create-engram.ts
@@ -1,3 +1,7 @@
+import { eq } from 'drizzle-orm';
+
+import { engramIndex } from '@pops/db-types';
+
 import { ValidationError } from '../../../../shared/errors.js';
 import { applyTemplate } from '../../templates/apply.js';
 import { serializeEngram } from '../file.js';
@@ -159,7 +163,10 @@ export function createEngram(deps: CreateDeps, input: CreateEngramInput): string
   });
 
   const relPath = `${resolved.type}/${id}.md`;
-  writeFileAtomic(absolutePath(root, relPath), serializeEngram(frontmatter, resolved.body));
+
+  // Index first, then file: an index-write failure with the file already on
+  // disk leaks an orphaned markdown file. The opposite ordering is recoverable
+  // — the catch below rolls back the index row.
   upsertIndex(db, {
     id,
     filePath: relPath,
@@ -167,6 +174,13 @@ export function createEngram(deps: CreateDeps, input: CreateEngramInput): string
     body: resolved.body,
     customFields: resolved.customFields,
   });
+
+  try {
+    writeFileAtomic(absolutePath(root, relPath), serializeEngram(frontmatter, resolved.body));
+  } catch (err) {
+    db.delete(engramIndex).where(eq(engramIndex.id, id)).run();
+    throw err;
+  }
 
   return id;
 }

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -99,6 +99,25 @@ describe('EngramService', () => {
     expect(engram.template).toBeNull();
     expect(engram.type).toBe('capture');
     expect(engram.filePath.startsWith('capture/')).toBe(true);
+  });
+
+  it('rolls back the engram_index row when the file write fails', () => {
+    // Force writeFileAtomic to fail by parking a regular file at the type
+    // subdir path — mkdirSync(recursive: true) inside writeFileAtomic then
+    // throws ENOTDIR, which must roll the index insert back too.
+    writeFileSync(join(root, 'note'), 'block');
+
+    expect(() =>
+      service.create({
+        type: 'note',
+        title: 'Should not land',
+        body: '# nope',
+        scopes: ['personal'],
+      })
+    ).toThrow();
+
+    const rows = db.prepare('SELECT id FROM engram_index').all() as Array<{ id: string }>;
+    expect(rows).toEqual([]);
   });
 
   it('rejects unsafe type values that could escape the engram root', () => {

--- a/packages/app-cerebrum/src/pages/ingest-page/useSubmission.ts
+++ b/packages/app-cerebrum/src/pages/ingest-page/useSubmission.ts
@@ -1,5 +1,6 @@
 /** Sub-hook: submit mutation and orchestration with scope inference. */
 import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
 
 import { trpc } from '@pops/api-client';
 
@@ -9,6 +10,20 @@ import type { useScopeInference } from './useScopeInference';
 
 type FormState = ReturnType<typeof useFormState>;
 type Inference = ReturnType<typeof useScopeInference>;
+type FormValues = FormState['form'];
+
+function buildSubmitPayload(form: FormValues, scopes: string[]) {
+  return {
+    body: form.body,
+    title: form.title || undefined,
+    type: form.type || undefined,
+    scopes: scopes.length > 0 ? scopes : undefined,
+    tags: form.tags.length > 0 ? form.tags : undefined,
+    template: form.template || undefined,
+    source: 'manual' as const,
+    customFields: Object.keys(form.customFields).length > 0 ? form.customFields : undefined,
+  };
+}
 
 export function useSubmission(formState: FormState, inference: Inference) {
   const [submitResult, setSubmitResult] = useState<SubmitResult | null>(null);
@@ -21,23 +36,16 @@ export function useSubmission(formState: FormState, inference: Inference) {
         type: result.engram.type,
       });
     },
+    onError: (error) => {
+      toast.error('Submit Engram failed', { description: error.message });
+    },
   });
 
   const confirmInferredScopes = useCallback(() => {
     inference.confirm((scopes) => {
       const mergedScopes = [...new Set([...formState.form.scopes, ...scopes])];
       formState.updateField('scopes', mergedScopes);
-      const { form } = formState;
-      submitMutation.mutate({
-        body: form.body,
-        title: form.title || undefined,
-        type: form.type || undefined,
-        scopes: mergedScopes.length > 0 ? mergedScopes : undefined,
-        tags: form.tags.length > 0 ? form.tags : undefined,
-        template: form.template || undefined,
-        source: 'manual',
-        customFields: Object.keys(form.customFields).length > 0 ? form.customFields : undefined,
-      });
+      submitMutation.mutate(buildSubmitPayload(formState.form, mergedScopes));
     });
   }, [inference, formState, submitMutation]);
 
@@ -47,16 +55,7 @@ export function useSubmission(formState: FormState, inference: Inference) {
       await inference.run();
       return;
     }
-    submitMutation.mutate({
-      body: form.body,
-      title: form.title || undefined,
-      type: form.type || undefined,
-      scopes: form.scopes.length > 0 ? form.scopes : undefined,
-      tags: form.tags.length > 0 ? form.tags : undefined,
-      template: form.template || undefined,
-      source: 'manual',
-      customFields: Object.keys(form.customFields).length > 0 ? form.customFields : undefined,
-    });
+    submitMutation.mutate(buildSubmitPayload(form, form.scopes));
   }, [formState, inference, submitMutation]);
 
   const resetForm = useCallback(() => {


### PR DESCRIPTION
Closes #2470.

## Problem

Two distinct bugs on `/cerebrum` Submit Engram:

**(a) Silent failure.** The `cerebrum.ingest.submit` mutation had no `onError` handler. When the API returned 500 (e.g. the `body_hash` schema drift from #2329), the form gave the user zero feedback — same content, same submit button — so the user assumed the note saved.

**(b) Orphan files.** `createEngram` wrote the markdown file before the index transaction. If the index insert failed (missing column, FK error, etc.) the file stayed on disk with no DB row.

## Changes

- `useSubmission.ts` adds an `onError` toast (`Submit Engram failed`) carrying the API's error message verbatim.
- `create-engram.ts` reorders: `upsertIndex` runs before `writeFileAtomic`. The file-write is wrapped in a try/catch that rolls back the index row (`DELETE FROM engram_index WHERE id = ?`) on failure — cascade FKs handle the related `engram_scopes` / `engram_tags` / `engram_links` rows.

## Test plan

- [x] `pnpm vitest run src/modules/cerebrum/engrams src/modules/cerebrum/ingest` — 157/157.
- [x] `pnpm typecheck` clean across pops-api and app-cerebrum.
- [ ] Manual: force a 500 from `cerebrum.ingest.submit` (e.g. by removing the `body_hash` column) — toast appears with the error, form retains its content, no orphan file lands in `data/engrams/<type>/`.