### PR TITLE
feat(ai): budget enforcement in trackInference (#2570)

### DIFF
--- a/apps/pops-api/src/index.ts
+++ b/apps/pops-api/src/index.ts
@@ -13,6 +13,7 @@ import {
   registerAiAlertsScheduler,
   unregisterAiAlertsScheduler,
 } from './modules/core/ai-alerts/scheduler.js';
+import { migrateLegacyBudgetSettings } from './modules/core/ai-budgets/service.js';
 import {
   registerAiLogRetentionScheduler,
   unregisterAiLogRetentionScheduler,
@@ -69,6 +70,14 @@ const ttlWatcher = startTtlWatcher();
 startThalamus().catch((err) => {
   console.error('[thalamus] Failed to start:', err);
 });
+
+// Convert legacy `ai.monthlyTokenBudget` / `ai.budgetExceededFallback`
+// settings into a row in `ai_budgets` (PRD-092 US-04). Idempotent.
+try {
+  migrateLegacyBudgetSettings();
+} catch (err) {
+  console.error('[ai-budgets] Legacy settings migration failed:', err);
+}
 
 // Register AI inference log retention scheduler (PRD-092 US-08)
 registerAiLogRetentionScheduler().catch((err: unknown) => {

--- a/apps/pops-api/src/lib/inference-budget-enforcement.ts
+++ b/apps/pops-api/src/lib/inference-budget-enforcement.ts
@@ -1,0 +1,132 @@
+/**
+ * Pre-call budget enforcement glue between `trackInference()` and the
+ * `core.aiBudgets` enforcement service (PRD-092 US-04).
+ *
+ * Returns the (possibly swapped) call params under which the live provider
+ * call should execute, or throws `BudgetExceededError` for hard blocks.
+ * Cached calls bypass this entirely — the middleware short-circuits before
+ * calling `enforceBudgets()`.
+ *
+ * Split out of `inference-middleware.ts` so both files stay under the
+ * project's max-lines lint budget.
+ */
+import {
+  evaluateBudgetsForCall,
+  findFallbackProvider,
+  type BudgetBreach,
+} from '../modules/core/ai-budgets/service.js';
+import { BudgetExceededError } from '../shared/errors.js';
+import { logger } from './logger.js';
+
+import type {
+  InferenceLogInsert,
+  ResolvedInferenceParams,
+  TrackInferenceParams,
+} from './inference-middleware-types.js';
+
+function blockedLogValues(
+  params: TrackInferenceParams,
+  resolved: ResolvedInferenceParams,
+  breach: BudgetBreach
+): InferenceLogInsert {
+  return {
+    provider: params.provider,
+    model: params.model,
+    operation: params.operation,
+    domain: resolved.domain,
+    contextId: resolved.contextId,
+    inputTokens: 0,
+    outputTokens: 0,
+    costUsd: 0,
+    latencyMs: 0,
+    status: 'budget-blocked',
+    cached: 0,
+    errorMessage: `budget '${breach.budget.id}' exceeded (${breach.limitType})`,
+  };
+}
+
+function throwBlocked(breach: BudgetBreach): never {
+  throw new BudgetExceededError({
+    budgetId: breach.budget.id,
+    limitType: breach.limitType,
+    currentUsage: breach.currentUsage,
+    limit: breach.limit,
+  });
+}
+
+function handleBlock(
+  params: TrackInferenceParams,
+  resolved: ResolvedInferenceParams,
+  breach: BudgetBreach,
+  insertLog: (values: InferenceLogInsert) => void
+): never {
+  insertLog(blockedLogValues(params, resolved, breach));
+  throwBlocked(breach);
+}
+
+function handleFallback(
+  params: TrackInferenceParams,
+  resolved: ResolvedInferenceParams,
+  breach: BudgetBreach,
+  insertLog: (values: InferenceLogInsert) => void
+): TrackInferenceParams {
+  const target = findFallbackProvider();
+  if (!target) {
+    logger.warn(
+      { budgetId: breach.budget.id, limitType: breach.limitType },
+      '[inference] Budget fallback with no active local provider — blocking call'
+    );
+    handleBlock(params, resolved, breach, insertLog);
+  }
+  logger.warn(
+    {
+      budgetId: breach.budget.id,
+      limitType: breach.limitType,
+      originalProvider: params.provider,
+      originalModel: params.model,
+      fallbackProvider: target.provider,
+      fallbackModel: target.model,
+    },
+    '[inference] Budget exceeded — routing to local fallback provider'
+  );
+  return { ...params, provider: target.provider, model: target.model };
+}
+
+export function enforceBudgets(
+  params: TrackInferenceParams,
+  resolved: ResolvedInferenceParams,
+  insertLog: (values: InferenceLogInsert) => void
+): TrackInferenceParams {
+  let breaches: BudgetBreach[];
+  try {
+    ({ breaches } = evaluateBudgetsForCall(params.provider, params.operation));
+  } catch (err) {
+    // Fail open: a broken budget query (e.g. ai_budgets table missing in a
+    // partially-mocked test context) must not stop legitimate AI calls.
+    logger.warn(
+      { err, provider: params.provider, operation: params.operation },
+      '[inference] Budget evaluation failed — proceeding without enforcement'
+    );
+    return params;
+  }
+  if (breaches.length === 0) return params;
+
+  const block = breaches.find((b) => b.budget.action === 'block');
+  if (block) handleBlock(params, resolved, block, insertLog);
+
+  const fallback = breaches.find((b) => b.budget.action === 'fallback');
+  if (fallback) return handleFallback(params, resolved, fallback, insertLog);
+
+  for (const warn of breaches.filter((b) => b.budget.action === 'warn')) {
+    logger.warn(
+      {
+        budgetId: warn.budget.id,
+        limitType: warn.limitType,
+        currentUsage: warn.currentUsage,
+        limit: warn.limit,
+      },
+      '[inference] Budget warning — proceeding with call'
+    );
+  }
+  return params;
+}

--- a/apps/pops-api/src/lib/inference-middleware-types.ts
+++ b/apps/pops-api/src/lib/inference-middleware-types.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared types between the inference middleware and its budget-enforcement
+ * helper. Extracted into a separate module so the two halves can import the
+ * same shapes without creating a cycle.
+ */
+
+export interface TrackInferenceParams {
+  provider: string;
+  model: string;
+  operation: string;
+  domain?: string;
+  contextId?: string;
+  cached?: boolean;
+}
+
+export interface ResolvedInferenceParams {
+  domain: string | null;
+  contextId: string | null;
+}
+
+export interface InferenceLogInsert {
+  provider: string;
+  model: string;
+  operation: string;
+  domain: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+  status: string;
+  cached: number;
+  contextId: string | null;
+  errorMessage: string | null;
+}

--- a/apps/pops-api/src/lib/inference-middleware.test.ts
+++ b/apps/pops-api/src/lib/inference-middleware.test.ts
@@ -1,7 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { setupTestContext } from '../shared/test-utils.js';
+import { upsertBudget } from '../modules/core/ai-budgets/service.js';
+import { BudgetExceededError } from '../shared/errors.js';
+import { seedAiUsage, setupTestContext } from '../shared/test-utils.js';
 import { trackInference } from './inference-middleware.js';
+import { logger } from './logger.js';
 
 import type { Database } from 'better-sqlite3';
 
@@ -199,5 +202,183 @@ describe('trackInference — Ollama-shaped responses', () => {
     const [row] = readLogs();
     expect(row?.input_tokens).toBe(0);
     expect(row?.output_tokens).toBe(0);
+  });
+});
+
+function seedLocalProvider(model = 'llama3:8b'): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO ai_providers (id, name, type, base_url, api_key_ref, status, created_at, updated_at)
+     VALUES (?, ?, 'local', ?, NULL, 'active', ?, ?)`
+  ).run('ollama', 'Ollama', 'http://localhost:11434', now, now);
+  db.prepare(
+    `INSERT INTO ai_model_pricing
+       (provider_id, model_id, input_cost_per_mtok, output_cost_per_mtok, is_default, created_at, updated_at)
+     VALUES (?, ?, 0, 0, 1, ?, ?)`
+  ).run('ollama', model, now, now);
+}
+
+describe('trackInference — budget enforcement', () => {
+  it('blocks the call and logs status=budget-blocked when a cost-block budget is exceeded', async () => {
+    upsertBudget({
+      id: 'global',
+      scopeType: 'global',
+      monthlyCostLimit: 1.0,
+      action: 'block',
+    });
+    seedAiUsage(db, { cost_usd: 0.6, created_at: new Date().toISOString() });
+    seedAiUsage(db, { cost_usd: 0.41, created_at: new Date().toISOString() });
+
+    let called = false;
+    await expect(
+      trackInference(
+        { provider: 'claude', model: 'claude-haiku-4-5-20251001', operation: 'entity-match' },
+        async () => {
+          called = true;
+          return { usage: { input_tokens: 1, output_tokens: 1 } };
+        }
+      )
+    ).rejects.toBeInstanceOf(BudgetExceededError);
+
+    expect(called).toBe(false);
+
+    const blocked = (
+      db.prepare("SELECT * FROM ai_inference_log WHERE status = 'budget-blocked'").all() as {
+        cost_usd: number;
+      }[]
+    )[0];
+    expect(blocked).toBeDefined();
+    expect(blocked?.cost_usd).toBe(0);
+  });
+
+  it('blocks the call when a token-block budget is exceeded and surfaces limitType=token', async () => {
+    upsertBudget({
+      id: 'global',
+      scopeType: 'global',
+      monthlyTokenLimit: 1000,
+      action: 'block',
+    });
+    seedAiUsage(db, {
+      input_tokens: 600,
+      output_tokens: 500,
+      created_at: new Date().toISOString(),
+    });
+
+    let caught: BudgetExceededError | null = null;
+    try {
+      await trackInference(
+        { provider: 'claude', model: 'claude-haiku-4-5-20251001', operation: 'entity-match' },
+        async () => ({ usage: { input_tokens: 1, output_tokens: 1 } })
+      );
+    } catch (err) {
+      if (err instanceof BudgetExceededError) caught = err;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught?.limitType).toBe('token');
+    expect(caught?.budgetId).toBe('global');
+    expect(caught?.limit).toBe(1000);
+    expect(caught?.currentUsage).toBe(1100);
+  });
+
+  it('proceeds and logs a warning when a warn budget is exceeded', async () => {
+    upsertBudget({
+      id: 'global',
+      scopeType: 'global',
+      monthlyCostLimit: 0.5,
+      action: 'warn',
+    });
+    seedAiUsage(db, { cost_usd: 0.6, created_at: new Date().toISOString() });
+
+    const warnSpy = vi.spyOn(logger, 'warn');
+    const result = await trackInference(
+      { provider: 'claude', model: 'claude-haiku-4-5-20251001', operation: 'entity-match' },
+      async () => ({ usage: { input_tokens: 10, output_tokens: 10 }, content: 'ok' })
+    );
+
+    expect(result).toMatchObject({ content: 'ok' });
+    const messages = warnSpy.mock.calls.map(([, msg]) => msg);
+    expect(messages.some((m) => typeof m === 'string' && m.includes('Budget warning'))).toBe(true);
+    warnSpy.mockRestore();
+
+    const success = (
+      db.prepare("SELECT * FROM ai_inference_log WHERE status = 'success'").all() as {
+        cost_usd: number;
+      }[]
+    )[0];
+    expect(success).toBeDefined();
+  });
+
+  it('routes to local fallback provider when a fallback budget is exceeded', async () => {
+    seedLocalProvider('llama3:8b');
+    upsertBudget({
+      id: 'global',
+      scopeType: 'global',
+      monthlyCostLimit: 0.5,
+      action: 'fallback',
+    });
+    seedAiUsage(db, { cost_usd: 1.0, created_at: new Date().toISOString() });
+
+    const result = await trackInference(
+      { provider: 'claude', model: 'claude-haiku-4-5-20251001', operation: 'entity-match' },
+      async () => ({ usage: { input_tokens: 5, output_tokens: 5 } })
+    );
+    expect(result).toBeDefined();
+
+    // The most recent success row should be the fallback call (ollama/llama3),
+    // not the pre-seeded usage row that put us over budget.
+    const row = (
+      db
+        .prepare(
+          "SELECT provider, model FROM ai_inference_log WHERE status = 'success' ORDER BY id DESC LIMIT 1"
+        )
+        .all() as { provider: string; model: string }[]
+    )[0];
+    expect(row?.provider).toBe('ollama');
+    expect(row?.model).toBe('llama3:8b');
+  });
+
+  it('blocks when fallback action is configured but no active local provider exists', async () => {
+    upsertBudget({
+      id: 'global',
+      scopeType: 'global',
+      monthlyCostLimit: 0.5,
+      action: 'fallback',
+    });
+    seedAiUsage(db, { cost_usd: 1.0, created_at: new Date().toISOString() });
+
+    await expect(
+      trackInference(
+        { provider: 'claude', model: 'claude-haiku-4-5-20251001', operation: 'entity-match' },
+        async () => ({ usage: { input_tokens: 1, output_tokens: 1 } })
+      )
+    ).rejects.toBeInstanceOf(BudgetExceededError);
+
+    const blocked = (
+      db.prepare("SELECT * FROM ai_inference_log WHERE status = 'budget-blocked'").all() as {
+        cost_usd: number;
+      }[]
+    )[0];
+    expect(blocked).toBeDefined();
+  });
+
+  it('does not enforce budgets on cached calls', async () => {
+    upsertBudget({
+      id: 'global',
+      scopeType: 'global',
+      monthlyCostLimit: 0.5,
+      action: 'block',
+    });
+    seedAiUsage(db, { cost_usd: 1.0, created_at: new Date().toISOString() });
+
+    const result = await trackInference(
+      {
+        provider: 'claude',
+        model: 'claude-haiku-4-5-20251001',
+        operation: 'entity-match',
+        cached: true,
+      },
+      async () => 'cached-result'
+    );
+    expect(result).toBe('cached-result');
   });
 });

--- a/apps/pops-api/src/lib/inference-middleware.test.ts
+++ b/apps/pops-api/src/lib/inference-middleware.test.ts
@@ -7,9 +7,11 @@ import { trackInference } from './inference-middleware.js';
 import { logger } from './logger.js';
 
 import type { Database } from 'better-sqlite3';
+import type { MockInstance } from 'vitest';
 
 const ctx = setupTestContext();
 let db: Database;
+let warnSpy: MockInstance<typeof logger.warn> | null = null;
 
 interface LoggedRow {
   provider: string;
@@ -44,6 +46,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  warnSpy?.mockRestore();
+  warnSpy = null;
   ctx.teardown();
 });
 
@@ -243,9 +247,9 @@ describe('trackInference — budget enforcement', () => {
     expect(called).toBe(false);
 
     const blocked = (
-      db.prepare("SELECT * FROM ai_inference_log WHERE status = 'budget-blocked'").all() as {
-        cost_usd: number;
-      }[]
+      db
+        .prepare("SELECT * FROM ai_inference_log WHERE status = 'budget-blocked'")
+        .all() as LoggedRow[]
     )[0];
     expect(blocked).toBeDefined();
     expect(blocked?.cost_usd).toBe(0);
@@ -289,7 +293,7 @@ describe('trackInference — budget enforcement', () => {
     });
     seedAiUsage(db, { cost_usd: 0.6, created_at: new Date().toISOString() });
 
-    const warnSpy = vi.spyOn(logger, 'warn');
+    warnSpy = vi.spyOn(logger, 'warn');
     const result = await trackInference(
       { provider: 'claude', model: 'claude-haiku-4-5-20251001', operation: 'entity-match' },
       async () => ({ usage: { input_tokens: 10, output_tokens: 10 }, content: 'ok' })
@@ -298,12 +302,9 @@ describe('trackInference — budget enforcement', () => {
     expect(result).toMatchObject({ content: 'ok' });
     const messages = warnSpy.mock.calls.map(([, msg]) => msg);
     expect(messages.some((m) => typeof m === 'string' && m.includes('Budget warning'))).toBe(true);
-    warnSpy.mockRestore();
 
     const success = (
-      db.prepare("SELECT * FROM ai_inference_log WHERE status = 'success'").all() as {
-        cost_usd: number;
-      }[]
+      db.prepare("SELECT * FROM ai_inference_log WHERE status = 'success'").all() as LoggedRow[]
     )[0];
     expect(success).toBeDefined();
   });
@@ -354,9 +355,9 @@ describe('trackInference — budget enforcement', () => {
     ).rejects.toBeInstanceOf(BudgetExceededError);
 
     const blocked = (
-      db.prepare("SELECT * FROM ai_inference_log WHERE status = 'budget-blocked'").all() as {
-        cost_usd: number;
-      }[]
+      db
+        .prepare("SELECT * FROM ai_inference_log WHERE status = 'budget-blocked'")
+        .all() as LoggedRow[]
     )[0];
     expect(blocked).toBeDefined();
   });

--- a/apps/pops-api/src/lib/inference-middleware.ts
+++ b/apps/pops-api/src/lib/inference-middleware.ts
@@ -1,35 +1,20 @@
 import { aiInferenceLog } from '@pops/db-types';
 
 import { getDrizzle } from '../db.js';
+import { enforceBudgets } from './inference-budget-enforcement.js';
 import { lookupPricing } from './inference-pricing.js';
 import { extractTokens } from './inference-tokens.js';
 import { logger } from './logger.js';
 
-export interface TrackInferenceParams {
-  provider: string;
-  model: string;
-  operation: string;
-  domain?: string;
-  contextId?: string;
-  cached?: boolean;
-}
+import type {
+  InferenceLogInsert,
+  ResolvedInferenceParams,
+  TrackInferenceParams,
+} from './inference-middleware-types.js';
 
-interface LogValues {
-  provider: string;
-  model: string;
-  operation: string;
-  domain: string | null;
-  inputTokens: number;
-  outputTokens: number;
-  costUsd: number;
-  latencyMs: number;
-  status: string;
-  cached: number;
-  contextId: string | null;
-  errorMessage: string | null;
-}
+export type { TrackInferenceParams } from './inference-middleware-types.js';
 
-function insertLog(values: LogValues): void {
+function insertLog(values: InferenceLogInsert): void {
   try {
     getDrizzle()
       .insert(aiInferenceLog)
@@ -44,12 +29,7 @@ function insertLog(values: LogValues): void {
   }
 }
 
-interface ResolvedParams {
-  domain: string | null;
-  contextId: string | null;
-}
-
-function resolveParams(params: TrackInferenceParams): ResolvedParams {
+function resolveParams(params: TrackInferenceParams): ResolvedInferenceParams {
   return {
     domain: params.domain ?? null,
     contextId: params.contextId ?? null,
@@ -66,10 +46,10 @@ function classifyError(error: unknown): { msg: string; isTimeout: boolean } {
 
 function buildLogValues(
   params: TrackInferenceParams,
-  resolved: ResolvedParams,
-  partial: Partial<LogValues> &
+  resolved: ResolvedInferenceParams,
+  partial: Partial<InferenceLogInsert> &
     Pick<
-      LogValues,
+      InferenceLogInsert,
       | 'inputTokens'
       | 'outputTokens'
       | 'costUsd'
@@ -78,7 +58,7 @@ function buildLogValues(
       | 'cached'
       | 'errorMessage'
     >
-): LogValues {
+): InferenceLogInsert {
   return {
     provider: params.provider,
     model: params.model,
@@ -91,7 +71,7 @@ function buildLogValues(
 
 async function trackCachedCall<T>(
   params: TrackInferenceParams,
-  resolved: ResolvedParams,
+  resolved: ResolvedInferenceParams,
   fn: () => Promise<T>
 ): Promise<T> {
   try {
@@ -127,7 +107,7 @@ async function trackCachedCall<T>(
 
 async function trackLiveCall<T>(
   params: TrackInferenceParams,
-  resolved: ResolvedParams,
+  resolved: ResolvedInferenceParams,
   fn: () => Promise<T>
 ): Promise<T> {
   const start = Date.now();
@@ -178,5 +158,6 @@ export async function trackInference<T>(
 ): Promise<T> {
   const resolved = resolveParams(params);
   if (params.cached ?? false) return trackCachedCall(params, resolved, fn);
-  return trackLiveCall(params, resolved, fn);
+  const effective = enforceBudgets(params, resolved, insertLog);
+  return trackLiveCall(effective, resolveParams(effective), fn);
 }

--- a/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
@@ -168,8 +168,12 @@ export function migrateLegacyBudgetSettings(): void {
   if (getSettingOrNull(LEGACY_MIGRATED_FLAG_KEY)) return;
 
   const db = getDrizzle();
-  const existing = db.select().from(aiBudgets).where(eq(aiBudgets.id, 'global')).all();
-  if (existing.length > 0) {
+  const existingGlobal = db
+    .select({ id: aiBudgets.id })
+    .from(aiBudgets)
+    .where(eq(aiBudgets.scopeType, 'global'))
+    .get();
+  if (existingGlobal) {
     setRawSetting(LEGACY_MIGRATED_FLAG_KEY, '1');
     return;
   }

--- a/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
@@ -85,8 +85,14 @@ function listApplicableBudgets(provider: string, operation: string): ApplicableB
     .all();
   if (rows.length === 0) return [];
   const start = monthStart();
+  const usageByScope = new Map<string, { currentTokenUsage: number; currentCostUsage: number }>();
   return rows.map((row) => {
-    const usage = getUsageForScope(db, row, start);
+    const scopeKey = `${row.scopeType}:${row.scopeValue ?? ''}`;
+    let usage = usageByScope.get(scopeKey);
+    if (!usage) {
+      usage = getUsageForScope(db, row, start);
+      usageByScope.set(scopeKey, usage);
+    }
     return {
       id: row.id,
       scopeType: row.scopeType,
@@ -215,7 +221,7 @@ export function findFallbackProvider(): { provider: string; model: string } | nu
     .from(aiProviders)
     .innerJoin(aiModelPricing, eq(aiModelPricing.providerId, aiProviders.id))
     .where(and(eq(aiProviders.type, 'local'), eq(aiProviders.status, 'active')))
-    .orderBy(desc(aiModelPricing.isDefault), asc(aiModelPricing.modelId))
+    .orderBy(asc(aiProviders.id), desc(aiModelPricing.isDefault), asc(aiModelPricing.modelId))
     .get();
   if (!row) return null;
   return { provider: row.providerId, model: row.modelId };

--- a/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
@@ -1,0 +1,217 @@
+/**
+ * Pre-call budget enforcement helpers (PRD-092 US-04).
+ *
+ * Split out of `service.ts` so the read-side CRUD/status code (mounted on
+ * `core.aiBudgets`) and the inference-middleware enforcement path can each
+ * stay under the project's max-lines lint budget.
+ */
+import { and, eq, gte, sql } from 'drizzle-orm';
+
+import { aiBudgets, aiInferenceLog } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
+import { getSettingOrNull, setRawSetting } from '../settings/service.js';
+import { upsertBudget } from './service.js';
+
+/**
+ * A single applicable budget for a (provider, operation) pair, evaluated
+ * against the current calendar month. `currentTokenUsage` / `currentCostUsage`
+ * are summed via a single aggregate query per scope.
+ */
+export interface ApplicableBudget {
+  id: string;
+  scopeType: string;
+  scopeValue: string | null;
+  monthlyTokenLimit: number | null;
+  monthlyCostLimit: number | null;
+  action: string;
+  currentTokenUsage: number;
+  currentCostUsage: number;
+}
+
+/**
+ * One limit (cost or token) that a budget has currently exceeded. Cost takes
+ * priority when both limits are set and both are over.
+ */
+export interface BudgetBreach {
+  budget: ApplicableBudget;
+  limitType: 'cost' | 'token';
+  currentUsage: number;
+  limit: number;
+}
+
+type BudgetRow = typeof aiBudgets.$inferSelect;
+
+function monthStart(): string {
+  const d = new Date();
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1, 0, 0, 0, 0)).toISOString();
+}
+
+function getUsageForScope(
+  db: ReturnType<typeof getDrizzle>,
+  row: BudgetRow,
+  start: string
+): { currentTokenUsage: number; currentCostUsage: number } {
+  const conditions = [gte(aiInferenceLog.createdAt, start)];
+  if (row.scopeType === 'provider' && row.scopeValue) {
+    conditions.push(eq(aiInferenceLog.provider, row.scopeValue));
+  } else if (row.scopeType === 'operation' && row.scopeValue) {
+    conditions.push(eq(aiInferenceLog.operation, row.scopeValue));
+  }
+  const [agg] = db
+    .select({
+      totalTokens: sql<number>`COALESCE(SUM(${aiInferenceLog.inputTokens} + ${aiInferenceLog.outputTokens}), 0)`,
+      totalCost: sql<number>`COALESCE(SUM(${aiInferenceLog.costUsd}), 0)`,
+    })
+    .from(aiInferenceLog)
+    .where(and(...conditions))
+    .all();
+  return {
+    currentTokenUsage: agg?.totalTokens ?? 0,
+    currentCostUsage: agg?.totalCost ?? 0,
+  };
+}
+
+function listApplicableBudgets(provider: string, operation: string): ApplicableBudget[] {
+  const db = getDrizzle();
+  const rows = db
+    .select()
+    .from(aiBudgets)
+    .where(
+      sql`(${aiBudgets.scopeType} = 'global')
+        OR (${aiBudgets.scopeType} = 'provider' AND ${aiBudgets.scopeValue} = ${provider})
+        OR (${aiBudgets.scopeType} = 'operation' AND ${aiBudgets.scopeValue} = ${operation})`
+    )
+    .all();
+  if (rows.length === 0) return [];
+  const start = monthStart();
+  return rows.map((row) => {
+    const usage = getUsageForScope(db, row, start);
+    return {
+      id: row.id,
+      scopeType: row.scopeType,
+      scopeValue: row.scopeValue,
+      monthlyTokenLimit: row.monthlyTokenLimit,
+      monthlyCostLimit: row.monthlyCostLimit,
+      action: row.action,
+      currentTokenUsage: usage.currentTokenUsage,
+      currentCostUsage: usage.currentCostUsage,
+    };
+  });
+}
+
+function evaluateBreach(budget: ApplicableBudget): BudgetBreach | null {
+  if (
+    budget.monthlyCostLimit != null &&
+    budget.monthlyCostLimit > 0 &&
+    budget.currentCostUsage >= budget.monthlyCostLimit
+  ) {
+    return {
+      budget,
+      limitType: 'cost',
+      currentUsage: budget.currentCostUsage,
+      limit: budget.monthlyCostLimit,
+    };
+  }
+  if (
+    budget.monthlyTokenLimit != null &&
+    budget.monthlyTokenLimit > 0 &&
+    budget.currentTokenUsage >= budget.monthlyTokenLimit
+  ) {
+    return {
+      budget,
+      limitType: 'token',
+      currentUsage: budget.currentTokenUsage,
+      limit: budget.monthlyTokenLimit,
+    };
+  }
+  return null;
+}
+
+/**
+ * Resolve every applicable budget for a (provider, operation) call and return
+ * any that are at-or-over their configured limit. Used by the inference
+ * middleware to decide whether to block, warn, or fall back before the
+ * provider call.
+ */
+export function evaluateBudgetsForCall(
+  provider: string,
+  operation: string
+): { breaches: BudgetBreach[]; allBudgets: ApplicableBudget[] } {
+  const allBudgets = listApplicableBudgets(provider, operation);
+  const breaches: BudgetBreach[] = [];
+  for (const b of allBudgets) {
+    const breach = evaluateBreach(b);
+    if (breach) breaches.push(breach);
+  }
+  return { breaches, allBudgets };
+}
+
+const LEGACY_TOKEN_BUDGET_KEY = 'ai.monthlyTokenBudget';
+const LEGACY_FALLBACK_KEY = 'ai.budgetExceededFallback';
+const LEGACY_MIGRATED_FLAG_KEY = 'ai.budgetSettingsMigrated';
+
+function mapLegacyFallbackToAction(raw: string | null): 'block' | 'warn' {
+  if (raw === 'skip') return 'block';
+  if (raw === 'alert') return 'warn';
+  return 'warn';
+}
+
+/**
+ * Idempotent startup migration from legacy `ai.monthlyTokenBudget` /
+ * `ai.budgetExceededFallback` settings into a global `ai_budgets` row.
+ * Runs at most once per database (gated by `ai.budgetSettingsMigrated`); also
+ * skips when a global budget row already exists, so re-running on a populated
+ * deployment is a no-op.
+ */
+export function migrateLegacyBudgetSettings(): void {
+  if (getSettingOrNull(LEGACY_MIGRATED_FLAG_KEY)) return;
+
+  const db = getDrizzle();
+  const existing = db.select().from(aiBudgets).where(eq(aiBudgets.id, 'global')).all();
+  if (existing.length > 0) {
+    setRawSetting(LEGACY_MIGRATED_FLAG_KEY, '1');
+    return;
+  }
+
+  const tokenSetting = getSettingOrNull(LEGACY_TOKEN_BUDGET_KEY);
+  const fallbackSetting = getSettingOrNull(LEGACY_FALLBACK_KEY);
+  if (!tokenSetting && !fallbackSetting) {
+    setRawSetting(LEGACY_MIGRATED_FLAG_KEY, '1');
+    return;
+  }
+
+  const parsedTokenLimit = tokenSetting ? Number(tokenSetting.value) : NaN;
+  const monthlyTokenLimit =
+    Number.isFinite(parsedTokenLimit) && parsedTokenLimit > 0 ? parsedTokenLimit : undefined;
+  const action = mapLegacyFallbackToAction(fallbackSetting?.value ?? null);
+
+  upsertBudget({
+    id: 'global',
+    scopeType: 'global',
+    monthlyTokenLimit,
+    action,
+  });
+  setRawSetting(LEGACY_MIGRATED_FLAG_KEY, '1');
+}
+
+/**
+ * Lookup an active local provider for `action='fallback'` budgets. Returns
+ * the first active local provider together with its default model. Returns
+ * `null` when no candidate is available — the middleware then treats fallback
+ * as block.
+ */
+export function findFallbackProvider(): { provider: string; model: string } | null {
+  const db = getDrizzle();
+  const rows = db.all<{ provider_id: string; model_id: string | null }>(
+    sql`SELECT p.id AS provider_id, m.model_id AS model_id
+        FROM ai_providers p
+        LEFT JOIN ai_model_pricing m ON m.provider_id = p.id
+        WHERE p.type = 'local' AND p.status = 'active'
+        ORDER BY (m.is_default = 1) DESC, m.model_id ASC
+        LIMIT 1`
+  );
+  const row = rows[0];
+  if (!row || !row.model_id) return null;
+  return { provider: row.provider_id, model: row.model_id };
+}

--- a/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
@@ -10,6 +10,7 @@ import { and, asc, desc, eq, gte, sql } from 'drizzle-orm';
 import { aiBudgets, aiInferenceLog, aiModelPricing, aiProviders } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
+import { logger } from '../../../lib/logger.js';
 import { getSettingOrNull, setRawSetting } from '../settings/service.js';
 import { upsertBudget } from './service.js';
 
@@ -144,7 +145,13 @@ export function evaluateBudgetsForCall(
   provider: string,
   operation: string
 ): { breaches: BudgetBreach[]; allBudgets: ApplicableBudget[] } {
-  const allBudgets = listApplicableBudgets(provider, operation);
+  let allBudgets: ApplicableBudget[];
+  try {
+    allBudgets = listApplicableBudgets(provider, operation);
+  } catch (err) {
+    logger.warn({ err, provider, operation }, '[ai-budgets] failed to read budgets — failing open');
+    return { breaches: [], allBudgets: [] };
+  }
   const breaches: BudgetBreach[] = [];
   for (const b of allBudgets) {
     const breach = evaluateBreach(b);
@@ -174,12 +181,15 @@ export function migrateLegacyBudgetSettings(): void {
   if (getSettingOrNull(LEGACY_MIGRATED_FLAG_KEY)) return;
 
   const db = getDrizzle();
-  const existingGlobal = db
+  // Skip if either: a global-scoped row already exists, or a row with id='global'
+  // already exists under a different scope. upsertBudget keys on id, so the
+  // latter would silently clobber unrelated data.
+  const conflict = db
     .select({ id: aiBudgets.id })
     .from(aiBudgets)
-    .where(eq(aiBudgets.scopeType, 'global'))
+    .where(sql`${aiBudgets.scopeType} = 'global' OR ${aiBudgets.id} = 'global'`)
     .get();
-  if (existingGlobal) {
+  if (conflict) {
     setRawSetting(LEGACY_MIGRATED_FLAG_KEY, '1');
     return;
   }

--- a/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/enforcement.ts
@@ -5,9 +5,9 @@
  * `core.aiBudgets`) and the inference-middleware enforcement path can each
  * stay under the project's max-lines lint budget.
  */
-import { and, eq, gte, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, sql } from 'drizzle-orm';
 
-import { aiBudgets, aiInferenceLog } from '@pops/db-types';
+import { aiBudgets, aiInferenceLog, aiModelPricing, aiProviders } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
 import { getSettingOrNull, setRawSetting } from '../settings/service.js';
@@ -203,15 +203,16 @@ export function migrateLegacyBudgetSettings(): void {
  */
 export function findFallbackProvider(): { provider: string; model: string } | null {
   const db = getDrizzle();
-  const rows = db.all<{ provider_id: string; model_id: string | null }>(
-    sql`SELECT p.id AS provider_id, m.model_id AS model_id
-        FROM ai_providers p
-        LEFT JOIN ai_model_pricing m ON m.provider_id = p.id
-        WHERE p.type = 'local' AND p.status = 'active'
-        ORDER BY (m.is_default = 1) DESC, m.model_id ASC
-        LIMIT 1`
-  );
-  const row = rows[0];
-  if (!row || !row.model_id) return null;
-  return { provider: row.provider_id, model: row.model_id };
+  const row = db
+    .select({
+      providerId: aiProviders.id,
+      modelId: aiModelPricing.modelId,
+    })
+    .from(aiProviders)
+    .innerJoin(aiModelPricing, eq(aiModelPricing.providerId, aiProviders.id))
+    .where(and(eq(aiProviders.type, 'local'), eq(aiProviders.status, 'active')))
+    .orderBy(desc(aiModelPricing.isDefault), asc(aiModelPricing.modelId))
+    .get();
+  if (!row) return null;
+  return { provider: row.providerId, model: row.modelId };
 }

--- a/apps/pops-api/src/modules/core/ai-budgets/service.test.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/service.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { seedAiUsage, setupTestContext } from '../../../shared/test-utils.js';
+import { seedAiUsage, seedSetting, setupTestContext } from '../../../shared/test-utils.js';
+import { setRawSetting } from '../settings/service.js';
 import * as service from './service.js';
 
 import type { Database } from 'better-sqlite3';
@@ -128,5 +129,149 @@ describe('getBudgetStatus', () => {
     const [status] = service.getBudgetStatus();
     // percentageUsed should be based on cost (4/20 = 20%), not tokens (150/1000 = 15%)
     expect(status?.percentageUsed).toBeCloseTo(20);
+  });
+});
+
+describe('evaluateBudgetsForCall', () => {
+  it('returns no breaches when no budgets exist', () => {
+    const { breaches, allBudgets } = service.evaluateBudgetsForCall('claude', 'entity-match');
+    expect(breaches).toHaveLength(0);
+    expect(allBudgets).toHaveLength(0);
+  });
+
+  it('identifies a cost breach on a global budget', () => {
+    service.upsertBudget({
+      id: 'global',
+      scopeType: 'global',
+      monthlyCostLimit: 1,
+      action: 'block',
+    });
+    seedAiUsage(db, { cost_usd: 1.1, created_at: new Date().toISOString() });
+
+    const { breaches } = service.evaluateBudgetsForCall('claude', 'entity-match');
+    expect(breaches).toHaveLength(1);
+    expect(breaches[0]?.limitType).toBe('cost');
+    expect(breaches[0]?.budget.id).toBe('global');
+  });
+
+  it('ignores provider-scoped budgets for a different provider', () => {
+    service.upsertBudget({
+      id: 'ollama-budget',
+      scopeType: 'provider',
+      scopeValue: 'ollama',
+      monthlyCostLimit: 1,
+      action: 'block',
+    });
+    seedAiUsage(db, {
+      provider: 'ollama',
+      cost_usd: 2,
+      created_at: new Date().toISOString(),
+    });
+
+    // The Claude call should not match the Ollama budget.
+    const { breaches: claudeBreaches } = service.evaluateBudgetsForCall('claude', 'entity-match');
+    expect(claudeBreaches).toHaveLength(0);
+
+    const { breaches: ollamaBreaches } = service.evaluateBudgetsForCall('ollama', 'entity-match');
+    expect(ollamaBreaches).toHaveLength(1);
+  });
+});
+
+describe('migrateLegacyBudgetSettings', () => {
+  it('is a no-op when no legacy settings exist', () => {
+    service.migrateLegacyBudgetSettings();
+    expect(service.listBudgets()).toHaveLength(0);
+  });
+
+  it('creates a global budget from ai.monthlyTokenBudget + ai.budgetExceededFallback=skip', () => {
+    seedSetting(db, { key: 'ai.monthlyTokenBudget', value: '50000' });
+    seedSetting(db, { key: 'ai.budgetExceededFallback', value: 'skip' });
+
+    service.migrateLegacyBudgetSettings();
+
+    const budgets = service.listBudgets();
+    expect(budgets).toHaveLength(1);
+    expect(budgets[0]?.id).toBe('global');
+    expect(budgets[0]?.scopeType).toBe('global');
+    expect(budgets[0]?.monthlyTokenLimit).toBe(50000);
+    expect(budgets[0]?.action).toBe('block');
+  });
+
+  it('maps fallback=alert to action=warn', () => {
+    seedSetting(db, { key: 'ai.monthlyTokenBudget', value: '20000' });
+    seedSetting(db, { key: 'ai.budgetExceededFallback', value: 'alert' });
+
+    service.migrateLegacyBudgetSettings();
+
+    const budgets = service.listBudgets();
+    expect(budgets[0]?.action).toBe('warn');
+  });
+
+  it('is idempotent — re-running does not duplicate or change the row', () => {
+    seedSetting(db, { key: 'ai.monthlyTokenBudget', value: '10000' });
+    service.migrateLegacyBudgetSettings();
+    expect(service.listBudgets()).toHaveLength(1);
+
+    // Mutate the legacy setting after the first migration; the migration
+    // should not re-apply (the `ai.budgetSettingsMigrated` flag gates re-runs).
+    setRawSetting('ai.monthlyTokenBudget', '99999');
+    service.migrateLegacyBudgetSettings();
+    const budgets = service.listBudgets();
+    expect(budgets).toHaveLength(1);
+    expect(budgets[0]?.monthlyTokenLimit).toBe(10000);
+  });
+
+  it('does not overwrite an existing global budget row', () => {
+    service.upsertBudget({
+      id: 'global',
+      scopeType: 'global',
+      monthlyCostLimit: 5,
+      action: 'warn',
+    });
+    seedSetting(db, { key: 'ai.monthlyTokenBudget', value: '99999' });
+    seedSetting(db, { key: 'ai.budgetExceededFallback', value: 'skip' });
+
+    service.migrateLegacyBudgetSettings();
+    const budgets = service.listBudgets();
+    expect(budgets).toHaveLength(1);
+    expect(budgets[0]?.monthlyCostLimit).toBe(5);
+    expect(budgets[0]?.action).toBe('warn');
+  });
+});
+
+describe('findFallbackProvider', () => {
+  it('returns null when no local provider is configured', () => {
+    expect(service.findFallbackProvider()).toBeNull();
+  });
+
+  it('returns the first active local provider with its default model', () => {
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO ai_providers (id, name, type, base_url, api_key_ref, status, created_at, updated_at)
+       VALUES (?, ?, 'local', ?, NULL, 'active', ?, ?)`
+    ).run('ollama', 'Ollama', 'http://localhost:11434', now, now);
+    db.prepare(
+      `INSERT INTO ai_model_pricing
+         (provider_id, model_id, input_cost_per_mtok, output_cost_per_mtok, is_default, created_at, updated_at)
+       VALUES (?, ?, 0, 0, 1, ?, ?)`
+    ).run('ollama', 'llama3:8b', now, now);
+
+    const found = service.findFallbackProvider();
+    expect(found).toEqual({ provider: 'ollama', model: 'llama3:8b' });
+  });
+
+  it('ignores inactive local providers', () => {
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO ai_providers (id, name, type, base_url, api_key_ref, status, created_at, updated_at)
+       VALUES (?, ?, 'local', ?, NULL, 'error', ?, ?)`
+    ).run('ollama', 'Ollama', 'http://localhost:11434', now, now);
+    db.prepare(
+      `INSERT INTO ai_model_pricing
+         (provider_id, model_id, input_cost_per_mtok, output_cost_per_mtok, is_default, created_at, updated_at)
+       VALUES (?, ?, 0, 0, 1, ?, ?)`
+    ).run('ollama', 'llama3:8b', now, now);
+
+    expect(service.findFallbackProvider()).toBeNull();
   });
 });

--- a/apps/pops-api/src/modules/core/ai-budgets/service.test.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/service.test.ts
@@ -274,4 +274,27 @@ describe('findFallbackProvider', () => {
 
     expect(service.findFallbackProvider()).toBeNull();
   });
+
+  it('skips active local providers with no pricing row and returns one that has pricing', () => {
+    const now = new Date().toISOString();
+    // First active local provider with NO pricing row — under the old LEFT JOIN
+    // implementation this row would win the ORDER BY tiebreak and return null.
+    db.prepare(
+      `INSERT INTO ai_providers (id, name, type, base_url, api_key_ref, status, created_at, updated_at)
+       VALUES (?, ?, 'local', ?, NULL, 'active', ?, ?)`
+    ).run('orphan', 'Orphan', 'http://localhost:9999', now, now);
+    // Second active local provider WITH a pricing row — this is the correct
+    // fallback candidate.
+    db.prepare(
+      `INSERT INTO ai_providers (id, name, type, base_url, api_key_ref, status, created_at, updated_at)
+       VALUES (?, ?, 'local', ?, NULL, 'active', ?, ?)`
+    ).run('ollama', 'Ollama', 'http://localhost:11434', now, now);
+    db.prepare(
+      `INSERT INTO ai_model_pricing
+         (provider_id, model_id, input_cost_per_mtok, output_cost_per_mtok, is_default, created_at, updated_at)
+       VALUES (?, ?, 0, 0, 1, ?, ?)`
+    ).run('ollama', 'llama3:8b', now, now);
+
+    expect(service.findFallbackProvider()).toEqual({ provider: 'ollama', model: 'llama3:8b' });
+  });
 });

--- a/apps/pops-api/src/modules/core/ai-budgets/service.ts
+++ b/apps/pops-api/src/modules/core/ai-budgets/service.ts
@@ -163,3 +163,10 @@ function buildBudgetStatus(
   const fields = computeBudgetStatusFields(budget, usage, monthStartDate);
   return { ...budget, ...usage, ...fields };
 }
+
+export {
+  evaluateBudgetsForCall,
+  findFallbackProvider,
+  migrateLegacyBudgetSettings,
+} from './enforcement.js';
+export type { ApplicableBudget, BudgetBreach } from './enforcement.js';

--- a/apps/pops-api/src/shared/errors.ts
+++ b/apps/pops-api/src/shared/errors.ts
@@ -44,3 +44,40 @@ export class ConflictError extends HttpError {
     this.name = 'ConflictError';
   }
 }
+
+/**
+ * Thrown by the inference middleware (PRD-092 US-04) when a pre-call budget
+ * check finds an applicable rule with `action='block'` (or `action='fallback'`
+ * with no viable local provider) whose current-month usage has reached or
+ * exceeded the configured limit. The 402 Payment Required status is the
+ * closest semantic match for "spending budget exhausted".
+ */
+export class BudgetExceededError extends HttpError {
+  public readonly budgetId: string;
+  public readonly limitType: 'cost' | 'token';
+  public readonly currentUsage: number;
+  public readonly limit: number;
+
+  constructor(params: {
+    budgetId: string;
+    limitType: 'cost' | 'token';
+    currentUsage: number;
+    limit: number;
+  }) {
+    super(
+      402,
+      `Budget '${params.budgetId}' exceeded: ${params.limitType} usage ${params.currentUsage} >= limit ${params.limit}`,
+      {
+        budgetId: params.budgetId,
+        limitType: params.limitType,
+        currentUsage: params.currentUsage,
+        limit: params.limit,
+      }
+    );
+    this.name = 'BudgetExceededError';
+    this.budgetId = params.budgetId;
+    this.limitType = params.limitType;
+    this.currentUsage = params.currentUsage;
+    this.limit = params.limit;
+  }
+}

--- a/docs/themes/05-ai/prds/092-ai-observability/README.md
+++ b/docs/themes/05-ai/prds/092-ai-observability/README.md
@@ -133,7 +133,7 @@ Build a multi-provider observability layer that tracks every AI inference call a
 | 01  | [us-01-provider-registry](us-01-provider-registry.md)         | Provider and model pricing tables, CRUD API, health check, seed Claude defaults                   | Done    | No (first)              |
 | 02  | [us-02-inference-log-schema](us-02-inference-log-schema.md)   | `ai_inference_log` table, migration from `ai_usage`, budget tables                                | Done    | Yes                     |
 | 03  | [us-03-inference-middleware](us-03-inference-middleware.md)   | Transparent tracking wrapper for all AI calls with automatic provider/model/latency logging       | Partial | Blocked by us-01, us-02 |
-| 04  | [us-04-budget-enforcement](us-04-budget-enforcement.md)       | Pre-call budget checks, exceeded actions (block/warn/fallback), budget status API                 | Partial | Blocked by us-02        |
+| 04  | [us-04-budget-enforcement](us-04-budget-enforcement.md)       | Pre-call budget checks, exceeded actions (block/warn/fallback), budget status API                 | Done    | Blocked by us-02        |
 | 05  | [us-05-stats-and-metrics-api](us-05-stats-and-metrics-api.md) | Replaces existing stats/history API with multi-provider, latency, and quality metrics             | Partial | Blocked by us-02        |
 | 06  | [us-06-monitoring-dashboard](us-06-monitoring-dashboard.md)   | Enhanced AI Ops dashboard with provider breakdown, latency charts, budget status, quality metrics | Partial | Blocked by us-05        |
 | 07  | [us-07-alert-rules](us-07-alert-rules.md)                     | Budget threshold, error spike, and latency degradation alerts with notification delivery          | Done    | Blocked by us-05        |

--- a/docs/themes/05-ai/prds/092-ai-observability/us-04-budget-enforcement.md
+++ b/docs/themes/05-ai/prds/092-ai-observability/us-04-budget-enforcement.md
@@ -12,17 +12,17 @@ As a system administrator, I want the platform to enforce spending limits on AI 
 > middleware-integrated unit tests are tracked in #2570. The budget data
 > model and read-side APIs (list/upsert/status) are already shipped.
 
-- [ ] Pre-call budget check is integrated into `trackInference()` (US-03): before executing a non-cached AI call, the middleware queries `ai_budgets` for all applicable rules (global, matching provider, matching operation)
-- [ ] For each applicable budget, the middleware sums `cost_usd` (for cost limits) or `input_tokens + output_tokens` (for token limits) from `ai_inference_log` for the current calendar month and the relevant scope
-- [ ] If any budget with `action='block'` is exceeded: the call is rejected without hitting the provider, a row is logged with `status='budget-blocked'` and `cost_usd=0`, and the function throws a typed `BudgetExceededError` with details about which budget was exceeded
-- [ ] If any budget with `action='warn'` is exceeded: a warning is logged (via the application logger), and the call proceeds normally
-- [ ] If any budget with `action='fallback'` is exceeded: the middleware attempts to route the call to a local provider (looked up from `ai_providers` where `type='local'` and `status='active'`); if no local provider is available, the call is blocked as with `action='block'`
+- [x] Pre-call budget check is integrated into `trackInference()` (US-03): before executing a non-cached AI call, the middleware queries `ai_budgets` for all applicable rules (global, matching provider, matching operation)
+- [x] For each applicable budget, the middleware sums `cost_usd` (for cost limits) or `input_tokens + output_tokens` (for token limits) from `ai_inference_log` for the current calendar month and the relevant scope
+- [x] If any budget with `action='block'` is exceeded: the call is rejected without hitting the provider, a row is logged with `status='budget-blocked'` and `cost_usd=0`, and the function throws a typed `BudgetExceededError` with details about which budget was exceeded
+- [x] If any budget with `action='warn'` is exceeded: a warning is logged (via the application logger), and the call proceeds normally
+- [x] If any budget with `action='fallback'` is exceeded: the middleware attempts to route the call to a local provider (looked up from `ai_providers` where `type='local'` and `status='active'`); if no local provider is available, the call is blocked as with `action='block'`
 - [x] Budget status API — `core.aiBudgets.getBudgetStatus` (mounted under `core.aiBudgets` rather than `core.aiObservability`): returns an array of budget objects, each containing `id`, `scope_type`, `scope_value`, `monthly_token_limit`, `monthly_cost_limit`, `action`, `current_token_usage`, `current_cost_usage`, `percentage_used` (of whichever limit is set), and `projected_exhaustion_date` (linear extrapolation: if current spend is X on day D of the month, exhaustion = limit / (X / D) days from month start)
 - [x] Budget CRUD API — `core.aiBudgets.list`: returns all budget rules; `core.aiBudgets.upsert`: creates or updates a budget rule by `id`
-- [ ] On application startup, a migration function checks for existing `ai.monthlyTokenBudget` and `ai.budgetExceededFallback` settings: if found and no `ai_budgets` row with `id='global'` exists, it creates one with the appropriate `monthly_token_limit` and `action` (`budgetExceededFallback='skip'` → `'block'`, `'alert'` → `'warn'`, unset or unrecognized → `'warn'`)
-- [ ] Budget check queries are efficient: use a single aggregate query per scope rather than loading all log rows
-- [ ] Unit test: create a budget with `monthly_cost_limit=1.00` and `action='block'`, insert `ai_inference_log` rows totaling $1.01 for the current month, call `trackInference` with a non-cached call, verify it throws `BudgetExceededError` and a row with `status='budget-blocked'` exists
-- [ ] Unit test: create a budget with `action='warn'` that is exceeded, verify the call proceeds and a warning is logged
+- [x] On application startup, a migration function checks for existing `ai.monthlyTokenBudget` and `ai.budgetExceededFallback` settings: if found and no `ai_budgets` row with `id='global'` exists, it creates one with the appropriate `monthly_token_limit` and `action` (`budgetExceededFallback='skip'` → `'block'`, `'alert'` → `'warn'`, unset or unrecognized → `'warn'`)
+- [x] Budget check queries are efficient: use a single aggregate query per scope rather than loading all log rows
+- [x] Unit test: create a budget with `monthly_cost_limit=1.00` and `action='block'`, insert `ai_inference_log` rows totaling $1.01 for the current month, call `trackInference` with a non-cached call, verify it throws `BudgetExceededError` and a row with `status='budget-blocked'` exists
+- [x] Unit test: create a budget with `action='warn'` that is exceeded, verify the call proceeds and a warning is logged
 - [x] Unit test: verify `getBudgetStatus` returns correct `percentage_used` and a reasonable `projected_exhaustion_date`
 
 ## Notes


### PR DESCRIPTION
## Summary

- Adds pre-call budget enforcement to `trackInference()` (PRD-092 US-04): non-cached calls now query `ai_budgets` for applicable global/provider/operation rules and aggregate current-month usage via a single `SUM` per scope.
- Implements the three `action` outcomes: `block` (logs `status='budget-blocked'`, throws new `BudgetExceededError`), `warn` (logs and proceeds), and `fallback` (routes to the first active local provider in `ai_providers`; blocks when none is available).
- New `BudgetExceededError` extends `HttpError` (402) and carries `budgetId`, `limitType` (`'cost' | 'token'`), `currentUsage`, `limit`.
- Idempotent startup migration in `index.ts` converts legacy `ai.monthlyTokenBudget` / `ai.budgetExceededFallback` settings into a global `ai_budgets` row (`skip` -> `block`, `alert` -> `warn`, unset -> `warn`). Skips when a `global` row already exists; gated by an `ai.budgetSettingsMigrated` flag for replay safety.
- Budget evaluation fails open if the underlying query throws (e.g. partially mocked DB in unit tests) so existing AI call paths aren't disrupted.
- Test coverage adds cost-block / token-block / warn / fallback-with-local / fallback-without-local / cached-bypass for `trackInference`, plus scope filtering for `evaluateBudgetsForCall`, all four legacy-settings migration branches, and `findFallbackProvider` behaviour.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint` (0 errors)
- [x] `pnpm typecheck`
- [x] `pnpm --filter @pops/api test` (4236 passing)
- [x] `cd packages/module-registry && pnpm build`

Closes #2570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI budget enforcement now evaluates configured budgets before inference calls, supporting block (reject), warn (log and proceed), and fallback (reroute to alternative provider) actions.
  * Automatic startup migration of legacy budget configuration into the new unified budget system.

* **Tests**
  * Added comprehensive budget enforcement testing including block, warn, fallback, and edge-case scenarios.

* **Documentation**
  * Updated budget enforcement acceptance criteria.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knoxio/pops/pull/2629)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->