### PR TITLE
feat(ai): daily observability summary cron (#2571)

### DIFF
--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -17,6 +17,10 @@ import {
   registerAiLogRetentionScheduler,
   unregisterAiLogRetentionScheduler,
 } from './modules/core/ai-observability/scheduler.js';
+import {
+  registerAiObservabilitySummaryScheduler,
+  unregisterAiObservabilitySummaryScheduler,
+} from './modules/core/ai-observability/summary-scheduler.js';
 import { startupCleanup } from './modules/core/envs/registry.js';
 import { startTtlWatcher } from './modules/core/envs/ttl-watcher.js';
 import { resumeSchedulerIfEnabled, stopPlexSchedulerTask } from './modules/media/plex/scheduler.js';
@@ -76,6 +80,11 @@ registerAiAlertsScheduler().catch((err: unknown) => {
   console.error('[ai-alerts] Failed to register scheduler:', err);
 });
 
+// Register AI observability summary scheduler (PRD-092 US-05)
+registerAiObservabilitySummaryScheduler().catch((err: unknown) => {
+  console.error('[ai-observability-summary] Failed to register scheduler:', err);
+});
+
 async function shutdown(signal: string): Promise<void> {
   console.warn(`[pops-api] ${signal} — shutting down`);
   // 1. Stop accepting new requests
@@ -87,6 +96,7 @@ async function shutdown(signal: string): Promise<void> {
   await stopThalamus();
   await unregisterAiLogRetentionScheduler();
   await unregisterAiAlertsScheduler();
+  await unregisterAiObservabilitySummaryScheduler();
   // 4. Wait for any in-progress rotation cycle to finish
   if (process.env['NODE_ENV'] !== 'test') {
     await waitForCycleEnd();

--- a/apps/pops-api/src/jobs/handlers/default.ts
+++ b/apps/pops-api/src/jobs/handlers/default.ts
@@ -7,6 +7,7 @@ import {
 } from '../../modules/cerebrum/thalamus/cross-source.js';
 import { runEvaluation } from '../../modules/core/ai-alerts/evaluator.js';
 import { runRetention } from '../../modules/core/ai-observability/retention.js';
+import { runSummary } from '../../modules/core/ai-observability/summary.js';
 
 import type { Job } from 'bullmq';
 
@@ -39,6 +40,21 @@ export async function process(job: Job<DefaultQueueJobData>): Promise<unknown> {
         cutoff: result.cutoff,
       },
       'AI inference log retention complete'
+    );
+    return result;
+  }
+
+  if (job.data.type === 'aiObservabilitySummary') {
+    const result = runSummary();
+    logger.info(
+      {
+        totalCalls: result.summary.totalCalls,
+        providers: result.summary.byProvider.length,
+        models: result.summary.byModel.length,
+        windowStart: result.summary.windowStart,
+        computedAt: result.summary.computedAt,
+      },
+      'AI observability summary complete'
     );
     return result;
   }

--- a/apps/pops-api/src/jobs/types.ts
+++ b/apps/pops-api/src/jobs/types.ts
@@ -71,6 +71,10 @@ export interface AiAlertEvaluationJobData {
   type: 'aiAlertEvaluation';
 }
 
+export interface AiObservabilitySummaryJobData {
+  type: 'aiObservabilitySummary';
+}
+
 export interface ClassifyEngramJobData {
   type: 'classifyEngram';
   engramId: string;
@@ -111,7 +115,8 @@ export type CurationQueueJobData = ClassifyEngramJobData | GliaJobData | Generic
 export type DefaultQueueJobData =
   | CrossSourceIndexJobData
   | AiLogRetentionJobData
-  | AiAlertEvaluationJobData;
+  | AiAlertEvaluationJobData
+  | AiObservabilitySummaryJobData;
 
 // ---------------------------------------------------------------------------
 // pops-dead-letter queue

--- a/apps/pops-api/src/modules/core/ai-observability/summary-scheduler.ts
+++ b/apps/pops-api/src/modules/core/ai-observability/summary-scheduler.ts
@@ -1,0 +1,80 @@
+/**
+ * BullMQ scheduler for the daily AI observability summary job (PRD-092 US-05).
+ *
+ * Registers a repeatable job on the `pops-default` queue that runs nightly
+ * at 03:00 UTC. The 03:00 slot intentionally runs before the 04:00 retention
+ * job so the summary always sees a complete dataset for the rolling window.
+ *
+ * When `REDIS_HOST` is unset the queue getter returns `null` and we log a
+ * warning instead of crashing — the API operates in degraded mode (the
+ * cached settings row is simply not refreshed and the dashboard falls back
+ * to live aggregation).
+ */
+import pino from 'pino';
+
+import { DEFAULT_JOB_OPTIONS, getDefaultQueue } from '../../../jobs/queues.js';
+
+import type { AiObservabilitySummaryJobData } from '../../../jobs/types.js';
+
+const logger = pino({ name: 'ai-observability-summary-scheduler' });
+
+export const AI_OBSERVABILITY_SUMMARY_SCHEDULER_ID = 'pops-ai-observability-summary';
+export const AI_OBSERVABILITY_SUMMARY_JOB_NAME = 'aiObservabilitySummary';
+/** Cron expression: 03:00 UTC every day. */
+export const AI_OBSERVABILITY_SUMMARY_CRON = '0 3 * * *';
+
+/**
+ * Register the daily summary scheduler. Safe to call multiple times —
+ * BullMQ's `upsertJobScheduler` keys off the scheduler ID.
+ *
+ * Returns `true` on success, `false` when Redis is disabled (degraded mode).
+ */
+export async function registerAiObservabilitySummaryScheduler(): Promise<boolean> {
+  if (!process.env['REDIS_HOST']) {
+    logger.warn(
+      'REDIS_HOST not set — AI observability summary disabled (degraded mode). Settings cache will not be refreshed.'
+    );
+    return false;
+  }
+
+  const queue = getDefaultQueue();
+  if (!queue) {
+    logger.warn(
+      'Default queue unavailable — AI observability summary disabled. Settings cache will not be refreshed.'
+    );
+    return false;
+  }
+
+  const data: AiObservabilitySummaryJobData = { type: 'aiObservabilitySummary' };
+
+  try {
+    await queue.upsertJobScheduler(
+      AI_OBSERVABILITY_SUMMARY_SCHEDULER_ID,
+      { pattern: AI_OBSERVABILITY_SUMMARY_CRON, tz: 'UTC' },
+      { name: AI_OBSERVABILITY_SUMMARY_JOB_NAME, data, opts: DEFAULT_JOB_OPTIONS }
+    );
+    logger.info(
+      {
+        schedulerId: AI_OBSERVABILITY_SUMMARY_SCHEDULER_ID,
+        cron: AI_OBSERVABILITY_SUMMARY_CRON,
+      },
+      'AI observability summary scheduler registered'
+    );
+    return true;
+  } catch (err: unknown) {
+    logger.error({ err }, 'Failed to register AI observability summary scheduler');
+    return false;
+  }
+}
+
+/** Deregister the scheduler — used during graceful shutdown. */
+export async function unregisterAiObservabilitySummaryScheduler(): Promise<void> {
+  if (!process.env['REDIS_HOST']) return;
+  const queue = getDefaultQueue();
+  if (!queue) return;
+  try {
+    await queue.removeJobScheduler(AI_OBSERVABILITY_SUMMARY_SCHEDULER_ID);
+  } catch (err: unknown) {
+    logger.error({ err }, 'Failed to deregister AI observability summary scheduler');
+  }
+}

--- a/apps/pops-api/src/modules/core/ai-observability/summary.test.ts
+++ b/apps/pops-api/src/modules/core/ai-observability/summary.test.ts
@@ -1,10 +1,3 @@
-/**
- * Unit tests for the daily observability summary job (PRD-092 US-05).
- *
- * `computeSummary` is exercised against a seeded in-memory DB; `runSummary`
- * is exercised end-to-end to verify the JSON envelope is persisted to the
- * `ai.observabilitySummary` settings row.
- */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { seedAiUsage, setupTestContext } from '../../../shared/test-utils.js';
@@ -93,10 +86,7 @@ describe('computeSummary', () => {
   });
 
   it('ignores rows with future timestamps (after windowEnd)', () => {
-    // In-window baseline.
     seedAiUsage(db, { created_at: isoDaysAgo(1) });
-    // Future-dated rows — bogus clock skew or backdated inserts — must not
-    // be counted in the rolling window.
     const oneMinuteAhead = new Date(NOW.getTime() + 60_000).toISOString();
     const oneDayAhead = new Date(NOW.getTime() + DAY_MS).toISOString();
     seedAiUsage(db, { created_at: oneMinuteAhead });
@@ -140,7 +130,6 @@ describe('computeSummary', () => {
   });
 
   it('groups by model and computes avgLatencyMs over success non-cached rows only', () => {
-    // 2 qualifying success rows for model-a: 100ms, 200ms → avg 150.
     seedAiUsage(db, {
       created_at: isoDaysAgo(1),
       model: 'model-a',
@@ -155,7 +144,6 @@ describe('computeSummary', () => {
       status: 'success',
       cached: 0,
     });
-    // Cached and failed rows for model-a — excluded from the latency avg.
     seedAiUsage(db, {
       created_at: isoDaysAgo(1),
       model: 'model-a',
@@ -170,7 +158,6 @@ describe('computeSummary', () => {
       status: 'error',
       cached: 0,
     });
-    // A second model with no qualifying rows — latency falls back to 0.
     seedAiUsage(db, {
       created_at: isoDaysAgo(1),
       model: 'model-b',
@@ -213,7 +200,6 @@ describe('runSummary', () => {
     seedAiUsage(db, { created_at: isoDaysAgo(1) });
     runSummary({ now: NOW });
 
-    // Add more usage and re-run with a later "now".
     const later = new Date(NOW.getTime() + 60_000);
     seedAiUsage(db, { created_at: isoDaysAgo(1) });
     runSummary({ now: later });

--- a/apps/pops-api/src/modules/core/ai-observability/summary.test.ts
+++ b/apps/pops-api/src/modules/core/ai-observability/summary.test.ts
@@ -48,7 +48,7 @@ describe('computeWindowStart', () => {
 
 describe('computeSummary', () => {
   it('returns zeros when there is no data', () => {
-    const summary = computeSummary({ db, now: NOW });
+    const summary = computeSummary({ now: NOW });
     expect(summary.totalCalls).toBe(0);
     expect(summary.totalInputTokens).toBe(0);
     expect(summary.totalOutputTokens).toBe(0);
@@ -75,7 +75,7 @@ describe('computeSummary', () => {
       cost_usd: 0.002,
     });
 
-    const summary = computeSummary({ db, now: NOW });
+    const summary = computeSummary({ now: NOW });
     expect(summary.totalCalls).toBe(2);
     expect(summary.totalInputTokens).toBe(300);
     expect(summary.totalOutputTokens).toBe(60);
@@ -88,8 +88,22 @@ describe('computeSummary', () => {
     seedAiUsage(db, { created_at: isoDaysAgo(31) });
     seedAiUsage(db, { created_at: isoDaysAgo(90) });
 
-    const summary = computeSummary({ db, now: NOW });
+    const summary = computeSummary({ now: NOW });
     expect(summary.totalCalls).toBe(2);
+  });
+
+  it('ignores rows with future timestamps (after windowEnd)', () => {
+    // In-window baseline.
+    seedAiUsage(db, { created_at: isoDaysAgo(1) });
+    // Future-dated rows — bogus clock skew or backdated inserts — must not
+    // be counted in the rolling window.
+    const oneMinuteAhead = new Date(NOW.getTime() + 60_000).toISOString();
+    const oneDayAhead = new Date(NOW.getTime() + DAY_MS).toISOString();
+    seedAiUsage(db, { created_at: oneMinuteAhead });
+    seedAiUsage(db, { created_at: oneDayAhead });
+
+    const summary = computeSummary({ now: NOW });
+    expect(summary.totalCalls).toBe(1);
   });
 
   it('computes cacheHitRate and errorRate as fractions of total calls', () => {
@@ -99,7 +113,7 @@ describe('computeSummary', () => {
     seedAiUsage(db, { created_at: isoDaysAgo(1), cached: 0, status: 'timeout' });
     seedAiUsage(db, { created_at: isoDaysAgo(1), cached: 0, status: 'budget-blocked' });
 
-    const summary = computeSummary({ db, now: NOW });
+    const summary = computeSummary({ now: NOW });
     expect(summary.totalCalls).toBe(5);
     expect(summary.cacheHitRate).toBeCloseTo(1 / 5);
     expect(summary.errorRate).toBeCloseTo(3 / 5);
@@ -110,7 +124,7 @@ describe('computeSummary', () => {
     seedAiUsage(db, { created_at: isoDaysAgo(1), provider: 'claude' });
     seedAiUsage(db, { created_at: isoDaysAgo(1), provider: 'openai' });
 
-    const summary = computeSummary({ db, now: NOW });
+    const summary = computeSummary({ now: NOW });
     expect(summary.byProvider).toHaveLength(2);
     expect(summary.byProvider[0]?.provider).toBe('claude');
     expect(summary.byProvider[0]?.calls).toBe(2);
@@ -158,7 +172,7 @@ describe('computeSummary', () => {
       cached: 0,
     });
 
-    const summary = computeSummary({ db, now: NOW });
+    const summary = computeSummary({ now: NOW });
     const a = summary.byModel.find((m) => m.model === 'model-a');
     const b = summary.byModel.find((m) => m.model === 'model-b');
     expect(a?.calls).toBe(4);
@@ -173,7 +187,7 @@ describe('runSummary', () => {
     seedAiUsage(db, { created_at: isoDaysAgo(1), input_tokens: 50, cost_usd: 0.0005 });
     seedAiUsage(db, { created_at: isoDaysAgo(2), input_tokens: 50, cost_usd: 0.0005 });
 
-    const { summary } = runSummary({ db, now: NOW });
+    const { summary } = runSummary({ now: NOW });
     expect(summary.totalCalls).toBe(2);
     expect(summary.computedAt).toBe(NOW.toISOString());
 
@@ -190,12 +204,12 @@ describe('runSummary', () => {
 
   it('overwrites the previous cached value on re-run', () => {
     seedAiUsage(db, { created_at: isoDaysAgo(1) });
-    runSummary({ db, now: NOW });
+    runSummary({ now: NOW });
 
     // Add more usage and re-run with a later "now".
     const later = new Date(NOW.getTime() + 60_000);
     seedAiUsage(db, { created_at: isoDaysAgo(1) });
-    runSummary({ db, now: later });
+    runSummary({ now: later });
 
     const row = getSettingOrNull(OBSERVABILITY_SUMMARY_SETTING_KEY);
     const parsed = JSON.parse(row!.value) as ObservabilitySummaryEnvelope;
@@ -204,7 +218,7 @@ describe('runSummary', () => {
   });
 
   it('writes a zeroed summary when there is no usage data', () => {
-    const { summary } = runSummary({ db, now: NOW });
+    const { summary } = runSummary({ now: NOW });
     expect(summary.totalCalls).toBe(0);
     expect(summary.byProvider).toEqual([]);
     expect(summary.byModel).toEqual([]);

--- a/apps/pops-api/src/modules/core/ai-observability/summary.test.ts
+++ b/apps/pops-api/src/modules/core/ai-observability/summary.test.ts
@@ -106,6 +106,13 @@ describe('computeSummary', () => {
     expect(summary.totalCalls).toBe(1);
   });
 
+  it.each([0, -1, 1.5, Number.NaN])(
+    'rejects non-positive-integer windowDays (%s)',
+    (windowDays) => {
+      expect(() => computeSummary({ now: NOW, windowDays })).toThrow(RangeError);
+    }
+  );
+
   it('computes cacheHitRate and errorRate as fractions of total calls', () => {
     seedAiUsage(db, { created_at: isoDaysAgo(1), cached: 1, status: 'success' });
     seedAiUsage(db, { created_at: isoDaysAgo(1), cached: 0, status: 'success' });

--- a/apps/pops-api/src/modules/core/ai-observability/summary.test.ts
+++ b/apps/pops-api/src/modules/core/ai-observability/summary.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for the daily observability summary job (PRD-092 US-05).
+ *
+ * `computeSummary` is exercised against a seeded in-memory DB; `runSummary`
+ * is exercised end-to-end to verify the JSON envelope is persisted to the
+ * `ai.observabilitySummary` settings row.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { seedAiUsage, setupTestContext } from '../../../shared/test-utils.js';
+import { getSettingOrNull } from '../settings/service.js';
+import {
+  OBSERVABILITY_SUMMARY_SETTING_KEY,
+  computeSummary,
+  computeWindowStart,
+  runSummary,
+} from './summary.js';
+
+import type { Database } from 'better-sqlite3';
+
+import type { ObservabilitySummaryEnvelope } from './summary.js';
+
+const ctx = setupTestContext();
+let db: Database;
+
+beforeEach(() => {
+  ({ db } = ctx.setup());
+});
+
+afterEach(() => {
+  ctx.teardown();
+});
+
+const NOW = new Date('2026-05-12T03:00:00Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+const isoDaysAgo = (days: number, hour = 12): string => {
+  const d = new Date(NOW);
+  d.setUTCDate(d.getUTCDate() - days);
+  d.setUTCHours(hour, 0, 0, 0);
+  return d.toISOString();
+};
+
+describe('computeWindowStart', () => {
+  it('subtracts the window in milliseconds from now', () => {
+    expect(computeWindowStart(30, NOW)).toBe(new Date(NOW.getTime() - 30 * DAY_MS).toISOString());
+  });
+});
+
+describe('computeSummary', () => {
+  it('returns zeros when there is no data', () => {
+    const summary = computeSummary({ db, now: NOW });
+    expect(summary.totalCalls).toBe(0);
+    expect(summary.totalInputTokens).toBe(0);
+    expect(summary.totalOutputTokens).toBe(0);
+    expect(summary.totalCostUsd).toBe(0);
+    expect(summary.cacheHitRate).toBe(0);
+    expect(summary.errorRate).toBe(0);
+    expect(summary.byProvider).toHaveLength(0);
+    expect(summary.byModel).toHaveLength(0);
+    expect(summary.windowEnd).toBe(NOW.toISOString());
+    expect(summary.windowStart).toBe(computeWindowStart(30, NOW));
+  });
+
+  it('aggregates totals across rows in the window', () => {
+    seedAiUsage(db, {
+      created_at: isoDaysAgo(1),
+      input_tokens: 100,
+      output_tokens: 20,
+      cost_usd: 0.001,
+    });
+    seedAiUsage(db, {
+      created_at: isoDaysAgo(5),
+      input_tokens: 200,
+      output_tokens: 40,
+      cost_usd: 0.002,
+    });
+
+    const summary = computeSummary({ db, now: NOW });
+    expect(summary.totalCalls).toBe(2);
+    expect(summary.totalInputTokens).toBe(300);
+    expect(summary.totalOutputTokens).toBe(60);
+    expect(summary.totalCostUsd).toBeCloseTo(0.003);
+  });
+
+  it('ignores rows older than the 30-day window', () => {
+    seedAiUsage(db, { created_at: isoDaysAgo(1) });
+    seedAiUsage(db, { created_at: isoDaysAgo(29) });
+    seedAiUsage(db, { created_at: isoDaysAgo(31) });
+    seedAiUsage(db, { created_at: isoDaysAgo(90) });
+
+    const summary = computeSummary({ db, now: NOW });
+    expect(summary.totalCalls).toBe(2);
+  });
+
+  it('computes cacheHitRate and errorRate as fractions of total calls', () => {
+    seedAiUsage(db, { created_at: isoDaysAgo(1), cached: 1, status: 'success' });
+    seedAiUsage(db, { created_at: isoDaysAgo(1), cached: 0, status: 'success' });
+    seedAiUsage(db, { created_at: isoDaysAgo(1), cached: 0, status: 'error' });
+    seedAiUsage(db, { created_at: isoDaysAgo(1), cached: 0, status: 'timeout' });
+    seedAiUsage(db, { created_at: isoDaysAgo(1), cached: 0, status: 'budget-blocked' });
+
+    const summary = computeSummary({ db, now: NOW });
+    expect(summary.totalCalls).toBe(5);
+    expect(summary.cacheHitRate).toBeCloseTo(1 / 5);
+    expect(summary.errorRate).toBeCloseTo(3 / 5);
+  });
+
+  it('groups by provider with descending call counts', () => {
+    seedAiUsage(db, { created_at: isoDaysAgo(1), provider: 'claude' });
+    seedAiUsage(db, { created_at: isoDaysAgo(1), provider: 'claude' });
+    seedAiUsage(db, { created_at: isoDaysAgo(1), provider: 'openai' });
+
+    const summary = computeSummary({ db, now: NOW });
+    expect(summary.byProvider).toHaveLength(2);
+    expect(summary.byProvider[0]?.provider).toBe('claude');
+    expect(summary.byProvider[0]?.calls).toBe(2);
+    expect(summary.byProvider[1]?.provider).toBe('openai');
+    expect(summary.byProvider[1]?.calls).toBe(1);
+  });
+
+  it('groups by model and computes avgLatencyMs over success non-cached rows only', () => {
+    // 2 qualifying success rows for model-a: 100ms, 200ms → avg 150.
+    seedAiUsage(db, {
+      created_at: isoDaysAgo(1),
+      model: 'model-a',
+      latency_ms: 100,
+      status: 'success',
+      cached: 0,
+    });
+    seedAiUsage(db, {
+      created_at: isoDaysAgo(1),
+      model: 'model-a',
+      latency_ms: 200,
+      status: 'success',
+      cached: 0,
+    });
+    // Cached and failed rows for model-a — excluded from the latency avg.
+    seedAiUsage(db, {
+      created_at: isoDaysAgo(1),
+      model: 'model-a',
+      latency_ms: 9999,
+      status: 'success',
+      cached: 1,
+    });
+    seedAiUsage(db, {
+      created_at: isoDaysAgo(1),
+      model: 'model-a',
+      latency_ms: 9999,
+      status: 'error',
+      cached: 0,
+    });
+    // A second model with no qualifying rows — latency falls back to 0.
+    seedAiUsage(db, {
+      created_at: isoDaysAgo(1),
+      model: 'model-b',
+      latency_ms: 9999,
+      status: 'error',
+      cached: 0,
+    });
+
+    const summary = computeSummary({ db, now: NOW });
+    const a = summary.byModel.find((m) => m.model === 'model-a');
+    const b = summary.byModel.find((m) => m.model === 'model-b');
+    expect(a?.calls).toBe(4);
+    expect(a?.avgLatencyMs).toBe(150);
+    expect(b?.calls).toBe(1);
+    expect(b?.avgLatencyMs).toBe(0);
+  });
+});
+
+describe('runSummary', () => {
+  it('persists the computed envelope to the ai.observabilitySummary settings row', () => {
+    seedAiUsage(db, { created_at: isoDaysAgo(1), input_tokens: 50, cost_usd: 0.0005 });
+    seedAiUsage(db, { created_at: isoDaysAgo(2), input_tokens: 50, cost_usd: 0.0005 });
+
+    const { summary } = runSummary({ db, now: NOW });
+    expect(summary.totalCalls).toBe(2);
+    expect(summary.computedAt).toBe(NOW.toISOString());
+
+    const row = getSettingOrNull(OBSERVABILITY_SUMMARY_SETTING_KEY);
+    expect(row).not.toBeNull();
+    const parsed = JSON.parse(row!.value) as ObservabilitySummaryEnvelope;
+    expect(parsed.totalCalls).toBe(2);
+    expect(parsed.totalInputTokens).toBe(100);
+    expect(parsed.totalCostUsd).toBeCloseTo(0.001);
+    expect(parsed.computedAt).toBe(NOW.toISOString());
+    expect(parsed.windowStart).toBe(computeWindowStart(30, NOW));
+    expect(parsed.windowEnd).toBe(NOW.toISOString());
+  });
+
+  it('overwrites the previous cached value on re-run', () => {
+    seedAiUsage(db, { created_at: isoDaysAgo(1) });
+    runSummary({ db, now: NOW });
+
+    // Add more usage and re-run with a later "now".
+    const later = new Date(NOW.getTime() + 60_000);
+    seedAiUsage(db, { created_at: isoDaysAgo(1) });
+    runSummary({ db, now: later });
+
+    const row = getSettingOrNull(OBSERVABILITY_SUMMARY_SETTING_KEY);
+    const parsed = JSON.parse(row!.value) as ObservabilitySummaryEnvelope;
+    expect(parsed.totalCalls).toBe(2);
+    expect(parsed.computedAt).toBe(later.toISOString());
+  });
+
+  it('writes a zeroed summary when there is no usage data', () => {
+    const { summary } = runSummary({ db, now: NOW });
+    expect(summary.totalCalls).toBe(0);
+    expect(summary.byProvider).toEqual([]);
+    expect(summary.byModel).toEqual([]);
+
+    const row = getSettingOrNull(OBSERVABILITY_SUMMARY_SETTING_KEY);
+    expect(row).not.toBeNull();
+    const parsed = JSON.parse(row!.value) as ObservabilitySummaryEnvelope;
+    expect(parsed.totalCalls).toBe(0);
+    expect(parsed.cacheHitRate).toBe(0);
+    expect(parsed.errorRate).toBe(0);
+  });
+});

--- a/apps/pops-api/src/modules/core/ai-observability/summary.ts
+++ b/apps/pops-api/src/modules/core/ai-observability/summary.ts
@@ -7,16 +7,19 @@
  * heavier aggregation queries on every load.
  *
  * Pure-ish service:
- *  - `computeSummary` is a deterministic function over a SQLite handle and
- *    is what the unit tests exercise.
+ *  - `computeSummary` is a deterministic function over the bound Drizzle
+ *    handle and is what the unit tests exercise (the test context swaps the
+ *    underlying DB before each test via `setDb`).
  *  - `runSummary` is the worker entry point — it calls `computeSummary` and
  *    persists the result via `setRawSetting`.
  */
-import { getDb } from '../../../db.js';
+import { and, asc, desc, gte, lt, sql, type SQL } from 'drizzle-orm';
+
+import { aiInferenceLog } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
 import { logger } from '../../../lib/logger.js';
 import { setRawSetting } from '../settings/service.js';
-
-import type BetterSqlite3 from 'better-sqlite3';
 
 /** Settings key the dashboard reads to skip live aggregation. */
 export const OBSERVABILITY_SUMMARY_SETTING_KEY = 'ai.observabilitySummary';
@@ -65,116 +68,119 @@ export interface ObservabilitySummaryEnvelope extends ObservabilitySummary {
 }
 
 interface OverallRow {
-  total_calls: number;
-  total_input_tokens: number;
-  total_output_tokens: number;
-  total_cost_usd: number;
-  cache_hits: number;
+  totalCalls: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+  cacheHits: number;
   errors: number;
 }
 
-interface ProviderRow {
-  provider: string;
-  calls: number;
-  input_tokens: number;
-  output_tokens: number;
-  cost_usd: number;
-}
+const EMPTY_OVERALL: OverallRow = {
+  totalCalls: 0,
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  totalCostUsd: 0,
+  cacheHits: 0,
+  errors: 0,
+};
 
-interface ModelRow {
-  provider: string;
-  model: string;
-  calls: number;
-  input_tokens: number;
-  output_tokens: number;
-  cost_usd: number;
-  /** SQLite returns NULL for AVG over an empty set; coerced to 0 below. */
-  avg_latency_ms: number | null;
-}
-
-function fetchOverall(db: BetterSqlite3.Database, windowStartIso: string): OverallRow {
-  const row = db
-    .prepare(
-      `SELECT
-          COUNT(*) AS total_calls,
-          COALESCE(SUM(input_tokens), 0) AS total_input_tokens,
-          COALESCE(SUM(output_tokens), 0) AS total_output_tokens,
-          COALESCE(SUM(cost_usd), 0) AS total_cost_usd,
-          SUM(CASE WHEN cached = 1 THEN 1 ELSE 0 END) AS cache_hits,
-          SUM(CASE WHEN status IN ('error','timeout','budget-blocked') THEN 1 ELSE 0 END) AS errors
-       FROM ai_inference_log
-       WHERE created_at >= ?`
-    )
-    .get(windowStartIso) as OverallRow | undefined;
-  return (
-    row ?? {
-      total_calls: 0,
-      total_input_tokens: 0,
-      total_output_tokens: 0,
-      total_cost_usd: 0,
-      cache_hits: 0,
-      errors: 0,
-    }
+/**
+ * Build the time-window predicate shared by all three aggregate queries.
+ * Inclusive lower bound, exclusive upper bound — future-dated rows are
+ * excluded because `windowEndIso` is pinned to "now" at the top of
+ * `computeSummary`.
+ */
+function windowWhere(windowStartIso: string, windowEndIso: string): SQL | undefined {
+  return and(
+    gte(aiInferenceLog.createdAt, windowStartIso),
+    lt(aiInferenceLog.createdAt, windowEndIso)
   );
 }
 
-function fetchByProvider(db: BetterSqlite3.Database, windowStartIso: string): ProviderBreakdown[] {
-  const rows = db
-    .prepare(
-      `SELECT
-          provider,
-          COUNT(*) AS calls,
-          COALESCE(SUM(input_tokens), 0) AS input_tokens,
-          COALESCE(SUM(output_tokens), 0) AS output_tokens,
-          COALESCE(SUM(cost_usd), 0) AS cost_usd
-       FROM ai_inference_log
-       WHERE created_at >= ?
-       GROUP BY provider
-       ORDER BY calls DESC, provider ASC`
-    )
-    .all(windowStartIso) as ProviderRow[];
+function fetchOverall(windowStartIso: string, windowEndIso: string): OverallRow {
+  const [row] = getDrizzle()
+    .select({
+      totalCalls: sql<number>`COUNT(*)`,
+      totalInputTokens: sql<number>`COALESCE(SUM(${aiInferenceLog.inputTokens}), 0)`,
+      totalOutputTokens: sql<number>`COALESCE(SUM(${aiInferenceLog.outputTokens}), 0)`,
+      totalCostUsd: sql<number>`COALESCE(SUM(${aiInferenceLog.costUsd}), 0)`,
+      cacheHits: sql<number>`COALESCE(SUM(CASE WHEN ${aiInferenceLog.cached} = 1 THEN 1 ELSE 0 END), 0)`,
+      errors: sql<number>`COALESCE(SUM(CASE WHEN ${aiInferenceLog.status} IN ('error','timeout','budget-blocked') THEN 1 ELSE 0 END), 0)`,
+    })
+    .from(aiInferenceLog)
+    .where(windowWhere(windowStartIso, windowEndIso))
+    .all();
+
+  if (!row) return { ...EMPTY_OVERALL };
+  return {
+    totalCalls: row.totalCalls ?? 0,
+    totalInputTokens: row.totalInputTokens ?? 0,
+    totalOutputTokens: row.totalOutputTokens ?? 0,
+    totalCostUsd: row.totalCostUsd ?? 0,
+    cacheHits: row.cacheHits ?? 0,
+    errors: row.errors ?? 0,
+  };
+}
+
+function fetchByProvider(windowStartIso: string, windowEndIso: string): ProviderBreakdown[] {
+  const rows = getDrizzle()
+    .select({
+      provider: aiInferenceLog.provider,
+      calls: sql<number>`COUNT(*)`,
+      inputTokens: sql<number>`COALESCE(SUM(${aiInferenceLog.inputTokens}), 0)`,
+      outputTokens: sql<number>`COALESCE(SUM(${aiInferenceLog.outputTokens}), 0)`,
+      costUsd: sql<number>`COALESCE(SUM(${aiInferenceLog.costUsd}), 0)`,
+    })
+    .from(aiInferenceLog)
+    .where(windowWhere(windowStartIso, windowEndIso))
+    .groupBy(aiInferenceLog.provider)
+    .orderBy(desc(sql<number>`COUNT(*)`), asc(aiInferenceLog.provider))
+    .all();
 
   return rows.map((r) => ({
     provider: r.provider,
     calls: r.calls,
-    inputTokens: r.input_tokens,
-    outputTokens: r.output_tokens,
-    costUsd: r.cost_usd,
+    inputTokens: r.inputTokens,
+    outputTokens: r.outputTokens,
+    costUsd: r.costUsd,
   }));
 }
 
-function fetchByModel(db: BetterSqlite3.Database, windowStartIso: string): ModelBreakdown[] {
-  // `avg_latency_ms` only considers `success` non-cached rows with
+function fetchByModel(windowStartIso: string, windowEndIso: string): ModelBreakdown[] {
+  // `avgLatencyMs` only considers `success` non-cached rows with
   // `latency_ms > 0` — matching the same filter used elsewhere in the
   // observability module so the numbers reconcile with the live dashboard.
-  const rows = db
-    .prepare(
-      `SELECT
-          provider,
-          model,
-          COUNT(*) AS calls,
-          COALESCE(SUM(input_tokens), 0) AS input_tokens,
-          COALESCE(SUM(output_tokens), 0) AS output_tokens,
-          COALESCE(SUM(cost_usd), 0) AS cost_usd,
-          AVG(CASE
-                WHEN status = 'success' AND cached = 0 AND latency_ms > 0
-                THEN latency_ms
-              END) AS avg_latency_ms
-       FROM ai_inference_log
-       WHERE created_at >= ?
-       GROUP BY provider, model
-       ORDER BY calls DESC, model ASC`
-    )
-    .all(windowStartIso) as ModelRow[];
+  // SQLite returns NULL for AVG over an empty set; coerced to 0 below.
+  const rows = getDrizzle()
+    .select({
+      provider: aiInferenceLog.provider,
+      model: aiInferenceLog.model,
+      calls: sql<number>`COUNT(*)`,
+      inputTokens: sql<number>`COALESCE(SUM(${aiInferenceLog.inputTokens}), 0)`,
+      outputTokens: sql<number>`COALESCE(SUM(${aiInferenceLog.outputTokens}), 0)`,
+      costUsd: sql<number>`COALESCE(SUM(${aiInferenceLog.costUsd}), 0)`,
+      avgLatencyMs: sql<number | null>`AVG(CASE
+            WHEN ${aiInferenceLog.status} = 'success'
+              AND ${aiInferenceLog.cached} = 0
+              AND ${aiInferenceLog.latencyMs} > 0
+            THEN ${aiInferenceLog.latencyMs}
+          END)`,
+    })
+    .from(aiInferenceLog)
+    .where(windowWhere(windowStartIso, windowEndIso))
+    .groupBy(aiInferenceLog.provider, aiInferenceLog.model)
+    .orderBy(desc(sql<number>`COUNT(*)`), asc(aiInferenceLog.model))
+    .all();
 
   return rows.map((r) => ({
     provider: r.provider,
     model: r.model,
     calls: r.calls,
-    inputTokens: r.input_tokens,
-    outputTokens: r.output_tokens,
-    costUsd: r.cost_usd,
-    avgLatencyMs: r.avg_latency_ms == null ? 0 : Math.round(r.avg_latency_ms),
+    inputTokens: r.inputTokens,
+    outputTokens: r.outputTokens,
+    costUsd: r.costUsd,
+    avgLatencyMs: r.avgLatencyMs == null ? 0 : Math.round(r.avgLatencyMs),
   }));
 }
 
@@ -188,36 +194,34 @@ export interface ComputeSummaryOptions {
   windowDays?: number;
   /** Override "now" — used by tests to pin the window. */
   now?: Date;
-  /** Database handle. Defaults to `getDb()`. */
-  db?: BetterSqlite3.Database;
 }
 
 /**
  * Aggregate the last `windowDays` of `ai_inference_log` into a single
- * summary object. Deterministic given `(db, now, windowDays)`.
+ * summary object. Deterministic given the active DB handle (resolved via
+ * `getDrizzle()`), `now`, and `windowDays`.
  */
 export function computeSummary(opts: ComputeSummaryOptions = {}): ObservabilitySummary {
-  const db = opts.db ?? getDb();
   const windowDays = opts.windowDays ?? SUMMARY_WINDOW_DAYS;
   const now = opts.now ?? new Date();
   const windowStart = computeWindowStart(windowDays, now);
   const windowEnd = now.toISOString();
 
-  const overall = fetchOverall(db, windowStart);
-  const byProvider = fetchByProvider(db, windowStart);
-  const byModel = fetchByModel(db, windowStart);
+  const overall = fetchOverall(windowStart, windowEnd);
+  const byProvider = fetchByProvider(windowStart, windowEnd);
+  const byModel = fetchByModel(windowStart, windowEnd);
 
-  const totalCalls = overall.total_calls;
-  const cacheHitRate = totalCalls > 0 ? overall.cache_hits / totalCalls : 0;
+  const totalCalls = overall.totalCalls;
+  const cacheHitRate = totalCalls > 0 ? overall.cacheHits / totalCalls : 0;
   const errorRate = totalCalls > 0 ? overall.errors / totalCalls : 0;
 
   return {
     windowStart,
     windowEnd,
     totalCalls,
-    totalInputTokens: overall.total_input_tokens,
-    totalOutputTokens: overall.total_output_tokens,
-    totalCostUsd: overall.total_cost_usd,
+    totalInputTokens: overall.totalInputTokens,
+    totalOutputTokens: overall.totalOutputTokens,
+    totalCostUsd: overall.totalCostUsd,
     cacheHitRate,
     errorRate,
     byProvider,
@@ -239,7 +243,7 @@ export interface RunSummaryResult {
  */
 export function runSummary(opts: RunSummaryOptions = {}): RunSummaryResult {
   const summary = computeSummary(opts);
-  const computedAt = (opts.now ?? new Date()).toISOString();
+  const computedAt = summary.windowEnd;
   const envelope: ObservabilitySummaryEnvelope = { ...summary, computedAt };
 
   setRawSetting(OBSERVABILITY_SUMMARY_SETTING_KEY, JSON.stringify(envelope));

--- a/apps/pops-api/src/modules/core/ai-observability/summary.ts
+++ b/apps/pops-api/src/modules/core/ai-observability/summary.ts
@@ -1,0 +1,260 @@
+/**
+ * Daily observability summary job (PRD-092 US-05).
+ *
+ * Aggregates the last 30 days of `ai_inference_log` rows into a single JSON
+ * blob and stores it under settings key `ai.observabilitySummary`. The
+ * dashboard reads this row for fast first-paint instead of re-running the
+ * heavier aggregation queries on every load.
+ *
+ * Pure-ish service:
+ *  - `computeSummary` is a deterministic function over a SQLite handle and
+ *    is what the unit tests exercise.
+ *  - `runSummary` is the worker entry point — it calls `computeSummary` and
+ *    persists the result via `setRawSetting`.
+ */
+import { getDb } from '../../../db.js';
+import { logger } from '../../../lib/logger.js';
+import { setRawSetting } from '../settings/service.js';
+
+import type BetterSqlite3 from 'better-sqlite3';
+
+/** Settings key the dashboard reads to skip live aggregation. */
+export const OBSERVABILITY_SUMMARY_SETTING_KEY = 'ai.observabilitySummary';
+
+/** Rolling window in days. */
+export const SUMMARY_WINDOW_DAYS = 30;
+
+export interface ProviderBreakdown {
+  provider: string;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
+export interface ModelBreakdown {
+  provider: string;
+  model: string;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  /** Mean latency over `success` non-cached rows with `latency_ms > 0`. 0 when none. */
+  avgLatencyMs: number;
+}
+
+export interface ObservabilitySummary {
+  /** Inclusive lower bound (ISO) for the window. */
+  windowStart: string;
+  /** Exclusive upper bound (ISO) for the window — i.e. "now". */
+  windowEnd: string;
+  totalCalls: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+  /** Fraction in [0,1]; 0 when no calls. */
+  cacheHitRate: number;
+  /** Fraction in [0,1] across `error|timeout|budget-blocked` rows; 0 when no calls. */
+  errorRate: number;
+  byProvider: ProviderBreakdown[];
+  byModel: ModelBreakdown[];
+}
+
+export interface ObservabilitySummaryEnvelope extends ObservabilitySummary {
+  computedAt: string;
+}
+
+interface OverallRow {
+  total_calls: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cost_usd: number;
+  cache_hits: number;
+  errors: number;
+}
+
+interface ProviderRow {
+  provider: string;
+  calls: number;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+}
+
+interface ModelRow {
+  provider: string;
+  model: string;
+  calls: number;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+  /** SQLite returns NULL for AVG over an empty set; coerced to 0 below. */
+  avg_latency_ms: number | null;
+}
+
+function fetchOverall(db: BetterSqlite3.Database, windowStartIso: string): OverallRow {
+  const row = db
+    .prepare(
+      `SELECT
+          COUNT(*) AS total_calls,
+          COALESCE(SUM(input_tokens), 0) AS total_input_tokens,
+          COALESCE(SUM(output_tokens), 0) AS total_output_tokens,
+          COALESCE(SUM(cost_usd), 0) AS total_cost_usd,
+          SUM(CASE WHEN cached = 1 THEN 1 ELSE 0 END) AS cache_hits,
+          SUM(CASE WHEN status IN ('error','timeout','budget-blocked') THEN 1 ELSE 0 END) AS errors
+       FROM ai_inference_log
+       WHERE created_at >= ?`
+    )
+    .get(windowStartIso) as OverallRow | undefined;
+  return (
+    row ?? {
+      total_calls: 0,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost_usd: 0,
+      cache_hits: 0,
+      errors: 0,
+    }
+  );
+}
+
+function fetchByProvider(db: BetterSqlite3.Database, windowStartIso: string): ProviderBreakdown[] {
+  const rows = db
+    .prepare(
+      `SELECT
+          provider,
+          COUNT(*) AS calls,
+          COALESCE(SUM(input_tokens), 0) AS input_tokens,
+          COALESCE(SUM(output_tokens), 0) AS output_tokens,
+          COALESCE(SUM(cost_usd), 0) AS cost_usd
+       FROM ai_inference_log
+       WHERE created_at >= ?
+       GROUP BY provider
+       ORDER BY calls DESC, provider ASC`
+    )
+    .all(windowStartIso) as ProviderRow[];
+
+  return rows.map((r) => ({
+    provider: r.provider,
+    calls: r.calls,
+    inputTokens: r.input_tokens,
+    outputTokens: r.output_tokens,
+    costUsd: r.cost_usd,
+  }));
+}
+
+function fetchByModel(db: BetterSqlite3.Database, windowStartIso: string): ModelBreakdown[] {
+  // `avg_latency_ms` only considers `success` non-cached rows with
+  // `latency_ms > 0` — matching the same filter used elsewhere in the
+  // observability module so the numbers reconcile with the live dashboard.
+  const rows = db
+    .prepare(
+      `SELECT
+          provider,
+          model,
+          COUNT(*) AS calls,
+          COALESCE(SUM(input_tokens), 0) AS input_tokens,
+          COALESCE(SUM(output_tokens), 0) AS output_tokens,
+          COALESCE(SUM(cost_usd), 0) AS cost_usd,
+          AVG(CASE
+                WHEN status = 'success' AND cached = 0 AND latency_ms > 0
+                THEN latency_ms
+              END) AS avg_latency_ms
+       FROM ai_inference_log
+       WHERE created_at >= ?
+       GROUP BY provider, model
+       ORDER BY calls DESC, model ASC`
+    )
+    .all(windowStartIso) as ModelRow[];
+
+  return rows.map((r) => ({
+    provider: r.provider,
+    model: r.model,
+    calls: r.calls,
+    inputTokens: r.input_tokens,
+    outputTokens: r.output_tokens,
+    costUsd: r.cost_usd,
+    avgLatencyMs: r.avg_latency_ms == null ? 0 : Math.round(r.avg_latency_ms),
+  }));
+}
+
+/** Compute the ISO timestamp `windowDays` ago from `now`. */
+export function computeWindowStart(windowDays: number, now: Date = new Date()): string {
+  return new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000).toISOString();
+}
+
+export interface ComputeSummaryOptions {
+  /** Override the rolling window (defaults to 30 days). */
+  windowDays?: number;
+  /** Override "now" — used by tests to pin the window. */
+  now?: Date;
+  /** Database handle. Defaults to `getDb()`. */
+  db?: BetterSqlite3.Database;
+}
+
+/**
+ * Aggregate the last `windowDays` of `ai_inference_log` into a single
+ * summary object. Deterministic given `(db, now, windowDays)`.
+ */
+export function computeSummary(opts: ComputeSummaryOptions = {}): ObservabilitySummary {
+  const db = opts.db ?? getDb();
+  const windowDays = opts.windowDays ?? SUMMARY_WINDOW_DAYS;
+  const now = opts.now ?? new Date();
+  const windowStart = computeWindowStart(windowDays, now);
+  const windowEnd = now.toISOString();
+
+  const overall = fetchOverall(db, windowStart);
+  const byProvider = fetchByProvider(db, windowStart);
+  const byModel = fetchByModel(db, windowStart);
+
+  const totalCalls = overall.total_calls;
+  const cacheHitRate = totalCalls > 0 ? overall.cache_hits / totalCalls : 0;
+  const errorRate = totalCalls > 0 ? overall.errors / totalCalls : 0;
+
+  return {
+    windowStart,
+    windowEnd,
+    totalCalls,
+    totalInputTokens: overall.total_input_tokens,
+    totalOutputTokens: overall.total_output_tokens,
+    totalCostUsd: overall.total_cost_usd,
+    cacheHitRate,
+    errorRate,
+    byProvider,
+    byModel,
+  };
+}
+
+export interface RunSummaryOptions extends ComputeSummaryOptions {}
+
+export interface RunSummaryResult {
+  summary: ObservabilitySummaryEnvelope;
+}
+
+/**
+ * Compute and persist the 30-day rolling summary to the settings table.
+ *
+ * Idempotent — re-running overwrites the cached value. Safe to call from
+ * the BullMQ worker without further locking.
+ */
+export function runSummary(opts: RunSummaryOptions = {}): RunSummaryResult {
+  const summary = computeSummary(opts);
+  const computedAt = (opts.now ?? new Date()).toISOString();
+  const envelope: ObservabilitySummaryEnvelope = { ...summary, computedAt };
+
+  setRawSetting(OBSERVABILITY_SUMMARY_SETTING_KEY, JSON.stringify(envelope));
+
+  logger.info(
+    {
+      totalCalls: envelope.totalCalls,
+      providers: envelope.byProvider.length,
+      models: envelope.byModel.length,
+      windowStart: envelope.windowStart,
+      windowEnd: envelope.windowEnd,
+      computedAt,
+    },
+    '[ai-observability-summary] Daily summary computed'
+  );
+
+  return { summary: envelope };
+}

--- a/apps/pops-api/src/modules/core/ai-observability/summary.ts
+++ b/apps/pops-api/src/modules/core/ai-observability/summary.ts
@@ -1,18 +1,3 @@
-/**
- * Daily observability summary job (PRD-092 US-05).
- *
- * Aggregates the last 30 days of `ai_inference_log` rows into a single JSON
- * blob and stores it under settings key `ai.observabilitySummary`. The
- * dashboard reads this row for fast first-paint instead of re-running the
- * heavier aggregation queries on every load.
- *
- * Pure-ish service:
- *  - `computeSummary` is a deterministic function over the bound Drizzle
- *    handle and is what the unit tests exercise (the test context swaps the
- *    underlying DB before each test via `setDb`).
- *  - `runSummary` is the worker entry point — it calls `computeSummary` and
- *    persists the result via `setRawSetting`.
- */
 import { and, asc, desc, gte, lt, sql, type SQL } from 'drizzle-orm';
 
 import { aiInferenceLog } from '@pops/db-types';
@@ -85,12 +70,6 @@ const EMPTY_OVERALL: OverallRow = {
   errors: 0,
 };
 
-/**
- * Build the time-window predicate shared by all three aggregate queries.
- * Inclusive lower bound, exclusive upper bound — future-dated rows are
- * excluded because `windowEndIso` is pinned to "now" at the top of
- * `computeSummary`.
- */
 function windowWhere(windowStartIso: string, windowEndIso: string): SQL | undefined {
   return and(
     gte(aiInferenceLog.createdAt, windowStartIso),
@@ -148,10 +127,7 @@ function fetchByProvider(windowStartIso: string, windowEndIso: string): Provider
 }
 
 function fetchByModel(windowStartIso: string, windowEndIso: string): ModelBreakdown[] {
-  // `avgLatencyMs` only considers `success` non-cached rows with
-  // `latency_ms > 0` — matching the same filter used elsewhere in the
-  // observability module so the numbers reconcile with the live dashboard.
-  // SQLite returns NULL for AVG over an empty set; coerced to 0 below.
+  // avgLatencyMs filter mirrors the live dashboard so cached and live numbers reconcile.
   const rows = getDrizzle()
     .select({
       provider: aiInferenceLog.provider,
@@ -170,7 +146,7 @@ function fetchByModel(windowStartIso: string, windowEndIso: string): ModelBreakd
     .from(aiInferenceLog)
     .where(windowWhere(windowStartIso, windowEndIso))
     .groupBy(aiInferenceLog.provider, aiInferenceLog.model)
-    .orderBy(desc(sql<number>`COUNT(*)`), asc(aiInferenceLog.model))
+    .orderBy(desc(sql<number>`COUNT(*)`), asc(aiInferenceLog.model), asc(aiInferenceLog.provider))
     .all();
 
   return rows.map((r) => ({
@@ -184,7 +160,6 @@ function fetchByModel(windowStartIso: string, windowEndIso: string): ModelBreakd
   }));
 }
 
-/** Compute the ISO timestamp `windowDays` ago from `now`. */
 export function computeWindowStart(windowDays: number, now: Date = new Date()): string {
   return new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000).toISOString();
 }
@@ -196,13 +171,11 @@ export interface ComputeSummaryOptions {
   now?: Date;
 }
 
-/**
- * Aggregate the last `windowDays` of `ai_inference_log` into a single
- * summary object. Deterministic given the active DB handle (resolved via
- * `getDrizzle()`), `now`, and `windowDays`.
- */
 export function computeSummary(opts: ComputeSummaryOptions = {}): ObservabilitySummary {
   const windowDays = opts.windowDays ?? SUMMARY_WINDOW_DAYS;
+  if (!Number.isInteger(windowDays) || windowDays <= 0) {
+    throw new RangeError(`windowDays must be a positive integer, got ${windowDays}`);
+  }
   const now = opts.now ?? new Date();
   const windowStart = computeWindowStart(windowDays, now);
   const windowEnd = now.toISOString();
@@ -235,12 +208,6 @@ export interface RunSummaryResult {
   summary: ObservabilitySummaryEnvelope;
 }
 
-/**
- * Compute and persist the 30-day rolling summary to the settings table.
- *
- * Idempotent — re-running overwrites the cached value. Safe to call from
- * the BullMQ worker without further locking.
- */
 export function runSummary(opts: RunSummaryOptions = {}): RunSummaryResult {
   const summary = computeSummary(opts);
   const computedAt = summary.windowEnd;


### PR DESCRIPTION
## Summary

- New BullMQ scheduler `summary-scheduler.ts` registers a repeatable job on `pops-default` at `0 3 * * *` UTC (one hour before the existing retention job so the rolling window sees a complete dataset). Degraded-mode fallback when `REDIS_HOST` is unset mirrors the retention scheduler.
- New worker handler `runSummary()` in `summary.ts` aggregates the last 30 days of `ai_inference_log` into totals, `byProvider`, and `byModel` breakdowns (including `cacheHitRate`, `errorRate`, and per-model `avgLatencyMs` over success non-cached rows with `latency_ms > 0`), then writes `{ ...metrics, computedAt }` to settings key `ai.observabilitySummary` via `setRawSetting`.
- Wired into the default queue dispatch alongside `aiLogRetention` / `aiAlertEvaluation`, and registered/unregistered from `apps/pops-api/src/index.ts` on boot/shutdown.

Closes #2571

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint` (0 errors)
- [x] `pnpm typecheck`
- [x] `pnpm test` in `apps/pops-api` (10 new tests in `summary.test.ts` pass; one unrelated flaky `thalamus/watcher` event-timing test reproduced clean on retry)
- [x] `pnpm build` in `packages/module-registry`