### PR TITLE
feat(cerebrum): glia thresholds from engrams/.config/glia.toml (#2579)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts
@@ -6,11 +6,12 @@
  * - missing/unreadable toml falls back to the settings DB
  * - mtime invalidation picks up in-process edits without restart
  */
+import * as fs from 'node:fs';
 import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { closeDb, setDb } from '../../../../db.js';
 import { createTestDb } from '../../../../shared/test-utils.js';
@@ -34,6 +35,16 @@ function bumpMtime(path: string, deltaSeconds: number): void {
   // even when two writes occur within the same millisecond.
   const now = Date.now() / 1000 + deltaSeconds;
   utimesSync(path, now, now);
+}
+
+/**
+ * Build a typed `NodeJS.ErrnoException` for tests that need to simulate a
+ * specific errno from `fs` without resorting to `as any`.
+ */
+function makeErrnoError(code: string, message: string): NodeJS.ErrnoException {
+  const err: NodeJS.ErrnoException = new Error(message);
+  err.code = code;
+  return err;
 }
 
 describe('loadGliaToml', () => {
@@ -85,7 +96,9 @@ propose_to_act_report_min_approved = 7
     expect(loadGliaToml(root)).toEqual({ proposeToActReportMinApproved: 7 });
   });
 
-  it('ignores non-numeric values', () => {
+  it('returns {} when any value has the wrong type', () => {
+    // Zod boundary validation rejects the whole file rather than silently
+    // skipping bad keys — this surfaces config bugs instead of hiding them.
     writeGliaToml(
       root,
       `
@@ -94,12 +107,107 @@ propose_to_act_report_min_approved = "not a number"
 demotion_revert_threshold = 4
 `
     );
-    expect(loadGliaToml(root)).toEqual({ demotionRevertThreshold: 4 });
+    expect(loadGliaToml(root)).toEqual({});
   });
 
   it('returns an empty object on malformed toml', () => {
     writeGliaToml(root, 'this is = = not valid toml [');
     expect(loadGliaToml(root)).toEqual({});
+  });
+
+  it('rejects out-of-range rejection rate (>1)', () => {
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_max_rejection_rate = 1.5
+demotion_revert_threshold = 4
+`
+    );
+    // Entire file fails validation → fallback to {} so callers cascade to DB / defaults.
+    expect(loadGliaToml(root)).toEqual({});
+  });
+
+  it('rejects negative count fields', () => {
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = -1
+`
+    );
+    expect(loadGliaToml(root)).toEqual({});
+  });
+
+  it('rejects non-integer day fields', () => {
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+act_report_to_silent_min_days = 7.5
+`
+    );
+    expect(loadGliaToml(root)).toEqual({});
+  });
+
+  it('returns {} and warns when statSync fails with a non-ENOENT error', () => {
+    // Force EACCES by chmodding the .config directory to 0 so the kernel
+    // refuses stat on the file inside it. This exercises the real fs error
+    // path without monkey-patching ESM namespaces.
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = 5
+`
+    );
+    const configDir = join(root, '.config');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    let errnoCode: string | undefined;
+    fs.chmodSync(configDir, 0o000);
+    try {
+      // The stat call should throw an errno error. Capture it directly to
+      // assert the precondition and skip the test if the platform doesn't
+      // enforce dir perms (e.g., running as root in CI).
+      try {
+        fs.statSync(gliaTomlPath(root));
+      } catch (err) {
+        errnoCode = (err as NodeJS.ErrnoException).code;
+      }
+      if (errnoCode === undefined || errnoCode === 'ENOENT') {
+        // Skip — the environment doesn't reproduce the EACCES path.
+        return;
+      }
+
+      expect(loadGliaToml(root)).toEqual({});
+      expect(warnSpy).toHaveBeenCalled();
+      const message = warnSpy.mock.calls[0]?.[0];
+      expect(typeof message).toBe('string');
+      expect(message).toContain('stat failed');
+    } finally {
+      // Restore perms so afterEach can remove the directory.
+      fs.chmodSync(configDir, 0o700);
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('produces a typed errno for the typed-throw helper', () => {
+    // Verifies that makeErrnoError stays in sync with NodeJS.ErrnoException
+    // — the property the loader narrows on. Cheap insurance against drift.
+    const err = makeErrnoError('EACCES', 'permission denied');
+    expect(err.code).toBe('EACCES');
+    expect(err.message).toBe('permission denied');
+  });
+
+  it('does not warn for ENOENT (expected fallback)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(loadGliaToml(root)).toEqual({});
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('picks up file edits via mtime invalidation', () => {

--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts
@@ -192,6 +192,26 @@ propose_to_act_report_min_approved = 5
     }
   });
 
+  it('returns an independent object each call (cache cannot be mutated)', () => {
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = 5
+`
+    );
+    const first = loadGliaToml(root);
+    expect(first.proposeToActReportMinApproved).toBe(5);
+
+    // Mutate the returned object — the cached entry must be unaffected.
+    first.proposeToActReportMinApproved = 999;
+    delete first.proposeToActReportMinApproved;
+
+    const second = loadGliaToml(root);
+    expect(second).not.toBe(first);
+    expect(second.proposeToActReportMinApproved).toBe(5);
+  });
+
   it('produces a typed errno for the typed-throw helper', () => {
     // Verifies that makeErrnoError stays in sync with NodeJS.ErrnoException
     // — the property the loader narrows on. Cheap insurance against drift.

--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for the glia.toml threshold loader (PRD-086 US-03 AC #7).
+ *
+ * Covers:
+ * - toml file takes precedence over the settings DB
+ * - missing/unreadable toml falls back to the settings DB
+ * - mtime invalidation picks up in-process edits without restart
+ */
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, setDb } from '../../../../db.js';
+import { createTestDb } from '../../../../shared/test-utils.js';
+import { setRawSetting } from '../../../core/settings/service.js';
+import { resetCerebrumCache } from '../../instance.js';
+import { gliaTomlPath, loadGliaToml, resetGliaTomlCache } from '../toml-config.js';
+import { getGliaThresholds } from '../types.js';
+
+import type { Database } from 'better-sqlite3';
+
+const ENV_KEY = 'ENGRAM_ROOT';
+
+function writeGliaToml(root: string, body: string): void {
+  const path = gliaTomlPath(root);
+  mkdirSync(join(root, '.config'), { recursive: true });
+  writeFileSync(path, body, 'utf8');
+}
+
+function bumpMtime(path: string, deltaSeconds: number): void {
+  // utimesSync overrides atime/mtime so the loader's mtime check sees a change
+  // even when two writes occur within the same millisecond.
+  const now = Date.now() / 1000 + deltaSeconds;
+  utimesSync(path, now, now);
+}
+
+describe('loadGliaToml', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'glia-toml-'));
+    resetGliaTomlCache();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    resetGliaTomlCache();
+  });
+
+  it('returns an empty object when the file is absent', () => {
+    expect(loadGliaToml(root)).toEqual({});
+  });
+
+  it('parses the [trust.graduation] section', () => {
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = 5
+propose_to_act_report_max_rejection_rate = 0.25
+act_report_to_silent_min_days = 14
+demotion_revert_threshold = 3
+demotion_window_days = 10
+`
+    );
+    expect(loadGliaToml(root)).toEqual({
+      proposeToActReportMinApproved: 5,
+      proposeToActReportMaxRejectionRate: 0.25,
+      actReportToSilentMinDays: 14,
+      demotionRevertThreshold: 3,
+      demotionWindowDays: 10,
+    });
+  });
+
+  it('returns only the keys present in the toml file', () => {
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = 7
+`
+    );
+    expect(loadGliaToml(root)).toEqual({ proposeToActReportMinApproved: 7 });
+  });
+
+  it('ignores non-numeric values', () => {
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = "not a number"
+demotion_revert_threshold = 4
+`
+    );
+    expect(loadGliaToml(root)).toEqual({ demotionRevertThreshold: 4 });
+  });
+
+  it('returns an empty object on malformed toml', () => {
+    writeGliaToml(root, 'this is = = not valid toml [');
+    expect(loadGliaToml(root)).toEqual({});
+  });
+
+  it('picks up file edits via mtime invalidation', () => {
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = 5
+`
+    );
+    expect(loadGliaToml(root).proposeToActReportMinApproved).toBe(5);
+
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = 11
+`
+    );
+    bumpMtime(gliaTomlPath(root), 10);
+
+    expect(loadGliaToml(root).proposeToActReportMinApproved).toBe(11);
+  });
+
+  it('serves cached result while mtime is unchanged', () => {
+    const path = gliaTomlPath(root);
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = 5
+`
+    );
+    expect(loadGliaToml(root).proposeToActReportMinApproved).toBe(5);
+
+    // Overwrite content but pin the mtime back to the original — the loader
+    // should serve the cached value, not re-parse.
+    const pinnedSeconds = 1_700_000_000;
+    utimesSync(path, pinnedSeconds, pinnedSeconds);
+    expect(loadGliaToml(root).proposeToActReportMinApproved).toBe(5);
+
+    writeFileSync(
+      path,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = 99
+`,
+      'utf8'
+    );
+    utimesSync(path, pinnedSeconds, pinnedSeconds);
+    expect(loadGliaToml(root).proposeToActReportMinApproved).toBe(5);
+  });
+});
+
+describe('getGliaThresholds precedence', () => {
+  let root: string;
+  let db: Database;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'glia-thresholds-'));
+    originalEnv = process.env[ENV_KEY];
+    process.env[ENV_KEY] = root;
+    resetCerebrumCache();
+    resetGliaTomlCache();
+    db = createTestDb();
+    setDb(db);
+  });
+
+  afterEach(() => {
+    closeDb();
+    rmSync(root, { recursive: true, force: true });
+    if (originalEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = originalEnv;
+    resetCerebrumCache();
+    resetGliaTomlCache();
+  });
+
+  it('returns hardcoded defaults when neither toml nor settings DB exist', () => {
+    expect(getGliaThresholds()).toEqual({
+      proposeToActReportMinApproved: 20,
+      proposeToActReportMaxRejectionRate: 0.1,
+      actReportToSilentMinDays: 60,
+      demotionRevertThreshold: 2,
+      demotionWindowDays: 7,
+    });
+  });
+
+  it('falls back to settings DB when toml is absent', () => {
+    setRawSetting('cerebrum.glia.proposeMinApproved', '42');
+    setRawSetting('cerebrum.glia.demotionWindowDays', '21');
+
+    const thresholds = getGliaThresholds();
+    expect(thresholds.proposeToActReportMinApproved).toBe(42);
+    expect(thresholds.demotionWindowDays).toBe(21);
+    // Untouched keys keep the hardcoded fallback.
+    expect(thresholds.actReportToSilentMinDays).toBe(60);
+  });
+
+  it('toml takes precedence over settings DB when both are present', () => {
+    setRawSetting('cerebrum.glia.proposeMinApproved', '42');
+    setRawSetting('cerebrum.glia.demotionWindowDays', '21');
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = 9
+`
+    );
+
+    const thresholds = getGliaThresholds();
+    // toml wins for keys it sets…
+    expect(thresholds.proposeToActReportMinApproved).toBe(9);
+    // …DB still wins per-key where toml is silent.
+    expect(thresholds.demotionWindowDays).toBe(21);
+  });
+
+  it('hot-reload: editing glia.toml is observed on the next call', () => {
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = 5
+`
+    );
+    expect(getGliaThresholds().proposeToActReportMinApproved).toBe(5);
+
+    writeGliaToml(
+      root,
+      `
+[trust.graduation]
+propose_to_act_report_min_approved = 17
+`
+    );
+    bumpMtime(gliaTomlPath(root), 10);
+
+    expect(getGliaThresholds().proposeToActReportMinApproved).toBe(17);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts
@@ -6,8 +6,15 @@
  * - missing/unreadable toml falls back to the settings DB
  * - mtime invalidation picks up in-process edits without restart
  */
-import * as fs from 'node:fs';
-import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -165,13 +172,13 @@ propose_to_act_report_min_approved = 5
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     let errnoCode: string | undefined;
-    fs.chmodSync(configDir, 0o000);
+    chmodSync(configDir, 0o000);
     try {
       // The stat call should throw an errno error. Capture it directly to
       // assert the precondition and skip the test if the platform doesn't
       // enforce dir perms (e.g., running as root in CI).
       try {
-        fs.statSync(gliaTomlPath(root));
+        statSync(gliaTomlPath(root));
       } catch (err) {
         errnoCode = (err as NodeJS.ErrnoException).code;
       }
@@ -187,7 +194,7 @@ propose_to_act_report_min_approved = 5
       expect(message).toContain('stat failed');
     } finally {
       // Restore perms so afterEach can remove the directory.
-      fs.chmodSync(configDir, 0o700);
+      chmodSync(configDir, 0o700);
       warnSpy.mockRestore();
     }
   });

