### PR TITLE
fix(mcp): set secret mode 0444 so node user can read pops_api_key

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -230,7 +230,8 @@ services:
     networks:
       - backend
     secrets:
-      - pops_api_key
+      - source: pops_api_key
+        mode: 0444
     environment:
       NODE_ENV: production
       POPS_API_URL: http://pops-api:3000


### PR DESCRIPTION
## Summary

- `pops-mcp` runs as the `node` user (non-root) for security
- Docker Compose mounts secrets as root-owned `0600` by default
- This made `/run/secrets/pops_api_key` unreadable inside the container, causing the API key load to fail silently and all tool calls to error with "POPS_API_KEY is required"
- Fix: set `mode: 0444` on the `pops_api_key` secret so any user in the container can read it

## Test plan

- [ ] `pops-mcp` container starts without "Could not read POPS_API_KEY_FILE" warning
- [ ] `GET /health` returns `{ status: 'ok', tools: 14 }`
- [ ] MCP tool calls succeed against live pops-api