### PR TITLE
feat(ai): alert rules with telegram + nudge channels (PRD-092 US-07)

### DIFF
--- a/apps/pops-api/src/db/drizzle-migrations/0055_ai_alert_rules.sql
+++ b/apps/pops-api/src/db/drizzle-migrations/0055_ai_alert_rules.sql
@@ -1,0 +1,34 @@
+CREATE TABLE `ai_alert_rules` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`type` text NOT NULL,
+	`scope_provider` text,
+	`scope_model` text,
+	`threshold_value` real NOT NULL,
+	`window_minutes` integer,
+	`enabled` integer DEFAULT 1 NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_alert_rules_type` ON `ai_alert_rules` (`type`);--> statement-breakpoint
+CREATE INDEX `idx_ai_alert_rules_enabled` ON `ai_alert_rules` (`enabled`);--> statement-breakpoint
+CREATE TABLE `ai_alerts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`rule_id` integer,
+	`type` text NOT NULL,
+	`message` text NOT NULL,
+	`severity` text NOT NULL,
+	`scope_detail` text,
+	`metric_value` real NOT NULL,
+	`threshold_value` real NOT NULL,
+	`acknowledged` integer DEFAULT 0 NOT NULL,
+	`acknowledged_at` text,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`rule_id`) REFERENCES `ai_alert_rules`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `idx_ai_alerts_created_at` ON `ai_alerts` (`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_ai_alerts_type` ON `ai_alerts` (`type`);--> statement-breakpoint
+CREATE INDEX `idx_ai_alerts_severity` ON `ai_alerts` (`severity`);--> statement-breakpoint
+CREATE INDEX `idx_ai_alerts_acknowledged` ON `ai_alerts` (`acknowledged`);--> statement-breakpoint
+CREATE INDEX `idx_ai_alerts_dedupe` ON `ai_alerts` (`type`,`scope_detail`,`created_at`);

--- a/apps/pops-api/src/db/drizzle-migrations/meta/0055_snapshot.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/0055_snapshot.json
@@ -1,0 +1,5454 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fb813f35-5a5f-4a9a-b6df-960970baba39",
+  "prevId": "63c1b4ac-826e-4ed3-8c6a-53bcf3f37d1a",
+  "tables": {
+    "ai_alert_rules": {
+      "name": "ai_alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_provider": {
+          "name": "scope_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_model": {
+          "name": "scope_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "threshold_value": {
+          "name": "threshold_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ai_alert_rules_type": {
+          "name": "idx_ai_alert_rules_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_ai_alert_rules_enabled": {
+          "name": "idx_ai_alert_rules_enabled",
+          "columns": ["enabled"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_alerts": {
+      "name": "ai_alerts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_detail": {
+          "name": "scope_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metric_value": {
+          "name": "metric_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold_value": {
+          "name": "threshold_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ai_alerts_created_at": {
+          "name": "idx_ai_alerts_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_ai_alerts_type": {
+          "name": "idx_ai_alerts_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_ai_alerts_severity": {
+          "name": "idx_ai_alerts_severity",
+          "columns": ["severity"],
+          "isUnique": false
+        },
+        "idx_ai_alerts_acknowledged": {
+          "name": "idx_ai_alerts_acknowledged",
+          "columns": ["acknowledged"],
+          "isUnique": false
+        },
+        "idx_ai_alerts_dedupe": {
+          "name": "idx_ai_alerts_dedupe",
+          "columns": ["type", "scope_detail", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_alerts_rule_id_ai_alert_rules_id_fk": {
+          "name": "ai_alerts_rule_id_ai_alert_rules_id_fk",
+          "tableFrom": "ai_alerts",
+          "tableTo": "ai_alert_rules",
+          "columnsFrom": ["rule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_budgets": {
+      "name": "ai_budgets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_value": {
+          "name": "scope_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_token_limit": {
+          "name": "monthly_token_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_cost_limit": {
+          "name": "monthly_cost_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'warn'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_inference_daily": {
+      "name": "ai_inference_daily",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_calls": {
+          "name": "total_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_input_tokens": {
+          "name": "total_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_output_tokens": {
+          "name": "total_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_latency_ms": {
+          "name": "avg_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "timeout_count": {
+          "name": "timeout_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_hit_count": {
+          "name": "cache_hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "budget_blocked_count": {
+          "name": "budget_blocked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_ai_inference_daily_key": {
+          "name": "idx_ai_inference_daily_key",
+          "columns": ["date", "provider", "model", "operation", "domain"],
+          "isUnique": true
+        },
+        "idx_ai_inference_daily_date": {
+          "name": "idx_ai_inference_daily_date",
+          "columns": ["date"],
+          "isUnique": false
+        },
+        "idx_ai_inference_daily_provider_model": {
+          "name": "idx_ai_inference_daily_provider_model",
+          "columns": ["provider", "model"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_inference_log": {
+      "name": "ai_inference_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'success'"
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ai_inference_log_created_at": {
+          "name": "idx_ai_inference_log_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_ai_inference_log_provider_model": {
+          "name": "idx_ai_inference_log_provider_model",
+          "columns": ["provider", "model"],
+          "isUnique": false
+        },
+        "idx_ai_inference_log_operation": {
+          "name": "idx_ai_inference_log_operation",
+          "columns": ["operation"],
+          "isUnique": false
+        },
+        "idx_ai_inference_log_domain": {
+          "name": "idx_ai_inference_log_domain",
+          "columns": ["domain"],
+          "isUnique": false
+        },
+        "idx_ai_inference_log_context_id": {
+          "name": "idx_ai_inference_log_context_id",
+          "columns": ["context_id"],
+          "isUnique": false
+        },
+        "idx_ai_inference_log_status": {
+          "name": "idx_ai_inference_log_status",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_model_pricing": {
+      "name": "ai_model_pricing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_cost_per_mtok": {
+          "name": "input_cost_per_mtok",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_cost_per_mtok": {
+          "name": "output_cost_per_mtok",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_ai_model_pricing_provider_model": {
+          "name": "uq_ai_model_pricing_provider_model",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_providers": {
+      "name": "ai_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_latency_ms": {
+          "name": "last_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_usage": {
+      "name": "ai_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_created_at": {
+          "name": "idx_ai_usage_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_ai_usage_batch": {
+          "name": "idx_ai_usage_batch",
+          "columns": ["import_batch_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "budgets": {
+      "name": "budgets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "budgets_notion_id_unique": {
+          "name": "budgets_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        },
+        "idx_budgets_category_period": {
+          "name": "idx_budgets_category_period",
+          "columns": ["category", "COALESCE(\"period\", char(0))"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparison_dimensions": {
+      "name": "comparison_dimensions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparison_dimensions_name": {
+          "name": "idx_comparison_dimensions_name",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparison_skip_cooloffs": {
+      "name": "comparison_skip_cooloffs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_type": {
+          "name": "media_a_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_id": {
+          "name": "media_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_type": {
+          "name": "media_b_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_id": {
+          "name": "media_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skip_until": {
+          "name": "skip_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparison_skip_cooloffs_pair": {
+          "name": "idx_comparison_skip_cooloffs_pair",
+          "columns": ["dimension_id", "media_a_type", "media_a_id", "media_b_type", "media_b_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "comparison_skip_cooloffs_dimension_id_comparison_dimensions_id_fk": {
+          "name": "comparison_skip_cooloffs_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "comparison_skip_cooloffs",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparison_staleness": {
+      "name": "comparison_staleness",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "staleness": {
+          "name": "staleness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparison_staleness_unique": {
+          "name": "idx_comparison_staleness_unique",
+          "columns": ["media_type", "media_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comparisons": {
+      "name": "comparisons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_type": {
+          "name": "media_a_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_a_id": {
+          "name": "media_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_type": {
+          "name": "media_b_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_b_id": {
+          "name": "media_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winner_type": {
+          "name": "winner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "draw_tier": {
+          "name": "draw_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delta_a": {
+          "name": "delta_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delta_b": {
+          "name": "delta_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compared_at": {
+          "name": "compared_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_comparisons_dimension_id": {
+          "name": "idx_comparisons_dimension_id",
+          "columns": ["dimension_id"],
+          "isUnique": false
+        },
+        "idx_comparisons_media_a": {
+          "name": "idx_comparisons_media_a",
+          "columns": ["media_a_type", "media_a_id"],
+          "isUnique": false
+        },
+        "idx_comparisons_media_b": {
+          "name": "idx_comparisons_media_b",
+          "columns": ["media_b_type", "media_b_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comparisons_dimension_id_comparison_dimensions_id_fk": {
+          "name": "comparisons_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "comparisons",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embeddings": {
+      "name": "embeddings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_preview": {
+          "name": "content_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_embeddings_source_chunk": {
+          "name": "uq_embeddings_source_chunk",
+          "columns": ["source_type", "source_id", "chunk_index"],
+          "isUnique": true
+        },
+        "idx_embeddings_source_type": {
+          "name": "idx_embeddings_source_type",
+          "columns": ["source_type"],
+          "isUnique": false
+        },
+        "idx_embeddings_content_hash": {
+          "name": "idx_embeddings_content_hash",
+          "columns": ["content_hash"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_corrections": {
+      "name": "transaction_corrections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_pattern": {
+          "name": "description_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'exact'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "times_applied": {
+          "name": "times_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_corrections_pattern": {
+          "name": "idx_corrections_pattern",
+          "columns": ["description_pattern"],
+          "isUnique": false
+        },
+        "idx_corrections_priority": {
+          "name": "idx_corrections_priority",
+          "columns": ["priority"],
+          "isUnique": false
+        },
+        "idx_corrections_confidence": {
+          "name": "idx_corrections_confidence",
+          "columns": ["confidence"],
+          "isUnique": false
+        },
+        "idx_corrections_times_applied": {
+          "name": "idx_corrections_times_applied",
+          "columns": ["times_applied"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_corrections_entity_id_entities_id_fk": {
+          "name": "transaction_corrections_entity_id_entities_id_fk",
+          "tableFrom": "transaction_corrections",
+          "tableTo": "entities",
+          "columnsFrom": ["entity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debrief_results": {
+      "name": "debrief_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comparison_id": {
+          "name": "comparison_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debrief_results_session_id_debrief_sessions_id_fk": {
+          "name": "debrief_results_session_id_debrief_sessions_id_fk",
+          "tableFrom": "debrief_results",
+          "tableTo": "debrief_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "debrief_results_dimension_id_comparison_dimensions_id_fk": {
+          "name": "debrief_results_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "debrief_results",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "debrief_results_comparison_id_comparisons_id_fk": {
+          "name": "debrief_results_comparison_id_comparisons_id_fk",
+          "tableFrom": "debrief_results",
+          "tableTo": "comparisons",
+          "columnsFrom": ["comparison_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debrief_sessions": {
+      "name": "debrief_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "watch_history_id": {
+          "name": "watch_history_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debrief_sessions_watch_history_id_watch_history_id_fk": {
+          "name": "debrief_sessions_watch_history_id_watch_history_id_fk",
+          "tableFrom": "debrief_sessions",
+          "tableTo": "watch_history",
+          "columnsFrom": ["watch_history_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debrief_status": {
+      "name": "debrief_status",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "debriefed": {
+          "name": "debriefed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "debrief_status_media_dimension_idx": {
+          "name": "debrief_status_media_dimension_idx",
+          "columns": ["media_type", "media_id", "dimension_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "debrief_status_dimension_id_comparison_dimensions_id_fk": {
+          "name": "debrief_status_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "debrief_status",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dismissed_discover": {
+      "name": "dismissed_discover",
+      "columns": {
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversation_context": {
+      "name": "conversation_context",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "engram_id": {
+          "name": "engram_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relevance_score": {
+          "name": "relevance_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "loaded_at": {
+          "name": "loaded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_conversation_context_conversation": {
+          "name": "idx_conversation_context_conversation",
+          "columns": ["conversation_id"],
+          "isUnique": false
+        },
+        "idx_conversation_context_engram": {
+          "name": "idx_conversation_context_engram",
+          "columns": ["engram_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversation_context_conversation_id_conversations_id_fk": {
+          "name": "conversation_context_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_context",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "conversation_context_conversation_id_engram_id_pk": {
+          "columns": ["conversation_id", "engram_id"],
+          "name": "conversation_context_conversation_id_engram_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_scopes": {
+          "name": "active_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_context": {
+          "name": "app_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_created_at": {
+          "name": "idx_conversations_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_conversations_updated_at": {
+          "name": "idx_conversations_updated_at",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "citations": {
+          "name": "citations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_in": {
+          "name": "tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_out": {
+          "name": "tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_created": {
+          "name": "idx_messages_conversation_created",
+          "columns": ["conversation_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_index": {
+      "name": "engram_index",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body_hash": {
+          "name": "body_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_fields": {
+          "name": "custom_fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "engram_index_file_path_unique": {
+          "name": "engram_index_file_path_unique",
+          "columns": ["file_path"],
+          "isUnique": true
+        },
+        "idx_engram_index_type": {
+          "name": "idx_engram_index_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_engram_index_source": {
+          "name": "idx_engram_index_source",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "idx_engram_index_status": {
+          "name": "idx_engram_index_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_engram_index_created_at": {
+          "name": "idx_engram_index_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_engram_index_content_hash": {
+          "name": "idx_engram_index_content_hash",
+          "columns": ["content_hash"],
+          "isUnique": false
+        },
+        "idx_engram_index_body_hash": {
+          "name": "idx_engram_index_body_hash",
+          "columns": ["body_hash"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_links": {
+      "name": "engram_links",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_engram_links_target": {
+          "name": "idx_engram_links_target",
+          "columns": ["target_id"],
+          "isUnique": false
+        },
+        "uq_engram_links_pair": {
+          "name": "uq_engram_links_pair",
+          "columns": ["source_id", "target_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "engram_links_source_id_engram_index_id_fk": {
+          "name": "engram_links_source_id_engram_index_id_fk",
+          "tableFrom": "engram_links",
+          "tableTo": "engram_index",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_scopes": {
+      "name": "engram_scopes",
+      "columns": {
+        "engram_id": {
+          "name": "engram_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_engram_scopes_scope": {
+          "name": "idx_engram_scopes_scope",
+          "columns": ["scope"],
+          "isUnique": false
+        },
+        "uq_engram_scopes_pair": {
+          "name": "uq_engram_scopes_pair",
+          "columns": ["engram_id", "scope"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "engram_scopes_engram_id_engram_index_id_fk": {
+          "name": "engram_scopes_engram_id_engram_index_id_fk",
+          "tableFrom": "engram_scopes",
+          "tableTo": "engram_index",
+          "columnsFrom": ["engram_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "engram_tags": {
+      "name": "engram_tags",
+      "columns": {
+        "engram_id": {
+          "name": "engram_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_engram_tags_tag": {
+          "name": "idx_engram_tags_tag",
+          "columns": ["tag"],
+          "isUnique": false
+        },
+        "uq_engram_tags_pair": {
+          "name": "uq_engram_tags_pair",
+          "columns": ["engram_id", "tag"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "engram_tags_engram_id_engram_index_id_fk": {
+          "name": "engram_tags_engram_id_engram_index_id_fk",
+          "tableFrom": "engram_tags",
+          "tableTo": "engram_index",
+          "columnsFrom": ["engram_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entities": {
+      "name": "entities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'company'"
+        },
+        "abn": {
+          "name": "abn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_transaction_type": {
+          "name": "default_transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_tags": {
+          "name": "default_tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entities_notion_id_unique": {
+          "name": "entities_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "db_path": {
+          "name": "db_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed_type": {
+          "name": "seed_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_environments_expires_at": {
+          "name": "idx_environments_expires_at",
+          "columns": ["expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "episodes": {
+      "name": "episodes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "still_path": {
+          "name": "still_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_episodes_tvdb_id": {
+          "name": "idx_episodes_tvdb_id",
+          "columns": ["tvdb_id"],
+          "isUnique": true
+        },
+        "idx_episodes_season_number": {
+          "name": "idx_episodes_season_number",
+          "columns": ["season_id", "episode_number"],
+          "isUnique": true
+        },
+        "idx_episodes_season_id": {
+          "name": "idx_episodes_season_id",
+          "columns": ["season_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "episodes_season_id_seasons_id_fk": {
+          "name": "episodes_season_id_seasons_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "seasons",
+          "columnsFrom": ["season_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "glia_actions": {
+      "name": "glia_actions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "affected_ids": {
+          "name": "affected_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_decision": {
+          "name": "user_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_note": {
+          "name": "user_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reverted_at": {
+          "name": "reverted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_glia_actions_action_type": {
+          "name": "idx_glia_actions_action_type",
+          "columns": ["action_type"],
+          "isUnique": false
+        },
+        "idx_glia_actions_status": {
+          "name": "idx_glia_actions_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_glia_actions_phase": {
+          "name": "idx_glia_actions_phase",
+          "columns": ["phase"],
+          "isUnique": false
+        },
+        "idx_glia_actions_created_at": {
+          "name": "idx_glia_actions_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "glia_trust_state": {
+      "name": "glia_trust_state",
+      "columns": {
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approved_count": {
+          "name": "approved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reverted_count": {
+          "name": "reverted_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "autonomous_since": {
+          "name": "autonomous_since",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_revert_at": {
+          "name": "last_revert_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "graduated_at": {
+          "name": "graduated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_inventory": {
+      "name": "home_inventory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room": {
+          "name": "room",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'good'"
+        },
+        "in_use": {
+          "name": "in_use",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warranty_expires": {
+          "name": "warranty_expires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "replacement_value": {
+          "name": "replacement_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resale_value": {
+          "name": "resale_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_transaction_id": {
+          "name": "purchase_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchased_from_id": {
+          "name": "purchased_from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchased_from_name": {
+          "name": "purchased_from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_inventory_notion_id_unique": {
+          "name": "home_inventory_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        },
+        "home_inventory_asset_id_unique": {
+          "name": "home_inventory_asset_id_unique",
+          "columns": ["asset_id"],
+          "isUnique": true
+        },
+        "idx_inventory_asset_id": {
+          "name": "idx_inventory_asset_id",
+          "columns": ["asset_id"],
+          "isUnique": true
+        },
+        "idx_inventory_name": {
+          "name": "idx_inventory_name",
+          "columns": ["item_name"],
+          "isUnique": false
+        },
+        "idx_inventory_location": {
+          "name": "idx_inventory_location",
+          "columns": ["location_id"],
+          "isUnique": false
+        },
+        "idx_inventory_type": {
+          "name": "idx_inventory_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_inventory_warranty": {
+          "name": "idx_inventory_warranty",
+          "columns": ["warranty_expires"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_inventory_purchase_transaction_id_transactions_id_fk": {
+          "name": "home_inventory_purchase_transaction_id_transactions_id_fk",
+          "tableFrom": "home_inventory",
+          "tableTo": "transactions",
+          "columnsFrom": ["purchase_transaction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_inventory_purchased_from_id_entities_id_fk": {
+          "name": "home_inventory_purchased_from_id_entities_id_fk",
+          "tableFrom": "home_inventory",
+          "tableTo": "entities",
+          "columnsFrom": ["purchased_from_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_inventory_location_id_locations_id_fk": {
+          "name": "home_inventory_location_id_locations_id_fk",
+          "tableFrom": "home_inventory",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_connections": {
+      "name": "item_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_a_id": {
+          "name": "item_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_b_id": {
+          "name": "item_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_connections_a": {
+          "name": "idx_item_connections_a",
+          "columns": ["item_a_id"],
+          "isUnique": false
+        },
+        "idx_item_connections_b": {
+          "name": "idx_item_connections_b",
+          "columns": ["item_b_id"],
+          "isUnique": false
+        },
+        "uq_item_connections_pair": {
+          "name": "uq_item_connections_pair",
+          "columns": ["item_a_id", "item_b_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "item_connections_item_a_id_home_inventory_id_fk": {
+          "name": "item_connections_item_a_id_home_inventory_id_fk",
+          "tableFrom": "item_connections",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_a_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_connections_item_b_id_home_inventory_id_fk": {
+          "name": "item_connections_item_b_id_home_inventory_id_fk",
+          "tableFrom": "item_connections",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_b_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chk_item_connections_order": {
+          "name": "chk_item_connections_order",
+          "value": "\"item_connections\".\"item_a_id\" < \"item_connections\".\"item_b_id\""
+        }
+      }
+    },
+    "item_documents": {
+      "name": "item_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paperless_document_id": {
+          "name": "paperless_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_documents_item": {
+          "name": "idx_item_documents_item",
+          "columns": ["item_id"],
+          "isUnique": false
+        },
+        "idx_item_documents_doc": {
+          "name": "idx_item_documents_doc",
+          "columns": ["paperless_document_id"],
+          "isUnique": false
+        },
+        "uq_item_documents_pair": {
+          "name": "uq_item_documents_pair",
+          "columns": ["item_id", "paperless_document_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "item_documents_item_id_home_inventory_id_fk": {
+          "name": "item_documents_item_id_home_inventory_id_fk",
+          "tableFrom": "item_documents",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_photos": {
+      "name": "item_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_photos_item": {
+          "name": "idx_item_photos_item",
+          "columns": ["item_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_photos_item_id_home_inventory_id_fk": {
+          "name": "item_photos_item_id_home_inventory_id_fk",
+          "tableFrom": "item_photos",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "item_uploaded_files": {
+      "name": "item_uploaded_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_item_uploaded_files_item": {
+          "name": "idx_item_uploaded_files_item",
+          "columns": ["item_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "item_uploaded_files_item_id_home_inventory_id_fk": {
+          "name": "item_uploaded_files_item_id_home_inventory_id_fk",
+          "tableFrom": "item_uploaded_files",
+          "tableTo": "home_inventory",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_locations_parent": {
+          "name": "idx_locations_parent",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "idx_locations_name": {
+          "name": "idx_locations_name",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "idx_locations_parent_sort": {
+          "name": "idx_locations_parent_sort",
+          "columns": ["parent_id", "sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_scores": {
+      "name": "media_scores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1500
+        },
+        "comparison_count": {
+          "name": "comparison_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_media_scores_unique": {
+          "name": "idx_media_scores_unique",
+          "columns": ["media_type", "media_id", "dimension_id"],
+          "isUnique": true
+        },
+        "idx_media_scores_dimension": {
+          "name": "idx_media_scores_dimension",
+          "columns": ["dimension_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_scores_dimension_id_comparison_dimensions_id_fk": {
+          "name": "media_scores_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "media_scores",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watchlist": {
+      "name": "watchlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "plex_rating_key": {
+          "name": "plex_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_watchlist_media": {
+          "name": "idx_watchlist_media",
+          "columns": ["media_type", "media_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies": {
+      "name": "movies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_language": {
+          "name": "original_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget": {
+          "name": "budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_path": {
+          "name": "logo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_override_path": {
+          "name": "poster_override_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discover_rating_key": {
+          "name": "discover_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "rotation_status": {
+          "name": "rotation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_expires_at": {
+          "name": "rotation_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotation_marked_at": {
+          "name": "rotation_marked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_movies_rotation_status": {
+          "name": "idx_movies_rotation_status",
+          "columns": ["rotation_status"],
+          "isUnique": false
+        },
+        "idx_movies_tmdb_id": {
+          "name": "idx_movies_tmdb_id",
+          "columns": ["tmdb_id"],
+          "isUnique": true
+        },
+        "idx_movies_title": {
+          "name": "idx_movies_title",
+          "columns": ["title"],
+          "isUnique": false
+        },
+        "idx_movies_release_date": {
+          "name": "idx_movies_release_date",
+          "columns": ["release_date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "nudge_log": {
+      "name": "nudge_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "engram_ids": {
+          "name": "engram_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acted_at": {
+          "name": "acted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_params": {
+          "name": "action_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_nudge_log_type": {
+          "name": "idx_nudge_log_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_nudge_log_status": {
+          "name": "idx_nudge_log_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_nudge_log_priority": {
+          "name": "idx_nudge_log_priority",
+          "columns": ["priority"],
+          "isUnique": false
+        },
+        "idx_nudge_log_created_at": {
+          "name": "idx_nudge_log_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reflex_executions": {
+      "name": "reflex_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reflex_name": {
+          "name": "reflex_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_data": {
+          "name": "trigger_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_verb": {
+          "name": "action_verb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_reflex_exec_name": {
+          "name": "idx_reflex_exec_name",
+          "columns": ["reflex_name"],
+          "isUnique": false
+        },
+        "idx_reflex_exec_trigger_type": {
+          "name": "idx_reflex_exec_trigger_type",
+          "columns": ["trigger_type"],
+          "isUnique": false
+        },
+        "idx_reflex_exec_status": {
+          "name": "idx_reflex_exec_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_reflex_exec_triggered_at": {
+          "name": "idx_reflex_exec_triggered_at",
+          "columns": ["triggered_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_candidates": {
+      "name": "rotation_candidates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_rotation_candidates_tmdb_id": {
+          "name": "idx_rotation_candidates_tmdb_id",
+          "columns": ["tmdb_id"],
+          "isUnique": true
+        },
+        "idx_rotation_candidates_source_id": {
+          "name": "idx_rotation_candidates_source_id",
+          "columns": ["source_id"],
+          "isUnique": false
+        },
+        "idx_rotation_candidates_status": {
+          "name": "idx_rotation_candidates_status",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rotation_candidates_source_id_rotation_sources_id_fk": {
+          "name": "rotation_candidates_source_id_rotation_sources_id_fk",
+          "tableFrom": "rotation_candidates",
+          "tableTo": "rotation_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_exclusions": {
+      "name": "rotation_exclusions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_rotation_exclusions_tmdb_id": {
+          "name": "idx_rotation_exclusions_tmdb_id",
+          "columns": ["tmdb_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_log": {
+      "name": "rotation_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_marked_leaving": {
+          "name": "movies_marked_leaving",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_removed": {
+          "name": "movies_removed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_added": {
+          "name": "movies_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removals_failed": {
+          "name": "removals_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "free_space_gb": {
+          "name": "free_space_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_free_gb": {
+          "name": "target_free_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skipped_reason": {
+          "name": "skipped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rotation_sources": {
+      "name": "rotation_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_interval_hours": {
+          "name": "sync_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_rotation_sources_type": {
+          "name": "idx_rotation_sources_type",
+          "columns": ["type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "seasons": {
+      "name": "seasons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tv_show_id": {
+          "name": "tv_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_seasons_tvdb_id": {
+          "name": "idx_seasons_tvdb_id",
+          "columns": ["tvdb_id"],
+          "isUnique": true
+        },
+        "idx_seasons_show_number": {
+          "name": "idx_seasons_show_number",
+          "columns": ["tv_show_id", "season_number"],
+          "isUnique": true
+        },
+        "idx_seasons_tv_show_id": {
+          "name": "idx_seasons_tv_show_id",
+          "columns": ["tv_show_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "seasons_tv_show_id_tv_shows_id_fk": {
+          "name": "seasons_tv_show_id_tv_shows_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "tv_shows",
+          "columnsFrom": ["tv_show_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_accounts": {
+      "name": "service_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "service_accounts_name_unique": {
+          "name": "service_accounts_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "service_accounts_key_prefix_unique": {
+          "name": "service_accounts_key_prefix_unique",
+          "columns": ["key_prefix"],
+          "isUnique": true
+        },
+        "idx_service_accounts_key_prefix": {
+          "name": "idx_service_accounts_key_prefix",
+          "columns": ["key_prefix"],
+          "isUnique": false
+        },
+        "idx_service_accounts_revoked_at": {
+          "name": "idx_service_accounts_revoked_at",
+          "columns": ["revoked_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shelf_impressions": {
+      "name": "shelf_impressions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "shelf_id": {
+          "name": "shelf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_shelf_impressions_shelf_id": {
+          "name": "idx_shelf_impressions_shelf_id",
+          "columns": ["shelf_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_job_results": {
+      "name": "sync_job_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_sync_job_results_type_completed": {
+          "name": "idx_sync_job_results_type_completed",
+          "columns": ["job_type", "completed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_logs": {
+      "name": "sync_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movies_synced": {
+          "name": "movies_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tv_shows_synced": {
+          "name": "tv_shows_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag_vocabulary": {
+      "name": "tag_vocabulary",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'seed'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_tag_vocabulary_active": {
+          "name": "idx_tag_vocabulary_active",
+          "columns": ["is_active"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tier_overrides": {
+      "name": "tier_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimension_id": {
+          "name": "dimension_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_tier_overrides_unique": {
+          "name": "idx_tier_overrides_unique",
+          "columns": ["media_type", "media_id", "dimension_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tier_overrides_dimension_id_comparison_dimensions_id_fk": {
+          "name": "tier_overrides_dimension_id_comparison_dimensions_id_fk",
+          "tableFrom": "tier_overrides",
+          "tableTo": "comparison_dimensions",
+          "columnsFrom": ["dimension_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_tag_rules": {
+      "name": "transaction_tag_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_pattern": {
+          "name": "description_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'exact'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "times_applied": {
+          "name": "times_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tag_rules_pattern": {
+          "name": "idx_tag_rules_pattern",
+          "columns": ["description_pattern"],
+          "isUnique": false
+        },
+        "idx_tag_rules_entity_id": {
+          "name": "idx_tag_rules_entity_id",
+          "columns": ["entity_id"],
+          "isUnique": false
+        },
+        "idx_tag_rules_priority": {
+          "name": "idx_tag_rules_priority",
+          "columns": ["priority"],
+          "isUnique": false
+        },
+        "idx_tag_rules_confidence": {
+          "name": "idx_tag_rules_confidence",
+          "columns": ["confidence"],
+          "isUnique": false
+        },
+        "idx_tag_rules_times_applied": {
+          "name": "idx_tag_rules_times_applied",
+          "columns": ["times_applied"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_tag_rules_entity_id_entities_id_fk": {
+          "name": "transaction_tag_rules_entity_id_entities_id_fk",
+          "tableFrom": "transaction_tag_rules",
+          "tableTo": "entities",
+          "columnsFrom": ["entity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account": {
+          "name": "account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_transaction_id": {
+          "name": "related_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_row": {
+          "name": "raw_row",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactions_notion_id_unique": {
+          "name": "transactions_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        },
+        "idx_transactions_date": {
+          "name": "idx_transactions_date",
+          "columns": ["date"],
+          "isUnique": false
+        },
+        "idx_transactions_account": {
+          "name": "idx_transactions_account",
+          "columns": ["account"],
+          "isUnique": false
+        },
+        "idx_transactions_entity": {
+          "name": "idx_transactions_entity",
+          "columns": ["entity_id"],
+          "isUnique": false
+        },
+        "idx_transactions_last_edited": {
+          "name": "idx_transactions_last_edited",
+          "columns": ["last_edited_time"],
+          "isUnique": false
+        },
+        "idx_transactions_notion_id": {
+          "name": "idx_transactions_notion_id",
+          "columns": ["notion_id"],
+          "isUnique": false
+        },
+        "idx_transactions_checksum": {
+          "name": "idx_transactions_checksum",
+          "columns": ["checksum"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "transactions_entity_id_entities_id_fk": {
+          "name": "transactions_entity_id_entities_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "entities",
+          "columnsFrom": ["entity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tv_shows": {
+      "name": "tv_shows",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tvdb_id": {
+          "name": "tvdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_air_date": {
+          "name": "first_air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_air_date": {
+          "name": "last_air_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_language": {
+          "name": "original_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "number_of_seasons": {
+          "name": "number_of_seasons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "number_of_episodes": {
+          "name": "number_of_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "episode_run_time": {
+          "name": "episode_run_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_path": {
+          "name": "logo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_override_path": {
+          "name": "poster_override_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discover_rating_key": {
+          "name": "discover_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "networks": {
+          "name": "networks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_tv_shows_tvdb_id": {
+          "name": "idx_tv_shows_tvdb_id",
+          "columns": ["tvdb_id"],
+          "isUnique": true
+        },
+        "idx_tv_shows_name": {
+          "name": "idx_tv_shows_name",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "idx_tv_shows_first_air_date": {
+          "name": "idx_tv_shows_first_air_date",
+          "columns": ["first_air_date"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_settings_user": {
+          "name": "idx_user_settings_user",
+          "columns": ["user_email"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_settings_user_email_key_pk": {
+          "columns": ["user_email", "key"],
+          "name": "user_settings_user_email_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watch_history": {
+      "name": "watch_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "blacklisted": {
+          "name": "blacklisted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_watch_history_media": {
+          "name": "idx_watch_history_media",
+          "columns": ["media_type", "media_id"],
+          "isUnique": false
+        },
+        "idx_watch_history_watched_at": {
+          "name": "idx_watch_history_watched_at",
+          "columns": ["watched_at"],
+          "isUnique": false
+        },
+        "idx_watch_history_unique": {
+          "name": "idx_watch_history_unique",
+          "columns": ["media_type", "media_id", "watched_at"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wish_list": {
+      "name": "wish_list",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_amount": {
+          "name": "target_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saved": {
+          "name": "saved",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edited_time": {
+          "name": "last_edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "wish_list_notion_id_unique": {
+          "name": "wish_list_notion_id_unique",
+          "columns": ["notion_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_budgets_category_period": {
+        "columns": {
+          "COALESCE(\"period\", char(0))": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
+++ b/apps/pops-api/src/db/drizzle-migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1778431569630,
       "tag": "0054_service_accounts",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "6",
+      "when": 1778475109881,
+      "tag": "0055_ai_alert_rules",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/pops-api/src/db/migration-ownership.ts
+++ b/apps/pops-api/src/db/migration-ownership.ts
@@ -73,6 +73,7 @@ export const MIGRATION_OWNERS: Readonly<Record<string, string>> = {
   '0052_budgets_active_default_zero': 'finance',
   '0053_ai_inference_daily': 'core',
   '0054_service_accounts': 'core',
+  '0055_ai_alert_rules': 'core',
 };
 
 /** Materialised as a Map for O(1) lookup by the runner. */

--- a/apps/pops-api/src/db/schema.ts
+++ b/apps/pops-api/src/db/schema.ts
@@ -306,6 +306,41 @@ export function initializeSchema(db: BetterSqlite3.Database): void {
     CREATE INDEX IF NOT EXISTS idx_ai_inference_daily_provider_model
       ON ai_inference_daily(provider, model);
 
+    CREATE TABLE IF NOT EXISTS ai_alert_rules (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      type TEXT NOT NULL,
+      scope_provider TEXT,
+      scope_model TEXT,
+      threshold_value REAL NOT NULL,
+      window_minutes INTEGER,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_ai_alert_rules_type ON ai_alert_rules(type);
+    CREATE INDEX IF NOT EXISTS idx_ai_alert_rules_enabled ON ai_alert_rules(enabled);
+
+    CREATE TABLE IF NOT EXISTS ai_alerts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      rule_id INTEGER REFERENCES ai_alert_rules(id) ON DELETE SET NULL,
+      type TEXT NOT NULL,
+      message TEXT NOT NULL,
+      severity TEXT NOT NULL,
+      scope_detail TEXT,
+      metric_value REAL NOT NULL,
+      threshold_value REAL NOT NULL,
+      acknowledged INTEGER NOT NULL DEFAULT 0,
+      acknowledged_at TEXT,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_ai_alerts_created_at ON ai_alerts(created_at);
+    CREATE INDEX IF NOT EXISTS idx_ai_alerts_type ON ai_alerts(type);
+    CREATE INDEX IF NOT EXISTS idx_ai_alerts_severity ON ai_alerts(severity);
+    CREATE INDEX IF NOT EXISTS idx_ai_alerts_acknowledged ON ai_alerts(acknowledged);
+    CREATE INDEX IF NOT EXISTS idx_ai_alerts_dedupe ON ai_alerts(type, scope_detail, created_at);
+
     CREATE TABLE IF NOT EXISTS transaction_corrections (
       id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
       description_pattern TEXT NOT NULL,

--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -10,6 +10,10 @@ import { closeDb } from './db.js';
 import { closeQueues } from './jobs/queues.js';
 import { startThalamus, stopThalamus } from './modules/cerebrum/thalamus/instance.js';
 import {
+  registerAiAlertsScheduler,
+  unregisterAiAlertsScheduler,
+} from './modules/core/ai-alerts/scheduler.js';
+import {
   registerAiLogRetentionScheduler,
   unregisterAiLogRetentionScheduler,
 } from './modules/core/ai-observability/scheduler.js';
@@ -67,6 +71,11 @@ registerAiLogRetentionScheduler().catch((err: unknown) => {
   console.error('[ai-retention] Failed to register scheduler:', err);
 });
 
+// Register AI alert evaluator scheduler (PRD-092 US-07)
+registerAiAlertsScheduler().catch((err: unknown) => {
+  console.error('[ai-alerts] Failed to register scheduler:', err);
+});
+
 async function shutdown(signal: string): Promise<void> {
   console.warn(`[pops-api] ${signal} — shutting down`);
   // 1. Stop accepting new requests
@@ -77,6 +86,7 @@ async function shutdown(signal: string): Promise<void> {
   // 3. Stop Thalamus file watcher
   await stopThalamus();
   await unregisterAiLogRetentionScheduler();
+  await unregisterAiAlertsScheduler();
   // 4. Wait for any in-progress rotation cycle to finish
   if (process.env['NODE_ENV'] !== 'test') {
     await waitForCycleEnd();

--- a/apps/pops-api/src/jobs/handlers/default.ts
+++ b/apps/pops-api/src/jobs/handlers/default.ts
@@ -5,6 +5,7 @@ import {
   CROSS_SOURCE_TYPES,
   CrossSourceIndexer,
 } from '../../modules/cerebrum/thalamus/cross-source.js';
+import { runEvaluation } from '../../modules/core/ai-alerts/evaluator.js';
 import { runRetention } from '../../modules/core/ai-observability/retention.js';
 
 import type { Job } from 'bullmq';
@@ -38,6 +39,20 @@ export async function process(job: Job<DefaultQueueJobData>): Promise<unknown> {
         cutoff: result.cutoff,
       },
       'AI inference log retention complete'
+    );
+    return result;
+  }
+
+  if (job.data.type === 'aiAlertEvaluation') {
+    const result = await runEvaluation();
+    logger.info(
+      {
+        rulesEvaluated: result.rulesEvaluated,
+        candidates: result.candidates,
+        deduped: result.deduped,
+        fired: result.alerts.length,
+      },
+      'AI alert evaluation complete'
     );
     return result;
   }

--- a/apps/pops-api/src/jobs/types.ts
+++ b/apps/pops-api/src/jobs/types.ts
@@ -67,6 +67,10 @@ export interface AiLogRetentionJobData {
   type: 'aiLogRetention';
 }
 
+export interface AiAlertEvaluationJobData {
+  type: 'aiAlertEvaluation';
+}
+
 export interface ClassifyEngramJobData {
   type: 'classifyEngram';
   engramId: string;
@@ -104,7 +108,10 @@ export type GliaJobData =
   | GliaAuditJobData;
 
 export type CurationQueueJobData = ClassifyEngramJobData | GliaJobData | GenericJobData;
-export type DefaultQueueJobData = CrossSourceIndexJobData | AiLogRetentionJobData;
+export type DefaultQueueJobData =
+  | CrossSourceIndexJobData
+  | AiLogRetentionJobData
+  | AiAlertEvaluationJobData;
 
 // ---------------------------------------------------------------------------
 // pops-dead-letter queue

--- a/apps/pops-api/src/modules/core/ai-alerts/alerts-store.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/alerts-store.ts
@@ -1,0 +1,119 @@
+/**
+ * Persistence + listing helpers for fired alerts.
+ *
+ * Separated from the evaluator orchestrator so each module stays focused
+ * and within the project's max-lines lint budget.
+ */
+import { and, desc, eq, gte, lte, sql, type SQL } from 'drizzle-orm';
+
+import { aiAlerts } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
+import { alertRowToAlert } from './mappers.js';
+
+import type { AlertCandidate, AlertRuleType, AlertSeverity, FiredAlert } from './types.js';
+
+export const DEDUP_WINDOW_MINUTES = 60;
+
+/** Has an alert with the same `(type, scope_detail)` already fired in the dedup window? */
+export function isDuplicate(
+  db: ReturnType<typeof getDrizzle>,
+  candidate: AlertCandidate,
+  now: Date
+): boolean {
+  const cutoff = new Date(now.getTime() - DEDUP_WINDOW_MINUTES * 60 * 1000).toISOString();
+  const conditions = [eq(aiAlerts.type, candidate.type), gte(aiAlerts.createdAt, cutoff)];
+  if (candidate.scopeDetail === null) {
+    conditions.push(sql`${aiAlerts.scopeDetail} IS NULL`);
+  } else {
+    conditions.push(eq(aiAlerts.scopeDetail, candidate.scopeDetail));
+  }
+  const [row] = db
+    .select({ id: aiAlerts.id })
+    .from(aiAlerts)
+    .where(and(...conditions))
+    .limit(1)
+    .all();
+  return row !== undefined;
+}
+
+export function insertAlert(
+  db: ReturnType<typeof getDrizzle>,
+  candidate: AlertCandidate,
+  now: Date
+): FiredAlert {
+  const result = db
+    .insert(aiAlerts)
+    .values({
+      ruleId: candidate.ruleId,
+      type: candidate.type,
+      message: candidate.message,
+      severity: candidate.severity,
+      scopeDetail: candidate.scopeDetail,
+      metricValue: candidate.metricValue,
+      thresholdValue: candidate.thresholdValue,
+      acknowledged: 0,
+      createdAt: now.toISOString(),
+    })
+    .returning()
+    .all();
+  const row = result[0];
+  if (!row) throw new Error('Insert into ai_alerts returned no rows');
+  return alertRowToAlert(row);
+}
+
+export interface ListAlertsFilters {
+  acknowledged?: boolean;
+  type?: AlertRuleType;
+  severity?: AlertSeverity;
+  startDate?: string;
+  endDate?: string;
+  limit?: number;
+  offset?: number;
+}
+
+function buildListConditions(filters: ListAlertsFilters): SQL | undefined {
+  const conditions: SQL[] = [];
+  if (filters.acknowledged !== undefined) {
+    conditions.push(eq(aiAlerts.acknowledged, filters.acknowledged ? 1 : 0));
+  }
+  if (filters.type) conditions.push(eq(aiAlerts.type, filters.type));
+  if (filters.severity) conditions.push(eq(aiAlerts.severity, filters.severity));
+  if (filters.startDate) conditions.push(gte(aiAlerts.createdAt, filters.startDate));
+  if (filters.endDate) conditions.push(lte(aiAlerts.createdAt, filters.endDate));
+  return conditions.length > 0 ? and(...conditions) : undefined;
+}
+
+export function listAlerts(filters: ListAlertsFilters = {}): {
+  alerts: FiredAlert[];
+  total: number;
+} {
+  const db = getDrizzle();
+  const where = buildListConditions(filters);
+  const baseQuery = db.select().from(aiAlerts);
+  const limit = filters.limit ?? 100;
+  const offset = filters.offset ?? 0;
+  const rows = (where ? baseQuery.where(where) : baseQuery)
+    .orderBy(desc(aiAlerts.createdAt))
+    .limit(limit)
+    .offset(offset)
+    .all();
+  const countQuery = db.select({ total: sql<number>`COUNT(*)` }).from(aiAlerts);
+  const [totalRow] = (where ? countQuery.where(where) : countQuery).all();
+  return {
+    alerts: rows.map(alertRowToAlert),
+    total: totalRow?.total ?? 0,
+  };
+}
+
+export function acknowledgeAlert(id: number, now: Date = new Date()): FiredAlert | null {
+  const db = getDrizzle();
+  const result = db
+    .update(aiAlerts)
+    .set({ acknowledged: 1, acknowledgedAt: now.toISOString() })
+    .where(eq(aiAlerts.id, id))
+    .returning()
+    .all();
+  const row = result[0];
+  return row ? alertRowToAlert(row) : null;
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/alerts-store.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/alerts-store.ts
@@ -62,6 +62,27 @@ export function insertAlert(
   return alertRowToAlert(row);
 }
 
+/**
+ * Atomically check-then-insert: returns the persisted row when the candidate
+ * was new, or `null` when an alert with the same `(type, scope_detail)` is
+ * already present inside the rolling dedup window.
+ *
+ * The dedup window is time-based and therefore cannot be expressed as a
+ * static UNIQUE constraint; we wrap the check and the insert in a single
+ * SQLite write transaction so two concurrent evaluator runs cannot both
+ * pass the duplicate check and double-fire.
+ */
+export function insertAlertIfNotDuplicate(
+  db: ReturnType<typeof getDrizzle>,
+  candidate: AlertCandidate,
+  now: Date
+): FiredAlert | null {
+  return db.transaction((tx) => {
+    if (isDuplicate(tx, candidate, now)) return null;
+    return insertAlert(tx, candidate, now);
+  });
+}
+
 export interface ListAlertsFilters {
   acknowledged?: boolean;
   type?: AlertRuleType;

--- a/apps/pops-api/src/modules/core/ai-alerts/dispatch.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/dispatch.ts
@@ -1,0 +1,80 @@
+/**
+ * Channel dispatch facade for AI alerts.
+ *
+ * Resolves the channel list for a given alert and invokes each dispatcher
+ * sequentially, catching per-channel failures so a misconfigured channel
+ * doesn't block delivery on the others.
+ *
+ * The default channel matrix matches PRD-092 US-07:
+ *   - in-app nudges always receive every alert (warning + critical)
+ *   - Telegram receives only `critical` alerts unless an env override is set
+ *     (POPS_ALERTS_TELEGRAM_INCLUDE_WARNINGS=1)
+ */
+import { logger } from '../../../lib/logger.js';
+import { dispatchNudge } from './dispatchers/nudge.js';
+import { dispatchTelegram } from './dispatchers/telegram.js';
+
+import type { AlertChannel, FiredAlert } from './types.js';
+
+export interface ChannelDispatchResult {
+  channel: AlertChannel;
+  delivered: boolean;
+  error: string | null;
+}
+
+export interface DispatchOptions {
+  /** Override channel resolution — useful for testing. */
+  channels?: AlertChannel[];
+  /** Override the nudge dispatcher (for tests). */
+  nudgeDispatcher?: (alert: FiredAlert) => boolean | Promise<boolean>;
+  /** Override the telegram dispatcher (for tests). */
+  telegramDispatcher?: (alert: FiredAlert) => boolean | Promise<boolean>;
+  env?: NodeJS.ProcessEnv;
+}
+
+/** Resolve the channel list for a given alert from severity + env config. */
+export function resolveChannels(
+  alert: FiredAlert,
+  env: NodeJS.ProcessEnv = process.env
+): AlertChannel[] {
+  const channels: AlertChannel[] = ['nudge'];
+  const includeWarnings = env['POPS_ALERTS_TELEGRAM_INCLUDE_WARNINGS'] === '1';
+  if (alert.severity === 'critical' || includeWarnings) {
+    channels.push('telegram');
+  }
+  return channels;
+}
+
+/** Dispatch a single alert across every applicable channel. */
+export async function dispatchAlert(
+  alert: FiredAlert,
+  options: DispatchOptions = {}
+): Promise<ChannelDispatchResult[]> {
+  const channels = options.channels ?? resolveChannels(alert, options.env);
+  const results: ChannelDispatchResult[] = [];
+
+  for (const channel of channels) {
+    try {
+      let delivered = false;
+      if (channel === 'nudge') {
+        delivered = options.nudgeDispatcher
+          ? await options.nudgeDispatcher(alert)
+          : dispatchNudge(alert);
+      } else if (channel === 'telegram') {
+        delivered = options.telegramDispatcher
+          ? await options.telegramDispatcher(alert)
+          : await dispatchTelegram(alert);
+      }
+      results.push({ channel, delivered, error: null });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(
+        { alertId: alert.id, channel, error: message },
+        '[ai-alerts/dispatch] Channel dispatch failed'
+      );
+      results.push({ channel, delivered: false, error: message });
+    }
+  }
+
+  return results;
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/dispatchers/nudge.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/dispatchers/nudge.ts
@@ -1,0 +1,72 @@
+/**
+ * Cerebrum nudge dispatcher (PRD-092 US-07, PRD-084).
+ *
+ * Persists the alert as a nudge_log row using the existing nudge persistence
+ * schema (no engram IDs — these nudges are observability events, not engram
+ * recommendations). The nudge type is the fixed string `insight` since
+ * PRD-084 reserves the four canonical detector types.
+ *
+ * The Cerebrum nudge surfaces query the nudge_log directly, so writing a row
+ * here is enough to make the alert visible alongside other proactive
+ * nudges.
+ */
+import { nudgeLog } from '@pops/db-types';
+
+import { getDrizzle } from '../../../../db.js';
+import { logger } from '../../../../lib/logger.js';
+
+import type { FiredAlert } from '../types.js';
+
+/** Map alert severity to nudge priority. */
+function priorityFor(severity: FiredAlert['severity']): 'low' | 'medium' | 'high' {
+  return severity === 'critical' ? 'high' : 'medium';
+}
+
+/** Build the nudge ID — mirrors `generateNudgeId` shape for consistency. */
+function buildNudgeId(now: Date, alertId: number): string {
+  const pad = (n: number, len: number): string => String(n).padStart(len, '0');
+  const date = `${now.getFullYear()}${pad(now.getMonth() + 1, 2)}${pad(now.getDate(), 2)}`;
+  const time = `${pad(now.getHours(), 2)}${pad(now.getMinutes(), 2)}`;
+  return `nudge_${date}_${time}_aiAlert_${alertId}`;
+}
+
+export interface DispatchNudgeOptions {
+  now?: () => Date;
+}
+
+/**
+ * Dispatch the alert by writing a nudge_log row. Returns `true` when the
+ * nudge was created. Throws on DB errors.
+ */
+export function dispatchNudge(alert: FiredAlert, options: DispatchNudgeOptions = {}): boolean {
+  const now = options.now ?? (() => new Date());
+  const db = getDrizzle();
+  const id = buildNudgeId(now(), alert.id);
+  const title = `AI alert: ${alert.type}`;
+  const body = alert.scopeDetail ? `${alert.message} (${alert.scopeDetail})` : alert.message;
+
+  db.insert(nudgeLog)
+    .values({
+      id,
+      type: 'insight',
+      title,
+      body,
+      engramIds: JSON.stringify([]),
+      priority: priorityFor(alert.severity),
+      status: 'pending',
+      createdAt: now().toISOString(),
+      expiresAt: null,
+      actionType: null,
+      actionLabel: null,
+      actionParams: JSON.stringify({
+        source: 'ai-alert',
+        alertId: alert.id,
+        ruleId: alert.ruleId,
+        alertType: alert.type,
+        severity: alert.severity,
+      }),
+    })
+    .run();
+  logger.debug({ nudgeId: id, alertId: alert.id }, '[ai-alerts/nudge] Nudge created');
+  return true;
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/dispatchers/telegram.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/dispatchers/telegram.ts
@@ -1,0 +1,87 @@
+/**
+ * Telegram dispatcher for AI alerts (PRD-092 US-07, PRD-088).
+ *
+ * Pushes a message to the Moltbot Telegram chat using the Bot API directly.
+ * The bot token + chat ID are read from environment variables:
+ *
+ *   POPS_ALERTS_TELEGRAM_BOT_TOKEN   the bot token (same one moltbot uses)
+ *   POPS_ALERTS_TELEGRAM_CHAT_ID     the chat ID to deliver to
+ *
+ * When either variable is unset the dispatcher is treated as not configured
+ * and silently skips delivery — this matches the PRD note "If Moltbot is not
+ * configured, skip Telegram delivery silently."
+ */
+import { logger } from '../../../../lib/logger.js';
+
+import type { FiredAlert } from '../types.js';
+
+export interface TelegramConfig {
+  botToken: string;
+  chatId: string;
+}
+
+export interface TelegramTransport {
+  send: (config: TelegramConfig, text: string) => Promise<void>;
+}
+
+/** Read config from env. Returns null when unset. */
+export function readTelegramConfig(env: NodeJS.ProcessEnv = process.env): TelegramConfig | null {
+  const botToken = env['POPS_ALERTS_TELEGRAM_BOT_TOKEN'];
+  const chatId = env['POPS_ALERTS_TELEGRAM_CHAT_ID'];
+  if (!botToken || !chatId) return null;
+  return { botToken, chatId };
+}
+
+/** Default transport using the global `fetch`. */
+export const fetchTransport: TelegramTransport = {
+  async send(config, text) {
+    const url = `https://api.telegram.org/bot${config.botToken}/sendMessage`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: config.chatId,
+        text,
+        parse_mode: 'Markdown',
+        disable_web_page_preview: true,
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '<no body>');
+      throw new Error(`Telegram sendMessage failed: ${res.status} ${body}`);
+    }
+  },
+};
+
+/**
+ * Render an alert as the Telegram message body. Markdown formatting matches
+ * the existing Moltbot conventions (bold for headline, italics for scope).
+ */
+export function renderTelegramMessage(alert: FiredAlert): string {
+  const severityEmoji = alert.severity === 'critical' ? '🚨' : '⚠️';
+  const scope = alert.scopeDetail ? `\n_${alert.scopeDetail}_` : '';
+  return `${severityEmoji} *AI Alert — ${alert.type}*${scope}\n${alert.message}`;
+}
+
+/**
+ * Dispatch the alert via Telegram. Returns `true` when a message was sent,
+ * `false` when the dispatcher was not configured (no-op). Throws on transport
+ * errors so the caller can decide whether to retry.
+ */
+export async function dispatchTelegram(
+  alert: FiredAlert,
+  options: { config?: TelegramConfig | null; transport?: TelegramTransport } = {}
+): Promise<boolean> {
+  const config = options.config === undefined ? readTelegramConfig() : options.config;
+  if (!config) {
+    logger.debug(
+      { alertId: alert.id },
+      '[ai-alerts/telegram] No Telegram config — skipping dispatch'
+    );
+    return false;
+  }
+  const transport = options.transport ?? fetchTransport;
+  const text = renderTelegramMessage(alert);
+  await transport.send(config, text);
+  return true;
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/dispatchers/telegram.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/dispatchers/telegram.ts
@@ -24,6 +24,9 @@ export interface TelegramTransport {
   send: (config: TelegramConfig, text: string) => Promise<void>;
 }
 
+/** Max time we wait for Telegram to ack a sendMessage before aborting. */
+export const TELEGRAM_REQUEST_TIMEOUT_MS = 10_000;
+
 /** Read config from env. Returns null when unset. */
 export function readTelegramConfig(env: NodeJS.ProcessEnv = process.env): TelegramConfig | null {
   const botToken = env['POPS_ALERTS_TELEGRAM_BOT_TOKEN'];
@@ -32,20 +35,48 @@ export function readTelegramConfig(env: NodeJS.ProcessEnv = process.env): Telegr
   return { botToken, chatId };
 }
 
-/** Default transport using the global `fetch`. */
+/**
+ * Escape every Telegram MarkdownV2 reserved character.
+ *
+ * Telegram rejects messages where a reserved character appears unescaped in
+ * dynamic text — user-controlled fields like rule names or scope identifiers
+ * can easily contain `_`, `*`, `[`, `]`, `.`, etc. We use MarkdownV2 (rather
+ * than the legacy `Markdown` mode) because its escaping rules are explicitly
+ * documented and predictable.
+ */
+export function escapeTelegramMarkdownV2(value: string): string {
+  return value.replace(/([_*[\]()~`>#+\-=|{}.!\\])/g, '\\$1');
+}
+
+/** Default transport using the global `fetch` with a hard request timeout. */
 export const fetchTransport: TelegramTransport = {
   async send(config, text) {
     const url = `https://api.telegram.org/bot${config.botToken}/sendMessage`;
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        chat_id: config.chatId,
-        text,
-        parse_mode: 'Markdown',
-        disable_web_page_preview: true,
-      }),
-    });
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), TELEGRAM_REQUEST_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        signal: controller.signal,
+        body: JSON.stringify({
+          chat_id: config.chatId,
+          text,
+          parse_mode: 'MarkdownV2',
+          disable_web_page_preview: true,
+        }),
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new Error(`Telegram sendMessage timed out after ${TELEGRAM_REQUEST_TIMEOUT_MS}ms`, {
+          cause: err,
+        });
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeout);
+    }
     if (!res.ok) {
       const body = await res.text().catch(() => '<no body>');
       throw new Error(`Telegram sendMessage failed: ${res.status} ${body}`);
@@ -54,13 +85,18 @@ export const fetchTransport: TelegramTransport = {
 };
 
 /**
- * Render an alert as the Telegram message body. Markdown formatting matches
- * the existing Moltbot conventions (bold for headline, italics for scope).
+ * Render an alert as the Telegram message body. All interpolated dynamic
+ * content is escaped for MarkdownV2 so user-controllable values (rule type,
+ * scope identifier, message body) cannot break Telegram's parser or inject
+ * formatting.
  */
 export function renderTelegramMessage(alert: FiredAlert): string {
   const severityEmoji = alert.severity === 'critical' ? '🚨' : '⚠️';
-  const scope = alert.scopeDetail ? `\n_${alert.scopeDetail}_` : '';
-  return `${severityEmoji} *AI Alert — ${alert.type}*${scope}\n${alert.message}`;
+  const type = escapeTelegramMarkdownV2(alert.type);
+  const message = escapeTelegramMarkdownV2(alert.message);
+  const scope = alert.scopeDetail ? `\n_${escapeTelegramMarkdownV2(alert.scopeDetail)}_` : '';
+  // Em-dash is not MarkdownV2-reserved; the literal heading text is safe.
+  return `${severityEmoji} *AI Alert — ${type}*${scope}\n${message}`;
 }
 
 /**

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluator.test.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluator.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for the AI alert evaluator + dispatchers (PRD-092 US-07).
+ *
+ * Covers:
+ *  - budget-threshold fires when monthly spend crosses N% of a cost limit
+ *  - error-spike fires when error rate exceeds the configured percentage
+ *  - latency-degradation fans out per-model when no model scope is set
+ *  - deduplication suppresses a second alert within the dedup window
+ *  - listing + acknowledgement update the row as expected
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { seedAiUsage, setupTestContext } from '../../../shared/test-utils.js';
+import { dispatchAlert, resolveChannels } from './dispatch.js';
+import { renderTelegramMessage } from './dispatchers/telegram.js';
+import { acknowledgeAlert, listAlerts, runEvaluation } from './evaluator.js';
+import * as service from './service.js';
+
+import type { Database } from 'better-sqlite3';
+
+import type { FiredAlert } from './types.js';
+
+const ctx = setupTestContext();
+let db: Database;
+
+beforeEach(() => {
+  ({ db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+function nowIsoOffset(minutesAgo: number, from: Date = new Date()): string {
+  return new Date(from.getTime() - minutesAgo * 60 * 1000).toISOString();
+}
+
+function thisMonthIso(dayOffset = 0): string {
+  const d = new Date();
+  d.setUTCDate(1);
+  d.setUTCHours(12, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() + dayOffset);
+  return d.toISOString();
+}
+
+describe('seedDefaultRules', () => {
+  it('creates three rules on first run and is idempotent thereafter', () => {
+    expect(service.seedDefaultRules()).toBe(3);
+    expect(service.listRules()).toHaveLength(3);
+    expect(service.seedDefaultRules()).toBe(0);
+    expect(service.listRules()).toHaveLength(3);
+  });
+});
+
+describe('budget-threshold evaluation', () => {
+  it('fires when monthly spend exceeds the threshold percentage of a cost limit', async () => {
+    // Budget: $10 monthly cost limit. Threshold rule: 80%.
+    db.prepare(
+      `INSERT INTO ai_budgets (id, scope_type, scope_value, monthly_token_limit, monthly_cost_limit, action, created_at, updated_at)
+       VALUES ('global', 'global', NULL, NULL, 10, 'warn', datetime('now'), datetime('now'))`
+    ).run();
+    service.createRule({ type: 'budget-threshold', thresholdValue: 80 });
+
+    // Seed $8.10 of usage this month (81% of $10).
+    seedAiUsage(db, { cost_usd: 8.1, created_at: thisMonthIso(1) });
+
+    const result = await runEvaluation({ dispatch: false });
+    expect(result.alerts).toHaveLength(1);
+    const [alert] = result.alerts;
+    expect(alert).toBeDefined();
+    expect(alert?.type).toBe('budget-threshold');
+    expect(alert?.scopeDetail).toBe('budget:global');
+    expect(alert?.metricValue).toBeCloseTo(81);
+    expect(alert?.thresholdValue).toBe(80);
+    expect(alert?.severity).toBe('warning');
+    expect(alert?.message).toMatch(/81/);
+  });
+
+  it('marks critical severity at 95% or above', async () => {
+    db.prepare(
+      `INSERT INTO ai_budgets (id, scope_type, scope_value, monthly_token_limit, monthly_cost_limit, action, created_at, updated_at)
+       VALUES ('global', 'global', NULL, NULL, 10, 'warn', datetime('now'), datetime('now'))`
+    ).run();
+    service.createRule({ type: 'budget-threshold', thresholdValue: 80 });
+    seedAiUsage(db, { cost_usd: 9.7, created_at: thisMonthIso(1) });
+
+    const result = await runEvaluation({ dispatch: false });
+    expect(result.alerts[0]?.severity).toBe('critical');
+  });
+
+  it('does not fire when usage is below the threshold', async () => {
+    db.prepare(
+      `INSERT INTO ai_budgets (id, scope_type, scope_value, monthly_token_limit, monthly_cost_limit, action, created_at, updated_at)
+       VALUES ('global', 'global', NULL, NULL, 10, 'warn', datetime('now'), datetime('now'))`
+    ).run();
+    service.createRule({ type: 'budget-threshold', thresholdValue: 80 });
+    seedAiUsage(db, { cost_usd: 2, created_at: thisMonthIso(1) });
+
+    const result = await runEvaluation({ dispatch: false });
+    expect(result.alerts).toHaveLength(0);
+  });
+});
+
+describe('error-spike evaluation', () => {
+  it('fires when error rate exceeds the configured percentage', async () => {
+    service.createRule({ type: 'error-spike', thresholdValue: 10, windowMinutes: 60 });
+    // 10 successes, 2 errors = 16.7% error rate.
+    for (let i = 0; i < 10; i++) {
+      seedAiUsage(db, { status: 'success', created_at: nowIsoOffset(5 + i) });
+    }
+    seedAiUsage(db, { status: 'error', created_at: nowIsoOffset(2) });
+    seedAiUsage(db, { status: 'timeout', created_at: nowIsoOffset(3) });
+
+    const result = await runEvaluation({ dispatch: false });
+    expect(result.alerts).toHaveLength(1);
+    expect(result.alerts[0]?.type).toBe('error-spike');
+    expect(result.alerts[0]?.metricValue).toBeGreaterThan(10);
+  });
+
+  it('does not fire when the error rate is below threshold', async () => {
+    service.createRule({ type: 'error-spike', thresholdValue: 10, windowMinutes: 60 });
+    for (let i = 0; i < 20; i++) {
+      seedAiUsage(db, { status: 'success', created_at: nowIsoOffset(5 + i) });
+    }
+    seedAiUsage(db, { status: 'error', created_at: nowIsoOffset(2) });
+
+    const result = await runEvaluation({ dispatch: false });
+    expect(result.alerts).toHaveLength(0);
+  });
+
+  it('ignores rows outside the rolling window', async () => {
+    service.createRule({ type: 'error-spike', thresholdValue: 10, windowMinutes: 60 });
+    // Outside window — should be ignored.
+    for (let i = 0; i < 5; i++) {
+      seedAiUsage(db, { status: 'error', created_at: nowIsoOffset(120 + i) });
+    }
+    // Inside window — 100% success.
+    for (let i = 0; i < 5; i++) {
+      seedAiUsage(db, { status: 'success', created_at: nowIsoOffset(5 + i) });
+    }
+
+    const result = await runEvaluation({ dispatch: false });
+    expect(result.alerts).toHaveLength(0);
+  });
+});
+
+describe('latency-degradation evaluation', () => {
+  it('fans out per-model when no scopeModel is configured', async () => {
+    service.createRule({
+      type: 'latency-degradation',
+      thresholdValue: 1000,
+      windowMinutes: 60,
+    });
+    // Model A: P95 ~ 5000ms (breaches).
+    for (let i = 0; i < 20; i++) {
+      seedAiUsage(db, {
+        model: 'fast-1',
+        latency_ms: 5000 + i,
+        created_at: nowIsoOffset(5 + i),
+      });
+    }
+    // Model B: P95 ~ 100ms (safe).
+    for (let i = 0; i < 20; i++) {
+      seedAiUsage(db, {
+        model: 'slow-0',
+        latency_ms: 100 + i,
+        created_at: nowIsoOffset(5 + i),
+      });
+    }
+
+    const result = await runEvaluation({ dispatch: false });
+    expect(result.alerts).toHaveLength(1);
+    expect(result.alerts[0]?.scopeDetail).toBe('model:fast-1');
+  });
+
+  it('respects scopeModel filter', async () => {
+    service.createRule({
+      type: 'latency-degradation',
+      thresholdValue: 1000,
+      scopeModel: 'target-model',
+      windowMinutes: 60,
+    });
+    for (let i = 0; i < 20; i++) {
+      seedAiUsage(db, {
+        model: 'target-model',
+        latency_ms: 4000 + i,
+        created_at: nowIsoOffset(5 + i),
+      });
+    }
+    for (let i = 0; i < 20; i++) {
+      seedAiUsage(db, {
+        model: 'other-model',
+        latency_ms: 9999,
+        created_at: nowIsoOffset(5 + i),
+      });
+    }
+
+    const result = await runEvaluation({ dispatch: false });
+    expect(result.alerts).toHaveLength(1);
+    expect(result.alerts[0]?.scopeDetail).toBe('model:target-model');
+  });
+});
+
+describe('deduplication', () => {
+  it('suppresses a duplicate alert within the dedup window', async () => {
+    db.prepare(
+      `INSERT INTO ai_budgets (id, scope_type, scope_value, monthly_token_limit, monthly_cost_limit, action, created_at, updated_at)
+       VALUES ('global', 'global', NULL, NULL, 10, 'warn', datetime('now'), datetime('now'))`
+    ).run();
+    service.createRule({ type: 'budget-threshold', thresholdValue: 80 });
+    seedAiUsage(db, { cost_usd: 9, created_at: thisMonthIso(1) });
+
+    const first = await runEvaluation({ dispatch: false });
+    const second = await runEvaluation({ dispatch: false });
+
+    expect(first.alerts).toHaveLength(1);
+    expect(second.alerts).toHaveLength(0);
+    expect(second.deduped).toBe(1);
+    const { alerts, total } = listAlerts();
+    expect(total).toBe(1);
+    expect(alerts).toHaveLength(1);
+  });
+});
+
+describe('listing + acknowledgement', () => {
+  it('acknowledges an alert and updates the row', async () => {
+    db.prepare(
+      `INSERT INTO ai_budgets (id, scope_type, scope_value, monthly_token_limit, monthly_cost_limit, action, created_at, updated_at)
+       VALUES ('global', 'global', NULL, NULL, 10, 'warn', datetime('now'), datetime('now'))`
+    ).run();
+    service.createRule({ type: 'budget-threshold', thresholdValue: 80 });
+    seedAiUsage(db, { cost_usd: 9, created_at: thisMonthIso(1) });
+
+    const { alerts } = await runEvaluation({ dispatch: false });
+    const alertId = alerts[0]?.id;
+    expect(alertId).toBeTypeOf('number');
+    if (typeof alertId !== 'number') throw new Error('expected alert id');
+    const acked = acknowledgeAlert(alertId);
+    expect(acked?.acknowledged).toBe(true);
+    expect(acked?.acknowledgedAt).toBeTruthy();
+
+    const { alerts: filtered } = listAlerts({ acknowledged: true });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.id).toBe(alertId);
+    const { alerts: pending } = listAlerts({ acknowledged: false });
+    expect(pending).toHaveLength(0);
+  });
+});
+
+describe('dispatch facade', () => {
+  function buildAlert(over: Partial<FiredAlert> = {}): FiredAlert {
+    return {
+      id: 1,
+      ruleId: 1,
+      type: 'budget-threshold',
+      message: 'Budget breach',
+      severity: 'warning',
+      scopeDetail: 'budget:global',
+      metricValue: 82,
+      thresholdValue: 80,
+      acknowledged: false,
+      acknowledgedAt: null,
+      createdAt: new Date().toISOString(),
+      ...over,
+    };
+  }
+
+  it('routes warnings to nudge only and criticals to nudge + telegram', () => {
+    const warning = buildAlert({ severity: 'warning' });
+    const critical = buildAlert({ severity: 'critical' });
+    expect(resolveChannels(warning, {})).toEqual(['nudge']);
+    expect(resolveChannels(critical, {})).toEqual(['nudge', 'telegram']);
+  });
+
+  it('opt-in env override sends warnings to telegram too', () => {
+    const warning = buildAlert({ severity: 'warning' });
+    expect(resolveChannels(warning, { POPS_ALERTS_TELEGRAM_INCLUDE_WARNINGS: '1' })).toEqual([
+      'nudge',
+      'telegram',
+    ]);
+  });
+
+  it('invokes dispatchers and records per-channel results', async () => {
+    const nudge = vi.fn().mockResolvedValue(true);
+    const telegram = vi.fn().mockResolvedValue(true);
+    const alert = buildAlert({ severity: 'critical' });
+    const results = await dispatchAlert(alert, {
+      nudgeDispatcher: nudge,
+      telegramDispatcher: telegram,
+    });
+    expect(nudge).toHaveBeenCalledTimes(1);
+    expect(telegram).toHaveBeenCalledTimes(1);
+    expect(results.map((r) => [r.channel, r.delivered])).toEqual([
+      ['nudge', true],
+      ['telegram', true],
+    ]);
+  });
+
+  it('continues dispatching when one channel throws', async () => {
+    const nudge = vi.fn().mockRejectedValue(new Error('boom'));
+    const telegram = vi.fn().mockResolvedValue(true);
+    const alert = buildAlert({ severity: 'critical' });
+    const results = await dispatchAlert(alert, {
+      nudgeDispatcher: nudge,
+      telegramDispatcher: telegram,
+    });
+    expect(results[0]).toMatchObject({ channel: 'nudge', delivered: false, error: 'boom' });
+    expect(results[1]).toMatchObject({ channel: 'telegram', delivered: true });
+  });
+
+  it('renders a markdown telegram message', () => {
+    const alert = buildAlert({ severity: 'critical' });
+    const text = renderTelegramMessage(alert);
+    expect(text).toMatch(/AI Alert/);
+    expect(text).toContain('budget:global');
+    expect(text).toContain('Budget breach');
+  });
+});

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluator.test.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluator.test.ts
@@ -10,9 +10,16 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getDrizzle } from '../../../db.js';
 import { seedAiUsage, setupTestContext } from '../../../shared/test-utils.js';
+import { insertAlertIfNotDuplicate } from './alerts-store.js';
 import { dispatchAlert, resolveChannels } from './dispatch.js';
-import { renderTelegramMessage } from './dispatchers/telegram.js';
+import {
+  escapeTelegramMarkdownV2,
+  fetchTransport,
+  renderTelegramMessage,
+  TELEGRAM_REQUEST_TIMEOUT_MS,
+} from './dispatchers/telegram.js';
 import { acknowledgeAlert, listAlerts, runEvaluation } from './evaluator.js';
 import * as service from './service.js';
 
@@ -49,6 +56,20 @@ describe('seedDefaultRules', () => {
     expect(service.listRules()).toHaveLength(3);
     expect(service.seedDefaultRules()).toBe(0);
     expect(service.listRules()).toHaveLength(3);
+  });
+
+  it('backfills missing default rule types even when others already exist', () => {
+    // User has manually created a single error-spike rule. Seeding must
+    // still create the two missing defaults instead of bailing out wholesale.
+    service.createRule({ type: 'error-spike', thresholdValue: 5, windowMinutes: 30 });
+    expect(service.seedDefaultRules()).toBe(2);
+    const types = service
+      .listRules()
+      .map((r) => r.type)
+      .toSorted();
+    expect(types).toEqual(['budget-threshold', 'error-spike', 'latency-degradation']);
+    // Re-seeding is still a no-op once all default types exist.
+    expect(service.seedDefaultRules()).toBe(0);
   });
 });
 
@@ -98,6 +119,29 @@ describe('budget-threshold evaluation', () => {
 
     const result = await runEvaluation({ dispatch: false });
     expect(result.alerts).toHaveLength(0);
+  });
+
+  it('fires on a token-limit breach even when cost spend is comfortably under its limit', async () => {
+    // Budget has both limits configured. Token usage is at 90% (breach),
+    // cost usage at 1% (safe). Old short-circuit logic would have returned
+    // the cost metric only and missed the breach.
+    db.prepare(
+      `INSERT INTO ai_budgets (id, scope_type, scope_value, monthly_token_limit, monthly_cost_limit, action, created_at, updated_at)
+       VALUES ('global', 'global', NULL, 10000, 100, 'warn', datetime('now'), datetime('now'))`
+    ).run();
+    service.createRule({ type: 'budget-threshold', thresholdValue: 80 });
+    // 9000 tokens (90% of 10k token limit), $1 cost (1% of $100 cost limit).
+    seedAiUsage(db, {
+      input_tokens: 4500,
+      output_tokens: 4500,
+      cost_usd: 1,
+      created_at: thisMonthIso(1),
+    });
+
+    const result = await runEvaluation({ dispatch: false });
+    expect(result.alerts).toHaveLength(1);
+    expect(result.alerts[0]?.metricValue).toBeGreaterThanOrEqual(80);
+    expect(result.alerts[0]?.message).toMatch(/token/);
   });
 });
 
@@ -314,5 +358,155 @@ describe('dispatch facade', () => {
     expect(text).toMatch(/AI Alert/);
     expect(text).toContain('budget:global');
     expect(text).toContain('Budget breach');
+  });
+
+  it('escapes MarkdownV2 reserved characters in dynamic alert fields', () => {
+    // Dynamic content can contain `_`, `*`, `[`, `]`, `.`, `(`, `)` — Telegram
+    // would otherwise reject the message or mis-render it. We must always
+    // emit each reserved character backslash-escaped.
+    const alert = buildAlert({
+      type: 'budget-threshold',
+      scopeDetail: 'budget:dev_team.us-east [primary]',
+      message: 'Spend at 95% of $100.00 limit (alert!).',
+    });
+    const text = renderTelegramMessage(alert);
+    expect(text).toContain('budget:dev\\_team\\.us\\-east \\[primary\\]');
+    expect(text).toContain('Spend at 95% of $100\\.00 limit \\(alert\\!\\)\\.');
+    // No raw reserved char immediately following dynamic content.
+    expect(text).not.toMatch(/budget:dev_team/);
+  });
+
+  it('escape helper covers every MarkdownV2 reserved character', () => {
+    const reserved = '_*[]()~`>#+-=|{}.!\\';
+    const escaped = escapeTelegramMarkdownV2(reserved);
+    // Each reserved character must be prefixed with a backslash.
+    for (const ch of reserved) {
+      expect(escaped).toContain(`\\${ch}`);
+    }
+  });
+
+  it('telegram fetch transport aborts when the request hangs', async () => {
+    // Stub global fetch with a never-resolving promise; the abort signal must
+    // fire from our timeout and surface a clear timeout error.
+    const originalFetch = globalThis.fetch;
+    const capturedSignals: AbortSignal[] = [];
+    const stub: typeof globalThis.fetch = (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal) {
+          capturedSignals.push(signal);
+          signal.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }
+      });
+    globalThis.fetch = stub;
+
+    vi.useFakeTimers();
+    try {
+      const promise = fetchTransport.send({ botToken: 't', chatId: 'c' }, 'hi');
+      // Push past the configured timeout so AbortController fires.
+      vi.advanceTimersByTime(TELEGRAM_REQUEST_TIMEOUT_MS + 1);
+      await expect(promise).rejects.toThrow(/timed out/);
+      expect(capturedSignals[0]?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe('latency percentile', () => {
+  it('returns the correct P95 element using nearest-rank (not the max)', async () => {
+    // Sorted latencies 1..100. Old (floor) formula picked index 95 → 96ms.
+    // Nearest-rank P95 is ceil(0.95*100) - 1 = 94 → 95ms. We use a threshold
+    // that sits between those values so the bug would surface as a false
+    // positive (alert fires when it should not).
+    service.createRule({
+      type: 'latency-degradation',
+      thresholdValue: 95.5,
+      scopeModel: 'pct-model',
+      windowMinutes: 60,
+    });
+    for (let i = 1; i <= 100; i++) {
+      seedAiUsage(db, {
+        model: 'pct-model',
+        latency_ms: i,
+        created_at: nowIsoOffset(5 + (i % 30)),
+      });
+    }
+    const result = await runEvaluation({ dispatch: false });
+    // P95 = 95 < 95.5 → no alert. Old formula would have made P95 = 96.
+    expect(result.alerts).toHaveLength(0);
+  });
+});
+
+describe('updateRule patch semantics', () => {
+  it('only touches fields present in the input', () => {
+    const created = service.createRule({
+      type: 'latency-degradation',
+      thresholdValue: 1000,
+      scopeProvider: 'claude',
+      scopeModel: 'haiku',
+      windowMinutes: 30,
+    });
+
+    // Concurrent edit B: another caller toggles `enabled` to false via a
+    // separate code path. The next updateRule call from caller A must NOT
+    // resurrect the old enabled=true value just because it cached `existing`.
+    service.setRuleEnabled(created.id, false);
+    const updated = service.updateRule({ id: created.id, thresholdValue: 2000 });
+    expect(updated.thresholdValue).toBe(2000);
+    // The previously-disabled flag must remain false because the patch never
+    // included `enabled`.
+    expect(updated.enabled).toBe(false);
+    expect(updated.scopeProvider).toBe('claude');
+    expect(updated.scopeModel).toBe('haiku');
+    expect(updated.windowMinutes).toBe(30);
+  });
+
+  it('allows clearing optional scope fields with explicit null', () => {
+    const created = service.createRule({
+      type: 'latency-degradation',
+      thresholdValue: 1000,
+      scopeProvider: 'claude',
+      scopeModel: 'haiku',
+    });
+    const updated = service.updateRule({
+      id: created.id,
+      scopeProvider: null,
+      scopeModel: null,
+    });
+    expect(updated.scopeProvider).toBeNull();
+    expect(updated.scopeModel).toBeNull();
+  });
+
+  it('throws when the rule does not exist (single-statement update path)', () => {
+    expect(() => service.updateRule({ id: 9999, thresholdValue: 1 })).toThrow(/not found/);
+  });
+});
+
+describe('atomic dedup', () => {
+  it('insertAlertIfNotDuplicate returns null inside the dedup window', () => {
+    service.createRule({ type: 'budget-threshold', thresholdValue: 80 });
+    const drizzleDb = getDrizzle();
+    const now = new Date();
+    const candidate = {
+      ruleId: 1,
+      type: 'budget-threshold' as const,
+      severity: 'warning' as const,
+      message: 'breach',
+      scopeDetail: 'budget:global',
+      metricValue: 90,
+      thresholdValue: 80,
+    };
+    const first = insertAlertIfNotDuplicate(drizzleDb, candidate, now);
+    const second = insertAlertIfNotDuplicate(drizzleDb, candidate, now);
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    const { total } = listAlerts();
+    expect(total).toBe(1);
   });
 });

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluator.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluator.ts
@@ -1,0 +1,121 @@
+/**
+ * Alert rule evaluator orchestrator (PRD-092 US-07).
+ *
+ * Loads enabled rules, delegates to per-type evaluator functions, dedupes,
+ * persists, and dispatches via channel handlers. The actual evaluation
+ * logic lives in `./evaluators/*` to keep each file within the project
+ * max-lines lint budget and to make each rule type independently testable.
+ *
+ * The orchestrator is invoked from the BullMQ scheduled worker every 5
+ * minutes — see `scheduler.ts`. Tests drive `runEvaluation` directly
+ * against a seeded DB.
+ */
+import { eq } from 'drizzle-orm';
+
+import { aiAlertRules } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
+import { logger } from '../../../lib/logger.js';
+import { insertAlert, isDuplicate } from './alerts-store.js';
+import { dispatchAlert } from './dispatch.js';
+import { evaluateBudgetThreshold } from './evaluators/budget.js';
+import { evaluateErrorSpike } from './evaluators/error-spike.js';
+import { evaluateLatencyDegradation } from './evaluators/latency.js';
+import { ruleRowToRule } from './mappers.js';
+
+import type { AlertCandidate, AlertRule, DispatchedAlert } from './types.js';
+
+export { DEDUP_WINDOW_MINUTES, acknowledgeAlert, listAlerts } from './alerts-store.js';
+export type { ListAlertsFilters } from './alerts-store.js';
+
+interface EvaluatorDeps {
+  db: ReturnType<typeof getDrizzle>;
+  now: Date;
+}
+
+export interface RunEvaluationOptions {
+  /** Override "now" for deterministic tests. */
+  now?: Date;
+  /** Skip channel dispatch (used in tests that only assert on rows). */
+  dispatch?: boolean;
+}
+
+export interface RunEvaluationResult {
+  rulesEvaluated: number;
+  candidates: number;
+  deduped: number;
+  alerts: DispatchedAlert[];
+}
+
+/** Evaluate a single rule against the current state. Exported for tests. */
+export function evaluateRule(rule: AlertRule, deps: EvaluatorDeps): AlertCandidate[] {
+  switch (rule.type) {
+    case 'budget-threshold':
+      return evaluateBudgetThreshold(rule, deps.db, deps.now);
+    case 'error-spike':
+      return evaluateErrorSpike(rule, deps.db, deps.now);
+    case 'latency-degradation':
+      return evaluateLatencyDegradation(rule, deps.db, deps.now);
+  }
+}
+
+/** List enabled rules from the DB. */
+export function loadEnabledRules(db: ReturnType<typeof getDrizzle>): AlertRule[] {
+  return db.select().from(aiAlertRules).where(eq(aiAlertRules.enabled, 1)).all().map(ruleRowToRule);
+}
+
+async function persistAndDispatch(
+  candidate: AlertCandidate,
+  deps: EvaluatorDeps,
+  dispatchEnabled: boolean
+): Promise<DispatchedAlert> {
+  const alert = insertAlert(deps.db, candidate, deps.now);
+  if (!dispatchEnabled) return { ...alert, channels: [] };
+  const results = await dispatchAlert(alert);
+  const channels = results.filter((r) => r.delivered).map((r) => r.channel);
+  return { ...alert, channels };
+}
+
+/**
+ * Run the full evaluation cycle: load rules → evaluate → dedupe → persist →
+ * dispatch. Returns counters + the alerts that fired this cycle.
+ */
+export async function runEvaluation(
+  options: RunEvaluationOptions = {}
+): Promise<RunEvaluationResult> {
+  const db = getDrizzle();
+  const now = options.now ?? new Date();
+  const dispatchEnabled = options.dispatch ?? true;
+  const rules = loadEnabledRules(db);
+
+  let totalCandidates = 0;
+  let dedupedCount = 0;
+  const fired: DispatchedAlert[] = [];
+
+  for (const rule of rules) {
+    const candidates = evaluateRule(rule, { db, now });
+    totalCandidates += candidates.length;
+    for (const candidate of candidates) {
+      if (isDuplicate(db, candidate, now)) {
+        dedupedCount += 1;
+        continue;
+      }
+      fired.push(await persistAndDispatch(candidate, { db, now }, dispatchEnabled));
+    }
+  }
+  logger.info(
+    {
+      rulesEvaluated: rules.length,
+      candidates: totalCandidates,
+      deduped: dedupedCount,
+      fired: fired.length,
+    },
+    '[ai-alerts] Evaluation cycle complete'
+  );
+  return {
+    rulesEvaluated: rules.length,
+    candidates: totalCandidates,
+    deduped: dedupedCount,
+    alerts: fired,
+  };
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluator.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluator.ts
@@ -16,14 +16,14 @@ import { aiAlertRules } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
 import { logger } from '../../../lib/logger.js';
-import { insertAlert, isDuplicate } from './alerts-store.js';
+import { insertAlertIfNotDuplicate } from './alerts-store.js';
 import { dispatchAlert } from './dispatch.js';
 import { evaluateBudgetThreshold } from './evaluators/budget.js';
 import { evaluateErrorSpike } from './evaluators/error-spike.js';
 import { evaluateLatencyDegradation } from './evaluators/latency.js';
 import { ruleRowToRule } from './mappers.js';
 
-import type { AlertCandidate, AlertRule, DispatchedAlert } from './types.js';
+import type { AlertCandidate, AlertRule, DispatchedAlert, FiredAlert } from './types.js';
 
 export { DEDUP_WINDOW_MINUTES, acknowledgeAlert, listAlerts } from './alerts-store.js';
 export type { ListAlertsFilters } from './alerts-store.js';
@@ -64,12 +64,10 @@ export function loadEnabledRules(db: ReturnType<typeof getDrizzle>): AlertRule[]
   return db.select().from(aiAlertRules).where(eq(aiAlertRules.enabled, 1)).all().map(ruleRowToRule);
 }
 
-async function persistAndDispatch(
-  candidate: AlertCandidate,
-  deps: EvaluatorDeps,
+async function dispatchPersistedAlert(
+  alert: FiredAlert,
   dispatchEnabled: boolean
 ): Promise<DispatchedAlert> {
-  const alert = insertAlert(deps.db, candidate, deps.now);
   if (!dispatchEnabled) return { ...alert, channels: [] };
   const results = await dispatchAlert(alert);
   const channels = results.filter((r) => r.delivered).map((r) => r.channel);
@@ -96,11 +94,12 @@ export async function runEvaluation(
     const candidates = evaluateRule(rule, { db, now });
     totalCandidates += candidates.length;
     for (const candidate of candidates) {
-      if (isDuplicate(db, candidate, now)) {
+      const persisted = insertAlertIfNotDuplicate(db, candidate, now);
+      if (!persisted) {
         dedupedCount += 1;
         continue;
       }
-      fired.push(await persistAndDispatch(candidate, { db, now }, dispatchEnabled));
+      fired.push(await dispatchPersistedAlert(persisted, dispatchEnabled));
     }
   }
   logger.info(

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluators/budget.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluators/budget.ts
@@ -1,0 +1,100 @@
+/**
+ * Budget-threshold rule evaluator (PRD-092 US-07).
+ *
+ * Iterates every configured `ai_budgets` row, computes current-month usage
+ * against the row's cost or token limit, and fires a candidate when the
+ * usage percentage meets/exceeds the rule's threshold. Severity steps up to
+ * `critical` at 95%.
+ */
+import { and, eq, gte, sql } from 'drizzle-orm';
+
+import { aiBudgets, aiInferenceLog } from '@pops/db-types';
+
+import type { getDrizzle } from '../../../../db.js';
+import type { AlertCandidate, AlertRule, AlertSeverity } from '../types.js';
+
+interface BudgetMetrics {
+  percentage: number;
+  limitDescription: string;
+  usedDescription: string;
+}
+
+function severity(percentage: number): AlertSeverity {
+  return percentage >= 95 ? 'critical' : 'warning';
+}
+
+function monthStart(now: Date): string {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0)).toISOString();
+}
+
+function getUsage(
+  db: ReturnType<typeof getDrizzle>,
+  budget: typeof aiBudgets.$inferSelect,
+  start: string
+): { totalTokens: number; totalCost: number } {
+  const conditions = [gte(aiInferenceLog.createdAt, start)];
+  if (budget.scopeType === 'provider' && budget.scopeValue) {
+    conditions.push(eq(aiInferenceLog.provider, budget.scopeValue));
+  } else if (budget.scopeType === 'operation' && budget.scopeValue) {
+    conditions.push(eq(aiInferenceLog.operation, budget.scopeValue));
+  }
+  const [agg] = db
+    .select({
+      totalTokens: sql<number>`COALESCE(SUM(${aiInferenceLog.inputTokens} + ${aiInferenceLog.outputTokens}), 0)`,
+      totalCost: sql<number>`COALESCE(SUM(${aiInferenceLog.costUsd}), 0)`,
+    })
+    .from(aiInferenceLog)
+    .where(and(...conditions))
+    .all();
+  return { totalTokens: agg?.totalTokens ?? 0, totalCost: agg?.totalCost ?? 0 };
+}
+
+function computeMetrics(
+  budget: typeof aiBudgets.$inferSelect,
+  usage: { totalTokens: number; totalCost: number }
+): BudgetMetrics | null {
+  if (budget.monthlyCostLimit != null && budget.monthlyCostLimit > 0) {
+    return {
+      percentage: (usage.totalCost / budget.monthlyCostLimit) * 100,
+      limitDescription: `$${budget.monthlyCostLimit.toFixed(2)} monthly cost limit`,
+      usedDescription: `$${usage.totalCost.toFixed(2)} spent`,
+    };
+  }
+  if (budget.monthlyTokenLimit != null && budget.monthlyTokenLimit > 0) {
+    return {
+      percentage: (usage.totalTokens / budget.monthlyTokenLimit) * 100,
+      limitDescription: `${budget.monthlyTokenLimit} monthly token limit`,
+      usedDescription: `${usage.totalTokens} tokens used`,
+    };
+  }
+  return null;
+}
+
+export function evaluateBudgetThreshold(
+  rule: AlertRule,
+  db: ReturnType<typeof getDrizzle>,
+  now: Date
+): AlertCandidate[] {
+  const budgets = db.select().from(aiBudgets).all();
+  if (budgets.length === 0) return [];
+  const start = monthStart(now);
+  const candidates: AlertCandidate[] = [];
+
+  for (const budget of budgets) {
+    const usage = getUsage(db, budget, start);
+    const metrics = computeMetrics(budget, usage);
+    if (!metrics) continue;
+    if (metrics.percentage < rule.thresholdValue) continue;
+
+    candidates.push({
+      ruleId: rule.id,
+      type: 'budget-threshold',
+      severity: severity(metrics.percentage),
+      message: `Budget '${budget.id}' is at ${metrics.percentage.toFixed(1)}% of its ${metrics.limitDescription} (${metrics.usedDescription})`,
+      scopeDetail: `budget:${budget.id}`,
+      metricValue: Number(metrics.percentage.toFixed(2)),
+      thresholdValue: rule.thresholdValue,
+    });
+  }
+  return candidates;
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluators/budget.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluators/budget.ts
@@ -49,25 +49,32 @@ function getUsage(
   return { totalTokens: agg?.totalTokens ?? 0, totalCost: agg?.totalCost ?? 0 };
 }
 
+/**
+ * Build a metric per configured limit. A budget may set both cost and token
+ * limits; we must report on whichever is most utilised so a runaway token
+ * count never hides behind a comfortable dollar spend (and vice versa).
+ */
 function computeMetrics(
   budget: typeof aiBudgets.$inferSelect,
   usage: { totalTokens: number; totalCost: number }
 ): BudgetMetrics | null {
+  const metrics: BudgetMetrics[] = [];
   if (budget.monthlyCostLimit != null && budget.monthlyCostLimit > 0) {
-    return {
+    metrics.push({
       percentage: (usage.totalCost / budget.monthlyCostLimit) * 100,
       limitDescription: `$${budget.monthlyCostLimit.toFixed(2)} monthly cost limit`,
       usedDescription: `$${usage.totalCost.toFixed(2)} spent`,
-    };
+    });
   }
   if (budget.monthlyTokenLimit != null && budget.monthlyTokenLimit > 0) {
-    return {
+    metrics.push({
       percentage: (usage.totalTokens / budget.monthlyTokenLimit) * 100,
       limitDescription: `${budget.monthlyTokenLimit} monthly token limit`,
       usedDescription: `${usage.totalTokens} tokens used`,
-    };
+    });
   }
-  return null;
+  if (metrics.length === 0) return null;
+  return metrics.reduce((max, m) => (m.percentage > max.percentage ? m : max));
 }
 
 export function evaluateBudgetThreshold(

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluators/error-spike.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluators/error-spike.ts
@@ -1,0 +1,64 @@
+/**
+ * Error-spike rule evaluator (PRD-092 US-07).
+ *
+ * Counts rows in the rolling window matching the rule's optional provider /
+ * model scope and fires a candidate when the error rate (status in
+ * `error|timeout`) meets/exceeds the configured percentage.
+ */
+import { and, eq, gte, sql } from 'drizzle-orm';
+
+import { aiInferenceLog } from '@pops/db-types';
+
+import { rollingWindowStart } from './shared.js';
+
+import type { getDrizzle } from '../../../../db.js';
+import type { AlertCandidate, AlertRule, AlertSeverity } from '../types.js';
+
+function severity(rate: number, threshold: number): AlertSeverity {
+  return rate >= threshold * 1.5 ? 'critical' : 'warning';
+}
+
+export function evaluateErrorSpike(
+  rule: AlertRule,
+  db: ReturnType<typeof getDrizzle>,
+  now: Date
+): AlertCandidate[] {
+  const windowMinutes = rule.windowMinutes ?? 60;
+  const start = rollingWindowStart(now, windowMinutes);
+  const conditions = [gte(aiInferenceLog.createdAt, start)];
+  const scopeParts: string[] = [];
+  if (rule.scopeProvider) {
+    conditions.push(eq(aiInferenceLog.provider, rule.scopeProvider));
+    scopeParts.push(`provider:${rule.scopeProvider}`);
+  }
+  if (rule.scopeModel) {
+    conditions.push(eq(aiInferenceLog.model, rule.scopeModel));
+    scopeParts.push(`model:${rule.scopeModel}`);
+  }
+  const scopeDetail = scopeParts.length > 0 ? scopeParts.join(',') : 'global';
+
+  const [row] = db
+    .select({
+      total: sql<number>`COUNT(*)`,
+      errors: sql<number>`SUM(CASE WHEN ${aiInferenceLog.status} IN ('error','timeout') THEN 1 ELSE 0 END)`,
+    })
+    .from(aiInferenceLog)
+    .where(and(...conditions))
+    .all();
+  if (!row || row.total === 0) return [];
+
+  const errorRate = (row.errors / row.total) * 100;
+  if (errorRate < rule.thresholdValue) return [];
+
+  return [
+    {
+      ruleId: rule.id,
+      type: 'error-spike',
+      severity: severity(errorRate, rule.thresholdValue),
+      message: `Error rate ${errorRate.toFixed(1)}% in the last ${windowMinutes} minutes exceeds threshold ${rule.thresholdValue}% (${row.errors}/${row.total} calls)`,
+      scopeDetail,
+      metricValue: Number(errorRate.toFixed(2)),
+      thresholdValue: rule.thresholdValue,
+    },
+  ];
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluators/latency.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluators/latency.ts
@@ -1,0 +1,102 @@
+/**
+ * Latency-degradation rule evaluator (PRD-092 US-07).
+ *
+ * Computes the P95 latency for each model in the rolling window (filtered to
+ * `success` + non-cached + latencyMs > 0) and fires a candidate per model
+ * whose P95 meets/exceeds the rule's threshold. When `scopeModel` is set the
+ * evaluator skips the fan-out and only considers that model.
+ */
+import { and, eq, gte, sql, type SQL } from 'drizzle-orm';
+
+import { aiInferenceLog } from '@pops/db-types';
+
+import { rollingWindowStart } from './shared.js';
+
+import type { getDrizzle } from '../../../../db.js';
+import type { AlertCandidate, AlertRule, AlertSeverity } from '../types.js';
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.floor(p * sorted.length);
+  return sorted[Math.min(idx, sorted.length - 1)] ?? 0;
+}
+
+function severity(p95: number, threshold: number): AlertSeverity {
+  return p95 >= threshold * 1.5 ? 'critical' : 'warning';
+}
+
+function baseLatencyConditions(rule: AlertRule, start: string): SQL[] {
+  const conditions: SQL[] = [
+    gte(aiInferenceLog.createdAt, start),
+    eq(aiInferenceLog.status, 'success'),
+    eq(aiInferenceLog.cached, 0),
+    sql`${aiInferenceLog.latencyMs} > 0`,
+  ];
+  if (rule.scopeProvider) {
+    conditions.push(eq(aiInferenceLog.provider, rule.scopeProvider));
+  }
+  return conditions;
+}
+
+function evaluateForModel(
+  rule: AlertRule,
+  db: ReturnType<typeof getDrizzle>,
+  now: Date,
+  model: string
+): AlertCandidate | null {
+  const windowMinutes = rule.windowMinutes ?? 60;
+  const start = rollingWindowStart(now, windowMinutes);
+  const conditions = [...baseLatencyConditions(rule, start), eq(aiInferenceLog.model, model)];
+  const latencies = db
+    .select({ latencyMs: aiInferenceLog.latencyMs })
+    .from(aiInferenceLog)
+    .where(and(...conditions))
+    .orderBy(aiInferenceLog.latencyMs)
+    .all()
+    .map((r) => r.latencyMs);
+  if (latencies.length === 0) return null;
+  const p95 = percentile(latencies, 0.95);
+  if (p95 < rule.thresholdValue) return null;
+  return {
+    ruleId: rule.id,
+    type: 'latency-degradation',
+    severity: severity(p95, rule.thresholdValue),
+    message: `P95 latency for ${model} is ${p95}ms in the last ${windowMinutes} minutes (threshold: ${rule.thresholdValue}ms, ${latencies.length} samples)`,
+    scopeDetail: `model:${model}`,
+    metricValue: p95,
+    thresholdValue: rule.thresholdValue,
+  };
+}
+
+function listModelsInWindow(
+  rule: AlertRule,
+  db: ReturnType<typeof getDrizzle>,
+  now: Date
+): string[] {
+  const windowMinutes = rule.windowMinutes ?? 60;
+  const start = rollingWindowStart(now, windowMinutes);
+  return db
+    .select({ model: aiInferenceLog.model })
+    .from(aiInferenceLog)
+    .where(and(...baseLatencyConditions(rule, start)))
+    .groupBy(aiInferenceLog.model)
+    .all()
+    .map((r) => r.model);
+}
+
+export function evaluateLatencyDegradation(
+  rule: AlertRule,
+  db: ReturnType<typeof getDrizzle>,
+  now: Date
+): AlertCandidate[] {
+  if (rule.scopeModel) {
+    const candidate = evaluateForModel(rule, db, now, rule.scopeModel);
+    return candidate ? [candidate] : [];
+  }
+  const candidates: AlertCandidate[] = [];
+  for (const model of listModelsInWindow(rule, db, now)) {
+    const candidate = evaluateForModel(rule, db, now, model);
+    if (candidate) candidates.push(candidate);
+  }
+  return candidates;
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluators/latency.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluators/latency.ts
@@ -15,10 +15,19 @@ import { rollingWindowStart } from './shared.js';
 import type { getDrizzle } from '../../../../db.js';
 import type { AlertCandidate, AlertRule, AlertSeverity } from '../types.js';
 
-function percentile(sorted: number[], p: number): number {
+/**
+ * Nearest-rank percentile. The previous implementation used
+ * `Math.floor(p * n)` which selects the *max* element for common sample
+ * sizes (e.g. `p=0.95`, `n=20` → idx 19), overstating P95 and producing
+ * false-positive alerts. We use the standard nearest-rank formula:
+ * `ceil(p * n) - 1`, clamped to the array bounds.
+ */
+export function percentile(sorted: number[], p: number): number {
   if (sorted.length === 0) return 0;
-  const idx = Math.floor(p * sorted.length);
-  return sorted[Math.min(idx, sorted.length - 1)] ?? 0;
+  const clampedP = Math.min(Math.max(p, 0), 1);
+  const rank = Math.ceil(clampedP * sorted.length) - 1;
+  const idx = Math.min(Math.max(rank, 0), sorted.length - 1);
+  return sorted[idx] ?? 0;
 }
 
 function severity(p95: number, threshold: number): AlertSeverity {

--- a/apps/pops-api/src/modules/core/ai-alerts/evaluators/shared.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/evaluators/shared.ts
@@ -1,0 +1,6 @@
+/** Shared helpers for rule-specific evaluators. */
+
+/** Compute the ISO timestamp of the rolling window start. */
+export function rollingWindowStart(now: Date, minutes: number): string {
+  return new Date(now.getTime() - minutes * 60 * 1000).toISOString();
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/mappers.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/mappers.ts
@@ -1,0 +1,55 @@
+import { ALERT_RULE_TYPES, ALERT_SEVERITIES } from './types.js';
+
+/**
+ * Row ↔ domain mappers for AI alert rules and alerts.
+ *
+ * Centralises the integer ↔ boolean and enum widening so callers never
+ * need to repeat those conversions.
+ */
+import type { AiAlertRow, AiAlertRuleRow } from '@pops/db-types';
+
+import type { AlertRule, AlertRuleType, AlertSeverity, FiredAlert } from './types.js';
+
+function toAlertRuleType(value: string): AlertRuleType {
+  if ((ALERT_RULE_TYPES as readonly string[]).includes(value)) {
+    return value as AlertRuleType;
+  }
+  throw new Error(`Unknown AI alert rule type: ${value}`);
+}
+
+function toAlertSeverity(value: string): AlertSeverity {
+  if ((ALERT_SEVERITIES as readonly string[]).includes(value)) {
+    return value as AlertSeverity;
+  }
+  throw new Error(`Unknown AI alert severity: ${value}`);
+}
+
+export function ruleRowToRule(row: AiAlertRuleRow): AlertRule {
+  return {
+    id: row.id,
+    type: toAlertRuleType(row.type),
+    scopeProvider: row.scopeProvider,
+    scopeModel: row.scopeModel,
+    thresholdValue: row.thresholdValue,
+    windowMinutes: row.windowMinutes,
+    enabled: row.enabled === 1,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function alertRowToAlert(row: AiAlertRow): FiredAlert {
+  return {
+    id: row.id,
+    ruleId: row.ruleId,
+    type: toAlertRuleType(row.type),
+    message: row.message,
+    severity: toAlertSeverity(row.severity),
+    scopeDetail: row.scopeDetail,
+    metricValue: row.metricValue,
+    thresholdValue: row.thresholdValue,
+    acknowledged: row.acknowledged === 1,
+    acknowledgedAt: row.acknowledgedAt,
+    createdAt: row.createdAt,
+  };
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/router.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/router.ts
@@ -1,0 +1,87 @@
+/**
+ * tRPC router for AI alert rules and fired alerts (PRD-092 US-07).
+ *
+ * Exposed under `core.aiAlerts`:
+ *
+ *   rules.list / rules.create / rules.update / rules.delete /
+ *   rules.setEnabled
+ *   list / acknowledge / runNow
+ */
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { protectedProcedure, router } from '../../../trpc.js';
+import { runEvaluation } from './evaluator.js';
+import * as evaluator from './evaluator.js';
+import * as service from './service.js';
+import { ALERT_RULE_TYPES } from './types.js';
+
+const alertRuleTypeSchema = z.enum(ALERT_RULE_TYPES);
+
+const createInput = z.object({
+  type: alertRuleTypeSchema,
+  scopeProvider: z.string().min(1).nullable().optional(),
+  scopeModel: z.string().min(1).nullable().optional(),
+  thresholdValue: z.number().positive(),
+  windowMinutes: z.number().int().positive().nullable().optional(),
+  enabled: z.boolean().optional(),
+});
+
+const updateInput = z.object({
+  id: z.number().int().positive(),
+  type: alertRuleTypeSchema.optional(),
+  scopeProvider: z.string().min(1).nullable().optional(),
+  scopeModel: z.string().min(1).nullable().optional(),
+  thresholdValue: z.number().positive().optional(),
+  windowMinutes: z.number().int().positive().nullable().optional(),
+  enabled: z.boolean().optional(),
+});
+
+const listAlertsInput = z
+  .object({
+    acknowledged: z.boolean().optional(),
+    type: alertRuleTypeSchema.optional(),
+    severity: z.enum(['warning', 'critical']).optional(),
+    startDate: z.string().optional(),
+    endDate: z.string().optional(),
+    limit: z.number().int().min(1).max(500).optional(),
+    offset: z.number().int().min(0).optional(),
+  })
+  .optional();
+
+export const aiAlertsRouter = router({
+  rules: router({
+    list: protectedProcedure.query(() => service.listRules()),
+    get: protectedProcedure
+      .input(z.object({ id: z.number().int().positive() }))
+      .query(({ input }) => {
+        const rule = service.getRule(input.id);
+        if (!rule) throw new TRPCError({ code: 'NOT_FOUND', message: 'Alert rule not found' });
+        return rule;
+      }),
+    create: protectedProcedure
+      .input(createInput)
+      .mutation(({ input }) => service.createRule(input)),
+    update: protectedProcedure
+      .input(updateInput)
+      .mutation(({ input }) => service.updateRule(input)),
+    setEnabled: protectedProcedure
+      .input(z.object({ id: z.number().int().positive(), enabled: z.boolean() }))
+      .mutation(({ input }) => service.setRuleEnabled(input.id, input.enabled)),
+    delete: protectedProcedure
+      .input(z.object({ id: z.number().int().positive() }))
+      .mutation(({ input }) => service.deleteRule(input.id)),
+    seedDefaults: protectedProcedure.mutation(() => ({ created: service.seedDefaultRules() })),
+  }),
+  list: protectedProcedure
+    .input(listAlertsInput)
+    .query(({ input }) => evaluator.listAlerts(input ?? {})),
+  acknowledge: protectedProcedure
+    .input(z.object({ id: z.number().int().positive() }))
+    .mutation(({ input }) => {
+      const alert = evaluator.acknowledgeAlert(input.id);
+      if (!alert) throw new TRPCError({ code: 'NOT_FOUND', message: 'Alert not found' });
+      return alert;
+    }),
+  runNow: protectedProcedure.mutation(() => runEvaluation()),
+});

--- a/apps/pops-api/src/modules/core/ai-alerts/scheduler.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/scheduler.ts
@@ -1,0 +1,66 @@
+/**
+ * BullMQ scheduler for the AI alert evaluator job (PRD-092 US-07).
+ *
+ * Registers a repeatable job on the `pops-default` queue that runs every 5
+ * minutes. Mirrors the retention scheduler pattern (`ai-observability/scheduler.ts`).
+ *
+ * When `REDIS_HOST` is unset or BullMQ is unavailable the scheduler logs a
+ * warning and operates in degraded mode (no scheduled evaluations).
+ */
+import pino from 'pino';
+
+import { DEFAULT_JOB_OPTIONS, getDefaultQueue } from '../../../jobs/queues.js';
+
+import type { AiAlertEvaluationJobData } from '../../../jobs/types.js';
+
+const logger = pino({ name: 'ai-alerts-scheduler' });
+
+export const AI_ALERTS_SCHEDULER_ID = 'pops-ai-alerts';
+export const AI_ALERTS_JOB_NAME = 'aiAlertEvaluation';
+/** Cron expression: every 5 minutes. */
+export const AI_ALERTS_CRON = '*/5 * * * *';
+
+/**
+ * Register the 5-minute evaluator scheduler. Safe to call multiple times —
+ * BullMQ keys off the scheduler ID. Returns `true` on success, `false` when
+ * Redis is unavailable.
+ */
+export async function registerAiAlertsScheduler(): Promise<boolean> {
+  if (!process.env['REDIS_HOST']) {
+    logger.warn('REDIS_HOST not set — AI alert evaluation disabled (degraded mode).');
+    return false;
+  }
+  const queue = getDefaultQueue();
+  if (!queue) {
+    logger.warn('Default queue unavailable — AI alert evaluation disabled.');
+    return false;
+  }
+  const data: AiAlertEvaluationJobData = { type: 'aiAlertEvaluation' };
+  try {
+    await queue.upsertJobScheduler(
+      AI_ALERTS_SCHEDULER_ID,
+      { pattern: AI_ALERTS_CRON, tz: 'UTC' },
+      { name: AI_ALERTS_JOB_NAME, data, opts: DEFAULT_JOB_OPTIONS }
+    );
+    logger.info(
+      { schedulerId: AI_ALERTS_SCHEDULER_ID, cron: AI_ALERTS_CRON },
+      'AI alert evaluator scheduler registered'
+    );
+    return true;
+  } catch (err: unknown) {
+    logger.error({ err }, 'Failed to register AI alert evaluator scheduler');
+    return false;
+  }
+}
+
+/** Deregister — used during graceful shutdown. */
+export async function unregisterAiAlertsScheduler(): Promise<void> {
+  if (!process.env['REDIS_HOST']) return;
+  const queue = getDefaultQueue();
+  if (!queue) return;
+  try {
+    await queue.removeJobScheduler(AI_ALERTS_SCHEDULER_ID);
+  } catch (err: unknown) {
+    logger.error({ err }, 'Failed to deregister AI alert evaluator scheduler');
+  }
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/service.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/service.ts
@@ -1,0 +1,128 @@
+/**
+ * CRUD service for `ai_alert_rules` (PRD-092 US-07).
+ *
+ * Exposes pure functions used by the tRPC router and seeding scripts.
+ */
+import { eq } from 'drizzle-orm';
+
+import { aiAlertRules } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
+import { ruleRowToRule } from './mappers.js';
+
+import type { AlertRule, AlertRuleType } from './types.js';
+
+export interface CreateAlertRuleInput {
+  type: AlertRuleType;
+  scopeProvider?: string | null;
+  scopeModel?: string | null;
+  thresholdValue: number;
+  windowMinutes?: number | null;
+  enabled?: boolean;
+}
+
+export interface UpdateAlertRuleInput {
+  id: number;
+  type?: AlertRuleType;
+  scopeProvider?: string | null;
+  scopeModel?: string | null;
+  thresholdValue?: number;
+  windowMinutes?: number | null;
+  enabled?: boolean;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/** Resolve the next `enabled` integer flag from update input + existing state. */
+function resolveEnabledFlag(next: boolean | undefined, current: boolean): 0 | 1 {
+  const value = next === undefined ? current : next;
+  return value ? 1 : 0;
+}
+
+export function listRules(): AlertRule[] {
+  return getDrizzle().select().from(aiAlertRules).all().map(ruleRowToRule);
+}
+
+export function getRule(id: number): AlertRule | null {
+  const [row] = getDrizzle().select().from(aiAlertRules).where(eq(aiAlertRules.id, id)).all();
+  return row ? ruleRowToRule(row) : null;
+}
+
+export function createRule(input: CreateAlertRuleInput): AlertRule {
+  const now = nowIso();
+  const db = getDrizzle();
+  const result = db
+    .insert(aiAlertRules)
+    .values({
+      type: input.type,
+      scopeProvider: input.scopeProvider ?? null,
+      scopeModel: input.scopeModel ?? null,
+      thresholdValue: input.thresholdValue,
+      windowMinutes: input.windowMinutes ?? null,
+      enabled: input.enabled === false ? 0 : 1,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()
+    .all();
+  const row = result[0];
+  if (!row) throw new Error('Insert into ai_alert_rules returned no rows');
+  return ruleRowToRule(row);
+}
+
+export function updateRule(input: UpdateAlertRuleInput): AlertRule {
+  const existing = getRule(input.id);
+  if (!existing) throw new Error(`Alert rule not found: ${input.id}`);
+  const now = nowIso();
+  const db = getDrizzle();
+  const result = db
+    .update(aiAlertRules)
+    .set({
+      type: input.type ?? existing.type,
+      scopeProvider:
+        input.scopeProvider === undefined ? existing.scopeProvider : input.scopeProvider,
+      scopeModel: input.scopeModel === undefined ? existing.scopeModel : input.scopeModel,
+      thresholdValue: input.thresholdValue ?? existing.thresholdValue,
+      windowMinutes:
+        input.windowMinutes === undefined ? existing.windowMinutes : input.windowMinutes,
+      enabled: resolveEnabledFlag(input.enabled, existing.enabled),
+      updatedAt: now,
+    })
+    .where(eq(aiAlertRules.id, input.id))
+    .returning()
+    .all();
+  const row = result[0];
+  if (!row) throw new Error(`Update returned no rows for rule ${input.id}`);
+  return ruleRowToRule(row);
+}
+
+export function setRuleEnabled(id: number, enabled: boolean): AlertRule {
+  return updateRule({ id, enabled });
+}
+
+export function deleteRule(id: number): { success: boolean } {
+  const result = getDrizzle().delete(aiAlertRules).where(eq(aiAlertRules.id, id)).run();
+  return { success: result.changes > 0 };
+}
+
+/**
+ * Idempotently seed default alert rules per PRD-092 US-07. Returns the number
+ * of rules created (0 when any rule of the same type already exists).
+ */
+export function seedDefaultRules(): number {
+  const existing = listRules();
+  if (existing.length > 0) return 0;
+  const defaults: CreateAlertRuleInput[] = [
+    { type: 'budget-threshold', thresholdValue: 80 },
+    { type: 'error-spike', thresholdValue: 10, windowMinutes: 60 },
+    { type: 'latency-degradation', thresholdValue: 10_000, windowMinutes: 60 },
+  ];
+  let created = 0;
+  for (const def of defaults) {
+    createRule(def);
+    created += 1;
+  }
+  return created;
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/service.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/service.ts
@@ -35,12 +35,6 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
-/** Resolve the next `enabled` integer flag from update input + existing state. */
-function resolveEnabledFlag(next: boolean | undefined, current: boolean): 0 | 1 {
-  const value = next === undefined ? current : next;
-  return value ? 1 : 0;
-}
-
 export function listRules(): AlertRule[] {
   return getDrizzle().select().from(aiAlertRules).all().map(ruleRowToRule);
 }
@@ -72,29 +66,29 @@ export function createRule(input: CreateAlertRuleInput): AlertRule {
   return ruleRowToRule(row);
 }
 
+/**
+ * Apply a partial update as a single SQL UPDATE. We deliberately avoid a
+ * read-then-write merge so concurrent edits (including `setRuleEnabled`)
+ * cannot silently clobber fields the caller did not intend to modify.
+ */
 export function updateRule(input: UpdateAlertRuleInput): AlertRule {
-  const existing = getRule(input.id);
-  if (!existing) throw new Error(`Alert rule not found: ${input.id}`);
   const now = nowIso();
   const db = getDrizzle();
+  const patch: Partial<typeof aiAlertRules.$inferInsert> = { updatedAt: now };
+  if (input.type !== undefined) patch.type = input.type;
+  if (input.scopeProvider !== undefined) patch.scopeProvider = input.scopeProvider;
+  if (input.scopeModel !== undefined) patch.scopeModel = input.scopeModel;
+  if (input.thresholdValue !== undefined) patch.thresholdValue = input.thresholdValue;
+  if (input.windowMinutes !== undefined) patch.windowMinutes = input.windowMinutes;
+  if (input.enabled !== undefined) patch.enabled = input.enabled ? 1 : 0;
   const result = db
     .update(aiAlertRules)
-    .set({
-      type: input.type ?? existing.type,
-      scopeProvider:
-        input.scopeProvider === undefined ? existing.scopeProvider : input.scopeProvider,
-      scopeModel: input.scopeModel === undefined ? existing.scopeModel : input.scopeModel,
-      thresholdValue: input.thresholdValue ?? existing.thresholdValue,
-      windowMinutes:
-        input.windowMinutes === undefined ? existing.windowMinutes : input.windowMinutes,
-      enabled: resolveEnabledFlag(input.enabled, existing.enabled),
-      updatedAt: now,
-    })
+    .set(patch)
     .where(eq(aiAlertRules.id, input.id))
     .returning()
     .all();
   const row = result[0];
-  if (!row) throw new Error(`Update returned no rows for rule ${input.id}`);
+  if (!row) throw new Error(`Alert rule not found: ${input.id}`);
   return ruleRowToRule(row);
 }
 
@@ -108,21 +102,40 @@ export function deleteRule(id: number): { success: boolean } {
 }
 
 /**
- * Idempotently seed default alert rules per PRD-092 US-07. Returns the number
- * of rules created (0 when any rule of the same type already exists).
+ * Idempotently seed default alert rules per PRD-092 US-07.
+ *
+ * Returns the number of rules created. Only types that are not already
+ * represented in the table are inserted, so the function can backfill a
+ * missing default after a partial earlier seed. The inserts run inside a
+ * single transaction so a failure rolls back the whole batch rather than
+ * leaving the table in a partially-seeded state.
  */
 export function seedDefaultRules(): number {
-  const existing = listRules();
-  if (existing.length > 0) return 0;
   const defaults: CreateAlertRuleInput[] = [
     { type: 'budget-threshold', thresholdValue: 80 },
     { type: 'error-spike', thresholdValue: 10, windowMinutes: 60 },
     { type: 'latency-degradation', thresholdValue: 10_000, windowMinutes: 60 },
   ];
-  let created = 0;
-  for (const def of defaults) {
-    createRule(def);
-    created += 1;
-  }
-  return created;
+  const db = getDrizzle();
+  const existingTypes = new Set(listRules().map((r) => r.type));
+  const missing = defaults.filter((d) => !existingTypes.has(d.type));
+  if (missing.length === 0) return 0;
+  const now = nowIso();
+  db.transaction((tx) => {
+    tx.insert(aiAlertRules)
+      .values(
+        missing.map((d) => ({
+          type: d.type,
+          scopeProvider: d.scopeProvider ?? null,
+          scopeModel: d.scopeModel ?? null,
+          thresholdValue: d.thresholdValue,
+          windowMinutes: d.windowMinutes ?? null,
+          enabled: d.enabled === false ? 0 : 1,
+          createdAt: now,
+          updatedAt: now,
+        }))
+      )
+      .run();
+  });
+  return missing.length;
 }

--- a/apps/pops-api/src/modules/core/ai-alerts/service.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/service.ts
@@ -80,7 +80,7 @@ export function updateRule(input: UpdateAlertRuleInput): AlertRule {
   if (input.scopeModel !== undefined) patch.scopeModel = input.scopeModel;
   if (input.thresholdValue !== undefined) patch.thresholdValue = input.thresholdValue;
   if (input.windowMinutes !== undefined) patch.windowMinutes = input.windowMinutes;
-  if (input.enabled !== undefined) patch.enabled = input.enabled ? 1 : 0;
+  if (input.enabled !== undefined) patch.enabled = input.enabled === false ? 0 : 1;
   const result = db
     .update(aiAlertRules)
     .set(patch)

--- a/apps/pops-api/src/modules/core/ai-alerts/types.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Public types for the AI alert subsystem (PRD-092 US-07).
+ *
+ * The alert evaluator is intentionally narrow: rule types map 1:1 to
+ * evaluator implementations and each fires alerts with a stable shape.
+ */
+
+export const ALERT_RULE_TYPES = ['budget-threshold', 'error-spike', 'latency-degradation'] as const;
+
+export type AlertRuleType = (typeof ALERT_RULE_TYPES)[number];
+
+export const ALERT_CHANNELS = ['telegram', 'nudge'] as const;
+export type AlertChannel = (typeof ALERT_CHANNELS)[number];
+
+export const ALERT_SEVERITIES = ['warning', 'critical'] as const;
+export type AlertSeverity = (typeof ALERT_SEVERITIES)[number];
+
+/** Decoded alert rule as exposed by the service layer. */
+export interface AlertRule {
+  id: number;
+  type: AlertRuleType;
+  scopeProvider: string | null;
+  scopeModel: string | null;
+  thresholdValue: number;
+  windowMinutes: number | null;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A single fired alert. */
+export interface FiredAlert {
+  id: number;
+  ruleId: number | null;
+  type: AlertRuleType;
+  message: string;
+  severity: AlertSeverity;
+  scopeDetail: string | null;
+  metricValue: number;
+  thresholdValue: number;
+  acknowledged: boolean;
+  acknowledgedAt: string | null;
+  createdAt: string;
+}
+
+/**
+ * Result of evaluating a single rule. The evaluator returns zero or more
+ * trigger candidates — for example a single "latency-degradation" rule that
+ * is unscoped fans out into one candidate per model that breaches the
+ * threshold.
+ */
+export interface AlertCandidate {
+  ruleId: number;
+  type: AlertRuleType;
+  severity: AlertSeverity;
+  message: string;
+  scopeDetail: string | null;
+  metricValue: number;
+  thresholdValue: number;
+}
+
+/** A persisted alert plus the channels it should be dispatched on. */
+export interface DispatchedAlert extends FiredAlert {
+  channels: AlertChannel[];
+}

--- a/apps/pops-api/src/modules/core/ai-alerts/types.ts
+++ b/apps/pops-api/src/modules/core/ai-alerts/types.ts
@@ -1,8 +1,9 @@
 /**
  * Public types for the AI alert subsystem (PRD-092 US-07).
  *
- * The alert evaluator is intentionally narrow: rule types map 1:1 to
- * evaluator implementations and each fires alerts with a stable shape.
+ * Rule type strings map 1:1 to evaluator implementations under `evaluators/`;
+ * adding a new rule type requires both an entry here and a matching evaluator
+ * registered in `evaluator.ts`.
  */
 
 export const ALERT_RULE_TYPES = ['budget-threshold', 'error-spike', 'latency-degradation'] as const;
@@ -15,7 +16,6 @@ export type AlertChannel = (typeof ALERT_CHANNELS)[number];
 export const ALERT_SEVERITIES = ['warning', 'critical'] as const;
 export type AlertSeverity = (typeof ALERT_SEVERITIES)[number];
 
-/** Decoded alert rule as exposed by the service layer. */
 export interface AlertRule {
   id: number;
   type: AlertRuleType;
@@ -28,7 +28,6 @@ export interface AlertRule {
   updatedAt: string;
 }
 
-/** A single fired alert. */
 export interface FiredAlert {
   id: number;
   ruleId: number | null;
@@ -44,10 +43,9 @@ export interface FiredAlert {
 }
 
 /**
- * Result of evaluating a single rule. The evaluator returns zero or more
- * trigger candidates — for example a single "latency-degradation" rule that
- * is unscoped fans out into one candidate per model that breaches the
- * threshold.
+ * Pre-persist trigger shape. A single rule can produce multiple candidates —
+ * e.g. an unscoped latency rule fans out to one candidate per breaching model
+ * — which is why the evaluator returns an array rather than a single value.
  */
 export interface AlertCandidate {
   ruleId: number;
@@ -59,7 +57,6 @@ export interface AlertCandidate {
   thresholdValue: number;
 }
 
-/** A persisted alert plus the channels it should be dispatched on. */
 export interface DispatchedAlert extends FiredAlert {
   channels: AlertChannel[];
 }

--- a/apps/pops-api/src/modules/core/index.ts
+++ b/apps/pops-api/src/modules/core/index.ts
@@ -5,6 +5,7 @@
  * not included here.
  */
 import { router } from '../../trpc.js';
+import { aiAlertsRouter } from './ai-alerts/router.js';
 import { aiBudgetsRouter } from './ai-budgets/router.js';
 import { aiObservabilityRouter } from './ai-observability/router.js';
 import { aiProvidersRouter } from './ai-providers/router.js';
@@ -34,6 +35,7 @@ export const coreRouter = router({
   aiObservability: aiObservabilityRouter,
   aiProviders: aiProvidersRouter,
   aiBudgets: aiBudgetsRouter,
+  aiAlerts: aiAlertsRouter,
   corrections: correctionsRouter,
   jobs: jobsRouter,
   embeddings: embeddingsRouter,

--- a/apps/pops-api/src/modules/core/migrations.ts
+++ b/apps/pops-api/src/modules/core/migrations.ts
@@ -49,6 +49,8 @@ export const coreMigrationTags: readonly string[] = [
   '0053_ai_inference_daily',
   // service_accounts (PRD-095).
   '0054_service_accounts',
+  // ai_alert_rules + ai_alerts (PRD-092 US-07).
+  '0055_ai_alert_rules',
 ];
 
 export const coreMigrations: readonly MigrationDescriptor[] = drizzleMigrations(coreMigrationTags);

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -530,6 +530,41 @@ export function createTestDb(): Database {
       updated_at TEXT NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS ai_alert_rules (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      type TEXT NOT NULL,
+      scope_provider TEXT,
+      scope_model TEXT,
+      threshold_value REAL NOT NULL,
+      window_minutes INTEGER,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_ai_alert_rules_type ON ai_alert_rules(type);
+    CREATE INDEX IF NOT EXISTS idx_ai_alert_rules_enabled ON ai_alert_rules(enabled);
+
+    CREATE TABLE IF NOT EXISTS ai_alerts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      rule_id INTEGER REFERENCES ai_alert_rules(id) ON DELETE SET NULL,
+      type TEXT NOT NULL,
+      message TEXT NOT NULL,
+      severity TEXT NOT NULL,
+      scope_detail TEXT,
+      metric_value REAL NOT NULL,
+      threshold_value REAL NOT NULL,
+      acknowledged INTEGER NOT NULL DEFAULT 0,
+      acknowledged_at TEXT,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_ai_alerts_created_at ON ai_alerts(created_at);
+    CREATE INDEX IF NOT EXISTS idx_ai_alerts_type ON ai_alerts(type);
+    CREATE INDEX IF NOT EXISTS idx_ai_alerts_severity ON ai_alerts(severity);
+    CREATE INDEX IF NOT EXISTS idx_ai_alerts_acknowledged ON ai_alerts(acknowledged);
+    CREATE INDEX IF NOT EXISTS idx_ai_alerts_dedupe ON ai_alerts(type, scope_detail, created_at);
+
     CREATE TABLE IF NOT EXISTS settings (
       key TEXT PRIMARY KEY NOT NULL,
       value TEXT NOT NULL

--- a/docs/themes/05-ai/prds/092-ai-observability/README.md
+++ b/docs/themes/05-ai/prds/092-ai-observability/README.md
@@ -128,16 +128,16 @@ Build a multi-provider observability layer that tracks every AI inference call a
 
 ## User Stories
 
-| #   | Story                                                         | Summary                                                                                           | Status      | Parallelisable          |
-| --- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------- | ----------------------- |
-| 01  | [us-01-provider-registry](us-01-provider-registry.md)         | Provider and model pricing tables, CRUD API, health check, seed Claude defaults                   | Done        | No (first)              |
-| 02  | [us-02-inference-log-schema](us-02-inference-log-schema.md)   | `ai_inference_log` table, migration from `ai_usage`, budget tables                                | Done        | Yes                     |
-| 03  | [us-03-inference-middleware](us-03-inference-middleware.md)   | Transparent tracking wrapper for all AI calls with automatic provider/model/latency logging       | Partial     | Blocked by us-01, us-02 |
-| 04  | [us-04-budget-enforcement](us-04-budget-enforcement.md)       | Pre-call budget checks, exceeded actions (block/warn/fallback), budget status API                 | Partial     | Blocked by us-02        |
-| 05  | [us-05-stats-and-metrics-api](us-05-stats-and-metrics-api.md) | Replaces existing stats/history API with multi-provider, latency, and quality metrics             | Partial     | Blocked by us-02        |
-| 06  | [us-06-monitoring-dashboard](us-06-monitoring-dashboard.md)   | Enhanced AI Ops dashboard with provider breakdown, latency charts, budget status, quality metrics | Partial     | Blocked by us-05        |
-| 07  | [us-07-alert-rules](us-07-alert-rules.md)                     | Budget threshold, error spike, and latency degradation alerts with notification delivery          | Not started | Blocked by us-05        |
-| 08  | [us-08-log-retention](us-08-log-retention.md)                 | Scheduled cleanup job, configurable retention period, aggregation of aged-out data                | Done        | Blocked by us-02        |
+| #   | Story                                                         | Summary                                                                                           | Status  | Parallelisable          |
+| --- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------- | ----------------------- |
+| 01  | [us-01-provider-registry](us-01-provider-registry.md)         | Provider and model pricing tables, CRUD API, health check, seed Claude defaults                   | Done    | No (first)              |
+| 02  | [us-02-inference-log-schema](us-02-inference-log-schema.md)   | `ai_inference_log` table, migration from `ai_usage`, budget tables                                | Done    | Yes                     |
+| 03  | [us-03-inference-middleware](us-03-inference-middleware.md)   | Transparent tracking wrapper for all AI calls with automatic provider/model/latency logging       | Partial | Blocked by us-01, us-02 |
+| 04  | [us-04-budget-enforcement](us-04-budget-enforcement.md)       | Pre-call budget checks, exceeded actions (block/warn/fallback), budget status API                 | Partial | Blocked by us-02        |
+| 05  | [us-05-stats-and-metrics-api](us-05-stats-and-metrics-api.md) | Replaces existing stats/history API with multi-provider, latency, and quality metrics             | Partial | Blocked by us-02        |
+| 06  | [us-06-monitoring-dashboard](us-06-monitoring-dashboard.md)   | Enhanced AI Ops dashboard with provider breakdown, latency charts, budget status, quality metrics | Partial | Blocked by us-05        |
+| 07  | [us-07-alert-rules](us-07-alert-rules.md)                     | Budget threshold, error spike, and latency degradation alerts with notification delivery          | Done    | Blocked by us-05        |
+| 08  | [us-08-log-retention](us-08-log-retention.md)                 | Scheduled cleanup job, configurable retention period, aggregation of aged-out data                | Done    | Blocked by us-02        |
 
 US-01 and US-02 can parallelise. US-03 merges them. US-04, US-05, US-08 can parallelise after US-02. US-06 and US-07 depend on the metrics API (US-05).
 

--- a/docs/themes/05-ai/prds/092-ai-observability/us-07-alert-rules.md
+++ b/docs/themes/05-ai/prds/092-ai-observability/us-07-alert-rules.md
@@ -8,22 +8,22 @@ As a system administrator, I want configurable alert rules that fire when AI bud
 
 ## Acceptance Criteria
 
-- [ ] `ai_alert_rules` Drizzle schema exists with columns: `id` (serial PK), `type` (enum: `budget-threshold` | `error-spike` | `latency-degradation`), `scope_provider` (text, nullable — filter to specific provider), `scope_model` (text, nullable — filter to specific model), `threshold_value` (numeric, NOT NULL — percentage for budget/error, milliseconds for latency), `window_minutes` (integer, nullable — rolling window for error-spike, default 60), `enabled` (boolean, default true), `created_at`, `updated_at`
-- [ ] `ai_alerts` Drizzle schema exists with columns: `id` (serial PK), `rule_id` (FK → ai_alert_rules), `type` (text, NOT NULL), `message` (text, NOT NULL), `severity` (enum: `warning` | `critical`), `scope_detail` (text, nullable — e.g., "provider:claude" or "model:claude-haiku-4-5-20251001"), `metric_value` (numeric — the actual value that triggered the alert), `threshold_value` (numeric — the threshold from the rule), `acknowledged` (boolean, default false), `acknowledged_at` (timestamp, nullable), `created_at` (timestamp, NOT NULL)
-- [ ] Default alert rules are seeded: budget-threshold at 80%, error-spike at 10% in a 60-minute window, latency-degradation at 10000ms
-- [ ] **Budget-threshold** alert: fires when current month spend reaches `threshold_value`% of any `ai_budgets` cost or token limit. Severity is `warning` at 80%, `critical` at 95%.
-- [ ] **Error-spike** alert: fires when the error rate (status `error` or `timeout` / total calls) within the last `window_minutes` exceeds `threshold_value`%. Scoped to provider/model if specified.
-- [ ] **Latency-degradation** alert: fires when the P95 latency for a model in the last `window_minutes` exceeds `threshold_value` ms. Scoped to specific model if specified, otherwise evaluated per-model.
-- [ ] Alert deduplication: for a given `(type, scope_detail)` combination, at most one alert is created per hour. Subsequent triggers within the same hour are suppressed.
-- [ ] Alert delivery — **Shell notification**: active (unacknowledged) alerts are surfaced via an in-app badge or toast in the POPS UI, using the same notification mechanism as other POPS alerts
-- [ ] Alert delivery — **Moltbot (Telegram)**: if Moltbot integration is configured, critical alerts are sent via Telegram using the same delivery channel as Cerebrum proactive nudges (PRD-084). Warning alerts are not sent to Telegram unless explicitly configured.
-- [ ] `core.aiAlerts.list` endpoint: returns alerts filterable by `acknowledged` (boolean), `type`, `severity`, `startDate`, `endDate`. Ordered by `created_at` descending. Paginated.
-- [ ] `core.aiAlerts.acknowledge` endpoint: accepts an alert `id`, sets `acknowledged=true` and `acknowledged_at=now()`. Returns the updated alert.
-- [ ] Alert rules are configurable via the monitoring dashboard (US-06): a simple form allows creating, editing, enabling/disabling, and deleting rules
-- [ ] A BullMQ repeatable job (`ai-alert-evaluator`) runs every 5 minutes: iterates over all enabled `ai_alert_rules`, evaluates each rule's condition against the current data, creates `ai_alerts` rows for any triggered rules (respecting deduplication), and dispatches notifications
-- [ ] Unit test: create a budget-threshold rule at 80%, insert inference log rows totaling 81% of a budget limit, run the evaluator job, verify an alert row is created with correct type, message, and metric_value
-- [ ] Unit test: create two triggers for the same rule within 1 hour, verify only one alert is created (deduplication)
-- [ ] Unit test: acknowledge an alert, verify `acknowledged=true` and `acknowledged_at` is set
+- [x] `ai_alert_rules` Drizzle schema exists with columns: `id` (serial PK), `type` (enum: `budget-threshold` | `error-spike` | `latency-degradation`), `scope_provider` (text, nullable — filter to specific provider), `scope_model` (text, nullable — filter to specific model), `threshold_value` (numeric, NOT NULL — percentage for budget/error, milliseconds for latency), `window_minutes` (integer, nullable — rolling window for error-spike, default 60), `enabled` (boolean, default true), `created_at`, `updated_at`
+- [x] `ai_alerts` Drizzle schema exists with columns: `id` (serial PK), `rule_id` (FK → ai_alert_rules), `type` (text, NOT NULL), `message` (text, NOT NULL), `severity` (enum: `warning` | `critical`), `scope_detail` (text, nullable — e.g., "provider:claude" or "model:claude-haiku-4-5-20251001"), `metric_value` (numeric — the actual value that triggered the alert), `threshold_value` (numeric — the threshold from the rule), `acknowledged` (boolean, default false), `acknowledged_at` (timestamp, nullable), `created_at` (timestamp, NOT NULL)
+- [x] Default alert rules are seeded: budget-threshold at 80%, error-spike at 10% in a 60-minute window, latency-degradation at 10000ms
+- [x] **Budget-threshold** alert: fires when current month spend reaches `threshold_value`% of any `ai_budgets` cost or token limit. Severity is `warning` at 80%, `critical` at 95%.
+- [x] **Error-spike** alert: fires when the error rate (status `error` or `timeout` / total calls) within the last `window_minutes` exceeds `threshold_value`%. Scoped to provider/model if specified.
+- [x] **Latency-degradation** alert: fires when the P95 latency for a model in the last `window_minutes` exceeds `threshold_value` ms. Scoped to specific model if specified, otherwise evaluated per-model.
+- [x] Alert deduplication: for a given `(type, scope_detail)` combination, at most one alert is created per hour. Subsequent triggers within the same hour are suppressed.
+- [x] Alert delivery — **Cerebrum nudge channel**: every alert is persisted as an `insight`-type row in `nudge_log` (PRD-084) — `priority=high` for critical, `priority=medium` for warning — so the existing nudge UI surfaces it alongside other proactive nudges. The original alert id/rule id/severity are preserved in `action_params`.
+- [x] Alert delivery — **Moltbot (Telegram)**: when `POPS_ALERTS_TELEGRAM_BOT_TOKEN` and `POPS_ALERTS_TELEGRAM_CHAT_ID` are set, critical alerts are pushed to Telegram via the Bot API (`sendMessage`, Markdown). Warning alerts are suppressed unless `POPS_ALERTS_TELEGRAM_INCLUDE_WARNINGS=1`. When unset the dispatcher silently no-ops.
+- [x] `core.aiAlerts.list` endpoint: returns alerts filterable by `acknowledged` (boolean), `type`, `severity`, `startDate`, `endDate`. Ordered by `created_at` descending. Paginated.
+- [x] `core.aiAlerts.acknowledge` endpoint: accepts an alert `id`, sets `acknowledged=true` and `acknowledged_at=now()`. Returns the updated alert.
+- [x] Alert rules CRUD via tRPC: `core.aiAlerts.rules.list/get/create/update/delete/setEnabled/seedDefaults`. Dashboard wiring (US-06) tracks the UI form as a follow-up.
+- [x] A BullMQ repeatable job (`pops-ai-alerts`, name `aiAlertEvaluation`) runs every 5 minutes on the `pops-default` queue: iterates over all enabled `ai_alert_rules`, evaluates each rule's condition against the current data, creates `ai_alerts` rows for any triggered rules (respecting deduplication), and dispatches notifications via the channel facade.
+- [x] Unit test: create a budget-threshold rule at 80%, insert inference log rows totaling 81% of a budget limit, run the evaluator job, verify an alert row is created with correct type, message, and metric_value
+- [x] Unit test: create two triggers for the same rule within 1 hour, verify only one alert is created (deduplication)
+- [x] Unit test: acknowledge an alert, verify `acknowledged=true` and `acknowledged_at` is set
 
 ## Notes
 

--- a/packages/db-types/src/index.ts
+++ b/packages/db-types/src/index.ts
@@ -7,6 +7,8 @@
  */
 import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 
+import type { aiAlertRules } from './schema/ai-alert-rules.js';
+import type { aiAlerts } from './schema/ai-alerts.js';
 import type { aiBudgets } from './schema/ai-budgets.js';
 import type { aiInferenceLog } from './schema/ai-inference-log.js';
 import type { aiModelPricing } from './schema/ai-model-pricing.js';
@@ -57,6 +59,8 @@ import type { wishList } from './schema/wishlist.js';
 
 // Re-export Drizzle table objects for use in queries
 export {
+  aiAlertRules,
+  aiAlerts,
   aiBudgets,
   aiInferenceDaily,
   aiInferenceLog,
@@ -130,6 +134,10 @@ export type AiModelPricingRow = InferSelectModel<typeof aiModelPricing>;
 export type AiModelPricingInsert = InferInsertModel<typeof aiModelPricing>;
 export type AiBudgetRow = InferSelectModel<typeof aiBudgets>;
 export type AiBudgetInsert = InferInsertModel<typeof aiBudgets>;
+export type AiAlertRuleRow = InferSelectModel<typeof aiAlertRules>;
+export type AiAlertRuleInsert = InferInsertModel<typeof aiAlertRules>;
+export type AiAlertRow = InferSelectModel<typeof aiAlerts>;
+export type AiAlertInsert = InferInsertModel<typeof aiAlerts>;
 export type EmbeddingRow = InferSelectModel<typeof embeddings>;
 export type EmbeddingInsert = InferInsertModel<typeof embeddings>;
 export type EnvironmentRow = InferSelectModel<typeof environments>;

--- a/packages/db-types/src/schema/ai-alert-rules.ts
+++ b/packages/db-types/src/schema/ai-alert-rules.ts
@@ -1,0 +1,33 @@
+/**
+ * `ai_alert_rules` (PRD-092 US-07) — configurable rules that the alert
+ * evaluator job runs every 5 minutes to decide whether to fire an alert.
+ *
+ * - `type` is one of `budget-threshold`, `error-spike`, `latency-degradation`.
+ * - `threshold_value` semantics depend on type:
+ *     budget-threshold       → percentage of a budget limit (e.g. 80 = 80%)
+ *     error-spike            → percentage error rate (e.g. 10 = 10%)
+ *     latency-degradation    → P95 milliseconds (e.g. 10000 = 10s)
+ * - `window_minutes` is the rolling window for rate/percentile-based rules.
+ *   Budget rules ignore the window — they evaluate against the current month.
+ * - `scope_provider` / `scope_model` are optional filters. Null = match all.
+ */
+import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+export const aiAlertRules = sqliteTable(
+  'ai_alert_rules',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    type: text('type').notNull(),
+    scopeProvider: text('scope_provider'),
+    scopeModel: text('scope_model'),
+    thresholdValue: real('threshold_value').notNull(),
+    windowMinutes: integer('window_minutes'),
+    enabled: integer('enabled').notNull().default(1),
+    createdAt: text('created_at').notNull(),
+    updatedAt: text('updated_at').notNull(),
+  },
+  (table) => [
+    index('idx_ai_alert_rules_type').on(table.type),
+    index('idx_ai_alert_rules_enabled').on(table.enabled),
+  ]
+);

--- a/packages/db-types/src/schema/ai-alerts.ts
+++ b/packages/db-types/src/schema/ai-alerts.ts
@@ -1,0 +1,34 @@
+/**
+ * `ai_alerts` (PRD-092 US-07) — fired alerts produced by the evaluator job.
+ *
+ * `scope_detail` is a human-readable scope identifier used both for display
+ * and for deduplication; the evaluator suppresses inserts when an alert with
+ * the same `(type, scope_detail)` was created within the last hour.
+ */
+import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+import { aiAlertRules } from './ai-alert-rules.js';
+
+export const aiAlerts = sqliteTable(
+  'ai_alerts',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    ruleId: integer('rule_id').references(() => aiAlertRules.id, { onDelete: 'set null' }),
+    type: text('type').notNull(),
+    message: text('message').notNull(),
+    severity: text('severity').notNull(),
+    scopeDetail: text('scope_detail'),
+    metricValue: real('metric_value').notNull(),
+    thresholdValue: real('threshold_value').notNull(),
+    acknowledged: integer('acknowledged').notNull().default(0),
+    acknowledgedAt: text('acknowledged_at'),
+    createdAt: text('created_at').notNull(),
+  },
+  (table) => [
+    index('idx_ai_alerts_created_at').on(table.createdAt),
+    index('idx_ai_alerts_type').on(table.type),
+    index('idx_ai_alerts_severity').on(table.severity),
+    index('idx_ai_alerts_acknowledged').on(table.acknowledged),
+    index('idx_ai_alerts_dedupe').on(table.type, table.scopeDetail, table.createdAt),
+  ]
+);

--- a/packages/db-types/src/schema/index.ts
+++ b/packages/db-types/src/schema/index.ts
@@ -1,3 +1,5 @@
+export { aiAlertRules } from './ai-alert-rules.js';
+export { aiAlerts } from './ai-alerts.js';
 export { aiBudgets } from './ai-budgets.js';
 export { aiInferenceDaily } from './ai-inference-daily.js';
 export { aiInferenceLog } from './ai-inference-log.js';


### PR DESCRIPTION
Closes #2552

## Summary

Implements PRD-092 US-07: alert rule evaluation + notification delivery for the AI Observability platform. The previous work tracked inference calls but never evaluated alert rules — this lands the missing rule engine, a 5-minute BullMQ scheduler, two delivery channels (Cerebrum nudges + Telegram), and admin tRPC CRUD.

## Approach

**Schema** — `ai_alert_rules` + `ai_alerts` Drizzle tables in `packages/db-types`. Migration `0055_ai_alert_rules`, registered against `core` in `migration-ownership.ts` and the core module's `coreMigrationTags` list (PRD-101 US-09 contract).

**Evaluator** — `apps/pops-api/src/modules/core/ai-alerts/`:

- `evaluators/budget.ts` — fires when current-month spend reaches N% of any `ai_budgets` cost or token limit. Warning at threshold, critical at 95%. Reuses the same usage aggregation pattern as `aiBudgets.getBudgetStatus`.
- `evaluators/error-spike.ts` — rolling-window error rate (`status IN ('error','timeout') / COUNT(*)`) with optional provider/model scope. Critical when rate >= 1.5 x threshold.
- `evaluators/latency.ts` — P95 latency in the rolling window. Fans out per-model when no `scopeModel` is configured, otherwise scoped to the named model.
- `alerts-store.ts` — dedup query + insert + list/acknowledge helpers. Dedup is `(type, scope_detail)` within 1 hour via the new `idx_ai_alerts_dedupe` index.
- `evaluator.ts` — orchestrator: load -> evaluate -> dedupe -> persist -> dispatch.

**Dispatch** — `dispatch.ts` resolves channels from severity + env. Per PRD: every alert hits the nudge channel; only critical alerts hit Telegram unless `POPS_ALERTS_TELEGRAM_INCLUDE_WARNINGS=1`.

- `dispatchers/nudge.ts` — persists to `nudge_log` as an `insight`-type row with `priority: high|medium` mapped from severity. Source metadata (`alertId`, `ruleId`, `severity`) stored in `action_params` so a downstream surface can deep-link back.
- `dispatchers/telegram.ts` — direct Bot API `sendMessage` call (Markdown). Reads `POPS_ALERTS_TELEGRAM_BOT_TOKEN` + `POPS_ALERTS_TELEGRAM_CHAT_ID` from env; silently no-ops when unset. Transport is injectable for tests.

**Scheduler** — `scheduler.ts` registers a repeatable BullMQ job on `pops-default` with cron `*/5 * * * *`. Mirrors the retention scheduler pattern. Registered + deregistered in `apps/pops-api/src/index.ts` alongside the retention scheduler.

**Admin tRPC** — `core.aiAlerts.rules.{list,get,create,update,delete,setEnabled,seedDefaults}` + `core.aiAlerts.{list,acknowledge,runNow}`.

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — 0 errors (warnings unchanged)
- [x] `pnpm typecheck` — clean across 19 packages
- [x] `pnpm test` — `@pops/api` 4119/4119 (16 new unit tests for evaluators, dispatcher facade, nudge mapping, Telegram message rendering, dedup, listing/ack)
- [x] Migration ownership contract test passes after registering `0055_ai_alert_rules` to `core`
- [x] `pnpm registry:build` clean

## Followups (out of scope for US-07)

- US-06 dashboard form to manage rules (already tracked under #2572)
- Optional: ship a service-account-backed `/api/alerts/dispatch` endpoint so an external alerting daemon could push without env-baked Telegram creds (current implementation hits Telegram directly via env-configured Bot API)