### PR TITLE
feat(cerebrum): complete agent ingest path (PRD-081 US-02)

### DIFF
--- a/apps/pops-api/src/mcp/__tests__/tool-registry.test.ts
+++ b/apps/pops-api/src/mcp/__tests__/tool-registry.test.ts
@@ -19,6 +19,14 @@ vi.mock('../../modules/cerebrum/ingest/pipeline.js', () => ({
         scopeInference: { scopes: [], source: 'fallback', confidence: 0 },
       };
     }
+    async quickCapture() {
+      return {
+        id: 'eng_test_capture',
+        path: 'personal/capture/eng_test_capture.md',
+        type: 'capture',
+        scopes: ['personal.captures'],
+      };
+    }
   },
 }));
 vi.mock('../../modules/cerebrum/query/query-service.js', () => ({
@@ -60,6 +68,7 @@ describe('listTools', () => {
     const names = listTools().map((t) => t.name);
     expect(names).toContain('cerebrum.search');
     expect(names).toContain('cerebrum.ingest');
+    expect(names).toContain('cerebrum.quickCapture');
     expect(names).toContain('cerebrum.engram.read');
     expect(names).toContain('cerebrum.engram.write');
     expect(names).toContain('cerebrum.query');
@@ -87,6 +96,11 @@ describe('dispatchTool', () => {
 
   it('dispatches cerebrum.ingest', () => {
     const result = dispatchTool('cerebrum.ingest', { body: 'content' });
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it('dispatches cerebrum.quickCapture', () => {
+    const result = dispatchTool('cerebrum.quickCapture', { text: 'a fleeting thought' });
     expect(result).toBeInstanceOf(Promise);
   });
 

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/agent-ingest.integration.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/agent-ingest.integration.test.ts
@@ -1,0 +1,406 @@
+/**
+ * End-to-end integration tests for the agent ingest path (PRD-081 US-02).
+ *
+ * Covers the MCP entry points `cerebrum.ingest` and `cerebrum.quickCapture`
+ * driving the full pipeline (normalise → classify → extract entities →
+ * infer scopes → persist) against a real SQLite database and a real engram
+ * file root. Only the external LLM calls and the BullMQ queue are mocked.
+ *
+ * The agent path shares every pipeline stage with the manual UI path
+ * (US-01) — these tests verify that the wrappers in `ai-tools/ingest.ts`
+ * deliver the same shape and run the same stages without reimplementation.
+ */
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createTestDb } from '../../../../shared/test-utils.js';
+
+import type { Database } from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+// ---------------------------------------------------------------------------
+// Mocks — external IO only. The IngestService and its sub-services run live.
+// ---------------------------------------------------------------------------
+
+let testDrizzle: BetterSQLite3Database;
+
+vi.mock('../../../../db.js', () => ({
+  getDrizzle: () => testDrizzle,
+  getDb: () => {
+    throw new Error('getDb should not be called in this integration test');
+  },
+  isVecAvailable: () => false,
+}));
+
+vi.mock('../../../../env.js', () => ({
+  getEnv: (name: string) => {
+    if (name === 'ANTHROPIC_API_KEY') return undefined;
+    return undefined;
+  },
+}));
+
+vi.mock('../../../../lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+/**
+ * Track classifyEngram job enqueues. The quick-capture path is supposed to
+ * fire-and-forget a curation job; we capture the engram id so tests can
+ * assert the wiring without a real Redis.
+ */
+const enqueued: { engramId: string }[] = [];
+
+vi.mock('../../../../jobs/queues.js', () => ({
+  getCurationQueue: () => ({
+    add: vi.fn(async (_name: string, data: { engramId: string }) => {
+      enqueued.push({ engramId: data.engramId });
+    }),
+  }),
+}));
+
+/**
+ * Classifier behaviour table. Each test sets `mockClassify` to control the
+ * type/template/confidence returned by `CortexClassifier.classify`. Default
+ * mimics a confident classification of `note`.
+ */
+const mockClassify = vi.fn(async () => ({
+  type: 'note',
+  confidence: 0.95,
+  template: null,
+  suggestedTags: ['cli-suggested'],
+}));
+
+vi.mock('../../ingest/classifier.js', () => ({
+  CortexClassifier: class {
+    classify = mockClassify;
+  },
+}));
+
+/**
+ * Entity extractor behaviour. Default returns one person + one project tag
+ * so we can verify they are merged into the engram's tag list.
+ */
+const mockExtract = vi.fn(async () => ({
+  entities: [
+    { type: 'person' as const, value: 'Alice', normalised: 'alice', confidence: 0.9 },
+    {
+      type: 'project' as const,
+      value: 'POPS',
+      normalised: 'pops',
+      confidence: 0.85,
+    },
+  ],
+  tags: ['person:alice', 'project:pops'],
+  referencedDates: [],
+}));
+
+vi.mock('../../ingest/entity-extractor.js', () => ({
+  CortexEntityExtractor: class {
+    extract = mockExtract;
+  },
+}));
+
+/**
+ * Scope inference behaviour. Default returns a single rule-derived scope;
+ * tests override to exercise the empty / blocked paths.
+ */
+type MockScopeInference = {
+  scopes: string[];
+  source: 'explicit' | 'rules' | 'llm' | 'fallback';
+  confidence: number;
+};
+const mockInfer = vi.fn<() => Promise<MockScopeInference>>(async () => ({
+  scopes: ['personal.notes'],
+  source: 'rules',
+  confidence: 0.9,
+}));
+
+vi.mock('../../ingest/scope-inference.js', () => ({
+  createScopeInferenceService: () => ({ infer: mockInfer }),
+}));
+
+vi.mock('../../../core/settings/service.js', async () => {
+  return {
+    getSettingValue: <T>(_key: string, fallback: T): T => fallback,
+  };
+});
+
+// --- Dynamic imports AFTER mocks ---
+
+const { handleCerebrumIngest, handleCerebrumQuickCapture } = await import('../ingest.js');
+const { resetCerebrumCache } = await import('../../instance.js');
+const { parseResult } = await import('./test-helpers.js');
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+let rawDb: Database;
+let tmpEngramRoot: string;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enqueued.length = 0;
+
+  rawDb = createTestDb();
+  testDrizzle = drizzle(rawDb);
+
+  tmpEngramRoot = join(
+    tmpdir(),
+    `pops-agent-ingest-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(tmpEngramRoot, { recursive: true });
+  process.env['ENGRAM_ROOT'] = tmpEngramRoot;
+  resetCerebrumCache();
+
+  // Restore default mock behaviours (cleared above).
+  mockClassify.mockImplementation(async () => ({
+    type: 'note',
+    confidence: 0.95,
+    template: null,
+    suggestedTags: ['cli-suggested'],
+  }));
+  mockExtract.mockImplementation(async () => ({
+    entities: [
+      { type: 'person' as const, value: 'Alice', normalised: 'alice', confidence: 0.9 },
+      { type: 'project' as const, value: 'POPS', normalised: 'pops', confidence: 0.85 },
+    ],
+    tags: ['person:alice', 'project:pops'],
+    referencedDates: [],
+  }));
+  mockInfer.mockImplementation(async () => ({
+    scopes: ['personal.notes'],
+    source: 'rules',
+    confidence: 0.9,
+  }));
+});
+
+afterEach(() => {
+  rawDb.close();
+  rmSync(tmpEngramRoot, { recursive: true, force: true });
+  delete process.env['ENGRAM_ROOT'];
+  resetCerebrumCache();
+});
+
+interface ParsedIngest {
+  engram: {
+    id: string;
+    title: string;
+    type: string;
+    scopes: string[];
+    filePath: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// cerebrum.ingest — full agent pipeline
+// ---------------------------------------------------------------------------
+
+describe('agent ingest path — cerebrum.ingest', () => {
+  it('runs classification + entity extraction + scope inference + write end-to-end', async () => {
+    const result = await handleCerebrumIngest({
+      body: 'Alice mentioned the POPS project status during standup today.',
+    });
+
+    expect(result.isError).toBeUndefined();
+
+    // Every pipeline stage was exercised by the agent path.
+    expect(mockClassify).toHaveBeenCalledTimes(1);
+    expect(mockExtract).toHaveBeenCalledTimes(1);
+    expect(mockInfer).toHaveBeenCalledTimes(1);
+
+    const parsed = parseResult(result) as ParsedIngest;
+    expect(parsed.engram.id).toMatch(/^eng_\d{8}_\d{4}_/);
+    expect(parsed.engram.type).toBe('note');
+    expect(parsed.engram.scopes).toContain('personal.notes');
+
+    // File written to disk and content preserved.
+    const content = readFileSync(join(tmpEngramRoot, parsed.engram.filePath), 'utf8');
+    expect(content).toContain('POPS project status');
+    expect(content).toContain('source: agent');
+
+    // Tags merged from entity extraction + classifier suggestions.
+    expect(content).toContain('person:alice');
+    expect(content).toContain('project:pops');
+    expect(content).toContain('cli-suggested');
+
+    // Index row materialised.
+    const row = rawDb
+      .prepare('SELECT id, type FROM engram_index WHERE id = ?')
+      .get(parsed.engram.id) as { id: string; type: string } | undefined;
+    expect(row).toBeDefined();
+    expect(row!.type).toBe('note');
+  });
+
+  it('skips classification when type is explicitly provided', async () => {
+    const result = await handleCerebrumIngest({
+      body: 'A meeting transcript with action items.',
+      type: 'meeting',
+      scopes: ['work.standups'],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockClassify).not.toHaveBeenCalled();
+    // Scopes were explicit; the scope-inference service still runs but
+    // surfaces the caller's explicit scopes as the result.
+    expect(mockInfer).toHaveBeenCalledTimes(1);
+
+    const parsed = parseResult(result) as ParsedIngest;
+    expect(parsed.engram.type).toBe('meeting');
+  });
+
+  it('extracts JSON metadata into customFields (frontmatter)', async () => {
+    const result = await handleCerebrumIngest({
+      body: JSON.stringify({
+        title: 'Q1 Review',
+        priority: 4,
+        owner: 'alice',
+        followups: ['next-quarter', 'budget'],
+      }),
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = parseResult(result) as ParsedIngest;
+
+    const content = readFileSync(join(tmpEngramRoot, parsed.engram.filePath), 'utf8');
+    // JSON preserved as a code block in the body.
+    expect(content).toContain('```json');
+    expect(content).toContain('Q1 Review');
+    // Scalar metadata fields promoted to frontmatter customFields.
+    expect(content).toContain('priority: 4');
+    expect(content).toContain('owner: alice');
+    expect(content).toContain('followups:');
+  });
+
+  it('returns VALIDATION_ERROR for empty body without invoking the pipeline', async () => {
+    const result = await handleCerebrumIngest({ body: '   ' });
+
+    expect(result.isError).toBe(true);
+    expect(mockClassify).not.toHaveBeenCalled();
+    expect(mockExtract).not.toHaveBeenCalled();
+    expect(mockInfer).not.toHaveBeenCalled();
+    const parsed = parseResult(result) as { code: string };
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('falls back to capture type when classification confidence is low', async () => {
+    mockClassify.mockImplementationOnce(async () => ({
+      type: 'capture',
+      confidence: 0.1,
+      template: null,
+      suggestedTags: [],
+    }));
+
+    const result = await handleCerebrumIngest({ body: 'ambiguous content' });
+    const parsed = parseResult(result) as ParsedIngest;
+    expect(parsed.engram.type).toBe('capture');
+  });
+
+  it('surfaces ValidationError from the engram service as VALIDATION_ERROR', async () => {
+    // When scope inference produces nothing AND no rule-engine fallback is
+    // available, `createEngram` throws ValidationError("at least one scope is
+    // required"). The agent path must surface that as a structured tool
+    // error instead of a generic 500.
+    mockInfer.mockImplementationOnce(async () => ({
+      scopes: [],
+      source: 'fallback',
+      confidence: 0,
+    }));
+
+    // Disable the rule-engine fallback so the empty scopes propagate.
+    const { getScopeRuleEngine } = await import('../../instance.js');
+    vi.spyOn(getScopeRuleEngine(), 'inferScopes').mockReturnValue([]);
+
+    const result = await handleCerebrumIngest({
+      body: 'content with no derivable scope',
+    });
+
+    expect(result.isError).toBe(true);
+    const parsed = parseResult(result) as { code: string; error: string };
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(parsed.error.toLowerCase()).toContain('scope');
+  });
+
+  it('does NOT use the quickCapture path for full ingest', async () => {
+    await handleCerebrumIngest({ body: 'should run full pipeline' });
+    // Full ingest never enqueues a classify job (that's the quickCapture
+    // contract). If this fails, someone has wired the wrong service.
+    expect(enqueued).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cerebrum.ingest — preview shape (delegates to IngestService.preview through
+// the pipeline; we verify the preview-friendly stage outputs are wired)
+// ---------------------------------------------------------------------------
+
+describe('agent ingest path — preview (tRPC shape)', () => {
+  it('IngestService.preview returns the parsed shape without writing', async () => {
+    const { IngestService } = await import('../../ingest/pipeline.js');
+    const svc = new IngestService();
+    const preview = await svc.preview({
+      body: 'Alice presented the POPS roadmap.',
+      source: 'agent',
+    });
+
+    expect(preview.normalisedBody).toContain('Alice presented the POPS roadmap.');
+    expect(preview.classification?.type).toBe('note');
+    expect(preview.entities.length).toBeGreaterThan(0);
+    expect(preview.scopeInference.scopes).toEqual(['personal.notes']);
+
+    // No file persisted — the engram_index table should be empty.
+    const count = rawDb.prepare('SELECT COUNT(*) AS n FROM engram_index').get() as { n: number };
+    expect(count.n).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cerebrum.quickCapture — agent path with async enrichment
+// ---------------------------------------------------------------------------
+
+describe('agent ingest path — cerebrum.quickCapture', () => {
+  it('persists a capture engram and enqueues an async classification job', async () => {
+    const result = await handleCerebrumQuickCapture({
+      text: 'fleeting thought about agent routing',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = parseResult(result) as {
+      engram: { id: string; type: string; scopes: string[]; filePath: string };
+    };
+
+    expect(parsed.engram.id).toMatch(/^eng_\d{8}_\d{4}_/);
+    expect(parsed.engram.type).toBe('capture');
+    expect(parsed.engram.scopes.length).toBeGreaterThan(0);
+
+    // File materialised on disk with source=agent.
+    const content = readFileSync(join(tmpEngramRoot, parsed.engram.filePath), 'utf8');
+    expect(content).toContain('source: agent');
+    expect(content).toContain('fleeting thought');
+
+    // Async enrichment job was enqueued for the new engram.
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0]!.engramId).toBe(parsed.engram.id);
+
+    // Quick capture bypasses the synchronous pipeline stages.
+    expect(mockClassify).not.toHaveBeenCalled();
+    expect(mockExtract).not.toHaveBeenCalled();
+  });
+
+  it('returns VALIDATION_ERROR for empty text', async () => {
+    const result = await handleCerebrumQuickCapture({ text: '   ' });
+    expect(result.isError).toBe(true);
+    const parsed = parseResult(result) as { code: string };
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(enqueued).toHaveLength(0);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/ingest.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/ingest.test.ts
@@ -3,10 +3,20 @@ import { describe, expect, it, vi } from 'vitest';
 import { handleJsonBody } from '../ingest.js';
 import { parseResult } from './test-helpers.js';
 
+/**
+ * Captured arguments from the most recent IngestService method calls. The
+ * mock writes here so individual tests can assert exactly what reached the
+ * pipeline (title, customFields, source, etc.) without exposing the mock
+ * class outside this scope.
+ */
+const lastSubmit: { input?: Record<string, unknown> } = {};
+const lastQuickCapture: { text?: string; source?: string } = {};
+
 // Mock the IngestService to avoid DB dependency in unit tests
 vi.mock('../../ingest/pipeline.js', () => ({
   IngestService: class MockIngestService {
     async submit(input: Record<string, unknown>) {
+      lastSubmit.input = input;
       return {
         engram: {
           id: 'eng_20260427_1200_test',
@@ -20,11 +30,21 @@ vi.mock('../../ingest/pipeline.js', () => ({
         scopeInference: { scopes: ['personal'], source: 'rules', confidence: 0.9 },
       };
     }
+    async quickCapture(text: string, source: string) {
+      lastQuickCapture.text = text;
+      lastQuickCapture.source = source;
+      return {
+        id: 'eng_20260427_1200_capture',
+        path: 'personal/capture/eng_20260427_1200_capture.md',
+        type: 'capture',
+        scopes: ['personal.captures'],
+      };
+    }
   },
 }));
 
 // Dynamic import of handler AFTER mock is set up
-const { handleCerebrumIngest } = await import('../ingest.js');
+const { handleCerebrumIngest, handleCerebrumQuickCapture } = await import('../ingest.js');
 
 describe('handleJsonBody', () => {
   it('returns the original body for non-JSON content', () => {
@@ -105,6 +125,50 @@ describe('handleJsonBody', () => {
     const result = handleJsonBody(json);
     expect(result.derivedTitle).toBe('Fallback');
   });
+
+  it('extracts scalar JSON fields into extractedFields', () => {
+    const json = '{"priority": 3, "active": true, "owner": "alice", "title": "T"}';
+    const result = handleJsonBody(json);
+    expect(result.extractedFields).toEqual({
+      priority: 3,
+      active: true,
+      owner: 'alice',
+    });
+  });
+
+  it('promotes scalar arrays to extractedFields', () => {
+    const json = '{"tags_seen": ["a", "b", "c"], "counts": [1, 2, 3]}';
+    const result = handleJsonBody(json);
+    expect(result.extractedFields).toEqual({
+      tags_seen: ['a', 'b', 'c'],
+      counts: [1, 2, 3],
+    });
+  });
+
+  it('skips nested object values in extractedFields', () => {
+    const json = '{"meta": {"nested": true}, "level": "high"}';
+    const result = handleJsonBody(json);
+    expect(result.extractedFields).toEqual({ level: 'high' });
+    expect(result.extractedFields['meta']).toBeUndefined();
+  });
+
+  it('skips reserved keys (title/name/body/content) in extractedFields', () => {
+    const json =
+      '{"title": "t", "name": "n", "body": "b", "content": "c", "text": "x", "other": "keep"}';
+    const result = handleJsonBody(json);
+    expect(result.extractedFields).toEqual({ other: 'keep' });
+  });
+
+  it('returns empty extractedFields for arrays', () => {
+    const json = '[1, 2, 3]';
+    const result = handleJsonBody(json);
+    expect(result.extractedFields).toEqual({});
+  });
+
+  it('returns empty extractedFields for non-JSON content', () => {
+    const result = handleJsonBody('plain text');
+    expect(result.extractedFields).toEqual({});
+  });
 });
 
 describe('handleCerebrumIngest', () => {
@@ -154,5 +218,87 @@ describe('handleCerebrumIngest', () => {
       scopes: ['valid', 42, null, 'also-valid'] as unknown as string[],
     });
     expect(result.isError).toBeUndefined();
+  });
+
+  it('forwards source=agent and full args to IngestService.submit', async () => {
+    lastSubmit.input = undefined;
+    await handleCerebrumIngest({
+      body: 'agent body',
+      title: 'Agent Title',
+      type: 'note',
+      scopes: ['personal'],
+      tags: ['t1', 't2'],
+    });
+    expect(lastSubmit.input).toMatchObject({
+      body: 'agent body',
+      title: 'Agent Title',
+      type: 'note',
+      scopes: ['personal'],
+      tags: ['t1', 't2'],
+      source: 'agent',
+    });
+  });
+
+  it('promotes JSON metadata into customFields', async () => {
+    lastSubmit.input = undefined;
+    await handleCerebrumIngest({
+      body: '{"title": "Doc", "priority": 5, "owner": "alice"}',
+    });
+    expect(lastSubmit.input?.['customFields']).toEqual({
+      priority: 5,
+      owner: 'alice',
+    });
+  });
+
+  it('does not pass customFields when JSON object has no extractable scalars', async () => {
+    lastSubmit.input = undefined;
+    await handleCerebrumIngest({ body: '{"title": "Only Title"}' });
+    expect(lastSubmit.input?.['customFields']).toBeUndefined();
+  });
+
+  it('returns the engram id, file path, type, and scopes from submit', async () => {
+    const result = await handleCerebrumIngest({ body: 'hello' });
+    const parsed = parseResult(result) as {
+      engram: { id: string; type: string; scopes: string[]; filePath: string };
+    };
+    expect(parsed.engram.id).toBe('eng_20260427_1200_test');
+    expect(parsed.engram.filePath).toBe('personal/note/eng_20260427_1200_test.md');
+    expect(parsed.engram.type).toBe('note');
+    expect(parsed.engram.scopes).toEqual(['personal']);
+  });
+});
+
+describe('handleCerebrumQuickCapture', () => {
+  it('returns VALIDATION_ERROR for empty text', async () => {
+    const result = await handleCerebrumQuickCapture({ text: '   ' });
+    const parsed = parseResult(result) as { code: string };
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns VALIDATION_ERROR for missing text', async () => {
+    const result = await handleCerebrumQuickCapture({});
+    const parsed = parseResult(result) as { code: string };
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('delegates to IngestService.quickCapture with source=agent', async () => {
+    lastQuickCapture.text = undefined;
+    lastQuickCapture.source = undefined;
+    await handleCerebrumQuickCapture({ text: 'a quick thought' });
+    expect(lastQuickCapture.text).toBe('a quick thought');
+    expect(lastQuickCapture.source).toBe('agent');
+  });
+
+  it('returns the captured engram id, path, type, and scopes', async () => {
+    const result = await handleCerebrumQuickCapture({ text: 'quick' });
+    expect(result.isError).toBeUndefined();
+    const parsed = parseResult(result) as {
+      engram: { id: string; type: string; scopes: string[]; filePath: string };
+    };
+    expect(parsed.engram.id).toBe('eng_20260427_1200_capture');
+    expect(parsed.engram.type).toBe('capture');
+    expect(parsed.engram.scopes).toEqual(['personal.captures']);
+    expect(parsed.engram.filePath).toBe('personal/capture/eng_20260427_1200_capture.md');
   });
 });

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/index.ts
@@ -10,7 +10,12 @@ import { engramWriteSchema, handleEngramWrite } from './engram-write.js';
  * the merged surface via MCP `tools/list` and Ego's tool context — there is
  * no per-module ad-hoc registration.
  */
-import { cerebrumIngestSchema, handleCerebrumIngest } from './ingest.js';
+import {
+  cerebrumIngestSchema,
+  cerebrumQuickCaptureSchema,
+  handleCerebrumIngest,
+  handleCerebrumQuickCapture,
+} from './ingest.js';
 import { cerebrumQuerySchema, handleCerebrumQuery } from './query.js';
 import { cerebrumSearchSchema, handleCerebrumSearch } from './search.js';
 
@@ -30,6 +35,13 @@ export const cerebrumAiTools: readonly AiToolDescriptor[] = [
       'Ingest new content into the Cerebrum knowledge base. Accepts plain text, Markdown, or JSON. Runs classification, entity extraction, and scope inference automatically.',
     inputSchema: cerebrumIngestSchema,
     handler: handleCerebrumIngest,
+  },
+  {
+    name: 'cerebrum.quickCapture',
+    description:
+      'Quick-capture raw text into the Cerebrum knowledge base. Stores immediately as type=capture; classification, entity extraction and scope inference run asynchronously after storage. Use this for low-latency fire-and-forget capture (Moltbot, mobile).',
+    inputSchema: cerebrumQuickCaptureSchema,
+    handler: handleCerebrumQuickCapture,
   },
   {
     name: 'cerebrum.engram.read',
@@ -57,6 +69,7 @@ export const cerebrumAiTools: readonly AiToolDescriptor[] = [
 export {
   handleCerebrumIngest,
   handleCerebrumQuery,
+  handleCerebrumQuickCapture,
   handleCerebrumSearch,
   handleEngramRead,
   handleEngramWrite,

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
@@ -12,18 +12,12 @@
  * agent input and manual input share every pipeline stage (normalise →
  * classify → extract → infer → write).
  */
+import { z } from 'zod';
+
 import { IngestService } from '../ingest/pipeline.js';
 import { mapServiceError, toolError, toolSuccess } from './result.js';
 
 import type { AiToolResult } from '@pops/types';
-
-interface IngestArgs {
-  body: string;
-  title?: string;
-  type?: string;
-  scopes?: string[];
-  tags?: string[];
-}
 
 const TITLE_KEYS = ['title', 'name', 'subject', 'label'] as const;
 
@@ -119,21 +113,35 @@ export function handleJsonBody(body: string): JsonBodyResult {
   };
 }
 
-function parseArgs(raw: Record<string, unknown>): IngestArgs {
-  const body = typeof raw['body'] === 'string' ? raw['body'] : '';
-  const title = typeof raw['title'] === 'string' ? raw['title'] : undefined;
-  const type = typeof raw['type'] === 'string' ? raw['type'] : undefined;
-  const scopes = Array.isArray(raw['scopes'])
-    ? (raw['scopes'] as unknown[]).filter((s): s is string => typeof s === 'string')
-    : undefined;
-  const tags = Array.isArray(raw['tags'])
-    ? (raw['tags'] as unknown[]).filter((s): s is string => typeof s === 'string')
-    : undefined;
-  return { body, title, type, scopes, tags };
+// Lenient string-array coercion: array inputs may include non-string entries
+// (agents sometimes send mixed JSON). Drop those rather than reject the call
+// — the dropped values weren't meaningful scopes/tags anyway.
+const stringArrayLenient = z.preprocess(
+  (value) =>
+    Array.isArray(value)
+      ? value.filter((entry): entry is string => typeof entry === 'string')
+      : value,
+  z.array(z.string()).optional()
+);
+
+const ingestArgsSchema = z.object({
+  body: z.string().optional().default(''),
+  title: z.string().optional(),
+  type: z.string().optional(),
+  scopes: stringArrayLenient,
+  tags: stringArrayLenient,
+});
+
+type IngestArgs = z.infer<typeof ingestArgsSchema>;
+
+function parseIngestArgs(raw: Record<string, unknown>): IngestArgs {
+  // `.catch` keeps the handler resilient to unexpected shapes — empty body
+  // falls through to the existing VALIDATION_ERROR path below.
+  return ingestArgsSchema.catch({ body: '' }).parse(raw);
 }
 
 export async function handleCerebrumIngest(raw: Record<string, unknown>): Promise<AiToolResult> {
-  const args = parseArgs(raw);
+  const args = parseIngestArgs(raw);
 
   if (!args.body.trim()) {
     return toolError('body is required and must be non-empty', 'VALIDATION_ERROR');
@@ -203,14 +211,9 @@ export const cerebrumIngestSchema = {
 // cerebrum.quickCapture — lightweight MCP tool for agent capture (PRD-081 US-02 AC #2)
 // ---------------------------------------------------------------------------
 
-interface QuickCaptureArgs {
-  text: string;
-}
-
-function parseQuickCaptureArgs(raw: Record<string, unknown>): QuickCaptureArgs {
-  const text = typeof raw['text'] === 'string' ? raw['text'] : '';
-  return { text };
-}
+const quickCaptureArgsSchema = z.object({
+  text: z.string().optional().default(''),
+});
 
 /**
  * MCP wrapper for `IngestService.quickCapture`. Stores raw text as a
@@ -221,7 +224,7 @@ function parseQuickCaptureArgs(raw: Record<string, unknown>): QuickCaptureArgs {
 export async function handleCerebrumQuickCapture(
   raw: Record<string, unknown>
 ): Promise<AiToolResult> {
-  const args = parseQuickCaptureArgs(raw);
+  const args = quickCaptureArgsSchema.catch({ text: '' }).parse(raw);
 
   if (!args.text.trim()) {
     return toolError('text is required and must be non-empty', 'VALIDATION_ERROR');

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
@@ -27,11 +27,6 @@ interface IngestArgs {
 
 const TITLE_KEYS = ['title', 'name', 'subject', 'label'] as const;
 
-/**
- * Keys that should NOT be promoted to `customFields` when extracted from a
- * JSON body — they are either consumed elsewhere (title) or duplicate the
- * body (body / content / text).
- */
 const RESERVED_JSON_KEYS = new Set<string>([...TITLE_KEYS, 'body', 'content', 'text']);
 
 /** Try to extract a title from a JSON object's well-known keys, falling back to a key summary. */

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
@@ -1,9 +1,16 @@
 /**
  * cerebrum.ingest — ingest content into the engram knowledge base.
  *
- * Delegates to IngestService. Also handles structured JSON detection:
- * if the body starts with `{` or `[` and parses as valid JSON, it is
- * converted to Markdown with the JSON in a fenced code block.
+ * Delegates to {@link IngestService}. Also handles structured JSON detection:
+ * when the body parses as a JSON object, the value is converted to Markdown
+ * (the object rendered inside a fenced ```json``` code block) and the
+ * top-level scalar keys are promoted into `customFields` so they land in the
+ * engram's frontmatter. Array bodies are wrapped without metadata extraction.
+ *
+ * The MCP tool shape is intentionally a thin wrapper around the same
+ * `IngestService.submit` procedure used by the manual UI (PRD-081 US-01) —
+ * agent input and manual input share every pipeline stage (normalise →
+ * classify → extract → infer → write).
  */
 import { IngestService } from '../ingest/pipeline.js';
 import { mapServiceError, toolError, toolSuccess } from './result.js';
@@ -19,6 +26,13 @@ interface IngestArgs {
 }
 
 const TITLE_KEYS = ['title', 'name', 'subject', 'label'] as const;
+
+/**
+ * Keys that should NOT be promoted to `customFields` when extracted from a
+ * JSON body — they are either consumed elsewhere (title) or duplicate the
+ * body (body / content / text).
+ */
+const RESERVED_JSON_KEYS = new Set<string>([...TITLE_KEYS, 'body', 'content', 'text']);
 
 /** Try to extract a title from a JSON object's well-known keys, falling back to a key summary. */
 function deriveTitleFromObject(obj: Record<string, unknown>): string | null {
@@ -38,29 +52,76 @@ function deriveTitleFromObject(obj: Record<string, unknown>): string | null {
 }
 
 /**
- * Detect structured JSON and convert to Markdown.
- * Returns a new body and optional derived title.
+ * Promote top-level scalar fields from a JSON body into `customFields`.
+ *
+ * Only primitives (string, number, boolean) and arrays of primitives are
+ * kept — deeply nested objects stay inside the JSON code block in the body
+ * to avoid polluting frontmatter with structures that frontmatter can't
+ * cleanly represent. Reserved keys (title aliases, body/content/text) are
+ * skipped because they are either consumed elsewhere or duplicate the body.
  */
-function handleJsonBody(body: string): { body: string; derivedTitle: string | null } {
+function extractCustomFieldsFromObject(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (RESERVED_JSON_KEYS.has(key.toLowerCase())) continue;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      out[key] = value;
+      continue;
+    }
+    if (
+      Array.isArray(value) &&
+      value.every((v) => typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')
+    ) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+export interface JsonBodyResult {
+  /** Either the original body (when not JSON) or the JSON wrapped in a fenced code block. */
+  body: string;
+  /** Title derived from a `title`/`name`/`subject`/`label` key, or a key summary. */
+  derivedTitle: string | null;
+  /** Top-level scalar JSON fields, to be merged into the engram's frontmatter customFields. */
+  extractedFields: Record<string, unknown>;
+}
+
+/**
+ * Detect structured JSON in the body.
+ *
+ * For JSON objects: returns the body wrapped in a fenced ```json``` block,
+ * a title derived from the object, and the object's scalar fields promoted
+ * to frontmatter via `extractedFields`. For JSON arrays: wraps in a code
+ * block but extracts no metadata. For non-JSON: returns the original body
+ * unchanged.
+ */
+export function handleJsonBody(body: string): JsonBodyResult {
   const trimmed = body.trim();
   if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
-    return { body, derivedTitle: null };
+    return { body, derivedTitle: null, extractedFields: {} };
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(trimmed);
   } catch {
-    return { body, derivedTitle: null };
+    return { body, derivedTitle: null, extractedFields: {} };
   }
 
   const isPlainObject = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed);
-  const derivedTitle = isPlainObject
-    ? deriveTitleFromObject(parsed as Record<string, unknown>)
-    : null;
-
   const mdBody = `\`\`\`json\n${trimmed}\n\`\`\``;
-  return { body: mdBody, derivedTitle };
+
+  if (!isPlainObject) {
+    return { body: mdBody, derivedTitle: null, extractedFields: {} };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  return {
+    body: mdBody,
+    derivedTitle: deriveTitleFromObject(obj),
+    extractedFields: extractCustomFieldsFromObject(obj),
+  };
 }
 
 function parseArgs(raw: Record<string, unknown>): IngestArgs {
@@ -84,8 +145,9 @@ export async function handleCerebrumIngest(raw: Record<string, unknown>): Promis
   }
 
   try {
-    const { body: processedBody, derivedTitle } = handleJsonBody(args.body);
+    const { body: processedBody, derivedTitle, extractedFields } = handleJsonBody(args.body);
     const title = args.title ?? derivedTitle ?? undefined;
+    const customFields = Object.keys(extractedFields).length > 0 ? extractedFields : undefined;
 
     const svc = new IngestService();
     const result = await svc.submit({
@@ -95,6 +157,7 @@ export async function handleCerebrumIngest(raw: Record<string, unknown>): Promis
       scopes: args.scopes,
       tags: args.tags,
       source: 'agent',
+      customFields,
     });
 
     return toolSuccess({
@@ -141,5 +204,59 @@ export const cerebrumIngestSchema = {
   required: ['body'] as const,
 };
 
-// Exported for testing
-export { handleJsonBody };
+// ---------------------------------------------------------------------------
+// cerebrum.quickCapture — lightweight MCP tool for agent capture (PRD-081 US-02 AC #2)
+// ---------------------------------------------------------------------------
+
+interface QuickCaptureArgs {
+  text: string;
+}
+
+function parseQuickCaptureArgs(raw: Record<string, unknown>): QuickCaptureArgs {
+  const text = typeof raw['text'] === 'string' ? raw['text'] : '';
+  return { text };
+}
+
+/**
+ * MCP wrapper for `IngestService.quickCapture`. Stores raw text as a
+ * `type=capture` engram and enqueues an async classification job. Used by
+ * agent paths (Claude Code, Moltbot) that want minimum friction; the heavy
+ * pipeline (classify/extract/scope) runs asynchronously.
+ */
+export async function handleCerebrumQuickCapture(
+  raw: Record<string, unknown>
+): Promise<AiToolResult> {
+  const args = parseQuickCaptureArgs(raw);
+
+  if (!args.text.trim()) {
+    return toolError('text is required and must be non-empty', 'VALIDATION_ERROR');
+  }
+
+  try {
+    const svc = new IngestService();
+    const result = await svc.quickCapture(args.text, 'agent');
+    return toolSuccess({
+      engram: {
+        id: result.id,
+        type: result.type,
+        scopes: result.scopes,
+        filePath: result.path,
+      },
+    });
+  } catch (err) {
+    return mapServiceError(err);
+  }
+}
+
+/** JSON Schema for the cerebrum.quickCapture tool input. */
+export const cerebrumQuickCaptureSchema = {
+  type: 'object' as const,
+  properties: {
+    text: {
+      type: 'string' as const,
+      description:
+        'Raw text to capture. Stored as type=capture; classification, entity extraction and scope inference run asynchronously after storage.',
+    },
+  },
+  required: ['text'] as const,
+};

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
@@ -115,19 +115,31 @@ export function handleJsonBody(body: string): JsonBodyResult {
 
 // Lenient string-array coercion: array inputs may include non-string entries
 // (agents sometimes send mixed JSON). Drop those rather than reject the call
-// — the dropped values weren't meaningful scopes/tags anyway.
-const stringArrayLenient = z.preprocess(
-  (value) =>
-    Array.isArray(value)
-      ? value.filter((entry): entry is string => typeof entry === 'string')
-      : value,
-  z.array(z.string()).optional()
-);
+// — the dropped values weren't meaningful scopes/tags anyway. A non-array
+// value (e.g. a stray string) falls through `.catch(undefined)` instead of
+// blowing up the whole call.
+const stringArrayLenient = z
+  .preprocess(
+    (value) =>
+      Array.isArray(value)
+        ? value.filter((entry): entry is string => typeof entry === 'string')
+        : value,
+    z.array(z.string()).optional()
+  )
+  .catch(undefined);
+
+// Each field carries its own `.catch` so that an agent sending a wrongly-typed
+// value (e.g. `body: 123` or `title: ["array"]`) falls back to the field-level
+// default without aborting the whole parse. Object-level `.catch` is not used
+// here because in Zod v4 it does not recover from individual field failures —
+// see https://zod.dev/api/modifiers/catch — so it would swallow real errors
+// while still failing the parse for unrelated reasons.
+const optionalString = z.string().optional().catch(undefined);
 
 const ingestArgsSchema = z.object({
-  body: z.string().optional().default(''),
-  title: z.string().optional(),
-  type: z.string().optional(),
+  body: z.string().catch('').default(''),
+  title: optionalString,
+  type: optionalString,
   scopes: stringArrayLenient,
   tags: stringArrayLenient,
 });
@@ -135,9 +147,7 @@ const ingestArgsSchema = z.object({
 type IngestArgs = z.infer<typeof ingestArgsSchema>;
 
 function parseIngestArgs(raw: Record<string, unknown>): IngestArgs {
-  // `.catch` keeps the handler resilient to unexpected shapes — empty body
-  // falls through to the existing VALIDATION_ERROR path below.
-  return ingestArgsSchema.catch({ body: '' }).parse(raw);
+  return ingestArgsSchema.parse(raw);
 }
 
 export async function handleCerebrumIngest(raw: Record<string, unknown>): Promise<AiToolResult> {
@@ -212,7 +222,7 @@ export const cerebrumIngestSchema = {
 // ---------------------------------------------------------------------------
 
 const quickCaptureArgsSchema = z.object({
-  text: z.string().optional().default(''),
+  text: z.string().catch('').default(''),
 });
 
 /**
@@ -224,7 +234,7 @@ const quickCaptureArgsSchema = z.object({
 export async function handleCerebrumQuickCapture(
   raw: Record<string, unknown>
 ): Promise<AiToolResult> {
-  const args = quickCaptureArgsSchema.catch({ text: '' }).parse(raw);
+  const args = quickCaptureArgsSchema.parse(raw);
 
   if (!args.text.trim()) {
     return toolError('text is required and must be non-empty', 'VALIDATION_ERROR');

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/result.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/result.ts
@@ -44,12 +44,37 @@ export function toolError(message: string, code: CerebrumToolErrorCode): AiToolR
  * the caller receives a generic message so we never leak stack traces, SQL
  * fragments, or other internals through MCP / Ego responses.
  */
+/**
+ * Pull a human-readable message out of a ValidationError's `details` payload.
+ *
+ * The service layer throws `new ValidationError({ message: '<reason>' })` so
+ * the field-level reason lives inside `details`, not in the top-level
+ * `Error.message` (which is always "Validation failed"). The MCP / Ego
+ * surface needs the actual reason, otherwise agents and humans see
+ * indistinguishable generic strings for every validation failure.
+ */
+function extractValidationMessage(err: ValidationError): string {
+  const details = err.details;
+  if (typeof details === 'string' && details.trim().length > 0) {
+    return details;
+  }
+  if (
+    typeof details === 'object' &&
+    details !== null &&
+    typeof (details as { message?: unknown }).message === 'string'
+  ) {
+    const message = (details as { message: string }).message;
+    if (message.trim().length > 0) return message;
+  }
+  return err.message;
+}
+
 export function mapServiceError(err: unknown): AiToolResult {
   if (err instanceof NotFoundError) {
     return toolError(err.message, 'NOT_FOUND');
   }
   if (err instanceof ValidationError) {
-    return toolError(err.message, 'VALIDATION_ERROR');
+    return toolError(extractValidationMessage(err), 'VALIDATION_ERROR');
   }
   logger.error({ err }, '[cerebrum.ai-tools] unhandled service error');
   return toolError('An unexpected internal error occurred', 'INTERNAL_ERROR');

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
@@ -51,10 +51,10 @@ raw input → normalize → classify type → match template → extract entitie
 
 ### MCP Tools
 
-| Tool                     | Parameters                          | Description                                           |
-| ------------------------ | ----------------------------------- | ----------------------------------------------------- |
-| `cerebrum_ingest`        | body, title?, type?, scopes?, tags? | Full ingestion via MCP — used by Claude Code sessions |
-| `cerebrum_quick_capture` | text                                | Quick capture via MCP — raw text in, engram out       |
+| Tool                    | Parameters                          | Description                                                                                                     |
+| ----------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `cerebrum.ingest`       | body, title?, type?, scopes?, tags? | Full ingestion via MCP — used by Claude Code sessions; runs the full pipeline (classify, extract, infer, write) |
+| `cerebrum.quickCapture` | text                                | Quick capture via MCP — raw text in, capture engram out; classification runs asynchronously                     |
 
 ## Business Rules
 
@@ -94,7 +94,7 @@ raw input → normalize → classify type → match template → extract entitie
 | #   | Story                                                 | Summary                                                                                                  | Status  | Parallelisable |
 | --- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------- | -------------- |
 | 01  | [us-01-manual-input](us-01-manual-input.md)           | Shell UI form for creating engrams: type selector, template fields, body editor, scope picker, tag input | Done    | No (first)     |
-| 02  | [us-02-agent-input](us-02-agent-input.md)             | MCP tools and API endpoint for writing engrams from Claude Code or external tools                        | Partial | Yes            |
+| 02  | [us-02-agent-input](us-02-agent-input.md)             | MCP tools and API endpoint for writing engrams from Claude Code or external tools                        | Done    | Yes            |
 | 03  | [us-03-quick-capture](us-03-quick-capture.md)         | Minimal-friction capture for Moltbot/CLI: raw text in, classified later                                  | Partial | Yes            |
 | 04  | [us-04-classification](us-04-classification.md)       | LLM-based content classification: infer type, match template, suggest tags                               | Done    | Yes            |
 | 05  | [us-05-entity-extraction](us-05-entity-extraction.md) | Extract people, projects, dates, topics from body into tags and frontmatter                              | Done    | Yes            |

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-02-agent-input.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-02-agent-input.md
@@ -1,7 +1,7 @@
 # US-02: Agent Input via MCP and API
 
 > PRD: [PRD-081: Ingestion Pipeline](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -9,14 +9,14 @@ As an AI agent (Claude Code session or external tool), I want to write engrams t
 
 ## Acceptance Criteria
 
-- [ ] An MCP tool `cerebrum_ingest` is registered with the pops MCP server, accepting parameters: `body` (required), `title` (optional), `type` (optional), `scopes` (optional string array), `tags` (optional string array)
-- [ ] An MCP tool `cerebrum_quick_capture` is registered for lightweight capture, accepting a single `text` parameter — delegates to `cerebrum.ingest.quickCapture`
+- [x] An MCP tool `cerebrum.ingest` is registered with the pops MCP server, accepting parameters: `body` (required), `title` (optional), `type` (optional), `scopes` (optional string array), `tags` (optional string array)
+- [x] An MCP tool `cerebrum.quickCapture` is registered for lightweight capture, accepting a single `text` parameter — delegates to `IngestService.quickCapture`
 - [x] The tRPC procedure `cerebrum.ingest.submit` accepts the full `IngestionRequest` schema and runs the complete pipeline (normalise, classify, extract, scope, deduplicate, write)
 - [x] When `type` is omitted, the pipeline runs Cortex classification on the body and assigns the inferred type
 - [x] When `scopes` are omitted, the pipeline runs scope inference (source-based rules first, then LLM-based analysis)
 - [x] Raw Markdown input is normalised (trimmed, line endings normalised, UTF-8 validated) before processing
-- [ ] Structured JSON input (detected by content inspection) is converted to Markdown with metadata extracted into frontmatter fields
-- [ ] The MCP tools return the created engram's ID, file path, type, and assigned scopes in the response
+- [x] Structured JSON input (detected by content inspection) is converted to Markdown with metadata extracted into frontmatter fields
+- [x] The MCP tools return the created engram's ID, file path, type, and assigned scopes in the response
 - [x] Invalid input (empty body, malformed scopes) returns structured error messages with field-level detail, not generic 500 errors
 
 ## Notes


### PR DESCRIPTION
Closes #2556

## Summary

- Registers `cerebrum.quickCapture` as a first-class MCP tool, mirroring the
  manual/CLI `cerebrum.ingest.quickCapture` tRPC route so agents (Claude Code,
  Moltbot) have a low-latency capture path without bypassing the registry.
- Promotes scalar JSON metadata from agent submissions into engram
  `customFields` (frontmatter) while keeping the JSON body as a fenced
  ``` ```json``` ``` block. Reserved keys (`title`/`body`/`content`/`text`) are
  filtered to avoid clobbering pipeline-derived fields.
- Surfaces `ValidationError` details through `mapServiceError` so agents see
  the actual field-level reason ("at least one scope is required", etc.)
  instead of the opaque "Validation failed" string.
- Ticks every US-02 acceptance criterion; the status table in PRD-081 README
  now reads `Done` for the agent-input row.

The agent path shares every pipeline stage with the manual UI — `submit()` and
`quickCapture()` on `IngestService` are unchanged, the MCP wrappers stay thin.

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — no new errors (158 pre-existing warnings unchanged)
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 4118/4118 pass
- [x] `pnpm --filter @pops/api test:integration` — 81/81 pass, including the
      new `agent-ingest.integration.test.ts` (10 tests covering full pipeline,
      explicit-type bypass, JSON metadata extraction, low-confidence
      classification, empty-body rejection, scope-rejection error surface,
      preview shape, and quickCapture enqueueing the async classification job)
- [x] `pnpm registry:build` — clean

## Notes

- The manual UI path (`packages/app-cerebrum/.../useSubmission.ts`) was
  already calling `cerebrum.ingest.submit` — no shared-code extraction was
  needed because both paths already converge on `IngestService.submit`.
- The Moltbot `/capture` skill keeps using the tRPC `quickCapture` route; the
  new MCP tool is for stdio-MCP agents (Claude Code) that prefer the tool
  surface to direct tRPC.