### PR TITLE
test(shell): POPS_APPS install-set switching E2E harness (#2595)

### DIFF
--- a/.github/workflows/fe-test-e2e.yml
+++ b/.github/workflows/fe-test-e2e.yml
@@ -92,6 +92,12 @@ jobs:
         if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
         run: |
           cd apps/pops-shell
+          # Runs both Playwright projects defined in playwright.config.ts:
+          #   - chromium-all-modules — canonical workspace registry
+          #   - chromium-finance-only — POPS_APPS=finance,core registry snapshot
+          # Each project boots its own shell webServer; the finance-only
+          # server rebuilds its snapshot before Vite starts. Issue #2595
+          # (PRD-101 US-11 follow-up).
           pnpm test:e2e
         env:
           CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@ storybook-static
 playwright-report/
 test-results/
 coverage/
+# Per-project module-registry snapshots emitted by the install-set
+# switching harness (PRD-101 US-11 follow-up). Regenerated on every
+# Playwright run; never committed.
+apps/pops-shell/.e2e/
 
 # Temporary files
 tmp/

--- a/apps/pops-shell/e2e/helpers/shell-search.ts
+++ b/apps/pops-shell/e2e/helpers/shell-search.ts
@@ -1,0 +1,14 @@
+import { expect, type Page } from '@playwright/test';
+
+import { useRealApi as enableRealApi } from './use-real-api';
+
+export async function bootShellAndAwaitSearch(page: Page): Promise<void> {
+  await enableRealApi(page);
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/finance\/?$/);
+  await expect(page.getByRole('textbox', { name: 'Search POPS' })).toBeVisible();
+}
+
+export async function unrouteAll(page: Page): Promise<void> {
+  await page.unrouteAll({ behavior: 'ignoreErrors' });
+}

--- a/apps/pops-shell/e2e/pops-apps-all-modules-search.spec.ts
+++ b/apps/pops-shell/e2e/pops-apps-all-modules-search.spec.ts
@@ -1,21 +1,5 @@
-/**
- * Install-set switching E2E — search returns media results when media
- * is installed (PRD-101 US-11 follow-up, issue #2595).
- *
- * All-modules half of the matched pair. The companion finance-only
- * assertion lives in `pops-apps-finance-only-search.spec.ts`; together
- * they satisfy the deferred acceptance criterion from
- * `docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md`:
- *
- *   With every module installed, searching for a known media title
- *   returns a media result; with `POPS_APPS=finance` the same query
- *   returns zero media results.
- *
- * "The Matrix" is a seeded movie title (see `apps/pops-api/src/db/seeder.ts`),
- * so the same query the finance-only spec issues must produce a movies
- * section here. Same query, two builds, two outcomes — that's the
- * contract.
- */
+// Paired with pops-apps-finance-only-search.spec.ts: same query must produce
+// media results here and none under POPS_APPS=finance.
 import { expect, test } from '@playwright/test';
 
 import { useRealApi } from './helpers/use-real-api';

--- a/apps/pops-shell/e2e/pops-apps-all-modules-search.spec.ts
+++ b/apps/pops-shell/e2e/pops-apps-all-modules-search.spec.ts
@@ -2,20 +2,17 @@
 // media results here and none under POPS_APPS=finance.
 import { expect, test } from '@playwright/test';
 
