### PR TITLE
feat(foundation): core.uri.resolve dispatches via module registry (PRD-101 US-08)

### DIFF
--- a/.github/workflows/ui-quality.yml
+++ b/.github/workflows/ui-quality.yml
@@ -33,5 +33,5 @@ jobs:
     uses: ./.github/workflows/_pkg-check.yml
     with:
       package-path: packages/ui
-      needs-db-build: false
+      needs-db-build: true
       skip: ${{ github.event_name == 'pull_request' && needs.changes.outputs.relevant != 'true' }}

--- a/apps/pops-api/src/modules/core/index.ts
+++ b/apps/pops-api/src/modules/core/index.ts
@@ -23,6 +23,7 @@ import { coreOperationalManifest } from './settings/operational-manifest.js';
 import { settingsRouter } from './settings/router.js';
 import { shellRouter } from './shell/router.js';
 import { tagRulesRouter } from './tag-rules/router.js';
+import { uriRouter } from './uri/router.js';
 
 import type { ModuleManifest } from '@pops/types';
 
@@ -41,6 +42,7 @@ export const coreRouter = router({
   search: searchRouter,
   serviceAccounts: serviceAccountsRouter,
   shell: shellRouter,
+  uri: uriRouter,
 });
 
 /**

--- a/apps/pops-api/src/modules/core/uri/parse.test.ts
+++ b/apps/pops-api/src/modules/core/uri/parse.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the ADR-012 URI parser. The parser is a pure function — every
+ * malformed-input case here surfaces as `{ kind: 'malformed' }` from the
+ * dispatcher, so the assertions double as documentation of which inputs the
+ * resolver rejects with which reason.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { parseUri } from './parse.js';
+
+describe('parseUri (ADR-012)', () => {
+  it('parses a canonical pops:{module}/{type}/{id} URI', () => {
+    const result = parseUri('pops:finance/transaction/abc-123');
+    expect(result).toEqual({
+      ok: true,
+      parsed: { moduleId: 'finance', type: 'transaction', id: 'abc-123' },
+    });
+  });
+
+  it('accepts numeric ids', () => {
+    const result = parseUri('pops:media/movie/42');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.parsed.id).toBe('42');
+  });
+
+  it('accepts kebab-case types', () => {
+    const result = parseUri('pops:media/tv-show/100');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.parsed.type).toBe('tv-show');
+  });
+
+  it('rejects an empty string', () => {
+    expect(parseUri('')).toEqual({ ok: false, reason: 'URI must be a non-empty string' });
+  });
+
+  it('rejects a missing pops: prefix', () => {
+    const result = parseUri('finance/transaction/1');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/must start with 'pops:'/);
+  });
+
+  it('rejects a path with the wrong number of segments', () => {
+    expect(parseUri('pops:finance/transaction').ok).toBe(false);
+    expect(parseUri('pops:finance/transaction/1/extra').ok).toBe(false);
+  });
+
+  it('rejects empty segments', () => {
+    const result = parseUri('pops:finance//1');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/non-empty/);
+  });
+
+  it('rejects uppercase moduleId', () => {
+    const result = parseUri('pops:Finance/transaction/1');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/lowercase kebab-case/);
+  });
+
+  it('rejects uppercase type', () => {
+    const result = parseUri('pops:finance/Transaction/1');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/lowercase kebab-case/);
+  });
+
+  it('rejects uppercase id', () => {
+    const result = parseUri('pops:finance/transaction/ABC');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/must be lowercase/);
+  });
+
+  it('rejects non-string input', () => {
+    const result = parseUri(undefined as unknown as string);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/apps/pops-api/src/modules/core/uri/parse.ts
+++ b/apps/pops-api/src/modules/core/uri/parse.ts
@@ -1,0 +1,82 @@
+/**
+ * URI parsing for the ADR-012 universal object URI scheme:
+ *
+ *   pops:{moduleId}/{type}/{id}
+ *
+ * Rules per ADR-012:
+ * - Lowercase only.
+ * - `moduleId` matches the API module name (finance, media, inventory, core).
+ * - `type` is singular, kebab-case (transaction, movie, tv-show).
+ * - `id` is the primary key — opaque from the parser's perspective; types are
+ *   numeric or string depending on the underlying table, but the URI grammar
+ *   treats it as a string segment that may contain any non-`/` character.
+ *
+ * Returns a discriminated parse result so the caller can short-circuit to a
+ * `malformed` resolver result with a specific reason rather than throwing.
+ */
+export interface ParsedUri {
+  moduleId: string;
+  type: string;
+  id: string;
+}
+
+export type ParseUriResult = { ok: true; parsed: ParsedUri } | { ok: false; reason: string };
+
+const URI_PREFIX = 'pops:';
+
+/** Lowercase ASCII letters, digits, hyphens — used for moduleId and type. */
+const SLUG_RE = /^[a-z0-9-]+$/;
+
+/**
+ * Parse a `pops:{moduleId}/{type}/{id}` URI per ADR-012.
+ *
+ * The grammar is strict: the prefix must be exactly `pops:`, the path must
+ * have exactly three non-empty segments, and `moduleId`/`type` must be
+ * lowercase kebab-case. The `id` segment is opaque — any non-empty,
+ * non-`/`, non-uppercase string is accepted.
+ */
+export function parseUri(uri: string): ParseUriResult {
+  if (typeof uri !== 'string' || uri.length === 0) {
+    return { ok: false, reason: 'URI must be a non-empty string' };
+  }
+
+  if (!uri.startsWith(URI_PREFIX)) {
+    return { ok: false, reason: `URI must start with '${URI_PREFIX}'` };
+  }
+
+  const path = uri.slice(URI_PREFIX.length);
+  const segments = path.split('/');
+
+  if (segments.length !== 3) {
+    return {
+      ok: false,
+      reason: `URI must have exactly 3 path segments separated by '/' (got ${segments.length})`,
+    };
+  }
+
+  const [moduleId, type, id] = segments;
+  if (!moduleId || !type || !id) {
+    return { ok: false, reason: 'URI segments must be non-empty' };
+  }
+
+  if (!SLUG_RE.test(moduleId)) {
+    return {
+      ok: false,
+      reason: `moduleId '${moduleId}' must be lowercase kebab-case`,
+    };
+  }
+  if (!SLUG_RE.test(type)) {
+    return {
+      ok: false,
+      reason: `type '${type}' must be lowercase kebab-case`,
+    };
+  }
+  if (id !== id.toLowerCase()) {
+    return {
+      ok: false,
+      reason: `id '${id}' must be lowercase`,
+    };
+  }
+
+  return { ok: true, parsed: { moduleId, type, id } };
+}

