### PR TITLE
fix(db): detect migration-file hash drift instead of crashing on re-run (#2610)

### DIFF
--- a/apps/pops-api/src/db/migration-apply.ts
+++ b/apps/pops-api/src/db/migration-apply.ts
@@ -1,0 +1,141 @@
+/**
+ * Single-entry apply path for the per-module migration runner.
+ *
+ * Split out of `per-module-migrations.ts` to keep that file under the
+ * per-file line cap. The responsibilities here are:
+ *
+ *   1. Read the SQL file for one tag.
+ *   2. Classify against the in-memory caches (drift detection, already-
+ *      applied short-circuit, backfill from legacy hash-only tracking).
+ *   3. When applying, run every statement inside a transaction with the
+ *      additive-DDL "already applied" recovery from `migration-backfill.ts`,
+ *      then record both `__drizzle_migrations` and `__pops_migration_tags`
+ *      rows atomically.
+ *
+ * The runner stays at the top level: ownership classification, journal
+ * iteration, and result-bucket aggregation.
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { logger } from '../lib/logger.js';
+import { isAlreadyAppliedError, splitStatements } from './migration-backfill.js';
+import { DRIZZLE_MIGRATIONS_DIRECTORY } from './migrations-runner.js';
+
+import type BetterSqlite3 from 'better-sqlite3';
+
+export type ApplyBucket = 'applied' | 'backfilled' | 'alreadyApplied';
+
+export interface ApplyCaches {
+  knownHashes: Set<string>;
+  knownTags: Map<string, string>;
+  insertDrizzle: BetterSqlite3.Statement;
+  insertTag: BetterSqlite3.Statement;
+}
+
+function readMigrationSql(tag: string): string {
+  return readFileSync(join(DRIZZLE_MIGRATIONS_DIRECTORY, `${tag}.sql`), 'utf8');
+}
+
+/**
+ * Drizzle's hashing function. `drizzle-orm/migrator` records each applied
+ * migration as `sha256(sql)`. We reproduce the same hash here so a DB
+ * upgraded from the pre-PRD-101 runtime keeps working unchanged.
+ */
+export function hashSql(sql: string): string {
+  return createHash('sha256').update(sql).digest('hex');
+}
+
+interface ApplyMigrationArgs {
+  db: BetterSqlite3.Database;
+  tag: string;
+  sql: string;
+  hash: string;
+  insertDrizzle: BetterSqlite3.Statement;
+  insertTag: BetterSqlite3.Statement;
+}
+
+/**
+ * Apply one migration's SQL inside a transaction. Per-statement errors
+ * matching the "already applied" patterns are caught and logged; any
+ * other error aborts the transaction.
+ */
+function applyMigration({
+  db,
+  tag,
+  sql,
+  hash,
+  insertDrizzle,
+  insertTag,
+}: ApplyMigrationArgs): 'applied' | 'backfilled' {
+  let didBackfill = false;
+  db.transaction(() => {
+    for (const stmt of splitStatements(sql)) {
+      try {
+        db.exec(stmt);
+      } catch (err) {
+        if (!isAlreadyAppliedError(err)) throw err;
+        didBackfill = true;
+        logger.info(
+          {
+            migrationTag: tag,
+            statementPreview: stmt.slice(0, 80),
+            sqliteError: (err as Error).message,
+          },
+          `[db] Migration "${tag}" statement already applied to schema — recording hash without re-running.`
+        );
+      }
+    }
+    const appliedAt = Date.now();
+    insertDrizzle.run(hash, appliedAt);
+    insertTag.run(tag, hash, appliedAt);
+  })();
+  return didBackfill ? 'backfilled' : 'applied';
+}
+
+/**
+ * Decide whether the entry is already on file (and how) or needs to be
+ * applied. Mutates `caches` to keep hash/tag tracking consistent within
+ * one boot when multiple journal entries share the same SQL body.
+ */
+export function classifyOrApply(
+  db: BetterSqlite3.Database,
+  tag: string,
+  caches: ApplyCaches
+): ApplyBucket {
+  const sql = readMigrationSql(tag);
+  const hash = hashSql(sql);
+
+  // Tag-based dedupe wins over hash-based dedupe (issue #2610).
+  const recordedHash = caches.knownTags.get(tag);
+  if (recordedHash !== undefined) {
+    if (recordedHash !== hash) {
+      logger.warn(
+        { migrationTag: tag, recordedHash, currentHash: hash },
+        `[db] Migration "${tag}" hash drift — file edited after apply, skipping re-run.`
+      );
+    }
+    return 'alreadyApplied';
+  }
+
+  if (caches.knownHashes.has(hash)) {
+    // Applied under the old hash-only tracking. Backfill the tag row so
+    // future drift gets caught.
+    caches.insertTag.run(tag, hash, Date.now());
+    caches.knownTags.set(tag, hash);
+    return 'alreadyApplied';
+  }
+
+  const outcome = applyMigration({
+    db,
+    tag,
+    sql,
+    hash,
+    insertDrizzle: caches.insertDrizzle,
+    insertTag: caches.insertTag,
+  });
+  caches.knownHashes.add(hash);
+  caches.knownTags.set(tag, hash);
+  return outcome;
+}

--- a/apps/pops-api/src/db/migration-tag-tracking.ts
+++ b/apps/pops-api/src/db/migration-tag-tracking.ts
@@ -1,0 +1,32 @@
+/**
+ * Tag-keyed migration tracking — sister table to `__drizzle_migrations`.
+ *
+ * `__drizzle_migrations` records applied migrations by SQL hash, which is
+ * fine for first-time apply but breaks down if a migration file is edited
+ * after-the-fact: a different hash makes the runner re-attempt the
+ * migration, and one-way statements (e.g. `UPDATE … SET new_col = old_col`
+ * after a rename) crash on the now-missing column. The remedy is to also
+ * record the tag — the file name minus extension — so the runner can
+ * detect "tag matches, hash drifted" and skip the re-run.
+ *
+ * Issue #2610 has the full incident write-up.
+ */
+import type BetterSqlite3 from 'better-sqlite3';
+
+export function ensureAppliedTagsTable(db: BetterSqlite3.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS "__pops_migration_tags" (
+      tag TEXT PRIMARY KEY,
+      hash TEXT NOT NULL,
+      applied_at INTEGER NOT NULL
+    )
+  `);
+}
+
+export function appliedTags(db: BetterSqlite3.Database): Map<string, string> {
+  const rows = db.prepare('SELECT tag, hash FROM __pops_migration_tags').all() as {
+    tag: string;
+    hash: string;
+  }[];
+  return new Map(rows.map((r) => [r.tag, r.hash]));
+}

--- a/apps/pops-api/src/db/per-module-migrations.test.ts
+++ b/apps/pops-api/src/db/per-module-migrations.test.ts
@@ -575,3 +575,123 @@ describe('warnOrphanMigrations', () => {
     });
   });
 });
+
+describe('hash drift (issue #2610)', () => {
+  it('skips the re-run when a migration file is edited after apply', async () => {
+    const { createHash } = await import('node:crypto');
+    const dir = fakeJournalDir();
+    const originalSql = [
+      'CREATE TABLE renamed_t (id INTEGER, new_col TEXT);',
+      '--> statement-breakpoint',
+      // The "one-way" statement that would fail if re-run on a DB where
+      // the migration already took effect (old_col no longer exists).
+      'UPDATE renamed_t SET new_col = old_col WHERE old_col IS NOT NULL;',
+    ].join('\n');
+    writeJournal(dir, [{ tag: '0034_rename', sql: originalSql }]);
+    const originalHash = createHash('sha256').update(originalSql).digest('hex');
+
+    // Now edit the file (a comment fix — body changes, hash differs) and
+    // re-run with the post-edit content visible to the runner.
+    const editedSql = `-- minor comment fix\n${originalSql}`;
+    writeFileSync(join(dir, '0034_rename.sql'), editedSql);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    await withDb((db) => {
+      // Pre-create the schema in its post-migration shape (no `old_col`)
+      // and record the migration as already applied under its ORIGINAL
+      // hash + tag — i.e. the state a real DB would be in after a normal
+      // apply followed by an unrelated edit to the SQL file.
+      db.exec('CREATE TABLE renamed_t (id INTEGER, new_col TEXT);');
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          hash TEXT NOT NULL,
+          created_at NUMERIC
+        )
+      `);
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS "__pops_migration_tags" (
+          tag TEXT PRIMARY KEY,
+          hash TEXT NOT NULL,
+          applied_at INTEGER NOT NULL
+        )
+      `);
+      const now = Date.now();
+      db.prepare('INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)').run(
+        originalHash,
+        now
+      );
+      db.prepare('INSERT INTO __pops_migration_tags (tag, hash, applied_at) VALUES (?, ?, ?)').run(
+        '0034_rename',
+        originalHash,
+        now
+      );
+
+      // Boot the runner against the edited SQL. It must NOT re-execute the
+      // UPDATE — that would throw `no such column: old_col`. The tag is on
+      // file, the hash drifted, the migration's effects are already in the
+      // schema. Detect drift, skip re-run.
+      const editedA = makeManifest('a', [{ id: '0034_rename', sql: editedSql }]);
+      const result = mod.runPerModuleMigrations(db, [editedA]);
+
+      expect(result.applied).toEqual([]);
+      expect(result.alreadyApplied).toEqual(['0034_rename']);
+    });
+  });
+
+  it('backfills __pops_migration_tags from existing __drizzle_migrations on first boot after upgrade', async () => {
+    const { createHash } = await import('node:crypto');
+    const dir = fakeJournalDir();
+    const sql = 'CREATE TABLE legacy_t (id INTEGER);';
+    writeJournal(dir, [{ tag: '0010_legacy', sql }]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    await withDb((db) => {
+      // DB applied this migration under the old hash-only tracking.
+      db.exec(sql);
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          hash TEXT NOT NULL,
+          created_at NUMERIC
+        )
+      `);
+      const hash = createHash('sha256').update(sql).digest('hex');
+      db.prepare('INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)').run(
+        hash,
+        Date.now()
+      );
+
+      const a = makeManifest('a', [{ id: '0010_legacy', sql }]);
+      const result = mod.runPerModuleMigrations(db, [a]);
+
+      expect(result.alreadyApplied).toEqual(['0010_legacy']);
+
+      // Tag table has been backfilled.
+      const tagRow = db
+        .prepare('SELECT tag, hash FROM __pops_migration_tags WHERE tag = ?')
+        .get('0010_legacy') as { tag: string; hash: string } | undefined;
+      expect(tagRow).toBeDefined();
+      expect(tagRow?.hash).toBe(hash);
+    });
+  });
+
+  it('records the tag alongside the hash on every fresh apply', async () => {
+    const dir = fakeJournalDir();
+    const sql = 'CREATE TABLE fresh_t (id INTEGER);';
+    writeJournal(dir, [{ tag: '0001_fresh', sql }]);
+    const mod = await loadRunnerWithJournalDir(dir);
+
+    await withDb((db) => {
+      const a = makeManifest('a', [{ id: '0001_fresh', sql }]);
+      mod.runPerModuleMigrations(db, [a]);
+
+      const rows = db.prepare('SELECT tag, hash FROM __pops_migration_tags').all() as {
+        tag: string;
+        hash: string;
+      }[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.tag).toBe('0001_fresh');
+    });
+  });
+});

