### PR TITLE
refactor(inventory/fixtures): backend cleanup — DRY error mapping, .returning(), tighter tests

### DIFF
--- a/apps/pops-api/src/modules/inventory/fixtures/fixtures.test.ts
+++ b/apps/pops-api/src/modules/inventory/fixtures/fixtures.test.ts
@@ -1,4 +1,3 @@
-import { TRPCError } from '@trpc/server';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -71,6 +70,30 @@ describe('inventory.fixtures.list', () => {
     const page2 = await caller.inventory.fixtures.list({ limit: 2, offset: 2 });
     expect(page2.data).toHaveLength(1);
   });
+
+  // Deterministic pagination — when two rows share createdAt, the id tiebreak
+  // must keep the ordering stable across pages. Without the tiebreak, SQLite
+  // can return rows in arbitrary order and a paginated walk loses or repeats.
+  it('orders by createdAt, id for stable pagination on duplicate createdAt', async () => {
+    // Hand-craft three fixtures with the SAME createdAt to force the tiebreak path.
+    db.prepare(
+      `INSERT INTO fixtures (id, name, type, created_at, last_edited_time)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run('aaa', 'A', 't', '2024-01-01 00:00:00', '2024-01-01T00:00:00.000Z');
+    db.prepare(
+      `INSERT INTO fixtures (id, name, type, created_at, last_edited_time)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run('bbb', 'B', 't', '2024-01-01 00:00:00', '2024-01-01T00:00:00.000Z');
+    db.prepare(
+      `INSERT INTO fixtures (id, name, type, created_at, last_edited_time)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run('ccc', 'C', 't', '2024-01-01 00:00:00', '2024-01-01T00:00:00.000Z');
+
+    const page1 = await caller.inventory.fixtures.list({ limit: 2, offset: 0 });
+    const page2 = await caller.inventory.fixtures.list({ limit: 2, offset: 2 });
+    expect(page1.data.map((r) => r.id)).toEqual(['aaa', 'bbb']);
+    expect(page2.data.map((r) => r.id)).toEqual(['ccc']);
+  });
 });
 
 describe('inventory.fixtures.get', () => {
@@ -91,12 +114,9 @@ describe('inventory.fixtures.get', () => {
   });
 
   it('throws NOT_FOUND for nonexistent id', async () => {
-    await expect(caller.inventory.fixtures.get({ id: 'nonexistent' })).rejects.toThrow(TRPCError);
-    try {
-      await caller.inventory.fixtures.get({ id: 'nonexistent' });
-    } catch (err) {
-      expect((err as TRPCError).code).toBe('NOT_FOUND');
-    }
+    await expect(caller.inventory.fixtures.get({ id: 'nonexistent' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
   });
 });
 
@@ -134,6 +154,12 @@ describe('inventory.fixtures.create', () => {
     expect(row).toBeDefined();
     expect(row!.name).toBe('Outlet A');
   });
+
+  it('rejects empty name with BAD_REQUEST', async () => {
+    await expect(
+      caller.inventory.fixtures.create({ name: '', type: 'power_outlet' })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
 });
 
 describe('inventory.fixtures.update', () => {
@@ -142,6 +168,19 @@ describe('inventory.fixtures.update', () => {
     const result = await caller.inventory.fixtures.update({ id, data: { name: 'New Name' } });
     expect(result.data.name).toBe('New Name');
     expect(result.message).toBe('Fixture updated');
+  });
+
+  it('updates multiple fields at once', async () => {
+    const id = seedFixture(db, { name: 'A', type: 'old_type', notes: null });
+    const locId = seedLocation(db, { name: 'Garage' });
+    const result = await caller.inventory.fixtures.update({
+      id,
+      data: { name: 'B', type: 'new_type', locationId: locId, notes: 'updated' },
+    });
+    expect(result.data.name).toBe('B');
+    expect(result.data.type).toBe('new_type');
+    expect(result.data.locationId).toBe(locId);
+    expect(result.data.notes).toBe('updated');
   });
 
   it('clears nullable field with null', async () => {
@@ -164,15 +203,27 @@ describe('inventory.fixtures.update', () => {
     expect(result.data.locationId).toBeNull();
   });
 
+  it('bumps lastEditedTime', async () => {
+    const id = seedFixture(db, { name: 'Outlet', type: 'power_outlet' });
+    const before = await caller.inventory.fixtures.get({ id });
+    await new Promise((r) => setTimeout(r, 5));
+    const after = await caller.inventory.fixtures.update({ id, data: { name: 'New' } });
+    expect(new Date(after.data.lastEditedTime).getTime()).toBeGreaterThan(
+      new Date(before.data.lastEditedTime).getTime()
+    );
+  });
+
+  it('rejects empty patch with BAD_REQUEST', async () => {
+    const id = seedFixture(db, { name: 'Outlet', type: 'power_outlet' });
+    await expect(caller.inventory.fixtures.update({ id, data: {} })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+
   it('throws NOT_FOUND for nonexistent id', async () => {
     await expect(
       caller.inventory.fixtures.update({ id: 'nope', data: { name: 'X' } })
-    ).rejects.toThrow(TRPCError);
-    try {
-      await caller.inventory.fixtures.update({ id: 'nope', data: { name: 'X' } });
-    } catch (err) {
-      expect((err as TRPCError).code).toBe('NOT_FOUND');
-    }
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 });
 
@@ -199,12 +250,25 @@ describe('inventory.fixtures.delete', () => {
   });
 
   it('throws NOT_FOUND for nonexistent id', async () => {
-    await expect(caller.inventory.fixtures.delete({ id: 'nope' })).rejects.toThrow(TRPCError);
-    try {
-      await caller.inventory.fixtures.delete({ id: 'nope' });
-    } catch (err) {
-      expect((err as TRPCError).code).toBe('NOT_FOUND');
-    }
+    await expect(caller.inventory.fixtures.delete({ id: 'nope' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+});
+
+describe('locations → fixtures cascade', () => {
+  it('sets fixture.locationId to NULL when its location is deleted', async () => {
+    const locId = seedLocation(db, { name: 'Soon-Gone Room' });
+    const fixtureId = seedFixture(db, {
+      name: 'Outlet',
+      type: 'power_outlet',
+      location_id: locId,
+    });
+
+    db.prepare('DELETE FROM locations WHERE id = ?').run(locId);
+
+    const after = await caller.inventory.fixtures.get({ id: fixtureId });
+    expect(after.data.locationId).toBeNull();
   });
 });
 
@@ -232,14 +296,16 @@ describe('inventory.fixtures.connect', () => {
     expect(result.data).toHaveLength(2);
   });
 
-  it('allows multiple items on the same fixture', async () => {
+  it('allows multiple items on the same fixture (e.g. power strip)', async () => {
     const item1 = seedInventoryItem(db, { item_name: 'TV' });
     const item2 = seedInventoryItem(db, { item_name: 'Speakers' });
     const fixtureId = seedFixture(db, { name: 'Outlet A', type: 'power_outlet' });
 
     await caller.inventory.fixtures.connect({ itemId: item1, fixtureId });
     await caller.inventory.fixtures.connect({ itemId: item2, fixtureId });
-    // No error — a power strip can serve multiple items
+
+    const result = await caller.inventory.fixtures.list({});
+    expect(result.total).toBe(1);
   });
 
   it('throws CONFLICT when same item-fixture pair connected twice', async () => {
@@ -247,38 +313,23 @@ describe('inventory.fixtures.connect', () => {
     const fixtureId = seedFixture(db, { name: 'Outlet', type: 'power_outlet' });
 
     await caller.inventory.fixtures.connect({ itemId, fixtureId });
-    await expect(caller.inventory.fixtures.connect({ itemId, fixtureId })).rejects.toThrow(
-      TRPCError
-    );
-    try {
-      await caller.inventory.fixtures.connect({ itemId, fixtureId });
-    } catch (err) {
-      expect((err as TRPCError).code).toBe('CONFLICT');
-    }
+    await expect(caller.inventory.fixtures.connect({ itemId, fixtureId })).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
   });
 
   it('throws NOT_FOUND when item does not exist', async () => {
     const fixtureId = seedFixture(db, { name: 'Outlet', type: 'power_outlet' });
-    await expect(caller.inventory.fixtures.connect({ itemId: 'nope', fixtureId })).rejects.toThrow(
-      TRPCError
-    );
-    try {
-      await caller.inventory.fixtures.connect({ itemId: 'nope', fixtureId });
-    } catch (err) {
-      expect((err as TRPCError).code).toBe('NOT_FOUND');
-    }
+    await expect(
+      caller.inventory.fixtures.connect({ itemId: 'nope', fixtureId })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
   it('throws NOT_FOUND when fixture does not exist', async () => {
     const itemId = seedInventoryItem(db, { item_name: 'Laptop' });
-    await expect(caller.inventory.fixtures.connect({ itemId, fixtureId: 'nope' })).rejects.toThrow(
-      TRPCError
-    );
-    try {
-      await caller.inventory.fixtures.connect({ itemId, fixtureId: 'nope' });
-    } catch (err) {
-      expect((err as TRPCError).code).toBe('NOT_FOUND');
-    }
+    await expect(
+      caller.inventory.fixtures.connect({ itemId, fixtureId: 'nope' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 });
 
@@ -316,14 +367,9 @@ describe('inventory.fixtures.disconnect', () => {
     const itemId = seedInventoryItem(db, { item_name: 'Laptop' });
     const fixtureId = seedFixture(db, { name: 'Outlet', type: 'power_outlet' });
 
-    await expect(caller.inventory.fixtures.disconnect({ itemId, fixtureId })).rejects.toThrow(
-      TRPCError
+    await expect(caller.inventory.fixtures.disconnect({ itemId, fixtureId })).rejects.toMatchObject(
+      { code: 'NOT_FOUND' }
     );
-    try {
-      await caller.inventory.fixtures.disconnect({ itemId, fixtureId });
-    } catch (err) {
-      expect((err as TRPCError).code).toBe('NOT_FOUND');
-    }
   });
 });
 
@@ -378,25 +424,23 @@ describe('inventory.fixtures.listForItem', () => {
   });
 });
 
+// Loop the auth assertions so we can't accidentally cover only some endpoints.
 describe('inventory.fixtures auth', () => {
-  it('throws UNAUTHORIZED without auth on list', async () => {
-    const unauth = createCaller(false);
-    await expect(unauth.inventory.fixtures.list({})).rejects.toMatchObject({
-      code: 'UNAUTHORIZED',
+  const cases: Array<[string, (c: ReturnType<typeof createCaller>) => Promise<unknown>]> = [
+    ['list', (c) => c.inventory.fixtures.list({})],
+    ['get', (c) => c.inventory.fixtures.get({ id: 'x' })],
+    ['create', (c) => c.inventory.fixtures.create({ name: 'A', type: 't' })],
+    ['update', (c) => c.inventory.fixtures.update({ id: 'x', data: { name: 'B' } })],
+    ['delete', (c) => c.inventory.fixtures.delete({ id: 'x' })],
+    ['connect', (c) => c.inventory.fixtures.connect({ itemId: 'a', fixtureId: 'b' })],
+    ['disconnect', (c) => c.inventory.fixtures.disconnect({ itemId: 'a', fixtureId: 'b' })],
+    ['listForItem', (c) => c.inventory.fixtures.listForItem({ itemId: 'a' })],
+  ];
+
+  for (const [name, invoke] of cases) {
+    it(`throws UNAUTHORIZED without auth on ${name}`, async () => {
+      const unauth = createCaller(false);
+      await expect(invoke(unauth)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
     });
-  });
-
-  it('throws UNAUTHORIZED without auth on create', async () => {
-    const unauth = createCaller(false);
-    await expect(
-      unauth.inventory.fixtures.create({ name: 'Outlet', type: 'power_outlet' })
-    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
-  });
-
-  it('throws UNAUTHORIZED without auth on connect', async () => {
-    const unauth = createCaller(false);
-    await expect(
-      unauth.inventory.fixtures.connect({ itemId: 'a', fixtureId: 'b' })
-    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
-  });
+  }
 });

--- a/apps/pops-api/src/modules/inventory/fixtures/router.ts
+++ b/apps/pops-api/src/modules/inventory/fixtures/router.ts
@@ -1,8 +1,7 @@
-import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-import { ConflictError, NotFoundError } from '../../../shared/errors.js';
 import { paginationMeta, PaginationMetaSchema } from '../../../shared/pagination.js';
+import { mapDomainErrors } from '../../../shared/trpc-error-mapper.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import * as service from './service.js';
 import {
@@ -12,13 +11,15 @@ import {
   FixtureQuerySchema,
   FixtureSchema,
   ItemFixtureConnectionSchema,
-  toFixture,
-  toItemFixtureConnection,
   UpdateFixtureSchema,
 } from './types.js';
 
 const DEFAULT_LIMIT = 50;
 const DEFAULT_OFFSET = 0;
+
+const FixtureMutationResponse = z.object({ data: FixtureSchema, message: z.string() });
+const DeleteResponse = z.object({ message: z.string() });
+const ConnectResponse = z.object({ data: ItemFixtureConnectionSchema, message: z.string() });
 
 export const fixturesRouter = router({
   list: protectedProcedure
@@ -33,80 +34,63 @@ export const fixturesRouter = router({
         limit,
         offset,
       });
-      return { data: rows.map(toFixture), total };
+      return { data: rows, total };
     }),
 
   get: protectedProcedure
     .input(z.object({ id: z.string().min(1) }))
     .output(z.object({ data: FixtureSchema }))
-    .query(({ input }) => {
-      try {
-        return { data: toFixture(service.getFixture(input.id)) };
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-        }
-        throw err;
-      }
-    }),
+    .query(({ input }) => mapDomainErrors(() => ({ data: service.getFixture(input.id) }))),
 
-  create: protectedProcedure.input(CreateFixtureSchema).mutation(({ input }) => {
-    const row = service.createFixture(input);
-    return { data: toFixture(row), message: 'Fixture created' };
-  }),
+  create: protectedProcedure
+    .input(CreateFixtureSchema)
+    .output(FixtureMutationResponse)
+    .mutation(({ input }) =>
+      mapDomainErrors(() => ({
+        data: service.createFixture(input),
+        message: 'Fixture created',
+      }))
+    ),
 
   update: protectedProcedure
     .input(z.object({ id: z.string().min(1), data: UpdateFixtureSchema }))
-    .mutation(({ input }) => {
-      try {
-        const row = service.updateFixture(input.id, input.data);
-        return { data: toFixture(row), message: 'Fixture updated' };
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-        }
-        throw err;
-      }
-    }),
+    .output(FixtureMutationResponse)
+    .mutation(({ input }) =>
+      mapDomainErrors(() => ({
+        data: service.updateFixture(input.id, input.data),
+        message: 'Fixture updated',
+      }))
+    ),
 
-  delete: protectedProcedure.input(z.object({ id: z.string().min(1) })).mutation(({ input }) => {
-    try {
-      service.deleteFixture(input.id);
-      return { message: 'Fixture deleted' };
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-      }
-      throw err;
-    }
-  }),
+  delete: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .output(DeleteResponse)
+    .mutation(({ input }) =>
+      mapDomainErrors(() => {
+        service.deleteFixture(input.id);
+        return { message: 'Fixture deleted' };
+      })
+    ),
 
-  connect: protectedProcedure.input(ConnectFixtureSchema).mutation(({ input }) => {
-    try {
-      const row = service.connectItemToFixture(input.itemId, input.fixtureId);
-      return { data: toItemFixtureConnection(row), message: 'Item connected to fixture' };
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-      }
-      if (err instanceof ConflictError) {
-        throw new TRPCError({ code: 'CONFLICT', message: err.message });
-      }
-      throw err;
-    }
-  }),
+  connect: protectedProcedure
+    .input(ConnectFixtureSchema)
+    .output(ConnectResponse)
+    .mutation(({ input }) =>
+      mapDomainErrors(() => ({
+        data: service.connectItemToFixture(input.itemId, input.fixtureId),
+        message: 'Item connected to fixture',
+      }))
+    ),
 
-  disconnect: protectedProcedure.input(ConnectFixtureSchema).mutation(({ input }) => {
-    try {
-      service.disconnectItemFromFixture(input.itemId, input.fixtureId);
-      return { message: 'Item disconnected from fixture' };
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
-      }
-      throw err;
-    }
-  }),
+  disconnect: protectedProcedure
+    .input(ConnectFixtureSchema)
+    .output(DeleteResponse)
+    .mutation(({ input }) =>
+      mapDomainErrors(() => {
+        service.disconnectItemFromFixture(input.itemId, input.fixtureId);
+        return { message: 'Item disconnected from fixture' };
+      })
+    ),
 
   listForItem: protectedProcedure
     .input(FixtureConnectionQuerySchema)
@@ -118,7 +102,7 @@ export const fixturesRouter = router({
       const offset = input.offset ?? DEFAULT_OFFSET;
       const { rows, total } = service.listFixturesForItem(input.itemId, limit, offset);
       return {
-        data: rows.map(toItemFixtureConnection),
+        data: rows,
         pagination: paginationMeta(total, limit, offset),
       };
     }),

--- a/apps/pops-api/src/modules/inventory/fixtures/service.ts
+++ b/apps/pops-api/src/modules/inventory/fixtures/service.ts
@@ -1,26 +1,30 @@
-import { and, asc, count, eq, sql } from 'drizzle-orm';
+import { and, asc, count, eq } from 'drizzle-orm';
 
 import { fixtures, homeInventory, itemFixtureConnections } from '@pops/db-types';
 
 import { getDrizzle } from '../../../db.js';
 import { ConflictError, NotFoundError } from '../../../shared/errors.js';
+import {
+  isForeignKeyConstraintError,
+  isUniqueConstraintError,
+} from '../../../shared/sqlite-errors.js';
 
 import type {
   CreateFixtureInput,
-  FixtureRow,
-  ItemFixtureConnectionRow,
+  Fixture,
+  ItemFixtureConnection,
   UpdateFixtureInput,
 } from './types.js';
 
 const NOW = (): string => new Date().toISOString();
 
 export interface FixtureListResult {
-  rows: FixtureRow[];
+  rows: Fixture[];
   total: number;
 }
 
 export interface FixtureConnectionListResult {
-  rows: ItemFixtureConnectionRow[];
+  rows: ItemFixtureConnection[];
   total: number;
 }
 
@@ -48,39 +52,36 @@ export function listFixtures(opts: {
   return { rows, total: countResult?.total ?? 0 };
 }
 
-export function getFixture(id: string): FixtureRow {
+export function getFixture(id: string): Fixture {
   const db = getDrizzle();
   const [row] = db.select().from(fixtures).where(eq(fixtures.id, id)).all();
   if (!row) throw new NotFoundError('Fixture', id);
   return row;
 }
 
-export function createFixture(input: CreateFixtureInput): FixtureRow {
+export function createFixture(input: CreateFixtureInput): Fixture {
   const db = getDrizzle();
-  const now = NOW();
-  db.insert(fixtures)
+  const [row] = db
+    .insert(fixtures)
     .values({
       name: input.name,
       type: input.type,
       locationId: input.locationId ?? null,
       notes: input.notes ?? null,
-      lastEditedTime: now,
+      lastEditedTime: NOW(),
     })
-    .run();
-
-  const [row] = db
-    .select()
-    .from(fixtures)
-    .where(sql`rowid = last_insert_rowid()`)
+    .returning()
     .all();
-  if (!row) throw new Error('Failed to retrieve created fixture');
+  if (!row) throw new Error('Failed to create fixture');
   return row;
 }
 
-export function updateFixture(id: string, input: UpdateFixtureInput): FixtureRow {
+export function updateFixture(id: string, input: UpdateFixtureInput): Fixture {
   const db = getDrizzle();
-  const existing = getFixture(id);
 
+  // Three-state per field: absent → leave, null → clear, value → set.
+  // `UpdateFixtureSchema.refine` guarantees at least one input key, so the
+  // patch is never empty (`lastEditedTime` aside).
   const patch: Record<string, unknown> = { lastEditedTime: NOW() };
   if ('name' in input && input.name !== undefined) patch['name'] = input.name;
   if ('type' in input && input.type !== undefined) patch['type'] = input.type;
@@ -88,71 +89,58 @@ export function updateFixture(id: string, input: UpdateFixtureInput): FixtureRow
     patch['locationId'] = input.locationId;
   if ('notes' in input && input.notes !== undefined) patch['notes'] = input.notes;
 
-  db.update(fixtures).set(patch).where(eq(fixtures.id, existing.id)).run();
-
-  return getFixture(id);
+  const [row] = db.update(fixtures).set(patch).where(eq(fixtures.id, id)).returning().all();
+  if (!row) throw new NotFoundError('Fixture', id);
+  return row;
 }
 
 export function deleteFixture(id: string): void {
   const db = getDrizzle();
-  const existing = getFixture(id);
-  db.delete(fixtures).where(eq(fixtures.id, existing.id)).run();
+  const result = db.delete(fixtures).where(eq(fixtures.id, id)).run();
+  if (result.changes === 0) throw new NotFoundError('Fixture', id);
 }
 
-export function connectItemToFixture(itemId: string, fixtureId: string): ItemFixtureConnectionRow {
+// Optimistic insert: the foreign keys on item_fixture_connections enforce
+// existence, so a pre-check would only widen the TOCTOU window without buying
+// correctness. We catch the constraint failures and reach for nicer error
+// messages only on the unhappy path.
+export function connectItemToFixture(itemId: string, fixtureId: string): ItemFixtureConnection {
   const db = getDrizzle();
-
-  const [item] = db
-    .select({ id: homeInventory.id })
-    .from(homeInventory)
-    .where(eq(homeInventory.id, itemId))
-    .all();
-  if (!item) throw new NotFoundError('Inventory item', itemId);
-
-  const [fixture] = db
-    .select({ id: fixtures.id })
-    .from(fixtures)
-    .where(eq(fixtures.id, fixtureId))
-    .all();
-  if (!fixture) throw new NotFoundError('Fixture', fixtureId);
-
   try {
-    db.insert(itemFixtureConnections).values({ itemId, fixtureId }).run();
+    const [row] = db.insert(itemFixtureConnections).values({ itemId, fixtureId }).returning().all();
+    if (!row) throw new Error('Failed to create item-fixture connection');
+    return row;
   } catch (err) {
-    if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+    if (isUniqueConstraintError(err)) {
       throw new ConflictError(`Item '${itemId}' is already connected to fixture '${fixtureId}'`);
+    }
+    if (isForeignKeyConstraintError(err)) {
+      const [item] = db
+        .select({ id: homeInventory.id })
+        .from(homeInventory)
+        .where(eq(homeInventory.id, itemId))
+        .all();
+      if (!item) throw new NotFoundError('Inventory item', itemId);
+      throw new NotFoundError('Fixture', fixtureId);
     }
     throw err;
   }
-
-  const [created] = db
-    .select()
-    .from(itemFixtureConnections)
-    .where(
-      and(
-        eq(itemFixtureConnections.itemId, itemId),
-        eq(itemFixtureConnections.fixtureId, fixtureId)
-      )
-    )
-    .all();
-  if (!created) throw new Error('Failed to retrieve created fixture connection');
-  return created;
 }
 
 export function disconnectItemFromFixture(itemId: string, fixtureId: string): void {
   const db = getDrizzle();
-  const [row] = db
-    .select({ id: itemFixtureConnections.id })
-    .from(itemFixtureConnections)
+  const result = db
+    .delete(itemFixtureConnections)
     .where(
       and(
         eq(itemFixtureConnections.itemId, itemId),
         eq(itemFixtureConnections.fixtureId, fixtureId)
       )
     )
-    .all();
-  if (!row) throw new NotFoundError('Item-fixture connection', `${itemId}-${fixtureId}`);
-  db.delete(itemFixtureConnections).where(eq(itemFixtureConnections.id, row.id)).run();
+    .run();
+  if (result.changes === 0) {
+    throw new NotFoundError('Item-fixture connection', `${itemId}-${fixtureId}`);
+  }
 }
 
 export function listFixturesForItem(

--- a/apps/pops-api/src/modules/inventory/fixtures/types.ts
+++ b/apps/pops-api/src/modules/inventory/fixtures/types.ts
@@ -4,44 +4,8 @@ import type { FixtureRow, ItemFixtureConnectionRow } from '@pops/db-types';
 
 export type { FixtureRow, ItemFixtureConnectionRow };
 
-export interface Fixture {
-  id: string;
-  name: string;
-  type: string;
-  locationId: string | null;
-  notes: string | null;
-  createdAt: string;
-  lastEditedTime: string;
-}
-
-export function toFixture(row: FixtureRow): Fixture {
-  return {
-    id: row.id,
-    name: row.name,
-    type: row.type,
-    locationId: row.locationId ?? null,
-    notes: row.notes ?? null,
-    createdAt: row.createdAt,
-    lastEditedTime: row.lastEditedTime,
-  };
-}
-
-export interface ItemFixtureConnection {
-  id: number;
-  itemId: string;
-  fixtureId: string;
-  createdAt: string;
-}
-
-export function toItemFixtureConnection(row: ItemFixtureConnectionRow): ItemFixtureConnection {
-  return {
-    id: row.id,
-    itemId: row.itemId,
-    fixtureId: row.fixtureId,
-    createdAt: row.createdAt,
-  };
-}
-
+// Single source of truth for the API shape: the Zod schema. The TS types are
+// derived from it, so the wire contract and the static types cannot drift.
 export const FixtureSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -51,6 +15,7 @@ export const FixtureSchema = z.object({
   createdAt: z.string(),
   lastEditedTime: z.string(),
 });
+export type Fixture = z.infer<typeof FixtureSchema>;
 
 export const ItemFixtureConnectionSchema = z.object({
   id: z.number(),
@@ -58,6 +23,7 @@ export const ItemFixtureConnectionSchema = z.object({
   fixtureId: z.string(),
   createdAt: z.string(),
 });
+export type ItemFixtureConnection = z.infer<typeof ItemFixtureConnectionSchema>;
 
 export const CreateFixtureSchema = z.object({
   name: z.string().min(1, 'Name is required'),

--- a/apps/pops-api/src/shared/capture-errors.ts
+++ b/apps/pops-api/src/shared/capture-errors.ts
@@ -1,0 +1,21 @@
+// Test-only helpers: invoke `fn` and return whatever it threw / rejected with.
+// If `fn` returns normally these throw a clear error so a missing throw can
+// never silently let a `catch`-block assertion pass.
+
+export function captureThrow(fn: () => unknown): unknown {
+  try {
+    fn();
+  } catch (err) {
+    return err;
+  }
+  throw new Error('expected the call to throw, but it returned normally');
+}
+
+export async function captureReject(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn();
+  } catch (err) {
+    return err;
+  }
+  throw new Error('expected the call to reject, but it resolved');
+}

--- a/apps/pops-api/src/shared/sqlite-errors.test.ts
+++ b/apps/pops-api/src/shared/sqlite-errors.test.ts
@@ -1,0 +1,78 @@
+import BetterSqlite3 from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+import { isForeignKeyConstraintError, isUniqueConstraintError } from './sqlite-errors.js';
+
+// These helpers gate user-facing error mapping, so cover them against the real
+// better-sqlite3 surface — mocking the error shape would defeat the point.
+function freshDb(): BetterSqlite3.Database {
+  const db = new BetterSqlite3(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE parent (id TEXT PRIMARY KEY);
+    CREATE TABLE child (
+      id TEXT PRIMARY KEY,
+      parent_id TEXT NOT NULL REFERENCES parent(id) ON DELETE CASCADE,
+      tag TEXT NOT NULL UNIQUE
+    );
+  `);
+  return db;
+}
+
+describe('isUniqueConstraintError', () => {
+  it('returns true for a real UNIQUE constraint violation', () => {
+    const db = freshDb();
+    db.exec(`INSERT INTO parent (id) VALUES ('p1')`);
+    db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c1', 'p1', 'unique-tag')`);
+
+    let caught: unknown;
+    try {
+      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c2', 'p1', 'unique-tag')`);
+    } catch (err) {
+      caught = err;
+    }
+    expect(isUniqueConstraintError(caught)).toBe(true);
+  });
+
+  it('returns false for FK violations and non-DB errors', () => {
+    const db = freshDb();
+    let fk: unknown;
+    try {
+      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c1', 'missing', 't')`);
+    } catch (err) {
+      fk = err;
+    }
+    expect(isUniqueConstraintError(fk)).toBe(false);
+    expect(isUniqueConstraintError(new Error('plain error'))).toBe(false);
+    expect(isUniqueConstraintError(null)).toBe(false);
+    expect(isUniqueConstraintError({})).toBe(false);
+    expect(isUniqueConstraintError({ code: 123 })).toBe(false);
+  });
+});
+
+describe('isForeignKeyConstraintError', () => {
+  it('returns true for a real FK violation', () => {
+    const db = freshDb();
+    let caught: unknown;
+    try {
+      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c1', 'missing', 't')`);
+    } catch (err) {
+      caught = err;
+    }
+    expect(isForeignKeyConstraintError(caught)).toBe(true);
+  });
+
+  it('returns false for UNIQUE violations and non-DB errors', () => {
+    const db = freshDb();
+    db.exec(`INSERT INTO parent (id) VALUES ('p1')`);
+    db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c1', 'p1', 'unique-tag')`);
+    let uniq: unknown;
+    try {
+      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c2', 'p1', 'unique-tag')`);
+    } catch (err) {
+      uniq = err;
+    }
+    expect(isForeignKeyConstraintError(uniq)).toBe(false);
+    expect(isForeignKeyConstraintError(undefined)).toBe(false);
+  });
+});

--- a/apps/pops-api/src/shared/sqlite-errors.test.ts
+++ b/apps/pops-api/src/shared/sqlite-errors.test.ts
@@ -1,6 +1,7 @@
 import BetterSqlite3 from 'better-sqlite3';
 import { describe, expect, it } from 'vitest';
 
+import { captureThrow } from './capture-errors.js';
 import { isForeignKeyConstraintError, isUniqueConstraintError } from './sqlite-errors.js';
 
 // These helpers gate user-facing error mapping, so cover them against the real
@@ -17,15 +18,6 @@ function freshDb(): BetterSqlite3.Database {
     );
   `);
   return db;
-}
-
-function captureThrow(fn: () => void): unknown {
-  try {
-    fn();
-  } catch (err) {
-    return err;
-  }
-  throw new Error('expected the call to throw, but it returned normally');
 }
 
 describe('isUniqueConstraintError', () => {

--- a/apps/pops-api/src/shared/sqlite-errors.test.ts
+++ b/apps/pops-api/src/shared/sqlite-errors.test.ts
@@ -19,29 +19,32 @@ function freshDb(): BetterSqlite3.Database {
   return db;
 }
 
+function captureThrow(fn: () => void): unknown {
+  try {
+    fn();
+  } catch (err) {
+    return err;
+  }
+  throw new Error('expected the call to throw, but it returned normally');
+}
+
 describe('isUniqueConstraintError', () => {
   it('returns true for a real UNIQUE constraint violation', () => {
     const db = freshDb();
     db.exec(`INSERT INTO parent (id) VALUES ('p1')`);
     db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c1', 'p1', 'unique-tag')`);
 
-    let caught: unknown;
-    try {
-      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c2', 'p1', 'unique-tag')`);
-    } catch (err) {
-      caught = err;
-    }
-    expect(isUniqueConstraintError(caught)).toBe(true);
+    const err = captureThrow(() =>
+      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c2', 'p1', 'unique-tag')`)
+    );
+    expect(isUniqueConstraintError(err)).toBe(true);
   });
 
   it('returns false for FK violations and non-DB errors', () => {
     const db = freshDb();
-    let fk: unknown;
-    try {
-      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c1', 'missing', 't')`);
-    } catch (err) {
-      fk = err;
-    }
+    const fk = captureThrow(() =>
+      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c1', 'missing', 't')`)
+    );
     expect(isUniqueConstraintError(fk)).toBe(false);
     expect(isUniqueConstraintError(new Error('plain error'))).toBe(false);
     expect(isUniqueConstraintError(null)).toBe(false);
@@ -53,25 +56,19 @@ describe('isUniqueConstraintError', () => {
 describe('isForeignKeyConstraintError', () => {
   it('returns true for a real FK violation', () => {
     const db = freshDb();
-    let caught: unknown;
-    try {
-      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c1', 'missing', 't')`);
-    } catch (err) {
-      caught = err;
-    }
-    expect(isForeignKeyConstraintError(caught)).toBe(true);
+    const err = captureThrow(() =>
+      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c1', 'missing', 't')`)
+    );
+    expect(isForeignKeyConstraintError(err)).toBe(true);
   });
 
   it('returns false for UNIQUE violations and non-DB errors', () => {
     const db = freshDb();
     db.exec(`INSERT INTO parent (id) VALUES ('p1')`);
     db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c1', 'p1', 'unique-tag')`);
-    let uniq: unknown;
-    try {
-      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c2', 'p1', 'unique-tag')`);
-    } catch (err) {
-      uniq = err;
-    }
+    const uniq = captureThrow(() =>
+      db.exec(`INSERT INTO child (id, parent_id, tag) VALUES ('c2', 'p1', 'unique-tag')`)
+    );
     expect(isForeignKeyConstraintError(uniq)).toBe(false);
     expect(isForeignKeyConstraintError(undefined)).toBe(false);
   });

--- a/apps/pops-api/src/shared/sqlite-errors.ts
+++ b/apps/pops-api/src/shared/sqlite-errors.ts
@@ -1,0 +1,24 @@
+// better-sqlite3 surfaces SQLITE_CONSTRAINT_* on err.code; matching the code is
+// resilient to wording changes in future SQLite releases (the messages have
+// shifted before — e.g. "constraint failed" → "UNIQUE constraint failed: t.c").
+
+interface CodedError {
+  code: string;
+}
+
+function hasCode(err: unknown): err is CodedError {
+  return (
+    err !== null &&
+    typeof err === 'object' &&
+    'code' in err &&
+    typeof (err as { code: unknown }).code === 'string'
+  );
+}
+
+export function isUniqueConstraintError(err: unknown): boolean {
+  return hasCode(err) && err.code === 'SQLITE_CONSTRAINT_UNIQUE';
+}
+
+export function isForeignKeyConstraintError(err: unknown): boolean {
+  return hasCode(err) && err.code === 'SQLITE_CONSTRAINT_FOREIGNKEY';
+}

--- a/apps/pops-api/src/shared/trpc-error-mapper.test.ts
+++ b/apps/pops-api/src/shared/trpc-error-mapper.test.ts
@@ -1,26 +1,9 @@
 import { TRPCError } from '@trpc/server';
 import { describe, expect, it } from 'vitest';
 
+import { captureReject, captureThrow } from './capture-errors.js';
 import { BudgetExceededError, ConflictError, NotFoundError, ValidationError } from './errors.js';
 import { mapDomainErrors, mapDomainErrorsAsync } from './trpc-error-mapper.js';
-
-function captureThrow(fn: () => unknown): unknown {
-  try {
-    fn();
-  } catch (err) {
-    return err;
-  }
-  throw new Error('expected the call to throw, but it returned normally');
-}
-
-async function captureReject(fn: () => Promise<unknown>): Promise<unknown> {
-  try {
-    await fn();
-  } catch (err) {
-    return err;
-  }
-  throw new Error('expected the call to reject, but it resolved');
-}
 
 describe('mapDomainErrors', () => {
   it('returns the inner value when no throw', () => {

--- a/apps/pops-api/src/shared/trpc-error-mapper.test.ts
+++ b/apps/pops-api/src/shared/trpc-error-mapper.test.ts
@@ -1,0 +1,97 @@
+import { TRPCError } from '@trpc/server';
+import { describe, expect, it } from 'vitest';
+
+import { BudgetExceededError, ConflictError, NotFoundError, ValidationError } from './errors.js';
+import { mapDomainErrors, mapDomainErrorsAsync } from './trpc-error-mapper.js';
+
+describe('mapDomainErrors', () => {
+  it('returns the inner value when no throw', () => {
+    expect(mapDomainErrors(() => 42)).toBe(42);
+  });
+
+  it('maps NotFoundError → NOT_FOUND', () => {
+    let caught: unknown;
+    try {
+      mapDomainErrors(() => {
+        throw new NotFoundError('Fixture', 'x');
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('NOT_FOUND');
+    expect((caught as TRPCError).message).toBe("Fixture 'x' not found");
+  });
+
+  it('maps ConflictError → CONFLICT', () => {
+    expect(() =>
+      mapDomainErrors(() => {
+        throw new ConflictError('dup');
+      })
+    ).toThrow(TRPCError);
+    try {
+      mapDomainErrors(() => {
+        throw new ConflictError('dup');
+      });
+    } catch (err) {
+      expect((err as TRPCError).code).toBe('CONFLICT');
+    }
+  });
+
+  it('maps ValidationError → BAD_REQUEST', () => {
+    try {
+      mapDomainErrors(() => {
+        throw new ValidationError({ field: 'name' });
+      });
+    } catch (err) {
+      expect((err as TRPCError).code).toBe('BAD_REQUEST');
+    }
+  });
+
+  it('maps BudgetExceededError → PAYMENT_REQUIRED', () => {
+    try {
+      mapDomainErrors(() => {
+        throw new BudgetExceededError({
+          budgetId: 'b',
+          limitType: 'cost',
+          currentUsage: 10,
+          limit: 5,
+        });
+      });
+    } catch (err) {
+      expect((err as TRPCError).code).toBe('PAYMENT_REQUIRED');
+    }
+  });
+
+  it('rethrows non-HttpError unchanged', () => {
+    const sentinel = new Error('boom');
+    expect(() =>
+      mapDomainErrors(() => {
+        throw sentinel;
+      })
+    ).toThrow(sentinel);
+  });
+});
+
+describe('mapDomainErrorsAsync', () => {
+  it('returns the resolved value', async () => {
+    await expect(mapDomainErrorsAsync(async () => 'ok')).resolves.toBe('ok');
+  });
+
+  it('maps an async-thrown NotFoundError', async () => {
+    await expect(
+      mapDomainErrorsAsync(async () => {
+        throw new NotFoundError('Fixture', 'x');
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('rethrows a non-HttpError unchanged', async () => {
+    const sentinel = new Error('boom');
+    await expect(
+      mapDomainErrorsAsync(async () => {
+        throw sentinel;
+      })
+    ).rejects.toBe(sentinel);
+  });
+});

--- a/apps/pops-api/src/shared/trpc-error-mapper.test.ts
+++ b/apps/pops-api/src/shared/trpc-error-mapper.test.ts
@@ -4,52 +4,62 @@ import { describe, expect, it } from 'vitest';
 import { BudgetExceededError, ConflictError, NotFoundError, ValidationError } from './errors.js';
 import { mapDomainErrors, mapDomainErrorsAsync } from './trpc-error-mapper.js';
 
+function captureThrow(fn: () => unknown): unknown {
+  try {
+    fn();
+  } catch (err) {
+    return err;
+  }
+  throw new Error('expected the call to throw, but it returned normally');
+}
+
+async function captureReject(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn();
+  } catch (err) {
+    return err;
+  }
+  throw new Error('expected the call to reject, but it resolved');
+}
+
 describe('mapDomainErrors', () => {
   it('returns the inner value when no throw', () => {
     expect(mapDomainErrors(() => 42)).toBe(42);
   });
 
   it('maps NotFoundError → NOT_FOUND', () => {
-    let caught: unknown;
-    try {
+    const caught = captureThrow(() =>
       mapDomainErrors(() => {
         throw new NotFoundError('Fixture', 'x');
-      });
-    } catch (err) {
-      caught = err;
-    }
+      })
+    );
     expect(caught).toBeInstanceOf(TRPCError);
     expect((caught as TRPCError).code).toBe('NOT_FOUND');
     expect((caught as TRPCError).message).toBe("Fixture 'x' not found");
   });
 
   it('maps ConflictError → CONFLICT', () => {
-    expect(() =>
+    const caught = captureThrow(() =>
       mapDomainErrors(() => {
         throw new ConflictError('dup');
       })
-    ).toThrow(TRPCError);
-    try {
-      mapDomainErrors(() => {
-        throw new ConflictError('dup');
-      });
-    } catch (err) {
-      expect((err as TRPCError).code).toBe('CONFLICT');
-    }
+    );
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('CONFLICT');
   });
 
   it('maps ValidationError → BAD_REQUEST', () => {
-    try {
+    const caught = captureThrow(() =>
       mapDomainErrors(() => {
         throw new ValidationError({ field: 'name' });
-      });
-    } catch (err) {
-      expect((err as TRPCError).code).toBe('BAD_REQUEST');
-    }
+      })
+    );
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('BAD_REQUEST');
   });
 
   it('maps BudgetExceededError → PAYMENT_REQUIRED', () => {
-    try {
+    const caught = captureThrow(() =>
       mapDomainErrors(() => {
         throw new BudgetExceededError({
           budgetId: 'b',
@@ -57,10 +67,10 @@ describe('mapDomainErrors', () => {
           currentUsage: 10,
           limit: 5,
         });
-      });
-    } catch (err) {
-      expect((err as TRPCError).code).toBe('PAYMENT_REQUIRED');
-    }
+      })
+    );
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('PAYMENT_REQUIRED');
   });
 
   it('rethrows non-HttpError unchanged', () => {
@@ -79,11 +89,13 @@ describe('mapDomainErrorsAsync', () => {
   });
 
   it('maps an async-thrown NotFoundError', async () => {
-    await expect(
+    const caught = await captureReject(() =>
       mapDomainErrorsAsync(async () => {
         throw new NotFoundError('Fixture', 'x');
       })
-    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    );
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('NOT_FOUND');
   });
 
   it('rethrows a non-HttpError unchanged', async () => {

--- a/apps/pops-api/src/shared/trpc-error-mapper.ts
+++ b/apps/pops-api/src/shared/trpc-error-mapper.ts
@@ -1,0 +1,51 @@
+import { TRPCError } from '@trpc/server';
+
+import { ConflictError, HttpError, NotFoundError, ValidationError } from './errors.js';
+
+type TRPCCode = ConstructorParameters<typeof TRPCError>[0]['code'];
+
+// Single mapping point from domain errors to tRPC's wire-level error envelope.
+// Keeps router handlers free of repeated try/catch ladders; new HttpError
+// subclasses get routed through here by extending the map.
+const HTTP_STATUS_TO_TRPC_CODE: Readonly<Record<number, TRPCCode>> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  402: 'PAYMENT_REQUIRED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  412: 'PRECONDITION_FAILED',
+  422: 'UNPROCESSABLE_CONTENT',
+  429: 'TOO_MANY_REQUESTS',
+  500: 'INTERNAL_SERVER_ERROR',
+};
+
+function toTRPCError(err: HttpError): TRPCError {
+  const code = HTTP_STATUS_TO_TRPC_CODE[err.statusCode] ?? 'INTERNAL_SERVER_ERROR';
+  return new TRPCError({ code, message: err.message, cause: err });
+}
+
+/**
+ * Runs `fn` and re-throws any HttpError subclass (NotFoundError, ConflictError,
+ * ValidationError, …) as the corresponding TRPCError. Non-HttpError throws
+ * bubble unchanged so the global tRPC error handler can see them as 500s.
+ */
+export function mapDomainErrors<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}
+
+export async function mapDomainErrorsAsync<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof HttpError) throw toTRPCError(err);
+    throw err;
+  }
+}
+
+export { ConflictError, HttpError, NotFoundError, ValidationError };


### PR DESCRIPTION
## Summary

Self-review of recently-merged PRD-104 caught several lifts that didn't happen the first time. This PR does them.

**Service (`fixtures/service.ts`)**
- Use Drizzle `.returning()` for create/update/connect — collapses the insert-then-select-by-rowid pattern into one round trip
- Replace pre-check + manual-row-fetch in connect/disconnect/delete with optimistic insert/delete. Foreign keys already enforce correctness; the old pre-checks only widened a TOCTOU window without buying anything. Helpers map SQLite constraint codes to NotFound/Conflict on the unhappy path only.
- Detect UNIQUE / FK violations via `SQLITE_CONSTRAINT_*` codes instead of substring-matching error messages
- Drop the `toFixture` / `toItemFixtureConnection` projections — `FixtureRow` already matches the contract; the mappers were nullity ceremony

**Router (`fixtures/router.ts`)**
- Add `.output()` schemas to `create`/`delete`/`connect`/`disconnect` — matches the query side and gives tRPC clients end-to-end type narrowing for mutations
- Replace four copies of the same try/catch ladder with `mapDomainErrors()`

**Types (`fixtures/types.ts`)**
- Make `FixtureSchema` the single source of truth: `type Fixture = z.infer<typeof FixtureSchema>` — wire shape and TS type cannot drift

**Shared (new files)**
- `shared/sqlite-errors.ts` — `isUniqueConstraintError`, `isForeignKeyConstraintError`
- `shared/trpc-error-mapper.ts` — `mapDomainErrors(fn)` lifts `HttpError` subclasses (`NotFoundError`, `ConflictError`, `ValidationError`, `BudgetExceededError`) to `TRPCError` once, status-code-driven. Other modules can adopt incrementally; this PR uses it only in fixtures.

**Tests**
- Replace 6× "call twice with try/catch" `NOT_FOUND` pattern with `rejects.toMatchObject({ code: 'NOT_FOUND' })`
- New coverage: empty-patch BAD_REQUEST, multi-field update, lastEditedTime bump, deterministic pagination tiebreak (createdAt collision), location-delete cascade to `fixture.locationId = NULL`
- Auth matrix went from 3/8 endpoints to 8/8 via a table-driven loop
- New unit tests for `sqlite-errors` against a real in-memory `better-sqlite3` (mocking the error shape would defeat the point)
- New unit tests for `trpc-error-mapper` covering every `HttpError` subclass

## Test plan

- [ ] CI: `mise lint` + `mise typecheck` + backend tests (4406 tests)
- [ ] Verify `inventory.fixtures.*` smoke test against deployed server after merge