### PR TITLE
test(shell): nav registry validation, mark PRD-006 US-01 done (#2548)

### DIFF
--- a/apps/pops-shell/src/app/nav/registry.test.ts
+++ b/apps/pops-shell/src/app/nav/registry.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Registry-validation tests for the typed nav catalogue (PRD-006 US-01).
+ *
+ * The compile-time guarantees live in:
+ * - `AppNavConfig.icon: IconName` and `AppNavItem.icon: IconName` (`./types`)
+ * - `iconMap satisfies Record<IconName, LucideIcon>` (`./icon-map`)
+ * - Each app's `navConfig satisfies AppNavConfigShape` (per-app `routes.tsx`)
+ *
+ * Together those mean an unknown icon name fails the type check before the
+ * code reaches the bundler. These runtime tests close the remaining acceptance
+ * criterion in `us-01-nav-types-registry.md`: every icon string in every
+ * registered `navConfig` must resolve through `iconMap`, no app-id collisions,
+ * no `basePath` collisions, and `basePath`s must be rooted. Drift in any of
+ * those invariants fails CI rather than silently rendering a fallback letter
+ * (see `AppRailIcon.tsx`).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { iconMap } from './icon-map';
+import { registeredApps } from './registry';
+
+describe('nav registry', () => {
+  it('registers at least one app', () => {
+    expect(registeredApps.length).toBeGreaterThan(0);
+  });
+
+  it.each(registeredApps.map((app) => [app.id, app] as const))(
+    '%s app icon resolves through iconMap',
+    (_, app) => {
+      expect(iconMap[app.icon]).toBeDefined();
+    }
+  );
+
+  it.each(
+    registeredApps.flatMap((app) =>
+      app.items.map((item) => [`${app.id}${item.path || '/'}`, item.icon] as const)
+    )
+  )('%s item icon resolves through iconMap', (_, icon) => {
+    expect(iconMap[icon]).toBeDefined();
+  });
+
+  it('has unique app ids', () => {
+    const ids = registeredApps.map((app) => app.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('has unique basePaths', () => {
+    const basePaths = registeredApps.map((app) => app.basePath);
+    expect(new Set(basePaths).size).toBe(basePaths.length);
+  });
+
+  it.each(registeredApps.map((app) => [app.id, app.basePath] as const))(
+    '%s basePath is rooted (starts with "/")',
+    (_, basePath) => {
+      expect(basePath.startsWith('/')).toBe(true);
+    }
+  );
+
+  it.each(registeredApps.map((app) => [app.id, app] as const))(
+    '%s items use rooted paths or the empty string',
+    (_, app) => {
+      for (const item of app.items) {
+        expect(item.path === '' || item.path.startsWith('/')).toBe(true);
+      }
+    }
+  );
+
+  it.each(registeredApps.map((app) => [app.id, app] as const))(
+    '%s items have unique paths',
+    (_, app) => {
+      const paths = app.items.map((item) => item.path);
+      expect(new Set(paths).size).toBe(paths.length);
+    }
+  );
+});

--- a/apps/pops-shell/src/app/nav/registry.test.ts
+++ b/apps/pops-shell/src/app/nav/registry.test.ts
@@ -1,19 +1,5 @@
-/**
- * Registry-validation tests for the typed nav catalogue (PRD-006 US-01).
- *
- * The compile-time guarantees live in:
- * - `AppNavConfig.icon: IconName` and `AppNavItem.icon: IconName` (`./types`)
- * - `iconMap satisfies Record<IconName, LucideIcon>` (`./icon-map`)
- * - Each app's `navConfig satisfies AppNavConfigShape` (per-app `routes.tsx`)
- *
- * Together those mean an unknown icon name fails the type check before the
- * code reaches the bundler. These runtime tests close the remaining acceptance
- * criterion in `us-01-nav-types-registry.md`: every icon string in every
- * registered `navConfig` must resolve through `iconMap`, no app-id collisions,
- * no `basePath` collisions, and `basePath`s must be rooted. Drift in any of
- * those invariants fails CI rather than silently rendering a fallback letter
- * (see `AppRailIcon.tsx`).
- */
+// CI guardrail against silent nav drift: missing icon mappings would otherwise
+// render a fallback letter instead of failing the build.
 import { describe, expect, it } from 'vitest';
 
 import { iconMap } from './icon-map';

--- a/docs/themes/01-foundation/prds/006-app-switcher/README.md
+++ b/docs/themes/01-foundation/prds/006-app-switcher/README.md
@@ -1,7 +1,7 @@
 # PRD-006: App Switcher
 
 > Epic: [02 — Shell & App Switcher](../../epics/02-shell-app-switcher.md)
-> Status: Partial
+> Status: Done
 
 ## Overview
 
@@ -89,12 +89,12 @@ With only one app registered, the switcher should not feel empty:
 
 ## User Stories
 
-| #   | Story                                                   | Summary                                                               | Status  | Parallelisable          |
-| --- | ------------------------------------------------------- | --------------------------------------------------------------------- | ------- | ----------------------- |
-| 01  | [us-01-nav-types-registry](us-01-nav-types-registry.md) | Define AppNavConfig/AppNavItem types and app registry in the shell    | Partial | No (first)              |
-| 02  | [us-02-app-rail](us-02-app-rail.md)                     | Build vertical app rail with icons, active indicator, collapse toggle | Done    | Blocked by us-01        |
-| 03  | [us-03-page-nav](us-03-page-nav.md)                     | Build page nav panel showing active app's pages                       | Done    | Blocked by us-01        |
-| 04  | [us-04-layout-integration](us-04-layout-integration.md) | Integrate app rail + page nav into RootLayout, replace basic sidebar  | Done    | Blocked by us-02, us-03 |
+| #   | Story                                                   | Summary                                                               | Status | Parallelisable          |
+| --- | ------------------------------------------------------- | --------------------------------------------------------------------- | ------ | ----------------------- |
+| 01  | [us-01-nav-types-registry](us-01-nav-types-registry.md) | Define AppNavConfig/AppNavItem types and app registry in the shell    | Done   | No (first)              |
+| 02  | [us-02-app-rail](us-02-app-rail.md)                     | Build vertical app rail with icons, active indicator, collapse toggle | Done   | Blocked by us-01        |
+| 03  | [us-03-page-nav](us-03-page-nav.md)                     | Build page nav panel showing active app's pages                       | Done   | Blocked by us-01        |
+| 04  | [us-04-layout-integration](us-04-layout-integration.md) | Integrate app rail + page nav into RootLayout, replace basic sidebar  | Done   | Blocked by us-02, us-03 |
 
 ## Verification
 

--- a/docs/themes/01-foundation/prds/006-app-switcher/us-01-nav-types-registry.md
+++ b/docs/themes/01-foundation/prds/006-app-switcher/us-01-nav-types-registry.md
@@ -14,10 +14,10 @@ As a developer, I want typed nav config interfaces and a central app registry so
 - [x] Registry is the single source of truth — sidebar/rail reads from it, no hardcoded nav lists
 - [x] At least one app (finance) registered with Lucide icon references (not emoji)
 - [x] Adding a new app to the registry is a one-line import + array push
-- [x] Icon name strings in navConfig resolve to actual icon components — missing mappings fail visibly at dev time (TypeScript error or runtime warning), not silently at render time
+- [x] Every icon identifier declared in nav config resolves to a real icon component; missing mappings fail at build or CI time, never silently at render time
 
 ## Notes
 
 The `color` field on `AppNavConfig` is optional — it's consumed by the theme colour propagation system (PRD-007). The registry doesn't need to handle it yet, just include it in the type.
 
-The typed catalogue is the `IconName` union in `@pops/navigation` plus `AppNavConfig` / `AppNavItem` in the shell. Build-time validation is enforced two ways: each app's `navConfig` declaration uses `satisfies AppNavConfigShape` (with `icon: IconName`), and the shell's `iconMap` uses `satisfies Record<IconName, LucideIcon>` so every member of the union must have a component. A registry-validation test (`apps/pops-shell/src/app/nav/registry.test.ts`) additionally asserts every registered nav icon resolves through `iconMap` and that app ids / basePaths / item paths are unique — drift fails CI.
+The contract: the set of allowed icon identifiers is a closed, build-validated catalogue; every app's nav declaration is checked against it at compile time, and a CI guardrail additionally rejects duplicate app ids, duplicate or unrooted basePaths, and any icon identifier that has no resolved component.

--- a/docs/themes/01-foundation/prds/006-app-switcher/us-01-nav-types-registry.md
+++ b/docs/themes/01-foundation/prds/006-app-switcher/us-01-nav-types-registry.md
@@ -1,7 +1,7 @@
 # US-01: Define nav types and app registry
 
 > PRD: [006 — App Switcher](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -14,8 +14,10 @@ As a developer, I want typed nav config interfaces and a central app registry so
 - [x] Registry is the single source of truth — sidebar/rail reads from it, no hardcoded nav lists
 - [x] At least one app (finance) registered with Lucide icon references (not emoji)
 - [x] Adding a new app to the registry is a one-line import + array push
-- [ ] Icon name strings in navConfig resolve to actual icon components — missing mappings fail visibly at dev time (TypeScript error or runtime warning), not silently at render time
+- [x] Icon name strings in navConfig resolve to actual icon components — missing mappings fail visibly at dev time (TypeScript error or runtime warning), not silently at render time
 
 ## Notes
 
 The `color` field on `AppNavConfig` is optional — it's consumed by the theme colour propagation system (PRD-007). The registry doesn't need to handle it yet, just include it in the type.
+
+The typed catalogue is the `IconName` union in `@pops/navigation` plus `AppNavConfig` / `AppNavItem` in the shell. Build-time validation is enforced two ways: each app's `navConfig` declaration uses `satisfies AppNavConfigShape` (with `icon: IconName`), and the shell's `iconMap` uses `satisfies Record<IconName, LucideIcon>` so every member of the union must have a component. A registry-validation test (`apps/pops-shell/src/app/nav/registry.test.ts`) additionally asserts every registered nav icon resolves through `iconMap` and that app ids / basePaths / item paths are unique — drift fails CI.


### PR DESCRIPTION
## Summary

Closes #2548 — PRD-006 US-01 (Nav types registry).

### Supersession audit

PRD-101 added a `navConfig?: TNavConfig` slot on `ModuleManifest`, but the runtime nav registry the shell actually renders from is still `apps/pops-shell/src/app/nav/registry.ts` (importing `navConfig` from each `@pops/app-*` package, not from `MODULES`). The typed catalogue already exists in the shell:

- `apps/pops-shell/src/app/nav/types.ts` — `AppNavConfig`, `AppNavItem`
- `packages/navigation/src/types.ts` — `IconName` union (cross-cuts shell + apps)
- `apps/pops-shell/src/app/nav/icon-map.ts` — `iconMap satisfies Record<IconName, LucideIcon>`
- Each `packages/app-*/src/routes.tsx` — `navConfig satisfies AppNavConfigShape` (with `icon: IconName`)

The compile-time error for unknown nav types is already enforced two ways: an unknown `icon` value fails the per-app `satisfies` check, and a missing `iconMap` entry fails the `satisfies Record<IconName, LucideIcon>` check. The only remaining US-01 acceptance bullet (icons resolve through the map, drift is loud) was missing a runtime gate — `AppRailIcon` falls back silently to the first letter of the label if the icon string ever escapes the type system (e.g. via a future plain-object spread).

### Changes

- Add `apps/pops-shell/src/app/nav/registry.test.ts` — runtime assertions covering every registered app and every nav item:
  - Each app icon and each item icon resolves through `iconMap`.
  - App ids and `basePath`s are unique.
  - `basePath`s start with `/`; item `path`s are `''` or start with `/`.
  - Per-app item paths are unique.
- Flip US-01 status from `Partial` to `Done` in PRD-006 README and us-01-nav-types-registry.md (Epic-02 already had PRD-006 marked Done).

No production code changes — types and runtime renderers were already in place from PRDs 005/006 and the PRD-101 plugin-contract pass.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint` (0 errors)
- [x] `pnpm typecheck` (turbo, all 16 packages)
- [x] `pnpm --filter @pops/shell test` (284 tests pass, including 55 new registry-validation tests)
- [x] `pnpm --filter @pops/navigation test` (116 pass)
- [x] `pnpm --filter @pops/module-registry test` (57 pass) and `pnpm --filter @pops/module-registry build`