### PR TITLE
feat(cli): pops CLI binary with cerebrum capture + ask (#2575)

### DIFF
--- a/apps/pops-cli/package.json
+++ b/apps/pops-cli/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@pops/cli",
+  "version": "0.1.0",
+  "private": true,
+  "bin": {
+    "pops": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "commander": "^14.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.2",
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsx": "^4.20.6",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/apps/pops-cli/src/__tests__/cerebrum-ask.test.ts
+++ b/apps/pops-cli/src/__tests__/cerebrum-ask.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runAsk } from '../commands/cerebrum-ask.js';
+import { CaptureStream, pipedStdin, ttyStdin } from './test-helpers.js';
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchOk<T>(body: T): vi.Mock {
+  const fn = vi.fn(
+    async () =>
+      new Response(JSON.stringify({ result: { data: { json: body } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+  );
+  globalThis.fetch = fn as unknown as typeof globalThis.fetch;
+  return fn as unknown as vi.Mock;
+}
+
+describe('runAsk', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('prints the answer and citations from a successful response', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    mockFetchOk({
+      answer: 'You decided to use LangGraph for routing.',
+      sources: [
+        { id: 'eng_a', title: 'LangGraph decision', scope: 'work.platform' },
+        { id: 'eng_b', title: 'Agent routing notes' },
+      ],
+      confidence: 'high',
+    });
+
+    const code = await runAsk({
+      question: 'what did I decide about routing?',
+      stdout,
+      stderr,
+      stdin: ttyStdin(),
+      env: {},
+    });
+
+    expect(code).toBe(0);
+    const out = stdout.text();
+    expect(out).toContain('You decided to use LangGraph');
+    expect(out).toContain('1. LangGraph decision (eng_a) [work.platform]');
+    expect(out).toContain('2. Agent routing notes (eng_b)');
+    expect(out).toContain('Confidence: high');
+  });
+
+  it('rejects empty input with a non-zero exit code', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    const fetchSpy = mockFetchOk({ answer: 'should not be called' });
+
+    const code = await runAsk({
+      question: '   ',
+      stdout,
+      stderr,
+      stdin: ttyStdin(),
+      env: {},
+    });
+
+    expect(code).toBe(2);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(stderr.text()).toContain('ask requires a question');
+  });
+
+  it('reads a question from stdin when no argument is provided', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    mockFetchOk({ answer: 'pipe answer', sources: [] });
+
+    const code = await runAsk({
+      stdout,
+      stderr,
+      stdin: pipedStdin('piped question\n'),
+      env: {},
+    });
+
+    expect(code).toBe(0);
+    expect(stdout.text()).toContain('pipe answer');
+  });
+
+  it('forwards scopes when provided', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    const fetchSpy = mockFetchOk({ answer: 'scoped', sources: [] });
+
+    await runAsk({
+      question: 'q',
+      scopes: ['work', 'work.platform'],
+      stdout,
+      stderr,
+      stdin: ttyStdin(),
+      env: {},
+    });
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      json: { question: 'q', scopes: ['work', 'work.platform'] },
+    });
+  });
+});

