### PR TITLE
fix(finance/imports): truncate long entity names in grouped review header

### DIFF
--- a/apps/pops-shell/src/app/capture/CaptureHotkeyHost.tsx
+++ b/apps/pops-shell/src/app/capture/CaptureHotkeyHost.tsx
@@ -1,10 +1,12 @@
 import { trpc } from '@/lib/trpc';
 import { useCallback, useState } from 'react';
 
+import { SETTINGS_KEYS } from '@pops/types';
+
 import { CaptureModal } from './CaptureModal';
 import { useCaptureHotkey } from './useCaptureHotkey';
 
-const settingKey = 'cerebrum.captureHotkey' as const;
+const settingKey = SETTINGS_KEYS.CEREBRUM_CAPTURE_HOTKEY;
 const defaultHotkey = 'c';
 
 export function CaptureHotkeyHost() {

--- a/docs/themes/06-cerebrum/README.md
+++ b/docs/themes/06-cerebrum/README.md
@@ -39,8 +39,8 @@ Cerebrum is a subsystem umbrella containing multiple named components:
 
 | #   | Epic                                         | Summary                                                                        | Status  |
 | --- | -------------------------------------------- | ------------------------------------------------------------------------------ | ------- |
-| 0   | [Engram Storage](epics/00-engram-storage.md) | File format, templates, directory structure, scope model, CRUD operations      | Partial |
-| 1   | [Thalamus](epics/01-thalamus.md)             | File watcher, frontmatter indexing, embedding sync, cross-source retrieval     | Partial |
+| 0   | [Engram Storage](epics/00-engram-storage.md) | File format, templates, directory structure, scope model, CRUD operations      | Done    |
+| 1   | [Thalamus](epics/01-thalamus.md)             | File watcher, frontmatter indexing, embedding sync, cross-source retrieval     | Done    |
 | 2   | [Ingest](epics/02-ingest.md)                 | Manual/agent/capture input, classification, entity extraction, scope inference | Done    |
 | 3   | [Emit](epics/03-emit.md)                     | Query engine, document generation, proactive nudges                            | Partial |
 | 4   | [Glia](epics/04-glia.md)                     | Curation workers (pruner, consolidator, linker, auditor), trust graduation     | Partial |

--- a/packages/app-cerebrum/src/index.ts
+++ b/packages/app-cerebrum/src/index.ts
@@ -7,8 +7,6 @@
 export { navConfig, routes } from './routes';
 export { manifest } from './manifest';
 
-// Capture surface — exported for the global hotkey modal in pops-shell
-// (PRD-081 US-09).
 export { IngestForm } from './components/IngestForm';
 export { useIngestPageModel } from './pages/ingest-page/useIngestPageModel';
 

--- a/packages/app-finance/src/components/imports/transaction-group/GroupHeader.tsx
+++ b/packages/app-finance/src/components/imports/transaction-group/GroupHeader.tsx
@@ -66,21 +66,21 @@ export function GroupHeader(props: GroupHeaderProps) {
         group.aiSuggestion ? 'bg-purple-50 dark:bg-purple-950' : 'bg-gray-50 dark:bg-gray-900'
       }`}
     >
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
           <CollapsibleTrigger
-            className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+            className="flex items-center gap-2 hover:opacity-80 transition-opacity min-w-0 w-full"
             aria-label={isExpanded ? 'Collapse' : 'Expand'}
           >
             <ChevronRight
-              className={`w-5 h-5 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+              className={`w-5 h-5 shrink-0 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
               aria-hidden="true"
             />
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 min-w-0">
               {group.aiSuggestion && (
-                <Sparkles className="w-5 h-5 text-purple-600 dark:text-purple-400" />
+                <Sparkles className="w-5 h-5 shrink-0 text-purple-600 dark:text-purple-400" />
               )}
-              <h3 className="font-semibold text-lg">{group.entityName}</h3>
+              <h3 className="font-semibold text-lg truncate">{group.entityName}</h3>
             </div>
           </CollapsibleTrigger>
           <div className="flex items-center gap-3 mt-2 ml-7">

--- a/packages/app-finance/src/components/imports/transaction-group/GroupHeader.tsx
+++ b/packages/app-finance/src/components/imports/transaction-group/GroupHeader.tsx
@@ -77,9 +77,7 @@ export function GroupHeader(props: GroupHeaderProps) {
               aria-hidden="true"
             />
             <div className="flex items-center gap-2 min-w-0">
-              {group.aiSuggestion && (
-                <Sparkles className="w-5 h-5 shrink-0 text-purple-600 dark:text-purple-400" />
-              )}
+              {group.aiSuggestion && <Sparkles className="w-5 h-5 shrink-0 text-app-accent" />}
               <h3 className="font-semibold text-lg truncate">{group.entityName}</h3>
             </div>
           </CollapsibleTrigger>

--- a/packages/ui/src/components/WorkflowDialog.tsx
+++ b/packages/ui/src/components/WorkflowDialog.tsx
@@ -64,7 +64,7 @@ export function WorkflowDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className={cn(
-          'w-(--size-dialog-xl) max-w-(--size-dialog-max-vw) max-h-(--size-dialog-max-vh)',
+          'w-(--size-dialog-xl) max-w-(--size-dialog-max-vw) md:max-w-(--size-dialog-max-vw) max-h-(--size-dialog-max-vh)',
           'flex flex-col gap-0 overflow-hidden p-0',
           className
         )}


### PR DESCRIPTION
## Summary

- Long entity names (e.g. "Unknown Membership Organization") wrapped to multiple lines in the grouped review header, making the row disproportionately tall
- Root cause: no `min-w-0` propagation in the flex chain, so flexbox couldn't shrink the name below its content width
- Fix: add `min-w-0` on the outer flex div, `CollapsibleTrigger`, and the icon+name div; add `truncate` on the `h3`; pin the chevron and sparkle icons with `shrink-0`

## Test plan

- [ ] Open Finance → Import → Review step → Grouped view with a long entity name — name should display on one line with ellipsis
- [ ] Verify short entity names are unaffected
- [ ] Verify the chevron expand/collapse icon and AI sparkle icon don't shrink