### PR TITLE
fix(ci): release tag-only, filter to strict semver tags

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -23,9 +23,11 @@ TMPDIR_RELEASE="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_RELEASE"' EXIT
 mktemp() { command mktemp "$TMPDIR_RELEASE/XXXXXX"; }
 
-# Filter to strict semver (vMAJOR.MINOR.PATCH) so legacy rolling tags like
-# v1, v2, v3, v4 don't get picked up as the previous release.
-LAST_TAG="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1 || true)"
+# Filter to strict vMAJOR.MINOR.PATCH so legacy rolling tags (v1, v2, …) and
+# pre-release / 4-segment variants (v1.2.3-rc.1, v1.2.3.4) don't get picked
+# up as the previous release. `git tag -l` uses globs which can't express
+# "anchored regex" — pipe through grep -E instead.
+LAST_TAG="$(git tag -l --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)"
 if [ -n "$LAST_TAG" ]; then
   RANGE="${LAST_TAG}..HEAD"
   CURRENT="${LAST_TAG#v}"

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
-# Compute next release from conventional commits since the last v* tag.
+# Compute next release from conventional commits since the last vX.Y.Z tag.
 #
-# Writes three things on success:
-#   - prepends a section to CHANGELOG.md
+# Writes two things on success (the workflow handles tagging + GitHub Release):
 #   - writes release-notes.md (used by `gh release create --notes-file`)
 #   - emits version / previous / release outputs on $GITHUB_OUTPUT
 #
-# Bump rules (pre-1.0 follows release-please's "bump-minor-pre-major" preset):
-#   - any  BREAKING CHANGE / `type!:` →  major  ; in 0.x, becomes minor
-#   - any  feat                       →  minor
-#   - any  fix | perf                 →  patch
-#   - everything else                 →  no release
+# Deliberately does NOT mutate CHANGELOG.md or version.txt in the working tree:
+# the repo ruleset requires changes to main to go through a PR, so the workflow
+# can't push a release commit directly. The GitHub Release is the source of
+# truth for changelog history.
+#
+# Bump rules (pre-1.0 collapses major into minor, like release-please's
+# "bump-minor-pre-major" preset):
+#   - any  BREAKING CHANGE / BREAKING-CHANGE / `type!:` →  major  ; in 0.x, becomes minor
+#   - any  feat                                         →  minor
+#   - any  fix | perf                                   →  patch
+#   - everything else                                   →  no release
 
 set -euo pipefail
 
@@ -18,7 +23,9 @@ TMPDIR_RELEASE="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_RELEASE"' EXIT
 mktemp() { command mktemp "$TMPDIR_RELEASE/XXXXXX"; }
 
-LAST_TAG="$(git tag -l 'v*' --sort=-v:refname | head -1 || true)"
+# Filter to strict semver (vMAJOR.MINOR.PATCH) so legacy rolling tags like
+# v1, v2, v3, v4 don't get picked up as the previous release.
+LAST_TAG="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1 || true)"
 if [ -n "$LAST_TAG" ]; then
   RANGE="${LAST_TAG}..HEAD"
   CURRENT="${LAST_TAG#v}"
@@ -102,19 +109,6 @@ emit_section revert "Reverts"
 emit_section docs   "Documentation"
 emit_section build  "Build"
 emit_section ci     "CI/CD"
-
-if [ ! -f CHANGELOG.md ]; then
-  printf '# Changelog\n\n' > CHANGELOG.md
-fi
-{
-  head -1 CHANGELOG.md
-  echo
-  cat "$NOTES"
-  tail -n +3 CHANGELOG.md
-} > CHANGELOG.md.new
-mv CHANGELOG.md.new CHANGELOG.md
-
-echo "$NEW" > version.txt
 
 cp "$NOTES" release-notes.md
 {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Skip the release commit itself so the workflow doesn't recurse.
-# Belt and suspenders: GITHUB_TOKEN-driven pushes also won't trigger push:
-# workflows, but this keeps intent explicit and survives if the token changes.
+# Only tag pushes and GitHub Release creates; no commits land on main. The repo
+# ruleset forbids direct pushes to main, so the workflow is tag-only by design
+# and the GitHub Release is the canonical changelog.
 permissions:
   contents: write
 
@@ -18,7 +18,6 @@ concurrency:
 jobs:
   release:
     name: Release
-    if: ${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -43,10 +42,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           NEW_VERSION: ${{ steps.compute.outputs.version }}
         run: |
-          git add CHANGELOG.md version.txt
-          git commit -m "chore(release): v${NEW_VERSION}"
           git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}"
-          git push origin "HEAD:${GITHUB_REF_NAME}" --follow-tags
+          git push origin "v${NEW_VERSION}"
           gh release create "v${NEW_VERSION}" \
             --title "v${NEW_VERSION}" \
             --notes-file release-notes.md

--- a/docs/runbooks/cut-release.md
+++ b/docs/runbooks/cut-release.md
@@ -7,9 +7,11 @@
 ## TL;DR
 
 1. Land changes on `main` using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `feat!:` for breaking).
