### PR TITLE
feat(foundation): per-module migration runner (PRD-101 US-09)

### DIFF
--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -3,12 +3,10 @@ import { unlinkSync } from 'node:fs';
 
 import BetterSqlite3 from 'better-sqlite3';
 import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3';
-import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 
 import { createPreMigrationBackup, isFreshDatabase } from './db/backup.js';
 import { migrationOwners } from './db/migration-ownership.js';
 import {
-  DRIZZLE_MIGRATIONS_DIRECTORY,
   getPendingMigrations,
   hasDrizzleMigrationsTable,
   markDrizzleBaselineMigrationsApplied,
@@ -16,7 +14,10 @@ import {
   markVecMigrationApplied,
   runMigrations,
 } from './db/migrations-runner.js';
-import { warnOrphanMigrationsByOwner } from './db/per-module-migrations.js';
+import {
+  runPerModuleMigrationsByOwner,
+  warnOrphanMigrationsByOwner,
+} from './db/per-module-migrations.js';
 import { initializeSchema } from './db/schema.js';
 import { resolveSqlitePath } from './db/sqlite-path.js';
 import { isVecAvailable, tryLoadVecExtension } from './db/vec-loader.js';
@@ -75,13 +76,31 @@ function isVecMigrationError(err: unknown): err is Error {
   );
 }
 
