### PR TITLE
refactor(mcp): tighten ToolDef.inputSchema, fix unhandled rejection, split /health & /ready

### DIFF
--- a/apps/pops-mcp/src/cleanup.test.ts
+++ b/apps/pops-mcp/src/cleanup.test.ts
@@ -1,13 +1,36 @@
 import { EventEmitter } from 'node:events';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Snapshot before module-level mutation so the suite restores cleanly even
+// when run alongside other tests in the same vitest worker.
+const originalNodeEnv = process.env['NODE_ENV'];
+const originalApiKey = process.env['POPS_API_KEY'];
 process.env['NODE_ENV'] = 'test';
 process.env['POPS_API_KEY'] = 'sa_test';
 
 const { attachServerCleanup } = await import('./index.js');
 
+afterAll(() => {
+  if (originalNodeEnv === undefined) delete process.env['NODE_ENV'];
+  else process.env['NODE_ENV'] = originalNodeEnv;
+  if (originalApiKey === undefined) delete process.env['POPS_API_KEY'];
+  else process.env['POPS_API_KEY'] = originalApiKey;
+});
+
 describe('attachServerCleanup', () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Restored at the end of each test via the .restoreAllMocks below — keeps
+    // the global console.error untouched even if an assertion throws first.
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
   it('calls server.close() exactly once when res emits "close"', async () => {
     const res = new EventEmitter();
     const close = vi.fn().mockResolvedValue(undefined);
@@ -18,13 +41,13 @@ describe('attachServerCleanup', () => {
     await new Promise<void>((r) => setImmediate(r));
 
     expect(close).toHaveBeenCalledTimes(1);
+    expect(errSpy).not.toHaveBeenCalled();
   });
 
   // Regression: an `await` inside the event listener used to discard the
   // returned promise, so a rejection here would crash the process with an
   // unhandled rejection. The .catch must absorb it.
   it('logs and swallows rejected server.close()', async () => {
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const res = new EventEmitter();
     const boom = new Error('close exploded');
     const close = vi.fn().mockRejectedValue(boom);
@@ -36,6 +59,5 @@ describe('attachServerCleanup', () => {
 
     expect(close).toHaveBeenCalledTimes(1);
     expect(errSpy).toHaveBeenCalledWith('[pops-mcp] server.close() failed:', boom);
-    errSpy.mockRestore();
   });
 });

--- a/apps/pops-mcp/src/cleanup.test.ts
+++ b/apps/pops-mcp/src/cleanup.test.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from 'node:events';
+
+import { describe, expect, it, vi } from 'vitest';
+
+process.env['NODE_ENV'] = 'test';
+process.env['POPS_API_KEY'] = 'sa_test';
+
+const { attachServerCleanup } = await import('./index.js');
+
+describe('attachServerCleanup', () => {
+  it('calls server.close() exactly once when res emits "close"', async () => {
+    const res = new EventEmitter();
+    const close = vi.fn().mockResolvedValue(undefined);
+    attachServerCleanup(res, { close });
+
+    res.emit('close');
+    // microtask drain — the awaited promise resolves on the next tick
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: an `await` inside the event listener used to discard the
+  // returned promise, so a rejection here would crash the process with an
+  // unhandled rejection. The .catch must absorb it.
+  it('logs and swallows rejected server.close()', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = new EventEmitter();
+    const boom = new Error('close exploded');
+    const close = vi.fn().mockRejectedValue(boom);
+    attachServerCleanup(res, { close });
+
+    res.emit('close');
+    await new Promise<void>((r) => setImmediate(r));
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(errSpy).toHaveBeenCalledWith('[pops-mcp] server.close() failed:', boom);
+    errSpy.mockRestore();
+  });
+});

--- a/apps/pops-mcp/src/health.test.ts
+++ b/apps/pops-mcp/src/health.test.ts
@@ -1,8 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import type { Server as HttpServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
+// Snapshot before module-level mutation so the suite restores cleanly even
+// when run alongside other tests in the same vitest worker.
+const originalNodeEnv = process.env['NODE_ENV'];
+const originalApiKey = process.env['POPS_API_KEY'];
 process.env['NODE_ENV'] = 'test';
 
 const { app } = await import('./index.js');
@@ -18,25 +22,30 @@ beforeAll(async () => {
   baseUrl = `http://127.0.0.1:${addr.port}`;
 });
 
+afterEach(() => {
+  // Every test below toggles POPS_API_KEY — reset to the snapshot per-test
+  // so the next test starts from the same baseline regardless of which one
+  // ran last (or whether one threw mid-assert).
+  if (originalApiKey === undefined) delete process.env['POPS_API_KEY'];
+  else process.env['POPS_API_KEY'] = originalApiKey;
+});
+
 afterAll(async () => {
   await new Promise<void>((resolve, reject) => {
     server.close((err) => (err ? reject(err) : resolve()));
   });
+  if (originalNodeEnv === undefined) delete process.env['NODE_ENV'];
+  else process.env['NODE_ENV'] = originalNodeEnv;
 });
 
 describe('GET /health', () => {
   it('returns 200 with status ok regardless of API key configuration', async () => {
-    const before = process.env['POPS_API_KEY'];
     delete process.env['POPS_API_KEY'];
-    try {
-      const res = await fetch(`${baseUrl}/health`);
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { status: string; tools: number };
-      expect(body.status).toBe('ok');
-      expect(body.tools).toBeGreaterThan(0);
-    } finally {
-      if (before !== undefined) process.env['POPS_API_KEY'] = before;
-    }
+    const res = await fetch(`${baseUrl}/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; tools: number };
+    expect(body.status).toBe('ok');
+    expect(body.tools).toBeGreaterThan(0);
   });
 });
 
@@ -56,16 +65,11 @@ describe('GET /ready', () => {
   });
 
   it('returns 503 degraded when POPS_API_KEY is missing', async () => {
-    const before = process.env['POPS_API_KEY'];
     delete process.env['POPS_API_KEY'];
-    try {
-      const res = await fetch(`${baseUrl}/ready`);
-      expect(res.status).toBe(503);
-      const body = (await res.json()) as { status: string; apiKeyConfigured: boolean };
-      expect(body.status).toBe('degraded');
-      expect(body.apiKeyConfigured).toBe(false);
-    } finally {
-      if (before !== undefined) process.env['POPS_API_KEY'] = before;
-    }
+    const res = await fetch(`${baseUrl}/ready`);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { status: string; apiKeyConfigured: boolean };
+    expect(body.status).toBe('degraded');
+    expect(body.apiKeyConfigured).toBe(false);
   });
 });

--- a/apps/pops-mcp/src/health.test.ts
+++ b/apps/pops-mcp/src/health.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { Server as HttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+process.env['NODE_ENV'] = 'test';
+
+const { app } = await import('./index.js');
+
+let server: HttpServer;
+let baseUrl = '';
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+describe('GET /health', () => {
+  it('returns 200 with status ok regardless of API key configuration', async () => {
+    const before = process.env['POPS_API_KEY'];
+    delete process.env['POPS_API_KEY'];
+    try {
+      const res = await fetch(`${baseUrl}/health`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string; tools: number };
+      expect(body.status).toBe('ok');
+      expect(body.tools).toBeGreaterThan(0);
+    } finally {
+      if (before !== undefined) process.env['POPS_API_KEY'] = before;
+    }
+  });
+});
+
+describe('GET /ready', () => {
+  it('returns 200 ready when POPS_API_KEY is configured', async () => {
+    process.env['POPS_API_KEY'] = 'sa_test';
+    const res = await fetch(`${baseUrl}/ready`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      apiKeyConfigured: boolean;
+      tools: number;
+    };
+    expect(body.status).toBe('ready');
+    expect(body.apiKeyConfigured).toBe(true);
+    expect(body.tools).toBeGreaterThan(0);
+  });
+
+  it('returns 503 degraded when POPS_API_KEY is missing', async () => {
+    const before = process.env['POPS_API_KEY'];
+    delete process.env['POPS_API_KEY'];
+    try {
+      const res = await fetch(`${baseUrl}/ready`);
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { status: string; apiKeyConfigured: boolean };
+      expect(body.status).toBe('degraded');
+      expect(body.apiKeyConfigured).toBe(false);
+    } finally {
+      if (before !== undefined) process.env['POPS_API_KEY'] = before;
+    }
+  });
+});

--- a/apps/pops-mcp/src/index.ts
+++ b/apps/pops-mcp/src/index.ts
@@ -41,8 +41,6 @@ export function createMcpServer(): Server {
         isError: true,
       };
     }
-    // CallToolRequestParams.arguments is `{ [key: string]: unknown } | undefined`
-    // already — assigning into Record<string, unknown> needs no cast.
     const args: Record<string, unknown> = rawArgs ?? {};
     try {
       return await tool.handler(args);

--- a/apps/pops-mcp/src/index.ts
+++ b/apps/pops-mcp/src/index.ts
@@ -33,7 +33,7 @@ export function createMcpServer(): Server {
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (req) => {
-    const { name, arguments: args } = req.params;
+    const { name, arguments: rawArgs } = req.params;
     const tool = allTools.find((t) => t.name === name);
     if (!tool) {
       return {
@@ -41,8 +41,11 @@ export function createMcpServer(): Server {
         isError: true,
       };
     }
+    // CallToolRequestParams.arguments is `{ [key: string]: unknown } | undefined`
+    // already — assigning into Record<string, unknown> needs no cast.
+    const args: Record<string, unknown> = rawArgs ?? {};
     try {
-      return await tool.handler((args ?? {}) as Record<string, unknown>);
+      return await tool.handler(args);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return {
@@ -58,20 +61,46 @@ export function createMcpServer(): Server {
 export const app: Express = express();
 app.use(express.json({ limit: '1mb' }));
 
+// EventEmitter listeners cannot be async — an `await` inside one returns a
+// promise the emitter discards. If `server.close()` rejected we'd hit
+// process.on('unhandledRejection'). Hook the cleanup once and surface failures
+// through .catch. Exported so a unit test can exercise the rejection path.
+export function attachServerCleanup(
+  res: { on: (event: 'close', cb: () => void) => unknown },
+  server: { close: () => Promise<void> }
+): void {
+  res.on('close', () => {
+    server.close().catch((err: unknown) => {
+      console.error('[pops-mcp] server.close() failed:', err);
+    });
+  });
+}
+
 app.post('/mcp', async (req, res) => {
   const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
   const server = createMcpServer();
 
-  res.on('close', async () => {
-    await server.close();
-  });
+  attachServerCleanup(res, server);
 
   await server.connect(transport);
   await transport.handleRequest(req, res, req.body);
 });
 
+// Liveness vs readiness:
+//   /health  — fast, no upstream calls, used by Docker HEALTHCHECK
+//   /ready   — verifies POPS_API_KEY is set (the most common misconfig);
+//              returns 503 when degraded so orchestrators can route around.
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok', tools: allTools.length });
+});
+
+app.get('/ready', (_req, res) => {
+  const apiKeyConfigured = Boolean(process.env['POPS_API_KEY']);
+  res.status(apiKeyConfigured ? 200 : 503).json({
+    status: apiKeyConfigured ? 'ready' : 'degraded',
+    apiKeyConfigured,
+    tools: allTools.length,
+  });
 });
 
 // Only start listening when run directly (not in tests)

--- a/apps/pops-mcp/src/tools/index.ts
+++ b/apps/pops-mcp/src/tools/index.ts
@@ -6,9 +6,6 @@ import { mediaTools } from './media.js';
 
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
 
-// Use the SDK's own `Tool['inputSchema']` shape rather than a stringly-typed
-// `Record<string, unknown>` so the compiler enforces `type: 'object'` and a
-// well-formed `properties` map at the definition site.
 export interface ToolDef {
   name: string;
   description: string;

--- a/apps/pops-mcp/src/tools/index.ts
+++ b/apps/pops-mcp/src/tools/index.ts
@@ -4,12 +4,15 @@ import { fixtureTools } from './inventory-fixtures.js';
 import { inventoryTools } from './inventory.js';
 import { mediaTools } from './media.js';
 
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
 
+// Use the SDK's own `Tool['inputSchema']` shape rather than a stringly-typed
+// `Record<string, unknown>` so the compiler enforces `type: 'object'` and a
+// well-formed `properties` map at the definition site.
 export interface ToolDef {
   name: string;
   description: string;
-  inputSchema: Record<string, unknown>;
+  inputSchema: Tool['inputSchema'];
   handler: (args: Record<string, unknown>) => Promise<CallToolResult>;
 }
 


### PR DESCRIPTION
## Summary

Three foundation-level fixes to `apps/pops-mcp`. None touch tool logic; all three were issues I caught in self-review of the original MCP server PR.

**1. ToolDef.inputSchema is now type-safe.** Was `Record<string, unknown>`, which let any malformed shape through. Now uses `Tool['inputSchema']` from `@modelcontextprotocol/sdk/types.js` so the JSON-Schema shape (`type: 'object'`, `properties` map, optional `required`) is checked at definition site. No tool definitions needed changes — they already conformed.

**2. Fix unhandled-rejection in `res.on('close')`.** The handler was an async arrow function; EventEmitter discards the returned promise. If `server.close()` rejected we'd hit `process.on('unhandledRejection')` and (under default Node config) crash the process. Wrapped in `.catch(log)` and extracted as `attachServerCleanup(res, server)` so the rejection path is unit-testable.

**3. Split `/health` from `/ready`.** The old `/health` returned 200 OK whether or not `POPS_API_KEY` was configured — a misconfigured pod would happily report healthy while every tool call failed. Now:
- `/health` — liveness, never fails (Docker HEALTHCHECK)
- `/ready` — returns 503 + `{ status: 'degraded' }` when `POPS_API_KEY` is missing

**4. Drop a stray cast.** `(args ?? {}) as Record<string, unknown>` is unnecessary — the SDK already types `req.params.arguments` as `{ [key: string]: unknown } | undefined`.

## Test plan

- [x] `mise lint` clean
- [x] `mise typecheck` clean
- [x] `pnpm --filter @pops/mcp test` — 142 passing (was 137; +5 new)
  - 3 endpoint round-trips against the live express app on an ephemeral port
  - 2 cleanup-callback tests including the rejection regression
- [ ] CI green
- [ ] After merge: `curl <pops-mcp>/health` returns 200, `/ready` returns 503 if API key is missing