### PR TITLE
chore(deps): pin ioredis via pnpm override to fix bullmq duplicate

### DIFF
--- a/apps/pops-api/package.json
+++ b/apps/pops-api/package.json
@@ -87,7 +87,7 @@
     "express-rate-limit": "^8.5.2",
     "gray-matter": "^4.0.3",
     "helmet": "^8.0.0",
-    "ioredis": "^5.10.1",
+    "ioredis": "^5.11.0",
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.3",
     "node-cron": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "sharp"
     ],
     "overrides": {
-      "cssstyle": "6.0.2"
+      "cssstyle": "6.0.2",
+      "ioredis": "5.11.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   cssstyle: 6.0.2
+  ioredis: 5.11.0
 
 importers:
 
@@ -87,8 +88,8 @@ importers:
         specifier: ^8.0.0
         version: 8.1.0
       ioredis:
-        specifier: ^5.10.1
-        version: 5.10.1
+        specifier: 5.11.0
+        version: 5.11.0
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -2282,8 +2283,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@ioredis/commands@1.5.1':
-    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
     resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
@@ -4617,8 +4618,8 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  cluster-key-slot@1.1.2:
-    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
     engines: {node: '>=0.10.0'}
 
   cmdk@1.1.1:
@@ -5514,8 +5515,8 @@ packages:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
 
-  ioredis@5.10.1:
-    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+  ioredis@5.11.0:
+    resolution: {integrity: sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==}
     engines: {node: '>=12.22.0'}
 
   ip-address@10.2.0:
@@ -5826,14 +5827,8 @@ packages:
     resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
     engines: {node: '>=22.13.0'}
 
-  lodash.defaults@4.2.0:
-    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
-
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
-
-  lodash.isarguments@3.1.0:
-    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
@@ -8261,7 +8256,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@ioredis/commands@1.5.1': {}
+  '@ioredis/commands@1.10.0': {}
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
@@ -10133,7 +10128,7 @@ snapshots:
   bullmq@5.76.10:
     dependencies:
       cron-parser: 4.9.0
-      ioredis: 5.10.1
+      ioredis: 5.11.0
       msgpackr: 2.0.1
       node-abort-controller: 3.1.1
       semver: 7.8.0
@@ -10225,7 +10220,7 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cluster-key-slot@1.1.2: {}
+  cluster-key-slot@1.1.1: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -11103,14 +11098,12 @@ snapshots:
 
   interpret@3.1.1: {}
 
-  ioredis@5.10.1:
+  ioredis@5.11.0:
     dependencies:
-      '@ioredis/commands': 1.5.1
-      cluster-key-slot: 1.1.2
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
       debug: 4.4.3
       denque: 2.1.0
-      lodash.defaults: 4.2.0
-      lodash.isarguments: 3.1.0
       redis-errors: 1.2.0
       redis-parser: 3.0.0
       standard-as-callback: 2.1.0
@@ -11378,11 +11371,7 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 10.0.0
 
-  lodash.defaults@4.2.0: {}
-
   lodash.includes@4.3.0: {}
-
-  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 


### PR DESCRIPTION
## Summary
Adds an `ioredis: 5.11.0` pnpm override so the workspace resolves a single copy of `ioredis`, and updates `apps/pops-api/package.json` to `^5.11.0` so the manifest matches the lockfile importer specifier and override.

## Why
In current repo state, `bullmq@5.76.10` pins `ioredis: 5.10.1` as a direct dependency. In Dependabot PR #2673 (motivating case), `bullmq@5.78.0` also pins `ioredis: 5.10.1`. When our workspace direct dep is bumped (e.g. to `^5.11.0`), pnpm resolves both copies and TS rejects passing a `Redis` instance to bullmq's `ConnectionOptions` because the types are nominally distinct (`TS2322`). This breaks Typecheck × 5, Backend Tests, Quality Checks, quality, and Validate Docker builds across the API.

Forcing a single version repo-wide unblocks future ioredis bumps without waiting for a corresponding bullmq release.

## Unblocks
- Dependabot PR #2673 — rebase on top of this and CI should go green.

## Test plan
- [x] `pnpm install` — lockfile contains only `ioredis@5.11.0`, `5.10.1` removed
- [x] `pnpm --filter @pops/api typecheck` — clean
- [x] `pnpm --filter @pops/api test` — 4406 / 4406 passing
- [x] `pnpm typecheck` (full monorepo) — clean