### PR TITLE
docs: rewrite modular-apps spike + open Epic 10 (#2510)

### DIFF
--- a/docs/architecture/adr-002-shell-architecture.md
+++ b/docs/architecture/adr-002-shell-architecture.md
@@ -43,3 +43,16 @@ Key reasons:
 - Cross-app navigation is instant (SPA, no full page reload)
 - Build time scales with total code, but Vite is fast and dev mode only processes the active route
 - Apps import from `@pops/ui` and shared packages, never from other apps. Cross-app communication goes through the API or shared stores in the shell
+
+## Surface Categories
+
+A module exposes one or more surfaces. The shell renders them differently:
+
+| Surface   | Render path                                                                                                 |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
+| `app`     | Page-routed module owning its navigation and pages (e.g. finance, media, inventory, ai, cerebrum)           |
+| `overlay` | Mounted into a shell chrome slot; summoned by shortcut/icon; no dedicated `/path` (e.g. ego floating panel) |
+
+A module may declare multiple surfaces. `ego` is **dual-surface** — it has both a `/cerebrum/chat` route (`app`) and a system-wide overlay panel (`overlay`) sharing tRPC state. Modules express this via `surfaces: ['app', 'overlay']` on their `ModuleManifest`.
+
+The set of installed modules is a runtime decision driven by the `POPS_APPS` and `POPS_OVERLAYS` env vars; the shell composes routers and routes from the manifests of installed modules only. See [Epic 10 — Modular Module Runtime](../themes/01-foundation/epics/10-modular-module-runtime.md), [PRD-098 (ModuleManifest)](../themes/01-foundation/prds/098-module-manifest/README.md), and [PRD-100 (Tier 1 loader)](../themes/01-foundation/prds/100-module-runtime-tier-1/README.md).

--- a/docs/architecture/adr-004-api-domain-modules.md
+++ b/docs/architecture/adr-004-api-domain-modules.md
@@ -33,3 +33,9 @@ Module rules:
 - Clear domain boundaries enforced by import rules
 - Cross-domain joins are trivial (same SQLite file)
 - Adding a new domain means adding a new module directory and registering its router
+
+## Manifest-Driven Composition
+
+Each domain module exports a `ModuleManifest` ([PRD-098](../themes/01-foundation/prds/098-module-manifest/README.md)) declaring its router, schema, settings, and surfaces. The tRPC root composes only the routers of modules listed in `POPS_APPS` / `POPS_OVERLAYS`; modules absent from those env vars do not mount, and their migrations do not run. Default (`POPS_APPS` unset) preserves current behaviour. See [Epic 10 — Modular Module Runtime](../themes/01-foundation/epics/10-modular-module-runtime.md) and [PRD-100](../themes/01-foundation/prds/100-module-runtime-tier-1/README.md).
+
+Cross-module import boundaries (`apps/pops-api/src/modules/<x>/**` may not import from `<y>/**` where x ≠ y, except `core`) are lint-enforced by [PRD-097](../themes/01-foundation/prds/097-module-import-boundaries/README.md), not honour-system.

--- a/docs/ideas/modular-apps-spike.md
+++ b/docs/ideas/modular-apps-spike.md
@@ -1,29 +1,18 @@
-# Spike — POPS as a suite of apps on a shell
+# Spike — POPS as a suite of modules on a shell
 
 Investigation only — recommendations, no code changes. Sibling spikes: [deployment-split](./deployment-split-spike.md), [feature-toggles](./feature-toggles-spike.md).
 
+Outcome: superseded by **Epic 10 — Modular Module Runtime** ([docs/themes/01-foundation/epics/10-modular-module-runtime.md](../themes/01-foundation/epics/10-modular-module-runtime.md)). The spike below describes the goal-state architecture; PRDs 097–100 carry the implementation.
+
 ## Question
 
-Restructure POPS so someone can install **only** finance, or **only** media, or "everything but ego", etc. The shell (auth, user, admin, settings, navigation, shared UI) is always present. Each app owns its data, API, and pages. Cross-app communication goes through well-defined contracts. **Apps can be added or removed progressively after install, not just at install time.**
+Restructure POPS so an operator can install **only** finance, **only** media, or "everything but ego". The shell (auth, user, admin, settings, navigation, shared UI) is always present. Each module owns its data, API, and surfaces. Cross-module communication goes through well-defined contracts. The set of installed modules is a runtime decision, not a compile-time one.
 
-## Current state — better than expected
+## Surface model — three categories
 
-The bones are already here:
+Three categories: **shell**, **app**, **overlay**.
 
-- `apps/pops-shell/src/app/router.tsx:10-13` — shell statically imports four app packages (`@pops/app-finance`, `@pops/app-media`, `@pops/app-inventory`, `@pops/app-ai`) and mounts their exported routes
-- `apps/pops-api/src/router.ts:24-30` — tRPC root manually composes per-domain routers (`finance`, `media`, `inventory`, `cerebrum`, `core`)
-- `packages/app-*` — each app is a proper workspace package with its own `src/index.ts`, routes, pages, store. Research confirms **no app imports another app** — apps import shared workspace packages (`@pops/ui`, `@pops/api-client`, `@pops/navigation`, `@pops/db-types`, `@pops/types`, etc.) and external libraries as needed
-- [ADR-002](../architecture/adr-002-shell-architecture.md) explicitly states "apps import from `@pops/ui` and shared packages, never from other apps. Cross-app communication goes through the API or shared stores"
-- [ADR-004](../architecture/adr-004-api-domain-modules.md) limits backend modules to importing from `core/` only
-- `@pops/navigation` already uses a **side-effect registry** (`registerResultComponent`) for search result components; backend search adapters are a separate registry (`registerSearchAdapter`) in `apps/pops-api/src/modules/core/search` — the seed of the right pattern
-
-So the architecture is already close. The remaining work is to make app presence a runtime decision instead of a compile-time one, and to formalise contracts.
-
-## The shell / app / overlay boundary
-
-Three categories, not two. This falls out of the ego question — ego is not a page-routed app, it's a system-wide overlay (like search) that is still installable/removable.
-
-Always present (the "shell"):
+Always present (the shell):
 
 | Surface            | Provided by                                                                                                       |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------- |
@@ -34,31 +23,29 @@ Always present (the "shell"):
 | API client + types | `packages/api-client`, `packages/db-types` (core schema)                                                          |
 | Shared entities    | `core/entities` ([ADR-005](../architecture/adr-005-shared-entities.md))                                           |
 
-Optional page-routed apps (own navigation, pages, domain data):
+Optional page-routed modules (own navigation, pages, domain data):
 
-| App                 | Tables owned                                                                                | Notes                                                               |
-| ------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| finance             | `transactions`, `budgets`, `wishlist`, `transaction_tag_rules`                              | Uses `entities` FK                                                  |
-| media               | `movies`, `tv_shows`, `comparisons`, `watch_history`, `watchlist`, `rotation_*`, ~11 tables | Heaviest; external integrations (Plex, TMDB, TVDB, Arr)             |
-| inventory           | `home_inventory`, `item_connections`, `item_documents`, `item_photos`, `locations`          | Uses `entities` FK                                                  |
-| ai-admin (`app-ai`) | `ai_usage`, `ai_providers`, `ai_model_pricing`, `ai_inference_log`, `ai_budgets`            | Admin surface for AI providers + usage; under the cerebrum umbrella |
-| engrams             | `engrams`, `debrief_*`, knowledge/notes schema                                              | Notion-like notes/knowledge app; under the cerebrum umbrella        |
-| _(future)_          | _(more under cerebrum)_                                                                     | Cerebrum is an umbrella theme, not a single app                     |
+| Module    | Tables owned                                                                                | Notes                                                                    |
+| --------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| finance   | `transactions`, `budgets`, `wishlist`, `transaction_tag_rules`                              | Uses `entities` FK                                                       |
+| media     | `movies`, `tv_shows`, `comparisons`, `watch_history`, `watchlist`, `rotation_*`, ~11 tables | Heaviest; external integrations (Plex, TMDB, TVDB, Arr)                  |
+| inventory | `home_inventory`, `item_connections`, `item_documents`, `item_photos`, `locations`          | Uses `entities` FK                                                       |
+| ai        | `ai_usage`, `ai_providers`, `ai_model_pricing`, `ai_inference_log`, `ai_budgets`            | AI ops admin surface                                                     |
+| cerebrum  | `engrams`, `glia_*`, `nudges`, `plexus_*`, `reflex_*`                                       | One togglable unit; sub-modules share hard internal deps and ship as one |
 
-Optional overlays (installable/removable, but no dedicated navigation space — they surface through shell chrome):
+Cerebrum is one togglable unit. Sub-modules (engrams, glia, nudges, plexus, reflex) have hard internal dependencies and ship together. Sub-toggles, where needed, are internal env flags rather than separate installable modules.
 
-| Overlay | Summoned from                                              | Owns                                                                    |
-| ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
-| search  | Top-bar icon + keyboard shortcut                           | Search adapters, recent-searches state (currently built into the shell) |
-| ego     | Floating assistant across every page (like a chat overlay) | Conversation history, persona/memory config, AI overlay session state   |
+Optional overlays (installable, no dedicated `/path` — they surface through shell chrome):
 
-Both categories are _installable_ — they register their routers, migrations, settings, and (for apps) routes. Overlays differ only in how they surface: no dedicated `/path` in the router, instead they hook into shell chrome via a registry. Today search lives inside the shell; under this model it graduates to a first-class overlay module, making ego a sibling rather than a special case.
+| Overlay | Summons via                                 | Owns                                                                         |
+| ------- | ------------------------------------------- | ---------------------------------------------------------------------------- |
+| ego     | Floating panel + keyboard shortcut + chrome | Conversation state shared with `/cerebrum/chat`; settings at `/settings/ego` |
 
-## What has to change
+`ego` is naturally **dual-surface** — it has both a `/cerebrum/chat` page and a system-wide overlay. The manifest models this by letting one module declare multiple surfaces, not by forcing a single `kind`. Future overlays (e.g. graduated `search`) follow the same pattern.
 
-### 1. Module manifest
+## Module manifest
 
-Each module (app or overlay) exports a manifest instead of bare `routes` + `navConfig`:
+Each module exports a manifest. Surfaces are an array, not a single `kind` — supporting dual-surface modules cleanly.
 
 ```ts
 // packages/app-finance/src/index.ts
@@ -66,131 +53,88 @@ export const manifest: ModuleManifest = {
   id: 'finance',
   name: 'Finance',
   version: '1.0.0',
-  kind: 'app',                    // 'app' | 'overlay'
+  surfaces: ['app'],
   frontend: { routes, navConfig, searchAdapters },
   backend: { router: financeRouter, jobs: [...] },
-  schema: financeSchemas,        // drizzle tables owned by this module
-  migrations: './migrations',     // module-owned migrations
-  dependsOn: ['core.entities'],   // contracts consumed
+  schema: financeSchemas,
+  dependsOn: ['core.entities'],
   provides: ['finance.transaction', 'finance.budget'],
-  settings: financeSettingsManifest,
-  onInstall: async (db) => {...}, // first-install side effects
-  onUninstall: async (db, opts) => {...}, // opts.mode: 'soft' | 'hard'
+  settings: financeSettingsManifest, // PRD-093 SettingsManifest, plugged in as a slot
 };
 
 // packages/overlay-ego/src/index.ts
 export const manifest: ModuleManifest = {
   id: 'ego',
   name: 'Ego',
-  kind: 'overlay',
+  surfaces: ['overlay', 'app'], // dual-surface: chrome overlay + /cerebrum/chat
   frontend: {
-    chromeSlot: 'assistant',     // where in shell chrome it mounts
-    component: EgoOverlay,
-    settingsRoute: '/settings/ego',
+    overlay: { component: EgoOverlay, chromeSlot: 'assistant', shortcut: 'mod+i' },
+    routes,
+    navConfig,
   },
   backend: { router: egoRouter, jobs: [...] },
-  schema: egoSchemas,             // owns conversation + memory tables
-  // ...
+  schema: egoSchemas,
+  settings: egoSettingsManifest, // settings live at /settings/ego (already exists)
 };
 ```
 
-### 2. Runtime registry (shell + API)
+`SettingsManifest` ([PRD-093](../themes/01-foundation/prds/093-unified-settings/README.md)) plugs in as a `settings` slot inside `ModuleManifest`, not as a parallel concept.
 
-- **Backend**: replace the manual `appRouter` composition with a loader that reads an "installed apps" list (from the DB `apps` table) and composes only those routers. Migrations run per-app on install.
-- **Frontend**: replace the four static imports in `router.tsx` with a fetch to `/api/shell/manifest` that returns which apps are installed, then dynamic `import()` of each. Vite already code-splits per app chunk — this works today if we switch the import style.
-- Routes for uninstalled apps redirect to a "not installed" page rather than 404, so links from other apps degrade gracefully.
+## Backend modules — already siblings
 
-### 3. Contracts for cross-app communication
+`apps/pops-api/src/modules/` already splits `ego/` and `cerebrum/` as siblings. The frontend manifest must mirror this: ego is its own module with its own surfaces, not nested inside cerebrum.
 
-Today, cross-app comms is implicit (shared `entities` FK, implicit URI resolution in `@pops/navigation`). Formalise as:
+Per-module migrations are deferred. `0038-0041` straddle cerebrum sub-modules; slicing them is cosmetic until there is a real driver. Hard-uninstall preflight (export → drop → null cross-refs) is also deferred — soft-by-default covers every current use case.
 
-- **Typed contracts**: `packages/contracts/` defines versioned interfaces (e.g. `core.entity@1`, `finance.transaction@1`). Apps consume via tRPC calls only.
-- **No cross-app imports at code level** (already enforced — keep enforcing).
-- **Optional dependencies**: an app that _can_ link to an object type from another app (e.g. inventory item linked from a finance transaction note) must declare it as optional and degrade when that app is absent. The URI resolver ([ADR-012](../architecture/adr-012-universal-object-uri.md)) needs to tolerate missing resolvers.
-- **FK hygiene**: cross-app FKs become nullable with `ON DELETE SET NULL`. No cascading deletes across app boundaries.
+## Cross-module communication
 
-### 4. Database — the real cost
+- Cross-module imports are forbidden at code level, enforced by [PRD-097](../themes/01-foundation/prds/097-module-import-boundaries/README.md) lint rules (not honour-system).
+- Cross-module data references go through tRPC contracts; FKs that cross module boundaries are nullable with `ON DELETE SET NULL`.
+- The URI resolver ([ADR-012](../architecture/adr-012-universal-object-uri.md)) and universal search degrade gracefully when a referenced module is absent.
 
-SQLite is one file, and today's FKs cross boundaries. Two sub-problems:
+## Tier 1 — env-driven runtime
 
-- **Install**: run that app's migrations against the shared DB. Each app owns a migration folder; `drizzle-kit` run scoped per app. The existing single-migrations model ([ADR-013](../architecture/adr-013-drizzle-orm.md)) needs to be sliced per app.
-- **Uninstall**: what happens to the data?
-  - _Soft uninstall_ (default): routes hidden, router unmounted, jobs stopped, data retained. Reinstall is instant.
-  - _Hard uninstall_: export (JSON) → drop tables → null cross-refs. Needs a per-app export format and user confirmation.
-  - Cross-app references (e.g. inventory items referenced from finance) must be scanned before hard uninstall. Show "this will break N links in finance" before proceeding.
+`POPS_APPS=finance,inventory` and `POPS_OVERLAYS=ego` decide what mounts at boot:
 
-### 5. Progressive add/remove UX
+- Backend tRPC root reads env, composes only listed modules' routers; migrations run only for listed modules.
+- Frontend fetches `/api/shell/manifest` to learn which modules are installed, then dynamic-imports them. Vite already code-splits per workspace package — switching from static to dynamic imports preserves the split.
+- Routes for absent modules redirect to a "not installed" page (not 404). Universal search and the URI resolver tolerate the gaps.
+- Default (`POPS_APPS` unset) behaves identically to today.
 
-- New admin page: **Apps**. Lists installed apps, available-but-not-installed apps, and a button to install/uninstall.
-- Install: runs migrations, seeds default settings, hot-registers the backend router, triggers shell manifest refresh.
-- Uninstall: soft by default; "Remove data" is a separate destructive confirmation.
-- Shell re-renders on manifest change without a full reload (React Router supports dynamic route trees; easier: reload on install/uninstall — fine for self-hosted single-user).
+Restart-on-change is acceptable; hot-register is not on the critical path.
 
-## Two tiers — ship in this order
-
-Restart-on-change is acceptable, so neither tier needs hot-register/hot-migrate. The difference is how the set of installed modules is _declared_.
-
-1. **Tier 1 — Declarative via env** (low risk, ~1 week):
-   - `POPS_APPS=finance,inventory,engrams` + `POPS_OVERLAYS=search,ego` at container start decide what gets mounted.
-   - Migrations run only for listed modules on boot.
-   - Changing the set requires a container restart. Default is soft: stopping a module keeps its tables and data intact.
-   - Covers the "third-party installs only finance" story via the operator's env file.
-2. **Tier 2 — Admin-UI driven (still restart to apply)** (~2 weeks after Tier 1):
-   - Admin **Modules** page lists installed, available, and removed modules.
-   - Install / soft-remove writes to an `installed_modules` table and prompts a restart (or triggers one for self-hosted).
-   - **Hard-remove** is a separate destructive action with a preflight:
-     - Scan cross-module FKs, show "this will null N links in finance, M in inventory" before confirming.
-     - Export the module's tables to JSON/SQL backup under `data/exports/<module>/<timestamp>/`.
-     - Drop tables in a transaction, null cross-refs, remove from `installed_modules`.
-   - Soft remains the default everywhere; hard is opt-in and gated behind a typed confirmation.
+Tier 2 (admin **Modules** page, install/remove from UI, hard-uninstall preflight) is deferred until there is a concrete driver.
 
 ## Advantages
 
-- Third-party installability — someone can run "just media" on their own server with no finance data model present
-- Smaller install footprint when features aren't wanted (fewer tables, fewer env vars required, fewer cron jobs)
-- Clearer architectural boundaries — contracts become explicit instead of implicit
-- Enables independent app versioning later if we want
-- Supports [deployment-split](./deployment-split-spike.md) — a split deploy repo can compose different POPS images for different hosts
-- Pairs with [feature-toggles](./feature-toggles-spike.md) — modules are the coarse grain, toggles the fine grain
+- An operator can run "just finance" or "everything but ego" without code changes
+- Smaller install footprint when features aren't wanted (fewer tables, fewer cron jobs, fewer required env vars)
+- Cross-module boundaries become explicit and lint-enforced
+- Pairs with [feature-toggles](./feature-toggles-spike.md): modules are coarse grain, toggles are fine grain
+- Pairs with [deployment-split](./deployment-split-spike.md): a split deploy repo can compose different POPS images for different hosts
 
 ## Disadvantages / risks
 
-- **Schema migrations get harder**: per-module migration folders, cross-module FK ordering, install/uninstall idempotency — real work
-- **Cross-module features degrade**: universal search, URI resolver, the ego overlay (all of which expect every domain to be present) need to handle absent modules
-- **More surface to test**: matrix of installed-module combinations grows fast. With 4 apps + 2 overlays that's 64 possible sets; test the sensible ones (everything, minimum viable, each-alone) not the full matrix
-- **Data gravity**: media owns the most schema — making it removable is a lot of work for what will probably always be installed on your server
-- **Single SQLite file**: works fine for this model; if someone wants "totally separate databases per module" that's a bigger rethink (and probably not needed)
-
-## Resolved
-
-- **Cerebrum is an umbrella theme, not an app.** Under it sit independently installable modules: `ego` (overlay), `engrams` (app — Notion-like knowledge/notes), `ai-admin` (app — the current `app-ai`: usage, prompts, rules, cache), and more to come.
-- **Ego is an overlay, not a page-routed app.** It behaves like an app (installable/removable, has settings, owns its data) but surfaces as a system-wide overlay like search. This justifies the `kind: 'overlay'` distinction in the manifest.
-- **Audience is both** — architectural hygiene for the current server AND third-party installability. Design contracts and manifests tight enough that `git clone && docker compose up` with `POPS_APPS=finance` produces a working single-app install.
-- **Restart-on-change is acceptable**, so hot-register is not on the critical path. Soft-remove is the default; hard-remove is a separately-gated destructive action.
-
-## Still open
-
-- Are per-module settings owned by the module (manifest registers them) or all in core? Manifest-owned feels right; revisit when the feature-toggle framework lands.
-- Does admin (user management, audit, system settings) live in the shell or become its own mini-app? Lean shell for now.
-- Are we willing to enforce "no cross-module code imports" via a lint rule (eslint-plugin-boundaries or dependency-cruiser), not just convention?
-- Where does `packages/app-ai` rename land? To `packages/app-ai-admin` (clearer) or stay `app-ai` with an updated description?
-- Does `packages/navigation` stay shell-level (search coexists with `ego` there) or split into `packages/overlay-search` + `packages/overlay-ego` once overlays are a formal category?
+- **Cross-module features must degrade**: universal search, URI resolver, and the ego overlay (which expects every domain to be present for context) need missing-module handling
+- **Test surface grows**: with N apps + M overlays, the install-set matrix grows quickly. Test only the sensible sets (everything; minimum viable; finance-only; cerebrum-absent), not the full matrix
+- **Per-module migrations stay deferred**: existing migrations cross sub-module boundaries. Slicing them is real work and not yet needed
+- **Single SQLite file**: works fine for this model. "Totally separate databases per module" is a bigger rethink that isn't on the table
 
 ## Recommendation
 
-Yes. Sequence:
+Yes. PRDs under Epic 10:
 
-1. Formalise the manifest + `kind: 'app' | 'overlay'` distinction
-2. Graduate `search` from shell-internal to a first-class overlay (no behaviour change, just the shape we want)
-3. Add the contracts package and the per-module migration layout
-4. Ship Tier 1 (`POPS_APPS` / `POPS_OVERLAYS` env, per-module migrations, registry-based composition)
-5. Build the admin **Modules** page with soft-install/remove + destructive hard-remove with preflight scan (Tier 2)
-6. Enforce "no cross-module imports" with a lint rule so the boundary stops being honour-system
-7. In parallel, start the split under the cerebrum umbrella: extract `engrams` as its own app, rename/repurpose `app-ai` → ai-admin, scaffold `overlay-ego`
+1. **PRD-097** — Cross-module import boundaries (lint). Ship first; honour-system is fragile.
+2. **PRD-098** — Module manifest type. Metadata-only contract; no runtime change. Prereq for the loader.
+3. **PRD-099** — Overlay surfaces + ego dual-surface. Extracts `packages/overlay-ego`, formalises overlay category.
+4. **PRD-100** — Tier 1 module runtime (`POPS_APPS` env loader). Manifest-driven router composition + dynamic frontend imports + not-installed fallback.
 
-## Next steps if we proceed
+Tier 2 (admin Modules page) and per-module migrations stay deferred.
 
-- Open an epic under a new `07-shell` theme (or extend `01-foundation`): "Modular module runtime".
-- PRDs: (1) manifest + registry, (2) per-module migrations, (3) frontend dynamic load, (4) contracts package, (5) admin Modules page incl. hard-remove preflight, (6) overlay category + ego scaffold, (7) engrams app extraction.
-- Write an ADR extending [ADR-002](../architecture/adr-002-shell-architecture.md) / [ADR-004](../architecture/adr-004-api-domain-modules.md) to lock in app-vs-overlay + the registry model.
-- Pre-work: audit cross-module FKs in `packages/db-types/src/schema/`, scope the split of `cerebrum` backend module into ego + engrams + ai-admin backends.
+## Closed questions
+
+- **Cerebrum is one unit, not an umbrella of sibling modules.** Engrams, glia, nudges, plexus, reflex have hard internal dependencies and ship together.
+- **Ego is dual-surface**, not a binary `app | overlay`. The manifest models surfaces as an array.
+- **`packages/app-ai` keeps its name.** It is the AI operations admin surface; rename was cosmetic.
+- **Per-module migration slicing is deferred** until a concrete driver appears.
+- **Hard-uninstall preflight is deferred**. Soft-by-default covers current use cases.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,16 +63,17 @@ Live status of every theme and epic. Updated as work completes.
 
 ### Phase 1 — Foundation
 
-| Epic                                  | Status | Notes                                                                                                                  |
-| ------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------- |
-| Project bootstrap (pnpm, Turbo, mise) | Done   | pnpm v10, Turbo orchestration, mise task runner                                                                        |
-| UI component library (`@pops/ui`)     | Done   | 86+ components, Storybook, Tailwind v4                                                                                 |
-| Shell & app switcher (`pops-shell`)   | Done   | Lazy-loaded apps, AppRail, responsive sidebar, app theme colour propagation                                            |
-| API modularisation (`pops-api`)       | Done   | 4 domain modules (core, finance, inventory, media)                                                                     |
-| DB schema patterns & migrations       | Done   | 28 tables, timestamp migrations, entity types                                                                          |
-| Responsive foundation                 | Done   | Tailwind v4 breakpoints, mobile-first, touch targets                                                                   |
-| Drizzle ORM migration                 | Done   | All modules use Drizzle ORM; raw SQL eliminated                                                                        |
-| Platform search (Epic 07)             | Done   | All 3 PRDs complete: search engine (PRD-057), search UI with keyboard nav (PRD-056), contextual intelligence (PRD-058) |
+| Epic                                  | Status      | Notes                                                                                                                  |
+| ------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Project bootstrap (pnpm, Turbo, mise) | Done        | pnpm v10, Turbo orchestration, mise task runner                                                                        |
+| UI component library (`@pops/ui`)     | Done        | 86+ components, Storybook, Tailwind v4                                                                                 |
+| Shell & app switcher (`pops-shell`)   | Done        | Lazy-loaded apps, AppRail, responsive sidebar, app theme colour propagation                                            |
+| API modularisation (`pops-api`)       | Done        | 4 domain modules (core, finance, inventory, media)                                                                     |
+| DB schema patterns & migrations       | Done        | 28 tables, timestamp migrations, entity types                                                                          |
+| Responsive foundation                 | Done        | Tailwind v4 breakpoints, mobile-first, touch targets                                                                   |
+| Drizzle ORM migration                 | Done        | All modules use Drizzle ORM; raw SQL eliminated                                                                        |
+| Platform search (Epic 07)             | Done        | All 3 PRDs complete: search engine (PRD-057), search UI with keyboard nav (PRD-056), contextual intelligence (PRD-058) |
+| Modular module runtime (Epic 10)      | Not started | PRDs 097-100: lint boundaries, ModuleManifest, overlay surfaces + ego dual-surface, Tier 1 `POPS_APPS` env loader      |
 
 ### Phase 2 — Core Apps
 

--- a/docs/themes/01-foundation/README.md
+++ b/docs/themes/01-foundation/README.md
@@ -19,20 +19,21 @@ Build a multi-app platform from a shared foundation: one monorepo, one shell, on
 
 ## Epics
 
-| #   | Epic                                                       | Summary                                                                                                           | Status  |
-| --- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------- |
-| 0   | [Project Bootstrap](epics/00-project-bootstrap.md)         | pnpm monorepo, Turbo, mise, TypeScript strict, ESLint, Prettier, Vitest, Playwright                               | Done    |
-| 1   | [UI Component Library](epics/01-ui-component-library.md)   | `@pops/ui` — Shadcn/Radix primitives, composites, design tokens, centralised styling, Storybook                   | Partial |
-| 2   | [Shell & App Switcher](epics/02-shell-app-switcher.md)     | `pops-shell` — lazy-loaded apps, AppRail, responsive sidebar, app theme colour propagation                        | Done    |
-| 3   | [API Server](epics/03-api-server.md)                       | `pops-api` — Express + tRPC, domain-grouped routers, middleware (auth, rate limiting, errors)                     | Done    |
-| 4   | [DB Schema Patterns](epics/04-db-schema-patterns.md)       | SQLite, timestamp migrations, shared entities, cross-domain FKs, seed data, UUIDs                                 | Done    |
-| 5   | [Responsive Foundation](epics/05-responsive-foundation.md) | Tailwind v4 breakpoints, mobile-first, 44x44px touch targets, component adaptations                               | Partial |
-| 6   | [Drizzle ORM](epics/06-drizzle-orm.md)                     | Type-safe queries and schema-as-code, replacing raw SQL                                                           | Done    |
-| 7   | [Search](epics/07-search.md)                               | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs | Done    |
-| 8   | [Settings System](epics/08-settings-system.md)             | Unified, self-registering settings page — modular sections per app, replaces scattered settings UIs               | Done    |
-| 9   | [Feature Toggles](epics/09-feature-toggles.md)             | FeatureManifest + `isEnabled()` helper, admin Features page, credential gating, per-user preferences              | Partial |
+| #   | Epic                                                         | Summary                                                                                                                | Status      |
+| --- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | ----------- |
+| 0   | [Project Bootstrap](epics/00-project-bootstrap.md)           | pnpm monorepo, Turbo, mise, TypeScript strict, ESLint, Prettier, Vitest, Playwright                                    | Done        |
+| 1   | [UI Component Library](epics/01-ui-component-library.md)     | `@pops/ui` — Shadcn/Radix primitives, composites, design tokens, centralised styling, Storybook                        | Partial     |
+| 2   | [Shell & App Switcher](epics/02-shell-app-switcher.md)       | `pops-shell` — lazy-loaded apps, AppRail, responsive sidebar, app theme colour propagation                             | Done        |
+| 3   | [API Server](epics/03-api-server.md)                         | `pops-api` — Express + tRPC, domain-grouped routers, middleware (auth, rate limiting, errors)                          | Done        |
+| 4   | [DB Schema Patterns](epics/04-db-schema-patterns.md)         | SQLite, timestamp migrations, shared entities, cross-domain FKs, seed data, UUIDs                                      | Done        |
+| 5   | [Responsive Foundation](epics/05-responsive-foundation.md)   | Tailwind v4 breakpoints, mobile-first, 44x44px touch targets, component adaptations                                    | Partial     |
+| 6   | [Drizzle ORM](epics/06-drizzle-orm.md)                       | Type-safe queries and schema-as-code, replacing raw SQL                                                                | Done        |
+| 7   | [Search](epics/07-search.md)                                 | Platform-wide search from TopBar, context-aware results, structured query syntax, cross-domain via universal URIs      | Done        |
+| 8   | [Settings System](epics/08-settings-system.md)               | Unified, self-registering settings page — modular sections per app, replaces scattered settings UIs                    | Done        |
+| 9   | [Feature Toggles](epics/09-feature-toggles.md)               | FeatureManifest + `isEnabled()` helper, admin Features page, credential gating, per-user preferences                   | Partial     |
+| 10  | [Modular Module Runtime](epics/10-modular-module-runtime.md) | Manifest contract + env-driven loader (`POPS_APPS`/`POPS_OVERLAYS`); lint-enforced module boundaries; overlay category | Not started |
 
-Epic 0 is prerequisite to everything. Epics 1-5 can be built incrementally. Epic 6 is independent. Epic 8 depends on Epic 4 (settings table) and Epic 2 (shell routing). Epic 9 depends on Epic 8 (manifest pattern) and Epic 4 (`user_settings` table).
+Epic 0 is prerequisite to everything. Epics 1-5 can be built incrementally. Epic 6 is independent. Epic 8 depends on Epic 4 (settings table) and Epic 2 (shell routing). Epic 9 depends on Epic 8 (manifest pattern) and Epic 4 (`user_settings` table). Epic 10 depends on Epics 2 and 3 (shell and API surface) and Epic 8 (settings manifest plugs in as a slot inside the module manifest).
 
 ## Key Decisions
 

--- a/docs/themes/01-foundation/epics/10-modular-module-runtime.md
+++ b/docs/themes/01-foundation/epics/10-modular-module-runtime.md
@@ -1,0 +1,38 @@
+# Epic 10: Modular Module Runtime
+
+> Theme: [Foundation](../README.md)
+
+## Scope
+
+Make the set of installed modules a runtime decision, not a compile-time one. Formalise the **shell / app / overlay** surface model, define a `ModuleManifest` contract every module exports, and ship a Tier 1 env-driven loader (`POPS_APPS`, `POPS_OVERLAYS`) that mounts only the listed modules. Cross-module import boundaries are lint-enforced, not honour-system.
+
+Implements the recommendations from [docs/ideas/modular-apps-spike.md](../../../ideas/modular-apps-spike.md). Supersedes the original spike framing where ego was a sub-module of cerebrum and modules had a binary `app | overlay` kind.
+
+## PRDs
+
+| #   | PRD                                                                        | Summary                                                                                        | Status      |
+| --- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------- |
+| 097 | [Module Import Boundaries](../prds/097-module-import-boundaries/README.md) | Lint rule banning cross-app and cross-module imports; baseline + CI integration                | Not started |
+| 098 | [Module Manifest](../prds/098-module-manifest/README.md)                   | `ModuleManifest` type + adoption across every app and api module (metadata-only)               | Not started |
+| 099 | [Overlay Surfaces](../prds/099-overlay-surfaces/README.md)                 | Overlay surface category, `packages/overlay-ego` extraction, ego as dual-surface               | Not started |
+| 100 | [Module Runtime — Tier 1](../prds/100-module-runtime-tier-1/README.md)     | `POPS_APPS` / `POPS_OVERLAYS` env loader, manifest-driven router composition, gated migrations | Not started |
+
+Parallelisation:
+
+- **PRD-097** is independent. Land it first to keep the next three from leaking new boundary violations.
+- **PRD-098** is metadata-only — additive exports, no runtime change. Independent of PRD-099.
+- **PRD-099** is recommended after PRD-098 so the overlay-ego extraction emits a manifest in the final shape.
+- **PRD-100** depends on PRD-098 (loader consumes the manifest shape).
+
+## Dependencies
+
+- **Requires:** Epic 02 (Shell & App Switcher — workspace-package shape), Epic 03 (API Server — domain-grouped routers), Epic 08 (Settings System — `SettingsManifest` plugs in as a slot inside `ModuleManifest`)
+- **Unlocks:** Operator-controlled install sets ("just finance"; "everything but ego"); tighter coupling discipline as more modules ship; future Tier 2 admin Modules page
+
+## Out of Scope
+
+- Tier 2 admin **Modules** page (install/remove from UI). Deferred until there is a concrete driver.
+- Per-module migration slicing. Existing migrations cross cerebrum sub-module boundaries; slicing is cosmetic until a real driver appears.
+- Hard-uninstall preflight (export → drop tables → null cross-refs). Soft-by-default covers every current use case.
+- Cerebrum sub-module toggles (engrams, glia, nudges, plexus, reflex). Cerebrum ships as one unit.
+- Migrating `search` from shell-internal to a first-class overlay. Tracked separately when it has its own driver.


### PR DESCRIPTION
## Summary

- Rewrites `docs/ideas/modular-apps-spike.md` to reflect the post-cerebrum reality: cerebrum ships as one togglable unit, ego is dual-surface, `SettingsManifest` plugs in as a slot inside `ModuleManifest`.
- Opens **Epic 10 — Modular Module Runtime** under Foundation with PRDs 097–100 (lint boundaries, manifest, overlay surfaces + ego dual-surface, Tier 1 `POPS_APPS` env loader).
- Updates ADR-002 (app/overlay surface categories), ADR-004 (manifest-driven router composition), the Foundation theme README, and the roadmap implementation tracker.

Closes #2510. Supersedes #2297.

## Test plan

- [ ] Skim spike doc — reads as goal-state, no migration framing
- [ ] Epic 10 PRD links all point at paths PRDs 097–100 will create
- [ ] Foundation theme README and roadmap show Epic 10 as Not started
- [ ] ADR-002 surface table + ADR-004 manifest-composition note read as accepted (not proposed)