--- a/apps/pops-api/src/db/per-module-migrations.ts
+++ b/apps/pops-api/src/db/per-module-migrations.ts
@@ -14,6 +14,15 @@
  * untouched — every entry already in `__drizzle_migrations` is treated as
  * applied and no re-application is attempted.
  *
+ * Hash drift (#2610): a sister table `__pops_migration_tags` records each
+ * applied migration by tag. When the SQL file is edited after apply the
+ * tag still matches but the hash differs — the runner skips the re-run
+ * with a warning, because one-way statements (e.g. `UPDATE … SET new_col
+ * = old_col` after a rename) would crash on the now-missing column. On
+ * first boot after upgrade, hashes already in `__drizzle_migrations` are
+ * backfilled into `__pops_migration_tags` so tag tracking starts without
+ * extra operator work.
+ *
  * Skipped (absent-module) migrations are NOT recorded — re-enabling the
  * module on a subsequent boot brings them in naturally.
  *
@@ -31,14 +40,13 @@
  * `no such column`) still crash the boot since they signal the migration's
  * preconditions are not actually met.
  */
-import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { z } from 'zod';
 
-import { logger } from '../lib/logger.js';
-import { isAlreadyAppliedError, splitStatements } from './migration-backfill.js';
+import { classifyOrApply, type ApplyCaches } from './migration-apply.js';
+import { appliedTags, ensureAppliedTagsTable } from './migration-tag-tracking.js';
 import { DRIZZLE_MIGRATIONS_DIRECTORY } from './migrations-runner.js';
 
 import type BetterSqlite3 from 'better-sqlite3';
