### PR TITLE
fix(ci): cap release notes at 120k chars to fit GitHub's 125k limit

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -115,9 +115,17 @@ emit_section ci     "CI/CD"
 # GitHub Releases caps the body at 125,000 characters. Truncate with a clear
 # tail note so the call succeeds even on first-time releases that roll up
 # every conventional commit since the initial commit.
+#
+# `head -c` slices by raw bytes, which can split a UTF-8 codepoint mid-sequence
+# and yield invalid UTF-8 (commit messages can contain emoji, non-ASCII text,
+# etc.). Run the cut through `iconv -c` to silently drop any trailing partial
+# byte sequence, so the file stays valid UTF-8.
 MAX_BYTES=120000
-if [ "$(wc -c < "$NOTES")" -gt "$MAX_BYTES" ]; then
-  head -c "$MAX_BYTES" "$NOTES" > release-notes.md
+if (( $(wc -c < "$NOTES") > MAX_BYTES )); then
+  # iconv writes valid UTF-8 to stdout, then exits 1 with a warning if the
+  # last codepoint was incomplete (which is exactly the case we're handling).
+  # The truncated file is already on disk by then, so swallow the exit code.
+  head -c "$MAX_BYTES" "$NOTES" | iconv -c -f UTF-8 -t UTF-8 > release-notes.md 2>/dev/null || true
   printf '\n\n_…notes truncated; see `git log %s..v%s` for the full range._\n' \
     "${LAST_TAG:-$PREV_REF}" "$NEW" >> release-notes.md
 else

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -112,7 +112,17 @@ emit_section docs   "Documentation"
 emit_section build  "Build"
 emit_section ci     "CI/CD"
 
-cp "$NOTES" release-notes.md
+# GitHub Releases caps the body at 125,000 characters. Truncate with a clear
+# tail note so the call succeeds even on first-time releases that roll up
+# every conventional commit since the initial commit.
+MAX_BYTES=120000
+if [ "$(wc -c < "$NOTES")" -gt "$MAX_BYTES" ]; then
+  head -c "$MAX_BYTES" "$NOTES" > release-notes.md
+  printf '\n\n_…notes truncated; see `git log %s..v%s` for the full range._\n' \
+    "${LAST_TAG:-$PREV_REF}" "$NEW" >> release-notes.md
+else
+  cp "$NOTES" release-notes.md
+fi
 {
   echo "version=$NEW"
   echo "previous=${LAST_TAG:-v0.0.0}"


### PR DESCRIPTION
## Summary
First real release run computed `v0.1.0` correctly and pushed the tag, but `gh release create` rejected the body with HTTP 422 `body is too long (maximum is 125000 characters)` — rolling up every conventional commit since the initial commit blew past the limit.

Truncate the notes file at 120k bytes (5k buffer) and append a tail note pointing at the git log range so the call always succeeds, even on a first-time release that aggregates years of history.

## Aftermath of the failed run
- `v0.1.0` git tag exists on main and was pushed by the failed workflow run.
- No GitHub Release is attached to it.
- The next release this workflow cuts will start from `v0.1.0` as the previous semver tag and bump to `v0.1.1` (this PR is a `fix:`, → patch bump). `v0.1.0` can be backfilled with a brief manual note if anyone wants one.

## Test plan
- [x] Trivial inline change — manually verified that `wc -c` thresholding triggers truncation when body > 120000 bytes.
- [ ] After merge, `release.yml` should compute `v0.1.1`, tag, and successfully create the GitHub Release (range is just this commit, so no truncation actually fires).