--- a/apps/pops-cli/src/__tests__/cerebrum-ask.test.ts
+++ b/apps/pops-cli/src/__tests__/cerebrum-ask.test.ts
@@ -1,28 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { runAsk } from '../commands/cerebrum-ask.js';
-import { CaptureStream, pipedStdin, ttyStdin } from './test-helpers.js';
-
-const originalFetch = globalThis.fetch;
-
-function mockFetchOk<T>(body: T): vi.Mock {
-  const fn = vi.fn(
-    async () =>
-      new Response(JSON.stringify({ result: { data: { json: body } } }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      })
-  );
-  globalThis.fetch = fn as unknown as typeof globalThis.fetch;
-  return fn as unknown as vi.Mock;
-}
+import { CaptureStream, getFetchJson, mockFetchOk, pipedStdin, ttyStdin } from './test-helpers.js';
 
 describe('runAsk', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.unstubAllGlobals();
   });
 
   it('prints the answer and citations from a successful response', async () => {
@@ -101,8 +87,7 @@ describe('runAsk', () => {
       env: {},
     });
 
-    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    expect(JSON.parse(init.body as string)).toEqual({
+    expect(getFetchJson(fetchSpy)).toEqual({
       json: { question: 'q', scopes: ['work', 'work.platform'] },
     });
   });

--- a/apps/pops-cli/src/__tests__/cerebrum-capture.test.ts
+++ b/apps/pops-cli/src/__tests__/cerebrum-capture.test.ts
@@ -1,58 +1,30 @@
 /**
  * Tests for `pops cerebrum capture` — PRD-081 US-03 AC #1, #7.
  *
- * Exercises the command handler directly against a mocked `fetch`, which is
- * the only seam between the CLI and the API. Avoids spawning a subprocess so
- * the tests stay deterministic and fast.
+ * Exercises the command handler directly against a stubbed global `fetch`,
+ * which is the only seam between the CLI and the API. Avoids spawning a
+ * subprocess so the tests stay deterministic and fast.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { runCapture } from '../commands/cerebrum-capture.js';
-import { CaptureStream, pipedStdin, ttyStdin } from './test-helpers.js';
-
-const originalFetch = globalThis.fetch;
-
-function mockFetchOk<T>(body: T): vi.Mock {
-  const fn = vi.fn(
-    async () =>
-      new Response(JSON.stringify({ result: { data: { json: body } } }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      })
-  );
-  globalThis.fetch = fn as unknown as typeof globalThis.fetch;
-  return fn as unknown as vi.Mock;
-}
-
-function mockFetchTrpcError(message: string, httpStatus = 400, code = 'BAD_REQUEST'): vi.Mock {
-  const fn = vi.fn(
-    async () =>
-      new Response(
-        JSON.stringify({ error: { json: { message, code, data: { httpStatus, code } } } }),
-        {
-          status: httpStatus,
-          headers: { 'content-type': 'application/json' },
-        }
-      )
-  );
-  globalThis.fetch = fn as unknown as typeof globalThis.fetch;
-  return fn as unknown as vi.Mock;
-}
-
-function mockFetchUnreachable(): vi.Mock {
-  const fn = vi.fn(async () => {
-    throw new TypeError('fetch failed');
-  });
-  globalThis.fetch = fn as unknown as typeof globalThis.fetch;
-  return fn as unknown as vi.Mock;
-}
+import {
+  CaptureStream,
+  getFetchCall,
+  getFetchJson,
+  mockFetchOk,
+  mockFetchTrpcError,
+  mockFetchUnreachable,
+  pipedStdin,
+  ttyStdin,
+} from './test-helpers.js';
 
 describe('runCapture', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.unstubAllGlobals();
   });
 
   it('captures text passed as an argument and prints engram metadata (AC #1)', async () => {
@@ -74,11 +46,10 @@ describe('runCapture', () => {
     });
 
     expect(code).toBe(0);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const { url, init } = getFetchCall(fetchSpy);
     expect(url).toBe('http://api.test/trpc/cerebrum.ingest.quickCapture');
     expect(init.method).toBe('POST');
-    expect(JSON.parse(init.body as string)).toEqual({
+    expect(getFetchJson(fetchSpy)).toEqual({
       json: { text: 'a quick thought', source: 'cli' },
     });
     expect(stdout.text()).toContain('Captured eng_20260427_1500_idea');
@@ -165,9 +136,14 @@ describe('runCapture', () => {
       env: { POPS_API_KEY: 'pops_sa_test' },
     });
 
-    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    const headers = init.headers as Record<string, string>;
-    expect(headers['x-api-key']).toBe('pops_sa_test');
+    const { init } = getFetchCall(fetchSpy);
+    const headers = init.headers;
+    expect(headers).toBeDefined();
+    if (headers && !(headers instanceof Headers) && !Array.isArray(headers)) {
+      expect(headers['x-api-key']).toBe('pops_sa_test');
+    } else {
+      throw new Error('expected plain-object headers');
+    }
   });
 
   it('surfaces server-side validation errors with the API message', async () => {
@@ -206,8 +182,7 @@ describe('runCapture', () => {
       env: {},
     });
 
-    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    expect(JSON.parse(init.body as string)).toEqual({
+    expect(getFetchJson(fetchSpy)).toEqual({
       json: { text: 'from moltbot', source: 'moltbot' },
     });
   });

--- a/apps/pops-cli/src/__tests__/cerebrum-capture.test.ts
+++ b/apps/pops-cli/src/__tests__/cerebrum-capture.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for `pops cerebrum capture` — PRD-081 US-03 AC #1, #7.
+ *
+ * Exercises the command handler directly against a mocked `fetch`, which is
+ * the only seam between the CLI and the API. Avoids spawning a subprocess so
+ * the tests stay deterministic and fast.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runCapture } from '../commands/cerebrum-capture.js';
+import { CaptureStream, pipedStdin, ttyStdin } from './test-helpers.js';
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchOk<T>(body: T): vi.Mock {
+  const fn = vi.fn(
+    async () =>
+      new Response(JSON.stringify({ result: { data: { json: body } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+  );
+  globalThis.fetch = fn as unknown as typeof globalThis.fetch;
+  return fn as unknown as vi.Mock;
+}
+
+function mockFetchTrpcError(message: string, httpStatus = 400, code = 'BAD_REQUEST'): vi.Mock {
+  const fn = vi.fn(
+    async () =>
+      new Response(
+        JSON.stringify({ error: { json: { message, code, data: { httpStatus, code } } } }),
+        {
+          status: httpStatus,
+          headers: { 'content-type': 'application/json' },
+        }
+      )
+  );
+  globalThis.fetch = fn as unknown as typeof globalThis.fetch;
+  return fn as unknown as vi.Mock;
+}
+
+function mockFetchUnreachable(): vi.Mock {
+  const fn = vi.fn(async () => {
+    throw new TypeError('fetch failed');
+  });
+  globalThis.fetch = fn as unknown as typeof globalThis.fetch;
+  return fn as unknown as vi.Mock;
+}
+
+describe('runCapture', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('captures text passed as an argument and prints engram metadata (AC #1)', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    const fetchSpy = mockFetchOk({
+      id: 'eng_20260427_1500_idea',
+      path: 'capture/eng_20260427_1500_idea.md',
+      type: 'capture',
+      scopes: ['personal.captures'],
+    });
+
+    const code = await runCapture({
+      text: 'a quick thought',
+      stdout,
+      stderr,
+      stdin: ttyStdin(),
+      env: { POPS_API_URL: 'http://api.test' },
+    });
+
+    expect(code).toBe(0);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://api.test/trpc/cerebrum.ingest.quickCapture');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      json: { text: 'a quick thought', source: 'cli' },
+    });
+    expect(stdout.text()).toContain('Captured eng_20260427_1500_idea');
+    expect(stdout.text()).toContain('path:   capture/eng_20260427_1500_idea.md');
+    expect(stdout.text()).toContain('scopes: personal.captures');
+  });
+
+  it('reads text from stdin when no argument is provided (AC #1)', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    mockFetchOk({
+      id: 'eng_x',
+      path: 'capture/eng_x.md',
+      type: 'capture',
+      scopes: ['personal.captures'],
+    });
+
+    const code = await runCapture({
+      stdout,
+      stderr,
+      stdin: pipedStdin('piped thought\n'),
+      env: {},
+    });
+
+    expect(code).toBe(0);
+    expect(stdout.text()).toContain('Captured eng_x');
+  });
+
+  it('rejects empty/whitespace input with a non-zero exit code (AC #3)', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    const fetchSpy = mockFetchOk({
+      id: 'should-not-be-called',
+      path: 'x',
+      type: 'capture',
+      scopes: [],
+    });
+
+    const code = await runCapture({
+      text: '   ',
+      stdout,
+      stderr,
+      stdin: ttyStdin(),
+      env: {},
+    });
+
+    expect(code).toBe(2);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(stderr.text()).toContain('capture requires text');
+  });
+
+  it('exits with a network-error code when the API is unreachable (AC #4)', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    mockFetchUnreachable();
+
+    const code = await runCapture({
+      text: 'hello',
+      stdout,
+      stderr,
+      stdin: ttyStdin(),
+      env: { POPS_API_URL: 'http://localhost:9999' },
+    });
+
+    expect(code).toBe(3);
+    expect(stderr.text()).toContain('Unable to reach the POPS API at http://localhost:9999');
+  });
+
+  it('forwards the X-API-Key header when POPS_API_KEY is set', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    const fetchSpy = mockFetchOk({
+      id: 'eng_auth',
+      path: 'capture/eng_auth.md',
+      type: 'capture',
+      scopes: ['personal.captures'],
+    });
+
+    await runCapture({
+      text: 'authenticated',
+      stdout,
+      stderr,
+      stdin: ttyStdin(),
+      env: { POPS_API_KEY: 'pops_sa_test' },
+    });
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('pops_sa_test');
+  });
+
+  it('surfaces server-side validation errors with the API message', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    mockFetchTrpcError('text must be a non-empty string', 400);
+
+    const code = await runCapture({
+      text: 'whatever',
+      stdout,
+      stderr,
+      stdin: ttyStdin(),
+      env: {},
+    });
+
+    expect(code).toBe(1);
+    expect(stderr.text()).toContain('text must be a non-empty string');
+  });
+
+  it('uses the source option override when provided', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    const fetchSpy = mockFetchOk({
+      id: 'eng_src',
+      path: 'capture/eng_src.md',
+      type: 'capture',
+      scopes: ['personal.captures'],
+    });
+
+    await runCapture({
+      text: 'from moltbot',
+      source: 'moltbot',
+      stdout,
+      stderr,
+      stdin: ttyStdin(),
+      env: {},
+    });
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      json: { text: 'from moltbot', source: 'moltbot' },
+    });
+  });
+});

--- a/apps/pops-cli/src/__tests__/config.test.ts
+++ b/apps/pops-cli/src/__tests__/config.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../config.js';
+
+describe('loadConfig', () => {
+  it('falls back to localhost:3000 when POPS_API_URL is unset', () => {
+    expect(loadConfig({}).apiUrl).toBe('http://localhost:3000');
+  });
+
+  it('strips a trailing slash from POPS_API_URL', () => {
+    expect(loadConfig({ POPS_API_URL: 'https://pops.local/' }).apiUrl).toBe('https://pops.local');
+  });
+
+  it('treats whitespace-only POPS_API_URL as unset', () => {
+    expect(loadConfig({ POPS_API_URL: '   ' }).apiUrl).toBe('http://localhost:3000');
+  });
+
+  it('returns POPS_API_KEY when set', () => {
+    expect(loadConfig({ POPS_API_KEY: 'pops_sa_abc' }).apiKey).toBe('pops_sa_abc');
+  });
+
+  it('returns undefined apiKey when POPS_API_KEY is unset or blank', () => {
+    expect(loadConfig({}).apiKey).toBeUndefined();
+    expect(loadConfig({ POPS_API_KEY: '   ' }).apiKey).toBeUndefined();
+  });
+});

--- a/apps/pops-cli/src/__tests__/test-helpers.ts
+++ b/apps/pops-cli/src/__tests__/test-helpers.ts
@@ -1,0 +1,38 @@
+import { Readable, Writable } from 'node:stream';
+
+/** In-memory writable stream that captures all writes for assertion. */
+export class CaptureStream extends Writable {
+  private chunks: string[] = [];
+  // commander/fetch only call `write`, but commander itself accesses `isTTY`
+  // when checking colour support; expose a deterministic value so tests don't
+  // depend on the host terminal.
+  readonly isTTY = false;
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    cb: (err?: Error | null) => void
+  ): void {
+    this.chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+    cb();
+  }
+
+  text(): string {
+    return this.chunks.join('');
+  }
+}
+
+/** Readable stream pretending to be a piped stdin (not a TTY). */
+export function pipedStdin(content: string): NodeJS.ReadStream {
+  const readable = Readable.from(Buffer.from(content, 'utf8'));
+  // The CLI checks `isTTY` to decide whether to wait on stdin.
+  Object.defineProperty(readable, 'isTTY', { value: false });
+  return readable as unknown as NodeJS.ReadStream;
+}
+
+/** Readable stream that pretends to be an interactive TTY (no piped input). */
+export function ttyStdin(): NodeJS.ReadStream {
+  const readable = new Readable({ read() {} });
+  Object.defineProperty(readable, 'isTTY', { value: true });
+  return readable as unknown as NodeJS.ReadStream;
+}

--- a/apps/pops-cli/src/__tests__/test-helpers.ts
+++ b/apps/pops-cli/src/__tests__/test-helpers.ts
@@ -1,11 +1,13 @@
 import { Readable, Writable } from 'node:stream';
 
+import { expect, vi } from 'vitest';
+
 /** In-memory writable stream that captures all writes for assertion. */
 export class CaptureStream extends Writable {
   private chunks: string[] = [];
-  // commander/fetch only call `write`, but commander itself accesses `isTTY`
-  // when checking colour support; expose a deterministic value so tests don't
-  // depend on the host terminal.
+  // commander and a few CLI helpers access `isTTY` when checking colour
+  // support; expose a deterministic value so tests don't depend on the host
+  // terminal.
   readonly isTTY = false;
 
   override _write(
@@ -23,16 +25,87 @@ export class CaptureStream extends Writable {
 }
 
 /** Readable stream pretending to be a piped stdin (not a TTY). */
-export function pipedStdin(content: string): NodeJS.ReadStream {
+export function pipedStdin(content: string): Readable & { isTTY: false } {
   const readable = Readable.from(Buffer.from(content, 'utf8'));
-  // The CLI checks `isTTY` to decide whether to wait on stdin.
-  Object.defineProperty(readable, 'isTTY', { value: false });
-  return readable as unknown as NodeJS.ReadStream;
+  return Object.assign(readable, { isTTY: false as const });
 }
 
-/** Readable stream that pretends to be an interactive TTY (no piped input). */
-export function ttyStdin(): NodeJS.ReadStream {
+/** Readable stream pretending to be an interactive TTY (no piped input). */
+export function ttyStdin(): Readable & { isTTY: true } {
   const readable = new Readable({ read() {} });
-  Object.defineProperty(readable, 'isTTY', { value: true });
-  return readable as unknown as NodeJS.ReadStream;
+  return Object.assign(readable, { isTTY: true as const });
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mocking
+//
+// All CLI tests exercise the command handler against a stubbed global
+// `fetch`. The helpers below intentionally use `vi.stubGlobal` instead of
+// reaching into `globalThis` directly so cleanup is automatic (via
+// `vi.unstubAllGlobals` in `afterEach`) and the test files don't need
+// to perform any unsafe type casts.
+// ---------------------------------------------------------------------------
+
+type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+export type FetchMock = ReturnType<typeof vi.fn<FetchFn>>;
+
+function stubFetch(impl: FetchFn): FetchMock {
+  const fn: FetchMock = vi.fn<FetchFn>(impl);
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+export function mockFetchOk<T>(body: T): FetchMock {
+  return stubFetch(
+    async () =>
+      new Response(JSON.stringify({ result: { data: { json: body } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+  );
+}
+
+export function mockFetchTrpcError(
+  message: string,
+  httpStatus = 400,
+  code = 'BAD_REQUEST'
+): FetchMock {
+  return stubFetch(
+    async () =>
+      new Response(
+        JSON.stringify({ error: { json: { message, code, data: { httpStatus, code } } } }),
+        {
+          status: httpStatus,
+          headers: { 'content-type': 'application/json' },
+        }
+      )
+  );
+}
+
+export function mockFetchUnreachable(): FetchMock {
+  return stubFetch(async () => {
+    throw new TypeError('fetch failed');
+  });
+}
+
+/**
+ * Safely extract a single fetch call so tests don't reach into
+ * `mock.calls[0]` directly. Asserts the spy was called exactly once and
+ * returns a typed view of the URL string and request init the CLI sent.
+ */
+export function getFetchCall(spy: FetchMock, index = 0): { url: string; init: RequestInit } {
+  expect(spy).toHaveBeenCalled();
+  const call = spy.mock.calls[index];
+  if (!call) throw new Error(`fetch call #${index} not recorded`);
+  const [input, init] = call;
+  const url = typeof input === 'string' ? input : input.toString();
+  return { url, init: init ?? {} };
+}
+
+/** Parse the JSON body the CLI sent on a recorded fetch call. */
+export function getFetchJson(spy: FetchMock, index = 0): unknown {
+  const { init } = getFetchCall(spy, index);
+  const body = init.body;
+  if (typeof body !== 'string') throw new Error('fetch body was not a string');
+  return JSON.parse(body);
 }

--- a/apps/pops-cli/src/api-client.ts
+++ b/apps/pops-cli/src/api-client.ts
@@ -1,0 +1,133 @@
+/**
+ * Minimal tRPC HTTP client. Speaks the SuperJSON-style transformer-free wire
+ * format that pops-api uses (`{ json: <payload> }` envelopes for inputs,
+ * `result.data.json` envelope on success).
+ *
+ * Kept dependency-free so the CLI binary stays small. The shared
+ * `@pops/api-client` package targets React and isn't appropriate here.
+ */
+import type { CliConfig } from './config.js';
+
+export interface ApiErrorPayload {
+  message: string;
+  code?: string;
+  httpStatus?: number;
+}
+
+export class ApiError extends Error {
+  readonly code: string | undefined;
+  readonly httpStatus: number | undefined;
+
+  constructor(payload: ApiErrorPayload) {
+    super(payload.message);
+    this.name = 'ApiError';
+    this.code = payload.code;
+    this.httpStatus = payload.httpStatus;
+  }
+}
+
+export class ApiUnreachableError extends Error {
+  constructor(
+    message: string,
+    readonly cause: unknown
+  ) {
+    super(message);
+    this.name = 'ApiUnreachableError';
+  }
+}
+
+interface TrpcSuccess<T> {
+  result: { data: { json: T } };
+}
+
+interface TrpcFailure {
+  error: {
+    json: { message: string; code?: string; data?: { httpStatus?: number; code?: string } };
+  };
+}
+
+function isTrpcSuccess<T>(value: unknown): value is TrpcSuccess<T> {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('result' in value)) return false;
+  const result = (value as { result?: unknown }).result;
+  if (typeof result !== 'object' || result === null) return false;
+  return 'data' in result;
+}
+
+function isTrpcFailure(value: unknown): value is TrpcFailure {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('error' in value)) return false;
+  const err = (value as { error?: unknown }).error;
+  return typeof err === 'object' && err !== null && 'json' in err;
+}
+
+async function sendRequest(
+  url: string,
+  headers: Record<string, string>,
+  input: unknown,
+  apiUrl: string
+): Promise<Response> {
+  try {
+    return await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ json: input }),
+    });
+  } catch (err) {
+    throw new ApiUnreachableError(
+      `Unable to reach the POPS API at ${apiUrl}. Is the server running?`,
+      err
+    );
+  }
+}
+
+async function parseBody(response: Response, url: string): Promise<unknown> {
+  const text = await response.text();
+  if (text.length === 0) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new ApiError({
+      message: `Unexpected non-JSON response from ${url} (status ${response.status})`,
+      httpStatus: response.status,
+    });
+  }
+}
+
+function throwFailure(parsed: unknown, response: Response): never {
+  const failure = isTrpcFailure(parsed) ? parsed.error.json : null;
+  const message = failure?.message ?? `Request failed with status ${response.status}`;
+  const code = failure?.code ?? failure?.data?.code;
+  throw new ApiError({
+    message,
+    code,
+    httpStatus: failure?.data?.httpStatus ?? response.status,
+  });
+}
+
+/**
+ * Invoke a tRPC mutation. The CLI doesn't make queries today, so we keep
+ * the surface narrow — easy to add `query` later if needed.
+ */
+export async function trpcMutation<T>(
+  config: CliConfig,
+  procedure: string,
+  input: unknown
+): Promise<T> {
+  const url = `${config.apiUrl}/trpc/${procedure}`;
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (config.apiKey) headers['x-api-key'] = config.apiKey;
+
+  const response = await sendRequest(url, headers, input, config.apiUrl);
+  const parsed = await parseBody(response, url);
+
+  if (!response.ok || isTrpcFailure(parsed)) throwFailure(parsed, response);
+  if (!isTrpcSuccess<T>(parsed)) {
+    throw new ApiError({
+      message: 'Malformed tRPC success response (no result.data.json)',
+      httpStatus: response.status,
+    });
+  }
+
+  return parsed.result.data.json;
+}

--- a/apps/pops-cli/src/api-client.ts
+++ b/apps/pops-cli/src/api-client.ts
@@ -50,8 +50,10 @@ function isTrpcSuccess<T>(value: unknown): value is TrpcSuccess<T> {
   if (typeof value !== 'object' || value === null) return false;
   if (!('result' in value)) return false;
   const result = (value as { result?: unknown }).result;
-  if (typeof result !== 'object' || result === null) return false;
-  return 'data' in result;
+  if (typeof result !== 'object' || result === null || !('data' in result)) return false;
+  const data = (result as { data?: unknown }).data;
+  if (typeof data !== 'object' || data === null) return false;
+  return 'json' in data;
 }
 
 function isTrpcFailure(value: unknown): value is TrpcFailure {

--- a/apps/pops-cli/src/commands/cerebrum-ask.ts
+++ b/apps/pops-cli/src/commands/cerebrum-ask.ts
@@ -1,0 +1,74 @@
+/**
+ * `pops cerebrum ask` — natural-language Q&A against the engram store.
+ *
+ * Accepts the question as a single argument or piped on stdin. Prints the
+ * answer followed by citations. Exit codes mirror `capture`: 2 for empty
+ * input, 3 for unreachable API, 1 for server-side errors.
+ */
+import { trpcMutation } from '../api-client.js';
+import { loadConfig } from '../config.js';
+import { writeApiError } from '../error-output.js';
+import { readStdin } from '../stdin.js';
+
+interface AskSource {
+  id?: string;
+  title?: string;
+  scope?: string;
+  url?: string;
+}
+
+interface AskResponse {
+  answer: string;
+  sources?: AskSource[];
+  confidence?: string;
+}
+
+export interface RunAskOptions {
+  question?: string;
+  scopes?: string[];
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+  stdin?: NodeJS.ReadStream;
+  env?: NodeJS.ProcessEnv;
+}
+
+function renderSource(s: AskSource, index: number): string {
+  const label = s.title ?? s.id ?? `source-${index + 1}`;
+  const id = s.id ? ` (${s.id})` : '';
+  const scope = s.scope ? ` [${s.scope}]` : '';
+  return `  ${index + 1}. ${label}${id}${scope}`;
+}
+
+function writeAskResult(stdout: NodeJS.WritableStream, result: AskResponse): void {
+  stdout.write(`${result.answer.trim()}\n`);
+  if (result.sources && result.sources.length > 0) {
+    stdout.write('\nSources:\n');
+    result.sources.forEach((source, i) => stdout.write(`${renderSource(source, i)}\n`));
+  }
+  if (result.confidence) {
+    stdout.write(`\nConfidence: ${result.confidence}\n`);
+  }
+}
+
+export async function runAsk(options: RunAskOptions): Promise<number> {
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+
+  const piped = await readStdin(options.stdin ?? process.stdin);
+  const question = (options.question ?? piped).trim();
+  if (question.length === 0) {
+    stderr.write('error: ask requires a question — pass it as an argument or pipe it on stdin\n');
+    return 2;
+  }
+
+  const config = loadConfig(options.env);
+  try {
+    const payload: { question: string; scopes?: string[] } = { question };
+    if (options.scopes && options.scopes.length > 0) payload.scopes = options.scopes;
+    const result = await trpcMutation<AskResponse>(config, 'cerebrum.query.ask', payload);
+    writeAskResult(stdout, result);
+    return 0;
+  } catch (err) {
+    return writeApiError(stderr, err);
+  }
+}

--- a/apps/pops-cli/src/commands/cerebrum-ask.ts
+++ b/apps/pops-cli/src/commands/cerebrum-ask.ts
@@ -8,7 +8,7 @@
 import { trpcMutation } from '../api-client.js';
 import { loadConfig } from '../config.js';
 import { writeApiError } from '../error-output.js';
-import { readStdin } from '../stdin.js';
+import { readStdin, type StdinSource } from '../stdin.js';
 
 interface AskSource {
   id?: string;
@@ -28,7 +28,7 @@ export interface RunAskOptions {
   scopes?: string[];
   stdout?: NodeJS.WritableStream;
   stderr?: NodeJS.WritableStream;
-  stdin?: NodeJS.ReadStream;
+  stdin?: StdinSource;
   env?: NodeJS.ProcessEnv;
 }
 

--- a/apps/pops-cli/src/commands/cerebrum-capture.ts
+++ b/apps/pops-cli/src/commands/cerebrum-capture.ts
@@ -1,0 +1,58 @@
+/**
+ * `pops cerebrum capture` — quick-capture a thought into the engram store.
+ *
+ * Accepts text as a single argument or piped on stdin. Empty/whitespace-only
+ * input exits with code 2 and a clear error message. Network failures exit
+ * with code 3. Server-side validation/auth errors exit with code 1.
+ */
+import { trpcMutation } from '../api-client.js';
+import { loadConfig } from '../config.js';
+import { writeApiError } from '../error-output.js';
+import { readStdin } from '../stdin.js';
+
+export interface QuickCaptureResponse {
+  id: string;
+  path: string;
+  type: string;
+  scopes: string[];
+}
+
+export interface RunCaptureOptions {
+  text?: string;
+  source?: string;
+  /** Injectable for tests — defaults to process.stdout/stderr. */
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+  /** Injectable for tests — defaults to process.stdin. */
+  stdin?: NodeJS.ReadStream;
+  /** Injectable for tests — defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+}
+
+export async function runCapture(options: RunCaptureOptions): Promise<number> {
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+
+  const piped = await readStdin(options.stdin ?? process.stdin);
+  const text = (options.text ?? piped).trim();
+  if (text.length === 0) {
+    stderr.write('error: capture requires text — pass it as an argument or pipe it on stdin\n');
+    return 2;
+  }
+
+  const config = loadConfig(options.env);
+  try {
+    const result = await trpcMutation<QuickCaptureResponse>(
+      config,
+      'cerebrum.ingest.quickCapture',
+      { text, source: options.source ?? 'cli' }
+    );
+    stdout.write(`Captured ${result.id}\n`);
+    stdout.write(`  path:   ${result.path}\n`);
+    stdout.write(`  type:   ${result.type}\n`);
+    stdout.write(`  scopes: ${result.scopes.join(', ') || '<none>'}\n`);
+    return 0;
+  } catch (err) {
+    return writeApiError(stderr, err);
+  }
+}

--- a/apps/pops-cli/src/commands/cerebrum-capture.ts
+++ b/apps/pops-cli/src/commands/cerebrum-capture.ts
@@ -8,7 +8,7 @@
 import { trpcMutation } from '../api-client.js';
 import { loadConfig } from '../config.js';
 import { writeApiError } from '../error-output.js';
-import { readStdin } from '../stdin.js';
+import { readStdin, type StdinSource } from '../stdin.js';
 
 export interface QuickCaptureResponse {
   id: string;
@@ -24,7 +24,7 @@ export interface RunCaptureOptions {
   stdout?: NodeJS.WritableStream;
   stderr?: NodeJS.WritableStream;
   /** Injectable for tests — defaults to process.stdin. */
-  stdin?: NodeJS.ReadStream;
+  stdin?: StdinSource;
   /** Injectable for tests — defaults to process.env. */
   env?: NodeJS.ProcessEnv;
 }

--- a/apps/pops-cli/src/config.ts
+++ b/apps/pops-cli/src/config.ts
@@ -1,0 +1,19 @@
+/**
+ * CLI configuration — resolves API base URL and auth header from the
+ * environment. Kept tiny on purpose: the CLI is a single-file binary in
+ * spirit, and config surface should be discoverable from --help.
+ */
+
+const DEFAULT_API_URL = 'http://localhost:3000';
+
+export interface CliConfig {
+  apiUrl: string;
+  apiKey: string | undefined;
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): CliConfig {
+  const rawUrl = env['POPS_API_URL']?.trim();
+  const apiUrl = rawUrl && rawUrl.length > 0 ? rawUrl.replace(/\/$/, '') : DEFAULT_API_URL;
+  const apiKey = env['POPS_API_KEY']?.trim() || undefined;
+  return { apiUrl, apiKey };
+}

--- a/apps/pops-cli/src/error-output.ts
+++ b/apps/pops-cli/src/error-output.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared error rendering for CLI commands. Maps the API error hierarchy to
+ * exit codes so every command behaves the same:
+ *
+ *   - 3 → API unreachable (network failure, server down, wrong URL)
+ *   - 1 → API responded with a typed tRPC error (validation, auth, etc.)
+ *   - 1 → anything else (unexpected throw)
+ */
+import { ApiError, ApiUnreachableError } from './api-client.js';
+
+export function writeApiError(stderr: NodeJS.WritableStream, err: unknown): number {
+  if (err instanceof ApiUnreachableError) {
+    stderr.write(`error: ${err.message}\n`);
+    return 3;
+  }
+  if (err instanceof ApiError) {
+    stderr.write(`error: ${err.message}\n`);
+    return 1;
+  }
+  stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+  return 1;
+}

--- a/apps/pops-cli/src/index.ts
+++ b/apps/pops-cli/src/index.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * `pops` CLI entrypoint. Spec: PRD-081 US-03 (capture) and follow-on ask.
+ *
+ * Reads `POPS_API_URL` (default `http://localhost:3000`) and
+ * `POPS_API_KEY` (optional, sent as `X-API-Key` for service-account auth)
+ * from the environment.
+ */
+import { Command } from 'commander';
+
+import { runAsk } from './commands/cerebrum-ask.js';
+import { runCapture } from './commands/cerebrum-capture.js';
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name('pops')
+    .description('POPS personal operations CLI')
+    .version('0.1.0', '-v, --version');
+
+  const cerebrum = program.command('cerebrum').description('Cerebrum knowledge base commands');
+
+  cerebrum
+    .command('capture')
+    .description('Capture a thought into the engram store (PRD-081 US-03)')
+    .argument('[text...]', 'text to capture; if omitted, read from stdin')
+    .option('--source <source>', 'engram source override', 'cli')
+    .action(async (text: string[], opts: { source?: string }) => {
+      const joined = text.length > 0 ? text.join(' ') : undefined;
+      const code = await runCapture({ text: joined, source: opts.source });
+      if (code !== 0) process.exitCode = code;
+    });
+
+  cerebrum
+    .command('ask')
+    .description('Ask a natural-language question against the engram store')
+    .argument('[question...]', 'question to ask; if omitted, read from stdin')
+    .option('--scope <scope>', 'limit to one or more scopes (repeatable)', collect, [])
+    .action(async (question: string[], opts: { scope: string[] }) => {
+      const joined = question.length > 0 ? question.join(' ') : undefined;
+      const code = await runAsk({ question: joined, scopes: opts.scope });
+      if (code !== 0) process.exitCode = code;
+    });
+
+  return program;
+}
+
+function collect(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+const program = buildProgram();
+program.parseAsync(process.argv).catch((err) => {
+  process.stderr.write(`fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/apps/pops-cli/src/stdin.ts
+++ b/apps/pops-cli/src/stdin.ts
@@ -1,9 +1,19 @@
 /**
+ * Structural type the CLI needs from a stdin-like stream: a TTY flag and
+ * async iteration over chunks. Kept narrower than `NodeJS.ReadStream` so
+ * tests can pass a plain `Readable` without unsafe casts.
+ */
+export interface StdinSource {
+  readonly isTTY?: boolean;
+  [Symbol.asyncIterator](): AsyncIterator<Buffer | string>;
+}
+
+/**
  * Read all of stdin to a string. Returns an empty string when stdin is a TTY
  * (interactive shell, no piped input) so the caller can fall back to
  * arguments without hanging waiting for an EOF the user will never type.
  */
-export async function readStdin(stream: NodeJS.ReadStream = process.stdin): Promise<string> {
+export async function readStdin(stream: StdinSource = process.stdin): Promise<string> {
   if (stream.isTTY) return '';
   const chunks: Buffer[] = [];
   for await (const chunk of stream) {

--- a/apps/pops-cli/src/stdin.ts
+++ b/apps/pops-cli/src/stdin.ts
@@ -1,0 +1,13 @@
+/**
+ * Read all of stdin to a string. Returns an empty string when stdin is a TTY
+ * (interactive shell, no piped input) so the caller can fall back to
+ * arguments without hanging waiting for an EOF the user will never type.
+ */
+export async function readStdin(stream: NodeJS.ReadStream = process.stdin): Promise<string> {
+  if (stream.isTTY) return '';
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/apps/pops-cli/tsconfig.json
+++ b/apps/pops-cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/apps/pops-cli/vitest.config.ts
+++ b/apps/pops-cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-03-quick-capture.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-03-quick-capture.md
@@ -1,7 +1,7 @@
 # US-03: Quick Capture via Moltbot and CLI
 
 > PRD: [PRD-081: Ingestion Pipeline](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -9,13 +9,13 @@ As a user on the go (via Moltbot on Telegram or the pops CLI), I want to fire of
 
 ## Acceptance Criteria
 
-- [ ] A `pops cerebrum capture "text"` CLI command accepts raw text as a single argument or from stdin and creates an engram via `cerebrum.ingest.quickCapture` (deferred — no `pops` CLI binary exists yet, tracked in #2575)
+- [x] A `pops cerebrum capture "text"` CLI command accepts raw text as a single argument or from stdin and creates a capture engram
 - [x] Moltbot accepts a `/capture` command (or a configurable prefix/trigger) followed by raw text and creates an engram via the same `quickCapture` path — defined in `apps/moltbot/skills/pops-cerebrum/SKILL.md`
 - [x] Quick capture assigns `type: capture`, `source: moltbot` (or `cli` depending on channel), and the fallback scope from `scope-rules.toml`
 - [x] Quick capture skips classification, entity extraction, and scope inference at ingestion time — the engram is written immediately
 - [x] A background job is enqueued (via BullMQ) to run Cortex classification and entity extraction on the captured engram asynchronously
 - [x] The background job updates the engram's `type`, `template`, `tags`, and `scopes` in both the file and the index when classification completes
-- [ ] The CLI command outputs the engram ID and a confirmation message; Moltbot responds with the engram ID and a brief confirmation — Moltbot side defined in the skill prompt (tracked together with the missing CLI in #2575)
+- [x] The CLI command outputs the engram ID and a confirmation message; Moltbot responds with the engram ID and a brief confirmation
 - [x] Captures with only whitespace or empty text are rejected with an error message
 
 ## Notes

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-03-quick-capture.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-03-quick-capture.md
@@ -10,7 +10,7 @@ As a user on the go (via Moltbot on Telegram or the pops CLI), I want to fire of
 ## Acceptance Criteria
 
 - [x] A `pops cerebrum capture "text"` CLI command accepts raw text as a single argument or from stdin and creates a capture engram
-- [x] Moltbot accepts a `/capture` command (or a configurable prefix/trigger) followed by raw text and creates an engram via the same `quickCapture` path — defined in `apps/moltbot/skills/pops-cerebrum/SKILL.md`
+- [x] Moltbot accepts a `/capture` command (or a configurable prefix/trigger) followed by raw text and creates an engram through the same quick-capture flow
 - [x] Quick capture assigns `type: capture`, `source: moltbot` (or `cli` depending on channel), and the fallback scope from `scope-rules.toml`
 - [x] Quick capture skips classification, entity extraction, and scope inference at ingestion time — the engram is written immediately
 - [x] A background job is enqueued (via BullMQ) to run Cortex classification and entity extraction on the captured engram asynchronously

--- a/mise.toml
+++ b/mise.toml
@@ -33,6 +33,16 @@ pnpm dev
 description = "Run all dev servers (using turbo)"
 run = "pnpm dev"
 
+[tasks."cli"]
+description = "Run the pops CLI from source (e.g. `mise cli cerebrum capture \"a thought\"`)"
+dir = "apps/pops-cli"
+run = "pnpm dev"
+
+[tasks."cli:build"]
+description = "Build the pops CLI to apps/pops-cli/dist"
+dir = "apps/pops-cli"
+run = "pnpm build"
+
 [tasks."dev:storybook"]
 description = "Run unified Storybook for all packages and apps"
 dir = "apps/pops-storybook"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,28 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  apps/pops-cli:
+    dependencies:
+      commander:
+        specifier: ^14.0.1
+        version: 14.0.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.2
+        version: 25.6.2
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.5(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   apps/pops-shell:
     dependencies:
       '@pops/api-client':


### PR DESCRIPTION
## Summary
- Bootstraps `apps/pops-cli/` (`@pops/cli`) — a tiny Commander-based CLI that talks to the pops-api tRPC HTTP endpoint. Single binary: `pops`.
- `pops cerebrum capture [text...]` — calls `cerebrum.ingest.quickCapture`. Accepts text via positional args or piped on stdin. Prints engram id, file path, type, and scopes.
- `pops cerebrum ask [question...]` — calls `cerebrum.query.ask`. Optionally scoped via repeated `--scope` flags. Prints answer, sources, and confidence.
- Reads `POPS_API_URL` (default `http://localhost:3000`) and `POPS_API_KEY` (sent as `X-API-Key`) from the env.
- Exit codes: `0` success, `1` server error, `2` empty input, `3` API unreachable.
- New mise tasks: `mise cli ...` (dev mode) and `mise cli:build`.

Closes #2575. PRD-081 US-03 AC #1 and #7.

## Test plan
- [x] Unit tests for capture: positional arg, stdin, empty-input rejection (exit 2), unreachable API (exit 3), `X-API-Key` forwarding, server-side validation error surface, `--source` override (16 tests total across capture/ask/config).
- [x] Manual smoke: `node dist/index.js cerebrum capture "..."` against unreachable API returns the friendly message and exit 3.
- [x] `pnpm typecheck` and `mise lint` clean across the workspace.
- [x] `pnpm build` produces `dist/index.js` which functions as the `pops` bin.