### PR TITLE
fix(finance/import): "Accept All as X" actually accepts

### DIFF
--- a/packages/app-finance/src/components/imports/hooks/bulk-assignment/types.ts
+++ b/packages/app-finance/src/components/imports/hooks/bulk-assignment/types.ts
@@ -37,8 +37,12 @@ export function pluralize(count: number): string {
 export function moveToMatched(
   prev: LocalTxState,
   transactions: ProcessedTransaction[],
-  entity: { entityId: string; entityName: string }
+  entity: { entityId: string; entityName: string; matchType?: 'manual' | 'ai' }
 ): LocalTxState {
+  // Default to 'manual' so EntitySection (which renders the AI-suggestion
+  // panel for matchType === 'ai') doesn't keep prompting the user to accept
+  // a suggestion they already accepted via Accept All / Create new for all.
+  const matchType = entity.matchType ?? 'manual';
   let updated = { ...prev };
   for (const transaction of transactions) {
     updated = {
@@ -52,7 +56,7 @@ export function moveToMatched(
           entity: {
             entityId: entity.entityId,
             entityName: entity.entityName,
-            matchType: 'ai' as const,
+            matchType,
             confidence: 1,
           },
           status: 'matched' as const,

--- a/packages/app-finance/src/components/imports/hooks/bulk-assignment/use-accept.ts
+++ b/packages/app-finance/src/components/imports/hooks/bulk-assignment/use-accept.ts
@@ -31,17 +31,16 @@ interface AcceptAllArgs {
   addPendingEntity: ReturnType<typeof useEntities>['addPendingEntity'];
   dbEntitiesData: ReturnType<typeof useEntities>['dbEntitiesData'];
   setLocalTransactions: Dispatch<SetStateAction<LocalTxState>>;
-  openRuleProposalDialog: UseBulkAssignmentArgs['openRuleProposalDialog'];
 }
 
+/**
+ * Bulk-accept assigns the AI-suggested entity directly without opening the
+ * Correction Proposal dialog. Users who want to edit the proposed rule before
+ * applying use the per-row Accept path (`useAcceptAiSuggestion`), which still
+ * routes through the dialog.
+ */
 export function useAcceptAll(args: AcceptAllArgs) {
-  const {
-    entities,
-    addPendingEntity,
-    dbEntitiesData,
-    setLocalTransactions,
-    openRuleProposalDialog,
-  } = args;
+  const { entities, addPendingEntity, dbEntitiesData, setLocalTransactions } = args;
   return useCallback(
     async (transactions: ProcessedTransaction[]) => {
       if (transactions.length === 0) return;
@@ -64,15 +63,14 @@ export function useAcceptAll(args: AcceptAllArgs) {
         setLocalTransactions((prev) =>
           moveToMatched(prev, transactions, { entityId: resolvedEntityId, entityName })
         );
-        toast.success(`Accepted ${pluralize(transactions.length)}`);
-        if (firstTx) openRuleProposalDialog(firstTx, resolvedEntityId, entityName);
+        toast.success(`Accepted ${pluralize(transactions.length)} as "${entityName}"`);
       } catch (error) {
         toast.error(
           `Failed to accept: ${error instanceof Error ? error.message : 'Unknown error'}`
         );
       }
     },
-    [entities, addPendingEntity, dbEntitiesData?.data, openRuleProposalDialog, setLocalTransactions]
+    [entities, addPendingEntity, dbEntitiesData?.data, setLocalTransactions]
   );
 }
 

--- a/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
+++ b/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
@@ -38,7 +38,6 @@ export function useBulkAssignment(args: UseBulkAssignmentArgs) {
     addPendingEntity,
     dbEntitiesData,
     setLocalTransactions,
-    openRuleProposalDialog,
   });
 
   const handleCreateAndAssignAll = useCallback(


### PR DESCRIPTION
Closes #2453.

## Problem

In Review → Uncertain, each merchant group has a `+ Accept All as "<EntityName>"` button. The label implies a one-click action but it actually opened the Correction Proposal dialog — the user then had to click `Apply ChangeSet` to actually commit. For an import with 45 uncertain groups, that's 90 clicks plus ~90 round-trips to `analyzeCorrection` (Claude Haiku) + `proposeChangeSet` for proposals the user is just going to confirm anyway.

## Changes

- `useAcceptAll` no longer calls `openRuleProposalDialog`. Bulk-accept matches the transactions against the suggested entity, fires a sonner toast (`Accepted N transactions as "X"`), and is done.
- Per-row Accept (`useAcceptAiSuggestion`) is unchanged — that path is for users who want to edit the proposed rule before applying, and it still routes through the dialog.

## Test plan

- [x] `pnpm vitest run src/components/imports` — 171/171.
- [x] `pnpm typecheck` clean.
- [ ] Manual: import a CSV that produces multiple uncertain groups. Click `Accept All as X` on a group — group moves to matched immediately, no dialog, no extra API calls beyond the import flow.