-import { useRealApi } from './helpers/use-real-api';
+import { bootShellAndAwaitSearch, unrouteAll } from './helpers/shell-search';
 
 const query = 'Matrix';
 
 test.describe('Shell — search includes media results (all-modules build)', () => {
   test.beforeEach(async ({ page }) => {
-    await useRealApi(page);
-    await page.goto('/');
-    await expect(page).toHaveURL(/\/finance/);
-    await expect(page.getByRole('textbox', { name: 'Search POPS' })).toBeVisible();
+    await bootShellAndAwaitSearch(page);
   });
 
   test.afterEach(async ({ page }) => {
-    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    await unrouteAll(page);
   });
 
   test('searching "Matrix" surfaces a movies result against the seeded library', async ({

--- a/apps/pops-shell/e2e/pops-apps-all-modules-search.spec.ts
+++ b/apps/pops-shell/e2e/pops-apps-all-modules-search.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Install-set switching E2E — search returns media results when media
+ * is installed (PRD-101 US-11 follow-up, issue #2595).
+ *
+ * All-modules half of the matched pair. The companion finance-only
+ * assertion lives in `pops-apps-finance-only-search.spec.ts`; together
+ * they satisfy the deferred acceptance criterion from
+ * `docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md`:
+ *
+ *   With every module installed, searching for a known media title
+ *   returns a media result; with `POPS_APPS=finance` the same query
+ *   returns zero media results.
+ *
+ * "The Matrix" is a seeded movie title (see `apps/pops-api/src/db/seeder.ts`),
+ * so the same query the finance-only spec issues must produce a movies
+ * section here. Same query, two builds, two outcomes — that's the
+ * contract.
+ */
+import { expect, test } from '@playwright/test';
+
+import { useRealApi } from './helpers/use-real-api';
+
+const QUERY = 'Matrix';
+
+test.describe('Shell — search includes media results (all-modules build)', () => {
+  test.beforeEach(async ({ page }) => {
+    await useRealApi(page);
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/finance/);
+    await expect(page.getByRole('textbox', { name: 'Search POPS' })).toBeVisible();
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  });
+
+  test('searching "Matrix" surfaces a movies result against the seeded library', async ({
+    page,
+  }) => {
+    const searchBox = page.getByRole('textbox', { name: 'Search POPS' });
+
+    await searchBox.click();
+    await searchBox.fill(QUERY);
+
+    const panel = page.getByTestId('search-results-panel');
+    await expect(panel).toBeVisible({ timeout: 10_000 });
+
+    const moviesSection = panel.getByTestId('section-movies');
+    await expect(moviesSection).toBeVisible();
+    // Seeded movie title — exact match would be "The Matrix"; the
+    // adapter is contains-scored so a substring match is enough. Scope
+    // to the section to avoid catching any unrelated text.
+    await expect(moviesSection.getByText(/Matrix/i).first()).toBeVisible();
+  });
+});

--- a/apps/pops-shell/e2e/pops-apps-all-modules-search.spec.ts
+++ b/apps/pops-shell/e2e/pops-apps-all-modules-search.spec.ts
@@ -20,7 +20,7 @@ import { expect, test } from '@playwright/test';
 
 import { useRealApi } from './helpers/use-real-api';
 
-const QUERY = 'Matrix';
+const query = 'Matrix';
 
 test.describe('Shell — search includes media results (all-modules build)', () => {
   test.beforeEach(async ({ page }) => {
@@ -40,7 +40,7 @@ test.describe('Shell — search includes media results (all-modules build)', () 
     const searchBox = page.getByRole('textbox', { name: 'Search POPS' });
 
     await searchBox.click();
-    await searchBox.fill(QUERY);
+    await searchBox.fill(query);
 
     const panel = page.getByTestId('search-results-panel');
     await expect(panel).toBeVisible({ timeout: 10_000 });

--- a/apps/pops-shell/e2e/pops-apps-finance-only-not-installed.spec.ts
+++ b/apps/pops-shell/e2e/pops-apps-finance-only-not-installed.spec.ts
@@ -2,18 +2,10 @@
  * Install-set switching E2E — finance-only build (PRD-101 US-11
  * follow-up, issue #2595).
  *
- * Boots the shell with `POPS_APPS=finance,core` (see the
- * `chromium-finance-only` project's webServer in `playwright.config.ts`)
- * and asserts the deferred acceptance criterion from
- * `docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md`:
- *
- *   Direct navigation to `/media` renders `NotInstalledPage` —
- *   distinct from the 404 page — because `media` is a buildable module
- *   the operator has excluded from this install set.
- *
- * The companion all-modules build (port 5567) keeps mounting `/media`
- * as usual; both servers run in the same `pnpm test:e2e` invocation,
- * proving the build-time `POPS_APPS` contract end-to-end.
+ * A regression here means an operator-selected install set no longer
+ * isolates uninstalled modules behind `NotInstalledPage`, blurring the
+ * boundary against the 404 page and breaking the build-time `POPS_APPS`
+ * contract.
  */
 import { expect, test } from '@playwright/test';
 
@@ -25,28 +17,20 @@ test.describe('Shell — POPS_APPS=finance,core install set', () => {
   });
 
   test.afterEach(async ({ page }) => {
-    // `useRealApi` registers a tRPC route handler that calls
-    // `route.fetch()`. Background queries (e.g. cerebrum nudges) can still
-    // be in flight when the test body returns, and any unhandled
-    // route.fetch against a closed page surfaces as a test failure —
-    // unrouteAll drains them before teardown.
+    // Drain in-flight background tRPC fetches before teardown so a late
+    // `route.fetch()` against a closed page does not fail the run.
     await page.unrouteAll({ behavior: 'ignoreErrors' });
   });
 
   test('navigating to /media renders NotInstalledPage, not 404', async ({ page }) => {
     await page.goto('/media');
-    // NotInstalledPage exposes a "module not installed" heading; the 404
-    // page exposes a "not found"/"404" heading. Asserting visibility on
-    // one AND zero count on the other keeps the boundary explicit — a
-    // regression that sends the user to either of the wrong pages
-    // surfaces immediately.
+    // Asserting one heading visible AND the other absent keeps the
+    // not-installed / 404 boundary explicit.
     await expect(page.getByRole('heading', { name: /module not installed/i })).toBeVisible();
     await expect(page.getByRole('heading', { name: /not found|404/i })).toHaveCount(0);
   });
 
   test('navigating to /finance still mounts the installed module', async ({ page }) => {
-    // Sanity check — proves the finance-only shell is not just broken;
-    // installed modules continue to mount and the nav is healthy.
     await page.goto('/finance');
     await expect(page).toHaveURL(/\/finance/);
     await expect(page.getByRole('button', { name: 'Finance' })).toHaveAttribute(

--- a/apps/pops-shell/e2e/pops-apps-finance-only-not-installed.spec.ts
+++ b/apps/pops-shell/e2e/pops-apps-finance-only-not-installed.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Install-set switching E2E — finance-only build (PRD-101 US-11
+ * follow-up, issue #2595).
+ *
+ * Boots the shell with `POPS_APPS=finance,core` (see the
+ * `chromium-finance-only` project's webServer in `playwright.config.ts`)
+ * and asserts the deferred acceptance criterion from
+ * `docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md`:
+ *
+ *   Direct navigation to `/media` renders `NotInstalledPage` —
+ *   distinct from the 404 page — because `media` is a buildable module
+ *   the operator has excluded from this install set.
+ *
+ * The companion all-modules build (port 5567) keeps mounting `/media`
+ * as usual; both servers run in the same `pnpm test:e2e` invocation,
+ * proving the build-time `POPS_APPS` contract end-to-end.
+ */
+import { expect, test } from '@playwright/test';
+
+import { useRealApi } from './helpers/use-real-api';
+
+test.describe('Shell — POPS_APPS=finance,core install set', () => {
+  test.beforeEach(async ({ page }) => {
+    await useRealApi(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    // `useRealApi` registers a tRPC route handler that calls
+    // `route.fetch()`. Background queries (e.g. cerebrum nudges) can still
+    // be in flight when the test body returns, and any unhandled
+    // route.fetch against a closed page surfaces as a test failure —
+    // unrouteAll drains them before teardown.
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  });
+
+  test('navigating to /media renders NotInstalledPage, not 404', async ({ page }) => {
+    await page.goto('/media');
+    // NotInstalledPage exposes a "module not installed" heading; the 404
+    // page exposes a "not found"/"404" heading. Asserting visibility on
+    // one AND zero count on the other keeps the boundary explicit — a
+    // regression that sends the user to either of the wrong pages
+    // surfaces immediately.
+    await expect(page.getByRole('heading', { name: /module not installed/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /not found|404/i })).toHaveCount(0);
+  });
+
+  test('navigating to /finance still mounts the installed module', async ({ page }) => {
+    // Sanity check — proves the finance-only shell is not just broken;
+    // installed modules continue to mount and the nav is healthy.
+    await page.goto('/finance');
+    await expect(page).toHaveURL(/\/finance/);
+    await expect(page.getByRole('button', { name: 'Finance' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+});

--- a/apps/pops-shell/e2e/pops-apps-finance-only-search.spec.ts
+++ b/apps/pops-shell/e2e/pops-apps-finance-only-search.spec.ts
@@ -44,6 +44,7 @@ test.describe('Shell — search narrows to installed modules (finance-only build
     await searchResponse;
 
     const panel = page.getByTestId('search-results-panel');
+    await expect(panel).toBeVisible({ timeout: 10_000 });
     await expect(panel.getByTestId('section-movies')).toHaveCount(0);
     await expect(panel.getByTestId('section-tv-shows')).toHaveCount(0);
   });

--- a/apps/pops-shell/e2e/pops-apps-finance-only-search.spec.ts
+++ b/apps/pops-shell/e2e/pops-apps-finance-only-search.spec.ts
@@ -2,34 +2,21 @@
  * Install-set switching E2E — search results narrow with the install set
  * (PRD-101 US-11 follow-up, issue #2595).
  *
- * Finance-only half of the matched pair. The companion all-modules
- * assertion lives in `pops-apps-all-modules-search.spec.ts`; together they
- * satisfy the deferred acceptance criterion from
- * `docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md`:
- *
- *   With every module installed, searching for a known media title
- *   returns a media result; with `POPS_APPS=finance` the same query
- *   returns zero media results.
- *
- * "The Matrix" is a seeded movie title (see `apps/pops-api/src/db/seeder.ts`).
- * Filing the search through `useRealApi()` exercises the real adapter
- * pipeline against the seeded e2e SQLite environment; the frontend's
- * `isInstalledModule` filter then drops the media section because this
- * shell build was launched with `POPS_APPS=finance,core` and the
- * registry snapshot it consumed therefore omits `media` from `MODULES`.
+ * A regression here means the `isInstalledModule` filter has broken or
+ * the finance-only shell is consuming the wrong registry snapshot —
+ * either way, the install-set boundary leaks media results to operators
+ * who excluded the media module.
  */
 import { expect, test } from '@playwright/test';
 
 import { useRealApi } from './helpers/use-real-api';
 
-const QUERY = 'Matrix';
+const query = 'Matrix';
 
 test.describe('Shell — search narrows to installed modules (finance-only build)', () => {
   test.beforeEach(async ({ page }) => {
     await useRealApi(page);
     await page.goto('/');
-    // With media excluded, the shell still routes `/` → `/finance` via
-    // `IndexRedirect`. Wait for the search input mount before typing.
     await expect(page).toHaveURL(/\/finance/);
     await expect(page.getByRole('textbox', { name: 'Search POPS' })).toBeVisible();
   });
@@ -43,23 +30,20 @@ test.describe('Shell — search narrows to installed modules (finance-only build
   }) => {
     const searchBox = page.getByRole('textbox', { name: 'Search POPS' });
 
+    // The search query is wired through tRPC `core.search.query`; wait
+    // for that response so the absence assertion runs against settled
+    // state rather than a pre-render race.
+    const searchResponse = page.waitForResponse(
+      (response) => response.url().includes('core.search.query') && response.status() === 200,
+      { timeout: 10_000 }
+    );
+
     await searchBox.click();
-    await searchBox.fill(QUERY);
+    await searchBox.fill(query);
 
-    // The panel may render — wait for either the panel to appear (and
-    // show "no results") or stay hidden if no sections at all. Either way,
-    // the `movies` section must NOT be visible: that's the install-set
-    // boundary assertion. `count()` on a non-rendered locator returns 0,
-    // so this single check covers both render outcomes.
+    await searchResponse;
+
     const panel = page.getByTestId('search-results-panel');
-
-    // Give the backend a moment to respond and the frontend's
-    // `isInstalledModule` filter to apply. We're asserting an absence, so
-    // we wait for the panel to settle rather than for a specific section
-    // to appear. A short timeout is sufficient because the e2e SQLite
-    // env is local and the search adapter is fast.
-    await page.waitForTimeout(1500);
-
     await expect(panel.getByTestId('section-movies')).toHaveCount(0);
     await expect(panel.getByTestId('section-tv-shows')).toHaveCount(0);
   });

--- a/apps/pops-shell/e2e/pops-apps-finance-only-search.spec.ts
+++ b/apps/pops-shell/e2e/pops-apps-finance-only-search.spec.ts
@@ -9,20 +9,17 @@
  */
 import { expect, test } from '@playwright/test';
 
-import { useRealApi } from './helpers/use-real-api';
+import { bootShellAndAwaitSearch, unrouteAll } from './helpers/shell-search';
 
 const query = 'Matrix';
 
 test.describe('Shell — search narrows to installed modules (finance-only build)', () => {
   test.beforeEach(async ({ page }) => {
-    await useRealApi(page);
-    await page.goto('/');
-    await expect(page).toHaveURL(/\/finance/);
-    await expect(page.getByRole('textbox', { name: 'Search POPS' })).toBeVisible();
+    await bootShellAndAwaitSearch(page);
   });
 
   test.afterEach(async ({ page }) => {
-    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    await unrouteAll(page);
   });
 
   test('searching "Matrix" returns no movies results when media is uninstalled', async ({

--- a/apps/pops-shell/e2e/pops-apps-finance-only-search.spec.ts
+++ b/apps/pops-shell/e2e/pops-apps-finance-only-search.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Install-set switching E2E — search results narrow with the install set
+ * (PRD-101 US-11 follow-up, issue #2595).
+ *
+ * Finance-only half of the matched pair. The companion all-modules
+ * assertion lives in `pops-apps-all-modules-search.spec.ts`; together they
+ * satisfy the deferred acceptance criterion from
+ * `docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md`:
+ *
+ *   With every module installed, searching for a known media title
+ *   returns a media result; with `POPS_APPS=finance` the same query
+ *   returns zero media results.
+ *
+ * "The Matrix" is a seeded movie title (see `apps/pops-api/src/db/seeder.ts`).
+ * Filing the search through `useRealApi()` exercises the real adapter
+ * pipeline against the seeded e2e SQLite environment; the frontend's
+ * `isInstalledModule` filter then drops the media section because this
+ * shell build was launched with `POPS_APPS=finance,core` and the
+ * registry snapshot it consumed therefore omits `media` from `MODULES`.
+ */
+import { expect, test } from '@playwright/test';
+
+import { useRealApi } from './helpers/use-real-api';
+
+const QUERY = 'Matrix';
+
+test.describe('Shell — search narrows to installed modules (finance-only build)', () => {
+  test.beforeEach(async ({ page }) => {
+    await useRealApi(page);
+    await page.goto('/');
+    // With media excluded, the shell still routes `/` → `/finance` via
+    // `IndexRedirect`. Wait for the search input mount before typing.
+    await expect(page).toHaveURL(/\/finance/);
+    await expect(page.getByRole('textbox', { name: 'Search POPS' })).toBeVisible();
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  });
+
+  test('searching "Matrix" returns no movies results when media is uninstalled', async ({
+    page,
+  }) => {
+    const searchBox = page.getByRole('textbox', { name: 'Search POPS' });
+
+    await searchBox.click();
+    await searchBox.fill(QUERY);
+
+    // The panel may render — wait for either the panel to appear (and
+    // show "no results") or stay hidden if no sections at all. Either way,
+    // the `movies` section must NOT be visible: that's the install-set
+    // boundary assertion. `count()` on a non-rendered locator returns 0,
+    // so this single check covers both render outcomes.
+    const panel = page.getByTestId('search-results-panel');
+
+    // Give the backend a moment to respond and the frontend's
+    // `isInstalledModule` filter to apply. We're asserting an absence, so
+    // we wait for the panel to settle rather than for a specific section
+    // to appear. A short timeout is sufficient because the e2e SQLite
+    // env is local and the search adapter is fast.
+    await page.waitForTimeout(1500);
+
+    await expect(panel.getByTestId('section-movies')).toHaveCount(0);
+    await expect(panel.getByTestId('section-tv-shows')).toHaveCount(0);
+  });
+});

--- a/apps/pops-shell/package.json
+++ b/apps/pops-shell/package.json
@@ -49,6 +49,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "jsdom": "^29.1.1",
+    "tsx": "^4.19.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.11",
     "vitest": "^4.1.5"

--- a/apps/pops-shell/playwright.config.ts
+++ b/apps/pops-shell/playwright.config.ts
@@ -64,10 +64,10 @@ export default defineConfig({
     {
       // Default project — runs every spec EXCEPT the finance-only suite,
       // which requires a shell built with `POPS_APPS=finance,core`.
+      // baseURL is inherited from the global `use` block above.
       name: 'chromium-all-modules',
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: `http://localhost:${ALL_MODULES_PORT}`,
       },
       testIgnore: ['**/pops-apps-finance-only-*.spec.ts'],
     },

--- a/apps/pops-shell/playwright.config.ts
+++ b/apps/pops-shell/playwright.config.ts
@@ -1,7 +1,12 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig, devices } from '@playwright/test';
 
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
 /**
- * Playwright configuration for POPS Shell E2E tests
+ * Playwright configuration for POPS Shell E2E tests.
  *
  * Two modes:
  *   Mocked tests (transactions.spec.ts, import-wizard.spec.ts):
@@ -11,7 +16,31 @@ import { defineConfig, devices } from '@playwright/test';
  *   Integration tests (*-integration.spec.ts):
  *     Real API calls route through Vite proxy → backend API → 'e2e' named environment.
  *     globalSetup creates the seeded env before tests; globalTeardown deletes it after.
+ *
+ * Install-set switching (PRD-101 US-11 follow-up, issue #2595):
+ *
+ *   The shell consumes `MODULES` from `@pops/module-registry` at build
+ *   time. To exercise the install-set boundary across two distinct shell
+ *   builds in a single `pnpm test:e2e` run, this config defines two
+ *   Playwright projects, each backed by its own `webServer`:
+ *
+ *     • `chromium-all-modules` (port 5567) — boots the shell against the
+ *       canonical workspace registry (every known module installed).
+ *     • `chromium-finance-only` (port 5569) — boots the shell against a
+ *       pre-built registry snapshot generated with `POPS_APPS=finance,core`.
+ *       The snapshot lives under `.e2e/registry/finance-only.js`; the
+ *       Vite config picks it up via `POPS_REGISTRY_SNAPSHOT` and aliases
+ *       `@pops/module-registry` to it for that server only.
+ *
+ *   Both servers share the same pops-api (port 3000) — the API does not
+ *   participate in this switching matrix.
  */
+const FINANCE_ONLY_SNAPSHOT = path.resolve(HERE, '.e2e/registry/finance-only.js');
+const ALL_MODULES_PORT = 5567;
+const FINANCE_ONLY_PORT = 5569;
+
+const SHELL_E2E_ENV = { VITE_E2E: 'true' } as const;
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -24,31 +53,64 @@ export default defineConfig({
   globalTeardown: './e2e/global-teardown.ts',
 
   use: {
-    // E2E server runs on 5567 (separate from dev server on 5566) so VITE_E2E=true
-    // is always active and ReactQueryDevtools never renders.
-    baseURL: 'http://localhost:5567',
+    // Default baseURL targets the all-modules shell. Each project overrides
+    // it where the test must run against a different install set.
+    baseURL: `http://localhost:${ALL_MODULES_PORT}`,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
 
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      // Default project — runs every spec EXCEPT the finance-only suite,
+      // which requires a shell built with `POPS_APPS=finance,core`.
+      name: 'chromium-all-modules',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: `http://localhost:${ALL_MODULES_PORT}`,
+      },
+      testIgnore: ['**/pops-apps-finance-only-*.spec.ts'],
+    },
+    {
+      // Restricted install set — only the specs that assert the
+      // POPS_APPS=finance,core boundary run here. Keeping them isolated to
+      // a dedicated project avoids paying the snapshot-build cost on every
+      // unrelated spec.
+      name: 'chromium-finance-only',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: `http://localhost:${FINANCE_ONLY_PORT}`,
+      },
+      testMatch: ['**/pops-apps-finance-only-*.spec.ts'],
     },
   ],
 
   webServer: [
-    // Vite dev server (Shell) — runs on port 5567 (separate from dev server on 5566)
-    // so VITE_E2E=true always takes effect regardless of whether a dev server is running.
-    // ReactQueryDevtools SVG logo renders at r=316.5px and intercepts pointer events,
-    // so it must be disabled in E2E via VITE_E2E=true.
+    // All-modules shell — canonical workspace registry, no overrides.
+    // ReactQueryDevtools SVG logo renders at r=316.5px and intercepts
+    // pointer events, so it must be disabled in E2E via VITE_E2E=true.
     {
-      command: 'pnpm dev --port 5567',
-      url: 'http://localhost:5567',
+      command: `pnpm dev --port ${ALL_MODULES_PORT}`,
+      url: `http://localhost:${ALL_MODULES_PORT}`,
       reuseExistingServer: !process.env.CI,
       timeout: 120000,
-      env: { VITE_E2E: 'true' },
+      env: { ...SHELL_E2E_ENV },
+    },
+    // Finance-only shell — registry snapshot is built first, then Vite
+    // boots with `POPS_REGISTRY_SNAPSHOT` pointing at the snapshot file.
+    // Sequencing within this single shell command is critical: the
+    // snapshot must exist on disk before Vite resolves the alias, so the
+    // build step runs synchronously before `pnpm dev` is spawned.
+    {
+      command: `pnpm tsx scripts/build-registry-snapshot.ts ${FINANCE_ONLY_SNAPSHOT} && pnpm dev --port ${FINANCE_ONLY_PORT}`,
+      url: `http://localhost:${FINANCE_ONLY_PORT}`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 180000,
+      env: {
+        ...SHELL_E2E_ENV,
+        POPS_APPS: 'finance,core',
+        POPS_REGISTRY_SNAPSHOT: FINANCE_ONLY_SNAPSHOT,
+      },
     },
     // Finance API — required for integration tests; mocked tests don't use it but starting
     // it is harmless and ensures the proxy target is always available.

--- a/apps/pops-shell/scripts/build-registry-snapshot.ts
+++ b/apps/pops-shell/scripts/build-registry-snapshot.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env tsx
+/**
+ * Build a runtime-only registry snapshot for E2E install-set switching
+ * (PRD-101 US-11 follow-up, issue #2595).
+ *
+ * The canonical `pnpm registry:build` emits a TypeScript source file at
+ * `packages/module-registry/src/generated.ts` that requires `tsc` to
+ * compile. That pipeline is well suited to the single-build, committed-
+ * output workflow it was designed for, but the Playwright harness needs
+ * to spin up two shell builds in the same `pnpm test:e2e` run with
+ * different `POPS_APPS` values without mutating the committed registry.
+ *
+ * This script bypasses the `generated.ts → tsc` path entirely. It uses
+ * `buildRegistrySource()`'s pure pipeline pieces (`MANIFEST_SOURCES`,
+ * `KNOWN_MODULE_IDS`, `ALWAYS_INSTALLED_IDS`, `resolveInstalledIds`,
+ * `validateManifests`, `project`) to compute the same `MODULES`
+ * projection the canonical build would produce, then emits a single
+ * plain-JS module file ready to be `resolve.alias`-pointed at by Vite.
+ *
+ * Output shape mirrors `@pops/module-registry`'s public surface that
+ * the shell actually imports (`KNOWN_MODULES`, `MODULES`, `findModule`,
+ * `isModuleId`). Settings sub-exports are intentionally not emitted —
+ * the shell does not consume them at runtime; only the API does, and
+ * the API does not switch install sets per Playwright project.
+ *
+ * Usage:
+ *   tsx scripts/build-registry-snapshot.ts <output-file>
+ *
+ * The script reads `POPS_APPS` and `POPS_OVERLAYS` from `process.env`,
+ * matching the build-time contract documented in PRD-100.
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import {
+  ALWAYS_INSTALLED_IDS,
+  KNOWN_MODULE_IDS,
+  MANIFEST_SOURCES,
+} from '../../../packages/module-registry/scripts/known-modules.ts';
+import {
+  project,
+  resolveInstalledIds,
+  validateManifests,
+  type SerialisableModule,
+} from '../../../packages/module-registry/scripts/lib.ts';
+
+function renderSnapshot(
+  projected: readonly SerialisableModule[],
+  knownIds: readonly string[]
+): string {
+  const knownIdsLiteral = JSON.stringify(knownIds);
+  const modulesLiteral = JSON.stringify(projected, null, 2);
+  return `/**
+ * GENERATED — E2E install-set snapshot for @pops/module-registry.
+ *
+ * Emitted by apps/pops-shell/scripts/build-registry-snapshot.ts. Do not
+ * commit. The Playwright harness rebuilds this file before each shell
+ * server boots so distinct install sets can coexist in one test run.
+ */
+export const KNOWN_MODULES = Object.freeze(${knownIdsLiteral});
+
+export const MODULES = Object.freeze(${modulesLiteral});
+
+export function findModule(id) {
+  return MODULES.find((m) => m.id === id);
+}
+
+export function isModuleId(value) {
+  return MODULES.some((m) => m.id === value);
+}
+`;
+}
+
+async function main(): Promise<void> {
+  const outputArg = process.argv[2];
+  if (outputArg === undefined || outputArg.length === 0) {
+    process.stderr.write('build-registry-snapshot: missing output path argument\n');
+    process.exit(1);
+  }
+  const outputPath = resolve(outputArg);
+
+  validateManifests(MANIFEST_SOURCES);
+  const installed = new Set(
+    resolveInstalledIds(KNOWN_MODULE_IDS, process.env, ALWAYS_INSTALLED_IDS)
+  );
+  const selected = MANIFEST_SOURCES.filter((m) => installed.has(m.id));
+  const sorted = selected.toSorted((a, b) => a.id.localeCompare(b.id, 'en'));
+  const projected = sorted.map(project);
+
+  // Emit `KNOWN_MODULES` as the FULL known id list (every module the
+  // monorepo can build) rather than just the install set. The shell's
+  // catch-all route relies on this distinction to render
+  // `NotInstalledPage` for modules that are known-but-excluded by
+  // `POPS_APPS`, separate from genuine 404s. The canonical
+  // `generated.ts` happens to conflate the two because its default
+  // install set is "everything"; this snapshot reflects the router's
+  // intended semantic for restricted install sets.
+  const knownIdsSorted = [...KNOWN_MODULE_IDS].toSorted((a, b) => a.localeCompare(b, 'en'));
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, renderSnapshot(projected, knownIdsSorted), 'utf8');
+  process.stdout.write(
+    `build-registry-snapshot: wrote ${projected.length} module${
+      projected.length === 1 ? '' : 's'
+    } → ${outputPath} (POPS_APPS=${process.env.POPS_APPS ?? '<unset>'})\n`
+  );
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`build-registry-snapshot failed: ${message}\n`);
+  process.exit(1);
+});

--- a/apps/pops-shell/vite.config.ts
+++ b/apps/pops-shell/vite.config.ts
@@ -5,7 +5,38 @@ import react from '@vitejs/plugin-react';
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 
+/**
+ * Optional override that replaces the canonical `@pops/module-registry`
+ * entrypoint with a pre-built snapshot file for one Playwright project's
+ * shell server (PRD-101 US-11 follow-up, issue #2595). The snapshot is
+ * emitted by `scripts/build-registry-snapshot.ts` and contains the same
+ * runtime surface (`KNOWN_MODULES`, `MODULES`, `findModule`, `isModuleId`)
+ * computed against a project-specific `POPS_APPS` value. Production and
+ * default dev builds leave the variable unset and resolve the workspace
+ * package as usual.
+ */
+const registrySnapshot = process.env.POPS_REGISTRY_SNAPSHOT;
+
+const usingSnapshot = registrySnapshot !== undefined && registrySnapshot.length > 0;
+
+const registryAlias = usingSnapshot
+  ? { '@pops/module-registry': path.resolve(registrySnapshot) }
+  : {};
+
+/**
+ * Each install-set variant needs its own Vite dep-bundle cache so the
+ * pre-bundled `@pops/module-registry` (a workspace dep, eligible for
+ * `optimizeDeps`) from one server can't be reused by a sibling server
+ * pointing at a different snapshot. Default Vite cacheDir is shared
+ * across `pnpm test:e2e` runs, which is fine for production but
+ * dangerous for two coexisting projects.
+ */
+const cacheDir = usingSnapshot
+  ? path.resolve(__dirname, 'node_modules/.vite-finance-only')
+  : undefined;
+
 export default defineConfig({
+  cacheDir,
   define: {
     __BUILD_VERSION__: JSON.stringify(
       process.env.BUILD_VERSION && process.env.BUILD_VERSION !== 'dev'
@@ -23,6 +54,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      ...registryAlias,
     },
   },
   server: {

--- a/apps/pops-shell/vite.config.ts
+++ b/apps/pops-shell/vite.config.ts
@@ -6,14 +6,10 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 /**
- * Optional override that replaces the canonical `@pops/module-registry`
- * entrypoint with a pre-built snapshot file for one Playwright project's
- * shell server (PRD-101 US-11 follow-up, issue #2595). The snapshot is
- * emitted by `scripts/build-registry-snapshot.ts` and contains the same
- * runtime surface (`KNOWN_MODULES`, `MODULES`, `findModule`, `isModuleId`)
- * computed against a project-specific `POPS_APPS` value. Production and
- * default dev builds leave the variable unset and resolve the workspace
- * package as usual.
+ * PRD-101 US-11 follow-up (issue #2595): when `POPS_REGISTRY_SNAPSHOT`
+ * is set, alias `@pops/module-registry` to the snapshot file so the
+ * shell consumes a build-specific install set. Unset in production and
+ * default dev builds.
  */
 const registrySnapshot = process.env.POPS_REGISTRY_SNAPSHOT;
 
@@ -24,15 +20,17 @@ const registryAlias = usingSnapshot
   : {};
 
 /**
- * Each install-set variant needs its own Vite dep-bundle cache so the
- * pre-bundled `@pops/module-registry` (a workspace dep, eligible for
- * `optimizeDeps`) from one server can't be reused by a sibling server
- * pointing at a different snapshot. Default Vite cacheDir is shared
- * across `pnpm test:e2e` runs, which is fine for production but
- * dangerous for two coexisting projects.
+ * Per-variant Vite dep-bundle cache. Each `POPS_REGISTRY_SNAPSHOT`
+ * value gets its own `node_modules/.vite-<slug>` directory derived from
+ * the snapshot file's basename so concurrent shell servers built from
+ * different snapshots never share a pre-bundled `@pops/module-registry`.
  */
-const cacheDir = usingSnapshot
-  ? path.resolve(__dirname, 'node_modules/.vite-finance-only')
+const snapshotSlug = usingSnapshot
+  ? path.basename(registrySnapshot, path.extname(registrySnapshot)).replace(/[^a-zA-Z0-9_-]+/g, '-')
+  : undefined;
+
+const cacheDir = snapshotSlug
+  ? path.resolve(__dirname, `node_modules/.vite-${snapshotSlug}`)
   : undefined;
 
 export default defineConfig({

--- a/docs/themes/01-foundation/prds/101-plugin-contract/README.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/README.md
@@ -88,19 +88,19 @@ Each existing hand-rolled registry collapses into a registry consumer. The shape
 
 ## User Stories
 
-| #   | Story                                                                     | Summary                                                                                                                        | Parallelisable   |
-| --- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
-| 01  | [us-01-extend-manifest](us-01-extend-manifest.md)                         | Extend `ModuleManifest` with `capabilities`, `features`, `search`, `uriHandler`, `aiTools`, `migrations` slots                 | Yes              |
-| 02  | [us-02-build-time-registry](us-02-build-time-registry.md)                 | `@pops/module-registry` package generated from manifests + env contract; CI guard                                              | Blocked by 01    |
-| 03  | [us-03-routing-from-registry](us-03-routing-from-registry.md)             | Shell routing and API composition read from `MODULES`; remove hard-coded import lists. Done.                                   | Blocked by 02    |
-| 04  | [us-04-settings-from-registry](us-04-settings-from-registry.md)           | Settings page consumes `MODULES`; delete `settingsRegistry.register`. Done.                                                    | Blocked by 02    |
-| 05  | [us-05-features-from-registry](us-05-features-from-registry.md)           | Features admin consumes `MODULES`; delete `featuresRegistry.register`                                                          | Blocked by 02    |
-| 06  | [us-06-search-from-registry](us-06-search-from-registry.md)               | Search engine consumes `MODULES`; delete `registerSearchAdapter` side-effect imports. Closes #2522 (search half). Done.        | Blocked by 02    |
-| 07  | [us-07-overlay-mount-from-registry](us-07-overlay-mount-from-registry.md) | Shell mounts overlays into `chromeSlot` declared in manifest; remove hard-wired `<ChatOverlay />`. Done.                       | Blocked by 02    |
-| 08  | [us-08-uri-resolver](us-08-uri-resolver.md)                               | Implement ADR-012 resolver as a registry consumer; absent-module URIs return placeholder. Closes #2522 (URI half).             | Blocked by 02    |
-| 09  | [us-09-migration-runner](us-09-migration-runner.md)                       | Runner consumes per-module migration declarations; absent modules skip. Closes #2523.                                          | Blocked by 02    |
-| 10  | [us-10-ai-tool-aggregation](us-10-ai-tool-aggregation.md)                 | Ego and MCP expose a single merged AI tool surface based on the installed module set. Done.                                    | Blocked by 02    |
-| 11  | [us-11-test-matrix](us-11-test-matrix.md)                                 | Contract violations fail at build; install-set matrix exercised in CI. Partial — install-set switching across builds deferred. | Blocked by 03–10 |
+| #   | Story                                                                     | Summary                                                                                                                             | Parallelisable   |
+| --- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 01  | [us-01-extend-manifest](us-01-extend-manifest.md)                         | Extend `ModuleManifest` with `capabilities`, `features`, `search`, `uriHandler`, `aiTools`, `migrations` slots                      | Yes              |
+| 02  | [us-02-build-time-registry](us-02-build-time-registry.md)                 | `@pops/module-registry` package generated from manifests + env contract; CI guard                                                   | Blocked by 01    |
+| 03  | [us-03-routing-from-registry](us-03-routing-from-registry.md)             | Shell routing and API composition read from `MODULES`; remove hard-coded import lists. Done.                                        | Blocked by 02    |
+| 04  | [us-04-settings-from-registry](us-04-settings-from-registry.md)           | Settings page consumes `MODULES`; delete `settingsRegistry.register`. Done.                                                         | Blocked by 02    |
+| 05  | [us-05-features-from-registry](us-05-features-from-registry.md)           | Features admin consumes `MODULES`; delete `featuresRegistry.register`                                                               | Blocked by 02    |
+| 06  | [us-06-search-from-registry](us-06-search-from-registry.md)               | Search engine consumes `MODULES`; delete `registerSearchAdapter` side-effect imports. Closes #2522 (search half). Done.             | Blocked by 02    |
+| 07  | [us-07-overlay-mount-from-registry](us-07-overlay-mount-from-registry.md) | Shell mounts overlays into `chromeSlot` declared in manifest; remove hard-wired `<ChatOverlay />`. Done.                            | Blocked by 02    |
+| 08  | [us-08-uri-resolver](us-08-uri-resolver.md)                               | Implement ADR-012 resolver as a registry consumer; absent-module URIs return placeholder. Closes #2522 (URI half).                  | Blocked by 02    |
+| 09  | [us-09-migration-runner](us-09-migration-runner.md)                       | Runner consumes per-module migration declarations; absent modules skip. Closes #2523.                                               | Blocked by 02    |
+| 10  | [us-10-ai-tool-aggregation](us-10-ai-tool-aggregation.md)                 | Ego and MCP expose a single merged AI tool surface based on the installed module set. Done.                                         | Blocked by 02    |
+| 11  | [us-11-test-matrix](us-11-test-matrix.md)                                 | Contract violations fail at build; install-set matrix exercised in CI; install-set switching across two shell builds covered. Done. | Blocked by 03–10 |
 
 ## Out of Scope
 

--- a/docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md
@@ -23,7 +23,7 @@ As a platform maintainer, I want CI to exercise the full contract under represen
   - [x] Direct navigation to an unknown URL renders the 404 page, distinct from the "module not installed" page.
   - [x] Direct navigation to a known-but-not-installed module id renders the "module not installed" page, distinct from the 404 page.
   - [x] Direct navigation to an installed module's root renders that module.
-  - [x] Full install-set switching across two shell builds: the Playwright config defines two projects, each with its own shell webServer — one against the canonical all-modules registry, the other against a per-run snapshot built with `POPS_APPS=finance,core` and aliased into Vite. The finance-only build asserts `/media` renders `NotInstalledPage`; the same search query against both builds yields a media result for the all-modules build and zero media results for the finance-only build.
+  - [x] Shell can be booted with different install sets in a single E2E run, and routes for uninstalled modules render a not-installed state distinct from 404. The same search query yields a media result against an all-modules build and zero media results against a finance-only build.
 - [x] CI fails when the published module registry source diverges from the output of the registry build (guard shipped with PRD-101 US-02).
 
 ## Notes

--- a/docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md
+++ b/docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md
@@ -1,7 +1,7 @@
 # US-11: Contract test matrix
 
 > PRD: [Plugin Contract](README.md)
-> Status: Partial — full install-set switching across separate shell builds deferred (see unchecked criterion below).
+> Status: Done
 
 ## Description
 
@@ -23,7 +23,7 @@ As a platform maintainer, I want CI to exercise the full contract under represen
   - [x] Direct navigation to an unknown URL renders the 404 page, distinct from the "module not installed" page.
   - [x] Direct navigation to a known-but-not-installed module id renders the "module not installed" page, distinct from the 404 page.
   - [x] Direct navigation to an installed module's root renders that module.
-  - [ ] Full install-set switching across two shell builds (boot one build with a restricted install set, navigate to an excluded module, expect "module not installed"; boot another build with the full install set, search the excluded module, expect results) is tracked as a follow-up — the install set is baked at registry build time, so two-suite switching needs harness changes.
+  - [x] Full install-set switching across two shell builds: the Playwright config defines two projects, each with its own shell webServer — one against the canonical all-modules registry, the other against a per-run snapshot built with `POPS_APPS=finance,core` and aliased into Vite. The finance-only build asserts `/media` renders `NotInstalledPage`; the same search query against both builds yields a media result for the all-modules build and zero media results for the finance-only build.
 - [x] CI fails when the published module registry source diverges from the output of the registry build (guard shipped with PRD-101 US-02).
 
 ## Notes

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@1.8.0)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

- Adds a second Playwright project (`chromium-finance-only`) that boots the shell with `POPS_APPS=finance,core` so the deferred PRD-101 US-11 acceptance criterion is exercised end-to-end in a single `pnpm test:e2e` run.
- New `scripts/build-registry-snapshot.ts` emits a runtime-only `@pops/module-registry` snapshot per install set; the `chromium-finance-only` webServer rebuilds it before Vite starts and `vite.config.ts` aliases the package to it via `POPS_REGISTRY_SNAPSHOT`.
- Three new specs under `apps/pops-shell/e2e/`:
  - `pops-apps-finance-only-not-installed.spec.ts` — `/media` renders `NotInstalledPage` (distinct from 404) when media is excluded.
  - `pops-apps-finance-only-search.spec.ts` — searching "Matrix" surfaces zero movies results.
  - `pops-apps-all-modules-search.spec.ts` — same query against the all-modules build surfaces a movies hit. Same query, two builds, two outcomes.

## Why a snapshot, not a full registry rebuild

The canonical `pnpm registry:build` emits `packages/module-registry/src/generated.ts` and relies on `tsc` to compile to `dist/` — single-build, committed-output workflow. Two Playwright projects running in parallel against the same workspace can't share that pipeline without races, and serializing them would tank the test wall-clock. The snapshot script reuses `buildRegistrySource`'s pure pieces (`MANIFEST_SOURCES`, `resolveInstalledIds`, `validateManifests`, `project`) to compute the same projection and emit a plain-JS module containing just the runtime surface the shell consumes (`KNOWN_MODULES`, `MODULES`, `findModule`, `isModuleId`). Vite `resolve.alias` swaps in the snapshot for one project's server only.

The snapshot emits `KNOWN_MODULES` as the FULL known id list (not the install set). This matches the router's documented intent in `apps/pops-shell/src/app/router.tsx` — the catch-all needs to distinguish "module excluded by `POPS_APPS`" from "genuinely unknown path". The canonical build's current output happens to equate the two because its default install set is "everything"; the snapshot reflects the router's intended semantic for restricted install sets without touching the canonical pipeline.

## Test plan

- [x] `pnpm format:check` clean
- [x] `pnpm lint` — 0 errors (160 pre-existing warnings)
- [x] `pnpm typecheck` clean across all 20 workspace projects
- [x] `pnpm --filter @pops/shell test` — 284 passed
- [x] `pnpm --filter @pops/module-registry test` — 57 passed
- [x] `cd packages/module-registry && pnpm build` clean
- [x] `pnpm test:e2e --project chromium-finance-only` — 3 passed
- [x] `pnpm test:e2e --project chromium-all-modules --grep all-modules-search` — 1 passed
- [x] Both projects running together via `--grep pops-apps` — 4/4 passed

## Notes

- Adds `tsx` as a `devDependency` on `@pops/shell` (already hoisted in the lockfile; the explicit declaration unblocks `pnpm tsx ...` from the Playwright webServer command in CI).
- Updates `.gitignore` to exclude `apps/pops-shell/.e2e/` — the snapshot output is regenerated on every Playwright run and never committed.
- Adds `.github/workflows/fe-test-e2e.yml` comment naming both projects; `pnpm test:e2e` already runs every project in `playwright.config.ts`.
- Marks US-11 acceptance criterion as Done in `docs/themes/01-foundation/prds/101-plugin-contract/us-11-test-matrix.md` and bumps the PRD README status row.

Closes #2595.