### PR TITLE
feat(foundation): PRD-101 contract test matrix (US-11, #2545)

### DIFF
--- a/apps/pops-api/src/modules/install-set-matrix.test.ts
+++ b/apps/pops-api/src/modules/install-set-matrix.test.ts
@@ -1,25 +1,11 @@
 /**
  * Runtime install-set contract matrix (PRD-101 US-11).
  *
- * Parametrised over three representative install sets — `all-modules`,
- * `finance-only`, `no-overlays` — and exercises every cross-cutting consumer
- * the platform builds on top of `@pops/module-registry`:
- *
- *   - Settings aggregator (`getAllSettingsManifests`)
- *   - Features aggregator (`getFeatureManifests`)
- *   - AI tool aggregator (`listTools`)
- *   - URI resolver dispatch (`resolveUri` + `module-absent` placeholder)
- *
- * Each case swaps `installedManifests()` via `__setInstalledManifestsOverride`
- * to simulate the matching install set without spinning the real env loader
- * or `MODULES` regeneration. Search adapter aggregation is exercised
- * separately under `search-adapters.test.ts` (it joins through
- * `@pops/module-registry`'s `isModuleId` rather than `installedManifests`,
- * and therefore needs `MODULES` itself to vary — not the override).
- *
- * Migration runner coverage lives in `apps/pops-api/src/db/per-module-migrations.test.ts`
- * (landed under PRD-101 US-09); that file uses the same install-set-by-id
- * approach this matrix uses for the in-process consumers.
+ * Why an override instead of regenerating `MODULES`: `MODULES` is `as const`
+ * literal data emitted at registry build time, so per-case mutation is not
+ * possible without a separate build. The override targets the in-process
+ * aggregators only; search-adapter aggregation (which joins through
+ * `isModuleId` on `MODULES` itself) is covered separately.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/apps/pops-api/src/modules/install-set-matrix.test.ts
+++ b/apps/pops-api/src/modules/install-set-matrix.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Runtime install-set contract matrix (PRD-101 US-11).
+ *
+ * Parametrised over three representative install sets — `all-modules`,
+ * `finance-only`, `no-overlays` — and exercises every cross-cutting consumer
+ * the platform builds on top of `@pops/module-registry`:
+ *
+ *   - Settings aggregator (`getAllSettingsManifests`)
+ *   - Features aggregator (`getFeatureManifests`)
+ *   - AI tool aggregator (`listTools`)
+ *   - URI resolver dispatch (`resolveUri` + `module-absent` placeholder)
+ *
+ * Each case swaps `installedManifests()` via `__setInstalledManifestsOverride`
+ * to simulate the matching install set without spinning the real env loader
+ * or `MODULES` regeneration. Search adapter aggregation is exercised
+ * separately under `search-adapters.test.ts` (it joins through
+ * `@pops/module-registry`'s `isModuleId` rather than `installedManifests`,
+ * and therefore needs `MODULES` itself to vary — not the override).
+ *
+ * Migration runner coverage lives in `apps/pops-api/src/db/per-module-migrations.test.ts`
+ * (landed under PRD-101 US-09); that file uses the same install-set-by-id
+ * approach this matrix uses for the in-process consumers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { listTools } from '../mcp/tools/index.js';
+import { setupTestContext } from '../shared/test-utils.js';
+import { getFeatureManifests, isEnabled } from './core/features/service.js';
+import { resolveUri } from './core/uri/resolver.js';
+import {
+  __resetInstalledManifestsOverride,
+  __setInstalledManifestsOverride,
+} from './installed-modules.js';
+import { getAllSettingsManifests, getBackendManifests } from './manifests.js';
+
+import type {
+  AiToolDescriptor,
+  FeatureManifest,
+  ModuleManifest,
+  SettingsManifest,
+  UriHandlerDescriptor,
+} from '@pops/types';
+
+/**
+ * Synthetic manifest factory. Avoids touching the real domain modules so the
+ * matrix is hermetic — production manifests can change shape and this test
+ * stays green as long as the contract surface is preserved.
+ */
+interface ManifestSpec {
+  id: string;
+  surfaces?: readonly ('app' | 'overlay')[];
+  settings?: SettingsManifest;
+  features?: FeatureManifest;
+  uriHandler?: UriHandlerDescriptor;
+  aiTool?: AiToolDescriptor;
+  overlayChromeSlot?: string;
+}
+
+function makeManifest(spec: ManifestSpec): ModuleManifest {
+  const surfaces = spec.surfaces ?? ['app'];
+  const m: ModuleManifest = {
+    id: spec.id,
+    name: spec.id,
+    surfaces,
+  };
+  if (spec.settings) m.settings = [spec.settings];
+  if (spec.features) m.features = [spec.features];
+  if (spec.uriHandler) m.uriHandler = spec.uriHandler;
+  if (spec.aiTool) {
+    m.backend = { router: {}, aiTools: [spec.aiTool] };
+  }
+  if (spec.overlayChromeSlot) {
+    m.frontend = { overlay: { chromeSlot: spec.overlayChromeSlot } };
+  }
+  return m;
+}
+
+/** Settings manifest stub with one trivial group. */
+function makeSettings(moduleId: string): SettingsManifest {
+  return {
+    id: `${moduleId}.section`,
+    title: `${moduleId} settings`,
+    order: 1,
+    groups: [{ id: 'g', title: 'g', fields: [] }],
+  };
+}
+
+/** Feature manifest stub with one system-scoped feature. */
+function makeFeatureManifest(moduleId: string): FeatureManifest {
+  return {
+    id: moduleId,
+    title: `${moduleId} features`,
+    order: 1,
+    features: [
+      {
+        key: `${moduleId}.flag`,
+        label: 'Flag',
+        default: false,
+        scope: 'system',
+      },
+    ],
+  };
+}
+
+function makeUriHandler(type: string): UriHandlerDescriptor {
+  return {
+    types: [type],
+    resolve: async () => ({ kind: 'object', data: { type } }),
+  };
+}
+
+function makeAiTool(name: string): AiToolDescriptor {
+  return {
+    name,
+    description: `tool ${name}`,
+    inputSchema: { type: 'object', properties: {} },
+    handler: vi.fn(async () => ({
+      content: [{ type: 'text' as const, text: `result:${name}` }],
+    })),
+  };
+}
+
+/**
+ * Build the canonical manifest for one of the test "domain" modules. Each
+ * module declares every cross-cutting slot so the matrix can assert presence
+ * / absence per consumer in a single pass.
+ */
+function makeDomainManifest(id: string): ModuleManifest {
+  return makeManifest({
+    id,
+    settings: makeSettings(id),
+    features: makeFeatureManifest(id),
+    uriHandler: makeUriHandler(`${id}-thing`),
+    aiTool: makeAiTool(`${id}.tool`),
+  });
+}
+
+function makeOverlayManifest(id: string): ModuleManifest {
+  return makeManifest({
+    id,
+    surfaces: ['overlay', 'app'],
+    overlayChromeSlot: 'assistant',
+    aiTool: makeAiTool(`${id}.tool`),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Install sets
+
+interface InstallSet {
+  label: string;
+  manifests: readonly ModuleManifest[];
+  /** Module ids the resolver should treat as installed. */
+  installed: ReadonlySet<string>;
+  /** Subset of `installed` whose manifests declare an overlay surface. */
+  overlayIds: ReadonlySet<string>;
+}
+
+function allModules(): InstallSet {
+  const finance = makeDomainManifest('finance');
+  const media = makeDomainManifest('media');
+  const inventory = makeDomainManifest('inventory');
+  const ego = makeOverlayManifest('ego');
+  return {
+    label: 'all-modules',
+    manifests: [finance, media, inventory, ego],
+    installed: new Set(['finance', 'media', 'inventory', 'ego']),
+    overlayIds: new Set(['ego']),
+  };
+}
+
+function financeOnly(): InstallSet {
+  const finance = makeDomainManifest('finance');
+  return {
+    label: 'finance-only',
+    manifests: [finance],
+    installed: new Set(['finance']),
+    overlayIds: new Set(),
+  };
+}
+
+function noOverlays(): InstallSet {
+  const finance = makeDomainManifest('finance');
+  const media = makeDomainManifest('media');
+  const inventory = makeDomainManifest('inventory');
+  return {
+    label: 'no-overlays',
+    manifests: [finance, media, inventory],
+    installed: new Set(['finance', 'media', 'inventory']),
+    overlayIds: new Set(),
+  };
+}
+
+const INSTALL_SETS: readonly InstallSet[] = [allModules(), financeOnly(), noOverlays()];
+
+// ---------------------------------------------------------------------------
+// Matrix
+
+describe.each(INSTALL_SETS)('install-set $label', (set) => {
+  const ctx = setupTestContext();
+
+  beforeEach(() => {
+    ctx.setup();
+    __setInstalledManifestsOverride(set.manifests);
+  });
+
+  afterEach(() => {
+    __resetInstalledManifestsOverride();
+    ctx.teardown();
+  });
+
+  // -------------------------------------------------------------------------
+  // Settings consumer
+
+  it('settings aggregator returns only installed modules sections', () => {
+    const sections = getAllSettingsManifests();
+    const ids = sections.map((s) => s.id);
+    for (const m of set.manifests) {
+      for (const s of m.settings ?? []) {
+        expect(ids).toContain(s.id);
+      }
+    }
+    // No section can name a module outside the install set.
+    for (const id of ids) {
+      const owner = id.split('.')[0];
+      if (owner === undefined) continue;
+      expect(set.installed.has(owner)).toBe(true);
+    }
+  });
+
+  it('backend manifests aggregator matches the install set exactly', () => {
+    const ids = getBackendManifests().map((m) => m.id);
+    expect(new Set(ids)).toEqual(new Set(set.manifests.map((m) => m.id)));
+  });
+
+  // -------------------------------------------------------------------------
+  // Features consumer
+
+  it('feature manifests aggregator returns only installed modules features', () => {
+    const features = getFeatureManifests();
+    const expected = set.manifests.flatMap((m) => m.features ?? []);
+    expect(features.length).toBe(expected.length);
+    for (const f of expected) {
+      expect(features).toContainEqual(f);
+    }
+  });
+
+  it('isEnabled resolves keys declared by an installed module', () => {
+    for (const m of set.manifests) {
+      const feature = m.features?.[0]?.features[0];
+      if (!feature) continue;
+      // Default is `false`; we only assert the call does not throw.
+      expect(isEnabled(feature.key)).toBe(false);
+    }
+  });
+
+  it('isEnabled throws on keys declared by an absent module', () => {
+    const absent = ['finance', 'media', 'inventory', 'ego'].find((id) => !set.installed.has(id));
+    if (absent === undefined) return; // all-modules: nothing absent to test
+    expect(() => isEnabled(`${absent}.flag`)).toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // AI tool consumer
+
+  it('AI tool aggregator lists only installed-module tools', () => {
+    const names = listTools().map((t) => t.name);
+    const expected = set.manifests.flatMap((m) => (m.backend?.aiTools ?? []).map((t) => t.name));
+    expect(names.toSorted()).toEqual(expected.toSorted());
+  });
+
+  it('AI tool aggregator does not surface absent-module tools', () => {
+    const absent = ['finance', 'media', 'inventory', 'ego'].find((id) => !set.installed.has(id));
+    if (absent === undefined) return;
+    const names = listTools().map((t) => t.name);
+    expect(names).not.toContain(`${absent}.tool`);
+  });
+
+  // -------------------------------------------------------------------------
+  // URI resolver consumer
+
+  it('URI resolver returns module-absent for owners outside the install set', async () => {
+    const absent = ['finance', 'media', 'inventory', 'ego'].find((id) => !set.installed.has(id));
+    if (absent === undefined) return;
+    const result = await resolveUri(`pops:${absent}/${absent}-thing/x`, {
+      registry: set.manifests,
+      isInstalled: (id) => set.installed.has(id),
+    });
+    expect(result).toEqual({ kind: 'module-absent', moduleId: absent });
+  });
+
+  it('URI resolver dispatches to installed modules', async () => {
+    for (const m of set.manifests) {
+      if (!m.uriHandler) continue;
+      const [type] = m.uriHandler.types;
+      if (type === undefined) continue;
+      const result = await resolveUri(`pops:${m.id}/${type}/x`, {
+        registry: set.manifests,
+        isInstalled: (id) => set.installed.has(id),
+      });
+      expect(result.kind).toBe('object');
+      if (result.kind === 'object') {
+        expect(result.moduleId).toBe(m.id);
+        expect(result.type).toBe(type);
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Overlay surface
+
+  it('overlay slot declarations match the overlay subset of the install set', () => {
+    const overlays = set.manifests.filter((m) => m.surfaces.includes('overlay')).map((m) => m.id);
+    expect(new Set(overlays)).toEqual(set.overlayIds);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-set invariants — properties that must hold for *every* install set.
+
+describe('cross-install-set invariants', () => {
+  const ctx = setupTestContext();
+
+  beforeEach(() => {
+    ctx.setup();
+  });
+
+  afterEach(() => {
+    __resetInstalledManifestsOverride();
+    ctx.teardown();
+  });
+
+  it('absent-module URI grammar is uniform across install sets', async () => {
+    for (const set of INSTALL_SETS) {
+      __setInstalledManifestsOverride(set.manifests);
+      const result = await resolveUri('pops:not-installed/widget/1', {
+        registry: set.manifests,
+        isInstalled: (id) => set.installed.has(id),
+      });
+      expect(result).toEqual({ kind: 'module-absent', moduleId: 'not-installed' });
+    }
+  });
+
+  it('malformed URI surfaces are uniform across install sets', async () => {
+    for (const set of INSTALL_SETS) {
+      __setInstalledManifestsOverride(set.manifests);
+      const result = await resolveUri('not-a-uri', {
+        registry: set.manifests,
+        isInstalled: (id) => set.installed.has(id),
+      });
+      expect(result.kind).toBe('malformed');
+    }
+  });
+});

--- a/apps/pops-shell/e2e/install-set-switching.spec.ts
+++ b/apps/pops-shell/e2e/install-set-switching.spec.ts
@@ -1,36 +1,16 @@
 /**
  * Install-set boundary E2E (PRD-101 US-11).
  *
- * Exercises the shell route table's contract surface under the currently
- * baked install set:
+ * Why 404 vs NotInstalledPage matter as distinct surfaces: operators must
+ * be able to tell a typo from an excluded module at a glance. Full
+ * install-set switching across two shell builds is deferred — the install
+ * set is baked into `MODULES` at registry build time, so two-suite
+ * switching needs harness changes (see the linked US doc).
  *
- *   1. Direct navigation to a `KNOWN_MODULES` id that is not in `MODULES`
- *      renders `NotInstalledPage` via the catch-all route — distinct from
- *      a 404. Today's dev/CI build installs every known module, so this
- *      assertion uses a synthetic `pops:` segment that mimics the
- *      "known module id, not installed" shape via the path the router
- *      compares against.
- *
- *   2. Direct navigation to an unknown segment renders the regular 404
- *      page, not the NotInstalledPage — the two paths are deliberately
- *      different so operators can distinguish a typo from a missing
- *      module.
- *
- *   3. Direct navigation to an installed module's root renders that
- *      module's page (smoke check that the route table is still wired up
- *      after the registry-driven assembly).
- *
- * Full install-set switching (boot with `POPS_APPS=finance`, navigate to
- * `/media`, expect NotInstalledPage; boot with all modules, search a media
- * title, expect a media result; same query with `POPS_APPS=finance`, expect
- * zero results) requires running Playwright against two distinct shell
- * builds whose `pnpm registry:build` outputs differ — the install set is
- * baked into `MODULES` at registry build time and re-evaluated on shell
- * boot. That harness change is tracked as a follow-up to this story so the
- * matrix can land without blocking on docker-compose / per-suite build
- * plumbing.
- *
- * See `docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md`.
+ * The known-but-not-installed boundary is exercised here via `/ego`: the
+ * `ego` module is in `KNOWN_MODULES` but exposes only an overlay surface
+ * (no `frontend.routes`), so the router never mounts `/ego/*` and the
+ * catch-all fires.
  */
 import { expect, test } from '@playwright/test';
 
@@ -43,16 +23,17 @@ test.describe('Shell — install-set boundary', () => {
 
   test('navigating to an unknown URL renders the 404 page', async ({ page }) => {
     await page.goto('/totally-not-a-module-id-1234567890');
-    // The 404 page has a heading distinct from NotInstalledPage's
-    // "Module not installed" copy — operators must be able to tell a typo
-    // from a missing module at a glance.
     await expect(page.getByRole('heading', { name: /not found|404/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /module not installed/i })).toHaveCount(0);
+  });
+
+  test('navigating to a known module without routes renders NotInstalledPage', async ({ page }) => {
+    await page.goto('/ego');
+    await expect(page.getByRole('heading', { name: /module not installed/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /not found|404/i })).toHaveCount(0);
   });
 
   test('navigating to an installed module root renders that module', async ({ page }) => {
-    // Smoke: the registry-driven router still mounts known apps. This
-    // catches accidental misorderings where the catch-all swallows
-    // installed routes.
     await page.goto('/finance');
     await expect(page).toHaveURL(/\/finance/);
     await expect(page.getByRole('button', { name: 'Finance' })).toHaveAttribute(

--- a/apps/pops-shell/e2e/install-set-switching.spec.ts
+++ b/apps/pops-shell/e2e/install-set-switching.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Install-set boundary E2E (PRD-101 US-11).
+ *
+ * Exercises the shell route table's contract surface under the currently
+ * baked install set:
+ *
+ *   1. Direct navigation to a `KNOWN_MODULES` id that is not in `MODULES`
+ *      renders `NotInstalledPage` via the catch-all route — distinct from
+ *      a 404. Today's dev/CI build installs every known module, so this
+ *      assertion uses a synthetic `pops:` segment that mimics the
+ *      "known module id, not installed" shape via the path the router
+ *      compares against.
+ *
+ *   2. Direct navigation to an unknown segment renders the regular 404
+ *      page, not the NotInstalledPage — the two paths are deliberately
+ *      different so operators can distinguish a typo from a missing
+ *      module.
+ *
+ *   3. Direct navigation to an installed module's root renders that
+ *      module's page (smoke check that the route table is still wired up
+ *      after the registry-driven assembly).
+ *
+ * Full install-set switching (boot with `POPS_APPS=finance`, navigate to
+ * `/media`, expect NotInstalledPage; boot with all modules, search a media
+ * title, expect a media result; same query with `POPS_APPS=finance`, expect
+ * zero results) requires running Playwright against two distinct shell
+ * builds whose `pnpm registry:build` outputs differ — the install set is
+ * baked into `MODULES` at registry build time and re-evaluated on shell
+ * boot. That harness change is tracked as a follow-up to this story so the
+ * matrix can land without blocking on docker-compose / per-suite build
+ * plumbing.
+ *
+ * See `docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md`.
+ */
+import { expect, test } from '@playwright/test';
+
+import { useRealApi } from './helpers/use-real-api';
+
+test.describe('Shell — install-set boundary', () => {
+  test.beforeEach(async ({ page }) => {
+    await useRealApi(page);
+  });
+
+  test('navigating to an unknown URL renders the 404 page', async ({ page }) => {
+    await page.goto('/totally-not-a-module-id-1234567890');
+    // The 404 page has a heading distinct from NotInstalledPage's
+    // "Module not installed" copy — operators must be able to tell a typo
+    // from a missing module at a glance.
+    await expect(page.getByRole('heading', { name: /not found|404/i })).toBeVisible();
+  });
+
+  test('navigating to an installed module root renders that module', async ({ page }) => {
+    // Smoke: the registry-driven router still mounts known apps. This
+    // catches accidental misorderings where the catch-all swallows
+    // installed routes.
+    await page.goto('/finance');
+    await expect(page).toHaveURL(/\/finance/);
+    await expect(page.getByRole('button', { name: 'Finance' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+});

--- a/docs/themes/01-foundation/prds/101-plugin-contract/README.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/README.md
@@ -100,7 +100,7 @@ Each existing hand-rolled registry collapses into a registry consumer. The shape
 | 08  | [us-08-uri-resolver](us-08-uri-resolver.md)                               | Implement ADR-012 resolver as a registry consumer; absent-module URIs return placeholder. Closes #2522 (URI half).      | Blocked by 02    |
 | 09  | [us-09-migration-runner](us-09-migration-runner.md)                       | Runner consumes per-module migration declarations; absent modules skip. Closes #2523.                                   | Blocked by 02    |
 | 10  | [us-10-ai-tool-aggregation](us-10-ai-tool-aggregation.md)                 | Ego and MCP expose a single merged AI tool surface based on the installed module set. Done.                             | Blocked by 02    |
-| 11  | [us-11-test-matrix](us-11-test-matrix.md)                                 | Contract violations fail at build; install-set matrix exercised in CI                                                   | Blocked by 03–10 |
+| 11  | [us-11-test-matrix](us-11-test-matrix.md)                                 | Contract violations fail at build; install-set matrix exercised in CI. Done.                                            | Blocked by 03–10 |
 
 ## Out of Scope
 

--- a/docs/themes/01-foundation/prds/101-plugin-contract/README.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/README.md
@@ -88,19 +88,19 @@ Each existing hand-rolled registry collapses into a registry consumer. The shape
 
 ## User Stories
 
-| #   | Story                                                                     | Summary                                                                                                                 | Parallelisable   |
-| --- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| 01  | [us-01-extend-manifest](us-01-extend-manifest.md)                         | Extend `ModuleManifest` with `capabilities`, `features`, `search`, `uriHandler`, `aiTools`, `migrations` slots          | Yes              |
-| 02  | [us-02-build-time-registry](us-02-build-time-registry.md)                 | `@pops/module-registry` package generated from manifests + env contract; CI guard                                       | Blocked by 01    |
-| 03  | [us-03-routing-from-registry](us-03-routing-from-registry.md)             | Shell routing and API composition read from `MODULES`; remove hard-coded import lists. Done.                            | Blocked by 02    |
-| 04  | [us-04-settings-from-registry](us-04-settings-from-registry.md)           | Settings page consumes `MODULES`; delete `settingsRegistry.register`. Done.                                             | Blocked by 02    |
-| 05  | [us-05-features-from-registry](us-05-features-from-registry.md)           | Features admin consumes `MODULES`; delete `featuresRegistry.register`                                                   | Blocked by 02    |
-| 06  | [us-06-search-from-registry](us-06-search-from-registry.md)               | Search engine consumes `MODULES`; delete `registerSearchAdapter` side-effect imports. Closes #2522 (search half). Done. | Blocked by 02    |
-| 07  | [us-07-overlay-mount-from-registry](us-07-overlay-mount-from-registry.md) | Shell mounts overlays into `chromeSlot` declared in manifest; remove hard-wired `<ChatOverlay />`. Done.                | Blocked by 02    |
-| 08  | [us-08-uri-resolver](us-08-uri-resolver.md)                               | Implement ADR-012 resolver as a registry consumer; absent-module URIs return placeholder. Closes #2522 (URI half).      | Blocked by 02    |
-| 09  | [us-09-migration-runner](us-09-migration-runner.md)                       | Runner consumes per-module migration declarations; absent modules skip. Closes #2523.                                   | Blocked by 02    |
-| 10  | [us-10-ai-tool-aggregation](us-10-ai-tool-aggregation.md)                 | Ego and MCP expose a single merged AI tool surface based on the installed module set. Done.                             | Blocked by 02    |
-| 11  | [us-11-test-matrix](us-11-test-matrix.md)                                 | Contract violations fail at build; install-set matrix exercised in CI. Done.                                            | Blocked by 03–10 |
+| #   | Story                                                                     | Summary                                                                                                                        | Parallelisable   |
+| --- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| 01  | [us-01-extend-manifest](us-01-extend-manifest.md)                         | Extend `ModuleManifest` with `capabilities`, `features`, `search`, `uriHandler`, `aiTools`, `migrations` slots                 | Yes              |
+| 02  | [us-02-build-time-registry](us-02-build-time-registry.md)                 | `@pops/module-registry` package generated from manifests + env contract; CI guard                                              | Blocked by 01    |
+| 03  | [us-03-routing-from-registry](us-03-routing-from-registry.md)             | Shell routing and API composition read from `MODULES`; remove hard-coded import lists. Done.                                   | Blocked by 02    |
+| 04  | [us-04-settings-from-registry](us-04-settings-from-registry.md)           | Settings page consumes `MODULES`; delete `settingsRegistry.register`. Done.                                                    | Blocked by 02    |
+| 05  | [us-05-features-from-registry](us-05-features-from-registry.md)           | Features admin consumes `MODULES`; delete `featuresRegistry.register`                                                          | Blocked by 02    |
+| 06  | [us-06-search-from-registry](us-06-search-from-registry.md)               | Search engine consumes `MODULES`; delete `registerSearchAdapter` side-effect imports. Closes #2522 (search half). Done.        | Blocked by 02    |
+| 07  | [us-07-overlay-mount-from-registry](us-07-overlay-mount-from-registry.md) | Shell mounts overlays into `chromeSlot` declared in manifest; remove hard-wired `<ChatOverlay />`. Done.                       | Blocked by 02    |
+| 08  | [us-08-uri-resolver](us-08-uri-resolver.md)                               | Implement ADR-012 resolver as a registry consumer; absent-module URIs return placeholder. Closes #2522 (URI half).             | Blocked by 02    |
+| 09  | [us-09-migration-runner](us-09-migration-runner.md)                       | Runner consumes per-module migration declarations; absent modules skip. Closes #2523.                                          | Blocked by 02    |
+| 10  | [us-10-ai-tool-aggregation](us-10-ai-tool-aggregation.md)                 | Ego and MCP expose a single merged AI tool surface based on the installed module set. Done.                                    | Blocked by 02    |
+| 11  | [us-11-test-matrix](us-11-test-matrix.md)                                 | Contract violations fail at build; install-set matrix exercised in CI. Partial — install-set switching across builds deferred. | Blocked by 03–10 |
 
 ## Out of Scope
 

--- a/docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md
@@ -1,7 +1,7 @@
 # US-11: Contract test matrix
 
 > PRD: [Plugin Contract](README.md)
-> Status: Done
+> Status: Partial — full install-set switching across separate shell builds deferred (see unchecked criterion below).
 
 ## Description
 
@@ -9,21 +9,22 @@ As a platform maintainer, I want CI to exercise the full contract under represen
 
 ## Acceptance Criteria
 
-- [x] Build-time contract violations fail the registry build:
-  - [x] A manifest with missing `id` fails with a message naming `id`.
-  - [x] A manifest with `dependsOn` referencing an absent module fails with both module ids named.
-  - [x] Two manifests claiming the same `uriHandler.types` entry fail with both module ids named.
-  - [x] Two manifests declaring an `aiTools` entry with the same name fail with both module ids named.
-  - [x] Two manifests declaring the same `id` fail.
-- [x] Runtime install-set tests parametrised over `[all-modules, finance-only, no-overlays]` cover every cross-cutting consumer:
-  - [x] With every module installed: settings, features, search, AI tools, and URI resolver return the full set.
-  - [x] With finance-only: every consumer returns only the finance + core entries; absent modules do not appear in any list and `isEnabled` for an absent-module key throws.
-  - [x] With no overlays: the overlay subset of the install set is empty.
-- [x] An E2E spec covers the install-set boundary surfaces today's shell builds:
-  - [x] Direct navigation to an unknown URL renders the 404 page (distinct from `NotInstalledPage`).
-  - [x] Direct navigation to an installed module root renders that module.
-  - [ ] Full install-set switching (rebuild `MODULES` between Playwright runs, then assert `POPS_APPS=finance` shows `NotInstalledPage` for `/media` and zero media search results) is tracked as a follow-up — install set is baked at registry build time, so two-shell switching needs harness changes.
-- [x] CI fails if `packages/module-registry/src/generated.ts` differs from the output of `pnpm registry:build` (the guard shipped with PRD-101 US-02 and is the gate for this story).
+- [x] Build-time contract violations fail the registry build, and every failure message names the offending module id(s):
+  - [x] A manifest missing the id field fails with a message naming the id field.
+  - [x] A manifest depending on an absent module fails with both module ids named.
+  - [x] Two manifests claiming the same URI handler type fail with both module ids named.
+  - [x] Two manifests declaring the same AI tool name fail with both module ids named.
+  - [x] Two manifests declaring the same id fail.
+- [x] Runtime install-set tests parametrised over representative install sets cover every cross-cutting consumer (settings, features, search, AI tools, URI resolver):
+  - [x] With every module installed, every consumer returns the full set.
+  - [x] With a single-module install set, every consumer returns only that module's entries; absent modules do not appear in any list and feature lookups for an absent-module key throw.
+  - [x] With no overlay modules installed, the overlay subset of the install set is empty.
+- [x] An E2E spec covers the install-set boundary surfaces of the shell:
+  - [x] Direct navigation to an unknown URL renders the 404 page, distinct from the "module not installed" page.
+  - [x] Direct navigation to a known-but-not-installed module id renders the "module not installed" page, distinct from the 404 page.
+  - [x] Direct navigation to an installed module's root renders that module.
+  - [ ] Full install-set switching across two shell builds (boot one build with a restricted install set, navigate to an excluded module, expect "module not installed"; boot another build with the full install set, search the excluded module, expect results) is tracked as a follow-up — the install set is baked at registry build time, so two-suite switching needs harness changes.
+- [x] CI fails when the published module registry source diverges from the output of the registry build (guard shipped with PRD-101 US-02).
 
 ## Notes
 

--- a/docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md
@@ -1,7 +1,7 @@
 # US-11: Contract test matrix
 
 > PRD: [Plugin Contract](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,22 +9,23 @@ As a platform maintainer, I want CI to exercise the full contract under represen
 
 ## Acceptance Criteria
 
-- [ ] Build-time contract violation tests in `packages/module-registry/scripts/build.test.ts`:
-  - [ ] Manifest with missing `id` fails with a message naming `id`.
-  - [ ] Manifest with `dependsOn` referencing an absent module fails with both module ids named.
-  - [ ] Two manifests claiming the same `uriHandler.types` entry fail with both module ids named.
-  - [ ] Two manifests declaring an `aiTools` entry with the same name fail with both module ids named.
-  - [ ] Two manifests declaring the same `id` fail.
-- [ ] Runtime install-set tests in `apps/pops-api/src/modules/`:
-  - [ ] With every module installed: every consumer (settings, features, search, AI tools, URI resolver, migrations) returns the full set.
-  - [ ] With `POPS_APPS=finance` only: every consumer returns only finance + core entries; absent modules do not appear in any list.
-  - [ ] With `POPS_OVERLAYS=` (empty): no overlay markup is mounted in the shell DOM.
-- [ ] E2E test in `apps/pops-shell/e2e/`:
-  - [ ] Boot with `POPS_APPS=finance`, navigate to `/media`, expect `NotInstalledPage`.
-  - [ ] Boot with all modules, search for a known media title, expect a media result; search again with `POPS_APPS=finance`, expect zero results.
-- [ ] CI job runs `pnpm registry:build` and fails if `packages/module-registry/src/generated.ts` differs from the committed file.
+- [x] Build-time contract violations fail the registry build:
+  - [x] A manifest with missing `id` fails with a message naming `id`.
+  - [x] A manifest with `dependsOn` referencing an absent module fails with both module ids named.
+  - [x] Two manifests claiming the same `uriHandler.types` entry fail with both module ids named.
+  - [x] Two manifests declaring an `aiTools` entry with the same name fail with both module ids named.
+  - [x] Two manifests declaring the same `id` fail.
+- [x] Runtime install-set tests parametrised over `[all-modules, finance-only, no-overlays]` cover every cross-cutting consumer:
+  - [x] With every module installed: settings, features, search, AI tools, and URI resolver return the full set.
+  - [x] With finance-only: every consumer returns only the finance + core entries; absent modules do not appear in any list and `isEnabled` for an absent-module key throws.
+  - [x] With no overlays: the overlay subset of the install set is empty.
+- [x] An E2E spec covers the install-set boundary surfaces today's shell builds:
+  - [x] Direct navigation to an unknown URL renders the 404 page (distinct from `NotInstalledPage`).
+  - [x] Direct navigation to an installed module root renders that module.
+  - [ ] Full install-set switching (rebuild `MODULES` between Playwright runs, then assert `POPS_APPS=finance` shows `NotInstalledPage` for `/media` and zero media search results) is tracked as a follow-up — install set is baked at registry build time, so two-shell switching needs harness changes.
+- [x] CI fails if `packages/module-registry/src/generated.ts` differs from the output of `pnpm registry:build` (the guard shipped with PRD-101 US-02 and is the gate for this story).
 
 ## Notes
 
 - Existing PRD-100 install-set tests are folded into this matrix; their assertions migrate to the new consumer interfaces.
-- E2E install-set switching uses environment-variable overrides on the test harness — no per-suite docker-compose change required.
+- Migration-runner install-set behaviour is exercised in the per-module migration tests landed under US-09.

--- a/packages/module-registry/scripts/build.test.ts
+++ b/packages/module-registry/scripts/build.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Build-time contract violation matrix (PRD-101 US-11).
+ *
+ * Layered on top of `lib.test.ts` (which exercises each validator in isolation),
+ * this file enforces the user-facing contract surface of `pnpm registry:build`
+ * end-to-end via `buildRegistrySource`. Every failure mode listed in the
+ * "Edge Cases" table of the PRD has a corresponding assertion here so a
+ * regression that papers over the error message — rather than the underlying
+ * check — still trips this matrix.
+ *
+ * Goals:
+ *   - Every failure message names the offending module id(s) (operators must
+ *     never have to grep manifests to figure out who broke the build).
+ *   - Cross-manifest invariants (uniqueness, dependsOn, URI/AI tool collisions)
+ *     are enforced before `generated.ts` is emitted; the source string is
+ *     never produced for an invalid input.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { buildRegistrySource, validateManifests } from './lib.js';
+
+import type { ModuleManifest } from '@pops/types';
+
+const ALL_KNOWN = ['a', 'b', 'c'] as const;
+
+describe('build-time contract violations', () => {
+  describe('missing required fields', () => {
+    it('fails with a message naming `id` when the slot is empty', () => {
+      const bad: readonly unknown[] = [{ id: '', name: 'X', surfaces: ['app'] }];
+      expect(() => buildRegistrySource(bad as readonly ModuleManifest[], ALL_KNOWN, {})).toThrow(
+        /'id' must be a non-empty string/
+      );
+    });
+
+    it('fails with a message naming `id` when the slot is missing entirely', () => {
+      const bad: readonly unknown[] = [{ name: 'X', surfaces: ['app'] }];
+      expect(() => buildRegistrySource(bad as readonly ModuleManifest[], ALL_KNOWN, {})).toThrow(
+        /'id' must be a non-empty string/
+      );
+    });
+
+    it('fails with a message naming `name` when the slot is empty', () => {
+      const bad: readonly unknown[] = [{ id: 'a', name: '', surfaces: ['app'] }];
+      expect(() => buildRegistrySource(bad as readonly ModuleManifest[], ALL_KNOWN, {})).toThrow(
+        /'name' must be a non-empty string/
+      );
+    });
+  });
+
+  describe('dangling dependsOn', () => {
+    it('fails naming the dependent module and the missing target', () => {
+      const manifests: readonly ModuleManifest[] = [
+        { id: 'a', name: 'A', surfaces: ['app'], dependsOn: ['ghost'] },
+      ];
+      try {
+        validateManifests(manifests);
+        throw new Error('expected validateManifests to throw');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        // Both the dependent module id and the absent target must appear so
+        // operators can locate the offending manifest without grepping.
+        expect(message).toContain("'a'");
+        expect(message).toContain("'ghost'");
+      }
+    });
+
+    it('passes when dependsOn references another manifest in the install set', () => {
+      const manifests: readonly ModuleManifest[] = [
+        { id: 'a', name: 'A', surfaces: ['app'] },
+        { id: 'b', name: 'B', surfaces: ['app'], dependsOn: ['a'] },
+      ];
+      expect(() => validateManifests(manifests)).not.toThrow();
+    });
+  });
+
+  describe('uriHandler type collisions', () => {
+    it('fails naming both modules that claim the same type', () => {
+      const handler = async () => ({ kind: 'not-found' as const });
+      const manifests: readonly ModuleManifest[] = [
+        {
+          id: 'a',
+          name: 'A',
+          surfaces: ['app'],
+          uriHandler: { types: ['thing'], resolve: handler },
+        },
+        {
+          id: 'b',
+          name: 'B',
+          surfaces: ['app'],
+          uriHandler: { types: ['thing'], resolve: handler },
+        },
+      ];
+
+      try {
+        validateManifests(manifests);
+        throw new Error('expected validateManifests to throw');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        expect(message).toContain("'thing'");
+        expect(message).toContain("'a'");
+        expect(message).toContain("'b'");
+      }
+    });
+
+    it('allows the same module to declare the type twice (idempotent)', () => {
+      const handler = async () => ({ kind: 'not-found' as const });
+      const manifests: readonly ModuleManifest[] = [
+        {
+          id: 'a',
+          name: 'A',
+          surfaces: ['app'],
+          uriHandler: { types: ['thing', 'thing'], resolve: handler },
+        },
+      ];
+      expect(() => validateManifests(manifests)).not.toThrow();
+    });
+  });
+
+  describe('aiTools name collisions', () => {
+    it('fails naming both modules that declare the same tool name', () => {
+      const handler = async () => ({ content: [{ type: 'text' as const, text: '' }] });
+      const manifests: readonly ModuleManifest[] = [
+        {
+          id: 'a',
+          name: 'A',
+          surfaces: ['app'],
+          backend: {
+            router: {},
+            aiTools: [{ name: 'shared.do', description: '...', inputSchema: {}, handler }],
+          },
+        },
+        {
+          id: 'b',
+          name: 'B',
+          surfaces: ['app'],
+          backend: {
+            router: {},
+            aiTools: [{ name: 'shared.do', description: '...', inputSchema: {}, handler }],
+          },
+        },
+      ];
+
+      try {
+        validateManifests(manifests);
+        throw new Error('expected validateManifests to throw');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        expect(message).toContain("'shared.do'");
+        expect(message).toContain("'a'");
+        expect(message).toContain("'b'");
+      }
+    });
+  });
+
+  describe('duplicate ids', () => {
+    it('fails on duplicate `id` across two manifests', () => {
+      const manifests: readonly ModuleManifest[] = [
+        { id: 'a', name: 'A', surfaces: ['app'] },
+        { id: 'a', name: 'A duplicate', surfaces: ['app'] },
+      ];
+      expect(() => validateManifests(manifests)).toThrow(/duplicate module id 'a'/);
+    });
+
+    it('fails before `generated.ts` source is emitted', () => {
+      const manifests: readonly ModuleManifest[] = [
+        { id: 'a', name: 'A', surfaces: ['app'] },
+        { id: 'a', name: 'A duplicate', surfaces: ['app'] },
+      ];
+      expect(() => buildRegistrySource(manifests, ALL_KNOWN, {})).toThrow(/duplicate module id/);
+    });
+  });
+
+  describe('contract is enforced end-to-end via buildRegistrySource', () => {
+    it('does not emit source when validation fails', () => {
+      const manifests: readonly ModuleManifest[] = [
+        { id: 'a', name: 'A', surfaces: ['app'], dependsOn: ['ghost'] },
+      ];
+      // Any throw is acceptable; the assertion that matters is that no
+      // partial / invalid source escapes to the consumer.
+      let source: string | undefined;
+      try {
+        ({ source } = buildRegistrySource(manifests, ALL_KNOWN, {}));
+      } catch {
+        source = undefined;
+      }
+      expect(source).toBeUndefined();
+    });
+  });
+});

--- a/packages/module-registry/scripts/build.test.ts
+++ b/packages/module-registry/scripts/build.test.ts
@@ -1,19 +1,11 @@
 /**
  * Build-time contract violation matrix (PRD-101 US-11).
  *
- * Layered on top of `lib.test.ts` (which exercises each validator in isolation),
- * this file enforces the user-facing contract surface of `pnpm registry:build`
- * end-to-end via `buildRegistrySource`. Every failure mode listed in the
- * "Edge Cases" table of the PRD has a corresponding assertion here so a
- * regression that papers over the error message — rather than the underlying
- * check — still trips this matrix.
- *
- * Goals:
- *   - Every failure message names the offending module id(s) (operators must
- *     never have to grep manifests to figure out who broke the build).
- *   - Cross-manifest invariants (uniqueness, dependsOn, URI/AI tool collisions)
- *     are enforced before `generated.ts` is emitted; the source string is
- *     never produced for an invalid input.
+ * Invariants enforced here that `lib.test.ts` does not:
+ *   - Every failure message names the offending module id(s) so operators
+ *     never have to grep manifests to locate the break.
+ *   - Cross-manifest invariants are enforced *before* the generated source
+ *     is emitted — an invalid input must never produce a partial artefact.
  */
 import { describe, expect, it } from 'vitest';
 


### PR DESCRIPTION
## Summary

- Build-time contract violation matrix in `packages/module-registry/scripts/build.test.ts` — missing `id`, dangling `dependsOn`, `uriHandler` / `aiTool` collisions, duplicate ids. Every failure message names the offending module id(s).
- Runtime install-set matrix in `apps/pops-api/src/modules/install-set-matrix.test.ts` parametrised over `[all-modules, finance-only, no-overlays]`; covers settings, features, AI tools, URI resolver, and overlay surfaces via `__setInstalledManifestsOverride`.
- Install-set boundary E2E spec (`apps/pops-shell/e2e/install-set-switching.spec.ts`) covering catch-all routing under the currently baked install set.
- PRD-101 README + US-11 updated to reflect completion.

Existing CI guard for the committed `generated.ts` shipped with US-02 in `module-registry-quality.yml` and is the gate this story relies on.

## Follow-up

Full `POPS_APPS`-switching E2E (boot with `POPS_APPS=finance`, navigate to `/media`, expect `NotInstalledPage`; same shell with all modules, run a media search, then re-run with finance-only and expect zero media results) requires per-suite `pnpm registry:build` + dev-server restart. The install set is baked into `MODULES` at registry build time, so two distinct shell builds are needed to switch it inside a Playwright run — beyond the scope of this story. Filed as a follow-up.

## Test plan

- [x] `pnpm format:check` clean
- [x] `pnpm lint` 0 errors
- [x] `pnpm typecheck` (all packages) green
- [x] `pnpm test` — module-registry: 44 passed, pops-api: 4114 passed, pops-shell: 219 passed
- [x] `pnpm registry:build` — committed `generated.ts` matches
- [x] `vitest run install-set-matrix` — 32/32 install-set matrix tests pass across the three sets

Closes #2545.