### PR TITLE
fix(cli): use raw tRPC wire format, not the SuperJSON envelope

### DIFF
--- a/apps/pops-cli/src/__tests__/api-client.test.ts
+++ b/apps/pops-cli/src/__tests__/api-client.test.ts
@@ -49,15 +49,14 @@ describe('trpcMutation wire format', () => {
 
   it('surfaces tRPC errors from `error.message` (no `.json` envelope on the error side either)', async () => {
     mockFetchTrpcError('text must be a non-empty string', 400, 'BAD_REQUEST');
-    await expect(
-      trpcMutation(
-        { apiUrl: 'http://api.test', apiKey: undefined },
-        'cerebrum.ingest.quickCapture',
-        {
-          text: '',
-        }
-      )
-    ).rejects.toThrow(ApiError);
+    const call = trpcMutation(
+      { apiUrl: 'http://api.test', apiKey: undefined },
+      'cerebrum.ingest.quickCapture',
+      { text: '' }
+    );
+    await expect(call).rejects.toBeInstanceOf(ApiError);
+    await expect(call).rejects.toThrow(/text must be a non-empty string/);
+    await expect(call).rejects.toMatchObject({ code: 'BAD_REQUEST', httpStatus: 400 });
   });
 
   it('forwards X-API-Key when the config supplies a key', async () => {

--- a/apps/pops-cli/src/__tests__/api-client.test.ts
+++ b/apps/pops-cli/src/__tests__/api-client.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Wire-format regression tests. These pin the request/response shape the CLI
+ * speaks to the pops-api tRPC endpoint, so a future change to either side
+ * breaks here instead of silently failing in the field.
+ *
+ * The pops-api router has no transformer configured (no `superjson`), so
+ * tRPC sends inputs as raw JSON (no `{ json: ... }` envelope) and successes
+ * come back as `{ result: { data: <payload> } }`. The original CLI shipped
+ * with a SuperJSON-style envelope and was rejected at runtime — see issue
+ * #2609.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiError, ApiUnreachableError, trpcMutation } from '../api-client.js';
+import { getFetchCall, getFetchJson, mockFetchOk, mockFetchTrpcError } from './test-helpers.js';
+
+describe('trpcMutation wire format', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the input as a raw JSON object, not wrapped in `{ json: ... }`', async () => {
+    const spy = mockFetchOk({ ok: true });
+    await trpcMutation(
+      { apiUrl: 'http://api.test', apiKey: undefined },
+      'cerebrum.ingest.quickCapture',
+      { text: 'hi', source: 'cli' }
+    );
+    expect(getFetchJson(spy)).toEqual({ text: 'hi', source: 'cli' });
+  });
+
+  it('reads the success payload from `result.data` (no `.json` envelope)', async () => {
+    mockFetchOk({ id: 'eng_x', path: 'capture/eng_x.md', type: 'capture', scopes: ['a'] });
+    const result = await trpcMutation<{ id: string }>(
+      { apiUrl: 'http://api.test', apiKey: undefined },
+      'cerebrum.ingest.quickCapture',
+      { text: 'hi' }
+    );
+    expect(result).toEqual({
+      id: 'eng_x',
+      path: 'capture/eng_x.md',
+      type: 'capture',
+      scopes: ['a'],
+    });
+  });
+
+  it('surfaces tRPC errors from `error.message` (no `.json` envelope on the error side either)', async () => {
+    mockFetchTrpcError('text must be a non-empty string', 400, 'BAD_REQUEST');
+    await expect(
+      trpcMutation(
+        { apiUrl: 'http://api.test', apiKey: undefined },
+        'cerebrum.ingest.quickCapture',
+        {
+          text: '',
+        }
+      )
+    ).rejects.toThrow(ApiError);
+  });
+
+  it('forwards X-API-Key when the config supplies a key', async () => {
+    const spy = mockFetchOk({ ok: true });
+    await trpcMutation({ apiUrl: 'http://api.test', apiKey: 'pops_sa_abc' }, 'cerebrum.query.ask', {
+      question: 'hi',
+    });
+    const { init } = getFetchCall(spy);
+    const headers = init.headers;
+    expect(headers).toBeDefined();
+    if (headers && !(headers instanceof Headers) && !Array.isArray(headers)) {
+      expect(headers['x-api-key']).toBe('pops_sa_abc');
+    } else {
+      throw new Error('expected plain-object headers');
+    }
+  });
+
+  it('wraps fetch-failure errors as ApiUnreachableError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('fetch failed');
+      })
+    );
+    await expect(
+      trpcMutation(
+        { apiUrl: 'http://localhost:9999', apiKey: undefined },
+        'cerebrum.ingest.quickCapture',
+        {
+          text: 'hi',
+        }
+      )
+    ).rejects.toBeInstanceOf(ApiUnreachableError);
+  });
+});

