### PR TITLE
fix(shell): mount app-ai admin routes from shell (PRD-097, #2517)

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -9,16 +9,5 @@
       "severity": "error",
       "name": "no-cross-api-module-import"
     }
-  },
-  {
-    "type": "dependency",
-    "from": "packages/app-cerebrum/src/routes.tsx",
-    "to": "packages/app-ai/src/index.ts",
-    "unresolvedTo": "@pops/app-ai",
-    "dependencyTypes": ["undetermined", "import"],
-    "rule": {
-      "severity": "error",
-      "name": "no-cross-app-import"
-    }
   }
 ]

--- a/apps/pops-shell/src/app/router.tsx
+++ b/apps/pops-shell/src/app/router.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { createBrowserRouter, Link, Navigate } from 'react-router';
+import { createBrowserRouter, Link, Navigate, Outlet } from 'react-router';
 
 /**
  * Shell router configuration
@@ -10,6 +10,7 @@ import { createBrowserRouter, Link, Navigate } from 'react-router';
  * The former /ai top-level route has been merged into /cerebrum/admin/*
  * (see issue #2333). Legacy /ai/* URLs redirect to /cerebrum/admin/*.
  */
+import { routes as aiAdminRoutes } from '@pops/app-ai';
 import { routes as cerebrumRoutes } from '@pops/app-cerebrum';
 import { routes as financeRoutes } from '@pops/app-finance';
 import { routes as inventoryRoutes } from '@pops/app-inventory';