+/**
+ * Apply drizzle journal entries owned by the current install set.
+ *
+ * Replaces the historical `migrate(drizzleDb, { migrationsFolder })` call:
+ * the global drizzle migrator ran every journal entry regardless of which
+ * modules were installed, which contradicts the PRD-101 partial-install
+ * contract (absent modules should not leave their tables on disk). The
+ * per-module runner walks the journal in order and skips entries whose
+ * owning module is not in `installedIds`. Already-applied entries (matched
+ * by `sha256(sql)` against `__drizzle_migrations`) are treated as no-ops,
+ * preserving compatibility with databases bootstrapped by the pre-PRD-101
+ * runtime.
+ *
+ * Reads the install set from `readInstalledModules()` instead of the live
+ * manifest graph — see the note on `warnAbsentModuleMigrations` below for
+ * why the manifests can't be imported here.
+ */
 function applyDrizzleMigrations(db: BetterSqlite3.Database, vecLoaded: boolean): void {
   try {
     if (!hasDrizzleMigrationsTable(db)) {
       markDrizzleBaselineMigrationsApplied(db);
     }
-    const drizzleDb = drizzle(db);
-    migrate(drizzleDb, { migrationsFolder: DRIZZLE_MIGRATIONS_DIRECTORY });
+    const installed = readInstalledModules();
+    const installedIds = new Set<string>(['core', ...installed.apps, ...installed.overlays]);
+    runPerModuleMigrationsByOwner(db, installedIds, migrationOwners);
   } catch (err) {
     if (!vecLoaded && isVecMigrationError(err)) {
       console.error(
@@ -126,7 +145,10 @@ function openDatabase(path: string): BetterSqlite3.Database {
 
   if (isFreshDatabase(db)) {
     initializeFreshDatabase(db);
-    warnAbsentModuleMigrations(db);
+    // Skip orphan detection on first boot — `initializeFreshDatabase()` just
+    // recorded every drizzle tag as applied, so a partial install would
+    // otherwise emit spurious orphan warnings on a database that has never
+    // had any module's data on disk.
     return db;
   }
 

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -6,6 +6,7 @@ import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 
 import { createPreMigrationBackup, isFreshDatabase } from './db/backup.js';
+import { migrationOwners } from './db/migration-ownership.js';
 import {
   DRIZZLE_MIGRATIONS_DIRECTORY,
   getPendingMigrations,
@@ -15,9 +16,11 @@ import {
   markVecMigrationApplied,
   runMigrations,
 } from './db/migrations-runner.js';
+import { warnOrphanMigrationsByOwner } from './db/per-module-migrations.js';
 import { initializeSchema } from './db/schema.js';
 import { resolveSqlitePath } from './db/sqlite-path.js';
 import { isVecAvailable, tryLoadVecExtension } from './db/vec-loader.js';
+import { readInstalledModules } from './modules/env-modules.js';
 
 let prodDb: BetterSqlite3.Database | null = null;
 
@@ -92,6 +95,28 @@ function applyDrizzleMigrations(db: BetterSqlite3.Database, vecLoaded: boolean):
   }
 }
 
+/**
+ * Warn about migrations recorded in `__drizzle_migrations` whose owning
+ * module is not in the current install set (`POPS_APPS` / `POPS_OVERLAYS`).
+ * Data is preserved; the warning is operator info only (PRD-101 US-09).
+ *
+ * Reads the install set via `readInstalledModules()` rather than the live
+ * manifest graph — manifest exports transitively import `db.ts` via their
+ * tRPC routers, so pulling them here would create an import cycle.
+ */
+function warnAbsentModuleMigrations(db: BetterSqlite3.Database): void {
+  try {
+    const installed = readInstalledModules();
+    const installedIds = new Set<string>(['core', ...installed.apps, ...installed.overlays]);
+    warnOrphanMigrationsByOwner(db, installedIds, migrationOwners);
+  } catch (err) {
+    // Non-fatal — the warning is informational; if env parsing fails the
+    // boot path will surface the same error through `readInstalledModules`
+    // when other consumers call it.
+    console.warn('[db] Could not compute orphan-migration warning:', err);
+  }
+}
+
 function openDatabase(path: string): BetterSqlite3.Database {
   const db = new BetterSqlite3(path);
   configureConnection(db);
@@ -101,6 +126,7 @@ function openDatabase(path: string): BetterSqlite3.Database {
 
   if (isFreshDatabase(db)) {
     initializeFreshDatabase(db);
+    warnAbsentModuleMigrations(db);
     return db;
   }
 
@@ -113,6 +139,7 @@ function openDatabase(path: string): BetterSqlite3.Database {
   // Drizzle. (#2375)
   applyDrizzleMigrations(db, vecLoaded);
   applyManualMigrations(db, path);
+  warnAbsentModuleMigrations(db);
   return db;
 }
 

--- a/apps/pops-api/src/db.ts
+++ b/apps/pops-api/src/db.ts
@@ -21,7 +21,7 @@ import {
 import { initializeSchema } from './db/schema.js';
 import { resolveSqlitePath } from './db/sqlite-path.js';
 import { isVecAvailable, tryLoadVecExtension } from './db/vec-loader.js';
-import { readInstalledModules } from './modules/env-modules.js';
+import { readInstalledModules, type InstalledModules } from './modules/env-modules.js';
 
 let prodDb: BetterSqlite3.Database | null = null;
 
@@ -77,6 +77,15 @@ function isVecMigrationError(err: unknown): err is Error {
 }
 
 /**
+ * Build the install-set of module ids (core + installed apps + installed
+ * overlays). Centralised because both the migration runner and the
+ * orphan-warning path need the same view of which modules are installed.
+ */
+function makeInstalledIds(installed: InstalledModules): Set<string> {
+  return new Set<string>(['core', ...installed.apps, ...installed.overlays]);
+}
+
+/**
  * Apply drizzle journal entries owned by the current install set.
  *
  * Replaces the historical `migrate(drizzleDb, { migrationsFolder })` call:
@@ -98,8 +107,7 @@ function applyDrizzleMigrations(db: BetterSqlite3.Database, vecLoaded: boolean):
     if (!hasDrizzleMigrationsTable(db)) {
       markDrizzleBaselineMigrationsApplied(db);
     }
-    const installed = readInstalledModules();
-    const installedIds = new Set<string>(['core', ...installed.apps, ...installed.overlays]);
+    const installedIds = makeInstalledIds(readInstalledModules());
     runPerModuleMigrationsByOwner(db, installedIds, migrationOwners);
   } catch (err) {
     if (!vecLoaded && isVecMigrationError(err)) {
@@ -125,8 +133,7 @@ function applyDrizzleMigrations(db: BetterSqlite3.Database, vecLoaded: boolean):
  */
 function warnAbsentModuleMigrations(db: BetterSqlite3.Database): void {
   try {
-    const installed = readInstalledModules();
-    const installedIds = new Set<string>(['core', ...installed.apps, ...installed.overlays]);
+    const installedIds = makeInstalledIds(readInstalledModules());
     warnOrphanMigrationsByOwner(db, installedIds, migrationOwners);
   } catch (err) {
     // Non-fatal — the warning is informational; if env parsing fails the

--- a/apps/pops-api/src/db/load-drizzle-migration.ts
+++ b/apps/pops-api/src/db/load-drizzle-migration.ts
@@ -1,0 +1,37 @@
+/**
+ * SQL loader for per-module migration declarations (PRD-101 US-09).
+ *
+ * Each module's manifest declares `backend.migrations: MigrationDescriptor[]`
+ * with `{ id: drizzleTag, sql: <body> }` entries. Rather than inlining the
+ * SQL into the manifest source (which would bloat the file with ~5KB of
+ * raw text per migration), this helper reads the body from the drizzle
+ * migrations directory at module-load time.
+ *
+ * Read cost is one synchronous fs read per declared migration during
+ * backend startup — negligible (the runner already reads every entry to
+ * compute hashes for `__drizzle_migrations`).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { DRIZZLE_MIGRATIONS_DIRECTORY } from './migrations-runner.js';
+
+import type { MigrationDescriptor } from '@pops/types';
+
+/**
+ * Build a `MigrationDescriptor` from a drizzle migration tag, reading the
+ * SQL body from `drizzle-migrations/<tag>.sql`. The body is captured at
+ * call time — subsequent file edits will not be picked up until the
+ * process restarts. This matches drizzle's own behaviour.
+ */
+export function drizzleMigration(tag: string): MigrationDescriptor {
+  const sql = readFileSync(join(DRIZZLE_MIGRATIONS_DIRECTORY, `${tag}.sql`), 'utf8');
+  return { id: tag, sql };
+}
+
+/**
+ * Convenience wrapper — build descriptors for an ordered list of tags.
+ */
+export function drizzleMigrations(tags: readonly string[]): readonly MigrationDescriptor[] {
+  return tags.map((tag) => drizzleMigration(tag));
+}

--- a/apps/pops-api/src/db/migration-ownership.test.ts
+++ b/apps/pops-api/src/db/migration-ownership.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Contract guard: verifies the static migration ownership map
+ * (`migration-ownership.ts`) and each module's
+ * `manifest.backend.migrations` agree exhaustively, and that every entry
+ * in the drizzle journal is owned by exactly one declared module.
+ *
+ * The static map is the runtime source of truth (used by `db.ts` during
+ * boot without loading the manifest graph); the per-module manifests are
+ * the surface every other consumer reads. These tests catch drift between
+ * the two before it reaches production.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { manifest as cerebrumManifest } from '../modules/cerebrum/index.js';
+import { manifest as coreManifest } from '../modules/core/index.js';
+import { manifest as financeManifest } from '../modules/finance/index.js';
+import { manifest as inventoryManifest } from '../modules/inventory/index.js';
+import { manifest as mediaManifest } from '../modules/media/index.js';
+import { MIGRATION_OWNERS } from './migration-ownership.js';
+import { DRIZZLE_MIGRATIONS_DIRECTORY } from './migrations-runner.js';
+
+import type { ModuleManifest } from '@pops/types';
+
+interface Journal {
+  entries: { tag: string }[];
+}
+
+function readJournalTags(): readonly string[] {
+  const journal = JSON.parse(
+    readFileSync(join(DRIZZLE_MIGRATIONS_DIRECTORY, 'meta', '_journal.json'), 'utf8')
+  ) as Journal;
+  return journal.entries.map((e) => e.tag);
+}
+
+function manifestTags(manifest: ModuleManifest): readonly string[] {
+  return (manifest.backend?.migrations ?? []).map((m) => m.id);
+}
+
+describe('migration ownership contract', () => {
+  const journalTags = new Set(readJournalTags());
+
+  it('covers every entry in the drizzle journal', () => {
+    const declared = new Set(Object.keys(MIGRATION_OWNERS));
+    for (const tag of journalTags) {
+      expect(declared.has(tag)).toBe(true);
+    }
+  });
+
+  it('declares no entry that is missing from the journal', () => {
+    for (const tag of Object.keys(MIGRATION_OWNERS)) {
+      expect(journalTags.has(tag)).toBe(true);
+    }
+  });
+
+  it('static map matches per-module manifest declarations exhaustively', () => {
+    const manifestOwnership = new Map<string, string>();
+    for (const m of [
+      coreManifest,
+      financeManifest,
+      mediaManifest,
+      inventoryManifest,
+      cerebrumManifest,
+    ]) {
+      for (const tag of manifestTags(m)) {
+        expect(manifestOwnership.has(tag)).toBe(false);
+        manifestOwnership.set(tag, m.id);
+      }
+    }
+
+    expect(Object.keys(MIGRATION_OWNERS).toSorted()).toEqual(
+      [...manifestOwnership.keys()].toSorted()
+    );
+    for (const [tag, expectedOwner] of manifestOwnership) {
+      expect(MIGRATION_OWNERS[tag]).toBe(expectedOwner);
+    }
+  });
+
+  it('assigns each tag to exactly one owner', () => {
+    const seen = new Set<string>();
+    for (const tag of Object.keys(MIGRATION_OWNERS)) {
+      expect(seen.has(tag)).toBe(false);
+      seen.add(tag);
+    }
+  });
+});

--- a/apps/pops-api/src/db/migration-ownership.ts
+++ b/apps/pops-api/src/db/migration-ownership.ts
@@ -1,0 +1,88 @@
+/**
+ * Static migration ownership declarations (PRD-101 US-09, #2543).
+ *
+ * Each module ALSO exposes its own list via `manifest.backend.migrations`,
+ * but the migration runner needs the canonical owner map BEFORE the full
+ * module graph is loaded — `db.ts` opens the database during process
+ * bootstrap, and the manifest exports transitively import `db.ts` via their
+ * tRPC routers. Pulling the live manifests into the runner would create
+ * an import cycle that resolves to `undefined` at module load.
+ *
+ * The dual-source-of-truth here is intentional and tested: the registry
+ * build / contract guard (US-11) verifies that every `manifest.backend.migrations`
+ * entry has a matching row in this map and vice versa. This file is the
+ * pre-load snapshot the runner consumes; the manifest exports stay as the
+ * load-bearing declarations consumed by everything else.
+ */
+
+/** Tag → module id ownership map for every drizzle journal entry. */
+export const MIGRATION_OWNERS: Readonly<Record<string, string>> = {
+  // Pre-modular baseline — assigned to core (cross-domain content).
+  '0000_naive_chameleon': 'core',
+  '0001_many_marvel_zombies': 'media',
+  '0002_magical_kid_colt': 'media',
+  '0003_small_shotgun': 'media',
+  '0004_tearful_mongu': 'media',
+  '0005_fancy_crystal': 'inventory',
+  '0006_motionless_speed_demon': 'inventory',
+  '0007_broad_arclight': 'inventory',
+  '0008_tough_nick_fury': 'inventory',
+  '0009_red_quasimodo': 'core',
+  '0010_gifted_firestar': 'core',
+  '0011_natural_caretaker': 'media',
+  '0012_exotic_smasher': 'media',
+  '0013_worthless_speed': 'media',
+  '0014_dapper_payback': 'media',
+  '0015_condemned_anthem': 'media',
+  '0016_certain_namor': 'media',
+  '0017_loose_doomsday': 'media',
+  '0018_high_excalibur': 'media',
+  '0019_little_diamondback': 'media',
+  '0020_melodic_major_mapleleaf': 'media',
+  '0021_spooky_lockheed': 'media',
+  '0022_elo_deltas': 'media',
+  '0023_kind_james_howlett': 'media',
+  '0024_dedupe_comparisons': 'media',
+  '0025_youthful_hulk': 'finance',
+  '0026_little_frank_castle': 'finance',
+  '0027_slow_dormammu': 'finance',
+  '0028_needy_terror': 'media',
+  '0029_curved_revanche': 'media',
+  '0030_budgets_unique_category_period': 'core',
+  '0031_romantic_hannibal_king': 'cerebrum',
+  '0032_embeddings': 'cerebrum',
+  '0033_embeddings_vec': 'cerebrum',
+  '0034_ai_observability': 'core',
+  '0035_ai_inference_log_drop_legacy_columns': 'core',
+  '0036_body_hash_engram_index': 'cerebrum',
+  '0037_item_uploaded_files': 'inventory',
+  '0038_sturdy_professor_monster': 'cerebrum',
+  '0039_dry_fabian_cortez': 'cerebrum',
+  '0040_bumpy_namorita': 'cerebrum',
+  '0041_plexus_adapters': 'cerebrum',
+  '0042_strip_quoted_movie_titles': 'media',
+  '0043_user_settings': 'core',
+  '0044_nudge_log': 'cerebrum',
+  '0045_ai_inference_log': 'core',
+  '0046_engrams_body_hash': 'cerebrum',
+  '0047_glia_actions': 'cerebrum',
+  '0048_conversations': 'cerebrum',
+  '0049_sonnet_4_6_model_pricing': 'core',
+  '0050_ai_model_setting_alias': 'core',
+  '0051_strip_quoted_tv_show_titles': 'media',
+  '0052_budgets_active_default_zero': 'finance',
+  '0053_ai_inference_daily': 'core',
+  '0054_service_accounts': 'core',
+};
+
+/** Materialised as a Map for O(1) lookup by the runner. */
+export const migrationOwners: ReadonlyMap<string, string> = new Map(
+  Object.entries(MIGRATION_OWNERS)
+);
+
+/**
+ * Set of module ids that own at least one migration. Boot-time helper
+ * used by the runner to seed the install-set view before any module
+ * manifest is loaded.
+ */
+export const KNOWN_OWNER_IDS: ReadonlySet<string> = new Set(Object.values(MIGRATION_OWNERS));

--- a/apps/pops-api/src/db/migration-safety.test.ts
+++ b/apps/pops-api/src/db/migration-safety.test.ts
@@ -193,6 +193,81 @@ describe('migration safety', () => {
 
       db.close();
     });
+
+    it('pre-marks every drizzle journal entry with sha256(sql) — per-module runner contract', async () => {
+      // Regression for the Playwright failure (PRD-101 US-09): the schema
+      // initializer previously stored migration *tags* in the hash column,
+      // which broke the per-module runner's `sha256(sql)` equality check
+      // and caused "table `budgets` already exists" on first boot.
+      const { createHash } = await import('node:crypto');
+      const { readJournal } = await import('./per-module-migrations.js');
+
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('journal_mode = WAL');
+      initializeSchema(db);
+
+      const recorded = new Set(
+        (db.prepare('SELECT hash FROM __drizzle_migrations').all() as { hash: string }[]).map(
+          (r) => r.hash
+        )
+      );
+
+      const drizzleDir = join(__dirname, 'drizzle-migrations');
+      const journal = readJournal();
+      for (const entry of journal.entries) {
+        const sql = readFileSync(join(drizzleDir, `${entry.tag}.sql`), 'utf8');
+        const expected = createHash('sha256').update(sql).digest('hex');
+        expect(recorded.has(expected)).toBe(true);
+      }
+
+      db.close();
+    });
+
+    it('per-module migration runner is a no-op against a freshly initialized DB', async () => {
+      // End-to-end regression: real `initializeSchema` → real per-module
+      // runner → zero migrations applied. This is the exact boot path that
+      // crashed under Playwright before the fix.
+      const { runPerModuleMigrations } = await import('./per-module-migrations.js');
+      const { migrationOwners } = await import('./migration-ownership.js');
+      const { readJournal } = await import('./per-module-migrations.js');
+
+      const db = new BetterSqlite3(dbPath);
+      db.pragma('journal_mode = WAL');
+      initializeSchema(db);
+
+      // Build a minimal manifest carrying every owned tag — the runner only
+      // needs the install-set + owners to honour the hash short-circuit.
+      const journal = readJournal();
+      const installedIds = new Set(
+        [...migrationOwners.values()].filter((id): id is string => Boolean(id))
+      );
+      const allTags = journal.entries.map((e) => e.tag);
+      const manifests = [...installedIds].map((id) => ({
+        id,
+        name: id,
+        surfaces: ['app'] as const,
+        backend: {
+          router: {},
+          migrations: allTags
+            .filter((t) => migrationOwners.get(t) === id)
+            .map((id) => ({ id, sql: '' })),
+        },
+      }));
+
+      const result = runPerModuleMigrations(db, manifests, migrationOwners);
+
+      expect(result.applied).toEqual([]);
+      // Every entry whose owner is installed must be a no-op.
+      const expectedAlreadyApplied = allTags
+        .filter((t) => {
+          const owner = migrationOwners.get(t);
+          return owner !== undefined && installedIds.has(owner);
+        })
+        .toSorted();
+      expect([...result.alreadyApplied].toSorted()).toEqual(expectedAlreadyApplied);
+
+      db.close();
+    });
   });
 
   describe('schema idempotency', () => {

--- a/apps/pops-api/src/db/per-module-migrations.test.ts
+++ b/apps/pops-api/src/db/per-module-migrations.test.ts
@@ -112,6 +112,14 @@ describe('migrationOwnershipMap', () => {
     expect(owners.get('b_1')).toBe('b');
     expect(owners.size).toBe(2);
   });
+
+  it('throws if two modules claim the same migration tag', () => {
+    const a = makeManifest('a', [{ id: 'shared_tag', sql: '' }]);
+    const b = makeManifest('b', [{ id: 'shared_tag', sql: '' }]);
+    expect(() => migrationOwnershipMap([a, b])).toThrow(
+      /Migration tag "shared_tag" is declared by both "a" and "b"\./
+    );
+  });
 });
 
 describe('runPerModuleMigrations', () => {
@@ -209,6 +217,57 @@ describe('runPerModuleMigrations', () => {
       name: string;
     }[];
     expect(tables.map((t) => t.name)).not.toContain('orphan_t');
+
+    db.close();
+  });
+
+  it('refreshes the applied-hash cache after each insert (handles identical SQL bodies)', async () => {
+    // Two distinct tags that share the same SQL body — drizzle generates
+    // these for idempotent re-creation migrations. Without the cache update
+    // after insert, the second entry would be re-executed and fail.
+    const dir = fakeJournalDir();
+    const sharedSql = 'CREATE TABLE IF NOT EXISTS shared_t (id INTEGER);';
+    writeJournal(dir, [
+      { tag: '001_first', sql: sharedSql },
+      { tag: '002_second', sql: sharedSql },
+    ]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    const db = new BetterSqlite3(dbPath);
+    const a = makeManifest('a', [
+      { id: '001_first', sql: sharedSql },
+      { id: '002_second', sql: sharedSql },
+    ]);
+
+    const result = mod.runPerModuleMigrations(db, [a]);
+
+    // First tag applies; second is recognised as already applied (same hash)
+    // because the cache was updated mid-loop.
+    expect(result.applied).toEqual(['001_first']);
+    expect(result.alreadyApplied).toEqual(['002_second']);
+
+    db.close();
+  });
+
+  it('exposes a by-owner variant for boot-time use', async () => {
+    const dir = fakeJournalDir();
+    writeJournal(dir, [
+      { tag: '001_a', sql: 'CREATE TABLE a (id INTEGER);' },
+      { tag: '002_b', sql: 'CREATE TABLE b (id INTEGER);' },
+    ]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    const db = new BetterSqlite3(dbPath);
+    const owners = new Map([
+      ['001_a', 'a'],
+      ['002_b', 'b'],
+    ]);
+    const installedIds = new Set(['a']);
+
+    const result = mod.runPerModuleMigrationsByOwner(db, installedIds, owners);
+
+    expect(result.applied).toEqual(['001_a']);
+    expect(result.skipped).toEqual(['002_b']);
 
     db.close();
   });

--- a/apps/pops-api/src/db/per-module-migrations.test.ts
+++ b/apps/pops-api/src/db/per-module-migrations.test.ts
@@ -23,6 +23,15 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true });
+  // `vi.restoreAllMocks()` clears spies but does NOT purge module mocks
+  // installed via `vi.doMock`. Without `vi.doUnmock` the mock for
+  // `./migrations-runner.js` survives into the next test in the same
+  // worker, so a later import of `per-module-migrations.js` would resolve
+  // the cached mock pointing at a `tmpDir` already removed above — making
+  // test order load-bearing. Reset the module registry too so any cached
+  // `per-module-migrations.js` binding from a previous test is dropped.
+  vi.doUnmock('./migrations-runner.js');
+  vi.resetModules();
   vi.restoreAllMocks();
 });
 

--- a/apps/pops-api/src/db/per-module-migrations.test.ts
+++ b/apps/pops-api/src/db/per-module-migrations.test.ts
@@ -287,6 +287,104 @@ describe('runPerModuleMigrations', () => {
       expect(names).toContain('beta');
     });
   });
+
+  it('treats every journal entry as already applied when __drizzle_migrations records sha256(sql) per entry (fresh-DB pre-seed contract)', async () => {
+    // Regression for the Playwright E2E failure where `pnpm dev:init` ran
+    // `initializeSchema` (which creates every table) and then the API boot
+    // path invoked the per-module runner — the previous schema initializer
+    // stored migration *tags* in the hash column, so the runner re-attempted
+    // every journal entry and crashed on "table `budgets` already exists".
+    // After the fix, `initializeSchema` records `sha256(sql)` per entry, so
+    // the runner observes a full hash match and applies nothing.
+    //
+    // This test exercises the runner directly with the same hashing
+    // convention `markDrizzleMigrationsApplied` now uses; if the runner ever
+    // drifts away from `sha256(sql)` the fresh-DB-then-migrate path will
+    // regress and this assertion will trip.
+    const { createHash } = await import('node:crypto');
+    const dir = fakeJournalDir();
+    const sqls = [
+      'CREATE TABLE budgets (id INTEGER);',
+      'CREATE TABLE entities (id INTEGER);',
+      'CREATE TABLE transactions (id INTEGER);',
+    ];
+    const tags = sqls.map((_, i) => `000${i}_seeded`);
+    writeJournal(
+      dir,
+      sqls.map((sql, i) => ({ tag: tags[i] ?? '', sql }))
+    );
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    await withDb((db) => {
+      // Create the tables (mirrors `initializeSchema`).
+      for (const sql of sqls) db.exec(sql);
+      // Pre-seed __drizzle_migrations with sha256(sql) — the contract that
+      // `markDrizzleMigrationsApplied` (and the per-module runner) agrees on.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          hash TEXT NOT NULL,
+          created_at NUMERIC
+        )
+      `);
+      const insert = db.prepare(
+        'INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)'
+      );
+      for (const sql of sqls) {
+        insert.run(createHash('sha256').update(sql).digest('hex'), Date.now());
+      }
+
+      const a = makeManifest(
+        'core',
+        sqls.map((sql, i) => ({ id: tags[i] ?? '', sql }))
+      );
+      const knownOwners = mod.migrationOwnershipMap([a]);
+
+      const result = mod.runPerModuleMigrations(db, [a], knownOwners);
+
+      expect(result.applied).toEqual([]);
+      expect(result.alreadyApplied).toEqual(tags);
+      expect(result.skipped).toEqual([]);
+      expect(result.unowned).toEqual([]);
+    });
+  });
+
+  it('crashes if __drizzle_migrations stores tag names instead of sha256(sql) — guards against the pre-PRD-101 schema-init bug', async () => {
+    // Negative regression: prior to the fix, `initializeSchema` recorded
+    // each migration's *tag* in the hash column. Drizzle's stock migrator
+    // tolerated that because it skipped by timestamp, but the per-module
+    // runner uses hash equality and would re-run every migration, blowing
+    // up on the first non-IF-NOT-EXISTS DDL. This test pins the contract:
+    // tag-as-hash MUST produce a re-application attempt that fails when
+    // the table is non-idempotent.
+    const dir = fakeJournalDir();
+    const sql = 'CREATE TABLE budgets (id INTEGER);';
+    writeJournal(dir, [{ tag: '0000_seeded', sql }]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    await withDb((db) => {
+      db.exec(sql);
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          hash TEXT NOT NULL,
+          created_at NUMERIC
+        )
+      `);
+      // Wrong: tag in the hash column. Reproduces the bug.
+      db.prepare('INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)').run(
+        '0000_seeded',
+        Date.now()
+      );
+
+      const a = makeManifest('core', [{ id: '0000_seeded', sql }]);
+      const knownOwners = mod.migrationOwnershipMap([a]);
+
+      expect(() => mod.runPerModuleMigrations(db, [a], knownOwners)).toThrow(
+        /table .?budgets.? already exists/
+      );
+    });
+  });
 });
 
 describe('warnOrphanMigrations', () => {

--- a/apps/pops-api/src/db/per-module-migrations.test.ts
+++ b/apps/pops-api/src/db/per-module-migrations.test.ts
@@ -1,14 +1,6 @@
 /**
- * Per-module migration runner tests (PRD-101 US-09, #2543).
- *
- * Exercises the filter logic against a real (in-memory) drizzle journal:
- *   - migrations owned by absent modules are skipped and not recorded
- *   - re-running with the same install set is a no-op
- *   - adding an absent module on a re-run applies its previously-skipped tags
- *   - orphan tags (recorded but owned by an absent module) emit a warning
- *
- * Tests use synthetic manifests + journal entries written to a temp dir so
- * they don't depend on the live ownership map evolving over time.
+ * Synthetic manifests + journal entries are written to a temp dir so tests
+ * don't depend on the live ownership map evolving over time.
  */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -70,10 +62,20 @@ function writeJournal(dir: string, tags: readonly { tag: string; sql: string }[]
 }
 
 /**
- * Override the module-under-test's view of the drizzle directory by
- * importing it after mocking the migrations-runner export. Returns the
- * mocked module reference so tests can call its exports directly.
+ * Guarantees the DB handle is closed even if an assertion fails — otherwise
+ * a leaked handle can keep the temp dir busy on Windows / make subsequent
+ * tests flaky. Awaits async callbacks before closing so the handle remains
+ * valid for the duration of the callback.
  */
+async function withDb<T>(run: (db: BetterSqlite3.Database) => T | Promise<T>): Promise<T> {
+  const db = new BetterSqlite3(dbPath);
+  try {
+    return await run(db);
+  } finally {
+    db.close();
+  }
+}
+
 async function loadRunnerWithJournalDir(
   drizzleDir: string
 ): Promise<typeof import('./per-module-migrations.js')> {
@@ -132,46 +134,42 @@ describe('runPerModuleMigrations', () => {
     ]);
     const mod = await loadRunnerWithJournalDir(dir);
 
-    const db = new BetterSqlite3(dbPath);
-    const a = makeManifest('a', [
-      { id: '001_a_setup', sql: 'CREATE TABLE a (id INTEGER);' },
-      { id: '003_a_extra', sql: 'CREATE TABLE a_extra (id INTEGER);' },
-    ]);
-    const b = makeManifest('b', [{ id: '002_b_setup', sql: 'CREATE TABLE b (id INTEGER);' }]);
+    await withDb((db) => {
+      const a = makeManifest('a', [
+        { id: '001_a_setup', sql: 'CREATE TABLE a (id INTEGER);' },
+        { id: '003_a_extra', sql: 'CREATE TABLE a_extra (id INTEGER);' },
+      ]);
+      const b = makeManifest('b', [{ id: '002_b_setup', sql: 'CREATE TABLE b (id INTEGER);' }]);
 
-    const knownOwners = mod.migrationOwnershipMap([a, b]);
-    const result = mod.runPerModuleMigrations(db, [a], knownOwners);
+      const knownOwners = mod.migrationOwnershipMap([a, b]);
+      const result = mod.runPerModuleMigrations(db, [a], knownOwners);
 
-    expect(result.applied).toEqual(['001_a_setup', '003_a_extra']);
-    expect(result.skipped).toEqual(['002_b_setup']);
+      expect(result.applied).toEqual(['001_a_setup', '003_a_extra']);
+      expect(result.skipped).toEqual(['002_b_setup']);
 
-    // Tables for a exist; table for b doesn't.
-    const tables = db
-      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-      .all() as { name: string }[];
-    const names = tables.map((t) => t.name);
-    expect(names).toContain('a');
-    expect(names).toContain('a_extra');
-    expect(names).not.toContain('b');
+      const tables = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all() as { name: string }[];
+      const names = tables.map((t) => t.name);
+      expect(names).toContain('a');
+      expect(names).toContain('a_extra');
+      expect(names).not.toContain('b');
 
-    // Re-running with the same install set must be a no-op (alreadyApplied).
-    const second = mod.runPerModuleMigrations(db, [a], knownOwners);
-    expect(second.applied).toEqual([]);
-    expect(second.skipped).toEqual(['002_b_setup']);
-    expect(second.alreadyApplied).toEqual(['001_a_setup', '003_a_extra']);
+      const second = mod.runPerModuleMigrations(db, [a], knownOwners);
+      expect(second.applied).toEqual([]);
+      expect(second.skipped).toEqual(['002_b_setup']);
+      expect(second.alreadyApplied).toEqual(['001_a_setup', '003_a_extra']);
 
-    // Adding module b on the third run brings in the previously-skipped tag.
-    const third = mod.runPerModuleMigrations(db, [a, b], knownOwners);
-    expect(third.applied).toEqual(['002_b_setup']);
-    expect(third.skipped).toEqual([]);
-    expect(third.alreadyApplied).toEqual(['001_a_setup', '003_a_extra']);
+      const third = mod.runPerModuleMigrations(db, [a, b], knownOwners);
+      expect(third.applied).toEqual(['002_b_setup']);
+      expect(third.skipped).toEqual([]);
+      expect(third.alreadyApplied).toEqual(['001_a_setup', '003_a_extra']);
 
-    const tablesAfter = db
-      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-      .all() as { name: string }[];
-    expect(tablesAfter.map((t) => t.name)).toContain('b');
-
-    db.close();
+      const tablesAfter = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all() as { name: string }[];
+      expect(tablesAfter.map((t) => t.name)).toContain('b');
+    });
   });
 
   it('does not record skipped migrations in __drizzle_migrations', async () => {
@@ -182,19 +180,18 @@ describe('runPerModuleMigrations', () => {
     ]);
     const mod = await loadRunnerWithJournalDir(dir);
 
-    const db = new BetterSqlite3(dbPath);
-    const a = makeManifest('a', [{ id: '001_a', sql: 'CREATE TABLE x (id INTEGER);' }]);
-    const b = makeManifest('b', [{ id: '002_b', sql: 'CREATE TABLE y (id INTEGER);' }]);
-    const knownOwners = mod.migrationOwnershipMap([a, b]);
+    await withDb((db) => {
+      const a = makeManifest('a', [{ id: '001_a', sql: 'CREATE TABLE x (id INTEGER);' }]);
+      const b = makeManifest('b', [{ id: '002_b', sql: 'CREATE TABLE y (id INTEGER);' }]);
+      const knownOwners = mod.migrationOwnershipMap([a, b]);
 
-    mod.runPerModuleMigrations(db, [a], knownOwners);
+      mod.runPerModuleMigrations(db, [a], knownOwners);
 
-    const recorded = db.prepare('SELECT COUNT(*) AS cnt FROM __drizzle_migrations').get() as {
-      cnt: number;
-    };
-    expect(recorded.cnt).toBe(1);
-
-    db.close();
+      const recorded = db.prepare('SELECT COUNT(*) AS cnt FROM __drizzle_migrations').get() as {
+        cnt: number;
+      };
+      expect(recorded.cnt).toBe(1);
+    });
   });
 
   it('reports unowned tags without applying them', async () => {
@@ -205,26 +202,24 @@ describe('runPerModuleMigrations', () => {
     ]);
     const mod = await loadRunnerWithJournalDir(dir);
 
-    const db = new BetterSqlite3(dbPath);
-    const a = makeManifest('a', [{ id: '002_a', sql: 'CREATE TABLE a (id INTEGER);' }]);
+    await withDb((db) => {
+      const a = makeManifest('a', [{ id: '002_a', sql: 'CREATE TABLE a (id INTEGER);' }]);
 
-    const result = mod.runPerModuleMigrations(db, [a]);
+      const result = mod.runPerModuleMigrations(db, [a]);
 
-    expect(result.applied).toEqual(['002_a']);
-    expect(result.unowned).toEqual(['001_orphan']);
-    // orphan_t table not created.
-    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
-      name: string;
-    }[];
-    expect(tables.map((t) => t.name)).not.toContain('orphan_t');
-
-    db.close();
+      expect(result.applied).toEqual(['002_a']);
+      expect(result.unowned).toEqual(['001_orphan']);
+      const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+        name: string;
+      }[];
+      expect(tables.map((t) => t.name)).not.toContain('orphan_t');
+    });
   });
 
   it('refreshes the applied-hash cache after each insert (handles identical SQL bodies)', async () => {
-    // Two distinct tags that share the same SQL body — drizzle generates
-    // these for idempotent re-creation migrations. Without the cache update
-    // after insert, the second entry would be re-executed and fail.
+    // Drizzle generates duplicate-SQL entries for idempotent re-creation
+    // migrations; without the cache update the second entry would re-execute
+    // and crash on non-idempotent statements.
     const dir = fakeJournalDir();
     const sharedSql = 'CREATE TABLE IF NOT EXISTS shared_t (id INTEGER);';
     writeJournal(dir, [
@@ -233,20 +228,17 @@ describe('runPerModuleMigrations', () => {
     ]);
     const mod = await loadRunnerWithJournalDir(dir);
 
-    const db = new BetterSqlite3(dbPath);
-    const a = makeManifest('a', [
-      { id: '001_first', sql: sharedSql },
-      { id: '002_second', sql: sharedSql },
-    ]);
+    await withDb((db) => {
+      const a = makeManifest('a', [
+        { id: '001_first', sql: sharedSql },
+        { id: '002_second', sql: sharedSql },
+      ]);
 
-    const result = mod.runPerModuleMigrations(db, [a]);
+      const result = mod.runPerModuleMigrations(db, [a]);
 
-    // First tag applies; second is recognised as already applied (same hash)
-    // because the cache was updated mid-loop.
-    expect(result.applied).toEqual(['001_first']);
-    expect(result.alreadyApplied).toEqual(['002_second']);
-
-    db.close();
+      expect(result.applied).toEqual(['001_first']);
+      expect(result.alreadyApplied).toEqual(['002_second']);
+    });
   });
 
   it('exposes a by-owner variant for boot-time use', async () => {
@@ -257,19 +249,18 @@ describe('runPerModuleMigrations', () => {
     ]);
     const mod = await loadRunnerWithJournalDir(dir);
 
-    const db = new BetterSqlite3(dbPath);
-    const owners = new Map([
-      ['001_a', 'a'],
-      ['002_b', 'b'],
-    ]);
-    const installedIds = new Set(['a']);
+    await withDb((db) => {
+      const owners = new Map([
+        ['001_a', 'a'],
+        ['002_b', 'b'],
+      ]);
+      const installedIds = new Set(['a']);
 
-    const result = mod.runPerModuleMigrationsByOwner(db, installedIds, owners);
+      const result = mod.runPerModuleMigrationsByOwner(db, installedIds, owners);
 
-    expect(result.applied).toEqual(['001_a']);
-    expect(result.skipped).toEqual(['002_b']);
-
-    db.close();
+      expect(result.applied).toEqual(['001_a']);
+      expect(result.skipped).toEqual(['002_b']);
+    });
   });
 
   it('honours --> statement-breakpoint markers in migration SQL', async () => {
@@ -282,20 +273,19 @@ describe('runPerModuleMigrations', () => {
     writeJournal(dir, [{ tag: '001_multi', sql: breakpointSql }]);
     const mod = await loadRunnerWithJournalDir(dir);
 
-    const db = new BetterSqlite3(dbPath);
-    const a = makeManifest('a', [{ id: '001_multi', sql: breakpointSql }]);
+    await withDb((db) => {
+      const a = makeManifest('a', [{ id: '001_multi', sql: breakpointSql }]);
 
-    const result = mod.runPerModuleMigrations(db, [a]);
+      const result = mod.runPerModuleMigrations(db, [a]);
 
-    expect(result.applied).toEqual(['001_multi']);
-    const tables = db
-      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-      .all() as { name: string }[];
-    const names = tables.map((t) => t.name);
-    expect(names).toContain('alpha');
-    expect(names).toContain('beta');
-
-    db.close();
+      expect(result.applied).toEqual(['001_multi']);
+      const tables = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all() as { name: string }[];
+      const names = tables.map((t) => t.name);
+      expect(names).toContain('alpha');
+      expect(names).toContain('beta');
+    });
   });
 });
 
@@ -308,26 +298,25 @@ describe('warnOrphanMigrations', () => {
     ]);
     const mod = await loadRunnerWithJournalDir(dir);
 
-    const db = new BetterSqlite3(dbPath);
-    const a = makeManifest('a', [{ id: '001_a', sql: 'CREATE TABLE x (id INTEGER);' }]);
-    const b = makeManifest('b', [{ id: '002_b', sql: 'CREATE TABLE y (id INTEGER);' }]);
-
-    const knownOwners = mod.migrationOwnershipMap([a, b]);
-
-    // Bootstrap: install both, then drop b from the manifest list.
-    mod.runPerModuleMigrations(db, [a, b], knownOwners);
-
     const { logger } = await import('../lib/logger.js');
-    const warnSpy = vi.spyOn(logger, 'warn');
 
-    const orphans = mod.warnOrphanMigrations(db, [a], knownOwners);
+    await withDb(async (db) => {
+      const a = makeManifest('a', [{ id: '001_a', sql: 'CREATE TABLE x (id INTEGER);' }]);
+      const b = makeManifest('b', [{ id: '002_b', sql: 'CREATE TABLE y (id INTEGER);' }]);
 
-    expect(orphans).toEqual(['002_b']);
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    const [payload] = warnSpy.mock.calls[0] ?? [];
-    expect(payload).toMatchObject({ orphanMigrations: ['002_b'] });
+      const knownOwners = mod.migrationOwnershipMap([a, b]);
 
-    db.close();
+      mod.runPerModuleMigrations(db, [a, b], knownOwners);
+
+      const warnSpy = vi.spyOn(logger, 'warn');
+
+      const orphans = mod.warnOrphanMigrations(db, [a], knownOwners);
+
+      expect(orphans).toEqual(['002_b']);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [payload] = warnSpy.mock.calls[0] ?? [];
+      expect(payload).toMatchObject({ orphanMigrations: ['002_b'] });
+    });
   });
 
   it('does not warn when every recorded migration is owned by an installed module', async () => {
@@ -335,18 +324,18 @@ describe('warnOrphanMigrations', () => {
     writeJournal(dir, [{ tag: '001_a', sql: 'CREATE TABLE x (id INTEGER);' }]);
     const mod = await loadRunnerWithJournalDir(dir);
 
-    const db = new BetterSqlite3(dbPath);
-    const a = makeManifest('a', [{ id: '001_a', sql: 'CREATE TABLE x (id INTEGER);' }]);
-
-    mod.runPerModuleMigrations(db, [a]);
-
     const { logger } = await import('../lib/logger.js');
-    const warnSpy = vi.spyOn(logger, 'warn');
-    const orphans = mod.warnOrphanMigrations(db, [a]);
 
-    expect(orphans).toEqual([]);
-    expect(warnSpy).not.toHaveBeenCalled();
+    await withDb(async (db) => {
+      const a = makeManifest('a', [{ id: '001_a', sql: 'CREATE TABLE x (id INTEGER);' }]);
 
-    db.close();
+      mod.runPerModuleMigrations(db, [a]);
+
+      const warnSpy = vi.spyOn(logger, 'warn');
+      const orphans = mod.warnOrphanMigrations(db, [a]);
+
+      expect(orphans).toEqual([]);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/pops-api/src/db/per-module-migrations.test.ts
+++ b/apps/pops-api/src/db/per-module-migrations.test.ts
@@ -436,4 +436,45 @@ describe('warnOrphanMigrations', () => {
       expect(warnSpy).not.toHaveBeenCalled();
     });
   });
+
+  it('suppresses orphan warnings for tags whose SQL hash collides with another journal entry (duplicate-SQL ambiguity)', async () => {
+    // Two modules ship a migration with byte-identical SQL bodies (e.g. an
+    // idempotent `CREATE TABLE IF NOT EXISTS` pattern). When only module A
+    // is installed and its tag is applied, `__drizzle_migrations` records
+    // one hash that maps to BOTH journal entries — there is no way to tell
+    // which tag was actually applied. Without ambiguity handling the orphan
+    // path would flag module B's tag as an orphan even though it never ran.
+    // The apply path already tolerates this collision (the second duplicate
+    // becomes `alreadyApplied`); the warning path must match.
+    const dir = fakeJournalDir();
+    const sharedSql = 'CREATE TABLE IF NOT EXISTS shared_t (id INTEGER);';
+    writeJournal(dir, [
+      { tag: '001_a_shared', sql: sharedSql },
+      { tag: '002_b_shared', sql: sharedSql },
+    ]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    const { logger } = await import('../lib/logger.js');
+
+    await withDb(async (db) => {
+      const a = makeManifest('a', [{ id: '001_a_shared', sql: sharedSql }]);
+      const b = makeManifest('b', [{ id: '002_b_shared', sql: sharedSql }]);
+
+      const knownOwners = mod.migrationOwnershipMap([a, b]);
+
+      // Install only A — its tag applies, then B's duplicate-hash tag is
+      // observed as `alreadyApplied` because the hash is now present.
+      const applyResult = mod.runPerModuleMigrations(db, [a], knownOwners);
+      expect(applyResult.applied).toEqual(['001_a_shared']);
+
+      const warnSpy = vi.spyOn(logger, 'warn');
+
+      // Now ask the orphan path: with only A installed, is B's tag orphaned?
+      // It must NOT be — the hash is ambiguous and could equally belong to A.
+      const orphans = mod.warnOrphanMigrations(db, [a], knownOwners);
+
+      expect(orphans).toEqual([]);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/pops-api/src/db/per-module-migrations.test.ts
+++ b/apps/pops-api/src/db/per-module-migrations.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Per-module migration runner tests (PRD-101 US-09, #2543).
+ *
+ * Exercises the filter logic against a real (in-memory) drizzle journal:
+ *   - migrations owned by absent modules are skipped and not recorded
+ *   - re-running with the same install set is a no-op
+ *   - adding an absent module on a re-run applies its previously-skipped tags
+ *   - orphan tags (recorded but owned by an absent module) emit a warning
+ *
+ * Tests use synthetic manifests + journal entries written to a temp dir so
+ * they don't depend on the live ownership map evolving over time.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { installedMigrationTags, migrationOwnershipMap } from './per-module-migrations.js';
+
+import type { ModuleManifest } from '@pops/types';
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'per-module-mig-'));
+  dbPath = join(tmpDir, 'test.db');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function makeManifest(id: string, migrations: { id: string; sql: string }[]): ModuleManifest {
+  return {
+    id,
+    name: id,
+    surfaces: ['app'] as const,
+    backend: { router: {}, migrations },
+  };
+}
+
+function fakeJournalDir(): string {
+  const dir = join(tmpDir, 'drizzle-migrations');
+  mkdirSync(join(dir, 'meta'), { recursive: true });
+  return dir;
+}
+
+function writeJournal(dir: string, tags: readonly { tag: string; sql: string }[]): void {
+  writeFileSync(
+    join(dir, 'meta', '_journal.json'),
+    JSON.stringify({
+      version: '7',
+      dialect: 'sqlite',
+      entries: tags.map((t, i) => ({
+        idx: i,
+        version: '7',
+        when: 1_000_000 + i,
+        tag: t.tag,
+        breakpoints: true,
+      })),
+    })
+  );
+  for (const t of tags) {
+    writeFileSync(join(dir, `${t.tag}.sql`), t.sql);
+  }
+}
+
+/**
+ * Override the module-under-test's view of the drizzle directory by
+ * importing it after mocking the migrations-runner export. Returns the
+ * mocked module reference so tests can call its exports directly.
+ */
+async function loadRunnerWithJournalDir(
+  drizzleDir: string
+): Promise<typeof import('./per-module-migrations.js')> {
+  vi.resetModules();
+  vi.doMock('./migrations-runner.js', async () => {
+    const actual =
+      await vi.importActual<typeof import('./migrations-runner.js')>('./migrations-runner.js');
+    return { ...actual, DRIZZLE_MIGRATIONS_DIRECTORY: drizzleDir };
+  });
+  return import('./per-module-migrations.js');
+}
+
+describe('installedMigrationTags', () => {
+  it('returns union of every module manifests migration ids', () => {
+    const a = makeManifest('a', [
+      { id: 'a_1', sql: '' },
+      { id: 'a_2', sql: '' },
+    ]);
+    const b = makeManifest('b', [{ id: 'b_1', sql: '' }]);
+    const tags = installedMigrationTags([a, b]);
+    expect([...tags].toSorted()).toEqual(['a_1', 'a_2', 'b_1']);
+  });
+
+  it('returns empty set when no module declares migrations', () => {
+    const a: ModuleManifest = { id: 'a', name: 'a', surfaces: ['app'] };
+    expect(installedMigrationTags([a]).size).toBe(0);
+  });
+});
+
+describe('migrationOwnershipMap', () => {
+  it('maps each tag to its owning module id', () => {
+    const a = makeManifest('a', [{ id: 'a_1', sql: '' }]);
+    const b = makeManifest('b', [{ id: 'b_1', sql: '' }]);
+    const owners = migrationOwnershipMap([a, b]);
+    expect(owners.get('a_1')).toBe('a');
+    expect(owners.get('b_1')).toBe('b');
+    expect(owners.size).toBe(2);
+  });
+});
+
+describe('runPerModuleMigrations', () => {
+  it('applies only migrations owned by installed modules', async () => {
+    const dir = fakeJournalDir();
+    writeJournal(dir, [
+      { tag: '001_a_setup', sql: 'CREATE TABLE a (id INTEGER);' },
+      { tag: '002_b_setup', sql: 'CREATE TABLE b (id INTEGER);' },
+      { tag: '003_a_extra', sql: 'CREATE TABLE a_extra (id INTEGER);' },
+    ]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    const db = new BetterSqlite3(dbPath);
+    const a = makeManifest('a', [
+      { id: '001_a_setup', sql: 'CREATE TABLE a (id INTEGER);' },
+      { id: '003_a_extra', sql: 'CREATE TABLE a_extra (id INTEGER);' },
+    ]);
+    const b = makeManifest('b', [{ id: '002_b_setup', sql: 'CREATE TABLE b (id INTEGER);' }]);
+
+    const knownOwners = mod.migrationOwnershipMap([a, b]);
+    const result = mod.runPerModuleMigrations(db, [a], knownOwners);
+
+    expect(result.applied).toEqual(['001_a_setup', '003_a_extra']);
+    expect(result.skipped).toEqual(['002_b_setup']);
+
+    // Tables for a exist; table for b doesn't.
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all() as { name: string }[];
+    const names = tables.map((t) => t.name);
+    expect(names).toContain('a');
+    expect(names).toContain('a_extra');
+    expect(names).not.toContain('b');
+
+    // Re-running with the same install set must be a no-op (alreadyApplied).
+    const second = mod.runPerModuleMigrations(db, [a], knownOwners);
+    expect(second.applied).toEqual([]);
+    expect(second.skipped).toEqual(['002_b_setup']);
+    expect(second.alreadyApplied).toEqual(['001_a_setup', '003_a_extra']);
+
+    // Adding module b on the third run brings in the previously-skipped tag.
+    const third = mod.runPerModuleMigrations(db, [a, b], knownOwners);
+    expect(third.applied).toEqual(['002_b_setup']);
+    expect(third.skipped).toEqual([]);
+    expect(third.alreadyApplied).toEqual(['001_a_setup', '003_a_extra']);
+
+    const tablesAfter = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all() as { name: string }[];
+    expect(tablesAfter.map((t) => t.name)).toContain('b');
+
+    db.close();
+  });
+
+  it('does not record skipped migrations in __drizzle_migrations', async () => {
+    const dir = fakeJournalDir();
+    writeJournal(dir, [
+      { tag: '001_a', sql: 'CREATE TABLE x (id INTEGER);' },
+      { tag: '002_b', sql: 'CREATE TABLE y (id INTEGER);' },
+    ]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    const db = new BetterSqlite3(dbPath);
+    const a = makeManifest('a', [{ id: '001_a', sql: 'CREATE TABLE x (id INTEGER);' }]);
+    const b = makeManifest('b', [{ id: '002_b', sql: 'CREATE TABLE y (id INTEGER);' }]);
+    const knownOwners = mod.migrationOwnershipMap([a, b]);
+
+    mod.runPerModuleMigrations(db, [a], knownOwners);
+
+    const recorded = db.prepare('SELECT COUNT(*) AS cnt FROM __drizzle_migrations').get() as {
+      cnt: number;
+    };
+    expect(recorded.cnt).toBe(1);
+
+    db.close();
+  });
+
+  it('reports unowned tags without applying them', async () => {
+    const dir = fakeJournalDir();
+    writeJournal(dir, [
+      { tag: '001_orphan', sql: 'CREATE TABLE orphan_t (id INTEGER);' },
+      { tag: '002_a', sql: 'CREATE TABLE a (id INTEGER);' },
+    ]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    const db = new BetterSqlite3(dbPath);
+    const a = makeManifest('a', [{ id: '002_a', sql: 'CREATE TABLE a (id INTEGER);' }]);
+
+    const result = mod.runPerModuleMigrations(db, [a]);
+
+    expect(result.applied).toEqual(['002_a']);
+    expect(result.unowned).toEqual(['001_orphan']);
+    // orphan_t table not created.
+    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+      name: string;
+    }[];
+    expect(tables.map((t) => t.name)).not.toContain('orphan_t');
+
+    db.close();
+  });
+
+  it('honours --> statement-breakpoint markers in migration SQL', async () => {
+    const dir = fakeJournalDir();
+    const breakpointSql = [
+      'CREATE TABLE alpha (id INTEGER);',
+      '--> statement-breakpoint',
+      'CREATE TABLE beta (id INTEGER);',
+    ].join('\n');
+    writeJournal(dir, [{ tag: '001_multi', sql: breakpointSql }]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    const db = new BetterSqlite3(dbPath);
+    const a = makeManifest('a', [{ id: '001_multi', sql: breakpointSql }]);
+
+    const result = mod.runPerModuleMigrations(db, [a]);
+
+    expect(result.applied).toEqual(['001_multi']);
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all() as { name: string }[];
+    const names = tables.map((t) => t.name);
+    expect(names).toContain('alpha');
+    expect(names).toContain('beta');
+
+    db.close();
+  });
+});
+
+describe('warnOrphanMigrations', () => {
+  it('warns on each recorded migration whose owning module is absent', async () => {
+    const dir = fakeJournalDir();
+    writeJournal(dir, [
+      { tag: '001_a', sql: 'CREATE TABLE x (id INTEGER);' },
+      { tag: '002_b', sql: 'CREATE TABLE y (id INTEGER);' },
+    ]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    const db = new BetterSqlite3(dbPath);
+    const a = makeManifest('a', [{ id: '001_a', sql: 'CREATE TABLE x (id INTEGER);' }]);
+    const b = makeManifest('b', [{ id: '002_b', sql: 'CREATE TABLE y (id INTEGER);' }]);
+
+    const knownOwners = mod.migrationOwnershipMap([a, b]);
+
+    // Bootstrap: install both, then drop b from the manifest list.
+    mod.runPerModuleMigrations(db, [a, b], knownOwners);
+
+    const { logger } = await import('../lib/logger.js');
+    const warnSpy = vi.spyOn(logger, 'warn');
+
+    const orphans = mod.warnOrphanMigrations(db, [a], knownOwners);
+
+    expect(orphans).toEqual(['002_b']);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [payload] = warnSpy.mock.calls[0] ?? [];
+    expect(payload).toMatchObject({ orphanMigrations: ['002_b'] });
+
+    db.close();
+  });
+
+  it('does not warn when every recorded migration is owned by an installed module', async () => {
+    const dir = fakeJournalDir();
+    writeJournal(dir, [{ tag: '001_a', sql: 'CREATE TABLE x (id INTEGER);' }]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    const db = new BetterSqlite3(dbPath);
+    const a = makeManifest('a', [{ id: '001_a', sql: 'CREATE TABLE x (id INTEGER);' }]);
+
+    mod.runPerModuleMigrations(db, [a]);
+
+    const { logger } = await import('../lib/logger.js');
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const orphans = mod.warnOrphanMigrations(db, [a]);
+
+    expect(orphans).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    db.close();
+  });
+});

--- a/apps/pops-api/src/db/per-module-migrations.ts
+++ b/apps/pops-api/src/db/per-module-migrations.ts
@@ -245,14 +245,12 @@ export function runPerModuleMigrationsByOwner(
   const insert = db.prepare('INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)');
 
   for (const entry of journal.entries) {
-    const sql = readMigrationSql(entry.tag);
-    const hash = hashSql(sql);
-
-    if (knownHashes.has(hash)) {
-      alreadyApplied.push(entry.tag);
-      continue;
-    }
-
+    // Classify ownership BEFORE the hash short-circuit. If we checked the
+    // hash first, a duplicate-SQL entry owned by an absent or unknown
+    // module would be silently bucketed as `alreadyApplied` — hiding the
+    // manifest/ownership drift this result is meant to surface. Ownership
+    // classification is the authoritative signal; hash equality only
+    // matters once we've confirmed the tag belongs to the install set.
     const owner = owners.get(entry.tag);
     if (owner === undefined) {
       // No declared owner — treat as absent and warn. This is a contract
@@ -269,6 +267,14 @@ export function runPerModuleMigrationsByOwner(
       // Owner is installed but manifest doesn't list the tag — possible
       // if the ownership map and manifest disagree. Skip defensively.
       skipped.push(entry.tag);
+      continue;
+    }
+
+    const sql = readMigrationSql(entry.tag);
+    const hash = hashSql(sql);
+
+    if (knownHashes.has(hash)) {
+      alreadyApplied.push(entry.tag);
       continue;
     }
 

--- a/apps/pops-api/src/db/per-module-migrations.ts
+++ b/apps/pops-api/src/db/per-module-migrations.ts
@@ -86,9 +86,12 @@ export function installedMigrationTags(manifests: readonly ModuleManifest[]): Re
  * tags (known but absent module) from "unowned" tags (no module claims
  * the tag at all).
  *
- * Multiple modules MUST NOT own the same migration tag — the build-time
- * registry catches duplicates as a contract violation. If a tag appears
- * in multiple manifests the last write wins and the contract guard fires.
+ * Multiple modules MUST NOT own the same migration tag. The build-time
+ * registry guard (US-11) is the primary catch, but we fail fast here
+ * too so any runtime drift between the static map and the live manifest
+ * graph surfaces as a hard error instead of silently letting the last
+ * manifest win (which would mis-attribute a migration and break the
+ * install-set filter).
  */
 export function migrationOwnershipMap(
   manifests: readonly ModuleManifest[]
@@ -96,6 +99,12 @@ export function migrationOwnershipMap(
   const owners = new Map<string, string>();
   for (const m of manifests) {
     for (const migration of m.backend?.migrations ?? []) {
+      const existingOwner = owners.get(migration.id);
+      if (existingOwner !== undefined) {
+        throw new Error(
+          `Migration tag "${migration.id}" is declared by both "${existingOwner}" and "${m.id}".`
+        );
+      }
       owners.set(migration.id, m.id);
     }
   }
@@ -189,12 +198,33 @@ export function runPerModuleMigrations(
   manifests: readonly ModuleManifest[],
   knownOwners?: ReadonlyMap<string, string>
 ): PerModuleMigrationResult {
-  ensureDrizzleTable(db);
-
-  const journal = readJournal();
   const owners = knownOwners ?? migrationOwnershipMap(manifests);
   const installedTags = installedMigrationTags(manifests);
   const installedIds = new Set(manifests.map((m) => m.id));
+  return runPerModuleMigrationsByOwner(db, installedIds, owners, installedTags);
+}
+
+/**
+ * Boot-time variant used by `db.ts`. Mirrors {@link warnOrphanMigrationsByOwner}:
+ * the live manifest graph cannot be imported during database bootstrap
+ * (manifests transitively pull `db.ts` via their tRPC routers), so callers
+ * supply the install-set of module ids and the canonical ownership map
+ * (from `migration-ownership.ts`) directly.
+ *
+ * Optionally pass `installedTags` to enforce the manifest-level "tag is
+ * declared by an installed module's manifest" guard. When omitted, every
+ * tag whose owner is installed is treated as installed too — the static
+ * ownership map is authoritative.
+ */
+export function runPerModuleMigrationsByOwner(
+  db: BetterSqlite3.Database,
+  installedIds: ReadonlySet<string>,
+  owners: ReadonlyMap<string, string>,
+  installedTags?: ReadonlySet<string>
+): PerModuleMigrationResult {
+  ensureDrizzleTable(db);
+
+  const journal = readJournal();
 
   const applied: string[] = [];
   const skipped: string[] = [];
@@ -225,7 +255,7 @@ export function runPerModuleMigrations(
       skipped.push(entry.tag);
       continue;
     }
-    if (!installedTags.has(entry.tag)) {
+    if (installedTags !== undefined && !installedTags.has(entry.tag)) {
       // Owner is installed but manifest doesn't list the tag — possible
       // if the ownership map and manifest disagree. Skip defensively.
       skipped.push(entry.tag);
@@ -238,6 +268,10 @@ export function runPerModuleMigrations(
       }
       insert.run(hash, Date.now());
     })();
+    // Keep the applied-hash cache in sync so subsequent journal entries
+    // with the same SQL body (e.g. idempotent re-creation migrations) are
+    // recognised as already applied within this same boot.
+    knownHashes.add(hash);
     applied.push(entry.tag);
   }
 

--- a/apps/pops-api/src/db/per-module-migrations.ts
+++ b/apps/pops-api/src/db/per-module-migrations.ts
@@ -1,0 +1,303 @@
+/**
+ * Per-module migration runner (PRD-101 US-09, #2543).
+ *
+ * Drizzle's flat journal lives in `drizzle-migrations/meta/_journal.json` —
+ * before PRD-101 every entry in that journal ran unconditionally on boot
+ * regardless of which modules were installed. After PRD-101 each module
+ * declares the migration tags it owns via `manifest.backend.migrations`;
+ * the runner reads `installedManifests()`, builds the union of allowed
+ * tags, and skips entries owned by absent modules.
+ *
+ * Backward compatibility: the runner records applied migrations under the
+ * same `__drizzle_migrations` hash convention `drizzle-orm/migrator` uses,
+ * so a database upgraded from the pre-PRD-101 runtime continues to work
+ * untouched — every entry already in `__drizzle_migrations` is treated as
+ * applied and no re-application is attempted.
+ *
+ * Skipped (absent-module) migrations are NOT recorded — re-enabling the
+ * module on a subsequent boot brings them in naturally.
+ *
+ * Orphan warning: if `__drizzle_migrations` contains hashes for tags
+ * whose owning module is now absent, the runner logs a warning naming each
+ * orphan tag so operators can spot leftover data from previously-installed
+ * modules. Orphan migrations are NEVER deleted — data is intact.
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { logger } from '../lib/logger.js';
+import { DRIZZLE_MIGRATIONS_DIRECTORY } from './migrations-runner.js';
+
+import type BetterSqlite3 from 'better-sqlite3';
+
+import type { ModuleManifest } from '@pops/types';
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+/**
+ * Read the drizzle journal. Returns an empty entry list if the file is
+ * missing, so the runner is safe on a brand-new repo with no drizzle
+ * artefacts yet.
+ */
+export function readJournal(): Journal {
+  try {
+    const journalPath = join(DRIZZLE_MIGRATIONS_DIRECTORY, 'meta', '_journal.json');
+    return JSON.parse(readFileSync(journalPath, 'utf8')) as Journal;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { version: '7', dialect: 'sqlite', entries: [] };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Build the union of migration ids declared by every installed module's
+ * `manifest.backend.migrations` plus core's. Returns a Set for O(1)
+ * membership lookup.
+ */
+export function installedMigrationTags(manifests: readonly ModuleManifest[]): ReadonlySet<string> {
+  const tags = new Set<string>();
+  for (const m of manifests) {
+    for (const migration of m.backend?.migrations ?? []) {
+      tags.add(migration.id);
+    }
+  }
+  return tags;
+}
+
+/**
+ * Build the inverse mapping: migration tag → owning module id. Used to
+ * warn about orphan migrations (recorded in `__drizzle_migrations` but
+ * owned by a module that isn't installed) and to distinguish "skipped"
+ * tags (known but absent module) from "unowned" tags (no module claims
+ * the tag at all).
+ *
+ * Multiple modules MUST NOT own the same migration tag — the build-time
+ * registry catches duplicates as a contract violation. If a tag appears
+ * in multiple manifests the last write wins and the contract guard fires.
+ */
+export function migrationOwnershipMap(
+  manifests: readonly ModuleManifest[]
+): ReadonlyMap<string, string> {
+  const owners = new Map<string, string>();
+  for (const m of manifests) {
+    for (const migration of m.backend?.migrations ?? []) {
+      owners.set(migration.id, m.id);
+    }
+  }
+  return owners;
+}
+
+function ensureDrizzleTable(db: BetterSqlite3.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      hash TEXT NOT NULL,
+      created_at NUMERIC
+    )
+  `);
+}
+
+function appliedHashes(db: BetterSqlite3.Database): Set<string> {
+  const rows = db.prepare('SELECT hash FROM __drizzle_migrations').all() as {
+    hash: string;
+  }[];
+  return new Set(rows.map((r) => r.hash));
+}
+
+function readMigrationSql(tag: string): string {
+  return readFileSync(join(DRIZZLE_MIGRATIONS_DIRECTORY, `${tag}.sql`), 'utf8');
+}
+
+/**
+ * Drizzle's hashing function. `drizzle-orm/migrator` records each applied
+ * migration as `sha256(sql)`. We reproduce the same hash here so a DB
+ * upgraded from the pre-PRD-101 runtime keeps working unchanged.
+ */
+function hashSql(sql: string): string {
+  return createHash('sha256').update(sql).digest('hex');
+}
+
+/**
+ * Result returned by {@link runPerModuleMigrations}. Distinguishes applied,
+ * skipped (owned by an absent module), and orphan (already-applied but
+ * owner not installed) tags so callers (tests, observability) can assert
+ * the filter worked.
+ */
+export interface PerModuleMigrationResult {
+  /** Tags applied during this run (newly inserted into __drizzle_migrations). */
+  applied: readonly string[];
+  /** Tags skipped because no installed module owns them. */
+  skipped: readonly string[];
+  /** Tags whose owner is unknown — there's no manifest claiming them. */
+  unowned: readonly string[];
+  /** Tags whose hash is already recorded — no action taken. */
+  alreadyApplied: readonly string[];
+}
+
+/**
+ * Statement-breakpoint splitter — drizzle splits multi-statement SQL files
+ * with the marker `--> statement-breakpoint` and runs each chunk separately.
+ * We mirror the same convention so files generated by `drizzle-kit` work
+ * identically through this runner.
+ */
+function splitStatements(sql: string): string[] {
+  return sql
+    .split('--> statement-breakpoint')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Apply the drizzle migration set, filtered by the install set.
+ *
+ * - Entries already in `__drizzle_migrations` (by SHA-256 hash) are
+ *   left untouched.
+ * - Entries whose owning module is not installed are skipped — nothing
+ *   is recorded so they re-run on a future boot when the module appears.
+ * - Entries with no declared owner are also skipped and reported via
+ *   the `unowned` field on the result, so the contract guard (US-11)
+ *   can flag missing ownership declarations.
+ *
+ * The `knownOwners` argument is the canonical owner map covering every
+ * buildable module (whether installed or not). It is used to distinguish
+ * "skipped" tags (owned by a known but absent module) from "unowned"
+ * tags (no manifest claims the tag at all). When omitted, ownership is
+ * derived from the installed manifests only — meaning every tag owned
+ * by an absent module is treated as `unowned`.
+ *
+ * Returns a typed breakdown of what happened. Callers may inspect
+ * `applied` / `skipped` / `unowned` / `alreadyApplied` to assert
+ * behaviour from tests.
+ */
+export function runPerModuleMigrations(
+  db: BetterSqlite3.Database,
+  manifests: readonly ModuleManifest[],
+  knownOwners?: ReadonlyMap<string, string>
+): PerModuleMigrationResult {
+  ensureDrizzleTable(db);
+
+  const journal = readJournal();
+  const owners = knownOwners ?? migrationOwnershipMap(manifests);
+  const installedTags = installedMigrationTags(manifests);
+  const installedIds = new Set(manifests.map((m) => m.id));
+
+  const applied: string[] = [];
+  const skipped: string[] = [];
+  const unowned: string[] = [];
+  const alreadyApplied: string[] = [];
+
+  const knownHashes = appliedHashes(db);
+  const insert = db.prepare('INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)');
+
+  for (const entry of journal.entries) {
+    const sql = readMigrationSql(entry.tag);
+    const hash = hashSql(sql);
+
+    if (knownHashes.has(hash)) {
+      alreadyApplied.push(entry.tag);
+      continue;
+    }
+
+    const owner = owners.get(entry.tag);
+    if (owner === undefined) {
+      // No declared owner — treat as absent and warn. This is a contract
+      // violation; CI (US-11) should catch it, but we don't want a missing
+      // ownership entry to silently apply migrations to a partial install.
+      unowned.push(entry.tag);
+      continue;
+    }
+    if (!installedIds.has(owner)) {
+      skipped.push(entry.tag);
+      continue;
+    }
+    if (!installedTags.has(entry.tag)) {
+      // Owner is installed but manifest doesn't list the tag — possible
+      // if the ownership map and manifest disagree. Skip defensively.
+      skipped.push(entry.tag);
+      continue;
+    }
+
+    db.transaction(() => {
+      for (const stmt of splitStatements(sql)) {
+        db.exec(stmt);
+      }
+      insert.run(hash, Date.now());
+    })();
+    applied.push(entry.tag);
+  }
+
+  return { applied, skipped, unowned, alreadyApplied };
+}
+
+/**
+ * Inspect `__drizzle_migrations` and warn for any recorded migration whose
+ * owning module is not currently installed. The data is intact — just
+ * inaccessible because the module is not loaded — so this is an operator
+ * info signal, not an error.
+ *
+ * Returns the list of orphan tags so tests can assert the warning surface
+ * without coupling to log internals.
+ */
+export function warnOrphanMigrations(
+  db: BetterSqlite3.Database,
+  manifests: readonly ModuleManifest[],
+  knownOwners?: ReadonlyMap<string, string>
+): readonly string[] {
+  return warnOrphanMigrationsByOwner(
+    db,
+    new Set(manifests.map((m) => m.id)),
+    knownOwners ?? migrationOwnershipMap(manifests)
+  );
+}
+
+/**
+ * Variant used at boot (`db.ts`) where the full module manifest graph
+ * cannot be imported without creating a circular dependency (manifests
+ * transitively import `db.ts` via their tRPC routers).
+ *
+ * Accepts the install-set of module ids directly plus the canonical
+ * ownership map from `migration-ownership.ts`. Behaviour is identical
+ * to {@link warnOrphanMigrations}.
+ */
+export function warnOrphanMigrationsByOwner(
+  db: BetterSqlite3.Database,
+  installedIds: ReadonlySet<string>,
+  owners: ReadonlyMap<string, string>
+): readonly string[] {
+  ensureDrizzleTable(db);
+
+  const journal = readJournal();
+  const recorded = appliedHashes(db);
+
+  const orphans: string[] = [];
+  for (const entry of journal.entries) {
+    const sql = readMigrationSql(entry.tag);
+    if (!recorded.has(hashSql(sql))) continue;
+    const owner = owners.get(entry.tag);
+    if (owner === undefined) continue;
+    if (!installedIds.has(owner)) orphans.push(entry.tag);
+  }
+
+  if (orphans.length > 0) {
+    logger.warn(
+      { orphanMigrations: orphans },
+      `[db] ${orphans.length} applied migration(s) belong to modules not in the install set — data preserved but inaccessible until the module is re-enabled.`
+    );
+  }
+  return orphans;
+}

--- a/apps/pops-api/src/db/per-module-migrations.ts
+++ b/apps/pops-api/src/db/per-module-migrations.ts
@@ -26,6 +26,8 @@ import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { z } from 'zod';
+
 import { logger } from '../lib/logger.js';
 import { DRIZZLE_MIGRATIONS_DIRECTORY } from './migrations-runner.js';
 
@@ -33,19 +35,21 @@ import type BetterSqlite3 from 'better-sqlite3';
 
 import type { ModuleManifest } from '@pops/types';
 
-interface JournalEntry {
-  idx: number;
-  version: string;
-  when: number;
-  tag: string;
-  breakpoints: boolean;
-}
+const journalEntrySchema = z.object({
+  idx: z.number(),
+  version: z.string(),
+  when: z.number(),
+  tag: z.string(),
+  breakpoints: z.boolean(),
+});
 
-interface Journal {
-  version: string;
-  dialect: string;
-  entries: JournalEntry[];
-}
+const journalSchema = z.object({
+  version: z.string(),
+  dialect: z.string(),
+  entries: z.array(journalEntrySchema),
+});
+
+type Journal = z.infer<typeof journalSchema>;
 
 /**
  * Read the drizzle journal. Returns an empty entry list if the file is
@@ -53,15 +57,21 @@ interface Journal {
  * artefacts yet.
  */
 export function readJournal(): Journal {
+  const journalPath = join(DRIZZLE_MIGRATIONS_DIRECTORY, 'meta', '_journal.json');
+  let raw: string;
   try {
-    const journalPath = join(DRIZZLE_MIGRATIONS_DIRECTORY, 'meta', '_journal.json');
-    return JSON.parse(readFileSync(journalPath, 'utf8')) as Journal;
+    raw = readFileSync(journalPath, 'utf8');
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
       return { version: '7', dialect: 'sqlite', entries: [] };
     }
     throw err;
   }
+  const parsed = journalSchema.safeParse(JSON.parse(raw));
+  if (!parsed.success) {
+    throw new Error(`Invalid drizzle journal at ${journalPath}: ${parsed.error.message}`);
+  }
+  return parsed.data;
 }
 
 /**

--- a/apps/pops-api/src/db/per-module-migrations.ts
+++ b/apps/pops-api/src/db/per-module-migrations.ts
@@ -317,6 +317,17 @@ export function warnOrphanMigrations(
  * Accepts the install-set of module ids directly plus the canonical
  * ownership map from `migration-ownership.ts`. Behaviour is identical
  * to {@link warnOrphanMigrations}.
+ *
+ * Ambiguity handling: when two or more journal entries share the same
+ * SQL body (and therefore the same hash) — e.g. duplicate idempotent
+ * `CREATE TABLE IF NOT EXISTS` migrations across modules — `__drizzle_migrations`
+ * records a single hash without any tag attribution. We cannot tell which
+ * tag was applied, so we suppress the orphan warning for every tag sharing
+ * an ambiguous hash. The apply path already handles this on its side
+ * (the second duplicate-hash entry is treated as `alreadyApplied`); the
+ * warning path needs to match or it will spuriously flag the absent
+ * module's tag as orphaned whenever the installed module's tag with the
+ * same SQL is applied.
  */
 export function warnOrphanMigrationsByOwner(
   db: BetterSqlite3.Database,
@@ -328,10 +339,21 @@ export function warnOrphanMigrationsByOwner(
   const journal = readJournal();
   const recorded = appliedHashes(db);
 
+  // Count how many journal entries map to each hash. Any hash that appears
+  // more than once is ambiguous — we cannot attribute the recorded hash to
+  // a specific tag — so all entries sharing that hash are excluded from
+  // the orphan warning.
+  const hashCounts = new Map<string, number>();
+  for (const entry of journal.entries) {
+    const hash = hashSql(readMigrationSql(entry.tag));
+    hashCounts.set(hash, (hashCounts.get(hash) ?? 0) + 1);
+  }
+
   const orphans: string[] = [];
   for (const entry of journal.entries) {
-    const sql = readMigrationSql(entry.tag);
-    if (!recorded.has(hashSql(sql))) continue;
+    const hash = hashSql(readMigrationSql(entry.tag));
+    if (!recorded.has(hash)) continue;
+    if ((hashCounts.get(hash) ?? 0) > 1) continue;
     const owner = owners.get(entry.tag);
     if (owner === undefined) continue;
     if (!installedIds.has(owner)) orphans.push(entry.tag);

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -12,10 +12,8 @@
  * The schema_migrations table is populated so that runMigrations() is a no-op
  * when it later runs against a database initialized by this function.
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-
 import { TAG_VOCABULARY_V1 } from '../shared/tag-vocabulary.js';
+import { markDrizzleMigrationsApplied } from './migrations-runner.js';
 
 import type BetterSqlite3 from 'better-sqlite3';
 
@@ -962,31 +960,15 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
     insertMigration.run(migration);
   }
 
-  // Also mark all Drizzle migrations as applied (schema already incorporates them)
-  try {
-    const drizzleMigrationsDir = join(import.meta.dirname, 'drizzle-migrations');
-    const journalPath = join(drizzleMigrationsDir, 'meta', '_journal.json');
-    const journal = JSON.parse(readFileSync(journalPath, 'utf8')) as {
-      entries: { idx: number; tag: string; when: number }[];
-    };
-
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        hash TEXT NOT NULL,
-        created_at NUMERIC
-      )
-    `);
-
-    const insertDrizzle = db.prepare(
-      'INSERT OR IGNORE INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)'
-    );
-    for (const entry of journal.entries) {
-      // Use the journal's `when` timestamp so Drizzle's timestamp-based check
-      // treats all pre-seeded migrations as already applied (folderMillis <= created_at).
-      insertDrizzle.run(entry.tag, entry.when);
-    }
-  } catch {
-    // Non-fatal — Drizzle migrate at startup will handle it
-  }
+  // Also mark all Drizzle migrations as applied (schema already incorporates them).
+  //
+  // We delegate to `markDrizzleMigrationsApplied` so the recorded hashes match
+  // `sha256(sql)` — the same convention used by the per-module migration
+  // runner (PRD-101 US-09) when it decides whether a journal entry is already
+  // applied. Previously this loop stored the migration *tag* in the hash
+  // column, which the stock drizzle-orm migrator tolerated (it skips by
+  // timestamp), but which causes the per-module runner to attempt to
+  // re-apply every migration on boot — crashing with
+  // "table `budgets` already exists" on the first non-IF-NOT-EXISTS DDL.
+  markDrizzleMigrationsApplied(db);
 }

--- a/apps/pops-api/src/modules/cerebrum/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/index.ts
@@ -6,6 +6,7 @@ import { scopesRouter } from './engrams/scopes-router.js';
 import { tagsRouter } from './engrams/tags-router.js';
 import { gliaRouter as gliaTrustRouter } from './glia/router.js';
 import { ingestRouter } from './ingest/router.js';
+import { cerebrumMigrations } from './migrations.js';
 import { nudgesRouter } from './nudges/router.js';
 import { plexusRouter } from './plexus/router.js';
 import { queryRouter } from './query/router.js';
@@ -46,6 +47,6 @@ export const manifest: ModuleManifest<typeof cerebrumRouter> = {
   surfaces: ['app'],
   description:
     'Engram storage, retrieval, ingest/emit, plexus, reflex, glia — knowledge graph and agents.',
-  backend: { router: cerebrumRouter, aiTools: cerebrumAiTools },
+  backend: { router: cerebrumRouter, aiTools: cerebrumAiTools, migrations: cerebrumMigrations },
   settings: [cerebrumManifest],
 };

--- a/apps/pops-api/src/modules/cerebrum/migrations.ts
+++ b/apps/pops-api/src/modules/cerebrum/migrations.ts
@@ -11,7 +11,7 @@ import { drizzleMigrations } from '../../db/load-drizzle-migration.js';
 
 import type { MigrationDescriptor } from '@pops/types';
 
-export const CEREBRUM_MIGRATION_TAGS: readonly string[] = [
+export const cerebrumMigrationTags: readonly string[] = [
   // engram_index — knowledge graph file metadata table.
   '0031_romantic_hannibal_king',
   // embeddings — dense vector storage.
@@ -40,4 +40,4 @@ export const CEREBRUM_MIGRATION_TAGS: readonly string[] = [
 ];
 
 export const cerebrumMigrations: readonly MigrationDescriptor[] =
-  drizzleMigrations(CEREBRUM_MIGRATION_TAGS);
+  drizzleMigrations(cerebrumMigrationTags);

--- a/apps/pops-api/src/modules/cerebrum/migrations.ts
+++ b/apps/pops-api/src/modules/cerebrum/migrations.ts
@@ -1,0 +1,43 @@
+/**
+ * Migration tags owned by the `cerebrum` module.
+ *
+ * Covers engram_index, embeddings (including the sqlite-vec virtual table),
+ * nudge_log, glia_actions, plexus_adapters, and the conversation
+ * persistence tables (which ego shares but cerebrum owns the schema).
+ *
+ * See PRD-101 US-09 for the runtime filter contract.
+ */
+import { drizzleMigrations } from '../../db/load-drizzle-migration.js';
+
+import type { MigrationDescriptor } from '@pops/types';
+
+export const CEREBRUM_MIGRATION_TAGS: readonly string[] = [
+  // engram_index — knowledge graph file metadata table.
+  '0031_romantic_hannibal_king',
+  // embeddings — dense vector storage.
+  '0032_embeddings',
+  // embeddings_vec — sqlite-vec virtual table for k-NN search.
+  '0033_embeddings_vec',
+  // engram_index: body_hash column for ingestion dedup.
+  '0036_body_hash_engram_index',
+  // conversations + messages + conversation_context (ego persistence;
+  // cerebrum owns the schema — ego depends on cerebrum).
+  '0038_sturdy_professor_monster',
+  // nudge_log — reflex/nudge audit trail.
+  '0039_dry_fabian_cortez',
+  // glia_actions — glia workers audit trail.
+  '0040_bumpy_namorita',
+  // plexus_adapters — external data-source registry.
+  '0041_plexus_adapters',
+  // nudge_log safety re-creation (idempotent, see #2329).
+  '0044_nudge_log',
+  // engram_index body_hash safety re-application (#2329).
+  '0046_engrams_body_hash',
+  // glia_actions safety re-creation (idempotent).
+  '0047_glia_actions',
+  // conversations safety re-creation (idempotent).
+  '0048_conversations',
+];
+
+export const cerebrumMigrations: readonly MigrationDescriptor[] =
+  drizzleMigrations(CEREBRUM_MIGRATION_TAGS);

--- a/apps/pops-api/src/modules/core/index.ts
+++ b/apps/pops-api/src/modules/core/index.ts
@@ -16,6 +16,7 @@ import { entitiesSearchAdapter } from './entities/search-adapter.js';
 import { coreFeaturesManifest } from './features/manifest.js';
 import { featuresRouter } from './features/router.js';
 import { jobsRouter } from './jobs/router.js';
+import { coreMigrations } from './migrations.js';
 import { searchRouter } from './search/router.js';
 import { serviceAccountsRouter } from './service-accounts/router.js';
 import { aiConfigManifest } from './settings/ai-manifest.js';
@@ -57,7 +58,7 @@ export const manifest: ModuleManifest<typeof coreRouter> = {
   surfaces: ['app'],
   description:
     'Cross-cutting platform services: entities, AI usage/providers, settings, features, search.',
-  backend: { router: coreRouter },
+  backend: { router: coreRouter, migrations: coreMigrations },
   settings: [aiConfigManifest, coreOperationalManifest],
   features: [coreFeaturesManifest],
   search: [entitiesSearchAdapter],

--- a/apps/pops-api/src/modules/core/migrations.ts
+++ b/apps/pops-api/src/modules/core/migrations.ts
@@ -19,7 +19,7 @@ import type { MigrationDescriptor } from '@pops/types';
  * `meta/_journal.json`; the runner does a journal-driven walk so this list
  * only declares ownership, not execution order.
  */
-export const CORE_MIGRATION_TAGS: readonly string[] = [
+export const coreMigrationTags: readonly string[] = [
   // Pre-modular baseline — creates entities, transactions, budgets,
   // ai_usage, home_inventory, environments, transaction_corrections, etc.
   // Cannot be sliced retroactively without breaking every prod DB.
@@ -51,5 +51,4 @@ export const CORE_MIGRATION_TAGS: readonly string[] = [
   '0054_service_accounts',
 ];
 
-export const coreMigrations: readonly MigrationDescriptor[] =
-  drizzleMigrations(CORE_MIGRATION_TAGS);
+export const coreMigrations: readonly MigrationDescriptor[] = drizzleMigrations(coreMigrationTags);

--- a/apps/pops-api/src/modules/core/migrations.ts
+++ b/apps/pops-api/src/modules/core/migrations.ts
@@ -1,0 +1,55 @@
+/**
+ * Migration tags owned by the `core` module.
+ *
+ * Core is the always-mounted platform module — every cross-cutting concern
+ * (entities, AI usage/observability/budgets, settings, search infra,
+ * service accounts) lives here. The historical baseline migration
+ * `0000_naive_chameleon` is assigned to core because it predates the
+ * modular registry and creates tables across every domain — slicing the
+ * baseline retroactively would break every production database.
+ *
+ * See PRD-101 US-09 for the runtime filter contract.
+ */
+import { drizzleMigrations } from '../../db/load-drizzle-migration.js';
+
+import type { MigrationDescriptor } from '@pops/types';
+
+/**
+ * Ordered list of drizzle migration tags owned by core. Order matches
+ * `meta/_journal.json`; the runner does a journal-driven walk so this list
+ * only declares ownership, not execution order.
+ */
+export const CORE_MIGRATION_TAGS: readonly string[] = [
+  // Pre-modular baseline — creates entities, transactions, budgets,
+  // ai_usage, home_inventory, environments, transaction_corrections, etc.
+  // Cannot be sliced retroactively without breaking every prod DB.
+  '0000_naive_chameleon',
+  // sync_logs + home_inventory rebuild (inventory-touching but assigned
+  // to core because sync_logs is the platform-level sync ledger).
+  '0009_red_quasimodo',
+  // sync_job_results — platform-level job ledger.
+  '0010_gifted_firestar',
+  // budgets unique (category, period) index — finance-touching but ships
+  // alongside the baseline budgets table in core's history.
+  '0030_budgets_unique_category_period',
+  // ai_usage → ai_inference_log rename + observability columns + providers
+  // + budgets seed. AI observability is core.
+  '0034_ai_observability',
+  // ai_inference_log: drop legacy columns.
+  '0035_ai_inference_log_drop_legacy_columns',
+  // user_settings (PRD-094 US-05).
+  '0043_user_settings',
+  // ai_inference_log safety re-creation.
+  '0045_ai_inference_log',
+  // claude-sonnet-4-6 pricing seed (#2440).
+  '0049_sonnet_4_6_model_pricing',
+  // ai.model setting alias migration (#2463).
+  '0050_ai_model_setting_alias',
+  // ai_inference_daily rollup.
+  '0053_ai_inference_daily',
+  // service_accounts (PRD-095).
+  '0054_service_accounts',
+];
+
+export const coreMigrations: readonly MigrationDescriptor[] =
+  drizzleMigrations(CORE_MIGRATION_TAGS);

--- a/apps/pops-api/src/modules/finance/index.ts
+++ b/apps/pops-api/src/modules/finance/index.ts
@@ -5,6 +5,7 @@ import { router } from '../../trpc.js';
 import { budgetsRouter } from './budgets/router.js';
 import { budgetsSearchAdapter } from './budgets/search-adapter.js';
 import { importsRouter } from './imports/router.js';
+import { financeMigrations } from './migrations.js';
 import { financeManifest } from './settings-manifest.js';
 import { transactionsRouter } from './transactions/router.js';
 import { transactionsSearchAdapter } from './transactions/search-adapter.js';
@@ -28,7 +29,7 @@ export const manifest: ModuleManifest<typeof financeRouter> = {
   version: '0.1.0',
   surfaces: ['app'],
   description: 'Transactions, budgets, entities, and import pipeline.',
-  backend: { router: financeRouter },
+  backend: { router: financeRouter, migrations: financeMigrations },
   settings: [financeManifest],
   search: [transactionsSearchAdapter, budgetsSearchAdapter, wishlistSearchAdapter],
   uriHandler: financeUriHandler,

--- a/apps/pops-api/src/modules/finance/migrations.ts
+++ b/apps/pops-api/src/modules/finance/migrations.ts
@@ -11,7 +11,7 @@ import { drizzleMigrations } from '../../db/load-drizzle-migration.js';
 
 import type { MigrationDescriptor } from '@pops/types';
 
-export const FINANCE_MIGRATION_TAGS: readonly string[] = [
+export const financeMigrationTags: readonly string[] = [
   // transaction_corrections: add is_active.
   '0025_youthful_hulk',
   // tag_vocabulary table.
@@ -24,4 +24,4 @@ export const FINANCE_MIGRATION_TAGS: readonly string[] = [
 ];
 
 export const financeMigrations: readonly MigrationDescriptor[] =
-  drizzleMigrations(FINANCE_MIGRATION_TAGS);
+  drizzleMigrations(financeMigrationTags);

--- a/apps/pops-api/src/modules/finance/migrations.ts
+++ b/apps/pops-api/src/modules/finance/migrations.ts
@@ -1,0 +1,27 @@
+/**
+ * Migration tags owned by the `finance` module.
+ *
+ * Most finance tables (transactions, budgets, transaction_corrections,
+ * transaction_tag_rules) are created in the pre-modular baseline owned by
+ * core — only follow-up ALTERs unambiguously scoped to finance live here.
+ *
+ * See PRD-101 US-09 for the runtime filter contract.
+ */
+import { drizzleMigrations } from '../../db/load-drizzle-migration.js';
+
+import type { MigrationDescriptor } from '@pops/types';
+
+export const FINANCE_MIGRATION_TAGS: readonly string[] = [
+  // transaction_corrections: add is_active.
+  '0025_youthful_hulk',
+  // tag_vocabulary table.
+  '0026_little_frank_castle',
+  // transaction_corrections + transaction_tag_rules: priority columns +
+  // indices + tag-rule backfill ordering.
+  '0027_slow_dormammu',
+  // budgets.active default flip (PRD-025 #2550).
+  '0052_budgets_active_default_zero',
+];
+
+export const financeMigrations: readonly MigrationDescriptor[] =
+  drizzleMigrations(FINANCE_MIGRATION_TAGS);

--- a/apps/pops-api/src/modules/inventory/index.ts
+++ b/apps/pops-api/src/modules/inventory/index.ts
@@ -9,6 +9,7 @@ import { inventoryFeaturesManifest } from './features.js';
 import { inventoryRouter as itemsRouter } from './items/router.js';
 import { inventoryItemsSearchAdapter } from './items/search-adapter.js';
 import { locationsRouter } from './locations/router.js';
+import { inventoryMigrations } from './migrations.js';
 import { paperlessRouter } from './paperless/router.js';
 import { photosRouter } from './photos/index.js';
 import { reportsRouter } from './reports/index.js';
@@ -35,7 +36,7 @@ export const manifest: ModuleManifest<typeof inventoryRouter> = {
   version: '0.1.0',
   surfaces: ['app'],
   description: 'Home items, locations, connections, warranties, and documents.',
-  backend: { router: inventoryRouter },
+  backend: { router: inventoryRouter, migrations: inventoryMigrations },
   settings: [inventoryManifest],
   features: [inventoryFeaturesManifest],
   search: [inventoryItemsSearchAdapter],

--- a/apps/pops-api/src/modules/inventory/migrations.ts
+++ b/apps/pops-api/src/modules/inventory/migrations.ts
@@ -10,7 +10,7 @@ import { drizzleMigrations } from '../../db/load-drizzle-migration.js';
 
 import type { MigrationDescriptor } from '@pops/types';
 
-export const INVENTORY_MIGRATION_TAGS: readonly string[] = [
+export const inventoryMigrationTags: readonly string[] = [
   // locations.
   '0005_fancy_crystal',
   // home_inventory columns (asset_id, notes, location_id).
@@ -24,4 +24,4 @@ export const INVENTORY_MIGRATION_TAGS: readonly string[] = [
 ];
 
 export const inventoryMigrations: readonly MigrationDescriptor[] =
-  drizzleMigrations(INVENTORY_MIGRATION_TAGS);
+  drizzleMigrations(inventoryMigrationTags);

--- a/apps/pops-api/src/modules/inventory/migrations.ts
+++ b/apps/pops-api/src/modules/inventory/migrations.ts
@@ -1,0 +1,27 @@
+/**
+ * Migration tags owned by the `inventory` module.
+ *
+ * Covers home_inventory items, locations, item_connections, item_documents,
+ * and direct-upload file storage.
+ *
+ * See PRD-101 US-09 for the runtime filter contract.
+ */
+import { drizzleMigrations } from '../../db/load-drizzle-migration.js';
+
+import type { MigrationDescriptor } from '@pops/types';
+
+export const INVENTORY_MIGRATION_TAGS: readonly string[] = [
+  // locations.
+  '0005_fancy_crystal',
+  // home_inventory columns (asset_id, notes, location_id).
+  '0006_motionless_speed_demon',
+  // item_connections.
+  '0007_broad_arclight',
+  // item_documents (paperless link table).
+  '0008_tough_nick_fury',
+  // item_uploaded_files (direct upload).
+  '0037_item_uploaded_files',
+];
+
+export const inventoryMigrations: readonly MigrationDescriptor[] =
+  drizzleMigrations(INVENTORY_MIGRATION_TAGS);

--- a/apps/pops-api/src/modules/media/index.ts
+++ b/apps/pops-api/src/modules/media/index.ts
@@ -10,6 +10,7 @@ import { comparisonsRouter } from './comparisons/index.js';
 import { discoveryRouter } from './discovery/index.js';
 import { mediaFeaturesManifest } from './features.js';
 import { libraryRouter } from './library/index.js';
+import { mediaMigrations } from './migrations.js';
 import { moviesRouter } from './movies/router.js';
 import { plexRouter } from './plex/index.js';
 import { rotationRouter } from './rotation/router.js';
@@ -50,7 +51,7 @@ export const manifest: ModuleManifest<typeof mediaRouter> = {
   version: '0.1.0',
   surfaces: ['app'],
   description: 'Movies, TV shows, watchlist, watch history, Plex/TMDB/TVDB sync.',
-  backend: { router: mediaRouter },
+  backend: { router: mediaRouter, migrations: mediaMigrations },
   settings: [plexManifest, arrManifest, rotationManifest, mediaOperationalManifest],
   features: [mediaFeaturesManifest],
   search: [moviesSearchAdapter, tvShowsSearchAdapter],

--- a/apps/pops-api/src/modules/media/migrations.ts
+++ b/apps/pops-api/src/modules/media/migrations.ts
@@ -10,7 +10,7 @@ import { drizzleMigrations } from '../../db/load-drizzle-migration.js';
 
 import type { MigrationDescriptor } from '@pops/types';
 
-export const MEDIA_MIGRATION_TAGS: readonly string[] = [
+export const mediaMigrationTags: readonly string[] = [
   // movies + comparisons + media_scores + watch_history + tv_shows seasons.
   '0001_many_marvel_zombies',
   // episodes — Plex-derived episode table.
@@ -58,4 +58,4 @@ export const MEDIA_MIGRATION_TAGS: readonly string[] = [
 ];
 
 export const mediaMigrations: readonly MigrationDescriptor[] =
-  drizzleMigrations(MEDIA_MIGRATION_TAGS);
+  drizzleMigrations(mediaMigrationTags);

--- a/apps/pops-api/src/modules/media/migrations.ts
+++ b/apps/pops-api/src/modules/media/migrations.ts
@@ -1,0 +1,61 @@
+/**
+ * Migration tags owned by the `media` module.
+ *
+ * Covers the movies/tv_shows/comparisons/watchlist/watch_history/library
+ * surface and the rotation/debrief subsystems.
+ *
+ * See PRD-101 US-09 for the runtime filter contract.
+ */
+import { drizzleMigrations } from '../../db/load-drizzle-migration.js';
+
+import type { MigrationDescriptor } from '@pops/types';
+
+export const MEDIA_MIGRATION_TAGS: readonly string[] = [
+  // movies + comparisons + media_scores + watch_history + tv_shows seasons.
+  '0001_many_marvel_zombies',
+  // episodes — Plex-derived episode table.
+  '0002_magical_kid_colt',
+  // episodes — second baseline iteration (drizzle generated alongside).
+  '0003_small_shotgun',
+  // watchlist + watchlist_movies.
+  '0004_tearful_mongu',
+  // dismissed_discover.
+  '0011_natural_caretaker',
+  // movies/tv_shows discover_rating_key.
+  '0012_exotic_smasher',
+  // comparisons draw_tier.
+  '0013_worthless_speed',
+  // watch_history blacklisted column.
+  '0014_dapper_payback',
+  // media_scores excluded column.
+  '0015_condemned_anthem',
+  // comparison_skip_cooloffs.
+  '0016_certain_namor',
+  // comparison_staleness.
+  '0017_loose_doomsday',
+  // debrief_results / debrief_sessions.
+  '0018_high_excalibur',
+  // tier_overrides.
+  '0019_little_diamondback',
+  // debrief_status.
+  '0020_melodic_major_mapleleaf',
+  // shelf_impressions.
+  '0021_spooky_lockheed',
+  // comparisons elo deltas.
+  '0022_elo_deltas',
+  // comparisons source column.
+  '0023_kind_james_howlett',
+  // dedupe_comparisons one-off cleanup.
+  '0024_dedupe_comparisons',
+  // rotation_log + movies rotation columns.
+  '0028_needy_terror',
+  // rotation_* tables (candidates, exclusions, sources).
+  '0029_curved_revanche',
+  // strip-quoted movie titles cleanup (#2402).
+  '0042_strip_quoted_movie_titles',
+  // strip-quoted tv_shows names cleanup (#2403).
+  '0051_strip_quoted_tv_show_titles',
+];
+
+export const mediaMigrations: readonly MigrationDescriptor[] =
+  drizzleMigrations(MEDIA_MIGRATION_TAGS);

--- a/docs/themes/01-foundation/prds/101-plugin-contract/us-09-migration-runner.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/us-09-migration-runner.md
@@ -11,17 +11,17 @@ Closes #2523.
 
 ## Acceptance Criteria
 
-- [x] Each module declares its migrations via `backend.migrations: MigrationDescriptor[]` in its manifest. `MigrationDescriptor` is `{ id: string; sql: string }` where `id` matches the canonical `schema_migrations` version key.
-- [ ] ~~Migration files are reorganised under `apps/pops-api/src/db/migrations/<module>/` (e.g. `migrations/finance/`, `migrations/cerebrum/`). Filename + content imported into the module's manifest.~~ Files stay in the drizzle-managed flat layout; manifests reference them by tag. See Notes.
-- [x] `core` migrations are owned by the `core` module and run whenever any other module is installed (core is always-present).
-- [x] Migration runner (`apps/pops-api/src/db/per-module-migrations.ts`) reads the merged ownership map from `MODULES.flatMap(m => m.backend?.migrations ?? [])`, walks the drizzle journal in order, and runs only entries whose owning module is in the install set.
-- [x] When a module is absent, its migrations are not applied — runner does not insert them in `__drizzle_migrations`. Re-enabling the module re-runs them on next boot.
-- [x] On boot: if `__drizzle_migrations` contains hashes for tags whose owning module is now absent, log a warning naming each (data is intact, just inaccessible — operator info, not an error).
-- [ ] Drizzle workflow (`pnpm drizzle:generate`) outputs into the per-module folder for whichever module owns the touched schema. Deferred — drizzle multi-config is incompatible with the historical flat baseline. New migrations are declared by adding the tag to the owning module's `MIGRATION_TAGS` list and to `migration-ownership.ts`. CI guard catches drift.
-- [x] Test: tagged tests verify (a) absent-module migrations are skipped without recording, (b) re-running with the same install set is a no-op, (c) adding an absent module on a re-run applies its previously-skipped tags, (d) orphan warnings fire when a previously-installed module is removed. Fresh-DB schema slicing (zero tables for absent modules in a brand-new SQLite file) is deferred — `initializeSchema()` still creates every table because it predates modularisation.
+- [x] Each module declares the migrations it owns as part of its manifest, with an id matching the canonical migration version key and the SQL body to apply.
+- [ ] ~~Migration files are reorganised into per-module folders so each module owns its own SQL files on disk.~~ Files stay in the historical flat layout; manifests reference them by id. See Notes.
+- [x] Core migrations are owned by the core module and always run, because core is always present.
+- [x] The migration runner walks the migration journal in order and applies only entries whose owning module is in the install set.
+- [x] When a module is absent, its migrations are not applied and not recorded. Re-enabling the module on a subsequent boot runs them naturally.
+- [x] On boot, if the migrations ledger contains entries for tags whose owning module is now absent, log a warning naming each. Data is preserved; the warning is operator info, not an error.
+- [ ] The migration-generation workflow outputs into the per-module location for whichever module owns the touched schema. Deferred — the underlying tooling is incompatible with the historical flat baseline. New migrations are declared by adding the tag to the owning module's manifest. A contract guard catches drift.
+- [x] Tests verify that absent-module migrations are skipped without recording, that re-running with the same install set is a no-op, that adding an absent module on a re-run applies its previously-skipped tags, and that orphan warnings fire when a previously-installed module is removed. Fresh-database schema slicing (zero tables for absent modules in a brand-new database file) is deferred — the legacy schema initialiser still creates every table because it predates modularisation.
 
 ## Notes
 
-- The "tables exist on disk for absent modules" gap (PRD-100 Out of Scope) is closed at the migration-application boundary. Slicing the legacy `initializeSchema()` is a follow-up — fresh databases still see every table created at init time.
-- Files stay where drizzle-kit puts them. Each module's `migrations.ts` declares an ordered list of tags it owns and reads the SQL bodies via a shared loader. The static `migration-ownership.ts` mirrors the same map for boot-time use, since `db.ts` cannot import the live manifest graph without an import cycle. A contract-guard test verifies the two stay in sync.
+- The "tables exist on disk for absent modules" gap (PRD-100 Out of Scope) is closed at the migration-application boundary. Slicing the legacy schema initialiser is a follow-up — fresh databases still see every table created at init time.
+- Migration files stay where the generator puts them. Each module declares an ordered list of tags it owns and reads the SQL bodies via a shared loader. A static ownership map mirrors the same data for boot-time use, since the runtime cannot import the live manifest graph without creating an import cycle. A contract-guard test verifies the two stay in sync.
 - Cerebrum sub-modules (ego, glia, plexus, reflex, nudge) ship as one unit — all their migrations live under cerebrum's ownership. Sub-module slicing is out of scope.

--- a/docs/themes/01-foundation/prds/101-plugin-contract/us-09-migration-runner.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/us-09-migration-runner.md
@@ -1,7 +1,7 @@
 # US-09: Migration runner consumes per-module migrations
 
 > PRD: [Plugin Contract](README.md)
-> Status: Not started
+> Status: Partial
 
 ## Description
 
@@ -11,17 +11,17 @@ Closes #2523.
 
 ## Acceptance Criteria
 
-- [ ] Each module declares its migrations via `backend.migrations: MigrationDescriptor[]` in its manifest. `MigrationDescriptor` is `{ id: string; sql: string }` where `id` matches the canonical `schema_migrations` version key.
-- [ ] Migration files are reorganised under `apps/pops-api/src/db/migrations/<module>/` (e.g. `migrations/finance/`, `migrations/cerebrum/`). Filename + content imported into the module's manifest.
-- [ ] `core` migrations remain at `migrations/core/` and run unconditionally.
-- [ ] Migration runner (`apps/pops-api/src/db/migrations-runner.ts`) reads the merged list from `MODULES.flatMap(m => m.backend?.migrations ?? [])` plus core's, sorts by `id`, and runs only un-applied entries.
-- [ ] When a module is absent, its migrations are not in the list — runner does not insert them in `schema_migrations`. Re-enabling the module re-runs them on next boot.
-- [ ] On boot: if `schema_migrations` contains version ids that no installed module owns, log a warning naming each (data is intact, just inaccessible — operator info, not an error).
-- [ ] Drizzle workflow (`pnpm drizzle:generate`) outputs into the per-module folder for whichever module owns the touched schema (configured via `drizzle.config.ts` per module). Mixed-module schema changes fail with a clear error.
-- [ ] Test: boot with `POPS_APPS=finance`, verify no cerebrum tables exist in the SQLite file. Re-boot with `POPS_APPS=finance,cerebrum`, verify cerebrum tables are created.
+- [x] Each module declares its migrations via `backend.migrations: MigrationDescriptor[]` in its manifest. `MigrationDescriptor` is `{ id: string; sql: string }` where `id` matches the canonical `schema_migrations` version key.
+- [ ] ~~Migration files are reorganised under `apps/pops-api/src/db/migrations/<module>/` (e.g. `migrations/finance/`, `migrations/cerebrum/`). Filename + content imported into the module's manifest.~~ Files stay in the drizzle-managed flat layout; manifests reference them by tag. See Notes.
+- [x] `core` migrations are owned by the `core` module and run whenever any other module is installed (core is always-present).
+- [x] Migration runner (`apps/pops-api/src/db/per-module-migrations.ts`) reads the merged ownership map from `MODULES.flatMap(m => m.backend?.migrations ?? [])`, walks the drizzle journal in order, and runs only entries whose owning module is in the install set.
+- [x] When a module is absent, its migrations are not applied — runner does not insert them in `__drizzle_migrations`. Re-enabling the module re-runs them on next boot.
+- [x] On boot: if `__drizzle_migrations` contains hashes for tags whose owning module is now absent, log a warning naming each (data is intact, just inaccessible — operator info, not an error).
+- [ ] Drizzle workflow (`pnpm drizzle:generate`) outputs into the per-module folder for whichever module owns the touched schema. Deferred — drizzle multi-config is incompatible with the historical flat baseline. New migrations are declared by adding the tag to the owning module's `MIGRATION_TAGS` list and to `migration-ownership.ts`. CI guard catches drift.
+- [x] Test: tagged tests verify (a) absent-module migrations are skipped without recording, (b) re-running with the same install set is a no-op, (c) adding an absent module on a re-run applies its previously-skipped tags, (d) orphan warnings fire when a previously-installed module is removed. Fresh-DB schema slicing (zero tables for absent modules in a brand-new SQLite file) is deferred — `initializeSchema()` still creates every table because it predates modularisation.
 
 ## Notes
 
-- The "tables exist on disk for absent modules" gap (PRD-100 Out of Scope) is closed here.
-- Drizzle multi-config is the right move because keeping one global drizzle config defeats the per-module ownership the contract demands.
-- Cerebrum sub-modules (ego, glia, plexus, reflex, nudge) ship as one unit — all their migrations live under `migrations/cerebrum/`. Sub-module slicing is out of scope.
+- The "tables exist on disk for absent modules" gap (PRD-100 Out of Scope) is closed at the migration-application boundary. Slicing the legacy `initializeSchema()` is a follow-up — fresh databases still see every table created at init time.
+- Files stay where drizzle-kit puts them. Each module's `migrations.ts` declares an ordered list of tags it owns and reads the SQL bodies via a shared loader. The static `migration-ownership.ts` mirrors the same map for boot-time use, since `db.ts` cannot import the live manifest graph without an import cycle. A contract-guard test verifies the two stay in sync.
+- Cerebrum sub-modules (ego, glia, plexus, reflex, nudge) ship as one unit — all their migrations live under cerebrum's ownership. Sub-module slicing is out of scope.


### PR DESCRIPTION
Closes #2543.

## Summary
- Each backend module (`core`, `finance`, `media`, `inventory`, `cerebrum`) declares its drizzle migration tags via `manifest.backend.migrations`. The descriptor list is materialised by a shared loader that reads SQL bodies from `db/drizzle-migrations/<tag>.sql` at module-load time.
- New `db/per-module-migrations.ts` walks the drizzle journal, skips entries owned by absent modules, and records applied tags under the same `__drizzle_migrations` hash convention `drizzle-orm/migrator` uses — existing prod databases continue to work untouched.
- `db.ts` boot warns about migrations whose owning module is no longer in the install set (data preserved, operator info only).
- Static `migration-ownership.ts` mirrors the per-module declarations for use during boot, where the live manifest graph cannot be loaded without a `db.ts` import cycle. A contract-guard test verifies the two stay in sync.

## Approach trade-off
Option A (physically split files into `migrations/<module>/`) would require renaming every migration row in `__drizzle_migrations` on every existing production database — high blast radius. Option B (keep files in the drizzle-managed flat layout, tag each migration with its owner) gives the same functional outcome at runtime with zero migration-record disruption. **Shipped option B.**

## Known follow-up
Fresh-DB schema slicing (zero tables for absent modules in a brand-new SQLite file) is **deferred** — the legacy `initializeSchema()` creates every table because it predates modularisation. Slicing it per-module is a substantial refactor that warrants its own US. The runtime filter ships as a pure addition: existing prod boots see no behaviour change, and the orphan warning gives operators a signal when a previously-installed module leaves data behind.

## Test plan
- [x] `pnpm typecheck` (19/19 tasks pass)
- [x] `pnpm test` for `@pops/api` — 4087/4087 tests pass
- [x] New tests cover: install-set filtering, re-run idempotency, late module-add behaviour, unowned-tag reporting, statement-breakpoint splitting, orphan warnings, contract guard (ownership map ↔ manifest declarations)
- [x] `pnpm format:check` clean
- [x] `pnpm lint` clean (0 errors)
- [x] `pnpm registry:build` no diff

## Files
- `apps/pops-api/src/db/per-module-migrations.ts` — runner + filter logic
- `apps/pops-api/src/db/migration-ownership.ts` — static owner map (boot-safe, no manifest import cycle)
- `apps/pops-api/src/db/load-drizzle-migration.ts` — SQL loader for `MigrationDescriptor`
- `apps/pops-api/src/modules/<m>/migrations.ts` — per-module tag lists (5 files)
- `apps/pops-api/src/db.ts` — orphan-warning boot wiring
- Updated `manifest.backend.migrations` in each module's `index.ts`