### PR TITLE
fix(shell): center topbar search, truncate build hashes

### DIFF
--- a/apps/pops-shell/src/app/layout/BuildVersion.test.ts
+++ b/apps/pops-shell/src/app/layout/BuildVersion.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { shortVersion } from './BuildVersion';
+
+describe('shortVersion', () => {
+  // The topbar showed two full 40-char SHAs side by side and exploded the
+  // header. We keep the one-letter prefix that distinguishes the frontend
+  // ('f') and api ('a') builds, then truncate the SHA to 7 chars.
+  it('truncates a 40-char frontend SHA to prefix + 7 chars', () => {
+    expect(shortVersion('f0f8b7ae0bb0fad395a43ba9b3309740a50db8080')).toBe('f0f8b7ae');
+  });
+
+  it('truncates a 40-char api SHA the same way', () => {
+    expect(shortVersion('a0f8b7ae0bb0fad395a43ba9b3309740a50db8080')).toBe('a0f8b7ae');
+  });
+
+  it("leaves 'dev' alone — it's already short and humans recognise it", () => {
+    expect(shortVersion('dev')).toBe('dev');
+  });
+
+  it('returns null for empty / missing input', () => {
+    expect(shortVersion(null)).toBeNull();
+    expect(shortVersion(undefined)).toBeNull();
+    expect(shortVersion('')).toBeNull();
+  });
+
+  it('truncates an unprefixed long value to 8 chars rather than letting it explode', () => {
+    expect(shortVersion('1234567890abcdef')).toBe('12345678');
+  });
+
+  it('leaves short non-prefixed strings alone', () => {
+    expect(shortVersion('v1.2.3')).toBe('v1.2.3');
+  });
+});

--- a/apps/pops-shell/src/app/layout/BuildVersion.tsx
+++ b/apps/pops-shell/src/app/layout/BuildVersion.tsx
@@ -1,5 +1,21 @@
 import { useEffect, useState } from 'react';
 
+/**
+ * Truncate a version label to a short SHA. Build hashes are 40 chars and
+ * blow out the topbar; sequential CI numbers used to be short enough to
+ * show in full but the build now stamps the full git SHA. We keep the
+ * one-letter prefix (`f` / `a`) and the first 7 hex chars — full value is
+ * still available via the title attribute for copy/paste.
+ */
+export function shortVersion(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  if (raw === 'dev') return raw;
+  const match = /^([fa])([0-9a-f]+)$/i.exec(raw);
+  if (!match) return raw.length > 8 ? raw.slice(0, 8) : raw;
+  const [, prefix, sha] = match;
+  return `${prefix}${(sha ?? '').slice(0, 7)}`;
+}
+
 /** Faded mono build version label showing frontend and API versions. */
 export function BuildVersion() {
   const [apiVersion, setApiVersion] = useState<string | null>(null);
@@ -16,7 +32,14 @@ export function BuildVersion() {
   }, []);
 
   const frontendVersion = __BUILD_VERSION__;
-  const parts = [frontendVersion, apiVersion].filter(Boolean).join(' · ');
+  const display = [shortVersion(frontendVersion), shortVersion(apiVersion)]
+    .filter(Boolean)
+    .join(' · ');
+  const fullTitle = [frontendVersion, apiVersion].filter(Boolean).join(' · ');
 
-  return <span className="text-[10px] text-muted-foreground/50 font-mono">{parts}</span>;
+  return (
+    <span className="text-[10px] text-muted-foreground/50 font-mono" title={fullTitle}>
+      {display}
+    </span>
+  );
 }

--- a/apps/pops-shell/src/app/layout/TopBar.tsx
+++ b/apps/pops-shell/src/app/layout/TopBar.tsx
@@ -26,26 +26,32 @@ export function TopBar() {
   return (
     <>
       <header className="bg-card border-b border-border h-14 md:h-16 flex items-center px-3 md:px-4 fixed top-0 w-full z-40">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={toggleSidebar}
-          className="min-w-[44px] min-h-[44px] mr-2 md:hidden"
-          aria-label={t('toggleSidebar')}
-        >
-          <Menu className="h-5 w-5" />
-        </Button>
+        <div className="flex flex-1 items-center min-w-0">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggleSidebar}
+            className="min-w-[44px] min-h-[44px] mr-2 md:hidden"
+            aria-label={t('toggleSidebar')}
+          >
+            <Menu className="h-5 w-5" />
+          </Button>
 
-        <div className="flex items-baseline gap-1.5">
-          <h1 className="text-xl md:text-2xl font-black bg-clip-text text-transparent bg-gradient-to-br from-[oklch(0.7_0.2_150)] via-[oklch(0.6_0.2_260)] to-[oklch(0.6_0.2_320)] tracking-tighter">
-            POPS
-          </h1>
-          <BuildVersion />
+          <div className="flex items-baseline gap-1.5 min-w-0">
+            <h1 className="text-xl md:text-2xl font-black bg-clip-text text-transparent bg-gradient-to-br from-[oklch(0.7_0.2_150)] via-[oklch(0.6_0.2_260)] to-[oklch(0.6_0.2_320)] tracking-tighter">
+              POPS
+            </h1>
+            <BuildVersion />
+          </div>
         </div>
 
-        <SearchInput />
+        <div className="flex flex-1 justify-center min-w-0">
+          <SearchInput />
+        </div>
 
-        <TopBarActions onOpenMobileSearch={() => setMobileSearchOpen(true)} />
+        <div className="flex flex-1 justify-end items-center min-w-0">
+          <TopBarActions onOpenMobileSearch={() => setMobileSearchOpen(true)} />
+        </div>
       </header>
 
       <MobileSearchOverlay open={mobileSearchOpen} onClose={() => setMobileSearchOpen(false)} />


### PR DESCRIPTION
## Summary

Two follow-ups for the topbar:

- **Hash explosion.** CI now stamps full git SHAs into \`BUILD_VERSION\` instead of short sequential numbers. Frontend + API labels side-by-side (\`f<40hex> · a<40hex>\`) blew out the header height. Truncate to prefix + 7 hex chars (\`f0f8b7ae · a0f8b7ae\`); full value stays available via the \`title\` attribute for copy/paste.
- **Search not centered.** Was packed against \`POPS\` on the left; with the hash bloat it drifted further. Restructure the topbar into three equal-flex columns so the search is geometrically centered regardless of left/right widths.

## Test plan

- [x] \`pnpm --filter @pops/shell test\` — 229 pass (incl. 6 new \`shortVersion\` cases covering 40-char SHA truncation, \`dev\` passthrough, null/empty, unprefixed fallback)
- [x] \`pnpm lint\` — 0 errors
- [x] Manual browser check at /finance: search visually centered, dev version shows compact