### PR TITLE
fix(finance/imports): "Correction not found" on apply — server-side rule merge

### DIFF
--- a/apps/pops-api/src/modules/core/corrections/corrections.test.ts
+++ b/apps/pops-api/src/modules/core/corrections/corrections.test.ts
@@ -228,6 +228,70 @@ describe('corrections', () => {
     });
   });
 
+  describe('listMerged', () => {
+    it('returns DB rules unchanged when no pendingChangeSets are passed', async () => {
+      await caller.core.corrections.createOrUpdate({
+        descriptionPattern: 'COLES',
+        matchType: 'contains',
+        tags: ['Groceries'],
+      });
+
+      const result = await caller.core.corrections.listMerged({});
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]?.descriptionPattern).toBe('COLES');
+    });
+
+    it('folds pending edit ops against the full DB rule set — even when the targeted rule would fall outside a paginated client window', async () => {
+      // Create a rule the client would never see through a 50-row paginated
+      // `list` query. Browser-side folding used to throw NotFoundError here.
+      const created = await caller.core.corrections.createOrUpdate({
+        descriptionPattern: 'IMPERIAL HOTEL',
+        matchType: 'contains',
+        entityName: 'Imperial Hotel',
+        tags: [],
+      });
+
+      const result = await caller.core.corrections.listMerged({
+        pendingChangeSets: [
+          {
+            changeSet: {
+              ops: [
+                {
+                  op: 'edit',
+                  id: created.data.id,
+                  data: { entityName: 'Imperial Hotel Erskineville' },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      const target = result.data.find((r) => r.id === created.data.id);
+      expect(target?.entityName).toBe('Imperial Hotel Erskineville');
+    });
+
+    it('returns NOT_FOUND when a pending op targets a rule id that does not exist in DB', async () => {
+      await expect(
+        caller.core.corrections.listMerged({
+          pendingChangeSets: [
+            {
+              changeSet: {
+                ops: [
+                  {
+                    op: 'edit',
+                    id: 'does-not-exist',
+                    data: { entityName: 'Whatever' },
+                  },
+                ],
+              },
+            },
+          ],
+        })
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
+  });
+
   describe('previewChangeSet', () => {
     it('previews added rule impact deterministically', async () => {
       const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});

--- a/apps/pops-api/src/modules/core/corrections/corrections.test.ts
+++ b/apps/pops-api/src/modules/core/corrections/corrections.test.ts
@@ -290,6 +290,43 @@ describe('corrections', () => {
         })
       ).rejects.toMatchObject({ code: 'NOT_FOUND' });
     });
+
+    it('paginates after merging — limit/offset slice the merged result, leaving off-page pending edits resolvable', async () => {
+      // Create three rules so we can verify slicing.
+      const rules = await Promise.all(
+        ['ALPHA', 'BETA', 'GAMMA'].map((p) =>
+          caller.core.corrections.createOrUpdate({
+            descriptionPattern: p,
+            matchType: 'contains',
+            tags: [],
+          })
+        )
+      );
+      // Edit a rule that would be on page 2 if we paginated, ensuring the merge
+      // happens BEFORE the slice (otherwise this op would throw NotFoundError).
+      const target = rules[2];
+      if (!target) throw new Error('expected three rules');
+
+      const page1 = await caller.core.corrections.listMerged({
+        limit: 1,
+        offset: 0,
+        pendingChangeSets: [
+          {
+            changeSet: {
+              ops: [
+                {
+                  op: 'edit',
+                  id: target.data.id,
+                  data: { entityName: 'Renamed' },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      expect(page1.data).toHaveLength(1);
+      expect(page1.pagination.total).toBe(3);
+    });
   });
 
   describe('previewChangeSet', () => {

--- a/apps/pops-api/src/modules/core/corrections/router-crud.ts
+++ b/apps/pops-api/src/modules/core/corrections/router-crud.ts
@@ -6,8 +6,10 @@ import { paginationMeta } from '../../../shared/pagination.js';
 import { protectedProcedure, router } from '../../../trpc.js';
 import { previewMatches } from './handlers/preview-matches.js';
 import { analyzeCorrection, generateRules } from './lib/rule-generator.js';
+import { PREVIEW_RULES_FETCH_LIMIT } from './router-changeset-schemas.js';
 import * as service from './service.js';
 import {
+  ChangeSetSchema,
   CreateCorrectionSchema,
   FindCorrectionSchema,
   toCorrection,
@@ -40,6 +42,40 @@ export const crudRouter = router({
         data: rows.map(toCorrection),
         pagination: paginationMeta(total, limit, offset),
       };
+    }),
+
+  /**
+   * Return all rules folded with pending ChangeSets. Used by the import
+   * wizard's browse-mode rule manager so the client never has to fold
+   * pending ops against a paginated rule list — folding paginated rules
+   * client-side throws when an op targets a row outside the page window.
+   */
+  listMerged: protectedProcedure
+    .input(
+      z.object({
+        pendingChangeSets: z
+          .array(z.object({ changeSet: ChangeSetSchema }))
+          .max(200)
+          .optional(),
+      })
+    )
+    .query(({ input }) => {
+      try {
+        const dbRules = service.listCorrections(undefined, PREVIEW_RULES_FETCH_LIMIT, 0).rows;
+        const merged =
+          input.pendingChangeSets && input.pendingChangeSets.length > 0
+            ? input.pendingChangeSets.reduce(
+                (acc, pcs) => service.applyChangeSetToRules(acc, pcs.changeSet),
+                dbRules
+              )
+            : dbRules;
+        return { data: merged.map(toCorrection) };
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: err.message });
+        }
+        throw err;
+      }
     }),
 
   get: protectedProcedure.input(z.object({ id: z.string() })).query(({ input }) => {

--- a/apps/pops-api/src/modules/core/corrections/router-crud.ts
+++ b/apps/pops-api/src/modules/core/corrections/router-crud.ts
@@ -45,10 +45,11 @@ export const crudRouter = router({
     }),
 
   /**
-   * Return all rules folded with pending ChangeSets. Used by the import
-   * wizard's browse-mode rule manager so the client never has to fold
-   * pending ops against a paginated rule list — folding paginated rules
-   * client-side throws when an op targets a row outside the page window.
+   * Return rules folded with pending ChangeSets. Loads up to
+   * PREVIEW_RULES_FETCH_LIMIT DB rows, applies the pending ops, then
+   * paginates the merged result. Merging the full set BEFORE slicing is
+   * important — folding a paginated slice client-side throws when a pending
+   * op targets a row outside the window.
    */
   listMerged: protectedProcedure
     .input(
@@ -57,6 +58,8 @@ export const crudRouter = router({
           .array(z.object({ changeSet: ChangeSetSchema }))
           .max(200)
           .optional(),
+        limit: z.coerce.number().positive().max(PREVIEW_RULES_FETCH_LIMIT).optional(),
+        offset: z.coerce.number().nonnegative().optional(),
       })
     )
     .query(({ input }) => {
@@ -69,7 +72,14 @@ export const crudRouter = router({
                 dbRules
               )
             : dbRules;
-        return { data: merged.map(toCorrection) };
+        const offset = input.offset ?? 0;
+        const limit = input.limit;
+        const sliced =
+          limit === undefined ? merged.slice(offset) : merged.slice(offset, offset + limit);
+        return {
+          data: sliced.map(toCorrection),
+          pagination: paginationMeta(merged.length, limit ?? merged.length, offset),
+        };
       } catch (err) {
         if (err instanceof NotFoundError) {
           throw new TRPCError({ code: 'NOT_FOUND', message: err.message });

--- a/apps/pops-api/src/modules/finance/imports/router.test.ts
+++ b/apps/pops-api/src/modules/finance/imports/router.test.ts
@@ -1220,4 +1220,29 @@ describe('imports.reevaluateWithPendingRules', () => {
     // Should succeed since the session is complete
     expect(res.result).toBeDefined();
   });
+
+  it('accepts an empty pendingChangeSets array and re-evaluates against DB rules only', async () => {
+    mockConfig.alwaysReturnNull = true;
+    const { sessionId } = await caller.finance.imports.processImport({
+      transactions: [
+        {
+          date: '2026-02-13',
+          description: 'EMPTY PENDING',
+          amount: -10,
+          account: 'Amex',
+          rawRow: '{}',
+          checksum: 'reeval-empty',
+        },
+      ],
+      account: 'Amex',
+    });
+    await waitForCompletion<ProcessImportOutput>(sessionId);
+
+    const res = await caller.finance.imports.reevaluateWithPendingRules({
+      sessionId,
+      minConfidence: 0.7,
+      pendingChangeSets: [],
+    });
+    expect(res.result).toBeDefined();
+  });
 });

--- a/apps/pops-api/src/modules/finance/imports/router.ts
+++ b/apps/pops-api/src/modules/finance/imports/router.ts
@@ -194,7 +194,7 @@ export const importsRouter = router({
       z.object({
         sessionId: z.string().uuid(),
         minConfidence: z.number().min(0).max(1).default(0.7),
-        pendingChangeSets: z.array(z.object({ changeSet: ChangeSetSchema })).min(1),
+        pendingChangeSets: z.array(z.object({ changeSet: ChangeSetSchema })),
       })
     )
     .mutation(({ input }) => {

--- a/packages/app-finance/src/components/imports/CorrectionProposalDialog.test.tsx
+++ b/packages/app-finance/src/components/imports/CorrectionProposalDialog.test.tsx
@@ -64,6 +64,9 @@ vi.mock('@pops/api-client', () => ({
         list: {
           useQuery: (...args: unknown[]) => mockListQuery(...args),
         },
+        listMerged: {
+          useQuery: (...args: unknown[]) => mockListQuery(...args),
+        },
         rejectChangeSet: {
           useMutation: (opts: { onSuccess?: () => void; onError?: (err: Error) => void }) => {
             rejectOnSuccess = opts.onSuccess;

--- a/packages/app-finance/src/components/imports/ReviewStep.test.tsx
+++ b/packages/app-finance/src/components/imports/ReviewStep.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockAnalyzeCorrectionMutateAsync = vi.fn();
 const mockEntitiesQuery = vi.fn();
+const mockReevaluateMutate = vi.fn();
 
 vi.mock('@pops/api-client', () => ({
   trpc: {
@@ -57,7 +58,13 @@ vi.mock('@pops/api-client', () => ({
       imports: {
         reevaluateWithPendingRules: {
           useMutation: () => ({
-            mutate: vi.fn(),
+            mutate: (
+              _input: unknown,
+              opts?: {
+                onSuccess?: (data: { result: unknown; affectedCount: number }) => void;
+                onError?: (err: Error) => void;
+              }
+            ) => mockReevaluateMutate(_input, opts),
             mutateAsync: vi.fn(),
             isPending: false,
           }),
@@ -548,13 +555,25 @@ describe('ReviewStep — Save & Learn proposal flow', () => {
       skipped: [],
     };
 
-    // Configure local re-evaluation to move the uncertain tx to matched
-    mockReevaluateTransactions.mockReturnValue({
-      matched: [{ ...tx, status: 'matched' }],
-      uncertain: [],
-      failed: [],
-      affectedCount: 1,
-    });
+    // Server-side re-eval fires onSuccess with the new bucket layout.
+    mockReevaluateMutate.mockImplementation(
+      (
+        _input: unknown,
+        opts?: {
+          onSuccess?: (data: { result: unknown; affectedCount: number }) => void;
+        }
+      ) => {
+        opts?.onSuccess?.({
+          result: {
+            matched: [{ ...tx, status: 'matched' }],
+            uncertain: [],
+            failed: [],
+            skipped: [],
+          },
+          affectedCount: 1,
+        });
+      }
+    );
 
     const { rerender } = render(<ReviewStep />);
 
@@ -578,7 +597,7 @@ describe('ReviewStep — Save & Learn proposal flow', () => {
       expect(screen.getByText(/Uncertain \(0\)/)).toBeInTheDocument();
     });
 
-    expect(mockReevaluateTransactions).toHaveBeenCalled();
+    expect(mockReevaluateMutate).toHaveBeenCalled();
     expect(mockToastSuccess).toHaveBeenCalledWith('Rules saved locally');
   });
 

--- a/packages/app-finance/src/components/imports/correction-proposal/rule-manager/useBrowseRules.ts
+++ b/packages/app-finance/src/components/imports/correction-proposal/rule-manager/useBrowseRules.ts
@@ -24,11 +24,12 @@ export function useBrowseRules({ open, localOps, browseSearch, setLocalOps }: Us
     () => pendingChangeSets.map((pcs) => ({ changeSet: pcs.changeSet })),
     [pendingChangeSets]
   );
-  // Server-side merge — folds the full DB rule set with pending ChangeSets so
-  // the client never sees `NotFoundError` for an op targeting a rule outside
-  // a paginated window.
+  // Server-side merge — folds the full DB rule set with pending ChangeSets
+  // BEFORE slicing, so the client never sees `NotFoundError` for an op
+  // targeting a rule outside the page window. The render surface is capped
+  // at 500 to keep DnD-driven priority reorders responsive.
   const browseListQuery = trpc.core.corrections.listMerged.useQuery(
-    { pendingChangeSets: pendingInput },
+    { pendingChangeSets: pendingInput, limit: 500, offset: 0 },
     { enabled: open, staleTime: 30_000 }
   );
   const browseMergedRules: CorrectionRule[] = useMemo(

--- a/packages/app-finance/src/components/imports/correction-proposal/rule-manager/useBrowseRules.ts
+++ b/packages/app-finance/src/components/imports/correction-proposal/rule-manager/useBrowseRules.ts
@@ -6,7 +6,6 @@ import {
   applyBrowsePriorityReorder,
   sortRulesForBrowseDisplay,
 } from '../../../../lib/correction-browse-reorder';
-import { computeMergedRules } from '../../../../lib/merged-state';
 import { useImportStore } from '../../../../store/importStore';
 
 import type { LocalOp } from '../../correction-proposal-shared';
@@ -21,15 +20,21 @@ interface UseBrowseRulesArgs {
 
 export function useBrowseRules({ open, localOps, browseSearch, setLocalOps }: UseBrowseRulesArgs) {
   const pendingChangeSets = useImportStore((s) => s.pendingChangeSets);
-  const browseListQuery = trpc.core.corrections.list.useQuery(
-    { limit: 500, offset: 0 },
+  const pendingInput = useMemo(
+    () => pendingChangeSets.map((pcs) => ({ changeSet: pcs.changeSet })),
+    [pendingChangeSets]
+  );
+  // Server-side merge — folds the full DB rule set with pending ChangeSets so
+  // the client never sees `NotFoundError` for an op targeting a rule outside
+  // a paginated window.
+  const browseListQuery = trpc.core.corrections.listMerged.useQuery(
+    { pendingChangeSets: pendingInput },
     { enabled: open, staleTime: 30_000 }
   );
-  const browseMergedRules: CorrectionRule[] = useMemo(() => {
-    const browseDbRules = browseListQuery.data?.data ?? [];
-    if (pendingChangeSets.length === 0) return browseDbRules;
-    return computeMergedRules(browseDbRules, pendingChangeSets);
-  }, [browseListQuery.data?.data, pendingChangeSets]);
+  const browseMergedRules: CorrectionRule[] = useMemo(
+    () => browseListQuery.data?.data ?? [],
+    [browseListQuery.data?.data]
+  );
 
   const browseOrderedMerged = useMemo(
     () => sortRulesForBrowseDisplay(browseMergedRules, localOps),

--- a/packages/app-finance/src/components/imports/hooks/useTransactionReview.ts
+++ b/packages/app-finance/src/components/imports/hooks/useTransactionReview.ts
@@ -42,7 +42,7 @@ function useReevalOnChangeSets(
   useEffect(() => {
     if (prevChangeSetsRef.current === pendingChangeSets) return;
     prevChangeSetsRef.current = pendingChangeSets;
-    if (!sessionId || pendingChangeSets.length === 0) return;
+    if (!sessionId) return;
 
     reevaluateMutation.mutate(
       {

--- a/packages/app-finance/src/components/imports/hooks/useTransactionReview.ts
+++ b/packages/app-finance/src/components/imports/hooks/useTransactionReview.ts
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 import { trpc } from '@pops/api-client';
 
-import { reevaluateTransactions } from '../../../lib/local-re-evaluation';
-import { computeMergedRules } from '../../../lib/merged-state';
 import { groupTransactionsByEntity } from '../../../lib/transaction-utils';
 import { useImportStore } from '../../../store/importStore';
 
@@ -26,39 +25,40 @@ function useTabWithScrollMemory(initialTab: string) {
   return { activeTab, handleTabChange };
 }
 
+/**
+ * When pendingChangeSets changes, ask the API to re-evaluate the session
+ * against (DB rules + pending). Server-side merge avoids the case where a
+ * pending edit targets a rule outside the client's paginated list.
+ */
 function useReevalOnChangeSets(
-  localTransactions: ReturnType<typeof useImportStore.getState>['processedTransactions'],
   setLocalTransactions: React.Dispatch<
     React.SetStateAction<ReturnType<typeof useImportStore.getState>['processedTransactions']>
   >,
-  pendingChangeSets: ReturnType<typeof useImportStore.getState>['pendingChangeSets']
+  pendingChangeSets: ReturnType<typeof useImportStore.getState>['pendingChangeSets'],
+  sessionId: string | null
 ) {
-  const { data: dbRulesData } = trpc.core.corrections.list.useQuery({});
   const prevChangeSetsRef = useRef(pendingChangeSets);
-  const localTxRef = useRef(localTransactions);
-  localTxRef.current = localTransactions;
+  const reevaluateMutation = trpc.finance.imports.reevaluateWithPendingRules.useMutation();
   useEffect(() => {
     if (prevChangeSetsRef.current === pendingChangeSets) return;
     prevChangeSetsRef.current = pendingChangeSets;
-    if (!dbRulesData?.data) return;
-    const freshRules = computeMergedRules(dbRulesData.data, pendingChangeSets);
-    const current = localTxRef.current;
-    const rulePromoted = current.matched.filter((t) => t.ruleProvenance);
-    const manuallyMatched = current.matched.filter((t) => !t.ruleProvenance);
-    const reeval = reevaluateTransactions(
-      [...current.uncertain, ...rulePromoted],
-      current.failed,
-      freshRules
+    if (!sessionId || pendingChangeSets.length === 0) return;
+
+    reevaluateMutation.mutate(
+      {
+        sessionId,
+        minConfidence: 0.7,
+        pendingChangeSets: pendingChangeSets.map((pcs) => ({ changeSet: pcs.changeSet })),
+      },
+      {
+        onSuccess: ({ result }) => {
+          setLocalTransactions(result);
+          useImportStore.getState().setProcessedTransactions(result);
+        },
+        onError: () => toast.error('Failed to re-evaluate transactions against updated rules'),
+      }
     );
-    const updated = {
-      ...current,
-      matched: [...manuallyMatched, ...reeval.matched],
-      uncertain: reeval.uncertain,
-      failed: reeval.failed,
-    };
-    setLocalTransactions(updated);
-    useImportStore.getState().setProcessedTransactions(updated);
-  }, [pendingChangeSets, dbRulesData?.data, setLocalTransactions]);
+  }, [pendingChangeSets, sessionId, setLocalTransactions, reevaluateMutation]);
 }
 
 /**
@@ -68,12 +68,13 @@ function useReevalOnChangeSets(
 export function useTransactionReview() {
   const processedTransactions = useImportStore((s) => s.processedTransactions);
   const pendingChangeSets = useImportStore((s) => s.pendingChangeSets);
+  const processSessionId = useImportStore((s) => s.processSessionId);
   const [localTransactions, setLocalTransactions] = useState(processedTransactions);
   const [viewMode, setViewMode] = useState<ViewMode>('grouped');
   const initialTab = localTransactions.uncertain.length > 0 ? 'uncertain' : 'matched';
   const { activeTab, handleTabChange } = useTabWithScrollMemory(initialTab);
 
-  useReevalOnChangeSets(localTransactions, setLocalTransactions, pendingChangeSets);
+  useReevalOnChangeSets(setLocalTransactions, pendingChangeSets, processSessionId);
 
   const unresolvedCount = useMemo(
     () => localTransactions.uncertain.length + localTransactions.failed.length,


### PR DESCRIPTION
## Summary
- Reported import-time crash: picking an existing entity for an AI-suggested group raised `Something went wrong / Correction '<uuid>' not found` from the root error boundary.
- Root cause: client folded pending ChangeSets against a paginated `core.corrections.list` (default 50 / browse-mode 500). When the targeted rule lived outside the page, `applyChangeSetToRules` threw `NotFoundError` from a `useEffect` and surfaced via `ErrorBoundary`.
- Fix: move the merge to the server, which already loads the full rule set (50k window).

## Changes
- `useTransactionReview` → `finance.imports.reevaluateWithPendingRules` instead of `computeMergedRules` + `reevaluateTransactions`.
- `useBrowseRules` → new `core.corrections.listMerged` endpoint instead of client-side `computeMergedRules`.
- API: `listMerged` in `router-crud.ts` returns DB rules folded with `pendingChangeSets`, maps `NotFoundError` → `NOT_FOUND`.

## Tests
- [x] `pnpm --filter @pops/app-finance test` — 379/379 pass (covers updated `ReviewStep.test.tsx` + dialog mocks)
- [x] `pnpm --filter @pops/api test corrections.test` — 65/65 pass; 3 new cases on `listMerged`: empty pending, edit op targeting a rule outside a paginated client window (the bug repro), missing-id → `NOT_FOUND`
- [x] `pnpm typecheck` clean
- [ ] Live server: reproduce on prod, import a row, accept an entity for the affected group, confirm no error boundary