-2. The `Release` workflow runs on push to main, bumps the version, prepends a section to `CHANGELOG.md`, commits, tags `vX.Y.Z`, and creates the GitHub Release in one shot — no PR ceremony.
+2. The `Release` workflow runs on push to main, bumps the version, tags `vX.Y.Z` at the current HEAD, and creates a GitHub Release with the grouped changelog — no commit on main, no PR ceremony.
 3. The new `vX.Y.Z` tag triggers `Publish Images` to publish `ghcr.io/knoxio/pops-{api,shell}:vX.Y.Z` (plus `X.Y`, `X`, and unprefixed forms).
 4. Update any deployer that pins `POPS_IMAGE_TAG` (knoxio lab tracks `main` via Watchtower, so no action needed there).
+
+The full changelog history lives in [GitHub Releases](https://github.com/knoxio/pops/releases) — there's no in-repo `CHANGELOG.md`. The repo ruleset requires all changes to main to go through a PR, so the workflow is tag-only by design.
 
 ## When to cut
 
@@ -63,16 +65,15 @@ release.yml runs on push to main
         │
         ▼
 .github/scripts/release.sh:
-  - reads commits since the last v* tag
+  - reads commits since the last vX.Y.Z tag
   - computes bump from conventional commit types
-  - prepends section to CHANGELOG.md
-  - updates version.txt
+  - writes release-notes.md (grouped changelog)
         │
         ▼
-job commits the changelog + tags vX.Y.Z + pushes
+job creates annotated tag vX.Y.Z at HEAD + pushes the tag
         │
         ▼
-gh release create publishes the GitHub Release
+gh release create publishes the GitHub Release with the notes
         │
         ▼
 publish-images.yml triggers on tag push, builds + tags:
@@ -110,7 +111,6 @@ docker compose -f infra/docker-compose.yml up -d
 
 ## First-time setup checklist (one-off)
 
-- [x] `version.txt` at the repo root (source of truth for the current version)
 - [x] `.github/workflows/release.yml` + `.github/scripts/release.sh`
 - [x] `.github/workflows/publish-images.yml` includes `type=semver` patterns for the `v*` tag trigger
 - [ ] First `vX.Y.Z` tag cut to exercise the pipeline end-to-end

--- a/docs/themes/00-platform/prds/096-application-packaging/us-05-versioning.md
+++ b/docs/themes/00-platform/prds/096-application-packaging/us-05-versioning.md
@@ -20,8 +20,8 @@ Establish a release process: cut semver `vX.Y.Z` tags on the pops repo when the 
 
 - Versioning scheme: **semver on git tag** (`v0.1.0`, `v0.2.0`, `v1.0.0`). Single product version covers both `pops-api` and `pops-shell` since they ship together.
 - Tagging in CI: `.github/workflows/publish-images.yml` already triggers on `tags: ['v*']`. The `docker/metadata-action` config now emits the version-tagged variants alongside `main` / `sha-<short>`.
-- Changelog & version bumps: `.github/workflows/release.yml` runs `.github/scripts/release.sh` on every push to `main`. The script reads commits since the last `v*` tag, computes the bump, prepends a section to `CHANGELOG.md`, updates `version.txt`, commits, tags `vX.Y.Z`, pushes, and creates the GitHub Release — no PR ceremony.
-- Recursion guard: the job skips itself when the head commit starts with `chore(release):`, and `GITHUB_TOKEN`-driven pushes don't re-trigger `push:` workflows.
+- Changelog & version bumps: `.github/workflows/release.yml` runs `.github/scripts/release.sh` on every push to `main`. The script reads commits since the last `vX.Y.Z` tag, computes the bump, and writes release-notes.md. The job then creates an annotated `vX.Y.Z` tag at HEAD, pushes the tag, and runs `gh release create` — no commit on main, no PR ceremony. The GitHub Release is the canonical changelog.
+- Tag-only by design: the repo ruleset forbids direct pushes to main, so the workflow only pushes tags. Legacy rolling tags (`v1`, `v2`, …) are ignored by the script's strict `vX.Y.Z` filter.
 - Runbook: `docs/runbooks/cut-release.md` documents when to cut, the Conventional Commits cheat sheet, the manual escape hatch, and how a deployer pins a version.
 
 ## Notes


### PR DESCRIPTION
## Summary
First run of the release workflow on main failed in two ways:
1. **Computed v5.0.0** because the script picked up legacy rolling tags `v1`/`v2`/`v3`/`v4` as "the last release"; bumped from 4.x → 5.0.0.
2. **Push rejected by branch ruleset** when the workflow tried to commit `CHANGELOG.md` + `version.txt` to main directly. The repo ruleset requires changes to main to go through a PR.

Fix:
- Filter previous-tag lookup to strict `vX.Y.Z` form, so legacy bare-major rolling tags are ignored.
- Drop the CHANGELOG.md and version.txt writes from the script and workflow. The job is now tag-only: create an annotated `vX.Y.Z` at HEAD, push the tag, `gh release create` with the grouped notes. The GitHub Release is the canonical changelog history.

The bogus `v5.0.0` git tag has been deleted (no GitHub Release was actually created — workflow failed before `gh release create`).

## Test plan
- [x] Dry-ran the script on a fake repo with bare `v1`/`v3` tags present plus two `feat:` commits — correctly bumped `0.0.0 → 0.1.0` ignoring v1/v3, wrote no CHANGELOG/version.txt.
- [ ] After merge, the release workflow on the merge commit should cut `v0.1.0` (the first real release) and trigger `Publish Images` to push `vX.Y.Z`-tagged images.