--- a/apps/pops-cli/src/__tests__/cerebrum-ask.test.ts
+++ b/apps/pops-cli/src/__tests__/cerebrum-ask.test.ts
@@ -88,7 +88,8 @@ describe('runAsk', () => {
     });
 
     expect(getFetchJson(fetchSpy)).toEqual({
-      json: { question: 'q', scopes: ['work', 'work.platform'] },
+      question: 'q',
+      scopes: ['work', 'work.platform'],
     });
   });
 });

--- a/apps/pops-cli/src/__tests__/cerebrum-capture.test.ts
+++ b/apps/pops-cli/src/__tests__/cerebrum-capture.test.ts
@@ -50,7 +50,8 @@ describe('runCapture', () => {
     expect(url).toBe('http://api.test/trpc/cerebrum.ingest.quickCapture');
     expect(init.method).toBe('POST');
     expect(getFetchJson(fetchSpy)).toEqual({
-      json: { text: 'a quick thought', source: 'cli' },
+      text: 'a quick thought',
+      source: 'cli',
     });
     expect(stdout.text()).toContain('Captured eng_20260427_1500_idea');
     expect(stdout.text()).toContain('path:   capture/eng_20260427_1500_idea.md');
@@ -183,7 +184,8 @@ describe('runCapture', () => {
     });
 
     expect(getFetchJson(fetchSpy)).toEqual({
-      json: { text: 'from moltbot', source: 'moltbot' },
+      text: 'from moltbot',
+      source: 'moltbot',
     });
   });
 });

