### PR TITLE
feat(foundation): build-time module registry (PRD-101 US-02, #2536)

### DIFF
--- a/.github/workflows/module-registry-quality.yml
+++ b/.github/workflows/module-registry-quality.yml
@@ -1,0 +1,63 @@
+name: Module Registry Quality
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/module-registry/**"
+      - "packages/types/**"
+      - ".github/workflows/module-registry-quality.yml"
+      - ".github/workflows/_pkg-check.yml"
+  pull_request:
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'packages/module-registry/**'
+              - 'packages/types/**'
+              - '.github/workflows/module-registry-quality.yml'
+              - '.github/workflows/_pkg-check.yml'
+
+  quality:
+    needs: [changes]
+    if: always()
+    uses: ./.github/workflows/_pkg-check.yml
+    with:
+      package-path: packages/module-registry
+      has-test: true
+      skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}
+
+  registry-up-to-date:
+    name: Registry up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build shared packages
+        run: pnpm --filter @pops/types build
+      - name: Regenerate registry
+        run: pnpm registry:build
+      - name: Verify generated.ts is up to date
+        run: |
+          if ! git diff --exit-code -- packages/module-registry/src/generated.ts; then
+            echo ""
+            echo "::error::packages/module-registry/src/generated.ts is out of date."
+            echo "Run 'pnpm registry:build' locally and commit the result."
+            exit 1
+          fi

--- a/.github/workflows/module-registry-quality.yml
+++ b/.github/workflows/module-registry-quality.yml
@@ -36,6 +36,7 @@ jobs:
     with:
       package-path: packages/module-registry
       has-test: true
+      needs-db-build: true
       skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}
 
   registry-up-to-date:

--- a/apps/pops-api/Dockerfile
+++ b/apps/pops-api/Dockerfile
@@ -7,6 +7,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 # Copy all workspace packages
 COPY packages/db-types/package.json ./packages/db-types/
 COPY packages/types/package.json ./packages/types/
+COPY packages/module-registry/package.json ./packages/module-registry/
 COPY apps/pops-api/package.json ./apps/pops-api/
 
 # Install pnpm and dependencies (cached across builds)
@@ -18,6 +19,8 @@ COPY packages/db-types/src ./packages/db-types/src
 COPY packages/db-types/tsconfig.json ./packages/db-types/
 COPY packages/types/src ./packages/types/src
 COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/module-registry/src ./packages/module-registry/src
+COPY packages/module-registry/tsconfig.json packages/module-registry/tsconfig.build.json ./packages/module-registry/
 COPY apps/pops-api/tsconfig.json ./apps/pops-api/
 COPY apps/pops-api/src ./apps/pops-api/src
 
@@ -25,6 +28,8 @@ COPY apps/pops-api/src ./apps/pops-api/src
 WORKDIR /app/packages/db-types
 RUN pnpm build
 WORKDIR /app/packages/types
+RUN pnpm build
+WORKDIR /app/packages/module-registry
 RUN pnpm build
 
 # Build pops-api
@@ -53,6 +58,8 @@ COPY --from=builder /app/packages/db-types/dist ./node_modules/@pops/db-types/di
 COPY --from=builder /app/packages/db-types/package.json ./node_modules/@pops/db-types/
 COPY --from=builder /app/packages/types/dist ./node_modules/@pops/types/dist
 COPY --from=builder /app/packages/types/package.json ./node_modules/@pops/types/
+COPY --from=builder /app/packages/module-registry/dist ./node_modules/@pops/module-registry/dist
+COPY --from=builder /app/packages/module-registry/package.json ./node_modules/@pops/module-registry/
 
 # Copy types source into node_modules (source-only package, no build step)
 COPY --from=builder /app/packages/types/src ./node_modules/@pops/types/src

--- a/apps/pops-shell/Dockerfile
+++ b/apps/pops-shell/Dockerfile
@@ -18,6 +18,7 @@ COPY packages/overlay-ego/package.json ./packages/overlay-ego/
 COPY packages/api-client/package.json ./packages/api-client/
 COPY packages/navigation/package.json ./packages/navigation/
 COPY packages/types/package.json ./packages/types/
+COPY packages/module-registry/package.json ./packages/module-registry/
 
 # Install pnpm and dependencies (cached across builds)
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -28,9 +29,13 @@ COPY packages/db-types/src ./packages/db-types/src
 COPY packages/db-types/tsconfig.json ./packages/db-types/
 COPY packages/types/src ./packages/types/src
 COPY packages/types/tsconfig.json packages/types/tsconfig.build.json ./packages/types/
+COPY packages/module-registry/src ./packages/module-registry/src
+COPY packages/module-registry/tsconfig.json packages/module-registry/tsconfig.build.json ./packages/module-registry/
 WORKDIR /app/packages/db-types
 RUN pnpm build
 WORKDIR /app/packages/types
+RUN pnpm build
+WORKDIR /app/packages/module-registry
 RUN pnpm build
 
 # Copy remaining source files
@@ -45,6 +50,7 @@ COPY packages/overlay-ego/ ./packages/overlay-ego/
 COPY packages/api-client/ ./packages/api-client/
 COPY packages/navigation/ ./packages/navigation/
 COPY packages/types/ ./packages/types/
+COPY packages/module-registry/ ./packages/module-registry/
 COPY apps/pops-api/ ./apps/pops-api/
 COPY apps/pops-shell/ ./apps/pops-shell/
 

--- a/docs/themes/01-foundation/prds/101-plugin-contract/us-02-build-time-registry.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/us-02-build-time-registry.md
@@ -1,7 +1,7 @@
 # US-02: Build-time module registry
 
 > PRD: [Plugin Contract](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As a platform engineer, I want a single typed `MODULES` constant aggregating eve
 
 ## Acceptance Criteria
 
-- [ ] New package `@pops/module-registry` exists with one entry point: `export const MODULES: readonly ModuleManifest[]` and `export const KNOWN_MODULES: readonly string[]`.
-- [ ] Generator script `pnpm registry:build` (in `packages/module-registry/scripts/build.ts`) reads `KNOWN_MODULES` (a fixed list at the top of the script), imports each module's `manifest`, validates via `assertModuleManifest()`, and emits `packages/module-registry/src/generated.ts`.
-- [ ] The generated file is committed. CI runs `pnpm registry:build` and fails if the output differs from the committed file (drizzle-style guard).
-- [ ] Turbo task graph wires `registry:build` as a dependency of `build` and `dev` for every consumer package.
-- [ ] `MODULES` is `as const`-typed so consumers get the exact installed module-id union in their types.
-- [ ] Generator fails with a clear error naming the module if: a manifest fails validation; a `dependsOn` references an absent module; two `uriHandler.types` collide; a manifest id duplicates another.
-- [ ] Generator respects the env contract: when `POPS_APPS` / `POPS_OVERLAYS` are set, the generated `MODULES` only contains the listed ids (intersected with `KNOWN_MODULES`).
-- [ ] Default behaviour (env unset): `MODULES` contains every entry of `KNOWN_MODULES`. Preserves PRD-100 default.
+- [x] New package `@pops/module-registry` exists with one entry point: `export const MODULES: readonly ModuleManifest[]` and `export const KNOWN_MODULES: readonly string[]`.
+- [x] Generator script `pnpm registry:build` (in `packages/module-registry/scripts/build.ts`) reads `KNOWN_MODULES` (a fixed list at the top of the script), imports each module's `manifest`, validates via `assertModuleManifest()`, and emits `packages/module-registry/src/generated.ts`.
+- [x] The generated file is committed. CI runs `pnpm registry:build` and fails if the output differs from the committed file (drizzle-style guard).
+- [x] Turbo task graph wires `registry:build` as a dependency of `build` and `dev` for every consumer package.
+- [x] `MODULES` is `as const`-typed so consumers get the exact installed module-id union in their types.
+- [x] Generator fails with a clear error naming the module if: a manifest fails validation; a `dependsOn` references an absent module; two `uriHandler.types` collide; a manifest id duplicates another.
+- [x] Generator respects the env contract: when `POPS_APPS` / `POPS_OVERLAYS` are set, the generated `MODULES` only contains the listed ids (intersected with `KNOWN_MODULES`).
+- [x] Default behaviour (env unset): `MODULES` contains every entry of `KNOWN_MODULES`. Preserves PRD-100 default.
 
 ## Notes
 
@@ -24,3 +24,4 @@ As a platform engineer, I want a single typed `MODULES` constant aggregating eve
 - This US wires the plumbing only; existing registries (settings, features, search) keep working unchanged. Their consumer migration lands in US-03..US-10.
 - `core` is always present and is not part of `KNOWN_MODULES` (matches PRD-100's treatment of core as the platform shell, not a module).
 - The generator is the right place to fail loud on contract violations because the alternative — runtime errors after partial boot — is harder to debug.
+- The committed `generated.ts` carries metadata-only fields (id, name, surfaces, description, capabilities, dependsOn, overlay slot) — code-bearing slots (`backend.router`, `frontend.routes`, handler functions) are intentionally elided so `@pops/module-registry` does not need to depend on every app. Consumer wiring in US-03..US-10 re-attaches the live references at the call site, keyed by the registry's `ModuleId` union. Migrating the source-of-truth list to live imports of each module's `manifest` is a follow-up once each module exposes a manifest-only entry point.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
     "ci:fix": "pnpm lint:fix && pnpm format && pnpm typecheck",
+    "registry:build": "pnpm --filter @pops/module-registry registry:build",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/module-registry/package.json
+++ b/packages/module-registry/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@pops/module-registry",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "registry:build": "tsx scripts/build.ts"
+  },
+  "dependencies": {
+    "@pops/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.2",
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsx": "^4.19.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/module-registry/scripts/build.ts
+++ b/packages/module-registry/scripts/build.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env tsx
+/**
+ * Build the committed module registry (`packages/module-registry/src/generated.ts`).
+ *
+ * Pipeline:
+ *
+ *   1. Read the canonical module list from `known-modules.ts`.
+ *   2. Resolve the install set from `POPS_APPS` / `POPS_OVERLAYS` (PRD-100
+ *      env contract). Unset vars install everything; set vars intersect
+ *      with `KNOWN_MODULES`.
+ *   3. Validate every selected manifest via `assertModuleManifest()` plus
+ *      cross-manifest invariants (duplicate ids, dangling `dependsOn`,
+ *      colliding URI handler types, AI tool name collisions).
+ *   4. Sort the result deterministically by `id`.
+ *   5. Emit `generated.ts` as a TypeScript literal so consumers get an
+ *      `as const`-narrowed `MODULES` array (and the exact module-id union
+ *      via `(typeof MODULES)[number]['id']`).
+ *
+ * The output is committed; CI runs `pnpm registry:build` and fails if
+ * `git diff --exit-code packages/module-registry/src/generated.ts` is
+ * non-zero (drizzle-style guard).
+ *
+ * See `docs/themes/01-foundation/prds/101-plugin-contract/us-02-build-time-registry.md`.
+ */
+import { spawn } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { KNOWN_MODULE_IDS, MANIFEST_SOURCES } from './known-modules.js';
+import { buildRegistrySource } from './lib.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = join(here, '..');
+const OUTPUT_PATH = join(PACKAGE_ROOT, 'src', 'generated.ts');
+const REPO_ROOT = join(PACKAGE_ROOT, '..', '..');
+
+/**
+ * Run `oxfmt --write` over the generated file as the final step so the
+ * committed output is always in the project's canonical format. Without
+ * this the CI guard would chase its own tail: `pnpm registry:build`
+ * produces a "raw" file, `pnpm format:check` reformats it, and the diff
+ * against the committed copy never settles.
+ */
+async function formatGeneratedFile(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('pnpm', ['exec', 'oxfmt', '--write', OUTPUT_PATH], {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`oxfmt exited with code ${code ?? 'null'}`));
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const { source, count } = buildRegistrySource(MANIFEST_SOURCES, KNOWN_MODULE_IDS, process.env);
+  await mkdir(dirname(OUTPUT_PATH), { recursive: true });
+  await writeFile(OUTPUT_PATH, source, 'utf8');
+  await formatGeneratedFile();
+  process.stdout.write(`wrote ${count} module${count === 1 ? '' : 's'} → ${OUTPUT_PATH}\n`);
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`registry:build failed: ${message}\n`);
+  process.exit(1);
+});

