### PR TITLE
feat(types): extend ModuleManifest with cross-cutting slots (PRD-101 US-01, #2535)

### DIFF
--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -17,7 +17,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 COPY packages/db-types/src ./packages/db-types/src
 COPY packages/db-types/tsconfig.json ./packages/db-types/
 COPY packages/types/src ./packages/types/src
-COPY packages/types/tsconfig.json ./packages/types/
+COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
 

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 COPY packages/db-types/src ./packages/db-types/src
 COPY packages/db-types/tsconfig.json ./packages/db-types/
 COPY packages/types/src ./packages/types/src
-COPY packages/types/tsconfig.json ./packages/types/
+COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
 WORKDIR /app/packages/db-types
 RUN pnpm build
 WORKDIR /app/packages/types

--- a/docs/themes/01-foundation/prds/101-plugin-contract/us-01-extend-manifest.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/us-01-extend-manifest.md
@@ -1,7 +1,7 @@
 # US-01: Extend ModuleManifest with cross-cutting slots
 
 > PRD: [Plugin Contract](README.md)
-> Status: Not started
+> Status: In progress
 
 ## Description
 
@@ -9,14 +9,14 @@ As a platform engineer, I want `ModuleManifest` to carry every slot the cross-cu
 
 ## Acceptance Criteria
 
-- [ ] `ModuleManifest` adds `capabilities?: readonly Capability[]` (typed RBAC scope ids); the existing `provides` field is removed.
-- [ ] `ModuleFrontendManifest` is unchanged structurally (already has `routes`, `navConfig`, `overlay`).
-- [ ] `ModuleBackendManifest` adds `aiTools?: readonly AiToolDescriptor[]`, `migrations?: readonly MigrationDescriptor[]`, and `ingestSources?: readonly IngestSourceDescriptor[]` (the last only as a typed slot — Cerebrum is the only consumer).
-- [ ] Top-level adds `features?: readonly FeatureManifest[]`, `search?: readonly SearchAdapterDescriptor[]`, and `uriHandler?: UriHandlerDescriptor`.
-- [ ] New descriptor types are exported from `@pops/types` with JSDoc on every field.
-- [ ] `assertModuleManifest()` validates each new slot's structural shape; failures name the offending field with the module id in the error.
-- [ ] Every existing module manifest (`packages/app-finance`, `app-media`, `app-inventory`, `app-cerebrum`, `app-ai`, `overlay-ego`) compiles against the new shape with no behaviour change. Slots that don't apply yet are simply omitted.
-- [ ] Type tests in `packages/types` exercise: `Capability` typed-scope inference, `MODULES` id union narrowing, descriptor optionality.
+- [x] `ModuleManifest` adds `capabilities?: readonly Capability[]` (typed RBAC scope ids); the existing `provides` field is removed.
+- [x] `ModuleFrontendManifest` is unchanged structurally (already has `routes`, `navConfig`, `overlay`).
+- [x] `ModuleBackendManifest` adds `aiTools?: readonly AiToolDescriptor[]`, `migrations?: readonly MigrationDescriptor[]`, and `ingestSources?: readonly IngestSourceDescriptor[]` (the last only as a typed slot — Cerebrum is the only consumer).
+- [x] Top-level adds `features?: readonly FeatureManifest[]`, `search?: readonly SearchAdapterDescriptor[]`, and `uriHandler?: UriHandlerDescriptor`.
+- [x] New descriptor types are exported from `@pops/types` with JSDoc on every field.
+- [x] `assertModuleManifest()` validates each new slot's structural shape; failures name the offending field with the module id in the error.
+- [x] Every existing module manifest (`packages/app-finance`, `app-media`, `app-inventory`, `app-cerebrum`, `app-ai`, `overlay-ego`) compiles against the new shape with no behaviour change. Slots that don't apply yet are simply omitted.
+- [x] Type tests in `packages/types` exercise: `Capability` typed-scope inference, `MODULES` id union narrowing, descriptor optionality.
 
 ## Notes
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,12 +12,16 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch --preserveWatchOutput",
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"(no tests in @pops/types)\""
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
   },
   "devDependencies": {
-    "typescript": "^6.0.3"
+    "@vitest/coverage-v8": "^4.1.5",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/types/src/ai-tool.ts
+++ b/packages/types/src/ai-tool.ts
@@ -1,0 +1,46 @@
+/**
+ * AI tool descriptor — per-module declaration of an MCP / Ego-callable tool
+ * (PRD-101 US-10). The shape mirrors the MCP `Tool` definition: a name, a
+ * human-readable description, a JSON-schema-like input schema, and a handler
+ * function the MCP server (or Ego) calls when the tool is invoked.
+ *
+ * The platform consumer (US-10) aggregates `MODULES.flatMap(m => m.backend?.aiTools)`
+ * into the MCP server's tool list. This package only defines the shape — no
+ * MCP SDK dependency leaks into `@pops/types`.
+ */
+
+/** Result of invoking an AI tool — kept structural so MCP and other callers can interpret. */
+export interface AiToolResult {
+  /** Free-form content returned to the caller. MCP wraps this into `CallToolResult.content`. */
+  content: readonly { type: 'text'; text: string }[];
+  /** Set when the tool failed; MCP surfaces it as `isError: true`. */
+  isError?: boolean;
+}
+
+/**
+ * Handler signature. Receives the parsed input (validated against `inputSchema`
+ * by the dispatcher) and returns the result. Async by contract — synchronous
+ * tools wrap themselves in `Promise.resolve`.
+ */
+export type AiToolHandler<TInput = Record<string, unknown>> = (
+  input: TInput
+) => Promise<AiToolResult>;
+
+export interface AiToolDescriptor<TInput = Record<string, unknown>> {
+  /**
+   * Globally unique tool name, namespaced by module: `cerebrum.search`,
+   * `finance.transaction.find`. Two manifests declaring the same name is a
+   * contract violation and the registry build (US-02) fails fast.
+   */
+  name: string;
+  /** Human-readable description shown to the model when listing tools. */
+  description: string;
+  /**
+   * JSON Schema describing the tool's input. The platform consumer passes
+   * this through to MCP unchanged; the shape is left as `Record<string, unknown>`
+   * to avoid pulling a JSON Schema dependency into `@pops/types`.
+   */
+  inputSchema: Record<string, unknown>;
+  /** Handler invoked by the MCP dispatcher (or Ego) with the parsed input. */
+  handler: AiToolHandler<TInput>;
+}

--- a/packages/types/src/capability.ts
+++ b/packages/types/src/capability.ts
@@ -1,0 +1,22 @@
+/**
+ * Capability — typed RBAC scope identifier (PRD-101).
+ *
+ * Capabilities supersede the free-form `provides: string[]` slot from PRD-098.
+ * They are the surface a future RBAC layer will consume; PRD-101 only defines
+ * the type and aggregates them into the `ModuleManifest`. No enforcement is
+ * wired in this PRD.
+ *
+ * Shape: `${ModuleId}.${string}` — namespaced under the owning module so
+ * `finance.transaction.read` cannot collide with `media.transaction.read`,
+ * and a typo at the module boundary is a type error rather than silent data.
+ *
+ * `ModuleId` defaults to `string` so a manifest authored in isolation (i.e.
+ * before the build-time registry from US-02 narrows the union) still
+ * type-checks. Consumers that have access to the generated `ModuleId` union
+ * (e.g. `@pops/module-registry`) can pass it explicitly:
+ *
+ * ```ts
+ * type FinanceCap = Capability<'finance'>; // 'finance.${string}'
+ * ```
+ */
+export type Capability<ModuleId extends string = string> = `${ModuleId}.${string}`;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -24,6 +24,12 @@ export type {
   FeatureScope,
   FeatureStatus,
 } from './feature-manifest.js';
+export type { Capability } from './capability.js';
+export type { UriHandlerDescriptor, UriResolution } from './uri-handler.js';
+export type { AiToolDescriptor, AiToolHandler, AiToolResult } from './ai-tool.js';
+export type { MigrationDescriptor } from './migration.js';
+export type { SearchAdapterDescriptor } from './search-adapter.js';
+export type { IngestSourceDescriptor } from './ingest-source.js';
 export { assertModuleManifest } from './module-manifest.js';
 export type {
   ModuleBackendManifest,

--- a/packages/types/src/ingest-source.ts
+++ b/packages/types/src/ingest-source.ts
@@ -1,0 +1,20 @@
+/**
+ * Ingest source descriptor — per-module declaration of an external data source
+ * the module can ingest from (PRD-101 US-01 typed slot only).
+ *
+ * Cerebrum's PRD-090 plugin system (Plexus) is the only consumer today and it
+ * stays internal to Cerebrum. This descriptor exists so the manifest contract
+ * has a typed home for it; no platform-level aggregator wires it in PRD-101.
+ *
+ * The shape stays minimal — `id` and `label` plus optional `description` —
+ * because each consumer interprets the source's runtime semantics. Concrete
+ * adapter logic lives in the owning module, not in `@pops/types`.
+ */
+export interface IngestSourceDescriptor {
+  /** Canonical id of the source, e.g. `plex`, `tmdb`, `gmail`. */
+  id: string;
+  /** Human-readable label shown in admin UIs. */
+  label: string;
+  /** Optional one-line description for admin UIs. */
+  description?: string;
+}

--- a/packages/types/src/manifest-assertions.ts
+++ b/packages/types/src/manifest-assertions.ts
@@ -1,0 +1,196 @@
+/**
+ * Internal structural-validation helpers for `assertModuleManifest`. Split
+ * out from `module-manifest.ts` to keep that file's exported surface and the
+ * runtime checks in tractable file sizes. Not re-exported from
+ * `@pops/types`; consumers call `assertModuleManifest` instead.
+ */
+import type { ModuleSurface } from './module-manifest.js';
+
+export function fail(context: string, message: string): never {
+  throw new TypeError(`${context}: ${message}`);
+}
+
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function assertNonEmptyString(value: unknown, context: string, field: string): void {
+  if (typeof value !== 'string' || value.length === 0) {
+    fail(context, `'${field}' must be a non-empty string`);
+  }
+}
+
+export function assertSurfaces(value: unknown, context: string): readonly ModuleSurface[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    fail(context, `'surfaces' must be a non-empty array`);
+  }
+  for (const s of value as readonly unknown[]) {
+    if (s !== 'app' && s !== 'overlay') {
+      fail(context, `invalid surface '${String(s)}'`);
+    }
+  }
+  return value as readonly ModuleSurface[];
+}
+
+export function assertCapabilities(value: unknown, context: string, moduleId: string): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    fail(context, `'capabilities' must be an array when set`);
+  }
+  for (const [i, cap] of (value as readonly unknown[]).entries()) {
+    if (typeof cap !== 'string' || cap.length === 0) {
+      fail(context, `'capabilities[${i}]' must be a non-empty string`);
+    }
+    const dot = cap.indexOf('.');
+    if (dot <= 0) {
+      fail(
+        context,
+        `'capabilities[${i}]' must be namespaced as '<moduleId>.<scope>' (got '${cap}')`
+      );
+    }
+    const ns = cap.slice(0, dot);
+    if (ns !== moduleId) {
+      fail(
+        context,
+        `'capabilities[${i}]' namespace '${ns}' does not match module id '${moduleId}'`
+      );
+    }
+  }
+}
+
+export function assertFeatures(value: unknown, context: string): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    fail(context, `'features' must be an array when set`);
+  }
+  for (const [i, m] of (value as readonly unknown[]).entries()) {
+    if (!isObject(m)) {
+      fail(context, `'features[${i}]' must be an object`);
+    }
+    assertNonEmptyString(m.id, context, `features[${i}].id`);
+    assertNonEmptyString(m.title, context, `features[${i}].title`);
+    if (typeof m.order !== 'number' || Number.isNaN(m.order)) {
+      fail(context, `'features[${i}].order' must be a number`);
+    }
+    if (!Array.isArray(m.features)) {
+      fail(context, `'features[${i}].features' must be an array`);
+    }
+  }
+}
+
+export function assertSearch(value: unknown, context: string): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    fail(context, `'search' must be an array when set`);
+  }
+  for (const [i, a] of (value as readonly unknown[]).entries()) {
+    if (!isObject(a)) {
+      fail(context, `'search[${i}]' must be an object`);
+    }
+    assertNonEmptyString(a.domain, context, `search[${i}].domain`);
+    assertNonEmptyString(a.icon, context, `search[${i}].icon`);
+    assertNonEmptyString(a.color, context, `search[${i}].color`);
+    if (typeof a.search !== 'function') {
+      fail(context, `'search[${i}].search' must be a function`);
+    }
+  }
+}
+
+export function assertUriHandler(value: unknown, context: string): void {
+  if (value === undefined) return;
+  if (!isObject(value)) {
+    fail(context, `'uriHandler' must be an object when set`);
+  }
+  if (!Array.isArray(value.types) || value.types.length === 0) {
+    fail(context, `'uriHandler.types' must be a non-empty array`);
+  }
+  for (const [i, t] of (value.types as readonly unknown[]).entries()) {
+    if (typeof t !== 'string' || t.length === 0) {
+      fail(context, `'uriHandler.types[${i}]' must be a non-empty string`);
+    }
+  }
+  if (typeof value.resolve !== 'function') {
+    fail(context, `'uriHandler.resolve' must be a function`);
+  }
+}
+
+export function assertAiTools(value: unknown, context: string): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    fail(context, `'backend.aiTools' must be an array when set`);
+  }
+  for (const [i, t] of (value as readonly unknown[]).entries()) {
+    if (!isObject(t)) {
+      fail(context, `'backend.aiTools[${i}]' must be an object`);
+    }
+    assertNonEmptyString(t.name, context, `backend.aiTools[${i}].name`);
+    assertNonEmptyString(t.description, context, `backend.aiTools[${i}].description`);
+    if (!isObject(t.inputSchema)) {
+      fail(context, `'backend.aiTools[${i}].inputSchema' must be an object`);
+    }
+    if (typeof t.handler !== 'function') {
+      fail(context, `'backend.aiTools[${i}].handler' must be a function`);
+    }
+  }
+}
+
+export function assertMigrations(value: unknown, context: string): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    fail(context, `'backend.migrations' must be an array when set`);
+  }
+  for (const [i, m] of (value as readonly unknown[]).entries()) {
+    if (!isObject(m)) {
+      fail(context, `'backend.migrations[${i}]' must be an object`);
+    }
+    assertNonEmptyString(m.id, context, `backend.migrations[${i}].id`);
+    if (typeof m.sql !== 'string') {
+      fail(context, `'backend.migrations[${i}].sql' must be a string`);
+    }
+  }
+}
+
+export function assertIngestSources(value: unknown, context: string): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    fail(context, `'backend.ingestSources' must be an array when set`);
+  }
+  for (const [i, s] of (value as readonly unknown[]).entries()) {
+    if (!isObject(s)) {
+      fail(context, `'backend.ingestSources[${i}]' must be an object`);
+    }
+    assertNonEmptyString(s.id, context, `backend.ingestSources[${i}].id`);
+    assertNonEmptyString(s.label, context, `backend.ingestSources[${i}].label`);
+  }
+}
+
+export function assertBackend(value: unknown, context: string): void {
+  if (value === undefined) return;
+  if (!isObject(value)) {
+    fail(context, `'backend' must be an object when set`);
+  }
+  if (value.router === undefined) {
+    fail(context, `'backend.router' is required when 'backend' is set`);
+  }
+  assertAiTools(value.aiTools, context);
+  assertMigrations(value.migrations, context);
+  assertIngestSources(value.ingestSources, context);
+}
+
+export function assertFrontend(
+  value: unknown,
+  surfaces: readonly ModuleSurface[],
+  context: string
+): void {
+  if (value === undefined) return;
+  if (!isObject(value)) {
+    fail(context, `'frontend' must be an object when set`);
+  }
+  if (!surfaces.includes('overlay')) return;
+  if (!isObject(value.overlay)) {
+    fail(context, `'frontend.overlay' is required when surfaces includes 'overlay'`);
+  }
+  if (typeof value.overlay.chromeSlot !== 'string') {
+    fail(context, `'frontend.overlay.chromeSlot' must be a string`);
+  }
+}