--- a/apps/pops-cli/src/__tests__/test-helpers.ts
+++ b/apps/pops-cli/src/__tests__/test-helpers.ts
@@ -58,7 +58,7 @@ function stubFetch(impl: FetchFn): FetchMock {
 export function mockFetchOk<T>(body: T): FetchMock {
   return stubFetch(
     async () =>
-      new Response(JSON.stringify({ result: { data: { json: body } } }), {
+      new Response(JSON.stringify({ result: { data: body } }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       })
@@ -72,13 +72,10 @@ export function mockFetchTrpcError(
 ): FetchMock {
   return stubFetch(
     async () =>
-      new Response(
-        JSON.stringify({ error: { json: { message, code, data: { httpStatus, code } } } }),
-        {
-          status: httpStatus,
-          headers: { 'content-type': 'application/json' },
-        }
-      )
+      new Response(JSON.stringify({ error: { message, code, data: { httpStatus, code } } }), {
+        status: httpStatus,
+        headers: { 'content-type': 'application/json' },
+      })
   );
 }
 

--- a/apps/pops-cli/src/api-client.ts
+++ b/apps/pops-cli/src/api-client.ts
@@ -1,7 +1,7 @@
 /**
- * Minimal tRPC HTTP client. Speaks the SuperJSON-style transformer-free wire
- * format that pops-api uses (`{ json: <payload> }` envelopes for inputs,
- * `result.data.json` envelope on success).
+ * Minimal tRPC HTTP client. Speaks the no-transformer wire format that
+ * pops-api uses today — inputs are sent as raw JSON (no `{ json: ... }`
+ * envelope) and successes come back as `{ result: { data: <payload> } }`.
  *
  * Kept dependency-free so the CLI binary stays small. The shared
  * `@pops/api-client` package targets React and isn't appropriate here.
@@ -37,30 +37,32 @@ export class ApiUnreachableError extends Error {
 }
 
 interface TrpcSuccess<T> {
-  result: { data: { json: T } };
+  result: { data: T };
+}
+
+interface TrpcFailureBody {
+  message: string;
+  code?: number | string;
+  data?: { httpStatus?: number; code?: string };
 }
 
 interface TrpcFailure {
-  error: {
-    json: { message: string; code?: string; data?: { httpStatus?: number; code?: string } };
-  };
+  error: TrpcFailureBody;
 }
 
 function isTrpcSuccess<T>(value: unknown): value is TrpcSuccess<T> {
   if (typeof value !== 'object' || value === null) return false;
   if (!('result' in value)) return false;
   const result = (value as { result?: unknown }).result;
-  if (typeof result !== 'object' || result === null || !('data' in result)) return false;
-  const data = (result as { data?: unknown }).data;
-  if (typeof data !== 'object' || data === null) return false;
-  return 'json' in data;
+  if (typeof result !== 'object' || result === null) return false;
+  return 'data' in result;
 }
 
 function isTrpcFailure(value: unknown): value is TrpcFailure {
   if (typeof value !== 'object' || value === null) return false;
   if (!('error' in value)) return false;
   const err = (value as { error?: unknown }).error;
-  return typeof err === 'object' && err !== null && 'json' in err;
+  return typeof err === 'object' && err !== null && 'message' in err;
 }
 
 async function sendRequest(
@@ -73,7 +75,7 @@ async function sendRequest(
     return await fetch(url, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ json: input }),
+      body: JSON.stringify(input),
     });
   } catch (err) {
     throw new ApiUnreachableError(
@@ -97,9 +99,10 @@ async function parseBody(response: Response, url: string): Promise<unknown> {
 }
 
 function throwFailure(parsed: unknown, response: Response): never {
-  const failure = isTrpcFailure(parsed) ? parsed.error.json : null;
+  const failure = isTrpcFailure(parsed) ? parsed.error : null;
   const message = failure?.message ?? `Request failed with status ${response.status}`;
-  const code = failure?.code ?? failure?.data?.code;
+  const code =
+    failure?.data?.code ?? (typeof failure?.code === 'string' ? failure.code : undefined);
   throw new ApiError({
     message,
     code,
@@ -126,10 +129,10 @@ export async function trpcMutation<T>(
   if (!response.ok || isTrpcFailure(parsed)) throwFailure(parsed, response);
   if (!isTrpcSuccess<T>(parsed)) {
     throw new ApiError({
-      message: 'Malformed tRPC success response (no result.data.json)',
+      message: 'Malformed tRPC success response (no result.data)',
       httpStatus: response.status,
     });
   }
 
-  return parsed.result.data.json;
+  return parsed.result.data;
 }


### PR DESCRIPTION
## Summary
The CLI shipped in #2608 wrapped every input as \`{ json: <payload> }\` and looked for \`result.data.json\` on the way back. pops-api has no tRPC transformer configured, so the server treated the wrapper as the actual input object and rejected every request with HTTP 400.

Verified end-to-end with the fix applied against a local dev server:

    $ pops cerebrum capture "real test after fix"
    Captured eng_20260511_2236_real-test-after-fix
      path:   capture/eng_20260511_2236_real-test-after-fix.md
      type:   capture
      scopes: personal.captures

    $ pops cerebrum ask "what engrams exist?"
    Based on the context provided, here are the engrams that exist:
    ...

## Changes
- Drop the \`{ json: ... }\` envelope on requests.
- Read success payloads from \`result.data\` and errors from \`error.message\`.
- New \`api-client.test.ts\` suite pins the wire format so a similar mismatch can't slip through unit tests again.
- Update existing test mocks + assertions to match the real wire format.

## Why the original tests passed
The mocks in \`test-helpers.ts\` produced the wrapped shape on both sides, so the CLI's wrong shape and the mock's wrong shape cancelled out. The new \`api-client.test.ts\` assertions are written against the real format.

## Test plan
- [x] \`pnpm typecheck\` and \`mise lint\` clean.
- [x] \`pnpm test\` — 21 tests pass.
- [x] Manual end-to-end against \`pnpm dev:api\`: both \`capture\` and \`ask\` work.