### PR TITLE
feat(cerebrum): global capture hotkey + modal (PRD-081 US-09)

### DIFF
--- a/apps/pops-shell/src/app/capture/CaptureHotkeyHost.tsx
+++ b/apps/pops-shell/src/app/capture/CaptureHotkeyHost.tsx
@@ -1,0 +1,24 @@
+import { trpc } from '@/lib/trpc';
+/**
+ * CaptureHotkeyHost — mounts at the shell root (PRD-081 US-09). Reads the
+ * configured capture hotkey, listens at the window level, and opens the
+ * CaptureModal on press.
+ */
+import { useCallback, useState } from 'react';
+
+import { CaptureModal } from './CaptureModal';
+import { useCaptureHotkey } from './useCaptureHotkey';
+
+const SETTING_KEY = 'cerebrum.captureHotkey' as const;
+const DEFAULT_HOTKEY = 'c';
+
+export function CaptureHotkeyHost() {
+  const [open, setOpen] = useState(false);
+  const settingQuery = trpc.core.settings.get.useQuery({ key: SETTING_KEY });
+  const hotkey = (settingQuery.data?.data?.value ?? DEFAULT_HOTKEY).trim();
+
+  const onTrigger = useCallback(() => setOpen(true), []);
+  useCaptureHotkey({ key: hotkey, enabled: !open, onTrigger });
+
+  return <CaptureModal open={open} onOpenChange={setOpen} />;
+}

--- a/apps/pops-shell/src/app/capture/CaptureHotkeyHost.tsx
+++ b/apps/pops-shell/src/app/capture/CaptureHotkeyHost.tsx
@@ -1,24 +1,19 @@
 import { trpc } from '@/lib/trpc';
-/**
- * CaptureHotkeyHost — mounts at the shell root (PRD-081 US-09). Reads the
- * configured capture hotkey, listens at the window level, and opens the
- * CaptureModal on press.
- */
 import { useCallback, useState } from 'react';
 
 import { CaptureModal } from './CaptureModal';
 import { useCaptureHotkey } from './useCaptureHotkey';
 
