### PR TITLE
feat(cerebrum): file-level revert for prune/consolidate/link (#2576)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/delete-engram.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/delete-engram.ts
@@ -1,0 +1,118 @@
+/**
+ * Hard-delete an engram: remove the file, the index row (cascading scopes,
+ * tags, and outbound links), strip any inbound link rows pointing at this id,
+ * and rewrite the frontmatter of inbound-linking engrams so their `links:`
+ * arrays no longer reference the deleted id.
+ *
+ * Used by consolidate revert (PRD-086 US-04) to remove the merged engram.
+ * Idempotent: missing files or missing index rows are no-ops.
+ */
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+
+import { eq } from 'drizzle-orm';
+
+import { engramIndex, engramLinks } from '@pops/db-types';
+
+import { parseEngramFile, serializeEngram } from '../file.js';
+import { absolutePath, parseCustomFields, writeFileAtomic } from './fs-helpers.js';
+import { findIndexRow, upsertIndex } from './upsert-index.js';
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+export type DeleteDeps = {
+  root: string;
+  db: BetterSQLite3Database;
+  now: () => Date;
+};
+
+export interface DeleteResult {
+  /** True if a file was removed from disk. */
+  fileRemoved: boolean;
+  /** True if an index row was removed. */
+  indexRemoved: boolean;
+  /** IDs of engrams whose `links:` arrays were rewritten to drop the deleted id. */
+  inboundLinkSourcesRewritten: string[];
+}
+
+export function deleteEngram(deps: DeleteDeps, id: string): DeleteResult {
+  const { root, db, now } = deps;
+  const row = findIndexRow(db, id);
+
+  const inboundSources = db
+    .select({ sourceId: engramLinks.sourceId })
+    .from(engramLinks)
+    .where(eq(engramLinks.targetId, id))
+    .all()
+    .map((r) => r.sourceId);
+
+  const rewritten: string[] = [];
+  for (const sourceId of inboundSources) {
+    if (sourceId === id) continue;
+    if (stripFrontmatterLink({ root, db, now }, sourceId, id)) {
+      rewritten.push(sourceId);
+    }
+  }
+
+  let fileRemoved = false;
+  let indexRemoved = false;
+
+  if (row) {
+    const abs = absolutePath(root, row.file_path);
+    if (existsSync(abs)) {
+      unlinkSync(abs);
+      fileRemoved = true;
+    }
+    db.transaction((tx) => {
+      tx.delete(engramLinks).where(eq(engramLinks.targetId, id)).run();
+      // Outbound links + scopes + tags cascade on engram_index.id delete.
+      tx.delete(engramIndex).where(eq(engramIndex.id, id)).run();
+    });
+    indexRemoved = true;
+  } else {
+    db.delete(engramLinks).where(eq(engramLinks.targetId, id)).run();
+  }
+
+  return { fileRemoved, indexRemoved, inboundLinkSourcesRewritten: rewritten };
+}
+
+/**
+ * Remove `targetId` from `sourceId`'s frontmatter `links` array. Returns
+ * `true` if a rewrite occurred. No-ops when the source is missing or did not
+ * actually reference the target.
+ */
+function stripFrontmatterLink(
+  deps: { root: string; db: BetterSQLite3Database; now: () => Date },
+  sourceId: string,
+  targetId: string
+): boolean {
+  const { root, db, now } = deps;
+  const sourceRow = findIndexRow(db, sourceId);
+  if (!sourceRow) return false;
+
+  const sourceAbs = absolutePath(root, sourceRow.file_path);
+  if (!existsSync(sourceAbs)) return false;
+
+  const content = readFileSync(sourceAbs, 'utf8');
+  const { frontmatter, body } = parseEngramFile(content);
+  const existing = frontmatter.links ?? [];
+  if (!existing.includes(targetId)) return false;
+
+  const nextLinks = existing.filter((l) => l !== targetId);
+  const { links: _links, ...rest } = frontmatter;
+  const nextFrontmatter = {
+    ...rest,
+    modified: now().toISOString(),
+    ...(nextLinks.length > 0 ? { links: nextLinks } : {}),
+  };
+
+  writeFileAtomic(sourceAbs, serializeEngram(nextFrontmatter, body));
+  const customFields = sourceRow.custom_fields ? parseCustomFields(sourceRow.custom_fields) : {};
+  upsertIndex(db, {
+    id: sourceId,
+    filePath: sourceRow.file_path,
+    frontmatter: nextFrontmatter,
+    body,
+    customFields,
+  });
+  return true;
+}

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.test.ts
@@ -17,6 +17,7 @@ import { createTestDb, makeClock } from '../../../../shared/test-utils.js';
 import { TemplateRegistry } from '../../templates/registry.js';
 import { seedDefaultTemplates } from '../../templates/seed.js';
 import { EngramService } from '../service.js';
+import { getIndexRow } from './upsert-index.js';
 
 import type { Database } from 'better-sqlite3';
 
@@ -59,5 +60,6 @@ describe('restoreEngram idempotency', () => {
 
     expect(result.moved).toBe(false);
     expect(result.filePath).toBe(archivedRel);
+    expect(getIndexRow(drizzle(db), engram.id).status).toBe('archived');
   });
 });

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the engram restore handler (PRD-086 US-04, #2576).
+ *
+ * Covers the idempotency guard for the edge case where the index row still
+ * points to `.archive/{type}/{id}.md` but the underlying file has been
+ * removed out-of-band (interrupted revert, manual cleanup, etc.). The handler
+ * must return `{ moved: false }` rather than throwing on `readFileSync`.
+ */
+import { existsSync, mkdtempSync, rmSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createTestDb } from '../../../../shared/test-utils.js';
+import { TemplateRegistry } from '../../templates/registry.js';
+import { seedDefaultTemplates } from '../../templates/seed.js';
+import { EngramService } from '../service.js';
+
+import type { Database } from 'better-sqlite3';
+
+function makeClock(start = new Date('2026-05-12T09:00:00Z')): () => Date {
+  let t = start.getTime();
+  return () => {
+    const d = new Date(t);
+    t += 60_000;
+    return d;
+  };
+}
+
+describe('restoreEngram idempotency', () => {
+  let db: Database;
+  let service: EngramService;
+  let root: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    root = mkdtempSync(join(tmpdir(), 'cerebrum-restore-'));
+    const templatesDir = join(root, '.templates');
+    seedDefaultTemplates(templatesDir);
+    service = new EngramService({
+      root,
+      db: drizzle(db),
+      templates: new TemplateRegistry(templatesDir),
+      now: makeClock(),
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    db.close();
+  });
+
+  it('returns moved: false when the archived file is missing on disk', () => {
+    const engram = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+    service.archive(engram.id);
+
+    // Index still points to .archive/..., but delete the file out-of-band.
+    const archivedRel = service.read(engram.id).engram.filePath;
+    expect(archivedRel.startsWith('.archive/')).toBe(true);
+    const archivedAbs = join(root, archivedRel);
+    expect(existsSync(archivedAbs)).toBe(true);
+    unlinkSync(archivedAbs);
+    expect(existsSync(archivedAbs)).toBe(false);
+
+    const { result } = service.restore(engram.id);
+
+    expect(result.moved).toBe(false);
+    expect(result.filePath).toBe(archivedRel);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.test.ts
@@ -13,21 +13,12 @@ import { join } from 'node:path';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { createTestDb } from '../../../../shared/test-utils.js';
+import { createTestDb, makeClock } from '../../../../shared/test-utils.js';
 import { TemplateRegistry } from '../../templates/registry.js';
 import { seedDefaultTemplates } from '../../templates/seed.js';
 import { EngramService } from '../service.js';
 
 import type { Database } from 'better-sqlite3';
-
-function makeClock(start = new Date('2026-05-12T09:00:00Z')): () => Date {
-  let t = start.getTime();
-  return () => {
-    const d = new Date(t);
-    t += 60_000;
-    return d;
-  };
-}
 
 describe('restoreEngram idempotency', () => {
   let db: Database;

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.ts
@@ -35,6 +35,12 @@ export function restoreEngram(deps: RestoreDeps, id: string): RestoreResult {
   }
 
   const archivedAbs = absolutePath(root, row.file_path);
+  // Idempotency: the index still points to `.archive/...` but the file is
+  // gone (e.g. a previous revert was interrupted, or the archive was pruned
+  // out-of-band). Treat as a no-op rather than throwing on readFileSync.
+  if (!existsSync(archivedAbs)) {
+    return { filePath: row.file_path, moved: false };
+  }
   const existingContent = readFileSync(archivedAbs, 'utf8');
   const { frontmatter, body } = parseEngramFile(existingContent);
 

--- a/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/handlers/restore-engram.ts
@@ -1,0 +1,63 @@
+/**
+ * Restore an archived engram back to its original `{type}/{id}.md` location
+ * with `status: active`. The inverse of `archiveEngram` (PRD-086 US-04).
+ *
+ * Idempotent: restoring an already-active engram (or one whose file is no
+ * longer under `.archive/`) is a no-op that returns the current path.
+ */
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+
+import { parseEngramFile, serializeEngram } from '../file.js';
+import { ARCHIVE_DIR, absolutePath, parseCustomFields, writeFileAtomic } from './fs-helpers.js';
+import { getIndexRow, upsertIndex } from './upsert-index.js';
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+export type RestoreDeps = {
+  root: string;
+  db: BetterSQLite3Database;
+  now: () => Date;
+};
+
+export interface RestoreResult {
+  /** Final file path of the restored engram (relative to root). */
+  filePath: string;
+  /** True if the file was moved out of `.archive/`; false if already active. */
+  moved: boolean;
+}
+
+export function restoreEngram(deps: RestoreDeps, id: string): RestoreResult {
+  const { root, db, now } = deps;
+  const row = getIndexRow(db, id);
+
+  if (!row.file_path.startsWith(`${ARCHIVE_DIR}/`)) {
+    return { filePath: row.file_path, moved: false };
+  }
+
+  const archivedAbs = absolutePath(root, row.file_path);
+  const existingContent = readFileSync(archivedAbs, 'utf8');
+  const { frontmatter, body } = parseEngramFile(existingContent);
+
+  const targetRelPath = `${frontmatter.type}/${id}.md`;
+  const targetAbs = absolutePath(root, targetRelPath);
+
+  const nextFrontmatter = {
+    ...frontmatter,
+    status: 'active' as const,
+    modified: now().toISOString(),
+  };
+
+  writeFileAtomic(targetAbs, serializeEngram(nextFrontmatter, body));
+  if (existsSync(archivedAbs)) unlinkSync(archivedAbs);
+
+  const customFields = row.custom_fields ? parseCustomFields(row.custom_fields) : {};
+  upsertIndex(db, {
+    id,
+    filePath: targetRelPath,
+    frontmatter: nextFrontmatter,
+    body,
+    customFields,
+  });
+
+  return { filePath: targetRelPath, moved: true };
+}

--- a/apps/pops-api/src/modules/cerebrum/engrams/service.ts
+++ b/apps/pops-api/src/modules/cerebrum/engrams/service.ts
@@ -10,6 +10,7 @@ import { parseEngramFile, serializeEngram } from './file.js';
 import { archiveEngram } from './handlers/archive-engram.js';
 import { changeEngramType } from './handlers/change-type.js';
 import { createEngram, type CreateEngramInput } from './handlers/create-engram.js';
+import { deleteEngram, type DeleteResult } from './handlers/delete-engram.js';
 import {
   absolutePath,
   applyTitleChange,
@@ -24,7 +25,8 @@ import {
   type ListEngramsResult,
 } from './handlers/list-engrams.js';
 import { reindexEngrams } from './handlers/rebuild-index.js';
-import { getIndexRow, upsertIndex } from './handlers/upsert-index.js';
+import { restoreEngram, type RestoreResult } from './handlers/restore-engram.js';
+import { findIndexRow, getIndexRow, upsertIndex } from './handlers/upsert-index.js';
 import { canTransitionStatus, type EngramFrontmatter, type EngramStatus } from './schema.js';
 import { buildEngram, type Engram } from './types.js';
 
@@ -147,6 +149,31 @@ export class EngramService {
   archive(id: string): Engram {
     archiveEngram({ root: this.root, db: this.db, now: this.now }, id);
     return this.loadEngram(id);
+  }
+
+  /**
+   * Move an archived engram back to `{type}/{id}.md` with `status: active`.
+   * Inverse of `archive()`. Idempotent — restoring an already-active engram is
+   * a no-op. Used by Glia prune/consolidate revert (PRD-086 US-04).
+   */
+  restore(id: string): { engram: Engram; result: RestoreResult } {
+    const result = restoreEngram({ root: this.root, db: this.db, now: this.now }, id);
+    return { engram: this.loadEngram(id), result };
+  }
+
+  /**
+   * Hard-delete an engram: removes the file, index row, outbound link rows
+   * (cascade), and strips inbound link references from other engrams'
+   * frontmatter. Used by consolidate revert to remove the merged engram.
+   * Idempotent — deleting a non-existent engram is a no-op.
+   */
+  hardDelete(id: string): DeleteResult {
+    return deleteEngram({ root: this.root, db: this.db, now: this.now }, id);
+  }
+
+  /** True iff `id` is present in the engram index. */
+  exists(id: string): boolean {
+    return findIndexRow(this.db, id) !== null;
   }
 
   /**

--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
@@ -286,6 +286,28 @@ describe('executeRevert (filesystem)', () => {
       expect(service.read(a.id).engram.links ?? []).not.toContain(b.id);
     });
 
+    it('is idempotent when the target engram has been deleted', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      const b = service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });
+      service.link(a.id, b.id);
+
+      // Target engram vanishes (hard-delete out-of-band). The unlink path
+      // would read b's frontmatter and throw — revert must skip cleanly.
+      service.hardDelete(b.id);
+      expect(service.exists(b.id)).toBe(false);
+      expect(service.exists(a.id)).toBe(true);
+
+      const action = makeAction({
+        actionType: 'link',
+        affectedIds: [a.id, b.id],
+        payload: { type: 'link', sourceId: a.id, targetId: b.id, reason: 'r', similarityScore: 1 },
+      });
+      const result = executeRevert(action, service);
+
+      expect(result.success).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
     it('is idempotent — re-reverting an already-unlinked pair succeeds', () => {
       const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
       const b = service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });

--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
@@ -275,6 +275,7 @@ describe('executeRevert (filesystem)', () => {
 
       expect(result.success).toBe(true);
       expect(service.read(a.id).engram.links ?? []).not.toContain(b.id);
+      expect(service.read(b.id).engram.links ?? []).not.toContain(a.id);
     });
 
     it('is idempotent when the target engram has been deleted', () => {

--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
@@ -105,7 +105,7 @@ describe('executeRevert (filesystem)', () => {
       expect(service.read(a.id).engram.status).toBe('active');
     });
 
-    it('reports per-id failure when one restore breaks', () => {
+    it('skips missing ids and restores existing archived engrams', () => {
       const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
       service.archive(a.id);
 
@@ -115,8 +115,6 @@ describe('executeRevert (filesystem)', () => {
       });
       const result = executeRevert(action, service);
 
-      // The missing id was idempotently skipped (exists() returned false), not
-      // reported as an error.
       expect(result.success).toBe(true);
       expect(result.restoredIds).toEqual([a.id]);
     });

--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
@@ -11,7 +11,7 @@ import { join } from 'node:path';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createTestDb } from '../../../../shared/test-utils.js';
+import { createTestDb, makeClock } from '../../../../shared/test-utils.js';
 import { EngramService } from '../../engrams/service.js';
 import { TemplateRegistry } from '../../templates/registry.js';
 import { seedDefaultTemplates } from '../../templates/seed.js';
@@ -25,15 +25,6 @@ import type { GliaAction } from '../types.js';
 vi.mock('../../../../lib/logger.js', () => ({
   logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
-
-function makeClock(start = new Date('2026-05-12T09:00:00Z')): () => Date {
-  let t = start.getTime();
-  return () => {
-    const d = new Date(t);
-    t += 60_000;
-    return d;
-  };
-}
 
 function makeAction(overrides: Partial<GliaAction> = {}): GliaAction {
   return {

--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/revert-operations.test.ts
@@ -1,128 +1,328 @@
 /**
- * Tests for revert operations (#2248).
+ * Tests for revert operations (PRD-086 US-04, #2576).
+ *
+ * Each path uses a real `EngramService` over a `mkdtemp` filesystem and an
+ * in-memory SQLite DB. Idempotency is exercised per action type.
  */
-import { describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createTestDb } from '../../../../shared/test-utils.js';
+import { EngramService } from '../../engrams/service.js';
+import { TemplateRegistry } from '../../templates/registry.js';
+import { seedDefaultTemplates } from '../../templates/seed.js';
+import { executeRevert } from '../revert-operations.js';
+
+import type { Database } from 'better-sqlite3';
+
+import type { ConsolidatePayload, LinkPayload } from '../../workers/types.js';
+import type { GliaAction } from '../types.js';
 
 vi.mock('../../../../lib/logger.js', () => ({
   logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
-import { executeRevert } from '../revert-operations.js';
-
-import type { GliaAction } from '../types.js';
+function makeClock(start = new Date('2026-05-12T09:00:00Z')): () => Date {
+  let t = start.getTime();
+  return () => {
+    const d = new Date(t);
+    t += 60_000;
+    return d;
+  };
+}
 
 function makeAction(overrides: Partial<GliaAction> = {}): GliaAction {
   return {
-    id: 'glia_prune_20260427_abc123',
+    id: 'glia_prune_20260512_aaaaaaaa',
     actionType: 'prune',
-    affectedIds: ['eng_1', 'eng_2'],
-    rationale: 'Stale engrams archived',
+    affectedIds: [],
+    rationale: 'test',
     payload: null,
     phase: 'act_report',
     status: 'executed',
     userDecision: null,
     userNote: null,
-    executedAt: '2026-04-27T10:00:00Z',
+    executedAt: '2026-05-12T10:00:00Z',
     decidedAt: null,
     revertedAt: null,
-    createdAt: '2026-04-27T09:00:00Z',
+    createdAt: '2026-05-12T09:00:00Z',
     ...overrides,
   };
 }
 
-function mockEngramService() {
-  return {
-    update: vi.fn(),
-    unlink: vi.fn(),
-  };
-}
+describe('executeRevert (filesystem)', () => {
+  let db: Database;
+  let root: string;
+  let service: EngramService;
 
-describe('executeRevert', () => {
+  beforeEach(() => {
+    db = createTestDb();
+    root = mkdtempSync(join(tmpdir(), 'glia-revert-'));
+    const templatesDir = join(root, '.templates');
+    seedDefaultTemplates(templatesDir);
+    service = new EngramService({
+      root,
+      db: drizzle(db),
+      templates: new TemplateRegistry(templatesDir),
+      now: makeClock(),
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    db.close();
+  });
+
   describe('prune revert', () => {
-    it('restores all affected engrams to active status', () => {
-      const svc = mockEngramService();
-      const action = makeAction({ actionType: 'prune', affectedIds: ['eng_1', 'eng_2'] });
+    it('moves archived engrams back to their original type folder', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      const b = service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });
+      const aPath = a.filePath;
+      const bPath = b.filePath;
 
-      const result = executeRevert(action, svc as never);
+      service.archive(a.id);
+      service.archive(b.id);
+      expect(existsSync(join(root, aPath))).toBe(false);
+      expect(existsSync(join(root, bPath))).toBe(false);
 
-      expect(svc.update).toHaveBeenCalledWith('eng_1', { status: 'active' });
-      expect(svc.update).toHaveBeenCalledWith('eng_2', { status: 'active' });
+      const action = makeAction({ actionType: 'prune', affectedIds: [a.id, b.id] });
+      const result = executeRevert(action, service);
+
       expect(result.success).toBe(true);
-      expect(result.restoredIds).toEqual(['eng_1', 'eng_2']);
+      expect(result.restoredIds.toSorted()).toEqual([a.id, b.id].toSorted());
+      expect(existsSync(join(root, aPath))).toBe(true);
+      expect(existsSync(join(root, bPath))).toBe(true);
+      expect(service.read(a.id).engram.status).toBe('active');
+      expect(service.read(b.id).engram.status).toBe('active');
     });
 
-    it('reports partial failure when some restores fail', () => {
-      const svc = mockEngramService();
-      svc.update.mockImplementation((id: string) => {
-        if (id === 'eng_2') throw new Error('Not found');
+    it('is idempotent — re-reverting a restored prune succeeds with no-op', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      service.archive(a.id);
+
+      const action = makeAction({ actionType: 'prune', affectedIds: [a.id] });
+      executeRevert(action, service);
+      const second = executeRevert(action, service);
+
+      // The second pass found the engram already active — restore is a no-op
+      // but does not throw.
+      expect(second.success).toBe(true);
+      expect(service.read(a.id).engram.status).toBe('active');
+    });
+
+    it('reports per-id failure when one restore breaks', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      service.archive(a.id);
+
+      const action = makeAction({
+        actionType: 'prune',
+        affectedIds: [a.id, 'eng_20260101_0000_missing'],
       });
+      const result = executeRevert(action, service);
 
-      const action = makeAction({ actionType: 'prune', affectedIds: ['eng_1', 'eng_2'] });
-      const result = executeRevert(action, svc as never);
-
-      expect(result.success).toBe(false);
-      expect(result.restoredIds).toEqual(['eng_1']);
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]).toContain('eng_2');
+      // The missing id was idempotently skipped (exists() returned false), not
+      // reported as an error.
+      expect(result.success).toBe(true);
+      expect(result.restoredIds).toEqual([a.id]);
     });
   });
 
   describe('consolidate revert', () => {
-    it('restores consolidated engrams to active', () => {
-      const svc = mockEngramService();
+    function setupConsolidatedScenario(): {
+      sources: { id: string; path: string }[];
+      mergedId: string;
+      externalLinkTarget: string;
+    } {
+      const s1 = service.create({ type: 'note', title: 'S1', body: '# S1', scopes: ['x'] });
+      const s2 = service.create({ type: 'note', title: 'S2', body: '# S2', scopes: ['x'] });
+      const s3 = service.create({ type: 'note', title: 'S3', body: '# S3', scopes: ['x'] });
+      // An external engram outside the cluster — the merged engram will link
+      // to it, and revert must scrub the inbound reference.
+      const external = service.create({
+        type: 'note',
+        title: 'Ext',
+        body: '# Ext',
+        scopes: ['x'],
+      });
+      const sources = [s1, s2, s3].map((e) => ({ id: e.id, path: e.filePath }));
+
+      const merged = service.create({
+        type: 'note',
+        title: 'Consolidated: S1',
+        body: '# Consolidated\n\n...',
+        scopes: ['x'],
+        source: 'agent',
+      });
+      service.link(merged.id, external.id);
+      for (const s of [s1, s2, s3]) service.archive(s.id);
+
+      return { sources, mergedId: merged.id, externalLinkTarget: external.id };
+    }
+
+    it('deletes the merged engram and restores all source engrams', () => {
+      const { sources, mergedId, externalLinkTarget } = setupConsolidatedScenario();
+      const mergedPath = service.read(mergedId).engram.filePath;
+
+      const payload: ConsolidatePayload = {
+        type: 'merge',
+        clusterIds: sources.map((s) => s.id),
+        mergedTitle: 'Consolidated: S1',
+        mergedTags: [],
+        mergedLinks: [externalLinkTarget],
+        mergedBody: '# Consolidated',
+        scope: 'x',
+        mergedEngramId: mergedId,
+      };
       const action = makeAction({
         actionType: 'consolidate',
-        affectedIds: ['eng_a', 'eng_b', 'eng_c'],
+        affectedIds: sources.map((s) => s.id),
+        payload,
       });
 
-      const result = executeRevert(action, svc as never);
+      const result = executeRevert(action, service);
 
-      expect(svc.update).toHaveBeenCalledTimes(3);
-      expect(result.restoredIds).toEqual(['eng_a', 'eng_b', 'eng_c']);
       expect(result.success).toBe(true);
+      expect(result.restoredIds.toSorted()).toEqual(sources.map((s) => s.id).toSorted());
+      expect(existsSync(join(root, mergedPath))).toBe(false);
+      expect(service.exists(mergedId)).toBe(false);
+      for (const s of sources) {
+        expect(existsSync(join(root, s.path))).toBe(true);
+        expect(service.read(s.id).engram.status).toBe('active');
+      }
+      // The external target's frontmatter must no longer reference the deleted
+      // merged engram (re-pointing of rewritten links).
+      expect(service.read(externalLinkTarget).engram.links).not.toContain(mergedId);
+    });
+
+    it('is idempotent — re-reverting an already-reverted consolidate is a no-op', () => {
+      const { sources, mergedId, externalLinkTarget } = setupConsolidatedScenario();
+      const payload: ConsolidatePayload = {
+        type: 'merge',
+        clusterIds: sources.map((s) => s.id),
+        mergedTitle: 'Consolidated: S1',
+        mergedTags: [],
+        mergedLinks: [externalLinkTarget],
+        mergedBody: '# Consolidated',
+        scope: 'x',
+        mergedEngramId: mergedId,
+      };
+      const action = makeAction({
+        actionType: 'consolidate',
+        affectedIds: sources.map((s) => s.id),
+        payload,
+      });
+
+      const first = executeRevert(action, service);
+      const second = executeRevert(action, service);
+
+      expect(first.success).toBe(true);
+      expect(second.success).toBe(true);
+      // Second pass restores nothing (sources already active, merged already
+      // gone) — but does not throw.
+      expect(second.restoredIds).toEqual([]);
+      expect(service.exists(mergedId)).toBe(false);
+      for (const s of sources) expect(service.read(s.id).engram.status).toBe('active');
+    });
+
+    it('still restores sources when the merged engram is missing from the payload', () => {
+      const { sources } = setupConsolidatedScenario();
+
+      // Payload without mergedEngramId — simulates an older action created
+      // before the metadata was being recorded.
+      const action = makeAction({
+        actionType: 'consolidate',
+        affectedIds: sources.map((s) => s.id),
+        payload: null,
+      });
+      const result = executeRevert(action, service);
+
+      expect(result.success).toBe(true);
+      expect(result.restoredIds.toSorted()).toEqual(sources.map((s) => s.id).toSorted());
     });
   });
 
   describe('link revert', () => {
-    it('unlinks using payload sourceId/targetId', () => {
-      const svc = mockEngramService();
+    it('unlinks using payload sourceId/targetId in both directions', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      const b = service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });
+      service.link(a.id, b.id);
+
+      const payload: LinkPayload = {
+        type: 'link',
+        sourceId: a.id,
+        targetId: b.id,
+        reason: 'similar',
+        similarityScore: 0.9,
+      };
       const action = makeAction({
         actionType: 'link',
-        affectedIds: ['eng_src', 'eng_tgt'],
-        payload: { sourceId: 'eng_src', targetId: 'eng_tgt' },
+        affectedIds: [a.id, b.id],
+        payload,
       });
+      const result = executeRevert(action, service);
 
-      const result = executeRevert(action, svc as never);
-
-      expect(svc.unlink).toHaveBeenCalledWith('eng_src', 'eng_tgt');
       expect(result.success).toBe(true);
+      expect(service.read(a.id).engram.links).not.toContain(b.id);
+      expect(service.read(b.id).engram.links).not.toContain(a.id);
     });
 
-    it('falls back to first two affectedIds when payload lacks IDs', () => {
-      const svc = mockEngramService();
+    it('falls back to first two affectedIds when payload is null', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      const b = service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });
+      service.link(a.id, b.id);
+
       const action = makeAction({
         actionType: 'link',
-        affectedIds: ['eng_x', 'eng_y'],
+        affectedIds: [a.id, b.id],
         payload: null,
       });
+      const result = executeRevert(action, service);
 
-      const result = executeRevert(action, svc as never);
-
-      expect(svc.unlink).toHaveBeenCalledWith('eng_x', 'eng_y');
       expect(result.success).toBe(true);
+      expect(service.read(a.id).engram.links ?? []).not.toContain(b.id);
+    });
+
+    it('is idempotent — re-reverting an already-unlinked pair succeeds', () => {
+      const a = service.create({ type: 'note', title: 'A', body: '# A', scopes: ['x'] });
+      const b = service.create({ type: 'note', title: 'B', body: '# B', scopes: ['x'] });
+      service.link(a.id, b.id);
+
+      const action = makeAction({
+        actionType: 'link',
+        affectedIds: [a.id, b.id],
+        payload: { type: 'link', sourceId: a.id, targetId: b.id, reason: 'r', similarityScore: 1 },
+      });
+      const first = executeRevert(action, service);
+      const second = executeRevert(action, service);
+
+      expect(first.success).toBe(true);
+      expect(second.success).toBe(true);
+      expect(service.read(a.id).engram.links ?? []).not.toContain(b.id);
+    });
+
+    it('returns failure when no pair can be resolved', () => {
+      const action = makeAction({
+        actionType: 'link',
+        affectedIds: ['eng_20260101_0000_only'],
+        payload: null,
+      });
+      const result = executeRevert(action, service);
+
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toMatch(/sourceId\/targetId or two affectedIds/);
     });
   });
 
   describe('audit revert', () => {
-    it('is a no-op (audit actions are informational)', () => {
-      const svc = mockEngramService();
-      const action = makeAction({ actionType: 'audit' });
-
-      const result = executeRevert(action, svc as never);
-
-      expect(svc.update).not.toHaveBeenCalled();
-      expect(svc.unlink).not.toHaveBeenCalled();
+    it('returns success without touching engrams', () => {
+      const action = makeAction({ actionType: 'audit', affectedIds: ['e1'] });
+      const result = executeRevert(action, service);
       expect(result.success).toBe(true);
+      expect(result.restoredIds).toEqual([]);
     });
   });
 });

--- a/apps/pops-api/src/modules/cerebrum/glia/revert-operations.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/revert-operations.ts
@@ -126,7 +126,10 @@ function revertLink(action: GliaAction, engramService: EngramService): RevertRes
   }
 
   try {
-    if (!engramService.exists(pair.sourceId)) {
+    // Idempotency: either side missing means the link can no longer exist.
+    // unlink() reads frontmatter from disk for both engrams, so a vanished
+    // target would surface as a read error rather than a clean no-op.
+    if (!engramService.exists(pair.sourceId) || !engramService.exists(pair.targetId)) {
       return { success: true, restoredIds: [], errors: [] };
     }
     engramService.unlink(pair.sourceId, pair.targetId);

--- a/apps/pops-api/src/modules/cerebrum/glia/revert-operations.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/revert-operations.ts
@@ -1,12 +1,22 @@
 /**
- * Revert operations for glia actions (#2248).
+ * Revert operations for glia actions (PRD-086 US-04, #2576).
  *
- * Implements revertAction logic for prune/consolidate/link action types.
- * Restores engrams from archived/consolidated state.
+ * Implements full file-level revert for prune/consolidate/link action types:
+ *
+ * - prune: moves `.archive/{type}/{id}.md` back to `{type}/{id}.md` and flips
+ *   the index row status to `active`.
+ * - consolidate: deletes the merged engram (file, index, inbound link
+ *   frontmatter references), then restores every source engram from
+ *   `.archive/` back to its original path.
+ * - link: removes the bidirectional link recorded in the action payload.
+ *
+ * Every operation is idempotent — re-reverting an already-reverted action
+ * succeeds as a no-op.
  */
 import { logger } from '../../../lib/logger.js';
 
 import type { EngramService } from '../engrams/service.js';
+import type { ConsolidatePayload, LinkPayload } from '../workers/types.js';
 import type { GliaAction } from './types.js';
 
 /** Result of a revert operation. */
@@ -33,15 +43,19 @@ export function executeRevert(action: GliaAction, engramService: EngramService):
   }
 }
 
-/** Revert a prune action: restore archived engrams to active. */
+/** Revert a prune action: move every archived engram back to its type folder. */
 function revertPrune(action: GliaAction, engramService: EngramService): RevertResult {
   const restoredIds: string[] = [];
   const errors: string[] = [];
 
   for (const id of action.affectedIds) {
     try {
-      engramService.update(id, { status: 'active' });
-      restoredIds.push(id);
+      if (!engramService.exists(id)) {
+        // Idempotency: source has been removed entirely — nothing to restore.
+        continue;
+      }
+      const { result } = engramService.restore(id);
+      if (result.moved) restoredIds.push(id);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       errors.push(`Failed to restore ${id}: ${msg}`);
@@ -52,52 +66,88 @@ function revertPrune(action: GliaAction, engramService: EngramService): RevertRe
   return { success: errors.length === 0, restoredIds, errors };
 }
 
-/** Revert a consolidate action: restore consolidated engrams to active. */
+/**
+ * Revert a consolidate action: delete the merged engram and restore all
+ * archived source engrams. The merged engram ID is read from
+ * `payload.mergedEngramId`, which the consolidator records at execution time.
+ */
 function revertConsolidate(action: GliaAction, engramService: EngramService): RevertResult {
   const restoredIds: string[] = [];
   const errors: string[] = [];
+  const payload = action.payload as ConsolidatePayload | null;
+
+  const mergedId = payload?.mergedEngramId;
+  if (mergedId) {
+    try {
+      engramService.hardDelete(mergedId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`Failed to delete merged engram ${mergedId}: ${msg}`);
+      logger.warn(
+        { mergedId, error: msg },
+        '[RevertOps] Consolidate revert: merged engram delete failed'
+      );
+    }
+  }
 
   for (const id of action.affectedIds) {
     try {
-      engramService.update(id, { status: 'active' });
-      restoredIds.push(id);
+      if (!engramService.exists(id)) continue;
+      const { result } = engramService.restore(id);
+      if (result.moved) restoredIds.push(id);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       errors.push(`Failed to restore ${id}: ${msg}`);
-      logger.warn({ engramId: id, error: msg }, '[RevertOps] Consolidate revert failed');
+      logger.warn({ engramId: id, error: msg }, '[RevertOps] Consolidate revert: restore failed');
     }
   }
 
   return { success: errors.length === 0, restoredIds, errors };
 }
 
-/** Revert a link action: remove the link between the affected engrams. */
+/**
+ * Revert a link action: remove the bidirectional link recorded in the payload.
+ * Falls back to the first two `affectedIds` when the payload is missing the
+ * pair (older proposals before LinkPayload was wired up).
+ *
+ * Idempotent — re-running on an already-unlinked pair succeeds (the engram
+ * service strips a non-existent entry without throwing).
+ */
 function revertLink(action: GliaAction, engramService: EngramService): RevertResult {
   const errors: string[] = [];
-  const payload = action.payload as { sourceId?: string; targetId?: string } | null;
-
-  if (payload?.sourceId && payload?.targetId) {
-    try {
-      engramService.unlink(payload.sourceId, payload.targetId);
-      return { success: true, restoredIds: [], errors: [] };
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      errors.push(`Failed to unlink: ${msg}`);
-    }
-  } else if (action.affectedIds.length >= 2) {
-    // Fallback: unlink first two affected IDs
-    const srcId = action.affectedIds[0];
-    const tgtId = action.affectedIds[1];
-    if (srcId && tgtId) {
-      try {
-        engramService.unlink(srcId, tgtId);
-        return { success: true, restoredIds: [], errors: [] };
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        errors.push(`Failed to unlink: ${msg}`);
-      }
-    }
+  const payload = action.payload as Partial<LinkPayload> | null;
+  const pair = resolveLinkPair(action, payload);
+  if (!pair) {
+    return {
+      success: false,
+      restoredIds: [],
+      errors: ['Link revert requires payload.sourceId/targetId or two affectedIds'],
+    };
   }
 
-  return { success: errors.length === 0, restoredIds: [], errors };
+  try {
+    if (!engramService.exists(pair.sourceId)) {
+      return { success: true, restoredIds: [], errors: [] };
+    }
+    engramService.unlink(pair.sourceId, pair.targetId);
+    return { success: true, restoredIds: [], errors: [] };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    errors.push(`Failed to unlink: ${msg}`);
+    logger.warn({ ...pair, error: msg }, '[RevertOps] Link revert failed');
+  }
+
+  return { success: false, restoredIds: [], errors };
+}
+
+function resolveLinkPair(
+  action: GliaAction,
+  payload: Partial<LinkPayload> | null
+): { sourceId: string; targetId: string } | null {
+  if (payload?.sourceId && payload?.targetId) {
+    return { sourceId: payload.sourceId, targetId: payload.targetId };
+  }
+  const [first, second] = action.affectedIds;
+  if (first && second) return { sourceId: first, targetId: second };
+  return null;
 }

--- a/apps/pops-api/src/modules/cerebrum/glia/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/router.ts
@@ -17,7 +17,9 @@ import {
   ValidationError,
 } from '../../../shared/errors.js';
 import { protectedProcedure, router } from '../../../trpc.js';
+import { getEngramService } from '../instance.js';
 import { getGliaServices } from './instance.js';
+import { executeRevert } from './revert-operations.js';
 import { ACTION_STATUSES, ACTION_TYPES, USER_DECISIONS } from './types.js';
 
 import type { ActionType } from './types.js';
@@ -118,16 +120,23 @@ const actionsRouter = router({
     }
   }),
 
-  /** Revert an executed action. */
+  /**
+   * Revert an executed action.
+   *
+   * Flow: flip the DB state first (idempotent — re-reverting returns the same
+   * row), then perform the file-level restore via `executeRevert`. The DB
+   * state change is the source of truth for "this action has been reverted"
+   * even when individual file ops report partial failures, so the caller can
+   * inspect `revertResult.errors` and retry the filesystem side without
+   * double-counting the revert in trust state. PRD-086 US-04, #2576.
+   */
   revert: protectedProcedure.input(z.object({ id: z.string().min(1) })).mutation(({ input }) => {
     try {
       const { actionService, trustMachine } = getGliaServices();
       const action = actionService.revertAction(input.id);
-
-      // Eagerly evaluate demotion after every revert
+      const revertResult = executeRevert(action, getEngramService());
       const transition = trustMachine.checkGraduation(action.actionType as ActionType);
-
-      return { action, transition };
+      return { action, transition, revertResult };
     } catch (err) {
       toTrpcError(err);
     }

--- a/apps/pops-api/src/modules/cerebrum/workers/consolidator.ts
+++ b/apps/pops-api/src/modules/cerebrum/workers/consolidator.ts
@@ -120,14 +120,19 @@ export class ConsolidatorWorker extends WorkerBase {
       phase
     );
     if (phase !== 'propose') {
-      this.executeMerge(cluster, mergePlan);
+      const mergedId = this.executeMerge(cluster, mergePlan);
+      mergePlan.mergedEngramId = mergedId;
       action.status = 'executed';
     }
     return action;
   }
 
-  /** Execute a merge — create consolidated engram and archive originals. */
-  private executeMerge(cluster: Engram[], plan: ConsolidatePayload): void {
+  /**
+   * Execute a merge — create the consolidated engram and archive originals.
+   * Returns the merged engram's ID so the caller can record it on the action
+   * payload (needed for revert per PRD-086 US-04).
+   */
+  private executeMerge(cluster: Engram[], plan: ConsolidatePayload): string {
     const dominantType = findDominantType(cluster);
     const merged = this.engramService.create({
       title: plan.mergedTitle,
@@ -143,5 +148,6 @@ export class ConsolidatorWorker extends WorkerBase {
     for (const original of cluster) {
       this.engramService.archive(original.id);
     }
+    return merged.id;
   }
 }

--- a/apps/pops-api/src/modules/cerebrum/workers/types.ts
+++ b/apps/pops-api/src/modules/cerebrum/workers/types.ts
@@ -85,6 +85,12 @@ export interface ConsolidatePayload extends PayloadBase {
   mergedLinks: string[];
   mergedBody: string;
   scope: string;
+  /**
+   * Engram ID of the merged file produced by `executeMerge`. Set only after
+   * the merge runs (non-propose phases). Required for `consolidate` revert
+   * to locate and remove the merged engram (PRD-086 US-04, #2576).
+   */
+  mergedEngramId?: string;
 }
 
 /** Linker-specific payload. */

--- a/apps/pops-api/src/shared/test-utils.ts
+++ b/apps/pops-api/src/shared/test-utils.ts
@@ -847,6 +847,24 @@ export function createTestDb(): Database {
 }
 
 /**
+ * Create a deterministic monotonically-increasing clock for tests.
+ *
+ * Each call returns the next `Date`, advancing by 60 seconds. Intended for
+ * services that accept a `now: () => Date` dependency so tests can assert on
+ * stable timestamps without leaning on `vi.useFakeTimers` for trivial cases.
+ *
+ * @param start - First `Date` to return; subsequent calls advance by 1 minute.
+ */
+export function makeClock(start = new Date('2026-05-12T09:00:00Z')): () => Date {
+  let t = start.getTime();
+  return () => {
+    const d = new Date(t);
+    t += 60_000;
+    return d;
+  };
+}
+
+/**
  * Seed a single entity row into the test DB.
  * Returns the id.
  */


### PR DESCRIPTION
## Summary

Implements PRD-086 US-04 AC #2/#3/#4 — full file-level revert for Glia prune, consolidate, and link actions. Replaces the status-only stubs in `executeRevert` with real filesystem operations and wires the function into the `cerebrum.glia.actions.revert` tRPC route.

- **prune**: moves `.archive/{type}/{id}.md` back to `{type}/{id}.md`, flips status to `active`.
- **consolidate**: hard-deletes the merged engram (file, index, inbound `engram_links` rows, and inbound frontmatter `links:` entries on external targets), then restores every source from `.archive/`. The consolidator now records `mergedEngramId` on the action payload after `executeMerge` so revert can find the merged file.
- **link**: unlinks the pair recorded in `payload.sourceId`/`targetId`, with a fallback to the first two `affectedIds` for legacy proposals.

All three paths are idempotent — re-reverting an already-reverted action returns success without re-doing work or throwing. Backed by two new engram handlers (`restore-engram.ts`, `delete-engram.ts`) and matching `EngramService.restore` / `EngramService.hardDelete` methods.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint` (0 errors)
- [x] `pnpm typecheck`
- [x] `pnpm --filter @pops/api test` (4272 passing)
- [x] `packages/module-registry` builds clean
- [x] 11 new tests in `revert-operations.test.ts` over `mkdtemp` fixtures cover each action type plus idempotency

Closes #2576.