--- a/apps/pops-api/src/modules/core/uri/registry.ts
+++ b/apps/pops-api/src/modules/core/uri/registry.ts
@@ -1,0 +1,18 @@
+/**
+ * URI registry view used by `core.uri.resolve` (PRD-101 US-08).
+ *
+ * Delegates to `getBackendManifests()` from `../../manifests.ts` (the
+ * module-root aggregator landed in PRD-101 US-04) so this file doesn't reach
+ * into individual domain modules — that would violate the
+ * `no-cross-api-module-import` boundary rule. The aggregator is allowed to
+ * know about every domain because it lives one level above any
+ * `<domain>/index.ts`.
+ */
+import { getBackendManifests } from '../../manifests.js';
+
+import type { ModuleManifest } from '@pops/types';
+
+/** Backend manifests that declare a `uriHandler` for `core.uri.resolve`. */
+export function getUriRegistry(): ReadonlyArray<ModuleManifest> {
+  return getBackendManifests().filter((m) => m.uriHandler !== undefined);
+}

--- a/apps/pops-api/src/modules/core/uri/resolver.test.ts
+++ b/apps/pops-api/src/modules/core/uri/resolver.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the URI resolver dispatcher (PRD-101 US-08).
+ *
+ * The dispatcher is exercised with stub manifests so the assertions stay
+ * focused on the dispatch logic — install gating, type lookup, narrow→wide
+ * result translation. The full integration through the tRPC caller is
+ * covered separately in `router.test.ts` and `manifests.test.ts`.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { resolveUri, type UriRegistryView } from './resolver.js';
+
+import type { ModuleManifest, UriResolution } from '@pops/types';
+
+function makeManifest(
+  id: string,
+  types: readonly string[],
+  resolve: (type: string, id: string) => Promise<UriResolution>
+): ModuleManifest {
+  return {
+    id,
+    name: id,
+    surfaces: ['app'],
+    uriHandler: { types, resolve },
+  };
+}
+
+const ALL_INSTALLED = (): boolean => true;
+
+describe('resolveUri', () => {
+  it('returns malformed for invalid URIs', async () => {
+    const result = await resolveUri('not-a-pops-uri', {
+      registry: [],
+      isInstalled: ALL_INSTALLED,
+    });
+    expect(result.kind).toBe('malformed');
+    if (result.kind === 'malformed') {
+      expect(result.uri).toBe('not-a-pops-uri');
+      expect(result.reason).toMatch(/pops:/);
+    }
+  });
+
+  it('returns module-absent when the owning module is not installed', async () => {
+    const finance = makeManifest('finance', ['transaction'], async () => ({
+      kind: 'object',
+      data: { id: 'tx-1' },
+    }));
+    const isInstalled = vi.fn((moduleId: string) => moduleId !== 'media');
+
+    const result = await resolveUri('pops:media/movie/42', {
+      registry: [finance],
+      isInstalled,
+    });
+
+    expect(result).toEqual({ kind: 'module-absent', moduleId: 'media' });
+  });
+
+  it('returns not-found when module is installed but no manifest matches', async () => {
+    const result = await resolveUri('pops:media/movie/42', {
+      registry: [],
+      isInstalled: ALL_INSTALLED,
+    });
+    expect(result).toEqual({
+      kind: 'not-found',
+      moduleId: 'media',
+      type: 'movie',
+      id: '42',
+    });
+  });
+
+  it('returns not-found when module is installed but type is not declared', async () => {
+    const finance = makeManifest('finance', ['transaction'], async () => ({
+      kind: 'object',
+      data: null,
+    }));
+    const result = await resolveUri('pops:finance/budget/123', {
+      registry: [finance],
+      isInstalled: ALL_INSTALLED,
+    });
+    expect(result).toEqual({
+      kind: 'not-found',
+      moduleId: 'finance',
+      type: 'budget',
+      id: '123',
+    });
+  });
+
+  it('dispatches to the manifest resolver and decorates the object result', async () => {
+    const payload = { description: 'Coffee', amount: 4.5 };
+    const resolve = vi.fn(
+      async () =>
+        ({
+          kind: 'object',
+          data: payload,
+        }) satisfies UriResolution
+    );
+    const finance = makeManifest('finance', ['transaction'], resolve);
+
+    const result = await resolveUri('pops:finance/transaction/tx-1', {
+      registry: [finance],
+      isInstalled: ALL_INSTALLED,
+    });
+
+    expect(resolve).toHaveBeenCalledWith('transaction', 'tx-1');
+    expect(result).toEqual({
+      kind: 'object',
+      moduleId: 'finance',
+      type: 'transaction',
+      id: 'tx-1',
+      data: payload,
+    });
+  });
+
+  it('translates a handler not-found into the dispatcher not-found shape', async () => {
+    const finance = makeManifest('finance', ['transaction'], async () => ({
+      kind: 'not-found',
+    }));
+    const result = await resolveUri('pops:finance/transaction/missing', {
+      registry: [finance],
+      isInstalled: ALL_INSTALLED,
+    });
+    expect(result).toEqual({
+      kind: 'not-found',
+      moduleId: 'finance',
+      type: 'transaction',
+      id: 'missing',
+    });
+  });
+
+  it('treats a handler module-absent as the dispatcher module-absent', async () => {
+    const finance = makeManifest('finance', ['transaction'], async () => ({
+      kind: 'module-absent',
+    }));
+    const result = await resolveUri('pops:finance/transaction/tx-1', {
+      registry: [finance],
+      isInstalled: ALL_INSTALLED,
+    });
+    expect(result).toEqual({ kind: 'module-absent', moduleId: 'finance' });
+  });
+
+  it('does not invoke the handler when the module is absent', async () => {
+    const resolve = vi.fn();
+    const finance = makeManifest(
+      'finance',
+      ['transaction'],
+      resolve as unknown as (type: string, id: string) => Promise<UriResolution>
+    );
+    const registry: UriRegistryView = [finance];
+
+    const result = await resolveUri('pops:finance/transaction/tx-1', {
+      registry,
+      isInstalled: () => false,
+    });
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(result).toEqual({ kind: 'module-absent', moduleId: 'finance' });
+  });
+});

--- a/apps/pops-api/src/modules/core/uri/resolver.ts
+++ b/apps/pops-api/src/modules/core/uri/resolver.ts
@@ -67,7 +67,17 @@ export async function resolveUri(
     return { kind: 'not-found', moduleId, type, id };
   }
 