-const SETTING_KEY = 'cerebrum.captureHotkey' as const;
-const DEFAULT_HOTKEY = 'c';
+const settingKey = 'cerebrum.captureHotkey' as const;
+const defaultHotkey = 'c';
 
 export function CaptureHotkeyHost() {
   const [open, setOpen] = useState(false);
-  const settingQuery = trpc.core.settings.get.useQuery({ key: SETTING_KEY });
+  const settingQuery = trpc.core.settings.get.useQuery({ key: settingKey });
   // Wait for the setting to resolve before binding — otherwise a user who
   // configured an empty hotkey would briefly trigger on the default 'c'.
   const hotkey = settingQuery.isSuccess
-    ? (settingQuery.data?.data?.value ?? DEFAULT_HOTKEY).trim()
+    ? (settingQuery.data?.data?.value ?? defaultHotkey).trim()
     : '';
 
   const onTrigger = useCallback(() => setOpen(true), []);

--- a/apps/pops-shell/src/app/capture/CaptureHotkeyHost.tsx
+++ b/apps/pops-shell/src/app/capture/CaptureHotkeyHost.tsx
@@ -15,10 +15,14 @@ const DEFAULT_HOTKEY = 'c';
 export function CaptureHotkeyHost() {
   const [open, setOpen] = useState(false);
   const settingQuery = trpc.core.settings.get.useQuery({ key: SETTING_KEY });
-  const hotkey = (settingQuery.data?.data?.value ?? DEFAULT_HOTKEY).trim();
+  // Wait for the setting to resolve before binding — otherwise a user who
+  // configured an empty hotkey would briefly trigger on the default 'c'.
+  const hotkey = settingQuery.isSuccess
+    ? (settingQuery.data?.data?.value ?? DEFAULT_HOTKEY).trim()
+    : '';
 
   const onTrigger = useCallback(() => setOpen(true), []);
-  useCaptureHotkey({ key: hotkey, enabled: !open, onTrigger });
+  useCaptureHotkey({ key: hotkey, enabled: !open && hotkey.length > 0, onTrigger });
 
   return <CaptureModal open={open} onOpenChange={setOpen} />;
 }

--- a/apps/pops-shell/src/app/capture/CaptureModal.tsx
+++ b/apps/pops-shell/src/app/capture/CaptureModal.tsx
@@ -1,0 +1,57 @@
+/**
+ * CaptureModal — global capture surface rendered as a Dialog (PRD-081 US-09).
+ * Renders the same IngestForm component used by the /cerebrum route, so the
+ * modal and the page share keyboard handling, scope autocomplete, Advanced
+ * disclosure, and bulk-paste behaviour.
+ */
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { IngestForm, useIngestPageModel } from '@pops/app-cerebrum';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@pops/ui';
+
+interface CaptureModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CaptureModal({ open, onOpenChange }: CaptureModalProps) {
+  const { t } = useTranslation('cerebrum');
+  const model = useIngestPageModel();
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      // Backdrop close (next=false from the radix overlay) is only allowed when
+      // the body is empty — protects against losing in-progress text.
+      if (!next && model.form.body.length > 0 && !model.bulkResults && !model.submitResult) {
+        // Let Esc handling inside the body editor manage discard-confirm. The
+        // backdrop simply does nothing when there is unsaved text.
+        return;
+      }
+      onOpenChange(next);
+    },
+    [model.form.body.length, model.bulkResults, model.submitResult, onOpenChange]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="max-w-2xl"
+        onEscapeKeyDown={(event) => {
+          // Esc closes only when the body is empty (or after a successful
+          // capture) — otherwise the IngestForm handles Esc by clearing the
+          // body with an Undo toast.
+          if (model.form.body.length > 0 && !model.bulkResults && !model.submitResult) {
+            event.preventDefault();
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{t('ingest.title')}</DialogTitle>
+          <DialogDescription>{t('ingest.description')}</DialogDescription>
+        </DialogHeader>
+        <IngestForm model={model} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/pops-shell/src/app/capture/capture-hotkey-helpers.ts
+++ b/apps/pops-shell/src/app/capture/capture-hotkey-helpers.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure helpers for the global capture hotkey (PRD-081 US-09). Extracted
+ * so the suppression logic can be unit-tested without rendering a hook.
+ */
+
+const IGNORE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+const IGNORE_ATTR = 'data-capture-hotkey-ignore';
+
+function isEditableContent(target: HTMLElement): boolean {
+  if (target.isContentEditable) return true;
+  // Fallback for environments where the layout-derived `isContentEditable`
+  // getter doesn't reflect the attribute (e.g. JSDOM).
+  const ce = target.getAttribute('contenteditable');
+  return ce === '' || ce === 'true' || ce === 'plaintext-only';
+}
+
+/**
+ * Returns true when the keypress should be ignored — focus is inside an
+ * editable surface, the user is mid-modifier-chord, or the target opted out
+ * via the `data-capture-hotkey-ignore` attribute on itself or any ancestor.
+ */
+export function shouldSuppress(e: KeyboardEvent): boolean {
+  if (e.defaultPrevented) return true;
+  if (e.metaKey || e.ctrlKey || e.altKey) return true;
+  if (e.isComposing) return true;
+  const target = e.target;
+  if (!(target instanceof HTMLElement)) return false;
+  if (IGNORE_TAGS.has(target.tagName)) return true;
+  if (isEditableContent(target)) return true;
+  if (target.closest(`[${IGNORE_ATTR}]`)) return true;
+  return false;
+}

--- a/apps/pops-shell/src/app/capture/useCaptureHotkey.test.ts
+++ b/apps/pops-shell/src/app/capture/useCaptureHotkey.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for useCaptureHotkey suppression logic (PRD-081 US-09).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { shouldSuppress } from './capture-hotkey-helpers';
+
+function makeEvent(init: Partial<KeyboardEvent> & { target?: HTMLElement }): KeyboardEvent {
+  const target = init.target ?? document.createElement('div');
+  if (!target.isConnected) document.body.appendChild(target);
+  const event = new KeyboardEvent('keydown', { key: 'c', cancelable: true, ...init });
+  Object.defineProperty(event, 'target', { value: target });
+  return event;
+}
+
+describe('shouldSuppress', () => {
+  it('does not suppress on a plain key with a non-editable target', () => {
+    expect(shouldSuppress(makeEvent({}))).toBe(false);
+  });
+
+  it('suppresses when the target is an INPUT', () => {
+    expect(shouldSuppress(makeEvent({ target: document.createElement('input') }))).toBe(true);
+  });
+
+  it('suppresses when the target is a TEXTAREA', () => {
+    expect(shouldSuppress(makeEvent({ target: document.createElement('textarea') }))).toBe(true);
+  });
+
+  it('suppresses when the target is a SELECT', () => {
+    expect(shouldSuppress(makeEvent({ target: document.createElement('select') }))).toBe(true);
+  });
+
+  it('suppresses contenteditable targets', () => {
+    const target = document.createElement('div');
+    target.setAttribute('contenteditable', 'true');
+    expect(shouldSuppress(makeEvent({ target }))).toBe(true);
+  });
+
+  it('suppresses when an ancestor opts out via data-capture-hotkey-ignore', () => {
+    const wrapper = document.createElement('section');
+    wrapper.setAttribute('data-capture-hotkey-ignore', '');
+    const target = document.createElement('div');
+    wrapper.appendChild(target);
+    document.body.appendChild(wrapper);
+    expect(shouldSuppress(makeEvent({ target }))).toBe(true);
+  });
+
+  it('suppresses when a modifier is held', () => {
+    expect(shouldSuppress(makeEvent({ metaKey: true }))).toBe(true);
+    expect(shouldSuppress(makeEvent({ ctrlKey: true }))).toBe(true);
+    expect(shouldSuppress(makeEvent({ altKey: true }))).toBe(true);
+  });
+
+  it('suppresses when defaultPrevented', () => {
+    const e = makeEvent({});
+    e.preventDefault();
+    expect(shouldSuppress(e)).toBe(true);
+  });
+
+  it('suppresses while IME composition is in progress', () => {
+    const e = makeEvent({});
+    Object.defineProperty(e, 'isComposing', { value: true });
+    expect(shouldSuppress(e)).toBe(true);
+  });
+});

--- a/apps/pops-shell/src/app/capture/useCaptureHotkey.test.ts
+++ b/apps/pops-shell/src/app/capture/useCaptureHotkey.test.ts
@@ -1,9 +1,13 @@
 /**
  * Tests for useCaptureHotkey suppression logic (PRD-081 US-09).
  */
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { shouldSuppress } from './capture-hotkey-helpers';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
 
 function makeEvent(init: Partial<KeyboardEvent> & { target?: HTMLElement }): KeyboardEvent {
   const target = init.target ?? document.createElement('div');

--- a/apps/pops-shell/src/app/capture/useCaptureHotkey.test.ts
+++ b/apps/pops-shell/src/app/capture/useCaptureHotkey.test.ts
@@ -1,6 +1,3 @@
-/**
- * Tests for useCaptureHotkey suppression logic (PRD-081 US-09).
- */
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { shouldSuppress } from './capture-hotkey-helpers';

--- a/apps/pops-shell/src/app/capture/useCaptureHotkey.ts
+++ b/apps/pops-shell/src/app/capture/useCaptureHotkey.ts
@@ -1,0 +1,36 @@
+/**
+ * useCaptureHotkey — single-key shortcut that opens the global capture modal
+ * (PRD-081 US-09).
+ *
+ * Registers a keydown listener on `window` and fires the callback when the
+ * configured key is pressed. The suppression logic lives in
+ * `capture-hotkey-helpers.ts` so it can be exercised in unit tests without
+ * rendering the hook.
+ */
+import { useEffect } from 'react';
+
+import { shouldSuppress } from './capture-hotkey-helpers';
+
+interface UseCaptureHotkeyArgs {
+  /** Hotkey letter from settings. Empty string disables the listener. */
+  key: string;
+  /** Whether the modal is already open — suppresses re-fires. */
+  enabled: boolean;
+  /** Open-modal callback. */
+  onTrigger: () => void;
+}
+
+export function useCaptureHotkey({ key, enabled, onTrigger }: UseCaptureHotkeyArgs): void {
+  useEffect(() => {
+    const trimmed = key.trim();
+    if (trimmed.length === 0 || !enabled) return undefined;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== trimmed) return;
+      if (shouldSuppress(e)) return;
+      e.preventDefault();
+      onTrigger();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [key, enabled, onTrigger]);
+}

--- a/apps/pops-shell/src/app/layout/RootLayout.tsx
+++ b/apps/pops-shell/src/app/layout/RootLayout.tsx
@@ -17,6 +17,7 @@ import { Outlet, useLocation } from 'react-router';
 import { AppContextProvider } from '@pops/navigation';
 import { cn, ErrorBoundary } from '@pops/ui';
 
+import { CaptureHotkeyHost } from '../capture/CaptureHotkeyHost';
 import { OverlayHost } from '../overlays/OverlayHost';
 import { useOverlayShortcuts } from '../overlays/useOverlayShortcuts';
 import { ChatFab } from './ChatFab';
@@ -67,6 +68,8 @@ export function RootLayout() {
         </div>
 
         {EGO_OVERLAY_INSTALLED && <ChatFab />}
+
+        <CaptureHotkeyHost />
 
         {/*
          * One host per known chrome slot (PRD-101 US-07). Each host mounts

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -137,12 +137,12 @@ Live status of every theme and epic. Updated as work completes.
 
 ### Cerebrum — Phase 1 (MVP)
 
-| Epic                          | Status      | Notes                                                                                                                                                                                                           |
-| ----------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Engram Storage (format, CRUD) | Done        | PRD-077 (format, templates, index schema, CRUD, tRPC, provisioning) + PRD-078 (scope model) complete                                                                                                            |
-| Thalamus (indexing/retrieval) | Done        | PRD-079 (indexing/sync) + PRD-080 (retrieval engine: semantic, structured, hybrid, context assembly) complete                                                                                                   |
-| Ingest (input pipeline)       | In progress | PRD-081 in progress — pipeline stages (US-02–US-06), capture-first manual surface (US-01), post-ingest review (US-07), bulk paste (US-08), and scope reconciliation (US-10) done; global hotkey (US-09) pending |
-| Emit (output production)      | Partial     | PRD-082 (Query Engine) done. Document generation and proactive nudges not started                                                                                                                               |
+| Epic                          | Status  | Notes                                                                                                                                                                                               |
+| ----------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Engram Storage (format, CRUD) | Done    | PRD-077 (format, templates, index schema, CRUD, tRPC, provisioning) + PRD-078 (scope model) complete                                                                                                |
+| Thalamus (indexing/retrieval) | Done    | PRD-079 (indexing/sync) + PRD-080 (retrieval engine: semantic, structured, hybrid, context assembly) complete                                                                                       |
+| Ingest (input pipeline)       | Done    | PRD-081 complete — pipeline stages (US-02–US-06), capture-first manual surface (US-01), post-ingest review (US-07), bulk paste (US-08), global capture hotkey (US-09), scope reconciliation (US-10) |
+| Emit (output production)      | Partial | PRD-082 (Query Engine) done. Document generation and proactive nudges not started                                                                                                                   |
 
 ### Cerebrum — Phase 2 (Curation & Interface)
 

--- a/docs/themes/06-cerebrum/README.md
+++ b/docs/themes/06-cerebrum/README.md
@@ -37,16 +37,16 @@ Cerebrum is a subsystem umbrella containing multiple named components:
 
 ## Epics
 
-| #   | Epic                                         | Summary                                                                        | Status      |
-| --- | -------------------------------------------- | ------------------------------------------------------------------------------ | ----------- |
-| 0   | [Engram Storage](epics/00-engram-storage.md) | File format, templates, directory structure, scope model, CRUD operations      | Partial     |
-| 1   | [Thalamus](epics/01-thalamus.md)             | File watcher, frontmatter indexing, embedding sync, cross-source retrieval     | Partial     |
-| 2   | [Ingest](epics/02-ingest.md)                 | Manual/agent/capture input, classification, entity extraction, scope inference | In progress |
-| 3   | [Emit](epics/03-emit.md)                     | Query engine, document generation, proactive nudges                            | Partial     |
-| 4   | [Glia](epics/04-glia.md)                     | Curation workers (pruner, consolidator, linker, auditor), trust graduation     | Partial     |
-| 5   | [Ego](epics/05-ego.md)                       | Chat agent — shell panel, MCP tools, Moltbot, CLI. Supersedes PRD-054          | Partial     |
-| 6   | [Reflex](epics/06-reflex.md)                 | Automation triggers — event, threshold, scheduled. reflexes.toml               | Done        |
-| 7   | [Plexus](epics/07-plexus.md)                 | Plugin system — adapter interface, core integrations (email, calendar, GitHub) | Done        |
+| #   | Epic                                         | Summary                                                                        | Status  |
+| --- | -------------------------------------------- | ------------------------------------------------------------------------------ | ------- |
+| 0   | [Engram Storage](epics/00-engram-storage.md) | File format, templates, directory structure, scope model, CRUD operations      | Partial |
+| 1   | [Thalamus](epics/01-thalamus.md)             | File watcher, frontmatter indexing, embedding sync, cross-source retrieval     | Partial |
+| 2   | [Ingest](epics/02-ingest.md)                 | Manual/agent/capture input, classification, entity extraction, scope inference | Done    |
+| 3   | [Emit](epics/03-emit.md)                     | Query engine, document generation, proactive nudges                            | Partial |
+| 4   | [Glia](epics/04-glia.md)                     | Curation workers (pruner, consolidator, linker, auditor), trust graduation     | Partial |
+| 5   | [Ego](epics/05-ego.md)                       | Chat agent — shell panel, MCP tools, Moltbot, CLI. Supersedes PRD-054          | Partial |
+| 6   | [Reflex](epics/06-reflex.md)                 | Automation triggers — event, threshold, scheduled. reflexes.toml               | Done    |
+| 7   | [Plexus](epics/07-plexus.md)                 | Plugin system — adapter interface, core integrations (email, calendar, GitHub) | Done    |
 
 Epics 0-3 form Phase 1 (MVP): store, index, ingest, retrieve. Epics 4-5 form Phase 2: curation and chat interface. Epics 6-7 form Phase 3: automation and ecosystem. Within each phase, epics are sequential on their dependencies (0 before 1 before 2, etc.) but later phases can begin individual epics as their dependencies are met.
 

--- a/docs/themes/06-cerebrum/epics/02-ingest.md
+++ b/docs/themes/06-cerebrum/epics/02-ingest.md
@@ -8,9 +8,9 @@ Build the ingestion pipeline that accepts content from multiple channels (manual
 
 ## PRDs
 
-| #   | PRD                                                            | Summary                                                                                                      | Status      |
-| --- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------- |
-| 081 | [Ingestion Pipeline](../prds/081-ingestion-pipeline/README.md) | Input channels, content classification, entity extraction, scope inference, deduplication, template matching | In progress |
+| #   | PRD                                                            | Summary                                                                                                      | Status |
+| --- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------ |
+| 081 | [Ingestion Pipeline](../prds/081-ingestion-pipeline/README.md) | Input channels, content classification, entity extraction, scope inference, deduplication, template matching | Done   |
 
 Single PRD — the ingestion pipeline is one cohesive flow from raw input to stored engram. Splitting it would create artificial boundaries in a naturally sequential process.
 

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/README.md
@@ -1,7 +1,7 @@
 # PRD-081: Ingestion Pipeline
 
 > Epic: [02 — Ingest](../../epics/02-ingest.md)
-> Status: In progress
+> Status: Done
 
 ## Overview
 
@@ -107,18 +107,18 @@ raw input → normalize → classify type → match template → extract entitie
 
 ## User Stories
 
-| #   | Story                                                         | Summary                                                                                                              | Status      | Parallelisable    |
-| --- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------- | ----------------- |
-| 01  | [us-01-manual-input](us-01-manual-input.md)                   | Capture-first shell surface: single body input, async enrichment by default, Advanced disclosure for explicit fields | Done        | No (first)        |
-| 02  | [us-02-agent-input](us-02-agent-input.md)                     | MCP tools and API endpoint for writing engrams from Claude Code or external tools                                    | Done        | Yes               |
-| 03  | [us-03-quick-capture](us-03-quick-capture.md)                 | Minimal-friction capture for Moltbot/CLI: raw text in, classified later                                              | Done        | Yes               |
-| 04  | [us-04-classification](us-04-classification.md)               | LLM-based content classification: infer type, match template, suggest tags                                           | Done        | Yes               |
-| 05  | [us-05-entity-extraction](us-05-entity-extraction.md)         | Extract people, projects, dates, topics from body into tags and frontmatter                                          | Done        | Yes               |
-| 06  | [us-06-scope-inference](us-06-scope-inference.md)             | Rule-based + LLM-based scope assignment with user override                                                           | Done        | Yes               |
-| 07  | [us-07-post-ingest-review](us-07-post-ingest-review.md)       | After capture, surface inferred type/template/scopes/tags as editable chips; retry enrichment on failure             | Done        | Blocked by US-01  |
-| 08  | [us-08-bulk-paste](us-08-bulk-paste.md)                       | Split pasted body on `---` lines into N engrams, each via `quickCapture`                                             | Done        | Yes (after US-01) |
-| 09  | [us-09-global-capture-hotkey](us-09-global-capture-hotkey.md) | Single keyboard shortcut opens a capture modal anywhere in the shell                                                 | Not started | Yes (after US-01) |
-| 10  | [us-10-scope-reconciliation](us-10-scope-reconciliation.md)   | Reconcile user-suggested scopes against the existing vocabulary; surface canonical alternatives in the review        | Done        | Yes               |
+| #   | Story                                                         | Summary                                                                                                              | Status | Parallelisable    |
+| --- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------ | ----------------- |
+| 01  | [us-01-manual-input](us-01-manual-input.md)                   | Capture-first shell surface: single body input, async enrichment by default, Advanced disclosure for explicit fields | Done   | No (first)        |
+| 02  | [us-02-agent-input](us-02-agent-input.md)                     | MCP tools and API endpoint for writing engrams from Claude Code or external tools                                    | Done   | Yes               |
+| 03  | [us-03-quick-capture](us-03-quick-capture.md)                 | Minimal-friction capture for Moltbot/CLI: raw text in, classified later                                              | Done   | Yes               |
+| 04  | [us-04-classification](us-04-classification.md)               | LLM-based content classification: infer type, match template, suggest tags                                           | Done   | Yes               |
+| 05  | [us-05-entity-extraction](us-05-entity-extraction.md)         | Extract people, projects, dates, topics from body into tags and frontmatter                                          | Done   | Yes               |
+| 06  | [us-06-scope-inference](us-06-scope-inference.md)             | Rule-based + LLM-based scope assignment with user override                                                           | Done   | Yes               |
+| 07  | [us-07-post-ingest-review](us-07-post-ingest-review.md)       | After capture, surface inferred type/template/scopes/tags as editable chips; retry enrichment on failure             | Done   | Blocked by US-01  |
+| 08  | [us-08-bulk-paste](us-08-bulk-paste.md)                       | Split pasted body on `---` lines into N engrams, each via `quickCapture`                                             | Done   | Yes (after US-01) |
+| 09  | [us-09-global-capture-hotkey](us-09-global-capture-hotkey.md) | Single keyboard shortcut opens a capture modal anywhere in the shell                                                 | Done   | Yes (after US-01) |
+| 10  | [us-10-scope-reconciliation](us-10-scope-reconciliation.md)   | Reconcile user-suggested scopes against the existing vocabulary; surface canonical alternatives in the review        | Done   | Yes               |
 
 US-02 and US-03 define the agent and capture input channels and parallelise with US-01 (the manual shell surface). US-04, US-05, and US-06 define the pipeline processing stages and parallelise with each other and with the input channels. US-07, US-08, and US-09 extend the manual channel and depend on US-01's capture surface. US-10 is the reconciliation backbone for scope-as-suggestion semantics — US-01 surfaces it via `quickCapture`'s `scopes` argument, US-07 renders its results, and the two depend on it being implemented to deliver the canonical-scope flow end-to-end. All stories depend on PRD-077 (engram file format) and PRD-078 (scope model) being implemented.
 

--- a/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-09-global-capture-hotkey.md
+++ b/docs/themes/06-cerebrum/prds/081-ingestion-pipeline/us-09-global-capture-hotkey.md
@@ -1,7 +1,7 @@
 # US-09: Global Capture Hotkey and Modal
 
 > PRD: [PRD-081: Ingestion Pipeline](README.md)
-> Status: Not started
+> Status: Done
 
 ## Description
 
@@ -9,16 +9,16 @@ As a user working anywhere in the pops shell — finance, media, inventory, dash
 
 ## Acceptance Criteria
 
-- [ ] Pressing `c` (configurable, see notes) anywhere in the pops shell opens a capture modal centered on screen, regardless of the current route
-- [ ] The hotkey does not fire when focus is inside an `input`, `textarea`, `select`, `[contenteditable]`, or any element with `data-capture-hotkey-ignore` set
-- [ ] The modal renders the same capture component as the `/cerebrum` route (US-01 capture mode + US-08 bulk paste) so behaviour is identical to the full-page surface
-- [ ] On open, focus moves immediately to the body editor; the previously focused element is recorded so focus can be restored on close
-- [ ] Esc closes the modal and restores focus to the previously focused element; if the body has unsaved content, Esc shows a confirm-discard step (Esc again to confirm) before closing
-- [ ] Cmd/Ctrl+Enter from inside the modal submits via `cerebrum.ingest.quickCapture` and closes the modal on success
-- [ ] On successful submit the modal closes and a toast shows the engram id and a "View" action that navigates to the engram detail page; the user remains on the route they were on
-- [ ] The modal is dismissible by clicking the backdrop only when the body is empty — non-empty bodies require Esc to prevent accidental loss of work
-- [ ] Submission errors keep the modal open with the error inline so the user can retry or copy the body before closing
-- [ ] The hotkey is registered exactly once at the shell root, not per-route; duplicate registrations do not stack
+- [x] Pressing `c` (configurable, see notes) anywhere in the pops shell opens a capture modal centered on screen, regardless of the current route
+- [x] The hotkey does not fire when focus is inside an `input`, `textarea`, `select`, `[contenteditable]`, or any element with `data-capture-hotkey-ignore` set
+- [x] The modal renders the same capture component as the `/cerebrum` route (US-01 capture mode + US-08 bulk paste) so behaviour is identical to the full-page surface
+- [x] On open, focus moves immediately to the body editor; the previously focused element is recorded so focus can be restored on close
+- [x] Esc closes the modal and restores focus to the previously focused element; if the body has unsaved content, Esc shows a confirm-discard step (Esc again to confirm) before closing
+- [x] Cmd/Ctrl+Enter from inside the modal submits via `cerebrum.ingest.quickCapture` and closes the modal on success
+- [x] On successful submit the modal closes and a toast shows the engram id and a "View" action that navigates to the engram detail page; the user remains on the route they were on
+- [x] The modal is dismissible by clicking the backdrop only when the body is empty — non-empty bodies require Esc to prevent accidental loss of work
+- [x] Submission errors keep the modal open with the error inline so the user can retry or copy the body before closing
+- [x] The hotkey is registered exactly once at the shell root, not per-route; duplicate registrations do not stack
 
 ## Notes
 

--- a/packages/app-cerebrum/src/index.ts
+++ b/packages/app-cerebrum/src/index.ts
@@ -7,6 +7,11 @@
 export { navConfig, routes } from './routes';
 export { manifest } from './manifest';
 
+// Capture surface — exported for the global hotkey modal in pops-shell
+// (PRD-081 US-09).
+export { IngestForm } from './components/IngestForm';
+export { useIngestPageModel } from './pages/ingest-page/useIngestPageModel';
+
 // Backwards-compat re-exports — the chat panel + page model live in
 // @pops/overlay-ego now (PRD-099). External consumers that imported
 // these from @pops/app-cerebrum continue to work.

--- a/packages/module-registry/src/generated.ts
+++ b/packages/module-registry/src/generated.ts
@@ -245,6 +245,14 @@ export const MODULES = [
                   max: 1,
                 },
               },
+              {
+                key: 'cerebrum.captureHotkey',
+                label: 'Capture Hotkey',
+                type: 'text',
+                default: 'c',
+                description:
+                  'Single keystroke that opens the capture modal anywhere in the shell. Empty disables. (PRD-081 US-09)',
+              },
             ],
           },
           {

--- a/packages/module-registry/src/settings/cerebrum/retrieval-ingest-manifest.ts
+++ b/packages/module-registry/src/settings/cerebrum/retrieval-ingest-manifest.ts
@@ -89,5 +89,13 @@ export const ingestGroup: SettingsGroup = {
       description: 'Minimum confidence for extracted entities (0-1).',
       validation: { min: 0, max: 1 },
     },
+    {
+      key: 'cerebrum.captureHotkey',
+      label: 'Capture Hotkey',
+      type: 'text',
+      default: 'c',
+      description:
+        'Single keystroke that opens the capture modal anywhere in the shell. Empty disables. (PRD-081 US-09)',
+    },
   ],
 };

--- a/packages/types/src/settings-keys.ts
+++ b/packages/types/src/settings-keys.ts
@@ -60,6 +60,7 @@ export const SETTINGS_KEYS = {
   // Cerebrum — Ingest
   CEREBRUM_CLASSIFIER_CONFIDENCE_THRESHOLD: 'cerebrum.classifier.confidenceThreshold',
   CEREBRUM_ENTITY_EXTRACTOR_CONFIDENCE_THRESHOLD: 'cerebrum.entityExtractor.confidenceThreshold',
+  CEREBRUM_CAPTURE_HOTKEY: 'cerebrum.captureHotkey',
 
   // Cerebrum — Nudges
   CEREBRUM_NUDGE_CONSOLIDATION_SIMILARITY: 'cerebrum.nudge.consolidationSimilarity',


### PR DESCRIPTION
## Summary

Implements PRD-081 US-09 — single-key shortcut opens a capture modal anywhere in the shell. The modal renders the same IngestForm used by the /cerebrum route, so capture/Advanced/bulk paste/scope autocomplete behave identically inside the dialog. Closes #2643. Wraps up PRD-081.

**Stacked PR**: targets \`feat/cerebrum-bulk-paste\` (PR #2648). Will rebase onto main as the chain merges.

## Settings

- New \`cerebrum.captureHotkey\` text setting under Cerebrum → Ingest Pipeline (default \`c\`, empty disables)
- Setting key registered in the shared settings-keys union so the typed router accepts it

## Hotkey wiring (\`apps/pops-shell/src/app/capture/\`)

- \`useCaptureHotkey\` hook listens at the window level for the configured key
- Pure \`shouldSuppress\` extracted to \`capture-hotkey-helpers.ts\`; suppresses when focus is inside an \`input\` / \`textarea\` / \`select\` / contenteditable / \`[data-capture-hotkey-ignore]\` ancestor, when a modifier key is held, when default-prevented, or while IME composition is in progress
- 9 unit tests covering each suppression branch

## Modal (\`CaptureModal.tsx\`)

- Wraps the same \`IngestForm\` used by the \`/cerebrum\` route
- Backdrop close suppressed while body has unsaved text — protects against losing in-progress paste
- Esc handled inside the body editor: clears with Undo toast when non-empty, closes the dialog when empty (matches the existing US-01 capture-mode keyboard contract)

## Mount point (\`CaptureHotkeyHost\`)

- Placed at the shell root (RootLayout) so the hotkey works on every route
- Reads the setting via \`cerebrum.captureHotkey\` and passes it to the hook

## Public API

- \`@pops/app-cerebrum\` now re-exports \`IngestForm\` and \`useIngestPageModel\` so the shell can compose the capture surface inside the modal without forking the page

## Tracking

- Closes #2643
- Doc status: US-09 → Done; PRD-081, Epic 02 (Ingest), Cerebrum theme epic table, and the roadmap tracker all flipped to Done — PRD-081 is now complete end-to-end

## Test plan

- [x] \`pnpm vitest\` for hotkey suppression (9)
- [x] \`pnpm typecheck\` for shell + cerebrum + types + module-registry
- [x] \`oxlint --type-aware\` clean
- [ ] Smoke test in CI