--- a/packages/types/src/migration.ts
+++ b/packages/types/src/migration.ts
@@ -1,0 +1,22 @@
+/**
+ * Migration descriptor — per-module backend migration declaration (PRD-101 US-09).
+ *
+ * Today the migration runner walks a global folder and applies every file
+ * unconditionally. After PRD-101 the runner consumes `MODULES.flatMap(m =>
+ * m.backend?.migrations)` and skips migrations belonging to modules not in
+ * the install set, so absent modules leave no rows in `schema_migrations`.
+ *
+ * The shape is intentionally minimal: `id` (the canonical version key written
+ * to `schema_migrations`) plus `sql` (the migration body to execute). The
+ * runner is responsible for ordering, idempotency, and transaction boundaries.
+ */
+export interface MigrationDescriptor {
+  /**
+   * Canonical migration version key, e.g. `2026_05_11_001_finance_init`.
+   * Matches the value written to `schema_migrations.version`. MUST be stable
+   * across releases — renaming is a breaking change for already-applied DBs.
+   */
+  id: string;
+  /** SQL body of the migration. */
+  sql: string;
+}

--- a/packages/types/src/module-manifest.test-d.ts
+++ b/packages/types/src/module-manifest.test-d.ts
@@ -1,0 +1,172 @@
+/**
+ * Compile-time type tests for `ModuleManifest` and the PRD-101 cross-cutting
+ * slots. This file is excluded from emit (`tsconfig.build.json`); it only
+ * exercises the type system. A regression here is a TypeScript compiler error
+ * surfaced by `pnpm typecheck` in CI.
+ */
+import type {
+  AiToolDescriptor,
+  Capability,
+  IngestSourceDescriptor,
+  MigrationDescriptor,
+  ModuleManifest,
+  SearchAdapterDescriptor,
+  UriHandlerDescriptor,
+  UriResolution,
+} from './index.js';
+
+/** Helper: assert a type is assignable to another, at compile time. */
+type Expect<T extends true> = T;
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Assignable<A, B> = A extends B ? true : false;
+
+/* -------------------------------------------------------------------------- */
+/* Capability — typed-scope inference                                         */
+/* -------------------------------------------------------------------------- */
+
+// Default Capability is `${string}.${string}` — any namespaced string fits.
+const _capDefault: Capability = 'finance.transaction.read';
+const _capDefault2: Capability = 'media.movie.write';
+
+// Narrowed to a single module id, only that namespace fits.
+type FinanceCap = Capability<'finance'>;
+const _capFinance: FinanceCap = 'finance.transaction.read';
+// @ts-expect-error — wrong namespace must not type-check
+const _capWrongNs: FinanceCap = 'media.movie.read';
+// @ts-expect-error — must include a dot-separated scope
+const _capNoDot: FinanceCap = 'finance';
+
+// Narrowed to a union of module ids — produces a union of namespaces.
+type CoreOrFinance = Capability<'core' | 'finance'>;
+type _ExpectCoreOrFinance = Expect<
+  Equal<CoreOrFinance, `core.${string}` | `finance.${string}`>
+>;
+const _capCore: CoreOrFinance = 'core.entity.read';
+const _capFin: CoreOrFinance = 'finance.budget.write';
+// @ts-expect-error — module not in the union
+const _capOutside: CoreOrFinance = 'media.movie.read';
+
+/* -------------------------------------------------------------------------- */
+/* MODULES id-union narrowing — simulated until US-02 ships                   */
+/* -------------------------------------------------------------------------- */
+
+// Simulates the PRD-101 US-02 generated `MODULES` constant. The id literal
+// flows through to give `Capability` a concrete namespace union.
+const SIMULATED_MODULES = [
+  { id: 'finance', name: 'Finance', surfaces: ['app'] as const },
+  { id: 'media', name: 'Media', surfaces: ['app'] as const },
+] as const;
+
+type SimulatedModuleId = (typeof SIMULATED_MODULES)[number]['id'];
+type _ExpectIdUnion = Expect<Equal<SimulatedModuleId, 'finance' | 'media'>>;
+
+type SimulatedCapability = Capability<SimulatedModuleId>;
+const _simCapOk: SimulatedCapability = 'finance.transaction.read';
+const _simCapOk2: SimulatedCapability = 'media.movie.read';
+// @ts-expect-error — module id outside the union
+const _simCapBad: SimulatedCapability = 'inventory.item.read';
+
+/* -------------------------------------------------------------------------- */
+/* Descriptor optionality                                                     */
+/* -------------------------------------------------------------------------- */
+
+// A minimal manifest must compile — every cross-cutting slot is optional.
+const _minimal: ModuleManifest = {
+  id: 'finance',
+  name: 'Finance',
+  surfaces: ['app'],
+};
+
+// A maximal manifest exercises every PRD-101 slot.
+const _maximal: ModuleManifest = {
+  id: 'finance',
+  name: 'Finance',
+  version: '0.1.0',
+  surfaces: ['app'],
+  description: 'desc',
+  dependsOn: ['core'],
+  capabilities: ['finance.transaction.read', 'finance.budget.write'],
+  features: [{ id: 'finance', title: 'Finance', order: 10, features: [] }],
+  search: [
+    {
+      domain: 'finance',
+      icon: 'wallet',
+      color: 'green',
+      search: () => [],
+    },
+  ],
+  uriHandler: {
+    types: ['transaction'],
+    resolve: async () => ({ kind: 'not-found' }),
+  },
+  backend: {
+    router: {},
+    aiTools: [
+      {
+        name: 'finance.transaction.find',
+        description: 'Find transactions',
+        inputSchema: { type: 'object' },
+        handler: async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+      },
+    ],
+    migrations: [{ id: '2026_05_11_001_finance_init', sql: 'SELECT 1' }],
+    ingestSources: [{ id: 'plaid', label: 'Plaid' }],
+  },
+};
+
+// Slots are individually omittable — TypeScript should not require any of them.
+const _onlyCapabilities: ModuleManifest = {
+  id: 'finance',
+  name: 'Finance',
+  surfaces: ['app'],
+  capabilities: ['finance.x'],
+};
+
+// Covers `_minimal` and `_maximal` use to keep the linter quiet about unused vars.
+type _UseAll = [
+  typeof _capDefault,
+  typeof _capDefault2,
+  typeof _capFinance,
+  typeof _capCore,
+  typeof _capFin,
+  typeof _simCapOk,
+  typeof _simCapOk2,
+  typeof _minimal,
+  typeof _maximal,
+  typeof _onlyCapabilities,
+];
+
+/* -------------------------------------------------------------------------- */
+/* UriResolution — discriminated union narrows on `kind`                      */
+/* -------------------------------------------------------------------------- */
+
+declare const _resolution: UriResolution<{ id: string }>;
+if (_resolution.kind === 'object') {
+  // `data` is reachable only on the `object` branch.
+  const _id: string = _resolution.data.id;
+  void _id;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Descriptor shapes are exported and structurally distinct                   */
+/* -------------------------------------------------------------------------- */
+
+type _AssignAiTool = Expect<
+  Assignable<
+    {
+      name: string;
+      description: string;
+      inputSchema: Record<string, unknown>;
+      handler: (i: Record<string, unknown>) => Promise<{
+        content: readonly { type: 'text'; text: string }[];
+      }>;
+    },
+    AiToolDescriptor
+  >
+>;
+
+type _AssignMigration = Expect<Assignable<{ id: string; sql: string }, MigrationDescriptor>>;
+type _AssignSearch = Expect<Assignable<SearchAdapterDescriptor, SearchAdapterDescriptor>>;
+type _AssignUri = Expect<Assignable<UriHandlerDescriptor, UriHandlerDescriptor>>;
+type _AssignIngest = Expect<Assignable<{ id: string; label: string }, IngestSourceDescriptor>>;

--- a/packages/types/src/module-manifest.test-d.ts
+++ b/packages/types/src/module-manifest.test-d.ts
@@ -39,9 +39,7 @@ const _capNoDot: FinanceCap = 'finance';
 
 // Narrowed to a union of module ids — produces a union of namespaces.
 type CoreOrFinance = Capability<'core' | 'finance'>;
-type _ExpectCoreOrFinance = Expect<
-  Equal<CoreOrFinance, `core.${string}` | `finance.${string}`>
->;
+type _ExpectCoreOrFinance = Expect<Equal<CoreOrFinance, `core.${string}` | `finance.${string}`>>;
 const _capCore: CoreOrFinance = 'core.entity.read';
 const _capFin: CoreOrFinance = 'finance.budget.write';
 // @ts-expect-error — module not in the union

--- a/packages/types/src/module-manifest.test.ts
+++ b/packages/types/src/module-manifest.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Runtime structural validation tests for `assertModuleManifest`. Each
+ * cross-cutting slot added in PRD-101 US-01 has at least one passing case
+ * and one failing case; the failing case asserts the error message names the
+ * offending field so the registry build (US-02) can surface it.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { assertModuleManifest } from './module-manifest.js';
+
+import type { ModuleManifest } from './module-manifest.js';
+
+const baseManifest = (): ModuleManifest => ({
+  id: 'finance',
+  name: 'Finance',
+  surfaces: ['app'],
+});
+
+describe('assertModuleManifest — base contract', () => {
+  it('accepts a minimal manifest', () => {
+    expect(() => assertModuleManifest(baseManifest())).not.toThrow();
+  });
+
+  it('rejects non-objects', () => {
+    expect(() => assertModuleManifest(null)).toThrow(/expected an object/);
+    expect(() => assertModuleManifest(42)).toThrow(/expected an object/);
+    expect(() => assertModuleManifest([])).toThrow(/expected an object/);
+  });
+
+  it('rejects empty id / name', () => {
+    expect(() => assertModuleManifest({ ...baseManifest(), id: '' })).toThrow(/'id'/);
+    expect(() => assertModuleManifest({ ...baseManifest(), name: '' })).toThrow(/'name'/);
+  });
+
+  it('rejects empty / invalid surfaces', () => {
+    expect(() => assertModuleManifest({ ...baseManifest(), surfaces: [] })).toThrow(/surfaces/);
+    expect(() =>
+      assertModuleManifest({ ...baseManifest(), surfaces: ['nope'] as unknown as string[] })
+    ).toThrow(/invalid surface/);
+  });
+
+  it('embeds the supplied context in the error', () => {
+    expect(() => assertModuleManifest({}, 'modules.finance')).toThrow(/^modules\.finance:/);
+  });
+});
+
+describe('assertModuleManifest — capabilities slot', () => {
+  it('accepts a capability namespaced under the module id', () => {
+    expect(() =>
+      assertModuleManifest({ ...baseManifest(), capabilities: ['finance.transaction.read'] })
+    ).not.toThrow();
+  });
+
+  it('rejects a non-array', () => {
+    expect(() =>
+      assertModuleManifest({ ...baseManifest(), capabilities: 'finance.x' as unknown as string[] })
+    ).toThrow(/'capabilities'/);
+  });
+
+  it('rejects a non-namespaced capability', () => {
+    expect(() =>
+      assertModuleManifest({ ...baseManifest(), capabilities: ['finance'] })
+    ).toThrow(/capabilities\[0\]/);
+  });
+
+  it('rejects a capability namespaced under a different module id', () => {
+    expect(() =>
+      assertModuleManifest({ ...baseManifest(), capabilities: ['media.movie.read'] })
+    ).toThrow(/capabilities\[0\].*finance/);
+  });
+});
+
+describe('assertModuleManifest — features slot', () => {
+  it('accepts a well-formed features manifest list', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        features: [{ id: 'finance', title: 'Finance', order: 10, features: [] }],
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects a non-array', () => {
+    expect(() =>
+      assertModuleManifest({ ...baseManifest(), features: {} as unknown as never })
+    ).toThrow(/'features'/);
+  });
+
+  it('reports the failing index and field', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        features: [{ id: '', title: 'X', order: 1, features: [] }] as unknown as never,
+      })
+    ).toThrow(/features\[0\]\.id/);
+  });
+
+  it('requires a numeric order', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        features: [
+          { id: 'finance', title: 'Finance', order: 'first', features: [] },
+        ] as unknown as never,
+      })
+    ).toThrow(/features\[0\]\.order/);
+  });
+});
+
+describe('assertModuleManifest — search slot', () => {
+  it('accepts a well-formed search adapter descriptor', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        search: [{ domain: 'finance', icon: 'wallet', color: 'green', search: () => [] }],
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects a missing search function', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        search: [
+          { domain: 'finance', icon: 'wallet', color: 'green' },
+        ] as unknown as never,
+      })
+    ).toThrow(/search\[0\]\.search/);
+  });
+});
+
+describe('assertModuleManifest — uriHandler slot', () => {
+  it('accepts a well-formed handler', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        uriHandler: {
+          types: ['transaction'],
+          resolve: async () => ({ kind: 'not-found' }),
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it('requires a non-empty types array', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        uriHandler: {
+          types: [],
+          resolve: async () => ({ kind: 'not-found' }),
+        } as unknown as never,
+      })
+    ).toThrow(/uriHandler\.types/);
+  });
+
+  it('requires a function resolver', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        uriHandler: {
+          types: ['transaction'],
+          resolve: 'nope',
+        } as unknown as never,
+      })
+    ).toThrow(/uriHandler\.resolve/);
+  });
+});
+
+describe('assertModuleManifest — backend.aiTools slot', () => {
+  it('accepts a well-formed AI tool descriptor', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        backend: {
+          router: {},
+          aiTools: [
+            {
+              name: 'finance.tx.find',
+              description: 'find',
+              inputSchema: { type: 'object' },
+              handler: async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+            },
+          ],
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it('reports a missing handler', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        backend: {
+          router: {},
+          aiTools: [
+            {
+              name: 'finance.tx.find',
+              description: 'find',
+              inputSchema: { type: 'object' },
+            },
+          ],
+        } as unknown as never,
+      })
+    ).toThrow(/backend\.aiTools\[0\]\.handler/);
+  });
+});
+
+describe('assertModuleManifest — backend.migrations slot', () => {
+  it('accepts a well-formed migration descriptor', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        backend: {
+          router: {},
+          migrations: [{ id: '2026_05_11_001_finance_init', sql: 'SELECT 1' }],
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it('reports a missing id', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        backend: {
+          router: {},
+          migrations: [{ sql: 'SELECT 1' }],
+        } as unknown as never,
+      })
+    ).toThrow(/backend\.migrations\[0\]\.id/);
+  });
+
+  it('rejects a non-string sql', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        backend: {
+          router: {},
+          migrations: [{ id: '001', sql: 123 }],
+        } as unknown as never,
+      })
+    ).toThrow(/backend\.migrations\[0\]\.sql/);
+  });
+});
+
+describe('assertModuleManifest — backend.ingestSources slot', () => {
+  it('accepts a well-formed ingest source descriptor', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        backend: {
+          router: {},
+          ingestSources: [{ id: 'plaid', label: 'Plaid' }],
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it('reports a missing label', () => {
+    expect(() =>
+      assertModuleManifest({
+        ...baseManifest(),
+        backend: {
+          router: {},
+          ingestSources: [{ id: 'plaid' }],
+        } as unknown as never,
+      })
+    ).toThrow(/backend\.ingestSources\[0\]\.label/);
+  });
+});
+
+describe('assertModuleManifest — frontend overlay invariant', () => {
+  it('requires frontend.overlay when surfaces includes overlay', () => {
+    expect(() =>
+      assertModuleManifest({
+        id: 'ego',
+        name: 'Ego',
+        surfaces: ['overlay'],
+        frontend: {},
+      })
+    ).toThrow(/frontend\.overlay/);
+  });
+
+  it('accepts a valid overlay declaration', () => {
+    expect(() =>
+      assertModuleManifest({
+        id: 'ego',
+        name: 'Ego',
+        surfaces: ['overlay'],
+        frontend: { overlay: { chromeSlot: 'assistant' } },
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/types/src/module-manifest.test.ts
+++ b/packages/types/src/module-manifest.test.ts
@@ -58,9 +58,9 @@ describe('assertModuleManifest — capabilities slot', () => {
   });
 
   it('rejects a non-namespaced capability', () => {
-    expect(() =>
-      assertModuleManifest({ ...baseManifest(), capabilities: ['finance'] })
-    ).toThrow(/capabilities\[0\]/);
+    expect(() => assertModuleManifest({ ...baseManifest(), capabilities: ['finance'] })).toThrow(
+      /capabilities\[0\]/
+    );
   });
 
   it('rejects a capability namespaced under a different module id', () => {
@@ -121,9 +121,7 @@ describe('assertModuleManifest — search slot', () => {
     expect(() =>
       assertModuleManifest({
         ...baseManifest(),
-        search: [
-          { domain: 'finance', icon: 'wallet', color: 'green' },
-        ] as unknown as never,
+        search: [{ domain: 'finance', icon: 'wallet', color: 'green' }] as unknown as never,
       })
     ).toThrow(/search\[0\]\.search/);
   });

--- a/packages/types/src/module-manifest.ts
+++ b/packages/types/src/module-manifest.ts
@@ -1,16 +1,40 @@
 /**
  * Module manifest types — the contract every POPS module exports so that the
- * shell (frontend) and the tRPC root (backend) can assemble themselves from
- * metadata rather than from hard-coded import lists.
+ * shell (frontend), the tRPC root (backend), and every cross-cutting concern
+ * (settings, features, search, AI tools, URI resolution, migrations) can
+ * assemble themselves from metadata rather than from hard-coded import lists
+ * or side-effect registrations.
  *
- * This module is metadata-only at the time of PRD-098. The runtime that
- * consumes these manifests (`POPS_APPS` / `POPS_OVERLAYS` env loader) lands in
- * PRD-100; the lint enforcement of cross-module boundaries that protects them
- * lands in PRD-097.
+ * PRD-098 introduced the metadata-only shape; PRD-100 added the env-driven
+ * loader; PRD-101 (this iteration) extends the shape with the slots the
+ * cross-cutting concerns need so a module is a single file describing
+ * everything the platform reads from it.
  *
- * See `docs/themes/01-foundation/prds/098-module-manifest/` for the full PRD.
+ * See `docs/themes/01-foundation/prds/101-plugin-contract/` for the PRD
+ * (`README.md`) and the per-slot user stories (`us-NN-*.md`). This file is
+ * types + structural validation only — consumer wiring lands in US-03..US-10.
  */
+import {
+  assertBackend,
+  assertCapabilities,
+  assertFeatures,
+  assertFrontend,
+  assertNonEmptyString,
+  assertSearch,
+  assertSurfaces,
+  assertUriHandler,
+  fail,
+  isObject,
+} from './manifest-assertions.js';
+
+import type { AiToolDescriptor } from './ai-tool.js';
+import type { Capability } from './capability.js';
+import type { FeatureManifest } from './feature-manifest.js';
+import type { IngestSourceDescriptor } from './ingest-source.js';
+import type { MigrationDescriptor } from './migration.js';
+import type { SearchAdapterDescriptor } from './search-adapter.js';
 import type { SettingsManifest } from './settings-manifest.js';
+import type { UriHandlerDescriptor } from './uri-handler.js';
 
 /**
  * Surfaces a module can present to the shell.
@@ -56,6 +80,22 @@ export interface ModuleFrontendManifest<TRoutes = unknown, TNavConfig = unknown>
 export interface ModuleBackendManifest<TRouter = unknown> {
   /** tRPC router (or equivalent) composed into the root by the loader. */
   router: TRouter;
+  /**
+   * MCP / Ego-callable tools this module exposes. Aggregated by the MCP
+   * server via `MODULES.flatMap(m => m.backend?.aiTools)` — see PRD-101 US-10.
+   */
+  aiTools?: readonly AiToolDescriptor[];
+  /**
+   * SQL migrations owned by this module. The migration runner skips entries
+   * whose owning module is not in the install set — see PRD-101 US-09.
+   */
+  migrations?: readonly MigrationDescriptor[];
+  /**
+   * External data sources this module ingests from. Typed slot only — the
+   * only consumer today is Cerebrum (Plexus, PRD-090) and that integration
+   * stays internal to the module. Reserved for future platform-level UIs.
+   */
+  ingestSources?: readonly IngestSourceDescriptor[];
 }
 
 /**
@@ -78,10 +118,30 @@ export interface ModuleManifest<TRouter = unknown, TRoutes = unknown, TNavConfig
   description?: string;
   /** Modules this one depends on at runtime; loader fails fast on a missing dep. */
   dependsOn?: readonly string[];
-  /** Capabilities this module provides (free-form strings, e.g. `finance.transaction`). */
-  provides?: readonly string[];
+  /**
+   * Typed RBAC capability identifiers this module owns, namespaced by id
+   * (e.g. `finance.transaction.read`). Supersedes the free-form `provides`
+   * slot from PRD-098. PRD-101 only defines the slot — RBAC enforcement is
+   * a future PRD.
+   */
+  capabilities?: readonly Capability[];
   /** Plugged in as a slot from PRD-093. */
   settings?: SettingsManifest;
+  /**
+   * Per-module feature toggle definitions (PRD-094). Aggregated by the
+   * features admin via `MODULES.flatMap(m => m.features)` — see PRD-101 US-05.
+   */
+  features?: readonly FeatureManifest[];
+  /**
+   * Search adapter declarations. Aggregated by the unified search engine via
+   * `MODULES.flatMap(m => m.search)` — see PRD-101 US-06.
+   */
+  search?: readonly SearchAdapterDescriptor[];
+  /**
+   * Object types this module owns under `pops:{id}/{type}/...` plus a resolver
+   * the central URI dispatcher invokes. ADR-012, PRD-101 US-08.
+   */
+  uriHandler?: UriHandlerDescriptor;
   /** Filled when the module exposes a backend tRPC router. */
   backend?: ModuleBackendManifest<TRouter>;
   /** Filled when the module exposes a frontend app or overlay. */
@@ -90,68 +150,27 @@ export interface ModuleManifest<TRouter = unknown, TRoutes = unknown, TNavConfig
 
 /**
  * Runtime guard that asserts a value satisfies the structural shape of
- * `ModuleManifest`. Used by the manifest assertion test (US-04). Throws
- * `TypeError` with a descriptive message on the first failed check so the
- * stack trace points at the offending module.
+ * `ModuleManifest`, including every PRD-101 cross-cutting slot.
+ *
+ * The registry build (PRD-101 US-02) calls this on every loaded manifest;
+ * failures throw `TypeError` with a message that names the offending field
+ * and embeds the supplied `context` so the caller can include the module id.
  */
-function fail(context: string, message: string): never {
-  throw new TypeError(`${context}: ${message}`);
-}
-
-function assertNonEmptyString(value: unknown, context: string, field: string): void {
-  if (typeof value !== 'string' || value.length === 0) {
-    fail(context, `'${field}' must be a non-empty string`);
-  }
-}
-
-function assertSurfaces(value: unknown, context: string): readonly ModuleSurface[] {
-  if (!Array.isArray(value) || value.length === 0) {
-    fail(context, `'surfaces' must be a non-empty array`);
-  }
-  for (const s of value as readonly unknown[]) {
-    if (s !== 'app' && s !== 'overlay') {
-      fail(context, `invalid surface '${String(s)}'`);
-    }
-  }
-  return value as readonly ModuleSurface[];
-}
-
-function assertBackend(value: unknown, context: string): void {
-  if (value === undefined) return;
-  if (!value || typeof value !== 'object') {
-    fail(context, `'backend' must be an object when set`);
-  }
-  if ((value as Record<string, unknown>).router === undefined) {
-    fail(context, `'backend.router' is required when 'backend' is set`);
-  }
-}
-
-function assertFrontend(value: unknown, surfaces: readonly ModuleSurface[], context: string): void {
-  if (value === undefined) return;
-  if (!value || typeof value !== 'object') {
-    fail(context, `'frontend' must be an object when set`);
-  }
-  if (!surfaces.includes('overlay')) return;
-  const f = value as Record<string, unknown>;
-  if (!f.overlay || typeof f.overlay !== 'object') {
-    fail(context, `'frontend.overlay' is required when surfaces includes 'overlay'`);
-  }
-  if (typeof (f.overlay as Record<string, unknown>).chromeSlot !== 'string') {
-    fail(context, `'frontend.overlay.chromeSlot' must be a string`);
-  }
-}
-
 export function assertModuleManifest(
   value: unknown,
   context = 'manifest'
 ): asserts value is ModuleManifest {
-  if (!value || typeof value !== 'object') {
+  if (!isObject(value)) {
     fail(context, 'expected an object');
   }
-  const m = value as Record<string, unknown>;
-  assertNonEmptyString(m.id, context, 'id');
-  assertNonEmptyString(m.name, context, 'name');
-  const surfaces = assertSurfaces(m.surfaces, context);
-  assertBackend(m.backend, context);
-  assertFrontend(m.frontend, surfaces, context);
+  assertNonEmptyString(value.id, context, 'id');
+  assertNonEmptyString(value.name, context, 'name');
+  const moduleId = value.id as string;
+  const surfaces = assertSurfaces(value.surfaces, context);
+  assertCapabilities(value.capabilities, context, moduleId);
+  assertFeatures(value.features, context);
+  assertSearch(value.search, context);
+  assertUriHandler(value.uriHandler, context);
+  assertBackend(value.backend, context);
+  assertFrontend(value.frontend, surfaces, context);
 }

--- a/packages/types/src/search-adapter.ts
+++ b/packages/types/src/search-adapter.ts
@@ -1,0 +1,31 @@
+/**
+ * Search adapter descriptor — per-module declaration of how the unified search
+ * engine queries a domain (PRD-101 US-06).
+ *
+ * Mirrors today's `SearchAdapter` interface from
+ * `apps/pops-api/src/modules/core/search/types.ts` so the migration to a
+ * registry-based engine in US-06 is a wiring change, not a contract change.
+ *
+ * The frontend `SearchAdapter` (in `./search.ts`) extends this with a render
+ * component; the descriptor here is backend-only and stays out of React's
+ * reach so `@pops/types` doesn't need to depend on it.
+ */
+import type { Query, SearchContext, SearchHit } from './search.js';
+
+export interface SearchAdapterDescriptor<TData = unknown> {
+  /** Domain identifier matching the owning module's id, e.g. `finance`, `media`. */
+  domain: string;
+  /** Lucide icon name for the section header in the unified search UI. */
+  icon: string;
+  /** App color token for section theming in the unified search UI. */
+  color: string;
+  /**
+   * Search the domain and return ranked hits. Sync or async — the engine
+   * awaits either way. Implementations MUST honour `options.limit` when set.
+   */
+  search(
+    query: Query,
+    context: SearchContext,
+    options?: { limit?: number }
+  ): SearchHit<TData>[] | Promise<SearchHit<TData>[]>;
+}

--- a/packages/types/src/uri-handler.ts
+++ b/packages/types/src/uri-handler.ts
@@ -1,0 +1,42 @@
+/**
+ * URI handler descriptor — per-module hook for the platform-wide URI resolver
+ * (ADR-012, PRD-101 US-08). A module declares the object types it owns under
+ * the `pops:{moduleId}/{type}/{...}` namespace and provides a resolver that
+ * the central dispatcher calls when a URI matching one of those types is
+ * requested.
+ *
+ * The resolver is intentionally generic over its successful payload (`TData`,
+ * defaulting to `unknown`). The platform consumer (US-08) is the only piece
+ * that erases it; per-module call sites can keep their narrow type.
+ */
+
+/**
+ * Outcome of a URI resolution.
+ *
+ * Discriminated union — the caller dispatches on `kind`:
+ * - `object`        — a real entity was found; `data` holds the typed payload
+ * - `not-found`     — the module is installed but no entity matches the id
+ * - `module-absent` — the owning module is not in `POPS_APPS`/`POPS_OVERLAYS`;
+ *                    the resolver was invoked anyway and is reporting back so
+ *                    the caller can render a placeholder rather than throw.
+ */
+export type UriResolution<TData = unknown> =
+  | { kind: 'object'; data: TData }
+  | { kind: 'not-found' }
+  | { kind: 'module-absent' };
+
+export interface UriHandlerDescriptor<TData = unknown> {
+  /**
+   * Object types this module owns, e.g. `['transaction', 'budget']`.
+   * Matched against the second segment of `pops:{moduleId}/{type}/{id}`.
+   * Two manifests declaring the same `(moduleId, type)` pair is a contract
+   * violation and the registry build (US-02) fails fast.
+   */
+  types: readonly string[];
+  /**
+   * Resolves a `(type, id)` pair to a `UriResolution`. The resolver MUST NOT
+   * throw on missing data — return `{ kind: 'not-found' }` instead. Throwing
+   * is reserved for hard failures (corrupt store, transport error).
+   */
+  resolve: (type: string, id: string) => Promise<UriResolution<TData>>;
+}

--- a/packages/types/tsconfig.build.json
+++ b/packages/types/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts"]
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -7,7 +7,8 @@
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["vitest/globals"]
   },
   "include": ["src"]
 }

--- a/packages/types/vitest.config.ts
+++ b/packages/types/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts', '**/*.test-d.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -935,9 +935,15 @@ importers:
 
   packages/types:
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/ui:
     dependencies:


### PR DESCRIPTION
Closes #2535.

## Summary

PRD-101 US-01 — extends `ModuleManifest` (in `@pops/types`) with the cross-cutting slots the platform needs to assemble itself from manifests rather than from side-effect registries.

- New top-level slots: `capabilities`, `features`, `search`, `uriHandler`. The free-form `provides: string[]` is removed (it was never set on any manifest).
- New `backend` slots: `aiTools`, `migrations`, `ingestSources`.
- New descriptor types exported from `@pops/types`:
  - `Capability<ModuleId extends string = string>` — template-literal `${ModuleId}.${string}`
  - `UriHandlerDescriptor` + `UriResolution` (discriminated union: `object` / `not-found` / `module-absent`)
  - `AiToolDescriptor` (+ `AiToolHandler`, `AiToolResult`) — mirrors MCP tool shape
  - `MigrationDescriptor` — `{ id, sql }`
  - `SearchAdapterDescriptor` — mirrors today's API-side `SearchAdapter`
  - `IngestSourceDescriptor` — typed slot only; no platform aggregator yet
- `assertModuleManifest()` validates each new slot's structural shape; failures embed the supplied context (module id) and name the offending field/index.
- All seven existing manifests (`core`, `finance`, `media`, `inventory`, `cerebrum`, `ego`, `ai`) compile against the new shape unchanged — every new slot is optional.
- Validator helpers split out into `manifest-assertions.ts` to keep `module-manifest.ts` under the `max-lines` cap.
- New compile-time type tests (`module-manifest.test-d.ts`) cover Capability typed-scope inference, simulated `MODULES` id-union narrowing, `UriResolution` discriminated narrowing, and descriptor optionality.
- New runtime tests (`module-manifest.test.ts`, 27 cases) exercise every slot's failure path.
- `@pops/types` now runs vitest via `pnpm test`; build emits to `dist/` (test files excluded via `tsconfig.build.json`).

This PR is types + validator only. Consumers (settings, features, search, URI resolver, migration runner, AI-tool aggregation, registry) come in PRDs/USs #2538-#2544.

## Test plan

- [x] `pnpm typecheck` (turbo: 17 tasks pass)
- [x] `pnpm lint` (0 errors)
- [x] `pnpm --filter @pops/types test` (27/27 pass)
- [x] `pnpm --filter @pops/api test src/modules/manifests.test.ts` (14/14 pass)
- [x] `pnpm --filter @pops/shell test src/tests/manifests.test.ts` (14/14 pass)
- [x] Existing module manifests (`finance`, `media`, `inventory`, `cerebrum`, `ego`, `ai`, `core`) compile unchanged
- [x] Acceptance criteria in `us-01-extend-manifest.md` flipped to `[x]`