### PR TITLE
feat(cerebrum): graduate quick-captured engrams to classified type folder (#2574)

### DIFF
--- a/apps/pops-api/src/jobs/handlers/curation.test.ts
+++ b/apps/pops-api/src/jobs/handlers/curation.test.ts
@@ -10,6 +10,7 @@ import type { Job } from 'bullmq';
 
 const mockRead = vi.fn();
 const mockUpdate = vi.fn();
+const mockChangeType = vi.fn();
 const mockClassify = vi.fn();
 const mockExtract = vi.fn();
 const mockInfer = vi.fn();
@@ -18,6 +19,7 @@ vi.mock('../../modules/cerebrum/instance.js', () => ({
   getEngramService: () => ({
     read: mockRead,
     update: mockUpdate,
+    changeType: mockChangeType,
   }),
   getScopeRuleEngine: () => ({
     getConfig: () => ({}),
@@ -196,6 +198,25 @@ describe('curation handler — classifyEngram', () => {
 
     const call = mockUpdate.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(call).not.toHaveProperty('template');
+  });
+
+  it('graduates a capture engram to its classified type via changeType (PRD-081 US-03 AC #6)', async () => {
+    await processJob(makeJob({ type: 'classifyEngram', engramId: 'eng_20260427_1500_test' }));
+
+    expect(mockChangeType).toHaveBeenCalledWith('eng_20260427_1500_test', 'idea');
+  });
+
+  it('does not call changeType when the classified type matches the current type', async () => {
+    mockClassify.mockResolvedValue({
+      type: 'capture',
+      confidence: 0.3,
+      template: null,
+      suggestedTags: [],
+    });
+
+    await processJob(makeJob({ type: 'classifyEngram', engramId: 'eng_20260427_1500_test' }));
+
+    expect(mockChangeType).not.toHaveBeenCalled();
   });
 
   it('throws for unknown job types', async () => {

--- a/apps/pops-api/src/jobs/handlers/curation.ts
+++ b/apps/pops-api/src/jobs/handlers/curation.ts
@@ -89,10 +89,6 @@ async function processClassifyEngram(engramId: string): Promise<{ engramId: stri
   }
   customFields['_enrichedHash'] = engram.contentHash;
 
-  // Persist the classified template so future renders pick up template
-  // scaffolding even though `type` itself is not mutable in-place (changing
-  // type would require a file move under {type}/{id}.md — tracked
-  // separately).
   const updateInput: UpdateEngramInput = {
     scopes: scopeResult.scopes,
     tags: mergedTags.length > 0 ? mergedTags : undefined,
@@ -102,6 +98,13 @@ async function processClassifyEngram(engramId: string): Promise<{ engramId: stri
     updateInput.template = classification.template;
   }
   engramService.update(engramId, updateInput);
+
+  // PRD-081 US-03 AC #6: graduate capture engrams to their classified type
+  // folder. `changeType` is a no-op when types already match, so this is safe
+  // to call unconditionally.
+  if (classification.type !== engram.type) {
+    engramService.changeType(engramId, classification.type);
+  }
 
   logger.info(
     {

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/change-type.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/change-type.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the engram type-change handler (PRD-081 US-03 AC #6).
+ *
+ * Verifies that a quick-captured engram graduates from `captures/{id}.md` to
+ * `{type}/{id}.md` atomically: the file moves, the index updates to the new
+ * `type`/`file_path`, the id is preserved, and existing links still resolve.
+ */
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ValidationError } from '../../../../shared/errors.js';
+import { createTestDb } from '../../../../shared/test-utils.js';
+import { TemplateRegistry } from '../../templates/registry.js';
+import { seedDefaultTemplates } from '../../templates/seed.js';
+import { parseEngramFile } from '../file.js';
+import { EngramService } from '../service.js';
+
+import type { Database } from 'better-sqlite3';
+
+function makeClock(start = new Date('2026-04-18T09:00:00Z')): () => Date {
+  let t = start.getTime();
+  return () => {
+    const d = new Date(t);
+    t += 60_000;
+    return d;
+  };
+}
+
+describe('EngramService.changeType (PRD-081 US-03 AC #6)', () => {
+  let db: Database;
+  let service: EngramService;
+  let root: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    root = mkdtempSync(join(tmpdir(), 'cerebrum-change-type-'));
+    const templatesDir = join(root, '.templates');
+    seedDefaultTemplates(templatesDir);
+    service = new EngramService({
+      root,
+      db: drizzle(db),
+      templates: new TemplateRegistry(templatesDir),
+      now: makeClock(),
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    db.close();
+  });
+
+  it('moves the file from capture/ to the new type folder and updates the index', () => {
+    const engram = service.create({
+      type: 'capture',
+      title: 'A thought',
+      body: '# A thought\n\nbody',
+      scopes: ['personal.captures'],
+      source: 'cli',
+    });
+    const oldPath = engram.filePath;
+    expect(oldPath.startsWith('capture/')).toBe(true);
+
+    const moved = service.changeType(engram.id, 'idea');
+
+    expect(moved.id).toBe(engram.id);
+    expect(moved.type).toBe('idea');
+    expect(moved.filePath).toBe(`idea/${engram.id}.md`);
+    expect(existsSync(join(root, oldPath))).toBe(false);
+    expect(existsSync(join(root, moved.filePath))).toBe(true);
+  });
+
+  it('preserves frontmatter (scopes, tags, source, custom fields) and body content', () => {
+    const engram = service.create({
+      type: 'capture',
+      title: 'A thought',
+      body: '# A thought\n\nThe original body.\n',
+      scopes: ['personal.captures'],
+      tags: ['raw', 'cli'],
+      source: 'cli',
+    });
+    // Stash a custom field via update so we know the change-type carries it.
+    service.update(engram.id, { customFields: { _enrichedHash: 'abc123' } });
+
+    const moved = service.changeType(engram.id, 'idea');
+
+    expect(new Set(moved.tags)).toEqual(new Set(['raw', 'cli']));
+    expect(moved.scopes).toEqual(['personal.captures']);
+    expect(moved.source).toBe('cli');
+    expect(moved.customFields['_enrichedHash']).toBe('abc123');
+
+    const content = readFileSync(join(root, moved.filePath), 'utf8');
+    const { frontmatter, body } = parseEngramFile(content);
+    expect(frontmatter.type).toBe('idea');
+    expect(frontmatter.id).toBe(engram.id);
+    expect(body).toContain('The original body.');
+  });
+
+  it('bumps `modified` but keeps `created`', () => {
+    const engram = service.create({
+      type: 'capture',
+      title: 'A thought',
+      body: '# A thought',
+      scopes: ['personal.captures'],
+    });
+    const moved = service.changeType(engram.id, 'idea');
+    expect(moved.created).toBe(engram.created);
+    expect(moved.modified).not.toBe(engram.modified);
+  });
+
+  it('keeps links to the moved engram intact (id-based, not path-based)', () => {
+    const capture = service.create({
+      type: 'capture',
+      title: 'Captured',
+      body: '# Captured',
+      scopes: ['personal.captures'],
+    });
+    const ref = service.create({
+      type: 'note',
+      title: 'Reference',
+      body: '# Reference',
+      scopes: ['personal'],
+    });
+    service.link(ref.id, capture.id);
+
+    service.changeType(capture.id, 'idea');
+
+    const reloadRef = service.read(ref.id).engram;
+    const reloadCapture = service.read(capture.id).engram;
+    expect(reloadRef.links).toContain(capture.id);
+    expect(reloadCapture.links).toContain(ref.id);
+    expect(reloadCapture.filePath).toBe(`idea/${capture.id}.md`);
+  });
+
+  it('is a no-op when the new type equals the current type', () => {
+    const engram = service.create({
+      type: 'idea',
+      title: 'Stays put',
+      body: '# Stays put',
+      scopes: ['personal.ideas'],
+    });
+    const before = service.read(engram.id).engram;
+    const after = service.changeType(engram.id, 'idea');
+    expect(after.filePath).toBe(before.filePath);
+    expect(after.modified).toBe(before.modified);
+  });
+
+  it('rejects unsafe type values', () => {
+    const engram = service.create({
+      type: 'capture',
+      title: 'Bad target',
+      body: '# Bad target',
+      scopes: ['personal.captures'],
+    });
+    expect(() => service.changeType(engram.id, '../etc')).toThrow(ValidationError);
+    expect(() => service.changeType(engram.id, '.archive')).toThrow(ValidationError);
+  });
+
+  it('refuses to overwrite an existing file at the destination', () => {
+    const engram = service.create({
+      type: 'capture',
+      title: 'Will collide',
+      body: '# Will collide',
+      scopes: ['personal.captures'],
+    });
+    // Park a file at the destination path before attempting the move.
+    const ideaDir = join(root, 'idea');
+    mkdirSync(ideaDir, { recursive: true });
+    writeFileSync(join(ideaDir, `${engram.id}.md`), 'occupied', { flag: 'w' });
+
+    expect(() => service.changeType(engram.id, 'idea')).toThrow(ValidationError);
+
+    // Original file still in place; index untouched.
+    expect(existsSync(join(root, engram.filePath))).toBe(true);
+    expect(service.read(engram.id).engram.type).toBe('capture');
+  });
+
+  it('rolls back the new file when the index upsert fails', () => {
+    const engram = service.create({
+      type: 'capture',
+      title: 'Rollback',
+      body: '# Rollback',
+      scopes: ['personal.captures'],
+    });
+
+    // Drop the engram_scopes junction so the upsert inside changeType throws
+    // *after* writing the new file (the file write happens before upsertIndex).
+    db.exec('DROP TABLE engram_scopes');
+
+    expect(() => service.changeType(engram.id, 'idea')).toThrow();
+
+    expect(existsSync(join(root, `idea/${engram.id}.md`))).toBe(false);
+    expect(existsSync(join(root, engram.filePath))).toBe(true);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/change-type.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/change-type.ts
@@ -1,0 +1,70 @@
+/**
+ * Engram type change with file move (PRD-081 US-03 AC #6).
+ *
+ * Quick-captured engrams land in `captures/{id}.md`. When the curation worker
+ * classifies them with high confidence into a real type (idea, note, ...), the
+ * file has to move to `{type}/{id}.md`. The id is unchanged, so any links
+ * pointing at this engram continue to resolve.
+ *
+ * Atomicity: write the new file → upsert the index pointing at the new path →
+ * unlink the old file. If the index upsert fails, the freshly-written file is
+ * removed and the old file remains the source of truth. If the final unlink
+ * fails, two files exist for one engram but the index points at the new
+ * (correct) one — reconcilable via `reindex`.
+ */
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+
+import { ValidationError } from '../../../../shared/errors.js';
+import { parseEngramFile, serializeEngram } from '../file.js';
+import { absolutePath, assertSafeType, parseCustomFields, writeFileAtomic } from './fs-helpers.js';
+import { getIndexRow, upsertIndex } from './upsert-index.js';
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+export type ChangeTypeDeps = {
+  root: string;
+  db: BetterSQLite3Database;
+  now: () => Date;
+};
+
+export function changeEngramType(deps: ChangeTypeDeps, id: string, newType: string): void {
+  const { root, db, now } = deps;
+  assertSafeType(newType);
+
+  const row = getIndexRow(db, id);
+  if (row.type === newType) return;
+
+  const oldRelPath = row.file_path;
+  const newRelPath = `${newType}/${id}.md`;
+  const oldAbs = absolutePath(root, oldRelPath);
+  const newAbs = absolutePath(root, newRelPath);
+
+  if (existsSync(newAbs)) {
+    throw new ValidationError({
+      message: `cannot change engram '${id}' type to '${newType}': target path '${newRelPath}' already exists`,
+    });
+  }
+
+  const { frontmatter, body } = parseEngramFile(readFileSync(oldAbs, 'utf8'));
+  const nextFrontmatter = {
+    ...frontmatter,
+    type: newType,
+    modified: now().toISOString(),
+  };
+  const customFields = row.custom_fields ? parseCustomFields(row.custom_fields) : {};
+
+  writeFileAtomic(newAbs, serializeEngram(nextFrontmatter, body));
+  try {
+    upsertIndex(db, {
+      id,
+      filePath: newRelPath,
+      frontmatter: nextFrontmatter,
+      body,
+      customFields,
+    });
+  } catch (err) {
+    if (existsSync(newAbs)) unlinkSync(newAbs);
+    throw err;
+  }
+  if (existsSync(oldAbs)) unlinkSync(oldAbs);
+}

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.ts
@@ -8,6 +8,7 @@ import { readFileSync } from 'node:fs';
 import { NotFoundError, ValidationError } from '../../../shared/errors.js';
 import { parseEngramFile, serializeEngram } from './file.js';
 import { archiveEngram } from './handlers/archive-engram.js';
+import { changeEngramType } from './handlers/change-type.js';
 import { createEngram, type CreateEngramInput } from './handlers/create-engram.js';
 import {
   absolutePath,
@@ -44,9 +45,9 @@ export interface UpdateEngramInput {
   status?: EngramStatus;
   /**
    * Template name to assign in frontmatter. Used by the async classification
-   * worker (PRD-081 US-03) to set a template after classification. Note that
-   * `type` is deliberately not mutable here — changing type requires a file
-   * move and is tracked separately.
+   * worker (PRD-081 US-03) to set a template after classification. `type` is
+   * not mutable through this method — use `changeType` for that since it
+   * requires a file move.
    */
   template?: string;
 }
@@ -145,6 +146,17 @@ export class EngramService {
 
   archive(id: string): Engram {
     archiveEngram({ root: this.root, db: this.db, now: this.now }, id);
+    return this.loadEngram(id);
+  }
+
+  /**
+   * Move an engram to a different type folder. Used by the curation worker
+   * (PRD-081 US-03 AC #6) when classification graduates a capture into its
+   * classified type. The engram id is preserved, so existing links remain
+   * valid.
+   */
+  changeType(id: string, newType: string): Engram {
+    changeEngramType({ root: this.root, db: this.db, now: this.now }, id, newType);
     return this.loadEngram(id);
   }
 

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-03-quick-capture.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-03-quick-capture.md
@@ -14,7 +14,7 @@ As a user on the go (via Moltbot on Telegram or the pops CLI), I want to fire of
 - [x] Quick capture assigns `type: capture`, `source: moltbot` (or `cli` depending on channel), and the fallback scope from `scope-rules.toml`
 - [x] Quick capture skips classification, entity extraction, and scope inference at ingestion time — the engram is written immediately
 - [x] A background job is enqueued (via BullMQ) to run Cortex classification and entity extraction on the captured engram asynchronously
-- [ ] The background job updates the engram's `type`, `template`, `tags`, and `scopes` in both the file and the index when classification completes — `template`, `tags`, and `scopes` now update; `type` change is deferred because it requires moving the file from `captures/{id}.md` to `{type}/{id}.md` (tracked in #2574)
+- [x] The background job updates the engram's `type`, `template`, `tags`, and `scopes` in both the file and the index when classification completes
 - [ ] The CLI command outputs the engram ID and a confirmation message; Moltbot responds with the engram ID and a brief confirmation — Moltbot side defined in the skill prompt (tracked together with the missing CLI in #2575)
 - [x] Captures with only whitespace or empty text are rejected with an error message
 


### PR DESCRIPTION
## Summary
- Adds `EngramService.changeType(id, newType)` to move an engram from `{oldType}/{id}.md` to `{newType}/{id}.md` and update the index. The engram id is preserved so existing links continue to resolve.
- Wires it into the curation worker — when classification produces a type that differs from the current type, the engram graduates from `capture/` to its classified folder.
- Atomicity: write new file → upsert index → unlink old. Index-upsert failure removes the new file (old remains source of truth); a failed final unlink leaves the index pointing at the new file with a reindex-reconcilable orphan.

Closes #2574. PRD-081 US-03 AC #6.

## Test plan
- [x] Unit tests for `changeType`: file moves, frontmatter preserved (scopes/tags/source/custom fields), `created` preserved + `modified` bumped, links remain valid (id-based), no-op on same-type, rejects unsafe types, refuses to overwrite existing destination, rollback when index upsert throws.
- [x] Curation handler tests: graduates capture → idea via `changeType`; no-op when classified type matches current type.
- [x] `pnpm typecheck` and `mise lint` clean.
- [x] All existing engram/curation tests still green (187 passing).