### PR TITLE
fix(ui): WorkflowDialog layout collapse on desktop — override md:max-w-lg

### DIFF
--- a/apps/pops-shell/src/app/capture/CaptureHotkeyHost.tsx
+++ b/apps/pops-shell/src/app/capture/CaptureHotkeyHost.tsx
@@ -1,10 +1,12 @@
 import { trpc } from '@/lib/trpc';
 import { useCallback, useState } from 'react';
 
+import { SETTINGS_KEYS } from '@pops/types';
+
 import { CaptureModal } from './CaptureModal';
 import { useCaptureHotkey } from './useCaptureHotkey';
 
-const settingKey = 'cerebrum.captureHotkey' as const;
+const settingKey = SETTINGS_KEYS.CEREBRUM_CAPTURE_HOTKEY;
 const defaultHotkey = 'c';
 
 export function CaptureHotkeyHost() {

--- a/docs/themes/06-cerebrum/README.md
+++ b/docs/themes/06-cerebrum/README.md
@@ -39,8 +39,8 @@ Cerebrum is a subsystem umbrella containing multiple named components:
 
 | #   | Epic                                         | Summary                                                                        | Status  |
 | --- | -------------------------------------------- | ------------------------------------------------------------------------------ | ------- |
-| 0   | [Engram Storage](epics/00-engram-storage.md) | File format, templates, directory structure, scope model, CRUD operations      | Partial |
-| 1   | [Thalamus](epics/01-thalamus.md)             | File watcher, frontmatter indexing, embedding sync, cross-source retrieval     | Partial |
+| 0   | [Engram Storage](epics/00-engram-storage.md) | File format, templates, directory structure, scope model, CRUD operations      | Done    |
+| 1   | [Thalamus](epics/01-thalamus.md)             | File watcher, frontmatter indexing, embedding sync, cross-source retrieval     | Done    |
 | 2   | [Ingest](epics/02-ingest.md)                 | Manual/agent/capture input, classification, entity extraction, scope inference | Done    |
 | 3   | [Emit](epics/03-emit.md)                     | Query engine, document generation, proactive nudges                            | Partial |
 | 4   | [Glia](epics/04-glia.md)                     | Curation workers (pruner, consolidator, linker, auditor), trust graduation     | Partial |

--- a/packages/app-cerebrum/src/index.ts
+++ b/packages/app-cerebrum/src/index.ts
@@ -7,8 +7,6 @@
 export { navConfig, routes } from './routes';
 export { manifest } from './manifest';
 
-// Capture surface — exported for the global hotkey modal in pops-shell
-// (PRD-081 US-09).
 export { IngestForm } from './components/IngestForm';
 export { useIngestPageModel } from './pages/ingest-page/useIngestPageModel';
 

--- a/packages/ui/src/components/WorkflowDialog.tsx
+++ b/packages/ui/src/components/WorkflowDialog.tsx
@@ -64,7 +64,7 @@ export function WorkflowDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className={cn(
-          'w-(--size-dialog-xl) max-w-(--size-dialog-max-vw) max-h-(--size-dialog-max-vh)',
+          'w-(--size-dialog-xl) max-w-(--size-dialog-max-vw) md:max-w-(--size-dialog-max-vw) max-h-(--size-dialog-max-vh)',
           'flex flex-col gap-0 overflow-hidden p-0',
           className
         )}


### PR DESCRIPTION
## Summary

- `DialogContent` primitive has `md:max-w-lg` (512px) in its default classes
- `tailwind-merge` only removes conflicts within the same modifier group, so `max-w-(--size-dialog-max-vw)` (base) did not evict the `md:`-prefixed rule
- At desktop widths the dialog was capped at 512px — below the 3-column grid's 620px minimum (260px ops + 0px middle + 360px impact), collapsing the middle column and causing the ImpactPanel to visually overlap the OpsListPanel in the correction proposal modal
- Fix: add `md:max-w-(--size-dialog-max-vw)` so `tailwind-merge` correctly drops `md:max-w-lg`

## Test plan

- [ ] Open Finance → Import → trigger a correction proposal — modal should render at full width (~1180px) with three visible columns
- [ ] Verify Operations, Detail, and Impact panels each occupy their correct columns with no overlap
- [ ] Confirm other (simple) dialogs throughout the app are unaffected