### PR TITLE
feat(api-client): tRPC fetch timeout + global network-error toast

### DIFF
--- a/apps/pops-shell/src/app/App.tsx
+++ b/apps/pops-shell/src/app/App.tsx
@@ -19,12 +19,15 @@ const NETWORK_ERROR_TOAST_ID = 'network-down';
 /**
  * Surface a toast only when the request never reached the server. Server-returned
  * 4xx/5xx errors keep their per-feature handling so this isn't toast spam.
+ *
+ * Note: queries retry on focus/remount by default, but mutations do not — so the
+ * copy avoids claiming "retrying" and points the user at the next concrete step.
  */
 function notifyNetworkError(err: unknown): void {
   if (!isNetworkError(err)) return;
-  toast.error("Couldn't reach the server. Retrying…", {
+  toast.error("Couldn't reach the server", {
     id: NETWORK_ERROR_TOAST_ID,
-    description: 'Check your connection. Pages will recover once the server responds.',
+    description: 'Check your connection. The page will refresh once the server responds.',
   });
 }
 

--- a/apps/pops-shell/src/app/App.tsx
+++ b/apps/pops-shell/src/app/App.tsx
@@ -1,16 +1,32 @@
 import { trpc, trpcClient } from '@/lib/trpc';
 import { useThemeStore } from '@/store/themeStore';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useEffect } from 'react';
 import { RouterProvider } from 'react-router';
+import { toast } from 'sonner';
 
 /**
  * Root App component with all providers
  */
+import { isNetworkError } from '@pops/api-client';
 import { Toaster, TooltipProvider } from '@pops/ui';
 
 import { router } from './router';
+
+const NETWORK_ERROR_TOAST_ID = 'network-down';
+
+/**
+ * Surface a toast only when the request never reached the server. Server-returned
+ * 4xx/5xx errors keep their per-feature handling so this isn't toast spam.
+ */
+function notifyNetworkError(err: unknown): void {
+  if (!isNetworkError(err)) return;
+  toast.error("Couldn't reach the server. Retrying…", {
+    id: NETWORK_ERROR_TOAST_ID,
+    description: 'Check your connection. Pages will recover once the server responds.',
+  });
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -18,6 +34,8 @@ const queryClient = new QueryClient({
       staleTime: 1000 * 60 * 5, // 5 minutes
     },
   },
+  queryCache: new QueryCache({ onError: notifyNetworkError }),
+  mutationCache: new MutationCache({ onError: notifyNetworkError }),
 });
 
 export function App() {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -25,16 +25,20 @@ function fetchWithTimeout(input: RequestInfo | URL, init?: RequestInit): Promise
   const timeoutId = setTimeout(() => controller.abort('timeout'), TRPC_FETCH_TIMEOUT_MS);
 
   // Chain the caller's signal (e.g. React Query cancellation) with our timeout
-  // so aborting either source aborts the request.
+  // so aborting either source aborts the request. The listener is registered
+  // with `once` and cleaned up explicitly in `finally` so a long-lived caller
+  // signal doesn't accumulate listeners across requests.
   const callerSignal = init?.signal;
+  const onCallerAbort = (): void => controller.abort(callerSignal?.reason);
   if (callerSignal) {
     if (callerSignal.aborted) controller.abort(callerSignal.reason);
-    else callerSignal.addEventListener('abort', () => controller.abort(callerSignal.reason));
+    else callerSignal.addEventListener('abort', onCallerAbort, { once: true });
   }
 
-  return fetch(input, { ...init, signal: controller.signal }).finally(() =>
-    clearTimeout(timeoutId)
-  );
+  return fetch(input, { ...init, signal: controller.signal }).finally(() => {
+    clearTimeout(timeoutId);
+    callerSignal?.removeEventListener('abort', onCallerAbort);
+  });
 }
 
 /**
@@ -71,15 +75,18 @@ function messageLooksLikeNetworkFailure(err: object): boolean {
  * returned by the server with a real status code?
  *
  * Server-returned errors have a `data` field with `httpStatus`. Network
- * failures don't make it that far, so they bubble up as a TRPCClientError
- * wrapping a fetch error or AbortError.
+ * failures don't make it that far — they bubble up as a TRPCClientError
+ * wrapping a fetch error, an AbortError, or a `DOMException` (which is
+ * not an `Error` subclass in browsers).
  */
 export function isNetworkError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   if ('data' in err && err.data != null) return false;
   if (messageLooksLikeNetworkFailure(err)) return true;
