### PR TITLE
fix(media/arr): test connection, download defaults config, and search tab spacing

### DIFF
--- a/apps/pops-shell/src/app/pages/settings-page/useTestActionHandler.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useTestActionHandler.ts
@@ -29,13 +29,17 @@ export function useTestActionHandler() {
       const parts = procedure.split('.');
       let current: unknown = utils.client;
       for (const part of parts) {
-        if (current === null || current === undefined || typeof current !== 'object') {
+        if (
+          current === null ||
+          current === undefined ||
+          (typeof current !== 'object' && typeof current !== 'function')
+        ) {
           throw new Error(`Unknown procedure: ${procedure}`);
         }
         current = (current as Record<string, unknown>)[part];
-        if (!current) throw new Error(`Unknown procedure: ${procedure}`);
+        if (current == null) throw new Error(`Unknown procedure: ${procedure}`);
       }
-      if (current !== null && typeof current === 'object') {
+      if (current !== null && (typeof current === 'object' || typeof current === 'function')) {
         const node = current as Record<string, unknown>;
         if (typeof node.query === 'function') {
           const result = await (node.query as () => Promise<unknown>)();

--- a/apps/pops-shell/src/app/pages/settings-page/useTestActionHandler.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useTestActionHandler.ts
@@ -1,14 +1,6 @@
 import { trpc } from '@/lib/trpc';
+import { traverseTrpcPath } from '@/lib/trpc-traverse';
 import { useCallback } from 'react';
-
-/**
- * Resolves a dot-delimited tRPC procedure name (e.g. "media.plex.testConnection")
- * to a callable query/mutate on the tRPC client and invokes it.
- *
- * Dynamic property traversal is unavoidable here because the procedure path
- * comes from settings manifest data at runtime. The tRPC client tree is typed
- * as a deeply nested object but we need to walk it with arbitrary string keys.
- */
 
 /** Throws if the procedure response signals a failed connection without throwing. */
 function assertConnected(result: unknown): void {
@@ -21,37 +13,27 @@ function assertConnected(result: unknown): void {
   }
 }
 
+/**
+ * Resolves a dot-delimited tRPC procedure name (e.g. "media.plex.testConnection")
+ * to a callable query/mutate on the tRPC client and invokes it.
+ *
+ * Dynamic property traversal is unavoidable here because the procedure path
+ * comes from settings manifest data at runtime.
+ */
 export function useTestActionHandler() {
   const utils = trpc.useUtils();
 
   return useCallback(
     async (procedure: string) => {
-      const parts = procedure.split('.');
-      let current: unknown = utils.client;
-      for (const part of parts) {
-        if (
-          current === null ||
-          current === undefined ||
-          (typeof current !== 'object' && typeof current !== 'function')
-        ) {
-          throw new Error(`Unknown procedure: ${procedure}`);
-        }
-        current = (current as Record<string, unknown>)[part];
-        if (current == null) throw new Error(`Unknown procedure: ${procedure}`);
-      }
-      if (current !== null && (typeof current === 'object' || typeof current === 'function')) {
-        const node = current as Record<string, unknown>;
-        if (typeof node.query === 'function') {
-          const result = await (node.query as () => Promise<unknown>)();
-          assertConnected(result);
-        } else if (typeof node.mutate === 'function') {
-          const result = await (node.mutate as (input: Record<string, never>) => Promise<unknown>)(
-            {}
-          );
-          assertConnected(result);
-        } else {
-          throw new Error(`Cannot call procedure: ${procedure}`);
-        }
+      const node = traverseTrpcPath(utils.client, procedure);
+      if (typeof node.query === 'function') {
+        const result = await (node.query as () => Promise<unknown>)();
+        assertConnected(result);
+      } else if (typeof node.mutate === 'function') {
+        const result = await (node.mutate as (input: Record<string, never>) => Promise<unknown>)(
+          {}
+        );
+        assertConnected(result);
       } else {
         throw new Error(`Cannot call procedure: ${procedure}`);
       }

--- a/apps/pops-shell/src/app/pages/settings-page/useTestActionHandler.ts
+++ b/apps/pops-shell/src/app/pages/settings-page/useTestActionHandler.ts
@@ -13,13 +13,7 @@ function assertConnected(result: unknown): void {
   }
 }
 
-/**
- * Resolves a dot-delimited tRPC procedure name (e.g. "media.plex.testConnection")
- * to a callable query/mutate on the tRPC client and invokes it.
- *
- * Dynamic property traversal is unavoidable here because the procedure path
- * comes from settings manifest data at runtime.
- */
+/** Dynamic traversal is unavoidable — procedure paths come from manifest data at runtime. */
 export function useTestActionHandler() {
   const utils = trpc.useUtils();
 

--- a/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.test.tsx
@@ -25,6 +25,7 @@ vi.mock('@/lib/trpc', () => ({
         },
       },
     },
+    useUtils: () => ({ client: {} }),
   },
 }));
 

--- a/apps/pops-shell/src/components/settings/SectionRenderer.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.tsx
@@ -7,6 +7,7 @@ import { GroupRenderer } from './section-renderer/GroupRenderer';
 import { useAutoSave } from './section-renderer/useAutoSave';
 import { useDynamicOptions } from './section-renderer/useDynamicOptions';
 import { useSettingsValues } from './section-renderer/useSettingsValues';
+import { useTrpcOptionsLoaders } from './section-renderer/useTrpcOptionsLoaders';
 
 import type { SettingsManifest } from '@pops/types';
 
@@ -46,7 +47,11 @@ export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: Sect
   const setBulkMutation = trpc.core.settings.setBulk.useMutation();
 
   const { values, setValues, loadedKeys } = useSettingsValues({ data, manifest });
-  const { dynamicOptions, loadingOptionKeys } = useDynamicOptions(optionsLoaders);
+  const trpcLoaders = useTrpcOptionsLoaders(manifest);
+  const mergedLoaders = optionsLoaders ? { ...trpcLoaders, ...optionsLoaders } : trpcLoaders;
+  const { dynamicOptions, loadingOptionKeys } = useDynamicOptions(
+    Object.keys(mergedLoaders).length > 0 ? mergedLoaders : undefined
+  );
   const { saveStates, handleChange } = useAutoSave({ setBulkMutation, fieldsByKey, setValues });
 
   const handleTestAction = useCallback(

--- a/apps/pops-shell/src/components/settings/SectionRenderer.tsx
+++ b/apps/pops-shell/src/components/settings/SectionRenderer.tsx
@@ -48,7 +48,10 @@ export function SectionRenderer({ manifest, optionsLoaders, onTestAction }: Sect
 
   const { values, setValues, loadedKeys } = useSettingsValues({ data, manifest });
   const trpcLoaders = useTrpcOptionsLoaders(manifest);
-  const mergedLoaders = optionsLoaders ? { ...trpcLoaders, ...optionsLoaders } : trpcLoaders;
+  const mergedLoaders = useMemo(
+    () => (optionsLoaders ? { ...trpcLoaders, ...optionsLoaders } : trpcLoaders),
+    [trpcLoaders, optionsLoaders]
+  );
   const { dynamicOptions, loadingOptionKeys } = useDynamicOptions(
     Object.keys(mergedLoaders).length > 0 ? mergedLoaders : undefined
   );

--- a/apps/pops-shell/src/components/settings/section-renderer/useTrpcOptionsLoaders.ts
+++ b/apps/pops-shell/src/components/settings/section-renderer/useTrpcOptionsLoaders.ts
@@ -1,0 +1,54 @@
+import { trpc } from '@/lib/trpc';
+import { useMemo } from 'react';
+
+import type { SettingsManifest } from '@pops/types';
+
+type Options = { value: string; label: string }[];
+type Loaders = Record<string, () => Promise<Options>>;
+
+function traverseClient(client: unknown, procedure: string): Record<string, unknown> {
+  const parts = procedure.split('.');
+  let current: unknown = client;
+  for (const part of parts) {
+    if (current == null || (typeof current !== 'object' && typeof current !== 'function')) {
+      throw new Error(`Unknown procedure: ${procedure}`);
+    }
+    current = (current as Record<string, unknown>)[part];
+    if (current == null) throw new Error(`Unknown procedure: ${procedure}`);
+  }
+  if (current == null || (typeof current !== 'object' && typeof current !== 'function')) {
+    throw new Error(`Cannot call procedure: ${procedure}`);
+  }
+  return current as Record<string, unknown>;
+}
+
+export function useTrpcOptionsLoaders(manifest: SettingsManifest): Loaders {
+  const utils = trpc.useUtils();
+
+  return useMemo(() => {
+    const loaders: Loaders = {};
+    for (const group of manifest.groups) {
+      for (const field of group.fields) {
+        if (!field.optionsLoader) continue;
+        const { procedure, valueKey, labelKey } = field.optionsLoader;
+        const key = field.key;
+        loaders[key] = async () => {
+          const node = traverseClient(utils.client, procedure);
+          let raw: unknown;
+          if (typeof node.query === 'function') {
+            raw = await (node.query as () => Promise<unknown>)();
+          } else {
+            throw new Error(`Procedure is not a query: ${procedure}`);
+          }
+          const result = raw as { data?: Record<string, unknown>[] };
+          const items = result?.data ?? [];
+          return items.map((item) => ({
+            value: String(item[valueKey]),
+            label: String(item[labelKey]),
+          }));
+        };
+      }
+    }
+    return loaders;
+  }, [manifest, utils]);
+}

--- a/apps/pops-shell/src/components/settings/section-renderer/useTrpcOptionsLoaders.ts
+++ b/apps/pops-shell/src/components/settings/section-renderer/useTrpcOptionsLoaders.ts
@@ -1,26 +1,11 @@
 import { trpc } from '@/lib/trpc';
+import { traverseTrpcPath } from '@/lib/trpc-traverse';
 import { useMemo, useRef } from 'react';
 
 import type { SettingsManifest } from '@pops/types';
 
 type Options = { value: string; label: string }[];
 type Loaders = Record<string, () => Promise<Options>>;
-
-function traverseClient(client: unknown, procedure: string): Record<string, unknown> {
-  const parts = procedure.split('.');
-  let current: unknown = client;
-  for (const part of parts) {
-    if (current == null || (typeof current !== 'object' && typeof current !== 'function')) {
-      throw new Error(`Unknown procedure: ${procedure}`);
-    }
-    current = (current as Record<string, unknown>)[part];
-    if (current == null) throw new Error(`Unknown procedure: ${procedure}`);
-  }
-  if (current == null || (typeof current !== 'object' && typeof current !== 'function')) {
-    throw new Error(`Cannot call procedure: ${procedure}`);
-  }
-  return current as Record<string, unknown>;
-}
 
 export function useTrpcOptionsLoaders(manifest: SettingsManifest): Loaders {
   const utils = trpc.useUtils();
@@ -38,7 +23,7 @@ export function useTrpcOptionsLoaders(manifest: SettingsManifest): Loaders {
         const { procedure, valueKey, labelKey } = field.optionsLoader;
         const key = field.key;
         loaders[key] = async () => {
-          const node = traverseClient(utilsRef.current.client, procedure);
+          const node = traverseTrpcPath(utilsRef.current.client, procedure);
           let raw: unknown;
           if (typeof node.query === 'function') {
             raw = await (node.query as () => Promise<unknown>)();

--- a/apps/pops-shell/src/components/settings/section-renderer/useTrpcOptionsLoaders.ts
+++ b/apps/pops-shell/src/components/settings/section-renderer/useTrpcOptionsLoaders.ts
@@ -1,5 +1,5 @@
 import { trpc } from '@/lib/trpc';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 
 import type { SettingsManifest } from '@pops/types';
 
@@ -24,6 +24,11 @@ function traverseClient(client: unknown, procedure: string): Record<string, unkn
 
 export function useTrpcOptionsLoaders(manifest: SettingsManifest): Loaders {
   const utils = trpc.useUtils();
+  // Keep a ref so loader closures always see the latest utils without causing
+  // the memo to invalidate on every render (utils identity is not stable in tests
+  // and can vary across render cycles in production too).
+  const utilsRef = useRef(utils);
+  utilsRef.current = utils;
 
   return useMemo(() => {
     const loaders: Loaders = {};
@@ -33,7 +38,7 @@ export function useTrpcOptionsLoaders(manifest: SettingsManifest): Loaders {
         const { procedure, valueKey, labelKey } = field.optionsLoader;
         const key = field.key;
         loaders[key] = async () => {
-          const node = traverseClient(utils.client, procedure);
+          const node = traverseClient(utilsRef.current.client, procedure);
           let raw: unknown;
           if (typeof node.query === 'function') {
             raw = await (node.query as () => Promise<unknown>)();
@@ -50,5 +55,5 @@ export function useTrpcOptionsLoaders(manifest: SettingsManifest): Loaders {
       }
     }
     return loaders;
-  }, [manifest, utils]);
+  }, [manifest]); // manifest only — utils accessed via ref to avoid reference churn
 }

--- a/apps/pops-shell/src/lib/trpc-traverse.ts
+++ b/apps/pops-shell/src/lib/trpc-traverse.ts
@@ -1,11 +1,4 @@
-/**
- * Traverse a dot-delimited tRPC procedure path on a proxy client, returning
- * the leaf node so callers can invoke `.query()` or `.mutate()`.
- *
- * Throws `Error("Unknown procedure: <path>")` if any segment is missing.
- * Throws `Error("Cannot call procedure: <path>")` if the final node is not
- * an object or function.
- */
+/** tRPC proxy nodes are functions, not objects — allow both types when traversing. */
 export function traverseTrpcPath(client: unknown, procedure: string): Record<string, unknown> {
   const parts = procedure.split('.');
   let current: unknown = client;

--- a/apps/pops-shell/src/lib/trpc-traverse.ts
+++ b/apps/pops-shell/src/lib/trpc-traverse.ts
@@ -1,0 +1,23 @@
+/**
+ * Traverse a dot-delimited tRPC procedure path on a proxy client, returning
+ * the leaf node so callers can invoke `.query()` or `.mutate()`.
+ *
+ * Throws `Error("Unknown procedure: <path>")` if any segment is missing.
+ * Throws `Error("Cannot call procedure: <path>")` if the final node is not
+ * an object or function.
+ */
+export function traverseTrpcPath(client: unknown, procedure: string): Record<string, unknown> {
+  const parts = procedure.split('.');
+  let current: unknown = client;
+  for (const part of parts) {
+    if (current == null || (typeof current !== 'object' && typeof current !== 'function')) {
+      throw new Error(`Unknown procedure: ${procedure}`);
+    }
+    current = (current as Record<string, unknown>)[part];
+    if (current == null) throw new Error(`Unknown procedure: ${procedure}`);
+  }
+  if (current == null || (typeof current !== 'object' && typeof current !== 'function')) {
+    throw new Error(`Cannot call procedure: ${procedure}`);
+  }
+  return current as Record<string, unknown>;
+}

--- a/packages/app-media/src/components/request-movie/RequestMovieFormContent.tsx
+++ b/packages/app-media/src/components/request-movie/RequestMovieFormContent.tsx
@@ -85,7 +85,9 @@ export function RequestMovieFormContent(props: RequestMovieFormContentProps) {
   if (props.isDownloadMode) {
     return (
       <p className="text-sm text-muted-foreground">
-        This movie will be added to Radarr using your rotation settings and marked as protected.
+        This movie will be added to Radarr using your configured quality profile and root folder. It
+        will be marked as protected, meaning it won&apos;t be automatically removed by rotation for
+        the duration of your protection window.
       </p>
     );
   }

--- a/packages/app-media/src/pages/search/SearchInput.tsx
+++ b/packages/app-media/src/pages/search/SearchInput.tsx
@@ -29,9 +29,15 @@ export function SearchInput({ query, mode, onQueryChange, onModeChange }: Search
 
       <Tabs value={mode} onValueChange={(v: string) => onModeChange(v as SearchMode)}>
         <TabsList>
-          <TabsTrigger value="both">Both</TabsTrigger>
-          <TabsTrigger value="movies">Movies</TabsTrigger>
-          <TabsTrigger value="tv">TV Shows</TabsTrigger>
+          <TabsTrigger value="both" className="px-4">
+            Both
+          </TabsTrigger>
+          <TabsTrigger value="movies" className="px-4">
+            Movies
+          </TabsTrigger>
+          <TabsTrigger value="tv" className="px-4">
+            TV Shows
+          </TabsTrigger>
         </TabsList>
       </Tabs>
     </>

--- a/packages/module-registry/src/generated.ts
+++ b/packages/module-registry/src/generated.ts
@@ -1196,6 +1196,34 @@ export const MODULES = [
               },
             ],
           },
+          {
+            id: 'download_defaults',
+            title: 'Download Defaults',
+            description:
+              'Quality profile and root folder used when downloading movies via the Download button.',
+            fields: [
+              {
+                key: 'rotation_quality_profile_id',
+                label: 'Quality Profile',
+                type: 'select',
+                optionsLoader: {
+                  procedure: 'media.arr.getQualityProfiles',
+                  valueKey: 'id',
+                  labelKey: 'name',
+                },
+              },
+              {
+                key: 'rotation_root_folder_path',
+                label: 'Root Folder',
+                type: 'select',
+                optionsLoader: {
+                  procedure: 'media.arr.getRootFolders',
+                  valueKey: 'path',
+                  labelKey: 'path',
+                },
+              },
+            ],
+          },
         ],
       },
       {

--- a/packages/module-registry/src/settings/media/manifests.ts
+++ b/packages/module-registry/src/settings/media/manifests.ts
@@ -91,6 +91,34 @@ export const arrManifest: SettingsManifest = {
         },
       ],
     },
+    {
+      id: 'download_defaults',
+      title: 'Download Defaults',
+      description:
+        'Quality profile and root folder used when downloading movies via the Download button.',
+      fields: [
+        {
+          key: 'rotation_quality_profile_id',
+          label: 'Quality Profile',
+          type: 'select',
+          optionsLoader: {
+            procedure: 'media.arr.getQualityProfiles',
+            valueKey: 'id',
+            labelKey: 'name',
+          },
+        },
+        {
+          key: 'rotation_root_folder_path',
+          label: 'Root Folder',
+          type: 'select',
+          optionsLoader: {
+            procedure: 'media.arr.getRootFolders',
+            valueKey: 'path',
+            labelKey: 'path',
+          },
+        },
+      ],
+    },
   ],
 };
 

--- a/packages/types/src/settings-manifest.ts
+++ b/packages/types/src/settings-manifest.ts
@@ -33,6 +33,12 @@ export interface SettingsField {
     procedure: string;
     label: string;
   };
+  /** Load options dynamically from a tRPC query procedure. The procedure must return `{ data: Record<string, unknown>[] }`. */
+  optionsLoader?: {
+    procedure: string;
+    valueKey: string;
+    labelKey: string;
+  };
 }
 
 export interface SettingsGroup {


### PR DESCRIPTION
## Summary

- **Test Radarr/Sonarr broken**: The tRPC proxy client wraps \`noop\` (a function) as its Proxy target, so \`typeof proxy === 'function'\`, not \`'object'\`. The traversal guard in \`useTestActionHandler\` was rejecting it immediately, causing every test-action button to throw \`Unknown procedure: ...\`. Fixed by allowing \`'function'\` type throughout the traversal.
- **Download movie failing**: The \`downloadAndProtect\` mutation reads \`rotation_quality_profile_id\` and \`rotation_root_folder_path\` from the settings DB, but there was no UI to configure them. Added a "Download Defaults" group to the Arr settings manifest with dynamically-loaded selects backed by \`media.arr.getQualityProfiles\` and \`media.arr.getRootFolders\`. This required adding an \`optionsLoader\` field to \`SettingsField\` and a new \`useTrpcOptionsLoaders\` hook wired into \`SectionRenderer\`.
- **"Protected" copy unclear**: Updated the download modal description to explicitly state that protection means the movie won't be auto-removed by rotation for the duration of the configured protection window.
- **Search segment selector spacing**: Added \`px-4\` to each \`TabsTrigger\` in the movie search input so all three tabs have consistent horizontal padding.

## Test plan

- [ ] Go to Settings → Arr; click "Test Radarr" — should succeed or return a meaningful connection error (not "Unknown procedure")
- [ ] Arr settings page shows a "Download Defaults" section with Quality Profile and Root Folder dropdowns populated from Radarr
- [ ] Save a quality profile and root folder, then click Download on a movie — the download modal should show the updated copy and the download should proceed without "Radarr quality profile or root folder not configured"
- [ ] Movie search segment selector tabs (Both / Movies / TV Shows) have even padding