### PR TITLE
refactor(mcp/inventory): unify write-tool style, drop  cast

### DIFF
--- a/apps/pops-mcp/src/tools/inventory-connections.test.ts
+++ b/apps/pops-mcp/src/tools/inventory-connections.test.ts
@@ -66,12 +66,12 @@ describe('inventory.connections.graph', () => {
     expect(call['maxDepth']).toBeUndefined();
   });
 
-  it('returns graph data with nodes and edges', async () => {
+  it('returns graph data wrapped in the data envelope', async () => {
     const result = await tool('inventory.connections.graph').handler({ itemId: 'item_1' });
     expect(result.isError).toBeUndefined();
-    const parsed = parseResult(result) as { nodes: unknown[]; edges: unknown[] };
-    expect(parsed.nodes).toHaveLength(2);
-    expect(parsed.edges).toHaveLength(1);
+    const parsed = parseResult(result) as { data: { nodes: unknown[]; edges: unknown[] } };
+    expect(parsed.data.nodes).toHaveLength(2);
+    expect(parsed.data.edges).toHaveLength(1);
   });
 
   it('returns isError when itemId is missing', async () => {
@@ -100,9 +100,9 @@ describe('inventory.connections.connect', () => {
       itemBId: 'item_2',
     });
     expect(result.isError).toBeUndefined();
-    const parsed = parseResult(result) as { itemAId: string; itemBId: string };
-    expect(parsed.itemAId).toBe('item_1');
-    expect(parsed.itemBId).toBe('item_2');
+    const parsed = parseResult(result) as { data: { itemAId: string; itemBId: string } };
+    expect(parsed.data.itemAId).toBe('item_1');
+    expect(parsed.data.itemBId).toBe('item_2');
   });
 
   it('returns isError when itemAId is missing', async () => {

--- a/apps/pops-mcp/src/tools/inventory-connections.ts
+++ b/apps/pops-mcp/src/tools/inventory-connections.ts
@@ -1,5 +1,5 @@
 import { getClient } from '../client.js';
-import { ok, reqStr, toolError } from './utils.js';
+import { ok, optNum, reqStr, toolError } from './utils.js';
 
 import type { ToolDef } from './index.js';
 
@@ -21,8 +21,8 @@ const connectionsList: ToolDef = {
     if (!itemId) return toolError('Missing required field: itemId');
     const result = await getClient().inventory.connections.listForItem.query({
       itemId,
-      limit: typeof args['limit'] === 'number' ? args['limit'] : undefined,
-      offset: typeof args['offset'] === 'number' ? args['offset'] : undefined,
+      limit: optNum(args, 'limit'),
+      offset: optNum(args, 'offset'),
     });
     return ok(result);
   },
@@ -45,9 +45,9 @@ const connectionsGraph: ToolDef = {
     if (!itemId) return toolError('Missing required field: itemId');
     const result = await getClient().inventory.connections.graph.query({
       itemId,
-      maxDepth: typeof args['maxDepth'] === 'number' ? args['maxDepth'] : undefined,
+      maxDepth: optNum(args, 'maxDepth'),
     });
-    return ok(result.data);
+    return ok(result);
   },
 };
 
@@ -65,11 +65,11 @@ const connectionsConnect: ToolDef = {
   },
   handler: async (args) => {
     const itemAId = reqStr(args, 'itemAId');
-    const itemBId = reqStr(args, 'itemBId');
     if (!itemAId) return toolError('Missing required field: itemAId');
+    const itemBId = reqStr(args, 'itemBId');
     if (!itemBId) return toolError('Missing required field: itemBId');
     const result = await getClient().inventory.connections.connect.mutate({ itemAId, itemBId });
-    return ok(result.data);
+    return ok(result);
   },
 };
 
@@ -87,8 +87,8 @@ const connectionsDisconnect: ToolDef = {
   },
   handler: async (args) => {
     const itemAId = reqStr(args, 'itemAId');
-    const itemBId = reqStr(args, 'itemBId');
     if (!itemAId) return toolError('Missing required field: itemAId');
+    const itemBId = reqStr(args, 'itemBId');
     if (!itemBId) return toolError('Missing required field: itemBId');
     const result = await getClient().inventory.connections.disconnect.mutate({ itemAId, itemBId });
     return ok(result);

--- a/apps/pops-mcp/src/tools/inventory-fixtures-write.ts
+++ b/apps/pops-mcp/src/tools/inventory-fixtures-write.ts
@@ -1,7 +1,20 @@
 import { getClient } from '../client.js';
-import { nullStr, ok, optStr, reqStr, toolError } from './utils.js';
+import { copyNullStr, copyOptStr, ok, optStr, reqStr, toolError } from './utils.js';
 
 import type { ToolDef } from './index.js';
+
+type FixturePatch = Parameters<
+  ReturnType<typeof getClient>['inventory']['fixtures']['update']['mutate']
+>[0]['data'];
+
+function buildFixturePatch(args: Record<string, unknown>): FixturePatch {
+  const patch: FixturePatch = {};
+  copyOptStr(patch, args, 'name');
+  copyOptStr(patch, args, 'type');
+  copyNullStr(patch, args, 'locationId');
+  copyNullStr(patch, args, 'notes');
+  return patch;
+}
 
 const fixturesCreate: ToolDef = {
   name: 'inventory.fixtures.create',
@@ -22,9 +35,9 @@ const fixturesCreate: ToolDef = {
   },
   handler: async (args) => {
     const name = reqStr(args, 'name');
+    if (!name) return toolError('Missing required field: name');
     const type = reqStr(args, 'type');
-    if (!name) return toolError('Invalid "name"');
-    if (!type) return toolError('Invalid "type"');
+    if (!type) return toolError('Missing required field: type');
     const result = await getClient().inventory.fixtures.create.mutate({
       name,
       type,
@@ -50,19 +63,13 @@ const fixturesUpdate: ToolDef = {
     },
     required: ['id'],
   },
+  // Note: empty-patch rejection happens at the tRPC layer via
+  // UpdateFixtureSchema.refine, so we don't duplicate the guard here. The
+  // backend returns BAD_REQUEST which propagates through the tRPC client.
   handler: async (args) => {
     const id = reqStr(args, 'id');
-    if (!id) return toolError('Invalid "id"');
-    const data: Record<string, unknown> = {};
-    const name = optStr(args, 'name');
-    if (name !== undefined) data['name'] = name;
-    const type = optStr(args, 'type');
-    if (type !== undefined) data['type'] = type;
-    const locationId = nullStr(args, 'locationId');
-    if (locationId !== undefined) data['locationId'] = locationId;
-    const notes = nullStr(args, 'notes');
-    if (notes !== undefined) data['notes'] = notes;
-    if (Object.keys(data).length === 0) return toolError('No fields to update');
+    if (!id) return toolError('Missing required field: id');
+    const data = buildFixturePatch(args);
     const result = await getClient().inventory.fixtures.update.mutate({ id, data });
     return ok(result);
   },
@@ -78,7 +85,7 @@ const fixturesDelete: ToolDef = {
   },
   handler: async (args) => {
     const id = reqStr(args, 'id');
-    if (!id) return toolError('Invalid "id"');
+    if (!id) return toolError('Missing required field: id');
     const result = await getClient().inventory.fixtures.delete.mutate({ id });
     return ok(result);
   },
@@ -97,9 +104,9 @@ const fixturesConnect: ToolDef = {
   },
   handler: async (args) => {
     const itemId = reqStr(args, 'itemId');
+    if (!itemId) return toolError('Missing required field: itemId');
     const fixtureId = reqStr(args, 'fixtureId');
-    if (!itemId) return toolError('Invalid "itemId"');
-    if (!fixtureId) return toolError('Invalid "fixtureId"');
+    if (!fixtureId) return toolError('Missing required field: fixtureId');
     const result = await getClient().inventory.fixtures.connect.mutate({ itemId, fixtureId });
     return ok(result);
   },
@@ -118,9 +125,9 @@ const fixturesDisconnect: ToolDef = {
   },
   handler: async (args) => {
     const itemId = reqStr(args, 'itemId');
+    if (!itemId) return toolError('Missing required field: itemId');
     const fixtureId = reqStr(args, 'fixtureId');
-    if (!itemId) return toolError('Invalid "itemId"');
-    if (!fixtureId) return toolError('Invalid "fixtureId"');
+    if (!fixtureId) return toolError('Missing required field: fixtureId');
     const result = await getClient().inventory.fixtures.disconnect.mutate({ itemId, fixtureId });
     return ok(result);
   },

--- a/apps/pops-mcp/src/tools/inventory-fixtures.test.ts
+++ b/apps/pops-mcp/src/tools/inventory-fixtures.test.ts
@@ -83,10 +83,10 @@ describe('inventory.fixtures.list', () => {
 describe('inventory.fixtures.get', () => {
   const tool = getTool('inventory.fixtures.get');
 
-  it('returns fixture by id', async () => {
+  it('returns fixture by id wrapped in the data envelope', async () => {
     const result = await tool.handler({ id: 'fixture_1' });
     expect(mockClient.inventory.fixtures.get.query).toHaveBeenCalledWith({ id: 'fixture_1' });
-    expect(parseResult(result)).toMatchObject({ id: 'fixture_1' });
+    expect(parseResult(result)).toMatchObject({ data: { id: 'fixture_1' } });
   });
 
   it('returns toolError for missing id', async () => {
@@ -185,10 +185,19 @@ describe('inventory.fixtures.update', () => {
     expect(mockClient.inventory.fixtures.update.mutate).not.toHaveBeenCalled();
   });
 
-  it('returns toolError when no patch fields provided', async () => {
-    const result = await tool.handler({ id: 'fixture_1' });
-    expect(result.isError).toBe(true);
-    expect(mockClient.inventory.fixtures.update.mutate).not.toHaveBeenCalled();
+  // Empty-patch rejection happens at the tRPC layer (UpdateFixtureSchema.refine).
+  // The MCP adapter forwards the call; the tRPC client surfaces a BAD_REQUEST
+  // which `handler` rethrows. Assert the rethrow rather than re-implementing
+  // a parallel guard at the MCP layer.
+  it('forwards an empty patch and lets the backend reject it', async () => {
+    mockClient.inventory.fixtures.update.mutate.mockRejectedValueOnce(
+      Object.assign(new Error('At least one field required'), { code: 'BAD_REQUEST' })
+    );
+    await expect(tool.handler({ id: 'fixture_1' })).rejects.toThrow(/At least one field required/);
+    expect(mockClient.inventory.fixtures.update.mutate).toHaveBeenCalledWith({
+      id: 'fixture_1',
+      data: {},
+    });
   });
 });
 

--- a/apps/pops-mcp/src/tools/inventory-fixtures.ts
+++ b/apps/pops-mcp/src/tools/inventory-fixtures.ts
@@ -40,9 +40,9 @@ const fixturesGet: ToolDef = {
   },
   handler: async (args) => {
     const id = reqStr(args, 'id');
-    if (!id) return toolError('Invalid "id"');
+    if (!id) return toolError('Missing required field: id');
     const result = await getClient().inventory.fixtures.get.query({ id });
-    return ok(result.data);
+    return ok(result);
   },
 };
 
@@ -60,7 +60,7 @@ const fixturesListForItem: ToolDef = {
   },
   handler: async (args) => {
     const itemId = reqStr(args, 'itemId');
-    if (!itemId) return toolError('Invalid "itemId"');
+    if (!itemId) return toolError('Missing required field: itemId');
     const result = await getClient().inventory.fixtures.listForItem.query({
       itemId,
       limit: optNum(args, 'limit'),

--- a/apps/pops-mcp/src/tools/inventory-items-write.ts
+++ b/apps/pops-mcp/src/tools/inventory-items-write.ts
@@ -1,25 +1,54 @@
 import { getClient } from '../client.js';
-import { nullNum, nullStr, ok, optBool, reqStr, toolError } from './utils.js';
+import {
+  copyNullNum,
+  copyNullStr,
+  copyOptBool,
+  copyOptStr,
+  nullNum,
+  nullStr,
+  ok,
+  optBool,
+  reqStr,
+  toolError,
+} from './utils.js';
 
 import type { ToolDef } from './index.js';
 
-const STR_FIELDS = [
-  'itemName',
-  'brand',
-  'model',
-  'itemId',
-  'room',
-  'type',
-  'condition',
-  'assetId',
-  'notes',
-  'purchaseDate',
-  'warrantyExpires',
-  'purchasedFromName',
-  'locationId',
-] as const;
+// Hoist the patch type from the tRPC mutation signature so it tracks the
+// backend schema automatically — no manual interface duplication, no escape
+// `as` cast at the call site.
+type ItemPatch = Parameters<
+  ReturnType<typeof getClient>['inventory']['items']['update']['mutate']
+>[0]['data'];
 
-const NUM_FIELDS = ['replacementValue', 'resaleValue', 'purchasePrice'] as const;
+function buildItemPatch(args: Record<string, unknown>): ItemPatch {
+  const patch: ItemPatch = {};
+  // itemName is NOT NULL in the backend schema, so use copyOptStr (drops nulls).
+  copyOptStr(patch, args, 'itemName');
+  for (const k of [
+    'brand',
+    'model',
+    'itemId',
+    'room',
+    'type',
+    'condition',
+    'locationId',
+    'assetId',
+    'notes',
+    'purchaseDate',
+    'warrantyExpires',
+    'purchasedFromName',
+  ]) {
+    copyNullStr(patch, args, k);
+  }
+  for (const k of ['replacementValue', 'resaleValue', 'purchasePrice']) {
+    copyNullNum(patch, args, k);
+  }
+  for (const k of ['inUse', 'deductible']) {
+    copyOptBool(patch, args, k);
+  }
+  return patch;
+}
 
 const itemsCreate: ToolDef = {
   name: 'inventory.items.create',
@@ -72,7 +101,7 @@ const itemsCreate: ToolDef = {
       purchasePrice: nullNum(args, 'purchasePrice'),
       purchasedFromName: nullStr(args, 'purchasedFromName'),
     });
-    return ok(result.data);
+    return ok(result);
   },
 };
 
@@ -117,27 +146,9 @@ const itemsUpdate: ToolDef = {
   handler: async (args) => {
     const id = reqStr(args, 'id');
     if (!id) return toolError('Missing required field: id');
-
-    const data: Record<string, unknown> = {};
-    for (const f of STR_FIELDS) {
-      const v = nullStr(args, f);
-      if (v !== undefined) data[f] = v;
-    }
-    for (const f of NUM_FIELDS) {
-      const v = nullNum(args, f);
-      if (v !== undefined) data[f] = v;
-    }
-    if ('inUse' in args && typeof args['inUse'] === 'boolean') data['inUse'] = args['inUse'];
-    if ('deductible' in args && typeof args['deductible'] === 'boolean')
-      data['deductible'] = args['deductible'];
-
-    const result = await getClient().inventory.items.update.mutate({
-      id,
-      data: data as Parameters<
-        ReturnType<typeof getClient>['inventory']['items']['update']['mutate']
-      >[0]['data'],
-    });
-    return ok(result.data);
+    const data = buildItemPatch(args);
+    const result = await getClient().inventory.items.update.mutate({ id, data });
+    return ok(result);
   },
 };
 

--- a/apps/pops-mcp/src/tools/inventory-items.test.ts
+++ b/apps/pops-mcp/src/tools/inventory-items.test.ts
@@ -52,11 +52,11 @@ describe('inventory.items.list', () => {
 });
 
 describe('inventory.items.get', () => {
-  it('passes id to tRPC and returns item', async () => {
+  it('passes id to tRPC and returns the data envelope', async () => {
     const result = await tool('inventory.items.get').handler({ id: 'item_1' });
     expect(mockClient.inventory.items.get.query).toHaveBeenCalledWith({ id: 'item_1' });
-    const parsed = parseResult(result) as { itemName: string };
-    expect(parsed.itemName).toBe('MacBook');
+    const parsed = parseResult(result) as { data: { itemName: string } };
+    expect(parsed.data.itemName).toBe('MacBook');
   });
 
   it('returns isError for missing id', async () => {
@@ -79,7 +79,9 @@ describe('inventory.items.create', () => {
       expect.objectContaining({ itemName: 'Sony TV' })
     );
     expect(result.isError).toBeUndefined();
-    expect((parseResult(result) as { id: string }).id).toBe('item_1');
+    const parsed = parseResult(result) as { data: { id: string }; message: string };
+    expect(parsed.data.id).toBe('item_1');
+    expect(parsed.message).toBe('Inventory item created');
   });
 
   it('passes all string fields', async () => {

--- a/apps/pops-mcp/src/tools/inventory-items.ts
+++ b/apps/pops-mcp/src/tools/inventory-items.ts
@@ -49,7 +49,7 @@ const itemGet: ToolDef = {
     const id = reqStr(args, 'id');
     if (!id) return toolError('Missing required field: id');
     const result = await getClient().inventory.items.get.query({ id });
-    return ok(result.data);
+    return ok(result);
   },
 };
 

--- a/apps/pops-mcp/src/tools/inventory-locations.test.ts
+++ b/apps/pops-mcp/src/tools/inventory-locations.test.ts
@@ -17,11 +17,11 @@ beforeEach(() => {
 });
 
 describe('inventory.locations.tree', () => {
-  it('calls tree.query and returns data', async () => {
+  it('calls tree.query and returns the data envelope', async () => {
     const result = await tool('inventory.locations.tree').handler({});
     expect(mockClient.inventory.locations.tree.query).toHaveBeenCalled();
-    const parsed = parseResult(result) as { id: string }[];
-    expect(parsed[0]).toMatchObject({ id: 'loc_1' });
+    const parsed = parseResult(result) as { data: { id: string }[] };
+    expect(parsed.data[0]).toMatchObject({ id: 'loc_1' });
     expect(result.isError).toBeUndefined();
   });
 });
@@ -41,8 +41,9 @@ describe('inventory.locations.create', () => {
       expect.objectContaining({ name: 'Office' })
     );
     expect(result.isError).toBeUndefined();
-    const parsed = parseResult(result) as { name: string };
-    expect(parsed.name).toBe('Office');
+    const parsed = parseResult(result) as { data: { name: string }; message: string };
+    expect(parsed.data.name).toBe('Office');
+    expect(parsed.message).toBe('Location created');
   });
 
   it('passes parentId string', async () => {
@@ -140,6 +141,7 @@ describe('inventory.locations.delete', () => {
     });
     expect(result.isError).toBeUndefined();
     const parsed = parseResult(result) as { message: string };
+    // delete already returned the unwrapped envelope (no `data` field).
     expect(parsed.message).toBe('Location deleted');
   });
 

--- a/apps/pops-mcp/src/tools/inventory-locations.ts
+++ b/apps/pops-mcp/src/tools/inventory-locations.ts
@@ -1,7 +1,24 @@
 import { getClient } from '../client.js';
-import { nullStr, ok, optBool, optStr, reqStr, toolError } from './utils.js';
+import { copyOptStr, nullStr, ok, optBool, optNum, reqStr, toolError } from './utils.js';
 
 import type { ToolDef } from './index.js';
+
+type LocationPatch = Parameters<
+  ReturnType<typeof getClient>['inventory']['locations']['update']['mutate']
+>[0]['data'];
+
+function buildLocationPatch(args: Record<string, unknown>): LocationPatch {
+  const patch: LocationPatch = {};
+  copyOptStr(patch, args, 'name');
+  // parentId is three-state (null clears to root); custom-handled.
+  if ('parentId' in args) {
+    const parentId = nullStr(args, 'parentId');
+    if (parentId !== undefined) patch.parentId = parentId;
+  }
+  const sortOrder = optNum(args, 'sortOrder');
+  if (sortOrder !== undefined) patch.sortOrder = sortOrder;
+  return patch;
+}
 
 const locationTree: ToolDef = {
   name: 'inventory.locations.tree',
@@ -10,7 +27,7 @@ const locationTree: ToolDef = {
   inputSchema: { type: 'object', properties: {} },
   handler: async () => {
     const result = await getClient().inventory.locations.tree.query();
-    return ok(result.data);
+    return ok(result);
   },
 };
 
@@ -46,9 +63,9 @@ const locationsCreate: ToolDef = {
     const result = await getClient().inventory.locations.create.mutate({
       name,
       parentId: nullStr(args, 'parentId'),
-      sortOrder: typeof args['sortOrder'] === 'number' ? args['sortOrder'] : undefined,
+      sortOrder: optNum(args, 'sortOrder'),
     });
-    return ok(result.data);
+    return ok(result);
   },
 };
 
@@ -72,15 +89,9 @@ const locationsUpdate: ToolDef = {
   handler: async (args) => {
     const id = reqStr(args, 'id');
     if (!id) return toolError('Missing required field: id');
-
-    const data: { name?: string; parentId?: string | null; sortOrder?: number } = {};
-    const name = optStr(args, 'name');
-    if (name !== undefined) data.name = name;
-    if ('parentId' in args) data.parentId = nullStr(args, 'parentId');
-    if (typeof args['sortOrder'] === 'number') data.sortOrder = args['sortOrder'];
-
+    const data = buildLocationPatch(args);
     const result = await getClient().inventory.locations.update.mutate({ id, data });
-    return ok(result.data);
+    return ok(result);
   },
 };
 
@@ -106,7 +117,6 @@ const locationsDelete: ToolDef = {
       id,
       force: optBool(args, 'force') ?? false,
     });
-    // Two possible shapes: { requiresConfirmation: true, stats } when items exist, { message } on success
     return ok(result);
   },
 };

--- a/apps/pops-mcp/src/tools/utils.test.ts
+++ b/apps/pops-mcp/src/tools/utils.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  copyNullNum,
+  copyNullStr,
+  copyOptBool,
+  copyOptStr,
+  nullNum,
+  nullStr,
+  ok,
+  optBool,
+  optNum,
+  optStr,
+  reqStr,
+  toolError,
+} from './utils.js';
+
+describe('ok / toolError', () => {
+  it('ok wraps JSON-stringified data', () => {
+    expect(ok({ a: 1 })).toEqual({ content: [{ type: 'text', text: '{\n  "a": 1\n}' }] });
+  });
+
+  it('toolError sets isError and surfaces the message', () => {
+    expect(toolError('boom')).toEqual({
+      content: [{ type: 'text', text: 'boom' }],
+      isError: true,
+    });
+  });
+});
+
+describe('reqStr', () => {
+  it('returns the string when present and non-empty', () => {
+    expect(reqStr({ x: 'hi' }, 'x')).toBe('hi');
+  });
+
+  it('returns null for absent, empty, or wrongly-typed inputs', () => {
+    expect(reqStr({}, 'x')).toBeNull();
+    expect(reqStr({ x: '' }, 'x')).toBeNull();
+    expect(reqStr({ x: 42 }, 'x')).toBeNull();
+    expect(reqStr({ x: null }, 'x')).toBeNull();
+  });
+});
+
+describe('optStr / optNum / optBool', () => {
+  it('returns the value when well-typed, undefined otherwise', () => {
+    expect(optStr({ x: 'a' }, 'x')).toBe('a');
+    expect(optStr({ x: 1 }, 'x')).toBeUndefined();
+    expect(optStr({}, 'x')).toBeUndefined();
+
+    expect(optNum({ x: 0 }, 'x')).toBe(0);
+    expect(optNum({ x: '1' }, 'x')).toBeUndefined();
+
+    expect(optBool({ x: false }, 'x')).toBe(false);
+    expect(optBool({ x: 'true' }, 'x')).toBeUndefined();
+  });
+});
+
+describe('nullStr (three-state)', () => {
+  it('absent → undefined (no-op)', () => {
+    expect(nullStr({}, 'x')).toBeUndefined();
+  });
+  it('explicit null → null (clear)', () => {
+    expect(nullStr({ x: null }, 'x')).toBeNull();
+  });
+  it('string → string (set)', () => {
+    expect(nullStr({ x: 'v' }, 'x')).toBe('v');
+  });
+  it('present but wrong type → undefined (skip)', () => {
+    expect(nullStr({ x: 1 }, 'x')).toBeUndefined();
+  });
+});
+
+describe('nullNum (three-state)', () => {
+  it('absent → undefined, null → null, number → number, wrong → undefined', () => {
+    expect(nullNum({}, 'x')).toBeUndefined();
+    expect(nullNum({ x: null }, 'x')).toBeNull();
+    expect(nullNum({ x: 0 }, 'x')).toBe(0);
+    expect(nullNum({ x: 'no' }, 'x')).toBeUndefined();
+  });
+});
+
+describe('copyOptStr', () => {
+  it('writes the string to out when present', () => {
+    const out: Record<string, unknown> = {};
+    copyOptStr(out, { name: 'a' }, 'name');
+    expect(out).toEqual({ name: 'a' });
+  });
+
+  it('does NOT write when absent', () => {
+    const out: Record<string, unknown> = {};
+    copyOptStr(out, {}, 'name');
+    expect('name' in out).toBe(false);
+  });
+
+  it('drops null (non-nullable variant must not write null)', () => {
+    const out: Record<string, unknown> = {};
+    copyOptStr(out, { name: null }, 'name');
+    expect('name' in out).toBe(false);
+  });
+});
+
+describe('copyOptBool', () => {
+  it('writes booleans (including false)', () => {
+    const out: Record<string, unknown> = {};
+    copyOptBool(out, { v: false }, 'v');
+    expect(out).toEqual({ v: false });
+  });
+
+  it('skips non-booleans', () => {
+    const out: Record<string, unknown> = {};
+    copyOptBool(out, { v: 'true' }, 'v');
+    expect('v' in out).toBe(false);
+  });
+});
+
+describe('copyNullStr (three-state)', () => {
+  it('passes string through', () => {
+    const out: Record<string, unknown> = {};
+    copyNullStr(out, { x: 'hi' }, 'x');
+    expect(out).toEqual({ x: 'hi' });
+  });
+
+  it('passes explicit null through (so callers can clear nullable columns)', () => {
+    const out: Record<string, unknown> = {};
+    copyNullStr(out, { x: null }, 'x');
+    expect(out).toEqual({ x: null });
+  });
+
+  it('skips when absent', () => {
+    const out: Record<string, unknown> = {};
+    copyNullStr(out, {}, 'x');
+    expect('x' in out).toBe(false);
+  });
+});
+
+describe('copyNullNum (three-state)', () => {
+  it('passes 0 through (not omitted)', () => {
+    const out: Record<string, unknown> = {};
+    copyNullNum(out, { x: 0 }, 'x');
+    expect(out).toEqual({ x: 0 });
+  });
+
+  it('passes explicit null through', () => {
+    const out: Record<string, unknown> = {};
+    copyNullNum(out, { x: null }, 'x');
+    expect(out).toEqual({ x: null });
+  });
+
+  it('skips when absent or wrong type', () => {
+    const out: Record<string, unknown> = {};
+    copyNullNum(out, {}, 'x');
+    copyNullNum(out, { x: 'no' }, 'x');
+    expect('x' in out).toBe(false);
+  });
+});

--- a/apps/pops-mcp/src/tools/utils.ts
+++ b/apps/pops-mcp/src/tools/utils.ts
@@ -44,11 +44,10 @@ export function nullNum(args: Record<string, unknown>, key: string): number | nu
   return typeof v === 'number' ? v : undefined;
 }
 
-// Patch builders for update handlers — copy a field into `out` iff the source
-// arg is present and well-typed. The three-state nullable variants (`copyNullStr`,
-// `copyNullNum`) pass an explicit `null` through to clear backend columns; the
-// `copy*` (non-nullable) variants drop nulls so callers can't accidentally try
-// to NULL a NOT-NULL column.
+// Pick the right helper to match the column's nullability: copyNullStr /
+// copyNullNum forward an explicit `null` so callers can CLEAR a nullable
+// backend column; copyOptStr / copyOptBool drop nulls so callers cannot
+// accidentally NULL a NOT-NULL column.
 type Patch = Record<string, unknown>;
 
 export function copyOptStr(out: Patch, args: Record<string, unknown>, key: string): void {

--- a/apps/pops-mcp/src/tools/utils.ts
+++ b/apps/pops-mcp/src/tools/utils.ts
@@ -43,3 +43,30 @@ export function nullNum(args: Record<string, unknown>, key: string): number | nu
   if (v === null) return null;
   return typeof v === 'number' ? v : undefined;
 }
+
+// Patch builders for update handlers — copy a field into `out` iff the source
+// arg is present and well-typed. The three-state nullable variants (`copyNullStr`,
+// `copyNullNum`) pass an explicit `null` through to clear backend columns; the
+// `copy*` (non-nullable) variants drop nulls so callers can't accidentally try
+// to NULL a NOT-NULL column.
+type Patch = Record<string, unknown>;
+
+export function copyOptStr(out: Patch, args: Record<string, unknown>, key: string): void {
+  const v = optStr(args, key);
+  if (v !== undefined) out[key] = v;
+}
+
+export function copyOptBool(out: Patch, args: Record<string, unknown>, key: string): void {
+  const v = optBool(args, key);
+  if (v !== undefined) out[key] = v;
+}
+
+export function copyNullStr(out: Patch, args: Record<string, unknown>, key: string): void {
+  const v = nullStr(args, key);
+  if (v !== undefined) out[key] = v;
+}
+
+export function copyNullNum(out: Patch, args: Record<string, unknown>, key: string): void {
+  const v = nullNum(args, key);
+  if (v !== undefined) out[key] = v;
+}


### PR DESCRIPTION
## Summary

Self-review of the recently-merged inventory MCP write tools (PRD-103, PRD-105) showed real inconsistencies between the three write-tool files. This PR picks one style for each axis and applies it everywhere.

**Type safety** — drop the `data as Parameters<...>['data']` cast in `inventory-items-write.ts`. The patch builder now uses `ItemPatch` lifted from the tRPC mutation signature, so the shape tracks the backend schema without an escape hatch.

**Return envelope** — every handler returns `ok(result)` (full tRPC envelope). Previously some unwrapped to `ok(result.data)` while others passed through, so MCP consumers couldn't predict the shape. Tests updated.

**Error messages** — standardise on `'Missing required field: <name>'`. `inventory-fixtures-write` was the lone holdout using `'Invalid "x"'`.

**DRY** — extract `copyOptStr` / `copyOptBool` / `copyNullStr` / `copyNullNum` patch-builder helpers in `utils.ts`. Three write tools were hand-rolling the same "copy if present" idiom; now they share. `items-write` also keeps its field-name array, so adding a new column is one entry.

**Empty-patch guard** — dropped from `fixtures-write`. `UpdateFixtureSchema.refine` on the backend already rejects empty patches with BAD_REQUEST; a parallel MCP-side guard meant the same rule lived in two places. Test updated to assert the backend rejection propagates.

**`optNum`** — `inventory-connections` was the only file inlining `typeof args['limit'] === 'number' ? args['limit'] : undefined`. Replaced with the helper.

**Test coverage** — new `utils.test.ts` (21 cases) covers every helper against absent / null / wrong-type / well-typed inputs. The helpers had zero direct coverage before this PR.

## Test plan

- [x] `mise lint` clean
- [x] `mise typecheck` clean
- [x] `pnpm --filter @pops/mcp test` — 158 tests passing (was 137; +21 new helper tests)
- [ ] CI green
- [ ] Smoke test all 8 tools against deployed server post-merge