### PR TITLE
feat(shell): ModuleManifest type + adopt incrementally (PRD-098, #2512)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -22,6 +22,8 @@ import { templatesRouter } from './templates/router.js';
 import { indexRouter } from './thalamus/router.js';
 import { gliaRouter as gliaWorkersRouter } from './workers/router.js';
 
+import type { ModuleManifest } from '@pops/types';
+
 export const cerebrumRouter = router({
   engrams: engramsRouter,
   scopes: scopesRouter,
@@ -36,3 +38,15 @@ export const cerebrumRouter = router({
   plexus: plexusRouter,
   reflex: reflexRouter,
 });
+
+/** PRD-098 manifest. Metadata-only; consumed by the PRD-100 loader. */
+export const manifest: ModuleManifest<typeof cerebrumRouter> = {
+  id: 'cerebrum',
+  name: 'Cerebrum',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description:
+    'Engram storage, retrieval, ingest/emit, plexus, reflex, glia — knowledge graph and agents.',
+  backend: { router: cerebrumRouter },
+  settings: cerebrumManifest,
+};

--- a/apps/pops-api/src/modules/core/index.ts
+++ b/apps/pops-api/src/modules/core/index.ts
@@ -33,6 +33,8 @@ import { searchRouter } from './search/router.js';
 import { settingsRouter } from './settings/router.js';
 import { tagRulesRouter } from './tag-rules/router.js';
 
+import type { ModuleManifest } from '@pops/types';
+
 export const coreRouter = router({
   entities: entitiesRouter,
   aiUsage: aiUsageRouter,
@@ -47,3 +49,18 @@ export const coreRouter = router({
   features: featuresRouter,
   search: searchRouter,
 });
+
+/**
+ * PRD-098 manifest. Core is the always-mounted shell module that every
+ * domain module is allowed to depend on. The PRD-100 loader treats `core`
+ * as non-optional regardless of `POPS_APPS`.
+ */
+export const manifest: ModuleManifest<typeof coreRouter> = {
+  id: 'core',
+  name: 'Core',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description:
+    'Cross-cutting platform services: entities, AI usage/providers, settings, features, search.',
+  backend: { router: coreRouter },
+};

--- a/apps/pops-api/src/modules/ego/index.ts
+++ b/apps/pops-api/src/modules/ego/index.ts
@@ -16,6 +16,8 @@ import { mergeRouters, router } from '../../trpc.js';
 import { contextRouter } from './router-context.js';
 import { chatRouter, conversationsRouter } from './router.js';
 
+import type { ModuleManifest } from '@pops/types';
+
 export const egoRouter = mergeRouters(
   chatRouter,
   router({
@@ -23,3 +25,19 @@ export const egoRouter = mergeRouters(
     context: contextRouter,
   })
 );
+
+/**
+ * PRD-098 manifest. Metadata-only; consumed by the PRD-100 loader.
+ * Ego is dual-surface (PRD-099): the frontend manifest in `packages/overlay-ego`
+ * declares `surfaces: ['app', 'overlay']`. The backend module declares only `app`
+ * because there is no separate "overlay backend" concept.
+ */
+export const manifest: ModuleManifest<typeof egoRouter> = {
+  id: 'ego',
+  name: 'Ego',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Conversational AI interface to Cerebrum (PRD-087).',
+  backend: { router: egoRouter },
+  settings: egoManifest,
+};

--- a/apps/pops-api/src/modules/finance/index.ts
+++ b/apps/pops-api/src/modules/finance/index.ts
@@ -17,9 +17,22 @@ import { importsRouter } from './imports/router.js';
 import { transactionsRouter } from './transactions/router.js';
 import { wishlistRouter } from './wishlist/router.js';
 
+import type { ModuleManifest } from '@pops/types';
+
 export const financeRouter = router({
   transactions: transactionsRouter,
   budgets: budgetsRouter,
   imports: importsRouter,
   wishlist: wishlistRouter,
 });
+
+/** PRD-098 manifest. Metadata-only; consumed by the PRD-100 loader. */
+export const manifest: ModuleManifest<typeof financeRouter> = {
+  id: 'finance',
+  name: 'Finance',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Transactions, budgets, entities, and import pipeline.',
+  backend: { router: financeRouter },
+  settings: financeManifest,
+};

--- a/apps/pops-api/src/modules/inventory/index.ts
+++ b/apps/pops-api/src/modules/inventory/index.ts
@@ -22,6 +22,8 @@ import { paperlessRouter } from './paperless/router.js';
 import { photosRouter } from './photos/index.js';
 import { reportsRouter } from './reports/index.js';
 
+import type { ModuleManifest } from '@pops/types';
+
 export const inventoryRouter = router({
   items: itemsRouter,
   locations: locationsRouter,
@@ -32,3 +34,14 @@ export const inventoryRouter = router({
   documentFiles: documentFilesRouter,
   paperless: paperlessRouter,
 });
+
+/** PRD-098 manifest. Metadata-only; consumed by the PRD-100 loader. */
+export const manifest: ModuleManifest<typeof inventoryRouter> = {
+  id: 'inventory',
+  name: 'Inventory',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Home items, locations, connections, warranties, and documents.',
+  backend: { router: inventoryRouter },
+  settings: inventoryManifest,
+};

--- a/apps/pops-api/src/modules/manifests.test.ts
+++ b/apps/pops-api/src/modules/manifests.test.ts
@@ -39,3 +39,55 @@ describe('PRD-098 backend module manifests', () => {
     }
   });
 });
+
+describe('PRD-098 assertModuleManifest negative cases', () => {
+  it('rejects a manifest with no backend and no frontend', () => {
+    expect(() => assertModuleManifest({ id: 'x', name: 'X', surfaces: ['app'] })).toThrow(
+      /at least one of 'backend' or 'frontend'/
+    );
+  });
+
+  it('rejects a backend whose router is null', () => {
+    expect(() =>
+      assertModuleManifest({
+        id: 'x',
+        name: 'X',
+        surfaces: ['app'],
+        backend: { router: null },
+      })
+    ).toThrow(/backend\.router/);
+  });
+
+  it('rejects an overlay surface without a frontend block', () => {
+    expect(() =>
+      assertModuleManifest({
+        id: 'x',
+        name: 'X',
+        surfaces: ['overlay'],
+        backend: { router: {} },
+      })
+    ).toThrow(/frontend\.overlay/);
+  });
+
+  it('rejects an overlay surface whose overlay config has no chromeSlot', () => {
+    expect(() =>
+      assertModuleManifest({
+        id: 'x',
+        name: 'X',
+        surfaces: ['overlay'],
+        frontend: { overlay: { shortcut: 'mod+i' } },
+      })
+    ).toThrow(/chromeSlot/);
+  });
+
+  it('accepts a frontend-only manifest with surfaces=[app]', () => {
+    expect(() =>
+      assertModuleManifest({
+        id: 'x',
+        name: 'X',
+        surfaces: ['app'],
+        frontend: { routes: [] },
+      })
+    ).not.toThrow();
+  });
+});

--- a/apps/pops-api/src/modules/manifests.test.ts
+++ b/apps/pops-api/src/modules/manifests.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertModuleManifest, type ModuleManifest } from '@pops/types';
+
+import { manifest as cerebrumManifest } from './cerebrum/index.js';
+import { manifest as coreManifest } from './core/index.js';
+import { manifest as egoManifest } from './ego/index.js';
+import { manifest as financeManifest } from './finance/index.js';
+import { manifest as inventoryManifest } from './inventory/index.js';
+import { manifest as mediaManifest } from './media/index.js';
+
+const manifests: ReadonlyArray<readonly [string, ModuleManifest]> = [
+  ['core', coreManifest],
+  ['finance', financeManifest],
+  ['inventory', inventoryManifest],
+  ['media', mediaManifest],
+  ['ego', egoManifest],
+  ['cerebrum', cerebrumManifest],
+];
+
+describe('PRD-098 backend module manifests', () => {
+  it.each(manifests)('%s manifest is structurally valid', (label, m) => {
+    expect(() => assertModuleManifest(m, label)).not.toThrow();
+  });
+
+  it.each(manifests)('%s manifest declares a backend router', (label, m) => {
+    expect(m.backend, `${label} should declare backend.router`).toBeDefined();
+    expect(m.backend?.router).toBeDefined();
+  });
+
+  it('manifest ids are unique across backend modules', () => {
+    const ids = manifests.map(([, m]) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every backend manifest id matches its label', () => {
+    for (const [label, m] of manifests) {
+      expect(m.id).toBe(label);
+    }
+  });
+});

--- a/apps/pops-api/src/modules/media/index.ts
+++ b/apps/pops-api/src/modules/media/index.ts
@@ -33,6 +33,8 @@ import { tvShowsRouter } from './tv-shows/index.js';
 import { watchHistoryRouter } from './watch-history/router.js';
 import { watchlistRouter } from './watchlist/router.js';
 
+import type { ModuleManifest } from '@pops/types';
+
 export const mediaRouter = router({
   movies: moviesRouter,
   tvShows: tvShowsRouter,
@@ -46,3 +48,18 @@ export const mediaRouter = router({
   plex: plexRouter,
   rotation: rotationRouter,
 });
+
+/**
+ * PRD-098 manifest. Metadata-only; consumed by the PRD-100 loader.
+ * Media owns multiple settings manifests (Plex, Arr, Rotation, Operational);
+ * they remain registered via `settingsRegistry.register` above and the
+ * `settings` slot is left empty until the unified registry consolidates.
+ */
+export const manifest: ModuleManifest<typeof mediaRouter> = {
+  id: 'media',
+  name: 'Media',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Movies, TV shows, watchlist, watch history, Plex/TMDB/TVDB sync.',
+  backend: { router: mediaRouter },
+};

--- a/apps/pops-shell/src/tests/manifests.test.ts
+++ b/apps/pops-shell/src/tests/manifests.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { manifest as aiManifest } from '@pops/app-ai';
+import { manifest as cerebrumManifest } from '@pops/app-cerebrum';
+import { manifest as financeManifest } from '@pops/app-finance';
+import { manifest as inventoryManifest } from '@pops/app-inventory';
+import { manifest as mediaManifest } from '@pops/app-media';
+import { assertModuleManifest, type ModuleManifest } from '@pops/types';
+
+const manifests: ReadonlyArray<readonly [string, ModuleManifest]> = [
+  ['ai', aiManifest],
+  ['cerebrum', cerebrumManifest],
+  ['finance', financeManifest],
+  ['inventory', inventoryManifest],
+  ['media', mediaManifest],
+];
+
+describe('PRD-098 frontend module manifests', () => {
+  it.each(manifests)('%s manifest is structurally valid', (label, m) => {
+    expect(() => assertModuleManifest(m, label)).not.toThrow();
+  });
+
+  it.each(manifests)('%s manifest declares frontend routes', (label, m) => {
+    expect(m.frontend, `${label} should declare frontend block`).toBeDefined();
+    expect(m.frontend?.routes, `${label} should declare frontend.routes`).toBeDefined();
+  });
+
+  it('manifest ids are unique across frontend modules', () => {
+    const ids = manifests.map(([, m]) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every frontend manifest id matches its label', () => {
+    for (const [label, m] of manifests) {
+      expect(m.id).toBe(label);
+    }
+  });
+});

--- a/docs/themes/01-foundation/prds/098-module-manifest/README.md
+++ b/docs/themes/01-foundation/prds/098-module-manifest/README.md
@@ -1,0 +1,64 @@
+# PRD-098: Module Manifest
+
+> Epic: [Modular Module Runtime](../../epics/10-modular-module-runtime.md)
+
+## Overview
+
+Define the `ModuleManifest` type and have every shipped module export a manifest constant. **Metadata-only at this PRD** — no runtime registry yet. Establishes the contract the runtime loader (PRD-100) and the overlay-ego extraction (PRD-099) will consume.
+
+## Type
+
+`ModuleManifest` lives in `@pops/types/src/module-manifest.ts` and is re-exported from the package root. Generic over the router/route/nav-config types so the package does not depend on tRPC, react-router, or `@pops/navigation`.
+
+```ts
+export type ModuleSurface = 'app' | 'overlay';
+
+export interface ModuleOverlayConfig {
+  chromeSlot: string;
+  shortcut?: string;
+}
+
+export interface ModuleManifest<TRouter = unknown, TRoutes = unknown, TNavConfig = unknown> {
+  id: string;
+  name: string;
+  version?: string;
+  surfaces: readonly ModuleSurface[];
+  description?: string;
+  dependsOn?: readonly string[];
+  provides?: readonly string[];
+  settings?: SettingsManifest; // PRD-093 slot
+  backend?: { router: TRouter };
+  frontend?: { routes?: TRoutes; navConfig?: TNavConfig; overlay?: ModuleOverlayConfig };
+}
+```
+
+`assertModuleManifest(value, context)` is a runtime guard exported from the same module, used by the assertion test (US-04). It throws `TypeError` with a descriptive context on the first failed check.
+
+## Adoption
+
+Each `packages/app-*` exports `manifest` alongside `routes` and `navConfig`. Each `apps/pops-api/src/modules/<x>` exports `manifest` referencing its router and (where applicable) its `SettingsManifest`. No runtime change: existing static imports of `routes` / routers continue to work; the manifest is additive metadata.
+
+## Edge Cases
+
+| Case                                                               | Behaviour                                                                                                                       |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| Module with multiple `SettingsManifest` registrations (e.g. media) | The `settings` slot is left empty; existing `settingsRegistry.register` calls remain. Single-manifest slot is enforced by type. |
+| Backend-only module (e.g. `core`)                                  | `frontend` is omitted. Loader still mounts it; `core` is non-optional in PRD-100.                                               |
+| Frontend-only app (no backend module)                              | `backend` is omitted.                                                                                                           |
+| Dual-surface module                                                | `surfaces: ['app', 'overlay']` and `frontend.overlay` is required.                                                              |
+
+## User Stories
+
+| #   | Story                                                             | Summary                                                                                     | Parallelisable     |
+| --- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------ |
+| 01  | [us-01-manifest-type](us-01-manifest-type.md)                     | Define `ModuleManifest` + `assertModuleManifest` in `@pops/types`                           | Yes                |
+| 02  | [us-02-export-from-apps](us-02-export-from-apps.md)               | Each `packages/app-*` exports `manifest` alongside existing exports                         | Blocked by 01      |
+| 03  | [us-03-export-from-api-modules](us-03-export-from-api-modules.md) | Each `apps/pops-api/src/modules/<x>` exports `manifest` referencing its router and settings | Blocked by 01      |
+| 04  | [us-04-typecheck-coverage](us-04-typecheck-coverage.md)           | Assertion test that every shipped module exports a valid manifest (frontend + backend)      | Blocked by 02 + 03 |
+
+## Out of Scope
+
+- Runtime consumption of the manifest (PRD-100).
+- Removing the existing `settingsRegistry.register` calls (parallel concern; manifest is a slot, not a replacement).
+- Schema/migration metadata in the manifest. Per-module migrations stay deferred (Epic 10 out-of-scope).
+- Hot-loading or watch-mode reloading on manifest changes.

--- a/docs/themes/01-foundation/prds/098-module-manifest/README.md
+++ b/docs/themes/01-foundation/prds/098-module-manifest/README.md
@@ -1,6 +1,7 @@
 # PRD-098: Module Manifest
 
 > Epic: [Modular Module Runtime](../../epics/10-modular-module-runtime.md)
+> Status: In progress
 
 ## Overview
 

--- a/docs/themes/01-foundation/prds/098-module-manifest/us-01-manifest-type.md
+++ b/docs/themes/01-foundation/prds/098-module-manifest/us-01-manifest-type.md
@@ -1,0 +1,20 @@
+# US-01: Manifest type in `@pops/types`
+
+> PRD: [Module Manifest](README.md)
+
+## Description
+
+As a module author, I want a single `ModuleManifest` type to import so that every module declares the same shape.
+
+## Acceptance Criteria
+
+- [ ] `ModuleManifest` is defined in `packages/types/src/module-manifest.ts` with the fields listed in the parent PRD.
+- [ ] `ModuleSurface`, `ModuleOverlayConfig`, `ModuleBackendManifest`, `ModuleFrontendManifest` are exported as named types.
+- [ ] `assertModuleManifest(value, context?)` is exported as a runtime type-guard that throws on any structural mismatch.
+- [ ] All new exports are re-exported from `packages/types/src/index.ts`.
+- [ ] The package builds cleanly: `cd packages/types && pnpm build` succeeds.
+
+## Notes
+
+- The package must not depend on tRPC, react-router, or `@pops/navigation`. Use generics for `TRouter`, `TRoutes`, `TNavConfig` so consumers narrow them.
+- The `settings` slot uses the existing `SettingsManifest` from PRD-093.

--- a/docs/themes/01-foundation/prds/098-module-manifest/us-01-manifest-type.md
+++ b/docs/themes/01-foundation/prds/098-module-manifest/us-01-manifest-type.md
@@ -1,6 +1,7 @@
 # US-01: Manifest type in `@pops/types`
 
 > PRD: [Module Manifest](README.md)
+> Status: In progress
 
 ## Description
 

--- a/docs/themes/01-foundation/prds/098-module-manifest/us-02-export-from-apps.md
+++ b/docs/themes/01-foundation/prds/098-module-manifest/us-02-export-from-apps.md
@@ -1,6 +1,7 @@
 # US-02: Frontend apps export a manifest
 
 > PRD: [Module Manifest](README.md)
+> Status: In progress
 
 ## Description
 

--- a/docs/themes/01-foundation/prds/098-module-manifest/us-02-export-from-apps.md
+++ b/docs/themes/01-foundation/prds/098-module-manifest/us-02-export-from-apps.md
@@ -1,0 +1,20 @@
+# US-02: Frontend apps export a manifest
+
+> PRD: [Module Manifest](README.md)
+
+## Description
+
+As a shell author, I want every `packages/app-*` to export `manifest` alongside its existing `routes` and `navConfig` so that the future runtime loader can introspect each app via one symbol.
+
+## Acceptance Criteria
+
+- [ ] Each of `app-finance`, `app-media`, `app-inventory`, `app-cerebrum`, `app-ai` defines a `src/manifest.ts` exporting a typed `manifest: ModuleManifest<...>`.
+- [ ] Each manifest declares: `id` (matches the package's slug), `name`, `version`, `surfaces: ['app']`, `description`, and `frontend: { routes, navConfig }`.
+- [ ] Each `src/index.ts` re-exports `manifest`.
+- [ ] No existing exports are removed; the change is additive.
+- [ ] `pnpm typecheck` passes for every modified package.
+
+## Notes
+
+- `@pops/types` is added as a dependency of the four apps that don't already depend on it (`app-finance`, `app-media`, `app-inventory`, `app-cerebrum`).
+- The `manifest` constant is intentionally the only new export — overlay handling (`overlay-ego`) lands in PRD-099.

--- a/docs/themes/01-foundation/prds/098-module-manifest/us-03-export-from-api-modules.md
+++ b/docs/themes/01-foundation/prds/098-module-manifest/us-03-export-from-api-modules.md
@@ -1,0 +1,20 @@
+# US-03: API modules export a manifest
+
+> PRD: [Module Manifest](README.md)
+
+## Description
+
+As an API author, I want every `apps/pops-api/src/modules/<x>` to export a `manifest` referencing its router (and its `SettingsManifest` where applicable) so that the future runtime loader can compose the tRPC root from metadata.
+
+## Acceptance Criteria
+
+- [ ] Each of `core`, `finance`, `inventory`, `media`, `ego`, `cerebrum` exports a typed `manifest: ModuleManifest<typeof <x>Router>` from its `index.ts`.
+- [ ] Each manifest declares `id` (matches the module folder name), `name`, `version`, `surfaces`, `description`, and `backend: { router }`.
+- [ ] Where the module owns a single `SettingsManifest`, the manifest sets `settings: <module>Manifest`. Where the module owns multiple settings manifests (media), the slot is left empty and the existing `settingsRegistry.register` calls remain.
+- [ ] Existing router exports (e.g. `financeRouter`) are unchanged.
+- [ ] `pnpm typecheck` and `pnpm test` pass for `apps/pops-api`.
+
+## Notes
+
+- The api module's `manifest` is the type-erased entry point — the generic argument lets the loader infer the router shape when introspecting at compile time.
+- The `core` module's manifest exists for symmetry, but `core` is treated as non-optional by the future PRD-100 loader.

--- a/docs/themes/01-foundation/prds/098-module-manifest/us-03-export-from-api-modules.md
+++ b/docs/themes/01-foundation/prds/098-module-manifest/us-03-export-from-api-modules.md
@@ -1,6 +1,7 @@
 # US-03: API modules export a manifest
 
 > PRD: [Module Manifest](README.md)
+> Status: In progress
 
 ## Description
 

--- a/docs/themes/01-foundation/prds/098-module-manifest/us-04-typecheck-coverage.md
+++ b/docs/themes/01-foundation/prds/098-module-manifest/us-04-typecheck-coverage.md
@@ -1,0 +1,20 @@
+# US-04: Manifest assertion test
+
+> PRD: [Module Manifest](README.md)
+
+## Description
+
+As a maintainer, I want a single test per surface (frontend + backend) that imports every shipped manifest and asserts its shape so that future modules cannot ship with a malformed manifest.
+
+## Acceptance Criteria
+
+- [ ] A backend test (`apps/pops-api/src/modules/manifests.test.ts`) imports each backend module's `manifest` and runs `assertModuleManifest` on it; tests pass.
+- [ ] A frontend test (`apps/pops-shell/src/tests/manifests.test.ts`) imports each frontend app's `manifest` and runs `assertModuleManifest` on it; tests pass.
+- [ ] Both tests assert that manifest `id`s are unique within their surface.
+- [ ] Both tests assert that each manifest's `id` matches the module's expected slug (the test's own label).
+- [ ] Tests fail loudly if a future module ships without a manifest export (the import itself fails) or with an invalid one.
+
+## Notes
+
+- Use `it.each` so a missing manifest fails on the specific module's row, not as one opaque suite failure.
+- Frontend manifests check `frontend.routes`; backend manifests check `backend.router`.

--- a/docs/themes/01-foundation/prds/098-module-manifest/us-04-typecheck-coverage.md
+++ b/docs/themes/01-foundation/prds/098-module-manifest/us-04-typecheck-coverage.md
@@ -1,6 +1,7 @@
 # US-04: Manifest assertion test
 
 > PRD: [Module Manifest](README.md)
+> Status: In progress
 
 ## Description
 

--- a/packages/app-ai/src/index.ts
+++ b/packages/app-ai/src/index.ts
@@ -5,3 +5,4 @@
  * to lazily load AI pages under /ai/*.
  */
 export { navConfig, routes } from './routes';
+export { manifest } from './manifest';

--- a/packages/app-ai/src/manifest.ts
+++ b/packages/app-ai/src/manifest.ts
@@ -1,0 +1,19 @@
+import { navConfig, routes } from './routes';
+
+/**
+ * AI Ops frontend module manifest (PRD-098).
+ * Metadata-only at this point — the runtime loader (PRD-100) will read it.
+ */
+import type { ModuleManifest } from '@pops/types';
+
+export const manifest: ModuleManifest<unknown, typeof routes, typeof navConfig> = {
+  id: 'ai',
+  name: 'AI Ops',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'AI usage, providers, model config, prompts, and rules browser.',
+  frontend: {
+    routes,
+    navConfig,
+  },
+};

--- a/packages/app-cerebrum/package.json
+++ b/packages/app-cerebrum/package.json
@@ -14,6 +14,7 @@
     "@pops/api-client": "workspace:*",
     "@pops/app-ai": "workspace:*",
     "@pops/navigation": "workspace:*",
+    "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.100.9",
     "lucide-react": "^1.14.0",

--- a/packages/app-cerebrum/src/index.ts
+++ b/packages/app-cerebrum/src/index.ts
@@ -5,5 +5,6 @@
  * to lazily load cerebrum pages under /cerebrum/*.
  */
 export { navConfig, routes } from './routes';
+export { manifest } from './manifest';
 export { ChatPanel } from './components/chat/ChatPanel';
 export { useChatPageModel } from './pages/chat-page/useChatPageModel';

--- a/packages/app-cerebrum/src/manifest.ts
+++ b/packages/app-cerebrum/src/manifest.ts
@@ -1,0 +1,19 @@
+import { navConfig, routes } from './routes';
+
+/**
+ * Cerebrum frontend module manifest (PRD-098).
+ * Metadata-only at this point — the runtime loader (PRD-100) will read it.
+ */
+import type { ModuleManifest } from '@pops/types';
+
+export const manifest: ModuleManifest<unknown, typeof routes, typeof navConfig> = {
+  id: 'cerebrum',
+  name: 'Cerebrum',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Engrams, retrieval, plexus, reflex, glia — knowledge graph and agents.',
+  frontend: {
+    routes,
+    navConfig,
+  },
+};

--- a/packages/app-finance/package.json
+++ b/packages/app-finance/package.json
@@ -19,6 +19,7 @@
     "@pops/api-client": "workspace:*",
     "@pops/db-types": "workspace:*",
     "@pops/navigation": "workspace:*",
+    "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.100.9",
     "@tanstack/react-table": "^8.21.3",

--- a/packages/app-finance/src/index.ts
+++ b/packages/app-finance/src/index.ts
@@ -5,6 +5,7 @@
  * to lazily load finance pages under /finance/*.
  */
 export { navConfig, routes } from './routes';
+export { manifest } from './manifest';
 
 // Side-effect: register search result components
 import './components/search/EntitiesResultComponent';

--- a/packages/app-finance/src/manifest.ts
+++ b/packages/app-finance/src/manifest.ts
@@ -1,0 +1,19 @@
+import { navConfig, routes } from './routes';
+
+/**
+ * Finance frontend module manifest (PRD-098).
+ * Metadata-only at this point — the runtime loader (PRD-100) will read it.
+ */
+import type { ModuleManifest } from '@pops/types';
+
+export const manifest: ModuleManifest<unknown, typeof routes, typeof navConfig> = {
+  id: 'finance',
+  name: 'Finance',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Transactions, budgets, entities, and import pipeline.',
+  frontend: {
+    routes,
+    navConfig,
+  },
+};

--- a/packages/app-inventory/package.json
+++ b/packages/app-inventory/package.json
@@ -18,6 +18,7 @@
     "@pops/api-client": "workspace:*",
     "@pops/db-types": "workspace:*",
     "@pops/navigation": "workspace:*",
+    "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.100.9",
     "@tanstack/react-table": "^8.21.3",

--- a/packages/app-inventory/src/index.ts
+++ b/packages/app-inventory/src/index.ts
@@ -5,6 +5,7 @@
  * to lazily load inventory pages under /inventory/*.
  */
 export { navConfig, routes } from './routes';
+export { manifest } from './manifest';
 
 // Side-effect: register search result components
 import './components/search/register';

--- a/packages/app-inventory/src/manifest.ts
+++ b/packages/app-inventory/src/manifest.ts
@@ -1,0 +1,19 @@
+import { navConfig, routes } from './routes';
+
+/**
+ * Inventory frontend module manifest (PRD-098).
+ * Metadata-only at this point — the runtime loader (PRD-100) will read it.
+ */
+import type { ModuleManifest } from '@pops/types';
+
+export const manifest: ModuleManifest<unknown, typeof routes, typeof navConfig> = {
+  id: 'inventory',
+  name: 'Inventory',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Home items, locations, connections, warranties, and documents.',
+  frontend: {
+    routes,
+    navConfig,
+  },
+};

--- a/packages/app-media/package.json
+++ b/packages/app-media/package.json
@@ -16,6 +16,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@pops/api-client": "workspace:*",
     "@pops/navigation": "workspace:*",
+    "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.100.9",
     "i18next": "^26.0.10",

--- a/packages/app-media/src/index.ts
+++ b/packages/app-media/src/index.ts
@@ -5,6 +5,7 @@
  * to lazily load media pages under /media/*.
  */
 export { navConfig, routes } from './routes';
+export { manifest } from './manifest';
 
 // Side-effect: register search result components
 import './components/search/register';

--- a/packages/app-media/src/manifest.ts
+++ b/packages/app-media/src/manifest.ts
@@ -1,0 +1,19 @@
+import { navConfig, routes } from './routes';
+
+/**
+ * Media frontend module manifest (PRD-098).
+ * Metadata-only at this point — the runtime loader (PRD-100) will read it.
+ */
+import type { ModuleManifest } from '@pops/types';
+
+export const manifest: ModuleManifest<unknown, typeof routes, typeof navConfig> = {
+  id: 'media',
+  name: 'Media',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'Movies, TV shows, watch history, and Plex/TMDB/TVDB sync.',
+  frontend: {
+    routes,
+    navConfig,
+  },
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -24,3 +24,11 @@ export type {
   FeatureScope,
   FeatureStatus,
 } from './feature-manifest.js';
+export { assertModuleManifest } from './module-manifest.js';
+export type {
+  ModuleBackendManifest,
+  ModuleFrontendManifest,
+  ModuleManifest,
+  ModuleOverlayConfig,
+  ModuleSurface,
+} from './module-manifest.js';

--- a/packages/types/src/module-manifest.ts
+++ b/packages/types/src/module-manifest.ts
@@ -1,0 +1,157 @@
+/**
+ * Module manifest types — the contract every POPS module exports so that the
+ * shell (frontend) and the tRPC root (backend) can assemble themselves from
+ * metadata rather than from hard-coded import lists.
+ *
+ * This module is metadata-only at the time of PRD-098. The runtime that
+ * consumes these manifests (`POPS_APPS` / `POPS_OVERLAYS` env loader) lands in
+ * PRD-100; the lint enforcement of cross-module boundaries that protects them
+ * lands in PRD-097.
+ *
+ * See `docs/themes/01-foundation/prds/098-module-manifest/` for the full PRD.
+ */
+import type { SettingsManifest } from './settings-manifest.js';
+
+/**
+ * Surfaces a module can present to the shell.
+ * - `app`     — page-routed module owning navigation and `/path` routes
+ * - `overlay` — mounted into a shell chrome slot; summoned by shortcut/icon
+ *
+ * A module may declare both: `surfaces: ['app', 'overlay']` — the dual-surface
+ * pattern (e.g. ego has both `/cerebrum/chat` and a floating panel).
+ */
+export type ModuleSurface = 'app' | 'overlay';
+
+export interface ModuleOverlayConfig {
+  /**
+   * Identifier of the chrome slot the overlay mounts into. Slot names are
+   * defined by the shell; unknown slots are ignored (with a warning) at
+   * mount time.
+   */
+  chromeSlot: string;
+  /**
+   * Optional keyboard shortcut to summon the overlay. Uses the same format
+   * as `mousetrap`/`tinykeys` (e.g. `mod+i`). Resolved by the shell.
+   */
+  shortcut?: string;
+}
+
+/**
+ * Frontend-side manifest fields. Generic over the route and nav config types
+ * so this package does not have to depend on `react-router` or `@pops/navigation`.
+ */
+export interface ModuleFrontendManifest<TRoutes = unknown, TNavConfig = unknown> {
+  /** Lazy `RouteObject[]` (or equivalent) mounted by the shell router. */
+  routes?: TRoutes;
+  /** Optional navigation config (icon, label, ordering). */
+  navConfig?: TNavConfig;
+  /** Set when `surfaces` includes `'overlay'`. */
+  overlay?: ModuleOverlayConfig;
+}
+
+/**
+ * Backend-side manifest fields. Generic over the router type so this package
+ * does not have to depend on tRPC.
+ */
+export interface ModuleBackendManifest<TRouter = unknown> {
+  /** tRPC router (or equivalent) composed into the root by the loader. */
+  router: TRouter;
+}
+
+/**
+ * The module manifest. Backend-only modules fill `backend`; frontend-only
+ * apps fill `frontend`; modules with both surfaces fill both.
+ *
+ * `id` is the canonical module identifier and the value the runtime loader
+ * matches against `POPS_APPS` / `POPS_OVERLAYS` entries.
+ */
+export interface ModuleManifest<TRouter = unknown, TRoutes = unknown, TNavConfig = unknown> {
+  /** Canonical id, e.g. `finance`, `media`, `ego`. Lowercase, no spaces. */
+  id: string;
+  /** Human-readable name, used in admin UIs. */
+  name: string;
+  /** Optional semver-ish version string. */
+  version?: string;
+  /** Which surfaces this module exposes. Must contain at least one entry. */
+  surfaces: readonly ModuleSurface[];
+  /** One-line description, used in admin UIs. */
+  description?: string;
+  /** Modules this one depends on at runtime; loader fails fast on a missing dep. */
+  dependsOn?: readonly string[];
+  /** Capabilities this module provides (free-form strings, e.g. `finance.transaction`). */
+  provides?: readonly string[];
+  /** Plugged in as a slot from PRD-093. */
+  settings?: SettingsManifest;
+  /** Filled when the module exposes a backend tRPC router. */
+  backend?: ModuleBackendManifest<TRouter>;
+  /** Filled when the module exposes a frontend app or overlay. */
+  frontend?: ModuleFrontendManifest<TRoutes, TNavConfig>;
+}
+
+/**
+ * Runtime guard that asserts a value satisfies the structural shape of
+ * `ModuleManifest`. Used by the manifest assertion test (US-04). Throws
+ * `TypeError` with a descriptive message on the first failed check so the
+ * stack trace points at the offending module.
+ */
+function fail(context: string, message: string): never {
+  throw new TypeError(`${context}: ${message}`);
+}
+
+function assertNonEmptyString(value: unknown, context: string, field: string): void {
+  if (typeof value !== 'string' || value.length === 0) {
+    fail(context, `'${field}' must be a non-empty string`);
+  }
+}
+
+function assertSurfaces(value: unknown, context: string): readonly ModuleSurface[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    fail(context, `'surfaces' must be a non-empty array`);
+  }
+  for (const s of value as readonly unknown[]) {
+    if (s !== 'app' && s !== 'overlay') {
+      fail(context, `invalid surface '${String(s)}'`);
+    }
+  }
+  return value as readonly ModuleSurface[];
+}
+
+function assertBackend(value: unknown, context: string): void {
+  if (value === undefined) return;
+  if (!value || typeof value !== 'object') {
+    fail(context, `'backend' must be an object when set`);
+  }
+  if ((value as Record<string, unknown>).router === undefined) {
+    fail(context, `'backend.router' is required when 'backend' is set`);
+  }
+}
+
+function assertFrontend(value: unknown, surfaces: readonly ModuleSurface[], context: string): void {
+  if (value === undefined) return;
+  if (!value || typeof value !== 'object') {
+    fail(context, `'frontend' must be an object when set`);
+  }
+  if (!surfaces.includes('overlay')) return;
+  const f = value as Record<string, unknown>;
+  if (!f.overlay || typeof f.overlay !== 'object') {
+    fail(context, `'frontend.overlay' is required when surfaces includes 'overlay'`);
+  }
+  if (typeof (f.overlay as Record<string, unknown>).chromeSlot !== 'string') {
+    fail(context, `'frontend.overlay.chromeSlot' must be a string`);
+  }
+}
+
+export function assertModuleManifest(
+  value: unknown,
+  context = 'manifest'
+): asserts value is ModuleManifest {
+  if (!value || typeof value !== 'object') {
+    fail(context, 'expected an object');
+  }
+  const m = value as Record<string, unknown>;
+  assertNonEmptyString(m.id, context, 'id');
+  assertNonEmptyString(m.name, context, 'name');
+  const surfaces = assertSurfaces(m.surfaces, context);
+  assertBackend(m.backend, context);
+  assertFrontend(m.frontend, surfaces, context);
+}

--- a/packages/types/src/module-manifest.ts
+++ b/packages/types/src/module-manifest.ts
@@ -121,18 +121,20 @@ function assertBackend(value: unknown, context: string): void {
   if (!value || typeof value !== 'object') {
     fail(context, `'backend' must be an object when set`);
   }
-  if ((value as Record<string, unknown>).router === undefined) {
-    fail(context, `'backend.router' is required when 'backend' is set`);
+  const router = (value as Record<string, unknown>).router;
+  if (router === undefined || router === null) {
+    fail(context, `'backend.router' must be present and non-null when 'backend' is set`);
   }
 }
 
-function assertFrontend(value: unknown, surfaces: readonly ModuleSurface[], context: string): void {
-  if (value === undefined) return;
+function assertFrontend(value: unknown, context: string): void {
   if (!value || typeof value !== 'object') {
-    fail(context, `'frontend' must be an object when set`);
+    fail(context, `'frontend' must be an object`);
   }
-  if (!surfaces.includes('overlay')) return;
-  const f = value as Record<string, unknown>;
+}
+
+function assertOverlayConfig(frontend: unknown, context: string): void {
+  const f = frontend as Record<string, unknown>;
   if (!f.overlay || typeof f.overlay !== 'object') {
     fail(context, `'frontend.overlay' is required when surfaces includes 'overlay'`);
   }
@@ -152,6 +154,15 @@ export function assertModuleManifest(
   assertNonEmptyString(m.id, context, 'id');
   assertNonEmptyString(m.name, context, 'name');
   const surfaces = assertSurfaces(m.surfaces, context);
+  if (m.backend === undefined && m.frontend === undefined) {
+    fail(context, `at least one of 'backend' or 'frontend' must be present`);
+  }
   assertBackend(m.backend, context);
-  assertFrontend(m.frontend, surfaces, context);
+  if (m.frontend !== undefined) assertFrontend(m.frontend, context);
+  if (surfaces.includes('overlay')) {
+    if (m.frontend === undefined) {
+      fail(context, `'frontend.overlay' is required when surfaces includes 'overlay'`);
+    }
+    assertOverlayConfig(m.frontend, context);
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../types
       '@pops/ui':
         specifier: workspace:*
         version: link:../ui
@@ -521,6 +524,9 @@ importers:
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../types
       '@pops/ui':
         specifier: workspace:*
         version: link:../ui
@@ -630,6 +636,9 @@ importers:
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../types
       '@pops/ui':
         specifier: workspace:*
         version: link:../ui
@@ -730,6 +739,9 @@ importers:
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../types
       '@pops/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
## Summary

- Defines `ModuleManifest` (+ `ModuleSurface`, `ModuleOverlayConfig`, `assertModuleManifest`) in `@pops/types/src/module-manifest.ts`. Generic over router/route/nav-config types so the package keeps zero runtime deps.
- Each `packages/app-{ai,cerebrum,finance,inventory,media}` exports a `manifest` alongside the existing `routes` / `navConfig`. Each `apps/pops-api/src/modules/{core,finance,inventory,media,ego,cerebrum}` exports a `manifest` referencing its router (and its `SettingsManifest` where there's exactly one).
- Adds assertion tests in `apps/pops-api` and `apps/pops-shell` that import every manifest and validate shape / id uniqueness / id-matches-folder.
- Metadata-only — no runtime change. The PRD-100 loader is the consumer.

Authors PRD-098 (`docs/themes/01-foundation/prds/098-module-manifest/`) with 4 USs.

Closes #2512.

## Test plan

- [ ] `pnpm typecheck` passes (covers all modified packages)
- [ ] `cd apps/pops-api && pnpm test src/modules/manifests.test.ts` passes (14 tests)
- [ ] `cd apps/pops-shell && pnpm test src/tests/manifests.test.ts` passes (12 tests)
- [ ] CI (per-package quality + tests) green