### PR TITLE
fix(finance/imports): promote rule confidence on user-approved edit proposals — unblocks Uncertain group accept

### DIFF
--- a/apps/pops-api/src/modules/core/corrections/handlers/changeset-builders.test.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/changeset-builders.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for changeset builders.
+ *
+ * Locks the regression that left `IMPERIAL HOTEL → Imperial Hotel Erskineville`
+ * stuck in Uncertain: when a proposal targets an existing low-confidence row,
+ * the edit op must promote `confidence` above the matcher's `minConfidence`
+ * threshold and force `isActive: true`. Otherwise the rule is filtered out by
+ * `findAllMatchingCorrectionFromRules` (pure-service.ts) and the txn never
+ * leaves Uncertain even after the user accepts the proposal.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  PROPOSAL_APPROVED_CONFIDENCE,
+  buildAddChangeSet,
+  buildEditChangeSet,
+} from './changeset-builders.js';
+
+import type { CorrectionRow, CorrectionSignal } from '../types.js';
+
+function makeSignal(overrides: Partial<CorrectionSignal> = {}): CorrectionSignal {
+  return {
+    descriptionPattern: 'IMPERIAL HOTEL',
+    matchType: 'contains',
+    entityId: 'entity-1',
+    entityName: 'Imperial Hotel Erskineville',
+    location: null,
+    tags: [],
+    transactionType: null,
+    ...overrides,
+  };
+}
+
+function makeExistingRow(overrides: Partial<CorrectionRow> = {}): CorrectionRow {
+  return {
+    id: 'rule-1',
+    descriptionPattern: 'IMPERIAL HOTEL',
+    matchType: 'contains',
+    entityId: null,
+    entityName: null,
+    location: null,
+    tags: '[]',
+    transactionType: null,
+    confidence: 0.5,
+    isActive: true,
+    priority: 0,
+    timesApplied: 0,
+    createdAt: new Date().toISOString(),
+    lastUsedAt: null,
+    ...overrides,
+  };
+}
+
+const baseBuildArgs = {
+  normalizedPattern: 'IMPERIAL HOTEL',
+  matchType: 'contains' as const,
+  hasFeedback: false,
+};
+
+describe('buildEditChangeSet', () => {
+  it('promotes a sub-threshold rule above the matcher minConfidence', () => {
+    const existing = makeExistingRow({ confidence: 0.5 });
+    const cs = buildEditChangeSet(existing, {
+      ...baseBuildArgs,
+      effectiveSignal: makeSignal(),
+    });
+
+    const editOp = cs.ops[0];
+    if (!editOp || editOp.op !== 'edit') throw new Error('expected edit op');
+    expect(editOp.data.confidence).toBe(PROPOSAL_APPROVED_CONFIDENCE);
+    expect(editOp.data.isActive).toBe(true);
+    // Confidence must be strictly above the 0.7 default minConfidence so the
+    // rule is eligible after the changeset is merged.
+    expect(editOp.data.confidence ?? 0).toBeGreaterThan(0.7);
+  });
+
+  it('does not downgrade an already-high confidence rule', () => {
+    const existing = makeExistingRow({ confidence: 0.99 });
+    const cs = buildEditChangeSet(existing, {
+      ...baseBuildArgs,
+      effectiveSignal: makeSignal(),
+    });
+
+    const editOp = cs.ops[0];
+    if (!editOp || editOp.op !== 'edit') throw new Error('expected edit op');
+    expect(editOp.data.confidence).toBe(0.99);
+  });
+
+  it('reactivates a previously-disabled rule the user is re-approving', () => {
+    const existing = makeExistingRow({ isActive: false, confidence: 0.95 });
+    const cs = buildEditChangeSet(existing, {
+      ...baseBuildArgs,
+      effectiveSignal: makeSignal(),
+    });
+
+    const editOp = cs.ops[0];
+    if (!editOp || editOp.op !== 'edit') throw new Error('expected edit op');
+    expect(editOp.data.isActive).toBe(true);
+  });
+
+  it('forwards the signal entity/location/tags/transactionType', () => {
+    const signal = makeSignal({
+      entityId: 'entity-9',
+      entityName: 'New Entity',
+      location: 'Sydney',
+      tags: ['food'],
+      transactionType: 'purchase',
+    });
+    const cs = buildEditChangeSet(makeExistingRow(), {
+      ...baseBuildArgs,
+      effectiveSignal: signal,
+    });
+
+    const editOp = cs.ops[0];
+    if (!editOp || editOp.op !== 'edit') throw new Error('expected edit op');
+    expect(editOp.data).toMatchObject({
+      entityId: 'entity-9',
+      entityName: 'New Entity',
+      location: 'Sydney',
+      tags: ['food'],
+      transactionType: 'purchase',
+    });
+  });
+});
+
+describe('buildAddChangeSet', () => {
+  it('uses the shared approved-confidence constant', () => {
+    const cs = buildAddChangeSet({
+      ...baseBuildArgs,
+      effectiveSignal: makeSignal(),
+    });
+    const addOp = cs.ops[0];
+    if (!addOp || addOp.op !== 'add') throw new Error('expected add op');
+    expect(addOp.data.confidence).toBe(PROPOSAL_APPROVED_CONFIDENCE);
+    expect(addOp.data.isActive).toBe(true);
+  });
+});

