### PR TITLE
feat(cerebrum): complete agent ingest path - MCP quick_capture + JSON metadata lift (#2556)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/ingest.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/ingest.test.ts
@@ -246,18 +246,33 @@ describe('handleCerebrumIngest — JSON metadata extraction (PRD-081 US-02 AC #7
 
   it('rejects prototype-pollution keys when lifting JSON into customFields', async () => {
     submitCalls.length = 0;
-    const json = JSON.stringify({
-      data: 'kept',
-      __proto__: { polluted: true },
-      constructor: { tampered: true },
-      prototype: 'no',
-    });
+    // Hand-rolled JSON string — `JSON.stringify` silently drops `__proto__` on
+    // an object literal, which would make this test pass for the wrong reason.
+    const json =
+      '{"data":"kept","__proto__":{"polluted":true},"constructor":{"tampered":true},"prototype":"no"}';
     await handleCerebrumIngest({ body: json });
 
     const call = submitCalls[0];
     const customFields = call?.['customFields'];
     expect(customFields).toEqual({ data: 'kept' });
     expect(Object.getPrototypeOf({}).polluted).toBeUndefined();
+  });
+
+  it('treats blank string args as if the caller omitted them so JSON-derived values surface', async () => {
+    submitCalls.length = 0;
+    const json = JSON.stringify({
+      title: 'JSON title',
+      type: 'meeting',
+    });
+    await handleCerebrumIngest({
+      body: json,
+      title: '   ',
+      type: '',
+    });
+
+    const call = submitCalls[0];
+    expect(call?.['title']).toBe('JSON title');
+    expect(call?.['type']).toBe('meeting');
   });
 
   it('trims whitespace from JSON-derived scopes/tags', async () => {

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/ingest.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/ingest.test.ts
@@ -243,4 +243,33 @@ describe('handleCerebrumIngest — JSON metadata extraction (PRD-081 US-02 AC #7
     expect(typeof forwardedBody).toBe('string');
     expect((forwardedBody as string).startsWith('```json')).toBe(true);
   });
+
+  it('rejects prototype-pollution keys when lifting JSON into customFields', async () => {
+    submitCalls.length = 0;
+    const json = JSON.stringify({
+      data: 'kept',
+      __proto__: { polluted: true },
+      constructor: { tampered: true },
+      prototype: 'no',
+    });
+    await handleCerebrumIngest({ body: json });
+
+    const call = submitCalls[0];
+    const customFields = call?.['customFields'];
+    expect(customFields).toEqual({ data: 'kept' });
+    expect(Object.getPrototypeOf({}).polluted).toBeUndefined();
+  });
+
+  it('trims whitespace from JSON-derived scopes/tags', async () => {
+    submitCalls.length = 0;
+    const json = JSON.stringify({
+      scopes: ['  work.sprint  ', ' personal '],
+      tags: [' retro ', '  raw'],
+    });
+    await handleCerebrumIngest({ body: json });
+
+    const call = submitCalls[0];
+    expect(call?.['scopes']).toEqual(['work.sprint', 'personal']);
+    expect(call?.['tags']).toEqual(['retro', 'raw']);
+  });
 });

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/ingest.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/ingest.test.ts
@@ -3,10 +3,15 @@ import { describe, expect, it, vi } from 'vitest';
 import { handleJsonBody } from '../ingest.js';
 import { parseResult } from './test-helpers.js';
 
+// Spy that records the last `submit` argument so we can assert what the
+// handler forwarded to the IngestService.
+const submitCalls: Record<string, unknown>[] = [];
+
 // Mock the IngestService to avoid DB dependency in unit tests
 vi.mock('../../ingest/pipeline.js', () => ({
   IngestService: class MockIngestService {
     async submit(input: Record<string, unknown>) {
+      submitCalls.push(input);
       return {
         engram: {
           id: 'eng_20260427_1200_test',
@@ -154,5 +159,88 @@ describe('handleCerebrumIngest', () => {
       scopes: ['valid', 42, null, 'also-valid'] as unknown as string[],
     });
     expect(result.isError).toBeUndefined();
+  });
+});
+
+describe('handleCerebrumIngest — JSON metadata extraction (PRD-081 US-02 AC #7)', () => {
+  it('lifts type/scopes/tags from a JSON body when the caller omits them', async () => {
+    submitCalls.length = 0;
+    const json = JSON.stringify({
+      title: 'Sprint review',
+      type: 'meeting',
+      scopes: ['work.sprint'],
+      tags: ['retro'],
+      attendees: ['alice', 'bob'],
+      decisions: ['ship friday'],
+    });
+    await handleCerebrumIngest({ body: json });
+
+    const call = submitCalls[0];
+    expect(call).toBeDefined();
+    expect(call?.['title']).toBe('Sprint review');
+    expect(call?.['type']).toBe('meeting');
+    expect(call?.['scopes']).toEqual(['work.sprint']);
+    expect(call?.['tags']).toEqual(['retro']);
+    expect(call?.['customFields']).toEqual({
+      attendees: ['alice', 'bob'],
+      decisions: ['ship friday'],
+    });
+  });
+
+  it('caller-supplied fields win over JSON-derived fields', async () => {
+    submitCalls.length = 0;
+    const json = JSON.stringify({
+      title: 'JSON title',
+      type: 'meeting',
+      scopes: ['work.json'],
+      data: 'kept',
+    });
+    await handleCerebrumIngest({
+      body: json,
+      title: 'Caller title',
+      type: 'note',
+      scopes: ['personal'],
+    });
+
+    const call = submitCalls[0];
+    expect(call?.['title']).toBe('Caller title');
+    expect(call?.['type']).toBe('note');
+    expect(call?.['scopes']).toEqual(['personal']);
+    // Non-native keys still flow through as customFields.
+    expect(call?.['customFields']).toEqual({ data: 'kept' });
+  });
+
+  it('merges caller-supplied tags with JSON-derived tags, deduping', async () => {
+    submitCalls.length = 0;
+    const json = JSON.stringify({ tags: ['from-json', 'shared'] });
+    await handleCerebrumIngest({
+      body: json,
+      tags: ['from-caller', 'shared'],
+    });
+
+    const call = submitCalls[0];
+    expect(call?.['tags']).toEqual(['from-caller', 'shared', 'from-json']);
+  });
+
+  it('does not include a customFields key when the JSON has no extra fields', async () => {
+    submitCalls.length = 0;
+    const json = JSON.stringify({ title: 'Only metadata', tags: ['x'] });
+    await handleCerebrumIngest({ body: json });
+
+    const call = submitCalls[0];
+    expect(call).not.toHaveProperty('customFields');
+  });
+
+  it('non-object JSON (array) contributes no derived metadata', async () => {
+    submitCalls.length = 0;
+    await handleCerebrumIngest({ body: '[1, 2, 3]' });
+
+    const call = submitCalls[0];
+    expect(call).toBeDefined();
+    expect(call).not.toHaveProperty('customFields');
+    // Body is still wrapped in a fenced code block.
+    const forwardedBody = call?.['body'];
+    expect(typeof forwardedBody).toBe('string');
+    expect((forwardedBody as string).startsWith('```json')).toBe(true);
   });
 });

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/quick-capture.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/quick-capture.test.ts
@@ -5,29 +5,46 @@
  * agent-supplied text and source, surfaces the resulting engram id/path/type/
  * scopes, and rejects empty input.
  */
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { parseResult } from './test-helpers.js';
 
 const quickCaptureCalls: { text: string; source: string | undefined }[] = [];
 
+const defaultResponse = {
+  id: 'eng_20260427_1500_quick',
+  path: 'capture/eng_20260427_1500_quick.md',
+  type: 'capture',
+  scopes: ['personal.captures'],
+};
+
+let quickCaptureImpl: (text: string, source?: string) => Promise<typeof defaultResponse> = async (
+  text,
+  source
+) => {
+  quickCaptureCalls.push({ text, source });
+  return defaultResponse;
+};
+
 vi.mock('../../ingest/pipeline.js', () => ({
   IngestService: class MockIngestService {
-    async quickCapture(text: string, source?: string) {
-      quickCaptureCalls.push({ text, source });
-      return {
-        id: 'eng_20260427_1500_quick',
-        path: 'capture/eng_20260427_1500_quick.md',
-        type: 'capture',
-        scopes: ['personal.captures'],
-      };
+    quickCapture(text: string, source?: string) {
+      return quickCaptureImpl(text, source);
     }
   },
 }));
 
 const { handleCerebrumQuickCapture } = await import('../quick-capture.js');
+const { NotFoundError, ValidationError } = await import('../../../../shared/errors.js');
 
 describe('handleCerebrumQuickCapture', () => {
+  afterEach(() => {
+    // Restore default impl in case a test swapped it out.
+    quickCaptureImpl = async (text, source) => {
+      quickCaptureCalls.push({ text, source });
+      return defaultResponse;
+    };
+  });
   it('returns VALIDATION_ERROR for empty text', async () => {
     const result = await handleCerebrumQuickCapture({ text: '   ' });
     const parsed = parseResult(result) as { error: string; code: string };
@@ -74,5 +91,40 @@ describe('handleCerebrumQuickCapture', () => {
     quickCaptureCalls.length = 0;
     await handleCerebrumQuickCapture({ text: 'mystery', source: 'unknown-source' });
     expect(quickCaptureCalls[0]?.source).toBeUndefined();
+  });
+
+  it('maps a thrown ValidationError to a VALIDATION_ERROR tool result', async () => {
+    quickCaptureImpl = async () => {
+      throw new ValidationError({ message: 'engram body is empty' });
+    };
+    const result = await handleCerebrumQuickCapture({ text: 'will throw' });
+    expect(result.isError).toBe(true);
+    const parsed = parseResult(result) as { error: string; code: string };
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    // ValidationError surfaces the generic "Validation failed" message —
+    // details ride along in the underlying error object but mapServiceError
+    // intentionally only forwards the message string.
+    expect(parsed.error).toContain('Validation failed');
+  });
+
+  it('maps a thrown NotFoundError to a NOT_FOUND tool result', async () => {
+    quickCaptureImpl = async () => {
+      throw new NotFoundError('CurationQueue', 'redis');
+    };
+    const result = await handleCerebrumQuickCapture({ text: 'will throw' });
+    expect(result.isError).toBe(true);
+    const parsed = parseResult(result) as { code: string };
+    expect(parsed.code).toBe('NOT_FOUND');
+  });
+
+  it('maps an unknown error to a generic INTERNAL_ERROR result without leaking internals', async () => {
+    quickCaptureImpl = async () => {
+      throw new Error('SELECT * FROM engrams failed: connection refused');
+    };
+    const result = await handleCerebrumQuickCapture({ text: 'will throw' });
+    expect(result.isError).toBe(true);
+    const parsed = parseResult(result) as { error: string; code: string };
+    expect(parsed.code).toBe('INTERNAL_ERROR');
+    expect(parsed.error).not.toContain('SELECT');
   });
 });

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/quick-capture.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/quick-capture.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the cerebrum.quick_capture MCP tool (PRD-081 US-02 AC #2).
+ *
+ * Verifies that the tool delegates to `IngestService.quickCapture` with the
+ * agent-supplied text and source, surfaces the resulting engram id/path/type/
+ * scopes, and rejects empty input.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { parseResult } from './test-helpers.js';
+
+const quickCaptureCalls: { text: string; source: string | undefined }[] = [];
+
+vi.mock('../../ingest/pipeline.js', () => ({
+  IngestService: class MockIngestService {
+    async quickCapture(text: string, source?: string) {
+      quickCaptureCalls.push({ text, source });
+      return {
+        id: 'eng_20260427_1500_quick',
+        path: 'capture/eng_20260427_1500_quick.md',
+        type: 'capture',
+        scopes: ['personal.captures'],
+      };
+    }
+  },
+}));
+
+const { handleCerebrumQuickCapture } = await import('../quick-capture.js');
+
+describe('handleCerebrumQuickCapture', () => {
+  it('returns VALIDATION_ERROR for empty text', async () => {
+    const result = await handleCerebrumQuickCapture({ text: '   ' });
+    const parsed = parseResult(result) as { error: string; code: string };
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns VALIDATION_ERROR when text is missing', async () => {
+    const result = await handleCerebrumQuickCapture({});
+    const parsed = parseResult(result) as { code: string };
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('delegates to IngestService.quickCapture and returns engram metadata', async () => {
+    quickCaptureCalls.length = 0;
+    const result = await handleCerebrumQuickCapture({ text: 'A raw thought' });
+    expect(result.isError).toBeUndefined();
+    expect(quickCaptureCalls[0]).toEqual({ text: 'A raw thought', source: undefined });
+
+    const parsed = parseResult(result) as {
+      engram: { id: string; filePath: string; type: string; scopes: string[] };
+    };
+    expect(parsed.engram).toEqual({
+      id: 'eng_20260427_1500_quick',
+      filePath: 'capture/eng_20260427_1500_quick.md',
+      type: 'capture',
+      scopes: ['personal.captures'],
+    });
+  });
+
+  it('forwards a recognised source when provided', async () => {
+    quickCaptureCalls.length = 0;
+    await handleCerebrumQuickCapture({ text: 'from moltbot', source: 'moltbot' });
+    expect(quickCaptureCalls[0]?.source).toBe('moltbot');
+  });
+
+  it('forwards plexus:* sources for plugin-driven ingestion', async () => {
+    quickCaptureCalls.length = 0;
+    await handleCerebrumQuickCapture({ text: 'from plugin', source: 'plexus:notion' });
+    expect(quickCaptureCalls[0]?.source).toBe('plexus:notion');
+  });
+
+  it('drops unrecognised sources and falls through to the service default', async () => {
+    quickCaptureCalls.length = 0;
+    await handleCerebrumQuickCapture({ text: 'mystery', source: 'unknown-source' });
+    expect(quickCaptureCalls[0]?.source).toBeUndefined();
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/quick-capture.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/__tests__/quick-capture.test.ts
@@ -93,6 +93,12 @@ describe('handleCerebrumQuickCapture', () => {
     expect(quickCaptureCalls[0]?.source).toBeUndefined();
   });
 
+  it('rejects a bare `plexus:` source (the pattern requires a name)', async () => {
+    quickCaptureCalls.length = 0;
+    await handleCerebrumQuickCapture({ text: 'no name', source: 'plexus:' });
+    expect(quickCaptureCalls[0]?.source).toBeUndefined();
+  });
+
   it('maps a thrown ValidationError to a VALIDATION_ERROR tool result', async () => {
     quickCaptureImpl = async () => {
       throw new ValidationError({ message: 'engram body is empty' });

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/index.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/index.ts
@@ -12,6 +12,7 @@ import { engramWriteSchema, handleEngramWrite } from './engram-write.js';
  */
 import { cerebrumIngestSchema, handleCerebrumIngest } from './ingest.js';
 import { cerebrumQuerySchema, handleCerebrumQuery } from './query.js';
+import { cerebrumQuickCaptureSchema, handleCerebrumQuickCapture } from './quick-capture.js';
 import { cerebrumSearchSchema, handleCerebrumSearch } from './search.js';
 
 import type { AiToolDescriptor } from '@pops/types';
@@ -30,6 +31,13 @@ export const cerebrumAiTools: readonly AiToolDescriptor[] = [
       'Ingest new content into the Cerebrum knowledge base. Accepts plain text, Markdown, or JSON. Runs classification, entity extraction, and scope inference automatically.',
     inputSchema: cerebrumIngestSchema,
     handler: handleCerebrumIngest,
+  },
+  {
+    name: 'cerebrum.quick_capture',
+    description:
+      'Lowest-friction capture path — store a raw thought as an engram immediately. Classification, entity extraction, and scope inference run asynchronously. Use this when the agent has a single piece of raw text to land with zero ceremony.',
+    inputSchema: cerebrumQuickCaptureSchema,
+    handler: handleCerebrumQuickCapture,
   },
   {
     name: 'cerebrum.engram.read',
@@ -57,6 +65,7 @@ export const cerebrumAiTools: readonly AiToolDescriptor[] = [
 export {
   handleCerebrumIngest,
   handleCerebrumQuery,
+  handleCerebrumQuickCapture,
   handleCerebrumSearch,
   handleEngramRead,
   handleEngramWrite,

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/ingest-json.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/ingest-json.ts
@@ -1,0 +1,134 @@
+/**
+ * Structured-JSON detection for `cerebrum.ingest`. When an agent submits a
+ * JSON object as the body, POPS-native fields (`title`/`type`/`scopes`/
+ * `tags`) are lifted into the ingest request and the remaining keys are
+ * persisted as frontmatter `customFields` (PRD-081 US-02 AC #7).
+ *
+ * Arrays and primitive JSON are still rendered as a fenced code block but
+ * contribute no derived metadata. Plain-text input round-trips unchanged.
+ */
+
+export interface JsonBodyResult {
+  body: string;
+  derivedTitle: string | null;
+  derivedType: string | null;
+  derivedScopes: string[] | null;
+  derivedTags: string[] | null;
+  customFields: Record<string, unknown>;
+}
+
+const TITLE_KEYS = ['title', 'name', 'subject', 'label'] as const;
+
+/**
+ * Keys that map directly onto POPS engram frontmatter and ingest request
+ * params. When the structured JSON body contains them, they are lifted out
+ * rather than being stuffed back into `customFields`.
+ */
+const NATIVE_FIELD_KEYS = new Set<string>(['title', 'type', 'scopes', 'tags']);
+
+const PROTOTYPE_POLLUTION_KEYS = new Set<string>(['__proto__', 'prototype', 'constructor']);
+
+function deriveTitleFromObject(obj: Record<string, unknown>): string | null {
+  for (const key of TITLE_KEYS) {
+    const val = obj[key];
+    if (typeof val === 'string' && val.trim().length > 0) {
+      return val.trim().slice(0, 120);
+    }
+  }
+  const keys = Object.keys(obj);
+  if (keys.length > 0) {
+    return `JSON: ${keys.slice(0, 5).join(', ')}${keys.length > 5 ? '…' : ''}`;
+  }
+  return null;
+}
+
+function emptyJsonResult(body: string): JsonBodyResult {
+  return {
+    body,
+    derivedTitle: null,
+    derivedType: null,
+    derivedScopes: null,
+    derivedTags: null,
+    customFields: {},
+  };
+}
+
+function pickStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const out: string[] = [];
+  for (const v of value) {
+    if (typeof v !== 'string') continue;
+    const trimmed = v.trim();
+    if (trimmed.length === 0) continue;
+    out.push(trimmed);
+  }
+  return out.length > 0 ? out : null;
+}
+
+function extractNativeFields(obj: Record<string, unknown>): {
+  derivedTitle: string | null;
+  derivedType: string | null;
+  derivedScopes: string[] | null;
+  derivedTags: string[] | null;
+} {
+  const titleRaw = obj['title'];
+  const derivedTitle =
+    typeof titleRaw === 'string' && titleRaw.trim().length > 0
+      ? titleRaw.trim().slice(0, 120)
+      : deriveTitleFromObject(obj);
+  const typeRaw = obj['type'];
+  const derivedType =
+    typeof typeRaw === 'string' && typeRaw.trim().length > 0 ? typeRaw.trim() : null;
+  return {
+    derivedTitle,
+    derivedType,
+    derivedScopes: pickStringArray(obj['scopes']),
+    derivedTags: pickStringArray(obj['tags']),
+  };
+}
+
+/**
+ * Copy non-native, non-prototype keys from a parsed JSON object into a
+ * prototype-less bag. Untrusted MCP tool input must not be able to inject
+ * `__proto__` / `constructor` payloads into the engram custom fields.
+ */
+function extractCustomFields(obj: Record<string, unknown>): Record<string, unknown> {
+  const customFields = Object.create(null) as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    if (!Object.prototype.hasOwnProperty.call(obj, key)) continue;
+    if (NATIVE_FIELD_KEYS.has(key)) continue;
+    if (PROTOTYPE_POLLUTION_KEYS.has(key)) continue;
+    customFields[key] = obj[key];
+  }
+  return customFields;
+}
+
+function tryParseJson(trimmed: string): unknown | undefined {
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+export function handleJsonBody(body: string): JsonBodyResult {
+  const trimmed = body.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+    return emptyJsonResult(body);
+  }
+  const parsed = tryParseJson(trimmed);
+  if (parsed === undefined) return emptyJsonResult(body);
+
+  const mdBody = `\`\`\`json\n${trimmed}\n\`\`\``;
+  const isPlainObject = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed);
+  if (!isPlainObject) {
+    return { ...emptyJsonResult(mdBody), body: mdBody };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  return {
+    body: mdBody,
+    ...extractNativeFields(obj),
+    customFields: extractCustomFields(obj),
+  };
+}

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
@@ -39,17 +39,39 @@ function mergeTags(
   return merged.length > 0 ? merged : undefined;
 }
 
+/**
+ * Treat blank or whitespace-only string args as if the caller had omitted
+ * them. Without this, `title: ''` would suppress the JSON-derived title via
+ * `args.title ?? json.derivedTitle` because `??` does not fall through for
+ * empty strings.
+ */
+function optionalTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function optionalStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: string[] = [];
+  for (const v of value) {
+    if (typeof v !== 'string') continue;
+    const trimmed = v.trim();
+    if (trimmed.length === 0) continue;
+    out.push(trimmed);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
 function parseArgs(raw: Record<string, unknown>): IngestArgs {
   const body = typeof raw['body'] === 'string' ? raw['body'] : '';
-  const title = typeof raw['title'] === 'string' ? raw['title'] : undefined;
-  const type = typeof raw['type'] === 'string' ? raw['type'] : undefined;
-  const scopes = Array.isArray(raw['scopes'])
-    ? (raw['scopes'] as unknown[]).filter((s): s is string => typeof s === 'string')
-    : undefined;
-  const tags = Array.isArray(raw['tags'])
-    ? (raw['tags'] as unknown[]).filter((s): s is string => typeof s === 'string')
-    : undefined;
-  return { body, title, type, scopes, tags };
+  return {
+    body,
+    title: optionalTrimmedString(raw['title']),
+    type: optionalTrimmedString(raw['type']),
+    scopes: optionalStringArray(raw['scopes']),
+    tags: optionalStringArray(raw['tags']),
+  };
 }
 
 export async function handleCerebrumIngest(raw: Record<string, unknown>): Promise<AiToolResult> {

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
@@ -1,13 +1,12 @@
 /**
  * cerebrum.ingest — ingest content into the engram knowledge base.
  *
- * Delegates to IngestService. Also handles structured JSON detection: when the
- * body parses as a JSON object, POPS-native fields (`title`, `type`, `scopes`,
- * `tags`) are lifted into the ingest request (unless the caller provided
- * their own) and remaining keys land in `customFields` so they end up as
- * frontmatter (PRD-081 US-02 AC #7).
+ * Delegates to IngestService. JSON detection and metadata lifting live in
+ * `ingest-json.ts`; this file handles arg parsing, tag merging, and the
+ * MCP-side request/response envelope.
  */
 import { IngestService } from '../ingest/pipeline.js';
+import { handleJsonBody } from './ingest-json.js';
 import { mapServiceError, toolError, toolSuccess } from './result.js';
 
 import type { AiToolResult } from '@pops/types';
@@ -18,131 +17,6 @@ interface IngestArgs {
   type?: string;
   scopes?: string[];
   tags?: string[];
-}
-
-interface JsonBodyResult {
-  body: string;
-  derivedTitle: string | null;
-  derivedType: string | null;
-  derivedScopes: string[] | null;
-  derivedTags: string[] | null;
-  customFields: Record<string, unknown>;
-}
-
-const TITLE_KEYS = ['title', 'name', 'subject', 'label'] as const;
-
-/**
- * Keys that map directly onto POPS engram frontmatter and ingest request
- * params. When the structured JSON body contains them, they are lifted out
- * rather than being stuffed back into `customFields`.
- */
-const NATIVE_FIELD_KEYS = new Set<string>(['title', 'type', 'scopes', 'tags']);
-
-/** Try to extract a title from a JSON object's well-known keys, falling back to a key summary. */
-function deriveTitleFromObject(obj: Record<string, unknown>): string | null {
-  for (const key of TITLE_KEYS) {
-    const val = obj[key];
-    if (typeof val === 'string' && val.trim().length > 0) {
-      return val.trim().slice(0, 120);
-    }
-  }
-
-  const keys = Object.keys(obj);
-  if (keys.length > 0) {
-    return `JSON: ${keys.slice(0, 5).join(', ')}${keys.length > 5 ? '…' : ''}`;
-  }
-
-  return null;
-}
-
-function emptyJsonResult(body: string): JsonBodyResult {
-  return {
-    body,
-    derivedTitle: null,
-    derivedType: null,
-    derivedScopes: null,
-    derivedTags: null,
-    customFields: {},
-  };
-}
-
-function pickStringArray(value: unknown): string[] | null {
-  if (!Array.isArray(value)) return null;
-  const out = value.filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
-  return out.length > 0 ? out : null;
-}
-
-/**
- * Pull the native engram fields out of a parsed JSON object. Caller-supplied
- * values still win at the handler level — this just surfaces what the JSON
- * itself offered.
- */
-function extractNativeFields(obj: Record<string, unknown>): {
-  derivedTitle: string | null;
-  derivedType: string | null;
-  derivedScopes: string[] | null;
-  derivedTags: string[] | null;
-} {
-  const titleRaw = obj['title'];
-  const derivedTitle =
-    typeof titleRaw === 'string' && titleRaw.trim().length > 0
-      ? titleRaw.trim().slice(0, 120)
-      : deriveTitleFromObject(obj);
-  const typeRaw = obj['type'];
-  const derivedType =
-    typeof typeRaw === 'string' && typeRaw.trim().length > 0 ? typeRaw.trim() : null;
-  return {
-    derivedTitle,
-    derivedType,
-    derivedScopes: pickStringArray(obj['scopes']),
-    derivedTags: pickStringArray(obj['tags']),
-  };
-}
-
-function extractCustomFields(obj: Record<string, unknown>): Record<string, unknown> {
-  const customFields: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(obj)) {
-    if (NATIVE_FIELD_KEYS.has(key)) continue;
-    customFields[key] = value;
-  }
-  return customFields;
-}
-
-function tryParseJson(trimmed: string): unknown | undefined {
-  try {
-    return JSON.parse(trimmed);
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Detect structured JSON and convert to Markdown. When the body is a plain
- * JSON object, POPS-native fields are lifted out and the remaining keys are
- * returned as `customFields` so they can be persisted into the engram
- * frontmatter. Arrays and non-object JSON are still rendered as a fenced
- * code block but contribute no extracted metadata.
- */
-function handleJsonBody(body: string): JsonBodyResult {
-  const trimmed = body.trim();
-  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
-    return emptyJsonResult(body);
-  }
-  const parsed = tryParseJson(trimmed);
-  if (parsed === undefined) return emptyJsonResult(body);
-
-  const mdBody = `\`\`\`json\n${trimmed}\n\`\`\``;
-  const isPlainObject = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed);
-  if (!isPlainObject) {
-    return { ...emptyJsonResult(mdBody), body: mdBody };
-  }
-
-  const obj = parsed as Record<string, unknown>;
-  return {
-    body: mdBody,
-    ...extractNativeFields(obj),
-    customFields: extractCustomFields(obj),
-  };
 }
 
 /**
@@ -247,5 +121,5 @@ export const cerebrumIngestSchema = {
   required: ['body'] as const,
 };
 
-// Exported for testing
-export { handleJsonBody };
+// Re-export for tests that exercise the JSON detector directly.
+export { handleJsonBody } from './ingest-json.js';

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/ingest.ts
@@ -1,9 +1,11 @@
 /**
  * cerebrum.ingest — ingest content into the engram knowledge base.
  *
- * Delegates to IngestService. Also handles structured JSON detection:
- * if the body starts with `{` or `[` and parses as valid JSON, it is
- * converted to Markdown with the JSON in a fenced code block.
+ * Delegates to IngestService. Also handles structured JSON detection: when the
+ * body parses as a JSON object, POPS-native fields (`title`, `type`, `scopes`,
+ * `tags`) are lifted into the ingest request (unless the caller provided
+ * their own) and remaining keys land in `customFields` so they end up as
+ * frontmatter (PRD-081 US-02 AC #7).
  */
 import { IngestService } from '../ingest/pipeline.js';
 import { mapServiceError, toolError, toolSuccess } from './result.js';
@@ -18,7 +20,23 @@ interface IngestArgs {
   tags?: string[];
 }
 
+interface JsonBodyResult {
+  body: string;
+  derivedTitle: string | null;
+  derivedType: string | null;
+  derivedScopes: string[] | null;
+  derivedTags: string[] | null;
+  customFields: Record<string, unknown>;
+}
+
 const TITLE_KEYS = ['title', 'name', 'subject', 'label'] as const;
+
+/**
+ * Keys that map directly onto POPS engram frontmatter and ingest request
+ * params. When the structured JSON body contains them, they are lifted out
+ * rather than being stuffed back into `customFields`.
+ */
+const NATIVE_FIELD_KEYS = new Set<string>(['title', 'type', 'scopes', 'tags']);
 
 /** Try to extract a title from a JSON object's well-known keys, falling back to a key summary. */
 function deriveTitleFromObject(obj: Record<string, unknown>): string | null {
@@ -37,30 +55,114 @@ function deriveTitleFromObject(obj: Record<string, unknown>): string | null {
   return null;
 }
 
+function emptyJsonResult(body: string): JsonBodyResult {
+  return {
+    body,
+    derivedTitle: null,
+    derivedType: null,
+    derivedScopes: null,
+    derivedTags: null,
+    customFields: {},
+  };
+}
+
+function pickStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const out = value.filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
+  return out.length > 0 ? out : null;
+}
+
 /**
- * Detect structured JSON and convert to Markdown.
- * Returns a new body and optional derived title.
+ * Pull the native engram fields out of a parsed JSON object. Caller-supplied
+ * values still win at the handler level — this just surfaces what the JSON
+ * itself offered.
  */
-function handleJsonBody(body: string): { body: string; derivedTitle: string | null } {
+function extractNativeFields(obj: Record<string, unknown>): {
+  derivedTitle: string | null;
+  derivedType: string | null;
+  derivedScopes: string[] | null;
+  derivedTags: string[] | null;
+} {
+  const titleRaw = obj['title'];
+  const derivedTitle =
+    typeof titleRaw === 'string' && titleRaw.trim().length > 0
+      ? titleRaw.trim().slice(0, 120)
+      : deriveTitleFromObject(obj);
+  const typeRaw = obj['type'];
+  const derivedType =
+    typeof typeRaw === 'string' && typeRaw.trim().length > 0 ? typeRaw.trim() : null;
+  return {
+    derivedTitle,
+    derivedType,
+    derivedScopes: pickStringArray(obj['scopes']),
+    derivedTags: pickStringArray(obj['tags']),
+  };
+}
+
+function extractCustomFields(obj: Record<string, unknown>): Record<string, unknown> {
+  const customFields: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (NATIVE_FIELD_KEYS.has(key)) continue;
+    customFields[key] = value;
+  }
+  return customFields;
+}
+
+function tryParseJson(trimmed: string): unknown | undefined {
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Detect structured JSON and convert to Markdown. When the body is a plain
+ * JSON object, POPS-native fields are lifted out and the remaining keys are
+ * returned as `customFields` so they can be persisted into the engram
+ * frontmatter. Arrays and non-object JSON are still rendered as a fenced
+ * code block but contribute no extracted metadata.
+ */
+function handleJsonBody(body: string): JsonBodyResult {
   const trimmed = body.trim();
   if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
-    return { body, derivedTitle: null };
+    return emptyJsonResult(body);
   }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed);
-  } catch {
-    return { body, derivedTitle: null };
-  }
-
-  const isPlainObject = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed);
-  const derivedTitle = isPlainObject
-    ? deriveTitleFromObject(parsed as Record<string, unknown>)
-    : null;
+  const parsed = tryParseJson(trimmed);
+  if (parsed === undefined) return emptyJsonResult(body);
 
   const mdBody = `\`\`\`json\n${trimmed}\n\`\`\``;
-  return { body: mdBody, derivedTitle };
+  const isPlainObject = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed);
+  if (!isPlainObject) {
+    return { ...emptyJsonResult(mdBody), body: mdBody };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  return {
+    body: mdBody,
+    ...extractNativeFields(obj),
+    customFields: extractCustomFields(obj),
+  };
+}
+
+/**
+ * Combine caller-supplied tags with tags lifted out of a JSON body. Both
+ * sources contribute; duplicates are stripped while preserving the order in
+ * which tags first appeared.
+ */
+function mergeTags(
+  callerTags: string[] | undefined,
+  jsonTags: string[] | null
+): string[] | undefined {
+  if (!callerTags && !jsonTags) return undefined;
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  for (const tag of [...(callerTags ?? []), ...(jsonTags ?? [])]) {
+    if (seen.has(tag)) continue;
+    seen.add(tag);
+    merged.push(tag);
+  }
+  return merged.length > 0 ? merged : undefined;
 }
 
 function parseArgs(raw: Record<string, unknown>): IngestArgs {
@@ -84,17 +186,21 @@ export async function handleCerebrumIngest(raw: Record<string, unknown>): Promis
   }
 
   try {
-    const { body: processedBody, derivedTitle } = handleJsonBody(args.body);
-    const title = args.title ?? derivedTitle ?? undefined;
+    const json = handleJsonBody(args.body);
+    const title = args.title ?? json.derivedTitle ?? undefined;
+    const type = args.type ?? json.derivedType ?? undefined;
+    const scopes = args.scopes ?? json.derivedScopes ?? undefined;
+    const tags = mergeTags(args.tags, json.derivedTags);
 
     const svc = new IngestService();
     const result = await svc.submit({
-      body: processedBody,
+      body: json.body,
       title,
-      type: args.type,
-      scopes: args.scopes,
-      tags: args.tags,
+      type,
+      scopes,
+      tags,
       source: 'agent',
+      ...(Object.keys(json.customFields).length > 0 ? { customFields: json.customFields } : {}),
     });
 
     return toolSuccess({

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/quick-capture.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/quick-capture.ts
@@ -56,9 +56,8 @@ export const cerebrumQuickCaptureSchema = {
     },
     source: {
       type: 'string' as const,
-      enum: [...ENGRAM_SOURCES],
       description:
-        'Origin of the capture. One of the known engram sources (manual, agent, moltbot, cli). Falls through to the IngestService default when omitted.',
+        'Origin of the capture. One of the known engram sources (manual, agent, moltbot, cli) or a `plexus:{name}` identifier for plugin-driven ingestion. Falls through to the IngestService default when omitted.',
     },
   },
   required: ['text'] as const,

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/quick-capture.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/quick-capture.ts
@@ -1,0 +1,65 @@
+/**
+ * cerebrum.quick_capture — lowest-friction agent-driven capture (PRD-081 US-02, US-03).
+ *
+ * Thin wrapper around `IngestService.quickCapture`. Agents (Claude Code,
+ * Moltbot, scripts) call this when they want to land a raw thought as an
+ * engram immediately — classification, entity extraction, and scope inference
+ * are deferred to the curation worker. The response includes the engram id,
+ * file path, type, and scopes so the agent can echo the id back to the user.
+ */
+import { ENGRAM_SOURCES, type EngramSource } from '../engrams/schema.js';
+import { IngestService } from '../ingest/pipeline.js';
+import { mapServiceError, toolError, toolSuccess } from './result.js';
+
+import type { AiToolResult } from '@pops/types';
+
+function isEngramSource(value: unknown): value is EngramSource {
+  if (typeof value !== 'string') return false;
+  if ((ENGRAM_SOURCES as readonly string[]).includes(value)) return true;
+  return value.startsWith('plexus:');
+}
+
+export async function handleCerebrumQuickCapture(
+  raw: Record<string, unknown>
+): Promise<AiToolResult> {
+  const text = typeof raw['text'] === 'string' ? raw['text'] : '';
+  const source = isEngramSource(raw['source']) ? raw['source'] : undefined;
+
+  if (!text.trim()) {
+    return toolError('text is required and must be non-empty', 'VALIDATION_ERROR');
+  }
+
+  try {
+    const svc = new IngestService();
+    const result = await svc.quickCapture(text, source);
+    return toolSuccess({
+      engram: {
+        id: result.id,
+        filePath: result.path,
+        type: result.type,
+        scopes: result.scopes,
+      },
+    });
+  } catch (err) {
+    return mapServiceError(err);
+  }
+}
+
+/** JSON Schema for the cerebrum.quick_capture tool input. */
+export const cerebrumQuickCaptureSchema = {
+  type: 'object' as const,
+  properties: {
+    text: {
+      type: 'string' as const,
+      description:
+        'Raw text to capture. Stored immediately as a capture engram; classification, entity extraction, and scope inference run asynchronously.',
+    },
+    source: {
+      type: 'string' as const,
+      enum: [...ENGRAM_SOURCES],
+      description:
+        'Origin of the capture. One of the known engram sources (manual, agent, moltbot, cli). Falls through to the IngestService default when omitted.',
+    },
+  },
+  required: ['text'] as const,
+};

--- a/apps/pops-api/src/modules/cerebrum/ai-tools/quick-capture.ts
+++ b/apps/pops-api/src/modules/cerebrum/ai-tools/quick-capture.ts
@@ -13,10 +13,12 @@ import { mapServiceError, toolError, toolSuccess } from './result.js';
 
 import type { AiToolResult } from '@pops/types';
 
+const PLEXUS_SOURCE_PATTERN = /^plexus:.+$/;
+
 function isEngramSource(value: unknown): value is EngramSource {
   if (typeof value !== 'string') return false;
   if ((ENGRAM_SOURCES as readonly string[]).includes(value)) return true;
-  return value.startsWith('plexus:');
+  return PLEXUS_SOURCE_PATTERN.test(value);
 }
 
 export async function handleCerebrumQuickCapture(
@@ -51,8 +53,10 @@ export const cerebrumQuickCaptureSchema = {
   properties: {
     text: {
       type: 'string' as const,
+      minLength: 1,
+      pattern: '\\S',
       description:
-        'Raw text to capture. Stored immediately as a capture engram; classification, entity extraction, and scope inference run asynchronously.',
+        'Raw text to capture. Must contain at least one non-whitespace character. Stored immediately as a capture engram; classification, entity extraction, and scope inference run asynchronously.',
     },
     source: {
       type: 'string' as const,

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-02-agent-input.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-02-agent-input.md
@@ -15,7 +15,7 @@ As an AI agent (Claude Code session or external tool), I want to write engrams t
 - [x] When `type` is omitted, the pipeline runs Cortex classification on the body and assigns the inferred type
 - [x] When `scopes` are omitted, the pipeline runs scope inference (source-based rules first, then LLM-based analysis)
 - [x] Raw Markdown input is normalised (trimmed, line endings normalised, UTF-8 validated) before processing
-- [x] Structured JSON input (detected by content inspection) is converted to Markdown with `title`/`type`/`scopes`/`tags` lifted into the ingest request and remaining keys persisted as frontmatter custom fields
+- [x] When the body parses as a plain JSON object, it is rendered as fenced JSON Markdown with `title`/`type`/`scopes`/`tags` lifted into the ingest request and remaining keys persisted as frontmatter custom fields. JSON arrays and primitives are still rendered as fenced JSON but contribute no derived metadata.
 - [x] The MCP tools return the created engram's ID, file path, type, and assigned scopes in the response
 - [x] Invalid input (empty body, malformed scopes) returns structured error messages with field-level detail, not generic 500 errors
 

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-02-agent-input.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-02-agent-input.md
@@ -9,14 +9,14 @@ As an AI agent (Claude Code session or external tool), I want to write engrams t
 
 ## Acceptance Criteria
 
-- [ ] An MCP tool `cerebrum_ingest` is registered with the pops MCP server, accepting parameters: `body` (required), `title` (optional), `type` (optional), `scopes` (optional string array), `tags` (optional string array)
-- [ ] An MCP tool `cerebrum_quick_capture` is registered for lightweight capture, accepting a single `text` parameter — delegates to `cerebrum.ingest.quickCapture`
+- [x] An MCP tool `cerebrum.ingest` is registered with the pops MCP server, accepting parameters: `body` (required), `title` (optional), `type` (optional), `scopes` (optional string array), `tags` (optional string array)
+- [x] An MCP tool `cerebrum.quick_capture` is registered for lightweight capture, accepting a `text` parameter (and optional `source`) — delegates to `IngestService.quickCapture`
 - [x] The tRPC procedure `cerebrum.ingest.submit` accepts the full `IngestionRequest` schema and runs the complete pipeline (normalise, classify, extract, scope, deduplicate, write)
 - [x] When `type` is omitted, the pipeline runs Cortex classification on the body and assigns the inferred type
 - [x] When `scopes` are omitted, the pipeline runs scope inference (source-based rules first, then LLM-based analysis)
 - [x] Raw Markdown input is normalised (trimmed, line endings normalised, UTF-8 validated) before processing
-- [ ] Structured JSON input (detected by content inspection) is converted to Markdown with metadata extracted into frontmatter fields
-- [ ] The MCP tools return the created engram's ID, file path, type, and assigned scopes in the response
+- [x] Structured JSON input (detected by content inspection) is converted to Markdown with `title`/`type`/`scopes`/`tags` lifted into the ingest request and remaining keys persisted as frontmatter custom fields
+- [x] The MCP tools return the created engram's ID, file path, type, and assigned scopes in the response
 - [x] Invalid input (empty body, malformed scopes) returns structured error messages with field-level detail, not generic 500 errors
 
 ## Notes

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-02-agent-input.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-02-agent-input.md
@@ -10,7 +10,7 @@ As an AI agent (Claude Code session or external tool), I want to write engrams t
 ## Acceptance Criteria
 
 - [x] An MCP tool `cerebrum.ingest` is registered with the pops MCP server, accepting parameters: `body` (required), `title` (optional), `type` (optional), `scopes` (optional string array), `tags` (optional string array)
-- [x] An MCP tool `cerebrum.quick_capture` is registered for lightweight capture, accepting a `text` parameter (and optional `source`) — delegates to `IngestService.quickCapture`
+- [x] An MCP tool `cerebrum.quick_capture` is registered for lightweight capture, accepting a `text` parameter (and optional `source`) and returning the captured engram's id, file path, type, and scopes
 - [x] The tRPC procedure `cerebrum.ingest.submit` accepts the full `IngestionRequest` schema and runs the complete pipeline (normalise, classify, extract, scope, deduplicate, write)
 - [x] When `type` is omitted, the pipeline runs Cortex classification on the body and assigns the inferred type
 - [x] When `scopes` are omitted, the pipeline runs scope inference (source-based rules first, then LLM-based analysis)

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-02-agent-input.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-02-agent-input.md
@@ -1,7 +1,7 @@
 # US-02: Agent Input via MCP and API
 
 > PRD: [PRD-081: Ingestion Pipeline](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 


### PR DESCRIPTION
## Summary
- Registers a new MCP tool `cerebrum.quick_capture` that delegates to `IngestService.quickCapture`. Returns the engram id, file path, type, and scopes.
- Extends the `cerebrum.ingest` JSON detector: when the body is a plain JSON object, POPS-native fields (`title`/`type`/`scopes`/`tags`) are lifted into the ingest request (caller-supplied values still win) and remaining keys flow into frontmatter `customFields`.
- Caller and JSON tags are merged and deduped. Arrays and primitive JSON still wrap as a fenced code block but contribute no derived metadata. Unknown sources fall through to the IngestService default; `plexus:{name}` namespaced sources pass through.

Closes #2556. PRD-081 US-02.

## Test plan
- [x] Unit tests for `cerebrum.quick_capture`: empty/missing text → `VALIDATION_ERROR`, delegates to service, surfaces id/path/type/scopes, forwards recognised + `plexus:*` sources, drops unknown sources.
- [x] Unit tests for JSON metadata lift: native fields surfaced from JSON, caller wins on conflict, tags merged & deduped, no `customFields` when JSON has none, arrays contribute no metadata.
- [x] `pnpm typecheck` and `mise lint` clean.
- [x] Existing MCP/cerebrum tests still green (1046 passing).