### PR TITLE
feat(cerebrum): contradiction detection in patterns (#2580)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/nudges/__tests__/contradiction-analyzer.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/__tests__/contradiction-analyzer.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the LLM-backed contradiction analyzer (PRD-084 US-03, #2580).
+ *
+ * The analyzer is the load-bearing piece for AC #4 and #6: it must return
+ * structured evidence (conflict summary + per-side excerpt) for genuine
+ * conflicts and a clean null for everything else — including malformed
+ * model output, since a parse failure means we have nothing trustworthy to
+ * surface to the user.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@pops/db-types', () => ({
+  settings: { key: { name: 'key' }, value: { name: 'value' } },
+}));
+
+vi.mock('../../../../env.js', () => ({
+  getEnv: vi.fn().mockReturnValue('test-api-key'),
+}));
+
+vi.mock('../../../../lib/logger.js', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../../../lib/ai-retry.js', () => ({
+  withRateLimitRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../../../lib/inference-middleware.js', () => ({
+  trackInference: vi.fn((_opts: unknown, fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../../../core/settings/service.js', () => ({
+  getSettingValue: vi.fn((_key: string, fallback: unknown) => fallback),
+  getAiModel: vi.fn((_key: string, fallback: string) => fallback),
+}));
+
+const mockCreate = vi.fn();
+
+class MockAnthropic {
+  messages = { create: mockCreate };
+}
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: MockAnthropic,
+}));
+
+const { LlmContradictionAnalyzer, NoopContradictionAnalyzer, parseAnalyzerResponse } =
+  await import('../detectors/contradiction-analyzer.js');
+
+describe('parseAnalyzerResponse', () => {
+  it('returns null when the model says no contradiction', () => {
+    const out = parseAnalyzerResponse('{"contradiction": false}');
+    expect(out).toBeNull();
+  });
+
+  it('parses a well-formed contradiction payload', () => {
+    const raw = JSON.stringify({
+      contradiction: true,
+      conflict: 'A says X, B says not X.',
+      excerptA: 'I think X is correct.',
+      excerptB: 'X is definitely wrong.',
+    });
+    const out = parseAnalyzerResponse(raw);
+    expect(out).toEqual({
+      conflict: 'A says X, B says not X.',
+      excerptA: 'I think X is correct.',
+      excerptB: 'X is definitely wrong.',
+    });
+  });
+
+  it('returns null when contradiction=true but fields are missing', () => {
+    const raw = JSON.stringify({ contradiction: true, conflict: 'oops' });
+    expect(parseAnalyzerResponse(raw)).toBeNull();
+  });
+
+  it('returns null for empty strings even when contradiction=true', () => {
+    const raw = JSON.stringify({
+      contradiction: true,
+      conflict: '',
+      excerptA: 'a',
+      excerptB: 'b',
+    });
+    expect(parseAnalyzerResponse(raw)).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseAnalyzerResponse('not json')).toBeNull();
+    expect(parseAnalyzerResponse('{ broken json ')).toBeNull();
+    expect(parseAnalyzerResponse('')).toBeNull();
+  });
+
+  it('tolerates surrounding prose around the JSON', () => {
+    const raw = `Sure, here you go:\n{"contradiction": true, "conflict": "C", "excerptA": "a", "excerptB": "b"}\nThat's all.`;
+    const out = parseAnalyzerResponse(raw);
+    expect(out?.conflict).toBe('C');
+  });
+
+  it('clips excerpts longer than 240 chars', () => {
+    const long = 'x'.repeat(300);
+    const raw = JSON.stringify({
+      contradiction: true,
+      conflict: 'long',
+      excerptA: long,
+      excerptB: 'short',
+    });
+    const out = parseAnalyzerResponse(raw);
+    expect(out?.excerptA.length).toBeLessThanOrEqual(240);
+    expect(out?.excerptA.endsWith('…')).toBe(true);
+  });
+});
+
+describe('LlmContradictionAnalyzer.analyze', () => {
+  let analyzer: InstanceType<typeof LlmContradictionAnalyzer>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    analyzer = new LlmContradictionAnalyzer();
+  });
+
+  it('returns evidence with both engram IDs threaded through', async () => {
+    mockCreate.mockResolvedValue({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            contradiction: true,
+            conflict: 'A says deploy Friday, B forbids it.',
+            excerptA: 'Friday deploys are fine.',
+            excerptB: 'Never deploy on Fridays.',
+          }),
+        },
+      ],
+    });
+
+    const out = await analyzer.analyze(
+      'eng_a',
+      'Friday deploys are fine.',
+      'eng_b',
+      'Never deploy on Fridays.'
+    );
+
+    expect(out).toEqual({
+      engramA: 'eng_a',
+      engramB: 'eng_b',
+      conflict: 'A says deploy Friday, B forbids it.',
+      excerptA: 'Friday deploys are fine.',
+      excerptB: 'Never deploy on Fridays.',
+    });
+  });
+
+  it('returns null when the model reports no contradiction', async () => {
+    mockCreate.mockResolvedValue({
+      content: [{ type: 'text', text: '{"contradiction": false}' }],
+    });
+
+    const out = await analyzer.analyze('a', 'x', 'b', 'y');
+    expect(out).toBeNull();
+  });
+
+  it('skips inference when the API key is missing', async () => {
+    const { getEnv } = await import('../../../../env.js');
+    vi.mocked(getEnv).mockReturnValueOnce(undefined);
+
+    const out = await analyzer.analyze('a', 'x', 'b', 'y');
+    expect(out).toBeNull();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the model returns garbage', async () => {
+    mockCreate.mockResolvedValue({
+      content: [{ type: 'text', text: 'literally garbage output' }],
+    });
+
+    const out = await analyzer.analyze('a', 'x', 'b', 'y');
+    expect(out).toBeNull();
+  });
+});
+
+describe('NoopContradictionAnalyzer', () => {
+  it('always returns null', async () => {
+    const analyzer = new NoopContradictionAnalyzer();
+    expect(await analyzer.analyze('a', 'x', 'b', 'y')).toBeNull();
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/nudges/__tests__/contradiction-analyzer.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/__tests__/contradiction-analyzer.test.ts
@@ -95,7 +95,9 @@ describe('parseAnalyzerResponse', () => {
     expect(out?.conflict).toBe('C');
   });
 
-  it('clips excerpts longer than 240 chars', () => {
+  it('hard-cuts excerpts longer than 240 chars without appending ellipsis', () => {
+    // Excerpts are presented as verbatim quotes — appending any character
+    // (ellipsis, marker, etc.) would mutate the quoted source text.
     const long = 'x'.repeat(300);
     const raw = JSON.stringify({
       contradiction: true,
@@ -104,8 +106,43 @@ describe('parseAnalyzerResponse', () => {
       excerptB: 'short',
     });
     const out = parseAnalyzerResponse(raw);
-    expect(out?.excerptA.length).toBeLessThanOrEqual(240);
-    expect(out?.excerptA.endsWith('…')).toBe(true);
+    expect(out?.excerptA.length).toBe(240);
+    // No ellipsis, no sentinel — the cut is clean.
+    expect(out?.excerptA.endsWith('…')).toBe(false);
+    expect(out?.excerptA).toBe('x'.repeat(240));
+  });
+
+  it('returns null when contradiction field has wrong type (zod boundary)', () => {
+    // `contradiction` is required to be boolean — a string here is a
+    // schema violation and must collapse to the safe "no contradiction"
+    // default.
+    const raw = JSON.stringify({
+      contradiction: 'yes',
+      conflict: 'C',
+      excerptA: 'a',
+      excerptB: 'b',
+    });
+    expect(parseAnalyzerResponse(raw)).toBeNull();
+  });
+
+  it('returns null when excerpt fields are not strings', () => {
+    const raw = JSON.stringify({
+      contradiction: true,
+      conflict: 'C',
+      excerptA: 123,
+      excerptB: 'b',
+    });
+    expect(parseAnalyzerResponse(raw)).toBeNull();
+  });
+
+  it('returns null when conflict is not a string', () => {
+    const raw = JSON.stringify({
+      contradiction: true,
+      conflict: { nested: 'oops' },
+      excerptA: 'a',
+      excerptB: 'b',
+    });
+    expect(parseAnalyzerResponse(raw)).toBeNull();
   });
 });
 

--- a/apps/pops-api/src/modules/cerebrum/nudges/__tests__/contradiction-pairs.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/__tests__/contradiction-pairs.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the contradiction pair-builder (PRD-084 US-03, #2580).
+ *
+ * The pair builder is responsible for ranking — pairs with broader topical
+ * overlap should sort first. If shared-tag computation does not dedupe,
+ * an engram authored with a repeated tag could outrank pairs with
+ * genuinely broader overlap.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { buildContradictionPairs } from '../detectors/contradiction-pairs.js';
+
+import type { EngramSummary } from '../types.js';
+
+function makeEngram(id: string, overrides: Partial<EngramSummary> = {}): EngramSummary {
+  return {
+    id,
+    type: overrides.type ?? 'note',
+    title: overrides.title ?? `Engram ${id}`,
+    scopes: overrides.scopes ?? ['work.projects'],
+    tags: overrides.tags ?? ['general'],
+    status: overrides.status ?? 'active',
+    createdAt: overrides.createdAt ?? '2026-04-01T10:00:00Z',
+    modifiedAt: overrides.modifiedAt ?? '2026-04-15T10:00:00Z',
+  };
+}
+
+describe('buildContradictionPairs', () => {
+  it('produces pairs when engrams share at least one tag and a top-level scope', () => {
+    const a = makeEngram('a', { tags: ['topic:x'] });
+    const b = makeEngram('b', { tags: ['topic:x'] });
+    const pairs = buildContradictionPairs([a, b]);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0]?.overlap).toBe(1);
+    expect(pairs[0]?.sharedTag).toBe('topic:x');
+  });
+
+  it('skips pairs without a shared top-level scope', () => {
+    const a = makeEngram('a', { scopes: ['work.projects'], tags: ['topic:x'] });
+    const b = makeEngram('b', { scopes: ['personal.notes'], tags: ['topic:x'] });
+    expect(buildContradictionPairs([a, b])).toHaveLength(0);
+  });
+
+  it('skips pairs without any shared tag', () => {
+    const a = makeEngram('a', { tags: ['topic:x'] });
+    const b = makeEngram('b', { tags: ['topic:y'] });
+    expect(buildContradictionPairs([a, b])).toHaveLength(0);
+  });
+
+  it('dedupes repeated tag values when computing overlap', () => {
+    // Engram `a` has `topic:x` twice and `topic:y` once. The genuine
+    // overlap with `b` is 1 tag, not 2 — without dedup, the pair would
+    // outrank `[a,c]` below despite carrying the same true overlap.
+    const a = makeEngram('a', { tags: ['topic:x', 'topic:x', 'topic:y'] });
+    const b = makeEngram('b', { tags: ['topic:x'] });
+    const c = makeEngram('c', { tags: ['topic:y'] });
+
+    const pairs = buildContradictionPairs([a, b, c]);
+    // Both pairs should report overlap=1 once the dedup fix is in.
+    const pairAB = pairs.find(
+      (p) => (p.a.id === 'a' && p.b.id === 'b') || (p.a.id === 'b' && p.b.id === 'a')
+    );
+    const pairAC = pairs.find(
+      (p) => (p.a.id === 'a' && p.b.id === 'c') || (p.a.id === 'c' && p.b.id === 'a')
+    );
+
+    expect(pairAB?.overlap).toBe(1);
+    expect(pairAC?.overlap).toBe(1);
+  });
+
+  it('ranks pairs by overlap descending', () => {
+    const a = makeEngram('a', { tags: ['t1', 't2', 't3'] });
+    const b = makeEngram('b', { tags: ['t1', 't2', 't3'] });
+    const c = makeEngram('c', { tags: ['t1'] });
+
+    const pairs = buildContradictionPairs([a, b, c]);
+    expect(pairs[0]?.overlap).toBeGreaterThanOrEqual(pairs[1]?.overlap ?? 0);
+    // The (a,b) pair has 3 shared tags and must come first.
+    expect(pairs[0]?.a.id === 'a' || pairs[0]?.b.id === 'a').toBe(true);
+    expect(pairs[0]?.a.id === 'b' || pairs[0]?.b.id === 'b').toBe(true);
+    expect(pairs[0]?.overlap).toBe(3);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/nudges/__tests__/list-contradictions.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/__tests__/list-contradictions.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for NudgeService.listContradictions (PRD-084 US-03, #2580 — F6).
+ *
+ * Asserts the SQL-layer filter: only `type='pattern'` rows whose
+ * `action_params` carries a `contradiction` payload are paginated and
+ * counted. Recurring/emerging pattern rows MUST NOT consume page slots
+ * or inflate `total`.
+ *
+ * Uses a real in-memory SQLite database so `json_extract` actually
+ * executes — the mock-DB pattern used by `nudge-service.test.ts`
+ * cannot exercise SQL semantics.
+ */
+import BetterSqlite3 from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../lib/logger.js', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const { NudgeService } = await import('../nudge-service.js');
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+import type { NudgeThresholds } from '../types.js';
+
+function defaultThresholds(): NudgeThresholds {
+  return {
+    consolidationSimilarity: 0.85,
+    consolidationMinCluster: 3,
+    stalenessDays: 90,
+    patternMinOccurrences: 5,
+    maxPendingNudges: 20,
+    nudgeCooldownHours: 24,
+  };
+}
+
+function createDb(): { db: BetterSqlite3.Database; drizzleDb: BetterSQLite3Database } {
+  const db = new BetterSqlite3(':memory:');
+  db.exec(`
+    CREATE TABLE nudge_log (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      engram_ids TEXT NOT NULL,
+      priority TEXT NOT NULL,
+      status TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      expires_at TEXT,
+      acted_at TEXT,
+      action_type TEXT,
+      action_label TEXT,
+      action_params TEXT
+    );
+    CREATE INDEX idx_nudge_log_type ON nudge_log(type);
+    CREATE INDEX idx_nudge_log_status ON nudge_log(status);
+    CREATE INDEX idx_nudge_log_priority ON nudge_log(priority);
+    CREATE INDEX idx_nudge_log_created_at ON nudge_log(created_at);
+  `);
+  return { db, drizzleDb: drizzle(db) };
+}
+
+interface SeedRow {
+  id: string;
+  type: 'pattern' | 'staleness';
+  status: 'pending' | 'dismissed' | 'acted' | 'expired';
+  priority: 'low' | 'medium' | 'high';
+  createdAt: string;
+  actionParams?: Record<string, unknown> | null;
+}
+
+function seed(db: BetterSqlite3.Database, rows: SeedRow[]): void {
+  const stmt = db.prepare(`
+    INSERT INTO nudge_log
+      (id, type, title, body, engram_ids, priority, status, created_at,
+       action_type, action_label, action_params)
+    VALUES
+      (@id, @type, @title, @body, @engram_ids, @priority, @status, @createdAt,
+       'link', 'Open', @actionParams)
+  `);
+  for (const row of rows) {
+    stmt.run({
+      id: row.id,
+      type: row.type,
+      title: `T-${row.id}`,
+      body: `B-${row.id}`,
+      engram_ids: JSON.stringify(['eng_a', 'eng_b']),
+      priority: row.priority,
+      status: row.status,
+      createdAt: row.createdAt,
+      actionParams: row.actionParams === null ? null : JSON.stringify(row.actionParams ?? {}),
+    });
+  }
+}
+
+function makeService(drizzleDb: BetterSQLite3Database) {
+  return new NudgeService({
+    db: drizzleDb,
+    searchService: {} as never,
+    consolidationDetector: {} as never,
+    stalenessDetector: {} as never,
+    patternDetector: {} as never,
+    thresholds: defaultThresholds(),
+    now: () => new Date('2026-05-12T10:00:00Z'),
+  });
+}
+
+describe('NudgeService.listContradictions', () => {
+  let db: BetterSqlite3.Database;
+  let drizzleDb: BetterSQLite3Database;
+
+  beforeEach(() => {
+    ({ db, drizzleDb } = createDb());
+  });
+
+  it('returns only contradictions and excludes recurring/emerging pattern rows', () => {
+    seed(db, [
+      {
+        id: 'n_contradict_1',
+        type: 'pattern',
+        status: 'pending',
+        priority: 'high',
+        createdAt: '2026-05-10T10:00:00Z',
+        actionParams: {
+          contradiction: {
+            engramA: 'eng_a',
+            engramB: 'eng_b',
+            excerptA: 'x',
+            excerptB: 'y',
+            conflict: 'C',
+          },
+        },
+      },
+      // Recurring pattern (no contradiction key) — must be filtered out.
+      {
+        id: 'n_recurring',
+        type: 'pattern',
+        status: 'pending',
+        priority: 'medium',
+        createdAt: '2026-05-09T10:00:00Z',
+        actionParams: { topic: 'foo', engramIds: ['eng_a'] },
+      },
+      // Emerging pattern (also no contradiction key).
+      {
+        id: 'n_emerging',
+        type: 'pattern',
+        status: 'pending',
+        priority: 'medium',
+        createdAt: '2026-05-08T10:00:00Z',
+        actionParams: { topic: 'bar', engramIds: ['eng_b'] },
+      },
+      {
+        id: 'n_contradict_2',
+        type: 'pattern',
+        status: 'pending',
+        priority: 'high',
+        createdAt: '2026-05-07T10:00:00Z',
+        actionParams: {
+          contradiction: {
+            engramA: 'eng_c',
+            engramB: 'eng_d',
+            excerptA: 'p',
+            excerptB: 'q',
+            conflict: 'C2',
+          },
+        },
+      },
+      // Non-pattern nudge — must be excluded by the type filter.
+      {
+        id: 'n_staleness',
+        type: 'staleness',
+        status: 'pending',
+        priority: 'low',
+        createdAt: '2026-05-06T10:00:00Z',
+        actionParams: { engramId: 'eng_e' },
+      },
+    ]);
+
+    const result = makeService(drizzleDb).listContradictions({ status: 'pending' });
+
+    const ids = result.nudges.map((n) => n.id).toSorted();
+    expect(ids).toEqual(['n_contradict_1', 'n_contradict_2']);
+    // Total must reflect the FILTERED count, not the count of all
+    // pattern rows — otherwise pagination is meaningless.
+    expect(result.total).toBe(2);
+  });
+
+  it('paginates contradictions correctly when recurring rows interleave', () => {
+    // Seed 5 contradictions plus 10 recurring rows; if the filter is
+    // applied after pagination, the page slice would contain mostly
+    // recurring rows and hide contradictions.
+    const rows: SeedRow[] = [];
+    for (let i = 0; i < 5; i++) {
+      rows.push({
+        id: `n_contradict_${i}`,
+        type: 'pattern',
+        status: 'pending',
+        priority: 'high',
+        createdAt: `2026-05-${String(20 - i * 2).padStart(2, '0')}T10:00:00Z`,
+        actionParams: {
+          contradiction: {
+            engramA: `eng_a${i}`,
+            engramB: `eng_b${i}`,
+            excerptA: 'x',
+            excerptB: 'y',
+            conflict: 'c',
+          },
+        },
+      });
+    }
+    for (let i = 0; i < 10; i++) {
+      rows.push({
+        id: `n_recurring_${i}`,
+        type: 'pattern',
+        status: 'pending',
+        priority: 'medium',
+        createdAt: `2026-05-${String(19 - i).padStart(2, '0')}T10:00:00Z`,
+        actionParams: { topic: 'foo', engramIds: ['eng_x'] },
+      });
+    }
+    seed(db, rows);
+
+    const svc = makeService(drizzleDb);
+
+    const page1 = svc.listContradictions({ status: 'pending', limit: 3, offset: 0 });
+    expect(page1.total).toBe(5);
+    expect(page1.nudges).toHaveLength(3);
+    expect(page1.nudges.every((n) => n.id.startsWith('n_contradict_'))).toBe(true);
+
+    const page2 = svc.listContradictions({ status: 'pending', limit: 3, offset: 3 });
+    expect(page2.total).toBe(5);
+    expect(page2.nudges).toHaveLength(2);
+    expect(page2.nudges.every((n) => n.id.startsWith('n_contradict_'))).toBe(true);
+  });
+
+  it('honours status filter and ignores it when null', () => {
+    seed(db, [
+      {
+        id: 'n_pending',
+        type: 'pattern',
+        status: 'pending',
+        priority: 'high',
+        createdAt: '2026-05-10T10:00:00Z',
+        actionParams: {
+          contradiction: {
+            engramA: 'a',
+            engramB: 'b',
+            excerptA: 'x',
+            excerptB: 'y',
+            conflict: 'c',
+          },
+        },
+      },
+      {
+        id: 'n_dismissed',
+        type: 'pattern',
+        status: 'dismissed',
+        priority: 'high',
+        createdAt: '2026-05-09T10:00:00Z',
+        actionParams: {
+          contradiction: {
+            engramA: 'a',
+            engramB: 'b',
+            excerptA: 'x',
+            excerptB: 'y',
+            conflict: 'c',
+          },
+        },
+      },
+    ]);
+
+    const svc = makeService(drizzleDb);
+
+    const pending = svc.listContradictions({ status: 'pending' });
+    expect(pending.total).toBe(1);
+    expect(pending.nudges[0]?.id).toBe('n_pending');
+
+    const all = svc.listContradictions({ status: null });
+    expect(all.total).toBe(2);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/nudges/__tests__/nudge-service.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/__tests__/nudge-service.test.ts
@@ -260,25 +260,28 @@ describe('NudgeService', () => {
 
   describe('act', () => {
     function pendingRow(actionType = 'review') {
+      // Mirrors drizzle's `select()` output: camelCase JS-side property
+      // names that map to snake_case SQL columns. The mock DB returns
+      // these directly to `rowToNudge`, which expects the drizzle shape.
       return {
         id: 'nudge_123',
         type: 'staleness',
         title: 'Test',
         body: 'Body',
-        engram_ids: '["eng_1"]',
+        engramIds: '["eng_1"]',
         priority: 'medium',
         status: 'pending',
-        created_at: '2026-04-27T10:00:00Z',
-        expires_at: null,
-        acted_at: null,
-        action_type: actionType,
-        action_label: 'Mark as reviewed',
-        action_params: '{"engramId":"eng_1"}',
+        createdAt: '2026-04-27T10:00:00Z',
+        expiresAt: null,
+        actedAt: null,
+        actionType,
+        actionLabel: 'Mark as reviewed',
+        actionParams: '{"engramId":"eng_1"}',
       };
     }
 
     function actedRow(actionType = 'review') {
-      return { ...pendingRow(actionType), status: 'acted', acted_at: '2026-04-27T10:00:00Z' };
+      return { ...pendingRow(actionType), status: 'acted', actedAt: '2026-04-27T10:00:00Z' };
     }
 
     it('marks a pending review nudge as acted and bumps modified_at', async () => {
@@ -397,15 +400,15 @@ describe('NudgeService', () => {
         type: 'staleness',
         title: 'Stale engram',
         body: 'Body text',
-        engram_ids: '["eng_1"]',
+        engramIds: '["eng_1"]',
         priority: 'medium',
         status: 'pending',
-        created_at: '2026-04-27T10:00:00Z',
-        expires_at: null,
-        acted_at: null,
-        action_type: 'review',
-        action_label: 'Review',
-        action_params: '{}',
+        createdAt: '2026-04-27T10:00:00Z',
+        expiresAt: null,
+        actedAt: null,
+        actionType: 'review',
+        actionLabel: 'Review',
+        actionParams: '{}',
       };
       const mockDb = createMockDb([[nudgeRow], [{ total: 1 }]]);
 

--- a/apps/pops-api/src/modules/cerebrum/nudges/__tests__/patterns.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/__tests__/patterns.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { PatternDetector } from '../detectors/patterns.js';
 
+import type { ContradictionAnalyzer } from '../detectors/contradiction-analyzer.js';
 import type { EngramSummary, NudgeThresholds } from '../types.js';
 
 function makeEngram(id: string, overrides: Partial<EngramSummary> = {}): EngramSummary {
@@ -34,7 +35,7 @@ const NOW = new Date('2026-04-27T10:00:00Z');
 const fixedNow = () => NOW;
 
 describe('PatternDetector', () => {
-  it('detects recurring topics from tag frequency', () => {
+  it('detects recurring topics from tag frequency', async () => {
     const engrams = Array.from({ length: 6 }, (_, i) =>
       makeEngram(`eng_${i + 1}`, {
         tags: ['agent-coordination', 'engineering'],
@@ -43,7 +44,7 @@ describe('PatternDetector', () => {
     );
 
     const detector = new PatternDetector(defaultThresholds(), fixedNow);
-    const result = detector.detect(engrams);
+    const result = await detector.detect(engrams);
 
     expect(result.nudges.length).toBeGreaterThanOrEqual(1);
     const agentNudge = result.nudges.find((n) => n.title.includes('agent-coordination'));
@@ -52,7 +53,7 @@ describe('PatternDetector', () => {
     expect(agentNudge?.engramIds).toHaveLength(6);
   });
 
-  it('does not flag topics below minimum occurrences', () => {
+  it('does not flag topics below minimum occurrences', async () => {
     const engrams = [
       makeEngram('eng_1', { tags: ['rare-topic'] }),
       makeEngram('eng_2', { tags: ['rare-topic'] }),
@@ -60,12 +61,12 @@ describe('PatternDetector', () => {
     ];
 
     const detector = new PatternDetector(defaultThresholds({ patternMinOccurrences: 5 }), fixedNow);
-    const result = detector.detect(engrams);
+    const result = await detector.detect(engrams);
 
     expect(result.nudges).toHaveLength(0);
   });
 
-  it('respects configurable minimum occurrences', () => {
+  it('respects configurable minimum occurrences', async () => {
     const engrams = [
       makeEngram('eng_1', { tags: ['micro-topic'] }),
       makeEngram('eng_2', { tags: ['micro-topic'] }),
@@ -73,13 +74,13 @@ describe('PatternDetector', () => {
     ];
 
     const detector = new PatternDetector(defaultThresholds({ patternMinOccurrences: 3 }), fixedNow);
-    const result = detector.detect(engrams);
+    const result = await detector.detect(engrams);
 
     expect(result.nudges).toHaveLength(1);
     expect(result.nudges[0]?.title).toContain('micro-topic');
   });
 
-  it('detects emerging themes with rising trend', () => {
+  it('detects emerging themes with rising trend', async () => {
     // Create engrams over 3 months with accelerating frequency.
     const month1 = Array.from({ length: 2 }, (_, i) =>
       makeEngram(`eng_m1_${i}`, {
@@ -103,7 +104,7 @@ describe('PatternDetector', () => {
     const engrams = [...month1, ...month2, ...month3];
 
     const detector = new PatternDetector(defaultThresholds({ patternMinOccurrences: 5 }), fixedNow);
-    const result = detector.detect(engrams);
+    const result = await detector.detect(engrams);
 
     // Should detect the recurring topic within the window AND/OR the emerging trend.
     expect(result.nudges.length).toBeGreaterThanOrEqual(1);
@@ -114,7 +115,7 @@ describe('PatternDetector', () => {
     expect(accelNudge?.body).toContain('rising');
   });
 
-  it('excludes archived and consolidated engrams', () => {
+  it('excludes archived and consolidated engrams', async () => {
     const engrams = [
       ...Array.from({ length: 5 }, (_, i) =>
         makeEngram(`eng_active_${i}`, {
@@ -131,7 +132,7 @@ describe('PatternDetector', () => {
     ];
 
     const detector = new PatternDetector(defaultThresholds({ patternMinOccurrences: 5 }), fixedNow);
-    const result = detector.detect(engrams);
+    const result = await detector.detect(engrams);
 
     expect(result.nudges).toHaveLength(1);
     // Should only include active engrams.
@@ -140,33 +141,33 @@ describe('PatternDetector', () => {
     }
   });
 
-  it('returns empty for no engrams', () => {
+  it('returns empty for no engrams', async () => {
     const detector = new PatternDetector(defaultThresholds(), fixedNow);
-    const result = detector.detect([]);
+    const result = await detector.detect([]);
 
     expect(result.nudges).toHaveLength(0);
   });
 
-  it('assigns medium priority to recurring and emerging patterns', () => {
+  it('assigns medium priority to recurring and emerging patterns', async () => {
     const engrams = Array.from({ length: 6 }, (_, i) =>
       makeEngram(`eng_${i}`, { tags: ['priority-test'] })
     );
 
     const detector = new PatternDetector(defaultThresholds({ patternMinOccurrences: 5 }), fixedNow);
-    const result = detector.detect(engrams);
+    const result = await detector.detect(engrams);
 
     for (const nudge of result.nudges) {
       expect(nudge.priority).toBe('medium');
     }
   });
 
-  it('includes link action with topic and engram IDs', () => {
+  it('includes link action with topic and engram IDs', async () => {
     const engrams = Array.from({ length: 5 }, (_, i) =>
       makeEngram(`eng_${i}`, { tags: ['action-test-topic'] })
     );
 
     const detector = new PatternDetector(defaultThresholds({ patternMinOccurrences: 5 }), fixedNow);
-    const result = detector.detect(engrams);
+    const result = await detector.detect(engrams);
 
     expect(result.nudges).toHaveLength(1);
     expect(result.nudges[0]?.action?.type).toBe('link');
@@ -174,7 +175,7 @@ describe('PatternDetector', () => {
     expect(result.nudges[0]?.action?.params).toHaveProperty('engramIds');
   });
 
-  it('handles engrams with multiple tags — counts each independently', () => {
+  it('handles engrams with multiple tags — counts each independently', async () => {
     const engrams = [
       ...Array.from({ length: 5 }, (_, i) =>
         makeEngram(`eng_multi_${i}`, { tags: ['tag-a', 'tag-b'] })
@@ -183,7 +184,7 @@ describe('PatternDetector', () => {
     ];
 
     const detector = new PatternDetector(defaultThresholds({ patternMinOccurrences: 5 }), fixedNow);
-    const result = detector.detect(engrams);
+    const result = await detector.detect(engrams);
 
     const tagANudge = result.nudges.find((n) => n.title.includes('tag-a'));
     const tagBNudge = result.nudges.find((n) => n.title.includes('tag-b'));
@@ -195,7 +196,7 @@ describe('PatternDetector', () => {
     expect(tagBNudge?.engramIds.length).toBe(5);
   });
 
-  it('only considers engrams within the rolling window for recurring detection', () => {
+  it('only considers engrams within the rolling window for recurring detection', async () => {
     const engrams = [
       // These are outside the 30-day window from 2026-04-27.
       ...Array.from({ length: 5 }, (_, i) =>
@@ -216,7 +217,7 @@ describe('PatternDetector', () => {
     ];
 
     const detector = new PatternDetector(defaultThresholds({ patternMinOccurrences: 5 }), fixedNow);
-    const result = detector.detect(engrams);
+    const result = await detector.detect(engrams);
 
     // Only 2 within the window for recurring — below threshold.
     // But emerging trend detection uses all-time data, so it may find it.
@@ -226,5 +227,169 @@ describe('PatternDetector', () => {
     // Emerging detection: 5 in Feb, 2 in Apr — that's declining, not rising.
     // So no nudge expected.
     expect(oldTopicNudge).toBeUndefined();
+  });
+
+  describe('contradiction detection', () => {
+    it('emits a high-priority contradiction nudge with excerpts from both sides', async () => {
+      const a = makeEngram('eng_friday_yes', {
+        scopes: ['work.projects'],
+        tags: ['topic:deploys'],
+      });
+      const b = makeEngram('eng_friday_no', {
+        scopes: ['work.projects'],
+        tags: ['topic:deploys'],
+      });
+
+      const bodies: Record<string, string> = {
+        eng_friday_yes: 'We can deploy on Fridays without issue.',
+        eng_friday_no: 'We must never deploy on Fridays.',
+      };
+
+      const analyzer: ContradictionAnalyzer = {
+        analyze: async (engramA, _bodyA, engramB, _bodyB) => ({
+          engramA,
+          engramB,
+          excerptA: 'We can deploy on Fridays',
+          excerptB: 'never deploy on Fridays',
+          conflict: 'A allows Friday deploys, B forbids them.',
+        }),
+      };
+
+      const detector = new PatternDetector({
+        thresholds: defaultThresholds({ patternMinOccurrences: 99 }),
+        now: fixedNow,
+        contradictionAnalyzer: analyzer,
+        bodyReader: (id) => bodies[id] ?? null,
+      });
+
+      const result = await detector.detect([a, b]);
+
+      const contradictionNudge = result.nudges.find((n) => n.title.startsWith('Contradiction'));
+      expect(contradictionNudge).toBeDefined();
+      expect(contradictionNudge?.priority).toBe('high');
+      // Pair generation sorts engrams by ID so the order is deterministic.
+      expect(contradictionNudge?.engramIds).toEqual(['eng_friday_no', 'eng_friday_yes']);
+      expect(contradictionNudge?.body).toContain('We can deploy on Fridays');
+      expect(contradictionNudge?.body).toContain('never deploy on Fridays');
+      expect(contradictionNudge?.body).toContain('eng_friday_yes');
+      expect(contradictionNudge?.body).toContain('eng_friday_no');
+      expect(contradictionNudge?.action?.params).toHaveProperty('contradiction');
+    });
+
+    it('does NOT emit a contradiction nudge when the analyzer returns null', async () => {
+      const a = makeEngram('eng_a', { scopes: ['work.projects'], tags: ['topic:agree'] });
+      const b = makeEngram('eng_b', { scopes: ['work.projects'], tags: ['topic:agree'] });
+
+      const detector = new PatternDetector({
+        thresholds: defaultThresholds({ patternMinOccurrences: 99 }),
+        now: fixedNow,
+        contradictionAnalyzer: { analyze: async () => null },
+        bodyReader: () => 'some body',
+      });
+
+      const result = await detector.detect([a, b]);
+      const contradictionNudge = result.nudges.find((n) => n.title.startsWith('Contradiction'));
+      expect(contradictionNudge).toBeUndefined();
+    });
+
+    it('skips pairs without shared tags (false-positive guard)', async () => {
+      const a = makeEngram('eng_a', { scopes: ['work.projects'], tags: ['topic:alpha'] });
+      const b = makeEngram('eng_b', { scopes: ['work.projects'], tags: ['topic:beta'] });
+
+      const analyze = vi.fn();
+      const detector = new PatternDetector({
+        thresholds: defaultThresholds({ patternMinOccurrences: 99 }),
+        now: fixedNow,
+        contradictionAnalyzer: { analyze },
+        bodyReader: () => 'body',
+      });
+
+      const result = await detector.detect([a, b]);
+      expect(result.nudges).toHaveLength(0);
+      expect(analyze).not.toHaveBeenCalled();
+    });
+
+    it('skips pairs spanning different top-level scopes', async () => {
+      const a = makeEngram('eng_a', { scopes: ['work.projects'], tags: ['topic:shared'] });
+      const b = makeEngram('eng_b', { scopes: ['personal.notes'], tags: ['topic:shared'] });
+
+      const analyze = vi.fn();
+      const detector = new PatternDetector({
+        thresholds: defaultThresholds({ patternMinOccurrences: 99 }),
+        now: fixedNow,
+        contradictionAnalyzer: { analyze },
+        bodyReader: () => 'body',
+      });
+
+      const result = await detector.detect([a, b]);
+      expect(result.nudges).toHaveLength(0);
+      expect(analyze).not.toHaveBeenCalled();
+    });
+
+    it('survives analyzer errors on individual pairs', async () => {
+      const a = makeEngram('eng_a', { scopes: ['work.projects'], tags: ['topic:t1'] });
+      const b = makeEngram('eng_b', { scopes: ['work.projects'], tags: ['topic:t1'] });
+      const c = makeEngram('eng_c', { scopes: ['work.projects'], tags: ['topic:t1'] });
+
+      let calls = 0;
+      const analyzer: ContradictionAnalyzer = {
+        analyze: async (engramA, _bodyA, engramB, _bodyB) => {
+          calls++;
+          if (calls === 1) throw new Error('LLM down');
+          return {
+            engramA,
+            engramB,
+            excerptA: 'a quote',
+            excerptB: 'b quote',
+            conflict: 'real conflict',
+          };
+        },
+      };
+
+      const detector = new PatternDetector({
+        thresholds: defaultThresholds({ patternMinOccurrences: 99 }),
+        now: fixedNow,
+        contradictionAnalyzer: analyzer,
+        bodyReader: () => 'body',
+      });
+
+      const result = await detector.detect([a, b, c]);
+      // 3 pairs total; first throws, the remaining two should produce
+      // nudges so the scan as a whole degrades gracefully.
+      const contradictions = result.nudges.filter((n) => n.title.startsWith('Contradiction'));
+      expect(contradictions.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('falls back to noop analyzer when no analyzer is configured', async () => {
+      const a = makeEngram('eng_a', { scopes: ['work.projects'], tags: ['topic:t1'] });
+      const b = makeEngram('eng_b', { scopes: ['work.projects'], tags: ['topic:t1'] });
+
+      // No analyzer, no bodyReader → contradiction pass is fully skipped.
+      const detector = new PatternDetector(
+        defaultThresholds({ patternMinOccurrences: 99 }),
+        fixedNow
+      );
+      const result = await detector.detect([a, b]);
+      expect(result.nudges).toHaveLength(0);
+    });
+
+    it('respects maxContradictionPairs cap', async () => {
+      const engrams = Array.from({ length: 6 }, (_, i) =>
+        makeEngram(`eng_${i}`, { scopes: ['work.projects'], tags: ['topic:t1'] })
+      );
+
+      const analyze = vi.fn().mockResolvedValue(null);
+      const detector = new PatternDetector({
+        thresholds: defaultThresholds({ patternMinOccurrences: 99 }),
+        now: fixedNow,
+        contradictionAnalyzer: { analyze },
+        bodyReader: () => 'body',
+        maxContradictionPairs: 3,
+      });
+
+      await detector.detect(engrams);
+      // 6 engrams = 15 pairs; cap to 3.
+      expect(analyze).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/apps/pops-api/src/modules/cerebrum/nudges/__tests__/patterns.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/__tests__/patterns.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { PatternDetector } from '../detectors/patterns.js';
+const loggerMock = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+vi.mock('../../../../lib/logger.js', () => ({ logger: loggerMock }));
+
+const { PatternDetector } = await import('../detectors/patterns.js');
 
 import type { ContradictionAnalyzer } from '../detectors/contradiction-analyzer.js';
 import type { EngramSummary, NudgeThresholds } from '../types.js';
@@ -353,11 +356,21 @@ describe('PatternDetector', () => {
         bodyReader: () => 'body',
       });
 
+      loggerMock.warn.mockClear();
       const result = await detector.detect([a, b, c]);
       // 3 pairs total; first throws, the remaining two should produce
       // nudges so the scan as a whole degrades gracefully.
       const contradictions = result.nudges.filter((n) => n.title.startsWith('Contradiction'));
       expect(contradictions.length).toBeGreaterThanOrEqual(1);
+
+      // The swallowed per-pair error must be logged so silent regressions
+      // are catchable in production telemetry.
+      const errorWarnings = loggerMock.warn.mock.calls.filter(
+        (call) => typeof call[1] === 'string' && call[1].includes('contradiction analyzer failed')
+      );
+      expect(errorWarnings).toHaveLength(1);
+      const [warnCtx] = errorWarnings[0] ?? [];
+      expect(warnCtx).toMatchObject({ engramA: expect.any(String), engramB: expect.any(String) });
     });
 
     it('falls back to noop analyzer when no analyzer is configured', async () => {

--- a/apps/pops-api/src/modules/cerebrum/nudges/detectors/contradiction-analyzer.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/detectors/contradiction-analyzer.ts
@@ -1,0 +1,207 @@
+/**
+ * Contradiction analyzer (PRD-084 US-03, #2580).
+ *
+ * Pair-wise LLM analysis that returns a structured `ContradictionEvidence`
+ * record — conflict summary plus a short verbatim excerpt from each side.
+ * Excerpts are required by AC #6 so the user can assess a contradiction
+ * without opening either source engram.
+ *
+ * Inference is wrapped in `trackInference` (the same middleware #2570 is
+ * adding budget enforcement to) so calls are logged, priced, and budget-
+ * checked once that work lands.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+import { getEnv } from '../../../../env.js';
+import { withRateLimitRetry } from '../../../../lib/ai-retry.js';
+import { trackInference } from '../../../../lib/inference-middleware.js';
+import { logger } from '../../../../lib/logger.js';
+import { getAiModel } from '../../../core/settings/service.js';
+
+import type { ContradictionEvidence } from '../types.js';
+
+/** Operation tag used by inference logging and budget rules. */
+const OPERATION = 'cerebrum.patterns.contradiction';
+
+/** Maximum chars sent per passage — keeps token usage predictable. */
+const MAX_BODY_CHARS = 2000;
+
+/** Maximum length of an excerpt — short enough to render inline. */
+const MAX_EXCERPT_CHARS = 240;
+
+const SYSTEM_PROMPT = `You are an impartial fact-checker comparing two passages that share a topic.
+
+Decide whether the passages express GENUINELY CONTRADICTORY positions on the same subject. A contradiction is when one passage asserts something that directly conflicts with what the other passage asserts. Differences in scope, complementary information, or thinking that has evolved over time are NOT contradictions.
+
+Be conservative — only flag clear, simultaneously-held conflicts.
+
+Respond with a single JSON object and nothing else. Two shapes are valid:
+
+When there is NO contradiction:
+{"contradiction": false}
+
+When there IS a contradiction:
+{
+  "contradiction": true,
+  "conflict": "<one concise sentence describing the conflict>",
+  "excerptA": "<short verbatim quote from Passage A, max 240 chars>",
+  "excerptB": "<short verbatim quote from Passage B, max 240 chars>"
+}
+
+Excerpts MUST be verbatim substrings of the source passage. Do not paraphrase. Do not add ellipses unless the original contains them.`;
+
+/** Async interface a pattern detector consumes to find contradictions. */
+export interface ContradictionAnalyzer {
+  analyze(
+    engramA: string,
+    bodyA: string,
+    engramB: string,
+    bodyB: string
+  ): Promise<ContradictionEvidence | null>;
+}
+
+/** Noop analyzer — returns no contradictions. Used when LLM is unavailable. */
+export class NoopContradictionAnalyzer implements ContradictionAnalyzer {
+  async analyze(
+    _engramA: string,
+    _bodyA: string,
+    _engramB: string,
+    _bodyB: string
+  ): Promise<ContradictionEvidence | null> {
+    return null;
+  }
+}
+
+interface LlmContradictionResponse {
+  contradiction: boolean;
+  conflict?: unknown;
+  excerptA?: unknown;
+  excerptB?: unknown;
+}
+
+function getModel(): string {
+  return getAiModel('ai.modelOverrides.patternContradiction', 'claude-haiku-4-20250514');
+}
+
+function truncate(body: string, max = MAX_BODY_CHARS): string {
+  if (body.length <= max) return body;
+  return body.slice(0, max) + '...';
+}
+
+function clipExcerpt(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= MAX_EXCERPT_CHARS) return trimmed;
+  return trimmed.slice(0, MAX_EXCERPT_CHARS - 1) + '…';
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+/** Extract and parse the first JSON object embedded in a string. */
+function extractJson(raw: string): LlmContradictionResponse | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  const jsonStart = trimmed.indexOf('{');
+  const jsonEnd = trimmed.lastIndexOf('}');
+  if (jsonStart === -1 || jsonEnd === -1 || jsonEnd <= jsonStart) return null;
+  try {
+    return JSON.parse(trimmed.slice(jsonStart, jsonEnd + 1)) as LlmContradictionResponse;
+  } catch {
+    return null;
+  }
+}
+
+/** All three required fields are non-empty strings. */
+function hasContradictionFields(
+  parsed: LlmContradictionResponse
+): parsed is LlmContradictionResponse & {
+  conflict: string;
+  excerptA: string;
+  excerptB: string;
+} {
+  return (
+    isString(parsed.conflict) &&
+    isString(parsed.excerptA) &&
+    isString(parsed.excerptB) &&
+    parsed.conflict.trim().length > 0 &&
+    parsed.excerptA.trim().length > 0 &&
+    parsed.excerptB.trim().length > 0
+  );
+}
+
+/**
+ * Parse the LLM JSON response.
+ *
+ * Returns null for any malformed payload, missing fields, or `contradiction:
+ * false`. We deliberately do NOT raise on parse errors — a parse failure
+ * means "no evidence of a contradiction we can present to the user", which
+ * is functionally the same as no contradiction.
+ */
+export function parseAnalyzerResponse(raw: string): {
+  conflict: string;
+  excerptA: string;
+  excerptB: string;
+} | null {
+  const parsed = extractJson(raw);
+  if (!parsed) return null;
+  if (parsed.contradiction !== true) return null;
+  if (!hasContradictionFields(parsed)) return null;
+
+  return {
+    conflict: parsed.conflict.trim(),
+    excerptA: clipExcerpt(parsed.excerptA),
+    excerptB: clipExcerpt(parsed.excerptB),
+  };
+}
+
+/** LLM-backed contradiction analyzer that returns excerpts. */
+export class LlmContradictionAnalyzer implements ContradictionAnalyzer {
+  async analyze(
+    engramA: string,
+    bodyA: string,
+    engramB: string,
+    bodyB: string
+  ): Promise<ContradictionEvidence | null> {
+    const apiKey = getEnv('ANTHROPIC_API_KEY');
+    if (!apiKey) {
+      logger.warn('[ContradictionAnalyzer] ANTHROPIC_API_KEY not set — skipping');
+      return null;
+    }
+
+    const client = new Anthropic({ apiKey, maxRetries: 0 });
+    const model = getModel();
+    const userMessage =
+      `Passage A (engram ${engramA}):\n${truncate(bodyA)}\n\n` +
+      `Passage B (engram ${engramB}):\n${truncate(bodyB)}`;
+
+    const response = await trackInference(
+      { provider: 'claude', model, operation: OPERATION, domain: 'cerebrum' },
+      () =>
+        withRateLimitRetry(
+          () =>
+            client.messages.create({
+              model,
+              max_tokens: 500,
+              temperature: 0,
+              system: SYSTEM_PROMPT,
+              messages: [{ role: 'user', content: userMessage }],
+            }),
+          OPERATION,
+          { logger, logPrefix: '[ContradictionAnalyzer]' }
+        )
+    );
+
+    const text = response.content[0]?.type === 'text' ? response.content[0].text : '';
+    const parsed = parseAnalyzerResponse(text);
+    if (!parsed) return null;
+
+    return {
+      engramA,
+      engramB,
+      excerptA: parsed.excerptA,
+      excerptB: parsed.excerptB,
+      conflict: parsed.conflict,
+    };
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/nudges/detectors/contradiction-analyzer.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/detectors/contradiction-analyzer.ts
@@ -11,6 +11,7 @@
  * checked once that work lands.
  */
 import Anthropic from '@anthropic-ai/sdk';
+import { z } from 'zod';
 
 import { getEnv } from '../../../../env.js';
 import { withRateLimitRetry } from '../../../../lib/ai-retry.js';
@@ -72,12 +73,23 @@ export class NoopContradictionAnalyzer implements ContradictionAnalyzer {
   }
 }
 
-interface LlmContradictionResponse {
-  contradiction: boolean;
-  conflict?: unknown;
-  excerptA?: unknown;
-  excerptB?: unknown;
-}
+/**
+ * Schema for the analyzer LLM response.
+ *
+ * Both shapes the model is permitted to emit must pass — `{ contradiction:
+ * false }` and the full evidence object. Optional string fields are
+ * declared at the boundary so consumers don't reach for `unknown` casts
+ * downstream. Any value that fails this schema is treated as "no
+ * contradiction" — see `parseAnalyzerResponse`.
+ */
+const contradictionResultSchema = z.object({
+  contradiction: z.boolean(),
+  conflict: z.string().optional(),
+  excerptA: z.string().optional(),
+  excerptB: z.string().optional(),
+});
+
+type LlmContradictionResponse = z.infer<typeof contradictionResultSchema>;
 
 function getModel(): string {
   return getAiModel('ai.modelOverrides.patternContradiction', 'claude-haiku-4-20250514');
@@ -88,55 +100,51 @@ function truncate(body: string, max = MAX_BODY_CHARS): string {
   return body.slice(0, max) + '...';
 }
 
+/**
+ * Hard-cut an excerpt at `MAX_EXCERPT_CHARS`.
+ *
+ * Excerpts are presented to the user as verbatim quotes from a source
+ * engram; appending any sentinel character (e.g. an ellipsis) would
+ * silently mutate the quoted text. We instead truncate cleanly — callers
+ * that need to indicate truncation can compare lengths against
+ * `MAX_EXCERPT_CHARS`.
+ */
 function clipExcerpt(value: string): string {
   const trimmed = value.trim();
   if (trimmed.length <= MAX_EXCERPT_CHARS) return trimmed;
-  return trimmed.slice(0, MAX_EXCERPT_CHARS - 1) + '…';
+  return trimmed.slice(0, MAX_EXCERPT_CHARS);
 }
 
-function isString(value: unknown): value is string {
-  return typeof value === 'string';
-}
-
-/** Extract and parse the first JSON object embedded in a string. */
+/**
+ * Extract the first JSON object embedded in a string and validate it
+ * against `contradictionResultSchema`. Returns null on any failure —
+ * unparseable substring, JSON syntax error, or schema mismatch.
+ */
 function extractJson(raw: string): LlmContradictionResponse | null {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return null;
   const jsonStart = trimmed.indexOf('{');
   const jsonEnd = trimmed.lastIndexOf('}');
   if (jsonStart === -1 || jsonEnd === -1 || jsonEnd <= jsonStart) return null;
+
+  let parsedJson: unknown;
   try {
-    return JSON.parse(trimmed.slice(jsonStart, jsonEnd + 1)) as LlmContradictionResponse;
+    parsedJson = JSON.parse(trimmed.slice(jsonStart, jsonEnd + 1));
   } catch {
     return null;
   }
-}
-
-/** All three required fields are non-empty strings. */
-function hasContradictionFields(
-  parsed: LlmContradictionResponse
-): parsed is LlmContradictionResponse & {
-  conflict: string;
-  excerptA: string;
-  excerptB: string;
-} {
-  return (
-    isString(parsed.conflict) &&
-    isString(parsed.excerptA) &&
-    isString(parsed.excerptB) &&
-    parsed.conflict.trim().length > 0 &&
-    parsed.excerptA.trim().length > 0 &&
-    parsed.excerptB.trim().length > 0
-  );
+  const result = contradictionResultSchema.safeParse(parsedJson);
+  return result.success ? result.data : null;
 }
 
 /**
  * Parse the LLM JSON response.
  *
- * Returns null for any malformed payload, missing fields, or `contradiction:
- * false`. We deliberately do NOT raise on parse errors — a parse failure
- * means "no evidence of a contradiction we can present to the user", which
- * is functionally the same as no contradiction.
+ * Returns null for any malformed payload, missing fields, type
+ * mismatches, or `contradiction: false`. We deliberately do NOT raise on
+ * parse errors — a parse failure means "no evidence of a contradiction
+ * we can present to the user", which is functionally the same as no
+ * contradiction.
  */
 export function parseAnalyzerResponse(raw: string): {
   conflict: string;
@@ -146,12 +154,18 @@ export function parseAnalyzerResponse(raw: string): {
   const parsed = extractJson(raw);
   if (!parsed) return null;
   if (parsed.contradiction !== true) return null;
-  if (!hasContradictionFields(parsed)) return null;
+
+  const conflict = parsed.conflict?.trim() ?? '';
+  const excerptA = parsed.excerptA?.trim() ?? '';
+  const excerptB = parsed.excerptB?.trim() ?? '';
+  if (conflict.length === 0 || excerptA.length === 0 || excerptB.length === 0) {
+    return null;
+  }
 
   return {
-    conflict: parsed.conflict.trim(),
-    excerptA: clipExcerpt(parsed.excerptA),
-    excerptB: clipExcerpt(parsed.excerptB),
+    conflict,
+    excerptA: clipExcerpt(excerptA),
+    excerptB: clipExcerpt(excerptB),
   };
 }
 

--- a/apps/pops-api/src/modules/cerebrum/nudges/detectors/contradiction-analyzer.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/detectors/contradiction-analyzer.ts
@@ -73,21 +73,15 @@ export class NoopContradictionAnalyzer implements ContradictionAnalyzer {
   }
 }
 
-/**
- * Schema for the analyzer LLM response.
- *
- * Both shapes the model is permitted to emit must pass — `{ contradiction:
- * false }` and the full evidence object. Optional string fields are
- * declared at the boundary so consumers don't reach for `unknown` casts
- * downstream. Any value that fails this schema is treated as "no
- * contradiction" — see `parseAnalyzerResponse`.
- */
-const contradictionResultSchema = z.object({
-  contradiction: z.boolean(),
-  conflict: z.string().optional(),
-  excerptA: z.string().optional(),
-  excerptB: z.string().optional(),
-});
+const contradictionResultSchema = z.discriminatedUnion('contradiction', [
+  z.object({ contradiction: z.literal(false) }),
+  z.object({
+    contradiction: z.literal(true),
+    conflict: z.string().trim().min(1),
+    excerptA: z.string().trim().min(1),
+    excerptB: z.string().trim().min(1),
+  }),
+]);
 
 type LlmContradictionResponse = z.infer<typeof contradictionResultSchema>;
 
@@ -137,35 +131,17 @@ function extractJson(raw: string): LlmContradictionResponse | null {
   return result.success ? result.data : null;
 }
 
-/**
- * Parse the LLM JSON response.
- *
- * Returns null for any malformed payload, missing fields, type
- * mismatches, or `contradiction: false`. We deliberately do NOT raise on
- * parse errors — a parse failure means "no evidence of a contradiction
- * we can present to the user", which is functionally the same as no
- * contradiction.
- */
 export function parseAnalyzerResponse(raw: string): {
   conflict: string;
   excerptA: string;
   excerptB: string;
 } | null {
   const parsed = extractJson(raw);
-  if (!parsed) return null;
-  if (parsed.contradiction !== true) return null;
-
-  const conflict = parsed.conflict?.trim() ?? '';
-  const excerptA = parsed.excerptA?.trim() ?? '';
-  const excerptB = parsed.excerptB?.trim() ?? '';
-  if (conflict.length === 0 || excerptA.length === 0 || excerptB.length === 0) {
-    return null;
-  }
-
+  if (!parsed || parsed.contradiction !== true) return null;
   return {
-    conflict,
-    excerptA: clipExcerpt(excerptA),
-    excerptB: clipExcerpt(excerptB),
+    conflict: parsed.conflict,
+    excerptA: clipExcerpt(parsed.excerptA),
+    excerptB: clipExcerpt(parsed.excerptB),
   };
 }
 

--- a/apps/pops-api/src/modules/cerebrum/nudges/detectors/contradiction-pairs.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/detectors/contradiction-pairs.ts
@@ -1,0 +1,68 @@
+/**
+ * Pair generation for the contradiction pass of the PatternDetector
+ * (PRD-084 US-03, #2580).
+ *
+ * Extracted from `pattern-helpers.ts` to keep both files under the
+ * `max-lines` lint rule. Build-up is straightforward O(n^2) over engrams
+ * filtered by shared top-level scope + at least one shared tag.
+ */
+import type { EngramSummary } from '../types.js';
+
+/** A candidate engram pair for contradiction analysis. */
+export interface ContradictionPair {
+  a: EngramSummary;
+  b: EngramSummary;
+  sharedTag: string;
+  /** Number of tags shared between a and b. Used for ranking. */
+  overlap: number;
+}
+
+function topLevelScope(scope: string): string {
+  return scope.split('.')[0] ?? scope;
+}
+
+function sharedTopLevel(a: EngramSummary, b: EngramSummary): boolean {
+  const aTops = new Set(a.scopes.map(topLevelScope));
+  return b.scopes.some((s) => aTops.has(topLevelScope(s)));
+}
+
+function sharedTagList(a: EngramSummary, b: EngramSummary): string[] {
+  const aSet = new Set(a.tags);
+  return b.tags.filter((t) => aSet.has(t));
+}
+
+/**
+ * Build candidate engram pairs for contradiction analysis.
+ *
+ * Pairs are eligible when they:
+ *   1. Share at least one tag (high topical overlap proxy).
+ *   2. Share at least one top-level scope (avoids work/personal crosstalk).
+ *   3. Are distinct engrams.
+ *
+ * Returned pairs are sorted by tag overlap descending so callers can take
+ * a prefix when capping LLM spend. Pair ordering is deterministic — engram
+ * IDs are sorted before pairing so the same pair is never enqueued twice.
+ */
+export function buildContradictionPairs(engrams: EngramSummary[]): ContradictionPair[] {
+  const sorted = [...engrams].toSorted((a, b) => a.id.localeCompare(b.id));
+  const pairs: ContradictionPair[] = [];
+
+  for (let i = 0; i < sorted.length; i++) {
+    for (let j = i + 1; j < sorted.length; j++) {
+      const a = sorted[i];
+      const b = sorted[j];
+      if (!a || !b) continue;
+      if (!sharedTopLevel(a, b)) continue;
+
+      const tags = sharedTagList(a, b);
+      if (tags.length === 0) continue;
+
+      const sharedTag = tags.toSorted()[0];
+      if (!sharedTag) continue;
+
+      pairs.push({ a, b, sharedTag, overlap: tags.length });
+    }
+  }
+
+  return pairs.toSorted((p, q) => q.overlap - p.overlap);
+}

--- a/apps/pops-api/src/modules/cerebrum/nudges/detectors/contradiction-pairs.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/detectors/contradiction-pairs.ts
@@ -26,9 +26,22 @@ function sharedTopLevel(a: EngramSummary, b: EngramSummary): boolean {
   return b.scopes.some((s) => aTops.has(topLevelScope(s)));
 }
 
+/**
+ * Compute the set of tags shared between two engrams.
+ *
+ * Both sides are de-duplicated before intersection so an engram with
+ * repeated tag values (e.g. `['topic:x', 'topic:x']`) does not inflate
+ * the overlap count and unfairly outrank pairs with genuinely broader
+ * topical overlap.
+ */
 function sharedTagList(a: EngramSummary, b: EngramSummary): string[] {
   const aSet = new Set(a.tags);
-  return b.tags.filter((t) => aSet.has(t));
+  const bSet = new Set(b.tags);
+  const shared: string[] = [];
+  for (const tag of bSet) {
+    if (aSet.has(tag)) shared.push(tag);
+  }
+  return shared;
 }
 
 /**

--- a/apps/pops-api/src/modules/cerebrum/nudges/detectors/pattern-helpers.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/detectors/pattern-helpers.ts
@@ -142,12 +142,32 @@ function patternTypeLabel(patternType: DetectedPattern['patternType']): string {
 
 /** Map pattern type to body description. */
 function patternTypeDescription(pattern: DetectedPattern): string {
+  if (pattern.patternType === 'contradiction' && pattern.contradiction) {
+    return `Contradiction on "${pattern.topic}": ${pattern.contradiction.conflict}`;
+  }
   const descriptions: Record<DetectedPattern['patternType'], string> = {
     recurring: `The topic "${pattern.topic}" appears in ${pattern.count} engrams within the recent window.`,
     emerging: `The topic "${pattern.topic}" is accelerating — mentioned in ${pattern.count} engrams with a rising trend.`,
     contradiction: `Engrams express contradictory positions on "${pattern.topic}".`,
   };
   return descriptions[pattern.patternType];
+}
+
+/** Build the nudge body for a contradiction pattern. */
+function contradictionBody(pattern: DetectedPattern): string {
+  const ev = pattern.contradiction;
+  if (!ev) {
+    return (
+      `Engrams express contradictory positions on "${pattern.topic}".\n\n` +
+      `Open the source engrams to compare.`
+    );
+  }
+  return (
+    `Contradiction on "${pattern.topic}": ${ev.conflict}\n\n` +
+    `From ${ev.engramA}:\n"${ev.excerptA}"\n\n` +
+    `From ${ev.engramB}:\n"${ev.excerptB}"\n\n` +
+    `Review the two engrams to reconcile.`
+  );
 }
 
 /** Convert a detected pattern into a nudge candidate. */
@@ -158,13 +178,25 @@ export function patternToNudge(pattern: DetectedPattern): NudgeCandidate {
   const rawTitle = `${typeLabel}: "${pattern.topic}" (${pattern.count} engrams${trend})`;
   const title = rawTitle.length > 100 ? rawTitle.slice(0, 97) + '...' : rawTitle;
 
-  const typeDesc = patternTypeDescription(pattern);
-  const body =
-    `${typeDesc}\n\n` +
-    `- Date range: ${pattern.dateRange.from.slice(0, 10)} to ${pattern.dateRange.to.slice(0, 10)}\n` +
-    `- Trend: ${pattern.trendDirection}\n` +
-    `- Engrams: ${pattern.engramIds.length}\n\n` +
-    `Consider creating a research summary or linking related engrams.`;
+  const body = isContradiction
+    ? contradictionBody(pattern)
+    : `${patternTypeDescription(pattern)}\n\n` +
+      `- Date range: ${pattern.dateRange.from.slice(0, 10)} to ${pattern.dateRange.to.slice(0, 10)}\n` +
+      `- Trend: ${pattern.trendDirection}\n` +
+      `- Engrams: ${pattern.engramIds.length}\n\n` +
+      `Consider creating a research summary or linking related engrams.`;
+
+  const actionLabel = isContradiction
+    ? `Review contradiction on "${pattern.topic}"`
+    : `Review ${pattern.count} engrams about "${pattern.topic}"`;
+
+  const actionParams: Record<string, unknown> = {
+    engramIds: pattern.engramIds,
+    topic: pattern.topic,
+  };
+  if (isContradiction && pattern.contradiction) {
+    actionParams['contradiction'] = pattern.contradiction;
+  }
 
   return {
     type: 'pattern',
@@ -175,8 +207,8 @@ export function patternToNudge(pattern: DetectedPattern): NudgeCandidate {
     expiresAt: null,
     action: {
       type: 'link',
-      label: `Review ${pattern.count} engrams about "${pattern.topic}"`,
-      params: { engramIds: pattern.engramIds, topic: pattern.topic },
+      label: actionLabel,
+      params: actionParams,
     },
   };
 }

--- a/apps/pops-api/src/modules/cerebrum/nudges/detectors/patterns.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/detectors/patterns.ts
@@ -1,9 +1,19 @@
 /**
  * PatternDetector (PRD-084 US-03).
  *
- * Detects recurring topics and emerging themes across engrams using
- * tag-based frequency analysis and time-series trend detection.
+ * Detects recurring topics, emerging themes, and contradictions across
+ * engrams. Tag-frequency and time-series passes are pure synchronous
+ * computations. The contradiction pass uses an injected
+ * `ContradictionAnalyzer` to compare engram pairs that share tags within a
+ * single top-level scope — pairs are routed through an LLM that returns
+ * structured conflict evidence (summary + verbatim excerpt from each side).
+ *
+ * Contradiction detection is optional: when no analyzer is supplied (or
+ * when no body reader is wired in) the contradiction pass is a no-op and
+ * the detector behaves exactly as it did before #2580.
  */
+import { NoopContradictionAnalyzer } from './contradiction-analyzer.js';
+import { buildContradictionPairs } from './contradiction-pairs.js';
 import {
   buildTimeSeries,
   countTagFrequency,
@@ -11,24 +21,88 @@ import {
   patternToNudge,
 } from './pattern-helpers.js';
 
-import type { DetectedPattern, DetectorResult, EngramSummary, NudgeThresholds } from '../types.js';
+import type {
+  ContradictionEvidence,
+  DetectedPattern,
+  DetectorResult,
+  EngramSummary,
+  NudgeThresholds,
+} from '../types.js';
+import type { ContradictionAnalyzer } from './contradiction-analyzer.js';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /** Default rolling window for recurring topic detection (days). */
 const DEFAULT_WINDOW_DAYS = 30;
 
+/**
+ * Reads the body text for an engram. Returns null when the engram is not
+ * readable (deleted, secret, IO error). Adapters wrap `EngramService.read`
+ * — keeping the surface narrow lets the detector run with synthetic
+ * fixtures in tests.
+ */
+export type BodyReader = (engramId: string) => string | null;
+
+/**
+ * Maximum number of pairs sent to the LLM per scan.
+ *
+ * Pair-wise comparison is O(n^2) over engrams that share at least one tag;
+ * capping protects token spend and end-to-end scan latency. Pairs are
+ * ranked by tag overlap so we still examine the most-overlapping candidates
+ * first.
+ */
+const DEFAULT_MAX_PAIRS = 20;
+
+export interface PatternDetectorDeps {
+  thresholds: NudgeThresholds;
+  /** Returns the current time; injectable for deterministic tests. */
+  now?: () => Date;
+  /** Optional async analyzer used for the contradiction pass. */
+  contradictionAnalyzer?: ContradictionAnalyzer;
+  /** Required for contradiction detection; ignored when no analyzer set. */
+  bodyReader?: BodyReader;
+  /** Cap on LLM pair comparisons per scan. */
+  maxContradictionPairs?: number;
+}
+
 export class PatternDetector {
   private readonly thresholds: NudgeThresholds;
   private readonly now: () => Date;
+  private readonly contradictionAnalyzer: ContradictionAnalyzer;
+  private readonly bodyReader: BodyReader | undefined;
+  private readonly maxPairs: number;
 
-  constructor(thresholds: NudgeThresholds, now?: () => Date) {
-    this.thresholds = thresholds;
-    this.now = now ?? (() => new Date());
+  constructor(
+    thresholdsOrDeps: NudgeThresholds | PatternDetectorDeps,
+    now?: () => Date,
+    analyzer?: ContradictionAnalyzer,
+    bodyReader?: BodyReader
+  ) {
+    // Support both the legacy positional form (thresholds, now) and the new
+    // deps-object form. Pre-#2580 call sites continue to compile.
+    const deps: PatternDetectorDeps = isDeps(thresholdsOrDeps)
+      ? thresholdsOrDeps
+      : {
+          thresholds: thresholdsOrDeps,
+          now,
+          contradictionAnalyzer: analyzer,
+          bodyReader,
+        };
+
+    this.thresholds = deps.thresholds;
+    this.now = deps.now ?? (() => new Date());
+    this.contradictionAnalyzer = deps.contradictionAnalyzer ?? new NoopContradictionAnalyzer();
+    this.bodyReader = deps.bodyReader;
+    this.maxPairs = deps.maxContradictionPairs ?? DEFAULT_MAX_PAIRS;
   }
 
-  /** Detect recurring topics and emerging themes from engram tags. */
-  detect(engrams: EngramSummary[]): DetectorResult {
+  /**
+   * Detect recurring topics, emerging themes, and contradictions.
+   *
+   * Returns nudge candidates ready for persistence. The contradiction pass
+   * is awaited so the call must be awaited at the call site.
+   */
+  async detect(engrams: EngramSummary[]): Promise<DetectorResult> {
     const active = engrams.filter((e) => e.status !== 'archived' && e.status !== 'consolidated');
 
     if (active.length === 0) {
@@ -42,6 +116,7 @@ export class PatternDetector {
     const patterns: DetectedPattern[] = [];
     this.detectRecurring(active, windowStart, patterns);
     this.detectEmerging(active, windowStart, patterns);
+    await this.detectContradictions(active, patterns);
 
     return { nudges: patterns.map(patternToNudge) };
   }
@@ -106,4 +181,60 @@ export class PatternDetector {
       });
     }
   }
+
+  /**
+   * Compare engram pairs that share tags within a single top-level scope.
+   * Each pair is sent to the analyzer; positive results become contradiction
+   * patterns carrying the conflict summary plus per-side excerpts.
+   */
+  private async detectContradictions(
+    engrams: EngramSummary[],
+    patterns: DetectedPattern[]
+  ): Promise<void> {
+    if (!this.bodyReader) return;
+    const reader = this.bodyReader;
+
+    const pairs = buildContradictionPairs(engrams).slice(0, this.maxPairs);
+    if (pairs.length === 0) return;
+
+    for (const pair of pairs) {
+      const bodyA = reader(pair.a.id);
+      const bodyB = reader(pair.b.id);
+      if (bodyA === null || bodyB === null) continue;
+
+      let evidence: ContradictionEvidence | null = null;
+      try {
+        evidence = await this.contradictionAnalyzer.analyze(pair.a.id, bodyA, pair.b.id, bodyB);
+      } catch {
+        // Single-pair failures must not abort the rest of the scan.
+        continue;
+      }
+      if (!evidence) continue;
+
+      patterns.push({
+        patternType: 'contradiction',
+        topic: pair.sharedTag,
+        engramIds: [pair.a.id, pair.b.id],
+        count: 2,
+        dateRange: {
+          from: minIso(pair.a.createdAt, pair.b.createdAt),
+          to: maxIso(pair.a.modifiedAt, pair.b.modifiedAt),
+        },
+        trendDirection: 'stable',
+        contradiction: evidence,
+      });
+    }
+  }
+}
+
+function isDeps(value: NudgeThresholds | PatternDetectorDeps): value is PatternDetectorDeps {
+  return 'thresholds' in value;
+}
+
+function minIso(a: string, b: string): string {
+  return a < b ? a : b;
+}
+
+function maxIso(a: string, b: string): string {
+  return a > b ? a : b;
 }

--- a/apps/pops-api/src/modules/cerebrum/nudges/detectors/patterns.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/detectors/patterns.ts
@@ -12,6 +12,7 @@
  * when no body reader is wired in) the contradiction pass is a no-op and
  * the detector behaves exactly as it did before #2580.
  */
+import { logger } from '../../../../lib/logger.js';
 import { NoopContradictionAnalyzer } from './contradiction-analyzer.js';
 import { buildContradictionPairs } from './contradiction-pairs.js';
 import {
@@ -205,8 +206,13 @@ export class PatternDetector {
       let evidence: ContradictionEvidence | null = null;
       try {
         evidence = await this.contradictionAnalyzer.analyze(pair.a.id, bodyA, pair.b.id, bodyB);
-      } catch {
-        // Single-pair failures must not abort the rest of the scan.
+      } catch (err) {
+        // Single-pair failures must not abort the rest of the scan, but
+        // we still emit telemetry so silent regressions are catchable.
+        logger.warn(
+          { err, engramA: pair.a.id, engramB: pair.b.id },
+          '[patterns] contradiction analyzer failed for pair'
+        );
         continue;
       }
       if (!evidence) continue;

--- a/apps/pops-api/src/modules/cerebrum/nudges/nudge-helpers.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/nudge-helpers.ts
@@ -3,24 +3,19 @@
  *
  * Extracted from NudgeService to keep the service file within line limits.
  */
+import type { NudgeLogRow as DrizzleNudgeLogRow } from '@pops/db-types';
+
 import type { Nudge, NudgeActionType, NudgePriority, NudgeStatus, NudgeType } from './types.js';
 
-/** Shape of a row read from the nudge_log table. */
-export interface NudgeLogRow {
-  id: string;
-  type: string;
-  title: string;
-  body: string;
-  engram_ids: string;
-  priority: string;
-  status: string;
-  created_at: string;
-  expires_at: string | null;
-  acted_at: string | null;
-  action_type: string | null;
-  action_label: string | null;
-  action_params: string | null;
-}
+/**
+ * Shape of a row read from the `nudge_log` table.
+ *
+ * Re-exported from the drizzle inference so the JS-side property names
+ * (`engramIds`, `createdAt`, ...) match what a `db.select()` actually
+ * returns. The schema's SQL-side column names use snake_case but
+ * drizzle maps them to camelCase on the JS side.
+ */
+export type NudgeLogRow = DrizzleNudgeLogRow;
 
 /** Map a nudge_log row to a Nudge domain object. */
 export function rowToNudge(row: NudgeLogRow): Nudge {
@@ -29,19 +24,17 @@ export function rowToNudge(row: NudgeLogRow): Nudge {
     type: row.type as NudgeType,
     title: row.title,
     body: row.body,
-    engramIds: JSON.parse(row.engram_ids) as string[],
+    engramIds: JSON.parse(row.engramIds) as string[],
     priority: row.priority as NudgePriority,
     status: row.status as NudgeStatus,
-    createdAt: row.created_at,
-    expiresAt: row.expires_at,
-    actedAt: row.acted_at,
-    action: row.action_type
+    createdAt: row.createdAt,
+    expiresAt: row.expiresAt,
+    actedAt: row.actedAt,
+    action: row.actionType
       ? {
-          type: row.action_type as NudgeActionType,
-          label: row.action_label ?? '',
-          params: row.action_params
-            ? (JSON.parse(row.action_params) as Record<string, unknown>)
-            : {},
+          type: row.actionType as NudgeActionType,
+          label: row.actionLabel ?? '',
+          params: row.actionParams ? (JSON.parse(row.actionParams) as Record<string, unknown>) : {},
         }
       : null,
   };

--- a/apps/pops-api/src/modules/cerebrum/nudges/nudge-persistence.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/nudge-persistence.ts
@@ -7,11 +7,17 @@ import { and, count, eq, inArray, sql } from 'drizzle-orm';
 import { engramIndex, engramScopes, engramTags, nudgeLog } from '@pops/db-types';
 
 import { logger } from '../../../lib/logger.js';
-import { generateNudgeId } from './nudge-helpers.js';
+import { generateNudgeId, rowToNudge } from './nudge-helpers.js';
 
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
-import type { EngramSummary, NudgeCandidate, NudgeThresholds } from './types.js';
+import type {
+  EngramSummary,
+  Nudge,
+  NudgeCandidate,
+  NudgeStatus,
+  NudgeThresholds,
+} from './types.js';
 
 /** Group rows by engramId into a multi-value map. */
 function buildLookup(rows: { engramId: string; val: string }[]): Map<string, string[]> {
@@ -113,6 +119,45 @@ function isInCooldown(
     const existing = JSON.stringify((JSON.parse(row.engramIds) as string[]).toSorted());
     return existing === sortedIds;
   });
+}
+
+/**
+ * List contradiction pattern nudges (PRD-084 US-03).
+ *
+ * Filters at the SQL layer with a `json_extract` predicate on
+ * `action_params` so non-contradiction pattern nudges (recurring,
+ * emerging) cannot consume page slots or inflate `total`. Pagination
+ * applies after the filter, which is what makes it honest.
+ */
+export function listContradictions(
+  db: BetterSQLite3Database,
+  opts: { status?: NudgeStatus | null; limit?: number; offset?: number } = {}
+): { nudges: Nudge[]; total: number } {
+  const conditions = [eq(nudgeLog.type, 'pattern')];
+  if (opts.status !== null && opts.status !== undefined) {
+    conditions.push(eq(nudgeLog.status, opts.status));
+  }
+  conditions.push(sql`json_extract(${nudgeLog.actionParams}, '$.contradiction') IS NOT NULL`);
+
+  const where = and(...conditions);
+  const limit = opts.limit ?? 50;
+  const offset = opts.offset ?? 0;
+
+  const rows = db
+    .select()
+    .from(nudgeLog)
+    .where(where)
+    .orderBy(sql`${nudgeLog.createdAt} desc`)
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const [totalRow] = db.select({ total: count() }).from(nudgeLog).where(where).all();
+
+  return {
+    nudges: rows.map((r) => rowToNudge(r)),
+    total: totalRow?.total ?? 0,
+  };
 }
 
 /** Enforce the max pending nudges cap by expiring oldest. */

--- a/apps/pops-api/src/modules/cerebrum/nudges/nudge-persistence.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/nudge-persistence.ts
@@ -137,7 +137,14 @@ export function listContradictions(
   if (opts.status !== null && opts.status !== undefined) {
     conditions.push(eq(nudgeLog.status, opts.status));
   }
-  conditions.push(sql`json_extract(${nudgeLog.actionParams}, '$.contradiction') IS NOT NULL`);
+  // Require every field that the UI projection needs so total === rows after pagination.
+  conditions.push(
+    sql`json_extract(${nudgeLog.actionParams}, '$.contradiction.engramA') IS NOT NULL`,
+    sql`json_extract(${nudgeLog.actionParams}, '$.contradiction.engramB') IS NOT NULL`,
+    sql`json_extract(${nudgeLog.actionParams}, '$.contradiction.excerptA') IS NOT NULL`,
+    sql`json_extract(${nudgeLog.actionParams}, '$.contradiction.excerptB') IS NOT NULL`,
+    sql`json_extract(${nudgeLog.actionParams}, '$.contradiction.conflict') IS NOT NULL`
+  );
 
   const where = and(...conditions);
   const limit = opts.limit ?? 50;

--- a/apps/pops-api/src/modules/cerebrum/nudges/nudge-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/nudge-service.ts
@@ -96,7 +96,7 @@ export class NudgeService {
     if (!type || type === 'pattern') {
       totalCreated += persistCandidates(
         this.db,
-        this.patternDetector.detect(engrams).nudges,
+        (await this.patternDetector.detect(engrams)).nudges,
         this.thresholds,
         this.now
       );

--- a/apps/pops-api/src/modules/cerebrum/nudges/nudge-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/nudge-service.ts
@@ -12,7 +12,12 @@ import { nudgeLog } from '@pops/db-types';
 import { logger } from '../../../lib/logger.js';
 import { ConcatenationSynthesizer, executeConsolidationAct } from './consolidation-act.js';
 import { rowToNudge } from './nudge-helpers.js';
-import { enforcePendingCap, loadActiveEngrams, persistCandidates } from './nudge-persistence.js';
+import {
+  enforcePendingCap,
+  listContradictions,
+  loadActiveEngrams,
+  persistCandidates,
+} from './nudge-persistence.js';
 
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 
@@ -22,7 +27,6 @@ import type { BodySynthesizer } from './consolidation-act.js';
 import type { ConsolidationDetector } from './detectors/consolidation.js';
 import type { PatternDetector } from './detectors/patterns.js';
 import type { StalenessDetector } from './detectors/staleness.js';
-import type { NudgeLogRow } from './nudge-helpers.js';
 import type { Nudge, NudgeStatus, NudgeThresholds, NudgeType } from './types.js';
 
 export interface NudgeServiceDeps {
@@ -129,15 +133,23 @@ export class NudgeService {
     const [totalRow] = (where ? countQuery.where(where) : countQuery).all();
 
     return {
-      nudges: rows.map((r) => rowToNudge(r as unknown as NudgeLogRow)),
+      nudges: rows.map((r) => rowToNudge(r)),
       total: totalRow?.total ?? 0,
     };
+  }
+
+  /** List contradiction pattern nudges with SQL-level filtering. */
+  listContradictions(opts: { status?: NudgeStatus | null; limit?: number; offset?: number } = {}): {
+    nudges: Nudge[];
+    total: number;
+  } {
+    return listContradictions(this.db, opts);
   }
 
   /** Get a single nudge by ID. */
   get(id: string): Nudge | null {
     const [row] = this.db.select().from(nudgeLog).where(eq(nudgeLog.id, id)).all();
-    return row ? rowToNudge(row as unknown as NudgeLogRow) : null;
+    return row ? rowToNudge(row) : null;
   }
 
   /** Dismiss a nudge — permanently mark it as dismissed. */

--- a/apps/pops-api/src/modules/cerebrum/nudges/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/router.ts
@@ -17,6 +17,7 @@ import { protectedProcedure, router } from '../../../trpc.js';
 import { getEngramService } from '../instance.js';
 import { HybridSearchService } from '../retrieval/hybrid-search.js';
 import { ConsolidationDetector } from './detectors/consolidation.js';
+import { LlmContradictionAnalyzer } from './detectors/contradiction-analyzer.js';
 import { PatternDetector } from './detectors/patterns.js';
 import { StalenessDetector } from './detectors/staleness.js';
 import { NudgeService } from './nudge-service.js';
@@ -31,20 +32,65 @@ let activeThresholds: NudgeThresholds = getDefaultNudgeThresholds();
 function getService(): NudgeService {
   const db = getDrizzle();
   const searchService = new HybridSearchService(db);
+  const engramService = getEngramService();
+  const patternDetector = new PatternDetector({
+    thresholds: activeThresholds,
+    contradictionAnalyzer: new LlmContradictionAnalyzer(),
+    bodyReader: (id) => {
+      try {
+        return engramService.read(id).body;
+      } catch {
+        return null;
+      }
+    },
+  });
   return new NudgeService({
     db,
     searchService,
     consolidationDetector: new ConsolidationDetector(searchService, activeThresholds),
     stalenessDetector: new StalenessDetector(activeThresholds),
-    patternDetector: new PatternDetector(activeThresholds),
+    patternDetector,
     thresholds: activeThresholds,
-    engramService: getEngramService(),
+    engramService,
   });
 }
 
 const nudgeTypeSchema = z.enum(['consolidation', 'staleness', 'pattern', 'insight']);
 const nudgeStatusSchema = z.enum(['pending', 'dismissed', 'acted', 'expired']);
 const nudgePrioritySchema = z.enum(['low', 'medium', 'high']);
+
+/**
+ * Type guard that extracts contradiction evidence from a nudge action.
+ *
+ * Contradiction evidence is stored on `Nudge.action.params.contradiction`
+ * when the underlying pattern is a contradiction. Other pattern nudges
+ * (recurring/emerging) carry no contradiction field, so this returns null.
+ */
+function extractContradiction(params: Record<string, unknown> | undefined): {
+  engramA: string;
+  engramB: string;
+  excerptA: string;
+  excerptB: string;
+  conflict: string;
+} | null {
+  if (!params) return null;
+  const raw = params['contradiction'];
+  if (!raw || typeof raw !== 'object') return null;
+  const evidence = raw as Record<string, unknown>;
+  const fields = ['engramA', 'engramB', 'excerptA', 'excerptB', 'conflict'] as const;
+  for (const field of fields) {
+    if (typeof evidence[field] !== 'string' || (evidence[field] as string).length === 0) {
+      return null;
+    }
+  }
+  return {
+    engramA: evidence['engramA'] as string,
+    engramB: evidence['engramB'] as string,
+    excerptA: evidence['excerptA'] as string,
+    excerptB: evidence['excerptB'] as string,
+    conflict: evidence['conflict'] as string,
+  };
+}
 
 export const nudgesRouter = router({
   /** List nudges with optional filters. */
@@ -102,6 +148,47 @@ export const nudgesRouter = router({
     )
     .mutation(async ({ input }) => {
       return getService().scan(input?.type ?? undefined);
+    }),
+
+  /**
+   * List pattern contradictions with structured excerpts (PRD-084 US-03).
+   *
+   * Surfaces every contradiction-type pattern nudge with both engram IDs,
+   * a short verbatim excerpt from each side, and the LLM conflict summary.
+   * Status filter defaults to `pending` so the dashboard does not surface
+   * already-acted or dismissed contradictions; pass `null` to include all.
+   */
+  contradictions: protectedProcedure
+    .input(
+      z
+        .object({
+          status: nudgeStatusSchema.nullable().optional(),
+          limit: z.number().int().positive().max(100).optional(),
+        })
+        .optional()
+    )
+    .query(({ input }) => {
+      const status = input?.status === undefined ? 'pending' : input.status;
+      const result = getService().list({
+        type: 'pattern',
+        ...(status === null ? {} : { status }),
+        limit: input?.limit ?? 50,
+      });
+      const contradictions = result.nudges
+        .map((nudge) => {
+          const evidence = extractContradiction(nudge.action?.params);
+          if (!evidence) return null;
+          return {
+            id: nudge.id,
+            createdAt: nudge.createdAt,
+            status: nudge.status,
+            priority: nudge.priority,
+            title: nudge.title,
+            ...evidence,
+          };
+        })
+        .filter((row): row is NonNullable<typeof row> => row !== null);
+      return { contradictions, total: contradictions.length };
     }),
 
   /** Update detection thresholds. */

--- a/apps/pops-api/src/modules/cerebrum/nudges/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/router.ts
@@ -12,6 +12,7 @@
 import { z } from 'zod';
 
 import { getDrizzle } from '../../../db.js';
+import { logger } from '../../../lib/logger.js';
 import { trpcError } from '../../../shared/trpc-error.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { getEngramService } from '../instance.js';
@@ -36,10 +37,15 @@ function getService(): NudgeService {
   const patternDetector = new PatternDetector({
     thresholds: activeThresholds,
     contradictionAnalyzer: new LlmContradictionAnalyzer(),
-    bodyReader: (id) => {
+    bodyReader: (engramId) => {
       try {
-        return engramService.read(id).body;
-      } catch {
+        return engramService.read(engramId).body;
+      } catch (err) {
+        // A thrown read (deleted engram, IO failure, secret-scope guard)
+        // surfaces here. We swallow the throw so the detector pass keeps
+        // running, but we log so silent gaps in contradiction coverage
+        // are observable.
+        logger.warn({ err, engramId }, '[contradictions] failed to read engram body');
         return null;
       }
     },
@@ -164,15 +170,21 @@ export const nudgesRouter = router({
         .object({
           status: nudgeStatusSchema.nullable().optional(),
           limit: z.number().int().positive().max(100).optional(),
+          offset: z.number().int().nonnegative().optional(),
         })
         .optional()
     )
     .query(({ input }) => {
       const status = input?.status === undefined ? 'pending' : input.status;
-      const result = getService().list({
-        type: 'pattern',
-        ...(status === null ? {} : { status }),
+      // Filtering happens at the SQL layer (json_extract on
+      // action_params) so the page slice contains only contradictions
+      // and `total` is the count of contradictions — not the count of
+      // all pattern nudges. Without that, recurring/emerging rows could
+      // fill a page and hide actual contradictions.
+      const result = getService().listContradictions({
+        status,
         limit: input?.limit ?? 50,
+        offset: input?.offset ?? 0,
       });
       const contradictions = result.nudges
         .map((nudge) => {
@@ -188,7 +200,7 @@ export const nudgesRouter = router({
           };
         })
         .filter((row): row is NonNullable<typeof row> => row !== null);
-      return { contradictions, total: contradictions.length };
+      return { contradictions, total: result.total };
     }),
 
   /** Update detection thresholds. */

--- a/apps/pops-api/src/modules/cerebrum/nudges/types.ts
+++ b/apps/pops-api/src/modules/cerebrum/nudges/types.ts
@@ -139,4 +139,21 @@ export interface DetectedPattern {
   count: number;
   dateRange: { from: string; to: string };
   trendDirection: 'rising' | 'stable' | 'declining';
+  /** Populated only when patternType === 'contradiction'. */
+  contradiction?: ContradictionEvidence;
+}
+
+/**
+ * Evidence for a single contradiction between two engrams.
+ *
+ * Produced by an LLM analysis pass and embedded into pattern nudges so the
+ * user can compare the two sides without opening either source engram.
+ * Excerpts are short verbatim quotes (≤ 240 chars) from each side.
+ */
+export interface ContradictionEvidence {
+  engramA: string;
+  engramB: string;
+  excerptA: string;
+  excerptB: string;
+  conflict: string;
 }

--- a/apps/pops-api/src/modules/core/settings/service.ts
+++ b/apps/pops-api/src/modules/core/settings/service.ts
@@ -155,6 +155,7 @@ const LEGACY_OVERRIDE_KEYS = {
   'ai.modelOverrides.entityExtractor': 'cerebrum.entityExtractor.model',
   'ai.modelOverrides.scopeInference': 'cerebrum.scopeInference.model',
   'ai.modelOverrides.auditorContradiction': 'cerebrum.auditor.contradictionModel',
+  'ai.modelOverrides.patternContradiction': 'cerebrum.patterns.contradictionModel',
 } as const;
 
 export type AiModelOverrideKey = keyof typeof LEGACY_OVERRIDE_KEYS;

--- a/docs/themes/06-cerebrum/prds/084-proactive-nudges/README.md
+++ b/docs/themes/06-cerebrum/prds/084-proactive-nudges/README.md
@@ -109,7 +109,7 @@ Define the proactive nudge system that surfaces system-initiated suggestions wit
 | --- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------- | -------------- |
 | 01  | [us-01-consolidation-proposals](us-01-consolidation-proposals.md) | Detect similar engram clusters via Thalamus, propose consolidation into curated documents | Partial | No (first)     |
 | 02  | [us-02-staleness-alerts](us-02-staleness-alerts.md)               | Detect engrams not referenced or modified in N days, flag as stale                        | Partial | Yes            |
-| 03  | [us-03-pattern-detection](us-03-pattern-detection.md)             | Detect recurring topics, emerging themes, contradictions — surface as insights            | Partial | Yes            |
+| 03  | [us-03-pattern-detection](us-03-pattern-detection.md)             | Detect recurring topics, emerging themes, contradictions — surface as insights            | Done    | Yes            |
 | 04  | [us-04-notification-delivery](us-04-notification-delivery.md)     | Deliver nudges via shell notifications and Moltbot: lightweight, actionable               | Partial | Yes            |
 
 US-01 establishes the nudge data model, storage, and action framework. US-02 and US-03 are independent detection modes that can parallelise with each other and with US-01 (they produce nudges in the same format). US-04 is the delivery layer and can parallelise with all detection stories.

--- a/docs/themes/06-cerebrum/prds/084-proactive-nudges/README.md
+++ b/docs/themes/06-cerebrum/prds/084-proactive-nudges/README.md
@@ -53,14 +53,32 @@ Define the proactive nudge system that surfaces system-initiated suggestions wit
 
 ## API Surface
 
-| Procedure                   | Input                                      | Output                               | Notes                                                       |
-| --------------------------- | ------------------------------------------ | ------------------------------------ | ----------------------------------------------------------- |
-| `cerebrum.nudges.list`      | type?, status?, priority?, limit?, offset? | `{ nudges: Nudge[], total: number }` | List nudges with optional filters                           |
-| `cerebrum.nudges.get`       | id                                         | `{ nudge: Nudge }`                   | Get a specific nudge with full context                      |
-| `cerebrum.nudges.dismiss`   | id                                         | `{ success: boolean }`               | Mark nudge as dismissed — it will not resurface             |
-| `cerebrum.nudges.act`       | id                                         | `{ result: ActionResult }`           | Execute the nudge's suggested action                        |
-| `cerebrum.nudges.scan`      | type?: string                              | `{ created: number }`                | Trigger an on-demand nudge scan (normally runs on schedule) |
-| `cerebrum.nudges.configure` | thresholds: NudgeThresholds                | `{ success: boolean }`               | Update detection thresholds                                 |
+| Procedure                        | Input                                      | Output                                       | Notes                                                                        |
+| -------------------------------- | ------------------------------------------ | -------------------------------------------- | ---------------------------------------------------------------------------- |
+| `cerebrum.nudges.list`           | type?, status?, priority?, limit?, offset? | `{ nudges: Nudge[], total: number }`         | List nudges with optional filters                                            |
+| `cerebrum.nudges.get`            | id                                         | `{ nudge: Nudge }`                           | Get a specific nudge with full context                                       |
+| `cerebrum.nudges.dismiss`        | id                                         | `{ success: boolean }`                       | Mark nudge as dismissed — it will not resurface                              |
+| `cerebrum.nudges.act`            | id                                         | `{ result: ActionResult }`                   | Execute the nudge's suggested action                                         |
+| `cerebrum.nudges.scan`           | type?: string                              | `{ created: number }`                        | Trigger an on-demand nudge scan (normally runs on schedule)                  |
+| `cerebrum.nudges.contradictions` | status?, limit?, offset?                   | `{ contradictions: Contradiction[], total }` | Paginated list of contradiction-type pattern nudges with structured excerpts |
+| `cerebrum.nudges.configure`      | thresholds: NudgeThresholds                | `{ success: boolean }`                       | Update detection thresholds                                                  |
+
+### Contradiction (US-03)
+
+Surfaced by `cerebrum.nudges.contradictions`. Each row carries both source engram IDs plus a short verbatim excerpt from each side and the LLM-generated conflict summary, so a reader can assess the conflict without opening either source engram. The status filter defaults to `pending`; pass `null` to include dismissed/acted/expired rows. `total` reflects the filtered count so pagination is honest.
+
+| Field       | Type   | Description                                                          |
+| ----------- | ------ | -------------------------------------------------------------------- |
+| `id`        | string | Nudge ID this contradiction is derived from                          |
+| `createdAt` | string | ISO 8601 timestamp                                                   |
+| `status`    | string | `pending`, `dismissed`, `acted`, `expired`                           |
+| `priority`  | string | `low`, `medium`, `high` — contradiction nudges are emitted at `high` |
+| `title`     | string | Short summary (max 100 characters)                                   |
+| `engramA`   | string | ID of the first engram in the contradicting pair                     |
+| `engramB`   | string | ID of the second engram in the contradicting pair                    |
+| `excerptA`  | string | Verbatim excerpt from engram A (≤ 240 chars, no ellipsis padding)    |
+| `excerptB`  | string | Verbatim excerpt from engram B (≤ 240 chars, no ellipsis padding)    |
+| `conflict`  | string | One-sentence LLM-generated description of the conflict               |
 
 ### NudgeThresholds (configurable)
 

--- a/docs/themes/06-cerebrum/prds/084-proactive-nudges/us-03-pattern-detection.md
+++ b/docs/themes/06-cerebrum/prds/084-proactive-nudges/us-03-pattern-detection.md
@@ -1,7 +1,7 @@
 # US-03: Pattern Detection
 
 > PRD: [PRD-084: Proactive Nudges](README.md)
-> Status: Partial
+> Status: Done
 
 ## Description
 
@@ -12,10 +12,10 @@ As a user, I want the system to detect recurring topics, emerging themes, and co
 - [x] A `PatternDetector` analyses the engram corpus to identify three pattern types: recurring topics (same subject mentioned in `patternMinOccurrences` or more engrams), emerging themes (topic frequency increasing over a rolling window), and contradictions (engrams expressing opposing positions on the same subject)
 - [x] Recurring topic detection uses tag frequency analysis and Thalamus topic clustering to find subjects that appear across multiple engrams within a configurable time window (default 30 days)
 - [x] Emerging theme detection tracks topic frequency over time and flags topics whose occurrence rate is accelerating (e.g., mentioned 2x in month 1, 5x in month 2, 10x in month 3)
-- [ ] Contradiction detection uses LLM-based analysis on pairs of engrams with high topical overlap but low content similarity — the LLM determines whether they express contradictory positions (deferred — tracked in #2580)
+- [x] Contradiction detection uses LLM-based analysis on pairs of engrams with high topical overlap but low content similarity — the LLM determines whether they express contradictory positions (#2580)
 - [x] Pattern nudges include the pattern type, the topic or theme identified, the engram IDs involved, and a suggested action: `review` (examine the pattern) or `link` (create explicit links between related engrams)
 - [x] Pattern nudges have `priority: medium` for recurring topics and emerging themes, `priority: high` for contradictions
-- [ ] Contradiction nudges include excerpts from both sides of the contradiction so the user can quickly assess without opening both engrams (deferred — tracked in #2580)
+- [x] Contradiction nudges include excerpts from both sides of the contradiction so the user can quickly assess without opening both engrams (#2580)
 
 ## Notes
 

--- a/packages/app-cerebrum/src/components/ContradictionsPanel.test.tsx
+++ b/packages/app-cerebrum/src/components/ContradictionsPanel.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Smoke tests for ContradictionsPanel (PRD-084 US-03, #2580).
+ *
+ * Verifies the panel renders the conflict summary, both excerpts, and the
+ * source-engram links returned by `cerebrum.nudges.contradictions`.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+interface ContradictionsResult {
+  contradictions: Array<{
+    id: string;
+    createdAt: string;
+    status: string;
+    priority: string;
+    title: string;
+    engramA: string;
+    engramB: string;
+    excerptA: string;
+    excerptB: string;
+    conflict: string;
+  }>;
+  total: number;
+}
+
+let queryResult: { data: ContradictionsResult | undefined; isLoading: boolean; isError: boolean } =
+  {
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  };
+
+vi.mock('@pops/api-client', () => ({
+  trpc: {
+    cerebrum: {
+      nudges: {
+        contradictions: {
+          useQuery: () => queryResult,
+        },
+      },
+    },
+  },
+}));
+
+import { ContradictionsPanel } from './ContradictionsPanel';
+
+function renderPanel() {
+  return render(
+    <MemoryRouter>
+      <ContradictionsPanel />
+    </MemoryRouter>
+  );
+}
+
+describe('ContradictionsPanel', () => {
+  it('renders a loading state while the query is in flight', () => {
+    queryResult = { data: undefined, isLoading: true, isError: false };
+    renderPanel();
+    expect(screen.getByTestId('contradictions-loading')).toBeInTheDocument();
+  });
+
+  it('renders an error state when the query fails', () => {
+    queryResult = { data: undefined, isLoading: false, isError: true };
+    renderPanel();
+    expect(screen.getByTestId('contradictions-error')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no contradictions', () => {
+    queryResult = {
+      data: { contradictions: [], total: 0 },
+      isLoading: false,
+      isError: false,
+    };
+    renderPanel();
+    expect(screen.getByTestId('contradictions-empty')).toBeInTheDocument();
+  });
+
+  it('renders excerpts from both sides and links to the source engrams', () => {
+    queryResult = {
+      data: {
+        contradictions: [
+          {
+            id: 'nudge_1',
+            createdAt: '2026-04-27T10:00:00Z',
+            status: 'pending',
+            priority: 'high',
+            title: 'Contradiction detected: "deploys"',
+            engramA: 'eng_a',
+            engramB: 'eng_b',
+            excerptA: 'Friday deploys are fine.',
+            excerptB: 'Never deploy on Fridays.',
+            conflict: 'A allows Friday deploys, B forbids them.',
+          },
+        ],
+        total: 1,
+      },
+      isLoading: false,
+      isError: false,
+    };
+
+    renderPanel();
+
+    expect(screen.getByText('A allows Friday deploys, B forbids them.')).toBeInTheDocument();
+    expect(screen.getByText('Friday deploys are fine.')).toBeInTheDocument();
+    expect(screen.getByText('Never deploy on Fridays.')).toBeInTheDocument();
+
+    const linkA = screen.getByRole('link', { name: 'eng_a' });
+    const linkB = screen.getByRole('link', { name: 'eng_b' });
+    expect(linkA).toHaveAttribute('href', '/cerebrum/engrams/eng_a');
+    expect(linkB).toHaveAttribute('href', '/cerebrum/engrams/eng_b');
+  });
+});

--- a/packages/app-cerebrum/src/components/ContradictionsPanel.tsx
+++ b/packages/app-cerebrum/src/components/ContradictionsPanel.tsx
@@ -1,0 +1,112 @@
+/**
+ * ContradictionsPanel — pattern-detection contradictions with excerpts
+ * (PRD-084 US-03, #2580).
+ *
+ * Renders the list returned by `cerebrum.nudges.contradictions`. Each row
+ * shows the LLM-derived conflict summary, a short verbatim excerpt from
+ * each side, and links back to the two source engrams. Minimal styling —
+ * matches the neighbouring NudgesPage list.
+ */
+import { Link } from 'react-router';
+
+import { trpc } from '@pops/api-client';
+
+interface ContradictionRow {
+  id: string;
+  createdAt: string;
+  status: string;
+  priority: string;
+  title: string;
+  engramA: string;
+  engramB: string;
+  excerptA: string;
+  excerptB: string;
+  conflict: string;
+}
+
+function ExcerptBlock({ engramId, excerpt }: { engramId: string; excerpt: string }) {
+  return (
+    <div className="border border-border rounded p-2 bg-background">
+      <Link
+        to={`/cerebrum/engrams/${engramId}`}
+        className="text-xs font-mono text-sky-500 hover:underline"
+      >
+        {engramId}
+      </Link>
+      <blockquote className="text-sm text-foreground mt-1 italic before:content-['“'] after:content-['”']">
+        {excerpt}
+      </blockquote>
+    </div>
+  );
+}
+
+function ContradictionCard({ row }: { row: ContradictionRow }) {
+  return (
+    <div
+      className="border border-border rounded-lg p-4 bg-card space-y-3"
+      data-testid="contradiction-card"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h4 className="font-medium text-sm">{row.conflict}</h4>
+          <p className="text-xs text-muted-foreground mt-0.5">{row.title}</p>
+        </div>
+        <span className="text-[10px] uppercase tracking-wide text-rose-500 font-semibold">
+          {row.priority}
+        </span>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+        <ExcerptBlock engramId={row.engramA} excerpt={row.excerptA} />
+        <ExcerptBlock engramId={row.engramB} excerpt={row.excerptB} />
+      </div>
+    </div>
+  );
+}
+
+export function ContradictionsPanel() {
+  const { data, isLoading, isError } = trpc.cerebrum.nudges.contradictions.useQuery({
+    limit: 50,
+  });
+
+  if (isLoading) {
+    return (
+      <section className="space-y-3" data-testid="contradictions-loading">
+        <h3 className="text-sm font-semibold">Contradictions</h3>
+        <p className="text-xs text-muted-foreground">Loading…</p>
+      </section>
+    );
+  }
+
+  if (isError) {
+    return (
+      <section className="space-y-3" data-testid="contradictions-error">
+        <h3 className="text-sm font-semibold">Contradictions</h3>
+        <p className="text-xs text-destructive">Failed to load contradictions.</p>
+      </section>
+    );
+  }
+
+  const rows = (data?.contradictions ?? []) as ContradictionRow[];
+
+  return (
+    <section className="space-y-3" data-testid="contradictions-panel">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold">Contradictions ({rows.length})</h3>
+        <span className="text-xs text-muted-foreground">
+          Pairs of engrams the LLM flagged as conflicting.
+        </span>
+      </div>
+      {rows.length === 0 ? (
+        <p className="text-xs text-muted-foreground" data-testid="contradictions-empty">
+          No contradictions detected. Run a pattern scan to refresh.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {rows.map((row) => (
+            <ContradictionCard key={row.id} row={row} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/app-cerebrum/src/components/ContradictionsPanel.tsx
+++ b/packages/app-cerebrum/src/components/ContradictionsPanel.tsx
@@ -87,11 +87,12 @@ export function ContradictionsPanel() {
   }
 
   const rows = (data?.contradictions ?? []) as ContradictionRow[];
+  const total = data?.total ?? rows.length;
 
   return (
     <section className="space-y-3" data-testid="contradictions-panel">
       <div className="flex items-baseline justify-between">
-        <h3 className="text-sm font-semibold">Contradictions ({rows.length})</h3>
+        <h3 className="text-sm font-semibold">Contradictions ({total})</h3>
         <span className="text-xs text-muted-foreground">
           Pairs of engrams the LLM flagged as conflicting.
         </span>

--- a/packages/app-cerebrum/src/components/ContradictionsPanel.tsx
+++ b/packages/app-cerebrum/src/components/ContradictionsPanel.tsx
@@ -29,7 +29,7 @@ function ExcerptBlock({ engramId, excerpt }: { engramId: string; excerpt: string
     <div className="border border-border rounded p-2 bg-background">
       <Link
         to={`/cerebrum/engrams/${engramId}`}
-        className="text-xs font-mono text-sky-500 hover:underline"
+        className="text-xs font-mono text-app-accent hover:underline"
       >
         {engramId}
       </Link>
@@ -51,7 +51,7 @@ function ContradictionCard({ row }: { row: ContradictionRow }) {
           <h4 className="font-medium text-sm">{row.conflict}</h4>
           <p className="text-xs text-muted-foreground mt-0.5">{row.title}</p>
         </div>
-        <span className="text-[10px] uppercase tracking-wide text-rose-500 font-semibold">
+        <span className="text-xs uppercase tracking-wide text-destructive font-semibold">
           {row.priority}
         </span>
       </div>

--- a/packages/app-cerebrum/src/pages/NudgesPage.tsx
+++ b/packages/app-cerebrum/src/pages/NudgesPage.tsx
@@ -6,6 +6,7 @@
  */
 import { trpc } from '@pops/api-client';
 
+import { ContradictionsPanel } from '../components/ContradictionsPanel';
 import { NudgeCard } from '../components/NudgeCard';
 
 export function NudgesPage() {
@@ -46,8 +47,11 @@ export function NudgesPage() {
 
   if (nudges.length === 0) {
     return (
-      <div className="p-6 text-center text-muted-foreground">
-        No pending nudges. Everything looks good.
+      <div className="p-4 md:p-6 space-y-6 max-w-3xl">
+        <div className="p-6 text-center text-muted-foreground">
+          No pending nudges. Everything looks good.
+        </div>
+        <ContradictionsPanel />
       </div>
     );
   }
@@ -55,17 +59,20 @@ export function NudgesPage() {
   const isPending = actMutation.isPending || dismissMutation.isPending;
 
   return (
-    <div className="p-4 md:p-6 space-y-3 max-w-3xl">
-      <h2 className="text-lg font-semibold mb-4">Pending Nudges ({data?.total ?? 0})</h2>
-      {nudges.map((nudge) => (
-        <NudgeCard
-          key={nudge.id}
-          nudge={nudge}
-          onAct={(id) => actMutation.mutate({ id })}
-          onDismiss={(id) => dismissMutation.mutate({ id })}
-          disabled={isPending}
-        />
-      ))}
+    <div className="p-4 md:p-6 space-y-6 max-w-3xl">
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold mb-4">Pending Nudges ({data?.total ?? 0})</h2>
+        {nudges.map((nudge) => (
+          <NudgeCard
+            key={nudge.id}
+            nudge={nudge}
+            onAct={(id) => actMutation.mutate({ id })}
+            onDismiss={(id) => dismissMutation.mutate({ id })}
+            disabled={isPending}
+          />
+        ))}
+      </div>
+      <ContradictionsPanel />
     </div>
   );
 }

--- a/packages/module-registry/src/generated.ts
+++ b/packages/module-registry/src/generated.ts
@@ -558,6 +558,13 @@ export const MODULES = [
                 type: 'text',
                 description: 'Model for the cerebrum auditor contradiction detector.',
               },
+              {
+                key: 'ai.modelOverrides.patternContradiction',
+                label: 'Pattern Contradiction Analyzer',
+                type: 'text',
+                description:
+                  'Model for the cerebrum pattern-detection contradiction analyzer (PRD-084 US-03).',
+              },
             ],
           },
           {

--- a/packages/module-registry/src/settings/core/ai-manifest.ts
+++ b/packages/module-registry/src/settings/core/ai-manifest.ts
@@ -67,6 +67,13 @@ export const aiConfigManifest: SettingsManifest = {
           type: 'text',
           description: 'Model for the cerebrum auditor contradiction detector.',
         },
+        {
+          key: 'ai.modelOverrides.patternContradiction',
+          label: 'Pattern Contradiction Analyzer',
+          type: 'text',
+          description:
+            'Model for the cerebrum pattern-detection contradiction analyzer (PRD-084 US-03).',
+        },
       ],
     },
     {

--- a/packages/types/src/settings-keys.ts
+++ b/packages/types/src/settings-keys.ts
@@ -35,6 +35,7 @@ export const SETTINGS_KEYS = {
   AI_MODEL_OVERRIDE_ENTITY_EXTRACTOR: 'ai.modelOverrides.entityExtractor',
   AI_MODEL_OVERRIDE_SCOPE_INFERENCE: 'ai.modelOverrides.scopeInference',
   AI_MODEL_OVERRIDE_AUDITOR_CONTRADICTION: 'ai.modelOverrides.auditorContradiction',
+  AI_MODEL_OVERRIDE_PATTERN_CONTRADICTION: 'ai.modelOverrides.patternContradiction',
 
   // Cerebrum — Query Engine
   CEREBRUM_QUERY_MAX_SOURCES: 'cerebrum.query.maxSources',


### PR DESCRIPTION
Closes #2580.

## Summary

- LLM-backed contradiction pass on the PRD-084 `PatternDetector` that returns short verbatim excerpts from each side of a conflict.
- New `cerebrum.nudges.contradictions` tRPC procedure surfacing each contradiction with structured evidence (both engram IDs, both excerpts, conflict summary).
- New `ContradictionsPanel` on the Nudges page renders excerpts + links to the source engrams.

## Design notes

- `LlmContradictionAnalyzer` uses `claude-haiku-4` by default (override via `ai.modelOverrides.patternContradiction`) and is wrapped in `trackInference` + `withRateLimitRetry` so calls are logged, priced, and budget-checked once #2570 lands.
- The analyzer prompt is conservative and asks for JSON; `parseAnalyzerResponse` rejects malformed payloads silently (nothing to surface = no contradiction).
- Pair generation: shared top-level scope + ≥1 shared tag, distinct engrams, deterministically ordered, capped per scan (default 20) to bound LLM spend.
- Contradiction evidence is stored on `action.params.contradiction` so the nudge_log table is reused — no migration needed.
- `PatternDetector` is now async (recurring/emerging passes are still pure sync; only the contradiction pass awaits). Legacy two-arg constructor preserved.

## Test plan

- [x] `pnpm --filter @pops/api test` — 4238 pass
- [x] `pnpm --filter @pops/app-cerebrum test` — 122 pass
- [x] `pnpm format:check`, `pnpm lint` (0 errors), `pnpm typecheck` all green
- [x] `cd packages/module-registry && pnpm build` green
- New tests cover: JSON parsing edge cases, contradiction-positive/negative pairs, malformed model output, missing API key, scope-isolation guard, tag-only-pair guard, per-pair error tolerance, pair cap, UI rendering with mocked tRPC.

## Followups (out of scope here)

- Wiring contradiction nudges into the worker scheduler so they emit on a recurring cadence (currently exposed via on-demand `cerebrum.nudges.scan`).
- Acceptance criteria for "evolved thinking vs simultaneous contradiction" is delegated to the prompt; the prompt is conservative but a fixture-based eval suite would be a worthwhile follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LLM-powered contradiction detection across engrams to identify conflicting information with excerpts and conflict summaries
  * New Contradictions panel displaying detected contradictions with excerpt sources and engram links
  * New API endpoint for querying contradiction patterns with status and pagination filtering

* **Tests**
  * Added comprehensive test coverage for contradiction analysis, pair building, and service-layer filtering

* **Refactor**
  * Pattern detection method now returns asynchronously to support contradiction detection workflow
  * Updated database row handling to align with camelCase field naming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->