### PR TITLE
feat(food): PRD-113 phase-1 seed (fixtures + mise db:seed:food)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -321,6 +321,7 @@
       "files": [
         "apps/pops-api/scripts/**/*.ts",
         "apps/pops-shell/e2e/**/*.ts",
+        "packages/app-*/scripts/**/*.ts",
         "services/*/src/scripts/**/*.ts"
       ],
       "rules": {

--- a/apps/pops-api/src/db/data-reset.ts
+++ b/apps/pops-api/src/db/data-reset.ts
@@ -55,6 +55,26 @@ const APPLICATION_TABLES = [
   'rotation_sources',
   'comparison_dimensions',
   'tag_vocabulary',
+  // Lists (PRD-112) — children first.
+  'list_items',
+  'lists',
+  // Food (PRD-106 → PRD-112) — children first, parents last so FK order holds
+  // even when `foreign_keys = ON` (the wipe runs with FKs OFF, but the order
+  // is documented as a safety net in case a caller forgets to disable them).
+  'batch_consumptions',
+  'recipe_runs',
+  'batches',
+  'plan_entries',
+  'plan_slots',
+  'substitutions',
+  'recipe_tags',
+  'recipe_versions',
+  'recipes',
+  'ingredient_aliases',
+  'ingredient_variants',
+  'prep_states',
+  'ingredients',
+  'slug_registry',
 ] as const;
 
 function resetAutoIncrementSequences(db: BetterSqlite3.Database): void {
@@ -68,8 +88,20 @@ function resetAutoIncrementSequences(db: BetterSqlite3.Database): void {
 
 /** Delete all application rows (call with `PRAGMA foreign_keys = OFF` if FK order is unknown). */
 export function deleteAllApplicationRows(db: BetterSqlite3.Database): void {
+  // Some legacy migration-safety tests apply only a subset of migrations, so
+  // not every table in the list will exist. Skip missing tables rather than
+  // throwing — the wipe semantics are "if it's there, clear it".
+  const existing = new Set(
+    (
+      db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`).all() as {
+        name: string;
+      }[]
+    ).map((row) => row.name)
+  );
   for (const name of APPLICATION_TABLES) {
-    db.exec(`DELETE FROM "${name}"`);
+    if (existing.has(name)) {
+      db.exec(`DELETE FROM "${name}"`);
+    }
   }
   resetAutoIncrementSequences(db);
 }

--- a/apps/pops-api/src/db/data-reset.ts
+++ b/apps/pops-api/src/db/data-reset.ts
@@ -74,6 +74,7 @@ const APPLICATION_TABLES = [
   'ingredient_variants',
   'prep_states',
   'ingredients',
+  'ingest_sources',
   'slug_registry',
 ] as const;
 

--- a/mise.toml
+++ b/mise.toml
@@ -120,9 +120,15 @@ dir = "apps/pops-api"
 run = "pnpm db:clear"
 
 [tasks."db:seed"]
-description = "Full wipe (all app tables) then seed comprehensive cross-domain test data"
+description = "Full wipe (all app tables) then seed comprehensive cross-domain test data (incl. PRD-113 food fixtures)"
 dir = "apps/pops-api"
-run = "pnpm db:seed"
+run = ["pnpm db:seed", "mise run db:seed:food"]
+
+[tasks."db:seed:food"]
+description = "Wipe food + lists tables only, then seed PRD-113 phase-1 food fixtures"
+dir = "packages/app-food"
+env = { SQLITE_PATH = "{{config_root}}/apps/pops-api/data/pops.db" }
+run = "pnpm db:seed:food"
 
 # ============================================================================
 # Drizzle ORM

--- a/packages/app-food/package.json
+++ b/packages/app-food/package.json
@@ -4,16 +4,20 @@
   "private": true,
   "type": "module",
   "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server.ts"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "db:seed:food": "tsx scripts/db-seed-food.ts"
   },
   "dependencies": {
-    "@pops/api-client": "workspace:*",
+    "@pops/app-lists": "workspace:*",
     "@pops/db-types": "workspace:*",
-    "@pops/navigation": "workspace:*",
     "@pops/types": "workspace:*",
     "@pops/ui": "workspace:*",
     "@tanstack/react-query": "5.101.0",
@@ -28,6 +32,7 @@
     "react-router": "^7.16.0"
   },
   "devDependencies": {
+    "@pops/navigation": "workspace:*",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -37,6 +42,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "better-sqlite3": "^12.10.0",
     "jsdom": "^29.1.1",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }

--- a/packages/app-food/scripts/db-seed-food.ts
+++ b/packages/app-food/scripts/db-seed-food.ts
@@ -1,0 +1,90 @@
+/**
+ * Food-only seed runner (PRD-113 phase 1).
+ *
+ * Wipes food + lists tables in the SQLite file at `SQLITE_PATH` (or the dev
+ * default `./apps/pops-api/data/pops.db` relative to the repo root) and
+ * invokes `seedFood`. Distinct from `apps/pops-api/scripts/db-seed.ts` —
+ * leaves finance, inventory, media, and ai_inference rows alone.
+ *
+ * Run via `mise run db:seed:food` from the repo root. The mise task `cd`s
+ * into `apps/pops-api` so `./data/pops.db` resolves correctly without an
+ * env override.
+ */
+import { existsSync } from 'node:fs';
+
+import BetterSqlite3 from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+
+import { seedFood } from '../src/db/seed';
+
+if (process.env.NODE_ENV === 'production') {
+  console.error("❌ Refusing to run: NODE_ENV is 'production'.");
+  console.error('   This script is for development/testing only.');
+  process.exit(1);
+}
+
+const DB_PATH = process.env.SQLITE_PATH ?? './data/pops.db';
+
+if (!existsSync(DB_PATH)) {
+  console.error(`❌ Database not found at ${DB_PATH}`);
+  console.log("💡 Run 'mise db:init' to create the database first");
+  process.exit(1);
+}
+
+// Wipe only food + lists tables. Children first; `foreign_keys = OFF` makes
+// the order purely defensive.
+const FOOD_AND_LISTS_TABLES = [
+  'list_items',
+  'lists',
+  'batch_consumptions',
+  'recipe_runs',
+  'batches',
+  'plan_entries',
+  'plan_slots',
+  'substitutions',
+  'recipe_tags',
+  'recipe_versions',
+  'recipes',
+  'ingredient_aliases',
+  'ingredient_variants',
+  'prep_states',
+  'ingredients',
+  'slug_registry',
+] as const;
+
+const db = new BetterSqlite3(DB_PATH);
+db.pragma('journal_mode = WAL');
+db.pragma('busy_timeout = 5000');
+
+console.log(`🌱 Seeding food + lists fixtures at ${DB_PATH}...\n`);
+
+db.pragma('foreign_keys = OFF');
+try {
+  db.transaction(() => {
+    for (const table of FOOD_AND_LISTS_TABLES) {
+      db.exec(`DELETE FROM "${table}"`);
+    }
+    const drizzleDb = drizzle(db);
+    const summary = seedFood(drizzleDb, drizzleDb);
+    console.log('\n✅ Food seed complete\n');
+    console.log('📊 Counts:');
+    console.log(`  prep_states:       ${summary.prepStates}`);
+    console.log(`  ingredients:       ${summary.ingredients}`);
+    console.log(`  variants:          ${summary.variants}`);
+    console.log(`  aliases:           ${summary.aliases}`);
+    console.log(`  substitutions:     ${summary.substitutions}`);
+    console.log(`  plan_slots:        ${summary.planSlots}`);
+    console.log(`  plan_entries:      ${summary.planEntries}`);
+    console.log(`  recipes:           ${summary.recipes}`);
+    console.log(`  recipe_versions:   ${summary.recipeVersions}`);
+    console.log(`  batches:           ${summary.batches}`);
+    console.log(`  recipe_runs:       ${summary.recipeRuns}`);
+    console.log(`  batch_consumptions:${summary.batchConsumptions}`);
+    console.log(`  lists:             ${summary.lists}`);
+    console.log(`  list_items:        ${summary.listItems}`);
+  })();
+} finally {
+  db.pragma('foreign_keys = ON');
+}
+
+db.close();

--- a/packages/app-food/scripts/db-seed-food.ts
+++ b/packages/app-food/scripts/db-seed-food.ts
@@ -49,6 +49,7 @@ const FOOD_AND_LISTS_TABLES = [
   'ingredient_variants',
   'prep_states',
   'ingredients',
+  'ingest_sources',
   'slug_registry',
 ] as const;
 

--- a/packages/app-food/src/db/__tests__/seed.test.ts
+++ b/packages/app-food/src/db/__tests__/seed.test.ts
@@ -1,0 +1,316 @@
+/**
+ * PRD-113 phase-1 seed tests.
+ *
+ * Applies every food + lists migration to an in-memory SQLite, runs
+ * `seedFood`, then asserts:
+ *
+ *   - the returned summary counts match expected per-table volumes
+ *   - the slug_registry holds an entry for every ingredient/recipe/prep-state
+ *   - the depth-cap (≤ 2 in fixtures, ≤ 3 in DB) is respected
+ *   - every PRD-109 context tag declared in the theme README success
+ *     criterion #4 is covered by at least one seeded substitution
+ *   - batches mix NULL `expires_at` (shelf-stable) and explicit expiry rows
+ *   - plan_entries mix slotted and ad-hoc (the prep-session entries)
+ *   - re-running seedFood is a no-op (skipped + zero counts)
+ *
+ * No Redis, no API process — pure schema + service exercise.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { eq, isNotNull, isNull, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { batches, planEntries, recipeRuns, slugRegistry, substitutions } from '../schema';
+import { seedFood, type SeedFoodSummary } from '../seed';
+
+import type { FoodDb } from '../services/internal';
+
+const MIGRATIONS = [
+  '0058_high_sentinel.sql', // PRD-106 ingredients + slug_registry + prep_states + aliases
+  '0059_useful_hiroim.sql', // PRD-107 recipes + recipe_versions + recipe_tags
+  '0060_familiar_leo.sql', // PRD-108 batches + recipe_runs + batch_consumptions
+  '0061_shocking_skreet.sql', // PRD-109 substitutions
+  '0062_chemical_donald_blake.sql', // PRD-112 lists + list_items
+  '0063_bumpy_wolverine.sql', // PRD-111 plan_slots + plan_entries
+].map((name) =>
+  readFileSync(
+    join(__dirname, '../../../../../apps/pops-api/src/db/drizzle-migrations', name),
+    'utf8'
+  )
+);
+
+function freshDb(): { db: FoodDb; raw: Database.Database } {
+  const raw = new Database(':memory:');
+  raw.pragma('foreign_keys = ON');
+  for (const migration of MIGRATIONS) {
+    const stmts = migration.split('--> statement-breakpoint');
+    for (const stmt of stmts) {
+      const trimmed = stmt.trim();
+      if (trimmed.length > 0) raw.exec(trimmed);
+    }
+  }
+  return { db: drizzle(raw), raw };
+}
+
+describe('PRD-113 phase-1 seed', () => {
+  let db: FoodDb;
+  let raw: Database.Database;
+  let summary: SeedFoodSummary;
+
+  beforeEach(() => {
+    ({ db, raw } = freshDb());
+    summary = seedFood(db, db);
+  });
+
+  describe('summary counts', () => {
+    it('seeds the canonical 15 prep_states (PRD-106)', () => {
+      expect(summary.prepStates).toBe(15);
+    });
+    it('seeds at least 20 ingredients (PRD-113 spec)', () => {
+      expect(summary.ingredients).toBeGreaterThanOrEqual(20);
+    });
+    it('seeds at least 30 aliases (PRD-113 spec)', () => {
+      expect(summary.aliases).toBeGreaterThanOrEqual(30);
+    });
+    it('seeds at least 4 recipes (smash-burger + pasta + roast + eggs)', () => {
+      expect(summary.recipes).toBeGreaterThanOrEqual(4);
+      expect(summary.recipeVersions).toBe(summary.recipes);
+    });
+    it('seeds 10 batches and 1 cook run with consumptions', () => {
+      expect(summary.batches).toBe(10);
+      expect(summary.recipeRuns).toBe(1);
+      expect(summary.batchConsumptions).toBeGreaterThan(0);
+    });
+    it('seeds both lists with items', () => {
+      expect(summary.lists).toBe(2);
+      expect(summary.listItems).toBeGreaterThan(0);
+    });
+    it('seeds plan slots including the user-added "late-night" slot', () => {
+      expect(summary.planSlots).toBe(6);
+    });
+  });
+
+  describe('slug_registry coverage', () => {
+    it('records a slug_registry entry per seeded ingredient', () => {
+      const ingredientSlugs = db
+        .select({ slug: slugRegistry.slug })
+        .from(slugRegistry)
+        .where(eq(slugRegistry.kind, 'ingredient'))
+        .all();
+      expect(ingredientSlugs.length).toBe(summary.ingredients);
+    });
+    it('records prep_state and recipe kinds too', () => {
+      const counts = db
+        .select({ kind: slugRegistry.kind, n: sql<number>`count(*)` })
+        .from(slugRegistry)
+        .groupBy(slugRegistry.kind)
+        .all();
+      const byKind = new Map(counts.map((r) => [r.kind, Number(r.n)]));
+      expect(byKind.get('prep_state')).toBe(summary.prepStates);
+      expect(byKind.get('recipe')).toBe(summary.recipes);
+    });
+  });
+
+  describe('ingredient hierarchy', () => {
+    it('respects depth ≤ 2 in fixtures (depth-3 cap is exercised separately)', () => {
+      // Count ingredients with parent_id IS NOT NULL — they're the depth-2 children.
+      const childRows = raw
+        .prepare(`SELECT COUNT(*) AS n FROM ingredients WHERE parent_id IS NOT NULL`)
+        .get() as { n: number };
+      // Fixtures: tomato → roma + cherry, potato → desiree
+      expect(childRows.n).toBe(3);
+    });
+    it('children FK back to a known parent', () => {
+      const orphans = raw
+        .prepare(
+          `SELECT COUNT(*) AS n FROM ingredients c
+             WHERE c.parent_id IS NOT NULL
+               AND NOT EXISTS (SELECT 1 FROM ingredients p WHERE p.id = c.parent_id)`
+        )
+        .get() as { n: number };
+      expect(orphans.n).toBe(0);
+    });
+  });
+
+  describe('substitution context tag coverage (theme README criterion #4)', () => {
+    const REQUIRED_TAGS = [
+      'savory',
+      'sweet',
+      'baking',
+      'frying',
+      'dressing',
+      'marinade',
+      'garnish',
+      'vegan',
+      'dairy-free',
+      'gluten-free',
+    ] as const;
+
+    it('at least one substitution per required context tag', () => {
+      const allRows = db.select({ tags: substitutions.contextTags }).from(substitutions).all();
+      const observed = new Set<string>();
+      for (const row of allRows) {
+        const parsed = JSON.parse(row.tags) as unknown;
+        if (Array.isArray(parsed)) {
+          for (const tag of parsed) {
+            if (typeof tag === 'string') observed.add(tag);
+          }
+        }
+      }
+      for (const required of REQUIRED_TAGS) {
+        expect(observed.has(required), `Missing seed coverage for tag "${required}"`).toBe(true);
+      }
+    });
+
+    it('includes at least one recipe-scoped substitution', () => {
+      const recipeScoped = db
+        .select({ n: sql<number>`count(*)` })
+        .from(substitutions)
+        .where(eq(substitutions.scope, 'recipe'))
+        .all();
+      expect(recipeScoped[0]?.n ?? 0).toBeGreaterThan(0);
+    });
+  });
+
+  describe('batches', () => {
+    it('includes at least one shelf-stable batch (NULL expires_at)', () => {
+      const shelfStable = db
+        .select({ n: sql<number>`count(*)` })
+        .from(batches)
+        .where(isNull(batches.expiresAt))
+        .all();
+      expect(shelfStable[0]?.n ?? 0).toBeGreaterThan(0);
+    });
+    it('includes at least one batch with explicit expires_at', () => {
+      const dated = db
+        .select({ n: sql<number>`count(*)` })
+        .from(batches)
+        .where(isNotNull(batches.expiresAt))
+        .all();
+      expect(dated[0]?.n ?? 0).toBeGreaterThan(0);
+    });
+    it('includes a freezer batch', () => {
+      const freezer = db
+        .select({ n: sql<number>`count(*)` })
+        .from(batches)
+        .where(eq(batches.location, 'freezer'))
+        .all();
+      expect(freezer[0]?.n ?? 0).toBeGreaterThan(0);
+    });
+    it('seeds two milk batches with different expires_at (FIFO fixture)', () => {
+      const milkRows = raw
+        .prepare(
+          `SELECT b.expires_at FROM batches b
+             JOIN ingredient_variants v ON v.id = b.variant_id
+             JOIN ingredients i ON i.id = v.ingredient_id
+             WHERE i.slug = 'milk' AND v.slug = 'full-cream'
+             ORDER BY b.expires_at ASC`
+        )
+        .all() as { expires_at: string }[];
+      expect(milkRows.length).toBe(2);
+      expect(milkRows[0]?.expires_at).not.toBe(milkRows[1]?.expires_at);
+    });
+    it('includes at least one batch with NULL prep_state', () => {
+      const nullPrep = db
+        .select({ n: sql<number>`count(*)` })
+        .from(batches)
+        .where(isNull(batches.prepStateId))
+        .all();
+      expect(nullPrep[0]?.n ?? 0).toBeGreaterThan(0);
+    });
+    it('wires the recipe_run yielded_batch_id back to a recipe_run batch', () => {
+      const runs = db.select().from(recipeRuns).all();
+      expect(runs.length).toBe(1);
+      expect(runs[0]?.yieldedBatchId).not.toBeNull();
+    });
+  });
+
+  describe('plan entries', () => {
+    it('mixes slotted dinners and ad-hoc-style snack entries', () => {
+      const dinners = db
+        .select({ n: sql<number>`count(*)` })
+        .from(planEntries)
+        .where(eq(planEntries.slot, 'dinner'))
+        .all();
+      const snacks = db
+        .select({ n: sql<number>`count(*)` })
+        .from(planEntries)
+        .where(eq(planEntries.slot, 'snack'))
+        .all();
+      expect(dinners[0]?.n ?? 0).toBeGreaterThan(0);
+      expect(snacks[0]?.n ?? 0).toBeGreaterThan(0);
+    });
+    it('puts two entries on the prep-session slot with distinct positions', () => {
+      const prepEntries = raw
+        .prepare(`SELECT position FROM plan_entries WHERE slot = 'prep-session' ORDER BY position`)
+        .all() as { position: number }[];
+      expect(prepEntries.length).toBe(2);
+      expect(prepEntries[0]?.position).toBe(0);
+      expect(prepEntries[1]?.position).toBe(1);
+    });
+  });
+
+  describe('idempotency', () => {
+    it('re-running seedFood returns skipped=true and zero counts', () => {
+      const reRun = seedFood(db, db);
+      expect(reRun.skipped).toBe(true);
+      expect(reRun.ingredients).toBe(0);
+      expect(reRun.recipes).toBe(0);
+    });
+    it('re-run leaves existing row counts intact', () => {
+      const before = raw.prepare(`SELECT COUNT(*) AS n FROM ingredients`).get() as { n: number };
+      seedFood(db, db);
+      const after = raw.prepare(`SELECT COUNT(*) AS n FROM ingredients`).get() as { n: number };
+      expect(after.n).toBe(before.n);
+    });
+  });
+
+  describe('variant shelf-life propagation', () => {
+    it('inherits per-ingredient defaults to variants when no override', () => {
+      // Butter: 30d fridge / 365d freezer. All 3 variants should inherit both.
+      const rows = raw
+        .prepare(
+          `SELECT v.slug, v.default_shelf_life_days_fridge AS fridge, v.default_shelf_life_days_freezer AS freezer
+             FROM ingredient_variants v JOIN ingredients i ON i.id = v.ingredient_id
+             WHERE i.slug = 'butter'`
+        )
+        .all() as { slug: string; fridge: number | null; freezer: number | null }[];
+      expect(rows.length).toBe(3);
+      for (const row of rows) {
+        expect(row.fridge).toBe(30);
+        expect(row.freezer).toBe(365);
+      }
+    });
+    it('respects per-variant overrides (corn fresh-cob / canned / frozen)', () => {
+      const rows = raw
+        .prepare(
+          `SELECT v.slug, v.default_shelf_life_days_fridge AS fridge, v.default_shelf_life_days_freezer AS freezer
+             FROM ingredient_variants v JOIN ingredients i ON i.id = v.ingredient_id
+             WHERE i.slug = 'corn'
+             ORDER BY v.slug`
+        )
+        .all() as { slug: string; fridge: number | null; freezer: number | null }[];
+      const bySlug = new Map(rows.map((r) => [r.slug, r]));
+      expect(bySlug.get('fresh-cob')?.fridge).toBe(5);
+      expect(bySlug.get('canned-brine')?.fridge).toBe(365);
+      expect(bySlug.get('frozen-kernels')?.freezer).toBe(365);
+      expect(bySlug.get('frozen-kernels')?.fridge).toBeNull();
+    });
+  });
+
+  describe('aliases', () => {
+    it('every alias resolves to exactly one of (ingredient, variant)', () => {
+      const orphans = raw
+        .prepare(
+          `SELECT COUNT(*) AS n FROM ingredient_aliases
+             WHERE (ingredient_id IS NULL AND variant_id IS NULL)
+                OR (ingredient_id IS NOT NULL AND variant_id IS NOT NULL)`
+        )
+        .get() as { n: number };
+      expect(orphans.n).toBe(0);
+    });
+  });
+});

--- a/packages/app-food/src/db/__tests__/seed.test.ts
+++ b/packages/app-food/src/db/__tests__/seed.test.ts
@@ -312,5 +312,12 @@ describe('PRD-113 phase-1 seed', () => {
         .get() as { n: number };
       expect(orphans.n).toBe(0);
     });
+    it('persists source="user" (PRD-106 enum has no "seed" value)', () => {
+      const sourceMix = raw
+        .prepare(`SELECT source, COUNT(*) AS n FROM ingredient_aliases GROUP BY source`)
+        .all() as { source: string; n: number }[];
+      expect(sourceMix.length).toBe(1);
+      expect(sourceMix[0]?.source).toBe('user');
+    });
   });
 });

--- a/packages/app-food/src/db/seed/data-aliases.ts
+++ b/packages/app-food/src/db/seed/data-aliases.ts
@@ -1,0 +1,77 @@
+/**
+ * PRD-113 fixture set — ingredient aliases.
+ *
+ * Targets either an ingredient or a variant. Exactly one of `ingredientSlug`
+ * / `variantOfIngredient` must be set; variant aliases scope under their
+ * parent ingredient. Source 'seed' marks the row as fixture-sourced (the
+ * canonical source vocabulary is user/llm/ingest per PRD-106; the seed uses
+ * 'user' as the closest approximation since "seeded" isn't an enum value).
+ */
+
+export interface AliasFixture {
+  alias: string;
+  /** Set when the alias points at a top-level ingredient. */
+  ingredientSlug?: string;
+  /** Set when the alias points at a variant. Combined with `variantSlug`. */
+  variantOfIngredient?: string;
+  variantSlug?: string;
+}
+
+export const ALIAS_FIXTURES: readonly AliasFixture[] = [
+  // Onion family
+  { alias: 'scallion', variantOfIngredient: 'onion', variantSlug: 'spring' },
+  { alias: 'spring onion', variantOfIngredient: 'onion', variantSlug: 'spring' },
+  { alias: 'green onion', variantOfIngredient: 'onion', variantSlug: 'spring' },
+  { alias: 'shallot', variantOfIngredient: 'onion', variantSlug: 'spring' },
+
+  // Olive oil
+  { alias: 'evoo', variantOfIngredient: 'olive-oil', variantSlug: 'extra-virgin' },
+  { alias: 'evo', variantOfIngredient: 'olive-oil', variantSlug: 'extra-virgin' },
+  { alias: 'xv olive oil', variantOfIngredient: 'olive-oil', variantSlug: 'extra-virgin' },
+
+  // Tomato
+  { alias: 'passata', variantOfIngredient: 'tomato', variantSlug: 'canned-whole' },
+  { alias: 'tinned tomato', variantOfIngredient: 'tomato', variantSlug: 'canned-whole' },
+  { alias: 'crushed tomato', variantOfIngredient: 'tomato', variantSlug: 'canned-diced' },
+
+  // Egg
+  { alias: 'eggs', ingredientSlug: 'egg' },
+
+  // Chicken
+  { alias: 'chook', ingredientSlug: 'chicken' },
+  { alias: 'chook breast', variantOfIngredient: 'chicken', variantSlug: 'breast' },
+  { alias: 'chicken mince', variantOfIngredient: 'chicken', variantSlug: 'mince' },
+  { alias: 'ground chicken', variantOfIngredient: 'chicken', variantSlug: 'mince' },
+
+  // Beef
+  { alias: 'mince', variantOfIngredient: 'beef', variantSlug: 'mince' },
+  { alias: 'ground beef', variantOfIngredient: 'beef', variantSlug: 'mince' },
+  { alias: 'hamburger', variantOfIngredient: 'beef', variantSlug: 'mince' },
+
+  // Cheese
+  { alias: 'parmesan', variantOfIngredient: 'cheese', variantSlug: 'parmesan-grated' },
+  { alias: 'parmigiano', variantOfIngredient: 'cheese', variantSlug: 'parmesan-grated' },
+  { alias: 'cheddar', variantOfIngredient: 'cheese', variantSlug: 'cheddar-shredded' },
+
+  // Sugar
+  { alias: 'powdered sugar', variantOfIngredient: 'sugar', variantSlug: 'icing' },
+  { alias: 'confectioners sugar', variantOfIngredient: 'sugar', variantSlug: 'icing' },
+
+  // Flour
+  { alias: 'all-purpose flour', variantOfIngredient: 'flour', variantSlug: 'plain' },
+  { alias: 'ap flour', variantOfIngredient: 'flour', variantSlug: 'plain' },
+
+  // Salt
+  { alias: 'kosher salt', variantOfIngredient: 'salt', variantSlug: 'flaky' },
+  { alias: 'sea salt', variantOfIngredient: 'salt', variantSlug: 'flaky' },
+
+  // Bread
+  { alias: 'sourdough', variantOfIngredient: 'bread', variantSlug: 'sourdough-loaf' },
+  { alias: 'bun', variantOfIngredient: 'bread', variantSlug: 'burger-bun' },
+
+  // Parsley
+  { alias: 'italian parsley', variantOfIngredient: 'parsley', variantSlug: 'flat-leaf' },
+
+  // Lemon
+  { alias: 'lemons', ingredientSlug: 'lemon' },
+];

--- a/packages/app-food/src/db/seed/data-aliases.ts
+++ b/packages/app-food/src/db/seed/data-aliases.ts
@@ -3,9 +3,9 @@
  *
  * Targets either an ingredient or a variant. Exactly one of `ingredientSlug`
  * / `variantOfIngredient` must be set; variant aliases scope under their
- * parent ingredient. Source 'seed' marks the row as fixture-sourced (the
- * canonical source vocabulary is user/llm/ingest per PRD-106; the seed uses
- * 'user' as the closest approximation since "seeded" isn't an enum value).
+ * parent ingredient. The seeder persists `source = 'user'` (PRD-106's enum
+ * is `user | llm | ingest`; there's no `seed` value, and `user` is the
+ * closest fit for human-curated rows that pre-populate the dev DB).
  */
 
 export interface AliasFixture {

--- a/packages/app-food/src/db/seed/data-batches.ts
+++ b/packages/app-food/src/db/seed/data-batches.ts
@@ -1,0 +1,194 @@
+/**
+ * PRD-113 fixture set — batches (+ one recipe run + its consumptions).
+ *
+ * 10 rows spanning the matrix:
+ *   - shelf-stable (NULL expires_at) — salt
+ *   - fridge with explicit expiry — chicken breast (close to today)
+ *   - freezer batch — beef mince
+ *   - 2× same variant with different expiry — milk → exercises FIFO ordering
+ *   - 1 with NULL prep_state — onion yellow
+ *   - 1 from a `recipe_run` source — smash-burger yields 360 g beef:mince:cooked
+ *
+ * `producedAt` / `expiresAt` are anchored to a stable date so the seed is
+ * deterministic. PRD-108 stores both as ISO strings.
+ */
+
+export type Location = 'pantry' | 'fridge' | 'freezer' | 'other';
+export type SourceType = 'purchase' | 'recipe_run' | 'gift' | 'other';
+
+export interface BatchFixture {
+  /** `<ingredient>:<variant>` compound slug. */
+  variantOfIngredient: string;
+  variantSlug: string;
+  /** Optional prep-state slug; NULL means "no prep applied yet". */
+  prepStateSlug?: string;
+  qtyRemaining: number;
+  unit: 'g' | 'ml' | 'count';
+  sourceType: SourceType;
+  /** Set for sourceType=recipe_run via the seeded recipe-run id. */
+  recipeRunRecipeSlug?: string;
+  location: Location;
+  /** ISO date string. */
+  producedAt: string;
+  /** ISO date string. NULL = shelf-stable. */
+  expiresAt: string | null;
+  notes?: string;
+}
+
+export const BATCH_ANCHOR_DATE = '2026-06-10';
+
+function isoOffset(offsetDays: number): string {
+  const base = new Date(`${BATCH_ANCHOR_DATE}T08:00:00Z`);
+  base.setUTCDate(base.getUTCDate() + offsetDays);
+  return base.toISOString();
+}
+
+export const BATCH_FIXTURES: readonly BatchFixture[] = [
+  // 1. Shelf-stable pantry salt — NULL expires_at
+  {
+    variantOfIngredient: 'salt',
+    variantSlug: 'table',
+    qtyRemaining: 500,
+    unit: 'g',
+    sourceType: 'purchase',
+    location: 'pantry',
+    producedAt: isoOffset(-30),
+    expiresAt: null,
+    notes: 'Shelf-stable; pantry default',
+  },
+  // 2. Fridge chicken close to expiry
+  {
+    variantOfIngredient: 'chicken',
+    variantSlug: 'breast',
+    qtyRemaining: 400,
+    unit: 'g',
+    sourceType: 'purchase',
+    location: 'fridge',
+    producedAt: isoOffset(-1),
+    expiresAt: isoOffset(1),
+    notes: '2-day fridge window',
+  },
+  // 3. Freezer beef mince
+  {
+    variantOfIngredient: 'beef',
+    variantSlug: 'mince',
+    qtyRemaining: 600,
+    unit: 'g',
+    sourceType: 'purchase',
+    location: 'freezer',
+    producedAt: isoOffset(-7),
+    expiresAt: isoOffset(173),
+    notes: '180-day freezer window',
+  },
+  // 4. Two milk batches, different expiry — exercises FIFO ordering
+  {
+    variantOfIngredient: 'milk',
+    variantSlug: 'full-cream',
+    qtyRemaining: 1000,
+    unit: 'ml',
+    sourceType: 'purchase',
+    location: 'fridge',
+    producedAt: isoOffset(-2),
+    expiresAt: isoOffset(5),
+    notes: 'Older milk — FIFO will draw from this one first',
+  },
+  // 5. Newer milk batch
+  {
+    variantOfIngredient: 'milk',
+    variantSlug: 'full-cream',
+    qtyRemaining: 1000,
+    unit: 'ml',
+    sourceType: 'purchase',
+    location: 'fridge',
+    producedAt: isoOffset(0),
+    expiresAt: isoOffset(7),
+  },
+  // 6. NULL prep_state onion in pantry — exercises the partial-NULL match in consumeForRun
+  {
+    variantOfIngredient: 'onion',
+    variantSlug: 'yellow',
+    qtyRemaining: 5,
+    unit: 'count',
+    sourceType: 'purchase',
+    location: 'pantry',
+    producedAt: isoOffset(-3),
+    expiresAt: isoOffset(11),
+  },
+  // 7. Olive oil pantry
+  {
+    variantOfIngredient: 'olive-oil',
+    variantSlug: 'extra-virgin',
+    qtyRemaining: 750,
+    unit: 'ml',
+    sourceType: 'purchase',
+    location: 'pantry',
+    producedAt: isoOffset(-60),
+    expiresAt: null,
+  },
+  // 8. Butter fridge
+  {
+    variantOfIngredient: 'butter',
+    variantSlug: 'unsalted',
+    qtyRemaining: 250,
+    unit: 'g',
+    sourceType: 'purchase',
+    location: 'fridge',
+    producedAt: isoOffset(-5),
+    expiresAt: isoOffset(25),
+  },
+  // 9. Cheese parmesan fridge
+  {
+    variantOfIngredient: 'cheese',
+    variantSlug: 'parmesan-grated',
+    qtyRemaining: 200,
+    unit: 'g',
+    sourceType: 'purchase',
+    location: 'fridge',
+    producedAt: isoOffset(-4),
+    expiresAt: isoOffset(26),
+    notes: 'Gift',
+  },
+  // 10. Recipe-run yielded batch — smash-burger seeded run produces 360 g cooked beef mince
+  {
+    variantOfIngredient: 'beef',
+    variantSlug: 'mince',
+    prepStateSlug: 'roughly-chopped',
+    qtyRemaining: 360,
+    unit: 'g',
+    sourceType: 'recipe_run',
+    recipeRunRecipeSlug: 'smash-burger',
+    location: 'fridge',
+    producedAt: isoOffset(-1),
+    expiresAt: isoOffset(2),
+    notes: 'Cooked patties from Sunday prep',
+  },
+];
+
+/**
+ * Single seeded `recipe_runs` row so batch #10 has a valid `source_id`. PRD-
+ * 108's `consumeForRun` is exercised by drawing 200 g beef from the freezer
+ * batch (#3) when this run is recorded.
+ */
+export interface RecipeRunFixture {
+  recipeSlug: string;
+  scaleFactor: number;
+  startedAtOffsetDays: number;
+  completedAtOffsetDays: number;
+  rating: number | null;
+  notes?: string;
+  /** Consumes recorded as part of the run — variants drawn from earlier batches. */
+  consumes: readonly { fromBatchIndex: number; qtyConsumed: number; unit: 'g' | 'ml' | 'count' }[];
+}
+
+export const RECIPE_RUN_FIXTURE: RecipeRunFixture = {
+  recipeSlug: 'smash-burger',
+  scaleFactor: 1.0,
+  startedAtOffsetDays: -1,
+  completedAtOffsetDays: -1,
+  rating: 4,
+  notes: 'Seeded Sunday prep run',
+  consumes: [
+    // Draws 200g cooked from batch #3 (beef mince freezer)
+    { fromBatchIndex: 2, qtyConsumed: 200, unit: 'g' },
+  ],
+};

--- a/packages/app-food/src/db/seed/data-ingredients-produce.ts
+++ b/packages/app-food/src/db/seed/data-ingredients-produce.ts
@@ -1,0 +1,127 @@
+/**
+ * PRD-113 fixture set — ingredients + variants (part 2: produce + bread).
+ *
+ * Hosts the depth-2 hierarchy (tomato → roma + cherry; potato → desiree) and
+ * the per-variant shelf-life overrides for corn (fresh-cob vs canned vs
+ * frozen).
+ */
+import type { IngredientFixture } from './types-ingredient';
+
+export const INGREDIENT_FIXTURES_PRODUCE_AND_BREAD: readonly IngredientFixture[] = [
+  {
+    name: 'Onion',
+    slug: 'onion',
+    defaultUnit: 'count',
+    shelfLifeDaysFridge: 14,
+    variants: [
+      { name: 'Yellow', slug: 'yellow' },
+      { name: 'Red', slug: 'red' },
+      { name: 'Spring', slug: 'spring' },
+    ],
+  },
+  {
+    name: 'Garlic',
+    slug: 'garlic',
+    defaultUnit: 'count',
+    shelfLifeDaysFridge: 30,
+    variants: [
+      { name: 'Whole head', slug: 'whole-head' },
+      { name: 'Peeled clove', slug: 'peeled-clove' },
+    ],
+  },
+  {
+    name: 'Tomato',
+    slug: 'tomato',
+    defaultUnit: 'count',
+    shelfLifeDaysFridge: 7,
+    variants: [
+      { name: 'Beefsteak', slug: 'beefsteak' },
+      { name: 'Canned whole', slug: 'canned-whole', shelfLifeDaysFridge: 365 },
+      { name: 'Canned diced', slug: 'canned-diced', shelfLifeDaysFridge: 365 },
+    ],
+    children: [
+      {
+        name: 'Roma tomato',
+        slug: 'roma-tomato',
+        defaultUnit: 'count',
+        shelfLifeDaysFridge: 7,
+        variants: [{ name: 'Standard', slug: 'standard' }],
+      },
+      {
+        name: 'Cherry tomato',
+        slug: 'cherry-tomato',
+        defaultUnit: 'count',
+        shelfLifeDaysFridge: 7,
+        variants: [{ name: 'Standard', slug: 'standard' }],
+      },
+    ],
+  },
+  {
+    name: 'Potato',
+    slug: 'potato',
+    defaultUnit: 'count',
+    shelfLifeDaysFridge: 30,
+    variants: [
+      { name: 'Royal blue', slug: 'royal-blue' },
+      { name: 'Kipfler', slug: 'kipfler' },
+    ],
+    children: [
+      {
+        name: 'Desiree potato',
+        slug: 'desiree-potato',
+        defaultUnit: 'count',
+        shelfLifeDaysFridge: 30,
+        variants: [{ name: 'Standard', slug: 'standard' }],
+      },
+    ],
+  },
+  {
+    name: 'Carrot',
+    slug: 'carrot',
+    defaultUnit: 'count',
+    shelfLifeDaysFridge: 21,
+    variants: [
+      { name: 'Standard', slug: 'standard' },
+      { name: 'Baby', slug: 'baby' },
+    ],
+  },
+  {
+    name: 'Lemon',
+    slug: 'lemon',
+    defaultUnit: 'count',
+    shelfLifeDaysFridge: 14,
+    variants: [{ name: 'Standard', slug: 'standard' }],
+  },
+  {
+    name: 'Corn',
+    slug: 'corn',
+    defaultUnit: 'count',
+    variants: [
+      { name: 'Fresh cob', slug: 'fresh-cob', shelfLifeDaysFridge: 5 },
+      { name: 'Canned brine', slug: 'canned-brine', shelfLifeDaysFridge: 365 },
+      { name: 'Frozen kernels', slug: 'frozen-kernels', shelfLifeDaysFreezer: 365 },
+    ],
+  },
+  {
+    name: 'Parsley',
+    slug: 'parsley',
+    defaultUnit: 'g',
+    shelfLifeDaysFridge: 7,
+    variants: [
+      { name: 'Flat leaf', slug: 'flat-leaf' },
+      { name: 'Curly', slug: 'curly' },
+    ],
+  },
+  {
+    name: 'Bread',
+    slug: 'bread',
+    defaultUnit: 'count',
+    shelfLifeDaysFridge: 7,
+    shelfLifeDaysFreezer: 90,
+    variants: [
+      { name: 'Sourdough loaf', slug: 'sourdough-loaf' },
+      { name: 'Burger bun', slug: 'burger-bun' },
+      { name: 'Flatbread', slug: 'flatbread' },
+    ],
+  },
+];

--- a/packages/app-food/src/db/seed/data-ingredients-protein.ts
+++ b/packages/app-food/src/db/seed/data-ingredients-protein.ts
@@ -1,0 +1,38 @@
+/**
+ * PRD-113 fixture set — ingredients + variants (part 3: proteins).
+ *
+ * Tight fridge windows (2d) + freezer extensions (90-180d) — primary input
+ * to PRD-108's `expires_at` auto-fill in seeded batches.
+ */
+import type { IngredientFixture } from './types-ingredient';
+
+export const INGREDIENT_FIXTURES_PROTEIN: readonly IngredientFixture[] = [
+  {
+    name: 'Chicken',
+    slug: 'chicken',
+    defaultUnit: 'g',
+    shelfLifeDaysFridge: 2,
+    shelfLifeDaysFreezer: 90,
+    variants: [
+      { name: 'Breast', slug: 'breast' },
+      { name: 'Thigh', slug: 'thigh' },
+      { name: 'Whole', slug: 'whole' },
+      { name: 'Mince', slug: 'mince' },
+    ],
+  },
+  {
+    name: 'Beef',
+    slug: 'beef',
+    defaultUnit: 'g',
+    shelfLifeDaysFridge: 2,
+    shelfLifeDaysFreezer: 180,
+    variants: [
+      { name: 'Chuck', slug: 'chuck' },
+      { name: 'Mince', slug: 'mince' },
+      { name: 'Ribeye', slug: 'ribeye' },
+    ],
+  },
+];
+
+/** Single ordered list — orchestrator iterates this rather than the per-group exports. */
+export const ALL_INGREDIENT_GROUPS_PROTEIN = INGREDIENT_FIXTURES_PROTEIN;

--- a/packages/app-food/src/db/seed/data-ingredients.ts
+++ b/packages/app-food/src/db/seed/data-ingredients.ts
@@ -1,0 +1,108 @@
+/**
+ * PRD-113 fixture set — ingredients + variants (part 1: shelf-stable + dairy + eggs).
+ *
+ * Spans (default_unit × variants × shelf_life). Pantry items (salt, pepper,
+ * sugar, flour) leave shelf-life NULL; dairy + eggs carry fridge defaults.
+ * Per-ingredient shelf-life defaults propagate to variants unless overridden.
+ */
+import type { IngredientFixture } from './types-ingredient';
+
+export const INGREDIENT_FIXTURES_PANTRY_AND_DAIRY: readonly IngredientFixture[] = [
+  {
+    name: 'Salt',
+    slug: 'salt',
+    defaultUnit: 'g',
+    notes: 'Shelf-stable',
+    variants: [
+      { name: 'Table', slug: 'table' },
+      { name: 'Flaky', slug: 'flaky' },
+    ],
+  },
+  {
+    name: 'Pepper',
+    slug: 'pepper',
+    defaultUnit: 'g',
+    notes: 'Shelf-stable',
+    variants: [
+      { name: 'Black ground', slug: 'black-ground' },
+      { name: 'White ground', slug: 'white-ground' },
+      { name: 'Pink whole', slug: 'pink-whole' },
+    ],
+  },
+  {
+    name: 'Olive oil',
+    slug: 'olive-oil',
+    defaultUnit: 'ml',
+    densityGPerMl: 0.91,
+    variants: [
+      { name: 'Extra virgin', slug: 'extra-virgin' },
+      { name: 'Light', slug: 'light' },
+    ],
+  },
+  {
+    name: 'Butter',
+    slug: 'butter',
+    defaultUnit: 'g',
+    shelfLifeDaysFridge: 30,
+    shelfLifeDaysFreezer: 365,
+    variants: [
+      { name: 'Unsalted', slug: 'unsalted' },
+      { name: 'Salted', slug: 'salted' },
+      { name: 'Cultured', slug: 'cultured' },
+    ],
+  },
+  {
+    name: 'Egg',
+    slug: 'egg',
+    defaultUnit: 'count',
+    shelfLifeDaysFridge: 21,
+    variants: [
+      { name: 'Large', slug: 'large' },
+      { name: 'Medium', slug: 'medium' },
+      { name: 'Small', slug: 'small' },
+    ],
+  },
+  {
+    name: 'Flour',
+    slug: 'flour',
+    defaultUnit: 'g',
+    variants: [
+      { name: 'Plain', slug: 'plain' },
+      { name: 'Bread', slug: 'bread' },
+      { name: 'Self-raising', slug: 'self-raising' },
+    ],
+  },
+  {
+    name: 'Sugar',
+    slug: 'sugar',
+    defaultUnit: 'g',
+    variants: [
+      { name: 'Caster', slug: 'caster' },
+      { name: 'Brown', slug: 'brown' },
+      { name: 'Icing', slug: 'icing' },
+    ],
+  },
+  {
+    name: 'Milk',
+    slug: 'milk',
+    defaultUnit: 'ml',
+    densityGPerMl: 1.03,
+    shelfLifeDaysFridge: 7,
+    variants: [
+      { name: 'Full cream', slug: 'full-cream' },
+      { name: 'Skim', slug: 'skim' },
+      { name: 'Oat', slug: 'oat' },
+    ],
+  },
+  {
+    name: 'Cheese',
+    slug: 'cheese',
+    defaultUnit: 'g',
+    shelfLifeDaysFridge: 30,
+    variants: [
+      { name: 'Colby block', slug: 'colby-block' },
+      { name: 'Cheddar shredded', slug: 'cheddar-shredded' },
+      { name: 'Parmesan grated', slug: 'parmesan-grated' },
+    ],
+  },
+];

--- a/packages/app-food/src/db/seed/data-lists.ts
+++ b/packages/app-food/src/db/seed/data-lists.ts
@@ -1,0 +1,125 @@
+/**
+ * PRD-113 fixture set — lists + items.
+ *
+ * Two lists owned by the food app (PRD-112 + PRD-141 shopping kind):
+ *
+ *   - "Weekly shopping" — `kind='shopping'`. Mix of `ref_kind=ingredient`
+ *     rows (which Epic 04's send-to-list flow merges by `(ref_kind, ref_id)`)
+ *     and free-text rows.
+ *   - "Pantry restock" — `kind='generic'` with mixed checked/unchecked items
+ *     so the UI has both states to render.
+ */
+
+export type ListKind = 'shopping' | 'generic';
+
+export interface ListFixture {
+  slug: string;
+  name: string;
+  kind: ListKind;
+  ownerApp: 'food';
+  items: readonly ListItemFixture[];
+}
+
+export interface ListItemFixture {
+  label: string;
+  /**
+   * When set, the item is created with `ref_kind = ingredient | variant` and
+   * the corresponding id; otherwise free-text.
+   */
+  refIngredientSlug?: string;
+  refVariantOfIngredient?: string;
+  refVariantSlug?: string;
+  qty?: number;
+  unit?: 'g' | 'ml' | 'count';
+  checked?: boolean;
+  notes?: string;
+}
+
+export const LIST_FIXTURES: readonly ListFixture[] = [
+  {
+    slug: 'weekly-shopping',
+    name: 'Weekly shopping',
+    kind: 'shopping',
+    ownerApp: 'food',
+    items: [
+      {
+        label: 'Olive oil — extra virgin',
+        refVariantOfIngredient: 'olive-oil',
+        refVariantSlug: 'extra-virgin',
+        qty: 750,
+        unit: 'ml',
+      },
+      {
+        label: 'Burger buns',
+        refVariantOfIngredient: 'bread',
+        refVariantSlug: 'burger-bun',
+        qty: 4,
+        unit: 'count',
+      },
+      {
+        label: 'Cheddar (shredded)',
+        refVariantOfIngredient: 'cheese',
+        refVariantSlug: 'cheddar-shredded',
+        qty: 200,
+        unit: 'g',
+      },
+      {
+        label: 'Beef mince',
+        refVariantOfIngredient: 'beef',
+        refVariantSlug: 'mince',
+        qty: 800,
+        unit: 'g',
+        notes: 'Smash burger',
+      },
+      {
+        label: 'Loose leaf tea',
+        // Free-text — no ingredient ref. Tests the unrefed code path.
+        qty: 100,
+        unit: 'g',
+      },
+    ],
+  },
+  {
+    slug: 'pantry-restock',
+    name: 'Pantry restock',
+    kind: 'generic',
+    ownerApp: 'food',
+    items: [
+      {
+        label: 'Salt',
+        refIngredientSlug: 'salt',
+        qty: 500,
+        unit: 'g',
+        checked: true,
+        notes: 'Restocked last week',
+      },
+      {
+        label: 'Plain flour',
+        refVariantOfIngredient: 'flour',
+        refVariantSlug: 'plain',
+        qty: 1000,
+        unit: 'g',
+      },
+      {
+        label: 'Brown sugar',
+        refVariantOfIngredient: 'sugar',
+        refVariantSlug: 'brown',
+        qty: 500,
+        unit: 'g',
+      },
+      {
+        label: 'Black pepper',
+        refVariantOfIngredient: 'pepper',
+        refVariantSlug: 'black-ground',
+        qty: 100,
+        unit: 'g',
+        checked: true,
+      },
+      {
+        label: 'Sourdough starter feed',
+        // Free-text again — exercises both checked + unchecked unrefed rows
+        notes: 'Stone-milled rye',
+      },
+    ],
+  },
+];

--- a/packages/app-food/src/db/seed/data-plan.ts
+++ b/packages/app-food/src/db/seed/data-plan.ts
@@ -1,0 +1,86 @@
+/**
+ * PRD-113 fixture set — plan slots + plan entries.
+ *
+ * Plan slots: the default vocabulary (breakfast/lunch/dinner/snack/prep-
+ * session). `is_default = 1` so `deleteSlot` refuses them (PRD-111 service
+ * invariant).
+ *
+ * Plan entries: a mix of slotted (Mon-Fri dinners + a Sunday prep-session)
+ * and ad-hoc lunches. Dates are anchored to a stable Monday so the seed is
+ * deterministic across re-runs.
+ */
+
+export interface PlanSlotFixture {
+  slug: string;
+  name: string;
+  displayOrder: number;
+  isDefault: 0 | 1;
+}
+
+/**
+ * Five default slots + one user-added slot so the seed exercises both
+ * `is_default = 1` and `is_default = 0` paths.
+ */
+export const PLAN_SLOT_FIXTURES: readonly PlanSlotFixture[] = [
+  { slug: 'breakfast', name: 'Breakfast', displayOrder: 10, isDefault: 1 },
+  { slug: 'lunch', name: 'Lunch', displayOrder: 20, isDefault: 1 },
+  { slug: 'dinner', name: 'Dinner', displayOrder: 30, isDefault: 1 },
+  { slug: 'snack', name: 'Snack', displayOrder: 40, isDefault: 1 },
+  { slug: 'prep-session', name: 'Prep session', displayOrder: 50, isDefault: 1 },
+  // User-added slot to exercise the `is_default = 0` path (PRD-111 amendment).
+  { slug: 'late-night', name: 'Late night', displayOrder: 60, isDefault: 0 },
+];
+
+/** Stable Monday anchor (kept as a constant so re-running the seed produces the same dates). */
+export const PLAN_WEEK_ANCHOR_MONDAY = '2026-06-15';
+
+/** Adds `offsetDays` to `PLAN_WEEK_ANCHOR_MONDAY`. */
+export function planDateForOffset(offsetDays: number): string {
+  const base = new Date(`${PLAN_WEEK_ANCHOR_MONDAY}T00:00:00Z`);
+  base.setUTCDate(base.getUTCDate() + offsetDays);
+  return base.toISOString().slice(0, 10);
+}
+
+export interface PlanEntryFixture {
+  /** `offsetDays` from `PLAN_WEEK_ANCHOR_MONDAY`. 0 = Monday, 6 = Sunday. */
+  offsetDays: number;
+  slot: string;
+  recipeSlug: string;
+  plannedServings?: number;
+  position?: number;
+  notes?: string;
+}
+
+/**
+ * 7 slotted + 2 ad-hoc entries. Two entries on Sunday's prep-session slot
+ * exercise the per-slot position ordering.
+ */
+export const PLAN_ENTRY_FIXTURES: readonly PlanEntryFixture[] = [
+  // Slotted dinners across the week
+  { offsetDays: 0, slot: 'dinner', recipeSlug: 'smash-burger', plannedServings: 2 },
+  { offsetDays: 1, slot: 'dinner', recipeSlug: 'weeknight-pasta', plannedServings: 2 },
+  { offsetDays: 2, slot: 'dinner', recipeSlug: 'roast-chicken', plannedServings: 4 },
+  // Lunches (some slotted, some ad-hoc-style via the 'snack' slot)
+  { offsetDays: 0, slot: 'lunch', recipeSlug: 'breakfast-eggs', plannedServings: 1 },
+  { offsetDays: 3, slot: 'lunch', recipeSlug: 'breakfast-eggs', plannedServings: 1 },
+  // Ad-hoc-style (snack slot, no time of day pinned)
+  { offsetDays: 1, slot: 'snack', recipeSlug: 'breakfast-eggs', plannedServings: 1 },
+  { offsetDays: 4, slot: 'snack', recipeSlug: 'breakfast-eggs', plannedServings: 1 },
+  // Sunday prep-session with two entries — exercises position 0 and 1
+  {
+    offsetDays: 6,
+    slot: 'prep-session',
+    recipeSlug: 'smash-burger',
+    plannedServings: 6,
+    position: 0,
+    notes: 'Batch patties for the week',
+  },
+  {
+    offsetDays: 6,
+    slot: 'prep-session',
+    recipeSlug: 'roast-chicken',
+    plannedServings: 4,
+    position: 1,
+    notes: 'Roast a whole bird; shred for lunches',
+  },
+];

--- a/packages/app-food/src/db/seed/data-prep-states.ts
+++ b/packages/app-food/src/db/seed/data-prep-states.ts
@@ -1,0 +1,26 @@
+/**
+ * PRD-113 fixture set — prep states. Canonical 15 from PRD-106.
+ */
+
+export interface PrepStateFixture {
+  name: string;
+  slug: string;
+}
+
+export const PREP_STATE_FIXTURES: readonly PrepStateFixture[] = [
+  { name: 'Whole', slug: 'whole' },
+  { name: 'Diced', slug: 'diced' },
+  { name: 'Sliced', slug: 'sliced' },
+  { name: 'Chopped', slug: 'chopped' },
+  { name: 'Shredded', slug: 'shredded' },
+  { name: 'Minced', slug: 'minced' },
+  { name: 'Julienned', slug: 'julienned' },
+  { name: 'Grated', slug: 'grated' },
+  { name: 'Crushed', slug: 'crushed' },
+  { name: 'Zested', slug: 'zested' },
+  { name: 'Juiced', slug: 'juiced' },
+  { name: 'Melted', slug: 'melted' },
+  { name: 'Softened', slug: 'softened' },
+  { name: 'Mashed', slug: 'mashed' },
+  { name: 'Roughly chopped', slug: 'roughly-chopped' },
+];

--- a/packages/app-food/src/db/seed/data-recipes.ts
+++ b/packages/app-food/src/db/seed/data-recipes.ts
@@ -1,0 +1,134 @@
+/**
+ * PRD-113 fixture set — recipe headers (phase 1: uncompiled DSL).
+ *
+ * Phase 1 stores the DSL body verbatim and leaves `recipe_versions.status =
+ * 'draft'` + `compile_state` uncompiled. Phase 2 (post PRD-116) replaces
+ * `seedRecipeHeaders` with a `seedRecipesAndCompile()` that invokes
+ * `compileRecipeVersion` so `recipe_lines` / `recipe_steps` get populated —
+ * that's the cross-PRD smoke test PRD-113 originally specced.
+ *
+ * The DSL bodies below are deliberately shaped to exercise the resolver's
+ * variant scoping (`onion:yellow`), alias resolution (`evoo`), recipe-as-
+ * ingredient refs (smash-burger consumes a beef:patty produced by another
+ * cook), and the yield form. Keeping them around now means phase 2 doesn't
+ * have to author them from scratch.
+ */
+
+export interface RecipeFixture {
+  slug: string;
+  recipeType?: 'plate' | 'component' | 'technique' | 'sauce' | 'dressing' | 'drink' | 'condiment';
+  title: string;
+  summary?: string;
+  servings?: number;
+  prepMinutes?: number;
+  cookMinutes?: number;
+  bodyDsl: string;
+}
+
+const SMASH_BURGER_DSL = `@title Smash burger
+@yield(beef:mince:cooked, 360:g)
+
+@step prep "Smash"
+  @ingredient beef:mince 600:g
+  @ingredient salt 4:g
+  @ingredient pepper:black-ground 2:g
+
+@step cook "Sear"
+  @ingredient evoo 10:ml
+
+@step assemble "Build"
+  @ingredient bread:burger-bun 4:count
+  @ingredient cheese:cheddar-shredded 80:g
+  @ingredient onion:yellow 1:count
+  @ingredient tomato:beefsteak 1:count
+`;
+
+const WEEKNIGHT_PASTA_DSL = `@title Weeknight pasta
+@yield(flour:plain:cooked, 800:g)
+
+@step prep "Mise"
+  @ingredient flour:plain 400:g
+  @ingredient garlic:peeled-clove 4:count
+  @ingredient tomato:canned-whole 800:g
+
+@step cook "Simmer"
+  @ingredient evoo 30:ml
+  @ingredient salt:table 8:g
+  @ingredient pepper:black-ground 2:g
+
+@step plate "Plate"
+  @ingredient parsley:flat-leaf 10:g
+  @ingredient cheese:parmesan-grated 40:g
+`;
+
+const ROAST_CHICKEN_DSL = `@title Roast chicken
+@yield(chicken:whole:roasted, 1600:g)
+
+@step prep "Brine"
+  @ingredient chicken:whole 1.8:kg
+  @ingredient salt:flaky 30:g
+
+@step cook "Roast"
+  @ingredient butter:unsalted 50:g
+  @ingredient lemon 1:count
+  @ingredient parsley:flat-leaf 20:g
+
+@step rest "Carve"
+  @ingredient pepper:black-ground 3:g
+`;
+
+const BREAKFAST_EGGS_DSL = `@title Breakfast eggs
+
+@step cook "Scramble"
+  @ingredient egg:large 3:count
+  @ingredient butter:unsalted 20:g
+  @ingredient milk:full-cream 30:ml
+
+@step plate "Serve"
+  @ingredient bread:sourdough-loaf 2:count
+  @ingredient salt:table 1:g
+  @ingredient pepper:black-ground 1:g
+`;
+
+export const RECIPE_FIXTURES: readonly RecipeFixture[] = [
+  {
+    slug: 'smash-burger',
+    recipeType: 'plate',
+    title: 'Smash burger',
+    summary: 'Cast-iron, crusty edges, simple toppings.',
+    servings: 4,
+    prepMinutes: 10,
+    cookMinutes: 15,
+    bodyDsl: SMASH_BURGER_DSL,
+  },
+  {
+    slug: 'weeknight-pasta',
+    recipeType: 'plate',
+    title: 'Weeknight pasta',
+    summary: 'Fast tomato sauce; pantry friendly.',
+    servings: 4,
+    prepMinutes: 10,
+    cookMinutes: 25,
+    bodyDsl: WEEKNIGHT_PASTA_DSL,
+  },
+  {
+    slug: 'roast-chicken',
+    recipeType: 'plate',
+    title: 'Roast chicken',
+    summary: 'Sunday roast; carcass becomes Monday stock.',
+    servings: 6,
+    prepMinutes: 20,
+    cookMinutes: 90,
+    bodyDsl: ROAST_CHICKEN_DSL,
+  },
+  {
+    slug: 'breakfast-eggs',
+    recipeType: 'plate',
+    title: 'Breakfast eggs',
+    summary: 'Three eggs, sourdough, no fuss.',
+    servings: 1,
+    prepMinutes: 2,
+    cookMinutes: 5,
+    bodyDsl: BREAKFAST_EGGS_DSL,
+  },
+];

--- a/packages/app-food/src/db/seed/data-substitutions.ts
+++ b/packages/app-food/src/db/seed/data-substitutions.ts
@@ -1,0 +1,116 @@
+/**
+ * PRD-113 fixture set — substitutions.
+ *
+ * Mix of global and recipe-scoped edges. Every PRD-109 context tag (savory,
+ * sweet, baking, frying, dressing, marinade, garnish, vegan, dairy-free,
+ * gluten-free) appears on at least one edge so theme README success
+ * criterion #4's "verified by integration tests" is satisfied at seed time.
+ */
+
+export type FoodContextTag =
+  | 'savory'
+  | 'sweet'
+  | 'baking'
+  | 'frying'
+  | 'dressing'
+  | 'marinade'
+  | 'garnish'
+  | 'vegan'
+  | 'dairy-free'
+  | 'gluten-free';
+
+export interface SubstitutionEndpointFixture {
+  /** Set when this side points at a top-level ingredient. */
+  ingredientSlug?: string;
+  /** Compound `<ingredient-slug>:<variant-slug>` for variant-scoped sides. */
+  variantOfIngredient?: string;
+  variantSlug?: string;
+}
+
+export interface SubstitutionFixture {
+  from: SubstitutionEndpointFixture;
+  to: SubstitutionEndpointFixture;
+  ratio?: number;
+  contextTags: readonly FoodContextTag[];
+  scope?: 'global' | 'recipe';
+  /** Required when `scope === 'recipe'`. */
+  recipeSlug?: string;
+  notes?: string;
+}
+
+export const SUBSTITUTION_FIXTURES: readonly SubstitutionFixture[] = [
+  // Dairy ↔ plant-based (covers vegan + dairy-free + frying + baking)
+  {
+    from: { ingredientSlug: 'butter' },
+    to: { variantOfIngredient: 'olive-oil', variantSlug: 'extra-virgin' },
+    ratio: 0.75,
+    contextTags: ['savory', 'frying'],
+    notes: '3/4 ratio when frying',
+  },
+  {
+    from: { variantOfIngredient: 'milk', variantSlug: 'full-cream' },
+    to: { variantOfIngredient: 'milk', variantSlug: 'oat' },
+    ratio: 1.0,
+    contextTags: ['vegan', 'dairy-free', 'baking'],
+  },
+  {
+    from: { ingredientSlug: 'butter' },
+    to: { variantOfIngredient: 'milk', variantSlug: 'oat' },
+    ratio: 1.0,
+    contextTags: ['vegan', 'dairy-free'],
+    notes: 'Approximation; not 1:1 in baking',
+  },
+  // Sugar swaps (covers sweet + baking)
+  {
+    from: { variantOfIngredient: 'sugar', variantSlug: 'caster' },
+    to: { variantOfIngredient: 'sugar', variantSlug: 'brown' },
+    ratio: 1.0,
+    contextTags: ['sweet', 'baking'],
+  },
+  // Flour (covers gluten-free)
+  {
+    from: { variantOfIngredient: 'flour', variantSlug: 'plain' },
+    to: { variantOfIngredient: 'flour', variantSlug: 'bread' },
+    ratio: 1.0,
+    contextTags: ['baking'],
+  },
+  {
+    from: { variantOfIngredient: 'flour', variantSlug: 'plain' },
+    to: { variantOfIngredient: 'corn', variantSlug: 'frozen-kernels' },
+    ratio: 0.5,
+    contextTags: ['gluten-free', 'baking'],
+    notes: 'Corn-based thickener swap; only sensible in some bakes',
+  },
+  // Protein (covers marinade + savory)
+  {
+    from: { variantOfIngredient: 'beef', variantSlug: 'mince' },
+    to: { variantOfIngredient: 'chicken', variantSlug: 'mince' },
+    ratio: 1.0,
+    contextTags: ['savory', 'marinade'],
+  },
+  // Cheese (covers garnish)
+  {
+    from: { variantOfIngredient: 'cheese', variantSlug: 'parmesan-grated' },
+    to: { variantOfIngredient: 'cheese', variantSlug: 'cheddar-shredded' },
+    ratio: 1.0,
+    contextTags: ['garnish', 'savory'],
+  },
+  // Onion (covers dressing)
+  {
+    from: { variantOfIngredient: 'onion', variantSlug: 'yellow' },
+    to: { variantOfIngredient: 'onion', variantSlug: 'red' },
+    ratio: 1.0,
+    contextTags: ['dressing', 'savory'],
+  },
+  // Recipe-scoped — pinned to the smash-burger fixture recipe so the seeder
+  // exercises the `scope='recipe'` path.
+  {
+    from: { variantOfIngredient: 'cheese', variantSlug: 'cheddar-shredded' },
+    to: { variantOfIngredient: 'cheese', variantSlug: 'colby-block' },
+    ratio: 1.0,
+    contextTags: ['savory'],
+    scope: 'recipe',
+    recipeSlug: 'smash-burger',
+    notes: 'Smash-burger override: colby beats cheddar for melt',
+  },
+];

--- a/packages/app-food/src/db/seed/index.ts
+++ b/packages/app-food/src/db/seed/index.ts
@@ -1,0 +1,87 @@
+/**
+ * PRD-113 phase 1 — food + lists seed entry point.
+ *
+ * Phase 1 ships the non-compile fixture set (ingredients, variants, prep
+ * states, aliases, substitutions, plan slots + entries, batches, recipe
+ * headers with uncompiled DSL, lists + items). Phase 2 will replace the
+ * `seedRecipeHeaders` call with a `seedRecipesAndCompile` step that invokes
+ * `compileRecipeVersion` once PRD-116 lands.
+ *
+ * Idempotency: the seed early-returns when the `slug_registry` already has
+ * rows. Re-running over a populated DB is a no-op (re-runs after a wipe
+ * insert again). Mixing seeded + non-seeded rows in `slug_registry` is not
+ * a supported state; callers wipe first.
+ *
+ * The food schemas and the lists schema share the same SQLite handle but
+ * each owns a typed Drizzle wrapper. The seed accepts the food wrapper and
+ * a lists wrapper (typically constructed from the same raw DB).
+ */
+import { sql } from 'drizzle-orm';
+
+import { slugRegistry } from '../schema';
+import { seedAliases } from './step-aliases';
+import { seedBatches } from './step-batches';
+import { seedIngredientsAndVariants } from './step-ingredients';
+import { seedLists } from './step-lists';
+import { seedPlan } from './step-plan';
+import { seedPrepStates } from './step-prep-states';
+import { seedRecipeHeaders } from './step-recipes';
+import { seedSubstitutions } from './step-substitutions';
+import { freshContext, type SeedFoodSummary, ZERO_COUNTS } from './types';
+
+import type { ListsDb } from '@pops/app-lists';
+
+import type { FoodDb } from '../services/internal';
+
+export type { SeedFoodSummary } from './types';
+
+function slugRegistryHasRows(db: FoodDb): boolean {
+  const rows = db
+    .select({ count: sql<number>`count(*)` })
+    .from(slugRegistry)
+    .all();
+  const count = rows[0]?.count ?? 0;
+  return count > 0;
+}
+
+/**
+ * Run the PRD-113 phase-1 seed.
+ *
+ * @param foodDb Drizzle wrapper over the SQLite handle (food domain).
+ * @param listsDb Drizzle wrapper over the SAME handle (lists domain).
+ * @returns Row counts per table; `skipped=true` when the slug_registry was
+ *   non-empty and the seed early-returned.
+ */
+export function seedFood(foodDb: FoodDb, listsDb: ListsDb): SeedFoodSummary {
+  if (slugRegistryHasRows(foodDb)) {
+    return { ...ZERO_COUNTS, skipped: true };
+  }
+  const ctx = freshContext();
+
+  const prepStates = seedPrepStates(foodDb, ctx);
+  const ingredientCounts = seedIngredientsAndVariants(foodDb, ctx);
+  const aliases = seedAliases(foodDb, ctx);
+  const recipeCounts = seedRecipeHeaders(foodDb, ctx);
+  const substitutions = seedSubstitutions(foodDb, ctx);
+  const planCounts = seedPlan(foodDb, ctx);
+  const batchCounts = seedBatches(foodDb, ctx);
+  const listCounts = seedLists(listsDb, ctx, ctx);
+
+  return {
+    skipped: false,
+    prepStates,
+    ingredients: ingredientCounts.ingredients,
+    variants: ingredientCounts.variants,
+    aliases,
+    substitutions,
+    planSlots: planCounts.planSlots,
+    planEntries: planCounts.planEntries,
+    recipes: recipeCounts.recipes,
+    recipeVersions: recipeCounts.recipeVersions,
+    batches: batchCounts.batches,
+    recipeRuns: batchCounts.recipeRuns,
+    batchConsumptions: batchCounts.batchConsumptions,
+    lists: listCounts.lists,
+    listItems: listCounts.listItems,
+  };
+}

--- a/packages/app-food/src/db/seed/step-aliases.ts
+++ b/packages/app-food/src/db/seed/step-aliases.ts
@@ -1,0 +1,49 @@
+/**
+ * PRD-113 seed step — ingredient_aliases.
+ *
+ * No service wrapper exists yet (PRD-122 will add one); the seed writes via
+ * direct Drizzle insert. Source is recorded as 'user' since that's the
+ * canonical "human-curated" value in PRD-106's enum.
+ */
+import { ingredientAliases } from '../schema';
+import { ALIAS_FIXTURES } from './data-aliases';
+
+import type { FoodDb } from '../services/internal';
+import type { SeedContext } from './types';
+
+function resolveAliasTarget(
+  fixture: (typeof ALIAS_FIXTURES)[number],
+  ctx: SeedContext
+): { ingredientId: number | null; variantId: number | null } {
+  if (fixture.ingredientSlug !== undefined) {
+    const id = ctx.ingredientIdBySlug.get(fixture.ingredientSlug);
+    if (id === undefined) {
+      throw new Error(`Alias target ingredient "${fixture.ingredientSlug}" missing from seed ctx`);
+    }
+    return { ingredientId: id, variantId: null };
+  }
+  if (fixture.variantOfIngredient !== undefined && fixture.variantSlug !== undefined) {
+    const key = `${fixture.variantOfIngredient}:${fixture.variantSlug}`;
+    const id = ctx.variantIdByCompositeSlug.get(key);
+    if (id === undefined) {
+      throw new Error(`Alias target variant "${key}" missing from seed ctx`);
+    }
+    return { ingredientId: null, variantId: id };
+  }
+  throw new Error(`Alias "${fixture.alias}" has neither ingredient nor variant target`);
+}
+
+export function seedAliases(db: FoodDb, ctx: SeedContext): number {
+  for (const fixture of ALIAS_FIXTURES) {
+    const target = resolveAliasTarget(fixture, ctx);
+    db.insert(ingredientAliases)
+      .values({
+        ingredientId: target.ingredientId,
+        variantId: target.variantId,
+        alias: fixture.alias,
+        source: 'user',
+      })
+      .run();
+  }
+  return ALIAS_FIXTURES.length;
+}

--- a/packages/app-food/src/db/seed/step-batches.ts
+++ b/packages/app-food/src/db/seed/step-batches.ts
@@ -66,14 +66,34 @@ function insertRecipeRunRow(db: FoodDb, ctx: SeedContext): number {
   return row.id;
 }
 
+function batchSourceId(fixture: BatchFixture, runId: number): number | null {
+  if (fixture.sourceType !== 'recipe_run') return null;
+  // Defensive: a recipe_run batch fixture must name the run it points at.
+  // Otherwise the source_id would silently fall back to NULL — defeating the
+  // provenance the source_type=recipe_run row was supposed to record.
+  if (fixture.recipeRunRecipeSlug === undefined) {
+    throw new Error(
+      `Batch fixture has sourceType='recipe_run' but no recipeRunRecipeSlug — provenance would be lost`
+    );
+  }
+  if (fixture.recipeRunRecipeSlug !== RECIPE_RUN_FIXTURE.recipeSlug) {
+    // Phase 1 only seeds one run; assert the fixture points at that one so
+    // adding a second run later forces the seeder to be updated rather than
+    // silently misattributing the batch.
+    throw new Error(
+      `Batch fixture recipeRunRecipeSlug "${fixture.recipeRunRecipeSlug}" does not match the seeded run "${RECIPE_RUN_FIXTURE.recipeSlug}"`
+    );
+  }
+  return runId;
+}
+
 function insertOneBatch(
   db: FoodDb,
   fixture: BatchFixture,
   ctx: SeedContext,
   runId: number
 ): number {
-  const sourceId =
-    fixture.sourceType === 'recipe_run' && fixture.recipeRunRecipeSlug !== undefined ? runId : null;
+  const sourceId = batchSourceId(fixture, runId);
   const inserted = db
     .insert(batches)
     .values({

--- a/packages/app-food/src/db/seed/step-batches.ts
+++ b/packages/app-food/src/db/seed/step-batches.ts
@@ -1,0 +1,144 @@
+/**
+ * PRD-113 seed step — batches + recipe_runs + batch_consumptions.
+ *
+ * No `createBatch` service exists yet (PRD-145 will own it); the seed inserts
+ * via Drizzle. The single seeded `recipe_runs` row + its `batch_consumptions`
+ * exercise the read path that PRD-147's fridge view consumes.
+ *
+ * Order matters:
+ *   1. Seed `recipe_runs` (no batches yet → `yielded_batch_id` left null).
+ *   2. Insert batches; one of them carries `source_type='recipe_run'` and
+ *      `source_id` = the seeded run id.
+ *   3. Patch the seeded run's `yielded_batch_id` to point at that batch.
+ *   4. Record the `batch_consumptions` rows tying the run to existing batches.
+ */
+import { eq } from 'drizzle-orm';
+
+import { batchConsumptions, batches, recipeRuns } from '../schema';
+import { BATCH_FIXTURES, RECIPE_RUN_FIXTURE, type BatchFixture } from './data-batches';
+
+import type { FoodDb } from '../services/internal';
+import type { SeedContext } from './types';
+
+function isoOffsetDays(offsetDays: number): string {
+  const base = new Date('2026-06-10T08:00:00Z');
+  base.setUTCDate(base.getUTCDate() + offsetDays);
+  return base.toISOString();
+}
+
+function variantIdFor(fixture: BatchFixture, ctx: SeedContext): number {
+  const key = `${fixture.variantOfIngredient}:${fixture.variantSlug}`;
+  const id = ctx.variantIdByCompositeSlug.get(key);
+  if (id === undefined) throw new Error(`Batch refers to unknown variant "${key}"`);
+  return id;
+}
+
+function prepStateIdFor(fixture: BatchFixture, ctx: SeedContext): number | null {
+  if (fixture.prepStateSlug === undefined) return null;
+  const id = ctx.prepStateIdBySlug.get(fixture.prepStateSlug);
+  if (id === undefined) {
+    throw new Error(`Batch refers to unknown prep_state "${fixture.prepStateSlug}"`);
+  }
+  return id;
+}
+
+function insertRecipeRunRow(db: FoodDb, ctx: SeedContext): number {
+  const versionId = ctx.recipeVersionIdByRecipeSlug.get(RECIPE_RUN_FIXTURE.recipeSlug);
+  if (versionId === undefined) {
+    throw new Error(`Seed run references unknown recipe "${RECIPE_RUN_FIXTURE.recipeSlug}"`);
+  }
+  const rows = db
+    .insert(recipeRuns)
+    .values({
+      recipeVersionId: versionId,
+      startedAt: isoOffsetDays(RECIPE_RUN_FIXTURE.startedAtOffsetDays),
+      completedAt: isoOffsetDays(RECIPE_RUN_FIXTURE.completedAtOffsetDays),
+      scaleFactor: RECIPE_RUN_FIXTURE.scaleFactor,
+      yieldedBatchId: null,
+      rating: RECIPE_RUN_FIXTURE.rating,
+      notes: RECIPE_RUN_FIXTURE.notes ?? null,
+    })
+    .returning()
+    .all();
+  const row = rows[0];
+  if (row === undefined) throw new Error('Seed recipe_runs insert returned no row');
+  ctx.recipeRunIdByRecipeSlug.set(RECIPE_RUN_FIXTURE.recipeSlug, row.id);
+  return row.id;
+}
+
+function insertOneBatch(
+  db: FoodDb,
+  fixture: BatchFixture,
+  ctx: SeedContext,
+  runId: number
+): number {
+  const sourceId =
+    fixture.sourceType === 'recipe_run' && fixture.recipeRunRecipeSlug !== undefined ? runId : null;
+  const inserted = db
+    .insert(batches)
+    .values({
+      variantId: variantIdFor(fixture, ctx),
+      prepStateId: prepStateIdFor(fixture, ctx),
+      qtyRemaining: fixture.qtyRemaining,
+      unit: fixture.unit,
+      sourceType: fixture.sourceType,
+      sourceId,
+      location: fixture.location,
+      producedAt: fixture.producedAt,
+      expiresAt: fixture.expiresAt,
+      notes: fixture.notes ?? null,
+    })
+    .returning()
+    .all();
+  const row = inserted[0];
+  if (row === undefined) throw new Error('Seed batches insert returned no row');
+  return row.id;
+}
+
+function insertAllBatches(
+  db: FoodDb,
+  ctx: SeedContext,
+  runId: number
+): { batchIds: readonly number[]; yieldedBatchId: number | null } {
+  const batchIds: number[] = [];
+  let yieldedBatchId: number | null = null;
+  for (const fixture of BATCH_FIXTURES) {
+    const id = insertOneBatch(db, fixture, ctx, runId);
+    batchIds.push(id);
+    if (fixture.sourceType === 'recipe_run') yieldedBatchId = id;
+  }
+  return { batchIds, yieldedBatchId };
+}
+
+function insertConsumptions(db: FoodDb, runId: number, batchIds: readonly number[]): number {
+  let count = 0;
+  for (const consume of RECIPE_RUN_FIXTURE.consumes) {
+    const batchId = batchIds[consume.fromBatchIndex];
+    if (batchId === undefined) {
+      throw new Error(`Seed consumption refs batch index ${consume.fromBatchIndex} (out of range)`);
+    }
+    db.insert(batchConsumptions)
+      .values({
+        recipeRunId: runId,
+        batchId,
+        qtyConsumed: consume.qtyConsumed,
+        unit: consume.unit,
+      })
+      .run();
+    count += 1;
+  }
+  return count;
+}
+
+export function seedBatches(
+  db: FoodDb,
+  ctx: SeedContext
+): { batches: number; recipeRuns: number; batchConsumptions: number } {
+  const runId = insertRecipeRunRow(db, ctx);
+  const { batchIds, yieldedBatchId } = insertAllBatches(db, ctx, runId);
+  if (yieldedBatchId !== null) {
+    db.update(recipeRuns).set({ yieldedBatchId }).where(eq(recipeRuns.id, runId)).run();
+  }
+  const consumed = insertConsumptions(db, runId, batchIds);
+  return { batches: batchIds.length, recipeRuns: 1, batchConsumptions: consumed };
+}

--- a/packages/app-food/src/db/seed/step-ingredients.ts
+++ b/packages/app-food/src/db/seed/step-ingredients.ts
@@ -1,0 +1,108 @@
+/**
+ * PRD-113 seed step — ingredients + variants.
+ *
+ * Walks the (parent → children) tree and inserts each ingredient via
+ * `createIngredient`, then `createVariant` per variant. Per-ingredient
+ * shelf-life defaults propagate to variants unless the variant overrides.
+ *
+ * Returns `{ ingredients, variants }` counts so the orchestrator can roll
+ * them into the SeedSummary.
+ */
+import { createIngredient } from '../services/ingredients';
+import { createVariant } from '../services/variants';
+import { INGREDIENT_FIXTURES_PANTRY_AND_DAIRY } from './data-ingredients';
+import { INGREDIENT_FIXTURES_PRODUCE_AND_BREAD } from './data-ingredients-produce';
+import { INGREDIENT_FIXTURES_PROTEIN } from './data-ingredients-protein';
+
+import type { FoodDb } from '../services/internal';
+import type { SeedContext } from './types';
+import type { IngredientFixture, VariantFixture } from './types-ingredient';
+
+const ALL_INGREDIENT_GROUPS: readonly (readonly IngredientFixture[])[] = [
+  INGREDIENT_FIXTURES_PANTRY_AND_DAIRY,
+  INGREDIENT_FIXTURES_PRODUCE_AND_BREAD,
+  INGREDIENT_FIXTURES_PROTEIN,
+];
+
+function variantKey(ingredientSlug: string, variantSlug: string): string {
+  return `${ingredientSlug}:${variantSlug}`;
+}
+
+function pickShelfLife(
+  parent: IngredientFixture,
+  variant: VariantFixture
+): { fridge: number | null; freezer: number | null } {
+  // Variant explicit overrides win; otherwise inherit from ingredient defaults.
+  const fridge =
+    variant.shelfLifeDaysFridge !== undefined
+      ? variant.shelfLifeDaysFridge
+      : (parent.shelfLifeDaysFridge ?? null);
+  const freezer =
+    variant.shelfLifeDaysFreezer !== undefined
+      ? variant.shelfLifeDaysFreezer
+      : (parent.shelfLifeDaysFreezer ?? null);
+  return { fridge, freezer };
+}
+
+function seedVariantsFor(
+  db: FoodDb,
+  parent: IngredientFixture,
+  parentId: number,
+  ctx: SeedContext
+): number {
+  for (const variant of parent.variants) {
+    const shelf = pickShelfLife(parent, variant);
+    const row = createVariant(db, {
+      ingredientId: parentId,
+      name: variant.name,
+      slug: variant.slug,
+      defaultUnit: variant.defaultUnit ?? parent.defaultUnit,
+      packageSizeG: variant.packageSizeG ?? null,
+      notes: variant.notes ?? null,
+      defaultShelfLifeDaysFridge: shelf.fridge,
+      defaultShelfLifeDaysFreezer: shelf.freezer,
+    });
+    ctx.variantIdByCompositeSlug.set(variantKey(parent.slug, variant.slug), row.id);
+  }
+  return parent.variants.length;
+}
+
+interface SeedTreeArgs {
+  fixture: IngredientFixture;
+  parentId: number | null;
+  counts: { ingredients: number; variants: number };
+}
+
+function seedTree(db: FoodDb, ctx: SeedContext, args: SeedTreeArgs): void {
+  const { fixture, parentId, counts } = args;
+  const row = createIngredient(db, {
+    name: fixture.name,
+    slug: fixture.slug,
+    defaultUnit: fixture.defaultUnit,
+    parentId,
+    densityGPerMl: fixture.densityGPerMl ?? null,
+    notes: fixture.notes ?? null,
+  });
+  ctx.ingredientIdBySlug.set(row.slug, row.id);
+  counts.ingredients += 1;
+  counts.variants += seedVariantsFor(db, fixture, row.id, ctx);
+
+  if (fixture.children !== undefined) {
+    for (const child of fixture.children) {
+      seedTree(db, ctx, { fixture: child, parentId: row.id, counts });
+    }
+  }
+}
+
+export function seedIngredientsAndVariants(
+  db: FoodDb,
+  ctx: SeedContext
+): { ingredients: number; variants: number } {
+  const counts = { ingredients: 0, variants: 0 };
+  for (const group of ALL_INGREDIENT_GROUPS) {
+    for (const fixture of group) {
+      seedTree(db, ctx, { fixture, parentId: null, counts });
+    }
+  }
+  return counts;
+}

--- a/packages/app-food/src/db/seed/step-lists.ts
+++ b/packages/app-food/src/db/seed/step-lists.ts
@@ -1,0 +1,78 @@
+/**
+ * PRD-113 seed step — lists + list_items (PRD-112 + PRD-141).
+ *
+ * Uses app-lists services so ref_kind / ref_id normalisation flows through
+ * the canonical code path. Items checked at fixture-time get an immediate
+ * `checkItem` call so `checked_at` is populated, matching prod behaviour.
+ */
+import { type AddItemInput, addItem, checkItem } from '@pops/app-lists';
+import { createList, type ListsDb } from '@pops/app-lists';
+
+import { LIST_FIXTURES, type ListItemFixture } from './data-lists';
+
+import type { SeedContext } from './types';
+
+interface ResolvedRef {
+  refKind: 'free' | 'ingredient' | 'variant';
+  refId: number | null;
+}
+
+function resolveItemRef(item: ListItemFixture, ctx: SeedContext): ResolvedRef {
+  if (item.refIngredientSlug !== undefined) {
+    const id = ctx.ingredientIdBySlug.get(item.refIngredientSlug);
+    if (id === undefined) {
+      throw new Error(`List item refs unknown ingredient "${item.refIngredientSlug}"`);
+    }
+    return { refKind: 'ingredient', refId: id };
+  }
+  if (item.refVariantOfIngredient !== undefined && item.refVariantSlug !== undefined) {
+    const key = `${item.refVariantOfIngredient}:${item.refVariantSlug}`;
+    const id = ctx.variantIdByCompositeSlug.get(key);
+    if (id === undefined) {
+      throw new Error(`List item refs unknown variant "${key}"`);
+    }
+    return { refKind: 'variant', refId: id };
+  }
+  return { refKind: 'free', refId: null };
+}
+
+function toAddItemInput(item: ListItemFixture, listId: number, ctx: SeedContext): AddItemInput {
+  const ref = resolveItemRef(item, ctx);
+  return {
+    listId,
+    label: item.label,
+    qty: item.qty ?? null,
+    unit: item.unit ?? null,
+    refKind: ref.refKind,
+    refId: ref.refId,
+    notes: item.notes ?? null,
+  };
+}
+
+export function seedLists(
+  db: ListsDb,
+  ctx: SeedContext,
+  foodCtx: SeedContext
+): { lists: number; listItems: number } {
+  // Both context handles point at the same maps; the second param mirrors the
+  // food context so resolveItemRef can pull ingredient/variant ids that were
+  // populated by earlier food steps. Kept explicit so the call site reads as
+  // "lists DB + food context".
+  let itemCount = 0;
+  for (const fixture of LIST_FIXTURES) {
+    const list = createList(db, {
+      name: fixture.name,
+      kind: fixture.kind,
+      ownerApp: fixture.ownerApp,
+    });
+    ctx.listIdBySlug.set(fixture.slug, list.id);
+    for (const item of fixture.items) {
+      const inserted = addItem(db, toAddItemInput(item, list.id, foodCtx));
+      if (item.checked === true) {
+        checkItem(db, inserted.id);
+      }
+      itemCount += 1;
+    }
+  }
+  return { lists: LIST_FIXTURES.length, listItems: itemCount };
+}

--- a/packages/app-food/src/db/seed/step-plan.ts
+++ b/packages/app-food/src/db/seed/step-plan.ts
@@ -1,0 +1,54 @@
+/**
+ * PRD-113 seed step — plan_slots + plan_entries.
+ *
+ * Seeds the default slot vocabulary directly (bypassing `addSlot` because
+ * the service forbids touching `is_default = 1` rows) plus the one
+ * user-added slot, then adds the plan_entries via `addPlanEntry`.
+ */
+import { planSlots } from '../schema';
+import { addPlanEntry } from '../services/plan';
+import { PLAN_ENTRY_FIXTURES, PLAN_SLOT_FIXTURES, planDateForOffset } from './data-plan';
+
+import type { FoodDb } from '../services/internal';
+import type { SeedContext } from './types';
+
+function seedSlots(db: FoodDb, ctx: SeedContext): number {
+  for (const fixture of PLAN_SLOT_FIXTURES) {
+    db.insert(planSlots)
+      .values({
+        slug: fixture.slug,
+        name: fixture.name,
+        displayOrder: fixture.displayOrder,
+        isDefault: fixture.isDefault,
+      })
+      .run();
+    ctx.planSlotBySlug.set(fixture.slug, { slug: fixture.slug, name: fixture.name });
+  }
+  return PLAN_SLOT_FIXTURES.length;
+}
+
+function seedEntries(db: FoodDb, ctx: SeedContext): number {
+  for (const fixture of PLAN_ENTRY_FIXTURES) {
+    const recipeId = ctx.recipeIdBySlug.get(fixture.recipeSlug);
+    if (recipeId === undefined) {
+      throw new Error(`Plan entry refers to unknown recipe "${fixture.recipeSlug}"`);
+    }
+    const versionId = ctx.recipeVersionIdByRecipeSlug.get(fixture.recipeSlug) ?? null;
+    addPlanEntry(db, {
+      date: planDateForOffset(fixture.offsetDays),
+      slot: fixture.slot,
+      recipeId,
+      recipeVersionId: versionId,
+      plannedServings: fixture.plannedServings ?? 1,
+      position: fixture.position,
+      notes: fixture.notes ?? null,
+    });
+  }
+  return PLAN_ENTRY_FIXTURES.length;
+}
+
+export function seedPlan(db: FoodDb, ctx: SeedContext): { planSlots: number; planEntries: number } {
+  const slots = seedSlots(db, ctx);
+  const entries = seedEntries(db, ctx);
+  return { planSlots: slots, planEntries: entries };
+}

--- a/packages/app-food/src/db/seed/step-prep-states.ts
+++ b/packages/app-food/src/db/seed/step-prep-states.ts
@@ -1,0 +1,19 @@
+/**
+ * PRD-113 seed step — prep_states.
+ *
+ * Calls `createPrepState` for each canonical entry so the slug_registry row
+ * is recorded via the service's transaction.
+ */
+import { createPrepState } from '../services/prep-states';
+import { PREP_STATE_FIXTURES } from './data-prep-states';
+
+import type { FoodDb } from '../services/internal';
+import type { SeedContext } from './types';
+
+export function seedPrepStates(db: FoodDb, ctx: SeedContext): number {
+  for (const fixture of PREP_STATE_FIXTURES) {
+    const row = createPrepState(db, fixture);
+    ctx.prepStateIdBySlug.set(row.slug, row.id);
+  }
+  return PREP_STATE_FIXTURES.length;
+}

--- a/packages/app-food/src/db/seed/step-recipes.ts
+++ b/packages/app-food/src/db/seed/step-recipes.ts
@@ -1,0 +1,40 @@
+/**
+ * PRD-113 seed step — recipe headers (phase 1).
+ *
+ * Calls `createRecipe` for each fixture and stashes both the recipe id and
+ * the first-version id in the SeedContext. The DSL body lives in
+ * `recipe_versions.body_dsl` as plain text; `compile_state` defaults to
+ * uncompiled and `status` to draft.
+ *
+ * Phase 2 (post PRD-116) replaces this step with one that calls
+ * `compileRecipeVersion` so the DSL → resolve → cycle → materialise path
+ * runs against real fixtures.
+ */
+import { createRecipe } from '../services/recipes';
+import { RECIPE_FIXTURES } from './data-recipes';
+
+import type { FoodDb } from '../services/internal';
+import type { SeedContext } from './types';
+
+export function seedRecipeHeaders(
+  db: FoodDb,
+  ctx: SeedContext
+): { recipes: number; recipeVersions: number } {
+  for (const fixture of RECIPE_FIXTURES) {
+    const result = createRecipe(db, {
+      slug: fixture.slug,
+      recipeType: fixture.recipeType ?? 'plate',
+      firstVersion: {
+        title: fixture.title,
+        bodyDsl: fixture.bodyDsl,
+        summary: fixture.summary ?? null,
+        servings: fixture.servings ?? null,
+        prepMinutes: fixture.prepMinutes ?? null,
+        cookMinutes: fixture.cookMinutes ?? null,
+      },
+    });
+    ctx.recipeIdBySlug.set(result.recipe.slug, result.recipe.id);
+    ctx.recipeVersionIdByRecipeSlug.set(result.recipe.slug, result.version.id);
+  }
+  return { recipes: RECIPE_FIXTURES.length, recipeVersions: RECIPE_FIXTURES.length };
+}

--- a/packages/app-food/src/db/seed/step-substitutions.ts
+++ b/packages/app-food/src/db/seed/step-substitutions.ts
@@ -1,0 +1,71 @@
+/**
+ * PRD-113 seed step — substitutions.
+ *
+ * Maps fixture endpoints (slug-based) to (ingredient_id | variant_id) and
+ * calls `createSubstitution`. Recipe-scoped fixtures resolve the recipe id
+ * from the SeedContext (so this step MUST run after `seedRecipeHeaders`).
+ */
+import {
+  createSubstitution,
+  type CreateSubstitutionInput,
+  type SubstitutionEndpoint,
+} from '../services/substitutions';
+import { SUBSTITUTION_FIXTURES } from './data-substitutions';
+
+import type { FoodDb } from '../services/internal';
+import type { SeedContext } from './types';
+
+function resolveEndpoint(
+  side: 'from' | 'to',
+  endpoint: (typeof SUBSTITUTION_FIXTURES)[number]['from'],
+  ctx: SeedContext
+): SubstitutionEndpoint {
+  if (endpoint.ingredientSlug !== undefined) {
+    const id = ctx.ingredientIdBySlug.get(endpoint.ingredientSlug);
+    if (id === undefined) {
+      throw new Error(`Sub ${side} ingredient "${endpoint.ingredientSlug}" missing from ctx`);
+    }
+    return { ingredientId: id };
+  }
+  if (endpoint.variantOfIngredient !== undefined && endpoint.variantSlug !== undefined) {
+    const key = `${endpoint.variantOfIngredient}:${endpoint.variantSlug}`;
+    const id = ctx.variantIdByCompositeSlug.get(key);
+    if (id === undefined) {
+      throw new Error(`Sub ${side} variant "${key}" missing from ctx`);
+    }
+    return { variantId: id };
+  }
+  throw new Error(`Sub ${side} endpoint has neither ingredient nor variant`);
+}
+
+function buildInput(
+  fixture: (typeof SUBSTITUTION_FIXTURES)[number],
+  ctx: SeedContext
+): CreateSubstitutionInput {
+  const from = resolveEndpoint('from', fixture.from, ctx);
+  const to = resolveEndpoint('to', fixture.to, ctx);
+  const scope = fixture.scope ?? 'global';
+  const recipeId =
+    scope === 'recipe' && fixture.recipeSlug !== undefined
+      ? ctx.recipeIdBySlug.get(fixture.recipeSlug)
+      : null;
+  if (scope === 'recipe' && recipeId === undefined) {
+    throw new Error(`Sub recipe scope requires known recipe; "${fixture.recipeSlug}" missing`);
+  }
+  return {
+    from,
+    to,
+    ratio: fixture.ratio,
+    contextTags: fixture.contextTags,
+    scope,
+    recipeId: recipeId ?? null,
+    notes: fixture.notes ?? null,
+  };
+}
+
+export function seedSubstitutions(db: FoodDb, ctx: SeedContext): number {
+  for (const fixture of SUBSTITUTION_FIXTURES) {
+    createSubstitution(db, buildInput(fixture, ctx));
+  }
+  return SUBSTITUTION_FIXTURES.length;
+}

--- a/packages/app-food/src/db/seed/step-substitutions.ts
+++ b/packages/app-food/src/db/seed/step-substitutions.ts
@@ -38,27 +38,35 @@ function resolveEndpoint(
   throw new Error(`Sub ${side} endpoint has neither ingredient nor variant`);
 }
 
+function resolveRecipeId(
+  fixture: (typeof SUBSTITUTION_FIXTURES)[number],
+  ctx: SeedContext
+): number | null {
+  if ((fixture.scope ?? 'global') !== 'recipe') return null;
+  // Defensive: a fixture declaring scope='recipe' without recipeSlug would
+  // otherwise silently insert a recipe-scoped sub with NULL recipe_id —
+  // violating PRD-109 invariants. Fail loud at seed time.
+  if (fixture.recipeSlug === undefined) {
+    throw new Error(`Sub fixture has scope='recipe' but no recipeSlug`);
+  }
+  const id = ctx.recipeIdBySlug.get(fixture.recipeSlug);
+  if (id === undefined) {
+    throw new Error(`Sub fixture references unknown recipe "${fixture.recipeSlug}"`);
+  }
+  return id;
+}
+
 function buildInput(
   fixture: (typeof SUBSTITUTION_FIXTURES)[number],
   ctx: SeedContext
 ): CreateSubstitutionInput {
-  const from = resolveEndpoint('from', fixture.from, ctx);
-  const to = resolveEndpoint('to', fixture.to, ctx);
-  const scope = fixture.scope ?? 'global';
-  const recipeId =
-    scope === 'recipe' && fixture.recipeSlug !== undefined
-      ? ctx.recipeIdBySlug.get(fixture.recipeSlug)
-      : null;
-  if (scope === 'recipe' && recipeId === undefined) {
-    throw new Error(`Sub recipe scope requires known recipe; "${fixture.recipeSlug}" missing`);
-  }
   return {
-    from,
-    to,
+    from: resolveEndpoint('from', fixture.from, ctx),
+    to: resolveEndpoint('to', fixture.to, ctx),
     ratio: fixture.ratio,
     contextTags: fixture.contextTags,
-    scope,
-    recipeId: recipeId ?? null,
+    scope: fixture.scope ?? 'global',
+    recipeId: resolveRecipeId(fixture, ctx),
     notes: fixture.notes ?? null,
   };
 }

--- a/packages/app-food/src/db/seed/types-ingredient.ts
+++ b/packages/app-food/src/db/seed/types-ingredient.ts
@@ -1,0 +1,33 @@
+/**
+ * Fixture shapes shared by the ingredient/variant fixture files.
+ *
+ * Split from `data-ingredients-*.ts` so the data files stay under the
+ * 200-line lint cap.
+ */
+
+export type Unit = 'g' | 'ml' | 'count';
+
+export interface VariantFixture {
+  name: string;
+  slug: string;
+  defaultUnit?: Unit;
+  packageSizeG?: number;
+  shelfLifeDaysFridge?: number | null;
+  shelfLifeDaysFreezer?: number | null;
+  notes?: string;
+}
+
+export interface IngredientFixture {
+  name: string;
+  slug: string;
+  defaultUnit: Unit;
+  densityGPerMl?: number;
+  /** Default fridge shelf-life applied to every variant unless overridden. */
+  shelfLifeDaysFridge?: number | null;
+  /** Default freezer shelf-life applied to every variant unless overridden. */
+  shelfLifeDaysFreezer?: number | null;
+  variants: readonly VariantFixture[];
+  /** Optional child ingredients (depth-2 hierarchy). */
+  children?: readonly IngredientFixture[];
+  notes?: string;
+}

--- a/packages/app-food/src/db/seed/types.ts
+++ b/packages/app-food/src/db/seed/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared types for the PRD-113 food seed.
+ *
+ * Phase 1 ships the non-compile fixture set: ingredients, variants, prep
+ * states, aliases, substitutions, plan slots + entries, lists + items,
+ * batches, and recipe headers with uncompiled DSL bodies. The cross-PRD
+ * smoke (DSL parse → resolve → cycle → materialise) lands in phase 2 once
+ * PRD-116 ships `compileRecipeVersion`.
+ */
+import type { ListsDb } from '@pops/app-lists';
+
+import type { FoodDb } from '../services/internal';
+
+/** Surface of every phase-1 step so the orchestrator can roll up counts. */
+export interface StepCounts {
+  prepStates: number;
+  ingredients: number;
+  variants: number;
+  aliases: number;
+  substitutions: number;
+  planSlots: number;
+  planEntries: number;
+  recipes: number;
+  recipeVersions: number;
+  batches: number;
+  recipeRuns: number;
+  batchConsumptions: number;
+  lists: number;
+  listItems: number;
+}
+
+/** Final summary returned by `seedFood`. */
+export interface SeedFoodSummary extends StepCounts {
+  /** Set when the seed early-returned because the slug_registry was non-empty. */
+  skipped: boolean;
+}
+
+export const ZERO_COUNTS: StepCounts = {
+  prepStates: 0,
+  ingredients: 0,
+  variants: 0,
+  aliases: 0,
+  substitutions: 0,
+  planSlots: 0,
+  planEntries: 0,
+  recipes: 0,
+  recipeVersions: 0,
+  batches: 0,
+  recipeRuns: 0,
+  batchConsumptions: 0,
+  lists: 0,
+  listItems: 0,
+};
+
+/**
+ * Resolved ids from upstream steps that downstream steps reference by slug.
+ * Threaded through the pipeline so every step works in terms of slugs in
+ * source and ids at insert time.
+ */
+export interface SeedContext {
+  prepStateIdBySlug: Map<string, number>;
+  ingredientIdBySlug: Map<string, number>;
+  /** Compound key `<ingredient-slug>:<variant-slug>` → id. */
+  variantIdByCompositeSlug: Map<string, number>;
+  recipeIdBySlug: Map<string, number>;
+  /** `<recipe-slug>` → version_no 1 row id (every recipe ships one draft version). */
+  recipeVersionIdByRecipeSlug: Map<string, number>;
+  /** `<recipe-slug>` → recipe_runs.id for the seeded cook run on smash-burger. */
+  recipeRunIdByRecipeSlug: Map<string, number>;
+  /** Slot slug → row (used by plan_entries inserts). */
+  planSlotBySlug: Map<string, { slug: string; name: string }>;
+  /** `<list-slug>` → list id. */
+  listIdBySlug: Map<string, number>;
+}
+
+export function freshContext(): SeedContext {
+  return {
+    prepStateIdBySlug: new Map(),
+    ingredientIdBySlug: new Map(),
+    variantIdByCompositeSlug: new Map(),
+    recipeIdBySlug: new Map(),
+    recipeVersionIdByRecipeSlug: new Map(),
+    recipeRunIdByRecipeSlug: new Map(),
+    planSlotBySlug: new Map(),
+    listIdBySlug: new Map(),
+  };
+}
+
+/** Both Drizzle wrappers point at the same SQLite handle; held separately because each package owns its typed wrapper. */
+export interface SeedDb {
+  food: FoodDb;
+  lists: ListsDb;
+}

--- a/packages/app-food/src/db/services/variants.ts
+++ b/packages/app-food/src/db/services/variants.ts
@@ -18,6 +18,10 @@ export interface CreateVariantInput {
   defaultUnit: 'g' | 'ml' | 'count';
   packageSizeG?: number | null;
   notes?: string | null;
+  /** PRD-108: feeds expiry auto-fill at cook time. Null = unknown / shelf-stable. */
+  defaultShelfLifeDaysFridge?: number | null;
+  /** PRD-108: feeds expiry auto-fill at cook time. Null = unknown / shelf-stable. */
+  defaultShelfLifeDaysFreezer?: number | null;
 }
 
 export function createVariant(db: FoodDb, input: CreateVariantInput): IngredientVariantRow {
@@ -31,6 +35,8 @@ export function createVariant(db: FoodDb, input: CreateVariantInput): Ingredient
       defaultUnit: input.defaultUnit,
       packageSizeG: input.packageSizeG ?? null,
       notes: input.notes ?? null,
+      defaultShelfLifeDaysFridge: input.defaultShelfLifeDaysFridge ?? null,
+      defaultShelfLifeDaysFreezer: input.defaultShelfLifeDaysFreezer ?? null,
     })
     .returning()
     .all();

--- a/packages/app-food/src/server.ts
+++ b/packages/app-food/src/server.ts
@@ -1,0 +1,22 @@
+/**
+ * @pops/app-food/server — server-only barrel for backend consumers.
+ *
+ * Re-exports the schema, errors, typed db services, and the PRD-113 phase-1
+ * seed entrypoint. Distinct from `./index` (the React surface consumed by
+ * the shell) so importing into Node-only code (pops-api seeder) doesn't pull
+ * React, react-router, lucide, etc. into the dependency graph.
+ */
+
+export * from './db/schema';
+export * from './db/errors';
+export * from './db/services/ingredients';
+export * from './db/services/variants';
+export * from './db/services/prep-states';
+export * from './db/services/recipes';
+export * from './db/services/recipe-versions';
+export * from './db/services/recipe-runs';
+export * from './db/services/batches';
+export * from './db/services/substitutions';
+export * from './db/services/plan';
+export { seedFood, type SeedFoodSummary } from './db/seed/index';
+export type { FoodDb } from './db/services/internal';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,15 +693,12 @@ importers:
 
   packages/app-food:
     dependencies:
-      '@pops/api-client':
+      '@pops/app-lists':
         specifier: workspace:*
-        version: link:../api-client
+        version: link:../app-lists
       '@pops/db-types':
         specifier: workspace:*
         version: link:../db-types
-      '@pops/navigation':
-        specifier: workspace:*
-        version: link:../navigation
       '@pops/types':
         specifier: workspace:*
         version: link:../types
@@ -739,6 +736,9 @@ importers:
         specifier: ^7.16.0
         version: 7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
+      '@pops/navigation':
+        specifier: workspace:*
+        version: link:../navigation
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -766,6 +766,9 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@1.8.0)
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

Ships PRD-113 phase 1: the **non-compile** food + lists fixture set so `mise db:seed` produces a populated food DB without waiting on PRD-116.

PRD-113 was originally specced as one PR gated on PRD-116 + PRD-110. Split into three phases so the bulk of the fixture set can land in parallel with the other in-flight Epic 00 work:

- **Phase 1 (this PR)** — ingredients/variants/prep_states/aliases/subs/plan/lists/batches + 4 recipe headers with uncompiled DSL. Does not touch `ingest_sources`, `recipe_lines`, `recipe_steps`, or `/food/data` UI.
- **Phase 2 (after PRD-116 merges)** — invoke `compileRecipeVersion` on the seeded recipe DSL bodies; that's the cross-PRD smoke test PRD-113 was originally specced as.
- **Phase 3 (after PRD-110 merges)** — 1–2 `ingest_sources` rows so the inbox page has provenance fixtures to render.

Coordination context in `.claude/food-app-roadmap.md` under the PRD-113 entry.

## What lands

- 15 prep_states · 20 ingredients · 56 variants · 31 aliases · 10 substitutions covering every PRD-109 context tag · 6 plan_slots · 9 plan_entries · 4 recipe headers (uncompiled DSL) · 10 batches · 1 recipe_run + consumptions · 2 lists (1 shopping / 1 generic) with ~10 items
- `mise db:seed:food` — food-only path (wipes food + lists tables, runs `seedFood`)
- `mise db:seed` — now chains the food seed after the cross-domain seed
- `apps/pops-api/src/db/data-reset.ts` — food + lists added to `APPLICATION_TABLES`; deletion is now tolerant of missing tables (preserves migration-safety tests that apply migration subsets)

## What does NOT land

- DSL compile pipeline integration (waits on PRD-116)
- `ingest_sources` rows (waits on PRD-110)
- PRD-123 `unit_conversions` + `ingredient_weights` seed rows (deferred per the existing I0e → I1b follow-up)
- E2E / Playwright for food (premature — only landing page exists)

## Non-collision contract with parallel in-flight work

- **PRD-110 (#2693, ingest_sources)** — phase 1 leaves the table empty. No file overlap.
- **PRD-116 (in-flight, compile pipeline)** — phase 1 leaves `recipe_lines` / `recipe_steps` / `recipe_version_proposed_slugs` empty. Recipe headers ship with raw DSL bodies + `compile_state` uncompiled. No file overlap.
- **PRD-122 (in-flight, `/food/data` UI)** — different layer entirely. No file overlap.

The only shared file is `apps/pops-api/src/db/data-reset.ts` (one additive change).

## Cycle-safety

`pops-api` does **not** depend on `@pops/app-food` (would create a build cycle via `@pops/api-client`). The seed lives in `@pops/app-food` and runs as a standalone tsx script invoked by mise.

## Service amendments

- `CreateVariantInput` extended with `defaultShelfLifeDays{Fridge,Freezer}` — additive. PRD-108 added the columns but never extended the service.

## Test plan

- [x] `pnpm typecheck` (23/23 turbo tasks)
- [x] `pnpm lint` (0 errors; pre-existing warnings untouched)
- [x] `pnpm test` (4416 + 228 + 300 + 81 = all tests green)
- [x] `pnpm test:integration` (81/81)
- [x] `pnpm build` (7/7)
- [x] `pnpm exec oxfmt --check .`
- [ ] Manual smoke: `mise db:init && mise db:seed:food` against local dev DB

## Roadmap

`.claude/food-app-roadmap.md` annotated with the phase split + decisions-log entry.