--- a/apps/pops-api/src/modules/core/corrections/handlers/changeset-builders.ts
+++ b/apps/pops-api/src/modules/core/corrections/handlers/changeset-builders.ts
@@ -1,5 +1,13 @@
 import type { ChangeSet, CorrectionRow, CorrectionSignal } from '../types.js';
 
+/**
+ * Confidence assigned to rules created or refreshed via a user-approved
+ * proposal. Must stay above the matcher's default minConfidence (0.7) so the
+ * rule actually fires; equal to the value `buildAddChangeSet` uses for new
+ * rules, so edit and add proposals produce equivalently trustworthy rules.
+ */
+export const PROPOSAL_APPROVED_CONFIDENCE = 0.95;
+
 interface BuildArgs {
   effectiveSignal: CorrectionSignal;
   normalizedPattern: string;
@@ -22,6 +30,11 @@ function changeSetSource(hasFeedback: boolean): string {
 }
 
 export function buildEditChangeSet(existing: CorrectionRow, args: BuildArgs): ChangeSet {
+  // A proposal edit means the user is confirming this pattern → entity again.
+  // Promote confidence and reactivate the rule so it actually fires during
+  // re-evaluation; otherwise low-confidence or disabled legacy rows silently
+  // swallow the user's choice and the txn stays in Uncertain.
+  const promotedConfidence = Math.max(existing.confidence, PROPOSAL_APPROVED_CONFIDENCE);
   return {
     source: changeSetSource(args.hasFeedback),
     reason: describeReason('update', args),
@@ -35,6 +48,8 @@ export function buildEditChangeSet(existing: CorrectionRow, args: BuildArgs): Ch
           location: args.effectiveSignal.location,
           tags: args.effectiveSignal.tags,
           transactionType: args.effectiveSignal.transactionType,
+          confidence: promotedConfidence,
+          isActive: true,
         },
       },
     ],
@@ -56,7 +71,7 @@ export function buildAddChangeSet(args: BuildArgs): ChangeSet {
           location: args.effectiveSignal.location ?? null,
           tags: args.effectiveSignal.tags ?? [],
           transactionType: args.effectiveSignal.transactionType ?? null,
-          confidence: 0.95,
+          confidence: PROPOSAL_APPROVED_CONFIDENCE,
           isActive: true,
         },
       },


### PR DESCRIPTION
## Summary
- When a correction proposal targets an existing rule (same pattern as the AI-analysed signal), `buildEditChangeSet` omitted `confidence` and `isActive`, so a stale low-confidence or disabled row survived the user's explicit approval. The import matcher filters by `confidence >= minConfidence` (default 0.7), so a 0.5 rule never fires — meaning Accept All / Choose existing / Create new for all all toast success but the txn stays in Uncertain after server re-evaluation clobbers the optimistic state.
- Edit proposals now set `confidence: max(existing, 0.95)` and `isActive: true`, mirroring `buildAddChangeSet`. Adds a shared `PROPOSAL_APPROVED_CONFIDENCE` constant.
- Adds `changeset-builders.test.ts` (5 cases): sub-threshold promotion, no-downgrade for already-high rules, reactivation of disabled rows, signal field forwarding, add-op parity. Test names reference the IMPERIAL HOTEL regression so the intent is searchable.

## Test plan
- [x] `pnpm vitest run` for `apps/pops-api/src/modules/core/corrections/` (99 tests pass)
- [x] `pnpm vitest run` for `apps/pops-api/src/modules/finance/imports/` (456 tests pass)
- [x] `pnpm vitest run` for `packages/app-finance/src/components/imports/` (181 tests pass)
- [x] `pnpm typecheck` clean across the monorepo
- [x] `pnpm lint` and `pnpm format:check` clean
- [ ] Manual: re-run a finance import that touches a pattern with a pre-existing low-confidence rule (e.g. IMPERIAL HOTEL → Imperial Hotel Erskineville) and confirm Accept All / Choose existing settles the txn into Matched after the proposal is approved.