@@ -148,19 +156,6 @@ function appliedHashes(db: BetterSqlite3.Database): Set<string> {
   return new Set(rows.map((r) => r.hash));
 }
 
-function readMigrationSql(tag: string): string {
-  return readFileSync(join(DRIZZLE_MIGRATIONS_DIRECTORY, `${tag}.sql`), 'utf8');
-}
-
-/**
- * Drizzle's hashing function. `drizzle-orm/migrator` records each applied
- * migration as `sha256(sql)`. We reproduce the same hash here so a DB
- * upgraded from the pre-PRD-101 runtime keeps working unchanged.
- */
-function hashSql(sql: string): string {
-  return createHash('sha256').update(sql).digest('hex');
-}
-
 /**
  * Result returned by {@link runPerModuleMigrations}. Distinguishes applied,
  * skipped (owned by an absent module), and orphan (already-applied but
@@ -184,47 +179,6 @@ export interface PerModuleMigrationResult {
   unowned: readonly string[];
   /** Tags whose hash is already recorded — no action taken. */
   alreadyApplied: readonly string[];
-}
-
-type ApplyOutcome = 'applied' | 'backfilled';
-
-interface ApplyMigrationArgs {
-  db: BetterSqlite3.Database;
-  tag: string;
-  sql: string;
-  hash: string;
-  insert: BetterSqlite3.Statement;
-}
-
-/**
- * Apply one migration's SQL inside a transaction. Per-statement errors
- * matching the "already applied" patterns (see `migration-backfill.ts`)
- * are caught and logged; any other error aborts the transaction. Returns
- * `backfilled` if at least one statement was skipped — useful so callers
- * can surface schema-vs-migration drift to the operator.
- */
-function applyMigration({ db, tag, sql, hash, insert }: ApplyMigrationArgs): ApplyOutcome {
-  let didBackfill = false;
-  db.transaction(() => {
-    for (const stmt of splitStatements(sql)) {
-      try {
-        db.exec(stmt);
-      } catch (err) {
-        if (!isAlreadyAppliedError(err)) throw err;
-        didBackfill = true;
-        logger.info(
-          {
-            migrationTag: tag,
-            statementPreview: stmt.slice(0, 80),
-            sqliteError: (err as Error).message,
-          },
-          `[db] Migration "${tag}" statement already applied to schema — recording hash without re-running.`
-        );
-      }
-    }
-    insert.run(hash, Date.now());
-  })();
-  return didBackfill ? 'backfilled' : 'applied';
 }
 
 /**
@@ -272,6 +226,21 @@ export function runPerModuleMigrations(
  * tag whose owner is installed is treated as installed too — the static
  * ownership map is authoritative.
  */