--- a/apps/pops-api/src/modules/cerebrum/glia/toml-config.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/toml-config.ts
@@ -13,6 +13,7 @@ import { statSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { parse as parseToml } from 'smol-toml';
+import { z } from 'zod';
 
 import type { GraduationThresholds } from './types.js';
 
@@ -33,48 +34,69 @@ export function gliaTomlPath(engramRoot: string): string {
   return join(engramRoot, CONFIG_RELATIVE_PATH);
 }
 
-function readNumber(obj: Record<string, unknown>, key: string): number | undefined {
-  const value = obj[key];
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  return undefined;
-}
+const nonNegativeInt = z.number().int().nonnegative();
+const rejectionRate = z.number().min(0).max(1);
 
-function pickGraduationSection(parsed: Record<string, unknown>): Record<string, unknown> {
-  const trust = parsed['trust'];
-  if (typeof trust !== 'object' || trust === null) return {};
-  const graduation = (trust as Record<string, unknown>)['graduation'];
-  if (typeof graduation !== 'object' || graduation === null) return {};
-  return graduation as Record<string, unknown>;
-}
+const graduationSchema = z
+  .object({
+    propose_to_act_report_min_approved: nonNegativeInt.optional(),
+    propose_to_act_report_max_rejection_rate: rejectionRate.optional(),
+    act_report_to_silent_min_days: nonNegativeInt.optional(),
+    demotion_revert_threshold: nonNegativeInt.optional(),
+    demotion_window_days: nonNegativeInt.optional(),
+  })
+  .strip();
+
+const gliaTomlSchema = z
+  .object({
+    trust: z
+      .object({
+        graduation: graduationSchema.optional(),
+      })
+      .strip()
+      .optional(),
+  })
+  .strip();
 
 /** Parse the `[trust.graduation]` block into a partial thresholds object. */
 export function parseGliaToml(content: string): PartialGraduationThresholds {
-  let raw: Record<string, unknown>;
+  let raw: unknown;
   try {
-    raw = parseToml(content) as Record<string, unknown>;
+    raw = parseToml(content);
   } catch (err) {
     console.warn(`[cerebrum] glia.toml parse failed: ${(err as Error).message}`);
     return {};
   }
 
-  const section = pickGraduationSection(raw);
+  const parsed = gliaTomlSchema.safeParse(raw);
+  if (!parsed.success) {
+    console.warn(
+      `[cerebrum] glia.toml validation failed: ${parsed.error.issues
+        .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+        .join('; ')}`
+    );
+    return {};
+  }
+
+  const section = parsed.data.trust?.graduation;
+  if (!section) return {};
+
   const result: PartialGraduationThresholds = {};
-
-  const proposeMinApproved = readNumber(section, 'propose_to_act_report_min_approved');
-  if (proposeMinApproved !== undefined) result.proposeToActReportMinApproved = proposeMinApproved;
-
-  const maxRejectionRate = readNumber(section, 'propose_to_act_report_max_rejection_rate');
-  if (maxRejectionRate !== undefined) result.proposeToActReportMaxRejectionRate = maxRejectionRate;
-
-  const minDays = readNumber(section, 'act_report_to_silent_min_days');
-  if (minDays !== undefined) result.actReportToSilentMinDays = minDays;
-
-  const demotionThreshold = readNumber(section, 'demotion_revert_threshold');
-  if (demotionThreshold !== undefined) result.demotionRevertThreshold = demotionThreshold;
-
-  const demotionWindow = readNumber(section, 'demotion_window_days');
-  if (demotionWindow !== undefined) result.demotionWindowDays = demotionWindow;
-
+  if (section.propose_to_act_report_min_approved !== undefined) {
+    result.proposeToActReportMinApproved = section.propose_to_act_report_min_approved;
+  }
+  if (section.propose_to_act_report_max_rejection_rate !== undefined) {
+    result.proposeToActReportMaxRejectionRate = section.propose_to_act_report_max_rejection_rate;
+  }
+  if (section.act_report_to_silent_min_days !== undefined) {
+    result.actReportToSilentMinDays = section.act_report_to_silent_min_days;
+  }
+  if (section.demotion_revert_threshold !== undefined) {
+    result.demotionRevertThreshold = section.demotion_revert_threshold;
+  }
+  if (section.demotion_window_days !== undefined) {
+    result.demotionWindowDays = section.demotion_window_days;
+  }
   return result;
 }
 
@@ -91,7 +113,11 @@ export function loadGliaToml(engramRoot: string): PartialGraduationThresholds {
   let mtimeMs: number;
   try {
     mtimeMs = statSync(path).mtimeMs;
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.warn(`[cerebrum] glia.toml stat failed at ${path}: ${(err as Error).message}`);
+    }
     cache.delete(path);
     return {};
   }

--- a/apps/pops-api/src/modules/cerebrum/glia/toml-config.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/toml-config.ts
@@ -124,7 +124,10 @@ export function loadGliaToml(engramRoot: string): PartialGraduationThresholds {
 
   const cached = cache.get(path);
   if (cached && cached.mtimeMs === mtimeMs) {
-    return cached.thresholds;
+    // Defensive copy — never hand callers the cached reference, otherwise
+    // a downstream mutation poisons every subsequent read until the file's
+    // mtime changes.
+    return { ...cached.thresholds };
   }
 
   let content: string;
@@ -143,7 +146,8 @@ export function loadGliaToml(engramRoot: string): PartialGraduationThresholds {
 
   const thresholds = parseGliaToml(content);
   cache.set(path, { mtimeMs, thresholds });
-  return thresholds;
+  // Return a copy so mutation by the caller can't corrupt the cache entry.
+  return { ...thresholds };
 }
 
 /** Test hook — clear the mtime cache. */

--- a/apps/pops-api/src/modules/cerebrum/glia/toml-config.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/toml-config.ts
@@ -1,0 +1,121 @@
+/**
+ * Glia threshold loader for `engrams/.config/glia.toml` (PRD-086 US-03 AC #7).
+ *
+ * Reads `[trust.graduation]` from the toml file and exposes a partial
+ * {@link GraduationThresholds} object containing only the keys the user set.
+ *
+ * Hot-reload semantics: the parsed result is cached and re-validated against
+ * the file's mtime on every call. Edits to `glia.toml` are picked up on the
+ * next evaluation without restart. If the file is absent or unreadable the
+ * loader returns an empty object so callers can fall back to other sources.
+ */
+import { statSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { parse as parseToml } from 'smol-toml';
+
+import type { GraduationThresholds } from './types.js';
+
+/** Subset of {@link GraduationThresholds} expressible in `glia.toml`. */
+export type PartialGraduationThresholds = Partial<GraduationThresholds>;
+
+const CONFIG_RELATIVE_PATH = join('.config', 'glia.toml');
+
+interface CacheEntry {
+  mtimeMs: number;
+  thresholds: PartialGraduationThresholds;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/** Resolve the absolute path to `<engramRoot>/.config/glia.toml`. */
+export function gliaTomlPath(engramRoot: string): string {
+  return join(engramRoot, CONFIG_RELATIVE_PATH);
+}
+
+function readNumber(obj: Record<string, unknown>, key: string): number | undefined {
+  const value = obj[key];
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return undefined;
+}
+
+function pickGraduationSection(parsed: Record<string, unknown>): Record<string, unknown> {
+  const trust = parsed['trust'];
+  if (typeof trust !== 'object' || trust === null) return {};
+  const graduation = (trust as Record<string, unknown>)['graduation'];
+  if (typeof graduation !== 'object' || graduation === null) return {};
+  return graduation as Record<string, unknown>;
+}
+
+/** Parse the `[trust.graduation]` block into a partial thresholds object. */
+export function parseGliaToml(content: string): PartialGraduationThresholds {
+  let raw: Record<string, unknown>;
+  try {
+    raw = parseToml(content) as Record<string, unknown>;
+  } catch (err) {
+    console.warn(`[cerebrum] glia.toml parse failed: ${(err as Error).message}`);
+    return {};
+  }
+
+  const section = pickGraduationSection(raw);
+  const result: PartialGraduationThresholds = {};
+
+  const proposeMinApproved = readNumber(section, 'propose_to_act_report_min_approved');
+  if (proposeMinApproved !== undefined) result.proposeToActReportMinApproved = proposeMinApproved;
+
+  const maxRejectionRate = readNumber(section, 'propose_to_act_report_max_rejection_rate');
+  if (maxRejectionRate !== undefined) result.proposeToActReportMaxRejectionRate = maxRejectionRate;
+
+  const minDays = readNumber(section, 'act_report_to_silent_min_days');
+  if (minDays !== undefined) result.actReportToSilentMinDays = minDays;
+
+  const demotionThreshold = readNumber(section, 'demotion_revert_threshold');
+  if (demotionThreshold !== undefined) result.demotionRevertThreshold = demotionThreshold;
+
+  const demotionWindow = readNumber(section, 'demotion_window_days');
+  if (demotionWindow !== undefined) result.demotionWindowDays = demotionWindow;
+
+  return result;
+}
+
+/**
+ * Load partial thresholds from `<engramRoot>/.config/glia.toml`.
+ *
+ * Returns an empty object when the file is missing or unreadable. Uses an
+ * mtime-keyed cache so repeated calls within the same process do not re-read
+ * the disk unless the file has changed.
+ */
+export function loadGliaToml(engramRoot: string): PartialGraduationThresholds {
+  const path = gliaTomlPath(engramRoot);
+
+  let mtimeMs: number;
+  try {
+    mtimeMs = statSync(path).mtimeMs;
+  } catch {
+    cache.delete(path);
+    return {};
+  }
+
+  const cached = cache.get(path);
+  if (cached && cached.mtimeMs === mtimeMs) {
+    return cached.thresholds;
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(path, 'utf8');
+  } catch (err) {
+    console.warn(`[cerebrum] glia.toml read failed at ${path}: ${(err as Error).message}`);
+    cache.delete(path);
+    return {};
+  }
+
+  const thresholds = parseGliaToml(content);
+  cache.set(path, { mtimeMs, thresholds });
+  return thresholds;
+}
+
+/** Test hook — clear the mtime cache. */
+export function resetGliaTomlCache(): void {
+  cache.clear();
+}

--- a/apps/pops-api/src/modules/cerebrum/glia/toml-config.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/toml-config.ts
@@ -131,7 +131,12 @@ export function loadGliaToml(engramRoot: string): PartialGraduationThresholds {
   try {
     content = readFileSync(path, 'utf8');
   } catch (err) {
-    console.warn(`[cerebrum] glia.toml read failed at ${path}: ${(err as Error).message}`);
+    // If the file was removed between statSync and readFileSync, ENOENT is
+    // an expected race and should stay quiet — same policy as the stat path.
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.warn(`[cerebrum] glia.toml read failed at ${path}: ${(err as Error).message}`);
+    }
     cache.delete(path);
     return {};
   }

--- a/apps/pops-api/src/modules/cerebrum/glia/toml-config.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/toml-config.ts
@@ -37,26 +37,25 @@ export function gliaTomlPath(engramRoot: string): string {
 const nonNegativeInt = z.number().int().nonnegative();
 const rejectionRate = z.number().min(0).max(1);
 
-const graduationSchema = z
-  .object({
-    propose_to_act_report_min_approved: nonNegativeInt.optional(),
-    propose_to_act_report_max_rejection_rate: rejectionRate.optional(),
-    act_report_to_silent_min_days: nonNegativeInt.optional(),
-    demotion_revert_threshold: nonNegativeInt.optional(),
-    demotion_window_days: nonNegativeInt.optional(),
-  })
-  .strip();
+// Zod v4 strips unknown keys from object schemas by default — no explicit
+// `.strip()` is required (and `z.strictObject` would be too aggressive here
+// since users may add commented-out keys or future fields the parser hasn't
+// learned yet).
+const graduationSchema = z.object({
+  propose_to_act_report_min_approved: nonNegativeInt.optional(),
+  propose_to_act_report_max_rejection_rate: rejectionRate.optional(),
+  act_report_to_silent_min_days: nonNegativeInt.optional(),
+  demotion_revert_threshold: nonNegativeInt.optional(),
+  demotion_window_days: nonNegativeInt.optional(),
+});
 
-const gliaTomlSchema = z
-  .object({
-    trust: z
-      .object({
-        graduation: graduationSchema.optional(),
-      })
-      .strip()
-      .optional(),
-  })
-  .strip();
+const gliaTomlSchema = z.object({
+  trust: z
+    .object({
+      graduation: graduationSchema.optional(),
+    })
+    .optional(),
+});
 
 /** Parse the `[trust.graduation]` block into a partial thresholds object. */
 export function parseGliaToml(content: string): PartialGraduationThresholds {

--- a/apps/pops-api/src/modules/cerebrum/glia/types.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/types.ts
@@ -81,6 +81,8 @@ export interface GraduationThresholds {
 }
 
 import { getSettingValue } from '../../core/settings/service.js';
+import { getEngramRoot } from '../instance.js';
+import { loadGliaToml } from './toml-config.js';
 
 /** Hardcoded graduation thresholds per ADR-021. */
 const FALLBACK_THRESHOLDS: GraduationThresholds = {
@@ -91,29 +93,46 @@ const FALLBACK_THRESHOLDS: GraduationThresholds = {
   demotionWindowDays: 7,
 };
 
-/** Read graduation thresholds from settings (with hardcoded fallbacks). */
+/**
+ * Read graduation thresholds for the trust machine.
+ *
+ * Precedence (PRD-086 US-03 AC #7): `engrams/.config/glia.toml` is the source
+ * of truth — it is re-read on every call (mtime-cached) so user edits take
+ * effect on the next evaluation without restart. The settings DB acts as a
+ * per-key fallback for thresholds the toml file does not set; the hardcoded
+ * ADR-021 defaults are the last resort. The toml file wins over the DB
+ * because the PRD documents the file as the user-facing knob.
+ */
 export function getGliaThresholds(): GraduationThresholds {
+  const toml = loadGliaToml(getEngramRoot());
   return {
-    proposeToActReportMinApproved: getSettingValue(
-      'cerebrum.glia.proposeMinApproved',
-      FALLBACK_THRESHOLDS.proposeToActReportMinApproved
-    ),
-    proposeToActReportMaxRejectionRate: getSettingValue(
-      'cerebrum.glia.proposeMaxRejectionRate',
-      FALLBACK_THRESHOLDS.proposeToActReportMaxRejectionRate
-    ),
-    actReportToSilentMinDays: getSettingValue(
-      'cerebrum.glia.actReportMinDays',
-      FALLBACK_THRESHOLDS.actReportToSilentMinDays
-    ),
-    demotionRevertThreshold: getSettingValue(
-      'cerebrum.glia.demotionRevertThreshold',
-      FALLBACK_THRESHOLDS.demotionRevertThreshold
-    ),
-    demotionWindowDays: getSettingValue(
-      'cerebrum.glia.demotionWindowDays',
-      FALLBACK_THRESHOLDS.demotionWindowDays
-    ),
+    proposeToActReportMinApproved:
+      toml.proposeToActReportMinApproved ??
+      getSettingValue(
+        'cerebrum.glia.proposeMinApproved',
+        FALLBACK_THRESHOLDS.proposeToActReportMinApproved
+      ),
+    proposeToActReportMaxRejectionRate:
+      toml.proposeToActReportMaxRejectionRate ??
+      getSettingValue(
+        'cerebrum.glia.proposeMaxRejectionRate',
+        FALLBACK_THRESHOLDS.proposeToActReportMaxRejectionRate
+      ),
+    actReportToSilentMinDays:
+      toml.actReportToSilentMinDays ??
+      getSettingValue(
+        'cerebrum.glia.actReportMinDays',
+        FALLBACK_THRESHOLDS.actReportToSilentMinDays
+      ),
+    demotionRevertThreshold:
+      toml.demotionRevertThreshold ??
+      getSettingValue(
+        'cerebrum.glia.demotionRevertThreshold',
+        FALLBACK_THRESHOLDS.demotionRevertThreshold
+      ),
+    demotionWindowDays:
+      toml.demotionWindowDays ??
+      getSettingValue('cerebrum.glia.demotionWindowDays', FALLBACK_THRESHOLDS.demotionWindowDays),
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `apps/pops-api/src/modules/cerebrum/glia/toml-config.ts` — an mtime-cached loader for `engrams/.config/glia.toml` that exposes the `[trust.graduation]` keys as a partial `GraduationThresholds`.
- Wires `loadGliaToml(getEngramRoot())` into `getGliaThresholds()`. Precedence is **toml file > settings DB (per-key fallback) > hardcoded ADR-021 defaults**, matching the PRD-086 US-03 AC #7 requirement that the toml file is the user-facing knob. Re-read on every call so edits land on the next evaluation without restart.
- Documents the precedence rationale inline in `types.ts`.

## Tests

- `apps/pops-api/src/modules/cerebrum/glia/__tests__/toml-config.test.ts` (11 cases) covers parsing, missing-file fallback, malformed-toml fallback, partial-key merge, toml-vs-DB precedence, and an mtime invalidation test that verifies hot-reload via `utimesSync`.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck`
- [x] `pnpm test` in `apps/pops-api` (4205 passed)
- [x] `pnpm --filter @pops/module-registry build`

Closes #2579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TOML configuration file support for Glia graduation thresholds with a defined precedence system: file-based settings override database-stored values, which override built-in defaults.
  * Implemented configuration hot-reload capability, allowing threshold updates to take effect immediately without requiring application restart.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knoxio/pops/pull/2626)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->