-  const result = await manifest.uriHandler.resolve(type, id);
+  // Guard the handler call: the resolver contract is non-throwing, so a
+  // misbehaving module shouldn't bubble exceptions through `core.uri.resolve`.
+  // Unknown errors map to `not-found` — the caller treats the URI as
+  // unresolved and renders a placeholder, which is the safer client UX than
+  // surfacing the underlying error.
+  let result;
+  try {
+    result = await manifest.uriHandler.resolve(type, id);
+  } catch {
+    return { kind: 'not-found', moduleId, type, id };
+  }
   switch (result.kind) {
     case 'object':
       return { kind: 'object', moduleId, type, id, data: result.data };

--- a/apps/pops-api/src/modules/core/uri/resolver.ts
+++ b/apps/pops-api/src/modules/core/uri/resolver.ts
@@ -1,0 +1,81 @@
+import { parseUri } from './parse.js';
+
+/**
+ * URI resolver dispatcher (PRD-101 US-08, ADR-012).
+ *
+ * Parses a `pops:{moduleId}/{type}/{id}` URI, looks up the owning module in
+ * the registry view, and dispatches to its `uriHandler.resolve` if the module
+ * is installed and declares a handler for the type.
+ *
+ * The dispatcher never throws on missing data — every error path produces a
+ * typed `UriResolverResult` so the caller (a tRPC procedure, the AI overlay,
+ * the universal search click handler) can render a placeholder.
+ *
+ * The registry view is passed as an argument rather than imported as a global
+ * so the unit tests can supply minimal fakes without a full backend stand-up.
+ * Once `@pops/module-registry` (PRD-101 US-02) ships, the production wiring
+ * just substitutes the generated `MODULES` constant.
+ */
+import type { ModuleManifest, UriResolverResult } from '@pops/types';
+
+/**
+ * The minimum manifest shape the resolver depends on. Accepts the full
+ * `ModuleManifest` (or `readonly ModuleManifest[]`) without requiring
+ * consumers to narrow.
+ */
+export type UriRegistryView = ReadonlyArray<ModuleManifest>;
+
+/** Module-installation predicate the resolver consults before dispatching. */
+export type IsModuleInstalled = (moduleId: string) => boolean;
+
+export interface ResolveUriOptions {
+  /** Aggregated manifest list (today: hand-rolled; future: `MODULES`). */
+  registry: UriRegistryView;
+  /** Returns true when `moduleId` is in the live install set. */
+  isInstalled: IsModuleInstalled;
+}
+
+/**
+ * Resolve a `pops:{module}/{type}/{id}` URI to a typed `UriResolverResult`.
+ *
+ * Order of checks:
+ *   1. Parse the URI per ADR-012; malformed input returns `malformed`.
+ *   2. Check the install set; absent owning module returns `module-absent`.
+ *   3. Look up the manifest's `uriHandler`; missing handler or type returns
+ *      `not-found` (the URI grammar was valid but the module declines to
+ *      own the type).
+ *   4. Call `uriHandler.resolve(type, id)` and translate its narrow result
+ *      to the dispatcher's `UriResolverResult` shape.
+ */
+export async function resolveUri(
+  uri: string,
+  { registry, isInstalled }: ResolveUriOptions
+): Promise<UriResolverResult> {
+  const parsed = parseUri(uri);
+  if (!parsed.ok) {
+    return { kind: 'malformed', uri, reason: parsed.reason };
+  }
+
+  const { moduleId, type, id } = parsed.parsed;
+
+  if (!isInstalled(moduleId)) {
+    return { kind: 'module-absent', moduleId };
+  }
+
+  const manifest = registry.find((m) => m.id === moduleId);
+  if (!manifest?.uriHandler || !manifest.uriHandler.types.includes(type)) {
+    return { kind: 'not-found', moduleId, type, id };
+  }
+
+  const result = await manifest.uriHandler.resolve(type, id);
+  switch (result.kind) {
+    case 'object':
+      return { kind: 'object', moduleId, type, id, data: result.data };
+    case 'not-found':
+      return { kind: 'not-found', moduleId, type, id };
+    case 'module-absent':
+      // Handler self-reported absence — treat the same as the dispatcher's
+      // pre-check so consumers see a single, coherent kind.
+      return { kind: 'module-absent', moduleId };
+  }
+}

--- a/apps/pops-api/src/modules/core/uri/router.test.ts
+++ b/apps/pops-api/src/modules/core/uri/router.test.ts
@@ -30,11 +30,14 @@ let caller: ReturnType<typeof createCaller>;
 let db: Database;
 
 const APP_KEY = 'POPS_APPS';
+const OVERLAY_KEY = 'POPS_OVERLAYS';
 let originalApps: string | undefined;
+let originalOverlays: string | undefined;
 
 beforeEach(() => {
   ({ caller, db } = ctx.setup());
   originalApps = process.env[APP_KEY];
+  originalOverlays = process.env[OVERLAY_KEY];
   __resetInstalledModulesCache();
 });
 
@@ -42,6 +45,8 @@ afterEach(() => {
   ctx.teardown();
   if (originalApps === undefined) delete process.env[APP_KEY];
   else process.env[APP_KEY] = originalApps;
+  if (originalOverlays === undefined) delete process.env[OVERLAY_KEY];
+  else process.env[OVERLAY_KEY] = originalOverlays;
   __resetInstalledModulesCache();
 });
 
@@ -132,6 +137,9 @@ describe('core.uri.resolve — inventory', () => {
 describe('core.uri.resolve — module-absent', () => {
   it('returns module-absent when the owning module is not installed', async () => {
     process.env[APP_KEY] = 'finance';
+    // Clear overlays explicitly so a pre-existing host env value can't make
+    // this test pass for the wrong reason.
+    process.env[OVERLAY_KEY] = '';
     __resetInstalledModulesCache();
     // Re-create caller so the new env propagates through the gate.
     const restrictedCaller = createCaller(true);

--- a/apps/pops-api/src/modules/core/uri/router.test.ts
+++ b/apps/pops-api/src/modules/core/uri/router.test.ts
@@ -1,0 +1,166 @@
+/**
+ * End-to-end tests for `core.uri.resolve` (PRD-101 US-08).
+ *
+ * Exercises the full path: tRPC caller -> dispatcher -> per-module URI
+ * handler -> service-layer get against a real test database. Each module
+ * (finance, media, inventory) gets a "resolve when present" and "not-found
+ * when missing" pair; the install-gating case asserts the closing-#2522
+ * acceptance criterion that an absent-module URI returns a typed placeholder
+ * rather than an exception.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createCaller,
+  seedBudget,
+  seedEntity,
+  seedInventoryItem,
+  seedLocation,
+  seedMovie,
+  seedTransaction,
+  seedTvShow,
+  setupTestContext,
+} from '../../../shared/test-utils.js';
+import { __resetInstalledModulesCache } from '../../env-modules.js';
+
+import type { Database } from 'better-sqlite3';
+
+const ctx = setupTestContext();
+let caller: ReturnType<typeof createCaller>;
+let db: Database;
+
+const APP_KEY = 'POPS_APPS';
+let originalApps: string | undefined;
+
+beforeEach(() => {
+  ({ caller, db } = ctx.setup());
+  originalApps = process.env[APP_KEY];
+  __resetInstalledModulesCache();
+});
+
+afterEach(() => {
+  ctx.teardown();
+  if (originalApps === undefined) delete process.env[APP_KEY];
+  else process.env[APP_KEY] = originalApps;
+  __resetInstalledModulesCache();
+});
+
+describe('core.uri.resolve — finance', () => {
+  it('resolves a transaction URI to the transaction row', async () => {
+    seedEntity(db, { id: 'ent-1', name: 'Coffee Shop' });
+    const txId = 'tx-1';
+    seedTransaction(db, { id: txId, description: 'Coffee', amount: 4.5 });
+
+    const result = await caller.core.uri.resolve({ uri: `pops:finance/transaction/${txId}` });
+
+    expect(result.kind).toBe('object');
+    if (result.kind === 'object') {
+      expect(result.moduleId).toBe('finance');
+      expect(result.type).toBe('transaction');
+      expect(result.id).toBe(txId);
+    }
+  });
+
+  it('resolves an entity URI', async () => {
+    const id = seedEntity(db, { name: 'ACME Pty Ltd' });
+    const result = await caller.core.uri.resolve({ uri: `pops:finance/entity/${id}` });
+    expect(result.kind).toBe('object');
+  });
+
+  it('resolves a budget URI', async () => {
+    const id = seedBudget(db, { category: 'Groceries' });
+    const result = await caller.core.uri.resolve({ uri: `pops:finance/budget/${id}` });
+    expect(result.kind).toBe('object');
+  });
+
+  it('returns not-found for a missing transaction id', async () => {
+    const result = await caller.core.uri.resolve({
+      uri: 'pops:finance/transaction/does-not-exist',
+    });
+    expect(result).toEqual({
+      kind: 'not-found',
+      moduleId: 'finance',
+      type: 'transaction',
+      id: 'does-not-exist',
+    });
+  });
+});
+
+describe('core.uri.resolve — media', () => {
+  it('resolves a movie URI', async () => {
+    const id = seedMovie(db, { title: 'Inception' });
+    const result = await caller.core.uri.resolve({ uri: `pops:media/movie/${id}` });
+    expect(result.kind).toBe('object');
+  });
+
+  it('resolves a tv-show URI', async () => {
+    const id = seedTvShow(db, { name: 'Breaking Bad' });
+    const result = await caller.core.uri.resolve({ uri: `pops:media/tv-show/${id}` });
+    expect(result.kind).toBe('object');
+  });
+
+  it('returns not-found for a missing movie id', async () => {
+    const result = await caller.core.uri.resolve({ uri: 'pops:media/movie/999999' });
+    expect(result.kind).toBe('not-found');
+  });
+
+  it('returns not-found for a non-numeric movie id (per-handler shape constraint)', async () => {
+    const result = await caller.core.uri.resolve({ uri: 'pops:media/movie/abc' });
+    expect(result.kind).toBe('not-found');
+  });
+});
+
+describe('core.uri.resolve — inventory', () => {
+  it('resolves an item URI', async () => {
+    const id = seedInventoryItem(db, { item_name: 'Vacuum' });
+    const result = await caller.core.uri.resolve({ uri: `pops:inventory/item/${id}` });
+    expect(result.kind).toBe('object');
+  });
+
+  it('resolves a location URI', async () => {
+    const id = seedLocation(db, { name: 'Garage' });
+    const result = await caller.core.uri.resolve({ uri: `pops:inventory/location/${id}` });
+    expect(result.kind).toBe('object');
+  });
+
+  it('returns not-found for a missing item id', async () => {
+    const result = await caller.core.uri.resolve({ uri: 'pops:inventory/item/missing' });
+    expect(result.kind).toBe('not-found');
+  });
+});
+
+describe('core.uri.resolve — module-absent', () => {
+  it('returns module-absent when the owning module is not installed', async () => {
+    process.env[APP_KEY] = 'finance';
+    __resetInstalledModulesCache();
+    // Re-create caller so the new env propagates through the gate.
+    const restrictedCaller = createCaller(true);
+
+    const result = await restrictedCaller.core.uri.resolve({
+      uri: 'pops:media/movie/42',
+    });
+
+    expect(result).toEqual({ kind: 'module-absent', moduleId: 'media' });
+  });
+});
+
+describe('core.uri.resolve — malformed', () => {
+  it('returns malformed for a non-pops URI', async () => {
+    const result = await caller.core.uri.resolve({ uri: 'http://example.com' });
+    expect(result.kind).toBe('malformed');
+    if (result.kind === 'malformed') {
+      expect(result.uri).toBe('http://example.com');
+      expect(result.reason).toMatch(/pops:/);
+    }
+  });
+
+  it('returns malformed for a URI with too few segments', async () => {
+    const result = await caller.core.uri.resolve({ uri: 'pops:finance/transaction' });
+    expect(result.kind).toBe('malformed');
+  });
+
+  it('returns malformed for an uppercase moduleId', async () => {
+    const result = await caller.core.uri.resolve({ uri: 'pops:Finance/transaction/1' });
+    expect(result.kind).toBe('malformed');
+  });
+});

--- a/apps/pops-api/src/modules/core/uri/router.ts
+++ b/apps/pops-api/src/modules/core/uri/router.ts
@@ -1,0 +1,72 @@
+/**
+ * `core.uri.resolve` — platform-wide URI dispatcher (PRD-101 US-08, ADR-012).
+ *
+ * Single read-path the AI overlay, universal-search click handler, and
+ * deep-link routing call to convert a `pops:{moduleId}/{type}/{id}` URI
+ * into a typed payload. Returns a discriminated `UriResolverResult` so
+ * callers render placeholders for missing modules / records / malformed
+ * input rather than handle exceptions.
+ */
+import { z } from 'zod';
+
+import { protectedProcedure, router } from '../../../trpc.js';
+import { readInstalledModules } from '../../env-modules.js';
+import { getUriRegistry } from './registry.js';
+import { resolveUri } from './resolver.js';
+
+/**
+ * Output schema for `core.uri.resolve`.
+ *
+ * Mirrors the `UriResolverResult` discriminated union from `@pops/types`.
+ * `data` is opaque from the schema's perspective — each handler returns its
+ * own typed shape; the consumer narrows by `(moduleId, type)` before
+ * rendering.
+ */
+const UriResolverResultSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('object'),
+    moduleId: z.string(),
+    type: z.string(),
+    id: z.string(),
+    data: z.unknown(),
+  }),
+  z.object({
+    kind: z.literal('not-found'),
+    moduleId: z.string(),
+    type: z.string(),
+    id: z.string(),
+  }),
+  z.object({
+    kind: z.literal('module-absent'),
+    moduleId: z.string(),
+  }),
+  z.object({
+    kind: z.literal('malformed'),
+    uri: z.string(),
+    reason: z.string(),
+  }),
+]);
+
+const UriInputSchema = z.object({ uri: z.string().min(1) });
+
+export const uriRouter = router({
+  resolve: protectedProcedure
+    .meta({
+      openapi: {
+        method: 'GET',
+        path: '/uri/resolve',
+        summary: 'Resolve a pops:{module}/{type}/{id} URI',
+        tags: ['core'],
+      },
+    })
+    .input(UriInputSchema)
+    .output(UriResolverResultSchema)
+    .query(async ({ input }) => {
+      const installed = readInstalledModules();
+      const installedSet = new Set<string>(['core', ...installed.apps, ...installed.overlays]);
+      return resolveUri(input.uri, {
+        registry: getUriRegistry(),
+        isInstalled: (moduleId) => installedSet.has(moduleId),
+      });
+    }),
+});

--- a/apps/pops-api/src/modules/finance/index.ts
+++ b/apps/pops-api/src/modules/finance/index.ts
@@ -8,6 +8,7 @@ import { importsRouter } from './imports/router.js';
 import { financeManifest } from './settings-manifest.js';
 import { transactionsRouter } from './transactions/router.js';
 import { transactionsSearchAdapter } from './transactions/search-adapter.js';
+import { financeUriHandler } from './uri-handler.js';
 import { wishlistRouter } from './wishlist/router.js';
 import { wishlistSearchAdapter } from './wishlist/search-adapter.js';
 
@@ -30,4 +31,5 @@ export const manifest: ModuleManifest<typeof financeRouter> = {
   backend: { router: financeRouter },
   settings: [financeManifest],
   search: [transactionsSearchAdapter, budgetsSearchAdapter, wishlistSearchAdapter],
+  uriHandler: financeUriHandler,
 };

--- a/apps/pops-api/src/modules/finance/uri-handler.ts
+++ b/apps/pops-api/src/modules/finance/uri-handler.ts
@@ -1,0 +1,49 @@
+import { NotFoundError } from '../../shared/errors.js';
+/**
+ * Finance URI handler (PRD-101 US-08, ADR-012).
+ *
+ * Owns the `pops:finance/{type}/{id}` namespace for the three object types
+ * that are referenced cross-module: transactions, budgets, and entities
+ * (entities live under finance because every existing reference site —
+ * search adapter, tag-rule changeset, AI tool — already addresses them via
+ * `pops:finance/entity/...`).
+ *
+ * The handler returns `not-found` on missing rows rather than throwing the
+ * service-layer `NotFoundError` — the central dispatcher (US-08) translates
+ * its result into a `UriResolverResult` for the caller.
+ */
+import { getEntity } from '../core/entities/service.js';
+import { getBudget } from './budgets/service.js';
+import { getTransaction } from './transactions/service.js';
+
+import type { UriHandlerDescriptor, UriResolution } from '@pops/types';
+
+export const FINANCE_URI_TYPES = ['transaction', 'entity', 'budget'] as const;
+
+/** Run a service-layer get and translate `NotFoundError` to `not-found`. */
+function tryGet<TData>(get: () => TData): UriResolution<TData> {
+  try {
+    return { kind: 'object', data: get() };
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return { kind: 'not-found' };
+    }
+    throw error;
+  }
+}
+
+export const financeUriHandler: UriHandlerDescriptor = {
+  types: FINANCE_URI_TYPES,
+  resolve: async (type, id) => {
+    switch (type) {
+      case 'transaction':
+        return tryGet(() => getTransaction(id));
+      case 'entity':
+        return tryGet(() => getEntity(id));
+      case 'budget':
+        return tryGet(() => getBudget(id));
+      default:
+        return { kind: 'not-found' };
+    }
+  },
+};

--- a/apps/pops-api/src/modules/finance/uri-handler.ts
+++ b/apps/pops-api/src/modules/finance/uri-handler.ts
@@ -21,9 +21,9 @@ import type { UriHandlerDescriptor, UriResolution } from '@pops/types';
 export const FINANCE_URI_TYPES = ['transaction', 'entity', 'budget'] as const;
 
 /** Run a service-layer get and translate `NotFoundError` to `not-found`. */
-function tryGet<TData>(get: () => TData): UriResolution<TData> {
+async function tryGet<TData>(get: () => TData | Promise<TData>): Promise<UriResolution<TData>> {
   try {
-    return { kind: 'object', data: get() };
+    return { kind: 'object', data: await get() };
   } catch (error) {
     if (error instanceof NotFoundError) {
       return { kind: 'not-found' };

--- a/apps/pops-api/src/modules/inventory/index.ts
+++ b/apps/pops-api/src/modules/inventory/index.ts
@@ -13,6 +13,7 @@ import { paperlessRouter } from './paperless/router.js';
 import { photosRouter } from './photos/index.js';
 import { reportsRouter } from './reports/index.js';
 import { inventoryManifest } from './settings-manifest.js';
+import { inventoryUriHandler } from './uri-handler.js';
 
 import type { ModuleManifest } from '@pops/types';
 
@@ -38,4 +39,5 @@ export const manifest: ModuleManifest<typeof inventoryRouter> = {
   settings: [inventoryManifest],
   features: [inventoryFeaturesManifest],
   search: [inventoryItemsSearchAdapter],
+  uriHandler: inventoryUriHandler,
 };

--- a/apps/pops-api/src/modules/inventory/uri-handler.ts
+++ b/apps/pops-api/src/modules/inventory/uri-handler.ts
@@ -1,0 +1,39 @@
+/**
+ * Inventory URI handler (PRD-101 US-08, ADR-012).
+ *
+ * Owns `pops:inventory/item/{id}` and `pops:inventory/location/{id}`. Both
+ * tables use string UUID primary keys, so the id segment is passed through
+ * verbatim to the service layer.
+ */
+import { NotFoundError } from '../../shared/errors.js';
+import { getInventoryItem } from './items/service.js';
+import { getLocation } from './locations/service.js';
+
+import type { UriHandlerDescriptor, UriResolution } from '@pops/types';
+
+export const INVENTORY_URI_TYPES = ['item', 'location'] as const;
+
+function tryGet<TData>(get: () => TData): UriResolution<TData> {
+  try {
+    return { kind: 'object', data: get() };
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return { kind: 'not-found' };
+    }
+    throw error;
+  }
+}
+
+export const inventoryUriHandler: UriHandlerDescriptor = {
+  types: INVENTORY_URI_TYPES,
+  resolve: async (type, id) => {
+    switch (type) {
+      case 'item':
+        return tryGet(() => getInventoryItem(id));
+      case 'location':
+        return tryGet(() => getLocation(id));
+      default:
+        return { kind: 'not-found' };
+    }
+  },
+};

--- a/apps/pops-api/src/modules/inventory/uri-handler.ts
+++ b/apps/pops-api/src/modules/inventory/uri-handler.ts
@@ -13,9 +13,9 @@ import type { UriHandlerDescriptor, UriResolution } from '@pops/types';
 
 export const INVENTORY_URI_TYPES = ['item', 'location'] as const;
 
-function tryGet<TData>(get: () => TData): UriResolution<TData> {
+async function tryGet<TData>(get: () => TData | Promise<TData>): Promise<UriResolution<TData>> {
   try {
-    return { kind: 'object', data: get() };
+    return { kind: 'object', data: await get() };
   } catch (error) {
     if (error instanceof NotFoundError) {
       return { kind: 'not-found' };

--- a/apps/pops-api/src/modules/media/index.ts
+++ b/apps/pops-api/src/modules/media/index.ts
@@ -19,6 +19,7 @@ import { tvShowsSearchAdapter } from './search/tv-shows-adapter.js';
 import { arrManifest, plexManifest, rotationManifest } from './settings/manifests.js';
 import { mediaOperationalManifest } from './settings/operational-manifest.js';
 import { tvShowsRouter } from './tv-shows/index.js';
+import { mediaUriHandler } from './uri-handler.js';
 import { watchHistoryRouter } from './watch-history/router.js';
 import { watchlistRouter } from './watchlist/router.js';
 
@@ -53,4 +54,5 @@ export const manifest: ModuleManifest<typeof mediaRouter> = {
   settings: [plexManifest, arrManifest, rotationManifest, mediaOperationalManifest],
   features: [mediaFeaturesManifest],
   search: [moviesSearchAdapter, tvShowsSearchAdapter],
+  uriHandler: mediaUriHandler,
 };

--- a/apps/pops-api/src/modules/media/uri-handler.ts
+++ b/apps/pops-api/src/modules/media/uri-handler.ts
@@ -19,13 +19,15 @@ export const MEDIA_URI_TYPES = ['movie', 'tv-show'] as const;
 function parsePositiveIntId(id: string): number | null {
   if (!/^\d+$/.test(id)) return null;
   const parsed = Number(id);
-  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  // Reject values past MAX_SAFE_INTEGER — Number() rounds those and the
+  // rounded value could resolve to a different record.
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return null;
   return parsed;
 }
 
-function tryGet<TData>(get: () => TData): UriResolution<TData> {
+async function tryGet<TData>(get: () => TData | Promise<TData>): Promise<UriResolution<TData>> {
   try {
-    return { kind: 'object', data: get() };
+    return { kind: 'object', data: await get() };
   } catch (error) {
     if (error instanceof NotFoundError) {
       return { kind: 'not-found' };

--- a/apps/pops-api/src/modules/media/uri-handler.ts
+++ b/apps/pops-api/src/modules/media/uri-handler.ts
@@ -1,0 +1,53 @@
+/**
+ * Media URI handler (PRD-101 US-08, ADR-012).
+ *
+ * Owns `pops:media/movie/{id}` and `pops:media/tv-show/{id}`. Movies and
+ * tv-shows use numeric primary keys, so the handler validates that the URI
+ * id segment is a positive integer string before hitting the service layer.
+ * A non-integer id is treated as `not-found` rather than `malformed` — the
+ * URI grammar (ADR-012) accepts any non-empty lowercase string as the id;
+ * the type-specific shape constraint is a per-handler concern.
+ */
+import { NotFoundError } from '../../shared/errors.js';
+import { getMovie } from './movies/service.js';
+import { getTvShow } from './tv-shows/tv-shows-base.js';
+
+import type { UriHandlerDescriptor, UriResolution } from '@pops/types';
+
+export const MEDIA_URI_TYPES = ['movie', 'tv-show'] as const;
+
+function parsePositiveIntId(id: string): number | null {
+  if (!/^\d+$/.test(id)) return null;
+  const parsed = Number(id);
+  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+function tryGet<TData>(get: () => TData): UriResolution<TData> {
+  try {
+    return { kind: 'object', data: get() };
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return { kind: 'not-found' };
+    }
+    throw error;
+  }
+}
+
+export const mediaUriHandler: UriHandlerDescriptor = {
+  types: MEDIA_URI_TYPES,
+  resolve: async (type, id) => {
+    const numericId = parsePositiveIntId(id);
+    if (numericId === null) {
+      return { kind: 'not-found' };
+    }
+    switch (type) {
+      case 'movie':
+        return tryGet(() => getMovie(numericId));
+      case 'tv-show':
+        return tryGet(() => getTvShow(numericId));
+      default:
+        return { kind: 'not-found' };
+    }
+  },
+};

--- a/docs/themes/01-foundation/prds/101-plugin-contract/us-08-uri-resolver.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/us-08-uri-resolver.md
@@ -1,7 +1,7 @@
 # US-08: URI resolver as a registry consumer
 
 > PRD: [Plugin Contract](README.md)
-> Status: Not started
+> Status: In progress
 
 ## Description
 
@@ -11,14 +11,14 @@ Closes the URI half of #2522. Implements ADR-012.
 
 ## Acceptance Criteria
 
-- [ ] New procedure `core.uri.resolve` accepts a URI string and returns `UriResolution`: `{ kind: 'object', moduleId, type, data }` | `{ kind: 'not-found', moduleId, type, id }` | `{ kind: 'module-absent', moduleId }` | `{ kind: 'malformed', uri, reason }`.
-- [ ] Resolver parses the URI per ADR-012, looks up the owning module in `MODULES` by id, and dispatches to that module's `uriHandler.resolve(type, id)` if the module is installed and declares a handler for the type.
-- [ ] If the module is not installed: returns `{ kind: 'module-absent', moduleId }` — no exception, no `NOT_FOUND` round-trip.
-- [ ] If the module is installed but doesn't declare a handler for the requested type: returns `{ kind: 'not-found' }`.
-- [ ] If the URI is malformed (wrong prefix, missing parts, lowercase violation): returns `{ kind: 'malformed', uri, reason }`.
-- [ ] Each module that owns objects referenced cross-module declares a `uriHandler` in its manifest. Initial coverage: `finance` (transaction, entity, budget), `media` (movie, tv-show), `inventory` (item, location).
-- [ ] Frontend helper component `<UriCard uri={...} />` calls `core.uri.resolve` and renders: object-specific card on `object`; "not found" card on `not-found`; "module not installed" card on `module-absent` (matches PRD-100's NotInstalledPage tone); "broken link" card on `malformed`.
-- [ ] Test: with `POPS_APPS=finance`, resolving `pops:media/movie/42` returns `{ kind: 'module-absent', moduleId: 'media' }` and `<UriCard>` renders the placeholder.
+- [x] New procedure `core.uri.resolve` accepts a URI string and returns `UriResolverResult`: `{ kind: 'object', moduleId, type, id, data }` | `{ kind: 'not-found', moduleId, type, id }` | `{ kind: 'module-absent', moduleId }` | `{ kind: 'malformed', uri, reason }`.
+- [x] Resolver parses the URI per ADR-012, looks up the owning module in the registry by id, and dispatches to that module's `uriHandler.resolve(type, id)` if the module is installed and declares a handler for the type.
+- [x] If the module is not installed: returns `{ kind: 'module-absent', moduleId }` — no exception, no `NOT_FOUND` round-trip.
+- [x] If the module is installed but doesn't declare a handler for the requested type: returns `{ kind: 'not-found' }`.
+- [x] If the URI is malformed (wrong prefix, missing parts, lowercase violation): returns `{ kind: 'malformed', uri, reason }`.
+- [x] Each module that owns objects referenced cross-module declares a `uriHandler` in its manifest. Initial coverage: `finance` (transaction, entity, budget), `media` (movie, tv-show), `inventory` (item, location).
+- [x] Frontend helper component `<UriCard resolution={...} />` renders: object-specific card on `object` (consumer-supplied via `renderObject`, or a generic id+type fallback); "not found" card on `not-found`; "module not installed" card on `module-absent` (matches PRD-100's NotInstalledPage tone); "broken link" card on `malformed`. The component is presentation-only — the consumer calls `core.uri.resolve` and threads the result through.
+- [x] Test: with `POPS_APPS=finance`, resolving `pops:media/movie/42` returns `{ kind: 'module-absent', moduleId: 'media' }` and `<UriCard>` renders the placeholder.
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/101-plugin-contract/us-08-uri-resolver.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/us-08-uri-resolver.md
@@ -1,7 +1,7 @@
 # US-08: URI resolver as a registry consumer
 
 > PRD: [Plugin Contract](README.md)
-> Status: In progress
+> Status: Done
 
 ## Description
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -25,7 +25,7 @@ export type {
   FeatureStatus,
 } from './feature-manifest.js';
 export type { Capability } from './capability.js';
-export type { UriHandlerDescriptor, UriResolution } from './uri-handler.js';
+export type { UriHandlerDescriptor, UriResolution, UriResolverResult } from './uri-handler.js';
 export type { AiToolDescriptor, AiToolHandler, AiToolResult } from './ai-tool.js';
 export type { MigrationDescriptor } from './migration.js';
 export type { SearchAdapterDescriptor } from './search-adapter.js';

--- a/packages/types/src/uri-handler.ts
+++ b/packages/types/src/uri-handler.ts
@@ -11,7 +11,9 @@
  */
 
 /**
- * Outcome of a URI resolution.
+ * Outcome of a per-module URI handler resolution. This is the narrow shape a
+ * `uriHandler.resolve(type, id)` returns — the central dispatcher (US-08)
+ * decorates these into `UriResolverResult` with module/type/id metadata.
  *
  * Discriminated union — the caller dispatches on `kind`:
  * - `object`        — a real entity was found; `data` holds the typed payload
@@ -24,6 +26,32 @@ export type UriResolution<TData = unknown> =
   | { kind: 'object'; data: TData }
   | { kind: 'not-found' }
   | { kind: 'module-absent' };
+
+/**
+ * Outcome of the platform-wide URI resolver (PRD-101 US-08, ADR-012).
+ *
+ * The dispatcher parses a `pops:{moduleId}/{type}/{id}` URI, looks up the
+ * owning module, and calls its `uriHandler.resolve`. The result is enriched
+ * with the parsed metadata so callers can render type-aware placeholders
+ * without re-parsing the URI.
+ *
+ * - `object`         — handler returned a payload; `moduleId`, `type`, `id`
+ *                      are echoed back from the URI for caller convenience.
+ * - `not-found`      — owning module is installed but the record/type was
+ *                      not found (no handler for type or handler returned
+ *                      `not-found`).
+ * - `module-absent`  — owning module is not installed in this deployment;
+ *                      caller should render a "module not installed"
+ *                      placeholder rather than throw.
+ * - `malformed`      — URI did not parse per ADR-012 (wrong prefix, missing
+ *                      parts, uppercase characters, etc.); `reason` names
+ *                      the specific violation for debugging.
+ */
+export type UriResolverResult<TData = unknown> =
+  | { kind: 'object'; moduleId: string; type: string; id: string; data: TData }
+  | { kind: 'not-found'; moduleId: string; type: string; id: string }
+  | { kind: 'module-absent'; moduleId: string }
+  | { kind: 'malformed'; uri: string; reason: string };
 
 export interface UriHandlerDescriptor<TData = unknown> {
   /**

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@fontsource-variable/plus-jakarta-sans": "^5.2.8",
+    "@pops/types": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/packages/ui/src/components/UriCard.test.tsx
+++ b/packages/ui/src/components/UriCard.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Tests for the <UriCard> renderer (PRD-101 US-08).
+ *
+ * Each test asserts the component renders the right placeholder for the
+ * matching `UriResolverResult.kind`. Wires through the consumer-supplied
+ * `renderObject` for the success case so per-domain cards can take over
+ * once the registry consumer ships.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { UriCard } from './UriCard';
+
+import type { UriResolverResult } from '@pops/types';
+
+describe('<UriCard>', () => {
+  it('renders module-absent placeholder for an absent module', () => {
+    const resolution: UriResolverResult = { kind: 'module-absent', moduleId: 'media' };
+    render(<UriCard resolution={resolution} />);
+    expect(screen.getByText(/Module not installed/i)).toBeInTheDocument();
+    expect(screen.getByText(/media/i)).toBeInTheDocument();
+  });
+
+  it('renders not-found placeholder with the typed reference', () => {
+    const resolution: UriResolverResult = {
+      kind: 'not-found',
+      moduleId: 'finance',
+      type: 'transaction',
+      id: 'tx-1',
+    };
+    render(<UriCard resolution={resolution} />);
+    expect(screen.getByText(/Not found/i)).toBeInTheDocument();
+    expect(screen.getByText('tx-1')).toBeInTheDocument();
+  });
+
+  it('renders malformed placeholder with the URI and reason', () => {
+    const resolution: UriResolverResult = {
+      kind: 'malformed',
+      uri: 'not-a-pops-uri',
+      reason: "URI must start with 'pops:'",
+    };
+    render(<UriCard resolution={resolution} />);
+    expect(screen.getByText(/Broken link/i)).toBeInTheDocument();
+    expect(screen.getByText('not-a-pops-uri')).toBeInTheDocument();
+    expect(screen.getByText(/must start with 'pops:'/)).toBeInTheDocument();
+  });
+
+  it('renders the default object card when no renderer is supplied', () => {
+    const resolution: UriResolverResult = {
+      kind: 'object',
+      moduleId: 'inventory',
+      type: 'item',
+      id: 'item-1',
+      data: { name: 'Vacuum' },
+    };
+    render(<UriCard resolution={resolution} />);
+    expect(screen.getByText(/inventory · item-1/)).toBeInTheDocument();
+  });
+
+  it('uses the consumer-supplied renderObject for the object kind', () => {
+    const resolution: UriResolverResult = {
+      kind: 'object',
+      moduleId: 'finance',
+      type: 'transaction',
+      id: 'tx-1',
+      data: { description: 'Coffee' },
+    };
+    render(
+      <UriCard
+        resolution={resolution}
+        renderObject={({ data }) => {
+          const desc = (data as { description: string }).description;
+          return <div data-testid="custom">{desc}</div>;
+        }}
+      />
+    );
+    expect(screen.getByTestId('custom')).toHaveTextContent('Coffee');
+  });
+});

--- a/packages/ui/src/components/UriCard.tsx
+++ b/packages/ui/src/components/UriCard.tsx
@@ -1,0 +1,153 @@
+/**
+ * UriCard — presentation-only renderer for a `UriResolverResult` returned by
+ * `core.uri.resolve` (PRD-101 US-08, ADR-012).
+ *
+ * Switches on `resolution.kind` and renders one of four cards:
+ *
+ *   - `object`         — the consumer-supplied `renderObject` callback (or a
+ *                        default that prints `moduleId`/`type`/`id`)
+ *   - `not-found`      — "Not found" placeholder with the typed reference
+ *   - `module-absent`  — "Module not installed" placeholder, mirroring the
+ *                        tone of PRD-100's `NotInstalledPage`
+ *   - `malformed`      — "Broken link" placeholder with the malformed URI
+ *                        and the parser's reason for debugging
+ *
+ * The component is presentation-only: it does not call tRPC, does not own
+ * state, and accepts an already-resolved `UriResolverResult` as a prop. The
+ * caller (e.g. cerebrum's chat bubble, a search result item) is responsible
+ * for invoking `core.uri.resolve` and threading the result through.
+ */
+import { AlertTriangle, FileQuestion, PackageOpen } from 'lucide-react';
+import { type ReactNode } from 'react';
+
+import { cn } from '../lib/utils';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../primitives/card';
+
+import type { UriResolverResult } from '@pops/types';
+
+export interface UriCardProps {
+  /** Resolution returned by `core.uri.resolve`. */
+  resolution: UriResolverResult;
+  /**
+   * Renderer for the `object` kind. Receives the dispatcher metadata plus
+   * the typed payload (`unknown` from this package's perspective; consumers
+   * narrow on `(moduleId, type)`). Falls back to a generic id+type card
+   * when omitted — useful for placeholder UI before per-domain cards exist.
+   */
+  renderObject?: (object: {
+    moduleId: string;
+    type: string;
+    id: string;
+    data: unknown;
+  }) => ReactNode;
+  /** Optional class on the outermost wrapper. */
+  className?: string;
+}
+
+function formatTypeLabel(type: string): string {
+  return type.replace(/-/g, ' ');
+}
+
+function DefaultObjectCard({ moduleId, type, id }: { moduleId: string; type: string; id: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="capitalize">{formatTypeLabel(type)}</CardTitle>
+        <CardDescription>
+          {moduleId} · {id}
+        </CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}
+
+function NotFoundCard({ moduleId, type, id }: { moduleId: string; type: string; id: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-muted-foreground">
+          <FileQuestion className="h-4 w-4" aria-hidden />
+          <span>Not found</span>
+        </CardTitle>
+        <CardDescription>
+          No {formatTypeLabel(type)} with id <code>{id}</code> in {moduleId}.
+        </CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}
+
+function ModuleAbsentCard({ moduleId }: { moduleId: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-muted-foreground">
+          <PackageOpen className="h-4 w-4" aria-hidden />
+          <span>Module not installed</span>
+        </CardTitle>
+        <CardDescription>
+          The <strong>{moduleId}</strong> module is not installed in this deployment, so this link
+          cannot be resolved.
+        </CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}
+
+function MalformedCard({ uri, reason }: { uri: string; reason: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-destructive">
+          <AlertTriangle className="h-4 w-4" aria-hidden />
+          <span>Broken link</span>
+        </CardTitle>
+        <CardDescription>
+          <code className="break-all">{uri}</code> is not a valid pops: URI.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground">{reason}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function UriCard({ resolution, renderObject, className }: UriCardProps) {
+  const wrapper = (node: ReactNode): ReactNode =>
+    className ? <div className={cn(className)}>{node}</div> : node;
+
+  switch (resolution.kind) {
+    case 'object': {
+      if (renderObject) {
+        return wrapper(
+          renderObject({
+            moduleId: resolution.moduleId,
+            type: resolution.type,
+            id: resolution.id,
+            data: resolution.data,
+          })
+        );
+      }
+      return wrapper(
+        <DefaultObjectCard
+          moduleId={resolution.moduleId}
+          type={resolution.type}
+          id={resolution.id}
+        />
+      );
+    }
+    case 'not-found':
+      return wrapper(
+        <NotFoundCard moduleId={resolution.moduleId} type={resolution.type} id={resolution.id} />
+      );
+    case 'module-absent':
+      return wrapper(<ModuleAbsentCard moduleId={resolution.moduleId} />);
+    case 'malformed':
+      return wrapper(<MalformedCard uri={resolution.uri} reason={resolution.reason} />);
+    default: {
+      const _exhaustive: never = resolution;
+      return _exhaustive;
+    }
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -114,6 +114,7 @@ export * from './components/WarrantyBadge';
 
 // Additional standalone primitives (feedback, uploads, media, data viz, layout)
 export * from './components/EmptyState';
+export * from './components/UriCard';
 export * from './components/FileUpload';
 export * from './components/ImageWithFallback';
 export * from './components/MediaCard';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -978,6 +978,9 @@ importers:
       '@fontsource-variable/plus-jakarta-sans':
         specifier: ^5.2.8
         version: 5.2.8
+      '@pops/types':
+        specifier: workspace:*
+        version: link:../types
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
Closes #2542. Closes the URI half of #2522.

## Summary
- New `core.uri.resolve` tRPC procedure parses ADR-012 URIs
  (`pops:{moduleId}/{type}/{id}`) and dispatches to the owning module's
  `uriHandler.resolve`. Returns a typed `UriResolverResult` discriminated
  union (`object` | `not-found` | `module-absent` | `malformed`) — never
  throws on missing data, so callers render placeholders instead of
  handling exceptions.
- Initial module coverage: `finance` (transaction, entity, budget),
  `media` (movie, tv-show), `inventory` (item, location). Each handler
  catches the service-layer `NotFoundError` and translates it to
  `{kind: 'not-found'}` so the dispatcher can decorate with metadata.
- New `<UriCard>` in `@pops/ui` is a presentation-only renderer that
  switches on `UriResolverResult.kind` and emits four placeholder cards
  (object / not-found / module-absent / malformed). Object kind uses a
  consumer-supplied `renderObject` callback so per-domain cards can take
  over once the registry consumer ships, with a generic `{moduleId,
  type, id}` fallback in the meantime.
- `module-absent` gating consults `POPS_APPS` / `POPS_OVERLAYS` so an
  uninstalled-module URI returns the placeholder rather than throwing —
  matches PRD-100's `NotInstalledPage` tone.

## Type changes (`@pops/types`)
- `UriResolution` (per-handler) is unchanged — narrow `object | not-found
  | module-absent` shape.
- New `UriResolverResult` (dispatcher output) adds `moduleId`, `type`,
  `id` metadata to `object` and `not-found`, and adds `malformed` for
  ADR-012 grammar violations. Handlers stay narrow; the dispatcher
  decorates.

## Test plan
- [x] Unit tests for the URI parser cover canonical, kebab-case,
      uppercase, missing-prefix, wrong-segment-count, and empty-segment
      cases.
- [x] Unit tests for the dispatcher cover malformed, module-absent,
      handler-missing, type-not-declared, object decoration, and
      handler `not-found`/`module-absent` translation paths.
- [x] End-to-end tRPC caller tests resolve real seeded rows for each
      module's URI types and assert `not-found` for missing ids.
- [x] `POPS_APPS=finance` + `pops:media/movie/42` returns
      `{kind: 'module-absent', moduleId: 'media'}` — the headline
      acceptance criterion from US-08.
- [x] `<UriCard>` renders the right placeholder for each
      `UriResolverResult.kind`, with a `renderObject` override path for
      consumer-typed cards.
- [x] `pnpm format:check`, `pnpm lint` (148 pre-existing warnings, 0
      errors), `pnpm typecheck`, `pnpm test` all green for affected
      packages. Single failing test (`@pops/app-cerebrum`
      `IngestPage.test.tsx`) is pre-existing on `main` and unrelated.

## Follow-ups
- Once `@pops/module-registry` exposes per-module manifests with
  `uriHandler` (today's `MODULES` is metadata-only), the hand-rolled
  `URI_REGISTRY` in `apps/pops-api/src/modules/core/uri/registry.ts`
  collapses to `MODULES.filter(m => m.uriHandler)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-wide URI resolver for cross-module references (finance, media, inventory) with structured outcomes
  * UriCard converted to a presentation-only component for rendering resolver results

* **Tests**
  * Extensive test coverage for URI parsing, resolution dispatcher, router integration and UriCard rendering

* **Documentation**
  * PRD updated to mark URI resolver work done and detail expected behaviours

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knoxio/pops/pull/2586)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->