### PR TITLE
fix(finance/imports): auto-rerun preview on op edit — unblocks Apply ChangeSet

### DIFF
--- a/packages/app-finance/src/components/imports/CorrectionProposalDialog.test.tsx
+++ b/packages/app-finance/src/components/imports/CorrectionProposalDialog.test.tsx
@@ -524,14 +524,13 @@ describe('CorrectionProposalDialog', () => {
     expect(screen.getByText(/COLES → Coles/)).toBeInTheDocument();
   });
 
-  it('editing a rule field marks the ChangeSet stale and disables Apply', async () => {
+  it('editing a rule field auto-reruns preview and re-enables Apply', async () => {
     seedTwoAddOps();
     renderDialog();
 
     await waitFor(() => {
       expect(screen.getByText(/Operations \(2\)/)).toBeInTheDocument();
     });
-    // Wait for the auto-preview to complete so Apply would otherwise be enabled.
     await waitFor(() => {
       expect(mockPreviewMutateAsync).toHaveBeenCalled();
     });
@@ -539,11 +538,17 @@ describe('CorrectionProposalDialog', () => {
     const applyBtn = screen.getByRole('button', { name: /Apply ChangeSet/i });
     await waitFor(() => expect(applyBtn).not.toBeDisabled());
 
+    const callsBefore = mockPreviewMutateAsync.mock.calls.length;
     const patternInput = screen.getByDisplayValue('WOOLWORTHS') as HTMLInputElement;
     fireEvent.change(patternInput, { target: { value: 'WOOLWORTHS METRO' } });
 
-    expect(screen.getByText(/Preview stale/i)).toBeInTheDocument();
-    expect(applyBtn).toBeDisabled();
+    // Preview should auto-rerun with the new content sig.
+    await waitFor(() => {
+      expect(mockPreviewMutateAsync.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+    // After rerun completes, dirty flag clears and Apply re-enables.
+    await waitFor(() => expect(applyBtn).not.toBeDisabled());
+    expect(screen.queryByText(/Preview stale/i)).not.toBeInTheDocument();
   });
 
   it("adds a new 'add' op via the Add operation menu", async () => {

--- a/packages/app-finance/src/components/imports/hooks/preview-effect-hooks.ts
+++ b/packages/app-finance/src/components/imports/hooks/preview-effect-hooks.ts
@@ -44,13 +44,27 @@ export interface CombinedEffectArgs extends BaseEffectShared {
 function opContentSig(o: LocalOp): string {
   if (o.kind === 'add') {
     const d = o.data;
-    return `${o.clientId}:${d.descriptionPattern}:${d.matchType}:${d.entityName ?? ''}:${d.transactionType ?? ''}:${d.location ?? ''}`;
+    return JSON.stringify([
+      o.clientId,
+      d.descriptionPattern,
+      d.matchType,
+      d.entityName ?? '',
+      d.transactionType ?? '',
+      d.location ?? '',
+    ]);
   }
   if (o.kind === 'edit') {
     const d = o.data;
-    return `${o.clientId}:${d.descriptionPattern ?? ''}:${d.matchType ?? ''}:${d.entityName ?? ''}:${d.transactionType ?? ''}:${d.location ?? ''}`;
+    return JSON.stringify([
+      o.clientId,
+      d.descriptionPattern ?? '',
+      d.matchType ?? '',
+      d.entityName ?? '',
+      d.transactionType ?? '',
+      d.location ?? '',
+    ]);
   }
-  return `${o.clientId}:${o.rationale}`;
+  return JSON.stringify([o.clientId, o.rationale]);
 }
 
 export function useCombinedEffect(args: CombinedEffectArgs): void {

--- a/packages/app-finance/src/components/imports/hooks/preview-effect-hooks.ts
+++ b/packages/app-finance/src/components/imports/hooks/preview-effect-hooks.ts
@@ -41,6 +41,18 @@ export interface CombinedEffectArgs extends BaseEffectShared {
   lastTokenRef: React.MutableRefObject<number>;
 }
 
+function opContentSig(o: LocalOp): string {
+  if (o.kind === 'add') {
+    const d = o.data;
+    return `${o.clientId}:${d.descriptionPattern}:${d.matchType}:${d.entityName ?? ''}:${d.transactionType ?? ''}:${d.location ?? ''}`;
+  }
+  if (o.kind === 'edit') {
+    const d = o.data;
+    return `${o.clientId}:${d.descriptionPattern ?? ''}:${d.matchType ?? ''}:${d.entityName ?? ''}:${d.transactionType ?? ''}:${d.location ?? ''}`;
+  }
+  return `${o.clientId}:${o.rationale}`;
+}
+
 export function useCombinedEffect(args: CombinedEffectArgs): void {
   const { open, localOps, minConfidence, previewTransactions, pendingChangeSets } = args;
   const {
@@ -58,7 +70,7 @@ export function useCombinedEffect(args: CombinedEffectArgs): void {
       return;
     }
     if (localOps.length === 0) return;
-    const sig = localOps.map((o) => o.clientId).join('|');
+    const sig = localOps.map(opContentSig).join('|');
     if (lastSigRef.current === sig && lastTokenRef.current === rerunToken) return;
     lastSigRef.current = sig;
     lastTokenRef.current = rerunToken;


### PR DESCRIPTION
## Summary

- Editing any field in the correction proposal (description pattern, entity name, match type, etc.) set `dirty=true` on the op but never triggered a preview re-run — `Apply ChangeSet` was permanently disabled until the user manually clicked the refresh icon
- Root cause: `useCombinedEffect` used only `clientId`s in its structural sig, so field edits were invisible to the effect
- Fix: extract `opContentSig` that fingerprints each op's fields; the effect sig now includes content, so any edit fires an auto-rerun which clears `dirty` on success and re-enables Apply
- The existing unit test that asserted the broken blocking behaviour has been updated to verify the correct auto-rerun path instead

## Test plan

- [ ] Open a correction proposal, edit the description pattern or entity name — Apply ChangeSet should re-enable automatically after the preview refreshes (no manual refresh click needed)
- [ ] Verify the "Preview stale" message disappears after the auto-rerun completes
- [ ] Confirm adding/removing operations still triggers a rerun as before
- [ ] Run `pnpm --filter @pops/app-finance test` — all tests pass