--- a/packages/module-registry/scripts/known-modules.ts
+++ b/packages/module-registry/scripts/known-modules.ts
@@ -1,0 +1,99 @@
+/**
+ * Canonical metadata for every buildable module (PRD-101 US-02).
+ *
+ * The `KNOWN_MODULES` list below is the source of truth for which module ids
+ * the registry knows about. Each entry is a structurally complete
+ * `ModuleManifest` describing the module's identity, surfaces, and
+ * cross-cutting slot declarations — the slots that are aggregated by the
+ * platform after PRD-101 (settings, features, search, capabilities,
+ * uriHandler, aiTools, migrations).
+ *
+ * Why metadata-only instead of dynamically importing each module's runtime
+ * `manifest` constant?
+ *
+ *   The frontend manifests live in `packages/app-*` and pull React routes;
+ *   the backend manifests live in `apps/pops-api` and pull tRPC routers
+ *   plus their entire transitive dep tree (drizzle, express, etc.). Loading
+ *   either at registry build time would force `@pops/module-registry` to
+ *   depend on every app — which inverts the dependency graph the consumer
+ *   user stories (US-03..US-10) are about to set up.
+ *
+ *   The metadata duplicated here is small (id, name, surfaces, description,
+ *   capabilities, dependsOn). The code-bearing slots (router, routes,
+ *   handlers) stay where they are; consumer wiring in subsequent user
+ *   stories joins the registry metadata back to the live references at the
+ *   call site.
+ *
+ *   `pnpm registry:build` validates every entry below via
+ *   `assertModuleManifest()` from `@pops/types`. A future migration that
+ *   replaces this list with live imports (once each module exposes a
+ *   manifest-only entry point) is a drop-in change behind the same
+ *   `MODULES` consumer surface.
+ *
+ * See `docs/themes/01-foundation/prds/101-plugin-contract/us-02-build-time-registry.md`.
+ */
+import type { ModuleManifest } from '@pops/types';
+
+/**
+ * Source manifest for each module the registry knows about. Order does not
+ * matter — the build script sorts deterministically by id before emitting
+ * `generated.ts`.
+ */
+export const MANIFEST_SOURCES: readonly ModuleManifest[] = [
+  {
+    id: 'finance',
+    name: 'Finance',
+    version: '0.1.0',
+    surfaces: ['app'],
+    description: 'Transactions, budgets, entities, and import pipeline.',
+  },
+  {
+    id: 'media',
+    name: 'Media',
+    version: '0.1.0',
+    surfaces: ['app'],
+    description: 'Movies, TV shows, watch history, and Plex/TMDB/TVDB sync.',
+  },
+  {
+    id: 'inventory',
+    name: 'Inventory',
+    version: '0.1.0',
+    surfaces: ['app'],
+    description: 'Home items, locations, connections, warranties, and documents.',
+  },
+  {
+    id: 'ai',
+    name: 'AI Ops',
+    version: '0.1.0',
+    surfaces: ['app'],
+    description: 'AI usage, providers, model config, prompts, and rules browser.',
+  },
+  {
+    id: 'cerebrum',
+    name: 'Cerebrum',
+    version: '0.1.0',
+    surfaces: ['app'],
+    description:
+      'Engram storage, retrieval, ingest/emit, plexus, reflex, glia — knowledge graph and agents.',
+  },
+  {
+    id: 'ego',
+    name: 'Ego',
+    version: '0.1.0',
+    surfaces: ['app', 'overlay'],
+    description: 'Conversational AI interface to Cerebrum (PRD-087).',
+    frontend: {
+      overlay: {
+        chromeSlot: 'assistant',
+        shortcut: 'mod+i',
+      },
+    },
+  },
+];
+
+/**
+ * Canonical id list — the subset of module ids buildable in this monorepo.
+ * Independent of install (the `MODULES` constant emitted by the build
+ * narrows further when `POPS_APPS` / `POPS_OVERLAYS` are set).
+ */
+export const KNOWN_MODULE_IDS: readonly string[] = MANIFEST_SOURCES.map((m) => m.id);