+type Bucket = keyof PerModuleMigrationResult;
+
+function classifyOwnership(
+  tag: string,
+  installedIds: ReadonlySet<string>,
+  owners: ReadonlyMap<string, string>,
+  installedTags: ReadonlySet<string> | undefined
+): Bucket | null {
+  const owner = owners.get(tag);
+  if (owner === undefined) return 'unowned';
+  if (!installedIds.has(owner)) return 'skipped';
+  if (installedTags !== undefined && !installedTags.has(tag)) return 'skipped';
+  return null;
+}
+
 export function runPerModuleMigrationsByOwner(
   db: BetterSqlite3.Database,
   installedIds: ReadonlySet<string>,
@@ -279,61 +248,30 @@ export function runPerModuleMigrationsByOwner(
   installedTags?: ReadonlySet<string>
 ): PerModuleMigrationResult {
   ensureDrizzleTable(db);
+  ensureAppliedTagsTable(db);
 
-  const journal = readJournal();
+  const buckets: Record<Bucket, string[]> = {
+    applied: [],
+    backfilled: [],
+    skipped: [],
+    unowned: [],
+    alreadyApplied: [],
+  };
+  const caches: ApplyCaches = {
+    knownHashes: appliedHashes(db),
+    knownTags: appliedTags(db),
+    insertDrizzle: db.prepare('INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)'),
+    insertTag: db.prepare(
+      'INSERT OR REPLACE INTO __pops_migration_tags (tag, hash, applied_at) VALUES (?, ?, ?)'
+    ),
+  };
 
-  const applied: string[] = [];
-  const backfilled: string[] = [];
-  const skipped: string[] = [];
-  const unowned: string[] = [];
-  const alreadyApplied: string[] = [];
-
-  const knownHashes = appliedHashes(db);
-  const insert = db.prepare('INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)');
-
-  for (const entry of journal.entries) {
-    // Classify ownership BEFORE the hash short-circuit. If we checked the
-    // hash first, a duplicate-SQL entry owned by an absent or unknown
-    // module would be silently bucketed as `alreadyApplied` — hiding the
-    // manifest/ownership drift this result is meant to surface. Ownership
-    // classification is the authoritative signal; hash equality only
-    // matters once we've confirmed the tag belongs to the install set.
-    const owner = owners.get(entry.tag);
-    if (owner === undefined) {
-      // No declared owner — treat as absent and warn. This is a contract
-      // violation; CI (US-11) should catch it, but we don't want a missing
-      // ownership entry to silently apply migrations to a partial install.
-      unowned.push(entry.tag);
-      continue;
-    }
-    if (!installedIds.has(owner)) {
-      skipped.push(entry.tag);
-      continue;
-    }
-    if (installedTags !== undefined && !installedTags.has(entry.tag)) {
-      // Owner is installed but manifest doesn't list the tag — possible
-      // if the ownership map and manifest disagree. Skip defensively.
-      skipped.push(entry.tag);
-      continue;
-    }
-
-    const sql = readMigrationSql(entry.tag);
-    const hash = hashSql(sql);
-
-    if (knownHashes.has(hash)) {
-      alreadyApplied.push(entry.tag);
-      continue;
-    }
-
-    const outcome = applyMigration({ db, tag: entry.tag, sql, hash, insert });
-    // Keep the applied-hash cache in sync so subsequent journal entries
-    // with the same SQL body (e.g. idempotent re-creation migrations) are
-    // recognised as already applied within this same boot.
-    knownHashes.add(hash);
-    (outcome === 'backfilled' ? backfilled : applied).push(entry.tag);
+  for (const entry of readJournal().entries) {
+    const early = classifyOwnership(entry.tag, installedIds, owners, installedTags);
+    buckets[early ?? classifyOrApply(db, entry.tag, caches)].push(entry.tag);
   }
 
-  return { applied, backfilled, skipped, unowned, alreadyApplied };
+  return buckets;
 }
 
 // Orphan-migration warning is split into `./migration-orphan-warn.js` to


### PR DESCRIPTION
Closes #2610.

## Problem
The per-module runner keyed migration deduping on `sha256(sql)` only. When a migration file was edited after apply (typo fix in a comment, whitespace change), the new hash didn't match the recorded one and the runner re-attempted the migration. One-way data-copy statements like

\`\`\`sql
UPDATE ai_inference_log SET context_id = import_batch_id
WHERE import_batch_id IS NOT NULL;
\`\`\`

then crashed with \`no such column: import_batch_id\`, because the column rename the same migration performed had already taken effect. The \`already-applied\` recovery in \`migration-backfill.ts\` only covers additive-DDL errors, not \`no such column\` / \`no such table\`.

Reproducer: any cosmetic edit to e.g. \`0034_ai_observability.sql\` on a DB that's past it.

## Fix
Add a sister table keyed by migration *tag* (not just hash):

\`\`\`sql
CREATE TABLE __pops_migration_tags (
  tag TEXT PRIMARY KEY,
  hash TEXT NOT NULL,
  applied_at INTEGER NOT NULL
)
\`\`\`

The runner now dedupes by tag first. Three paths:
1. Tag in \`__pops_migration_tags\`, hash matches → \`alreadyApplied\` (silent).
2. Tag in \`__pops_migration_tags\`, hash differs → log \`hash drift — file edited after apply, skipping re-run\` warning, bucket as \`alreadyApplied\`.
3. Tag not in \`__pops_migration_tags\` but hash IS in \`__drizzle_migrations\` → migration was applied under the old hash-only tracking; backfill the tag row and bucket as \`alreadyApplied\`.

On first boot after this lands, every applied migration whose file is unchanged automatically backfills into the new table — no operator work required.

Split \`applyMigration\` and \`classifyOrApply\` into \`migration-apply.ts\`, and the new tag-table helpers into \`migration-tag-tracking.ts\`, to keep \`per-module-migrations.ts\` under the per-file line cap.

## Test plan
- [x] Three new tests in \`per-module-migrations.test.ts\` cover the drift skip, the legacy backfill, and the fresh-apply tag-recording paths.
- [x] All 21 tests in the suite pass.
- [x] \`pnpm typecheck\` and \`mise lint\` clean.

## Operator note
For DBs that are already in the broken state (hash drift before this fix), the workaround is still: either revert the file content or manually \`DELETE FROM __drizzle_migrations WHERE hash = '<old-hash>'\` then re-run, or insert the current hash. After this fix lands, the same edit won't break anything going forward.