### PR TITLE
feat(cerebrum): stream cerebrum.query answers over SSE (#2596)

### DIFF
--- a/apps/pops-api/src/app.ts
+++ b/apps/pops-api/src/app.ts
@@ -11,6 +11,7 @@ import { envRouter } from './modules/core/envs/router.js';
 import { readInstalledModules } from './modules/env-modules.js';
 import { openApiDocument } from './openapi.js';
 import { appRouter } from './router.js';
+import cerebrumQueryStreamRouter from './routes/cerebrum/query-stream.js';
 import egoChatStreamRouter from './routes/ego/chat-stream.js';
 import healthRouter from './routes/health.js';
 import inventoryDocumentFilesRouter from './routes/inventory/document-files.js';
@@ -83,6 +84,9 @@ export function createApp(): express.Express {
   // Ego SSE streaming — POST /api/ego/chat/stream
   // Placed after auth + env context so the user is authenticated and the DB is scoped.
   app.use(egoChatStreamRouter);
+
+  // Cerebrum Query SSE streaming — POST /api/cerebrum/query/stream (PRD-082, issue #2596).
+  app.use(cerebrumQueryStreamRouter);
 
   // OpenAPI spec endpoint
   app.get('/api/openapi.json', (_req, res) => {

--- a/apps/pops-api/src/modules/cerebrum/query/query-llm.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/query-llm.ts
@@ -1,0 +1,67 @@
+/**
+ * Non-streaming LLM client for the Cerebrum Query Engine (PRD-082).
+ *
+ * Encapsulates the rate-limit retry + inference tracking around the
+ * Anthropic `messages.create` call so `query-service.ts` stays under the
+ * `max-lines` budget. The streaming variant lives in `query-stream.ts`.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+import { getEnv } from '../../../env.js';
+import { withRateLimitRetry } from '../../../lib/ai-retry.js';
+import { trackInference } from '../../../lib/inference-middleware.js';
+import { logger } from '../../../lib/logger.js';
+import { getAiModel } from '../../core/settings/service.js';
+
+const OPERATION = 'cerebrum.query';
+
+const LLM_UNAVAILABLE_MSG =
+  "I don't have enough information to answer that fully. (LLM unavailable)";
+const LLM_ERROR_MSG = "I don't have enough information to answer that fully. (LLM error)";
+
+function getQueryModel(): string {
+  return getAiModel('ai.modelOverrides.query', 'claude-sonnet-4-6');
+}
+
+/**
+ * Call Claude for query answer generation. Gracefully degrades when the
+ * API key is missing or the call throws — callers always receive a string
+ * suitable for display.
+ */
+export async function callQueryLlm(systemPrompt: string, question: string): Promise<string> {
+  const apiKey = getEnv('ANTHROPIC_API_KEY');
+  if (!apiKey) {
+    logger.warn('[QueryEngine] ANTHROPIC_API_KEY not set — returning retrieval-only answer');
+    return LLM_UNAVAILABLE_MSG;
+  }
+
+  const client = new Anthropic({ apiKey, maxRetries: 0 });
+  const model = getQueryModel();
+
+  try {
+    const response = await trackInference(
+      { provider: 'claude', model, operation: OPERATION, domain: 'cerebrum' },
+      () =>
+        withRateLimitRetry(
+          () =>
+            client.messages.create({
+              model,
+              max_tokens: 1024,
+              temperature: 0,
+              system: systemPrompt,
+              messages: [{ role: 'user', content: question }],
+            }),
+          OPERATION,
+          { logger, logPrefix: '[QueryEngine]' }
+        )
+    );
+
+    return response.content[0]?.type === 'text' ? response.content[0].text : '';
+  } catch (err) {
+    logger.error(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[QueryEngine] LLM call failed'
+    );
+    return LLM_ERROR_MSG;
+  }
+}

--- a/apps/pops-api/src/modules/cerebrum/query/query-service.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/query-service.ts
@@ -6,21 +6,18 @@
  *   retrieve — retrieval-only (no LLM), returns sources
  *   explain  — debug: shows what the pipeline would do without executing
  */
-import Anthropic from '@anthropic-ai/sdk';
-
 import { getDrizzle } from '../../../db.js';
-import { getEnv } from '../../../env.js';
-import { withRateLimitRetry } from '../../../lib/ai-retry.js';
-import { trackInference } from '../../../lib/inference-middleware.js';
-import { logger } from '../../../lib/logger.js';
-import { getAiModel, getSettingValue } from '../../core/settings/service.js';
+import { getSettingValue } from '../../core/settings/service.js';
 import { ContextAssemblyService } from '../retrieval/context-assembly.js';
 import { HybridSearchService } from '../retrieval/hybrid-search.js';
 import { CitationParser } from './citation-parser.js';
 import { buildQuerySystemPrompt } from './prompts.js';
+import { callQueryLlm } from './query-llm.js';
+import { streamQueryAnswer } from './query-stream.js';
 import { QueryScopeInferencer } from './scope-inferencer.js';
 
-import type { RetrievalFilters } from '../retrieval/types.js';
+import type { RetrievalFilters, RetrievalResult } from '../retrieval/types.js';
+import type { QueryStreamEvent } from './query-stream.js';
 import type {
   ConfidenceLevel,
   QueryDomain,
@@ -30,25 +27,39 @@ import type {
   SourceCitation,
 } from './types.js';
 
-const OPERATION = 'cerebrum.query';
-
-function getQueryModel(): string {
-  return getAiModel('ai.modelOverrides.query', 'claude-sonnet-4-6');
-}
-
-function getQueryMaxSources(): number {
-  return getSettingValue('cerebrum.query.maxSources', 10);
-}
-
-function getQueryRelevanceThreshold(): number {
-  return getSettingValue('cerebrum.query.relevanceThreshold', 0.3);
-}
-
-function getQueryTokenBudget(): number {
-  return getSettingValue('cerebrum.query.tokenBudget', 4096);
-}
+const getQueryMaxSources = (): number => getSettingValue('cerebrum.query.maxSources', 10);
+const getQueryRelevanceThreshold = (): number =>
+  getSettingValue('cerebrum.query.relevanceThreshold', 0.3);
+const getQueryTokenBudget = (): number => getSettingValue('cerebrum.query.tokenBudget', 4096);
 
 const NO_INFO_ANSWER = "I don't have information about that.";
+
+type PreparedQuery =
+  | { kind: 'no-results'; scopes: string[] }
+  | {
+      kind: 'prepared';
+      question: string;
+      scopes: string[];
+      results: RetrievalResult[];
+      systemPrompt: string;
+    };
+
+/**
+ * Emit a single-event "no results" stream so the SSE route doesn't have to
+ * special-case the empty-retrieval branch.
+ */
+async function* emitNoResultsStream(scopes: string[]): AsyncGenerator<QueryStreamEvent> {
+  yield { type: 'token', text: NO_INFO_ANSWER };
+  yield {
+    type: 'done',
+    answer: NO_INFO_ANSWER,
+    sources: [],
+    scopes,
+    confidence: 'low',
+    tokensIn: 0,
+    tokensOut: 0,
+  };
+}
 
 /** Map domain names to Thalamus sourceType values. */
 const DOMAIN_MAP: Record<QueryDomain, string> = {
@@ -97,45 +108,23 @@ export class QueryService {
    * Full NL Q&A pipeline: infer scopes → retrieve → LLM → parse citations.
    */
   async ask(request: QueryRequest): Promise<QueryResponse> {
-    const question = request.question.trim();
-    const maxSources = request.maxSources ?? getQueryMaxSources();
-    const includeSecret = request.includeSecret ?? false;
-
-    // 1. Scope inference.
-    const scopeResult = this.inferencer.infer(question, undefined, request.scopes, includeSecret);
-
-    // 2. Build filters and retrieve.
-    const filters = buildRetrievalFilters(scopeResult.scopes, includeSecret, request.domains);
-    const hybridSearch = new HybridSearchService(getDrizzle());
-    const relevanceThreshold = getQueryRelevanceThreshold();
-    const results = await hybridSearch.hybrid(question, filters, maxSources, relevanceThreshold);
-
-    // 3. Zero results → short-circuit.
-    if (results.length === 0) {
+    const prepared = await this.prepareCommon(request);
+    if (prepared.kind === 'no-results') {
       return {
         answer: NO_INFO_ANSWER,
         sources: [],
-        scopes: scopeResult.scopes,
+        scopes: prepared.scopes,
         confidence: 'low',
       };
     }
 
-    // 4. Assemble context for LLM.
-    const assembled = this.assembler.assemble({
-      query: question,
-      results,
-      tokenBudget: getQueryTokenBudget(),
-      includeMetadata: true,
-    });
+    // Generate answer via LLM (non-streaming).
+    const llmAnswer = await callQueryLlm(prepared.systemPrompt, prepared.question);
 
-    // 5. Generate answer via LLM.
-    const systemPrompt = buildQuerySystemPrompt(assembled.context);
-    const llmAnswer = await this.callLlm(systemPrompt, question);
+    // Parse citations.
+    const { cleanedAnswer, citations } = this.citationParser.parse(llmAnswer, prepared.results);
 
-    // 6. Parse citations.
-    const { cleanedAnswer, citations } = this.citationParser.parse(llmAnswer, results);
-
-    // 7. Compute confidence — downgrade if zero valid citations.
+    // Compute confidence — downgrade if zero valid citations.
     let confidence = computeConfidence(citations);
     if (citations.length === 0) {
       confidence = 'low';
@@ -144,8 +133,65 @@ export class QueryService {
     return {
       answer: cleanedAnswer,
       sources: citations,
-      scopes: scopeResult.scopes,
+      scopes: prepared.scopes,
       confidence,
+    };
+  }
+
+  /**
+   * Streaming variant of `ask()`. Performs the same retrieval and context
+   * assembly pipeline up-front, then returns an async generator that yields
+   * `token` events while the LLM streams and a final `done` event with
+   * parsed citations + confidence.
+   *
+   * Used by `POST /api/cerebrum/query/stream` (PRD-082, issue #2596).
+   */
+  async prepareStream(request: QueryRequest): Promise<AsyncGenerator<QueryStreamEvent>> {
+    const prepared = await this.prepareCommon(request);
+    if (prepared.kind === 'no-results') {
+      return emitNoResultsStream(prepared.scopes);
+    }
+
+    return streamQueryAnswer({
+      systemPrompt: prepared.systemPrompt,
+      question: prepared.question,
+      retrievedResults: prepared.results,
+      scopes: prepared.scopes,
+    });
+  }
+
+  /**
+   * Shared pre-LLM pipeline used by both the one-shot `ask()` and the
+   * streaming `prepareStream()` entry points.
+   */
+  private async prepareCommon(request: QueryRequest): Promise<PreparedQuery> {
+    const question = request.question.trim();
+    const maxSources = request.maxSources ?? getQueryMaxSources();
+    const includeSecret = request.includeSecret ?? false;
+
+    const scopeResult = this.inferencer.infer(question, undefined, request.scopes, includeSecret);
+    const filters = buildRetrievalFilters(scopeResult.scopes, includeSecret, request.domains);
+    const hybridSearch = new HybridSearchService(getDrizzle());
+    const relevanceThreshold = getQueryRelevanceThreshold();
+    const results = await hybridSearch.hybrid(question, filters, maxSources, relevanceThreshold);
+
+    if (results.length === 0) {
+      return { kind: 'no-results', scopes: scopeResult.scopes };
+    }
+
+    const assembled = this.assembler.assemble({
+      query: question,
+      results,
+      tokenBudget: getQueryTokenBudget(),
+      includeMetadata: true,
+    });
+
+    return {
+      kind: 'prepared',
+      question,
+      scopes: scopeResult.scopes,
+      results,
+      systemPrompt: buildQuerySystemPrompt(assembled.context),
     };
   }
 
@@ -206,46 +252,6 @@ export class QueryService {
       },
       secretNotice,
     };
-  }
-
-  /** Call the LLM for answer generation. Gracefully degrades if API key is missing. */
-  private async callLlm(systemPrompt: string, question: string): Promise<string> {
-    const apiKey = getEnv('ANTHROPIC_API_KEY');
-    if (!apiKey) {
-      logger.warn('[QueryEngine] ANTHROPIC_API_KEY not set — returning retrieval-only answer');
-      return "I don't have enough information to answer that fully. (LLM unavailable)";
-    }
-
-    const client = new Anthropic({ apiKey, maxRetries: 0 });
-    const model = getQueryModel();
-
-    try {
-      const response = await trackInference(
-        { provider: 'claude', model, operation: OPERATION, domain: 'cerebrum' },
-        () =>
-          withRateLimitRetry(
-            () =>
-              client.messages.create({
-                model,
-                max_tokens: 1024,
-                temperature: 0,
-                system: systemPrompt,
-                messages: [{ role: 'user', content: question }],
-              }),
-            OPERATION,
-            { logger, logPrefix: '[QueryEngine]' }
-          )
-      );
-
-      const text = response.content[0]?.type === 'text' ? response.content[0].text : '';
-      return text;
-    } catch (err) {
-      logger.error(
-        { error: err instanceof Error ? err.message : String(err) },
-        '[QueryEngine] LLM call failed'
-      );
-      return "I don't have enough information to answer that fully. (LLM error)";
-    }
   }
 }
 

--- a/apps/pops-api/src/modules/cerebrum/query/query-stream.ts
+++ b/apps/pops-api/src/modules/cerebrum/query/query-stream.ts
@@ -1,0 +1,200 @@
+/**
+ * Streaming generator for the Cerebrum Query Engine (PRD-082, issue #2596).
+ *
+ * Companion to `query-service.ts`: assembles the same retrieval/context
+ * pipeline but yields incremental `token` chunks while the LLM is streaming
+ * and a final `done` event with parsed citations + confidence.
+ *
+ * Mirrors the event shape of the Ego streaming generator
+ * (`modules/cerebrum/ego/engine-stream.ts`) so the SSE route handler in
+ * `routes/cerebrum/query-stream.ts` can use the same SSE wire format.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+
+import { getEnv } from '../../../env.js';
+import { trackInference } from '../../../lib/inference-middleware.js';
+import { logger } from '../../../lib/logger.js';
+import { getAiModel, getSettingValue } from '../../core/settings/service.js';
+import { CitationParser } from './citation-parser.js';
+
+import type { MessageStream } from '@anthropic-ai/sdk/lib/MessageStream';
+
+import type { RetrievalResult } from '../retrieval/types.js';
+import type { ConfidenceLevel, SourceCitation } from './types.js';
+
+const OPERATION = 'cerebrum.query.stream';
+
+const LLM_UNAVAILABLE_MSG =
+  "I don't have enough information to answer that fully. (LLM unavailable)";
+const LLM_ERROR_MSG = "I don't have enough information to answer that fully. (LLM error)";
+
+function getQueryModel(): string {
+  return getAiModel('ai.modelOverrides.query', 'claude-sonnet-4-6');
+}
+
+function getQueryStreamMaxTokens(): number {
+  return getSettingValue('cerebrum.query.maxTokens', 1024);
+}
+
+/** Event yielded while tokens are still streaming. */
+export interface QueryStreamToken {
+  type: 'token';
+  text: string;
+}
+
+/** Final event emitted after the LLM stream completes. */
+export interface QueryStreamDone {
+  type: 'done';
+  /** Cleaned answer text (citations stripped of hallucinations). */
+  answer: string;
+  sources: SourceCitation[];
+  scopes: string[];
+  confidence: ConfidenceLevel;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/** Union type for all events yielded by `streamQueryAnswer`. */
+export type QueryStreamEvent = QueryStreamToken | QueryStreamDone;
+
+function computeConfidence(sources: SourceCitation[]): ConfidenceLevel {
+  if (sources.length === 0) return 'low';
+  const topScore = sources[0]?.relevance ?? 0;
+  if (topScore > 0.8) return 'high';
+  if (topScore >= 0.5) return 'medium';
+  return 'low';
+}
+
+/** Track streaming inference after the stream completes. */
+function trackStreamInference(model: string, tokensIn: number, tokensOut: number): void {
+  trackInference({ provider: 'claude', model, operation: OPERATION, domain: 'cerebrum' }, () =>
+    Promise.resolve({ usage: { input_tokens: tokensIn, output_tokens: tokensOut } })
+  ).catch((err) => {
+    logger.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[QueryEngine] Failed to track streaming inference'
+    );
+  });
+}
+
+interface RawLlmStreamParams {
+  client: Anthropic;
+  model: string;
+  systemPrompt: string;
+  question: string;
+}
+
+/** Yield text deltas from the Anthropic stream + a final usage record. */
+async function* iterateLlmStream(
+  params: RawLlmStreamParams
+): AsyncGenerator<
+  { kind: 'delta'; text: string } | { kind: 'final'; tokensIn: number; tokensOut: number }
+> {
+  let stream: MessageStream;
+  try {
+    stream = params.client.messages.stream({
+      model: params.model,
+      max_tokens: getQueryStreamMaxTokens(),
+      temperature: 0,
+      system: params.systemPrompt,
+      messages: [{ role: 'user', content: params.question }],
+    });
+  } catch (err) {
+    logger.error(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[QueryEngine] Stream creation failed'
+    );
+    yield { kind: 'delta', text: LLM_ERROR_MSG };
+    yield { kind: 'final', tokensIn: 0, tokensOut: 0 };
+    return;
+  }
+
+  try {
+    for await (const event of stream) {
+      if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+        yield { kind: 'delta', text: event.delta.text };
+      }
+    }
+    const finalMessage = await stream.finalMessage();
+    yield {
+      kind: 'final',
+      tokensIn: finalMessage.usage.input_tokens,
+      tokensOut: finalMessage.usage.output_tokens,
+    };
+  } catch (err) {
+    logger.error(
+      { error: err instanceof Error ? err.message : String(err) },
+      '[QueryEngine] Stream processing failed'
+    );
+    yield { kind: 'final', tokensIn: 0, tokensOut: 0 };
+  }
+}
+
+interface StreamQueryAnswerParams {
+  systemPrompt: string;
+  question: string;
+  retrievedResults: RetrievalResult[];
+  scopes: string[];
+}
+
+/**
+ * Stream a query answer token-by-token, then emit a single `done` event with
+ * the parsed citation set, computed confidence and the final scopes used.
+ *
+ * Gracefully degrades when ANTHROPIC_API_KEY is missing or the SDK call
+ * fails: yields a fallback message then a `done` event with low confidence.
+ */
+export async function* streamQueryAnswer(
+  params: StreamQueryAnswerParams
+): AsyncGenerator<QueryStreamEvent> {
+  const { systemPrompt, question, retrievedResults, scopes } = params;
+  const apiKey = getEnv('ANTHROPIC_API_KEY');
+  const citationParser = new CitationParser();
+
+  if (!apiKey) {
+    logger.warn('[QueryEngine] ANTHROPIC_API_KEY not set — yielding fallback answer');
+    yield { type: 'token', text: LLM_UNAVAILABLE_MSG };
+    yield {
+      type: 'done',
+      answer: LLM_UNAVAILABLE_MSG,
+      sources: [],
+      scopes,
+      confidence: 'low',
+      tokensIn: 0,
+      tokensOut: 0,
+    };
+    return;
+  }
+
+  const client = new Anthropic({ apiKey, maxRetries: 0 });
+  const model = getQueryModel();
+
+  let fullText = '';
+  let tokensIn = 0;
+  let tokensOut = 0;
+
+  for await (const event of iterateLlmStream({ client, model, systemPrompt, question })) {
+    if (event.kind === 'delta') {
+      fullText += event.text;
+      yield { type: 'token', text: event.text };
+    } else {
+      tokensIn = event.tokensIn;
+      tokensOut = event.tokensOut;
+    }
+  }
+
+  trackStreamInference(model, tokensIn, tokensOut);
+
+  const { cleanedAnswer, citations } = citationParser.parse(fullText, retrievedResults);
+  const confidence: ConfidenceLevel = citations.length === 0 ? 'low' : computeConfidence(citations);
+
+  yield {
+    type: 'done',
+    answer: cleanedAnswer,
+    sources: citations,
+    scopes,
+    confidence,
+    tokensIn,
+    tokensOut,
+  };
+}

--- a/apps/pops-api/src/routes/cerebrum/query-stream.test.ts
+++ b/apps/pops-api/src/routes/cerebrum/query-stream.test.ts
@@ -1,12 +1,3 @@
-/**
- * Tests for the Cerebrum Query SSE streaming route (PRD-082, issue #2596).
- *
- * Mocks the QueryService so we can drive the stream from a fake async
- * generator and assert the wire-format emitted by the Express handler:
- *   data: {"type":"token","text":"..."}
- *   data: {"type":"done","answer":"...","sources":[...], ...}
- *   data: {"type":"error","message":"..."}
- */
 import { type AddressInfo } from 'node:net';
 
 import express from 'express';

--- a/apps/pops-api/src/routes/cerebrum/query-stream.test.ts
+++ b/apps/pops-api/src/routes/cerebrum/query-stream.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the Cerebrum Query SSE streaming route (PRD-082, issue #2596).
+ *
+ * Mocks the QueryService so we can drive the stream from a fake async
+ * generator and assert the wire-format emitted by the Express handler:
+ *   data: {"type":"token","text":"..."}
+ *   data: {"type":"done","answer":"...","sources":[...], ...}
+ *   data: {"type":"error","message":"..."}
+ */
+import { type AddressInfo } from 'node:net';
+
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Server } from 'node:http';
+
+import type { QueryStreamEvent } from '../../modules/cerebrum/query/query-stream.js';
+
+const mockPrepareStream = vi.fn();
+
+vi.mock('../../modules/cerebrum/query/query-service.js', () => ({
+  QueryService: class MockQueryService {
+    prepareStream = mockPrepareStream;
+  },
+}));
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import queryStreamRouter from './query-stream.js';
+
+async function* makeStream(events: QueryStreamEvent[]): AsyncGenerator<QueryStreamEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+/** Parse the raw SSE payload into the list of decoded data objects. */
+function parseSseBody(body: string): Array<Record<string, unknown>> {
+  const lines = body.split('\n');
+  const events: Array<Record<string, unknown>> = [];
+  for (const line of lines) {
+    if (!line.startsWith('data: ')) continue;
+    events.push(JSON.parse(line.slice(6)) as Record<string, unknown>);
+  }
+  return events;
+}
+
+interface StreamResponse {
+  status: number;
+  contentType: string | null;
+  body: string;
+}
+
+let server: Server | undefined;
+let baseUrl = '';
+
+function startServer(): Promise<void> {
+  const app = express();
+  app.use(express.json());
+  app.use(queryStreamRouter);
+  return new Promise((resolve) => {
+    server = app.listen(0, () => {
+      const address = server?.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+}
+
+async function stopServer(): Promise<void> {
+  if (!server) return;
+  await new Promise<void>((resolve, reject) => {
+    server?.close((err) => (err ? reject(err) : resolve()));
+  });
+  server = undefined;
+}
+
+/** Make a streaming POST against the running server and buffer the body. */
+async function postStream(body: unknown): Promise<StreamResponse> {
+  const response = await fetch(`${baseUrl}/api/cerebrum/query/stream`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  return {
+    status: response.status,
+    contentType: response.headers.get('content-type'),
+    body: text,
+  };
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await startServer();
+});
+
+afterEach(async () => {
+  await stopServer();
+});
+
+describe('POST /api/cerebrum/query/stream', () => {
+  it('rejects an empty body with 400', async () => {
+    const res = await postStream({});
+    expect(res.status).toBe(400);
+    expect(mockPrepareStream).not.toHaveBeenCalled();
+  });
+
+  it('streams token events followed by a done event', async () => {
+    mockPrepareStream.mockResolvedValue(
+      makeStream([
+        { type: 'token', text: 'Hello' },
+        { type: 'token', text: ' world' },
+        {
+          type: 'done',
+          answer: 'Hello world',
+          sources: [
+            {
+              id: 'eng_20260417_0942_test',
+              type: 'engram',
+              title: 'Test engram',
+              excerpt: 'Some excerpt',
+              relevance: 0.9,
+              scope: 'work.engineering',
+            },
+          ],
+          scopes: ['work.engineering'],
+          confidence: 'high',
+          tokensIn: 100,
+          tokensOut: 50,
+        },
+      ])
+    );
+
+    const res = await postStream({ question: 'what did i decide?' });
+
+    expect(res.status).toBe(200);
+    expect(res.contentType).toContain('text/event-stream');
+
+    // eslint-disable-next-line no-console
+    console.log('DEBUG status=', res.status, 'body length=', res.body.length, 'body=', res.body);
+    const events = parseSseBody(res.body);
+    expect(events).toHaveLength(3);
+    expect(events[0]).toEqual({ type: 'token', text: 'Hello' });
+    expect(events[1]).toEqual({ type: 'token', text: ' world' });
+    expect(events[2]).toMatchObject({
+      type: 'done',
+      answer: 'Hello world',
+      confidence: 'high',
+      tokensIn: 100,
+      tokensOut: 50,
+    });
+    const doneEvent = events[2];
+    expect(doneEvent).toBeDefined();
+    expect(Array.isArray(doneEvent?.['sources'])).toBe(true);
+    const sources = doneEvent?.['sources'] as Array<{ id: string }>;
+    expect(sources[0]?.id).toBe('eng_20260417_0942_test');
+  });
+
+  it('forwards optional filters (scopes, domains, includeSecret) to the service', async () => {
+    mockPrepareStream.mockResolvedValue(
+      makeStream([
+        {
+          type: 'done',
+          answer: '',
+          sources: [],
+          scopes: ['work.*'],
+          confidence: 'low',
+          tokensIn: 0,
+          tokensOut: 0,
+        },
+      ])
+    );
+
+    await postStream({
+      question: 'what changed?',
+      scopes: ['work.*'],
+      domains: ['engrams'],
+      includeSecret: true,
+      maxSources: 5,
+    });
+
+    expect(mockPrepareStream).toHaveBeenCalledWith({
+      question: 'what changed?',
+      scopes: ['work.*'],
+      domains: ['engrams'],
+      includeSecret: true,
+      maxSources: 5,
+    });
+  });
+
+  it('emits an error event when the service throws after headers were sent', async () => {
+    mockPrepareStream.mockRejectedValue(new Error('boom'));
+
+    const res = await postStream({ question: 'will this fail?' });
+
+    // SSE headers were already flushed, so the status is 200 and the error
+    // event arrives in the body — same shape as the ego stream route.
+    expect(res.status).toBe(200);
+    const events = parseSseBody(res.body);
+    const errorEvent = events.find((e) => e['type'] === 'error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent?.['message']).toBe('boom');
+  });
+
+  it('emits an error event when the stream itself throws mid-iteration', async () => {
+    async function* failingStream(): AsyncGenerator<QueryStreamEvent> {
+      yield { type: 'token', text: 'partial' };
+      throw new Error('stream blew up');
+    }
+    mockPrepareStream.mockResolvedValue(failingStream());
+
+    const res = await postStream({ question: 'midstream failure?' });
+
+    expect(res.status).toBe(200);
+    const events = parseSseBody(res.body);
+    expect(events[0]).toEqual({ type: 'token', text: 'partial' });
+    const errorEvent = events.find((e) => e['type'] === 'error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent?.['message']).toBe('stream blew up');
+  });
+});

--- a/apps/pops-api/src/routes/cerebrum/query-stream.test.ts
+++ b/apps/pops-api/src/routes/cerebrum/query-stream.test.ts
@@ -139,8 +139,6 @@ describe('POST /api/cerebrum/query/stream', () => {
     expect(res.status).toBe(200);
     expect(res.contentType).toContain('text/event-stream');
 
-    // eslint-disable-next-line no-console
-    console.log('DEBUG status=', res.status, 'body length=', res.body.length, 'body=', res.body);
     const events = parseSseBody(res.body);
     expect(events).toHaveLength(3);
     expect(events[0]).toEqual({ type: 'token', text: 'Hello' });

--- a/apps/pops-api/src/routes/cerebrum/query-stream.ts
+++ b/apps/pops-api/src/routes/cerebrum/query-stream.ts
@@ -1,0 +1,115 @@
+/**
+ * SSE endpoint for streaming Cerebrum Query answers (PRD-082, issue #2596).
+ *
+ * POST /api/cerebrum/query/stream
+ *
+ * Accepts the same body as `cerebrum.query.ask`, but returns an SSE stream
+ * mirroring the shape used by `/api/ego/chat/stream`:
+ *   data: {"type":"token","text":"..."}
+ *   data: {"type":"done","answer":"...","sources":[...],"scopes":[...],
+ *          "confidence":"high|medium|low","tokensIn":N,"tokensOut":N}
+ *   data: {"type":"error","message":"..."}
+ */
+import { type Router as ExpressRouter, Router } from 'express';
+import { z } from 'zod';
+
+import { logger } from '../../lib/logger.js';
+import { QueryService } from '../../modules/cerebrum/query/query-service.js';
+import { HttpError, NotFoundError, ValidationError } from '../../shared/errors.js';
+
+import type { Response } from 'express';
+
+import type { QueryDomain } from '../../modules/cerebrum/query/types.js';
+
+const router: ExpressRouter = Router();
+
+const domainEnum = z.enum(['engrams', 'transactions', 'media', 'inventory']);
+
+const bodySchema = z.object({
+  question: z.string().min(1),
+  scopes: z.array(z.string().min(1)).optional(),
+  includeSecret: z.boolean().optional(),
+  maxSources: z.number().int().positive().max(50).optional(),
+  domains: z.array(domainEnum).optional(),
+});
+
+/** Set standard SSE response headers. */
+function setSseHeaders(res: Response): void {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+}
+
+/** Write a single SSE data event. */
+function writeSseEvent(res: Response, data: Record<string, unknown>): void {
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+/** Map domain-level errors into a user-facing message string. */
+function describeError(err: unknown): string {
+  if (err instanceof NotFoundError || err instanceof ValidationError) return err.message;
+  if (err instanceof HttpError) return err.message;
+  return err instanceof Error ? err.message : 'Internal server error';
+}
+
+interface PipeStreamParams {
+  res: Response;
+  service: QueryService;
+  input: z.infer<typeof bodySchema>;
+}
+
+/** Stream events to the SSE client. */
+async function pipeStreamEvents(params: PipeStreamParams): Promise<void> {
+  const { res, service, input } = params;
+
+  const stream = await service.prepareStream({
+    question: input.question,
+    scopes: input.scopes,
+    includeSecret: input.includeSecret,
+    maxSources: input.maxSources,
+    domains: input.domains as QueryDomain[] | undefined,
+  });
+
+  for await (const event of stream) {
+    // Stop writing once the response stream has been destroyed (client gone).
+    if (res.writableEnded || res.destroyed) break;
+
+    if (event.type === 'token') {
+      writeSseEvent(res, { type: 'token', text: event.text });
+    } else {
+      writeSseEvent(res, {
+        type: 'done',
+        answer: event.answer,
+        sources: event.sources,
+        scopes: event.scopes,
+        confidence: event.confidence,
+        tokensIn: event.tokensIn,
+        tokensOut: event.tokensOut,
+      });
+    }
+  }
+}
+
+router.post('/api/cerebrum/query/stream', async (req, res) => {
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid request body', details: parsed.error.issues });
+    return;
+  }
+
+  setSseHeaders(res);
+
+  try {
+    await pipeStreamEvents({ res, service: new QueryService(), input: parsed.data });
+  } catch (err) {
+    const message = describeError(err);
+    logger.error({ error: message }, '[QueryEngine] SSE stream error');
+    writeSseEvent(res, { type: 'error', message });
+  }
+
+  res.end();
+});
+
+export default router;

--- a/packages/app-cerebrum/src/pages/QueryPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/QueryPage.test.tsx
@@ -1,7 +1,17 @@
-import { act, render, screen } from '@testing-library/react';
+/**
+ * Tests for the Cerebrum Query page (PRD-082).
+ *
+ * Validates the integration between the page-level state machine and the
+ * SSE streaming endpoint mounted at `/api/cerebrum/query/stream`
+ * (issue #2596). The `fetch` global is replaced with a mock that emits a
+ * canned stream of `token` and `done` events; we assert the panel updates
+ * progressively as tokens arrive and that the citation set is appended
+ * once the `done` event lands.
+ */
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const toastErrorMock = vi.fn();
 const toastSuccessMock = vi.fn();
@@ -12,28 +22,13 @@ vi.mock('sonner', () => ({
   },
 }));
 
-const mockAskMutate = vi.fn();
 const mockEmitMutate = vi.fn();
-let askPending = false;
 let emitPending = false;
-let askCallbacks: { onSuccess?: (data: unknown) => void; onError?: (err: unknown) => void } = {};
 let emitCallbacks: { onSuccess?: (data: unknown) => void; onError?: (err: unknown) => void } = {};
 
 vi.mock('@pops/api-client', () => ({
   trpc: {
     cerebrum: {
-      query: {
-        ask: {
-          useMutation: (cb: typeof askCallbacks) => {
-            askCallbacks = cb;
-            return {
-              mutate: (...args: unknown[]) => mockAskMutate(...args),
-              isPending: askPending,
-              error: null,
-            };
-          },
-        },
-      },
       emit: {
         generate: {
           useMutation: (cb: typeof emitCallbacks) => {
@@ -54,6 +49,31 @@ import { QueryPage } from './QueryPage';
 
 const STORAGE_KEY = 'pops.cerebrum.query-history';
 
+interface StreamEvent {
+  type: 'token' | 'done' | 'error';
+  [key: string]: unknown;
+}
+
+/** Build a streaming Response whose body emits the provided SSE events. */
+function makeStreamResponse(events: StreamEvent[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
 function renderPage() {
   return render(
     <MemoryRouter>
@@ -64,11 +84,14 @@ function renderPage() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  askPending = false;
   emitPending = false;
-  askCallbacks = {};
   emitCallbacks = {};
   window.localStorage.clear();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
 });
 
 describe('QueryPage', () => {
@@ -79,48 +102,67 @@ describe('QueryPage', () => {
     expect(screen.getByTestId('query-history-empty')).toBeInTheDocument();
   });
 
-  it('rejects an empty question with a toast and does not call the mutation', async () => {
+  it('rejects an empty question with a toast and does not call the stream endpoint', async () => {
     renderPage();
     await userEvent.click(screen.getByTestId('query-ask'));
-    expect(mockAskMutate).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(toastErrorMock).toHaveBeenCalledWith('A question is required.');
   });
 
-  it('submits a question, persists history, and renders the answer with engram citation links', async () => {
+  it('progressively updates the panel as token events arrive then appends citations on done', async () => {
+    fetchMock.mockResolvedValue(
+      makeStreamResponse([
+        { type: 'token', text: 'You ' },
+        { type: 'token', text: 'decided ' },
+        { type: 'token', text: 'to ship.' },
+        {
+          type: 'done',
+          answer: 'You decided to ship.',
+          sources: [
+            {
+              id: 'eng_20260417_0942_decide',
+              type: 'engram',
+              title: 'Decision: ship',
+              excerpt: 'we will ship on Friday',
+              relevance: 0.92,
+              scope: 'work.engineering',
+            },
+            {
+              id: 'txn_abc',
+              type: 'transaction',
+              title: 'Hosting bill',
+              excerpt: 'monthly invoice',
+              relevance: 0.55,
+              scope: 'work.ops',
+            },
+          ],
+          scopes: ['work.*'],
+          confidence: 'high',
+          tokensIn: 50,
+          tokensOut: 25,
+        },
+      ])
+    );
+
     renderPage();
     await userEvent.type(screen.getByLabelText('Question'), 'what did i decide?');
     await userEvent.click(screen.getByTestId('query-ask'));
 
-    expect(mockAskMutate).toHaveBeenCalledWith({ question: 'what did i decide?' });
-
-    act(() => {
-      askCallbacks.onSuccess?.({
-        answer: 'You decided to ship.',
-        sources: [
-          {
-            id: 'eng_20260417_0942_decide',
-            type: 'engram',
-            title: 'Decision: ship',
-            excerpt: 'we will ship on Friday',
-            relevance: 0.92,
-            scope: 'work.engineering',
-          },
-          {
-            id: 'txn_abc',
-            type: 'transaction',
-            title: 'Hosting bill',
-            excerpt: 'monthly invoice',
-            relevance: 0.55,
-            scope: 'work.ops',
-          },
-        ],
-        scopes: ['work.*'],
-        confidence: 'high',
-      });
+    // Stream completes; full answer + citations + confidence are visible.
+    await waitFor(() => {
+      expect(screen.getByText('You decided to ship.')).toBeInTheDocument();
     });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/cerebrum/query/stream',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const fetchCall = fetchMock.mock.calls[0] as [string, { body: string }];
+    expect(JSON.parse(fetchCall[1].body)).toEqual({ question: 'what did i decide?' });
 
     expect(screen.getByTestId('query-answer')).toBeInTheDocument();
-    expect(screen.getByText('You decided to ship.')).toBeInTheDocument();
     const link = screen.getByTestId('query-source-link');
     expect(link).toHaveAttribute('href', '/cerebrum/engrams/eng_20260417_0942_decide');
     expect(screen.getByTestId('query-confidence').textContent).toContain('High');
@@ -129,22 +171,108 @@ describe('QueryPage', () => {
     expect(Array.isArray(persisted)).toBe(true);
   });
 
-  it('surfaces an error toast when the mutation fails', () => {
-    renderPage();
-    act(() => {
-      askCallbacks.onError?.(new Error('boom'));
+  it('renders intermediate token text before the done event arrives', async () => {
+    // Hand-crafted stream: we hold the controller so we can flush tokens
+    // one-by-one and assert the panel re-renders between them.
+    const encoder = new TextEncoder();
+    let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controllerRef = controller;
+      },
     });
-    expect(toastErrorMock).toHaveBeenCalledWith('boom');
+    fetchMock.mockResolvedValue(
+      new Response(body, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    renderPage();
+    await userEvent.type(screen.getByLabelText('Question'), 'progressive?');
+    await userEvent.click(screen.getByTestId('query-ask'));
+
+    // Flush the first token.
+    await act(async () => {
+      controllerRef?.enqueue(
+        encoder.encode(`data: ${JSON.stringify({ type: 'token', text: 'Partial' })}\n\n`)
+      );
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Partial')).toBeInTheDocument();
+    });
+
+    // Flush another token; the panel should now show the cumulative text.
+    await act(async () => {
+      controllerRef?.enqueue(
+        encoder.encode(`data: ${JSON.stringify({ type: 'token', text: ' answer' })}\n\n`)
+      );
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Partial answer')).toBeInTheDocument();
+    });
+
+    // Finish the stream.
+    await act(async () => {
+      controllerRef?.enqueue(
+        encoder.encode(
+          `data: ${JSON.stringify({
+            type: 'done',
+            answer: 'Partial answer',
+            sources: [],
+            scopes: [],
+            confidence: 'low',
+            tokensIn: 0,
+            tokensOut: 0,
+          })}\n\n`
+        )
+      );
+      controllerRef?.close();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('query-confidence').textContent).toContain('Low');
+    });
+  });
+
+  it('surfaces an error toast when the SSE pipeline emits an error event', async () => {
+    fetchMock.mockResolvedValue(makeStreamResponse([{ type: 'error', message: 'boom' }]));
+
+    renderPage();
+    await userEvent.type(screen.getByLabelText('Question'), 'broken?');
+    await userEvent.click(screen.getByTestId('query-ask'));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith('boom');
+    });
     expect(screen.getByTestId('query-error')).toBeInTheDocument();
   });
 
-  it('renders the loading skeleton while a request is in flight', () => {
-    askPending = true;
+  it('surfaces an error toast when fetch itself rejects', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
     renderPage();
-    expect(screen.getByTestId('query-loading')).toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText('Question'), 'down?');
+    await userEvent.click(screen.getByTestId('query-ask'));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith('network down');
+    });
   });
 
-  it('re-runs a past query when clicked in the history sidebar', async () => {
+  it('re-runs a past query against the streaming endpoint when clicked in history', async () => {
+    fetchMock.mockResolvedValue(
+      makeStreamResponse([
+        {
+          type: 'done',
+          answer: 'replayed',
+          sources: [],
+          scopes: ['work.*'],
+          confidence: 'low',
+          tokensIn: 0,
+          tokensOut: 0,
+        },
+      ])
+    );
     window.localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify([
@@ -162,7 +290,12 @@ describe('QueryPage', () => {
     );
     renderPage();
     await userEvent.click(screen.getByTestId('query-history-rerun'));
-    expect(mockAskMutate).toHaveBeenCalledWith({
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const fetchCall = fetchMock.mock.calls[0] as [string, { body: string }];
+    expect(fetchCall[0]).toBe('/api/cerebrum/query/stream');
+    expect(JSON.parse(fetchCall[1].body)).toEqual({
       question: 'replay me',
       scopes: ['work.*'],
       domains: ['engrams'],
@@ -170,18 +303,27 @@ describe('QueryPage', () => {
     });
   });
 
-  it('dispatches save-as-document via the emit pipeline', async () => {
+  it('dispatches save-as-document via the emit pipeline once an answer has streamed', async () => {
+    fetchMock.mockResolvedValue(
+      makeStreamResponse([
+        {
+          type: 'done',
+          answer: 'answer',
+          sources: [],
+          scopes: ['work.engineering'],
+          confidence: 'low',
+          tokensIn: 0,
+          tokensOut: 0,
+        },
+      ])
+    );
+
     renderPage();
     await userEvent.type(screen.getByLabelText('Question'), 'topic q');
     await userEvent.type(screen.getByLabelText('Scopes (comma-separated)'), 'work.engineering');
     await userEvent.click(screen.getByTestId('query-ask'));
-    act(() => {
-      askCallbacks.onSuccess?.({
-        answer: 'answer',
-        sources: [],
-        scopes: ['work.engineering'],
-        confidence: 'low',
-      });
+    await waitFor(() => {
+      expect(screen.getByTestId('query-answer')).toBeInTheDocument();
     });
     await userEvent.click(screen.getByTestId('query-save-document'));
     expect(mockEmitMutate).toHaveBeenCalledWith(

--- a/packages/app-cerebrum/src/pages/QueryPage.test.tsx
+++ b/packages/app-cerebrum/src/pages/QueryPage.test.tsx
@@ -72,7 +72,6 @@ function makeStreamResponse(events: StreamEvent[]): Response {
 }
 
 const fetchMock = vi.fn();
-const originalFetch = globalThis.fetch;
 
 function renderPage() {
   return render(
@@ -87,11 +86,11 @@ beforeEach(() => {
   emitPending = false;
   emitCallbacks = {};
   window.localStorage.clear();
-  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  vi.stubGlobal('fetch', fetchMock);
 });
 
 afterEach(() => {
-  globalThis.fetch = originalFetch;
+  vi.unstubAllGlobals();
 });
 
 describe('QueryPage', () => {
@@ -148,7 +147,6 @@ describe('QueryPage', () => {
     await userEvent.type(screen.getByLabelText('Question'), 'what did i decide?');
     await userEvent.click(screen.getByTestId('query-ask'));
 
-    // Stream completes; full answer + citations + confidence are visible.
     await waitFor(() => {
       expect(screen.getByText('You decided to ship.')).toBeInTheDocument();
     });
@@ -172,8 +170,6 @@ describe('QueryPage', () => {
   });
 
   it('renders intermediate token text before the done event arrives', async () => {
-    // Hand-crafted stream: we hold the controller so we can flush tokens
-    // one-by-one and assert the panel re-renders between them.
     const encoder = new TextEncoder();
     let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null;
     const body = new ReadableStream<Uint8Array>({

--- a/packages/app-cerebrum/src/query/mutations.ts
+++ b/packages/app-cerebrum/src/query/mutations.ts
@@ -1,16 +1,22 @@
 /**
- * tRPC mutation wrappers for the Query view model.
+ * Mutation wrappers for the Query view model.
  *
- * Centralises the success/error handling for `cerebrum.query.ask` and
- * `cerebrum.emit.generate`. Split out of `useQueryPageModel` so each
- * surface stays within the line/complexity caps.
+ * `useAskMutation` consumes the SSE streaming endpoint
+ * (`/api/cerebrum/query/stream`, PRD-082 issue #2596) and progressively
+ * surfaces tokens / final citations through the supplied callbacks.
+ * `useSaveDocumentMutation` is a thin wrapper around the existing tRPC
+ * `cerebrum.emit.generate` mutation for "save as document".
  */
+import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
 import { trpc } from '@pops/api-client';
 
 import { extractMessage } from '../utils/errors';
+import { streamQuery } from './query-stream-client';
+
+import type { MutableRefObject } from 'react';
 
 import type { ValidatedQueryRequest } from './form-mapping';
 import type { QueryAnswer, QueryHistoryEntry } from './types';
@@ -53,23 +59,118 @@ export function buildSaveRequest(request: ValidatedQueryRequest): SaveDocumentRe
   };
 }
 
-export function useAskMutation(bindings: AskBindings) {
-  return trpc.cerebrum.query.ask.useMutation({
-    onSuccess: (result: QueryAnswer | undefined) => {
-      if (!result) {
-        bindings.setError(bindings.unknownErrorMessage);
-        return;
-      }
-      bindings.setAnswer(result);
+export interface AskMutationHandle {
+  /** Start streaming an ask request. */
+  mutate: (request: ValidatedQueryRequest) => void;
+  /** True while a stream is in-flight (between mutate() and the done/error event). */
+  isPending: boolean;
+}
+
+function buildPartialAnswer(text: string): QueryAnswer {
+  return { answer: text, sources: [], scopes: [], confidence: 'low' };
+}
+
+function buildFinalAnswer(done: {
+  answer: string;
+  sources: QueryAnswer['sources'];
+  scopes: string[];
+  confidence: QueryAnswer['confidence'];
+}): QueryAnswer {
+  return {
+    answer: done.answer,
+    sources: done.sources,
+    scopes: done.scopes,
+    confidence: done.confidence,
+  };
+}
+
+interface StreamSink {
+  bindings: AskBindings;
+  pendingRef: MutableRefObject<AskInvocation | null>;
+  abortRef: MutableRefObject<AbortController | null>;
+  setIsPending: (next: boolean) => void;
+  reportError: (message: string) => void;
+}
+
+/**
+ * Build the SSE callback set the streaming client invokes. Extracted so
+ * `useAskMutation` stays under the per-function line budget.
+ */
+function buildStreamCallbacks(sink: StreamSink): Parameters<typeof streamQuery>[1] {
+  const { bindings, pendingRef, abortRef, setIsPending, reportError } = sink;
+  const finish = (): void => {
+    setIsPending(false);
+    abortRef.current = null;
+  };
+  return {
+    onToken: (cumulative) => bindings.setAnswer(buildPartialAnswer(cumulative)),
+    onDone: (done) => {
+      const finalAnswer = buildFinalAnswer(done);
+      bindings.setAnswer(finalAnswer);
       bindings.setError(null);
-      if (bindings.pending) bindings.updateStats(bindings.pending.historyId, result);
+      const pending = pendingRef.current;
+      if (pending) bindings.updateStats(pending.historyId, finalAnswer);
+      finish();
     },
-    onError: (err: unknown) => {
-      const message = extractMessage(err, bindings.unknownErrorMessage);
+    onError: (message) => {
+      reportError(message);
+      finish();
+    },
+  };
+}
+
+/**
+ * Wire a streaming ask request into the page-level state setters.
+ *
+ * Tokens progressively grow the `answer.answer` field; once the `done`
+ * event arrives, the citations + scopes + confidence are appended and
+ * `pending` history stats are updated. Errors invoke `setError` and surface
+ * a toast — same contract the tRPC version used to honour.
+ */
+export function useAskMutation(bindings: AskBindings): AskMutationHandle {
+  const [isPending, setIsPending] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const pendingRef = useRef<AskInvocation | null>(bindings.pending);
+  // `bindings` is rebuilt every render; keep a ref so the streaming
+  // callbacks always see the latest snapshot without re-binding the hook.
+  pendingRef.current = bindings.pending;
+
+  const reportError = useCallback(
+    (message: string) => {
       bindings.setError(message);
       toast.error(message);
     },
-  });
+    [bindings]
+  );
+
+  const mutate = useCallback(
+    (request: ValidatedQueryRequest) => {
+      if (isPending) return;
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setIsPending(true);
+      bindings.setError(null);
+      bindings.setAnswer(null);
+
+      const callbacks = buildStreamCallbacks({
+        bindings,
+        pendingRef,
+        abortRef,
+        setIsPending,
+        reportError,
+      });
+      void streamQuery(request, callbacks, { signal: controller.signal }).catch((err: unknown) => {
+        if (err instanceof Error && err.name === 'AbortError') return;
+        reportError(extractMessage(err, bindings.unknownErrorMessage));
+        setIsPending(false);
+        abortRef.current = null;
+      });
+    },
+    [bindings, isPending, reportError]
+  );
+
+  return { mutate, isPending };
 }
 
 interface SaveResult {

--- a/packages/app-cerebrum/src/query/query-stream-client.ts
+++ b/packages/app-cerebrum/src/query/query-stream-client.ts
@@ -1,0 +1,129 @@
+/**
+ * Low-level SSE client for the Cerebrum Query streaming endpoint
+ * (PRD-082, issue #2596).
+ *
+ * Fetches `/api/cerebrum/query/stream`, decodes the SSE wire format, and
+ * dispatches structured `token`, `done` and `error` events to caller-
+ * supplied handlers. Mirrors the shape of `useStreamingChat` in
+ * `overlay-ego` so both surfaces share the same SSE conventions.
+ */
+import type { ValidatedQueryRequest } from './form-mapping';
+import type { QueryConfidence, QuerySourceCitation } from './types';
+
+/** SSE token event yielded while the LLM is still streaming. */
+interface SseTokenEvent {
+  type: 'token';
+  text: string;
+}
+
+/** SSE done event yielded once the LLM stream completes. */
+interface SseDoneEvent {
+  type: 'done';
+  answer: string;
+  sources: QuerySourceCitation[];
+  scopes: string[];
+  confidence: QueryConfidence;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/** SSE error event yielded if the pipeline fails. */
+interface SseErrorEvent {
+  type: 'error';
+  message: string;
+}
+
+type SseEvent = SseTokenEvent | SseDoneEvent | SseErrorEvent;
+
+export interface StreamQueryCallbacks {
+  /** Called for each `token` event. Receives the *cumulative* answer text. */
+  onToken: (cumulativeAnswer: string) => void;
+  /** Called when the pipeline emits its final `done` event. */
+  onDone: (done: SseDoneEvent) => void;
+  /** Called when the pipeline emits an `error` event or the fetch fails. */
+  onError: (message: string) => void;
+}
+
+/** Parse a single `data: ...` line into a typed SSE event. */
+function parseSseEvent(line: string): SseEvent | null {
+  if (!line.startsWith('data: ')) return null;
+  try {
+    return JSON.parse(line.slice(6)) as SseEvent;
+  } catch {
+    return null;
+  }
+}
+
+interface DispatchParams {
+  event: SseEvent;
+  cumulativeAnswer: { current: string };
+  callbacks: StreamQueryCallbacks;
+}
+
+/** Apply a single decoded SSE event to the streaming state. */
+function dispatchEvent(params: DispatchParams): void {
+  const { event, cumulativeAnswer, callbacks } = params;
+  if (event.type === 'token') {
+    cumulativeAnswer.current += event.text;
+    callbacks.onToken(cumulativeAnswer.current);
+  } else if (event.type === 'done') {
+    callbacks.onDone(event);
+  } else if (event.type === 'error') {
+    callbacks.onError(event.message);
+  }
+}
+
+/** Read the SSE body chunk-by-chunk and dispatch each `data:` line. */
+async function processStream(
+  body: ReadableStream<Uint8Array>,
+  callbacks: StreamQueryCallbacks
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  const cumulativeAnswer = { current: '' };
+  let buffer = '';
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const event = parseSseEvent(trimmed);
+      if (!event) continue;
+      dispatchEvent({ event, cumulativeAnswer, callbacks });
+    }
+  }
+}
+
+/**
+ * Stream a query answer from the SSE endpoint. Returns a Promise that
+ * resolves once the server has closed the connection (or rejects with the
+ * underlying fetch error). The caller is responsible for state management;
+ * this function is intentionally side-effect free apart from the supplied
+ * callbacks.
+ */
+export async function streamQuery(
+  request: ValidatedQueryRequest,
+  callbacks: StreamQueryCallbacks,
+  init: { signal?: AbortSignal } = {}
+): Promise<void> {
+  const response = await fetch('/api/cerebrum/query/stream', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+    signal: init.signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Stream request failed: ${response.status}`);
+  }
+  if (!response.body) {
+    throw new Error('Response body is null');
+  }
+  await processStream(response.body, callbacks);
+}

--- a/packages/app-cerebrum/src/query/useQueryPageModel.ts
+++ b/packages/app-cerebrum/src/query/useQueryPageModel.ts
@@ -1,15 +1,5 @@
 /**
  * View model for the Query page (`/cerebrum/query`, PRD-082).
- *
- * Composes the history state, mutation wrappers and action callbacks
- * extracted into sibling modules. Kept deliberately small so the page
- * component stays a dumb consumer and so each sub-piece stays
- * unit-testable in isolation.
- *
- * Streaming is wired through the SSE endpoint
- * `/api/cerebrum/query/stream` (issue #2596) via `useAskMutation`. The
- * answer panel state is updated incrementally as tokens arrive and the
- * citation set is appended on the final `done` event.
  */
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/packages/app-cerebrum/src/query/useQueryPageModel.ts
+++ b/packages/app-cerebrum/src/query/useQueryPageModel.ts
@@ -6,10 +6,10 @@
  * component stays a dumb consumer and so each sub-piece stays
  * unit-testable in isolation.
  *
- * Streaming is not yet supported server-side — `cerebrum.query.ask`
- * returns the answer in one shot. When PRD-082 adds streaming, the
- * answer panel is already laid out for a progressively-rendered
- * answer; only the mutation wrapper needs to change.
+ * Streaming is wired through the SSE endpoint
+ * `/api/cerebrum/query/stream` (issue #2596) via `useAskMutation`. The
+ * answer panel state is updated incrementally as tokens arrive and the
+ * citation set is appended on the final `done` event.
  */
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';


### PR DESCRIPTION
## Summary

- Adds `POST /api/cerebrum/query/stream` — an SSE endpoint that emits `token`, `done`, and `error` events mirroring the wire format used by `/api/ego/chat/stream`. The retrieval + context-assembly pipeline is shared with `cerebrum.query.ask`; the LLM call is routed through `messages.stream()` for token-by-token delivery and a final `done` event carries the parsed citation set, scopes and confidence.
- Swaps `useAskMutation` in `@pops/app-cerebrum` to fetch the new SSE endpoint and progressively re-render the answer panel as tokens arrive. Citations are appended on the `done` event and errors flow through the existing toast surface.
- Refactors `QueryService` to extract the non-streaming Anthropic call into `query-llm.ts` so the file stays under the `max-lines` budget after the new `prepareStream()` method.

Closes #2596.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint` (0 errors, 160 pre-existing warnings unchanged)
- [x] `pnpm typecheck` (all 20 packages)
- [x] `pnpm --filter @pops/api test` (4272 passed)
- [x] `pnpm --filter @pops/app-cerebrum test` (123 passed)
- [x] `cd packages/module-registry && pnpm build`

Manual smoke tests TBD against a live server.