@@ -78,7 +79,27 @@ export const router = createBrowserRouter([
       {
         path: 'cerebrum',
         element: <RequireModule moduleId="cerebrum" />,
-        children: withSuspense(cerebrumRoutes),
+        children: [
+          ...withSuspense(cerebrumRoutes),
+          // /cerebrum/admin/* surfaces app-ai pages — composed here in
+          // the shell rather than inside @pops/app-cerebrum (PRD-097
+          // boundaries forbid app-* → app-* imports).
+          {
+            path: 'admin',
+            element: (
+              <Suspense
+                fallback={
+                  <div className="flex items-center justify-center h-64 text-muted-foreground">
+                    Loading…
+                  </div>
+                }
+              >
+                <Outlet />
+              </Suspense>
+            ),
+            children: aiAdminRoutes,
+          },
+        ],
       },
       // Legacy /ai/* redirects — keep bookmarks and deep-links working.
       { path: 'ai', element: <Navigate to="/cerebrum" replace /> },

--- a/apps/pops-shell/src/app/router.tsx
+++ b/apps/pops-shell/src/app/router.tsx
@@ -1,6 +1,3 @@
-import { Suspense } from 'react';
-import { createBrowserRouter, Link, Navigate, Outlet } from 'react-router';
-
 /**
  * Shell router configuration
  *
@@ -10,6 +7,9 @@ import { createBrowserRouter, Link, Navigate, Outlet } from 'react-router';
  * The former /ai top-level route has been merged into /cerebrum/admin/*
  * (see issue #2333). Legacy /ai/* URLs redirect to /cerebrum/admin/*.
  */
+import { Suspense } from 'react';
+import { createBrowserRouter, Link, Navigate, Outlet } from 'react-router';
+
 import { routes as aiAdminRoutes } from '@pops/app-ai';
 import { routes as cerebrumRoutes } from '@pops/app-cerebrum';
 import { routes as financeRoutes } from '@pops/app-finance';
@@ -23,6 +23,10 @@ import { NotFoundPage } from './pages/NotFoundPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { RequireModule } from './RequireModule';
 
+const SuspenseFallback = (
+  <div className="flex items-center justify-center h-64 text-muted-foreground">Loading…</div>
+);
+
 /**
  * Wrap lazy-loaded routes with Suspense so React can show a fallback
  * while the chunk loads.
@@ -31,15 +35,7 @@ const withSuspense = (routes: typeof financeRoutes) =>
   routes.map((route) => ({
     ...route,
     element: route.element ? (
-      <Suspense
-        fallback={
-          <div className="flex items-center justify-center h-64 text-muted-foreground">
-            Loading…
-          </div>
-        }
-      >
-        {route.element}
-      </Suspense>
+      <Suspense fallback={SuspenseFallback}>{route.element}</Suspense>
     ) : undefined,
   }));
 
@@ -87,13 +83,7 @@ export const router = createBrowserRouter([
           {
             path: 'admin',
             element: (
-              <Suspense
-                fallback={
-                  <div className="flex items-center justify-center h-64 text-muted-foreground">
-                    Loading…
-                  </div>
-                }
-              >
+              <Suspense fallback={SuspenseFallback}>
                 <Outlet />
               </Suspense>
             ),

--- a/packages/app-cerebrum/package.json
+++ b/packages/app-cerebrum/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@pops/api-client": "workspace:*",
-    "@pops/app-ai": "workspace:*",
     "@pops/navigation": "workspace:*",
     "@pops/overlay-ego": "workspace:*",
     "@pops/types": "workspace:*",

--- a/packages/app-cerebrum/src/routes.tsx
+++ b/packages/app-cerebrum/src/routes.tsx
@@ -5,12 +5,12 @@
  * these via @pops/app-cerebrum and mounts them under /cerebrum/*.
  *
  * AI admin pages (usage, prompts, rules, cache) are mounted under
- * /cerebrum/admin/* — imported from @pops/app-ai.
+ * /cerebrum/admin/* by the shell, which composes them from
+ * @pops/app-ai. Cross-app composition lives in the shell, not here
+ * — this package may not import from another @pops/app-* per
+ * PRD-097 boundaries.
  */
-import { lazy, Suspense } from 'react';
-import { Outlet } from 'react-router';
-
-import { routes as aiAdminRoutes } from '@pops/app-ai';
+import { lazy } from 'react';
 
 import type { RouteObject } from 'react-router';
 
@@ -71,19 +71,6 @@ export const routes: RouteObject[] = [
   { path: 'chat', element: <ChatPage /> },
   { path: 'nudges', element: <NudgesPage /> },
   { path: 'proposals', element: <ProposalQueuePage /> },
-  {
-    path: 'admin',
-    element: (
-      <Suspense
-        fallback={
-          <div className="flex items-center justify-center h-64 text-muted-foreground">
-            Loading…
-          </div>
-        }
-      >
-        <Outlet />
-      </Suspense>
-    ),
-    children: aiAdminRoutes,
-  },
+  // /cerebrum/admin/* is composed by the shell from @pops/app-ai;
+  // see apps/pops-shell/src/app/router.tsx.
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,9 +433,6 @@ importers:
       '@pops/api-client':
         specifier: workspace:*
         version: link:../api-client
-      '@pops/app-ai':
-        specifier: workspace:*
-        version: link:../app-ai
       '@pops/navigation':
         specifier: workspace:*
         version: link:../navigation


### PR DESCRIPTION
## Summary

`packages/app-cerebrum/src/routes.tsx` was importing `routes as aiAdminRoutes` from `@pops/app-ai` and mounting them under `/cerebrum/admin/*`. That was the last remaining cross-app import violation baselined in PRD-097.

This PR moves the composition up one level: the shell (`apps/pops-shell/src/app/router.tsx`) mounts the AI admin routes directly under `/cerebrum/admin/*`. Behaviour is unchanged — same URLs, same pages — but `app-cerebrum` no longer crosses an `app-* → app-*` boundary.

Drops 1 entry from `.dependency-cruiser-known-violations.json`. No more cross-app violations remain.

Closes #2517.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint:boundaries` clean (cross-app violations: 0)
- [x] Shell tests still pass (188/188)
- [ ] CI green
- [ ] Manual: visit `/cerebrum/admin`, `/cerebrum/admin/prompts`, `/cerebrum/admin/rules`, `/cerebrum/admin/cache` — they all render