### PR TITLE
feat(cerebrum): glia digest reports for autonomous actions (#2577)

### DIFF
--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/autonomous-digest.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/autonomous-digest.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Unit tests for the autonomous-action digest builder (#2577).
+ *
+ * Verifies grouping, ordering, anomaly detection, and renderer output
+ * without touching the database — these are pure-function checks.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAutonomousDigest,
+  DEFAULT_REJECTION_RATE_ANOMALY_THRESHOLD,
+  renderAutonomousDigestText,
+} from '../digest-reports.js';
+
+import type { GliaAction, GliaTrustState, ActionType, TrustPhase } from '../types.js';
+
+function autonomousAction(overrides: Partial<GliaAction> = {}): GliaAction {
+  return {
+    id: 'glia_prune_20260510_a',
+    actionType: 'prune',
+    affectedIds: ['eng_1'],
+    rationale: 'Stale engram archived',
+    payload: null,
+    phase: 'act_report',
+    status: 'executed',
+    userDecision: null,
+    userNote: null,
+    executedAt: '2026-05-10T10:00:00Z',
+    decidedAt: null,
+    revertedAt: null,
+    createdAt: '2026-05-10T09:00:00Z',
+    ...overrides,
+  };
+}
+
+function trustState(
+  actionType: ActionType,
+  currentPhase: TrustPhase,
+  overrides: Partial<GliaTrustState> = {}
+): GliaTrustState {
+  return {
+    actionType,
+    currentPhase,
+    approvedCount: 0,
+    rejectedCount: 0,
+    revertedCount: 0,
+    autonomousSince: currentPhase === 'propose' ? null : '2026-04-01T00:00:00Z',
+    lastRevertAt: null,
+    graduatedAt: currentPhase === 'propose' ? null : '2026-04-01T00:00:00Z',
+    updatedAt: '2026-05-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('buildAutonomousDigest', () => {
+  it('groups actions by type and lists affected engrams with rationale', () => {
+    const actions: GliaAction[] = [
+      autonomousAction({
+        id: 'a1',
+        actionType: 'prune',
+        affectedIds: ['eng_1'],
+        rationale: 'Stale 1',
+        executedAt: '2026-05-10T10:00:00Z',
+      }),
+      autonomousAction({
+        id: 'a2',
+        actionType: 'prune',
+        affectedIds: ['eng_2'],
+        rationale: 'Stale 2',
+        executedAt: '2026-05-10T11:00:00Z',
+      }),
+      autonomousAction({
+        id: 'a3',
+        actionType: 'link',
+        affectedIds: ['eng_3', 'eng_4'],
+        rationale: 'Cross reference',
+        executedAt: '2026-05-10T12:00:00Z',
+      }),
+    ];
+
+    const report = buildAutonomousDigest({
+      actions,
+      trustStates: [trustState('prune', 'act_report'), trustState('link', 'act_report')],
+      postGraduationExecutedByType: { prune: 2, link: 1 },
+      postGraduationRevertedByType: { prune: 0, link: 0 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    expect(report.totalAutonomousActions).toBe(3);
+    expect(report.groups).toHaveLength(2);
+
+    // Highest-volume group first; ties broken alphabetically.
+    expect(report.groups[0]?.actionType).toBe('prune');
+    expect(report.groups[0]?.count).toBe(2);
+    expect(report.groups[0]?.actions.map((a) => a.id)).toEqual(['a1', 'a2']);
+    expect(report.groups[0]?.actions[0]?.affectedIds).toEqual(['eng_1']);
+    expect(report.groups[0]?.actions[0]?.rationale).toBe('Stale 1');
+
+    expect(report.groups[1]?.actionType).toBe('link');
+    expect(report.groups[1]?.count).toBe(1);
+    expect(report.groups[1]?.actions[0]?.affectedIds).toEqual(['eng_3', 'eng_4']);
+  });
+
+  it('sorts entries inside a group chronologically', () => {
+    const actions: GliaAction[] = [
+      autonomousAction({ id: 'late', executedAt: '2026-05-10T12:00:00Z' }),
+      autonomousAction({ id: 'early', executedAt: '2026-05-10T08:00:00Z' }),
+      autonomousAction({ id: 'mid', executedAt: '2026-05-10T10:00:00Z' }),
+    ];
+
+    const report = buildAutonomousDigest({
+      actions,
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: { prune: 3 },
+      postGraduationRevertedByType: { prune: 0 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    expect(report.groups[0]?.actions.map((a) => a.id)).toEqual(['early', 'mid', 'late']);
+  });
+
+  it('skips rows that are not actually autonomous', () => {
+    const actions: GliaAction[] = [
+      autonomousAction({ id: 'autonomous' }),
+      // decidedAt populated → user-driven, must be filtered out defensively.
+      autonomousAction({ id: 'user-driven', decidedAt: '2026-05-10T09:30:00Z' }),
+      // status != executed → not a completed autonomous action.
+      autonomousAction({ id: 'pending', status: 'pending', executedAt: null }),
+    ];
+
+    const report = buildAutonomousDigest({
+      actions,
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: { prune: 1 },
+      postGraduationRevertedByType: { prune: 0 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    expect(report.groups[0]?.actions.map((a) => a.id)).toEqual(['autonomous']);
+  });
+
+  it('returns an empty report when there are no actions', () => {
+    const report = buildAutonomousDigest({
+      actions: [],
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: {},
+      postGraduationRevertedByType: {},
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    expect(report.totalAutonomousActions).toBe(0);
+    expect(report.groups).toEqual([]);
+    expect(report.anomalies).toEqual([]);
+  });
+});
+
+describe('buildAutonomousDigest anomalies', () => {
+  it('flags an action type whose post-graduation rejection rate exceeds the default threshold', () => {
+    // 4 reverted / 10 total = 40% — above the 30% default.
+    const report = buildAutonomousDigest({
+      actions: [autonomousAction()],
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: { prune: 6 },
+      postGraduationRevertedByType: { prune: 4 },
+      period: 'weekly',
+      startDate: '2026-05-04T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    expect(report.anomalies).toHaveLength(1);
+    const anomaly = report.anomalies[0];
+    expect(anomaly?.actionType).toBe('prune');
+    expect(anomaly?.rejectionRatePostGraduation).toBeCloseTo(0.4);
+    expect(anomaly?.threshold).toBe(DEFAULT_REJECTION_RATE_ANOMALY_THRESHOLD);
+    expect(anomaly?.executedCount).toBe(6);
+    expect(anomaly?.revertedCount).toBe(4);
+  });
+
+  it('does not flag types in propose phase', () => {
+    const report = buildAutonomousDigest({
+      actions: [],
+      trustStates: [trustState('prune', 'propose', { autonomousSince: null })],
+      postGraduationExecutedByType: { prune: 1 },
+      postGraduationRevertedByType: { prune: 10 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+    expect(report.anomalies).toEqual([]);
+  });
+
+  it('respects a custom threshold', () => {
+    const report = buildAutonomousDigest({
+      actions: [],
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: { prune: 8 },
+      // 2/10 = 20% — above a 15% threshold, below the 30% default.
+      postGraduationRevertedByType: { prune: 2 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+      rejectionRateThreshold: 0.15,
+    });
+
+    expect(report.anomalies).toHaveLength(1);
+    expect(report.anomalies[0]?.rejectionRatePostGraduation).toBeCloseTo(0.2);
+    expect(report.anomalies[0]?.threshold).toBe(0.15);
+  });
+
+  it('does not flag when total post-graduation activity is zero', () => {
+    const report = buildAutonomousDigest({
+      actions: [],
+      trustStates: [trustState('link', 'act_report')],
+      postGraduationExecutedByType: { link: 0 },
+      postGraduationRevertedByType: { link: 0 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+    expect(report.anomalies).toEqual([]);
+  });
+});
+
+describe('renderAutonomousDigestText', () => {
+  it('renders groups, affected engrams, and anomalies in plain text', () => {
+    const report = buildAutonomousDigest({
+      actions: [
+        autonomousAction({
+          id: 'a1',
+          actionType: 'prune',
+          affectedIds: ['eng_1'],
+          rationale: 'Stale',
+        }),
+        autonomousAction({
+          id: 'a2',
+          actionType: 'link',
+          affectedIds: ['eng_a', 'eng_b'],
+          rationale: 'Linked',
+        }),
+      ],
+      trustStates: [trustState('prune', 'act_report'), trustState('link', 'act_report')],
+      postGraduationExecutedByType: { prune: 1, link: 6 },
+      postGraduationRevertedByType: { prune: 0, link: 4 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    const text = renderAutonomousDigestText(report);
+    expect(text).toContain('Daily Glia digest — 2 autonomous actions');
+    expect(text).toContain('prune (1)');
+    expect(text).toContain('link (1)');
+    expect(text).toContain('[eng_1] Stale');
+    expect(text).toContain('[eng_a, eng_b] Linked');
+    expect(text).toContain('Anomalies');
+    expect(text).toContain('link: 40.0% post-graduation rejection rate (4/10)');
+  });
+
+  it('truncates per-group previews above 5 entries', () => {
+    const actions: GliaAction[] = Array.from({ length: 7 }, (_, i) =>
+      autonomousAction({
+        id: `a${i}`,
+        executedAt: `2026-05-10T10:0${i}:00Z`,
+      })
+    );
+    const report = buildAutonomousDigest({
+      actions,
+      trustStates: [trustState('prune', 'act_report')],
+      postGraduationExecutedByType: { prune: 7 },
+      postGraduationRevertedByType: { prune: 0 },
+      period: 'daily',
+      startDate: '2026-05-10T00:00:00Z',
+      endDate: '2026-05-11T00:00:00Z',
+    });
+
+    const text = renderAutonomousDigestText(report);
+    expect(text).toContain('+2 more');
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/digest-service.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/digest-service.test.ts
@@ -22,12 +22,10 @@ import type { Database } from 'better-sqlite3';
 import type { DigestDeliveryChannels } from '../digest-service.js';
 import type { ActionType } from '../types.js';
 
-/** Clock that returns a fixed time — no auto-advance to keep timestamps tidy. */
 function fixedClock(iso: string): () => Date {
   return () => new Date(iso);
 }
 
-/** Make a clock that returns sequential timestamps starting from `iso`. */
 function steppingClock(iso: string, stepMs = 1_000): () => Date {
   let t = new Date(iso).getTime();
   return () => {
@@ -51,7 +49,6 @@ function makeChannels(): {
   };
 }
 
-/** Seed an autonomous action by promoting the action type, then creating. */
 function seedAutonomous(
   svc: GliaActionService,
   actionType: ActionType,
@@ -123,8 +120,6 @@ describe('GliaDigestService', () => {
   });
 
   it('flags an anomaly when post-graduation rejection rate exceeds the threshold', async () => {
-    // Promote `prune` to act_report and seed 10 autonomous executions then
-    // revert 4 of them — 40% rejection rate, above the 30% default.
     actionService.updateTrustState('prune', {
       currentPhase: 'act_report',
       autonomousSince: '2026-04-01T00:00:00Z',
@@ -172,7 +167,6 @@ describe('GliaDigestService', () => {
         }).id
       );
     }
-    // 2/10 = 20% — would not trip at default 30%, must trip at 15%.
     const r0 = seeded[0];
     const r1 = seeded[1];
     if (r0) actionService.revertAction(r0);
@@ -199,7 +193,6 @@ describe('GliaDigestService', () => {
   });
 
   it('suppresses delivery when all action types in the digest are in silent phase', async () => {
-    // Seed an autonomous action while in act_report, then promote to silent.
     seedAutonomous(actionService, 'audit', { rationale: 'Quiet audit' });
     actionService.updateTrustState('audit', {
       currentPhase: 'silent',
@@ -221,7 +214,6 @@ describe('GliaDigestService', () => {
   });
 
   it('still delivers when at least one action type in the digest is in act_report', async () => {
-    // Two action types — `link` in act_report, `audit` in silent.
     seedAutonomous(actionService, 'link', { rationale: 'Linked' });
     seedAutonomous(actionService, 'audit', { rationale: 'Audited' });
     actionService.updateTrustState('audit', {

--- a/apps/pops-api/src/modules/cerebrum/glia/__tests__/digest-service.test.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/__tests__/digest-service.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Integration tests for GliaDigestService (#2577).
+ *
+ * Exercises the full pipeline against an in-memory DB: autonomous-action
+ * query → grouping → anomaly detection → channel delivery (mocked).
+ *
+ * Covers PRD-086 US-04 AC #5/#6:
+ *   - Grouping by action type with affected engrams + rationale
+ *   - Anomaly tripping on high post-graduation rejection rate
+ *   - Silent-phase suppression
+ *   - Empty-period happy path (no delivery attempted)
+ */
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createTestDb } from '../../../../shared/test-utils.js';
+import { GliaActionService } from '../action-service.js';
+import { GliaDigestService } from '../digest-service.js';
+
+import type { Database } from 'better-sqlite3';
+
+import type { DigestDeliveryChannels } from '../digest-service.js';
+import type { ActionType } from '../types.js';
+
+/** Clock that returns a fixed time — no auto-advance to keep timestamps tidy. */
+function fixedClock(iso: string): () => Date {
+  return () => new Date(iso);
+}
+
+/** Make a clock that returns sequential timestamps starting from `iso`. */
+function steppingClock(iso: string, stepMs = 1_000): () => Date {
+  let t = new Date(iso).getTime();
+  return () => {
+    const d = new Date(t);
+    t += stepMs;
+    return d;
+  };
+}
+
+function makeChannels(): {
+  channels: DigestDeliveryChannels;
+  shell: ReturnType<typeof vi.fn>;
+  moltbot: ReturnType<typeof vi.fn>;
+} {
+  const shell = vi.fn().mockReturnValue(true);
+  const moltbot = vi.fn().mockResolvedValue(true);
+  return {
+    channels: { shell, moltbot },
+    shell,
+    moltbot,
+  };
+}
+
+/** Seed an autonomous action by promoting the action type, then creating. */
+function seedAutonomous(
+  svc: GliaActionService,
+  actionType: ActionType,
+  options: { affectedIds?: string[]; rationale?: string } = {}
+): { id: string } {
+  svc.updateTrustState(actionType, {
+    currentPhase: 'act_report',
+    autonomousSince: '2026-04-01T00:00:00Z',
+    graduatedAt: '2026-04-01T00:00:00Z',
+  });
+  const action = svc.createAction({
+    actionType,
+    affectedIds: options.affectedIds ?? ['eng_default'],
+    rationale: options.rationale ?? 'Autonomous rationale',
+  });
+  return { id: action.id };
+}
+
+describe('GliaDigestService', () => {
+  let db: Database;
+  let actionService: GliaActionService;
+
+  beforeEach(() => {
+    db = createTestDb();
+    actionService = new GliaActionService(
+      drizzle(db),
+      steppingClock('2026-05-10T10:00:00Z', 60_000)
+    );
+    actionService.seedTrustStates();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('builds a digest grouped by action type with affected engrams and rationale', async () => {
+    seedAutonomous(actionService, 'prune', {
+      affectedIds: ['eng_1'],
+      rationale: 'Stale engram 1',
+    });
+    seedAutonomous(actionService, 'prune', {
+      affectedIds: ['eng_2'],
+      rationale: 'Stale engram 2',
+    });
+    seedAutonomous(actionService, 'link', {
+      affectedIds: ['eng_3', 'eng_4'],
+      rationale: 'Linked',
+    });
+
+    const { channels, shell, moltbot } = makeChannels();
+    const digest = new GliaDigestService(actionService, {
+      now: fixedClock('2026-05-11T01:00:00Z'),
+      channels,
+    });
+
+    const result = await digest.generate({ period: 'daily' });
+
+    expect(result.report.totalAutonomousActions).toBe(3);
+    expect(result.report.groups.map((g) => g.actionType)).toEqual(['prune', 'link']);
+    expect(result.report.groups[0]?.actions.map((a) => a.rationale)).toEqual([
+      'Stale engram 1',
+      'Stale engram 2',
+    ]);
+    expect(result.report.groups[1]?.actions[0]?.affectedIds).toEqual(['eng_3', 'eng_4']);
+
+    expect(result.delivery.attempted).toBe(true);
+    expect(shell).toHaveBeenCalledOnce();
+    expect(moltbot).toHaveBeenCalledOnce();
+  });
+
+  it('flags an anomaly when post-graduation rejection rate exceeds the threshold', async () => {
+    // Promote `prune` to act_report and seed 10 autonomous executions then
+    // revert 4 of them — 40% rejection rate, above the 30% default.
+    actionService.updateTrustState('prune', {
+      currentPhase: 'act_report',
+      autonomousSince: '2026-04-01T00:00:00Z',
+    });
+    const seeded: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      seeded.push(
+        actionService.createAction({
+          actionType: 'prune',
+          affectedIds: [`eng_${i}`],
+          rationale: `Autonomous ${i}`,
+        }).id
+      );
+    }
+    for (let i = 0; i < 4; i++) {
+      const id = seeded[i];
+      if (id) actionService.revertAction(id);
+    }
+
+    const { channels } = makeChannels();
+    const digest = new GliaDigestService(actionService, {
+      now: fixedClock('2026-05-11T01:00:00Z'),
+      channels,
+    });
+
+    const result = await digest.generate({ period: 'weekly' });
+    expect(result.report.anomalies).toHaveLength(1);
+    const anomaly = result.report.anomalies[0];
+    expect(anomaly?.actionType).toBe('prune');
+    expect(anomaly?.rejectionRatePostGraduation).toBeCloseTo(0.4);
+  });
+
+  it('respects a custom rejection-rate threshold', async () => {
+    actionService.updateTrustState('link', {
+      currentPhase: 'act_report',
+      autonomousSince: '2026-04-01T00:00:00Z',
+    });
+    const seeded: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      seeded.push(
+        actionService.createAction({
+          actionType: 'link',
+          affectedIds: [`eng_${i}`],
+          rationale: 'Link',
+        }).id
+      );
+    }
+    // 2/10 = 20% — would not trip at default 30%, must trip at 15%.
+    const r0 = seeded[0];
+    const r1 = seeded[1];
+    if (r0) actionService.revertAction(r0);
+    if (r1) actionService.revertAction(r1);
+
+    const { channels } = makeChannels();
+    const digest = new GliaDigestService(actionService, {
+      now: fixedClock('2026-05-11T01:00:00Z'),
+      channels,
+    });
+
+    const defaultResult = await digest.generate({
+      period: 'weekly',
+      deliver: false,
+    });
+    expect(defaultResult.report.anomalies).toEqual([]);
+
+    const tightResult = await digest.generate({
+      period: 'weekly',
+      rejectionRateThreshold: 0.15,
+      deliver: false,
+    });
+    expect(tightResult.report.anomalies).toHaveLength(1);
+  });
+
+  it('suppresses delivery when all action types in the digest are in silent phase', async () => {
+    // Seed an autonomous action while in act_report, then promote to silent.
+    seedAutonomous(actionService, 'audit', { rationale: 'Quiet audit' });
+    actionService.updateTrustState('audit', {
+      currentPhase: 'silent',
+      autonomousSince: '2026-04-01T00:00:00Z',
+    });
+
+    const { channels, shell, moltbot } = makeChannels();
+    const digest = new GliaDigestService(actionService, {
+      now: fixedClock('2026-05-11T01:00:00Z'),
+      channels,
+    });
+
+    const result = await digest.generate({ period: 'daily' });
+    expect(result.report.totalAutonomousActions).toBe(1);
+    expect(result.delivery.attempted).toBe(false);
+    expect(result.delivery.suppressedReason).toMatch(/silent phase/);
+    expect(shell).not.toHaveBeenCalled();
+    expect(moltbot).not.toHaveBeenCalled();
+  });
+
+  it('still delivers when at least one action type in the digest is in act_report', async () => {
+    // Two action types — `link` in act_report, `audit` in silent.
+    seedAutonomous(actionService, 'link', { rationale: 'Linked' });
+    seedAutonomous(actionService, 'audit', { rationale: 'Audited' });
+    actionService.updateTrustState('audit', {
+      currentPhase: 'silent',
+      autonomousSince: '2026-04-01T00:00:00Z',
+    });
+
+    const { channels, shell, moltbot } = makeChannels();
+    const digest = new GliaDigestService(actionService, {
+      now: fixedClock('2026-05-11T01:00:00Z'),
+      channels,
+    });
+
+    const result = await digest.generate({ period: 'daily' });
+    expect(result.delivery.attempted).toBe(true);
+    expect(shell).toHaveBeenCalledOnce();
+    expect(moltbot).toHaveBeenCalledOnce();
+  });
+
+  it('does not attempt delivery for an empty period (no autonomous actions)', async () => {
+    const { channels, shell, moltbot } = makeChannels();
+    const digest = new GliaDigestService(actionService, {
+      now: fixedClock('2026-05-11T01:00:00Z'),
+      channels,
+    });
+
+    const result = await digest.generate({ period: 'daily' });
+    expect(result.report.totalAutonomousActions).toBe(0);
+    expect(result.report.groups).toEqual([]);
+    expect(result.delivery.attempted).toBe(false);
+    expect(result.delivery.suppressedReason).toMatch(/No autonomous actions/);
+    expect(shell).not.toHaveBeenCalled();
+    expect(moltbot).not.toHaveBeenCalled();
+  });
+
+  it('filters to a single action type when requested', async () => {
+    seedAutonomous(actionService, 'prune', { rationale: 'P' });
+    seedAutonomous(actionService, 'link', { rationale: 'L' });
+
+    const { channels } = makeChannels();
+    const digest = new GliaDigestService(actionService, {
+      now: fixedClock('2026-05-11T01:00:00Z'),
+      channels,
+    });
+
+    const result = await digest.generate({ period: 'daily', actionType: 'prune' });
+    expect(result.report.totalAutonomousActions).toBe(1);
+    expect(result.report.groups.map((g) => g.actionType)).toEqual(['prune']);
+  });
+
+  it('skips delivery when caller passes deliver=false', async () => {
+    seedAutonomous(actionService, 'prune', { rationale: 'P' });
+    const { channels, shell, moltbot } = makeChannels();
+    const digest = new GliaDigestService(actionService, {
+      now: fixedClock('2026-05-11T01:00:00Z'),
+      channels,
+    });
+
+    const result = await digest.generate({ period: 'daily', deliver: false });
+    expect(result.report.totalAutonomousActions).toBe(1);
+    expect(result.delivery.attempted).toBe(false);
+    expect(shell).not.toHaveBeenCalled();
+    expect(moltbot).not.toHaveBeenCalled();
+  });
+
+  it('records per-channel failures without throwing', async () => {
+    seedAutonomous(actionService, 'prune', { rationale: 'P' });
+    const channels: DigestDeliveryChannels = {
+      shell: vi.fn().mockImplementation(() => {
+        throw new Error('shell down');
+      }),
+      moltbot: vi.fn().mockResolvedValue(true),
+    };
+    const digest = new GliaDigestService(actionService, {
+      now: fixedClock('2026-05-11T01:00:00Z'),
+      channels,
+    });
+
+    const result = await digest.generate({ period: 'daily' });
+    expect(result.delivery.attempted).toBe(true);
+
+    const shellResult = result.delivery.channels.find((c) => c.channel === 'shell');
+    expect(shellResult?.delivered).toBe(false);
+    expect(shellResult?.reason).toBe('shell down');
+
+    const moltbotResult = result.delivery.channels.find((c) => c.channel === 'moltbot');
+    expect(moltbotResult?.delivered).toBe(true);
+  });
+});

--- a/apps/pops-api/src/modules/cerebrum/glia/action-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/action-service.ts
@@ -12,11 +12,14 @@ import { gliaActions, gliaTrustState } from '@pops/db-types/schema';
 
 import { ConflictError, NotFoundError, ValidationError } from '../../../shared/errors.js';
 import {
+  countAutonomousExecutionsSince,
+  countAutonomousRevertsSince,
   countRevertsInWindow,
   generateActionId,
   getActionById,
   getTrustStateByType,
   listAllTrustStates,
+  listAutonomousActionsInWindow,
   queryActions,
   toGliaAction,
 } from './helpers.js';
@@ -190,6 +193,21 @@ export class GliaActionService {
   }
   countRevertsInWindow(actionType: ActionType, windowStart: string): number {
     return countRevertsInWindow(this.db, actionType, windowStart);
+  }
+
+  /** Autonomous actions executed in a window (used by the digest). */
+  listAutonomousActionsInWindow(startDate: string, endDate: string): GliaAction[] {
+    return listAutonomousActionsInWindow(this.db, startDate, endDate);
+  }
+
+  /** Count autonomous executions for a type since a given timestamp. */
+  countAutonomousExecutionsSince(actionType: ActionType, sinceIso: string): number {
+    return countAutonomousExecutionsSince(this.db, actionType, sinceIso);
+  }
+
+  /** Count autonomous reverts for a type since a given timestamp. */
+  countAutonomousRevertsSince(actionType: ActionType, sinceIso: string): number {
+    return countAutonomousRevertsSince(this.db, actionType, sinceIso);
   }
 
   /** Update trust state directly (used by the trust machine). */

--- a/apps/pops-api/src/modules/cerebrum/glia/autonomous-digest.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/autonomous-digest.ts
@@ -105,11 +105,16 @@ export function buildAutonomousDigest(input: AutonomousDigestInput): AutonomousD
     threshold
   );
 
+  // Sum from groups so the total reflects rows that survived the defensive
+  // filter in `groupAutonomousActions` — `input.actions.length` would overcount
+  // anything the caller passed in that wasn't a clean autonomous execution.
+  const totalAutonomousActions = groups.reduce((sum, group) => sum + group.count, 0);
+
   return {
     period: input.period,
     startDate: input.startDate,
     endDate: input.endDate,
-    totalAutonomousActions: input.actions.length,
+    totalAutonomousActions,
     groups,
     anomalies,
   };

--- a/apps/pops-api/src/modules/cerebrum/glia/autonomous-digest.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/autonomous-digest.ts
@@ -1,14 +1,3 @@
-/**
- * Autonomous-action digest builder (#2577 — PRD-086 US-04 AC #5/#6).
- *
- * Pure functions: takes a pre-filtered list of autonomous `glia_actions`
- * rows plus per-action-type post-graduation counts, groups by action type,
- * and flags anomalies on high rejection rates.
- *
- * Split out from `digest-reports.ts` to keep that file under the
- * `max-lines` lint threshold.
- */
-
 import type { ActionType, GliaAction, GliaTrustState } from './types.js';
 
 /**

--- a/apps/pops-api/src/modules/cerebrum/glia/autonomous-digest.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/autonomous-digest.ts
@@ -1,0 +1,229 @@
+/**
+ * Autonomous-action digest builder (#2577 — PRD-086 US-04 AC #5/#6).
+ *
+ * Pure functions: takes a pre-filtered list of autonomous `glia_actions`
+ * rows plus per-action-type post-graduation counts, groups by action type,
+ * and flags anomalies on high rejection rates.
+ *
+ * Split out from `digest-reports.ts` to keep that file under the
+ * `max-lines` lint threshold.
+ */
+
+import type { ActionType, GliaAction, GliaTrustState } from './types.js';
+
+/**
+ * Default rejection-rate threshold above which the post-graduation anomaly
+ * fires. Picked at 30% to match the task brief — the propose→act_report gate
+ * is 10%, so 30% is the smallest multiple that unambiguously indicates the
+ * worker has regressed since being trusted. Configurable per-call through
+ * `buildAutonomousDigest` options.
+ */
+export const DEFAULT_REJECTION_RATE_ANOMALY_THRESHOLD = 0.3;
+
+/** A single autonomous action surfaced in the digest. */
+export interface DigestActionEntry {
+  id: string;
+  affectedIds: string[];
+  rationale: string;
+  executedAt: string;
+}
+
+/** Per action-type grouping in the digest. */
+export interface DigestActionGroup {
+  actionType: ActionType;
+  count: number;
+  actions: DigestActionEntry[];
+}
+
+/**
+ * Anomaly: action type whose post-graduation rejection/revert rate exceeds
+ * the configured threshold.
+ *
+ * `rejectionRatePostGraduation` is computed as
+ * `revertedCount / (executedAutonomous + revertedCount)` since the trust
+ * state's `autonomousSince` timestamp — once an action type graduates to
+ * `act_report`, the user can no longer reject pre-execution, so reverts
+ * are the only signal of dissatisfaction.
+ */
+export interface DigestAnomaly {
+  actionType: ActionType;
+  rejectionRatePostGraduation: number;
+  threshold: number;
+  autonomousSince: string;
+  executedCount: number;
+  revertedCount: number;
+}
+
+/** The full autonomous digest payload returned by `cerebrum.glia.digest`. */
+export interface AutonomousDigestReport {
+  period: 'daily' | 'weekly';
+  startDate: string;
+  endDate: string;
+  totalAutonomousActions: number;
+  groups: DigestActionGroup[];
+  anomalies: DigestAnomaly[];
+}
+
+export interface AutonomousDigestInput {
+  /** Autonomous (status=executed, decided_at IS NULL) actions in window. */
+  actions: GliaAction[];
+  /** Current trust state for every action type — used for anomaly detection. */
+  trustStates: GliaTrustState[];
+  /**
+   * Counts of executed autonomous actions by action type since each type's
+   * `autonomousSince` timestamp. Used to compute the post-graduation rate.
+   */
+  postGraduationExecutedByType: Partial<Record<ActionType, number>>;
+  /**
+   * Counts of reverted autonomous actions by action type since each type's
+   * `autonomousSince` timestamp.
+   */
+  postGraduationRevertedByType: Partial<Record<ActionType, number>>;
+  period: 'daily' | 'weekly';
+  startDate: string;
+  endDate: string;
+  rejectionRateThreshold?: number;
+}
+
+/**
+ * Build the autonomous-action digest for `cerebrum.glia.digest`.
+ *
+ * Caller is responsible for filtering to autonomous executions
+ * (`status='executed'` AND `decided_at IS NULL`) — defensive checks here
+ * skip anything that slips through.
+ *
+ * Pure function: no DB access. The caller assembles input from the action
+ * service so this stays trivially testable.
+ */
+export function buildAutonomousDigest(input: AutonomousDigestInput): AutonomousDigestReport {
+  const threshold = input.rejectionRateThreshold ?? DEFAULT_REJECTION_RATE_ANOMALY_THRESHOLD;
+  const groups = groupAutonomousActions(input.actions);
+  const anomalies = detectRejectionAnomalies(
+    input.trustStates,
+    input.postGraduationExecutedByType,
+    input.postGraduationRevertedByType,
+    threshold
+  );
+
+  return {
+    period: input.period,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    totalAutonomousActions: input.actions.length,
+    groups,
+    anomalies,
+  };
+}
+
+function groupAutonomousActions(actions: GliaAction[]): DigestActionGroup[] {
+  const buckets = new Map<ActionType, DigestActionEntry[]>();
+  for (const action of actions) {
+    // Defensive: caller should already filter these out.
+    if (action.decidedAt !== null || action.status !== 'executed') continue;
+    if (action.executedAt === null) continue;
+
+    const entry: DigestActionEntry = {
+      id: action.id,
+      affectedIds: action.affectedIds,
+      rationale: action.rationale,
+      executedAt: action.executedAt,
+    };
+    const existing = buckets.get(action.actionType);
+    if (existing) {
+      existing.push(entry);
+    } else {
+      buckets.set(action.actionType, [entry]);
+    }
+  }
+
+  const groups: DigestActionGroup[] = [];
+  for (const [actionType, entries] of buckets) {
+    // Within a group, sort by executedAt ascending so the digest reads
+    // chronologically when rendered as a bullet list.
+    entries.sort((a, b) => a.executedAt.localeCompare(b.executedAt));
+    groups.push({ actionType, count: entries.length, actions: entries });
+  }
+  // Stable order across groups: highest volume first, ties broken alphabetically.
+  groups.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.actionType.localeCompare(b.actionType);
+  });
+
+  return groups;
+}
+
+function detectRejectionAnomalies(
+  trustStates: GliaTrustState[],
+  executedByType: Partial<Record<ActionType, number>>,
+  revertedByType: Partial<Record<ActionType, number>>,
+  threshold: number
+): DigestAnomaly[] {
+  const anomalies: DigestAnomaly[] = [];
+  for (const state of trustStates) {
+    // Anomaly only meaningful once a type has actually graduated.
+    if (!state.autonomousSince) continue;
+    if (state.currentPhase === 'propose') continue;
+
+    const executed = executedByType[state.actionType] ?? 0;
+    const reverted = revertedByType[state.actionType] ?? 0;
+    const total = executed + reverted;
+    if (total === 0) continue;
+
+    const rate = reverted / total;
+    if (rate > threshold) {
+      anomalies.push({
+        actionType: state.actionType,
+        rejectionRatePostGraduation: rate,
+        threshold,
+        autonomousSince: state.autonomousSince,
+        executedCount: executed,
+        revertedCount: reverted,
+      });
+    }
+  }
+  return anomalies;
+}
+
+/**
+ * Render the autonomous digest as a concise plain-text summary suitable for
+ * the shell nudge body and the Telegram/Moltbot message body. Kept short
+ * enough to skim in under 30 seconds (PRD-086 US-04 note).
+ *
+ * Markdown is intentionally avoided here — the Telegram dispatcher escapes
+ * the body for MarkdownV2 when it forwards, and the shell notification
+ * surface renders it as plain text.
+ */
+export function renderAutonomousDigestText(report: AutonomousDigestReport): string {
+  const lines: string[] = [];
+  const periodLabel = report.period === 'daily' ? 'Daily' : 'Weekly';
+  lines.push(`${periodLabel} Glia digest — ${report.totalAutonomousActions} autonomous actions`);
+
+  for (const group of report.groups) {
+    lines.push('');
+    lines.push(`${group.actionType} (${group.count}):`);
+    // Cap the per-group preview at 5 entries so the message stays skimmable.
+    // The full list is still queryable via `cerebrum.glia.actions.history`.
+    const previewLimit = 5;
+    for (const entry of group.actions.slice(0, previewLimit)) {
+      const affected = entry.affectedIds.join(', ');
+      lines.push(`  - [${affected}] ${entry.rationale}`);
+    }
+    if (group.actions.length > previewLimit) {
+      lines.push(`  - +${group.actions.length - previewLimit} more`);
+    }
+  }
+
+  if (report.anomalies.length > 0) {
+    lines.push('');
+    lines.push('Anomalies:');
+    for (const anomaly of report.anomalies) {
+      const pct = (anomaly.rejectionRatePostGraduation * 100).toFixed(1);
+      const total = anomaly.executedCount + anomaly.revertedCount;
+      lines.push(
+        `  - ${anomaly.actionType}: ${pct}% post-graduation rejection rate (${anomaly.revertedCount}/${total})`
+      );
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts
@@ -1,15 +1,3 @@
-/**
- * Default delivery channels for the autonomous Glia digest (#2577).
- *
- * Two channels:
- *   - `shell`: persists a row in `nudge_log` so the shell notification surface
- *     picks up the digest alongside other proactive nudges (PRD-084 framework).
- *   - `moltbot`: forwards the digest body to the Moltbot Telegram chat using
- *     the same env-driven config the ai-alerts module uses
- *     (POPS_ALERTS_TELEGRAM_BOT_TOKEN / POPS_ALERTS_TELEGRAM_CHAT_ID). Falls
- *     back to a no-op when unconfigured — matches the PRD note "If Moltbot is
- *     not configured, skip Telegram delivery silently."
- */
 import { randomUUID } from 'node:crypto';
 
 import { nudgeLog } from '@pops/db-types';

--- a/apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts
@@ -10,6 +10,8 @@
  *     back to a no-op when unconfigured — matches the PRD note "If Moltbot is
  *     not configured, skip Telegram delivery silently."
  */
+import { randomUUID } from 'node:crypto';
+
 import { nudgeLog } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
@@ -34,7 +36,11 @@ function buildShellNudgeId(now: Date): string {
   const pad = (n: number, len: number): string => String(n).padStart(len, '0');
   const date = `${now.getFullYear()}${pad(now.getMonth() + 1, 2)}${pad(now.getDate(), 2)}`;
   const time = `${pad(now.getHours(), 2)}${pad(now.getMinutes(), 2)}${pad(now.getSeconds(), 2)}`;
-  return `nudge_${date}_${time}_gliaDigest`;
+  const ms = pad(now.getMilliseconds(), 3);
+  // Append a UUID slice so parallel triggers within the same millisecond still
+  // produce distinct IDs — second-level precision alone collides under load.
+  const nonce = randomUUID().slice(0, 8);
+  return `nudge_${date}_${time}${ms}_${nonce}_gliaDigest`;
 }
 
 /**

--- a/apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts
@@ -1,0 +1,134 @@
+/**
+ * Default delivery channels for the autonomous Glia digest (#2577).
+ *
+ * Two channels:
+ *   - `shell`: persists a row in `nudge_log` so the shell notification surface
+ *     picks up the digest alongside other proactive nudges (PRD-084 framework).
+ *   - `moltbot`: forwards the digest body to the Moltbot Telegram chat using
+ *     the same env-driven config the ai-alerts module uses
+ *     (POPS_ALERTS_TELEGRAM_BOT_TOKEN / POPS_ALERTS_TELEGRAM_CHAT_ID). Falls
+ *     back to a no-op when unconfigured — matches the PRD note "If Moltbot is
+ *     not configured, skip Telegram delivery silently."
+ */
+import { nudgeLog } from '@pops/db-types';
+
+import { getDrizzle } from '../../../db.js';
+import { logger } from '../../../lib/logger.js';
+import {
+  escapeTelegramMarkdownV2,
+  fetchTransport,
+  readTelegramConfig,
+} from '../../core/ai-alerts/dispatchers/telegram.js';
+
+import type { AutonomousDigestReport } from './digest-reports.js';
+import type { DigestDeliveryChannels } from './digest-service.js';
+
+/** Map digest urgency to nudge priority — anomalies bump severity. */
+function priorityFor(report: AutonomousDigestReport): 'low' | 'medium' | 'high' {
+  if (report.anomalies.length > 0) return 'high';
+  if (report.totalAutonomousActions >= 10) return 'medium';
+  return 'low';
+}
+
+function buildShellNudgeId(now: Date): string {
+  const pad = (n: number, len: number): string => String(n).padStart(len, '0');
+  const date = `${now.getFullYear()}${pad(now.getMonth() + 1, 2)}${pad(now.getDate(), 2)}`;
+  const time = `${pad(now.getHours(), 2)}${pad(now.getMinutes(), 2)}${pad(now.getSeconds(), 2)}`;
+  return `nudge_${date}_${time}_gliaDigest`;
+}
+
+/**
+ * Persist the digest as a shell notification.
+ *
+ * Engram IDs union'd across all groups so the existing nudge UI can deep-link
+ * back to the affected engrams without us needing a separate digest viewer.
+ */
+export function deliverShellDigest(
+  report: AutonomousDigestReport,
+  body: string,
+  now: Date = new Date()
+): boolean {
+  const db = getDrizzle();
+  const id = buildShellNudgeId(now);
+  const title = `Glia ${report.period} digest — ${report.totalAutonomousActions} autonomous actions`;
+  const engramIds = collectEngramIds(report);
+
+  db.insert(nudgeLog)
+    .values({
+      id,
+      type: 'insight',
+      title,
+      body,
+      engramIds: JSON.stringify(engramIds),
+      priority: priorityFor(report),
+      status: 'pending',
+      createdAt: now.toISOString(),
+      expiresAt: null,
+      actionType: null,
+      actionLabel: null,
+      actionParams: JSON.stringify({
+        source: 'glia-digest',
+        period: report.period,
+        startDate: report.startDate,
+        endDate: report.endDate,
+        totalAutonomousActions: report.totalAutonomousActions,
+        anomalyCount: report.anomalies.length,
+      }),
+    })
+    .run();
+
+  logger.debug(
+    { nudgeId: id, period: report.period, total: report.totalAutonomousActions },
+    '[glia/digest] Shell digest delivered'
+  );
+  return true;
+}
+
+/**
+ * Forward the digest body to Moltbot/Telegram.
+ *
+ * Returns `false` when no Telegram config is present (silent skip — matches
+ * the ai-alerts behaviour). Throws on transport errors so the caller can
+ * record the failure.
+ */
+export async function deliverMoltbotDigest(
+  report: AutonomousDigestReport,
+  body: string
+): Promise<boolean> {
+  const config = readTelegramConfig();
+  if (!config) {
+    logger.debug(
+      { period: report.period },
+      '[glia/digest] No Telegram config — skipping Moltbot delivery'
+    );
+    return false;
+  }
+
+  const header = `🧠 *Glia ${report.period} digest*`;
+  // Telegram MarkdownV2 chokes on raw `.`, `(`, `)` etc — escape the plain
+  // body before sending. The header is a static literal so it's safe.
+  const text = `${header}\n\n${escapeTelegramMarkdownV2(body)}`;
+
+  await fetchTransport.send(config, text);
+  logger.debug(
+    { period: report.period, total: report.totalAutonomousActions },
+    '[glia/digest] Moltbot digest delivered'
+  );
+  return true;
+}
+
+function collectEngramIds(report: AutonomousDigestReport): string[] {
+  const set = new Set<string>();
+  for (const group of report.groups) {
+    for (const entry of group.actions) {
+      for (const id of entry.affectedIds) set.add(id);
+    }
+  }
+  return [...set];
+}
+
+/** Default channel pair backed by nudge_log + Telegram. */
+export const defaultDigestChannels: DigestDeliveryChannels = {
+  shell: deliverShellDigest,
+  moltbot: deliverMoltbotDigest,
+};

--- a/apps/pops-api/src/modules/cerebrum/glia/digest-reports.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/digest-reports.ts
@@ -1,10 +1,28 @@
 /**
- * Digest reports for glia actions (#2248).
+ * Digest reports for glia actions (#2248, #2577).
  *
  * Generates daily/weekly digest summaries of glia curation activity.
  * Reports include action counts by type, approval rates, and notable events.
+ *
+ * The autonomous-action digest used by `cerebrum.glia.digest` lives in
+ * `autonomous-digest.ts` — re-exported here so consumers can import either
+ * surface from the same module path.
  */
 import type { GliaAction, ActionType } from './types.js';
+
+export {
+  DEFAULT_REJECTION_RATE_ANOMALY_THRESHOLD,
+  buildAutonomousDigest,
+  renderAutonomousDigestText,
+} from './autonomous-digest.js';
+
+export type {
+  AutonomousDigestInput,
+  AutonomousDigestReport,
+  DigestActionEntry,
+  DigestActionGroup,
+  DigestAnomaly,
+} from './autonomous-digest.js';
 
 /** A single digest report. */
 export interface DigestReport {

--- a/apps/pops-api/src/modules/cerebrum/glia/digest-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/digest-service.ts
@@ -147,7 +147,10 @@ export class GliaDigestService {
     report: AutonomousDigestReport,
     allTrustStates: GliaTrustState[]
   ): Promise<DigestDeliveryResult> {
-    if (report.totalAutonomousActions === 0 && report.anomalies.length === 0) {
+    if (report.totalAutonomousActions === 0) {
+      // Anomalies derived from zero in-window actions carry no actionable
+      // signal, so suppress unconditionally rather than guarding on
+      // `anomalies.length` (#2577 issue body: empty periods are not delivered).
       return {
         attempted: false,
         suppressedReason: 'No autonomous actions in period',

--- a/apps/pops-api/src/modules/cerebrum/glia/digest-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/digest-service.ts
@@ -1,22 +1,3 @@
-/**
- * Digest service for autonomous Glia actions (PRD-086 US-04 AC #5/#6, #2577).
- *
- * Orchestrates the autonomous-action digest pipeline:
- *   1. Query autonomous actions in the requested period.
- *   2. Gather post-graduation execution/revert counts per action type.
- *   3. Build the digest payload (`buildAutonomousDigest`).
- *   4. Optionally deliver via shell notification (nudge_log) and Moltbot
- *      (Telegram).
- *
- * Phase handling (PRD-086 US-04 AC #6):
- *   - Delivery is allowed only when at least one action type currently in
- *     the digest is in `act_report` phase.
- *   - If every action type in the digest is in `silent` phase, delivery is
- *     suppressed — silent-phase types intentionally produce no digest.
- *   - Empty digests are suppressed entirely (edge case in PRD-086 README:
- *     "Digest generated with zero autonomous actions ... no notification
- *     sent").
- */
 import {
   buildAutonomousDigest,
   dailyDigestRange,

--- a/apps/pops-api/src/modules/cerebrum/glia/digest-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/digest-service.ts
@@ -1,0 +1,240 @@
+/**
+ * Digest service for autonomous Glia actions (PRD-086 US-04 AC #5/#6, #2577).
+ *
+ * Orchestrates the autonomous-action digest pipeline:
+ *   1. Query autonomous actions in the requested period.
+ *   2. Gather post-graduation execution/revert counts per action type.
+ *   3. Build the digest payload (`buildAutonomousDigest`).
+ *   4. Optionally deliver via shell notification (nudge_log) and Moltbot
+ *      (Telegram).
+ *
+ * Phase handling (PRD-086 US-04 AC #6):
+ *   - Delivery is allowed only when at least one action type currently in
+ *     the digest is in `act_report` phase.
+ *   - If every action type in the digest is in `silent` phase, delivery is
+ *     suppressed — silent-phase types intentionally produce no digest.
+ *   - Empty digests are suppressed entirely (edge case in PRD-086 README:
+ *     "Digest generated with zero autonomous actions ... no notification
+ *     sent").
+ */
+import {
+  buildAutonomousDigest,
+  dailyDigestRange,
+  renderAutonomousDigestText,
+  weeklyDigestRange,
+} from './digest-reports.js';
+import { ACTION_TYPES } from './types.js';
+
+import type { GliaActionService } from './action-service.js';
+import type { AutonomousDigestReport } from './digest-reports.js';
+import type { ActionType, GliaTrustState, TrustPhase } from './types.js';
+
+/** Output of a single delivery channel. */
+export interface DeliveryChannelResult {
+  channel: 'shell' | 'moltbot';
+  delivered: boolean;
+  /** Reason for non-delivery — populated when `delivered=false`. */
+  reason: string | null;
+}
+
+export interface DigestDeliveryResult {
+  /** Whether delivery was attempted at all (false when suppressed). */
+  attempted: boolean;
+  /** Reason for suppression — null when `attempted=true`. */
+  suppressedReason: string | null;
+  channels: DeliveryChannelResult[];
+}
+
+export interface DigestResult {
+  report: AutonomousDigestReport;
+  delivery: DigestDeliveryResult;
+}
+
+export interface GenerateDigestInput {
+  period?: 'daily' | 'weekly';
+  /** Restrict the digest to a single action type. */
+  actionType?: ActionType;
+  /** Override the anomaly threshold (default 30%). */
+  rejectionRateThreshold?: number;
+  /** When false, the digest is computed but not delivered. Default true. */
+  deliver?: boolean;
+}
+
+/** Channels invoked by the digest delivery step. */
+export interface DigestDeliveryChannels {
+  /** Persist a shell notification. Returns true when accepted. */
+  shell: (report: AutonomousDigestReport, body: string) => Promise<boolean> | boolean;
+  /** Forward to Moltbot/Telegram. Returns true when sent. */
+  moltbot: (report: AutonomousDigestReport, body: string) => Promise<boolean>;
+}
+
+export interface DigestServiceOptions {
+  now?: () => Date;
+  channels?: DigestDeliveryChannels;
+}
+
+export class GliaDigestService {
+  private readonly now: () => Date;
+  private readonly channels: DigestDeliveryChannels | null;
+
+  constructor(
+    private readonly actionService: GliaActionService,
+    options: DigestServiceOptions = {}
+  ) {
+    this.now = options.now ?? (() => new Date());
+    this.channels = options.channels ?? null;
+  }
+
+  async generate(input: GenerateDigestInput = {}): Promise<DigestResult> {
+    const period = input.period ?? 'daily';
+    const { startDate, endDate } =
+      period === 'daily' ? dailyDigestRange(this.now()) : weeklyDigestRange(this.now());
+
+    let actions = this.actionService.listAutonomousActionsInWindow(startDate, endDate);
+    if (input.actionType) {
+      actions = actions.filter((a) => a.actionType === input.actionType);
+    }
+
+    const trustStates = this.actionService.listTrustStates();
+    const filteredTrustStates = input.actionType
+      ? trustStates.filter((s) => s.actionType === input.actionType)
+      : trustStates;
+
+    const { executedByType, revertedByType } = this.gatherPostGraduationCounts(filteredTrustStates);
+
+    const report = buildAutonomousDigest({
+      actions,
+      trustStates: filteredTrustStates,
+      postGraduationExecutedByType: executedByType,
+      postGraduationRevertedByType: revertedByType,
+      period,
+      startDate,
+      endDate,
+      rejectionRateThreshold: input.rejectionRateThreshold,
+    });
+
+    const deliver = input.deliver ?? true;
+    const delivery = deliver
+      ? await this.maybeDeliver(report, trustStates)
+      : { attempted: false, suppressedReason: 'Delivery disabled by caller', channels: [] };
+
+    return { report, delivery };
+  }
+
+  private gatherPostGraduationCounts(trustStates: GliaTrustState[]): {
+    executedByType: Partial<Record<ActionType, number>>;
+    revertedByType: Partial<Record<ActionType, number>>;
+  } {
+    const executedByType: Partial<Record<ActionType, number>> = {};
+    const revertedByType: Partial<Record<ActionType, number>> = {};
+
+    for (const state of trustStates) {
+      if (!state.autonomousSince) continue;
+      executedByType[state.actionType] = this.actionService.countAutonomousExecutionsSince(
+        state.actionType,
+        state.autonomousSince
+      );
+      revertedByType[state.actionType] = this.actionService.countAutonomousRevertsSince(
+        state.actionType,
+        state.autonomousSince
+      );
+    }
+
+    return { executedByType, revertedByType };
+  }
+
+  private async maybeDeliver(
+    report: AutonomousDigestReport,
+    allTrustStates: GliaTrustState[]
+  ): Promise<DigestDeliveryResult> {
+    if (report.totalAutonomousActions === 0 && report.anomalies.length === 0) {
+      return {
+        attempted: false,
+        suppressedReason: 'No autonomous actions in period',
+        channels: [],
+      };
+    }
+
+    const phasesInReport = collectPhasesInReport(report, allTrustStates);
+    if (!phasesInReport.has('act_report')) {
+      // Every type in the digest is silent (or somehow propose, which would
+      // mean no autonomous actions — handled above). Silent phase intentionally
+      // suppresses delivery per PRD-086 US-04 AC #6.
+      return {
+        attempted: false,
+        suppressedReason: 'All action types in digest are in silent phase',
+        channels: [],
+      };
+    }
+
+    const channels = this.channels;
+    if (!channels) {
+      return {
+        attempted: false,
+        suppressedReason: 'No delivery channels configured',
+        channels: [],
+      };
+    }
+
+    const body = renderAutonomousDigestText(report);
+    const channelResults: DeliveryChannelResult[] = [];
+
+    const shellResult = await this.invokeChannel(() => channels.shell(report, body));
+    channelResults.push({ channel: 'shell', ...shellResult });
+
+    const moltbotResult = await this.invokeChannel(() => channels.moltbot(report, body));
+    channelResults.push({ channel: 'moltbot', ...moltbotResult });
+
+    return { attempted: true, suppressedReason: null, channels: channelResults };
+  }
+
+  private async invokeChannel(
+    fn: () => Promise<boolean> | boolean
+  ): Promise<{ delivered: boolean; reason: string | null }> {
+    try {
+      const delivered = await fn();
+      return delivered
+        ? { delivered: true, reason: null }
+        : { delivered: false, reason: 'Channel returned false (not configured)' };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return { delivered: false, reason };
+    }
+  }
+}
+
+function collectPhasesInReport(
+  report: AutonomousDigestReport,
+  trustStates: GliaTrustState[]
+): Set<TrustPhase> {
+  const phaseByType = new Map<ActionType, TrustPhase>();
+  for (const state of trustStates) {
+    phaseByType.set(state.actionType, state.currentPhase);
+  }
+
+  const phases = new Set<TrustPhase>();
+  // Phase membership comes from the action types actually represented in the
+  // digest (groups + anomalies). If neither, the empty-period guard fired
+  // upstream so this is unreachable.
+  const typesInReport = new Set<ActionType>();
+  for (const group of report.groups) {
+    typesInReport.add(group.actionType);
+  }
+  for (const anomaly of report.anomalies) {
+    typesInReport.add(anomaly.actionType);
+  }
+
+  for (const type of typesInReport) {
+    const phase = phaseByType.get(type);
+    if (phase) phases.add(phase);
+  }
+  return phases;
+}
+
+/**
+ * Build the canonical list of action types — exported so callers can iterate
+ * deterministically when wiring per-type digests.
+ */
+export function listKnownActionTypes(): readonly ActionType[] {
+  return ACTION_TYPES;
+}

--- a/apps/pops-api/src/modules/cerebrum/glia/helpers.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/helpers.ts
@@ -3,7 +3,7 @@
  *
  * Extracted from action-service.ts to keep files under the max-lines limit.
  */
-import { and, asc, desc, eq, gte, isNull, lte, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, isNull, lt, lte, sql } from 'drizzle-orm';
 
 import { gliaActions, gliaTrustState } from '@pops/db-types/schema';
 
@@ -130,6 +130,9 @@ export function listAllTrustStates(db: BetterSQLite3Database): GliaTrustState[] 
  * without user approval). Window is matched against `executed_at` because
  * created_at could be earlier than execution for delayed worker runs.
  *
+ * The end bound is exclusive (`executedAt < endDate`) so a row pinned on the
+ * boundary cannot appear in two consecutive digests.
+ *
  * No pagination — digest windows are bounded (daily/weekly) and the volume
  * is expected to be small. If this assumption breaks, callers should add
  * a cap rather than mutating this helper into a paged query.
@@ -147,7 +150,7 @@ export function listAutonomousActionsInWindow(
         eq(gliaActions.status, 'executed'),
         isNull(gliaActions.decidedAt),
         gte(gliaActions.executedAt, startDate),
-        lte(gliaActions.executedAt, endDate)
+        lt(gliaActions.executedAt, endDate)
       )
     )
     .orderBy(asc(gliaActions.executedAt))

--- a/apps/pops-api/src/modules/cerebrum/glia/helpers.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/helpers.ts
@@ -3,7 +3,7 @@
  *
  * Extracted from action-service.ts to keep files under the max-lines limit.
  */
-import { and, desc, eq, gte, lte, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, isNull, lte, sql } from 'drizzle-orm';
 
 import { gliaActions, gliaTrustState } from '@pops/db-types/schema';
 
@@ -121,6 +121,86 @@ export function getTrustStateByType(
 /** List all trust states. */
 export function listAllTrustStates(db: BetterSQLite3Database): GliaTrustState[] {
   return db.select().from(gliaTrustState).all().map(toTrustState);
+}
+
+/**
+ * Query autonomous actions executed in a window.
+ *
+ * Autonomous = `status='executed'` AND `decided_at IS NULL` (workers acted
+ * without user approval). Window is matched against `executed_at` because
+ * created_at could be earlier than execution for delayed worker runs.
+ *
+ * No pagination — digest windows are bounded (daily/weekly) and the volume
+ * is expected to be small. If this assumption breaks, callers should add
+ * a cap rather than mutating this helper into a paged query.
+ */
+export function listAutonomousActionsInWindow(
+  db: BetterSQLite3Database,
+  startDate: string,
+  endDate: string
+): GliaAction[] {
+  const rows = db
+    .select()
+    .from(gliaActions)
+    .where(
+      and(
+        eq(gliaActions.status, 'executed'),
+        isNull(gliaActions.decidedAt),
+        gte(gliaActions.executedAt, startDate),
+        lte(gliaActions.executedAt, endDate)
+      )
+    )
+    .orderBy(asc(gliaActions.executedAt))
+    .all();
+  return rows.map(toGliaAction);
+}
+
+/**
+ * Count autonomous actions still in `executed` status since a given timestamp.
+ *
+ * Excludes reverted rows so the digest can compute the rejection rate as
+ * `reverted / (executed + reverted)` without double-counting actions that
+ * have already been rolled back.
+ */
+export function countAutonomousExecutionsSince(
+  db: BetterSQLite3Database,
+  actionType: ActionType,
+  sinceIso: string
+): number {
+  const result = db
+    .select({ count: sql<number>`count(*)` })
+    .from(gliaActions)
+    .where(
+      and(
+        eq(gliaActions.actionType, actionType),
+        eq(gliaActions.status, 'executed'),
+        isNull(gliaActions.decidedAt),
+        gte(gliaActions.executedAt, sinceIso)
+      )
+    )
+    .get();
+  return result?.count ?? 0;
+}
+
+/** Count autonomous reverts (decided_at IS NULL, status=reverted) since timestamp. */
+export function countAutonomousRevertsSince(
+  db: BetterSQLite3Database,
+  actionType: ActionType,
+  sinceIso: string
+): number {
+  const result = db
+    .select({ count: sql<number>`count(*)` })
+    .from(gliaActions)
+    .where(
+      and(
+        eq(gliaActions.actionType, actionType),
+        eq(gliaActions.status, 'reverted'),
+        isNull(gliaActions.decidedAt),
+        gte(gliaActions.revertedAt, sinceIso)
+      )
+    )
+    .get();
+  return result?.count ?? 0;
 }
 
 /** Count reverts within a rolling window for a given action type. */

--- a/apps/pops-api/src/modules/cerebrum/glia/instance.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/instance.ts
@@ -7,17 +7,23 @@
  */
 import { getDrizzle } from '../../../db.js';
 import { GliaActionService } from './action-service.js';
+import { defaultDigestChannels } from './digest-channels.js';
+import { GliaDigestService } from './digest-service.js';
 import { GliaTrustMachine } from './trust-machine.js';
 
 interface GliaServices {
   actionService: GliaActionService;
   trustMachine: GliaTrustMachine;
+  digestService: GliaDigestService;
 }
 
 /** Build Glia services bound to the current request's drizzle context. */
 export function getGliaServices(): GliaServices {
   const actionService = new GliaActionService(getDrizzle());
   const trustMachine = new GliaTrustMachine(actionService);
+  const digestService = new GliaDigestService(actionService, {
+    channels: defaultDigestChannels,
+  });
 
-  return { actionService, trustMachine };
+  return { actionService, trustMachine, digestService };
 }

--- a/apps/pops-api/src/modules/cerebrum/glia/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/router.ts
@@ -174,18 +174,7 @@ const trustStateRouter = router({
   }),
 });
 
-/**
- * `cerebrum.glia.digest` — summarise autonomous actions for the configured
- * period and (optionally) deliver via shell + Moltbot.
- *
- * Suppression rules (PRD-086 US-04 AC #6):
- *   - Action types in `silent` phase do not emit a digest.
- *   - Empty periods are not delivered.
- *
- * The returned payload reflects whatever ran: callers can read
- * `delivery.attempted` and `delivery.suppressedReason` to understand why a
- * notification did or did not fire.
- */
+/** Audit-trail surface for PRD-086 US-04 AC #5/#6 — suppression semantics live in the service. */
 const digestProcedure = protectedProcedure
   .input(
     z
@@ -200,7 +189,9 @@ const digestProcedure = protectedProcedure
   .mutation(async ({ input }) => {
     try {
       const { digestService } = getGliaServices();
-      return digestService.generate(input ?? {});
+      // Await so a rejected Promise is funnelled through `toTrpcError` instead
+      // of escaping the procedure unchanged.
+      return await digestService.generate(input ?? {});
     } catch (err) {
       toTrpcError(err);
     }

--- a/apps/pops-api/src/modules/cerebrum/glia/router.ts
+++ b/apps/pops-api/src/modules/cerebrum/glia/router.ts
@@ -20,6 +20,8 @@ import { protectedProcedure, router } from '../../../trpc.js';
 import { getGliaServices } from './instance.js';
 import { ACTION_STATUSES, ACTION_TYPES, USER_DECISIONS } from './types.js';
 
+const periodSchema = z.enum(['daily', 'weekly']);
+
 import type { ActionType } from './types.js';
 
 const actionTypeSchema = z.enum(ACTION_TYPES);
@@ -172,7 +174,40 @@ const trustStateRouter = router({
   }),
 });
 
+/**
+ * `cerebrum.glia.digest` — summarise autonomous actions for the configured
+ * period and (optionally) deliver via shell + Moltbot.
+ *
+ * Suppression rules (PRD-086 US-04 AC #6):
+ *   - Action types in `silent` phase do not emit a digest.
+ *   - Empty periods are not delivered.
+ *
+ * The returned payload reflects whatever ran: callers can read
+ * `delivery.attempted` and `delivery.suppressedReason` to understand why a
+ * notification did or did not fire.
+ */
+const digestProcedure = protectedProcedure
+  .input(
+    z
+      .object({
+        period: periodSchema.optional(),
+        actionType: actionTypeSchema.optional(),
+        rejectionRateThreshold: z.number().gt(0).lte(1).optional(),
+        deliver: z.boolean().optional(),
+      })
+      .optional()
+  )
+  .mutation(async ({ input }) => {
+    try {
+      const { digestService } = getGliaServices();
+      return digestService.generate(input ?? {});
+    } catch (err) {
+      toTrpcError(err);
+    }
+  });
+
 export const gliaRouter = router({
   actions: actionsRouter,
   trustState: trustStateRouter,
+  digest: digestProcedure,
 });

--- a/docs/themes/06-cerebrum/prds/086-trust-graduation/us-04-audit-trail.md
+++ b/docs/themes/06-cerebrum/prds/086-trust-graduation/us-04-audit-trail.md
@@ -14,8 +14,8 @@ As a user, I need an immutable audit trail of every Glia action with the ability
 - [ ] Reverting a `consolidate` action restores all source engrams from `.archive/` to their original paths with `status: active`, deletes the merged engram file and index entry, and re-points any links that were updated during consolidation back to the original engram IDs (deferred — tracked in #2576)
 - [ ] Reverting a `link` action calls `unlinkEngrams()` to remove the bidirectional link that was created, updating both engram files and the `engram_links` table (the unlink call exists today; covered by #2576's verification work)
 - [x] Reverting an `audit` action returns an error — audit actions are informational and non-destructive, there is nothing to revert
-- [ ] A digest report generator produces a summary of all autonomous actions for a given period (daily or weekly, configurable): counts by action type, list of affected engrams with rationale, and any anomalies (e.g., high rejection rate post-graduation) (deferred — tracked in #2577)
-- [ ] Digest reports are delivered via the existing notification system (shell notification area + Moltbot if enabled) during the `act_report` phase — suppressed during `silent` phase (deferred — tracked in #2577)
+- [x] A digest report generator produces a summary of all autonomous actions for a given period (daily or weekly, configurable): counts by action type, list of affected engrams with rationale, and any anomalies (e.g., high rejection rate post-graduation)
+- [x] Digest reports are delivered via the existing notification system (shell notification area + Moltbot if enabled) during the `act_report` phase — suppressed during `silent` phase
 - [x] The audit trail is queryable via `cerebrum.glia.actions.history` with filters for action type, status, and date range, returning paginated results
 
 ## Notes


### PR DESCRIPTION
## Summary

- Adds `cerebrum.glia.digest` tRPC procedure that summarises autonomous glia actions (`status='executed'`, `decided_at IS NULL`) for a daily or weekly window, grouped by action type with affected engrams and rationale.
- Flags anomalies on high post-graduation rejection rate (default 30%, configurable per call via `rejectionRateThreshold`).
- Wires delivery into the existing notification framework: shell uses the `nudge_log` table (PRD-084), Moltbot reuses the ai-alerts Telegram dispatcher / env config.
- Respects trust phase: delivery fires when at least one action type in the digest is in `act_report`, and is suppressed when every type in the digest is in `silent` (PRD-086 US-04 AC #6). Empty periods are not delivered.

## Files

- `apps/pops-api/src/modules/cerebrum/glia/autonomous-digest.ts` — pure digest builder + renderer
- `apps/pops-api/src/modules/cerebrum/glia/digest-service.ts` — orchestrator (query → group → anomalies → delivery)
- `apps/pops-api/src/modules/cerebrum/glia/digest-channels.ts` — shell (nudge_log) + Moltbot (Telegram) default channels
- `apps/pops-api/src/modules/cerebrum/glia/router.ts` — adds `digest` procedure under `cerebrum.glia`
- `apps/pops-api/src/modules/cerebrum/glia/helpers.ts` + `action-service.ts` — new query helpers for autonomous actions and post-graduation counts

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint` (0 errors; pre-existing warnings unchanged)
- [x] `pnpm typecheck`
- [x] `pnpm --filter @pops/api test` (4286 passing — includes 16 new tests across `autonomous-digest.test.ts` + `digest-service.test.ts`)
- [x] `packages/module-registry` build

Closes #2577.