### PR TITLE
fix(finance/imports): bulk Accept All seeds rule proposal, sort merged entities

### DIFF
--- a/packages/app-finance/src/components/imports/hooks/bulk-assignment/use-accept.ts
+++ b/packages/app-finance/src/components/imports/hooks/bulk-assignment/use-accept.ts
@@ -31,46 +31,57 @@ interface AcceptAllArgs {
   addPendingEntity: ReturnType<typeof useEntities>['addPendingEntity'];
   dbEntitiesData: ReturnType<typeof useEntities>['dbEntitiesData'];
   setLocalTransactions: Dispatch<SetStateAction<LocalTxState>>;
+  generateProposal: UseBulkAssignmentArgs['generateProposal'];
+}
+
+function resolveEntityId(
+  entityName: string,
+  entities: AcceptAllArgs['entities'],
+  addPendingEntity: AcceptAllArgs['addPendingEntity'],
+  dbEntitiesData: AcceptAllArgs['dbEntitiesData']
+): string {
+  const existing = entities?.find((e) => e.name.toLowerCase() === entityName.toLowerCase())?.id;
+  if (existing) return existing;
+  const pending = addPendingEntity({ name: entityName, type: 'company' }, dbEntitiesData?.data);
+  return pending.tempId;
 }
 
 /**
- * Bulk-accept assigns the AI-suggested entity directly without opening the
- * Correction Proposal dialog. Users who want to edit the proposed rule before
- * applying use the per-row Accept path (`useAcceptAiSuggestion`), which still
- * routes through the dialog.
+ * Bulk-accept assigns the AI-suggested entity to every transaction in the
+ * group and then opens the Correction Proposal dialog seeded from the first
+ * transaction. Approving the proposal persists a rule, so future imports
+ * match the same descriptor automatically instead of re-prompting.
  */
 export function useAcceptAll(args: AcceptAllArgs) {
-  const { entities, addPendingEntity, dbEntitiesData, setLocalTransactions } = args;
+  const { entities, addPendingEntity, dbEntitiesData, setLocalTransactions, generateProposal } =
+    args;
   return useCallback(
     async (transactions: ProcessedTransaction[]) => {
       if (transactions.length === 0) return;
       const firstTx = transactions[0];
       const entityName = firstTx?.entity?.entityName;
-      if (!entityName) {
+      if (!firstTx || !entityName) {
         toast.error('No entity name found');
         return;
       }
       try {
-        let entityId = entities?.find((e) => e.name.toLowerCase() === entityName.toLowerCase())?.id;
-        if (!entityId) {
-          const pending = addPendingEntity(
-            { name: entityName, type: 'company' },
-            dbEntitiesData?.data
-          );
-          entityId = pending.tempId;
-        }
-        const resolvedEntityId = entityId;
-        setLocalTransactions((prev) =>
-          moveToMatched(prev, transactions, { entityId: resolvedEntityId, entityName })
-        );
+        const entityId = resolveEntityId(entityName, entities, addPendingEntity, dbEntitiesData);
+        setLocalTransactions((prev) => moveToMatched(prev, transactions, { entityId, entityName }));
         toast.success(`Accepted ${pluralize(transactions.length)} as "${entityName}"`);
+        void generateProposal({
+          triggeringTransaction: firstTx,
+          entityId,
+          entityName,
+          location: firstTx.location ?? null,
+          transactionType: firstTx.transactionType ?? null,
+        });
       } catch (error) {
         toast.error(
           `Failed to accept: ${error instanceof Error ? error.message : 'Unknown error'}`
         );
       }
     },
-    [entities, addPendingEntity, dbEntitiesData?.data, setLocalTransactions]
+    [entities, addPendingEntity, dbEntitiesData, setLocalTransactions, generateProposal]
   );
 }
 

--- a/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
+++ b/packages/app-finance/src/components/imports/hooks/useBulkAssignment.ts
@@ -38,6 +38,7 @@ export function useBulkAssignment(args: UseBulkAssignmentArgs) {
     addPendingEntity,
     dbEntitiesData,
     setLocalTransactions,
+    generateProposal,
   });
 
   const handleCreateAndAssignAll = useCallback(

--- a/packages/app-finance/src/lib/merged-state.test.ts
+++ b/packages/app-finance/src/lib/merged-state.test.ts
@@ -252,15 +252,15 @@ describe('computeMergedEntities', () => {
     expect(result).toBe(dbEntities);
   });
 
-  it('adds pending entities after DB entities when no collision', () => {
+  it('merges pending entities alphabetically with DB entities', () => {
     const dbEntities = [makeEntity({ id: 'e1', name: 'Woolworths' })];
     const pending = [makePendingEntity({ name: 'Coles' })];
 
     const result = computeMergedEntities(dbEntities, pending);
     expect(result).toHaveLength(2);
-    expect(result[0].name).toBe('Woolworths');
-    expect(result[1].name).toBe('Coles');
-    expect(result[1].id).toMatch(/^temp:entity:/);
+    expect(result[0].name).toBe('Coles');
+    expect(result[0].id).toMatch(/^temp:entity:/);
+    expect(result[1].name).toBe('Woolworths');
   });
 
   it('replaces DB entity when pending entity has same name', () => {
@@ -286,11 +286,12 @@ describe('computeMergedEntities', () => {
 
     const result = computeMergedEntities(dbEntities, pending);
     expect(result).toHaveLength(3);
-    // Aldi (non-colliding DB) comes first
+    // Sorted alphabetically: Aldi (non-colliding DB), Coles (pending), Woolworths (pending)
     expect(result[0].name).toBe('Aldi');
     expect(result[0].id).toBe('e3');
-    // Then pending entities
+    expect(result[1].name).toBe('Coles');
     expect(result[1].type).toBe('updated');
+    expect(result[2].name).toBe('Woolworths');
     expect(result[2].type).toBe('updated');
   });
 
@@ -312,8 +313,9 @@ describe('computeMergedEntities', () => {
 
     const result = computeMergedEntities([], pending);
     expect(result).toHaveLength(2);
-    expect(result[0].name).toBe('New Corp');
-    expect(result[1].name).toBe('Another Corp');
+    // Sorted alphabetically
+    expect(result[0].name).toBe('Another Corp');
+    expect(result[1].name).toBe('New Corp');
     expect(result[0].aliases).toEqual([]);
     expect(result[0].abn).toBeNull();
     expect(result[0].defaultTransactionType).toBeNull();

--- a/packages/app-finance/src/lib/merged-state.ts
+++ b/packages/app-finance/src/lib/merged-state.ts
@@ -64,7 +64,9 @@ let _cachedEntitiesOutput: Entity[] | null = null;
  * Adapt pending entities to the `Entity` interface and merge them with DB
  * entities. When a pending entity's name matches a DB entity's name
  * (case-insensitive), the pending version replaces the DB entry.
- * DB entities appear first, followed by non-colliding pending entities.
+ * The merged list is sorted alphabetically by name (case-insensitive) so
+ * newly-added pending entities appear in their natural position rather than
+ * appended at the end.
  * Memoized by reference equality on both input arrays.
  */
 export function computeMergedEntities(
@@ -82,10 +84,14 @@ export function computeMergedEntities(
   }
 
   if (pendingEntities.length === 0) {
+    // DB list is already sorted server-side; nothing to merge in.
     _cachedEntitiesInput = { dbEntities, pending: pendingEntities };
     _cachedEntitiesOutput = dbEntities;
     return dbEntities;
   }
+
+  const byName = (a: Entity, b: Entity) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
 
   // Build a set of pending entity names (lowercased) for collision detection
   const pendingNameSet = new Set(pendingEntities.map((pe) => pe.name.toLowerCase()));
@@ -106,9 +112,9 @@ export function computeMergedEntities(
   // Filter out DB entities that collide with pending entities
   const filteredDb = dbEntities.filter((e) => !pendingNameSet.has(e.name.toLowerCase()));
 
-  // DB entities first, then non-colliding pending (all pending are non-colliding
-  // with each other since addPendingEntity enforces uniqueness)
-  const result = [...filteredDb, ...adaptedPending];
+  // Merge then sort alphabetically by name so pending entities slot in by name
+  // instead of being appended at the end.
+  const result = [...filteredDb, ...adaptedPending].toSorted(byName);
 
   _cachedEntitiesInput = { dbEntities, pending: pendingEntities };
   _cachedEntitiesOutput = result;


### PR DESCRIPTION
## Summary
- Bulk **Accept All as \"X\"** in the import review now opens the Correction Proposal dialog after assigning the entity locally — approving the proposal persists a rule so future imports auto-match the same descriptor instead of re-prompting. Mirrors the existing per-row Accept flow and the \"Create new for all\" path.
- `computeMergedEntities` now sorts the merged DB + pending entity list alphabetically (case-insensitive), so newly created session-pending entities slot in by name instead of being appended at the end of the entity dropdown.

## Test plan
- [x] `pnpm --filter @pops/app-finance test` — 379/379 passing
- [x] `pnpm --filter @pops/app-finance typecheck` — clean
- [x] lint clean for changed files (pre-existing `no-underscore-dangle` warnings on memo caches unrelated)
- [ ] Manual: import a CSV with a new merchant like \"PROVENDER AUSTRALIA Waterloo\" → click \"Accept All as Provender Australia\" → proposal dialog opens with the inferred pattern → approve → re-import same descriptor and confirm it now matches automatically.
- [ ] Manual: open the bulk entity selector dropdown after creating a new entity mid-session and confirm it sorts alphabetically into the list rather than appearing at the bottom.