+  // `DOMException` (Web abort errors) is not an `Error` subclass, so the
+  // recursion needs to follow any throwable-shaped cause, not just `Error`.
   const cause = 'cause' in err ? err.cause : undefined;
-  if (cause instanceof Error) return isNetworkError(cause);
+  if (cause && typeof cause === 'object') return isNetworkError(cause);
   return false;
 }
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -14,6 +14,30 @@ import type { AppRouter } from '@pops/api';
 export const trpc = createTRPCReact<AppRouter>();
 
 /**
+ * Without a timeout a hung backend leaves tRPC requests pending forever and
+ * the UI stuck on skeleton loaders. 15s is long enough for slow queries but
+ * short enough that the user notices something is wrong.
+ */
+export const TRPC_FETCH_TIMEOUT_MS = 15_000;
+
+function fetchWithTimeout(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort('timeout'), TRPC_FETCH_TIMEOUT_MS);
+
+  // Chain the caller's signal (e.g. React Query cancellation) with our timeout
+  // so aborting either source aborts the request.
+  const callerSignal = init?.signal;
+  if (callerSignal) {
+    if (callerSignal.aborted) controller.abort(callerSignal.reason);
+    else callerSignal.addEventListener('abort', () => controller.abort(callerSignal.reason));
+  }
+
+  return fetch(input, { ...init, signal: controller.signal }).finally(() =>
+    clearTimeout(timeoutId)
+  );
+}
+
+/**
  * tRPC client instance with httpBatchLink.
  * Batches multiple requests into a single HTTP call for better performance.
  * The shell passes this to <trpc.Provider>.
@@ -23,8 +47,40 @@ export const trpcClient = trpc.createClient({
     httpBatchLink({
       url: '/trpc', // Proxied by Vite to localhost:3000 in dev
       maxURLLength: 2083,
+      fetch: fetchWithTimeout,
     }),
   ],
 });
+
+const NETWORK_ERROR_FRAGMENTS = [
+  'Failed to fetch',
+  'NetworkError',
+  'Network request failed',
+  'aborted',
+  'timeout',
+];
+
+function messageLooksLikeNetworkFailure(err: object): boolean {
+  if (!('message' in err) || typeof err.message !== 'string') return false;
+  return NETWORK_ERROR_FRAGMENTS.some((fragment) => (err.message as string).includes(fragment));
+}
+
+/**
+ * Heuristic: is this error a network/transport-level failure (server
+ * unreachable, request aborted, fetch threw) rather than a tRPC error
+ * returned by the server with a real status code?
+ *
+ * Server-returned errors have a `data` field with `httpStatus`. Network
+ * failures don't make it that far, so they bubble up as a TRPCClientError
+ * wrapping a fetch error or AbortError.
+ */
+export function isNetworkError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  if ('data' in err && err.data != null) return false;
+  if (messageLooksLikeNetworkFailure(err)) return true;
+  const cause = 'cause' in err ? err.cause : undefined;
+  if (cause instanceof Error) return isNetworkError(cause);
+  return false;
+}
 
 export type { AppRouter };


### PR DESCRIPTION
Closes #2462.

## Problem

When `pops-api` is unreachable (paused, crashed, dropped Cloudflare tunnel), every list page sat on its skeleton loaders forever. No timeout, no banner, no toast. The user couldn't tell hung from slow — and on a self-hosted setup, tunnel hiccups are routine.

## Changes

- `httpBatchLink` now wraps `fetch` with a 15s `AbortController` timeout (`TRPC_FETCH_TIMEOUT_MS`). The caller's signal — e.g. React Query cancellation — is chained, so an abort from either source cancels the request.
- Export `isNetworkError(err)`: heuristic that distinguishes transport failures from server-returned tRPC errors. Server errors carry a populated `.data` field; network errors don't, and surface as `Failed to fetch` / `NetworkError` / `aborted` / `timeout`.
- Configure the shell's `QueryClient` with `QueryCache` + `MutationCache` global `onError`. On a network error it fires a single deduped sonner toast (`id: 'network-down'`): `Couldn't reach the server. Retrying…`. Server-returned 4xx/5xx with their per-feature handling are unaffected — no toast spam.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm vitest run` for `apps/pops-shell` — 174/174.
- [ ] Manual: `lsof -ti:3000 | xargs kill -STOP`, open `/finance/entities` — toast appears within ~15s. `kill -CONT <pid>` and the page recovers.