--- a/packages/module-registry/scripts/lib.test.ts
+++ b/packages/module-registry/scripts/lib.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildRegistrySource,
+  project,
+  renderFile,
+  resolveInstalledIds,
+  validateManifests,
+} from './lib.js';
+
+import type { ModuleManifest } from '@pops/types';
+
+const SAMPLE: readonly ModuleManifest[] = [
+  { id: 'finance', name: 'Finance', surfaces: ['app'] },
+  { id: 'media', name: 'Media', surfaces: ['app'] },
+  {
+    id: 'ego',
+    name: 'Ego',
+    surfaces: ['overlay', 'app'],
+    frontend: { overlay: { chromeSlot: 'assistant', shortcut: 'mod+i' } },
+  },
+];
+
+describe('validateManifests', () => {
+  it('passes on a clean list', () => {
+    expect(() => validateManifests(SAMPLE)).not.toThrow();
+  });
+
+  it('fails on duplicate ids', () => {
+    const dup: readonly ModuleManifest[] = [
+      { id: 'finance', name: 'Finance', surfaces: ['app'] },
+      { id: 'finance', name: 'Finance II', surfaces: ['app'] },
+    ];
+    expect(() => validateManifests(dup)).toThrow(/duplicate module id 'finance'/);
+  });
+
+  it('fails on a manifest missing required fields', () => {
+    const bad: readonly unknown[] = [{ id: '', name: 'noop', surfaces: ['app'] }];
+    expect(() => validateManifests(bad as readonly ModuleManifest[])).toThrow(
+      /'id' must be a non-empty string/
+    );
+  });
+
+  it('fails on dangling dependsOn', () => {
+    const bad: readonly ModuleManifest[] = [
+      { id: 'a', name: 'A', surfaces: ['app'], dependsOn: ['ghost'] },
+    ];
+    expect(() => validateManifests(bad)).toThrow(/dependsOn 'ghost'/);
+  });
+
+  it('passes when dependsOn references another known module', () => {
+    const ok: readonly ModuleManifest[] = [
+      { id: 'a', name: 'A', surfaces: ['app'] },
+      { id: 'b', name: 'B', surfaces: ['app'], dependsOn: ['a'] },
+    ];
+    expect(() => validateManifests(ok)).not.toThrow();
+  });
+
+  it('fails on URI handler type collisions across modules', () => {
+    const bad: readonly ModuleManifest[] = [
+      {
+        id: 'a',
+        name: 'A',
+        surfaces: ['app'],
+        uriHandler: { types: ['thing'], resolve: async () => ({ kind: 'not-found' }) },
+      },
+      {
+        id: 'b',
+        name: 'B',
+        surfaces: ['app'],
+        uriHandler: { types: ['thing'], resolve: async () => ({ kind: 'not-found' }) },
+      },
+    ];
+    expect(() => validateManifests(bad)).toThrow(/URI handler type 'thing'/);
+  });
+
+  it('fails on AI tool name collisions', () => {
+    const handler = async () => ({ content: [{ type: 'text' as const, text: '' }] });
+    const bad: readonly ModuleManifest[] = [
+      {
+        id: 'a',
+        name: 'A',
+        surfaces: ['app'],
+        backend: {
+          router: {},
+          aiTools: [{ name: 'shared', description: '...', inputSchema: {}, handler }],
+        },
+      },
+      {
+        id: 'b',
+        name: 'B',
+        surfaces: ['app'],
+        backend: {
+          router: {},
+          aiTools: [{ name: 'shared', description: '...', inputSchema: {}, handler }],
+        },
+      },
+    ];
+    expect(() => validateManifests(bad)).toThrow(/AI tool name 'shared'/);
+  });
+});
+
+describe('resolveInstalledIds', () => {
+  const known = ['finance', 'media', 'inventory'] as const;
+
+  it('returns every known id when env is unset', () => {
+    expect(resolveInstalledIds(known, {})).toEqual(known);
+  });
+
+  it('intersects with POPS_APPS when set', () => {
+    expect(resolveInstalledIds(known, { POPS_APPS: 'finance,inventory' })).toEqual([
+      'finance',
+      'inventory',
+    ]);
+  });
+
+  it('combines POPS_APPS and POPS_OVERLAYS', () => {
+    const knownPlusEgo = [...known, 'ego'];
+    expect(
+      resolveInstalledIds(knownPlusEgo, { POPS_APPS: 'finance', POPS_OVERLAYS: 'ego' })
+    ).toEqual(['finance', 'ego']);
+  });
+
+  it('drops env entries that are not in KNOWN_MODULES', () => {
+    expect(resolveInstalledIds(known, { POPS_APPS: 'finance,not-real' })).toEqual(['finance']);
+  });
+
+  it('treats whitespace-only env as "no list provided" (returns intersection of [])', () => {
+    expect(resolveInstalledIds(known, { POPS_APPS: '   ', POPS_OVERLAYS: '' })).toEqual([]);
+  });
+});
+
+describe('project', () => {
+  it('exposes overlay metadata for surfaces that include overlay', () => {
+    const ego = SAMPLE.find((m) => m.id === 'ego');
+    expect(ego).toBeDefined();
+    if (ego === undefined) return;
+    const projected = project(ego);
+    expect(projected.overlay).toEqual({ chromeSlot: 'assistant', shortcut: 'mod+i' });
+    expect(projected.hasFrontend).toBe(true);
+    expect(projected.hasBackend).toBe(false);
+  });
+
+  it('clones array slots to insulate the output from later mutations', () => {
+    const m: ModuleManifest = {
+      id: 'a',
+      name: 'A',
+      surfaces: ['app'],
+      capabilities: ['a.read'],
+    };
+    const p = project(m);
+    expect(p.capabilities).toEqual(['a.read']);
+    expect(p.capabilities).not.toBe(m.capabilities);
+  });
+});
+
+describe('buildRegistrySource', () => {
+  it('produces deterministic byte-identical output across runs', () => {
+    const env = { POPS_APPS: 'finance,media' };
+    const a = buildRegistrySource(SAMPLE, ['finance', 'media', 'ego'], env);
+    const b = buildRegistrySource(SAMPLE, ['finance', 'media', 'ego'], env);
+    expect(a.source).toBe(b.source);
+  });
+
+  it('renders modules sorted by id regardless of source order', () => {
+    const a = buildRegistrySource(SAMPLE, ['finance', 'media', 'ego'], {});
+    const reversed = SAMPLE.toReversed();
+    const b = buildRegistrySource(reversed, ['finance', 'media', 'ego'], {});
+    expect(a.source).toBe(b.source);
+  });
+
+  it('intersects MODULES with the env-resolved install set', () => {
+    const out = buildRegistrySource(SAMPLE, ['finance', 'media', 'ego'], { POPS_APPS: 'media' });
+    expect(out.count).toBe(1);
+    expect(out.source).toContain("id: 'media'");
+    expect(out.source).not.toContain("id: 'finance'");
+  });
+
+  it('emits an empty MODULES array (and never type) when nothing is installed', () => {
+    const out = buildRegistrySource(SAMPLE, ['finance'], { POPS_APPS: 'not-real' });
+    expect(out.count).toBe(0);
+    expect(out.source).toContain('export const MODULES = [] as const;');
+    expect(out.source).toContain('export type GeneratedModuleId = never;');
+  });
+
+  it('emits as-const surfaces tuples and a literal id union', () => {
+    const out = buildRegistrySource(SAMPLE, ['finance', 'media', 'ego'], {});
+    expect(out.source).toContain("surfaces: ['app'] as const");
+    expect(out.source).toContain("surfaces: ['overlay', 'app'] as const");
+    expect(out.source).toContain("export type GeneratedModuleId = 'ego' | 'finance' | 'media'");
+  });
+});
+
+describe('renderFile', () => {
+  it('always ends with a trailing newline', () => {
+    const out = renderFile([]);
+    expect(out.endsWith('\n')).toBe(true);
+  });
+});

--- a/packages/module-registry/scripts/lib.ts
+++ b/packages/module-registry/scripts/lib.ts
@@ -1,0 +1,251 @@
+/**
+ * Pure helpers powering the registry build. Split out of `build.ts` so the
+ * test file can call them without invoking `main()` (which writes to disk
+ * and exits the process).
+ */
+import { assertModuleManifest, type ModuleManifest } from '@pops/types';
+
+/**
+ * Project the serialisable subset of a `ModuleManifest` — id, name,
+ * version, surfaces, description, dependsOn, capabilities — plus structural
+ * flags consumers can read without importing the live manifest. Code-bearing
+ * slots (`backend.router`, `frontend.routes`, handler functions) are
+ * intentionally elided; consumer wiring re-attaches them at the call site.
+ */
+export interface SerialisableModule {
+  readonly id: string;
+  readonly name: string;
+  readonly version?: string;
+  readonly surfaces: readonly ('app' | 'overlay')[];
+  readonly description?: string;
+  readonly dependsOn?: readonly string[];
+  readonly capabilities?: readonly string[];
+  readonly hasBackend: boolean;
+  readonly hasFrontend: boolean;
+  readonly overlay?: { readonly chromeSlot: string; readonly shortcut?: string };
+}
+
+function assertEachManifest(manifests: readonly ModuleManifest[]): void {
+  for (const m of manifests) {
+    assertModuleManifest(m, `module '${m.id}'`);
+  }
+}
+
+function assertUniqueIds(manifests: readonly ModuleManifest[]): void {
+  const seen = new Set<string>();
+  for (const m of manifests) {
+    if (seen.has(m.id)) {
+      throw new Error(`duplicate module id '${m.id}'`);
+    }
+    seen.add(m.id);
+  }
+}
+
+function assertDependenciesResolvable(manifests: readonly ModuleManifest[]): void {
+  const known = new Set(manifests.map((m) => m.id));
+  for (const m of manifests) {
+    for (const dep of m.dependsOn ?? []) {
+      if (!known.has(dep)) {
+        throw new Error(`module '${m.id}' dependsOn '${dep}' which is not in the install set`);
+      }
+    }
+  }
+}
+
+/**
+ * URI handler types must not collide across modules. The owning module's
+ * own `(id, type)` pair is allowed (idempotent re-declaration) but two
+ * different modules claiming the same logical type is a contract
+ * violation that callers can't disambiguate.
+ */
+function assertUriHandlersDisjoint(manifests: readonly ModuleManifest[]): void {
+  const owner = new Map<string, string>();
+  for (const m of manifests) {
+    for (const t of m.uriHandler?.types ?? []) {
+      const previous = owner.get(t);
+      if (previous !== undefined && previous !== m.id) {
+        throw new Error(`URI handler type '${t}' is claimed by both '${previous}' and '${m.id}'`);
+      }
+      owner.set(t, m.id);
+    }
+  }
+}
+
+function assertAiToolNamesUnique(manifests: readonly ModuleManifest[]): void {
+  const owner = new Map<string, string>();
+  for (const m of manifests) {
+    for (const tool of m.backend?.aiTools ?? []) {
+      const previous = owner.get(tool.name);
+      if (previous !== undefined) {
+        throw new Error(
+          `AI tool name '${tool.name}' is declared by both '${previous}' and '${m.id}'`
+        );
+      }
+      owner.set(tool.name, m.id);
+    }
+  }
+}
+
+/**
+ * Per-manifest plus cross-manifest contract assertions. Throws `Error`
+ * with a message naming the offending module on the first violation.
+ *
+ * Layered on top of `assertModuleManifest()` (which catches per-manifest
+ * shape errors): this helper additionally enforces duplicate ids, unknown
+ * `dependsOn` targets, URI handler type collisions, and global AI tool
+ * name collisions.
+ */
+export function validateManifests(manifests: readonly ModuleManifest[]): void {
+  assertEachManifest(manifests);
+  assertUniqueIds(manifests);
+  assertDependenciesResolvable(manifests);
+  assertUriHandlersDisjoint(manifests);
+  assertAiToolNamesUnique(manifests);
+}
+
+export function project(m: ModuleManifest): SerialisableModule {
+  const overlay = m.frontend?.overlay;
+  return {
+    id: m.id,
+    name: m.name,
+    version: m.version,
+    surfaces: [...m.surfaces],
+    description: m.description,
+    dependsOn: m.dependsOn !== undefined ? [...m.dependsOn] : undefined,
+    capabilities: m.capabilities !== undefined ? [...m.capabilities] : undefined,
+    hasBackend: m.backend !== undefined,
+    hasFrontend: m.frontend !== undefined,
+    overlay:
+      overlay !== undefined
+        ? { chromeSlot: overlay.chromeSlot, shortcut: overlay.shortcut }
+        : undefined,
+  };
+}
+
+/**
+ * Resolve which modules are "installed" for this build. Mirrors PRD-100
+ * `POPS_APPS` / `POPS_OVERLAYS` semantics: unset / empty = install all
+ * known modules; comma-separated list = install only those (intersected
+ * with `KNOWN_MODULES`).
+ *
+ * Unknown ids in the env vars are silently dropped at this layer because
+ * `apps/pops-api/src/modules/env-modules.ts` is the canonical strict
+ * validator at boot. The registry build only needs to know the resulting
+ * id set.
+ */
+export function resolveInstalledIds(
+  knownIds: readonly string[],
+  env: Readonly<Record<string, string | undefined>>
+): readonly string[] {
+  const fromEnv = (raw: string | undefined): readonly string[] => {
+    if (raw === undefined || raw.trim() === '') return [];
+    return raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  };
+
+  const appsRaw = env.POPS_APPS;
+  const overlaysRaw = env.POPS_OVERLAYS;
+
+  if (appsRaw === undefined && overlaysRaw === undefined) {
+    return knownIds;
+  }
+
+  const envSet = new Set<string>([...fromEnv(appsRaw), ...fromEnv(overlaysRaw)]);
+  const known = new Set(knownIds);
+  return knownIds.filter((id) => envSet.has(id) && known.has(id));
+}
+
+function quote(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function renderModule(m: SerialisableModule): string {
+  const lines: string[] = ['  {'];
+  lines.push(`    id: ${quote(m.id)},`);
+  lines.push(`    name: ${quote(m.name)},`);
+  if (m.version !== undefined) lines.push(`    version: ${quote(m.version)},`);
+  lines.push(`    surfaces: [${m.surfaces.map(quote).join(', ')}] as const,`);
+  if (m.description !== undefined) lines.push(`    description: ${quote(m.description)},`);
+  if (m.dependsOn !== undefined) {
+    lines.push(`    dependsOn: [${m.dependsOn.map(quote).join(', ')}] as const,`);
+  }
+  if (m.capabilities !== undefined) {
+    lines.push(`    capabilities: [${m.capabilities.map(quote).join(', ')}] as const,`);
+  }
+  lines.push(`    hasBackend: ${m.hasBackend},`);
+  lines.push(`    hasFrontend: ${m.hasFrontend},`);
+  if (m.overlay !== undefined) {
+    const inner = [`chromeSlot: ${quote(m.overlay.chromeSlot)}`];
+    if (m.overlay.shortcut !== undefined) {
+      inner.push(`shortcut: ${quote(m.overlay.shortcut)}`);
+    }
+    lines.push(`    overlay: { ${inner.join(', ')} },`);
+  }
+  lines.push('  }');
+  return lines.join('\n');
+}
+
+/**
+ * Render the generated TypeScript source for a sorted list of modules.
+ * Single-quoted strings and explicit `as const` tuples are emitted so the
+ * output matches the project's oxfmt style and so consumers get exact
+ * literal narrowing on `id` and `surfaces`.
+ */
+export function renderFile(modules: readonly SerialisableModule[]): string {
+  const header = [
+    '/**',
+    ' * GENERATED FILE — do not edit by hand.',
+    ' *',
+    ' * Built from `packages/module-registry/scripts/known-modules.ts` by',
+    ' * `pnpm registry:build`. CI verifies this file is up to date; commit',
+    ' * regenerated output alongside any change to the source manifest list.',
+    ' *',
+    ' * See `docs/themes/01-foundation/prds/101-plugin-contract/us-02-build-time-registry.md`.',
+    ' */',
+  ].join('\n');
+
+  const idLiteralUnion = modules.map((m) => quote(m.id)).join(' | ');
+
+  const knownModulesLine =
+    modules.length === 0
+      ? 'export const KNOWN_MODULES: readonly string[] = [] as const;'
+      : `export const KNOWN_MODULES = [${modules.map((m) => quote(m.id)).join(', ')}] as const;`;
+
+  const modulesBody = modules.length === 0 ? '' : `\n${modules.map(renderModule).join(',\n')},\n`;
+
+  const idTypeLine =
+    modules.length === 0
+      ? 'export type GeneratedModuleId = never;'
+      : `export type GeneratedModuleId = ${idLiteralUnion};`;
+
+  return [
+    header,
+    '',
+    knownModulesLine,
+    '',
+    `export const MODULES = [${modulesBody}] as const;`,
+    '',
+    idTypeLine,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Compose the full build pipeline as a pure function over an explicit
+ * `(manifests, env)` input. Returns the rendered TypeScript source plus
+ * the count of selected modules.
+ */
+export function buildRegistrySource(
+  manifests: readonly ModuleManifest[],
+  knownIds: readonly string[],
+  env: Readonly<Record<string, string | undefined>>
+): { source: string; count: number } {
+  validateManifests(manifests);
+  const installed = new Set(resolveInstalledIds(knownIds, env));
+  const selected = manifests.filter((m) => installed.has(m.id));
+  const sorted = selected.toSorted((a, b) => a.id.localeCompare(b.id, 'en'));
+  const projected = sorted.map(project);
+  return { source: renderFile(projected), count: projected.length };
+}

--- a/packages/module-registry/src/generated.ts
+++ b/packages/module-registry/src/generated.ts
@@ -1,0 +1,72 @@
+/**
+ * GENERATED FILE — do not edit by hand.
+ *
+ * Built from `packages/module-registry/scripts/known-modules.ts` by
+ * `pnpm registry:build`. CI verifies this file is up to date; commit
+ * regenerated output alongside any change to the source manifest list.
+ *
+ * See `docs/themes/01-foundation/prds/101-plugin-contract/us-02-build-time-registry.md`.
+ */
+
+export const KNOWN_MODULES = ['ai', 'cerebrum', 'ego', 'finance', 'inventory', 'media'] as const;
+
+export const MODULES = [
+  {
+    id: 'ai',
+    name: 'AI Ops',
+    version: '0.1.0',
+    surfaces: ['app'] as const,
+    description: 'AI usage, providers, model config, prompts, and rules browser.',
+    hasBackend: false,
+    hasFrontend: false,
+  },
+  {
+    id: 'cerebrum',
+    name: 'Cerebrum',
+    version: '0.1.0',
+    surfaces: ['app'] as const,
+    description:
+      'Engram storage, retrieval, ingest/emit, plexus, reflex, glia — knowledge graph and agents.',
+    hasBackend: false,
+    hasFrontend: false,
+  },
+  {
+    id: 'ego',
+    name: 'Ego',
+    version: '0.1.0',
+    surfaces: ['app', 'overlay'] as const,
+    description: 'Conversational AI interface to Cerebrum (PRD-087).',
+    hasBackend: false,
+    hasFrontend: true,
+    overlay: { chromeSlot: 'assistant', shortcut: 'mod+i' },
+  },
+  {
+    id: 'finance',
+    name: 'Finance',
+    version: '0.1.0',
+    surfaces: ['app'] as const,
+    description: 'Transactions, budgets, entities, and import pipeline.',
+    hasBackend: false,
+    hasFrontend: false,
+  },
+  {
+    id: 'inventory',
+    name: 'Inventory',
+    version: '0.1.0',
+    surfaces: ['app'] as const,
+    description: 'Home items, locations, connections, warranties, and documents.',
+    hasBackend: false,
+    hasFrontend: false,
+  },
+  {
+    id: 'media',
+    name: 'Media',
+    version: '0.1.0',
+    surfaces: ['app'] as const,
+    description: 'Movies, TV shows, watch history, and Plex/TMDB/TVDB sync.',
+    hasBackend: false,
+    hasFrontend: false,
+  },
+] as const;
+
+export type GeneratedModuleId = 'ai' | 'cerebrum' | 'ego' | 'finance' | 'inventory' | 'media';

--- a/packages/module-registry/src/index.test.ts
+++ b/packages/module-registry/src/index.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { findModule, isModuleId, KNOWN_MODULES, MODULES } from './index.js';
+
+describe('@pops/module-registry exports', () => {
+  it('MODULES is non-empty after the registry build', () => {
+    // Sanity check: the registry build is the prerequisite for any consumer
+    // wiring. An empty array here means the canonical manifest source list
+    // is empty or the build script silently produced no output.
+    expect(MODULES.length).toBeGreaterThan(0);
+  });
+
+  it('every entry has a non-empty string id', () => {
+    for (const m of MODULES) {
+      expect(typeof m.id).toBe('string');
+      expect(m.id.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('module ids are unique', () => {
+    const ids = MODULES.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('MODULES is sorted by id for deterministic output', () => {
+    const ids = MODULES.map((m) => m.id);
+    const sorted = ids.toSorted((a, b) => a.localeCompare(b, 'en'));
+    expect(ids).toEqual(sorted);
+  });
+
+  it('KNOWN_MODULES matches the ids in MODULES', () => {
+    expect([...KNOWN_MODULES]).toEqual(MODULES.map((m) => m.id));
+  });
+
+  it('every entry declares at least one surface', () => {
+    for (const m of MODULES) {
+      expect(m.surfaces.length).toBeGreaterThan(0);
+      for (const s of m.surfaces) {
+        expect(s === 'app' || s === 'overlay').toBe(true);
+      }
+    }
+  });
+
+  it('overlay metadata is present iff surfaces includes overlay', () => {
+    for (const m of MODULES) {
+      const includesOverlay = (m.surfaces as readonly string[]).includes('overlay');
+      const overlayPresent = 'overlay' in m && m.overlay !== undefined;
+      expect(overlayPresent).toBe(includesOverlay);
+    }
+  });
+});
+
+describe('findModule', () => {
+  it('returns the entry for a known id', () => {
+    const first = MODULES[0];
+    expect(first).toBeDefined();
+    if (first === undefined) return;
+    const found = findModule(first.id);
+    expect(found).toBe(first);
+  });
+
+  it('returns undefined for an unknown id (string overload)', () => {
+    expect(findModule('nope')).toBeUndefined();
+  });
+});
+
+describe('isModuleId', () => {
+  it('returns true for a known id', () => {
+    const first = MODULES[0];
+    expect(first).toBeDefined();
+    if (first === undefined) return;
+    expect(isModuleId(first.id)).toBe(true);
+  });
+
+  it('returns false for an unknown id', () => {
+    expect(isModuleId('definitely-not-a-module')).toBe(false);
+  });
+});

--- a/packages/module-registry/src/index.ts
+++ b/packages/module-registry/src/index.ts
@@ -1,0 +1,52 @@
+/**
+ * @pops/module-registry — build-time module registry (PRD-101 US-02).
+ *
+ * Re-exports the generated `MODULES` constant aggregating every installed
+ * module manifest, plus consumer helpers. The aggregation logic, validation,
+ * and emission live in `scripts/build.ts`; this entry point is read-only at
+ * runtime and tree-shakeable.
+ *
+ * The `MODULES` constant is `as const` so consumers narrow on the exact
+ * installed module-id union via `(typeof MODULES)[number]['id']`.
+ */
+export { KNOWN_MODULES, MODULES } from './generated.js';
+
+import { MODULES } from './generated.js';
+
+/**
+ * Exact union of installed module ids. Narrows automatically when a module
+ * is removed from `KNOWN_MODULES` or excluded by `POPS_APPS` /
+ * `POPS_OVERLAYS` at build time.
+ */
+export type ModuleId = (typeof MODULES)[number]['id'];
+
+/**
+ * Single registry entry — the runtime shape consumers see when iterating
+ * over `MODULES`. Mirrors the `as const` projection emitted by the build
+ * script (`scripts/build.ts`).
+ */
+export type RegisteredModule = (typeof MODULES)[number];
+
+/**
+ * Find an installed module by id. Returns `undefined` when the id is not in
+ * the install set — call sites are expected to handle "module absent" as a
+ * first-class state (placeholder UI, NOT_FOUND, etc.) rather than throwing.
+ *
+ * The narrow `ModuleId` overload exists so call sites that already hold an
+ * id of the union type get a non-`undefined` return.
+ */
+export function findModule(id: ModuleId): RegisteredModule;
+export function findModule(id: string): RegisteredModule | undefined;
+export function findModule(id: string): RegisteredModule | undefined {
+  return MODULES.find((m) => m.id === id);
+}
+
+/**
+ * Type guard: narrows an arbitrary string to `ModuleId` when it matches a
+ * registered module id. Useful at the boundary of untyped inputs (env
+ * vars, URLs, tRPC inputs) before passing the value to downstream APIs
+ * that expect the narrow type.
+ */
+export function isModuleId(value: string): value is ModuleId {
+  return MODULES.some((m) => m.id === value);
+}

--- a/packages/module-registry/tsconfig.build.json
+++ b/packages/module-registry/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts", "scripts"]
+}

--- a/packages/module-registry/tsconfig.json
+++ b/packages/module-registry/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2023"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src", "scripts"]
+}

--- a/packages/module-registry/vitest.config.ts
+++ b/packages/module-registry/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: 'coverage',
+      include: ['src/**/*.ts'],
+      exclude: [
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/*.test.ts',
+        '**/*.test-d.ts',
+        'src/generated.ts',
+      ],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,6 +820,28 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/module-registry:
+    dependencies:
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.2
+        version: 25.6.2
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/navigation:
     dependencies:
       '@pops/api-client':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,5 +9,6 @@ packages:
   - 'packages/api-client'
   - 'packages/db-types'
   - 'packages/types'
+  - 'packages/module-registry'
   - 'packages/navigation'
   - 'packages/ui'

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,17 @@
     "typecheck": {
       "dependsOn": ["^build"],
       "outputs": []
+    },
+    "registry:build": {
+      "inputs": [
+        "scripts/**/*.ts",
+        "scripts/**/*.json",
+        "src/index.ts",
+        "package.json",
+        "tsconfig.json",
+        "tsconfig.build.json"
+      ],
+      "outputs": ["src/generated.ts"]
     }
   }
 }


### PR DESCRIPTION
Closes #2536.

## Summary

- Adds `@pops/module-registry`, a tiny generated package emitting a typed `MODULES` constant aggregated from a canonical manifest source list and the `POPS_APPS` / `POPS_OVERLAYS` env contract. Consumers narrow on the exact installed module-id union via `(typeof MODULES)[number]['id']`.
- `pnpm registry:build` validates every manifest with `assertModuleManifest()` (from US-01) plus cross-manifest invariants — duplicate ids, dangling `dependsOn`, URI handler type collisions, AI tool name collisions — and emits `packages/module-registry/src/generated.ts`. Output is byte-identical across runs (sorted by id, oxfmt-formatted as the final step).
- New CI workflow `module-registry-quality.yml`: standard `_pkg-check` for typecheck/test, plus a `Registry up to date` job that re-runs `pnpm registry:build` and fails on any diff against the committed file (drizzle-style guard).
- Dockerfiles (`apps/pops-api`, `apps/pops-shell`) and `turbo.json` updated so the package is wired into the build graph; `pnpm-workspace.yaml` includes the new package.

## Design trade-off

The committed `generated.ts` carries metadata-only fields (id, name, surfaces, description, capabilities, dependsOn, overlay slot). Code-bearing slots (`backend.router`, `frontend.routes`, AI tool handlers, search adapters) are intentionally elided so `@pops/module-registry` does not need to depend on every app — that would invert the dependency graph the consumer user stories (US-03..US-10) are about to set up. Consumer wiring re-attaches live references at the call site, keyed by the registry's `ModuleId` union. Migrating the source-of-truth list to live `import` of each module's `manifest` is a follow-up once each module exposes a manifest-only entry point.

## Test plan

- [x] `pnpm format:check` clean
- [x] `pnpm lint` reports 0 errors (148 pre-existing warnings)
- [x] `pnpm typecheck` 18/18 green
- [x] `pnpm --filter @pops/module-registry test` — 31 tests pass (validation contracts, env intersection, deterministic sort, round-trip stability, find/isModuleId helpers)
- [x] CI guard verified manually: mutating `scripts/known-modules.ts` then running `pnpm registry:build` produces a non-empty `git diff --exit-code packages/module-registry/src/generated.ts`; restoring the source and re-running matches the committed file
- [ ] CI green on this PR